### PR TITLE
Upstream Driver changes for Swift-in-Apple-OSs

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -46,6 +46,10 @@ namespace swift {
   /// Return true if the given triple represents any simulator.
   bool tripleIsAnySimulator(const llvm::Triple &triple);
 
+  /// Returns true if the given triple represents an OS that ships with ABI-stable
+  /// swift libraries (eg. in /usr/lib/swift).
+  bool tripleHasSwiftInTheOS(const llvm::Triple &triple);
+
   /// Returns the platform name for a given target triple.
   ///
   /// For example, the iOS simulator has the name "iphonesimulator", while real

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -46,9 +46,9 @@ namespace swift {
   /// Return true if the given triple represents any simulator.
   bool tripleIsAnySimulator(const llvm::Triple &triple);
 
-  /// Returns true if the given triple represents an OS that ships with ABI-stable
-  /// swift libraries (eg. in /usr/lib/swift).
-  bool tripleHasSwiftInTheOS(const llvm::Triple &triple);
+  /// Returns true if the given triple represents an OS that ships with
+  /// ABI-stable swift libraries (eg. in /usr/lib/swift).
+  bool tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple);
 
   /// Returns the platform name for a given target triple.
   ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -502,6 +502,12 @@ def static_stdlib: Flag<["-"], "static-stdlib">,
 def no_static_stdlib: Flag<["-"], "no-static-stdlib">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Don't statically link the Swift standard library">;
+def toolchain_stdlib_rpath: Flag<["-"], "toolchain-stdlib-rpath">,
+  Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
+  HelpText<"Add an rpath entry for the toolchain's standard library, rather than the OS's">;
+def no_stdlib_rpath: Flag<["-"], "no-stdlib-rpath">,
+  Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
+  HelpText<"Don't add any rpath entries.">;
 
 def static_executable : Flag<["-"], "static-executable">,
   HelpText<"Statically link the executable">;

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -55,21 +55,20 @@ bool swift::tripleIsAnySimulator(const llvm::Triple &triple) {
 }
 
 
-bool swift::tripleHasSwiftInTheOS(const llvm::Triple &triple) {
-  unsigned major, minor, revision;
+bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
   if (triple.isMacOSX()) {
-    triple.getMacOSXVersion(major, minor, revision);
-    return llvm::VersionTuple(major, minor, revision) >=
-      llvm::VersionTuple(10, 14, 4);
+    // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
+    // rpath-based install name until 10.15.
+    return triple.isMacOSXVersionLT(10, 15);
+
   } else if (triple.isiOS()) {
-    triple.getiOSVersion(major, minor, revision);
-    return llvm::VersionTuple(major, minor, revision) >=
-      llvm::VersionTuple(12, 2);
+    return triple.isOSVersionLT(12, 2);
+
   } else if (triple.isWatchOS()) {
-    triple.getOSVersion(major, minor, revision);
-    return llvm::VersionTuple(major, minor, revision) >=
-      llvm::VersionTuple(5, 2);
+    return triple.isOSVersionLT(5, 2);
   }
+
+  // Other platforms don't have Swift installed as part of the OS by default.
   return false;
 }
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -54,6 +54,25 @@ bool swift::tripleIsAnySimulator(const llvm::Triple &triple) {
     tripleIsAppleTVSimulator(triple);
 }
 
+
+bool swift::tripleHasSwiftInTheOS(const llvm::Triple &triple) {
+  unsigned major, minor, revision;
+  if (triple.isMacOSX()) {
+    triple.getMacOSXVersion(major, minor, revision);
+    return llvm::VersionTuple(major, minor, revision) >=
+      llvm::VersionTuple(10, 14, 4);
+  } else if (triple.isiOS()) {
+    triple.getiOSVersion(major, minor, revision);
+    return llvm::VersionTuple(major, minor, revision) >=
+      llvm::VersionTuple(12, 2);
+  } else if (triple.isWatchOS()) {
+    triple.getOSVersion(major, minor, revision);
+    return llvm::VersionTuple(major, minor, revision) >=
+      llvm::VersionTuple(5, 2);
+  }
+  return false;
+}
+
 DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {
   if (triple.isiOS()) {
     if (triple.isTvOS()) {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -401,7 +401,7 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
       Arguments.push_back("-rpath");
       Arguments.push_back(context.Args.MakeArgString(path));
     }
-  } else if (tripleHasSwiftInTheOS(getTriple()) ||
+  } else if (!tripleRequiresRPathForSwiftInOS(getTriple()) ||
              context.Args.hasArg(options::OPT_no_stdlib_rpath)) {
     // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
     // install_name the stdlib will be an absolute path like

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -458,11 +458,46 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(path));
   }
 
-  // FIXME: We probably shouldn't be adding an rpath here unless we know ahead
-  // of time the standard library won't be copied. SR-1967
-  for (auto path : RuntimeLibPaths) {
+  if (context.Args.hasArg(options::OPT_toolchain_stdlib_rpath)) {
+    // If the user has explicitly asked for a toolchain stdlib, we should
+    // provide one using -rpath. This used to be the default behaviour but it
+    // was considered annoying in at least the SwiftPM scenario (see
+    // https://bugs.swift.org/browse/SR-1967) and is obsolete in all scenarios
+    // of deploying for Swift-in-the-OS. We keep it here as an optional
+    // behaviour so that people downloading snapshot toolchains for testing new
+    // stdlibs will be able to link to the stdlib bundled in that toolchain.
+    for (auto path : RuntimeLibPaths) {
+      Arguments.push_back("-rpath");
+      Arguments.push_back(context.Args.MakeArgString(path));
+    }
+  } else if (tripleHasSwiftInTheOS(Triple) ||
+             context.Args.hasArg(options::OPT_no_stdlib_rpath)) {
+    // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
+    // install_name the stdlib will be an absolute path like
+    // /usr/lib/swift/libswiftCore.dylib, and we do not need to provide an rpath
+    // at all.
+    //
+    // Also, if the user explicitly asks for no rpath entry, we assume they know
+    // what they're doing and do not add one here.
+  } else {
+    // The remaining cases are back-deploying (to OSs predating
+    // Swift-in-the-OS). In these cases, the stdlib will be giving us (via
+    // stdlib/linker-support/magic-symbols-for-install-name.c) an LC_ID_DYLIB
+    // install_name that is rpath-relative, like @rpath/libswiftCore.dylib.
+    //
+    // If we're linking an app bundle, it's possible there's an embedded stdlib
+    // in there, in which case we'd want to put @executable_path/../Frameworks
+    // in the rpath to find and prefer it, but (a) we don't know when we're
+    // linking an app bundle and (b) we probably _never_ will be because Xcode
+    // links using clang, not the swift driver.
+    //
+    // So that leaves us with the case of linking a command-line app. These are
+    // only supported by installing a secondary package that puts some frozen
+    // Swift-in-OS libraries in the /usr/lib/swift location. That's the best we
+    // can give for rpath, though it might fail at runtime if the support
+    // package isn't installed.
     Arguments.push_back("-rpath");
-    Arguments.push_back(context.Args.MakeArgString(path));
+    Arguments.push_back(context.Args.MakeArgString("/usr/lib/swift"));
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -245,6 +245,116 @@ static void findARCLiteLibPath(const toolchains::Darwin &TC,
   }
 }
 
+void
+toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
+                                        const DynamicLinkJobAction &job,
+                                        const JobContext &context) const {
+
+  // Link compatibility libraries, if we're deploying back to OSes that
+  // have an older Swift runtime.
+  SmallString<128> SharedResourceDirPath;
+  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
+  Optional<llvm::VersionTuple> runtimeCompatibilityVersion;
+  
+  if (context.Args.hasArg(options::OPT_runtime_compatibility_version)) {
+    auto value = context.Args.getLastArgValue(
+                                    options::OPT_runtime_compatibility_version);
+    if (value.equals("5.0")) {
+      runtimeCompatibilityVersion = llvm::VersionTuple(5, 0);
+    } else if (value.equals("none")) {
+      runtimeCompatibilityVersion = None;
+    } else {
+      // TODO: diagnose unknown runtime compatibility version?
+    }
+  } else if (job.getKind() == LinkKind::Executable) {
+    runtimeCompatibilityVersion
+                   = getSwiftRuntimeCompatibilityVersionForTarget(getTriple());
+  }
+  
+  if (runtimeCompatibilityVersion) {
+    if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
+      // Swift 5.0 compatibility library
+      SmallString<128> BackDeployLib;
+      BackDeployLib.append(SharedResourceDirPath);
+      llvm::sys::path::append(BackDeployLib, "libswiftCompatibility50.a");
+      
+      if (llvm::sys::fs::exists(BackDeployLib)) {
+        Arguments.push_back("-force_load");
+        Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+      }
+    }
+  }
+    
+  if (job.getKind() == LinkKind::Executable) {
+    if (runtimeCompatibilityVersion)
+      if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
+        // Swift 5.0 dynamic replacement compatibility library.
+        SmallString<128> BackDeployLib;
+        BackDeployLib.append(SharedResourceDirPath);
+        llvm::sys::path::append(BackDeployLib,
+                                "libswiftCompatibilityDynamicReplacements.a");
+
+        if (llvm::sys::fs::exists(BackDeployLib)) {
+          Arguments.push_back("-force_load");
+          Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+        }
+      }
+  }
+
+  // Add the runtime library link path, which is platform-specific and found
+  // relative to the compiler.
+  SmallVector<std::string, 4> RuntimeLibPaths;
+  getRuntimeLibraryPaths(RuntimeLibPaths, context.Args,
+                         context.OI.SDKPath, /*Shared=*/true);
+
+  for (auto path : RuntimeLibPaths) {
+    Arguments.push_back("-L");
+    Arguments.push_back(context.Args.MakeArgString(path));
+  }
+
+  if (context.Args.hasArg(options::OPT_toolchain_stdlib_rpath)) {
+    // If the user has explicitly asked for a toolchain stdlib, we should
+    // provide one using -rpath. This used to be the default behaviour but it
+    // was considered annoying in at least the SwiftPM scenario (see
+    // https://bugs.swift.org/browse/SR-1967) and is obsolete in all scenarios
+    // of deploying for Swift-in-the-OS. We keep it here as an optional
+    // behaviour so that people downloading snapshot toolchains for testing new
+    // stdlibs will be able to link to the stdlib bundled in that toolchain.
+    for (auto path : RuntimeLibPaths) {
+      Arguments.push_back("-rpath");
+      Arguments.push_back(context.Args.MakeArgString(path));
+    }
+  } else if (tripleHasSwiftInTheOS(getTriple()) ||
+             context.Args.hasArg(options::OPT_no_stdlib_rpath)) {
+    // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
+    // install_name the stdlib will be an absolute path like
+    // /usr/lib/swift/libswiftCore.dylib, and we do not need to provide an rpath
+    // at all.
+    //
+    // Also, if the user explicitly asks for no rpath entry, we assume they know
+    // what they're doing and do not add one here.
+  } else {
+    // The remaining cases are back-deploying (to OSs predating
+    // Swift-in-the-OS). In these cases, the stdlib will be giving us (via
+    // stdlib/linker-support/magic-symbols-for-install-name.c) an LC_ID_DYLIB
+    // install_name that is rpath-relative, like @rpath/libswiftCore.dylib.
+    //
+    // If we're linking an app bundle, it's possible there's an embedded stdlib
+    // in there, in which case we'd want to put @executable_path/../Frameworks
+    // in the rpath to find and prefer it, but (a) we don't know when we're
+    // linking an app bundle and (b) we probably _never_ will be because Xcode
+    // links using clang, not the swift driver.
+    //
+    // So that leaves us with the case of linking a command-line app. These are
+    // only supported by installing a secondary package that puts some frozen
+    // Swift-in-OS libraries in the /usr/lib/swift location. That's the best we
+    // can give for rpath, though it might fail at runtime if the support
+    // package isn't installed.
+    Arguments.push_back("-rpath");
+    Arguments.push_back(context.Args.MakeArgString("/usr/lib/swift"));
+  }
+}
+
 ToolChain::InvocationInfo
 toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
                                         const JobContext &context) const {
@@ -396,109 +506,7 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
   Arguments.push_back("-arch");
   Arguments.push_back(context.Args.MakeArgString(getTriple().getArchName()));
 
-  // Link compatibility libraries, if we're deploying back to OSes that
-  // have an older Swift runtime.
-  SmallString<128> SharedResourceDirPath;
-  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
-  Optional<llvm::VersionTuple> runtimeCompatibilityVersion;
-  
-  if (context.Args.hasArg(options::OPT_runtime_compatibility_version)) {
-    auto value = context.Args.getLastArgValue(
-                                    options::OPT_runtime_compatibility_version);
-    if (value.equals("5.0")) {
-      runtimeCompatibilityVersion = llvm::VersionTuple(5, 0);
-    } else if (value.equals("none")) {
-      runtimeCompatibilityVersion = None;
-    } else {
-      // TODO: diagnose unknown runtime compatibility version?
-    }
-  } else if (job.getKind() == LinkKind::Executable) {
-    runtimeCompatibilityVersion
-                         = getSwiftRuntimeCompatibilityVersionForTarget(Triple);
-  }
-  
-  if (runtimeCompatibilityVersion) {
-    if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
-      // Swift 5.0 compatibility library
-      SmallString<128> BackDeployLib;
-      BackDeployLib.append(SharedResourceDirPath);
-      llvm::sys::path::append(BackDeployLib, "libswiftCompatibility50.a");
-      
-      if (llvm::sys::fs::exists(BackDeployLib)) {
-        Arguments.push_back("-force_load");
-        Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
-      }
-    }
-  }
-    
-  if (job.getKind() == LinkKind::Executable) {
-    if (runtimeCompatibilityVersion)
-      if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
-        // Swift 5.0 dynamic replacement compatibility library.
-        SmallString<128> BackDeployLib;
-        BackDeployLib.append(SharedResourceDirPath);
-        llvm::sys::path::append(BackDeployLib,
-                                "libswiftCompatibilityDynamicReplacements.a");
-
-        if (llvm::sys::fs::exists(BackDeployLib)) {
-          Arguments.push_back("-force_load");
-          Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
-        }
-      }
-  }
-
-  SmallVector<std::string, 4> RuntimeLibPaths;
-  getRuntimeLibraryPaths(RuntimeLibPaths, context.Args,
-                         context.OI.SDKPath, /*Shared=*/true);
-
-  // Add the runtime library link path, which is platform-specific and found
-  // relative to the compiler.
-  for (auto path : RuntimeLibPaths) {
-    Arguments.push_back("-L");
-    Arguments.push_back(context.Args.MakeArgString(path));
-  }
-
-  if (context.Args.hasArg(options::OPT_toolchain_stdlib_rpath)) {
-    // If the user has explicitly asked for a toolchain stdlib, we should
-    // provide one using -rpath. This used to be the default behaviour but it
-    // was considered annoying in at least the SwiftPM scenario (see
-    // https://bugs.swift.org/browse/SR-1967) and is obsolete in all scenarios
-    // of deploying for Swift-in-the-OS. We keep it here as an optional
-    // behaviour so that people downloading snapshot toolchains for testing new
-    // stdlibs will be able to link to the stdlib bundled in that toolchain.
-    for (auto path : RuntimeLibPaths) {
-      Arguments.push_back("-rpath");
-      Arguments.push_back(context.Args.MakeArgString(path));
-    }
-  } else if (tripleHasSwiftInTheOS(Triple) ||
-             context.Args.hasArg(options::OPT_no_stdlib_rpath)) {
-    // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
-    // install_name the stdlib will be an absolute path like
-    // /usr/lib/swift/libswiftCore.dylib, and we do not need to provide an rpath
-    // at all.
-    //
-    // Also, if the user explicitly asks for no rpath entry, we assume they know
-    // what they're doing and do not add one here.
-  } else {
-    // The remaining cases are back-deploying (to OSs predating
-    // Swift-in-the-OS). In these cases, the stdlib will be giving us (via
-    // stdlib/linker-support/magic-symbols-for-install-name.c) an LC_ID_DYLIB
-    // install_name that is rpath-relative, like @rpath/libswiftCore.dylib.
-    //
-    // If we're linking an app bundle, it's possible there's an embedded stdlib
-    // in there, in which case we'd want to put @executable_path/../Frameworks
-    // in the rpath to find and prefer it, but (a) we don't know when we're
-    // linking an app bundle and (b) we probably _never_ will be because Xcode
-    // links using clang, not the swift driver.
-    //
-    // So that leaves us with the case of linking a command-line app. These are
-    // only supported by installing a secondary package that puts some frozen
-    // Swift-in-OS libraries in the /usr/lib/swift location. That's the best we
-    // can give for rpath, though it might fail at runtime if the support
-    // package isn't installed.
-    Arguments.push_back("-rpath");
-    Arguments.push_back(context.Args.MakeArgString("/usr/lib/swift"));
-  }
+  addArgsToLinkStdlib(Arguments, job, context);
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
     SmallString<128> LibProfile;

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -27,6 +27,9 @@ namespace toolchains {
 class LLVM_LIBRARY_VISIBILITY Darwin : public ToolChain {
 protected:
 
+  void addLinkerInputArgs(InvocationInfo &II,
+                          const JobContext &context) const;
+
   void addArgsToLinkARCLite(llvm::opt::ArgStringList &Arguments,
                             const JobContext &context) const;
 

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -34,6 +34,9 @@ protected:
                            const DynamicLinkJobAction &job,
                            const JobContext &context) const;
 
+  void addProfileGenerationArgs(llvm::opt::ArgStringList &Arguments,
+                                const JobContext &context) const;
+
   void addDeploymentTargetArgs(llvm::opt::ArgStringList &Arguments,
                                const JobContext &context) const;
 

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -30,6 +30,10 @@ protected:
   void addArgsToLinkARCLite(llvm::opt::ArgStringList &Arguments,
                             const JobContext &context) const;
 
+  void addSanitizerArgs(llvm::opt::ArgStringList &Arguments,
+                        const DynamicLinkJobAction &job,
+                        const JobContext &context) const;
+
   void addArgsToLinkStdlib(llvm::opt::ArgStringList &Arguments,
                            const DynamicLinkJobAction &job,
                            const JobContext &context) const;

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -34,6 +34,9 @@ protected:
                            const DynamicLinkJobAction &job,
                            const JobContext &context) const;
 
