### PR TITLE
[Serialization] Drop a class if the superclass can't be found

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 491; // mangled class names as vtable keys
+const uint16_t SWIFTMODULE_VERSION_MINOR = 492; // dependency types for classes
 
 using DeclIDField = BCFixed<31>;
 
@@ -981,7 +981,8 @@ namespace decls_block {
     TypeIDField,            // superclass
     AccessLevelField,       // access level
     BCVBR<4>,               // number of conformances
-    BCArray<TypeIDField>    // inherited types
+    BCVBR<4>,               // number of inherited types
+    BCArray<TypeIDField>    // inherited types, followed by dependency types
     // Trailed by the generic parameters (if any), the members record, and
     // finally conformance info (if any).
   >;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 492; // dependency types for classes
+const uint16_t SWIFTMODULE_VERSION_MINOR = 493; // dependency types for structs
 
 using DeclIDField = BCFixed<31>;
 
@@ -948,7 +948,8 @@ namespace decls_block {
     GenericEnvironmentIDField, // generic environment
     AccessLevelField,       // access level
     BCVBR<4>,               // number of conformances
-    BCArray<TypeIDField>    // inherited types
+    BCVBR<4>,               // number of inherited types
+    BCArray<TypeIDField>    // inherited types, followed by dependency types
     // Trailed by the generic parameters (if any), the members record, and
     // finally conformance info (if any).
   >;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2488,14 +2488,25 @@ public:
     bool isObjC;
     GenericEnvironmentID genericEnvID;
     uint8_t rawAccessLevel;
-    unsigned numConformances;
-    ArrayRef<uint64_t> rawInheritedIDs;
+    unsigned numConformances, numInheritedTypes;
+    ArrayRef<uint64_t> rawInheritedAndDependencyIDs;
 
     decls_block::StructLayout::readRecord(scratch, nameID, contextID,
                                           isImplicit, isObjC, genericEnvID,
                                           rawAccessLevel,
-                                          numConformances,
-                                          rawInheritedIDs);
+                                          numConformances, numInheritedTypes,
+                                          rawInheritedAndDependencyIDs);
+
+    Identifier name = MF.getIdentifier(nameID);
+
+    for (TypeID dependencyID :
+           rawInheritedAndDependencyIDs.slice(numInheritedTypes)) {
+      auto dependency = MF.getTypeChecked(dependencyID);
+      if (!dependency) {
+        return llvm::make_error<TypeError>(
+            name, takeErrorInfo(dependency.takeError()));
+      }
+    }
 
     auto DC = MF.getDeclContext(contextID);
     if (declOrOffset.isComplete())
@@ -2505,10 +2516,8 @@ public:
     if (declOrOffset.isComplete())
       return declOrOffset;
 
-    auto theStruct = MF.createDecl<StructDecl>(SourceLoc(),
-                                               MF.getIdentifier(nameID),
-                                               SourceLoc(), None, genericParams,
-                                               DC);
+    auto theStruct = MF.createDecl<StructDecl>(SourceLoc(), name, SourceLoc(),
+                                               None, genericParams, DC);
     declOrOffset = theStruct;
 
     // Read the generic environment.
@@ -2528,7 +2537,8 @@ public:
 
     theStruct->computeType();
 
-    handleInherited(theStruct, rawInheritedIDs);
+    handleInherited(theStruct,
+                    rawInheritedAndDependencyIDs.slice(0, numInheritedTypes));
 
     theStruct->setMemberLoader(&MF, MF.DeclTypeCursor.GetCurrentBitNo());
     skipRecord(MF.DeclTypeCursor, decls_block::MEMBERS);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3418,15 +3418,27 @@ public:
     GenericEnvironmentID genericEnvID;
     TypeID superclassID;
     uint8_t rawAccessLevel;
-    unsigned numConformances;
-    ArrayRef<uint64_t> rawInheritedIDs;
+    unsigned numConformances, numInheritedTypes;
+    ArrayRef<uint64_t> rawInheritedAndDependencyIDs;
     decls_block::ClassLayout::readRecord(scratch, nameID, contextID,
                                          isImplicit, isObjC,
                                          requiresStoredPropertyInits,
                                          inheritsSuperclassInitializers,
                                          genericEnvID, superclassID,
                                          rawAccessLevel, numConformances,
-                                         rawInheritedIDs);
+                                         numInheritedTypes,
+                                         rawInheritedAndDependencyIDs);
+
+    Identifier name = MF.getIdentifier(nameID);
+
+    for (TypeID dependencyID :
+           rawInheritedAndDependencyIDs.slice(numInheritedTypes)) {
+      auto dependency = MF.getTypeChecked(dependencyID);
+      if (!dependency) {
+        return llvm::make_error<TypeError>(
+            name, takeErrorInfo(dependency.takeError()));
+      }
+    }
 
     auto DC = MF.getDeclContext(contextID);
     if (declOrOffset.isComplete())
