### PR TITLE
[ConstraintSystem] Use `missing conformance` fix to diagnose contextual failures

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2053,7 +2053,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   // system had a contextual type specified, we use it - it will have a purpose
   // indicator which allows us to give a very "to the point" diagnostic.
   Diag<Type, Type> diagID;
-  Diag<Type, Type> diagIDProtocol;
   Diag<Type> nilDiag;
   std::function<void(void)> nilFollowup;
 
@@ -2070,7 +2069,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
                      "contextual type");
   case CTP_Initialization:
     diagID = diag::cannot_convert_initializer_value;
-    diagIDProtocol = diag::cannot_convert_initializer_value_protocol;
     nilDiag = diag::cannot_convert_initializer_value_nil;
     nilFollowup = [this] {
       TypeRepr *patternTR = CS.getContextualTypeLoc().getTypeRepr();
@@ -2096,7 +2094,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     }
 
     diagID = diag::cannot_convert_to_return_type;
-    diagIDProtocol = diag::cannot_convert_to_return_type_protocol;
     nilDiag = diag::cannot_convert_to_return_type_nil;
     break;
   case CTP_ThrowStmt: {
@@ -2144,12 +2141,10 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
 
   case CTP_EnumCaseRawValue:
     diagID = diag::cannot_convert_raw_initializer_value;
-    diagIDProtocol = diag::cannot_convert_raw_initializer_value;
     nilDiag = diag::cannot_convert_raw_initializer_value_nil;
     break;
   case CTP_DefaultParameter:
     diagID = diag::cannot_convert_default_arg_value;
-    diagIDProtocol = diag::cannot_convert_default_arg_value_protocol;
     nilDiag = diag::cannot_convert_default_arg_value_nil;
     break;
 
@@ -2169,42 +2164,34 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     return true;
   case CTP_YieldByValue:
     diagID = diag::cannot_convert_yield_value;
-    diagIDProtocol = diag::cannot_convert_yield_value_protocol;
     nilDiag = diag::cannot_convert_yield_value_nil;
     break;
   case CTP_CallArgument:
     diagID = diag::cannot_convert_argument_value;
-    diagIDProtocol = diag::cannot_convert_argument_value_protocol;
     nilDiag = diag::cannot_convert_argument_value_nil;
     break;
   case CTP_ClosureResult:
     diagID = diag::cannot_convert_closure_result;
-    diagIDProtocol = diag::cannot_convert_closure_result_protocol;
     nilDiag = diag::cannot_convert_closure_result_nil;
     break;
   case CTP_ArrayElement:
     diagID = diag::cannot_convert_array_element;
-    diagIDProtocol = diag::cannot_convert_array_element_protocol;
     nilDiag = diag::cannot_convert_array_element_nil;
     break;
   case CTP_DictionaryKey:
     diagID = diag::cannot_convert_dict_key;
-    diagIDProtocol = diag::cannot_convert_dict_key_protocol;
     nilDiag = diag::cannot_convert_dict_key_nil;
     break;
   case CTP_DictionaryValue:
     diagID = diag::cannot_convert_dict_value;
-    diagIDProtocol = diag::cannot_convert_dict_value_protocol;
     nilDiag = diag::cannot_convert_dict_value_nil;
     break;
   case CTP_CoerceOperand:
     diagID = diag::cannot_convert_coerce;
-    diagIDProtocol = diag::cannot_convert_coerce_protocol;
     nilDiag = diag::cannot_convert_coerce_nil;
     break;
   case CTP_AssignSource:
     diagID = diag::cannot_convert_assign;
-    diagIDProtocol = diag::cannot_convert_assign_protocol;
     nilDiag = diag::cannot_convert_assign_nil;
     break;
   }
