### PR TITLE
[SIL] Fix `[differentiable]` where clause parsing.

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1029,10 +1029,6 @@ static bool parseDifferentiableAttr(
     P.consumeToken();
     if (parseFnName(VJPName)) return true;
   }
-  // Parse ']'.
-  if (P.parseToken(tok::r_square,
-                   diag::sil_attr_differentiable_expected_rsquare))
-    return true;
   // Parse a trailing 'where' clause if any.
   TrailingWhereClause *WhereClause = nullptr;
   if (P.Tok.is(tok::kw_where)) {
@@ -1044,6 +1040,10 @@ static bool parseDifferentiableAttr(
     WhereClause = TrailingWhereClause::create(SP.SILMod.getASTContext(),
                                               whereLoc, requirementReprs);
   }
+  // Parse ']'.
+  if (P.parseToken(tok::r_square,
+                   diag::sil_attr_differentiable_expected_rsquare))
+    return true;
   // Create a SILDifferentiableAttr and we are done.
   auto *Attr = SILDifferentiableAttr::create(
       SP.SILMod, {SourceIndex, ParamIndices}, JVPName.str(), VJPName.str(),

--- a/test/AutoDiff/differentiable_sil_attr.sil
+++ b/test/AutoDiff/differentiable_sil_attr.sil
@@ -5,13 +5,27 @@ sil_stage raw
 import Builtin
 import Swift
 
-sil public @bar_vjp : $@convention(thin) (Float, Float) -> (Float, (Float) -> Float) {
-entry(%0: $Float, %1: $Float):
-  return undef: $(Float, (Float) -> Float)
-}
-
-// CHECK-LABEL: [differentiable source 0 wrt 0, 1 vjp @bar_vjp] @bar
-sil public [differentiable source 0 wrt 0, 1 vjp @bar_vjp] @bar : $@convention(thin) (Float, Float) -> Float {
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @bar_vjp] @bar
+sil [differentiable source 0 wrt 0, 1 vjp @bar_vjp] @bar : $@convention(thin) (Float, Float) -> Float {
 entry(%0: $Float, %1: $Float):
   return undef: $Float
+}
+
+sil @bar_vjp : $@convention(thin) (Float, Float) -> (Float, (Float) -> (Float, Float)) {
+entry(%0: $Float, %1: $Float):
+  return undef: $(Float, (Float) -> (Float, Float))
+}
+
+// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @foo_vjp] @foo
+sil [differentiable source 0 wrt 0, 1 vjp @foo_vjp] @foo : $@convention(thin) <T, U, V> (@in_guaranteed T, @in_guaranteed U, @in_guaranteed V) -> @out V {
+entry(%0 : $*V, %1 : $*T, %2 : $*U, %3 : $*V):
+  return undef: $()
+}
+
+sil @$foo_vjp : $@convention(thin) <T, U, V> (@in_guaranteed T, @in_guaranteed U, @in_guaranteed V) -> (@out V, @owned @callee_guaranteed (@in_guaranteed V) -> (@out T, @out U)) {
+// %1                                             // user: %4
+// %2                                             // user: %5
+// %3                                             // user: %6
+bb0(%0 : $*V, %1 : $*T, %2 : $*U, %3 : $*V):
+  return undef: $@callee_guaranteed (@in_guaranteed V) -> (@out T, @out U)
 }


### PR DESCRIPTION
Parse where clause before closing `]`.
This fixes parsing canonical SIL files:
```
# foo.swift: program containing `[differentiable]` attribute.
$ swiftc -emit-sil foo.swift
$ swift foo.sil # now works
```