@@ -3436,10 +3448,8 @@ public:
     if (declOrOffset.isComplete())
       return declOrOffset;
 
-    auto theClass = MF.createDecl<ClassDecl>(SourceLoc(),
-                                             MF.getIdentifier(nameID),
-                                             SourceLoc(), None, genericParams,
-                                             DC);
+    auto theClass = MF.createDecl<ClassDecl>(SourceLoc(), name, SourceLoc(),
+                                             None, genericParams, DC);
     declOrOffset = theClass;
 
     MF.configureGenericEnvironment(theClass, genericEnvID);
@@ -3463,7 +3473,8 @@ public:
 
     theClass->computeType();
 
-    handleInherited(theClass, rawInheritedIDs);
+    handleInherited(theClass,
+                    rawInheritedAndDependencyIDs.slice(0, numInheritedTypes));
 
     theClass->setMemberLoader(&MF, MF.DeclTypeCursor.GetCurrentBitNo());
     theClass->setHasDestructor();

--- a/test/Serialization/Recovery/Inputs/custom-modules/SuperclassObjC.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/SuperclassObjC.h
@@ -1,0 +1,9 @@
+@interface Root
+- (instancetype)init;
+@end
+
+#if !BAD
+@interface DisappearingSuperclass : Root
+@end
+#else
+#endif

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -9,6 +9,7 @@ module IndirectlyImported {
 module Overrides { header "Overrides.h" }
 module ProtocolInheritance { header "ProtocolInheritance.h" }
 module RenameAcrossVersions { header "RenameAcrossVersions.h" }
+module SuperclassObjC { header "SuperclassObjC.h" }
 module Typedefs { header "Typedefs.h" }
 module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }

--- a/test/Serialization/Recovery/superclass.swift
+++ b/test/Serialization/Recovery/superclass.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-sil -enable-objc-interop -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules %s > /dev/null
+
+// RUN: %target-swift-ide-test -enable-objc-interop -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck -check-prefix CHECK -check-prefix CHECK-ALWAYS %s
+
+// RUN: %target-swift-ide-test -enable-objc-interop -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD | %FileCheck -check-prefix CHECK-RECOVERY -check-prefix CHECK-ALWAYS %s
+
+// RUN: %target-swift-frontend -typecheck -enable-objc-interop -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s -verify
+
+#if TEST
+
+import Lib
+
+func use(_: C2_CRTPish) {}
+func use(_: C3_NestingCRTPish) {}
+func use(_: C4_ExtensionNestingCRTPish) {}
+
+// FIXME: Better to import the class and make it unavailable.
+func use(_: A1_Sub) {} // expected-error {{use of undeclared type 'A1_Sub'}}
+func use(_: A2_Grandchild) {} // expected-error {{use of undeclared type 'A2_Grandchild'}}
+
+#else // TEST
+
+import SuperclassObjC
+
+// CHECK-LABEL: class A1_Sub : DisappearingSuperclass {
+// CHECK-RECOVERY-NOT: class A1_Sub
+public class A1_Sub: DisappearingSuperclass {}
+// CHECK-LABEL: class A2_Grandchild : A1_Sub {
+// CHECK-RECOVERY-NOT: class A2_Grandchild
+public class A2_Grandchild: A1_Sub {}
+
+// CHECK-LABEL: class B_ConstrainedGeneric<T> where T : DisappearingSuperclass {
+// CHECK-RECOVERY-NOT: class B_ConstrainedGeneric
+public class B_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
+
+// CHECK-ALWAYS-LABEL: class C1_GenericBase<T> {
+public class C1_GenericBase<T> {}
+
+// CHECK-ALWAYS-LABEL: class C2_CRTPish : C1_GenericBase<C2_CRTPish> {
+public class C2_CRTPish: C1_GenericBase<C2_CRTPish> {}
+// CHECK-ALWAYS-LABEL: class C3_NestingCRTPish : C1_GenericBase<C3_NestingCRTPish.Nested> {
+public class C3_NestingCRTPish: C1_GenericBase<C3_NestingCRTPish.Nested> {
+  public struct Nested {}
+}
+// CHECK-ALWAYS-LABEL: class C4_ExtensionNestingCRTPish : C1_GenericBase<C4_ExtensionNestingCRTPish.Nested> {
+public class C4_ExtensionNestingCRTPish: C1_GenericBase<C4_ExtensionNestingCRTPish.Nested> {}
+extension C4_ExtensionNestingCRTPish {
+  public struct Nested {}
+}
+
+#endif // TEST

--- a/test/Serialization/Recovery/superclass.swift
+++ b/test/Serialization/Recovery/superclass.swift
@@ -30,9 +30,13 @@ public class A1_Sub: DisappearingSuperclass {}
 // CHECK-RECOVERY-NOT: class A2_Grandchild
 public class A2_Grandchild: A1_Sub {}
 
