### PR TITLE
Add the protocols RealFunctions and Real

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -510,7 +510,7 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 }
 
 //===----------------------------------------------------------------------===//
-// RealProtocol conformance
+// Real protocol conformance
 //===----------------------------------------------------------------------===//
 
 %from SwiftMathFunctions import *

--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -510,12 +510,12 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 }
 
 //===----------------------------------------------------------------------===//
-// Real conformance
+// RealProtocol conformance
 //===----------------------------------------------------------------------===//
 
 %from SwiftMathFunctions import *
 
-extension CGFloat: ElementaryFunctions {
+extension CGFloat: Real {
 % for func in ElementaryFunctions + RealFunctions:
 
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -30,7 +30,7 @@ import SwiftShims
 /// ```
 ///
 /// Additional operations, such as `atan2(y:x:)`, `hypot(_:_:)` and some
-/// special functions, are provided on the Real protocol, which refines both
+/// special functions, are provided on Real, which refines both
 /// ElementaryFunctions and FloatingPoint.
 ///
 /// [elfn]: http://en.wikipedia.org/wiki/Elementary_function
@@ -60,12 +60,82 @@ public protocol ElementaryFunctions {
   static func root(_ x: Self, _ n: Int) -> Self
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol RealFunctions: ElementaryFunctions {
+%for func in RealFunctions:
+
+  ${func.comment}
+  static func ${func.decl("Self")}
+%end
+
+  /// `atan(y/x)` with quadrant fixup.
+  ///
+  /// There is an infinite family of angles whose tangent is `y/x`. `atan2`
+  /// selects the representative that is the angle between the vector `(x, y)`
+  /// and the real axis in the range [-π, π].
+  static func atan2(y: Self, x: Self) -> Self
+
+#if !os(Windows)
+  //  lgamma is not available on Windows.
+  //  TODO: provide an implementation of lgamma with the stdlib to support
+  //  Windows so we can vend a uniform interface.
+
+  /// `log(gamma(x))` computed without undue overflow.
+  ///
+  /// `log(abs(gamma(x)))` is returned. To get the sign of `gamma(x)` cheaply,
+  /// use `signGamma(x)`.
+  static func logGamma(_ x: Self) -> Self
+#endif
+}
+
+/// A type that models the real numbers.
+///
+/// Conformance to this protocol means that all the FloatingPoint operations
+/// are available, as well as the ElementaryFunctions, plus the following
+/// additional math functions: atan2, erf, erc, hypot, tgamma.
+///
+/// logGamma and signGamma are also available on non-Windows platforms.
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+public protocol Real: RealFunctions, FloatingPoint { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension Real {
+#if !os(Windows)
+  //  lgamma is not available on Windows; no lgamma means signGamma
+  //  is basically useless, so don't bother exposing it.
+
+  /// The sign of `gamma(x)`.
+  ///
+  /// This function is typically used in conjunction with `logGamma(x)`, which
+  /// computes `log(abs(gamma(x)))`, to recover the sign information that is
+  /// lost to the absolute value.
+  ///
+  /// `gamma(x)` has a simple pole at each non-positive integer and an
+  /// essential singularity at infinity; we arbitrarily choose to return
+  /// `.plus` for the sign in those cases. For all other values, `signGamma(x)`
+  /// is `.plus` if `x >= 0` or `trunc(x)` is odd, and `.minus` otherwise.
+  @_alwaysEmitIntoClient
+  public static func signGamma(_ x: Self) -> FloatingPointSign {
+    if x >= 0 { return .plus }
+    let trunc = x.rounded(.towardZero)
+    // Treat poles as gamma(x) == +inf. This is arbitrary, but we need to
+    // pick one sign or the other.
+    if x == trunc { return .plus }
+    // Result is .minus if trunc is even, .plus otherwise. To figure out if
+    // trunc is even or odd, check if trunc/2 is an integer.
+    let halfTrunc = trunc/2
+    if halfTrunc == halfTrunc.rounded(.towardZero) { return .minus }
+    return .plus
+  }
+#endif
+}
+
 %for type in all_floating_point_types():
 % if type.bits == 80:
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
 % end
 % Self = type.stdlib_name
-extension ${Self}: ElementaryFunctions {
+extension ${Self}: Real {
 % for func in ElementaryFunctions + RealFunctions:
 
   @_alwaysEmitIntoClient
@@ -167,7 +237,43 @@ extension SIMD where Scalar: ElementaryFunctions {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD where Scalar: RealFunctions {
+% for func in RealFunctions:
+
+  @_alwaysEmitIntoClient
+  public static func ${func.decl("Self")} {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.${func.swiftName}(${func.params(suffix="[i]")})
+    }
+    return r
+  }
+% end
+
+  public static func atan2(y: Self, x: Self) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.atan2(y: y[i], x: x[i])
+    }
+    return r
+  }
+#if !os(Windows)
+
+  public static func logGamma(_ x: Self) -> Self {
+    var r = Self()
+    for i in r.indices {
+      r[i] = Scalar.logGamma(x[i])
+    }
+    return r
+  }
+#endif
+}
+
 %for n in [2,3,4,8,16,32,64]:
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension SIMD${n}: ElementaryFunctions where Scalar: ElementaryFunctions { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension SIMD${n}: RealFunctions where Scalar: RealFunctions { }
 %end

--- a/test/stdlib/MathFunctions.swift.gyb
+++ b/test/stdlib/MathFunctions.swift.gyb
@@ -79,6 +79,22 @@ internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+internal extension Real where Self: BinaryFloatingPoint {
+  static func realFunctionTests() {
+    expectEqualWithTolerance(0.54041950027058415544357836460859991, Self.atan2(y: 0.375, x: 0.625))
+    expectEqualWithTolerance(0.72886898685566255885926910969319788, Self.hypot(0.375, 0.625))
+    expectEqualWithTolerance(0.4041169094348222983238250859191217675, Self.erf(0.375))
+    expectEqualWithTolerance(0.5958830905651777016761749140808782324, Self.erfc(0.375))
+    expectEqualWithTolerance(2.3704361844166009086464735041766525098, Self.gamma(0.375))
+#if !os(Windows)
+    expectEqualWithTolerance( -0.11775527074107877445136203331798850, Self.logGamma(1.375), ulps: 16)
+    expectEqual(.plus,  Self.signGamma(1.375))
+    expectEqual(.minus, Self.signGamma(-2.375))
+#endif
+  }
+}
+
 %for T in ['Float', 'Double', 'CGFloat', 'Float80']:
 % if T == 'Float80':
 #if (arch(i386) || arch(x86_64)) && !os(Windows)
@@ -90,6 +106,7 @@ internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
 MathTests.test("${T}") {
   if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
     ${T}.elementaryFunctionTests()
+    ${T}.realFunctionTests()
   }
 }
 


### PR DESCRIPTION
RealFunctions refines ElementaryFunctions, adding operations that only make sense for types that model the real numbers (as opposed to complex, quaternions, matrices, etc, which all can plausibly conform to ElementaryFunctions). SIMD types whose elements conform also conform, beecause the operations are interpreted componentwise.

We also introduce Real, which restricts to RealFunctions + FloatingPoint, effectively removing the SIMD types. This does not add any new conformances; rather it is intended as a practical protocol for use in writing generic code (which would otherwise be constrained to RealFunctions & FloatingPoint more often than not).

This is a small modification of what we pitched and approved as SE-0246, so I'm going to re-pitch and run a minor revision proposal through SE for it.