@@ -2317,9 +2304,13 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   // When complaining about conversion to a protocol type, complain about
   // conformance instead of "conversion".
   if (contextualType->is<ProtocolType>() ||
-      contextualType->is<ProtocolCompositionType>())
-    diagID = diagIDProtocol;
-  
+      contextualType->is<ProtocolCompositionType>()) {
+    MissingContextualConformanceFailure failure(
+        expr, CS, CTP, exprType, contextualType,
+        CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));
+    return failure.diagnoseAsError();
+  }
+
   // Try to simplify irrelevant details of function types.  For example, if
   // someone passes a "() -> Float" function to a "() throws -> Int"
   // parameter, then uttering the "throws" may confuse them into thinking that

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2303,8 +2303,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
 
   // When complaining about conversion to a protocol type, complain about
   // conformance instead of "conversion".
-  if (contextualType->is<ProtocolType>() ||
-      contextualType->is<ProtocolCompositionType>()) {
+  if (contextualType->isExistentialType()) {
     MissingContextualConformanceFailure failure(
         expr, CS, CTP, exprType, contextualType,
         CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2887,3 +2887,65 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
                                      eltType, contextualType, anchor);
   return true;
 }
+
+bool MissingContextualConformanceFailure::diagnoseAsError() {
+  auto *anchor = getAnchor();
+  auto path = getLocator()->getPath();
+
+  Optional<Diag<Type, Type>> diagnostic;
+  if (path.empty()) {
+    assert(isa<AssignExpr>(anchor));
+    diagnostic = getDiagnosticFor(CTP_AssignSource);
+  } else {
+    const auto &last = path.back();
+    switch (last.getKind()) {
+    case ConstraintLocator::ContextualType:
+      assert(Context != CTP_Unused);
+      diagnostic = getDiagnosticFor(Context);
+      break;
+    }
+  }
+
+  emitDiagnostic(anchor->getLoc(), *diagnostic, getFromType(), getToType());
+  return true;
+}
+
+Optional<Diag<Type, Type>>
+MissingContextualConformanceFailure::getDiagnosticFor(
+    ContextualTypePurpose context) {
+  switch (context) {
+  case CTP_Initialization:
+    return diag::cannot_convert_initializer_value_protocol;
+  case CTP_ReturnStmt:
+  case CTP_ReturnSingleExpr:
+    return diag::cannot_convert_to_return_type_protocol;
+  case CTP_EnumCaseRawValue:
+    return diag::cannot_convert_raw_initializer_value;
+  case CTP_DefaultParameter:
+    return diag::cannot_convert_default_arg_value_protocol;
+  case CTP_YieldByValue:
+    return diag::cannot_convert_yield_value_protocol;
+  case CTP_CallArgument:
+    return diag::cannot_convert_argument_value_protocol;
+  case CTP_ClosureResult:
+    return diag::cannot_convert_closure_result_protocol;
+  case CTP_ArrayElement:
+    return diag::cannot_convert_array_element_protocol;
+  case CTP_DictionaryKey:
+    return diag::cannot_convert_dict_key_protocol;
+  case CTP_DictionaryValue:
+    return diag::cannot_convert_dict_value_protocol;
+  case CTP_CoerceOperand:
+    return diag::cannot_convert_coerce_protocol;
+  case CTP_AssignSource:
+    return diag::cannot_convert_assign_protocol;
+
+  case CTP_ThrowStmt:
+  case CTP_Unused:
+  case CTP_CannotFail:
+  case CTP_YieldByReference:
+  case CTP_CalleeResult:
+    break;
+  }
+  return None;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2903,10 +2903,28 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
       assert(Context != CTP_Unused);
       diagnostic = getDiagnosticFor(Context);
       break;
+
+    default:
+      break;
     }
   }
 
-  emitDiagnostic(anchor->getLoc(), *diagnostic, getFromType(), getToType());
+  if (!diagnostic)
+    return false;
+
+  auto srcType = getFromType();
+  auto dstType = getToType();
+
+  emitDiagnostic(anchor->getLoc(), *diagnostic, srcType, dstType);
+
+  if (isa<InOutExpr>(anchor))
+    return true;
+
+  if (srcType->isAny() && dstType->isAnyObject()) {
+    emitDiagnostic(anchor->getLoc(), diag::any_as_anyobject_fixit)
+        .fixItInsertAfter(anchor->getEndLoc(), " as AnyObject");
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1203,6 +1203,27 @@ public:
   bool diagnoseAsError() override;
 };
 
