### PR TITLE
[AutoDiff] [stdlib] Deprecate 'CotangentVector' in favor of 'TangentVector'.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -107,7 +107,6 @@ namespace swift {
   class VarDecl;
   class UnifiedStatsReporter;
   // SWIFT_ENABLE_TENSORFLOW
-  enum class AutoDiffAssociatedVectorSpaceKind : unsigned;
   class VectorSpace;
   class AutoDiffParameterIndices;
   class DifferentiableAttr;
@@ -276,8 +275,7 @@ public:
   llvm::StringMap<Type> RemappedTypes;
 
   /// Cache of autodiff-associated vector spaces.
-  llvm::DenseMap<std::pair<Type, unsigned>,
-                 Optional<VectorSpace>> AutoDiffVectorSpaces;
+  llvm::DenseMap<Type, Optional<VectorSpace>> AutoDiffVectorSpaces;
 
   /// Cache of `@differentiable` attributes keyed by parameter indices. This
   /// helps us diagnose multiple `@differentiable`s that are with respect to the

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -551,11 +551,6 @@ public:
   }
 };
 
-/// The kind of an associated type.
-enum class AutoDiffAssociatedVectorSpaceKind : unsigned {
-  Tangent = 0, Cotangent = 1
-};
-
 /// Automatic differentiation utility namespace.
 namespace autodiff {
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2715,7 +2715,7 @@ NOTE(protocol_witness_missing_specific_differentiable_attr,none,
 // @differentiating
 ERROR(differentiating_attr_expected_result_tuple,none,
       "'@differentiating' attribute requires function to return a two-element tuple of type "
-      "'(value: T..., pullback: (U.CotangentVector) -> T.CotangentVector...)' or "
+      "'(value: T..., pullback: (U.TangentVector) -> T.TangentVector...)' or "
       "'(value: T..., differential: (T.TangentVector...) -> U.TangentVector)'", ())
 ERROR(differentiating_attr_invalid_result_tuple_value_label,none,
       "'@differentiating' attribute requires function to return a two-element "

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -135,11 +135,9 @@ IDENTIFIER(zero)
 IDENTIFIER(Scalar)
 // Differentiable
 IDENTIFIER(AllDifferentiableVariables)
-IDENTIFIER(CotangentVector)
 IDENTIFIER(TangentVector)
 IDENTIFIER(allDifferentiableVariables)
 IDENTIFIER(moved)
-IDENTIFIER(tangentVector)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -86,9 +86,6 @@ PROTOCOL(TensorGroup)
 PROTOCOL_(TensorFlowDataTypeCompatible)
 PROTOCOL(TensorProtocol)
 PROTOCOL(VectorNumeric)
-// TODO(TF-213): Remove underscore `Differentiable` protocols.
-PROTOCOL(__Differentiable)
-PROTOCOL(_Differentiable)
 PROTOCOL(Differentiable)
 
 PROTOCOL_(ObjectiveCBridgeable)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1096,20 +1096,17 @@ public:
   TypeTraitResult canBeClass();
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Return the associated tangent or cotangent type. Return the null type if
-  /// there is no associated tangent/cotangent type.
-  ///
-  /// `kind` specifies whether to return the tangent or cotangent type.
+  /// Return the associated tangent type. Return the null type if there is no
+  /// associated tangent type.
   ///
   /// If the type conforms to `Differentiable`, then the associated
-  /// tangent/cotangent type is the associated `TangentVector`/`CotangentVector`
-  /// from the `Differentiable` requirement. If the type is a tuple, then the
-  /// associated tangent/cotangent type is the elementwise tangent/cotangent
-  /// type of its elements. If the type is a builtin float, then the associated
-  /// tangent/cotangent type is itself. Otherwise, there is no associated type.
+  /// tangent type is the associated `TangentVector` from the `Differentiable`
+  /// requirement. If the type is a tuple, then the associated tangent type is
+  /// the elementwise tangent type of its elements. If the type is a builtin
+  /// float, then the associated tangent type is itself. Otherwise, there is no
+  /// associated type.
   Optional<VectorSpace>
-  getAutoDiffAssociatedVectorSpace(AutoDiffAssociatedVectorSpaceKind kind,
-                                   LookupConformanceFn lookupConformance);
+  getAutoDiffAssociatedTangentSpace(LookupConformanceFn lookupConformance);
 
 private:
   // Make vanilla new/delete illegal for Types.
@@ -3074,12 +3071,12 @@ public:
   ///
   /// By default, if the original type has a self parameter list and parameter
   /// indices include self, the computed associated function type will return a
-  /// linear map taking/returning self's tangent/cotangent *last* instead of
-  /// first, for consistency with SIL.
+  /// linear map taking/returning self's tangent *last* instead of first, for
+  /// consistency with SIL.
   ///
-  /// If `makeSelfParamFirst` is true, self's tangent/cotangent is reordered to
-  /// appear first. This should be used during type-checking, e.g.
-  /// type-checking `@differentiable` and `@differentiating` attributes.
+  /// If `makeSelfParamFirst` is true, self's tangent is reordered to appear
+  /// first. This should be used during type-checking, e.g. type-checking
+  /// `@differentiable` and `@differentiating` attributes.
   ///
   /// \note The original function type (`self`) need not be `@differentiable`.
   /// The resulting function will preserve all `ExtInfo` of the original

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -985,7 +985,7 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   //       rethrows -> (R, (...T.TangentVector) -> R.TangentVector)
   // VJP:
   //   <...T...(arity), R> (@differentiable (...T) throws -> R, ...T)
-  //       rethrows -> (R, (R.CotangentVector) -> ...T.CotangentVector)
+  //       rethrows -> (R, (R.TangentVector) -> ...T.TangentVector)
   unsigned numGenericParams = 1 + arity;
   BuiltinGenericSignatureBuilder builder(Context, numGenericParams);
   // Look up the Differentiable protocol.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4364,13 +4364,12 @@ makeFunctionType(AnyFunctionType *copy, ArrayRef<AnyFunctionType::Param> params,
   return FunctionType::get(params, retTy, copy->getExtInfo());
 }
 
-Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
-    AutoDiffAssociatedVectorSpaceKind kind,
+Optional<VectorSpace> TypeBase::getAutoDiffAssociatedTangentSpace(
     LookupConformanceFn lookupConformance) {
   assert(lookupConformance);
   auto &ctx = getASTContext();
 
-  std::pair<Type, unsigned> cacheKey {this, (unsigned)kind};
+  Type cacheKey = this;
   auto lookup = ctx.AutoDiffVectorSpaces.find(cacheKey);
   if (lookup != ctx.AutoDiffVectorSpaces.end())
     return lookup->getSecond();
@@ -4379,11 +4378,11 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
     return vs;
   };
 
-  // Functions' tangent/cotangent is the same function except the innermost
-  // return type being replaced by its tangent/cotangent.
+  // Functions' tangent is the same function except the innermost return type
+  // being replaced by its tangent.
   if (auto *fnTy = getAs<AnyFunctionType>()) {
-    auto resultSpace = fnTy->getResult()->getAutoDiffAssociatedVectorSpace(
-        kind, lookupConformance);
+    auto resultSpace = fnTy->getResult()->getAutoDiffAssociatedTangentSpace(
+        lookupConformance);
     if (!resultSpace)
       return cache(None);
     return cache(VectorSpace::getFunction(
@@ -4391,12 +4390,12 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
                          fnTy->getOptGenericSignature())));
   }
 
-  // Tuples' tangent/cotangent is a tuple of each element's Tangent/Cotangent.
+  // Tuples' tangent is a tuple of each element's Tangent.
   if (auto *tupleTy = getAs<TupleType>()) {
     SmallVector<TupleTypeElt, 8> newElts;
     for (auto elt : tupleTy->getElements()) {
       auto eltSpace = elt.getType()
-          ->getAutoDiffAssociatedVectorSpace(kind, lookupConformance);
+          ->getAutoDiffAssociatedTangentSpace(lookupConformance);
       if (!eltSpace)
         continue;
       newElts.push_back(elt.getWithType(eltSpace->getType()));
@@ -4410,22 +4409,12 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedVectorSpace(
     return cache(VectorSpace::getTuple(tupleType));
   }
 
-  // Find the TangentVector/CotangentVector associated type on the
-  // Differentiable protocol.
+  // Find the TangentVector associated type on the Differentiable protocol.
   auto *differentiableProtocol =
-      ctx.getProtocol(KnownProtocolKind::__Differentiable);
+      ctx.getProtocol(KnownProtocolKind::Differentiable);
   assert(differentiableProtocol && "Could not find __Differentiable protocol");
-  Identifier associatedTypeIdentifier;
-  switch (kind) {
-  case AutoDiffAssociatedVectorSpaceKind::Tangent:
-    associatedTypeIdentifier = ctx.Id_TangentVector;
-    break;
-  case AutoDiffAssociatedVectorSpaceKind::Cotangent:
-    associatedTypeIdentifier = ctx.Id_CotangentVector;
-    break;
-  }
   auto associatedTypeLookup =
-      differentiableProtocol->lookupDirect(associatedTypeIdentifier);
+      differentiableProtocol->lookupDirect(ctx.Id_TangentVector);
   assert(associatedTypeLookup.size() == 1);
   auto *dependentType = DependentMemberType::get(
       differentiableProtocol->getDeclaredInterfaceType(),
@@ -4448,7 +4437,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
   // JVP: (T...) -> ((R...),
   //                 (T.TangentVector...) -> (R.TangentVector...))
   // VJP: (T...) -> ((R...),
-  //                 (R.CotangentVector...) -> (T.CotangentVector...))
+  //                 (R.TangentVector...) -> (T.TangentVector...))
   //
   // Note that both can be written as "(T...) -> ((R...), Closure)", so we build
   // "Closure" and then use common code to wrap "Closure" in the outer function
@@ -4487,23 +4476,20 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
     SmallVector<AnyFunctionType::Param, 8> differentialParams;
     for (auto wrtParamType : wrtParamTypes)
       differentialParams.push_back(
-          AnyFunctionType::Param(wrtParamType->getAutoDiffAssociatedVectorSpace(
-              AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
+          AnyFunctionType::Param(
+              wrtParamType->getAutoDiffAssociatedTangentSpace(lookupConformance)
                   ->getType()));
 
     SmallVector<TupleTypeElt, 8> differentialResults;
     if (auto *resultTuple = originalResult->getAs<TupleType>()) {
       auto resultTupleEltType = resultTuple->getElementType(resultIndex);
-      differentialResults.push_back(
-          resultTupleEltType->getAutoDiffAssociatedVectorSpace(
-              AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
-                  ->getType());
+      differentialResults.push_back(resultTupleEltType
+          ->getAutoDiffAssociatedTangentSpace(lookupConformance)->getType());
     } else {
       assert(resultIndex == 0 && "resultIndex out of bounds");
       differentialResults.push_back(
-          originalResult->getAutoDiffAssociatedVectorSpace(
-              AutoDiffAssociatedVectorSpaceKind::Tangent, lookupConformance)
-                  ->getType());
+          originalResult->getAutoDiffAssociatedTangentSpace(lookupConformance)
+              ->getType());
     }
     Type differentialResult =
         differentialResults.size() > 1
@@ -4515,28 +4501,26 @@ AnyFunctionType *AnyFunctionType::getAutoDiffAssociatedFunctionType(
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
     // closure is the VJP "pullback":
-    //   (R.CotangentVector...) -> (T.CotangentVector...)
+    //   (R.TangentVector...) -> (T.TangentVector...)
     SmallVector<AnyFunctionType::Param, 8> pullbackParams;
     if (auto *resultTuple = originalResult->getAs<TupleType>()) {
       auto resultTupleEltType = resultTuple->getElementType(resultIndex);
       pullbackParams.push_back(
-          AnyFunctionType::Param(
-              resultTupleEltType->getAutoDiffAssociatedVectorSpace(
-                  AutoDiffAssociatedVectorSpaceKind::Cotangent,
-                  lookupConformance)->getType()));
+          AnyFunctionType::Param(resultTupleEltType
+              ->getAutoDiffAssociatedTangentSpace(lookupConformance)
+                  ->getType()));
     } else {
       assert(resultIndex == 0 && "resultIndex out of bounds");
       pullbackParams.push_back(
-          AnyFunctionType::Param(
-              originalResult->getAutoDiffAssociatedVectorSpace(
-                  AutoDiffAssociatedVectorSpaceKind::Cotangent,
-                  lookupConformance)->getType()));
+          AnyFunctionType::Param(originalResult
+              ->getAutoDiffAssociatedTangentSpace(lookupConformance)
+                  ->getType()));
     }
 
     SmallVector<TupleTypeElt, 8> pullbackResults;
     for (auto wrtParamType : wrtParamTypes)
-      pullbackResults.push_back(wrtParamType->getAutoDiffAssociatedVectorSpace(
-          AutoDiffAssociatedVectorSpaceKind::Cotangent, lookupConformance)
+      pullbackResults.push_back(wrtParamType
+          ->getAutoDiffAssociatedTangentSpace(lookupConformance)
               ->getType());
     Type pullbackResult = pullbackResults.size() > 1
                               ? TupleType::get(pullbackResults, ctx)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4412,7 +4412,7 @@ Optional<VectorSpace> TypeBase::getAutoDiffAssociatedTangentSpace(
   // Find the TangentVector associated type on the Differentiable protocol.
   auto *differentiableProtocol =
       ctx.getProtocol(KnownProtocolKind::Differentiable);
-  assert(differentiableProtocol && "Could not find __Differentiable protocol");
+  assert(differentiableProtocol && "Could not find Differentiable protocol");
   auto associatedTypeLookup =
       differentiableProtocol->lookupDirect(ctx.Id_TangentVector);
   assert(associatedTypeLookup.size() == 1);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4192,9 +4192,6 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::TensorFlowDataTypeCompatible:
   case KnownProtocolKind::TensorProtocol:
   case KnownProtocolKind::VectorNumeric:
-  // TODO(TF-213): Remove underscore `Differentiable` protocols.
-  case KnownProtocolKind::__Differentiable:
-  case KnownProtocolKind::_Differentiable:
   case KnownProtocolKind::Differentiable:
     return SpecialProtocol::None;
   }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -595,7 +595,6 @@ bool SILType::isLoweringOf(SILModule &Mod, CanType formalType) {
 // SWIFT_ENABLE_TENSORFLOW
 /// Returns true if this SILType is a differentiable type.
 bool SILType::isDifferentiable(SILModule &M) const {
-  return getASTType()->getAutoDiffAssociatedVectorSpace(
-      AutoDiffAssociatedVectorSpaceKind::Tangent,
+  return getASTType()->getAutoDiffAssociatedTangentSpace(
       LookUpConformanceInModule(M.getSwiftModule())).hasValue();
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3444,8 +3444,8 @@ SILGenFunction::getOrCreateAutoDiffLinearMapReorderingThunk(
     break;
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
-    auto selfCotanInfo = thunkConv.getResults().back();
-    if (selfCotanInfo.isFormalDirect()) {
+    auto selfTanInfo = thunkConv.getResults().back();
+    if (selfTanInfo.isFormalDirect()) {
       for (auto *indRes : indirectResults)
         argValues.push_back(indRes);
     } else {
@@ -3468,8 +3468,8 @@ SILGenFunction::getOrCreateAutoDiffLinearMapReorderingThunk(
     break;
   }
   case AutoDiffAssociatedFunctionKind::VJP: {
-    auto selfCotanInfo = thunkConv.getResults().back();
-    if (selfCotanInfo.isFormalIndirect()) {
+    auto selfTanInfo = thunkConv.getResults().back();
+    if (selfTanInfo.isFormalIndirect()) {
       thunkSGF.B.createReturn(loc, apply);
       break;
     }
@@ -3572,7 +3572,7 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionReorderingThunk(
 
   // Otherwise, generate a thunk for reordering:
   // - The differential self tangent parameter: move from first to last.
-  // - The pullback self cotangent result: move from first to last.
+  // - The pullback self tangent result: move from first to last.
   SmallVector<SILValue, 8> directResults;
   extractAllElements(apply, thunkSGF.B, directResults);
   auto linearMap = directResults.back();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -83,7 +83,7 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
     return canDeriveVectorNumeric(Nominal, DC);
 
   // SWIFT_ENABLE_TENSORFLOW
-  if (*knownProtocol == KnownProtocolKind::__Differentiable)
+  if (*knownProtocol == KnownProtocolKind::Differentiable)
     return canDeriveDifferentiable(Nominal, DC);
 
   if (auto *enumDecl = dyn_cast<EnumDecl>(Nominal)) {
@@ -244,7 +244,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     // SWIFT_ENABLE_TENSORFLOW
     // Differentiable.allDifferentiableVariables
     if (name.isSimpleName(ctx.Id_allDifferentiableVariables))
-      return getRequirement(KnownProtocolKind::__Differentiable);
+      return getRequirement(KnownProtocolKind::Differentiable);
 
     return nullptr;
   }
@@ -305,18 +305,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
       auto argumentNames = name.getArgumentNames();
       if (argumentNames.size() == 1 &&
           argumentNames[0] == ctx.getIdentifier("along")) {
-        return getRequirement(KnownProtocolKind::__Differentiable);
-      }
-    }
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // Differentiable.tangentVector(from:)
-    if (name.isCompoundName() &&
-        name.getBaseName() == ctx.Id_tangentVector) {
-      auto argumentNames = name.getArgumentNames();
-      if (argumentNames.size() == 1 &&
-          argumentNames[0] == ctx.getIdentifier("from")) {
-        return getRequirement(KnownProtocolKind::__Differentiable);
+        return getRequirement(KnownProtocolKind::Differentiable);
       }
     }
 
@@ -374,12 +363,10 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
 
     // SWIFT_ENABLE_TENSORFLOW
     // Differentiable.TangentVector
-    // Differentiable.CotangentVector
     // Differentiable.AllDifferentiableVariables
     if (name.isSimpleName(ctx.Id_TangentVector) ||
-        name.isSimpleName(ctx.Id_CotangentVector) ||
         name.isSimpleName(ctx.Id_AllDifferentiableVariables))
-      return getRequirement(KnownProtocolKind::__Differentiable);
+      return getRequirement(KnownProtocolKind::Differentiable);
 
     // SWIFT_ENABLE_TENSORFLOW
     // VectorNumeric.Scalar

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3191,7 +3191,7 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
 
   // The result type should be a two-element tuple.
   // Either a value and pullback:
-  //     (value: R, pullback: (R.CotangentVector) -> (T.CotangentVector...)
+  //     (value: R, pullback: (R.TangentVector) -> (T.TangentVector...)
   // Or a value and differential:
   //     (value: R, differential: (T.TangentVector...) -> (R.TangentVector)
   auto derivativeResultType = derivative->getResultInterfaceType();
@@ -3219,7 +3219,7 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     autoDiffAssocTyId = ctx.Id_TangentVector;
   } else if (funcResultElt.getName().str() == "pullback") {
     kind = AutoDiffAssociatedFunctionKind::VJP;
-    autoDiffAssocTyId = ctx.Id_CotangentVector;
+    autoDiffAssocTyId = ctx.Id_TangentVector;
   } else {
     TC.diagnose(attr->getLocation(),
                 diag::differentiating_attr_invalid_result_tuple_func_label);
@@ -3227,7 +3227,7 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     return;
   }
   // `value: R` result tuple element must conform to `Differentiable`.
-  auto diffableProto = ctx.getProtocol(KnownProtocolKind::__Differentiable);
+  auto diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
   auto valueResultType = valueResultElt.getType();
   if (valueResultType->hasTypeParameter())
     valueResultType = derivative->mapTypeIntoContext(valueResultType);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1516,133 +1516,6 @@ void MultiConformanceChecker::checkAllConformances() {
   }
 }
 
-static void diagnoseConformanceImpliedByConditionalConformance(
-    DiagnosticEngine &Diags, NormalProtocolConformance *conformance,
-    NormalProtocolConformance *implyingConf, bool issueFixit) {
-  Type T = conformance->getType();
-  auto proto = conformance->getProtocol();
-  Type protoType = proto->getDeclaredType();
-  auto implyingProto = implyingConf->getProtocol()->getDeclaredType();
-  auto loc = implyingConf->getLoc();
-  Diags.diagnose(loc, diag::conditional_conformances_cannot_imply_conformances,
-                 T, implyingProto, protoType);
-
-  if (!issueFixit)
-    return;
-
-  // Now we get down to business: constructing a few options for new
-  // extensions. They all look like:
-  //
-  // extension T: ProtoType where ... {
-  //     <# witnesses #>
-  // }
-  //
-  // The options are:
-  //
-  // - if possible, the original bounds relaxed, when the requirements match the
-  //   conforming protocol, e.g. 'X: Hashable where T: Hashable' often
-  //   corresponds to 'X: Equatable where T: Equatable'. This fixit is included
-  //   if all the requirements are conformance constraints to the protocol
-  //   that implies the conformance.
-  // - the same bounds: ... is copied from the implying extension
-  // - new bounds: ... becomes a placeholder
-  //
-  // We could also suggest adding ", ProtoType" to the existing extension,
-  // but we don't think having multiple conformances in a single extension
-  // (especially conditional ones) is good Swift style, and so we don't
-  // want to encourage it.
-
-  auto ext = cast<ExtensionDecl>(implyingConf->getDeclContext());
-  auto &ctxt = ext->getASTContext();
-
-  auto &SM = ctxt.SourceMgr;
-  StringRef extraIndent;
-  StringRef indent = Lexer::getIndentationForLine(SM, loc, &extraIndent);
-
-  // First, the bits that aren't the requirements are the same for all the
-  // types.
-  llvm::SmallString<128> prefix;
-  llvm::SmallString<128> suffix;
-  {
-    llvm::raw_svector_ostream prefixStream(prefix);
-    llvm::raw_svector_ostream suffixStream(suffix);
-
-    ValueDecl *decl = T->getAnyNominal();
-    if (!decl)
-      decl = T->getAnyGeneric();
-
-    prefixStream << "extension " << decl->getFullName() << ": " << protoType << " ";
-    suffixStream << " {\n"
-                 << indent << extraIndent << "<#witnesses#>\n"
-                 << indent << "}\n\n"
-                 << indent;
-  }
-
-  if (!ctxt.LangOpts.DiagnosticsEditorMode) {
-    // The fixits below are too complicated for the command line: the suggested
-    // code ends up not being displayed, and the text by itself doesn't help. So
-    // instead we skip all that and just have some text.
-    Diags.diagnose(loc,
-                   diag::note_explicitly_state_conditional_conformance_noneditor,
-                   prefix.str());
-    return;
-  }
-
-  // First, we do the fixit for "matching" requirements (i.e. X: P where T: P).
-  bool matchingIsValid = true;
-  llvm::SmallString<128> matchingFixit = prefix;
-  {
-    llvm::raw_svector_ostream matchingStream(matchingFixit);
-    matchingStream << "where ";
-    bool first = true;
-    for (const auto &req : implyingConf->getConditionalRequirements()) {
-      auto firstType = req.getFirstType();
-      // T: ImplyingProto => T: Proto
-      if (req.getKind() == RequirementKind::Conformance &&
-          req.getSecondType()->isEqual(implyingProto)) {
-        auto comma = first ? "" : ", ";
-        matchingStream << comma << firstType << ": " << protoType;
-        first = false;
-        continue;
-      }
-      // something didn't work out, so give up on this fixit.
-      matchingIsValid = false;
-      break;
-    }
-  }
-
-  if (matchingIsValid) {
-    matchingFixit += suffix;
-    Diags
-        .diagnose(loc,
-                  diag::note_explicitly_state_conditional_conformance_relaxed)
-        .fixItInsert(loc, matchingFixit);
-  }
-
-  // Next, do the fixit for using the same requirements, but be resilient to a
-  // missing `where` clause: this is one of a few fixits that get emitted here,
-  // and so is a very low priority diagnostic, and so shouldn't crash.
-  if (auto TWC = ext->getTrailingWhereClause()) {
-    llvm::SmallString<128> sameFixit = prefix;
-    auto CSR =
-        Lexer::getCharSourceRangeFromSourceRange(SM, TWC->getSourceRange());
-    sameFixit += SM.extractText(CSR);
-    sameFixit += suffix;
-    Diags
-        .diagnose(loc, diag::note_explicitly_state_conditional_conformance_same)
-        .fixItInsert(loc, sameFixit);
-  }
-
-  // And finally, just the generic new-requirements one:
-  llvm::SmallString<128> differentFixit = prefix;
-  differentFixit += "where <#requirements#>";
-  differentFixit += suffix;
-  Diags
-      .diagnose(loc,
-                diag::note_explicitly_state_conditional_conformance_different)
-      .fixItInsert(loc, differentFixit);
-}
-
 /// Determine whether the type \c T conforms to the protocol \c Proto,
 /// recording the complete witness table if it does.
 ProtocolConformance *MultiConformanceChecker::
@@ -1826,21 +1699,6 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
       // those suggestions will go in the current DeclContext, but really they
       // should go into the new extension we (might) suggest here.
       impliedDisablesMissingWitnessFixits = true;
-
-      // SWIFT_ENABLE_TENSORFLOW
-      // Before diagnosing implied conditional conformances, check if the
-      // implied protocol is an underscored protocol for internal purposes
-      // (e.g. `_Differentiable` or `__Differentiable`, which are workarounds
-      // for TF-213). If so, allow the implied conformance.
-      auto *proto = conformance->getProtocol();
-      auto &ctx = DC->getASTContext();
-      // TODO(TF-213): Remove underscore `Differentiable` protocols.
-      if (proto != ctx.getProtocol(KnownProtocolKind::__Differentiable) &&
-          proto != ctx.getProtocol(KnownProtocolKind::_Differentiable) ) {
-        diagnoseConformanceImpliedByConditionalConformance(
-            TC.Diags, conformance, implyingConf, issueFixit);
-        conformance->setInvalid();
-      }
     }
   }
 
@@ -5530,8 +5388,7 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
     return derived.deriveVectorNumeric(Requirement);
 
   // SWIFT_ENABLE_TENSORFLOW
-  // TODO(TF-213): Replace with `KnownProtocolKind::Differentiable`.
-  case KnownProtocolKind::__Differentiable:
+  case KnownProtocolKind::Differentiable:
     return derived.deriveDifferentiable(Requirement);
 
   default:
@@ -5562,8 +5419,7 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
     return derived.deriveKeyPathIterable(AssocType);
   case KnownProtocolKind::VectorNumeric:
     return derived.deriveVectorNumeric(AssocType);
-  // TODO(TF-213): Replace with `KnownProtocolKind::Differentiable`.
-  case KnownProtocolKind::__Differentiable:
+  case KnownProtocolKind::Differentiable:
     return derived.deriveDifferentiable(AssocType);
   default:
     return nullptr;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2629,8 +2629,7 @@ bool TypeResolver::isDifferentiableType(Type ty) {
     ty = DC->mapTypeIntoContext(ty);
   }
   return ty
-      ->getAutoDiffAssociatedVectorSpace(
-          AutoDiffAssociatedVectorSpaceKind::Tangent,
+      ->getAutoDiffAssociatedTangentSpace(
           LookUpConformanceInModule(DC->getParentModule()))
       .hasValue();
 }

--- a/stdlib/private/DifferentiationUnittest/GenericLifetimeTracked.swift
+++ b/stdlib/private/DifferentiationUnittest/GenericLifetimeTracked.swift
@@ -117,15 +117,10 @@ extension Tracked : Strideable where T : Strideable, T.Stride == T.Stride.Magnit
 // For now, `T` must be restricted to trivial types (like `Float` or `Tensor`).
 extension Tracked : Differentiable
   where T : Differentiable, T == T.AllDifferentiableVariables,
-        T == T.TangentVector, T == T.CotangentVector
+        T == T.TangentVector
 {
   public typealias AllDifferentiableVariables = Tracked<T.AllDifferentiableVariables>
   public typealias TangentVector = Tracked<T.TangentVector>
-  public typealias CotangentVector = Tracked<T.CotangentVector>
-  @inlinable @inline(__always)
-  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return Tracked<T.TangentVector>(value.tangentVector(from: cotangent.value))
-  }
 }
 
 @differentiable(vjp: _vjpAdd)
@@ -146,14 +141,14 @@ public extension Differentiable {
   @inlinable
   func gradient(
     in f: @differentiable (Self) -> Tracked<Float>
-  ) -> CotangentVector {
+  ) -> TangentVector {
     return self.pullback(in: f)(1)
   }
 
   @inlinable
   func gradient<T : Differentiable>(
     at x: T, in f: @differentiable (Self, T) -> Tracked<Float>
-  ) -> (CotangentVector, T.CotangentVector) {
+  ) -> (TangentVector, T.TangentVector) {
     return self.pullback(at: x, in: f)(1)
   }
 }

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -101,7 +101,6 @@ public protocol TensorFlowFloatingPoint :
   TensorFlowScalar & BinaryFloatingPoint & Differentiable
   where Self.RawSignificand: FixedWidthInteger,
         Self == Self.TangentVector,
-        Self == Self.CotangentVector,
         Self == Self.AllDifferentiableVariables {}
 
 extension Float : TensorFlowFloatingPoint {}

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -48,14 +48,14 @@ public extension Differentiable {
   @inlinable
   func gradient<R : TensorFlowFloatingPoint>(
     in f: @differentiable (Self) -> Tensor<R>
-  ) -> CotangentVector {
+  ) -> TangentVector {
     return self.pullback(in: f)(Tensor<R>(1))
   }
 
   @inlinable
   func valueWithGradient<R : TensorFlowFloatingPoint>(
     in f: @differentiable (Self) -> Tensor<R>
-  ) -> (value: Tensor<R>, gradient: CotangentVector) {
+  ) -> (value: Tensor<R>, gradient: TangentVector) {
     let (y, pb) = self.valueWithPullback(in: f)
     return (y, pb(Tensor<R>(1)))
   }
@@ -63,14 +63,14 @@ public extension Differentiable {
   @inlinable
   func gradient<T : Differentiable, R : TensorFlowFloatingPoint>(
     at x: T, in f: @differentiable (Self, T) -> Tensor<R>
-  ) -> (CotangentVector, T.CotangentVector) {
+  ) -> (TangentVector, T.TangentVector) {
     return self.pullback(at: x, in: f)(Tensor<R>(1))
   }
 
   @inlinable
   func valueWithGradient<T : Differentiable, R : TensorFlowFloatingPoint>(
     at x: T, in f: @differentiable (Self, T) -> Tensor<R>
-  ) -> (value: Tensor<R>, gradient: (CotangentVector, T.CotangentVector)) {
+  ) -> (value: Tensor<R>, gradient: (TangentVector, T.TangentVector)) {
     let (y, pb) = self.valueWithPullback(at: x, in: f)
     return (y, pb(Tensor<R>(1)))
   }
@@ -85,7 +85,7 @@ public extension Differentiable {
 @inlinable
 public func valueWithGradient<T, R>(
   at x: T, in f: @differentiable (T) -> Tensor<R>
-) -> (value: Tensor<R>, gradient: T.CotangentVector)
+) -> (value: Tensor<R>, gradient: T.TangentVector)
 where T : Differentiable, R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, in: f)
   return (y, pullback(Tensor<R>(1)))
@@ -94,7 +94,7 @@ where T : Differentiable, R : TensorFlowFloatingPoint {
 @inlinable
 public func valueWithGradient<T, U, R>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
-) -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
+) -> (value: Tensor<R>, gradient: (T.TangentVector, U.TangentVector))
   where T : Differentiable, U : Differentiable,
         R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, y, in: f)
@@ -105,7 +105,7 @@ public func valueWithGradient<T, U, R>(
 public func valueWithGradient<T, U, V, R>(
   at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> Tensor<R>
 ) -> (value: Tensor<R>,
-      gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
+      gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : TensorFlowFloatingPoint {
   let (y, pullback) = valueWithPullback(at: x, y, z, in: f)
@@ -117,7 +117,7 @@ public func valueWithGradient<T, U, V, R>(
 @inlinable
 public func valueWithGradient<T, R>(
   of f: @escaping @differentiable (T) -> Tensor<R>
-) -> (T) -> (value: Tensor<R>, gradient: T.CotangentVector)
+) -> (T) -> (value: Tensor<R>, gradient: T.TangentVector)
   where T : Differentiable, R : TensorFlowFloatingPoint {
   return { x in valueWithGradient(at: x, in: f) }
 }
@@ -126,7 +126,7 @@ public func valueWithGradient<T, R>(
 public func valueWithGradient<T, U, R>(
   of f: @escaping @differentiable (T, U) -> Tensor<R>
 ) -> (T, U)
-    -> (value: Tensor<R>, gradient: (T.CotangentVector, U.CotangentVector))
+    -> (value: Tensor<R>, gradient: (T.TangentVector, U.TangentVector))
   where T : Differentiable, U : Differentiable,
         R : TensorFlowFloatingPoint {
   return { x, y in valueWithGradient(at: x, y, in: f) }
@@ -137,7 +137,7 @@ public func valueWithGradient<T, U, V, R>(
   of f: @escaping @differentiable (T, U, V) -> Tensor<R>
 ) -> (T, U, V)
     -> (value: Tensor<R>,
-        gradient: (T.CotangentVector, U.CotangentVector, V.CotangentVector))
+        gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : TensorFlowFloatingPoint {
   return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
@@ -148,7 +148,7 @@ public func valueWithGradient<T, U, V, R>(
 @inlinable
 public func gradient<T, R>(
   at x: T, in f: @differentiable (T) -> Tensor<R>
-) -> T.CotangentVector
+) -> T.TangentVector
   where T : Differentiable, R : TensorFlowFloatingPoint {
   return pullback(at: x, in: f)(Tensor<R>(1))
 }
@@ -156,7 +156,7 @@ public func gradient<T, R>(
 @inlinable
 public func gradient<T, U, R>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> Tensor<R>
-) -> (T.CotangentVector, U.CotangentVector)
+) -> (T.TangentVector, U.TangentVector)
   where T : Differentiable, U : Differentiable,
         R : TensorFlowFloatingPoint {
   return pullback(at: x, y, in: f)(Tensor<R>(1))
@@ -165,7 +165,7 @@ public func gradient<T, U, R>(
 @inlinable
 public func gradient<T, U, V, R>(
   at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> Tensor<R>
-) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
+) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : TensorFlowFloatingPoint {
   return pullback(at: x, y, z, in: f)(Tensor<R>(1))
@@ -176,7 +176,7 @@ public func gradient<T, U, V, R>(
 @inlinable
 public func gradient<T, R>(
   of f: @escaping @differentiable (T) -> Tensor<R>
-) -> (T) -> T.CotangentVector
+) -> (T) -> T.TangentVector
   where T : Differentiable, R : TensorFlowFloatingPoint {
   return { x in gradient(at: x, in: f) }
 }
@@ -184,7 +184,7 @@ public func gradient<T, R>(
 @inlinable
 public func gradient<T, U, R>(
   of f: @escaping @differentiable (T, U) -> Tensor<R>
-) -> (T, U) -> (T.CotangentVector, U.CotangentVector)
+) -> (T, U) -> (T.TangentVector, U.TangentVector)
   where T : Differentiable, U : Differentiable,
         R : TensorFlowFloatingPoint {
   return { x, y in gradient(at: x, y, in: f) }
@@ -193,7 +193,7 @@ public func gradient<T, U, R>(
 @inlinable
 public func gradient<T, U, V, R>(
   of f: @escaping @differentiable (T, U, V) -> Tensor<R>
-) -> (T, U, V) -> (T.CotangentVector, U.CotangentVector, V.CotangentVector)
+) -> (T, U, V) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where T : Differentiable, U : Differentiable, V : Differentiable,
         R : TensorFlowFloatingPoint {
   return { x, y, z in gradient(at: x, y, z, in: f) }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -107,12 +107,7 @@ extension Tensor : ShapedVectorNumeric where Scalar : Numeric {}
 
 extension Tensor : Differentiable where Scalar : TensorFlowFloatingPoint {
   public typealias TangentVector = Tensor
-  public typealias CotangentVector = Tensor
   public typealias AllDifferentiableVariables = Tensor
-  @inlinable
-  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return cotangent
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1934,7 +1934,7 @@ extension Array where Element : Differentiable {
 
     @usableFromInline
     func _vjpBase() ->
-      ([Element], (Array<Element>.CotangentVector) -> CotangentVector) {
+      ([Element], (Array<Element>.TangentVector) -> TangentVector) {
       return (base, { $0 })
     }
 
@@ -1944,7 +1944,7 @@ extension Array where Element : Differentiable {
 
     @usableFromInline
     static func _vjpInit(_ base: [Element]) ->
-      (Array.DifferentiableView, (CotangentVector) -> CotangentVector) {
+      (Array.DifferentiableView, (TangentVector) -> TangentVector) {
       return (Array.DifferentiableView(base), { $0 })
     }
 
@@ -1952,8 +1952,6 @@ extension Array where Element : Differentiable {
 
     public typealias TangentVector =
       Array<Element.TangentVector>.DifferentiableView
-    public typealias CotangentVector =
-      Array<Element.CotangentVector>.DifferentiableView
     public typealias AllDifferentiableVariables =
       Array<Element.AllDifferentiableVariables>.DifferentiableView
 
@@ -1982,19 +1980,6 @@ extension Array where Element : Differentiable {
           "direction with different count \(direction.base.count)")
       return DifferentiableView(
         zip(base, direction.base).map { $0.moved(along: $1) })
-    }
-
-    public func tangentVector(from cotangentVector: CotangentVector) ->
-      TangentVector {
-      precondition(
-        base.count == cotangentVector.base.count,
-        "cannot use Array.DifferentiableView with count \(base.count) to " +
-          "get tangentVector from cotangentVector with different count " +
-          "\(cotangentVector.base.count)")
-      return TangentVector(zip(base, cotangentVector.base).map {
-        (selfElement, cotangentVectorElement) in
-        selfElement.tangentVector(from: cotangentVectorElement)
-      })
     }
   }
 }
@@ -2065,16 +2050,14 @@ extension Array.DifferentiableView : AdditiveArithmetic
 /// Makes `Array` differentiable as the product manifold of `Element`
 /// multiplied with itself `count` times.
 extension Array : Differentiable where Element : Differentiable {
-  // In an ideal world, `TangentVector`, `CotangentVector`, and
+  // In an ideal world, `TangentVector`, `TangentVector`, and
   // `AllDifferentiableVariables` would all be `Array`s. Unfortunately, we
   // can't conform `Array` to `AdditiveArithmetic` for `TangentVector` and
-  // `CotangentVector`, because `Array` already has a static `+` method with
+  // `TangentVector`, because `Array` already has a static `+` method with
   // different semantics from `AdditiveArithmetic` `+`. So we use
   // `Array.DifferentiableView` for all these associated types.
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
-  public typealias CotangentVector =
-    Array<Element.CotangentVector>.DifferentiableView
   public typealias AllDifferentiableVariables =
     Array<Element.AllDifferentiableVariables>.DifferentiableView
 
@@ -2092,40 +2075,35 @@ extension Array : Differentiable where Element : Differentiable {
   public func moved(along direction: TangentVector) -> Array {
     return DifferentiableView(self).moved(along: direction).base
   }
-
-  public func tangentVector(from cotangentVector: CotangentVector) ->
-    TangentVector {
-    return DifferentiableView(self).tangentVector(from: cotangentVector)
-  }
 }
 
 extension Array where Element : Differentiable {
   public func _vjpSubscript(index: Int) ->
-    (Element, (Element.CotangentVector) -> CotangentVector)
+    (Element, (Element.TangentVector) -> TangentVector)
   {
-    func pullback(_ gradientIn: Element.CotangentVector) -> CotangentVector {
-      var gradientOut = Array<Element.CotangentVector>(
+    func pullback(_ gradientIn: Element.TangentVector) -> TangentVector {
+      var gradientOut = Array<Element.TangentVector>(
         repeating: .zero,
         count: count)
       gradientOut[index] = gradientIn
-      return CotangentVector(gradientOut)
+      return TangentVector(gradientOut)
     }
     return (self[index], pullback)
   }
 
   public static func _vjpPlus(_ lhs: [Element], _ rhs: [Element]) ->
-    ([Element], (CotangentVector) -> (CotangentVector, CotangentVector)) {
-      func pullback(_ gradientIn: CotangentVector) ->
-        (CotangentVector, CotangentVector) {
+    ([Element], (TangentVector) -> (TangentVector, TangentVector)) {
+      func pullback(_ gradientIn: TangentVector) ->
+        (TangentVector, TangentVector) {
         precondition(
           gradientIn.base.count == lhs.count + rhs.count,
           "+ should receive gradient with count equal to sum of operand " +
             "counts, but counts are: gradient \(gradientIn.base.count), " +
             "lhs \(lhs.count), rhs \(rhs.count)")
         return (
-          CotangentVector(Array<Element.CotangentVector>(
+          TangentVector(Array<Element.TangentVector>(
             gradientIn.base[0..<lhs.count])),
-          CotangentVector(Array<Element.CotangentVector>(
+          TangentVector(Array<Element.TangentVector>(
             gradientIn.base[lhs.count...])))
       }
       return (lhs + rhs, pullback)

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1845,7 +1845,7 @@ extension FloatingPoint {
   @_transparent
   // SWIFT_ENABLE_TENSORFLOW
   @differentiable(wrt: self, vjp: _vjpSquareRoot
-                  where Self : Differentiable, Self == Self.CotangentVector)
+                  where Self : Differentiable, Self == Self.TangentVector)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )
@@ -1868,7 +1868,7 @@ extension FloatingPoint {
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
   @differentiable(wrt: (self, lhs, rhs), vjp: _vjpAddingProduct
-                  where Self : Differentiable, Self == Self.CotangentVector)
+                  where Self : Differentiable, Self == Self.TangentVector)
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)
@@ -2030,7 +2030,7 @@ extension FloatingPoint {
 
 /// SWIFT_ENABLE_TENSORFLOW
 extension FloatingPoint where Self : Differentiable,
-                              Self == Self.CotangentVector {
+                              Self == Self.TangentVector {
   /// The vector-Jacobian product function of `addingProduct`. Returns the
   /// original result and pullback of `addingProduct` with respect to `self`,
   /// `lhs` and `rhs`.

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1882,11 +1882,7 @@ extension ${Self} : VectorNumeric {
 
 extension ${Self} : Differentiable {
   public typealias TangentVector = ${Self}
-  public typealias CotangentVector = ${Self}
   public typealias AllDifferentiableVariables = ${Self}
-  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return cotangent
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/anyderivative.swift
+++ b/test/AutoDiff/anyderivative.swift
@@ -20,19 +20,19 @@ AnyDerivativeTests.test("Vector") {
   expectEqual(AnyDerivative(Vector.TangentVector(x: 4, y: 4)), tan + tan)
   expectEqual(AnyDerivative(Vector.TangentVector(x: 0, y: 0)), tan - tan)
   expectEqual(AnyDerivative(Vector.TangentVector(x: 4, y: 4)), tan.moved(along: tan))
-  expectEqual(AnyDerivative(Vector.TangentVector(x: 2, y: 2)), tan.tangentVector(from: tan))
+  expectEqual(AnyDerivative(Vector.TangentVector(x: 2, y: 2)), tan)
 }
 
 AnyDerivativeTests.test("Generic") {
   var tan = AnyDerivative(Generic<Float>.TangentVector(x: 1))
-  let cotan = AnyDerivative(Generic<Float>.CotangentVector(x: 1))
+  let cotan = AnyDerivative(Generic<Float>.TangentVector(x: 1))
   tan += tan
   expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 2)), tan)
   expectEqual(tan, tan.allDifferentiableVariables)
   expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 4)), tan + tan)
   expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 0)), tan - tan)
   expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 4)), tan.moved(along: tan))
-  expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 1)), tan.tangentVector(from: cotan))
+  expectEqual(AnyDerivative(Generic<Float>.TangentVector(x: 1)), cotan)
 }
 
 AnyDerivativeTests.test("Zero") {
@@ -45,7 +45,7 @@ AnyDerivativeTests.test("Zero") {
   expectEqual(zero, zero.allDifferentiableVariables)
 
   var tan = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
-  expectEqual(zero, tan.tangentVector(from: zero))
+  expectEqual(zero, zero)
   expectEqual(AnyDerivative(Vector.TangentVector.zero), tan - tan)
   expectNotEqual(AnyDerivative(Vector.TangentVector.zero), zero)
   expectNotEqual(AnyDerivative.zero, tan - tan)
@@ -55,8 +55,8 @@ AnyDerivativeTests.test("Zero") {
   expectEqual(tan, tan - zero)
   expectEqual(tan, tan.moved(along: zero))
   expectEqual(tan, zero.moved(along: tan))
-  expectEqual(zero, tan.tangentVector(from: zero))
-  expectEqual(tan, zero.tangentVector(from: tan))
+  expectEqual(zero, zero)
+  expectEqual(tan, tan)
 }
 
 AnyDerivativeTests.test("Casting") {
@@ -95,23 +95,23 @@ AnyDerivativeTests.test("Derivatives") {
   do {
     let x = AnyDerivative(Vector.TangentVector(x: 4, y: 5))
     let y = AnyDerivative(Vector.TangentVector(x: -2, y: -1))
-    let v = AnyDerivative(Vector.CotangentVector(x: 1, y: 1))
-    let expectedVJP = Vector.CotangentVector(x: 3, y: 3)
+    let v = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
+    let expectedVJP = Vector.TangentVector(x: 3, y: 3)
 
     let (𝛁x, 𝛁y) = pullback(at: x, y, in: tripleSum)(v)
-    expectEqual(expectedVJP, 𝛁x.base as? Vector.CotangentVector)
-    expectEqual(expectedVJP, 𝛁y.base as? Vector.CotangentVector)
+    expectEqual(expectedVJP, 𝛁x.base as? Vector.TangentVector)
+    expectEqual(expectedVJP, 𝛁y.base as? Vector.TangentVector)
   }
 
   do {
     let x = AnyDerivative(Generic<Double>.TangentVector(x: 4))
     let y = AnyDerivative(Generic<Double>.TangentVector(x: -2))
-    let v = AnyDerivative(Generic<Double>.CotangentVector(x: 1))
-    let expectedVJP = Generic<Double>.CotangentVector(x: 3)
+    let v = AnyDerivative(Generic<Double>.TangentVector(x: 1))
+    let expectedVJP = Generic<Double>.TangentVector(x: 3)
 
     let (𝛁x, 𝛁y) = pullback(at: x, y, in: tripleSum)(v)
-    expectEqual(expectedVJP, 𝛁x.base as? Generic<Double>.CotangentVector)
-    expectEqual(expectedVJP, 𝛁y.base as? Generic<Double>.CotangentVector)
+    expectEqual(expectedVJP, 𝛁x.base as? Generic<Double>.TangentVector)
+    expectEqual(expectedVJP, 𝛁y.base as? Generic<Double>.TangentVector)
   }
 
   // Test `AnyDerivative` initializer.
@@ -120,7 +120,7 @@ AnyDerivativeTests.test("Derivatives") {
           T.AllDifferentiableVariables == T,
           // NOTE: The requirement below should be defined on `Differentiable`.
           // But it causes a crash due to generic signature minimization bug.
-          T.CotangentVector == T.CotangentVector.AllDifferentiableVariables
+          T.TangentVector == T.TangentVector.AllDifferentiableVariables
   {
     let any = AnyDerivative(x)
     return any + any
@@ -136,17 +136,17 @@ AnyDerivativeTests.test("Derivatives") {
 
   do {
     let x = Vector.TangentVector(x: 4, y: 5)
-    let v = AnyDerivative(Vector.CotangentVector(x: 1, y: 1))
+    let v = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
     let 𝛁x = pullback(at: x, in: { x in typeErased(x) })(v)
-    let expectedVJP = Vector.CotangentVector(x: 2, y: 2)
+    let expectedVJP = Vector.TangentVector(x: 2, y: 2)
     expectEqual(expectedVJP, 𝛁x)
   }
 
   do {
     let x = Generic<Double>.TangentVector(x: 4)
-    let v = AnyDerivative(Generic<Double>.CotangentVector(x: 1))
+    let v = AnyDerivative(Generic<Double>.TangentVector(x: 1))
     let 𝛁x = pullback(at: x, in: { x in typeErased(x) })(v)
-    let expectedVJP = Generic<Double>.CotangentVector(x: 2)
+    let expectedVJP = Generic<Double>.TangentVector(x: 2)
     expectEqual(expectedVJP, 𝛁x)
   }
 }

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -24,7 +24,7 @@ func weird<T>(_ x: T) -> T {
 }
 func vjpWeirdExtraRequirements<
   T : Differentiable & CaseIterable
->(_ x: T) -> (T, (T.CotangentVector) -> T.CotangentVector)
+>(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector)
   where T.AllCases : ExpressibleByStringLiteral
 {
   return (x, { $0 })

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -13,9 +13,7 @@ public struct Foo : Differentiable {
 // CHECK-AST:   @_fieldwiseDifferentiable public struct AllDifferentiableVariables
 // CHECK-AST:     public typealias AllDifferentiableVariables = Foo.AllDifferentiableVariables
 // CHECK-AST:     public typealias TangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:     public typealias CotangentVector = Foo.AllDifferentiableVariables
 // CHECK-AST:   public typealias TangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:   public typealias CotangentVector = Foo.AllDifferentiableVariables
 
 // CHECK-SILGEN-LABEL: // Foo.a.getter
 // CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0] [ossa] @$s33derived_differentiable_properties3FooV1aSfvg : $@convention(method) (Foo) -> Float
@@ -31,7 +29,6 @@ let _: @differentiable (AdditiveTangentIsSelf) -> Float = { x in
 // CHECK-AST:         internal var a: Float
 // CHECK-AST:         internal init(a: Float)
 // CHECK-AST:         internal typealias TangentVector = AdditiveTangentIsSelf
-// CHECK-AST:         internal typealias CotangentVector = AdditiveTangentIsSelf
 // CHECK-AST:         internal typealias AllDifferentiableVariables = AdditiveTangentIsSelf
 
 struct TestNoDerivative : Differentiable {
@@ -46,9 +43,7 @@ struct TestNoDerivative : Differentiable {
 // CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, VectorNumeric
 // CHECK-AST:           internal typealias AllDifferentiableVariables = TestNoDerivative.AllDifferentiableVariables
 // CHECK-AST:           internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:           internal typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
 // CHECK-AST:         internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:         internal typealias CotangentVector = TestNoDerivative.AllDifferentiableVariables
 
 struct TestKeyPathIterable : Differentiable, KeyPathIterable {
   var w: Float
@@ -62,29 +57,24 @@ struct TestKeyPathIterable : Differentiable, KeyPathIterable {
 // CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, VectorNumeric
 // CHECK-AST:           internal typealias AllDifferentiableVariables = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:           internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:           internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:         internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:         internal typealias CotangentVector = TestKeyPathIterable.AllDifferentiableVariables
 
-struct GenericCotanMember<T : Differentiable> : Differentiable, AdditiveArithmetic {
-  var x: T.CotangentVector
+struct GenericTanMember<T : Differentiable> : Differentiable, AdditiveArithmetic {
+  var x: T.TangentVector
 }
 
 // TODO(TF-316): Revisit after `Differentiable` derived conformances behavior is standardized.
-// `AllDifferentiableVariables` and `CotangentVector` structs need not both be synthesized.
+// `AllDifferentiableVariables` and `TangentVector` structs need not both be synthesized.
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct GenericCotanMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable {
-// CHECK-AST:         var x: T.CotangentVector
-// CHECK-AST:         internal init(x: T.CotangentVector)
-// CHECK-AST:         internal typealias TangentVector = GenericCotanMember<T>
-// CHECK-AST-LABEL:   @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable
-// CHECK-AST:           internal typealias TangentVector = GenericCotanMember<T>
-// CHECK-AST:           internal typealias CotangentVector = GenericCotanMember<T>.CotangentVector
-// CHECK-AST:           internal typealias AllDifferentiableVariables = GenericCotanMember<T>.AllDifferentiableVariables
-// CHECK-AST-LABEL:   @_fieldwiseDifferentiable internal struct CotangentVector : Differentiable, AdditiveArithmetic
-// CHECK-AST:           internal typealias TangentVector = GenericCotanMember<T>.CotangentVector
-// CHECK-AST:           internal typealias CotangentVector = GenericCotanMember<T>
-// CHECK-AST:           internal typealias AllDifferentiableVariables = GenericCotanMember<T>.CotangentVector
+// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct GenericTanMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable
+// CHECK-AST:   internal var x: T.TangentVector
+// CHECK-AST:   internal init(x: T.TangentVector)
+// CHECK-AST:   internal typealias TangentVector = GenericTanMember<T>
+// CHECK-AST:   internal typealias AllDifferentiableVariables = GenericTanMember<T>
+// CHECK-AST:   internal static var zero: GenericTanMember<T> { get }
+// CHECK-AST:   internal static func + (lhs: GenericTanMember<T>, rhs: GenericTanMember<T>) -> GenericTanMember<T>
+// CHECK-AST:   internal static func - (lhs: GenericTanMember<T>, rhs: GenericTanMember<T>) -> GenericTanMember<T>
+// CHECK-AST:   @_implements(Equatable, ==(_:_:)) internal static func __derived_struct_equals(_ a: GenericTanMember<T>, _ b: GenericTanMember<T>) -> Bool
 
 public struct ConditionallyDifferentiable<T> {
   public let x: T

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -33,7 +33,7 @@ public func foo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> T {
 // CHECK: bb0(%0 : $*T, %1 : $Float, %2 : $*T):
 
 @_silgen_name("dfoo_indir_ret")
-public func dfoo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> (T, (T.CotangentVector) -> (Float, T.CotangentVector)) {
+public func dfoo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> (T, (T.TangentVector) -> (Float, T.TangentVector)) {
   return (y, { v in (x, v) })
 }
 
@@ -111,7 +111,6 @@ extension DiffStoredProp : VectorNumeric {
 
 extension DiffStoredProp : Differentiable {
   typealias TangentVector = DiffStoredProp
-  typealias CotangentVector = DiffStoredProp
 }
 
 //===----------------------------------------------------------------------===//
@@ -151,7 +150,6 @@ extension DiffComputedProp : VectorNumeric {
 
 extension DiffComputedProp : Differentiable {
   typealias TangentVector = DiffComputedProp
-  typealias CotangentVector = DiffComputedProp
 }
 
 // CHECK-LABEL: DiffComputedProp.computedProp.getter

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -264,7 +264,6 @@ extension JVPStruct : VectorNumeric {
 
 extension JVPStruct : Differentiable {
   typealias TangentVector = JVPStruct
-  typealias CotangentVector = JVPStruct
 }
 
 extension JVPStruct {
@@ -353,7 +352,7 @@ func vjp2ParamsVJP(x: Float, y: Float) -> (Float, (Float) -> (Float, Float)) {
   return (x + y, { v in (v, v) })
 }
 
-// expected-error @+1 {{'vjpWrongTypeVJP' does not have expected type '(Float) -> (Float, (Float.CotangentVector) -> Float.CotangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
+// expected-error @+1 {{'vjpWrongTypeVJP' does not have expected type '(Float) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float) -> (Float, (Float) -> Float)'}}
 @differentiable(vjp: vjpWrongTypeVJP)
 func vjpWrongType(x: Float) -> Float {
   return x
@@ -387,14 +386,14 @@ struct VJPStruct {
   @differentiable(vjp: storedPropVJP)
   let storedImmutableOk: Float
 
-  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.CotangentVector) -> VJPStruct.CotangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
   @differentiable(vjp: storedPropVJP)
   let storedImmutableWrongType: Double
 
   @differentiable(vjp: storedPropVJP)
   var storedMutableOk: Float
 
-  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.CotangentVector) -> VJPStruct.CotangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
   @differentiable(vjp: storedPropVJP)
   var storedMutableWrongType: Double
 }
@@ -421,7 +420,6 @@ extension VJPStruct : VectorNumeric {
 
 extension VJPStruct : Differentiable {
   typealias TangentVector = VJPStruct
-  typealias CotangentVector = VJPStruct
 }
 
 extension VJPStruct {
@@ -459,7 +457,7 @@ extension VJPStruct {
     }
   }
 
-  // expected-error @+1 {{'computedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.CotangentVector) -> VJPStruct.CotangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  // expected-error @+1 {{'computedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
   @differentiable(vjp: computedPropVJP)
   var computedPropWrongType: Double {
     return 0
@@ -501,7 +499,7 @@ func where1<T>(x: T) -> T {
 func jvpWhere1<T : Differentiable>(x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
   return (x, { v in v })
 }
-func vjpWhere1<T : Differentiable>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector) {
+func vjpWhere1<T : Differentiable>(x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
   return (x, { v in v })
 }
 
@@ -543,7 +541,6 @@ struct ResultLabelTest {
 struct Tensor<Scalar> : AdditiveArithmetic {}
 extension Tensor : Differentiable where Scalar : Differentiable {
   typealias TangentVector = Tensor
-  typealias CotangentVector = Tensor
   typealias AllDifferentiableVariables = Tensor
   func moved(along direction: Tensor) -> Tensor { return self }
   func tangentVector(from cotangent: Tensor) -> Tensor { return cotangent }
@@ -584,12 +581,12 @@ protocol MethodDiffReq {
 }
 
 extension MethodDiffReq where Self : Differentiable {
-  func vjpFoo(x: Self) -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+  func vjpFoo(x: Self) -> (Self, (Self.TangentVector) -> Self.TangentVector) {
     return (self, { $0 })
   }
 }
 
-// expected-error @+1 {{'vjpNonvariadic' does not have expected type '(Float, Int32...) -> (Float, (Float.CotangentVector) -> Float.CotangentVector)' (aka '(Float, Int32...) -> (Float, (Float) -> Float)')}}
+// expected-error @+1 {{'vjpNonvariadic' does not have expected type '(Float, Int32...) -> (Float, (Float.TangentVector) -> Float.TangentVector)' (aka '(Float, Int32...) -> (Float, (Float) -> Float)')}}
 @differentiable(wrt: x, vjp: vjpNonvariadic)
 func variadic(_ x: Float, indices: Int32...) -> Float {
   return x

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -10,11 +10,11 @@ _ = gradient(at: Float(1), in: { x in identity(x) })
 // Verify that local buffers are immediately set to zero.
 
 // CHECK-SIL-LABEL: sil hidden @AD__identity__adjoint_src_0_wrt_0
-// CHECK-SIL:      [[ORIG_COTAN:%.*]] = alloc_stack $τ_0_0.CotangentVector
+// CHECK-SIL:      [[ORIG_COTAN:%.*]] = alloc_stack $τ_0_0.TangentVector
 // CHECK-SIL-NEXT: [[ORIG_COTAN_BEGIN:%.*]] = begin_access [init] [static] [no_nested_conflict] [[ORIG_COTAN]]
-// CHECK-SIL-NEXT: [[ZERO_WITNESS:%.*]] = witness_method $τ_0_0.CotangentVector, #AdditiveArithmetic.zero!getter.1
-// CHECK-SIL-NEXT: [[ORIG_COTAN_METATYPE:%.*]] = metatype $@thick τ_0_0.CotangentVector.Type
-// CHECK-SIL-NEXT: [[EMIT_ZERO_INDIRECT:%.*]] = apply [[ZERO_WITNESS]]<τ_0_0.CotangentVector>([[ORIG_COTAN_BEGIN]], [[ORIG_COTAN_METATYPE]])
+// CHECK-SIL-NEXT: [[ZERO_WITNESS:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter.1
+// CHECK-SIL-NEXT: [[ORIG_COTAN_METATYPE:%.*]] = metatype $@thick τ_0_0.TangentVector.Type
+// CHECK-SIL-NEXT: [[EMIT_ZERO_INDIRECT:%.*]] = apply [[ZERO_WITNESS]]<τ_0_0.TangentVector>([[ORIG_COTAN_BEGIN]], [[ORIG_COTAN_METATYPE]])
 // CHECK-SIL-NEXT: end_access [[ORIG_COTAN_BEGIN]]
 // CHECK-SIL: }
 

--- a/test/AutoDiff/separate_cotangent_type.swift
+++ b/test/AutoDiff/separate_cotangent_type.swift
@@ -8,7 +8,7 @@ import Darwin.C
 import Glibc
 #endif
 
-var SeparateCotangentTypeTests = TestSuite("SeparateCotangentType")
+var SeparateTangentTypeTests = TestSuite("SeparateTangentType")
 
 @_fieldwiseDifferentiable
 struct DifferentiableSubset : Differentiable {
@@ -21,49 +21,35 @@ struct DifferentiableSubset : Differentiable {
   @_fieldwiseDifferentiable
   struct TangentVector : Differentiable, VectorNumeric {
     typealias TangentVector = DifferentiableSubset.TangentVector
-    typealias CotangentVector = DifferentiableSubset.CotangentVector
     var w: Float
     var b: Float
-    func tangentVector(from cotan: CotangentVector) -> TangentVector {
+    func tangentVector(from cotan: TangentVector) -> TangentVector {
       return TangentVector(w: cotan.w, b: cotan.b)
     }
-  }
-  @_fieldwiseDifferentiable
-  struct CotangentVector : Differentiable, VectorNumeric {
-    typealias TangentVector = DifferentiableSubset.CotangentVector
-    typealias CotangentVector = DifferentiableSubset.TangentVector
-    var w: Float
-    var b: Float
-    func tangentVector(from cotan: CotangentVector) -> TangentVector {
-      return TangentVector(w: cotan.w, b: cotan.b)
-    }
-  }
-  func tangentVector(from cotan: CotangentVector) -> TangentVector {
-    return TangentVector(w: cotan.w, b: cotan.b)
   }
   func moved(along v: TangentVector) -> DifferentiableSubset {
     return DifferentiableSubset(w: w.moved(along: v.w), b: b.moved(along: v.b), flag: flag)
   }
 }
 
-SeparateCotangentTypeTests.test("Trivial") {
+SeparateTangentTypeTests.test("Trivial") {
   let x = DifferentiableSubset(w: 0, b: 1, flag: false)
   let pb = pullback(at: x) { x in x }
-  expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+  expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
 }
 
-SeparateCotangentTypeTests.test("Initialization") {
+SeparateTangentTypeTests.test("Initialization") {
   let x = DifferentiableSubset(w: 0, b: 1, flag: false)
   let pb = pullback(at: x) { x in DifferentiableSubset(w: 1, b: 2, flag: true) }
-  expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+  expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
 }
 
-// FIXME(SR-9602): If `CotangentVector` is not marked
+// FIXME(SR-9602): If `TangentVector` is not marked
 // `@_fieldwiseProductSpace`, call the VJP of the memberwise initializer.
-// SeparateCotangentTypeTests.test("SomeArithmetics") {
+// SeparateTangentTypeTests.test("SomeArithmetics") {
 //   let x = DifferentiableSubset(w: 0, b: 1, flag: false)
 //   let pb = pullback(at: x) { x in DifferentiableSubset(w: x.w * x.w, b: x.b * x.b, flag: true) }
-//   expectEqual(pb(DifferentiableSubset.CotangentVector.zero), DifferentiableSubset.CotangentVector.zero)
+//   expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
 // }
 
 runAllTests()

--- a/test/Sema/struct_differentiable_member_types.swift
+++ b/test/Sema/struct_differentiable_member_types.swift
@@ -16,4 +16,4 @@ struct Foo : Differentiable {
 // synthesized member types require extra non-trivial work, due to the
 // current type-checker design.
 let randomGlobal = 1
-extension Foo.CotangentVector : Proto {}
+extension Foo.TangentVector : Proto {}

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -51,7 +51,7 @@ func testOnlyWhereClause<T : Numeric>(x: T) -> T {
 func testWhereClause<T : Numeric>(x: T) -> T {
   return x
 }
-func vjpTestWhereClause<T>(x: T) -> (T, (T.CotangentVector) -> T.CotangentVector)
+func vjpTestWhereClause<T>(x: T) -> (T, (T.TangentVector) -> T.TangentVector)
   where T : Numeric, T : Differentiable
 {
   return (x, { v in v })
@@ -67,33 +67,33 @@ extension P {
   }
 }
 extension P where Self : Differentiable {
-  func vjpTestWhereClauseMethod() -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+  func vjpTestWhereClauseMethod() -> (Self, (Self.TangentVector) -> Self.TangentVector) {
     return (self, { v in v })
   }
 }
 
-// CHECK: @differentiable(wrt: x, vjp: vjpTestWhereClauseMethodTypeConstraint where T : Differentiable, T == T.CotangentVector)
+// CHECK: @differentiable(wrt: x, vjp: vjpTestWhereClauseMethodTypeConstraint where T : Differentiable, T == T.TangentVector)
 // CHECK-NEXT: func testWhereClauseMethodTypeConstraint<T>(x: T) -> T where T : Numeric
-@differentiable(vjp: vjpTestWhereClauseMethodTypeConstraint where T : Differentiable, T == T.CotangentVector)
+@differentiable(vjp: vjpTestWhereClauseMethodTypeConstraint where T : Differentiable, T == T.TangentVector)
 func testWhereClauseMethodTypeConstraint<T : Numeric>(x: T) -> T {
   return x
 }
 func vjpTestWhereClauseMethodTypeConstraint<T>(x: T) -> (T, (T) -> T)
-  where T : Numeric, T : Differentiable, T == T.CotangentVector
+  where T : Numeric, T : Differentiable, T == T.TangentVector
 {
   return (x, { v in v })
 }
 
 extension P {
-  // CHECK: @differentiable(wrt: self, vjp: vjpTestWhereClauseMethodTypeConstraint where Self : Differentiable, Self == Self.CotangentVector)
+  // CHECK: @differentiable(wrt: self, vjp: vjpTestWhereClauseMethodTypeConstraint where Self : Differentiable, Self == Self.TangentVector)
   // CHECK-NEXT: func testWhereClauseMethodTypeConstraint() -> Self
-  @differentiable(wrt: self, vjp: vjpTestWhereClauseMethodTypeConstraint where Self.CotangentVector == Self, Self : Differentiable)
+  @differentiable(wrt: self, vjp: vjpTestWhereClauseMethodTypeConstraint where Self.TangentVector == Self, Self : Differentiable)
   func testWhereClauseMethodTypeConstraint() -> Self {
     return self
   }
 }
-extension P where Self : Differentiable, Self == Self.CotangentVector {
-  func vjpTestWhereClauseMethodTypeConstraint() -> (Self, (Self.CotangentVector) -> Self.CotangentVector) {
+extension P where Self : Differentiable, Self == Self.TangentVector {
+  func vjpTestWhereClauseMethodTypeConstraint() -> (Self, (Self.TangentVector) -> Self.TangentVector) {
     return (self, { v in v })
   }
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_indirect.swift
@@ -35,7 +35,7 @@ extension Tensor where Scalar : Differentiable & FloatingPoint {
   func foo(_ x: Scalar) -> Scalar {
     return x
   }
-  func vjpFoo(_ x: Scalar) -> (Scalar, (Scalar.CotangentVector) -> Scalar.CotangentVector) {
+  func vjpFoo(_ x: Scalar) -> (Scalar, (Scalar.TangentVector) -> Scalar.TangentVector) {
     return (x, { v in v })
   }
 }
@@ -163,7 +163,7 @@ TensorADTests.testAllBackends("GenericLayerMembers") {
       rhs.applied(to: lhs.applied(to: input))
     }(seed)
     let 𝛁combined = pullback(at: combined) { $0.applied(to: input) }(seed)
-    expectEqual(Sequential.CotangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
+    expectEqual(Sequential.TangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
   }
   testFixedInput()
 
@@ -178,7 +178,7 @@ TensorADTests.testAllBackends("GenericLayerMembers") {
       rhs.applied(to: lhs.applied(to: input))
     }(seed)
     let 𝛁combined = pullback(at: combined) { $0.applied(to: input) }(seed)
-    expectEqual(Sequential.CotangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
+    expectEqual(Sequential.TangentVector(lhs: 𝛁lhs, rhs: 𝛁rhs), 𝛁combined)
   }
   testWrtInput(Tensor(randomUniform: [2, 3]))
 }
@@ -203,7 +203,7 @@ TensorADTests.testAllBackends("GenericWrapperLayer") {
 
   let 𝛁wrapper = pullback(at: wrapper) { $0.applied(to: input) }(seed)
   let 𝛁dense = pullback(at: dense) { $0.applied(to: input) }(seed)
-  expectEqual(Wrapper.CotangentVector(layer: 𝛁dense), 𝛁wrapper)
+  expectEqual(Wrapper.TangentVector(layer: 𝛁dense), 𝛁wrapper)
 }
 
 runAllTests()


### PR DESCRIPTION
This PR removes the `CotangentVector` associated type and make it equal to `TangentVector`.

Mathematically, types conforming to the `Differentiable` protocol represent a Riemannian manifold, whose metric is inner products, which provide an isomorphism between a tangent space and a cotangent space at a point.

Some theoretical and practical reasons:
* It is not possible to correctly represent dual vectors in Swift today because functions cannot conform to protocols (`(TangentVector) -> Scalar` cannot conform to `AdditiveArithmetic`).
* In computation, it is always more practical to compute numerical tangent vectors instead of true cotangent vectors (partially applied dot product functions).
* The mutually recursive generic constraints triggered a significant bug in the type checker ([SR-9595](https://bugs.swift.org/browse/SR-9595)) that required a lot of workarounds ([TF-213](https://bugs.swift.org/browse/TF-213)), in particular, an ugly split of 3 protocols: `__Differentiable`, `_Differentiable`, and `Differentiable`.
* The split between `TangentVector` and `CotangentVector` makes user-defined conformances complicated.

Changes include:
* Remove `associatedtype CotangentVector` from `Differentiable`.
* Define `typealias CotangentVector = TangentVector` in `Differentiable` with a deprecation message.
* Merge `__Differentiable` and `_Differentiable` back into `Differentiable`.
* Replace all mentions of "cotangent" with "tangent" in the code base.
* Adapt derived conformances logic.
* Adapt tests.

Defines away [TF-213](https://bugs.swift.org/browse/TF-213).