### PR TITLE
[5.1 4/24] Update “unable to load standard library” test (#23990)

### DIFF
--- a/test/Misc/fatal_error.swift
+++ b/test/Misc/fatal_error.swift
@@ -1,5 +1,7 @@
-// RUN: not %target-swift-frontend -typecheck %s -sdk "" 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-MODULE %s
-// RUN: not %target-swift-frontend -typecheck %s -resource-dir / 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-STDLIB %s
+// RUN: %empty-directory(%t)
+
+// RUN: not %target-swift-frontend -typecheck %s -sdk %t 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-MODULE %s
+// RUN: not %target-swift-frontend -typecheck %s -resource-dir %t -sdk %t 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=NO-STDLIB %s
 
 // NO-MODULE: error: no such module 'NonExistent'
 


### PR DESCRIPTION
Cherry-picks #23990 to swift-5.1-branch-04-24-2019.

> One of the subtests of Misc/fatal_error.swift assumes that Swift.swiftmodule is located purely based on the resource directory. It can now also be located in the SDK, so the test needs to be updated. Fixes rdar://problem/49665477.

Original reviewed by @jrose-apple.

-----

This PR modifies one test to handle cases where content could be located in the SDK. It is also compatible with cases where the content is *not* in the SDK, and has passed in internal-master for nearly a month now. It doesn't change any shipping software at all.