### PR TITLE
[5.1] [ModuleInterface] Pass -Rmodule-interface-rebuild to sub-invocation

### DIFF
--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -167,7 +167,8 @@ public:
   static bool buildSwiftModuleFromSwiftInterface(
     ASTContext &Ctx, StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
-    bool SerializeDependencyHashes, bool TrackSystemDependencies);
+    bool SerializeDependencyHashes, bool TrackSystemDependencies,
+    bool RemarkOnRebuildFromInterface);
 };
 
 /// Extract the specified-or-defaulted -module-cache-path that winds up in

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -603,7 +603,7 @@ static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
-      FEOpts.TrackSystemDeps);
+      FEOpts.TrackSystemDeps, FEOpts.RemarkOnRebuildFromModuleInterface);
 }
 
 static bool compileLLVMIR(CompilerInvocation &Invocation,

--- a/test/ParseableInterface/ModuleCache/RebuildRemarks/rebuild-transitive-import.swift
+++ b/test/ParseableInterface/ModuleCache/RebuildRemarks/rebuild-transitive-import.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Build)
+// RUN: %empty-directory(%t/ModuleCache)
+
+// 1. Create a module called InnerModule, and put its interface into the build dir.
+// RUN: echo 'public func inInnerModule() {}' | %target-swift-frontend - -typecheck -emit-module-interface-path %t/Build/InnerModule.swiftinterface -enable-library-evolution -swift-version 5 -module-name InnerModule
+
+// 2. Build the .swiftinterface to a .swiftmodule, which will have a dependency on the interface
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/Build/InnerModule.swiftmodule %t/Build/InnerModule.swiftinterface
+
+// 3. Touch the interface so the module becomes out of date.
+// RUN: touch %t/Build/InnerModule.swiftinterface
+
+// 4. Create a module called OuterModule that imports InnerModule, and put its interface into the build dir.
+// RUN: echo 'import InnerModule' | %target-swift-frontend - -emit-module -o %t/Build/OuterModule.swiftmodule -module-name OuterModule -I %t/Build
+
+// 5. Build this file, and expect that InnerModule is out of date
+// RUN: %target-swift-frontend -typecheck %s -I %t/Build -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache 2>&1 | %FileCheck %s
+
+import OuterModule
+
+// CHECK: rebuilding module 'InnerModule' from interface '{{.*}}/Build/InnerModule.swiftinterface'
+// CHECK: compiled module is out of date: '{{.*}}/Build/InnerModule.swiftmodule'
+// CHECK: dependency is out of date: '{{.*}}/Build/InnerModule.swiftinterface'


### PR DESCRIPTION
Previously, we wouldn't pass this flag to sub-invocations, which means
that if we had to fall back and recompile a transitive import, we
wouldn't get a remark.

rdar://50729662

Cherry-pick of #24737 to 5.1 branch. Reviewed by @jrose-apple.