### PR TITLE
Run stable ABI tests on all Apple platforms

### DIFF
--- a/test/IRGen/class_update_callback_without_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout.sil
@@ -1,14 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution %s -target x86_64-apple-macosx10.14.3 | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OLD -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution %s -target x86_64-apple-macosx10.14.4 | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NEW -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution -O %s -target x86_64-apple-macosx10.14.3
-// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution -O %s -target x86_64-apple-macosx10.14.4
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution %s -target %target-pre-stable-abi-triple | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OLD --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-OLD-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution -O %s -target %target-pre-stable-abi-triple
 
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
 
 // With the old deployment target, these classes use the 'singleton' metadata
 // initialization pattern. The class is not statically visible to Objective-C,
@@ -19,6 +15,9 @@
 // initialization pattern. These class *are* visible to Objective-C, and the
 // Swift runtime realizes them using the new _objc_realizeClassFromSwift()
 // entry point.
+//
+// See class_update_callback_without_fixed_layout_stable_abi.swift, which uses
+// the same input file, for the stable ABI deployment target test.
 
 sil_stage canonical
 
@@ -44,9 +43,10 @@ sil_vtable SubclassOfClassWithResilientField {}
 
 
 // Field offsets are not statically known:
-// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5firstSivpWvd" = hidden constant i64 16, align 8
-// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd" = hidden global i64 0, align 8
-// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5thirdSivpWvd" = hidden global i64 0, align 8
+// CHECK-32-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5firstSivpWvd" = hidden constant i32 8
+// CHECK-64-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5firstSivpWvd" = hidden constant i64 16
+// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd" = hidden global [[INT]] 0
+// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5thirdSivpWvd" = hidden global [[INT]] 0
 
 
 // RO-data for ClassWithResilientField:
@@ -61,7 +61,7 @@ sil_vtable SubclassOfClassWithResilientField {}
 // -- the update callback
 // CHECK-NEW-SAME: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMU"
 
-// CHECK-SAME: }, section "__DATA, __objc_const", align 8
+// CHECK-SAME: }, section "__DATA, __objc_const"
 
 // Class has static metadata:
 // CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMf"
