### PR TITLE
[5.1][Interpreter] Fall back to loading Swift dylibs from /usr/lib/swift on Apple platforms.

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -72,9 +72,6 @@ public:
 
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;
-  
-  /// Whether the runtime library path is set to the compiler-relative default.
-  bool RuntimeLibraryPathIsDefault = true;
 
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -64,8 +64,9 @@ public:
   /// Path to search for compiler-relative header files.
   std::string RuntimeResourcePath;
 
-  /// Path to search for compiler-relative stdlib dylibs.
-  std::string RuntimeLibraryPath;
+  /// Paths to search for compiler-relative stdlib dylibs, in order of
+  /// preference.
+  std::vector<std::string> RuntimeLibraryPaths;
 
   /// Paths to search for stdlib modules. One of these will be compiler-relative.
   std::vector<std::string> RuntimeLibraryImportPaths;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -183,7 +183,7 @@ public:
 
   void setMainExecutablePath(StringRef Path);
 
-  void setRuntimeResourcePath(StringRef Path, bool IsDefault = false);
+  void setRuntimeResourcePath(StringRef Path);
 
   void setSDKPath(const std::string &Path);
 

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -39,10 +39,6 @@ using namespace swift;
 using namespace swift::driver;
 using namespace llvm::opt;
 
-/// The path for Swift libraries in the OS. (Duplicated from Immediate.cpp.
-/// Eventually we should consolidate this.)
-#define OS_LIBRARY_PATH "/usr/lib/swift"
-
 std::string
 toolchains::Darwin::findProgramRelativeToSwiftImpl(StringRef name) const {
   StringRef swiftPath = getDriver().getSwiftProgramPath();
@@ -76,15 +72,12 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
                                         const JobContext &context) const {
   InvocationInfo II = ToolChain::constructInvocation(job, context);
 
-  SmallString<128> envValue(OS_LIBRARY_PATH ":");
-
   SmallString<128> runtimeLibraryPath;
   getRuntimeLibraryPath(runtimeLibraryPath, context.Args, /*Shared=*/true);
-  envValue.append(runtimeLibraryPath);
 
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_LIBRARY_PATH",
                                      ":", options::OPT_L, context.Args,
-                                     envValue);
+                                     runtimeLibraryPath);
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
                                      ":", options::OPT_F, context.Args);
   // FIXME: Add options::OPT_Fsystem paths to DYLD_FRAMEWORK_PATH as well.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -30,6 +30,11 @@
 using namespace swift;
 using namespace llvm::opt;
 
+#if defined(__APPLE__) && defined(__MACH__)
+/// The path for Swift libraries in the OS.
+#define OS_LIBRARY_PATH "/usr/lib/swift"
+#endif
+
 swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
 }
@@ -66,7 +71,11 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
-  SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  SearchPathOpts.RuntimeLibraryPaths.clear();
+  SearchPathOpts.RuntimeLibraryPaths.push_back(LibPath.str());
+#if defined(__APPLE__) && defined(__MACH__)
+  SearchPathOpts.RuntimeLibraryPaths.push_back(OS_LIBRARY_PATH);
+#endif
 
   // Set up the import paths containing the swiftmodules for the libraries in
   // RuntimeLibraryPath.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -39,7 +39,7 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::sys::path::remove_filename(LibPath); // Remove /swift
   llvm::sys::path::remove_filename(LibPath); // Remove /bin
   llvm::sys::path::append(LibPath, "lib", "swift");
-  setRuntimeResourcePath(LibPath.str(), /*IsDefault=*/true);
+  setRuntimeResourcePath(LibPath.str());
 }
 
 /// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
@@ -87,11 +87,9 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   }
 }
 
