### PR TITLE
Remove a stray llvm::dbgs() from compile time debugging.

### DIFF
--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -129,7 +129,6 @@ bool AccessedStorageResult::mergeAccesses(
   // can occur ~1000 elements. 200 is large enough to cover "normal" code,
   // while ensuring compile time isn't affected.
   if (storageAccessSet.size() > 200) {
-    llvm::dbgs() << "BIG SET " << storageAccessSet.size() << "\n";
     setWorstEffects();
     return true;
   }


### PR DESCRIPTION
(cherry picked from commit 1120617b648770f81c9b32933afa42f9dc0621a3)
