### PR TITLE
[Interpreter] Fall back to loading Swift dylibs from /usr/lib/swift on Apple platforms.

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -64,8 +64,9 @@ public:
   /// Path to search for compiler-relative header files.
   std::string RuntimeResourcePath;
 
-  /// Path to search for compiler-relative stdlib dylibs.
-  std::string RuntimeLibraryPath;
+  /// Paths to search for compiler-relative stdlib dylibs, in order of
+  /// preference.
+  std::vector<std::string> RuntimeLibraryPaths;
 
   /// Paths to search for stdlib modules. One of these will be compiler-relative.
   std::vector<std::string> RuntimeLibraryImportPaths;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -30,6 +30,11 @@
 using namespace swift;
 using namespace llvm::opt;
 
+#if defined(__APPLE__) && defined(__MACH__)
+/// The path for Swift libraries in the OS.
+#define OS_LIBRARY_PATH "/usr/lib/swift"
+#endif
+
 swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
 }
@@ -66,7 +71,11 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
-  SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  SearchPathOpts.RuntimeLibraryPaths.clear();
+  SearchPathOpts.RuntimeLibraryPaths.push_back(LibPath.str());
+#if defined(__APPLE__) && defined(__MACH__)
+  SearchPathOpts.RuntimeLibraryPaths.push_back(OS_LIBRARY_PATH);
+#endif
 
   // Set up the import paths containing the swiftmodules for the libraries in
   // RuntimeLibraryPath.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -30,10 +30,8 @@
 using namespace swift;
 using namespace llvm::opt;
 
-#if defined(__APPLE__) && defined(__MACH__)
-/// The path for Swift libraries in the OS.
-#define OS_LIBRARY_PATH "/usr/lib/swift"
-#endif
+/// The path for Swift libraries in the OS on Darwin.
+#define DARWIN_OS_LIBRARY_PATH "/usr/lib/swift"
 
 swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
@@ -73,9 +71,8 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
   SearchPathOpts.RuntimeLibraryPaths.clear();
   SearchPathOpts.RuntimeLibraryPaths.push_back(LibPath.str());