+class MissingContextualConformanceFailure final : public ContextualFailure {
+  ContextualTypePurpose Context;
+
+public:
+  MissingContextualConformanceFailure(Expr *root, ConstraintSystem &cs,
+                                      ContextualTypePurpose context, Type type,
+                                      Type protocolType,
+                                      ConstraintLocator *locator)
+      : ContextualFailure(root, cs, type, protocolType, locator),
+        Context(context) {
+    assert(protocolType->is<ProtocolType>() ||
+           protocolType->is<ProtocolCompositionType>());
+  }
+
+  bool diagnoseAsError() override;
+
+private:
+  static Optional<Diag<Type, Type>>
+  getDiagnosticFor(ContextualTypePurpose purpose);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -324,14 +324,15 @@ private:
 /// ```
 class MissingConformanceFailure final : public RequirementFailure {
   Type NonConformingType;
-  ProtocolDecl *Protocol;
+  Type ProtocolType;
 
 public:
   MissingConformanceFailure(Expr *expr, ConstraintSystem &cs,
                             ConstraintLocator *locator,
-                            std::pair<Type, ProtocolDecl *> conformance)
+                            std::pair<Type, Type> conformance)
       : RequirementFailure(cs, expr, RequirementKind::Conformance, locator),
-        NonConformingType(conformance.first), Protocol(conformance.second) {}
+        NonConformingType(conformance.first), ProtocolType(conformance.second) {
+  }
 
   bool diagnoseAsError() override;
 
@@ -341,7 +342,7 @@ private:
   Type getLHS() const override { return NonConformingType; }
 
   /// The protocol generic requirement expected associated type to conform to.
-  Type getRHS() const override { return Protocol->getDeclaredType(); }
+  Type getRHS() const override { return ProtocolType; }
 
 protected:
   DiagOnDecl getDiagnosticOnDecl() const override {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -161,15 +161,15 @@ RelabelArguments::create(ConstraintSystem &cs,
 
 bool MissingConformance::diagnose(Expr *root, bool asNote) const {
   MissingConformanceFailure failure(root, getConstraintSystem(), getLocator(),
-                                    {NonConformingType, Protocol});
+                                    {NonConformingType, ProtocolType});
   return failure.diagnose(asNote);
 }
 
 MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
-                                               ProtocolDecl *protocol,
+                                               Type protocolType,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      MissingConformance(cs, type, protocol, locator);
+      MissingConformance(cs, type, protocolType, locator);
 }
 
 bool SkipSameTypeRequirement::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -364,12 +364,13 @@ private:
 /// Add a new conformance to the type to satisfy a requirement.
 class MissingConformance final : public ConstraintFix {
   Type NonConformingType;
-  ProtocolDecl *Protocol;
+  // This could either be a protocol or protocol composition.
+  Type ProtocolType;
 
-  MissingConformance(ConstraintSystem &cs, Type type, ProtocolDecl *protocol,
+  MissingConformance(ConstraintSystem &cs, Type type, Type protocolType,
                      ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AddConformance, locator),
-        NonConformingType(type), Protocol(protocol) {}
+        NonConformingType(type), ProtocolType(protocolType) {}
 
 public:
   std::string getName() const override {
@@ -379,12 +380,12 @@ public:
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static MissingConformance *create(ConstraintSystem &cs, Type type,
-                                    ProtocolDecl *protocol,
+                                    Type protocolType,
                                     ConstraintLocator *locator);
 
   Type getNonConformingType() { return NonConformingType; }
 
-  ProtocolDecl *getProtocol() { return Protocol; }
+  Type getProtocolType() { return ProtocolType; }
 };
 
 /// Skip same-type generic requirement constraint,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -363,14 +363,19 @@ private:
 
 /// Add a new conformance to the type to satisfy a requirement.
 class MissingConformance final : public ConstraintFix {
+  // Determines whether given protocol type comes from the context e.g.
+  // assignment destination or argument comparison.
+  bool IsContextual;
+
   Type NonConformingType;
   // This could either be a protocol or protocol composition.
   Type ProtocolType;
 
-  MissingConformance(ConstraintSystem &cs, Type type, Type protocolType,
-                     ConstraintLocator *locator)
+  MissingConformance(ConstraintSystem &cs, bool isContextual, Type type,
+                     Type protocolType, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AddConformance, locator),
-        NonConformingType(type), ProtocolType(protocolType) {}
+        IsContextual(isContextual), NonConformingType(type),
+        ProtocolType(protocolType) {}
 
 public:
   std::string getName() const override {
@@ -379,9 +384,13 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static MissingConformance *create(ConstraintSystem &cs, Type type,
-                                    Type protocolType,
-                                    ConstraintLocator *locator);
+  static MissingConformance *forRequirement(ConstraintSystem &cs, Type type,
+                                            Type protocolType,
+                                            ConstraintLocator *locator);
+
+  static MissingConformance *forContextual(ConstraintSystem &cs, Type type,
+                                           Type protocolType,
+                                           ConstraintLocator *locator);
 
   Type getNonConformingType() { return NonConformingType; }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1762,8 +1762,28 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
       case SolutionKind::Unsolved:
         break;
 
-      case SolutionKind::Error:
-        return getTypeMatchFailure(locator);
+      case SolutionKind::Error: {
+        if (!shouldAttemptFixes())
+          return getTypeMatchFailure(locator);
+
+        if (auto last = locator.last()) {
+          // TODO(diagnostics): Diagnosing missing conformances
+          // associated with arguments requires having general
+          // conversion failures implemented first, otherwise
+          // we would be misdiagnosing ambiguous cases associated
+          // with overloaded declarations.
+          if (last->getKind() == ConstraintLocator::ApplyArgToParam)
+            return getTypeMatchFailure(locator);
+        }
+
+        auto *fix = MissingConformance::forContextual(
+            *this, type1, proto, getConstraintLocator(locator));
+
+        if (recordFix(fix))
+          return getTypeMatchFailure(locator);
+
+        break;
+      }
     }
   }
 
@@ -2040,12 +2060,8 @@ bool ConstraintSystem::repairFailures(
     return false;
   };
 
-  auto repairByAddingConformance = [&](Type lhs, Type rhs) -> bool {
-    if (lhs->isTypeVariableOrMember())
-      return false;
-
-    if (rhs->isAny() ||
-        !(rhs->is<ProtocolType>() || rhs->is<ProtocolCompositionType>()))
+  auto repairByAnyToAnyObjectCast = [&](Type lhs, Type rhs) -> bool {
+    if (!(lhs->isAny() && rhs->isAnyObject()))
       return false;
 
     conversionsOrFixes.push_back(MissingConformance::forContextual(
@@ -2072,14 +2088,14 @@ bool ConstraintSystem::repairFailures(
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;
 
-      if (repairByAddingConformance(lhs, rhs))
-        return true;
-
       if (isa<InOutExpr>(AE->getSrc())) {
         conversionsOrFixes.push_back(
             RemoveAddressOf::create(*this, getConstraintLocator(locator)));
         return true;
       }
+
+      if (repairByAnyToAnyObjectCast(lhs, rhs))
+        return true;
     }
 
     return false;
@@ -2166,7 +2182,7 @@ bool ConstraintSystem::repairFailures(
     if (repairByInsertingExplicitCall(lhs, rhs))
       return true;
 
-    if (repairByAddingConformance(lhs, rhs))
+    if (repairByAnyToAnyObjectCast(lhs, rhs))
       return true;
 
     // If both types are key path, the only differences

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3347,8 +3347,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Error;
       }
 
-      auto *fix = MissingConformance::create(*this, type, protocol,
-                                             getConstraintLocator(locator));
+      auto *fix =
+          MissingConformance::create(*this, type, protocol->getDeclaredType(),
+                                     getConstraintLocator(locator));
       if (!recordFix(fix))
         return SolutionKind::Solved;
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -710,7 +710,7 @@ static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
     auto missingConform = (MissingConformance *)fix;
     requirementKind = RequirementKind::Conformance;
     type = missingConform->getNonConformingType();
-    missingType = missingConform->getProtocol()->getDeclaredType();
+    missingType = missingConform->getProtocolType();
     break;
   }
   case FixKind::SkipSameTypeRequirement: {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -201,7 +201,7 @@ func testProtocols(_ b: B, bp: BProto) {
   var c1 : Cat1Proto = b
   var bcat1 = b.getAsProtoWithCat()!
   c1 = bcat1
-  bcat1 = c1 // expected-error{{value of type 'Cat1Proto' does not conform to 'BProto & Cat1Proto' in assignment}}
+  bcat1 = c1 // expected-error{{value of type 'Cat1Proto' does not conform to 'BProto' in assignment}}
 }
 
 // Methods only defined in a protocol

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -349,7 +349,7 @@ func forceUniversalBridgeToAnyObject<T, U: KnownClassProtocol>(a: T, b: U, c: An
 
   z = a // expected-error{{does not conform to 'AnyObject'}}
   z = b
-  z = c // expected-error{{does not conform to 'AnyObject'}}
+  z = c // expected-error{{does not conform to 'AnyObject'}} expected-note {{cast 'Any' to 'AnyObject'}} {{8-8= as AnyObject}}
   z = d // expected-error{{does not conform to 'AnyObject'}}
   z = e
   z = f

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -41,8 +41,8 @@ f0(f)
 f0(b)
 f1(i)
 
-f1(f) // expected-error{{argument type 'Float' does not conform to expected type 'Barable & Fooable'}}
-f1(b) // expected-error{{argument type 'Barable' does not conform to expected type 'Barable & Fooable'}}
+f1(f) // expected-error{{argument type 'Float' does not conform to expected type 'Fooable'}}
+f1(b) // expected-error{{argument type 'Barable' does not conform to expected type 'Fooable'}}
 
 //===----------------------------------------------------------------------===//
 // Subtyping

--- a/test/TypeCoercion/protocols.swift
+++ b/test/TypeCoercion/protocols.swift
@@ -43,9 +43,13 @@ func testPrintableCoercion(_ ip1: IsPrintable1,
                            inp2: IsNotPrintable2,
                            op: OtherPrintable) {
   var p : MyPrintable = ip1 // okay
+  let _: MyPrintable & Titled = Book(title: "")
+  // expected-error@-1 {{value of type 'Book' does not conform to specified type 'MyPrintable'}}
   p = ip1 // okay
   p = ip2 // okay
   p = inp1 // expected-error{{value of type 'IsNotPrintable1' does not conform to 'MyPrintable' in assignment}}
+  let _: MyPrintable = inp1
+  // expected-error@-1 {{value of type 'IsNotPrintable1' does not conform to specified type 'MyPrintable'}}
   p = inp2 // expected-error{{value of type 'IsNotPrintable2' does not conform to 'MyPrintable' in assignment}}
   p = op // expected-error{{value of type 'OtherPrintable' does not conform to 'MyPrintable' in assignment}}
   _ = p

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -111,7 +111,7 @@ func testConversion() {
 
   // Conversions among existential types.
   var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
-  x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'FooProtocol & SuperREPLPrintable' in assignment}}
+  x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'SuperREPLPrintable' in assignment}}
   x = x2
 
   // Subtyping

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -97,8 +97,8 @@ func basicSubtyping(
   anyObject: AnyObject) {
 
   // Errors
-  let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base & P2'}}
-  let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base<Int> & P2'}}
+  let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
+  let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
   let _: P3 = baseAndP1 // expected-error {{value of type 'Base<Int> & P1' does not conform to specified type 'P3'}}
   let _: P3 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'P3'}}
   let _: Derived = baseAndP1 // expected-error {{cannot convert value of type 'Base<Int> & P1' to specified type 'Derived'}}


### PR DESCRIPTION
Extend use of `missing protocol conformance` fix to cover contextual
failures, such as:

- Assignment mismatches, where destination requires source to conform
   to certain protocol (or protocol composition);
- Incorrect returns where returned type doesn't conform to the
   protocol specified in the signature.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
