### PR TITLE
[SIL Optimization] Add a mandatory optimization pass for optimizing the new os log APIs based on string interpolation.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -470,6 +470,27 @@ NOTE(switch_value_case_doesnt_yield, none, "missing yield in the %0 case",
 NOTE(try_branch_doesnt_yield, none, "missing yield when error is "
      "%select{not |}0thrown", (bool))
 
+// OS log optimization dianostics.
+
+ERROR(oslog_message_argument_not_found, none, "no argument of type %0 in "
+  " the os log call", (Identifier))
+
+ERROR(oslog_dynamic_message, none, "os log methods must be passed a string "
+      "interpolation literal. 'OSLogMessage' must not be constructed explicitly",
+      ())
+
+ERROR(oslog_const_evaluation_error, none, "constant evaluating 'OSLogMessage'"
+  "implementation failed.", ())
+
+ERROR(oslog_non_constant_message, none, "'OSLogMessage' struct is "
+      "unoptimizable: 'init' is not constant evaluable", ())
+
+ERROR(oslog_non_constant_interpolation, none, "'OSLogInterpolation' struct is "
+      "unoptimizable: 'init' is not constant evaluable", ())
+
+ERROR(oslog_property_not_constant, none, "'OSLogInterpolation.%0' is not a "
+      "constant: formatting and privacy options must be literals", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -178,6 +178,9 @@ IDENTIFIER_(ErrorType)
 IDENTIFIER(Code)
 IDENTIFIER_(nsError)
 
+// Custom string interpolation type used by os log APIs.
+IDENTIFIER(OSLogMessage)
+
 #undef IDENTIFIER
 #undef IDENTIFIER_
 #undef IDENTIFIER_WITH_NAME

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -309,6 +309,7 @@ PASS(SerializeSILPass, "serialize-sil",
      "Utility pass. Serializes the current SILModule")
 PASS(YieldOnceCheck, "yield-once-check",
     "Check correct usage of yields in yield-once coroutines")
+PASS(OSLogOptimization, "os-log-optimization", "Optimize os log calls")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -20,4 +20,5 @@ silopt_register_sources(
   SemanticARCOpts.cpp
   SILGenCleanup.cpp
   YieldOnceCheck.cpp
+  OSLogOptimization.cpp
 )

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -1,0 +1,686 @@
+//===--- OSLogOptimizer.cpp - Optimizes calls to OS Log ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This pass implements SIL-level optimizations and diagnostics for the
+/// os log APIs based on string interpolations. The APIs are implemented
+/// in the files: OSLogMessage.swift, OSLog.swift. This pass constant evaluates
+/// the log calls along with the auto-generated calls to the custom string
+/// interpolation methods, which processes the string interpolation
+/// passed to the log calls, and folds the constants found during the
+/// evaluation. The constants that are folded include the C format string that
+/// is constructed by the custom string interpolation methods from the string
+/// interpolation, and the size and headers of the byte buffer into which
+/// arguments are packed. This pass is closely tied to the implementation of
+/// the log APIs.
+///
+/// Pass Dependencies: MandatoryInlining. This pass also uses
+/// `ConstExprStepEvaluator` defined in `Utils/ConstExpr.cpp`.
+///
+/// Algorithm Overview:
+///
+/// This pass implements a function-level transformation that collects calls
+/// to the os log APIs, which are annotated with an @_semantics attribute,
+/// and performs the following steps on each such call.
+///
+///  1. Determines the range of instructions to constant evaluate.
+///    The range starts from the first instruction that corresponds to the
+///     construction of the custom string interpolation to the last instruction
+///     of the body of the log call. The log call is also inlined into the
+///     caller.
+///
+///  2. Constant evaluates the range of instruction identified in Step 1 and
+///     collects string and integer-valued instructions who values were found
+///     to be constants. The evaluation uses 'ConsExprStepEvaluator' utility.
+///
+///  3. After constant evaluation, the string and integer-value properties
+///     of the custom string interpolation type: `OSLogInterpolation` must be
+///     constants. This property is checked and any violations are diagnosed.
+///     The errors discovered here may arise from the implementation of the
+///     log APIs in the  overlay or could be because of wrong usage of the
+///     log APIs.
+///     TODO: these errors will be diagnosed by a separate, dedicated pass.
+///
+///  4. The constant instructions that were found in step 2 are folded by
+///     generating SIL code that produces the constants. This also removes
+///     instructions that are dead after folding.
+///
+/// Code Overview:
+///
+/// The function 'OSLogOptimization::run' implements the overall driver for
+/// step 1 to 4. The functions 'OSLogOptimization::inlineLogCallAndGetLast' and
+/// 'beginOfInterpolation' implement step 1 i.e., they compute the range of
+///  instructions to evaluate. The functions 'constantFold' is a driver for the
+/// steps 2 to 4. Step 2 is implemented by the function 'collectConstants',
+/// step 3 by 'detectAndDiagnoseErrors', and step 4 by 'substituteConstants' and
+/// 'emitCodeForSymbolicValue'. The remaining functions in the file implement
+/// the subtasks and utilities needed by the above functions.
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/SubstitutionMap.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILLocation.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/ConstExpr.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/SILInliner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "llvm/ADT/MapVector.h"
+
+using namespace swift;
+
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&... args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+namespace {
+
+/// If the given instruction is a call to the compiler-intrinsic initializer
+/// of String that accepts string literals, return the called function.
+/// Otherwise, return nullptr.
+static SILFunction *getStringMakeUTF8Init(SILInstruction *inst) {
+  auto *apply = dyn_cast<ApplyInst>(inst);
+  if (!apply)
+    return nullptr;
+
+  SILFunction *callee = apply->getCalleeFunction();
+  if (!callee || !callee->hasSemanticsAttr("string.makeUTF8"))
+    return nullptr;
+  return callee;
+}
+
+// A cache of string-related, SIL information that is needed to create and
+// initalize strings from raw string literals. This information is
+// extracted from instructions while they are constant evaluated. Though the
+// information contained here can be constructed from scratch, extracting it
+// from existing instructions is more efficient.
+class StringSILInfo {
+  /// SILFunction corresponding to an intrinsic string initializer that
+  /// constructs a Swift String from a string literal.
+  SILFunction *stringInitIntrinsic = nullptr;
+
+  /// SIL metatype of String.
+  SILType stringMetatype = SILType();
+
+public:
+  /// Extract and cache the required string-related information from the
+  /// given instruction, if possible.
+  void extractStringInfoFromInstruction(SILInstruction *inst) {
+    // If the cache is already initialized do nothing.
+    if (stringInitIntrinsic)
+      return;
+
+    SILFunction *callee = getStringMakeUTF8Init(inst);
+    if (!callee)
+      return;
+
+    this->stringInitIntrinsic = callee;
+
+    MetatypeInst *stringMetatypeInst =
+        dyn_cast<MetatypeInst>(inst->getOperand(4)->getDefiningInstruction());
+    this->stringMetatype = stringMetatypeInst->getType();
+  }
+
+  SILFunction *getStringInitIntrinsic() const {
+    assert(stringInitIntrinsic);
+    return stringInitIntrinsic;
+  }
+
+  SILType getStringMetatype() const {
+    assert(stringMetatype);
+    return stringMetatype;
+  }
+};
+
+/// State needed for constant folding.
+class FoldState {
+public:
+  /// Storage for symbolic values constructed during interpretation.
+  SymbolicValueBumpAllocator allocator;
+
+  /// Evaluator for evaluating instructions one by one.
+  ConstExprStepEvaluator constantEvaluator;
+
+  /// Information needed for folding strings.
+  StringSILInfo stringInfo;
+
+private:
+  /// Single-valued instructions that were found to be constants during
+  /// constant evaluation.
+  SmallVector<SingleValueInstruction *, 4> constantValuedInstructions;
+
+public:
+  FoldState(SILFunction *fun) : constantEvaluator(allocator, fun) {}
+
+  void addConstantInstruction(SingleValueInstruction *value) {
+    constantValuedInstructions.push_back(value);
+  }
+
+  ArrayRef<SingleValueInstruction *> getConstantInstructions() {
+    return ArrayRef<SingleValueInstruction *>(constantValuedInstructions);
+  }
+};
+
+/// Return true if and only if the given nominal type declaration is that of
+/// a stdlib Int or stdlib Bool.
+static bool isStdlibIntegerOrBoolDecl(NominalTypeDecl *numberDecl,
+                                      ASTContext &astCtx) {
+  return (numberDecl == astCtx.getIntDecl() ||
+          numberDecl == astCtx.getInt8Decl() ||
+          numberDecl == astCtx.getInt16Decl() ||
+          numberDecl == astCtx.getInt32Decl() ||
+          numberDecl == astCtx.getInt64Decl() ||
+          numberDecl == astCtx.getUIntDecl() ||
+          numberDecl == astCtx.getUInt8Decl() ||
+          numberDecl == astCtx.getUInt16Decl() ||
+          numberDecl == astCtx.getUInt32Decl() ||
+          numberDecl == astCtx.getUInt64Decl() ||
+          numberDecl == astCtx.getBoolDecl());
+}
+
+/// Return true if and only if the given SIL type represents a String or
+/// a Stdlib or builtin integer type.
+static bool isIntegerOrStringType(SILType silType, ASTContext &astContext) {
+  if (silType.is<BuiltinIntegerType>()) {
+    return true;
+  }
+
+  NominalTypeDecl *nominalDecl = silType.getNominalOrBoundGenericNominal();
+  if (!nominalDecl) {
+    return false;
+  }
+
+  return (nominalDecl == astContext.getStringDecl()) ||
+         isStdlibIntegerOrBoolDecl(nominalDecl, astContext);
+}
+
+/// Decide if the given instruction (which could possibly be a call) should
+/// be constant evaluated.
+///
+/// \returns true iff the given instruction is not a call or if it is, it calls
+/// a known string operation, such as concat/append etc., or calls an os log
+/// overlay function annotated with a semantics attribute.
+static bool shouldAttemptEvaluation(SILInstruction *inst) {
+  auto *apply = dyn_cast<ApplyInst>(inst);
+  if (!apply)
+    return true;
+
+  SILFunction *calleeFun = apply->getCalleeFunction();
+  if (!calleeFun)
+    return false;
+
+  return calleeFun->hasSemanticsAttrThatStartsWith("string.") ||
+         calleeFun->hasSemanticsAttrThatStartsWith("oslog.");
+}
+
+/// Skip or evaluate the given instruction based on the evaluation policy and
+/// handle errors. The policy is to evaluate all non-apply instructions as well
+/// as apply instructions that either invoke a known string operation or an os
+/// log specific function that constructs compile-time constants
+/// (like format string). Every other function call is skipped.
+/// This includes calls that manipulate runtime values such as the arguments
+/// (i.e, interpolated expressions) or the raw byte buffer.
+static std::pair<Optional<SILBasicBlock::iterator>, Optional<SymbolicValue>>
+evaluateOrSkip(ConstExprStepEvaluator &stepEval,
+               SILBasicBlock::iterator instI) {
+  SILInstruction *inst = &(*instI);
+
+  // Note that skipping a call conservatively approximates its effects on the
+  // interpreter state.
+  if (shouldAttemptEvaluation(inst)) {
+    return stepEval.tryEvaluateOrElseMakeEffectsNonConstant(instI);
+  }
+  return stepEval.skipByMakingEffectsNonConstant(instI);
+}
+
+/// Check whether a single-valued instruction is foldable. String or integer
+/// valued instructions are foldable with the exceptions:
+///   - Addresses-valued instructions cannot be folded.
+///   - Literal instruction need not be folded.
+///   - "String.makeUTF8" instrinsic initializer need not be folded as it is
+///     used only on string literals.
+///   - StructInst cannot be folded. We can only fold its arguments and not the
+///     instruction itself.
+static bool isInstructionFoldable(SingleValueInstruction *inst) {
+  ASTContext &astContext = inst->getFunction()->getASTContext();
+  ;
+  SILType silType = inst->getType();
+
+  return (!silType.isAddress() && !isa<LiteralInst>(inst) &&
+          !isa<StructInst>(inst) && !getStringMakeUTF8Init(inst) &&
+          isIntegerOrStringType(silType, astContext));
+}
+
+/// Constant evaluate the instructions in the range 'first' to 'last'.
+/// Add foldable, constant-valued instructions discovered during the evaluation
+/// to the 'foldState' passed in.
+/// \returns error information for emitting diagnostics if the evaluation
+/// failed.
+static Optional<SymbolicValue> collectConstants(SILBasicBlock::iterator first,
+                                                SILBasicBlock::iterator last,
+                                                FoldState &foldState) {
+
+  ConstExprStepEvaluator &constantEvaluator = foldState.constantEvaluator;
+
+  for (auto currI = first; currI != last;) {
+    SILInstruction *currInst = &(*currI);
+
+    // Initialize string info from this instruction if possible.
+    foldState.stringInfo.extractStringInfoFromInstruction(currInst);
+
+    Optional<SymbolicValue> errorInfo = None;
+    Optional<SILBasicBlock::iterator> nextI = None;
+
+    std::tie(nextI, errorInfo) = evaluateOrSkip(constantEvaluator, currI);
+    if (!nextI) {
+      return errorInfo;
+    }
+    // Set the next instruction to continue evaluation from.
+    currI = nextI.getValue();
+
+    // If the instruction is foldable and if we found a constant value for
+    // the result of the instruction, record it.
+    auto *singleValInst = dyn_cast<SingleValueInstruction>(currInst);
+    if (!singleValInst || !isInstructionFoldable(singleValInst)) {
+      continue;
+    }
+
+    Optional<SymbolicValue> constantVal =
+        constantEvaluator.lookupConstValue(singleValInst);
+    if (constantVal.hasValue()) {
+      foldState.addConstantInstruction(singleValInst);
+    }
+  }
+  return None; // No error.
+}
+
+/// Generate SIL code that computes the constant given by the symbolic value
+/// `symVal`. Note that strings and struct-typed constant values will require
+/// multiple instructions to be emitted.
+/// \param symVal symbolic value for which SIL code needs to be emitted.
+/// \param expectedType the expected type of the instruction that would be
+/// computing the symbolic value `symVal`. The type is accepted as a
+/// parameter as some symbolic values like integer constants can inhabit more
+/// than one type.
+/// \param builder SILBuilder that provides the context for emitting the code
+/// for the symbolic value
+/// \param loc SILLocation to use in the emitted instructions.
+/// \param stringInfo String.init and metatype information for generating code
+/// for string literals.
+static SILValue emitCodeForSymbolicValue(SymbolicValue symVal,
+                                         SILType &expectedType,
+                                         SILBuilder &builder, SILLocation &loc,
+                                         StringSILInfo &stringInfo) {
+  ASTContext &astContext = expectedType.getASTContext();
+
+  switch (symVal.getKind()) {
+  case SymbolicValue::String: {
+    assert(astContext.getStringDecl() ==
+           expectedType.getNominalOrBoundGenericNominal());
+
+    StringRef stringVal = symVal.getStringValue();
+    StringLiteralInst *stringLitInst = builder.createStringLiteral(
+        loc, stringVal, StringLiteralInst::Encoding::UTF8);
+
+    // Create a builtin word for the size of the string
+    IntegerLiteralInst *sizeInst = builder.createIntegerLiteral(
+        loc, SILType::getBuiltinWordType(astContext), stringVal.size());
+    // Set isAscii to false.
+    IntegerLiteralInst *isAscii = builder.createIntegerLiteral(
+        loc, SILType::getBuiltinIntegerType(1, astContext), 0);
+    // Create a metatype inst.
+    MetatypeInst *metatypeInst =
+        builder.createMetatype(loc, stringInfo.getStringMetatype());
+
+    auto args = SmallVector<SILValue, 4>();
+    args.push_back(stringLitInst);
+    args.push_back(sizeInst);
+    args.push_back(isAscii);
+    args.push_back(metatypeInst);
+
+    FunctionRefInst *stringInitRef =
+        builder.createFunctionRef(loc, stringInfo.getStringInitIntrinsic());
+    ApplyInst *applyInst = builder.createApply(
+        loc, stringInitRef, SubstitutionMap(), ArrayRef<SILValue>(args), false);
+    return applyInst;
+  }
+  case SymbolicValue::Integer: { // Builtin integer types.
+    APInt resInt = symVal.getIntegerValue();
+    assert(expectedType.is<BuiltinIntegerType>());
+
+    IntegerLiteralInst *intLiteralInst =
+        builder.createIntegerLiteral(loc, expectedType, resInt);
+    return intLiteralInst;
+  }
+  case SymbolicValue::Aggregate: {
+    // Support only stdlib integer or bool structs.
+    StructDecl *structDecl = expectedType.getStructOrBoundGenericStruct();
+    assert(structDecl);
+    assert(isStdlibIntegerOrBoolDecl(structDecl, astContext));
+
+    VarDecl *propertyDecl = structDecl->getStoredProperties().front();
+    SILType propertyType =
+        expectedType.getFieldType(propertyDecl, builder.getModule());
+    SymbolicValue propertyVal = symVal.lookThroughSingleElementAggregates();
+    SILValue newPropertySIL = emitCodeForSymbolicValue(
+        propertyVal, propertyType, builder, loc, stringInfo);
+    StructInst *newStructInst = builder.createStruct(
+        loc, expectedType, ArrayRef<SILValue>(newPropertySIL));
+    return newStructInst;
+  }
+  default: {
+    assert(false && "Symbolic value kind is not supported");
+  }
+  }
+}
+
+/// Given a fold state with constant-valued instructions, substitute the
+/// instructions with the constant values. The constant values could be strings
+/// or Stdlib integer-struct values or builtin integers.
+static void substituteConstants(FoldState &foldState) {
+
+  ConstExprStepEvaluator &evaluator = foldState.constantEvaluator;
+
+  SmallVector<SILInstruction *, 4> deletedInsts;
+  for (SingleValueInstruction *constantInst :
+       foldState.getConstantInstructions()) {
+    SymbolicValue constantVal =
+        evaluator.lookupConstValue(constantInst).getValue();
+
+    SILBuilderWithScope builder(constantInst);
+    SILLocation loc = constantInst->getLoc();
+    SILType instType = constantInst->getType();
+    SILValue foldedSILVal = emitCodeForSymbolicValue(
+        constantVal, instType, builder, loc, foldState.stringInfo);
+
+    constantInst->replaceAllUsesWith(foldedSILVal);
+    deletedInsts.push_back(constantInst);
+  }
+
+  recursivelyDeleteTriviallyDeadInstructions(deletedInsts, true,
+                                             [&](SILInstruction *DeadI) {});
+}
+
+/// Detect and emit diagnostics for errors found during evaluation. Errors
+/// can happen due to incorrect implementation of the os log API in the
+/// overlay or due to incorrect use of the os log API.
+/// TODO: some of the checks here would be made redundant by a dedicated
+/// diagnostics check that will happen before the optimization starts.
+static bool detectAndDiagnoseErrors(Optional<SymbolicValue> errorInfo,
+                                    SingleValueInstruction *osLogMessageAddr,
+                                    FoldState &foldState) {
+  ConstExprStepEvaluator &constantEvaluator = foldState.constantEvaluator;
+  SILLocation loc = osLogMessageAddr->getLoc();
+  SourceLoc sourceLoc = loc.getSourceLoc();
+  SILFunction *fn = osLogMessageAddr->getFunction();
+  SILModule &module = fn->getModule();
+  ASTContext &astContext = fn->getASTContext();
+  bool errorDetected = false;
+
+  // If we have errorInfo that indicates a fail-stop error, diagnose it.
+  if (errorInfo && constantEvaluator.isFailStopError(*errorInfo)) {
+    assert(errorInfo->getKind() == SymbolicValue::Unknown);
+    diagnose(astContext, sourceLoc, diag::oslog_const_evaluation_error);
+    errorInfo->emitUnknownDiagnosticNotes(loc);
+    errorDetected = true;
+  }
+
+  // Check if the OSLogMessage and OSLogInterpolation instances are correctly
+  // inferred as constants. If not, it implies incorrect implementation
+  // of the os log API in the overlay. Diagnostics here are for os log
+  // library authors.
+  Optional<SymbolicValue> osLogMessageAddrValueOpt =
+      constantEvaluator.lookupConstValue(osLogMessageAddr);
+  assert(osLogMessageAddrValueOpt.hasValue() &&
+         osLogMessageAddrValueOpt->getKind() == SymbolicValue::Address);
+
+  SmallVector<unsigned, 2> accessPath;
+  SymbolicValue osLogMessageValue =
+      osLogMessageAddrValueOpt->getAddressValue(accessPath)->getValue();
+  if (!osLogMessageValue.isConstant()) {
+    diagnose(astContext, sourceLoc, diag::oslog_non_constant_message);
+    return true;
+  }
+
+  SymbolicValue osLogInterpolationValue =
+      osLogMessageValue.lookThroughSingleElementAggregates();
+  if (!osLogInterpolationValue.isConstant()) {
+    diagnose(astContext, sourceLoc, diag::oslog_non_constant_interpolation);
+    return true;
+  }
+
+  // Check if every proprety of the OSLogInterpolation instance that is a
+  // string or integer has a constant value. If this is violated this could
+  // be an indication of an error in the usage of the API. Diagnostics emitted
+  // here are for the users of the os log APIs.
+  SILType osLogMessageType = osLogMessageAddr->getType();
+  StructDecl *structDecl = osLogMessageType.getStructOrBoundGenericStruct();
+  assert(structDecl);
+
+  VarDecl *interpolationPropDecl = structDecl->getStoredProperties().front();
+  SILType osLogInterpolationType =
+      osLogMessageType.getFieldType(interpolationPropDecl, module);
+  StructDecl *interpolationStruct =
+      osLogInterpolationType.getStructOrBoundGenericStruct();
+  assert(interpolationStruct);
+
+  auto propertyDecls = interpolationStruct->getStoredProperties();
+  ArrayRef<SymbolicValue> propertyValues =
+      osLogInterpolationValue.getAggregateValue();
+  auto propValueI = propertyValues.begin();
+
+  for (auto *propDecl : propertyDecls) {
+    SymbolicValue propertyValue = *(propValueI++);
+    if (propertyValue.isConstant()) {
+      continue;
+    }
+
+    if (!isIntegerOrStringType(
+            osLogInterpolationType.getFieldType(propDecl, module),
+            astContext)) {
+      continue;
+    }
+
+    diagnose(astContext, sourceLoc, diag::oslog_property_not_constant,
+             propDecl->getNameStr());
+    errorDetected = true;
+    break;
+  }
+  return errorDetected;
+}
+
+/// Given a range of instructions from `first` to `last`, fold the constants
+/// that could be discovered by constant evaluating the instructions.
+static void constantFold(SILBasicBlock::iterator first,
+                         SILBasicBlock::iterator last) {
+
+  SILInstruction *firstInst = &(*first);
+
+  // Initialize fold state.
+  FoldState state(firstInst->getFunction());
+
+  auto errorInfo = collectConstants(first, last, state);
+
+  // At this point, the `OSLogMessage` instance should be mapped to a symbolic
+  // value in the interpreter state. Furthermore, its format string and
+  // interger-valued fields (other than `OSLogArguments`) must be constants.
+  // If this is not the case, it means the formatting options or privacy
+  // qualifiers provided by the user were not inferred as compile-time
+  // constants. Detect and diagnose this scenario.
+  assert(isa<SingleValueInstruction>(firstInst));
+  bool errorDetected = detectAndDiagnoseErrors(
+      errorInfo, dyn_cast<SingleValueInstruction>(firstInst), state);
+  if (errorDetected)
+    return;
+
+  substituteConstants(state);
+}
+
+/// Find an argument of type OSLogMessage from the given os log call.
+static SILValue findOSLogMessageArgument(ApplyInst *oslogCall) {
+  ASTContext &astContext = oslogCall->getFunction()->getASTContext();
+
+  for (auto argument : oslogCall->getArguments()) {
+    SILType argumentType = argument->getType();
+    auto *structDecl = argumentType.getStructOrBoundGenericStruct();
+    if (!structDecl)
+      continue;
+
+    if (structDecl->getName() == astContext.Id_OSLogMessage) {
+      return argument;
+    }
+  }
+  return SILValue();
+}
+
+/// Given an os log call that is passed a string interpolation,
+/// find the first instruction that marks the begining of the string
+/// interpolation. Normally, this instruction is the alloc_stack of the
+/// string interpolation type, which in this case if 'OSLogMessage'.
+/// Constant evaluation and folding must begin from this instruction.
+static Optional<SILBasicBlock::iterator>
+beginOfInterpolation(ApplyInst *oslogCall) {
+  SILFunction *caller = oslogCall->getFunction();
+
+  // Find an argument to the call with name 'OSLogMessage'. Since the log
+  // function definition may change/shuffle its arguments and also since mock
+  // test helpers for log functions do exist, do not rely on the position of
+  // the argument and instead look for an argument with a name.
+  auto &astContext = caller->getASTContext();
+  auto oslogMessageArgument = findOSLogMessageArgument(oslogCall);
+  assert(oslogMessageArgument && "No argument of type 'OSLogMessage' in the "
+                                 "os log call");
+
+  auto *stringInterpolAllocInst =
+      oslogMessageArgument->getDefiningInstruction();
+  if (!stringInterpolAllocInst ||
+      !isa<AllocStackInst>(stringInterpolAllocInst)) {
+    diagnose(astContext, oslogCall->getLoc().getSourceLoc(),
+             diag::oslog_dynamic_message);
+    return None;
+  }
+
+  // Assumption: the alloc_stack of the string interpolation type 'OSLogMessage'
+  // must precede every other instruction relevant to the string interpolation.
+  return stringInterpolAllocInst->getIterator();
+}
+
+/// If the SILInstruction is a call to an os log function, return the call
+/// as an ApplyInst. Otherwise, return nullptr.
+static ApplyInst *getAsOSLogCall(SILInstruction *inst) {
+  auto *applyInst = dyn_cast<ApplyInst>(inst);
+  if (!applyInst) {
+    return nullptr;
+  }
+
+  SILFunction *callee = applyInst->getCalleeFunction();
+  if (!callee || !callee->hasSemanticsAttrThatStartsWith("oslog.log")) {
+    return nullptr;
+  }
+
+  // Default argument generators created for a function also inherit
+  // the semantics attribute of the function. Therefore, check that there are
+  // at least two operands for this apply instruction.
+  if (applyInst->getNumOperands() > 1) {
+    return applyInst;
+  }
+  return nullptr;
+}
+
+class OSLogOptimization : public SILFunctionTransform {
+
+  ~OSLogOptimization() override {}
+
+  /// Inline the given os log Call, by loading and linking the callee if it has
+  /// not been loaded yet, and return the last inlined instruction.
+  /// \param oslogCall log call instruction to inline.
+  /// \returns last instruction of the callee after inlining.
+  SILBasicBlock::iterator inlineLogCallAndGetLast(ApplyInst *oslogCall) {
+    SILFunction *callee = oslogCall->getReferencedFunction();
+    assert(callee);
+
+    // Load and link the called os log function before inlining. This is needed
+    // to link shared functions that are used in the callee body.
+    if (callee->isExternalDeclaration()) {
+      callee->getModule().loadFunction(callee);
+      assert(!callee->isExternalDeclaration());
+      oslogCall->getFunction()->getModule().linkFunction(
+          callee, SILModule::LinkingMode::LinkNormal);
+    }
+
+    // Inline the log call into the caller and find the last instruction of the
+    // log call.
+    SILOptFunctionBuilder funcBuilder(*this);
+    SILBasicBlock *lastBB =
+        SILInliner::inlineFullApply(
+            oslogCall, SILInliner::InlineKind::PerformanceInline, funcBuilder)
+            .second;
+    return lastBB->end();
+  }
+
+  /// The entry point to the transformation.
+  void run() override {
+    // Don't rerun optimization on deserialized functions or stdlib functions.
+    if (getFunction()->wasDeserializedCanonical()) {
+      return;
+    }
+
+    auto &fun = *getFunction();
+
+    // Collect all os log calls in the function.
+    SmallVector<ApplyInst *, 4> oslogCalls;
+    for (auto &bb : fun) {
+      for (auto &inst : bb) {
+        auto oslogCall = getAsOSLogCall(&inst);
+        if (!oslogCall)
+          continue;
+        oslogCalls.push_back(oslogCall);
+      }
+    }
+
+    // Optimize each os log call found. Optimizing a call will change the
+    // function body by inlining functions and folding constants.
+    for (auto *oslogCall : oslogCalls) {
+
+      // Find the range of instructions that have to be constant evaluated
+      // and folded. The relevant instructions start at the begining of the
+      // string interpolation passed to the log call and end at the last
+      // instruction of the body of the called os log function (which will be
+      // inlined).
+      Optional<SILBasicBlock::iterator> firstI =
+          beginOfInterpolation(oslogCall);
+      if (!firstI)
+        continue;
+
+      SILBasicBlock::iterator lastI = inlineLogCallAndGetLast(oslogCall);
+      constantFold(firstI.getValue(), lastI);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createOSLogOptimization() {
+  return new OSLogOptimization();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -128,6 +128,11 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.addDiagnoseInfiniteRecursion();
   P.addYieldOnceCheck();
   P.addEmitDFDiagnostics();
+
+  // This phase performs optimizations necessary for correct interoperation of
+  // Swift os log APIs with C os_log ABIs.
+  P.addOSLogOptimization();
+
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
 }

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -44,7 +44,7 @@ public enum Privacy {
 /// be used in the string interpolations passed to the log APIs.
 /// This limit is imposed by the ABI of os_log.
 @_transparent
-public var maxOSLogArgumentCount: Int { return 48 }
+public var maxOSLogArgumentCount: UInt8 { return 48 }
 
 @usableFromInline
 @_transparent

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -primary-file %s -o /dev/null -verify
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// Tests for the diagnostics produced by the OSLogOptimization pass that
+// performs compile-time analysis and optimization of the new os log prototype
+// APIs. The tests here check whether bad user inputs are diagnosed correctly.
+// The tests here model the possible invalid inputs to the os log methods.
+// TODO: diagnostics will be improved.
+
+import OSLogPrototype
+
+if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+
+  func testDynamicLogMessage(h: Logger, message: OSLogMessage) {
+    h.log(level: .debug, message) // expected-error {{os log methods must be passed a string interpolation literal. 'OSLogMessage' must not be constructed explicitly}}
+  }
+
+  func testNonconstantFormatOption(h: Logger, formatOpt: IntFormat) {
+    h.log(level: .debug, "Minimum integer value: \(Int.min, format: formatOpt)")
+    // expected-error @-1 {{'OSLogInterpolation.formatString' is not a constant: formatting and privacy options must be literals}}
+  }
+
+  func testNonconstantPrivacyOption(h: Logger,  privacyOpt: Privacy) {
+    h.log(level: .debug, "Minimum integer value: \(Int.min, privacy: privacyOpt)")
+    // expected-error @-1 {{'OSLogInterpolation.formatString' is not a constant: formatting and privacy options must be literals}}
+  }
+
+  // FIXME: the following two tests should produce diagnostics and are not
+  // valid uses of the log APIs. The string interpolation passed to the os log
+  // call must be apart of the log call, it cannot be constructed earlier.
+  func testNoninlinedOSLogMessage(h: Logger) {
+    let logMessage: OSLogMessage = "Minimum integer value: \(Int.min)"
+    h.log(level: .debug, logMessage)
+  }
+
+  func testNoninlinedOSLogMessageComplex(h: Logger, b: Bool) {
+    let logMessage: OSLogMessage = "Maximum integer value: \(Int.max)"
+    if !b {
+      return;
+    }
+    h.log(level: .debug, logMessage)
+  }
+}
+

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -1,0 +1,237 @@
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -primary-file %s |  %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// Tests for the OSLogOptimization pass that performs compile-time analysis
+// and optimization of the new os log prototype APIs. The tests here check
+// whether specific compile-time constants such as the format string,
+// the size of the byte buffer etc. are literals after the mandatory pipeline.
+
+import OSLogPrototype
+
+if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest23testSimpleInterpolationL_1hy0aB06LoggerV_tF
+  func testSimpleInterpolation(h: Logger) {
+    h.log(level: .debug, "Minimum integer value: \(Int.min)")
+
+    // Check if there is a call to withCString with a literal format string.
+    // CHECK-DAG is used here as it is easier to perform the checks backwards
+    // from uses to the definitions.
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}lld"
+    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Minimum integer value: %{public}d"
+
+    // Check integer constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 8
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 1
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest34testInterpolationWithFormatOptionsL_1hy0aB06LoggerV_tF
+  func testInterpolationWithFormatOptions(h: Logger) {
+    h.log(level: .info, "Maximum integer value: \(Int.max, format: .hex)")
+
+    // Check if there is a call to withCString with a literal format string.
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Maximum integer value: %{public}llx"
+    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Maximum integer value: %{public}x"
+
+    // Check integer constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 8
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 1
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest44testInterpolationWithFormatOptionsAndPrivacyL_1hy0aB06LoggerV_tF
+  func testInterpolationWithFormatOptionsAndPrivacy(h: Logger) {
+    let privateID = 0x79abcdef
+    h.log(
+      level: .error,
+      "Private Identifier: \(privateID, format: .hex, privacy: .private)")
+
+    // Check if there is a call to withCString with a literal format string.
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Private Identifier: %{private}llx"
+    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Private Identifier: %{private}x"
+
+    // Check integer constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 8
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 1
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 1
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest38testInterpolationWithMultipleArgumentsL_1hy0aB06LoggerV_tF
+  func testInterpolationWithMultipleArguments(h: Logger) {
+    let privateID = 0x79abcdef
+    let filePermissions = 0o777
+    let pid = 122225
+    h.log(
+      level: .error,
+      """
+      Access prevented: process \(pid) initiated by \
+      user: \(privateID, privacy: .private) attempted resetting \
+      permissions to \(filePermissions, format: .octal)
+      """)
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}lld initiated by user: %{private}lld attempted resetting permissions to %{public}llo"
+    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "Access prevented: process %{public}d initiated by user: %{private}d attempted resetting permissions to %{public}o"
+
+    // Check integer constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 32
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 20
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 1
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 3
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest25testLogMessageWithoutDataL_1hy0aB06LoggerV_tF
+  func testLogMessageWithoutData(h: Logger) {
+    // FIXME: here `ExpressibleByStringLiteral` conformance of OSLogMessage
+    // is used. In this case, the `alloc-stack` instruction from where
+    // constant evaluation begins happens after the construction of the
+    // string literal in SIL. Therefore, the constant evaluator ends up
+    // using the backward mode to identify the string literal. Eliminate
+    // reliance on this backward mode by identifying the first instruction
+    // to start interpreting correctly in this case.
+    h.log("A message with no data")
+
+    // Check if there is a call to withCString with a literal format string.
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "A message with no data"
+
+    // Check other constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int{{[0-9]+}}, 2
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 0
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest22testEscapingOfPercentsL_1hy0aB06LoggerV_tF
+  func testEscapingOfPercents(h: Logger) {
+    h.log("Process failed after 99% completion")
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Process failed after 99%% completion"
+  }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest18testDoublePercentsL_1hy0aB06LoggerV_tF
+  func testDoublePercents(h: Logger) {
+    h.log("Double percents: %%")
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "Double percents: %%%%"
+  }
+
+  // FIXME: Small format strings are not correctly logged as small string
+  // literals (which are less than 16 bytes) are not stored as null terminated
+  // utf8 string in the text segment. Instead they are stored as a pair of
+  // Int64. Therefore, `withCString` does not produce a pointer to the text
+  // segement and hence logging does not happen correctly.
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest22testSmallFormatStringsL_1hy0aB06LoggerV_tF
+  func testSmallFormatStrings(h: Logger) {
+    h.log("a")
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "a"
+  }
+
+  /// A stress test that checks whether the optimizer handle messages with more
+  /// than 48 interpolated expressions. Interpolated expressions beyond this
+  /// limit must be ignored.
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest31testMessageWithTooManyArgumentsL_1hy0aB06LoggerV_tF
+  func testMessageWithTooManyArguments(h: Logger) {
+    h.log(
+      level: .error,
+      """
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \(1) \
+      \(1) \(1) \(1) \(1) \(1) \(48) \(49)
+      """)
+
+    // Check if there is a call to withCString with a literal format string.
+
+    // CHECK-DAG: try_apply [[WITHCSTRING:%[0-9]+]]<()>({{%.*}}, {{%.*}}, [[FORMATSTR:%[0-9]+]])
+    // CHECK-DAG: [[WITHCSTRING]] = function_ref @$sSS11withCStringyxxSPys4Int8VGKXEKlF
+    // CHECK-DAG: [[FORMATSTR]] = apply [[STRINGINIT:%.*]]([[LIT:%.*]], {{%.*}}, {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+    // CHECK-64-DAG: [[LIT]] = string_literal utf8 "%{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld %{public}lld "
+    // CHECK-32-DAG: [[LIT]] = string_literal utf8 "%{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d %{public}d "
+
+    // Check integer constants passed to the withCString closure: buffersize,
+    // premable and argument count.
+
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 482
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 290
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 48
+  }
+}
+

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1044,3 +1044,35 @@ bb0:
   %11 = apply %10(%3, %5, %7, %9) : $@convention(thin) (IntFormat, Bool, Int64, Bool) -> @owned String
   return %11 : $String
 } // CHECK: Returns string: "%{public}llu"
+
+// String.percentEscapedString.getter
+// The semantics attribute is used by the interpreter.
+sil [serialized] [readonly] [_semantics "string.escapePercent.get"] @$sSS14OSLogPrototypeE20percentEscapedStringSSvg : $@convention(method) (@guaranteed String) -> @owned String
+
+// CHECK-LABEL: @interpretStringPercentEscape
+sil @interpretStringPercentEscape : $@convention(thin) () -> @owned String {
+bb0:
+  %1 = string_literal utf8 "a%"
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = metatype $@thin String.Type
+  %5 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = apply %5(%1, %2, %3, %4) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %8 = function_ref @$sSS14OSLogPrototypeE20percentEscapedStringSSvg : $@convention(method) (@guaranteed String) -> @owned String
+  %9 = apply %8(%6) : $@convention(method) (@guaranteed String) -> @owned String
+  return %9 : $String
+} // CHECK: Returns string: "a%%"
+
+// CHECK-LABEL: @interpretEscapeMutiplePercent
+sil @interpretEscapeMutiplePercent : $@convention(thin) () -> @owned String {
+bb0:
+  %1 = string_literal utf8 "%%%a% %%b%"
+  %2 = integer_literal $Builtin.Word, 10
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = metatype $@thin String.Type
+  %5 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = apply %5(%1, %2, %3, %4) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %8 = function_ref @$sSS14OSLogPrototypeE20percentEscapedStringSSvg : $@convention(method) (@guaranteed String) -> @owned String
+  %9 = apply %8(%6) : $@convention(method) (@guaranteed String) -> @owned String
+  return %9 : $String
+} // CHECK: Returns string: "%%%%%%a%% %%%%b%%"

--- a/test/stdlib/OSLogPrototypeExecTest.swift
+++ b/test/stdlib/OSLogPrototypeExecTest.swift
@@ -392,12 +392,12 @@ InterpolationTestSuite.test("interpolation of too many arguments") {
       expectEqual(
         String(
           repeating: "%{public}\(intPrefix)d ",
-          count: maxOSLogArgumentCount),
+          count: Int(maxOSLogArgumentCount)),
         formatString)
 
       let bufferChecker = OSLogBufferChecker(buffer)
       bufferChecker.checkSummaryBytes(
-        argumentCount: UInt8(maxOSLogArgumentCount),
+        argumentCount: maxOSLogArgumentCount,
         hasPrivate: false,
         hasNonScalar: false)
 
@@ -408,7 +408,7 @@ InterpolationTestSuite.test("interpolation of too many arguments") {
               startIndex: $0,
               flag: .publicFlag,
               expectedInt: 1) },
-          count: maxOSLogArgumentCount)
+          count: Int(maxOSLogArgumentCount))
       )
   })
 }


### PR DESCRIPTION
This fixes the PR: https://github.com/apple/swift/pull/24336 that was merged but later reverted as it failed in '--debug-swift-stdlib' mode. This PR fixes the error by making a small change to the implementation in the overlay in file: OSLogMessage.swift. 
