### PR TITLE
[Test] Add runtime 9999-availability check for a new test in Swift 5.1

### DIFF
--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -873,7 +873,11 @@ PropertyListEncoderTests.test("testEncodingTopLevelStructuredSingleClass") { Tes
 PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPropertyListEncoder().testEncodingTopLevelDeepStructuredType() }
 PropertyListEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestPropertyListEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 PropertyListEncoderTests.test("testEncodingTopLevelNullableType") { TestPropertyListEncoder().testEncodingTopLevelNullableType() }
-PropertyListEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") { TestPropertyListEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey() }
+PropertyListEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") {
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    TestPropertyListEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey()
+  }
+}
 PropertyListEncoderTests.test("testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey") {
   expectCrash() {
     TestPropertyListEncoder().testEncodingConflictedTypeNestedContainersWithTheSameTopLevelKey()


### PR DESCRIPTION
The testEncodingMultipleNestedContainersWithTheSameTopLevelKey check is new
in Swift 5.1 and will not pass when running with a 5.0 stdlib.

rdar://problem/50151131