### PR TITLE
[IDE] Disable constraint system diagnostics during code completion

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -634,7 +634,7 @@ namespace swift {
     }
 
     /// Return all \c DiagnosticConsumers.
-    ArrayRef<DiagnosticConsumer *> getConsumers() {
+    ArrayRef<DiagnosticConsumer *> getConsumers() const {
       return Consumers;
     }
 

--- a/include/swift/AST/DiagnosticSuppression.h
+++ b/include/swift/AST/DiagnosticSuppression.h
@@ -37,6 +37,7 @@ class DiagnosticSuppression {
 public:
   explicit DiagnosticSuppression(DiagnosticEngine &diags);
   ~DiagnosticSuppression();
+  static bool isEnabled(const DiagnosticEngine &diags);
 };
 
 }

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -103,13 +103,6 @@ public:
            rangeContainsTokenLoc(Enclosing, Inner.End);
   }
 
-  /// Returns true if range \p R contains the code-completion location, if any.
-  bool rangeContainsCodeCompletionLoc(SourceRange R) const {
-    return CodeCompletionBufferID
-               ? rangeContainsTokenLoc(R, getCodeCompletionLoc())
-               : false;
-  }
-
   /// Returns the buffer ID for the specified *valid* location.
   ///
   /// Because a valid source location always corresponds to a source buffer,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -923,6 +923,10 @@ DiagnosticSuppression::~DiagnosticSuppression() {
     diags.addConsumer(*consumer);
 }
 
+bool DiagnosticSuppression::isEnabled(const DiagnosticEngine &diags) {
+  return diags.getConsumers().empty();
+}
+
 BufferIndirectlyCausingDiagnosticRAII::BufferIndirectlyCausingDiagnosticRAII(
     const SourceFile &SF)
     : Diags(SF.getASTContext().Diags) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -496,12 +496,6 @@ bool TypeChecker::typeCheckFunctionBuilderFuncBody(FuncDecl *FD,
       options |= TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType;
   }
 
-  // If we are performing code-completion inside the functions body, supress
-  // diagnostics to workaround typechecking performance problems.
-  if (Context.SourceMgr.rangeContainsCodeCompletionLoc(
-          FD->getBody()->getSourceRange()))
-    options |= TypeCheckExprFlags::SuppressDiagnostics;
-
   // Type-check the single result expression.
   Type returnExprType = typeCheckExpression(returnExpr, FD,
                                             TypeLoc::withoutLoc(returnType),
@@ -579,12 +573,6 @@ ConstraintSystem::TypeMatchResult ConstraintSystem::applyFunctionBuilder(
     }
     assert(!builderType->hasTypeParameter());
   }
-
-  // If we are performing code-completion inside the closure body, supress
-  // diagnostics to workaround typechecking performance problems.
-  if (getASTContext().SourceMgr.rangeContainsCodeCompletionLoc(
-          closure->getSourceRange()))
-    Options |= ConstraintSystemFlags::SuppressDiagnostics;
 
   BuilderClosureVisitor visitor(getASTContext(), this,
                                 /*wantExpr=*/true, builderType);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
@@ -2175,7 +2176,8 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   // Construct a constraint system from this expression.
   ConstraintSystemOptions csOptions = ConstraintSystemFlags::AllowFixes;
 
-  if (options.contains(TypeCheckExprFlags::SuppressDiagnostics))
+  if (options.contains(TypeCheckExprFlags::SuppressDiagnostics) ||
+      DiagnosticSuppression::isEnabled(Diags))
     csOptions |= ConstraintSystemFlags::SuppressDiagnostics;
 
   if (options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2134,7 +2134,7 @@ private:
 
   void maybeProduceFallbackDiagnostic(Expr *expr) const {
     if (Options.contains(TypeCheckExprFlags::SubExpressionDiagnostics) ||
-        Options.contains(TypeCheckExprFlags::SuppressDiagnostics))
+        DiagnosticSuppression::isEnabled(TC.Diags))
       return;
 
     // Before producing fatal error here, let's check if there are any "error"
@@ -2176,8 +2176,7 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   // Construct a constraint system from this expression.
   ConstraintSystemOptions csOptions = ConstraintSystemFlags::AllowFixes;
 
-  if (options.contains(TypeCheckExprFlags::SuppressDiagnostics) ||
-      DiagnosticSuppression::isEnabled(Diags))
+  if (DiagnosticSuppression::isEnabled(Diags))
     csOptions |= ConstraintSystemFlags::SuppressDiagnostics;
 
   if (options.contains(TypeCheckExprFlags::AllowUnresolvedTypeVariables))

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
@@ -2031,10 +2032,10 @@ Expr* TypeChecker::constructCallToSuperInit(ConstructorDecl *ctor,
   if (ctor->hasThrows())
     r = new (Context) TryExpr(SourceLoc(), r, Type(), /*implicit=*/true);
 
+  DiagnosticSuppression suppression(Diags);
   auto resultTy =
       typeCheckExpression(r, ctor, TypeLoc(), CTP_Unused,
-                          TypeCheckExprFlags::IsDiscarded |
-                              TypeCheckExprFlags::SuppressDiagnostics);
+                          TypeCheckExprFlags::IsDiscarded);
   if (!resultTy)
     return nullptr;
   

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -760,8 +760,7 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   TypeChecker &TC = createTypeChecker(ctx);
 
   auto resultTy = TC.typeCheckExpression(parsedExpr, DC, TypeLoc(),
-                                    ContextualTypePurpose::CTP_Unused,
-                                    TypeCheckExprFlags::SuppressDiagnostics);
+                                         ContextualTypePurpose::CTP_Unused);
   return !resultTy;
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -235,9 +235,6 @@ enum class TypeCheckExprFlags {
   /// that we force for style or other reasons.
   DisableStructuralChecks = 0x02,
 
-  /// Set if the client wants diagnostics suppressed.
-  SuppressDiagnostics = 0x04,
-
   /// If set, the client wants a best-effort solution to the constraint system,
   /// but can tolerate a solution where all of the constraints are solved, but
   /// not all type variables have been determined.  In this case, the constraint


### PR DESCRIPTION
It seems disabling diagnostics doesn't introduce any regression.

rdar://problem/50679428
