### PR TITLE
Deprecate nearbyint and rint on CGFloat

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -589,10 +589,18 @@ BinaryFunctions = [
 }%
 
 %for ufunc in UnaryFunctions:
+% if ufunc in ['rint','nearbyint']:
+@available(swift, deprecated: 5.1, message: "Swift does not model dynamic rounding modes, use x.rounded(.toNearestOrEven) instead.")
+@_transparent
+public func ${ufunc}(_ x: CGFloat) -> CGFloat {
+  return x.rounded(.toNearestOrEven)
+}
+% else:
 @_transparent
 public func ${ufunc}(_ x: CGFloat) -> CGFloat {
   return CGFloat(${ufunc}(x.native))
 }
+% end
 
 %end
 


### PR DESCRIPTION
These functions have never actually been supported in Swift, because Swift does not model the dynamic floating point environment. They may have worked occasionally in the past, but that was only accidental. Deprecate them with an explanatory message.