-#if defined(__APPLE__) && defined(__MACH__)
-  SearchPathOpts.RuntimeLibraryPaths.push_back(OS_LIBRARY_PATH);
-#endif
+  if (Triple.isOSDarwin())
+    SearchPathOpts.RuntimeLibraryPaths.push_back(DARWIN_OS_LIBRARY_PATH);
 
   // Set up the import paths containing the swiftmodules for the libraries in
   // RuntimeLibraryPath.

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1066,9 +1066,12 @@ class ParseableInterfaceModuleLoaderImpl {
   }
 
   bool isInResourceDir(StringRef path) {
-    StringRef resourceDir = ctx.SearchPathOpts.RuntimeLibraryPath;
-    if (resourceDir.empty()) return false;
-    return path.startswith(resourceDir);
+    for (auto &RuntimeLibraryPath : ctx.SearchPathOpts.RuntimeLibraryPaths) {
+      if (path.startswith(RuntimeLibraryPath)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /// Finds the most appropriate .swiftmodule, whose dependencies are up to

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1066,12 +1066,9 @@ class ParseableInterfaceModuleLoaderImpl {
   }
 
   bool isInResourceDir(StringRef path) {
-    for (auto &RuntimeLibraryPath : ctx.SearchPathOpts.RuntimeLibraryPaths) {
-      if (path.startswith(RuntimeLibraryPath)) {
-        return true;
-      }
-    }
-    return false;
+    StringRef resourceDir = ctx.SearchPathOpts.RuntimeResourcePath;
+    if (resourceDir.empty()) return false;
+    return path.startswith(resourceDir);
   }
 
   /// Finds the most appropriate .swiftmodule, whose dependencies are up to

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1227,7 +1227,23 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
     if (!doesPlatformUseLegacyLayouts(platformName, archName))
       return;
 
-    defaultPath.append(IGM.Context.SearchPathOpts.RuntimeLibraryPath);
+    // Find the first runtime library path that exists.
+    bool found = false;
+    for (auto &RuntimeLibraryPath
+         : IGM.Context.SearchPathOpts.RuntimeLibraryPaths) {
+      if (llvm::sys::fs::exists(RuntimeLibraryPath)) {
+        defaultPath.append(RuntimeLibraryPath);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      auto joined = llvm::join(IGM.Context.SearchPathOpts.RuntimeLibraryPaths,
+                               "', '");
+      llvm::report_fatal_error("Unable to find a runtime library path at '"
+                               + joined + "'");
+    }
+
     llvm::sys::path::append(defaultPath, "layouts-");
     defaultPath.append(archName);
     defaultPath.append(".yaml");

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -66,8 +66,18 @@ static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
   return loadRuntimeLib(Path);
 }
 
-void *swift::immediate::loadSwiftRuntime(StringRef runtimeLibPath) {
-  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPath);
+static void *loadRuntimeLib(StringRef sharedLibName,
+                            const std::vector<std::string> runtimeLibPaths) {
+  for (auto &runtimeLibPath : runtimeLibPaths) {
+    if (void *handle = loadRuntimeLib(sharedLibName, runtimeLibPath))
+      return handle;
+  }
+  return nullptr;
+}
+
+void *swift::immediate::loadSwiftRuntime(const std::vector<std::string>
+                                         &runtimeLibPaths) {
+  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
 }
 
 static bool tryLoadLibrary(LinkLibrary linkLib,
@@ -105,9 +115,9 @@ static bool tryLoadLibrary(LinkLibrary linkLib,
     if (!success)
       success = loadRuntimeLib(stem);
 
-    // If that fails, try our runtime library path.
+    // If that fails, try our runtime library paths.
     if (!success)
-      success = loadRuntimeLib(stem, searchPathOpts.RuntimeLibraryPath);
+      success = loadRuntimeLib(stem, searchPathOpts.RuntimeLibraryPaths);
     break;
   }
   case LibraryKind::Framework: {
@@ -240,7 +250,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   //
   // This must be done here, before any library loading has been done, to avoid
   // racing with the static initializers in user code.
-  auto stdlib = loadSwiftRuntime(Context.SearchPathOpts.RuntimeLibraryPath);
+  auto stdlib = loadSwiftRuntime(Context.SearchPathOpts.RuntimeLibraryPaths);
   if (!stdlib) {
     CI.getDiags().diagnose(SourceLoc(),
                            diag::error_immediate_mode_missing_stdlib);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -59,7 +59,8 @@ static void *loadRuntimeLib(StringRef runtimeLibPathWithName) {
 #endif
 }
 
-static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
+static void *loadRuntimeLibAtPath(StringRef sharedLibName,
+                                  StringRef runtimeLibPath) {
   // FIXME: Need error-checking.
   llvm::SmallString<128> Path = runtimeLibPath;
   llvm::sys::path::append(Path, sharedLibName);
@@ -67,16 +68,16 @@ static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
 }
 
 static void *loadRuntimeLib(StringRef sharedLibName,
-                            const std::vector<std::string> runtimeLibPaths) {
+                            ArrayRef<std::string> runtimeLibPaths) {
   for (auto &runtimeLibPath : runtimeLibPaths) {
-    if (void *handle = loadRuntimeLib(sharedLibName, runtimeLibPath))
+    if (void *handle = loadRuntimeLibAtPath(sharedLibName, runtimeLibPath))
       return handle;
   }
   return nullptr;
 }
 
-void *swift::immediate::loadSwiftRuntime(const std::vector<std::string>
-                                         &runtimeLibPaths) {
+void *swift::immediate::loadSwiftRuntime(ArrayRef<std::string>
+                                         runtimeLibPaths) {
   return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
 }
 

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -37,8 +37,8 @@ namespace immediate {
 /// Returns a handle to the runtime suitable for other \c dlsym or \c dlclose
 /// calls or \c null if an error occurred.
 ///
-/// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-void *loadSwiftRuntime(const std::vector<std::string> &runtimeLibPaths);
+/// \param runtimeLibPaths Paths to search for stdlib dylibs.
+void *loadSwiftRuntime(ArrayRef<std::string> runtimeLibPaths);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -38,7 +38,7 @@ namespace immediate {
 /// calls or \c null if an error occurred.
 ///
 /// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-void *loadSwiftRuntime(StringRef runtimeLibPath);
+void *loadSwiftRuntime(const std::vector<std::string> &runtimeLibPaths);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -969,7 +969,7 @@ public:
     ASTContext &Ctx = CI.getASTContext();
     Ctx.LangOpts.EnableAccessControl = false;
     if (!ParseStdlib) {
-      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath)) {
+      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPaths)) {
         CI.getDiags().diagnose(SourceLoc(),
                                diag::error_immediate_mode_missing_stdlib);
         return;


### PR DESCRIPTION
Continue to load the dylibs next to the compiler if they exist. If they don't, then use the OS's dylibs.

Requires LLDB PR https://github.com/apple/swift-lldb/pull/1596.

rdar://problem/47528005