### PR TITLE
[5.1] Restore elementwise min/max on SIMD

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -467,7 +467,6 @@ extension SIMD where Scalar: Comparable {
     return lhs .> Self(repeating: rhs)
   }
   
-  /*  Temporarily removed pending plan for Swift.min / Swift.max
   @_alwaysEmitIntoClient
   public mutating func clamp(lowerBound: Self, upperBound: Self) {
     self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)
@@ -475,9 +474,8 @@ extension SIMD where Scalar: Comparable {
 
   @_alwaysEmitIntoClient
   public func clamped(lowerBound: Self, upperBound: Self) -> Self {
-    return Swift.min(upperBound, Swift.max(lowerBound, self))
+    return pointwiseMin(upperBound, pointwiseMax(lowerBound, self))
   }
-  */
 }
 
 extension SIMD where Scalar: FixedWidthInteger {
@@ -549,6 +547,42 @@ extension SIMD where Scalar: FloatingPoint {
   @_alwaysEmitIntoClient
   public static var one: Self {
     return Self(repeating: 1)
+  }
+  
+  /// The lanewise minimum of two vectors.
+  ///
+  /// Each element of the result is the minimum of the corresponding elements
+  /// of the inputs.
+  @_alwaysEmitIntoClient
+  public static func min(_ a: Self, _ b: Self) -> Self {
+    var result = Self()
+    for i in result.indices {
+      result[i] = Scalar.minimum(a[i], b[i])
+    }
+    return result
+  }
+  
+  /// The lanewise maximum of two vectors.
+  ///
+  /// Each element of the result is the minimum of the corresponding elements
+  /// of the inputs.
+  @_alwaysEmitIntoClient
+  public static func max(_ a: Self, _ b: Self) -> Self {
+    var result = Self()
+    for i in result.indices {
+      result[i] = Scalar.maximum(a[i], b[i])
+    }
+    return result
+  }
+  
+  @_alwaysEmitIntoClient
+  public mutating func clamp(lowerBound: Self, upperBound: Self) {
+    self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)
+  }
+
+  @_alwaysEmitIntoClient
+  public func clamped(lowerBound: Self, upperBound: Self) -> Self {
+    return pointwiseMin(upperBound, pointwiseMax(lowerBound, self))
   }
 }
 
@@ -1343,20 +1377,45 @@ public func all<Storage>(_ mask: SIMDMask<Storage>) -> Bool {
   return mask._storage.max() < 0
 }
 
