### PR TITLE
[ParseSIL] Fix parsing type constraint requirements.

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -951,10 +951,10 @@ void SILParser::convertRequirements(SILFunction *F,
     }
 
     if (Req.getKind() == RequirementReprKind::TypeConstraint) {
-      auto FirstType = ResolveToInterfaceType(Req.getFirstTypeLoc());
-      auto SecondType = ResolveToInterfaceType(Req.getSecondTypeLoc());
-      Requirement ConvertedRequirement(RequirementKind::Conformance, FirstType,
-                                       SecondType);
+      auto Subject = ResolveToInterfaceType(Req.getSubjectLoc());
+      auto Constraint = ResolveToInterfaceType(Req.getConstraintLoc());
+      Requirement ConvertedRequirement(RequirementKind::Conformance, Subject,
+                                       Constraint);
       To.push_back(ConvertedRequirement);
       continue;
     }


### PR DESCRIPTION
Use `RequirementRepr::getSubjectLoc` and `RequirementRepr::getConstraintLoc` on type constraint requirements. Previously, `getFirstTypeLoc` and `getSecondTypeLoc` were incorrectly called -  those can only be used for same type requirements.

---

I'm not sure how to add a test. In `master` branch, `SILParser::convertRequirements` is only used to parse `[specialize]` attribute requirements, but `[specialize]` attributes do not contain type constraint requirements.