### PR TITLE
[Runtime] Adjust to conforming type when instantiating witness table.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -615,7 +615,8 @@ swift_conformsToProtocolImpl(const Metadata * const type,
   if (!description)
     return nullptr;
 
-  return description->getWitnessTable(type);
+  return description->getWitnessTable(
+      findConformingSuperclass(type, description));
 }
 
 const ContextDescriptor *

--- a/test/Runtime/associated_type_demangle_inherited.swift
+++ b/test/Runtime/associated_type_demangle_inherited.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-stdlib %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+import Swift
+import StdlibUnittest
+
+class Key<T>: RawRepresentable {
+  typealias RawValue = T
+
+  let rawValue: T
+
+  required init(rawValue: T) {
+    self.rawValue = rawValue
+  }
+}
+
+extension Key: Hashable where T: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+}
+
+extension Key: Equatable where T: Equatable {
+    static func == (lhs: Key, rhs: Key) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+}
+
+class SpecificKey: Key<String> { }
+
+extension SpecificKey {
+    static let name = SpecificKey(rawValue: "name")
+}
+
+let AssociatedTypeDemangleTests = TestSuite("AssociatedTypeDemangle")
+
+AssociatedTypeDemangleTests.test("superclass substitutions") {
+  var dictionary: [SpecificKey: String] = [:]
+  dictionary[SpecificKey.name] = "Hello"
+
+  expectEqual(["Hello"], dictionary.values.map { $0 })
+}
+
+runAllTests()


### PR DESCRIPTION
When we find a protocol conformance descriptor for a given type, make sure
we adjust to the conforming type of that descriptor (following the superclass
chain as needed) before instantiating the witness table.

Fixes rdar://problem/49741838.
