### PR TITLE
[TSan] Add positive test for TSan + Dispatch on Linux

### DIFF
--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // REQUIRES: libdispatch
+// UNSUPPORTED: OS=linux-gnu
 
 import Dispatch
 

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -2,9 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s -check-prefix=TSAN
 
-// TSan is currently only supported on 64 bit mac and simulators.
-// (We do not test the simulators here.)
-// REQUIRES: CPU=x86_64, OS=macosx
+// TSan is only supported on 64 bit.
+// REQUIRES: PTRSIZE=64
 
 // TSAN: define {{.*}} @"$s4main4testyyF"() [[DEFAULT_ATTRS:#[0-9]+]]
 public func test() {

--- a/test/IRGen/tsan_coroutines.swift
+++ b/test/IRGen/tsan_coroutines.swift
@@ -1,9 +1,8 @@
 // This test case used to crash when tsan ran before co-routine lowering.
 // RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | %FileCheck %s
 
-// TSan is currently only supported on 64 bit mac and simulators.
-// (We do not test the simulators here.)
-// REQUIRES: CPU=x86_64, OS=macosx
+// TSan is only supported on 64 bit.
+// REQUIRES: PTRSIZE=64
 
 public class C { }
 
@@ -23,7 +22,7 @@ extension Foobar {
     }
 
     // We used to crash emitting the subscript function.
-    // CHECK: define swiftcc { i8*, %T15tsan_coroutines1CC* } @"$s15tsan_coroutines6FoobarVyAA1CCAC5IndexVcir"
+    // CHECK: define{{( dllexport| protected)?}} swiftcc { i8*, %T15tsan_coroutines1CC* } @"$s15tsan_coroutines6FoobarVyAA1CCAC5IndexVcir"
     @_borrowed
     public subscript(position: Index) -> C {
         return things.values[position.myIndex]

--- a/test/Profiler/instrprof_tsan.swift
+++ b/test/Profiler/instrprof_tsan.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir -profile-generate -sanitize=thread %s | %FileCheck %s
 
-// REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
+// TSan is only supported on 64 bit.
+// REQUIRES: PTRSIZE=64
 
 // CHECK: define {{.*}}empty
 // CHECK-NOT: load{{.*}}empty

--- a/test/Runtime/lazy_witness_table_cycle.swift
+++ b/test/Runtime/lazy_witness_table_cycle.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: objc_interop
+// REQUIRES: foundation
 
 // SR-5958
 import Foundation

--- a/test/SILGen/tsan_instrumentation.swift
+++ b/test/SILGen/tsan_instrumentation.swift
@@ -1,9 +1,7 @@
 // RUN: %target-swift-emit-silgen -sanitize=thread %s | %FileCheck %s
-// REQUIRES: tsan_runtime
 
-// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
-// don't support TSan.
-// UNSUPPORTED: remote_run
+// TSan is only supported on 64 bit.
+// REQUIRES: PTRSIZE=64
 
 func takesInout(_ p: inout Int) { }
 func takesInout(_ p: inout MyStruct) { }

--- a/test/Sanitizers/tsan-emptyarraystorage.swift
+++ b/test/Sanitizers/tsan-emptyarraystorage.swift
@@ -3,6 +3,7 @@
 // RUN: %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
+// REQUIRES: foundation
 // UNSUPPORTED: OS=tvos
 
 // FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs

--- a/test/Sanitizers/tsan-libdispatch.swift
+++ b/test/Sanitizers/tsan-libdispatch.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
+// RUN: %target-codesign %t_tsan-binary
+// RUN: not env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: tsan_runtime
+// UNSUPPORTED: OS=tvos
+
+// FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
+// don't support TSan.
+// UNSUPPORTED: remote_run
+
+// Test ThreadSanitizer execution end-to-end with libdispatch.
+
+import Dispatch
+
+let sync1 = DispatchSemaphore(value: 0)
+let sync2 = DispatchSemaphore(value: 0)
+let finish = DispatchSemaphore(value: 0)
+
+let q = DispatchQueue(label: "q", attributes: .concurrent)
+
+var racy = 1
+
+q.async {
+  sync1.wait()
+  sync2.signal()
+  racy = 2
+  finish.signal()
+}
+q.async {
+  sync1.signal()
+  sync2.wait()
+  racy = 3
+  finish.signal()
+}
+
+finish.wait()
+finish.wait()
+
+print("Done!")
+
+// CHECK: ThreadSanitizer: data race
+// CHECK: Done!

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread -o %t_tsan-binary
+// RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=thread %import-libdispatch -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
 // RUN: not env %env-TSAN_OPTIONS="abort_on_error=0" %target-run %t_tsan-binary 2>&1 | %FileCheck %s
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -983,19 +983,18 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
-    libdispatch_build_dir = make_path(config.swift_obj_root, os.pardir,
-        'libdispatch%s' % config.variant_suffix, 'src')
-    libdispatch_build_artifacts = [
-        make_path(libdispatch_build_dir, 'libdispatch.so'),
-        make_path(libdispatch_build_dir, 'libswiftDispatch.so'),
-        make_path(libdispatch_build_dir, 'swift', 'Dispatch.swiftmodule')]
-    if (all(os.path.exists(p) for p in libdispatch_build_artifacts)):
+    libdispatch_artifact_dir = make_path(config.libdispatch_build_path, 'src')
+    libdispatch_artifacts = [
+        make_path(libdispatch_artifact_dir, 'libdispatch.so'),
+        make_path(libdispatch_artifact_dir, 'libswiftDispatch.so'),
+        make_path(libdispatch_artifact_dir, 'swift', 'Dispatch.swiftmodule')]
+    if (all(os.path.exists(p) for p in libdispatch_artifacts)):
         config.available_features.add('libdispatch')
-        config.libdispatch_build_dir = libdispatch_build_dir
+        config.libdispatch_artifact_dir = libdispatch_artifact_dir
         libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
-        libdispatch_swift_module_dir = make_path(libdispatch_build_dir, 'swift')
+        libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'swift')
         config.import_libdispatch = ('-I %s -I %s -L %s'
-            % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_build_dir))
+            % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir))
 
     config.target_build_swift = (
         '%s -target %s %s %s %s %s %s'
@@ -1412,7 +1411,7 @@ if os.path.exists(static_libswiftCore_path):
 # default Swift tests to use the just-built libraries
 target_stdlib_path = platform_module_dir
 if not kIsWindows:
-	libdispatch_path = getattr(config, 'libdispatch_build_dir', '')
+	libdispatch_path = getattr(config, 'libdispatch_artifact_dir', '')
 	if 'use_os_stdlib' not in lit_config.params:
 		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
 		config.target_run = (

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -728,6 +728,10 @@ if run_vendor == 'apple':
     config.target_codesign = "codesign -f -s -"
     config.target_runtime = "objc"
 
+    config.available_features.add('libdispatch')
+    config.available_features.add('foundation')
+    config.available_features.add('objc_interop')
+
     xcrun_prefix = (
         "xcrun --toolchain %s --sdk %r" %
         (config.darwin_xcrun_toolchain, config.variant_sdk))
@@ -978,6 +982,21 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
       config.target_sdk_name = "linux"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
+
+    libdispatch_build_dir = make_path(config.swift_obj_root, os.pardir,
+        'libdispatch%s' % config.variant_suffix, 'src')
+    libdispatch_build_artifacts = [
+        make_path(libdispatch_build_dir, 'libdispatch.so'),
+        make_path(libdispatch_build_dir, 'libswiftDispatch.so'),
+        make_path(libdispatch_build_dir, 'swift', 'Dispatch.swiftmodule')]
+    if (all(os.path.exists(p) for p in libdispatch_build_artifacts)):
+        config.available_features.add('libdispatch')
+        config.libdispatch_build_dir = libdispatch_build_dir
+        libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
+        libdispatch_swift_module_dir = make_path(libdispatch_build_dir, 'swift')
+        config.import_libdispatch = ('-I %s -I %s -L %s'
+            % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_build_dir))
+
     config.target_build_swift = (
         '%s -target %s %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
@@ -1294,7 +1313,7 @@ runtime_libs = {
     'fuzzer': 'fuzzer_runtime'
 }
 
-if run_ptrsize != "32":
+if run_ptrsize == '64' and 'libdispatch' in config.available_features:
     runtime_libs['tsan'] = 'tsan_runtime'
 
 check_runtime_libs(runtime_libs)
@@ -1393,14 +1412,15 @@ if os.path.exists(static_libswiftCore_path):
 # default Swift tests to use the just-built libraries
 target_stdlib_path = platform_module_dir
 if not kIsWindows:
+	libdispatch_path = getattr(config, 'libdispatch_build_dir', '')
 	if 'use_os_stdlib' not in lit_config.params:
 		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
 		config.target_run = (
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}' " # Linux option
+			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(target_stdlib_path)) + config.target_run
+			.format(target_stdlib_path, libdispatch_path)) + config.target_run
 	else:
 		os_stdlib_path = ''
 		if run_vendor == 'apple':
