### PR TITLE
[ASTMangler] Mangle nested imported error structs correctly

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -155,7 +155,9 @@ Type ASTBuilder::createNominalType(GenericTypeDecl *decl, Type parent) {
   // Imported types can be renamed to be members of other (non-generic)
   // types, but the mangling does not have a parent type. Just use the
   // declared type directly in this case and skip the parent check below.
-  if (nominalDecl->hasClangNode() && !nominalDecl->isGenericContext())
+  bool isImported = nominalDecl->hasClangNode() ||
+      nominalDecl->getAttrs().hasAttribute<ClangImporterSynthesizedTypeAttr>();
+  if (isImported && !nominalDecl->isGenericContext())
     return nominalDecl->getDeclaredType();
 
   // Validate the parent type.
@@ -177,7 +179,9 @@ Type ASTBuilder::createTypeAliasType(GenericTypeDecl *decl, Type parent) {
   // Imported types can be renamed to be members of other (non-generic)
   // types, but the mangling does not have a parent type. Just use the
   // declared type directly in this case and skip the parent check below.
-  if (aliasDecl->hasClangNode() && !aliasDecl->isGenericContext())
+  bool isImported = aliasDecl->hasClangNode() ||
+      aliasDecl->getAttrs().hasAttribute<ClangImporterSynthesizedTypeAttr>();
+  if (isImported && !aliasDecl->isGenericContext())
     return aliasDecl->getDeclaredInterfaceType();
 
   // Validate the parent type.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1493,6 +1493,12 @@ ASTMangler::getSpecialManglingContext(const ValueDecl *decl,
     }
   }
 
+  // Importer-synthesized types should always be mangled in the
+  // ClangImporterContext, even if an __attribute__((swift_name())) nests them
+  // inside a Swift type syntactically.
+  if (decl->getAttrs().hasAttribute<ClangImporterSynthesizedTypeAttr>())
+    return ASTMangler::ClangImporterContext;
+
   return None;
 }
 

--- a/test/IRGen/Inputs/error_domains.h
+++ b/test/IRGen/Inputs/error_domains.h
@@ -23,3 +23,15 @@ extern NSString *TypedefDomain2;
 typedef enum __attribute__((ns_error_domain(TypedefDomain2))) {
   Illness
 } TypedefError2;
