### PR TITLE
[5.1-04-24] Parser: avoid skipping inactive code if we are building syntax trees.

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -638,6 +638,11 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     SmallVector<ASTNode, 16> Elements;
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);
+    } else if (SyntaxContext->isEnabled()) {
+      // We shouldn't skip code if we are building syntax tree.
+      // The parser will keep running and we just discard the AST part.
+      SmallVector<ASTNode, 16> dropedElements;
+      parseElements(dropedElements, false);
     } else {
       DiagnosticTransaction DT(Diags);
       skipUntilConditionalBlockClose();

--- a/test/Syntax/diagnostics_verify.swift
+++ b/test/Syntax/diagnostics_verify.swift
@@ -19,3 +19,7 @@ class { // expected-error {{unknown declaration syntax exists in the source}}
   // expected-error@-4 {{top-level statement cannot begin with a closure expression}}
 
 }
+
+#if swift(<1)
+print("Wat")
+#endif


### PR DESCRIPTION
If syntax trees are requested, we shouldn't skip inactive code. Notice the
inactive code won't be skipped in SwiftSyntax because we always set
PerformConditionEvaluation false for the in-process parser.

This is mostly needed for testing purposes where we add -verify-syntax-tree
to regular compiler invocations.

rdar://50837165