@@ -1411,9 +1431,9 @@ if not kIsWindows:
 		config.target_run = (
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}' " # Linux option
+			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(all_stdlib_path)) + config.target_run
+			.format(all_stdlib_path, libdispatch_path)) + config.target_run
 			
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
@@ -1457,7 +1477,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
 
 #
-# When changing substitutions, update docs/Testing.rst.
+# When changing substitutions, update docs/Testing.md.
 #
 
 config.substitutions.append(('%target-runtime', config.target_runtime))
@@ -1580,6 +1600,7 @@ config.substitutions.append(('%FileCheck',
         config.filecheck,
         '--enable-windows-compatibility' if kIsWindows else '')))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
+config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')
@@ -1608,25 +1629,5 @@ if platform.system() == 'Linux':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
 
-if run_vendor == 'apple':
-    config.available_features.add('libdispatch')
-    config.available_features.add('foundation')
-    config.available_features.add('objc_interop')
-else:
-    # TODO(yln): Works with the packaged swift distribution, but not during build.
-    #            We need to make libdispatch/foundation available in the test resource directory
-    #            or pass along the proper library include paths in the compiler invocations that are used
-    #            to build the tests.
-    def has_lib(name):
-        return False
-
-    if has_lib('dispatch'):
-        config.available_features.add('libdispatch')
-    else:
-        # TSan runtime requires libdispatch on non-Apple platforms
-        config.available_features.discard('tsan_runtime')
-
-    if has_lib('Foundation'):
-        config.available_features.add('foundation')
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -32,6 +32,7 @@ config.swift_test_results_dir = \
 
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
+config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
 
 # --- Darwin ---
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: libdispatch
+// UNSUPPORTED: OS=linux-gnu
 
 import Dispatch
 import StdlibUnittest