@@ -94,10 +94,6 @@ public class ClassWithResilientEnum {
 
 sil_vtable ClassWithResilientEnum {}
 
-// Field offsets are not statically known:
-// CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout22ClassWithResilientEnumC5firstAA0jhI7PayloadOvpWvd" = hidden global i64 0, align 8
-// CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout22ClassWithResilientEnumC6seconds4Int8VvpWvd" = hidden global i64 0, align 8
-
 
 // Make sure extra inhabitants work when reading a legacy layout -- the
 // Optional<ResilientRef> should be 8 bytes in size, not 9
@@ -109,8 +105,8 @@ public class ClassWithResilientRef {
 sil_vtable ClassWithResilientRef {}
 
 // Field offsets are not statically known:
-// CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout21ClassWithResilientRefC5first16resilient_struct0iJ0VSgvpWvd" = hidden global i64 0, align 8
-// CHECK-LABEL: @"$s42class_update_callback_without_fixed_layout21ClassWithResilientRefC6secondSivpWvd" = hidden global i64 0, align 8
+// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout21ClassWithResilientRefC5first16resilient_struct0iJ0VSgvpWvd" = hidden global [[INT]] 0
+// CHECK-DAG: @"$s42class_update_callback_without_fixed_layout21ClassWithResilientRefC6secondSivpWvd" = hidden global [[INT]] 0
 
 
 // When allocating a class with resiliently-sized fields, we must still load
@@ -121,36 +117,42 @@ sil_vtable ClassWithResilientRef {}
 sil @allocClassWithResilientField : $@convention(thin) () -> () {
 bb0:
 
-// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMa"(i64 0)
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMa"([[INT]] 0)
 // CHECK-NEXT: [[META:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
-// CHECK-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
+// CHECK-32-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 28
+// CHECK-64-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
 // CHECK-NEXT: [[SIZE_PTR:%.*]] = bitcast i8* [[SIZE_ADDR]] to i32*
-// CHECK-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]], align 8
-// CHECK-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
-// CHECK-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
+// CHECK-32-NEXT: [[SIZE:%.*]] = load i32, i32* [[SIZE_PTR]]
+// CHECK-64-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]]
+// CHECK-64-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
+// CHECK-32-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 32
+// CHECK-64-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
 // CHECK-NEXT: [[ALIGN_PTR:%.*]] = bitcast i8* [[ALIGN_ADDR]] to i16*
-// CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]], align 4
-// CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to i64
-// CHECK-NEXT: [[ALLOC:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[META]], i64 [[SIZE]], i64 [[ALIGN]])
+// CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]]
+// CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to [[INT]]
+// CHECK-NEXT: [[ALLOC:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[META]], [[INT]] [[SIZE]], [[INT]] [[ALIGN]])
   %c = alloc_ref $ClassWithResilientField
 
 // ... dealloc_ref also does the same thing.
 
 // CHECK-NEXT: [[SELF:%.*]] = bitcast %swift.refcounted* [[ALLOC]] to %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC*
 // CHECK-NEXT: [[ISA_ADDR:%.*]] = getelementptr inbounds %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC, %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC* [[SELF]], i32 0, i32 0, i32 0
-// CHECK-NEXT: [[META:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]], align 8
+// CHECK-NEXT: [[META:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
-// CHECK-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
+// CHECK-32-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 28
+// CHECK-64-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48
 // CHECK-NEXT: [[SIZE_PTR:%.*]] = bitcast i8* [[SIZE_ADDR]] to i32*
-// CHECK-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]], align 8
-// CHECK-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
-// CHECK-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
+// CHECK-32-NEXT: [[SIZE:%.*]] = load i32, i32* [[SIZE_PTR]]
+// CHECK-64-NEXT: [[SIZE_2:%.*]] = load i32, i32* [[SIZE_PTR]]
+// CHECK-64-NEXT: [[SIZE:%.*]] = zext i32 [[SIZE_2]] to i64
+// CHECK-32-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 32
+// CHECK-64-NEXT: [[ALIGN_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 52
 // CHECK-NEXT: [[ALIGN_PTR:%.*]] = bitcast i8* [[ALIGN_ADDR]] to i16*
-// CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]], align 4
-// CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to i64
+// CHECK-NEXT: [[ALIGN_2:%.*]] = load i16, i16* [[ALIGN_PTR]]
+// CHECK-NEXT: [[ALIGN:%.*]] = zext i16 [[ALIGN_2]] to [[INT]]
 // CHECK-NEXT: [[ALLOC:%.*]] = bitcast %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC* [[SELF]] to %swift.refcounted*
-// CHECK-NEXT: call void @swift_deallocClassInstance(%swift.refcounted* [[ALLOC]], i64 [[SIZE]], i64 [[ALIGN]])
+// CHECK-NEXT: call void @swift_deallocClassInstance(%swift.refcounted* [[ALLOC]], [[INT]] [[SIZE]], [[INT]] [[ALIGN]])
   dealloc_ref %c : $ClassWithResilientField
 
   %result = tuple ()
@@ -183,22 +185,23 @@ bb0:
 // Accessing a field whose offset depends on resilient types should
 // use the field offset global.
 
-// CHECK-LABEL: define swiftcc {{(dllexport )?}}{{(protected )?}}i64 @accessClassWithResilientField(%T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC*)
+// CHECK-32-LABEL: define swiftcc {{(dllexport )?}}{{(protected )?}}i32 @accessClassWithResilientField(%T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC*)
+// CHECK-64-LABEL: define swiftcc {{(dllexport )?}}{{(protected )?}}i64 @accessClassWithResilientField(%T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC*)
 sil @accessClassWithResilientField : $@convention(thin) (@guaranteed ClassWithResilientField) -> Int {
 bb0(%0 : $ClassWithResilientField):
 
-// CHECK:        [[OFFSET:%.*]] = load i64, i64* @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5thirdSivpWvd", align 8
+// CHECK:        [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldC5thirdSivpWvd"
 // CHECK-NEXT:   [[SELF_ADDR:%.*]] = bitcast %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC* %0 to i8*
-// CHECK-NEXT:   [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SELF_ADDR]], i64 [[OFFSET]]
+// CHECK-NEXT:   [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[SELF_ADDR]], [[INT]] [[OFFSET]]
 // CHECK-NEXT:   [[FIELD_PTR2:%.*]] = bitcast i8* [[FIELD_ADDR]] to %TSi*
 // CHECK-NEXT:   [[FIELD_PTR:%.*]] = getelementptr inbounds %TSi, %TSi* [[FIELD_PTR2]], i32 0, i32 0
 
   %1 = ref_element_addr %0 : $ClassWithResilientField, #ClassWithResilientField.third
 
-// CHECK-NEXT:   [[VALUE:%.*]] = load i64, i64* [[FIELD_PTR]], align 8
+// CHECK-NEXT:   [[VALUE:%.*]] = load [[INT]], [[INT]]* [[FIELD_PTR]]
   %2 = load %1 : $*Int
 
-// CHECK-NEXT:   ret i64 [[VALUE]]
+// CHECK-NEXT:   ret [[INT]] [[VALUE]]
   return %2 : $Int
 }
 
@@ -209,7 +212,7 @@ bb0(%0 : $ClassWithResilientField):
 
 // CHECK-NEW-LABEL: define internal %objc_class* @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMU"(%objc_class*, i8*)
 // CHECK-NEW: entry:
-// CHECK-NEW-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMa"(i64 0)
+// CHECK-NEW-NEXT: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s42class_update_callback_without_fixed_layout23ClassWithResilientFieldCMa"([[INT]] 0)
 // CHECK-NEW-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
 // CHECK-NEW-NEXT: [[RESULT:%.*]] = bitcast %swift.type* [[METADATA]] to %objc_class*
 // CHECK-NEW-NEXT: ret %objc_class* [[RESULT]]
@@ -223,9 +226,11 @@ bb0(%0 : $ClassWithResilientField):
 // CHECK: entry:
 // CHECK-NEXT: [[FIELDS:%.*]] = alloca [3 x i8**]
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
-// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{10|13}}
+// CHECK-32-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 13
+// CHECK-64-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 10
 // CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [3 x i8**]* [[FIELDS]] to i8*
-// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 {{12|24}}, i8* [[FIELDS_ADDR]])
+// CHECK-32-NEXT: call void @llvm.lifetime.start.p0i8(i64 12, i8* [[FIELDS_ADDR]])
+// CHECK-64-NEXT: call void @llvm.lifetime.start.p0i8(i64 24, i8* [[FIELDS_ADDR]])
 // CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [3 x i8**], [3 x i8**]* [[FIELDS]], i32 0, i32 0
 
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct4SizeVMa"([[INT]] 319)
@@ -270,7 +275,8 @@ bb0(%0 : $ClassWithResilientField):
 // CHECK: entry:
 // CHECK-NEXT: [[FIELDS:%.*]] = alloca [0 x i8**]
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* %0 to [[INT]]*
-// CHECK-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] {{11|14}}
+// CHECK-32-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 17
+// CHECK-64-NEXT: [[FIELDS_DEST:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 14
 // CHECK-NEXT: [[FIELDS_ADDR:%.*]] = bitcast [0 x i8**]* [[FIELDS]] to i8*
 // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 0, i8* [[FIELDS_ADDR]])
 // CHECK-NEXT: [[FIELDS_PTR:%.*]] = getelementptr inbounds [0 x i8**], [0 x i8**]* [[FIELDS]], i32 0, i32 0

--- a/test/IRGen/class_update_callback_without_fixed_layout_stable_abi.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout_stable_abi.sil
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution %S/class_update_callback_without_fixed_layout.sil -target %target-stable-abi-triple | %FileCheck %S/class_update_callback_without_fixed_layout.sil --check-prefix=CHECK --check-prefix=CHECK-NEW --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-NEW-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend  -I %t -emit-ir -enable-library-evolution -O %S/class_update_callback_without_fixed_layout.sil -target %target-stable-abi-triple
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_stable_abi

--- a/test/IRGen/eager-class-initialization-stable-abi.swift
+++ b/test/IRGen/eager-class-initialization-stable-abi.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/eager-class-initialization.swift -target %target-stable-abi-triple -emit-ir | %FileCheck %S/eager-class-initialization.swift -DINT=i%target-ptrsize --check-prefix=CHECK
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_stable_abi

--- a/test/IRGen/eager-class-initialization.swift
+++ b/test/IRGen/eager-class-initialization.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-OLD
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -target x86_64-apple-macosx10.14.4 -emit-ir | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK
-// REQUIRES: CPU=x86_64
-// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -target %target-pre-stable-abi-triple | %FileCheck %s -DINT=i%target-ptrsize --check-prefix=CHECK --check-prefix=CHECK-OLD
+
+// REQUIRES: objc_interop
+
+// See also eager-class-initialization-stable-abi.swift, for the stable ABI
+// deployment target test.
 
 import Foundation
 

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -3,15 +3,14 @@
 // RUN: %target-run %t/encode %t/test.arc
 // RUN: plutil -p %t/test.arc | %FileCheck -check-prefix=CHECK-ARCHIVE %s
 
-// RUN: %target-build-swift %s -module-name=test -o %t/decode
+// RUN: %target-build-swift %s -module-name=test -o %t/decode -target %target-pre-stable-abi-triple
 // RUN: %target-run %t/decode %t/test.arc --stdlib-unittest-in-process
-
-// RUN: %target-build-swift %s -module-name=test -o %t/decode -target x86_64-apple-macosx10.14.4 -link-objc-runtime
-// RUN: %target-run %t/decode %t/test.arc NEW --stdlib-unittest-in-process
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
+
+// See also archive_attributes_stable_abi.swift, for the stable ABI
+// deployment target test.
 
 import Foundation
 import StdlibUnittest
@@ -158,7 +157,7 @@ DecodeTestSuite.test("Decode") {
   }
 
   if CommandLine.arguments[2] == "NEW" {
-    if #available(macOS 10.14.4, *) {
+    if #available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *) {
       doIt()
     }
     return

--- a/test/Interpreter/SDK/archive_attributes_stable_abi.swift
+++ b/test/Interpreter/SDK/archive_attributes_stable_abi.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/archive_attributes.swift -module-name=test -DENCODE -o %t/encode
+// RUN: %target-run %t/encode %t/test.arc
+// RUN: plutil -p %t/test.arc | %FileCheck -check-prefix=CHECK-ARCHIVE %S/archive_attributes.swift
+
+// RUN: %target-build-swift %S/archive_attributes.swift -module-name=test -o %t/decode -target %target-stable-abi-triple -link-objc-runtime
+// RUN: %target-run %t/decode %t/test.arc NEW --stdlib-unittest-in-process
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: swift_stable_abi

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -3,14 +3,14 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -disable-nskeyedarchiver-diagnostics 2>&1 | %FileCheck -check-prefix CHECK-NO-DIAGS %s
 
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target x86_64-apple-macosx10.14.3 > %t/old.ast
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target x86_64-apple-macosx10.14.4 > %t/new.ast
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target %target-pre-stable-abi-triple > %t/old.ast
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -dump-ast -target %target-stable-abi-triple > %t/new.ast
 
 // RUN: %FileCheck --check-prefix=CHECK-OLD %s < %t/old.ast
 // RUN: %FileCheck --check-prefix=NEGATIVE %s < %t/old.ast
 // RUN: %FileCheck --check-prefix=NEGATIVE --check-prefix=NEGATIVE-NEW %s < %t/new.ast
 
-// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
 
 // CHECK-NO-DIAGS-NOT: NSCoding
 // CHECK-NO-DIAGS-NOT: unstable

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -568,6 +568,46 @@ if config.benchmark_o != 'Benchmark_O':
 # Add substitutions for the run target triple, CPU, OS, and pointer size.
 config.substitutions.append(('%target-triple', config.variant_triple))
 
+if run_vendor == 'apple':
+    # iOS 12.2 does not support 32-bit targets, so we cannot run tests that
+    # want to deploy to an iOS that has Swift in the OS.
+    if run_os == 'ios' and run_ptrsize == '32':
+        pre_stable_version = '10'
+    else:
+        config.available_features.add('swift_stable_abi')
+        PRE_STABLE_VERSION = {
+            'macosx': '10.14.3',
+            'ios': '12.1',
+            'tvos': '12.1',
+            'watchos': '5.1'
+        }
+        pre_stable_version = PRE_STABLE_VERSION.get(run_os, '')
+
+    config.pre_stable_abi_triple = '%s-%s-%s%s' % (run_cpu, run_vendor, run_os,
+                                                   pre_stable_version)
+    STABLE_VERSION = {
+        'macosx': '10.14.4',
+        'ios': '12.2',
+        'tvos': '12.2',
+        'watchos': '5.2'
+    }
+    stable_version = STABLE_VERSION.get(run_os, '')
+    config.stable_abi_triple = '%s-%s-%s%s' % (run_cpu, run_vendor, run_os,
+                                               stable_version)
+else:
+    config.pre_stable_abi_triple = config.variant_triple
+    config.stable_abi_triple = config.variant_triple
+
+# On Apple platforms, this substitution names the maximum OS version *without*
+# Swift in the OS. On non-Apple platforms this is equivalent to %target-triple.
+config.substitutions.append(('%target-pre-stable-abi-triple',
+                             config.pre_stable_abi_triple))
+
+# On Apple platforms, this substitution names the minimum OS version *with*
+# Swift in the OS. On non-Apple platforms this is equivalent to %target-triple.
+config.substitutions.append(('%target-stable-abi-triple',
+                             config.stable_abi_triple))
+
 # Sanitizers are not supported on iOS7, yet all tests are configured to start
 # testing with the earliest supported platform, which happens to be iOS7 for
 # Swift.

--- a/validation-test/Runtime/class_stubs_weak.m
+++ b/validation-test/Runtime/class_stubs_weak.m
@@ -5,7 +5,9 @@
 // RUN: %target-build-swift -emit-library -emit-module -o %t/libfirst.dylib -emit-objc-header-path %t/first.h %S/Inputs/class-stubs-weak/first.swift -Xlinker -install_name -Xlinker @executable_path/libfirst.dylib -enable-library-evolution
 // RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -emit-objc-header-path %t/second.h -I %t %S/Inputs/class-stubs-weak/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -Xfrontend -enable-resilient-objc-class-stubs -DBEFORE
 // RUN: cp %S/Inputs/class-stubs-weak/module.map %t/
-// RUN: xcrun %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref
+
+// Note: This is the just-built Clang, not the system Clang.
+// RUN: xcrun -sdk %sdk %clang %s -I %t -L %t -fmodules -fobjc-arc -o %t/main -lfirst -lsecond -Wl,-U,_objc_loadClassref -target %target-triple
 
 // Now rebuild the library, omitting the weak-exported class
 // RUN: %target-build-swift -emit-library -o %t/libsecond.dylib -I %t %S/Inputs/class-stubs-weak/second.swift -Xlinker -install_name -Xlinker @executable_path/libsecond.dylib -lfirst -L %t -Xfrontend -enable-resilient-objc-class-stubs
@@ -14,7 +16,7 @@
 // RUN: %target-run %t/main %t/libfirst.dylib %t/libsecond.dylib
 
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
 
 #import <dlfcn.h>
 #import <stdio.h>

--- a/validation-test/Runtime/class_update_callback_without_fixed_layout.m
+++ b/validation-test/Runtime/class_update_callback_without_fixed_layout.m
@@ -5,7 +5,7 @@
 // RUN: %target-build-swift -emit-library -emit-module -o %t/libResilient.dylib %S/Inputs/class-layout-from-objc/Resilient.swift -Xlinker -install_name -Xlinker @executable_path/libResilient.dylib -enable-library-evolution -DSMALL
 
 // RUN: %target-clang -c %S/Inputs/class-layout-from-objc/OneWordSuperclass.m -fmodules -fobjc-arc -o %t/OneWordSuperclass.o
-// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %t -I %S/Inputs/class-layout-from-objc/ %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -target x86_64-apple-macosx10.14.4
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %t -I %S/Inputs/class-layout-from-objc/ %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -target %target-stable-abi-triple
 // RUN: %target-clang %S/class_update_callback_with_fixed_layout.m -I %S/Inputs/class-layout-from-objc/ -I %t -fmodules -fobjc-arc -o %t/main -lResilient -lClasses -L %t
 // RUN: %target-codesign %t/main %t/libResilient.dylib %t/libClasses.dylib
 // RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
@@ -15,7 +15,7 @@
 // RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
 
 // Try again when the class itself is also resilient.
-// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %S/Inputs/class-layout-from-objc/ -I %t %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -target x86_64-apple-macosx10.14.4
+// RUN: %target-build-swift -emit-library -o %t/libClasses.dylib -emit-objc-header-path %t/Classes.h -I %S/Inputs/class-layout-from-objc/ -I %t %S/Inputs/class-layout-from-objc/Classes.swift %t/OneWordSuperclass.o -Xlinker -install_name -Xlinker @executable_path/libClasses.dylib -lResilient -L %t -target %target-stable-abi-triple
 // RUN: %target-codesign %t/libClasses.dylib
 // RUN: %target-run %t/main NEW %t/libResilient.dylib %t/libClasses.dylib
 
@@ -25,7 +25,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
+// REQUIRES: swift_stable_abi
 
 // The actual source code for the test is in class_update_callback_with_fixed_layout.m.

--- a/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
+++ b/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -enable-library-evolution %S/../../test/Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/%target-library-name(resilient_struct)
 
-// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main %target-rpath(%t) -target x86_64-apple-macosx10.14.4
+// RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main %target-rpath(%t) -target %target-stable-abi-triple
 // RUN: %target-codesign %t/main
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/libresilient_class%{target-shared-library-suffix}


### PR DESCRIPTION
A number of tests exercise features only available in Apple OSes that
shipped with Swift 5.0 in the OS; this includes the following versions:

- macOS 10.14.4
- iOS 12.2
- tvOS 12.2
- watchOS 5.2

Previously these tests were restricted to running on macOS only, with
an explicit -target x86_64-apple-macosx10.14.4. To get better test
coverage, add a new %target-stable-abi-triple substitution which
expands to a triple with the correct OS version on all Apple platforms.

On non-Apple platforms, this is the same as %target-variant-triple,
but for now any test that uses this exercises Apple platform features
anyway.

One caveat is that since iOS 12.2 does not have a 32-bit slice, we
have to skip any tests that use -target %target-stable-abi-triple
on this platform. A new swift_stable_abi feature flag can be tested
with 'REQUIRES: swift_stable_abi'. To get maximum test coverage,
I split off a 'stable_abi' version of a few tests that build with both
an old and new deployment target. This allows the old deployment
target case to still be tested on 32-bit iOS.