### PR TITLE
[CodeCompletion] Call argument completion for implicit member expression

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -209,7 +209,7 @@ public:
 
   virtual void completeAssignmentRHS(AssignExpr *E) {};
 
-  virtual void completeCallArg(CodeCompletionExpr *E) {};
+  virtual void completeCallArg(CodeCompletionExpr *E, bool isFirst) {};
 
   virtual void completeReturnStmt(CodeCompletionExpr *E) {};
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Type.h"
@@ -289,7 +290,9 @@ static void collectPossibleCalleesByQualifiedLookup(
     Type declaredMemberType = VD->getInterfaceType();
     if (VD->getDeclContext()->isTypeContext()) {
       if (isa<FuncDecl>(VD)) {
-        if (!isOnMetaType)
+        if (!isOnMetaType && VD->isStatic())
+          continue;
+        if (isOnMetaType == VD->isStatic())
           declaredMemberType =
               declaredMemberType->castTo<AnyFunctionType>()->getResult();
       } else if (isa<ConstructorDecl>(VD)) {
@@ -407,6 +410,31 @@ static bool collectPossibleCalleesForSubscript(
   return !candidates.empty();
 }
 
+/// For the given \p unresolvedMemberExpr, collect possible callee types and
+/// declarations.
+static bool collectPossibleCalleesForUnresolvedMember(
+    DeclContext &DC, UnresolvedMemberExpr *unresolvedMemberExpr,
+    SmallVectorImpl<FunctionTypeAndDecl> &candidates) {
+  auto currModule = DC.getParentModule();
+  auto baseName = unresolvedMemberExpr->getName().getBaseName();
+
+  // Get the context of the expression itself.
+  ExprContextInfo contextInfo(&DC, unresolvedMemberExpr);
+  for (auto expectedTy : contextInfo.getPossibleTypes()) {
+    if (!expectedTy->mayHaveMembers())
+      continue;
+    SmallVector<FunctionTypeAndDecl, 2> members;
+    collectPossibleCalleesByQualifiedLookup(DC, MetatypeType::get(expectedTy),
+                                            baseName, members);
+    for (auto member : members) {
+      if (isReferenceableByImplicitMemberExpr(currModule, &DC, expectedTy,
+                                              member.second))
+        candidates.push_back(member);
+    }
+  }
+  return !candidates.empty();
+}
+
 /// Get index of \p CCExpr in \p Args. \p Args is usually a \c TupleExpr
 /// or \c ParenExpr.
 /// \returns \c true if success, \c false if \p CCExpr is not a part of \p Args.
@@ -470,6 +498,11 @@ class ExprContextAnalyzer {
       if (!collectPossibleCalleesForSubscript(*DC, subscriptExpr, Candidates))
         return false;
       Arg = subscriptExpr->getIndex();
+    } else if (auto *unresolvedMemberExpr = dyn_cast<UnresolvedMemberExpr>(E)) {
+      if (!collectPossibleCalleesForUnresolvedMember(*DC, unresolvedMemberExpr,
+                                                     Candidates))
+        return false;
+      Arg = unresolvedMemberExpr->getArgument();
     } else {
       llvm_unreachable("unexpected expression kind");
     }
@@ -484,7 +517,8 @@ class ExprContextAnalyzer {
     // Collect possible types (or labels) at the position.
     {
       bool MayNeedName = !HasName && !E->isImplicit() &&
-                         (isa<CallExpr>(E) | isa<SubscriptExpr>(E));
+                         (isa<CallExpr>(E) | isa<SubscriptExpr>(E) ||
+                          isa<UnresolvedMemberExpr>(E));
       SmallPtrSet<TypeBase *, 4> seenTypes;
       SmallPtrSet<Identifier, 4> seenNames;
       for (auto &typeAndDecl : Candidates) {
@@ -493,18 +527,30 @@ class ExprContextAnalyzer {
           memberDC = typeAndDecl.second->getInnermostDeclContext();
 
         auto Params = typeAndDecl.first->getParams();
-        if (Position >= Params.size())
-          continue;
-        const auto &Param = Params[Position];
-        if (Param.hasLabel() && MayNeedName) {
-          if (seenNames.insert(Param.getLabel()).second)
-            recordPossibleName(Param.getLabel().str());
-        } else {
-          Type ty = Param.getOldType();
-          if (memberDC && ty->hasTypeParameter())
-            ty = memberDC->mapTypeIntoContext(ty);
-          if (seenTypes.insert(ty.getPointer()).second)
-            recordPossibleType(ty);
+        ParameterList *paramList = nullptr;
+        if (auto VD = typeAndDecl.second) {
+          if (auto FD = dyn_cast<AbstractFunctionDecl>(VD))
+            paramList = FD->getParameters();
+          else if (auto SD = dyn_cast<SubscriptDecl>(VD))
+            paramList = SD->getIndices();
+          if (paramList && paramList->size() != Params.size())
+            paramList = nullptr;
+        }
+        for (auto Pos = Position; Pos < Params.size(); ++Pos) {
+          const auto &Param = Params[Pos];
+          if (Param.hasLabel() && MayNeedName) {
+            if (seenNames.insert(Param.getLabel()).second)
+              recordPossibleName(Param.getLabel().str());
+            if (paramList && paramList->get(Position)->isDefaultArgument())
+              continue;
+          } else {
+            Type ty = Param.getOldType();
+            if (memberDC && ty->hasTypeParameter())
+              ty = memberDC->mapTypeIntoContext(ty);
+            if (seenTypes.insert(ty.getPointer()).second)
+              recordPossibleType(ty);
+          }
+          break;
         }
       }
     }
@@ -515,6 +561,7 @@ class ExprContextAnalyzer {
     switch (Parent->getKind()) {
     case ExprKind::Call:
     case ExprKind::Subscript:
+    case ExprKind::UnresolvedMember:
     case ExprKind::Binary:
     case ExprKind::PrefixUnary: {
       analyzeApplyExpr(Parent);
@@ -706,11 +753,14 @@ public:
         case ExprKind::Assign:
         case ExprKind::Array:
           return true;
+        case ExprKind::UnresolvedMember:
+          return true;
         case ExprKind::Tuple: {
           auto ParentE = Parent.getAsExpr();
           return !ParentE ||
                  (!isa<CallExpr>(ParentE) && !isa<SubscriptExpr>(ParentE) &&
-                  !isa<BinaryExpr>(ParentE));
+                  !isa<BinaryExpr>(ParentE) &&
+                  !isa<UnresolvedMemberExpr>(ParentE));
         }
         case ExprKind::Closure:
           return isSingleExpressionBodyForCodeCompletion(
@@ -778,4 +828,76 @@ ExprContextInfo::ExprContextInfo(DeclContext *DC, Expr *TargetExpr) {
   ExprContextAnalyzer Analyzer(DC, TargetExpr, PossibleTypes, PossibleNames,
                                PossibleCallees, singleExpressionBody);
   Analyzer.Analyze();
+}
+
+//===----------------------------------------------------------------------===//
+// isReferenceableByImplicitMemberExpr(ModuleD, DeclContext, Type, ValueDecl)
+//===----------------------------------------------------------------------===//
+
+bool swift::ide::isReferenceableByImplicitMemberExpr(
+        ModuleDecl *CurrModule, DeclContext *DC, Type T, ValueDecl *VD) {
+
+  if (VD->isOperator())
+    return false;
+
+  if (!VD->hasInterfaceType())
+    return false;
+
+  if (T->getOptionalObjectType() &&
+      VD->getModuleContext()->isStdlibModule()) {
+    // In optional context, ignore '.init(<some>)', 'init(nilLiteral:)',
+    if (isa<ConstructorDecl>(VD))
+      return false;
+    // TODO: Ignore '.some(<Wrapped>)' and '.none' too *in expression
+    // context*. They are useful in pattern context though.
+  }
+
+  // Enum element decls can always be referenced by implicit member
+  // expression.
+  if (isa<EnumElementDecl>(VD))
+    return true;
+
+  // Only non-failable constructors are implicitly referenceable.
+  if (auto CD = dyn_cast<ConstructorDecl>(VD)) {
+    switch (CD->getFailability()) {
+      case OTK_None:
+      case OTK_ImplicitlyUnwrappedOptional:
+        return true;
+      case OTK_Optional:
+        return false;
+    }
+  }
+
+  // Otherwise, check the result type matches the contextual type.
+  auto declTy = T->getTypeOfMember(CurrModule, VD);
+  if (declTy->is<ErrorType>())
+    return false;
+
+  // Member types can also be implicitly referenceable as long as it's
+  // convertible to the contextual type.
+  if (auto CD = dyn_cast<TypeDecl>(VD)) {
+    declTy = declTy->getMetatypeInstanceType();
+
+    // Emit construction for the same type via typealias doesn't make sense
+    // because we are emitting all `.init()`s.
+    if (declTy->isEqual(T))
+      return false;
+    return swift::isConvertibleTo(declTy, T, *DC);
+  }
+
+  // Only static member can be referenced.
+  if (!VD->isStatic())
+    return false;
+
+  if (isa<FuncDecl>(VD)) {
+    // Strip '(Self.Type) ->' and parameters.
+    declTy = declTy->castTo<AnyFunctionType>()->getResult();
+    declTy = declTy->castTo<AnyFunctionType>()->getResult();
+  } else if (auto FT = declTy->getAs<AnyFunctionType>()) {
+    // The compiler accepts 'static var factory: () -> T' for implicit
+    // member expression.
+    // FIXME: This emits just 'factory'. We should emit 'factory()' instead.
+    declTy = FT->getResult();
+  }
+  return declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC);
 }

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -352,8 +352,13 @@ static bool collectPossibleCalleesForApply(
   auto *fnExpr = callExpr->getFn();
 
   if (auto type = fnExpr->getType()) {
-    if (auto *funcType = type->getAs<AnyFunctionType>())
-      candidates.emplace_back(funcType, fnExpr->getReferencedDecl().getDecl());
+    if (auto *funcType = type->getAs<AnyFunctionType>()) {
+      auto refDecl = fnExpr->getReferencedDecl();
+      if (!refDecl)
+        if (auto apply = dyn_cast<ApplyExpr>(fnExpr))
+          refDecl = apply->getFn()->getReferencedDecl();
+      candidates.emplace_back(funcType, refDecl.getDecl());
+    }
   } else if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
     if (auto *decl = DRE->getDecl()) {
       auto declType = decl->getInterfaceType();

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -71,6 +71,10 @@ public:
   }
 };
 
+/// Returns whether \p VD is referenceable with implicit member expression.
+bool isReferenceableByImplicitMemberExpr(
+    ModuleDecl *CurrModule, DeclContext *DC, Type T, ValueDecl *VD);
+
 } // namespace ide
 } // namespace swift
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -39,7 +39,7 @@ public:
   void completeForEachSequenceBeginning(CodeCompletionExpr *E) override;
   void completeCaseStmtBeginning() override;
 
-  void completeCallArg(CodeCompletionExpr *E) override;
+  void completeCallArg(CodeCompletionExpr *E, bool isFirst) override;
   void completeReturnStmt(CodeCompletionExpr *E) override;
   void completeYieldStmt(CodeCompletionExpr *E,
                          Optional<unsigned> yieldIndex) override;
@@ -61,7 +61,8 @@ void ContextInfoCallbacks::completeForEachSequenceBeginning(
   CurDeclContext = P.CurDeclContext;
   ParsedExpr = E;
 }
-void ContextInfoCallbacks::completeCallArg(CodeCompletionExpr *E) {
+void ContextInfoCallbacks::completeCallArg(CodeCompletionExpr *E,
+                                           bool isFirst) {
   CurDeclContext = P.CurDeclContext;
   ParsedExpr = E;
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3043,7 +3043,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
       // Handle call arguments specially because it may need argument labels.
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
       if (CodeCompletion)
-        CodeCompletion->completeCallArg(CCExpr);
+        CodeCompletion->completeCallArg(CCExpr, PreviousLoc == leftLoc);
       consumeIf(tok::code_complete);
       SubExpr = CCExpr;
       Status.setHasCodeCompletion();

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -74,6 +74,15 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CURRIED_SELF_2 | %FileCheck %s -check-prefix=CURRIED_SELF_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CURRIED_SELF_3 | %FileCheck %s -check-prefix=CURRIED_SELF_1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_METHOD_AFTERPAREN_1 | %FileCheck %s -check-prefix=STATIC_METHOD_AFTERPAREN_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_METHOD_AFTERPAREN_2 | %FileCheck %s -check-prefix=STATIC_METHOD_AFTERPAREN_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_METHOD_SECOND | %FileCheck %s -check-prefix=STATIC_METHOD_SECOND
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_METHOD_SKIPPED | %FileCheck %s -check-prefix=STATIC_METHOD_SKIPPED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_AFTERPAREN_1 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_AFTERPAREN_2 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_SECOND | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SECOND
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_SKIPPED | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SKIPPED
+
 var i1 = 1
 var i2 = 2
 var oi1 : Int?
@@ -612,4 +621,69 @@ class TestImplicitlyCurriedSelf {
 // CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int, Int) -> ()#]{{; name=.+$}}
 // CURRIED_SELF_1: End completions
   }
+}
+
+class TestStaticMemberCall {
+  static func create1(arg1: Int) -> TestStaticMemberCall {
+    return TestStaticMemberCall()
+  }
+  static func create2(_ arg1: Int, arg2: Int = 0, arg3: Int = 1, arg4: Int = 2) -> TestStaticMemberCall {
+    return TestStaticMemberCall()
+  }
+}
+func testStaticMemberCall() {
+  let _ = TestStaticMemberCall.create1(#^STATIC_METHOD_AFTERPAREN_1^#)
+// STATIC_METHOD_AFTERPAREN_1: Begin completions, 1 items
+// STATIC_METHOD_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// STATIC_METHOD_AFTERPAREN_1: End completions
+
+  let _ = TestStaticMemberCall.create2(#^STATIC_METHOD_AFTERPAREN_2^#)
+// STATIC_METHOD_AFTERPAREN_2: Begin completions
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: Int[#Int#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
+// STATIC_METHOD_AFTERPAREN_2: End completions
+
+  let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
+// STATIC_METHOD_SECOND: Begin completions, 3 items
+// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg2: [#Argument name#];
+// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg3: [#Argument name#];
+// STATIC_METHOD_SECOND: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// STATIC_METHOD_SECOND: End completions
+
+  let _ = TestStaticMemberCall.create2(1, arg3: 2, #^STATIC_METHOD_SKIPPED^#)
+// STATIC_METHOD_SKIPPED: Begin completions, 2 items
+// FIXME: 'arg3' shouldn't be suggested.
+// STATIC_METHOD_SKIPPED: Keyword/ExprSpecific:               arg3: [#Argument name#];
+// STATIC_METHOD_SKIPPED: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// STATIC_METHOD_SKIPPED: End completions
+}
+func testImplicitMember() {
+  let _: TestStaticMemberCall = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_1^#)
+// IMPLICIT_MEMBER_AFTERPAREN_1: Begin completions, 1 items
+// IMPLICIT_MEMBER_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// IMPLICIT_MEMBER_AFTERPAREN_1: End completions
+
+  let _: TestStaticMemberCall = .create2(#^IMPLICIT_MEMBER_AFTERPAREN_2^#)
+// IMPLICIT_MEMBER_AFTERPAREN_2: Begin completions
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal:     ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal:     ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/TypeRelation[Identical]: Int[#Int#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
+// IMPLICIT_MEMBER_AFTERPAREN_2: End completions
+
+  let _: TestStaticMemberCall = .create2(1, #^IMPLICIT_MEMBER_SECOND^#)
+// IMPLICIT_MEMBER_SECOND: Begin completions, 3 items
+// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg2: [#Argument name#];
+// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg3: [#Argument name#];
+// IMPLICIT_MEMBER_SECOND: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// IMPLICIT_MEMBER_SECOND: End completions
+
+  let _: TestStaticMemberCall = .create2(1, arg3: 2, #^IMPLICIT_MEMBER_SKIPPED^#)
+// IMPLICIT_MEMBER_SKIPPED: Begin completions, 2 items
+// FIXME: 'arg3' shouldn't be suggested.
+// IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg3: [#Argument name#];
+// IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg4: [#Argument name#];
+// IMPLICIT_MEMBER_SKIPPED: End completions
 }


### PR DESCRIPTION
Implement following completions for implicit member expression.

```swift
class MyType {
  static func foo(_: Int, name: String, file: String = "", line: Int? = nil) -> MyType
}
func foo() -> MyType {
  // Call signature completion after opening paren.
  return .foo(<HERE> // -> <#Int#>, name: <#String#>
                     //    <#Int#>, name: <#String#>, file: <#String#>, line: <#Int?#>
                     //    ... other global completions.

  // Argument label completion
  return .foo(1, <HERE> // -> name:

  // Collect call arguments if the parameter is defaulted.
  return .foo(1, name: "test", <HERE> // -> file:
                                      //    line:
```

rdar://problem/50696432