### PR TITLE
Don't print extensions to conform to protocols that aren't printed

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -337,8 +337,7 @@ void printEnumElementsAsCases(
     llvm::DenseSet<EnumElementDecl *> &UnhandledElements,
     llvm::raw_ostream &OS);
 
-void getInheritedForPrinting(const Decl *decl,
-                             llvm::function_ref<bool(const Decl*)> shouldPrint,
+void getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
                              llvm::SmallVectorImpl<TypeLoc> &Results);
 
 } // namespace swift

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -505,10 +505,10 @@ struct PrintOptions {
 
   void clearSynthesizedExtension();
 
-  bool shouldPrint(const Decl* D) {
+  bool shouldPrint(const Decl* D) const {
     return CurrentPrintabilityChecker->shouldPrint(D, *this);
   }
-  bool shouldPrint(const Pattern* P) {
+  bool shouldPrint(const Pattern* P) const {
     return CurrentPrintabilityChecker->shouldPrint(P, *this);
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1618,7 +1618,9 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     auto Ext = cast<ExtensionDecl>(D);
     // If the extension doesn't add protocols or has no members that we should
     // print then skip printing it.
-    if (Ext->getLocalProtocols().empty()) {
+    SmallVector<TypeLoc, 8> ProtocolsToPrint;
+    getInheritedForPrinting(Ext, Options, ProtocolsToPrint);
+    if (ProtocolsToPrint.empty()) {
       bool HasMemberToPrint = false;
       for (auto Member : Ext->getMembers()) {
         if (shouldPrint(Member, Options)) {

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -417,8 +417,10 @@ bool swift::emitParseableInterface(raw_ostream &out,
   SmallVector<Decl *, 16> topLevelDecls;
   M->getTopLevelDecls(topLevelDecls);
   for (const Decl *D : topLevelDecls) {
+    InheritedProtocolCollector::collectProtocols(inheritedProtocolMap, D);
+
     if (!D->shouldPrintInContext(printOptions) ||
-        !printOptions.CurrentPrintabilityChecker->shouldPrint(D, printOptions)){
+        !printOptions.shouldPrint(D)) {
       InheritedProtocolCollector::collectSkippedConditionalConformances(
           inheritedProtocolMap, D);
       continue;
@@ -426,8 +428,6 @@ bool swift::emitParseableInterface(raw_ostream &out,
 
     D->print(out, printOptions);
     out << "\n";
-
-    InheritedProtocolCollector::collectProtocols(inheritedProtocolMap, D);
   }
 
   // Print dummy extensions for any protocols that were indirectly conformed to.

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -267,8 +267,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
   unsigned countInherits(ExtensionDecl *ED) {
     SmallVector<TypeLoc, 4> Results;
-    getInheritedForPrinting(
-        ED, [&](const Decl *D) { return Options.shouldPrint(D); }, Results);
+    getInheritedForPrinting(ED, Options, Results);
     return Results.size();
   }
 

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -52,7 +52,7 @@ public struct B2: PublicBaseProto, PrivateSubProto {}
 // CHECK-END: extension conformances.B3 : conformances.PublicBaseProto {}
 public struct B3: PublicBaseProto & PrivateSubProto {}
 // CHECK: public struct B4 : PublicBaseProto {
-// CHECK: extension B4 {
+// NEGATIVE-NOT: extension B4 {
 // NEGATIVE-NOT: extension conformances.B4
 public struct B4: PublicBaseProto {}
 extension B4: PrivateSubProto {}
@@ -62,7 +62,7 @@ extension B4: PrivateSubProto {}
 public struct B5: PrivateSubProto {}
 extension B5: PublicBaseProto {}
 // CHECK: public struct B6 {
-// CHECK: extension B6 {
+// NEGATIVE-NOT: extension B6 {
 // CHECK: extension B6 : PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B6
 public struct B6 {}
@@ -70,7 +70,7 @@ extension B6: PrivateSubProto {}
 extension B6: PublicBaseProto {}
 // CHECK: public struct B7 {
 // CHECK: extension B7 : PublicBaseProto {
-// CHECK: extension B7 {
+// NEGATIVE-NOT: extension B7 {
 // NEGATIVE-NOT: extension conformances.B7
 public struct B7 {}
 extension B7: PublicBaseProto {}
@@ -107,7 +107,7 @@ public struct C1: PrivateSubProto, AnotherPrivateSubProto {}
 // CHECK-END: extension conformances.C2 : conformances.PublicBaseProto {}
 public struct C2: PrivateSubProto & AnotherPrivateSubProto {}
 // CHECK: public struct C3 {
-// CHECK: extension C3 {
+// NEGATIVE-NOT: extension C3 {
 // CHECK-END: extension conformances.C3 : conformances.PublicBaseProto {}
 public struct C3: PrivateSubProto {}
 extension C3: AnotherPrivateSubProto {}
@@ -135,7 +135,7 @@ public struct D4: APublicSubProto & PrivateSubProto {}
 public struct D5: PrivateSubProto {}
 extension D5: PublicSubProto {}
 // CHECK: public struct D6 : PublicSubProto {
-// CHECK: extension D6 {
+// NEGATIVE-NOT: extension D6 {
 // NEGATIVE-NOT: extension conformances.D6
 public struct D6: PublicSubProto {}
 extension D6: PrivateSubProto {}
@@ -211,6 +211,18 @@ extension VeryNewMacProto: PrivateSubProto {}
 // CHECK: public struct VeryNewMacProto {
 // CHECK-END: @available(OSX, introduced: 10.98)
 // CHECK-END-NEXT: extension conformances.VeryNewMacProto : conformances.PublicBaseProto {}
+
+public struct PrivateProtoConformer {}
+extension PrivateProtoConformer : PrivateProto {
+  public var member: Int { return 0 }
+}
+// CHECK: public struct PrivateProtoConformer {
+// CHECK: extension PrivateProtoConformer {
+// CHECK-NEXT: public var member: Int {
+// CHECK-NEXT:   get
+// CHECK-NEXT: }
+// CHECK-NEXT: {{^}$}}
+// NEGATIVE-NOT: extension conformances.PrivateProtoConformer
 
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -547,7 +547,7 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
     passInheritsAndConformancesForValueDecl(TAD, Consumer);
   } else if (const auto *TD = dyn_cast<TypeDecl>(D)) {
     llvm::SmallVector<TypeLoc, 4> AllInherits;
-    getInheritedForPrinting(TD, [](const Decl* d) { return true; }, AllInherits);
+    getInheritedForPrinting(TD, PrintOptions(), AllInherits);
     passInherits(AllInherits, Consumer);
     passConforms(TD->getSatisfiedProtocolRequirements(/*Sorted=*/true),
                  Consumer);


### PR DESCRIPTION
Try a little harder to avoid printing empty extensions by seeing if any of the inherited protocols are actually going to be printed. Previously this just made things a little prettier, but with implementation-only imports it's a correctness issue, since there may be extensions of implementation-only types that do in fact conform to non-public protocols.

rdar://problem/50748072