### PR TITLE
More type checked accessors

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -28,6 +28,7 @@ namespace llvm {
 
 namespace swift {
 
+class ConcreteDeclRef;
 class ProtocolConformance;
 
 /// A ProtocolConformanceRef is a handle to a protocol conformance which
@@ -136,6 +137,14 @@ public:
   }
 
   Type getTypeWitnessByName(Type type, Identifier name) const;
+
+  /// Find a particular named function witness for a type that conforms to
+  /// the given protocol.
+  ///
+  /// \param type The conforming type.
+  ///
+  /// \param name The name of the requirement.
+  ConcreteDeclRef getWitnessByName(Type type, DeclName name) const;
 
   /// Determine whether this conformance is canonical.
   bool isCanonical() const;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -135,10 +135,7 @@ public:
     return llvm::hash_value(conformance.Union.getOpaqueValue());
   }
 
-  static Type
-  getTypeWitnessByName(Type type,
-                       ProtocolConformanceRef conformance,
-                       Identifier name);
+  Type getTypeWitnessByName(Type type, Identifier name) const;
 
   /// Determine whether this conformance is canonical.
   bool isCanonical() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4225,8 +4225,7 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
       *bridgedValueType = type;
 
     // Find the Objective-C class type we bridge to.
-    return ProtocolConformanceRef::getTypeWitnessByName(
-        type, *conformance, Id_ObjectiveCType);
+    return conformance->getTypeWitnessByName(type, Id_ObjectiveCType);
   }
 
   // Do we conform to Error?

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -142,15 +142,14 @@ ProtocolConformanceRef::subst(Type origType,
 }
 
 Type
