### PR TITLE
[ConstraintSystem] Detect and diagnose conversion failures related to…

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -669,7 +669,7 @@ private:
 
 /// Intended to diagnose any possible contextual failure
 /// e.g. argument/parameter, closure result, conversions etc.
-class ContextualFailure final : public FailureDiagnostic {
+class ContextualFailure : public FailureDiagnostic {
   Type FromType, ToType;
 
 public:
@@ -677,6 +677,10 @@ public:
                     ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator), FromType(resolve(lhs)),
         ToType(resolve(rhs)) {}
+
+  Type getFromType() const { return resolveType(FromType); }
+
+  Type getToType() const { return resolveType(ToType); }
 
   bool diagnoseAsError() override;
 
@@ -1177,6 +1181,23 @@ public:
   ExtraneousReturnFailure(Expr *root, ConstraintSystem &cs,
                           ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
+/// Diagnose a contextual mismatch between expected collection element type
+/// and the one provided (e.g. source of the assignment or argument to a call)
+/// e.g.:
+///
+/// ```swift
+/// let _: [Int] = ["hello"]
+/// ```
+class CollectionElementContextualFailure final : public ContextualFailure {
+public:
+  CollectionElementContextualFailure(Expr *root, ConstraintSystem &cs,
+                                     Type eltType, Type contextualType,
+                                     ConstraintLocator *locator)
+      : ContextualFailure(root, cs, eltType, contextualType, locator) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -504,3 +504,18 @@ RemoveReturn *RemoveReturn::create(ConstraintSystem &cs,
                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) RemoveReturn(cs, locator);
 }
+
+bool CollectionElementContextualMismatch::diagnose(Expr *root,
+                                                   bool asNote) const {
+  CollectionElementContextualFailure failure(
+      root, getConstraintSystem(), getFromType(), getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+CollectionElementContextualMismatch *
+CollectionElementContextualMismatch::create(ConstraintSystem &cs, Type srcType,
+                                            Type dstType,
+                                            ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      CollectionElementContextualMismatch(cs, srcType, dstType, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -886,6 +886,23 @@ public:
   static RemoveReturn *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
 
+class CollectionElementContextualMismatch final : public ContextualMismatch {
+  CollectionElementContextualMismatch(ConstraintSystem &cs, Type srcType,
+                                      Type dstType, ConstraintLocator *locator)
+      : ContextualMismatch(cs, srcType, dstType, locator) {}
+
+public:
+  std::string getName() const override {
+    return "fix collection element contextual mismatch";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static CollectionElementContextualMismatch *
+  create(ConstraintSystem &cs, Type srcType, Type dstType,
+         ConstraintLocator *locator);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2185,6 +2185,14 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::TupleElement: {
+    if (anchor && (isa<ArrayExpr>(anchor) || isa<DictionaryExpr>(anchor))) {
+      conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
+          *this, lhs, rhs, getConstraintLocator(locator)));
+    }
+    break;
+  }
+
   default:
     break;
   }

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -107,8 +107,7 @@ func longArray() {
 
 // <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to ArrayProtocol
 func rdar25563498<T : ExpressibleByArrayLiteral>(t: T) {
-  var x: T = [1] // expected-error {{cannot convert value of type '[Int]' to specified type 'T'}}
-  // expected-warning@-1{{variable 'x' was never used; consider replacing with '_' or removing it}}
+  var x: T = [1] // expected-error {{cannot convert value of type 'Int' to expected element type 'T.ArrayLiteralElement'}}
 }
 
 func rdar25563498_ok<T : ExpressibleByArrayLiteral>(t: T) -> T

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -603,7 +603,7 @@ func r22470302(_ c: r22470302Class) {
 // <rdar://problem/21928143> QoI: Pointfree reference to generic initializer in generic context does not compile
 extension String {
   @available(*, unavailable, message: "calling this is unwise")
-  func unavail<T : Sequence> // expected-note 2 {{'unavail' has been explicitly marked unavailable here}}
+  func unavail<T : Sequence> // expected-note {{'unavail' has been explicitly marked unavailable here}}
     (_ a : T) -> String where T.Iterator.Element == String {}
 }
 extension Array {
@@ -612,7 +612,7 @@ extension Array {
   }
   
   func h() -> String {
-    return "foo".unavail([0])  // expected-error {{'unavail' is unavailable: calling this is unwise}}
+    return "foo".unavail([0])  // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
   }
 }
 

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -19,13 +19,13 @@ func useDict<K, V>(_ d: MyDictionary<K,V>) {}
 useDictStringInt(["Hello" : 1])
 useDictStringInt(["Hello" : 1, "World" : 2])
 useDictStringInt(["Hello" : 1, "World" : 2.5])
-// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary value type 'DictStringInt.Value' (aka 'Int')}}
 useDictStringInt([4.5 : 2])
-// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'String'}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt([nil : 2])
 // expected-error@-1 {{'nil' is not compatible with expected dictionary key type 'String'}}
 useDictStringInt([7 : 1, "World" : 2])
-// expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+// expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt(["Hello" : nil])
 // expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'Int'}}
 

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -221,6 +221,5 @@ func rdar46459603() {
   // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Dictionary<String, E>.Values' and '[E]'}}
   // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
   _ = [arr.values] == [[e]]
-  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '[Dictionary<String, E>.Values]' and '[[E]]'}}
-  // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
+  // expected-error@-1 {{protocol type 'Any' cannot conform to 'Equatable' because only concrete types can conform to protocols}}
 }

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -26,7 +26,7 @@ func arraySameType() {
 
     let _: SameType = [works]
     let _: SameType = [fails]
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{cannot convert value of type 'Fails' to expected element type 'Works'}}
 
     let _: SameType = arrayWorks
     let _: SameType = arrayFails
@@ -51,7 +51,7 @@ func dictionarySameType() {
 
     let _: SameType = [0 : works]
     let _: SameType = [0 : fails]
-    // expected-error@-1 {{contextual type 'SameType' cannot be used with dictionary literal}}
+    // expected-error@-1 {{cannot convert value of type 'Fails' to expected dictionary value type 'Works'}}
 
     let _: SameType = dictWorks
     let _: SameType = dictFails

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -157,7 +157,8 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>${diag_suffix}'}}
   takesConstPointer([0, 1, 2])
   // <rdar://problem/22308330> QoI: CSDiags doesn't handle array -> pointer impl conversions well
-  takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type '[Double]' to expected argument type 'UnsafePointer<Int>}}
+  takesConstPointer([0.0, 1.0, 2.0])
+  // expected-error@-1 3 {{annot convert value of type 'Double' to expected element type 'Int'}}
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafePointer<Int> = &i // expected-error {{use of extraneous '&'}}

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -83,11 +83,14 @@ c3 as C4 // expected-error {{'C3' is not convertible to 'C4'; did you mean to us
 1 as Int as String // expected-error{{cannot convert value of type 'Int' to type 'String' in coercion}}
 Double(1) as Double as String // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
 ["awd"] as [Int] // expected-error{{cannot convert value of type 'String' to expected element type 'Int'}}
-([1, 2, 1.0], 1) as ([String], Int) // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
+([1, 2, 1.0], 1) as ([String], Int)
+// expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
+// expected-error@-2   {{cannot convert value of type 'Double' to expected element type 'String'}}
 [[1]] as [[String]] // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
 (1, 1.0) as (Int, Int) // expected-error{{cannot convert value of type 'Double' to type 'Int' in coercion}}
 (1.0, 1, "asd") as (String, Int, Float) // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
-(1, 1.0, "a", [1, 23]) as (Int, Double, String, [String]) // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
+(1, 1.0, "a", [1, 23]) as (Int, Double, String, [String])
+// expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
 
 _ = [1] as! [String] // expected-warning{{cast from '[Int]' to unrelated type '[String]' always fails}}
 _ = [(1, (1, 1))] as! [(Int, (String, Int))] // expected-warning{{cast from '[(Int, (Int, Int))]' to unrelated type '[(Int, (String, Int))]' always fails}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -739,8 +739,8 @@ func invalidDictionaryLiteral() {
 }
 
 
-[4].joined(separator: [1]) // expected-error {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'StringProtocol'}}
-[4].joined(separator: [[[1]]]) // expected-error {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'StringProtocol'}}
+[4].joined(separator: [1]) // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+[4].joined(separator: [[[1]]]) // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
 
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons


### PR DESCRIPTION
… collection element types

Detect and diagnose a contextual mismatch between expected
collection element type and the one provided (e.g. source
of the assignment or argument to a call) e.g.:

```swift
let _: [Int] = ["hello"]

func foo(_: [Int]) {}
foo(["hello"])
```

Resolves: rdar://problem/33914447

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
