### PR TITLE
[build-script] Transform IndexStoreDB and SorcekitLSP to use ProductBuilder

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -964,20 +964,16 @@ class BuildScriptInvocation(object):
 
         # Non-build-script-impl products...
         # Note: currently only supports building for the host.
-        for host_target in [self.args.host_target]:
+        for host_target in [
+                StdlibDeploymentTarget.get_target_for_name(
+                    self.args.host_target)]:
             for product_class in product_classes:
                 if product_class.is_build_script_impl_product():
                     continue
-                product_source = product_class.product_source_name()
-                product_name = product_class.product_name()
-                product = product_class(
-                    args=self.args,
-                    toolchain=self.toolchain,
-                    source_dir=self.workspace.source_dir(product_source),
-                    build_dir=self.workspace.build_dir(
-                        host_target, product_name))
-                product.build(host_target)
-                product.test(host_target)
+                builder = product_class.new_builder(
+                    self.args, self.toolchain, self.workspace, host_target)
+                builder.build()
+                builder.test()
 
         # Extract symbols...
         for host_target in all_hosts:

--- a/utils/swift_build_support/swift_build_support/products/build_script_helper_builder.py
+++ b/utils/swift_build_support/swift_build_support/products/build_script_helper_builder.py
@@ -1,0 +1,61 @@
+# swift_build_support/product_builders/build_script_helper_b... -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import abc
+import os
+import platform
+
+from . import product
+from .. import shell, targets
+
+
+class BuildScriptHelperBuilder(product.ProductBuilder):
+    def __init__(self, product_class, args, toolchain, workspace, host):
+        self.__source_dir = workspace.source_dir(
+            product_class.product_source_name())
+        self.__build_dir = workspace.build_dir(host.name,
+                                               product_class.product_name())
+        self.__args = args
+
+    def build(self):
+        self.__run_build_script_helper('build')
+
+    def test(self):
+        if self._should_test():
+            self.__run_build_script_helper('test')
+
+    @abc.abstractmethod
+    def _should_test(self):
+        pass
+
+    def __run_build_script_helper(self, action):
+        script_path = os.path.join(
+            self.__source_dir, 'Utilities', 'build-script-helper.py')
+        toolchain_path = self.__args.install_destdir
+        if platform.system() == 'Darwin':
+            # The prefix is an absolute path, so concatenate without os.path.
+            toolchain_path += \
+                targets.darwin_toolchain_prefix(self.__args.install_prefix)
+        if self.__args.build_variant == 'Debug':
+            configuration = 'debug'
+        else:
+            configuration = 'release'
+        helper_cmd = [
+            script_path,
+            action,
+            '--verbose',
+            '--package-path', self.__source_dir,
+            '--build-path', self.__build_dir,
+            '--configuration', configuration,
+            '--toolchain', toolchain_path,
+        ]
+        shell.call(helper_cmd)

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -30,13 +30,14 @@ class Ninja(product.Product):
 
     @classmethod
     def new_builder(cls, args, toolchain, workspace, host):
-        return NinjaBuilder(cls, args, toolchain, workspace)
+        return NinjaBuilder(cls, args, toolchain, workspace, host)
 
 
 class NinjaBuilder(product.ProductBuilder):
-    def __init__(self, product_class, args, toolchain, workspace):
+    def __init__(self, product_class, args, toolchain, workspace, host):
         self.source_dir = workspace.source_dir(
             product_class.product_source_name())
+        # host is ignored. Ninja only builds for the build host.
         self.build_dir = workspace.build_dir('build',
                                              product_class.product_name())
         self.args = args

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -40,20 +40,6 @@ class Product(object):
         """
         return True
 
-    def build(self, host_target):
-        """build() -> void
-
-        Perform the build, for a non-build-script-impl product.
-        """
-        raise NotImplementedError
-
-    def test(self, host_target):
-        """test() -> void
-
-        Run the tests, for a non-build-script-impl product.
-        """
-        raise NotImplementedError
-
     def __init__(self, args, toolchain, source_dir, build_dir):
         self.args = args
         self.toolchain = toolchain
@@ -81,7 +67,7 @@ class ProductBuilder(object):
     """
 
     @abc.abstractmethod
-    def __init__(self, product_class, args, toolchain, workspace):
+    def __init__(self, product_class, args, toolchain, workspace, host):
         """
         Create a product builder for the given product class.
 
@@ -102,6 +88,10 @@ class ProductBuilder(object):
             to be located. A builder should use the workspace to access its own
             source/build directory, as well as other products source/build
             directories.
+        host : `swift_build_support.targets.Target`
+            The target host for the product. The product is intended to be used
+            in the given target, even if the build machine is of a different OS
+            and/or architecture.
         """
         pass
 

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -10,8 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
-from . import indexstoredb
 from . import product