--- a/test/stdlib/DispatchData.swift
+++ b/test/stdlib/DispatchData.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 4 %s -o %t/a.out-4 && %target-codesign %t/a.out-4 && %target-run %t/a.out-4
-// RUN: %target-build-swift -swift-version 4.2 %s -o %t/a.out-4.2 && %target-codesign %t/a.out-4.2 && %target-run %t/a.out-4.2
+// RUN: %target-build-swift -swift-version 4   %s %import-libdispatch -o %t/a.out-4   && %target-codesign %t/a.out-4   && %target-run %t/a.out-4
+// RUN: %target-build-swift -swift-version 4.2 %s %import-libdispatch -o %t/a.out-4.2 && %target-codesign %t/a.out-4.2 && %target-run %t/a.out-4.2
 // REQUIRES: executable_test
 // REQUIRES: libdispatch
 
@@ -22,11 +22,12 @@ DispatchAPI.test("dispatch_data_t deallocator") {
 	let q = DispatchQueue(label: "dealloc queue")
 	var t = 0
 
-	autoreleasepool {
+	do {
 		let size = 1024
 		let p = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
 		let _ = DispatchData(bytesNoCopy: UnsafeBufferPointer(start: p, count: size), deallocator: .custom(q, {
 			t = 1
+			p.deallocate();
 		}))
 	}
 

--- a/test/stdlib/DispatchDeprecationMacOS.swift
+++ b/test/stdlib/DispatchDeprecationMacOS.swift
@@ -1,8 +1,7 @@
 // RUN: %swift -typecheck -target x86_64-apple-macosx10.9 -verify -sdk %sdk %s
 // REQUIRES: OS=macosx
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
-import Foundation
 import Dispatch
 
 // Don't warn because these APIs were deprecated in macOS 10.10 and the

--- a/test/stdlib/DispatchDeprecationWatchOS.swift
+++ b/test/stdlib/DispatchDeprecationWatchOS.swift
@@ -1,8 +1,7 @@
 // RUN: %swift -typecheck -target i386-apple-watchos2.0 -verify -sdk %sdk %s
 // REQUIRES: CPU=i386, OS=watchos
-// REQUIRES: objc_interop
+// REQUIRES: libdispatch
 
-import Foundation
 import Dispatch
 
 // These are deprecated on all versions of watchOS.

--- a/test/stdlib/DispatchRenames.swift
+++ b/test/stdlib/DispatchRenames.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift %import-libdispatch
 // REQUIRES: libdispatch
 
 import Dispatch

--- a/test/stdlib/DispatchTypes.swift
+++ b/test/stdlib/DispatchTypes.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -typecheck %s
 
 // REQUIRES: libdispatch
+// UNSUPPORTED: OS=linux-gnu
 
 import Dispatch
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2402,6 +2402,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SOURCE_DIR}"
                     -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${host} cmark)"
                     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH="${LIBDISPATCH_SOURCE_DIR}"
