### PR TITLE
test: make test paths more portable

### DIFF
--- a/test/ParseableInterface/ModuleCache/RebuildRemarks/rebuild-transitive-import.swift
+++ b/test/ParseableInterface/ModuleCache/RebuildRemarks/rebuild-transitive-import.swift
@@ -19,6 +19,6 @@
 
 import OuterModule
 
-// CHECK: rebuilding module 'InnerModule' from interface '{{.*}}/Build/InnerModule.swiftinterface'
-// CHECK: compiled module is out of date: '{{.*}}/Build/InnerModule.swiftmodule'
-// CHECK: dependency is out of date: '{{.*}}/Build/InnerModule.swiftinterface'
+// CHECK: rebuilding module 'InnerModule' from interface '{{.*}}{{[/\\]}}Build{{[/\\]}}InnerModule.swiftinterface'
+// CHECK: compiled module is out of date: '{{.*}}{{[/\\]}}Build{{[/\\]}}InnerModule.swiftmodule'
+// CHECK: dependency is out of date: '{{.*}}{{[/\\]}}Build{{[/\\]}}InnerModule.swiftinterface'


### PR DESCRIPTION
Windows uses `\` as the separator rather than `/`.  Adjust the tests for
this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