+from .build_script_helper_builder import BuildScriptHelperBuilder
 
 
 class SourceKitLSP(product.Product):
@@ -23,11 +23,16 @@ class SourceKitLSP(product.Product):
     def is_build_script_impl_product(cls):
         return False
 
-    def build(self, host_target):
-        indexstoredb.run_build_script_helper(
-            'build', host_target, self, self.args)
+    @classmethod
+    def new_builder(cls, args, toolchain, workspace, host):
+        return SourceKitLSPBuilder(cls, args, toolchain, workspace, host)
 
-    def test(self, host_target):
-        if self.args.test and self.args.test_sourcekitlsp:
-            indexstoredb.run_build_script_helper(
-                'test', host_target, self, self.args)
+
+class SourceKitLSPBuilder(BuildScriptHelperBuilder):
+    def __init__(self, product_class, args, toolchain, workspace, host):
+        BuildScriptHelperBuilder.__init__(self, product_class, args, toolchain,
+                                          workspace, host)
+        self.__args = args
+
+    def _should_test(self):
+        return self.__args.test and self.__args.test_sourcekitlsp

--- a/utils/swift_build_support/tests/products/test_benchmarks.py
+++ b/utils/swift_build_support/tests/products/test_benchmarks.py
@@ -1,0 +1,100 @@
+# tests/products/test_benchmarks.py -----------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products.benchmarks import Benchmarks
+from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.workspace import Workspace
+
+
+class BenchmarkTestCase(unittest.TestCase):
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, 'swift', 'benchmarks'))
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        self.host = StdlibDeploymentTarget.host_target()
+
+        # Setup args
+        self.args = argparse.Namespace(
+            install_destdir='/dest/dir/path',
+            install_prefix='/install/prefix/path.toolchain/usr')
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.args = None
+
+    def test_build(self):
+        builder = Benchmarks.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_toolchain_path = self.args.install_destdir
+        if platform.system() == 'Darwin':
+            expected_toolchain_path += '/install/prefix/path.toolchain'
+
+        expected_output = "+ {} --verbose --package-path {} --build-path {} "\
+                          "--toolchain {}\n".format(
+                              os.path.join(self.workspace.source_dir('swift'),
+                                           'benchmark', 'scripts',
+                                           'build_script_helper.py'),
+                              os.path.join(self.workspace.source_dir('swift'),
+                                           'benchmark'),
+                              self.workspace.build_dir(self.host.name,
+                                                       'benchmarks'),
+                              expected_toolchain_path)
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test(self):
+        builder = Benchmarks.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        expected_output = """\
++ {bin_dir}/Benchmark_Onone --num-iters=1 XorLoop
++ {bin_dir}/Benchmark_O --num-iters=1 XorLoop
++ {bin_dir}/Benchmark_Osize --num-iters=1 XorLoop
+""".format(bin_dir=os.path.join(
+            self.workspace.build_dir(
+                self.host.name, 'benchmarks'), 'bin'))
+        self.assertEqual(self.stdout.getvalue(), expected_output)