+  void addDeploymentTargetArgs(llvm::opt::ArgStringList &Arguments,
+                               const JobContext &context) const;
+
   InvocationInfo constructInvocation(const InterpretJobAction &job,
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const DynamicLinkJobAction &job,

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -27,6 +27,9 @@ namespace toolchains {
 class LLVM_LIBRARY_VISIBILITY Darwin : public ToolChain {
 protected:
 
+  void addArgsToLinkARCLite(llvm::opt::ArgStringList &Arguments,
+                            const JobContext &context) const;
+
   void addArgsToLinkStdlib(llvm::opt::ArgStringList &Arguments,
                            const DynamicLinkJobAction &job,
                            const JobContext &context) const;

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -26,6 +26,11 @@ namespace toolchains {
 
 class LLVM_LIBRARY_VISIBILITY Darwin : public ToolChain {
 protected:
+
+  void addArgsToLinkStdlib(llvm::opt::ArgStringList &Arguments,
+                           const DynamicLinkJobAction &job,
+                           const JobContext &context) const;
+
   InvocationInfo constructInvocation(const InterpretJobAction &job,
                                      const JobContext &context) const override;
   InvocationInfo constructInvocation(const DynamicLinkJobAction &job,

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -1,0 +1,42 @@
+// REQUIRES: OS=macosx
+// Note: This is really about the /host/ environment, but since there are RUN
+// lines for multiple targets anyway it doesn't make a huge difference.
+
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// RPATH: bin/ld{{"? }}
+// RPATH-SAME: -rpath {{"?/usr/lib/swift(-.+)?"? }}
+// RPATH-SAME: -o {{[^ ]+}}
+
+// NO-RPATH-NOT: -rpath{{ }}
+
+// ### Test with -no-stdlib-rpath
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift -no-stdlib-rpath | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift -no-stdlib-rpath | %FileCheck -check-prefix NO-RPATH %s
+
+// ### Test with -toolchain-stdlib-rpath
+// RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
+
+// TOOLCHAIN-RPATH: bin/ld{{"? }}
+// TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}
+// TOOLCHAIN-RPATH-SAME: -o {{[^ ]+}}

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -16,7 +16,6 @@
 // OSX: {{.*}}.o{{[ "]}}
 // OSX: {{-syslibroot|--sysroot}} {{[^ ]*}}/Inputs/clang-importer-sdk
 // OSX: -L {{[^ ]*}}/Inputs/clang-importer-sdk{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}swift
-// OSX: -rpath {{[^ ]*}}/Inputs/clang-importer-sdk{{/|\\\\}}usr{{/|\\\\}}lib{{/|\\\\}}swift
 
 // LINUX-NOT: warning: no such SDK:
 // LINUX: bin{{/|\\\\}}swift

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -380,12 +380,12 @@ if kIsWindows:
                                                             config.swift_driver_test_options,
                                                             config.swift_stdlib_msvc_runtime)) )
     config.substitutions.append( ('%swiftc_driver',
-                                  "%r %s %s %s" % (config.swiftc, mcp_opt,
-                                                   config.swift_test_options,
-                                                   config.swift_driver_test_options)) )
+                                  "%r -toolchain-stdlib-rpath %s %s %s" % (config.swiftc, mcp_opt,
+                                                                           config.swift_test_options,
+                                                                           config.swift_driver_test_options)) )
 else:
     config.substitutions.append( ('%swift_driver', "env SDKROOT= %r %s %s %s" % (config.swift, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
-    config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
+    config.substitutions.append( ('%swiftc_driver', "env SDKROOT= %r -toolchain-stdlib-rpath %s %s %s" % (config.swiftc, mcp_opt, config.swift_test_options, config.swift_driver_test_options)) )
 config.substitutions.append( ('%sil-opt', "%r %s %s" % (config.sil_opt, mcp_opt, config.sil_test_options)) )
 config.substitutions.append( ('%sil-func-extractor', "%r %s" % (config.sil_func_extractor, mcp_opt)) )
 config.substitutions.append( ('%sil-llvm-gen', "%r %s" % (config.sil_llvm_gen, mcp_opt)) )
@@ -771,7 +771,8 @@ if run_vendor == 'apple':
            (run_cpu, run_os, run_vers, clang_mcp_opt))
 
        config.target_build_swift = (
-           "%s %s %s -F %r -Xlinker -rpath -Xlinker %r %s %s %s %s" %
+           ("%s %s %s -F %r -toolchain-stdlib-rpath " +
+            "-Xlinker -rpath -Xlinker %r %s %s %s %s") %
            (xcrun_prefix, config.swiftc, target_options,
             extra_frameworks_dir,
             "/tmp/swifttest-device/lib",
@@ -805,7 +806,7 @@ if run_vendor == 'apple':
             (run_cpu, run_os, run_vers, clang_mcp_opt))
 
         config.target_build_swift = (
-            "%s %s %s -F %r %s %s %s %s" %
+            "%s %s %s -F %r -toolchain-stdlib-rpath %s %s %s %s" %
             (xcrun_prefix, config.swiftc, target_options,
              extra_frameworks_dir,
              sdk_overlay_linker_opt, config.swift_test_options,
@@ -839,7 +840,9 @@ if run_vendor == 'apple':
             (run_cpu, run_os, run_vers, clang_mcp_opt))
 
         config.target_build_swift = (
-            "%s %s %s -F %r -Xlinker -rpath -Xlinker %r %s %s %s %s -F %r -Xlinker -rpath -Xlinker %r"
+            ("%s %s %s -F %r -toolchain-stdlib-rpath "
+             + "-Xlinker -rpath -Xlinker %r %s %s %s %s "
+             + "-F %r -Xlinker -rpath -Xlinker %r")
             % (xcrun_prefix, config.swiftc, target_options,
                extra_frameworks_dir, extra_frameworks_dir,
                sdk_overlay_linker_opt, config.swift_test_options,
@@ -889,7 +892,7 @@ if run_vendor == 'apple':
     subst_target_swift_ide_test_mock_sdk_after = \
         target_options_for_mock_sdk_after
     config.target_swiftc_driver = (
-        "%s %s %s" %
+        "%s %s -toolchain-stdlib-rpath %s" %
         (xcrun_prefix, config.swiftc, target_options))
     config.target_clang = (
         "%s clang++ %s" %
@@ -1009,7 +1012,7 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
             % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir))
 
     config.target_build_swift = (
-        '%s -target %s %s %s %s %s %s'
+        '%s -target %s -toolchain-stdlib-rpath %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
            config.swift_test_options, config.swift_driver_test_options,
            swift_execution_tests_extra_flags))
@@ -1037,7 +1040,7 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
-        "%s -target %s %s %s" %
+        "%s -target %s -toolchain-stdlib-rpath %s %s" %
         (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
@@ -1153,6 +1156,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_swiftc_driver = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
+        '-toolchain-stdlib-rpath',
         '-Xcc', '--sysroot={}'.format(config.variant_sdk),
         '-Xclang-linker', '--sysroot={}'.format(config.variant_sdk),
         '-tools-directory', tools_directory,


### PR DESCRIPTION
Cherry-pick a bunch of changes that deal with the Swift stdlib and overlays living in /usr/lib/swift/, mostly from Graydon before he left the Swift project. These changes shipped in Apple Swift 5.0 but never made it back to open source.

(not urgent at this point because we're so late with it)

rdar://problem/50748941