### PR TITLE
Driver: use `-Xlinker` rather than `-Wl` (NFC)

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -71,8 +71,10 @@ toolchains::Windows::constructInvocation(const LinkJobAction &job,
   if (!Linker.empty())
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 
-  if (context.OI.DebugInfoFormat == IRGenDebugInfoFormat::CodeView)
-      Arguments.push_back("-Wl,/DEBUG");
+  if (context.OI.DebugInfoFormat == IRGenDebugInfoFormat::CodeView) {
+      Arguments.push_back("-Xlinker");
+      Arguments.push_back("/DEBUG");
+  }
 
   // Configure the toolchain.
   // By default, use the system clang++ to link.


### PR DESCRIPTION
This is just nicer to read and makes the option standout better.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
