### PR TITLE
TF-494: Conform `Array.DifferentiableView` to `CustomStringConvertible`

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1917,7 +1917,7 @@ extension Array where Element : Differentiable {
   /// The view of an array as the differentiable product manifold of `Element`
   /// multiplied with itself `count` times.
   @_fixed_layout
-  public struct DifferentiableView : Differentiable, CustomStringConvertible {
+  public struct DifferentiableView : Differentiable {
     private var _base: [Element]
 
     /// The viewed array.
@@ -1996,10 +1996,6 @@ extension Array where Element : Differentiable {
         selfElement.tangentVector(from: cotangentVectorElement)
       })
     }
-    
-    public var description: String {
-      return base.description
-    }
   }
 }
 
@@ -2009,6 +2005,13 @@ extension Array.DifferentiableView : Equatable where Element : Equatable {
     rhs: Array.DifferentiableView
   ) -> Bool {
     return lhs.base == rhs.base
+  }
+}
+
+extension Array.DifferentiableView : CustomStringConvertible
+where Element : Differentiable {
+  public var description: String {
+    return base.description
   }
 }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -2008,8 +2008,7 @@ extension Array.DifferentiableView : Equatable where Element : Equatable {
   }
 }
 
-extension Array.DifferentiableView : CustomStringConvertible
-where Element : Differentiable {
+extension Array.DifferentiableView : CustomStringConvertible {
   public var description: String {
     return base.description
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1917,7 +1917,7 @@ extension Array where Element : Differentiable {
   /// The view of an array as the differentiable product manifold of `Element`
   /// multiplied with itself `count` times.
   @_fixed_layout
-  public struct DifferentiableView : Differentiable {
+  public struct DifferentiableView : Differentiable, CustomStringConvertible {
     private var _base: [Element]
 
     /// The viewed array.
@@ -1995,6 +1995,10 @@ extension Array where Element : Differentiable {
         (selfElement, cotangentVectorElement) in
         selfElement.tangentVector(from: cotangentVectorElement)
       })
+    }
+    
+    public var description: String {
+      return base.description
     }
   }
 }


### PR DESCRIPTION
Implements this [JIRA ticket](https://bugs.swift.org/browse/TF-494).

There isn't much logic here so I don't think tests are necessary, and unsure how to unit test that the correct thing get's printed, but the JIRA example works as expected:
<img width="341" alt="Screen Shot 2019-05-13 at 11 30 08 AM" src="https://user-images.githubusercontent.com/15171576/57645171-8c2d2080-7572-11e9-9200-accb0b0b5c71.png">
