### PR TITLE
Opaque types require a newer Swift runtime.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4055,6 +4055,10 @@ ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",
       (DeclName, StringRef, llvm::VersionTuple))
 
+ERROR(availability_opaque_types_only_version_newer, none,
+      "'some' return types are only available in %0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -299,7 +299,7 @@ namespace swift {
     
     /// Enable the experimental opaque result types feature.
     bool EnableOpaqueResultTypes = true;
-
+    
     /// To mimic existing system, set to false.
     /// To experiment with including file-private and private dependency info,
     /// set to true.

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1327,6 +1327,32 @@ static void fixAvailability(SourceRange ReferenceRange,
   }
 }
 
+void TypeChecker::diagnosePotentialOpaqueTypeUnavailability(
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC,
+    const UnavailabilityReason &Reason) {
+  // We only emit diagnostics for API unavailability, not for explicitly
+  // weak-linked symbols.
+  if (Reason.getReasonKind() !=
+      UnavailabilityReason::Kind::RequiresOSVersionRange) {
+    return;
+  }
+
+  auto RequiredRange = Reason.getRequiredOSVersionRange();
+  {
+    auto Err =
+      diagnose(ReferenceRange.Start, diag::availability_opaque_types_only_version_newer,
+               prettyPlatformString(targetPlatform(Context.LangOpts)),
+               Reason.getRequiredOSVersionRange().getLowerEndpoint());
+
+    // Direct a fixit to the error if an existing guard is nearly-correct
+    if (fixAvailabilityByNarrowingNearbyVersionCheck(ReferenceRange,
+                                                     ReferenceDC,
+                                                     RequiredRange, *this, Err))
+      return;
+  }
+  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, *this);
+}
+
 void TypeChecker::diagnosePotentialUnavailability(
     const Decl *D, DeclName Name, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC, const UnavailabilityReason &Reason) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -158,9 +158,26 @@ static void revertDependentTypeLoc(TypeLoc &tl) {
   tl.setType(Type());
 }
 
-///
-/// Generic functions
-///
+//
+// Generic functions
+//
+
+static AvailabilityContext getOpaqueTypeAvailability(ASTContext &Context) {
+  if (Context.LangOpts.DisableAvailabilityChecking)
+    return AvailabilityContext::alwaysAvailable();
+  
+  auto target = Context.LangOpts.Target;
+  
+  if (target.isMacOSX()
+      || target.isiOS()
+      || target.isWatchOS())
+    // TODO: Update with OS versions that ship with runtime support
+    return AvailabilityContext(
+                           VersionRange::allGTE(llvm::VersionTuple(9999,0,0)));
+  
+  
+  return AvailabilityContext::alwaysAvailable();
+}
 
 /// Get the opaque type representing the return type of a declaration, or
 /// create it if it does not yet exist.
@@ -170,6 +187,16 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   // If the decl already has an opaque type decl for its return type, use it.
   if (auto existingDecl = originatingDecl->getOpaqueResultTypeDecl()) {
     return existingDecl->getDeclaredInterfaceType();
+  }
+  
+  // Check the availability of the opaque type runtime support.
+  auto runningOS = overApproximateAvailabilityAtLocation(repr->getLoc(),
+                                    originatingDecl->getInnermostDeclContext());
+  auto availability = getOpaqueTypeAvailability(Context);
+  if (!runningOS.isContainedIn(availability)) {
+    diagnosePotentialOpaqueTypeUnavailability(repr->getSourceRange(),
+       originatingDecl->getInnermostDeclContext(),
+       UnavailabilityReason::requiresVersionRange(availability.getOSVersion()));
   }
   
   // Try to resolve the constraint repr. It should be some kind of existential

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1999,6 +1999,10 @@ public:
                                        const DeclContext *ReferenceDC,
                                        const UnavailabilityReason &Reason);
 
