### PR TITLE
[5.1] [code-completion] Handle nested keypath dynamic lookup correctly

### DIFF
--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -923,6 +923,11 @@ static void lookupVisibleDynamicMemberLookupDecls(
     LazyResolver *typeResolver, GenericSignatureBuilder *GSB,
     VisitedSet &visited, llvm::DenseSet<TypeBase *> &seenDynamicLookup);
 
+/// Enumerates all members of \c baseType, including both directly visible and
+/// members visible by keypath dynamic member lookup.
+///
+/// \note This is an implementation detail of \c lookupVisibleMemberDecls and
+/// exists to create the correct recursion for dynamic member lookup.
 static void lookupVisibleMemberAndDynamicMemberDecls(
     Type baseType, VisibleDeclConsumer &consumer,
     KeyPathDynamicMemberConsumer &dynamicMemberConsumer, const DeclContext *DC,
@@ -936,6 +941,12 @@ static void lookupVisibleMemberAndDynamicMemberDecls(
                                         seenDynamicLookup);
 }
 
+/// Enumerates all keypath dynamic members of \c baseType, as seen from the
+/// context \c dc.
+///
+/// If \c baseType is \c @dynamicMemberLookup, this looks up any keypath
+/// dynamic member subscripts and looks up the members of the keypath's root
+/// type.
 static void lookupVisibleDynamicMemberLookupDecls(
     Type baseType, KeyPathDynamicMemberConsumer &consumer,
     const DeclContext *dc, LookupState LS, DeclVisibilityKind reason,

--- a/test/IDE/complete_keypath_member_lookup.swift
+++ b/test/IDE/complete_keypath_member_lookup.swift
@@ -142,9 +142,9 @@ func testShadow1(r: Shadow1<Point>) {
   r.#^testShadow1^#
 }
 // testShadow1-NOT: x[#Int#];
-// testShadow1: Decl[InstanceVar]/CurrNominal:      x[#String#];
-// testShadow1-NOT: x[#Int#];
 // testShadow1: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testShadow1-NOT: x[#Int#];
+// testShadow1: Decl[InstanceVar]/CurrNominal:      x[#String#];
 
 @dynamicMemberLookup
 protocol P {
@@ -312,16 +312,16 @@ func testAnyObjectRoot1(r: AnyObjectRoot) {
 func testNested1(r: Lens<Lens<Point>>) {
   r.#^testNested1^#
 // testNested1: Begin completions
-// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
-// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testNested1-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testNested1-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
 // testNested1: End completions
 }
 
 func testNested2(r: Lens<Lens<Lens<Point>>>) {
   r.#^testNested2^#
 // testNested2: Begin completions
-// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
-// FIXME-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
+// testNested2-DAG: Decl[InstanceVar]/CurrNominal:      x[#Int#];
+// testNested2-DAG: Decl[InstanceVar]/CurrNominal:      y[#Int#];
 // testNested2: End completions
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24540 to swift-5.1-branch
Reviewed by: @rintaro

---

If the root type of the KeyPath also has dynamic member lookup, we need
to look through it.

rdar://problem/50450037