### PR TITLE
[5.1] api-digester: avoid looking up node update table to collect renamed declarations. NFC

### DIFF
--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -24,7 +24,7 @@ cake1: InfixOperator ..*.. has been changed to a PrefixOperator
 cake1: Protocol ProtocolToEnum has been changed to a Enum
 
 /* Renamed Decls */
-cake1: Func S1.foo5(x:y:) has been renamed to Func S1.foo5(x:y:z:)
+cake1: Func S1.foo5(x:y:) has been renamed to Func foo5(x:y:z:)
 cake1: Struct Somestruct2 has been renamed to Struct NSSomestruct2
 
 /* Type Changes */

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -23,7 +23,7 @@ cake1: InfixOperator ..*.. has been changed to a PrefixOperator
 cake1: Protocol ProtocolToEnum has been changed to a Enum
 
 /* Renamed Decls */
-cake1: Func S1.foo5(x:y:) has been renamed to Func S1.foo5(x:y:z:)
+cake1: Func S1.foo5(x:y:) has been renamed to Func foo5(x:y:z:)
 cake1: Struct Somestruct2 has been renamed to Struct NSSomestruct2
 
 /* Type Changes */

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1942,10 +1942,9 @@ void DiagnosisEmitter::handle(const SDKNodeDecl *Node, NodeAnnotation Anno) {
     return;
   }
   case NodeAnnotation::Rename: {
-    auto *Count = UpdateMap.findUpdateCounterpart(Node)->getAs<SDKNodeDecl>();
     Node->emitDiag(diag::renamed_decl,
-        Ctx.buffer((Twine(getDeclKindStr(Count->getDeclKind())) + " " +
-          Count->getFullyQualifiedName()).str()));
+        Ctx.buffer((Twine(getDeclKindStr(Node->getDeclKind())) + " " +
+          Node->getAnnotateComment(NodeAnnotation::RenameNewName)).str()));
     return;
   }
   default:


### PR DESCRIPTION
We could simply get the new name from the node annotation of the decl before renaming.
