### PR TITLE
[AutoDiff] Introduce @NoDerivative property delegate and deprecate AllDifferentiableVariables.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -134,10 +134,8 @@ IDENTIFIER_(typeList)
 IDENTIFIER(zero)
 IDENTIFIER(Scalar)
 // Differentiable
-IDENTIFIER(AllDifferentiableVariables)
 IDENTIFIER(CotangentVector)
 IDENTIFIER(TangentVector)
-IDENTIFIER(allDifferentiableVariables)
 IDENTIFIER(moved)
 IDENTIFIER(tangentVector)
 

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -82,4 +82,7 @@ KNOWN_STDLIB_TYPE_DECL(KeyedEncodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(KeyedDecodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(RangeReplaceableCollection, ProtocolDecl, 1)
 
+// SWIFT_ENABLE_TENSORFLOW
+KNOWN_STDLIB_TYPE_DECL(NoDerivative, NominalTypeDecl, 1)
+
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -241,11 +241,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     if (name.isSimpleName(ctx.Id_typeList))
       return getRequirement(KnownProtocolKind::TensorGroup);
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // Differentiable.allDifferentiableVariables
-    if (name.isSimpleName(ctx.Id_allDifferentiableVariables))
-      return getRequirement(KnownProtocolKind::__Differentiable);
-
     return nullptr;
   }
 
@@ -375,10 +370,8 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     // SWIFT_ENABLE_TENSORFLOW
     // Differentiable.TangentVector
     // Differentiable.CotangentVector
-    // Differentiable.AllDifferentiableVariables
     if (name.isSimpleName(ctx.Id_TangentVector) ||
-        name.isSimpleName(ctx.Id_CotangentVector) ||
-        name.isSimpleName(ctx.Id_AllDifferentiableVariables))
+        name.isSimpleName(ctx.Id_CotangentVector))
       return getRequirement(KnownProtocolKind::__Differentiable);
 
     // SWIFT_ENABLE_TENSORFLOW

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -68,8 +68,6 @@ public protocol __Differentiable {
   associatedtype TangentVector : AdditiveArithmetic
   /// The cotangent bundle of this differentiable manifold.
   associatedtype CotangentVector : AdditiveArithmetic
-  /// The type of all differentiable variables in this type.
-  typealias AllDifferentiableVariables = Self
 
   /// Returns `self` moved along the value space towards the given tangent
   /// vector. In Riemannian geometry (mathematics), this represents an
@@ -105,6 +103,9 @@ public protocol Differentiable : _Differentiable
 // END DIFFERENTIABLE
 
 public extension Differentiable {
+  @available(*, deprecated, message: "'AllDifferentiableVariables' will be replaced by 'Self'")
+  typealias AllDifferentiableVariables = Self
+  
   @available(*, deprecated, message: "'allDifferentiableVariables' will be replaced by 'self'")
   var allDifferentiableVariables: AllDifferentiableVariables {
     _read { yield self }
@@ -496,10 +497,6 @@ public func gradient<T, U, V, R>(
 @_propertyDelegate
 public struct NoDerivative<Value> {
   public var value: Value
-
-  public init(_ value: Value) {
-    self.value = value
-  }
 }
 
 extension NoDerivative : Differentiable {

--- a/test/AutoDiff/derived_conformances.swift
+++ b/test/AutoDiff/derived_conformances.swift
@@ -22,12 +22,10 @@ DerivedConformanceTests.test("MemberwiseInitializers") {
   expectEqual(AllVarStoredPropertiesHaveInitialValue.zero.y, 0)
 
   struct HasNoDerivativeConstant: Differentiable {
-    @noDerivative let constant1 = Float(1)
-    @noDerivative let constant2 = Double(1)
+    @NoDerivative var constant1 = Float(1)
+    @NoDerivative var constant2 = Double(1)
     var x = Float(1)
   }
-  expectEqual(HasNoDerivativeConstant.AllDifferentiableVariables(x: 0),
-              HasNoDerivativeConstant.AllDifferentiableVariables.zero)
   expectEqual(HasNoDerivativeConstant.CotangentVector(x: 0),
               HasNoDerivativeConstant.CotangentVector.zero)
 }


### PR DESCRIPTION
Before:
```swift
struct Foo : Differentiable {
  var x: Float
  @noDerivative var y: Float

  // Synthesized:
  // struct AllDifferentiableVariables : Differentiable {
  //   var x: Float
  //   ...
  // }
  // struct TangentVector: AdditiveArithmetic, Differentiable {
  //   var x: Float
  //   ...
  // }
  // struct CotangentVector: AdditiveArithmetic, Differentiable {
  //   var x: Float
  //   ...
  // }
  // ...
}
```

After:
```swift
struct Foo : Differentiable {
  var x: Float
  @NoDerivative var y: Float

  // Synthesized:
  // struct TangentVector: AdditiveArithmetic, Differentiable {
  //   var x: Float
  //   var y: NoDerivative<Float>.TangentVector
  //   ...
  // }
  // struct CotangentVector: AdditiveArithmetic, Differentiable {
  //   var x: Float
  //   var y: NoDerivative<Float>.CotangentVector
  //   ...
  // }
  // ...
}
```

Of course, we need to change derived conformances and drop `@noDerivative` as well. It's not finished work.