-ProtocolConformanceRef::getTypeWitnessByName(Type type,
-                                             ProtocolConformanceRef conformance,
-                                             Identifier name) {
-  assert(!conformance.isInvalid());
+ProtocolConformanceRef::getTypeWitnessByName(Type type, Identifier name) const {
+  assert(!isInvalid());
 
   // Find the named requirement.
-  ProtocolDecl *proto = conformance.getRequirement();
+  ProtocolDecl *proto = getRequirement();
   AssociatedTypeDecl *assocType = nullptr;
-  auto members = proto->lookupDirect(name);
+  auto members = proto->lookupDirect(name,
+                      NominalTypeDecl::LookupDirectFlags::IgnoreNewExtensions);
   for (auto member : members) {
     assocType = dyn_cast<AssociatedTypeDecl>(member);
     if (assocType)
@@ -162,7 +161,7 @@ ProtocolConformanceRef::getTypeWitnessByName(Type type,
     return nullptr;
 
   return assocType->getDeclaredInterfaceType().subst(
-    SubstitutionMap::getProtocolSubstitutions(proto, type, conformance));
+    SubstitutionMap::getProtocolSubstitutions(proto, type, *this));
 }
 
 void *ProtocolConformance::operator new(size_t bytes, ASTContext &context,

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1377,10 +1377,9 @@ private:
 
     // Dig out the Objective-C type.
     auto conformance = conformances.front();
-    Type objcType = ProtocolConformanceRef::getTypeWitnessByName(
-                      nominal->getDeclaredType(),
-                      ProtocolConformanceRef(conformance),
-                      ctx.Id_ObjectiveCType);
+    Type objcType = ProtocolConformanceRef(conformance).getTypeWitnessByName(
+                                           nominal->getDeclaredType(),
+                                           ctx.Id_ObjectiveCType);
     if (!objcType) return nullptr;
 
     // Dig out the Objective-C class.

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -223,9 +223,8 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     auto conformance = foreignRepresentation.second;
     assert(conformance && "Missing conformance?");
     Type bridgedTy =
-      ProtocolConformanceRef::getTypeWitnessByName(
-        t, ProtocolConformanceRef(conformance),
-        M.getASTContext().Id_ObjectiveCType);
+      ProtocolConformanceRef(conformance).getTypeWitnessByName(
+        t, M.getASTContext().Id_ObjectiveCType);
     assert(bridgedTy && "Missing _ObjectiveCType witness?");
     if (purpose == BridgedTypePurpose::ForResult && clangTy)
       bridgedTy = OptionalType::get(bridgedTy);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3985,10 +3985,7 @@ namespace {
     }
 
     Expr *visitLazyInitializerExpr(LazyInitializerExpr *expr) {
-      // Since `LazyInitializerExpr` should always have a type set,
-      // there is no need to do anything here.
-      assert(cs.getType(expr)->isEqual(expr->getSubExpr()->getType()));
-      return expr;
+      llvm_unreachable("Already type-checked");
     }
     
     Expr *visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1740,8 +1740,8 @@ static Type isRawRepresentable(Type fromType, const ConstraintSystem &CS) {
   if (!conformance)
     return Type();
 
-  Type rawTy = ProtocolConformanceRef::getTypeWitnessByName(
-      fromType, *conformance, CS.getASTContext().Id_RawValue);
+  Type rawTy = conformance->getTypeWitnessByName(
+      fromType, CS.getASTContext().Id_RawValue);
   return rawTy;
 }
 
@@ -2119,9 +2119,9 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
                                     ConformanceCheckFlags::InExpression)) {
         Type errorCodeType = CS.getType(expr);
         Type errorType =
-          ProtocolConformanceRef::getTypeWitnessByName(errorCodeType, *conformance,
-                                                       TC.Context.Id_ErrorType)
-                                                         ->getCanonicalType();
+          conformance->getTypeWitnessByName(errorCodeType,
+                                            TC.Context.Id_ErrorType)
+            ->getCanonicalType();
         if (errorType) {
           auto diag = diagnose(expr->getLoc(), diag::cannot_throw_error_code,
                                errorCodeType, errorType);
@@ -6253,9 +6253,8 @@ bool FailureDiagnosis::visitArrayExpr(ArrayExpr *E) {
         = CS.TC.conformsToProtocol(contextualType, ALC, CS.DC,
                                    ConformanceCheckFlags::InExpression)) {
     Type contextualElementType =
-        ProtocolConformanceRef::getTypeWitnessByName(
-            contextualType, *Conformance,
-            CS.getASTContext().Id_ArrayLiteralElement)
+        Conformance->getTypeWitnessByName(
+          contextualType, CS.getASTContext().Id_ArrayLiteralElement)
             ->getDesugaredType();
 
     // Type check each of the subexpressions in place, passing down the contextual
@@ -6343,13 +6342,13 @@ bool FailureDiagnosis::visitDictionaryExpr(DictionaryExpr *E) {
     }
 
     contextualKeyType =
-        ProtocolConformanceRef::getTypeWitnessByName(
-            contextualType, *Conformance, CS.getASTContext().Id_Key)
+        Conformance->getTypeWitnessByName(
+          contextualType, CS.getASTContext().Id_Key)
             ->getDesugaredType();
 
     contextualValueType =
-        ProtocolConformanceRef::getTypeWitnessByName(
-            contextualType, *Conformance, CS.getASTContext().Id_Value)
+        Conformance->getTypeWitnessByName(
+          contextualType, CS.getASTContext().Id_Value)
             ->getDesugaredType();
 
     assert(contextualKeyType && contextualValueType &&

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2887,9 +2887,7 @@ namespace {
     }
 
     Type visitLazyInitializerExpr(LazyInitializerExpr *expr) {
-      auto type = expr->getType();
-      assert(type && "LazyInitializerExpr should always have type set");
-      return type;
+      llvm_unreachable("Already type-checked");
     }
 
     Type visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -668,20 +668,6 @@ public:
                      bool ignoreTopLevelInjection = false,
                      Optional<Pattern*> typeFromPattern = None) const;
 
-  /// Convert the given optional-producing expression to a Bool
-  /// indicating whether the optional has a value.
-  ///
-  /// This operation cannot fail.
-  ///
-  /// \param expr The expression to coerce. The type of this expression
-  /// must be T?.
-  ///
-  /// \param locator Locator used to describe the location of this expression.
-  ///
-  /// \returns a Bool expression indicating whether the optional
-  /// contains a value.
-  Expr *convertOptionalToBool(Expr *expr, ConstraintLocator *locator) const;
-
   /// Compute the set of substitutions for a generic signature opened at the
   /// given locator.
   ///

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4325,8 +4325,8 @@ void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {
     // Hack: If we've used a conformance to the _BridgedStoredNSError
     // protocol, also use the RawRepresentable and _ErrorCodeProtocol
     // conformances on the Code associated type witness.
-    if (auto codeType = ProtocolConformanceRef::getTypeWitnessByName(
-                          type, *conformance, Context.Id_Code)) {
+    if (auto codeType = conformance->getTypeWitnessByName(
+                          type, Context.Id_Code)) {
       (void)conformsToProtocol(codeType, errorCodeProto, dc,
                                ConformanceCheckFlags::Used);
       (void)conformsToProtocol(codeType, rawProto, dc,
@@ -4340,8 +4340,8 @@ void TypeChecker::useBridgedNSErrorConformances(DeclContext *dc, Type type) {
                      (ConformanceCheckFlags::SuppressDependencyTracking|
                       ConformanceCheckFlags::Used));
   if (conformance && conformance->isConcrete()) {
-    if (Type errorType = ProtocolConformanceRef::getTypeWitnessByName(
-          type, *conformance, Context.Id_ErrorType)) {
+    if (Type errorType = conformance->getTypeWitnessByName(
+          type, Context.Id_ErrorType)) {
       (void)conformsToProtocol(errorType, bridgedStoredNSError, dc,
                                ConformanceCheckFlags::Used);
     }
@@ -5663,7 +5663,7 @@ Type TypeChecker::getWitnessType(Type type, ProtocolDecl *protocol,
                                  ProtocolConformanceRef conformance,
                                  Identifier name,
                                  Diag<> brokenProtocolDiag) {
-  Type ty = ProtocolConformanceRef::getTypeWitnessByName(type, conformance, name);
+  Type ty = conformance.getTypeWitnessByName(type, name);
   if (!ty &&
       !(conformance.isConcrete() && conformance.getConcrete()->isInvalid()))
     diagnose(protocol->getLoc(), brokenProtocolDiag);

--- a/test/Compatibility/attr_override_lazy.swift
+++ b/test/Compatibility/attr_override_lazy.swift
@@ -1,13 +1,13 @@
-// RUN: %target-swift-frontend -swift-version 4 -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 4 -emit-silgen %s -verify | %FileCheck %s
 
 class Base {
-  var foo: Int { return 0 }
-  var bar: Int = 0
+  var foo: Int { return 0 } // expected-note {{attempt to override property here}}
+  var bar: Int = 0 // expected-note {{attempt to override property here}}
 }
 
 class Sub : Base {
-  lazy override var foo: Int = 1
-  lazy override var bar: Int = 1
+  lazy override var foo: Int = 1 // expected-warning {{cannot override with a stored property 'foo'}}
+  lazy override var bar: Int = 1 // expected-warning {{cannot override with a stored property 'bar'}}
   func test() -> Int {
     // CHECK-LABEL: sil {{.*}}@$s18attr_override_lazy3SubC4testSiyF
     // CHECK: class_method %0 : $Sub, #Sub.foo!getter.1

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -311,8 +311,7 @@ func propertyWithDidSetTakingOldValue() {
   p = zero
 }
 
-// CHECK: // setter of p #1 : Swift.Int in observers.propertyWithDidSetTakingOldValue()
-// CHECK-NEXT: sil {{.*}} [ossa] @$s9observers32propertyWithDidSetTakingOldValueyyF1pL_Sivs
+// CHECK-LABEL: sil private [ossa] @$s9observers32propertyWithDidSetTakingOldValueyyF1pL_Sivs
 // CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : @guaranteed ${ var Int }):
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]

--- a/test/SILGen/optional_to_bool.swift
+++ b/test/SILGen/optional_to_bool.swift
@@ -6,10 +6,10 @@ extension Int: P {}
 public class A {}
 public class B: A {
   // CHECK-LABEL: sil [ossa] @$s16optional_to_bool1BC1x{{[_0-9a-zA-Z]*}}vg
-  // CHECK:         select_enum {{%.*}} : $Optional<Int>
+  // CHECK:         switch_enum {{%.*}} : $Optional<Int>
   public lazy var x: Int = 0
   // CHECK-LABEL: sil [ossa] @$s16optional_to_bool1BC1y{{[_0-9a-zA-Z]*}}vg
-  // CHECK:         select_enum_addr {{%.*}} : $*Optional<P>
+  // CHECK:         switch_enum_addr {{%.*}} : $*Optional<P>
   public lazy var y: P = 0
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/24665. Now observer setters and lazy property getters are synthesized with fully checked bodies. This brings us slightly closer to removing ExternalDefinitions and UsedConformances.