### PR TITLE
[AST] Inherit doc-brief comment from protocol, superclass, and requirement

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -286,7 +286,6 @@ public:
 
   /// To sanitize a malformed utf8 string to a well-formed one.
   static std::string sanitizeUtf8(StringRef Text);
-  static ValueDecl* findConformancesWithDocComment(ValueDecl *VD);
 
 private:
   virtual void anchor();

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -22,15 +22,22 @@ class TypeDecl;
 struct RawComment;
 
 class DocComment {
+  const Decl *D;
   swift::markup::Document *Doc = nullptr;
   swift::markup::CommentParts Parts;
 
-  DocComment(swift::markup::Document *Doc, swift::markup::CommentParts Parts)
-      : Doc(Doc), Parts(Parts) {}
+  DocComment(const Decl *D, swift::markup::Document *Doc,
+             swift::markup::CommentParts Parts)
+      : D(D), Doc(Doc), Parts(Parts) {}
+
 public:
-  static DocComment *create(swift::markup::MarkupContext &MC, RawComment RC);
+  static DocComment *create(const Decl *D, swift::markup::MarkupContext &MC,
+                            RawComment RC);
 
   void addInheritanceNote(swift::markup::MarkupContext &MC, TypeDecl *base);
+
+  const Decl *getDecl() const { return D; }
+  void setDecl(const Decl *D) { this->D = D; }
 
   const swift::markup::Document *getDocument() const { return Doc; }
 
@@ -106,4 +113,3 @@ void printBriefComment(RawComment RC, llvm::raw_ostream &OS);
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_COMMENT_H
-

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -18,20 +18,19 @@
 
 namespace swift {
 class Decl;
-class DocComment;
+class TypeDecl;
 struct RawComment;
 
 class DocComment {
-  const Decl *D;
-  const swift::markup::Document *Doc = nullptr;
-  const swift::markup::CommentParts Parts;
+  swift::markup::Document *Doc = nullptr;
+  swift::markup::CommentParts Parts;
 
+  DocComment(swift::markup::Document *Doc, swift::markup::CommentParts Parts)
+      : Doc(Doc), Parts(Parts) {}
 public:
-  DocComment(const Decl *D, swift::markup::Document *Doc,
-             swift::markup::CommentParts Parts)
-      : D(D), Doc(Doc), Parts(Parts) {}
+  static DocComment *create(swift::markup::MarkupContext &MC, RawComment RC);
 
-  const Decl *getDecl() const { return D; }
+  void addInheritanceNote(swift::markup::MarkupContext &MC, TypeDecl *base);
 
   const swift::markup::Document *getDocument() const { return Doc; }
 
@@ -87,18 +86,23 @@ public:
 };
 
 /// Get a parsed documentation comment for the declaration, if there is one.
-Optional<DocComment *>getSingleDocComment(swift::markup::MarkupContext &Context,
-                                          const Decl *D);
+DocComment *getSingleDocComment(swift::markup::MarkupContext &Context,
+                                const Decl *D);
+
+const Decl *getDocCommentProvidingDecl(const Decl *D);
 
 /// Attempt to get a doc comment from the declaration, or other inherited
 /// sources, like from base classes or protocols.
-Optional<DocComment *> getCascadingDocComment(swift::markup::MarkupContext &MC,
-                                             const Decl *D);
+DocComment *getCascadingDocComment(swift::markup::MarkupContext &MC,
+                                   const Decl *D);
 
 /// Extract comments parts from the given Markup node.
 swift::markup::CommentParts
 extractCommentParts(swift::markup::MarkupContext &MC,
                     swift::markup::MarkupASTNode *Node);
+
+/// Extract brief comment from \p RC, and print it to \p OS .
+void printBriefComment(RawComment RC, llvm::raw_ostream &OS);
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_COMMENT_H

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -349,7 +349,7 @@ struct PrintOptions {
 
   /// Whether to print the doc-comment from the conformance if a member decl
   /// has no associated doc-comment by itself.
-  bool ElevateDocCommentFromConformance = false;
+  bool CascadeDocComment = false;
 
   /// Whether to print the content of an extension decl inside the type decl where it
   /// extends from.
@@ -480,7 +480,7 @@ struct PrintOptions {
     result.SkipDeinit = true;
     result.ExcludeAttrList.push_back(DAK_DiscardableResult);
     result.EmptyLineBetweenMembers = true;
-    result.ElevateDocCommentFromConformance = true;
+    result.CascadeDocComment = true;
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::Always;
     result.PrintDocumentationComments = true;

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -479,12 +479,10 @@ swift::getCascadingDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
   auto *doc = getSingleDocComment(MC, docD);
   assert(doc && "getDocCommentProvidingDecl() returned decl with no comment");
 
-  // Iff the doc is inherited from overridden decl, add a note about that.
-  // FIXME: This is inconsistent <rdar://problem/49043711>, but let's keep the
-  // behavior for now.
+  // If the doc-comment is inherited from other decl, add a note about it.
   if (docD != D)
-    if (auto baseClassD = docD->getDeclContext()->getSelfClassDecl())
-      doc->addInheritanceNote(MC, baseClassD);
+    if (auto baseD = docD->getDeclContext()->getSelfNominalTypeDecl())
+      doc->addInheritanceNote(MC, baseD);
 
   return doc;
 }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -16,12 +16,14 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/RawComment.h"
 #include "swift/Markup/Markup.h"
+#include <queue>
 
 using namespace swift;
 
@@ -30,6 +32,7 @@ void *DocComment::operator new(size_t Bytes, swift::markup::MarkupContext &MC,
   return MC.allocate(Bytes, Alignment);
 }
 
+namespace {
 Optional<swift::markup::ParamField *> extractParamOutlineItem(
     swift::markup::MarkupContext &MC,
     swift::markup::MarkupASTNode *Node) {
@@ -282,6 +285,21 @@ bool extractSimpleField(
 
   return NormalItems.empty();
 }
+} // namespace
+
+void swift::printBriefComment(RawComment RC, llvm::raw_ostream &OS) {
+  markup::MarkupContext MC;
+  markup::LineList LL = MC.getLineList(RC);
+  auto *markupDoc = markup::parseDocument(MC, LL);
+
+  auto children = markupDoc->getChildren();
+  if (children.empty())
+    return;
+  auto FirstParagraph = dyn_cast<swift::markup::Paragraph>(children.front());
+  if (!FirstParagraph)
+    return;
+  swift::markup::printInlinesUnder(FirstParagraph, OS);
+}
 
 swift::markup::CommentParts
 swift::extractCommentParts(swift::markup::MarkupContext &MC,
@@ -334,126 +352,167 @@ swift::extractCommentParts(swift::markup::MarkupContext &MC,
   return Parts;
 }
 
-Optional<DocComment *>
-swift::getSingleDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
+DocComment *DocComment::create(markup::MarkupContext &MC, RawComment RC) {
+  assert(!RC.isEmpty());
+  swift::markup::LineList LL = MC.getLineList(RC);
+  auto *Doc = swift::markup::parseDocument(MC, LL);
+  auto Parts = extractCommentParts(MC, Doc);
+  return new (MC) DocComment(Doc, Parts);
+}
+
+void DocComment::addInheritanceNote(swift::markup::MarkupContext &MC,
+                                    TypeDecl *base) {
+  auto text = MC.allocateCopy("This documentation comment was inherited from ");
+  auto name = MC.allocateCopy(base->getNameStr());
+  auto period = MC.allocateCopy(".");
+  auto paragraph = markup::Paragraph::create(MC, {
+    markup::Text::create(MC, text),
+    markup::Code::create(MC, name),
+    markup::Text::create(MC, period)});
+
+  auto note = markup::NoteField::create(MC, {paragraph});
+
+  SmallVector<const markup::MarkupASTNode *, 8> BodyNodes{
+    Parts.BodyNodes.begin(), Parts.BodyNodes.end()};
+  BodyNodes.push_back(note);
+  Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
+}
+
+DocComment *swift::getSingleDocComment(swift::markup::MarkupContext &MC,
+                                       const Decl *D) {
   PrettyStackTraceDecl StackTrace("parsing comment for", D);
 
   auto RC = D->getRawComment();
   if (RC.isEmpty())
-    return None;
-
-  swift::markup::LineList LL = MC.getLineList(RC);
-  auto *Doc = swift::markup::parseDocument(MC, LL);
-  auto Parts = extractCommentParts(MC, Doc);
-  return new (MC) DocComment(D, Doc, Parts);
-}
-
-static Optional<DocComment *>
-getAnyBaseClassDocComment(swift::markup::MarkupContext &MC,
-                          const ClassDecl *CD,
-                          const Decl *D) {
-  RawComment RC;
-
-  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
-    const auto *BaseDecl = VD->getOverriddenDecl();
-    while (BaseDecl) {
-      RC = BaseDecl->getRawComment();
-      if (!RC.isEmpty()) {
-        swift::markup::LineList LL = MC.getLineList(RC);
-        auto *Doc = swift::markup::parseDocument(MC, LL);
-        auto Parts = extractCommentParts(MC, Doc);
-
-        SmallString<48> RawCascadeText;
-        llvm::raw_svector_ostream OS(RawCascadeText);
-        OS << "This documentation comment was inherited from ";
-
-
-        auto *Text = swift::markup::Text::create(MC, MC.allocateCopy(OS.str()));
-
-        auto BaseClass = BaseDecl->getDeclContext()->getSelfClassDecl();
-
-        auto *BaseClassMonospace =
-          swift::markup::Code::create(MC,
-                                      MC.allocateCopy(BaseClass->getNameStr()));
-
-        auto *Period = swift::markup::Text::create(MC, ".");
-
-        auto *Para = swift::markup::Paragraph::create(MC, {
-          Text, BaseClassMonospace, Period
-        });
-        auto CascadeNote = swift::markup::NoteField::create(MC, {Para});
-
-        SmallVector<const swift::markup::MarkupASTNode *, 8> BodyNodes {
-          Parts.BodyNodes.begin(),
-          Parts.BodyNodes.end()
-        };
-        BodyNodes.push_back(CascadeNote);
-        Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
-
-        return new (MC) DocComment(D, Doc, Parts);
-      }
-
-      BaseDecl = BaseDecl->getOverriddenDecl();
-    }
-  }
-  
-  return None;
-}
-
-static Optional<DocComment *>
-getProtocolRequirementDocComment(swift::markup::MarkupContext &MC,
-                                 const ProtocolDecl *ProtoExt,
-                                 const Decl *D) {
-
-  auto getSingleRequirementWithNonemptyDoc = [](const ProtocolDecl *P,
-                                                const ValueDecl *VD)
-    -> const ValueDecl * {
-      SmallVector<ValueDecl *, 2> Members;
-      P->lookupQualified(const_cast<ProtocolDecl *>(P),
-                         VD->getFullName(),
-                         NLOptions::NL_ProtocolMembers,
-                         Members);
-    SmallVector<const ValueDecl *, 1> ProtocolRequirements;
-    for (auto Member : Members)
-      if (isa<ProtocolDecl>(Member->getDeclContext()) &&
-          Member->isProtocolRequirement())
-        ProtocolRequirements.push_back(Member);
-
-    if (ProtocolRequirements.size() == 1) {
-      auto Requirement = ProtocolRequirements.front();
-      if (!Requirement->getRawComment().isEmpty())
-        return Requirement;
-    }
-
     return nullptr;
-  };
-
-  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
-    SmallVector<const ValueDecl *, 4> RequirementsWithDocs;
-    if (auto Requirement = getSingleRequirementWithNonemptyDoc(ProtoExt, VD))
-      RequirementsWithDocs.push_back(Requirement);
-
-    if (RequirementsWithDocs.size() == 1)
-      return getSingleDocComment(MC, RequirementsWithDocs.front());
-  }
-  return None;
+  return DocComment::create(MC, RC);
 }
 
-Optional<DocComment *>
+namespace {
+const ValueDecl *findOverriddenDeclWithDocComment(const ValueDecl *VD) {
+  // Only applies to class member.
+  if (!VD->getDeclContext()->getSelfClassDecl())
+    return nullptr;
+
+  while (auto *baseDecl = VD->getOverriddenDecl()) {
+    if (!baseDecl->getRawComment().isEmpty())
+      return baseDecl;
+    VD = baseDecl;
+  }
+
+  return nullptr;
+}
+
+const ValueDecl *findDefaultProvidedDeclWithDocComment(const ValueDecl *VD) {
+  auto protocol = VD->getDeclContext()->getExtendedProtocolDecl();
+  // Only applies to protocol extension member.
+  if (!protocol)
+    return nullptr;
+
+  ValueDecl *requirement = nullptr;
+
+  SmallVector<ValueDecl *, 2> members;
+  protocol->lookupQualified(const_cast<ProtocolDecl *>(protocol),
+                            VD->getFullName(), NLOptions::NL_ProtocolMembers,
+                            members);
+
+  for (auto *member : members) {
+    if (!isa<ProtocolDecl>(member->getDeclContext()) ||
+        !member->isProtocolRequirement() ||
+        member->getRawComment().isEmpty())
+      continue;
+    if (requirement)
+      // Found two or more decls with doc-comment.
+      return nullptr;
+
+    requirement = member;
+  }
+  return requirement;
+}
+
+const ValueDecl *findRequirementDeclWithDocComment(const ValueDecl *VD) {
+  std::queue<const ValueDecl *> requirements;
+  while (true) {
+    for (auto *req : VD->getSatisfiedProtocolRequirements()) {
+      if (!req->getRawComment().isEmpty())
+        return req;
+      else
+        requirements.push(req);
+    }
+    if (requirements.empty())
+      return nullptr;
+    VD = requirements.front();
+    requirements.pop();
+  }
+}
+} // namespace
+
+const Decl *swift::getDocCommentProvidingDecl(const Decl *D) {
+  if (!D->canHaveComment())
+    return nullptr;
+
+  if (!D->getRawComment().isEmpty())
+    return D;
+
+  auto *VD = dyn_cast<ValueDecl>(D);
+  if (!VD)
+    return nullptr;
+
+  if (auto *overriden = findOverriddenDeclWithDocComment(VD))
+    return overriden;
+
+  if (auto *requirement = findDefaultProvidedDeclWithDocComment(VD))
+    return requirement;
+
+  if (auto *requirement = findRequirementDeclWithDocComment(VD))
+    return requirement;
+
+  return nullptr;
+}
+
+DocComment *
 swift::getCascadingDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
-  auto Doc = getSingleDocComment(MC, D);
-  if (Doc.hasValue())
-    return Doc;
+  auto *docD = getDocCommentProvidingDecl(D);
+  if (!docD)
+    return nullptr;
 
-  // If this refers to a class member, check to see if any
-  // base classes have a doc comment and cascade it to here.
-  if (const auto *CD = D->getDeclContext()->getSelfClassDecl())
-    if (auto BaseClassDoc = getAnyBaseClassDocComment(MC, CD, D))
-      return BaseClassDoc;
+  auto *doc = getSingleDocComment(MC, docD);
+  assert(doc && "getDocCommentProvidingDecl() returned decl with no comment");
 
-  if (const auto *PE = D->getDeclContext()->getExtendedProtocolDecl())
-    if (auto ReqDoc = getProtocolRequirementDocComment(MC, PE, D))
-      return ReqDoc;
+  // Iff the doc is inherited from overridden decl, add a note about that.
+  // FIXME: This is inconsistent <rdar://problem/49043711>, but let's keep the
+  // behavior for now.
+  if (docD != D)
+    if (auto baseClassD = docD->getDeclContext()->getSelfClassDecl())
+      doc->addInheritanceNote(MC, baseClassD);
 
-  return None;
+  return doc;
+}
+
+StringRef Decl::getBriefComment() const {
+  if (!this->canHaveComment())
+    return StringRef();
+
+  // Ensure the serialized doc is populated to ASTContext.
+  auto RC = getRawComment();
+
+  // Check the cache in ASTContext.
+  auto &Context = getASTContext();
+  if (Optional<StringRef> Comment = Context.getBriefComment(this))
+    return Comment.getValue();
+
+  StringRef Result;
+  if (RC.isEmpty())
+    if (auto *docD = getDocCommentProvidingDecl(this))
+      RC = docD->getRawComment();
+  if (!RC.isEmpty()) {
+    SmallString<256> BriefStr;
+    llvm::raw_svector_ostream OS(BriefStr);
+    printBriefComment(RC, OS);
+    Result = Context.AllocateCopy(BriefStr.str());
+  }
+
+  // Cache it.
+  Context.setBriefComment(this, Result);
+  return Result;
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -266,10 +266,10 @@ void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
     return;
   static swift::markup::MarkupContext MC;
   auto DC = getSingleDocComment(MC, D);
-  if (!DC.hasValue())
+  if (!DC)
     return;
   SwiftDocWordExtractor Extractor(Words);
-  for (auto Part : DC.getValue()->getBodyNodes()) {
+  for (auto Part : DC->getBodyNodes()) {
     switch (Part->getKind()) {
       case ASTNodeKind::KeywordField:
       case ASTNodeKind::RecommendedField:

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -258,7 +258,7 @@ struct CommentToXMLConverter {
     OS << "</Tags>";
   }
 
-  void visitDocComment(const DocComment *DC);
+  void visitDocComment(const Decl *D, const DocComment *DC);
   void visitCommentParts(const swift::markup::CommentParts &Parts);
 };
 } // unnamed namespace
@@ -297,8 +297,7 @@ void CommentToXMLConverter::visitCommentParts(const swift::markup::CommentParts 
   }
 }
 
-void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
-  const Decl *D = DC->getDecl();
+void CommentToXMLConverter::visitDocComment(const Decl *D, const DocComment *DC) {
 
   StringRef RootEndTag;
   if (isa<AbstractFunctionDecl>(D)) {
@@ -460,11 +459,11 @@ bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
 
   swift::markup::MarkupContext MC;
   auto DC = getCascadingDocComment(MC, D);
-  if (!DC.hasValue())
+  if (!DC)
     return false;
 
   CommentToXMLConverter Converter(OS);
-  Converter.visitDocComment(DC.getValue());
+  Converter.visitDocComment(D, DC);
 
   OS.flush();
   return true;
@@ -473,10 +472,10 @@ bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
 bool ide::getLocalizationKey(const Decl *D, raw_ostream &OS) {
   swift::markup::MarkupContext MC;
   auto DC = getCascadingDocComment(MC, D);
-  if (!DC.hasValue())
+  if (!DC)
     return false;
 
-  if (const auto LKF = DC.getValue()->getLocalizationKeyField()) {
+  if (const auto LKF = DC->getLocalizationKeyField()) {
     printInlinesUnder(LKF.getValue(), OS);
     return true;
   }

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -258,7 +258,7 @@ struct CommentToXMLConverter {
     OS << "</Tags>";
   }
 
-  void visitDocComment(const Decl *D, const DocComment *DC);
+  void visitDocComment(const DocComment *DC);
   void visitCommentParts(const swift::markup::CommentParts &Parts);
 };
 } // unnamed namespace
@@ -297,7 +297,8 @@ void CommentToXMLConverter::visitCommentParts(const swift::markup::CommentParts 
   }
 }
 
-void CommentToXMLConverter::visitDocComment(const Decl *D, const DocComment *DC) {
+void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
+  const Decl *D = DC->getDecl();
 
   StringRef RootEndTag;
   if (isa<AbstractFunctionDecl>(D)) {
@@ -463,7 +464,7 @@ bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
     return false;
 
   CommentToXMLConverter Converter(OS);
-  Converter.visitDocComment(D, DC);
+  Converter.visitDocComment(DC);
 
   OS.flush();
   return true;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1405,9 +1405,9 @@ bool IndexSwiftASTWalker::indexComment(const Decl *D) {
 
   swift::markup::MarkupContext MC;
   auto DC = getSingleDocComment(MC, D);
-  if (!DC.hasValue())
+  if (!DC)
     return true;
-  for (StringRef tagName : DC.getValue()->getTags()) {
+  for (StringRef tagName : DC->getTags()) {
     tagName = tagName.trim();
     if (tagName.empty())
       continue;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -257,8 +257,8 @@ private:
   void printDocumentationComment(Decl *D) {
     swift::markup::MarkupContext MC;
     auto DC = getSingleDocComment(MC, D);
-    if (DC.hasValue())
-      ide::getDocumentationCommentAsDoxygen(DC.getValue(), os);
+    if (DC)
+      ide::getDocumentationCommentAsDoxygen(DC, os);
   }
 
   /// Prints an encoded string, escaped properly for C.

--- a/test/IDE/comment_inherited_protocol.swift
+++ b/test/IDE/comment_inherited_protocol.swift
@@ -63,11 +63,11 @@ protocol ChildProtocol : ParentProtocol1, ParentProtocol2 {
 extension ChildProtocol {
   // Should come from ParentProtocol1.
   func onlyParent1() {}
-  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test15ParentProtocol1P11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract></CommentParts></Function>]
+  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract></CommentParts></Function>]
 
   // Should come from ParentProtocol1.
   var onlyParent1Var: Int { return 0 }
-  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test15ParentProtocol1P14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract></CommentParts></Other>]
+  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test13ChildProtocolPAAE14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract></CommentParts></Other>]
 
   // Should come from ParentProtocol1.
   subscript(index: Int) -> Int { return 0 }
@@ -75,11 +75,11 @@ extension ChildProtocol {
 
   // Should come from ParentProtocol1.
   typealias AssocType = Int
-  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocTypeQa</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
+  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test13ChildProtocolPAAE9AssocTypea</USR><Declaration>typealias AssocType = Int</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
 
   // Should come from ParentProtocol2.
   func onlyParent2() {}
-  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test15ParentProtocol2P11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract></CommentParts></Function>]
+  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract></CommentParts></Function>]
 
   // Should show nothing because the requirement is in both parents.
   func commonParentRequirement() {}

--- a/test/IDE/comment_inherited_protocol.swift
+++ b/test/IDE/comment_inherited_protocol.swift
@@ -63,23 +63,23 @@ protocol ChildProtocol : ParentProtocol1, ParentProtocol2 {
 extension ChildProtocol {
   // Should come from ParentProtocol1.
   func onlyParent1() {}
-  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract></CommentParts></Function>]
+  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
 
   // Should come from ParentProtocol1.
   var onlyParent1Var: Int { return 0 }
-  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test13ChildProtocolPAAE14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract></CommentParts></Other>]
+  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test13ChildProtocolPAAE14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
 
   // Should come from ParentProtocol1.
   subscript(index: Int) -> Int { return 0 }
-  // CHECK: Subscript/subscript {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>subscript(_:)</Name><USR>{{.*}}</USR><Declaration>subscript(index: Int) -&gt; Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.subscript(index:)</Para></Abstract></CommentParts></Other>]
+  // CHECK: Subscript/subscript {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>subscript(_:)</Name><USR>{{.*}}</USR><Declaration>subscript(index: Int) -&gt; Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.subscript(index:)</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
 
   // Should come from ParentProtocol1.
   typealias AssocType = Int
-  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test13ChildProtocolPAAE9AssocTypea</USR><Declaration>typealias AssocType = Int</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
+  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test13ChildProtocolPAAE9AssocTypea</USR><Declaration>typealias AssocType = Int</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
 
   // Should come from ParentProtocol2.
   func onlyParent2() {}
-  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract></CommentParts></Function>]
+  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol2</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
 
   // Should show nothing because the requirement is in both parents.
   func commonParentRequirement() {}

--- a/test/IDE/comment_inherited_protocol.swift
+++ b/test/IDE/comment_inherited_protocol.swift
@@ -63,11 +63,11 @@ protocol ChildProtocol : ParentProtocol1, ParentProtocol2 {
 extension ChildProtocol {
   // Should come from ParentProtocol1.
   func onlyParent1() {}
-  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
+  // CHECK: Func/onlyParent1 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1()</Name><USR>s:14swift_ide_test15ParentProtocol1P11onlyParent1yyF</USR><Declaration>func onlyParent1()</Declaration><CommentParts><Abstract><Para>ParentProtocol1.onlyParent1()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
 
   // Should come from ParentProtocol1.
   var onlyParent1Var: Int { return 0 }
-  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test13ChildProtocolPAAE14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
+  // CHECK: Var/onlyParent1Var {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent1Var</Name><USR>s:14swift_ide_test15ParentProtocol1P14onlyParent1VarSivp</USR><Declaration>var onlyParent1Var: Int { get }</Declaration><CommentParts><Abstract><Para>ParentProtocol.onlyParent1Var</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
 
   // Should come from ParentProtocol1.
   subscript(index: Int) -> Int { return 0 }
@@ -75,11 +75,11 @@ extension ChildProtocol {
 
   // Should come from ParentProtocol1.
   typealias AssocType = Int
-  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test13ChildProtocolPAAE9AssocTypea</USR><Declaration>typealias AssocType = Int</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
+  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocTypeQa</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol1</codeVoice>.</Para></Note></Discussion></CommentParts></Other>]
 
   // Should come from ParentProtocol2.
   func onlyParent2() {}
-  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test13ChildProtocolPAAE11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol2</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
+  // CHECK: Func/onlyParent2 {{.*}} DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>onlyParent2()</Name><USR>s:14swift_ide_test15ParentProtocol2P11onlyParent2yyF</USR><Declaration>func onlyParent2()</Declaration><CommentParts><Abstract><Para>ParentProtocol2.onlyParent2()</Para></Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ParentProtocol2</codeVoice>.</Para></Note></Discussion></CommentParts></Function>]
 
   // Should show nothing because the requirement is in both parents.
   func commonParentRequirement() {}

--- a/test/Misc/Inputs/dumped_api.swift
+++ b/test/Misc/Inputs/dumped_api.swift
@@ -55,5 +55,9 @@ public class FooIteratorBox<
   Base: IteratorProtocol
 > : AnyIterator<Base.Element> {
 
+  /// Advance to the next element and return it, or `nil` if no next
+  /// element exists.
+  ///
+  /// Note: subclasses must override this method.
   public override func next() -> Base.Element?
 }

--- a/test/SourceKit/CodeComplete/complete_docbrief_1.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_1.swift
@@ -1,0 +1,53 @@
+protocol P {
+  /// This is a doc comment of P.foo
+  ///
+  /// Do whatever.
+  func foo()
+
+  /// This is a doc comment of P.bar
+  ///
+  /// May have default information.
+  func bar()
+}
+
+extension P {
+  func bar() {}
+}
+
+struct S: P {
+  func foo() {}
+}
+
+func test() {
+  S().
+}
+
+// All in main module.
+// RUN: %sourcekitd-test -req=complete -pos=22:7 %s -- %s -module-name DocBriefTest | %FileCheck %s -check-prefix=CHECK
+
+// CHECK: {
+// CHECK:   key.results: [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "bar()",
+// CHECK-NEXT:       key.sourcetext: "bar()",
+// CHECK-NEXT:       key.description: "bar()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.bar",
+// CHECK-NEXT:       key.context: source.codecompletion.context.superclass,
+// CHECK-NEXT:       key.num_bytes_to_erase: 0,
+// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1PPAAE3baryyF",
+// CHECK-NEXT:       key.modulename: "DocBriefTest"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "foo()",
+// CHECK-NEXT:       key.sourcetext: "foo()",
+// CHECK-NEXT:       key.description: "foo()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+// CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.num_bytes_to_erase: 0,
+// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
+// CHECK-NEXT:       key.modulename: "DocBriefTest"
+// CHECK-NEXT:     }

--- a/test/SourceKit/CodeComplete/complete_docbrief_2.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_2.swift
@@ -1,0 +1,46 @@
+// BEGIN Module.swift
+public protocol P {
+  /// This is a doc comment of P.foo
+  ///
+  /// Do whatever.
+  func foo()
+}
+
+// BEGIN User.swift
+import DocBriefTest
+struct S: P {
+  func foo() {}
+}
+
+func test() {
+  S().
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
+// RUN:     %t/Module.swift
+
+// RUN: %sourcekitd-test -req=complete -pos=7:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
+
+// CHECK: {
+// CHECK:   key.results: [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "foo()",
+// CHECK-NEXT:       key.sourcetext: "foo()",
+// CHECK-NEXT:       key.description: "foo()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+// CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.num_bytes_to_erase: 0,
+// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefUser1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
+// CHECK-NEXT:       key.modulename: "DocBriefUser"
+// CHECK-NEXT:     }
+

--- a/test/SourceKit/CodeComplete/complete_docbrief_3.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_3.swift
@@ -1,0 +1,47 @@
+// BEGIN Module.swift
+public protocol P {
+  /// This is a doc comment of P.foo
+  ///
+  /// Do whatever.
+  func foo()
+}
+
+public struct S: P {
+  public init() {}
+  public func foo() {}
+}
+
+// BEGIN User.swift
+import DocBriefTest
+func test() {
+  S().foo()
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name DocBriefTest \
+// RUN:     -emit-module-path %t/Modules/DocBriefTest.swiftmodule \
+// RUN:     -emit-module-doc-path %t/Modules/DocBriefTest.swiftdoc \
+// RUN:     %t/Module.swift
+
+// RUN: %sourcekitd-test -req=complete -pos=3:7 %t/User.swift -- %t/User.swift -I %t/Modules -target %target-triple -module-name DocBriefUser | %FileCheck %s -check-prefix=CHECK
+
+// CHECK: {
+// CHECK:   key.results: [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
+// CHECK-NEXT:       key.name: "foo()",
+// CHECK-NEXT:       key.sourcetext: "foo()",
+// CHECK-NEXT:       key.description: "foo()",
+// CHECK-NEXT:       key.typename: "Void",
+// CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+// CHECK-NEXT:       key.context: source.codecompletion.context.thisclass,
+// CHECK-NEXT:       key.num_bytes_to_erase: 0,
+// CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
+// CHECK-NEXT:       key.modulename: "DocBriefTest"
+// CHECK-NEXT:     }
+

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -777,15 +777,6 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   }
   unsigned DocCommentEnd = SS.size();
 
-  if (DocCommentEnd == DocCommentBegin) {
-    if (auto *Req = ASTPrinter::findConformancesWithDocComment(
-        const_cast<ValueDecl*>(VD))) {
-      llvm::raw_svector_ostream OS(SS);
-      ide::getDocumentationCommentAsXML(Req, OS);
-    }
-    DocCommentEnd = SS.size();
-  }
-
   unsigned DeclBegin = SS.size();
   {
     llvm::raw_svector_ostream OS(SS);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2334,8 +2334,8 @@ public:
 
     swift::markup::MarkupContext MC;
     auto DC = getSingleDocComment(MC, D);
-    if (DC.hasValue())
-      swift::markup::dump(DC.getValue()->getDocument(), OS);
+    if (DC)
+      swift::markup::dump(DC->getDocument(), OS);
 
     return true;
   }


### PR DESCRIPTION
```swift
protocol MyProtocol {
  /// Doc for MyProtocol.foo
  func foo()

  /// Doc for MyProtocol.bar
  func bar()
}
class BaseClass {
  /// Doc for BaseClass.baz
  func baz() {}
}
```
These doc-comments are now inherited like:
```swift
extension MyProtocol {
  func foo() {} // Inherits doc from MyProtocol.foo()
}
class  DerivedClass : BaseClass {
  func bar() {} // Inherits doc from MyProtocol.bar()
  override func baz() {} // Inherits doc from BaseClass.baz()
}
```
rdar://problem/38422822
rdar://problem/49043711
rdar://problem/49066202