--- a/utils/swift_build_support/tests/products/test_build_script_helper_builder.py
+++ b/utils/swift_build_support/tests/products/test_build_script_helper_builder.py
@@ -1,0 +1,173 @@
+# tests/products/test_build_script_helper_builder.py -------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products.build_script_helper_builder import \
+    BuildScriptHelperBuilder
+from swift_build_support.products.product import Product
+from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.workspace import Workspace
+
+
+# BuildScriptHelperBuilder needs concrete subclasses to work.
+class TestingBuildScriptHelperBuilder(BuildScriptHelperBuilder):
+    def _should_test(self):
+        return True
+
+
+class NonTestingBuildScriptHelperBuilder(BuildScriptHelperBuilder):
+    def _should_test(self):
+        return False
+
+
+# We also need a concrete product
+class MockProduct(Product):
+    pass
+
+
+class BuildScriptHelperBuilderTestCase(unittest.TestCase):
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, MockProduct.product_source_name()))
+
+        self.host = StdlibDeploymentTarget.host_target()
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup args
+        self.args = argparse.Namespace(
+            build_variant=None,
+            install_destdir='/dest/dir/path',
+            install_prefix='/install/prefix/path.toolchain/usr')
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+        # Setup some expected values which are reused in many tests
+        self.expected_source_dir = self.workspace.source_dir(
+            MockProduct.product_source_name())
+        self.expected_script_path = os.path.join(self.expected_source_dir,
+                                                 'Utilities',
+                                                 'build-script-helper.py')
+        self.expected_build_dir = self.workspace.build_dir(
+            self.host.name, MockProduct.product_name())
+        self.expected_toolchain_path = self.args.install_destdir
+        if platform.system() == 'Darwin':
+            self.expected_toolchain_path += '/install/prefix/path.toolchain'
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.args = None
+
+    def test_build_debug(self):
+        self.args.build_variant = 'Debug'
+
+        builder = NonTestingBuildScriptHelperBuilder(
+            MockProduct, self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_output = "+ {} build --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_build_release(self):
+        self.args.build_variant = 'Release'
+
+        builder = NonTestingBuildScriptHelperBuilder(
+            MockProduct, self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_output = "+ {} build --verbose --package-path {} "\
+                          "--build-path {} --configuration release "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_build_release_with_debinfo(self):
+        self.args.build_variant = 'RelWithDebInfo'
+
+        builder = NonTestingBuildScriptHelperBuilder(
+            MockProduct, self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_output = "+ {} build --verbose --package-path {} "\
+                          "--build-path {} --configuration release "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test_with_non_testing_product(self):
+        self.args.build_variant = 'Debug'
+
+        builder = NonTestingBuildScriptHelperBuilder(
+            MockProduct, self.args, None, self.workspace, self.host)
+        builder.test()
+
+        self.assertEqual(self.stdout.getvalue(), "")
+
+    def test_test_with_testing_product(self):
+        self.args.build_variant = 'Debug'
+
+        builder = TestingBuildScriptHelperBuilder(
+            MockProduct, self.args, None, self.workspace, self.host)
+        builder.test()
+
+        expected_output = "+ {} test --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)

--- a/utils/swift_build_support/tests/products/test_indexstoredb.py
+++ b/utils/swift_build_support/tests/products/test_indexstoredb.py
@@ -1,0 +1,123 @@
+# tests/products/test_indexstoredb.py ---------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products.indexstoredb import IndexStoreDB
+from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.workspace import Workspace
+
+
+class IndexStoreDBTestCase(unittest.TestCase):
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, IndexStoreDB.product_source_name()))
+
+        self.host = StdlibDeploymentTarget.host_target()
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup args
+        self.args = argparse.Namespace(
+            build_variant='Debug',
+            install_destdir='/dest/dir/path',
+            install_prefix='/install/prefix/path.toolchain/usr',
+            test=None,
+            test_indexstoredb=None)
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+        # Setup some expected values which are reused in many tests
+        self.expected_source_dir = self.workspace.source_dir(
+            IndexStoreDB.product_source_name())
+        self.expected_script_path = os.path.join(self.expected_source_dir,
+                                                 'Utilities',
+                                                 'build-script-helper.py')
+        self.expected_build_dir = self.workspace.build_dir(
+            self.host.name, IndexStoreDB.product_name())
+        self.expected_toolchain_path = self.args.install_destdir
+        if platform.system() == 'Darwin':
+            self.expected_toolchain_path += '/install/prefix/path.toolchain'
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.args = None
+
+    def test_build(self):
+        builder = IndexStoreDB.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_output = "+ {} build --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test_with_enabled_testing(self):
+        self.args.test = True
+        self.args.test_indexstoredb = True
+
+        builder = IndexStoreDB.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        expected_output = "+ {} test --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test_with_disabled_testing(self):
+        self.args.test = False
+        self.args.test_indexstoredb = False
+
+        builder = IndexStoreDB.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        self.assertEqual(self.stdout.getvalue(), "")

--- a/utils/swift_build_support/tests/products/test_sourcekitlsp.py
+++ b/utils/swift_build_support/tests/products/test_sourcekitlsp.py
@@ -1,0 +1,123 @@
+# tests/products/test_sourcekitlsp.py ----------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products.sourcekitlsp import SourceKitLSP
+from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.workspace import Workspace
+
+
+class SourceKitLSPTestCase(unittest.TestCase):
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, SourceKitLSP.product_source_name()))
+
+        self.host = StdlibDeploymentTarget.host_target()
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup args
+        self.args = argparse.Namespace(
+            build_variant='Debug',
+            install_destdir='/dest/dir/path',
+            install_prefix='/install/prefix/path.toolchain/usr',
+            test=None,
+            test_sourcekitlsp=None)
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+        # Setup some expected values which are reused in many tests
+        self.expected_source_dir = self.workspace.source_dir(
+            SourceKitLSP.product_source_name())
+        self.expected_script_path = os.path.join(self.expected_source_dir,
+                                                 'Utilities',
+                                                 'build-script-helper.py')
+        self.expected_build_dir = self.workspace.build_dir(
+            self.host.name, SourceKitLSP.product_name())
+        self.expected_toolchain_path = self.args.install_destdir
+        if platform.system() == 'Darwin':
+            self.expected_toolchain_path += '/install/prefix/path.toolchain'
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.args = None
+
+    def test_build(self):
+        builder = SourceKitLSP.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.build()
+
+        expected_output = "+ {} build --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test_with_enabled_testing(self):
+        self.args.test = True
+        self.args.test_sourcekitlsp = True
+
+        builder = SourceKitLSP.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        expected_output = "+ {} test --verbose --package-path {} "\
+                          "--build-path {} --configuration debug "\
+                          "--toolchain {}\n".format(
+                              self.expected_script_path,
+                              self.expected_source_dir,
+                              self.expected_build_dir,
+                              self.expected_toolchain_path)
+
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test_with_disabled_testing(self):
+        self.args.test = False
+        self.args.test_sourcekitlsp = False
+
+        builder = SourceKitLSP.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        self.assertEqual(self.stdout.getvalue(), "")

