### PR TITLE
[Test] Add availability to the ResilientNSObject test in objc_getClass.swift

### DIFF
--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -225,6 +225,7 @@ testSuite.test("ResilientNSObject")
                 reason: "objc_getClass hook not present"))
   .requireOwnProcess()
   .code {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
   requireClass(named: "_TtC4main27ResilientSubclassOfNSObject",
                demangledName: "main.ResilientSubclassOfNSObject")
   requireClass(named: "_TtC4main34ResilientSubclassOfGenericNSObject",


### PR DESCRIPTION
This is a new test in Swift 5.1 that is not expected to pass when running
with the Swift 5.0 runtime library.

rdar://problem/50175915