-void CompilerInvocation::setRuntimeResourcePath(StringRef Path,
-                                                bool IsDefault) {
+void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {
   SearchPathOpts.RuntimeResourcePath = Path;
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
-  SearchPathOpts.RuntimeLibraryPathIsDefault = IsDefault;
 }
 
 void CompilerInvocation::setTargetTriple(StringRef Triple) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -30,10 +30,8 @@
 using namespace swift;
 using namespace llvm::opt;
 
-#if defined(__APPLE__) && defined(__MACH__)
-/// The path for Swift libraries in the OS.
-#define OS_LIBRARY_PATH "/usr/lib/swift"
-#endif
+/// The path for Swift libraries in the OS on Darwin.
+#define DARWIN_OS_LIBRARY_PATH "/usr/lib/swift"
 
 swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
@@ -73,9 +71,8 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
   SearchPathOpts.RuntimeLibraryPaths.clear();
   SearchPathOpts.RuntimeLibraryPaths.push_back(LibPath.str());
-#if defined(__APPLE__) && defined(__MACH__)
-  SearchPathOpts.RuntimeLibraryPaths.push_back(OS_LIBRARY_PATH);
-#endif
+  if (Triple.isOSDarwin())
+    SearchPathOpts.RuntimeLibraryPaths.push_back(DARWIN_OS_LIBRARY_PATH);
 
   // Set up the import paths containing the swiftmodules for the libraries in
   // RuntimeLibraryPath.

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1066,9 +1066,12 @@ class ParseableInterfaceModuleLoaderImpl {
   }
 
   bool isInResourceDir(StringRef path) {
-    StringRef resourceDir = ctx.SearchPathOpts.RuntimeLibraryPath;
-    if (resourceDir.empty()) return false;
-    return path.startswith(resourceDir);
+    for (auto &RuntimeLibraryPath : ctx.SearchPathOpts.RuntimeLibraryPaths) {
+      if (path.startswith(RuntimeLibraryPath)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /// Finds the most appropriate .swiftmodule, whose dependencies are up to

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1066,12 +1066,9 @@ class ParseableInterfaceModuleLoaderImpl {
   }
 
   bool isInResourceDir(StringRef path) {
-    for (auto &RuntimeLibraryPath : ctx.SearchPathOpts.RuntimeLibraryPaths) {
-      if (path.startswith(RuntimeLibraryPath)) {
-        return true;
-      }
-    }
-    return false;
+    StringRef resourceDir = ctx.SearchPathOpts.RuntimeResourcePath;
+    if (resourceDir.empty()) return false;
+    return path.startswith(resourceDir);
   }
 
   /// Finds the most appropriate .swiftmodule, whose dependencies are up to

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -66,8 +66,18 @@ static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
   return loadRuntimeLib(Path);
 }
 
-void *swift::immediate::loadSwiftRuntime(StringRef runtimeLibPath) {
-  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPath);
+static void *loadRuntimeLib(StringRef sharedLibName,
+                            const std::vector<std::string> runtimeLibPaths) {
+  for (auto &runtimeLibPath : runtimeLibPaths) {
+    if (void *handle = loadRuntimeLib(sharedLibName, runtimeLibPath))
+      return handle;
+  }
+  return nullptr;
+}
+
+void *swift::immediate::loadSwiftRuntime(const std::vector<std::string>
+                                         &runtimeLibPaths) {
+  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
 }
 
 static bool tryLoadLibrary(LinkLibrary linkLib,
@@ -105,9 +115,9 @@ static bool tryLoadLibrary(LinkLibrary linkLib,
     if (!success)
       success = loadRuntimeLib(stem);
 
-    // If that fails, try our runtime library path.
+    // If that fails, try our runtime library paths.
     if (!success)
-      success = loadRuntimeLib(stem, searchPathOpts.RuntimeLibraryPath);
+      success = loadRuntimeLib(stem, searchPathOpts.RuntimeLibraryPaths);
     break;
   }
   case LibraryKind::Framework: {
@@ -240,7 +250,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   //
   // This must be done here, before any library loading has been done, to avoid
   // racing with the static initializers in user code.
-  auto stdlib = loadSwiftRuntime(Context.SearchPathOpts.RuntimeLibraryPath);
+  auto stdlib = loadSwiftRuntime(Context.SearchPathOpts.RuntimeLibraryPaths);
   if (!stdlib) {
     CI.getDiags().diagnose(SourceLoc(),
                            diag::error_immediate_mode_missing_stdlib);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -59,7 +59,8 @@ static void *loadRuntimeLib(StringRef runtimeLibPathWithName) {
 #endif
 }
 
-static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
+static void *loadRuntimeLibAtPath(StringRef sharedLibName,
+                                  StringRef runtimeLibPath) {
   // FIXME: Need error-checking.
   llvm::SmallString<128> Path = runtimeLibPath;
   llvm::sys::path::append(Path, sharedLibName);
@@ -67,16 +68,16 @@ static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
 }
 
 static void *loadRuntimeLib(StringRef sharedLibName,
-                            const std::vector<std::string> runtimeLibPaths) {
+                            ArrayRef<std::string> runtimeLibPaths) {
   for (auto &runtimeLibPath : runtimeLibPaths) {
-    if (void *handle = loadRuntimeLib(sharedLibName, runtimeLibPath))
+    if (void *handle = loadRuntimeLibAtPath(sharedLibName, runtimeLibPath))
       return handle;
   }
   return nullptr;
 }
 
-void *swift::immediate::loadSwiftRuntime(const std::vector<std::string>
-                                         &runtimeLibPaths) {
+void *swift::immediate::loadSwiftRuntime(ArrayRef<std::string>
+                                         runtimeLibPaths) {
   return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
 }
 

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -51,22 +51,10 @@
 using namespace swift;
 using namespace swift::immediate;
 
-/// The path for Swift libraries in the OS.
-#define OS_LIBRARY_PATH "/usr/lib/swift"
-
 static void *loadRuntimeLib(StringRef runtimeLibPathWithName) {
 #if defined(_WIN32)
   return LoadLibraryA(runtimeLibPathWithName.str().c_str());
 #else
-#if defined(__APPLE__) && defined(__MACH__)
-  if (!llvm::sys::path::is_absolute(runtimeLibPathWithName)) {
-    // Try an absolute path search for Swift in the OS first.
-    llvm::SmallString<128> absolutePath(OS_LIBRARY_PATH);
-    llvm::sys::path::append(absolutePath, runtimeLibPathWithName);
-    auto result = dlopen(absolutePath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
-    if (result) return result;
-  }
-#endif
   return dlopen(runtimeLibPathWithName.str().c_str(), RTLD_LAZY | RTLD_GLOBAL);
 #endif
 }
@@ -78,16 +66,8 @@ static void *loadRuntimeLib(StringRef sharedLibName, StringRef runtimeLibPath) {
   return loadRuntimeLib(Path);
 }
 
-void *swift::immediate::loadSwiftRuntime(StringRef runtimeLibPath,
-                                         bool IsDefault) {
-  StringRef LibName = "libswiftCore" LTDL_SHLIB_EXT;
-#if defined(__APPLE__) && defined(__MACH__)
-  if (IsDefault) {
-    auto result = loadRuntimeLib(LibName);
-    if (result) return result;
-  }
-#endif
-  return loadRuntimeLib(LibName, runtimeLibPath);
+void *swift::immediate::loadSwiftRuntime(StringRef runtimeLibPath) {
+  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPath);
 }
 
 static bool tryLoadLibrary(LinkLibrary linkLib,
@@ -260,9 +240,7 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   //
   // This must be done here, before any library loading has been done, to avoid
   // racing with the static initializers in user code.
-  auto stdlib = loadSwiftRuntime(
-    Context.SearchPathOpts.RuntimeLibraryPath,
-    Context.SearchPathOpts.RuntimeLibraryPathIsDefault);
+  auto stdlib = loadSwiftRuntime(Context.SearchPathOpts.RuntimeLibraryPath);
   if (!stdlib) {
     CI.getDiags().diagnose(SourceLoc(),
                            diag::error_immediate_mode_missing_stdlib);

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -37,8 +37,8 @@ namespace immediate {
 /// Returns a handle to the runtime suitable for other \c dlsym or \c dlclose
 /// calls or \c null if an error occurred.
 ///
-/// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-void *loadSwiftRuntime(const std::vector<std::string> &runtimeLibPaths);
+/// \param runtimeLibPaths Paths to search for stdlib dylibs.
+void *loadSwiftRuntime(ArrayRef<std::string> runtimeLibPaths);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -38,7 +38,7 @@ namespace immediate {
 /// calls or \c null if an error occurred.
 ///
 /// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-void *loadSwiftRuntime(StringRef runtimeLibPath);
+void *loadSwiftRuntime(const std::vector<std::string> &runtimeLibPaths);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -38,8 +38,7 @@ namespace immediate {
 /// calls or \c null if an error occurred.
 ///
 /// \param runtimeLibPath Path to search for compiler-relative stdlib dylibs.
-/// \param IsDefault If true, the path is the default compiler-relative path.
-void *loadSwiftRuntime(StringRef runtimeLibPath, bool IsDefault);
+void *loadSwiftRuntime(StringRef runtimeLibPath);
 bool tryLoadLibraries(ArrayRef<LinkLibrary> LinkLibraries,
                       SearchPathOptions SearchPathOpts,
                       DiagnosticEngine &Diags);

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -969,7 +969,7 @@ public:
     ASTContext &Ctx = CI.getASTContext();
     Ctx.LangOpts.EnableAccessControl = false;
     if (!ParseStdlib) {
-      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath)) {
+      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPaths)) {
         CI.getDiags().diagnose(SourceLoc(),
                                diag::error_immediate_mode_missing_stdlib);
         return;

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -969,8 +969,7 @@ public:
     ASTContext &Ctx = CI.getASTContext();
     Ctx.LangOpts.EnableAccessControl = false;
     if (!ParseStdlib) {
-      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath,
-                            Ctx.SearchPathOpts.RuntimeLibraryPathIsDefault)) {
+      if (!loadSwiftRuntime(Ctx.SearchPathOpts.RuntimeLibraryPath)) {
         CI.getDiags().diagnose(SourceLoc(),
                                diag::error_immediate_mode_missing_stdlib);
         return;

--- a/test/Driver/Inputs/print-var.sh
+++ b/test/Driver/Inputs/print-var.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 last_arg=${@: -1}
-echo ${!last_arg:-NO_VALUE}
+echo ${!last_arg}

--- a/test/Driver/environment-mac.swift
+++ b/test/Driver/environment-mac.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=macosx
 
-// RUN: %swift_driver -driver-use-frontend-path %S/Inputs/print-var.sh %s DYLD_LIBRARY_PATH | %FileCheck %s --dump-input fail
+// RUN: %swift_driver -driver-use-frontend-path %S/Inputs/print-var.sh %s DYLD_LIBRARY_PATH | %FileCheck %s
 
 // CHECK: {{^/usr/lib/swift:}}

--- a/test/Driver/environment-mac.swift
+++ b/test/Driver/environment-mac.swift
@@ -1,5 +1,0 @@
-// REQUIRES: OS=macosx
-
-// RUN: %swift_driver -driver-use-frontend-path %S/Inputs/print-var.sh %s DYLD_LIBRARY_PATH | %FileCheck %s
-
-// CHECK: {{^/usr/lib/swift:}}

--- a/test/Driver/environment-mac.swift
+++ b/test/Driver/environment-mac.swift
@@ -2,7 +2,4 @@
 
 // RUN: %swift_driver -driver-use-frontend-path %S/Inputs/print-var.sh %s DYLD_LIBRARY_PATH | %FileCheck %s --dump-input fail
 
-// Pass if the variable is not set at all. Something causes the
-// variable to get lost in PR testing. Accept that for now. This is
-// a temporary solution and so this will go away soon in any case.
-// CHECK: {{(^/usr/lib/swift:)|(^NO_VALUE$)}}
+// CHECK: {{^/usr/lib/swift:}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -15,20 +15,20 @@
 
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY %s
-// CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH={{(/usr/lib/swift:)?}}/RSRC/macosx{{$}}
+// CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
 // CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
-// CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:(/usr/lib/swift:)?[^:]+/lib/swift/macosx$}}
+// CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2 %s
-// CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:(/usr/lib/swift:)?[^:]+/lib/swift/macosx$}}
+// CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
 // RUN: env DYLD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2-ENV %s
-// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:(/usr/lib/swift:)?[^:]+/lib/swift/macosx:/abc/$}}
+// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/abc/$}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
@@ -56,7 +56,7 @@
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #
 // CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
-// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:(/usr/lib/swift:)?[^:]+/lib/swift/macosx($| )}}
+// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}

--- a/test/Interpreter/repl_autolinking.swift
+++ b/test/Interpreter/repl_autolinking.swift
@@ -4,10 +4,7 @@
 // RUN: sed -n -e '/REPL_START$/,/REPL_END$/ p' %s > %t/repl.swift
 // RUN: %target-swiftc_driver -emit-library %t/a.swift -I %t -L %t -emit-module-path %t/ModuleA.swiftmodule -autolink-force-load -module-link-name ModuleA -module-name ModuleA -o %t/libModuleA.dylib
 // RUN: %target-swiftc_driver -emit-library %t/b.swift -I %t -L %t -emit-module-path %t/ModuleB.swiftmodule -autolink-force-load -module-link-name ModuleB -module-name ModuleB -o %t/libModuleB.dylib
-// RUN: DYLD_LIBRARY_PATH=/usr/lib/swift %swift -repl -I %t -L %t < %t/repl.swift 2>&1 | %FileCheck %s
-
-// FIXME: remove DYLD_LIBRARY_PATH from the last command when we fix the 
-// interpreter's runtime library lookup.
+// RUN: %swift -repl -I %t -L %t < %t/repl.swift 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_repl
 // UNSUPPORTED: OS=linux-gnu


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24838 to 5.1. This also reverts https://github.com/apple/swift/pull/23983, which was a temporary change superseded this one.

Requires LLDB PR https://github.com/apple/swift-lldb/pull/1597.

Continue to load the dylibs next to the compiler if they exist. If they don't, then use the OS's dylibs.

rdar://problem/47528005