--- a/utils/swift_build_support/tests/products/test_tsan_libdispatch.py
+++ b/utils/swift_build_support/tests/products/test_tsan_libdispatch.py
@@ -1,0 +1,119 @@
+# tests/products/test_tsan_libdispatch.py ------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support.products import TSanLibDispatch
+from swift_build_support.targets import StdlibDeploymentTarget
+from swift_build_support.workspace import Workspace
+
+
+class BuildScriptHelperBuilderTestCase(unittest.TestCase):
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, 'compiler-rt'))
+
+        self.host = StdlibDeploymentTarget.host_target()
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup args
+        self.args = argparse.Namespace(
+            install_destdir='/dest/dir/path')
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+        # Setup some expected values which are reused in many tests
+        # self.expected_source_dir = self.workspace.source_dir(
+        #     MockProduct.product_source_name())
+        # self.expected_script_path = os.path.join(self.expected_source_dir,
+        #                                          'Utilities',
+        #                                          'build-script-helper.py')
+        # self.expected_build_dir = self.workspace.build_dir(
+        #     self.host.name, MockProduct.product_name())
+        # self.expected_toolchain_path = self.args.install_destdir
+        # if platform.system() == 'Darwin':
+        #     self.expected_toolchain_path += '/install/prefix/path.toolchain'
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.args = None
+
+    def test_build(self):
+        builder = TSanLibDispatch.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.build()
+
+        build_dir = self.workspace.build_dir(
+            self.host.name, TSanLibDispatch.product_name())
+
+        cmake_cmd = "cmake -GNinja "\
+                    "-DCMAKE_PREFIX_PATH=/dest/dir/path/usr "\
+                    "-DCMAKE_C_COMPILER=/dest/dir/path/usr/bin/clang "\
+                    "-DCMAKE_CXX_COMPILER=/dest/dir/path/usr/bin/clang++ "\
+                    "-DCMAKE_BUILD_TYPE=Release "\
+                    "-DLLVM_ENABLE_ASSERTIONS=ON "\
+                    "-DCOMPILER_RT_INCLUDE_TESTS=ON "\
+                    "-DCOMPILER_RT_BUILD_XRAY=OFF "\
+                    "-DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON "\
+                    "-DCOMPILER_RT_LIBDISPATCH_INSTALL_PATH="\
+                    "/dest/dir/path/usr " +\
+                    self.workspace.source_dir('compiler-rt')
+
+        expected_output = """\
++ rm -rf {}
++ mkdir -p {}
++ pushd {}
++ {}
++ ninja tsan
++ popd
+""".format(build_dir, build_dir, build_dir, cmake_cmd)
+        self.assertEqual(self.stdout.getvalue(), expected_output)
+
+    def test_test(self):
+        builder = TSanLibDispatch.new_builder(
+            self.args, None, self.workspace, self.host)
+        builder.test()
+
+        expected_output = """\
++ pushd {}
++ env LIT_FILTER=libdispatch ninja check-tsan
++ popd
+""".format(self.workspace.build_dir(self.host.name,
+                                    TSanLibDispatch.product_name()))
+        self.assertEqual(self.stdout.getvalue(), expected_output)


### PR DESCRIPTION
Create a new helper builder for IndexStoreDB and SourceKitLSP called
BuildScriptHelperBuilder (because the invoked script is called
build-script-helper.py). Move most of the code that existed in a
function in indexstore.db into that helper class.

Create small subtypes of the helper paramtrized for IndexStoreDB and
SourceKitLSP.

Modify the main build-script to invoke the new build instead of the
Product class directly. This way, when all the products use builders
to be build, all of them will use the same Python invocations, but
some of them will use build-script-impl, and others will use
build-script-helper.py.