+
+@interface Nested @end
+
+extern NSString * const NestedTagDomain;
+typedef MY_ERROR_ENUM(int, NestedTagError, NestedTagDomain) {
+  Trappedness
+} __attribute__((swift_name("Nested.TagError")));
+
+extern NSString *NestedTypedefDomain;
+typedef enum __attribute__((ns_error_domain(NestedTypedefDomain))) {
+  Brokenness
+} NestedTypedefError __attribute__((swift_name("Nested.TypedefError")));

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -13,6 +13,18 @@ sil @use_metatypes : $@convention(thin) () -> () {
 bb0:
   %take = function_ref @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
 
+// CHECK:         [[NestedTypedefErrorCode_NAME:@[0-9]+]] = private constant [29 x i8] c"Code\00NNestedTypedefError\00St\00\00"
+// CHECK:         @"$sSo18NestedTypedefErroraMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x0006_0012>
+// CHECK-SAME:    @"$sSoMXM"
+// CHECK-SAME:    [29 x i8]* [[NestedTypedefErrorCode_NAME]]
+
+// CHECK:         [[NestedTagError_NAME:@[0-9]+]] = private constant [29 x i8] c"TagError\00NNestedTagError\00Re\00\00"
+// CHECK:         @"$sSC14NestedTagErrorLeVMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x0006_0011>
+// CHECK-SAME:    @"$sSCMXM"
+// CHECK-SAME:    [29 x i8]* [[NestedTagError_NAME]]
+
 // CHECK:         [[TypedefError2Code_NAME:@[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
 // CHECK:         @"$sSo13TypedefError2aMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
@@ -48,6 +60,12 @@ bb0:
 
   %3 = metatype $@thick TypedefError2.Code.Type
   apply %take<TypedefError2.Code>(%3) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+  %4 = metatype $@thick Nested.TagError.Type
+  apply %take<Nested.TagError>(%4) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+  %5 = metatype $@thick Nested.TypedefError.Code.Type
+  apply %take<Nested.TypedefError.Code>(%5) : $@convention(thin) <T> (@thick T.Type) -> ()
 
   %ret = tuple ()
   return %ret : $()

--- a/test/Inputs/custom-modules/ErrorEnums.h
+++ b/test/Inputs/custom-modules/ErrorEnums.h
@@ -17,8 +17,13 @@ struct Wrapper {
   int unrelatedValue;
 };
 
-// Not actually an error enum, since those can't be import-as-member'd right 
-// now, but it can still hang with us.
+NSString * const MyMemberErrorDomain;
+typedef NS_ENUM(int, MyMemberError) {
+  MyMemberErrorA,
+  MyMemberErrorB,
+} __attribute__((ns_error_domain(MyMemberErrorDomain))) __attribute__((swift_name("Wrapper.MemberError")));
+
+// Not actually an error enum, but it can still hang with us.
 typedef NS_ENUM(int, MyMemberEnum) {
   MyMemberEnumA,
   MyMemberEnumB,

--- a/test/RemoteAST/foreign_types.swift
+++ b/test/RemoteAST/foreign_types.swift
@@ -28,6 +28,12 @@ printType(RenamedError.self)
 printType(RenamedError.Code.self)
 // CHECK: found type: RenamedError.Code{{$}}
 
+printType(Wrapper.MemberError.self)
+// CHECK: found type: Wrapper.MemberError{{$}}
+
+printType(Wrapper.MemberError.Code.self)
+// CHECK: found type: Wrapper.MemberError.Code{{$}}
+
 printType(Wrapper.MemberEnum.self)
 // CHECK: found type: Wrapper.MemberEnum{{$}}
 

--- a/test/TypeDecoder/foreign_types.swift
+++ b/test/TypeDecoder/foreign_types.swift
@@ -26,6 +26,8 @@ do {
     let x3 = MyError.Code.good
     let x4 = RenamedError.good
     let x5 = RenamedError.Code.good
+    let x5b = Wrapper.MemberError.A
+    let x5c = Wrapper.MemberError.Code.A
     let x6 = Wrapper.MemberEnum.A
     let x7 = WrapperByAttribute(0)
     let x8 = IceCube(width: 0, height: 0, depth: 0)
@@ -38,6 +40,8 @@ do {
     let x3 = MyError.Code.self
     let x4 = RenamedError.self
     let x5 = RenamedError.Code.self
+    let x5b = Wrapper.MemberError.self
+    let x5c = Wrapper.MemberError.Code.self
     let x6 = Wrapper.MemberEnum.self
     let x7 = WrapperByAttribute.self
     let x8 = IceCube.self
@@ -50,6 +54,8 @@ do {
 // DEMANGLE-TYPE: $sSo7MyErrorLeVD
 // DEMANGLE-TYPE: $sSo14MyRenamedErrorVD
 // DEMANGLE-TYPE: $sSo14MyRenamedErrorLeVD
+// DEMANGLE-TYPE: $sSo13MyMemberErrorVD
+// DEMANGLE-TYPE: $sSo13MyMemberErrorLeVD
 // DEMANGLE-TYPE: $sSo12MyMemberEnumVD
 // DEMANGLE-TYPE: $sSo18WrapperByAttributeaD
 // DEMANGLE-TYPE: $sSo7IceCubeVD
@@ -62,6 +68,8 @@ do {
 // CHECK-TYPE: MyError
 // CHECK-TYPE: RenamedError.Code
 // CHECK-TYPE: RenamedError
+// CHECK-TYPE: Wrapper.MemberError.Code
+// CHECK-TYPE: Wrapper.MemberError
 // CHECK-TYPE: Wrapper.MemberEnum
 // CHECK-TYPE: WrapperByAttribute
 // CHECK-TYPE: IceCube
@@ -74,6 +82,8 @@ do {
 // DEMANGLE-TYPE: $sSC7MyErrorLeVmD
 // DEMANGLE-TYPE: $sSo14MyRenamedErrorVmD
 // DEMANGLE-TYPE: $sSC14MyRenamedErrorLeVmD
+// DEMANGLE-TYPE: $sSo13MyMemberErrorVmD
+// DEMANGLE-TYPE: $sSC13MyMemberErrorLeVmD
 // DEMANGLE-TYPE: $sSo12MyMemberEnumVmD
 // DEMANGLE-TYPE: $sSo18WrapperByAttributeamD
 // DEMANGLE-TYPE: $sSo7IceCubeVmD
@@ -86,6 +96,8 @@ do {
 // CHECK-TYPE: MyError.Type
 // CHECK-TYPE: RenamedError.Code.Type
 // CHECK-TYPE: RenamedError.Type
+// CHECK-TYPE: Wrapper.MemberError.Code.Type
+// CHECK-TYPE: Wrapper.MemberError.Type
 // CHECK-TYPE: Wrapper.MemberEnum.Type
 // CHECK-TYPE: WrapperByAttribute.Type
 // CHECK-TYPE: IceCube.Type
@@ -98,6 +110,8 @@ do {
 // DEMANGLE-DECL: $sSo7MyErrorLeV
 // DEMANGLE-DECL: $sSo14MyRenamedErrorV
 // DEMANGLE-DECL: $sSo14MyRenamedErrorLeV
+// DEMANGLE-DECL: $sSo13MyMemberErrorV
+// DEMANGLE-DECL: $sSo13MyMemberErrorLeV
 // DEMANGLE-DECL: $sSo12MyMemberEnumV
 // DEMANGLE-DECL: $sSo18WrapperByAttributea
 // DEMANGLE-DECL: $sSo7IceCubeV
@@ -110,6 +124,8 @@ do {
 // CHECK-DECL: ErrorEnums.(file).MyError.Code
 // CHECK-DECL: ErrorEnums.(file).RenamedError.Code
 // CHECK-DECL: ErrorEnums.(file).RenamedError.Code
+// CHECK-DECL: ErrorEnums.(file).Wrapper extension.MemberError.Code
+// CHECK-DECL: ErrorEnums.(file).Wrapper extension.MemberError.Code
 // CHECK-DECL: ErrorEnums.(file).Wrapper extension.MemberEnum
 // CHECK-DECL: ErrorEnums.(file).WrapperByAttribute
 // CHECK-DECL: CoreCooling.(file).IceCube


### PR DESCRIPTION
Error structs synthesized by ClangImporter can be renamed using `SWIFT_NAME()` to syntactically appear anywhere in the type hierarchy with any name, but they should always be mangled as `__C_Synthesized.related decl ‘e’ of <clang enum name>`. Unfortunately, when `SWIFT_NAME()` was used to nest the error struct inside another type, an ASTMangler bug would cause it to be mangled as `<parent type>.related decl ‘e’ of <clang enum name>`, and an ASTDemangler bug would also require a valid parent type. This created a mismatch between the compiler’s and runtime’s manglings which caused crashes when you tried to match the imported error struct in a `catch`.

This PR corrects the compiler bugs so that it generates the mangling the runtime expects. This is theoretically ABI-breaking, but as far as I can determine nobody has shipped the incorrectly mangled names, presumably because they crash when you try to use them.

Fixes <rdar://problem/48040880>.

(This PR does not affect the mangling of error types written in Swift, only ones imported from Clang.)