### PR TITLE
Revert "[Foundation] Fix availability of NSValue.value(of:)"

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
+++ b/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
@@ -24,7 +24,6 @@ ${ ObjectiveCBridgeableImplementationForNSValue("CGSize") }
 ${ ObjectiveCBridgeableImplementationForNSValue("CGAffineTransform") }
 
 extension NSValue {
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     public func value<StoredType>(of type: StoredType.Type) -> StoredType? {
         if StoredType.self is AnyObject.Type {
             let encoding = String(cString: objCType)
@@ -42,7 +41,11 @@ extension NSValue {
             }
             let allocated = UnsafeMutablePointer<StoredType>.allocate(capacity: 1)
             defer { allocated.deallocate() }
-            getValue(allocated, size: storedSize)
+            if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+            	getValue(allocated, size: storedSize)
+        	} else {
+        		getValue(allocated)
+        	}
             return allocated.pointee
         }
         return nil

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -92,8 +92,6 @@ nsValueBridging.test("NSValue can only be cast back to its original type") {
 }
 
 nsValueBridging.test("NSValue fetching method should be able to convert constructed values safely") {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
-
   let range = NSRange(location: 17, length: 38)
   let value = NSValue(range: range)
   expectEqual(value.value(of: NSRange.self)?.location, range.location)


### PR DESCRIPTION
Reverts apple/swift#24498, which seems to have broken multiple bots.