-/*
-Temporarily removed while we investigate compile-time regressions caused by
-introducing these global functions.
- 
 /// The lanewise minimum of two vectors.
 ///
 /// Each element of the result is the minimum of the corresponding elements
 /// of the inputs.
 @_alwaysEmitIntoClient
-public func min<V>(_ lhs: V, _ rhs: V) -> V
-where V: SIMD, V.Scalar: Comparable {
-  var result = V()
+public func pointwiseMin<T>(_ a: T, _ b: T) -> T
+where T: SIMD, T.Scalar: Comparable {
+  var result = T()
   for i in result.indices {
-    result[i] = min(lhs[i], rhs[i])
+    result[i] = min(a[i], b[i])
+  }
+  return result
+}
+
+/// The lanewise maximum of two vectors.
+///
+/// Each element of the result is the minimum of the corresponding elements
+/// of the inputs.
+@_alwaysEmitIntoClient
+public func pointwiseMax<T>(_ a: T, _ b: T) -> T
+where T: SIMD, T.Scalar: Comparable {
+  var result = T()
+  for i in result.indices {
+    result[i] = max(a[i], b[i])
+  }
+  return result
+}
+
+
+/// The lanewise minimum of two vectors.
+///
+/// Each element of the result is the minimum of the corresponding elements
+/// of the inputs.
+@_alwaysEmitIntoClient
+public func pointwiseMin<T>(_ a: T, _ b: T) -> T
+where T: SIMD, T.Scalar: FloatingPoint {
+  var result = T()
+  for i in result.indices {
+    result[i] = T.Scalar.minimum(a[i], b[i])
   }
   return result
 }
@@ -1366,41 +1425,11 @@ where V: SIMD, V.Scalar: Comparable {
 /// Each element of the result is the maximum of the corresponding elements
 /// of the inputs.
 @_alwaysEmitIntoClient
-public func max<V>(_ lhs: V, _ rhs: V) -> V
-where V: SIMD, V.Scalar: Comparable {
-  var result = V()
+public func pointwiseMax<T>(_ a: T, _ b: T) -> T
+where T: SIMD, T.Scalar: FloatingPoint {
+  var result = T()
   for i in result.indices {
-    result[i] = max(lhs[i], rhs[i])
+    result[i] = T.Scalar.maximum(a[i], b[i])
   }
   return result
 }
-
-
-/// The lanewise minimum of two vectors.
-///
-/// Each element of the result is the minimum of the corresponding elements
-/// of the inputs.
-@_alwaysEmitIntoClient
-public func min<V>(_ lhs: V, _ rhs: V) -> V
-where V: SIMD, V.Scalar: FloatingPoint {
-  var result = V()
-  for i in result.indices {
-    result[i] = V.Scalar.minimum(lhs[i], rhs[i])
-  }
-  return result
-}
-
-/// The lanewise maximum of two vectors.
-///
-/// Each element of the result is the maximum of the corresponding elements
-/// of the inputs.
-@_alwaysEmitIntoClient
-public func max<V>(_ lhs: V, _ rhs: V) -> V
-where V: SIMD, V.Scalar: FloatingPoint {
-  var result = V()
-  for i in result.indices {
-    result[i] = V.Scalar.maximum(lhs[i], rhs[i])
-  }
-  return result
-}
-*/

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -549,32 +549,6 @@ extension SIMD where Scalar: FloatingPoint {
     return Self(repeating: 1)
   }
   
-  /// The lanewise minimum of two vectors.
-  ///
-  /// Each element of the result is the minimum of the corresponding elements
-  /// of the inputs.
-  @_alwaysEmitIntoClient
-  public static func min(_ a: Self, _ b: Self) -> Self {
-    var result = Self()
-    for i in result.indices {
-      result[i] = Scalar.minimum(a[i], b[i])
-    }
-    return result
-  }
-  
-  /// The lanewise maximum of two vectors.
-  ///
-  /// Each element of the result is the minimum of the corresponding elements
-  /// of the inputs.
-  @_alwaysEmitIntoClient
-  public static func max(_ a: Self, _ b: Self) -> Self {
-    var result = Self()
-    for i in result.indices {
-      result[i] = Scalar.maximum(a[i], b[i])
-    }
-    return result
-  }
-  
   @_alwaysEmitIntoClient
   public mutating func clamp(lowerBound: Self, upperBound: Self) {
     self = self.clamped(lowerBound: lowerBound, upperBound: upperBound)


### PR DESCRIPTION
Having these as free functions causes expression too complex issues due to overload vis-a-vis min. There are (at least) three plausible solutions:

Fix the typechecker. This is infeasable in the short term; or more precisely, we do not know how much work is involved.

Give these operations different names. Candidates discussed with core team include "pointwiseMin", "elementwiseMin", "lanewiseMin"; these all suffer from the flaw that when someone writes "min" in a SIMD context, they are essentially always looking for either the horizontal minimum (reduction) on a single vector or--more often--the lanewise minimum of two vectors (this operation). It would be odd to give the operation that people actually want the unnecessarily verbose name.

Make these operations static; this is, in effect, a different name, but it's one which frequently allows eliding the qualifier:

let x = v + .min(v, w)

After considerable back-and-forth discussion with core, we settled on pointwiseMin and pointwiseMax. These aren't perfect, but they are explicit, which is worth a lot.

This rounds out SE-0251 for 5.1-branch.

Cherry-pick of https://github.com/apple/swift/pull/24136