### PR TITLE
build: remove unnecessary property sets (NFC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,6 @@ endif()
 
 set(SWIFT_ANALYZE_CODE_COVERAGE FALSE CACHE STRING
     "Build Swift with code coverage instrumenting enabled [FALSE, NOT-MERGED, MERGED]")
-set_property(CACHE SWIFT_ANALYZE_CODE_COVERAGE PROPERTY
-    STRINGS FALSE "NOT-MERGED" "MERGED")
 
 # SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
 # can be reused when a new version of Swift comes out (assuming the user hasn't
@@ -171,8 +169,6 @@ endif()
 
 set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
     "Build type for the Swift standard library and SDK overlays [Debug, RelWithDebInfo, Release, MinSizeRel]")
-set_property(CACHE SWIFT_STDLIB_BUILD_TYPE PROPERTY
-    STRINGS "Debug" "RelWithDebInfo" "Release" "MinSizeRel")
 # Allow the user to specify the standard library CMAKE_MSVC_RUNTIME_LIBRARY
 # value.  The following values are valid:
 #   - MultiThreaded (/MT)

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -65,10 +65,6 @@ option(SWIFT_ENABLE_PARSEABLE_MODULE_INTERFACES
 set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
   "Build type for the Swift standard library and SDK overlays.")
 
-set_property(CACHE SWIFT_STDLIB_BUILD_TYPE PROPERTY
-  STRINGS
-    "Debug" "RelWithDebInfo" "Release" "MinSizeRel")
-
 # -----------------------------------------------------------------------------
 # Constants
 


### PR DESCRIPTION
These properties are extraneous.  They are never queried, and the
`set(...CACHE)` which precedes them will ensure that the value is
cached.  This should be functionally equivalent.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
