### PR TITLE
vim: highlight `lazy`

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -39,6 +39,7 @@ syn keyword swiftDefinitionModifier
       \ fileprivate
       \ final
       \ internal
+      \ lazy
       \ nonmutating
       \ open
       \ override


### PR DESCRIPTION
`lazy` can modify the `var` definition.  Add that as a modifier.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