+  void diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
+                                           const DeclContext *ReferenceDC,
+                                           const UnavailabilityReason &Reason);
+  
   /// Emits a diagnostic for a reference to a storage accessor that is
   /// potentially unavailable.
   void diagnosePotentialAccessorUnavailability(

--- a/test/IRGen/dynamic_replaceable_opaque_return.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/lazy_opaque_result_type.swift
+++ b/test/IRGen/lazy_opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=OpaqueArchetypeSpecializer -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -disable-availability-checking -Xllvm -sil-disable-pass=OpaqueArchetypeSpecializer -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll
 
 protocol P { }

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
-// RUN: %target-swift-frontend -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
 public protocol O {
   func bar()

--- a/test/IRGen/opaque_result_type_access_path.swift
+++ b/test/IRGen/opaque_result_type_access_path.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64 || CPU=x86_64
 
-// Check that the IRGenMangler does not crashq when mangling a conformance
+// Check that the IRGenMangler does not crash when mangling a conformance
 // access path with an opaque result type as root.
 // As a bonus, also do a runtime test to check that there is no miscompile.
 

--- a/test/IRGen/opaque_result_type_debug.swift
+++ b/test/IRGen/opaque_result_type_debug.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -g -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -g -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s
 
 public protocol P {}
 extension Int: P {} 

--- a/test/IRGen/opaque_result_type_global.swift
+++ b/test/IRGen/opaque_result_type_global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
 
 // rdar://problem/49818962
 func foo() -> some Collection {

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
@@ -9,15 +9,18 @@ extension Int: P {
 
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func bar(_ x: Int) -> some P {
   return x
 }
 
 struct Container {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   func bar(_ x: Int) -> some P {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   var computedProperty : some P {
     get {
       return 2
@@ -27,6 +30,7 @@ struct Container {
     }
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   subscript(_ x: Int) -> some P {
     get {
       return 2

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
@@ -8,17 +8,20 @@ struct Pair : P {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @_dynamicReplacement(for:bar(_:))
 func _replacement_bar(y x: Int) -> some P {
   return Pair()
 }
 
 extension Container {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for:bar(_:))
   func _replacement_bar(y x: Int) -> some P {
     return Pair()
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for: computedProperty)
   var _replacement_computedProperty : some P {
      get {
@@ -28,6 +31,8 @@ extension Container {
       print("replacement \(newValue)")
      }
   }
+
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for: subscript(_:))
   subscript(y x: Int) -> some P {
     get {

--- a/test/Interpreter/dynamic_replacement_opaque_result.swift
+++ b/test/Interpreter/dynamic_replacement_opaque_result.swift
@@ -33,6 +33,7 @@ private func target_library_name(_ name: String) -> String {
 #endif
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func test() {
   print(MemoryLayout.size(ofValue: bar(5)))
   print(MemoryLayout.size(ofValue: Container().bar(5)))
@@ -52,7 +53,11 @@ func test() {
 // CHECK: 2
 // CHECK: 8
 // CHECK: 2
-test()
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  test()
+} else {
+  print("8 8 5 5 8 2 8 2")
+}
 
 var executablePath = CommandLine.arguments[0]
 executablePath.removeLast(4)
@@ -73,4 +78,8 @@ executablePath.removeLast(4)
 // CHECK: 1
 // CHECK: 16
 // CHECK: 1
-test()
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  test()
+} else {
+  print("16 16 1 1 16 1 16 1")
+}

--- a/test/ParseableInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ParseableInterface/Inputs/opaque-result-types-client.swift
@@ -13,6 +13,7 @@ func getAssocSubscriptType<T: AssocTypeInference>(_ x: T) -> T.AssocSubscript {
 struct MyFoo: Foo {}
 struct YourFoo: Foo {}
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func someTypeIsTheSame() {
   var a = foo(0)
   a = foo(0)

--- a/test/ParseableInterface/opaque-result-types.swift
+++ b/test/ParseableInterface/opaque-result-types.swift
@@ -7,16 +7,19 @@ public protocol Foo {}
 extension Int: Foo {}
 
 // CHECK-LABEL: public func foo(_: Int) -> some Foo
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
 // CHECK-LABEL: @inlinable public func foo(_: String) -> some Foo {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
 // CHECK-LABEL: public func foo<T>(_ x: T) -> some Foo where T : OpaqueResultTypes.Foo
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
@@ -32,43 +35,53 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
   // CHECK-LABEL: public func foo(_: Int) -> some Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Bas: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -78,30 +91,37 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo(_ x: U) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -111,9 +131,11 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T, U>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public var prop: some Foo {
     return 123
   }
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public subscript() -> some Foo {
     return 123
   }
@@ -123,70 +145,87 @@ public struct Bar<T>: AssocTypeInference {
   // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct Zim: AssocTypeInference {
   public init() {}
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Zang: AssocTypeInference {
     public init() {}
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -196,9 +235,11 @@ public struct Zim: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<U>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public var prop: some Foo {
     return 123
   }
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public subscript() -> some Foo {
     return 123
   }

--- a/test/SIL/Serialization/opaque_return_type_serialize.sil
+++ b/test/SIL/Serialization/opaque_return_type_serialize.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OpaqueReturnTypeExporter.swiftmodule -module-name OpaqueReturnTypeExporter %S/Inputs/OpaqueReturnTypeExporter.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module -emit-module-path %t/OpaqueReturnTypeExporter.swiftmodule -module-name OpaqueReturnTypeExporter %S/Inputs/OpaqueReturnTypeExporter.swift
 // RUN: %target-sil-opt -I %t %s -emit-sib -module-name test -o %t/test.sib
-// RUN: %target-swift-frontend -I %t -emit-ir %t/test.sib
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir %t/test.sib
 
 import OpaqueReturnTypeExporter
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s | %FileCheck %s
 
 protocol P {}
 protocol Q: AnyObject {}

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
+// RUN: %target-swift-frontend -disable-availability-checking -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
 // We want to check two things here:
 // - Correctness
 // - That certain "is" checks are eliminated based on static analysis at compile-time

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %S/Inputs/specialize_opaque_type_archetypes_2.swift -module-name External -emit-module -emit-module-path %t/External.swiftmodule
-// RUN: %target-swift-frontend %S/Inputs/specialize_opaque_type_archetypes_3.swift -enable-library-evolution -module-name External2 -emit-module -emit-module-path %t/External2.swiftmodule
-// RUN: %target-swift-frontend %S/Inputs/specialize_opaque_type_archetypes_4.swift -I %t -enable-library-evolution -module-name External3 -emit-module -emit-module-path %t/External3.swiftmodule
-// RUN: %target-swift-frontend %S/Inputs/specialize_opaque_type_archetypes_3.swift -I %t -enable-library-evolution -module-name External2 -Osize -emit-module -o - | %target-sil-opt -module-name External2 | %FileCheck --check-prefix=RESILIENT %s
-// RUN: %target-swift-frontend -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil  -sil-verify-all %s | %FileCheck %s
-// RUN: %target-swift-frontend -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_2.swift -module-name External -emit-module -emit-module-path %t/External.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -enable-library-evolution -module-name External2 -emit-module -emit-module-path %t/External2.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_4.swift -I %t -enable-library-evolution -module-name External3 -emit-module -emit-module-path %t/External3.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -I %t -enable-library-evolution -module-name External2 -Osize -emit-module -o - | %target-sil-opt -module-name External2 | %FileCheck --check-prefix=RESILIENT %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil  -sil-verify-all %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s
 
 import External
 import External2

--- a/test/Serialization/opaque_circularity.swift
+++ b/test/Serialization/opaque_circularity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -emit-module %s
+// RUN: %target-swiftc_driver -Xfrontend -disable-availability-checking -emit-module %s
 
 // rdar://problem/49829836
 

--- a/test/Serialization/opaque_cross_file.swift
+++ b/test/Serialization/opaque_cross_file.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -verify %s | %FileCheck %s
 
 import OpaqueCrossFileB
 

--- a/test/TBD/opaque_result_type.swift
+++ b/test/TBD/opaque_result_type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
 
 public protocol O {
   func bar()

--- a/test/TypeDecoder/opaque_return_type.swift
+++ b/test/TypeDecoder/opaque_return_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-executable %s -g -o %t/opaque_return_type -emit-module
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -emit-executable %s -g -o %t/opaque_return_type -emit-module
 // RUN: sed -ne '/\/\/ *DEMANGLE: /s/\/\/ *DEMANGLE: *//p' < %s > %t/input
 // RUN: %lldb-moduleimport-test %t/opaque_return_type -type-from-mangled=%t/input | %FileCheck %s
 

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -enable-opaque-result-types %s
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify -enable-opaque-result-types %s
 
 protocol P {
   func paul()

--- a/test/type/opaque_constraint_order.swift
+++ b/test/type/opaque_constraint_order.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
 
 // rdar://problem/50309983, make sure that the generic signature built for
 // an opaque return type is correct when there are associated type constraints

--- a/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
+++ b/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null %s
 
 protocol P {
   associatedtype AT


### PR DESCRIPTION
Check the availability of decls that declare an opaque return type to ensure they deploy to a
runtime that supports opaque types.

rdar://problem/50731151