+                    -DSWIFT_PATH_TO_LIBDISPATCH_BUILD:PATH="$(build_directory ${host} libdispatch)"
                 )
 
                 if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then

--- a/validation-test/Runtime/weak-reference-racetests-dispatch.swift
+++ b/validation-test/Runtime/weak-reference-racetests-dispatch.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-build-swift %s %import-libdispatch -o %t_binary
+// RUN: %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: libdispatch

--- a/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -3,7 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: tsan_runtime
-// REQUIRES: objc_interop
+// REQUIRES: foundation
 
 // Check that TSan ignores the retain count update locks in the runtime.
 

--- a/validation-test/Sanitizers/tsan-type-metadata.swift
+++ b/validation-test/Sanitizers/tsan-type-metadata.swift
@@ -1,8 +1,7 @@
-// RUN: %target-swiftc_driver -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
+// RUN: %target-swiftc_driver -target %sanitizers-target-triple -sanitize=thread %import-libdispatch %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
-// REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
 
 // We expect not to report any races on this testcase.

--- a/validation-test/Sanitizers/witness_table_lookup.swift
+++ b/validation-test/Sanitizers/witness_table_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift -sanitize=thread -target %sanitizers-target-triple %s -o %t_binary
+// RUN: %target-build-swift -sanitize=thread %import-libdispatch -target %sanitizers-target-triple %s -o %t_binary
 // RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -50,6 +50,7 @@ else:
 
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
+config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
 
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")


### PR DESCRIPTION
1) Enable tests that use `import Dispatch` on Linux. Add substitution
       `%import-libdispatch` that needs to be used for all cross-platform
       tests (i.e., tests that are intended to be run on other platforms
       than Darwin) that do `import Dispatch` or enable thread sanitizer.
    
2) Make sure as many existing Dispatch and TSan tests as possible run on
       Linux. Mark tests that would require substantial work with
       `UNSUPPORTED: OS=linux-gnu`.
    
3) Add integration-style Swift test that shows that TSan finds a simple
       race when using `Dispatch.async` incorrectly. A more complete test
       suite for TSan's libdispatch support lives on the LLVM/compiler-rt
       side.
    
rdar://problem/49177535
