### PR TITLE
SectionRef::getContents() now returns Expected

### DIFF
--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -107,26 +107,38 @@ public:
 
 /// Look inside the object file 'ObjectFile' and append any linker flags found in
 /// its ".swift1_autolink_entries" section to 'LinkerFlags'.
-static void
+/// Return 'true' if there was an error, and 'false' otherwise.
+static bool
 extractLinkerFlagsFromObjectFile(const llvm::object::ObjectFile *ObjectFile,
-                                 std::vector<std::string> &LinkerFlags) {
+                                 std::vector<std::string> &LinkerFlags,
+                                 CompilerInstance &Instance) {
   // Search for the section we hold autolink entries in
   for (auto &Section : ObjectFile->sections()) {
     llvm::StringRef SectionName;
     Section.getName(SectionName);
     if (SectionName == ".swift1_autolink_entries") {
-      llvm::StringRef SectionData;
-      Section.getContents(SectionData);
+      llvm::Expected<llvm::StringRef> SectionData = Section.getContents();
+      if (!SectionData) {
+        std::string message;
+        {
+          llvm::raw_string_ostream os(message);
+          logAllUnhandledErrors(SectionData.takeError(), os, "");
+        }
+        Instance.getDiags().diagnose(SourceLoc(), diag::error_open_input_file,
+                                  ObjectFile->getFileName() , message);
+        return true;
+      }
 
       // entries are null-terminated, so extract them and push them into
       // the set.
       llvm::SmallVector<llvm::StringRef, 4> SplitFlags;
-      SectionData.split(SplitFlags, llvm::StringRef("\0", 1), -1,
-                        /*KeepEmpty=*/false);
+      SectionData->split(SplitFlags, llvm::StringRef("\0", 1), -1,
+          /*KeepEmpty=*/false);
       for (const auto &Flag : SplitFlags)
         LinkerFlags.push_back(Flag);
     }
   }
+  return false;
 }
 
 /// Look inside the binary 'Bin' and append any linker flags found in its
@@ -138,12 +150,10 @@ static bool extractLinkerFlags(const llvm::object::Binary *Bin,
                                StringRef BinaryFileName,
                                std::vector<std::string> &LinkerFlags) {
   if (auto *ObjectFile = llvm::dyn_cast<llvm::object::ELFObjectFileBase>(Bin)) {
-    extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags);
-    return false;
+    return extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags, Instance);
   } else if (auto *ObjectFile =
                  llvm::dyn_cast<llvm::object::COFFObjectFile>(Bin)) {
-    extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags);
-    return false;
+    return extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags, Instance);
   } else if (auto *Archive = llvm::dyn_cast<llvm::object::Archive>(Bin)) {
     llvm::Error Error = llvm::Error::success();
     for (const auto &Child : Archive->children(Error)) {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -169,10 +169,15 @@ collectASTModules(llvm::cl::list<std::string> &InputNames,
           (ELF && Name == swift::ELFASTSectionName) ||
           (COFF && Name == swift::COFFASTSectionName)) {
         uint64_t Size = Section.getSize();
-        StringRef ContentsReference;
-        Section.getContents(ContentsReference);
+
+        llvm::Expected<llvm::StringRef> ContentsReference = Section.getContents();
+        if (!ContentsReference) {
+          llvm::outs() << "error: " << name << " "
+            << errorToErrorCode(OF.takeError()).message() << "\n";
+          return false;
+        }
         char *Module = Alloc.Allocate<char>(Size);
-        std::memcpy(Module, (void *)ContentsReference.begin(), Size);
+        std::memcpy(Module, (void *)ContentsReference->begin(), Size);
         Modules.push_back({Module, Size});
       }
     }


### PR DESCRIPTION
Updated uses of object::SectionRef::getContents() since it now returns
an Expected<StringRef> instead of modifying the one it's passed.

See also: git-svn-id:
https://llvm.org/svn/llvm-project/llvm/trunk@360892
91177308-0d34-0410-b5e6-96231b3b80d8

See also: https://github.com/apple/swift-llvm/commit/7287acf23f80ec42d032e7d019453aa80286caa7