-// CHECK-LABEL: class B_ConstrainedGeneric<T> where T : DisappearingSuperclass {
-// CHECK-RECOVERY-NOT: class B_ConstrainedGeneric
-public class B_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
+// CHECK-LABEL: class B1_ConstrainedGeneric<T> where T : DisappearingSuperclass {
+// CHECK-RECOVERY-NOT: class B1_ConstrainedGeneric
+public class B1_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
+
+// CHECK-LABEL: struct B2_ConstrainedGeneric<T> where T : DisappearingSuperclass {
+// CHECK-RECOVERY-NOT: struct B2_ConstrainedGeneric
+public struct B2_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
 
 // CHECK-ALWAYS-LABEL: class C1_GenericBase<T> {
 public class C1_GenericBase<T> {}

--- a/test/Serialization/Recovery/typedefs-in-enums.swift
+++ b/test/Serialization/Recovery/typedefs-in-enums.swift
@@ -110,4 +110,31 @@ public func producesOkayEnum() -> OkayEnum { return .noPayload }
 // CHECK-LABEL: func producesOkayEnum() -> OkayEnum
 // CHECK-RECOVERY-LABEL: func producesOkayEnum() -> OkayEnum
 
+
+extension Int /* or any imported type, really */ {
+  public enum OkayEnumWithSelfRefs {
+    public struct Nested {}
+    indirect case selfRef(OkayEnumWithSelfRefs)
+    case nested(Nested)
+  }
+}
+// CHECK-LABEL: extension Int {
+//  CHECK-NEXT:   enum OkayEnumWithSelfRefs {
+//  CHECK-NEXT:     struct Nested {
+//  CHECK-NEXT:       init()
+//  CHECK-NEXT:     }
+//  CHECK-NEXT:     indirect case selfRef(Int.OkayEnumWithSelfRefs)
+//  CHECK-NEXT:     case nested(Int.OkayEnumWithSelfRefs.Nested)
+//  CHECK-NEXT:   }
+//  CHECK-NEXT: }
+// CHECK-RECOVERY-LABEL: extension Int {
+//  CHECK-RECOVERY-NEXT:   enum OkayEnumWithSelfRefs {
+//  CHECK-RECOVERY-NEXT:     struct Nested {
+//  CHECK-RECOVERY-NEXT:       init()
+//  CHECK-RECOVERY-NEXT:     }
+//  CHECK-RECOVERY-NEXT:     indirect case selfRef(Int.OkayEnumWithSelfRefs)
+//  CHECK-RECOVERY-NEXT:     case nested(Int.OkayEnumWithSelfRefs.Nested)
+//  CHECK-RECOVERY-NEXT:   }
+//  CHECK-RECOVERY-NEXT: }
+
 #endif // TEST

--- a/validation-test/Serialization/Inputs/custom-modules/SuperclassObjC.h
+++ b/validation-test/Serialization/Inputs/custom-modules/SuperclassObjC.h
@@ -1,0 +1,9 @@
+@interface Root
+- (instancetype)init;
+@end
+
+#if !BAD
+@interface DisappearingSuperclass : Root
+@end
+#else
+#endif

--- a/validation-test/Serialization/Inputs/custom-modules/module.modulemap
+++ b/validation-test/Serialization/Inputs/custom-modules/module.modulemap
@@ -1,1 +1,2 @@
 module rdar40899824Helper { header "rdar40899824Helper.h" }
+module SuperclassObjC { header "SuperclassObjC.h" }

--- a/validation-test/Serialization/crash-superclass-dependency-cycle.swift
+++ b/validation-test/Serialization/crash-superclass-dependency-cycle.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Lib.swiftmodule -I %S/Inputs/custom-modules %s
+
+// FIXME: We need a way to handle the cyclic dependency here.
+// rdar://problem/50835214
+// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DBAD
+
+public class GenericBase<T> {}
+public class Sub: GenericBase<Grandchild.Nested> {
+}
+public class Grandchild: Sub {
+  public class Nested {}
+}

--- a/validation-test/Serialization/crash-superclass-dependency-removal.swift
+++ b/validation-test/Serialization/crash-superclass-dependency-removal.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Lib.swiftmodule -enable-objc-interop -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -enable-objc-interop -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// FIXME: We need a way to handle the disappearing superclass in a position we
+// can't track easily from the containing class. rdar://problem/50835214
+// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -enable-objc-interop -I %t -I %S/Inputs/custom-modules -Xcc -DBAD
+
+import SuperclassObjC
+
+public class GenericBase<T> {}
+
+// CHECK: class Sub : GenericBase<Sub.Nested> {
+public class Sub: GenericBase<Sub.Nested> {
+  public class Nested: DisappearingSuperclass {}
+}


### PR DESCRIPTION
...instead of crashing. Not a perfect answer because it opens us up to cyclic dependencies that weren't there before (see the new validation-test cases), but probably a net win in practice.

rdar://problem/50125674