### PR TITLE
Remove remaining usages of `CotangentVector` and `tangentVector(from:)`.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3207,7 +3207,6 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
   auto funcResultElt = derivativeResultTupleType->getElement(1);
   // Get derivative kind and associated function identifier.
   AutoDiffAssociatedFunctionKind kind;
-  Identifier autoDiffAssocTyId;
   if (valueResultElt.getName().str() != "value") {
     TC.diagnose(attr->getLocation(),
                 diag::differentiating_attr_invalid_result_tuple_value_label);
@@ -3216,10 +3215,8 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
   }
   if (funcResultElt.getName().str() == "differential") {
     kind = AutoDiffAssociatedFunctionKind::JVP;
-    autoDiffAssocTyId = ctx.Id_TangentVector;
   } else if (funcResultElt.getName().str() == "pullback") {
     kind = AutoDiffAssociatedFunctionKind::VJP;
-    autoDiffAssocTyId = ctx.Id_TangentVector;
   } else {
     TC.diagnose(attr->getLocation(),
                 diag::differentiating_attr_invalid_result_tuple_func_label);
@@ -3376,14 +3373,14 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
         assert(conf &&
                "Expected checked parameter to conform to `Differentiable`");
         auto paramAssocType = ProtocolConformanceRef::getTypeWitnessByName(
-            paramType, *conf, autoDiffAssocTyId, ctx.getLazyResolver());
+            paramType, *conf, ctx.Id_TangentVector, ctx.getLazyResolver());
         return TupleTypeElt(paramAssocType);
       });
 
   // Check differential/pullback type.
   // Get vector type: the associated type of the value result type.
   auto vectorTy = ProtocolConformanceRef::getTypeWitnessByName(
-      valueResultType, *valueResultConf, autoDiffAssocTyId,
+      valueResultType, *valueResultConf, ctx.Id_TangentVector,
       ctx.getLazyResolver());
 
   // Compute expected differential/pullback type.

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -4,7 +4,7 @@ import StdlibUnittest
 
 var ArrayAutodiffTests = TestSuite("ArrayAutodiff")
 
-typealias FloatArrayGrad = Array<Float>.CotangentVector
+typealias FloatArrayGrad = Array<Float>.TangentVector
 
 ArrayAutodiffTests.test("ArrayIdentity") {
   func arrayIdentity(_ x: [Float]) -> [Float] {
@@ -39,21 +39,21 @@ ArrayAutodiffTests.test("ArrayConcat") {
   }
 
   expectEqual(
-    TwoArrays.CotangentVector(
+    TwoArrays.TangentVector(
       a: FloatArrayGrad([1, 1]),
       b: FloatArrayGrad([1, 0])),
     gradient(
       at: TwoArrays(a: [0, 0], b: [0, 0]),
       in: sumFirstThreeConcatted))
   expectEqual(
-    TwoArrays.CotangentVector(
+    TwoArrays.TangentVector(
       a: FloatArrayGrad([1, 1, 1, 0]),
       b: FloatArrayGrad([0, 0])),
     gradient(
       at: TwoArrays(a: [0, 0, 0, 0], b: [0, 0]),
       in: sumFirstThreeConcatted))
   expectEqual(
-    TwoArrays.CotangentVector(
+    TwoArrays.TangentVector(
       a: FloatArrayGrad([]),
       b: FloatArrayGrad([1, 1, 1, 0])),
     gradient(

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -36,7 +36,6 @@ extension S : Differentiable, VectorNumeric {
   static func * (lhs: Float, rhs: S) -> S { return S(p: lhs * rhs.p) }
 
   typealias TangentVector = S
-  typealias CotangentVector = S
 }
 
 // expected-error @+2 {{function is not differentiable}}

--- a/test/AutoDiff/derivative_registration.swift
+++ b/test/AutoDiff/derivative_registration.swift
@@ -58,9 +58,9 @@ extension Wrapper {
 
   @differentiating(multiply)
   func _vjpMultiply(_ x: Float)
-    -> (value: Float, pullback: (Float) -> (Wrapper.CotangentVector, Float)) {
+    -> (value: Float, pullback: (Float) -> (Wrapper.TangentVector, Float)) {
     return (float * x, { v in
-      (Wrapper.CotangentVector(float: v * x), v * self.float)
+      (Wrapper.TangentVector(float: v * x), v * self.float)
     })
   }
 }
@@ -68,7 +68,7 @@ DerivativeRegistrationTests.test("InstanceMethod") {
   let x: Float = 2
   let wrapper = Wrapper(float: 3)
   let (𝛁wrapper, 𝛁x) = wrapper.gradient(at: x) { wrapper, x in wrapper.multiply(x) }
-  expectEqual(Wrapper.CotangentVector(float: 2), 𝛁wrapper)
+  expectEqual(Wrapper.TangentVector(float: 2), 𝛁wrapper)
   expectEqual(3, 𝛁x)
 }
 

--- a/test/AutoDiff/derived_conformances.swift
+++ b/test/AutoDiff/derived_conformances.swift
@@ -28,8 +28,8 @@ DerivedConformanceTests.test("MemberwiseInitializers") {
   }
   expectEqual(HasNoDerivativeConstant.AllDifferentiableVariables(x: 0),
               HasNoDerivativeConstant.AllDifferentiableVariables.zero)
-  expectEqual(HasNoDerivativeConstant.CotangentVector(x: 0),
-              HasNoDerivativeConstant.CotangentVector.zero)
+  expectEqual(HasNoDerivativeConstant.TangentVector(x: 0),
+              HasNoDerivativeConstant.TangentVector.zero)
 }
 
 runAllTests()

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -543,7 +543,6 @@ extension Tensor : Differentiable where Scalar : Differentiable {
   typealias TangentVector = Tensor
   typealias AllDifferentiableVariables = Tensor
   func moved(along direction: Tensor) -> Tensor { return self }
-  func tangentVector(from cotangent: Tensor) -> Tensor { return cotangent }
 }
 @differentiable(where Scalar : Differentiable)
 func where2<Scalar : Numeric>(x: Tensor<Scalar>) -> Tensor<Scalar> {

--- a/test/AutoDiff/differentiable_requirement_cross_module.swift
+++ b/test/AutoDiff/differentiable_requirement_cross_module.swift
@@ -8,12 +8,7 @@ import differentiable_requirement_other_module
 // The `foo` protocol requirement is `@differentiable` and has an `Empty` parameter.
 extension Empty : Differentiable {
   public typealias TangentVector = Empty
-  public typealias CotangentVector = Empty
   public typealias AllDifferentiableVariables = Empty
-
-  public func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return cotangent
-  }
 }
 
 // expected-error @+1 {{type 'Conforming' does not conform to protocol 'DifferentiableRequirement'}}

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -14,7 +14,6 @@ struct TangentSpace : VectorNumeric {
 
 extension TangentSpace : Differentiable {
   typealias TangentVector = TangentSpace
-  typealias CotangentVector = TangentSpace
 }
 
 struct Space {
@@ -48,12 +47,8 @@ struct Space {
 
 extension Space : Differentiable {
   typealias TangentVector = TangentSpace
-  typealias CotangentVector = TangentSpace
   func moved(along: TangentSpace) -> Space {
     return Space(x: x + along.dx, y: y + along.dy)
-  }
-  func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return cotangent
   }
 }
 
@@ -78,8 +73,8 @@ struct GenericMemberWrapper<T : Differentiable> : Differentiable {
   @differentiable(vjp: vjpX)
   var x: T
 
-  func vjpX() -> (T, (T.CotangentVector) -> GenericMemberWrapper.CotangentVector) {
-    return (x, { CotangentVector(x: $0) })
+  func vjpX() -> (T, (T.TangentVector) -> GenericMemberWrapper.TangentVector) {
+    return (x, { TangentVector(x: $0) })
   }
 }
 
@@ -87,7 +82,7 @@ E2EDifferentiablePropertyTests.test("generic stored property") {
   let actualGrad = gradient(at: GenericMemberWrapper<Float>(x: 1)) { point in
     return 2 * point.x
   }
-  let expectedGrad = GenericMemberWrapper<Float>.CotangentVector(x: 2)
+  let expectedGrad = GenericMemberWrapper<Float>.TangentVector(x: 2)
   expectEqual(expectedGrad, actualGrad)
 }
 
@@ -98,7 +93,6 @@ struct ProductSpaceSelfTangent : VectorNumeric {
 
 extension ProductSpaceSelfTangent : Differentiable {
   typealias TangentVector = ProductSpaceSelfTangent
-  typealias CotangentVector = ProductSpaceSelfTangent
 }
 
 E2EDifferentiablePropertyTests.test("fieldwise product space, self tangent") {
@@ -115,7 +109,6 @@ struct ProductSpaceOtherTangentTangentSpace : VectorNumeric {
 
 extension ProductSpaceOtherTangentTangentSpace : Differentiable {
   typealias TangentVector = ProductSpaceOtherTangentTangentSpace
-  typealias CotangentVector = ProductSpaceOtherTangentTangentSpace
 }
 
 @_fieldwiseDifferentiable
@@ -125,12 +118,8 @@ struct ProductSpaceOtherTangent {
 
 extension ProductSpaceOtherTangent : Differentiable {
   typealias TangentVector = ProductSpaceOtherTangentTangentSpace
-  typealias CotangentVector = ProductSpaceOtherTangentTangentSpace
   func moved(along: ProductSpaceOtherTangentTangentSpace) -> ProductSpaceOtherTangent {
     return ProductSpaceOtherTangent(x: x + along.x, y: y + along.y)
-  }
-  func tangentVector(from cotangent: CotangentVector) -> TangentVector {
-    return cotangent
   }
 }
 

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -40,7 +40,6 @@ extension Parameter {
 
 extension Parameter : Differentiable, VectorNumeric {
   typealias TangentVector = Parameter
-  typealias CotangentVector = Parameter
   typealias Scalar = Float
   typealias Shape = ()
   init(repeating repeatedValue: Float, shape: ()) {
@@ -150,7 +149,7 @@ struct DiffWrtSelf : Differentiable {
     return (x, { (dself, dx, dy) in dx })
   }
   func _vjpCall<T : Differentiable, U : Differentiable>(_ x: T, _ y: U)
-    -> (T, (T.CotangentVector) -> (DiffWrtSelf.CotangentVector, T.CotangentVector, U.CotangentVector)) {
+    -> (T, (T.TangentVector) -> (DiffWrtSelf.TangentVector, T.TangentVector, U.TangentVector)) {
     return (x, { (.zero, $0, .zero) })
   }
 }
@@ -166,7 +165,6 @@ struct CustomParameter : Equatable {
 
 extension CustomParameter : Differentiable, VectorNumeric {
   typealias TangentVector = CustomParameter
-  typealias CotangentVector = CustomParameter
   typealias Scalar = Float
   typealias Shape = ()
   init(repeating repeatedValue: Float, shape: ()) {

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -9,15 +9,14 @@ protocol DiffReq : Differentiable {
   func f(_ x: Float) -> Float
 }
 
-extension DiffReq where TangentVector : AdditiveArithmetic, CotangentVector : AdditiveArithmetic {
-  func gradF(at x: Float) -> (Self.CotangentVector, Float) {
+extension DiffReq where TangentVector : AdditiveArithmetic {
+  func gradF(at x: Float) -> (Self.TangentVector, Float) {
     return (valueWithPullback(at: x) { s, x in s.f(x) }).1(1)
   }
 }
 
 struct Quadratic : DiffReq, Equatable {
   typealias TangentVector = Quadratic
-  typealias CotangentVector = Quadratic
 
   @differentiable(wrt: (self), vjp: vjpA)
   let a: Float

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -11,8 +11,6 @@ public struct Vector : AdditiveArithmetic, VectorNumeric, Differentiable, Equata
   public var y: Float
   public var nonTrivialStuff = NonTrivialStuff()
   public typealias TangentVector = Vector
-  public typealias CotangentVector = Vector
-  public func tangentVector(from cotangent: CotangentVector) -> TangentVector { return cotangent }
   public typealias Scalar = Float
   public static var zero: Vector { return Vector(0) }
   public init(_ scalar: Float) { self.x = scalar; self.y = scalar }

--- a/test/AutoDiff/separate_cotangent_type.swift
+++ b/test/AutoDiff/separate_cotangent_type.swift
@@ -23,9 +23,6 @@ struct DifferentiableSubset : Differentiable {
     typealias TangentVector = DifferentiableSubset.TangentVector
     var w: Float
     var b: Float
-    func tangentVector(from cotan: TangentVector) -> TangentVector {
-      return TangentVector(w: cotan.w, b: cotan.b)
-    }
   }
   func moved(along v: TangentVector) -> DifferentiableSubset {
     return DifferentiableSubset(w: w.moved(along: v.w), b: b.moved(along: v.b), flag: flag)

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -185,7 +185,7 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
   let 𝛁foo = pullback(at: Float(4), in: { input -> Foo in
     let foo = Foo(stored: input)
     return foo + foo
-  })(Foo.CotangentVector(stored: 1))
+  })(Foo.TangentVector(stored: 1))
   expectEqual(2, 𝛁foo)
 
   let 𝛁computed = gradient(at: Float(4)) { input -> Float in
@@ -214,7 +214,7 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
   let 𝛁custom = pullback(at: Float(4), in: { input -> Custom in
     let foo = Custom(x: input)
     return foo + foo
-  })(Custom.CotangentVector(x: 1))
+  })(Custom.TangentVector(x: 1))
   expectEqual(2, 𝛁custom)
 }
 
@@ -238,7 +238,7 @@ SimpleMathTests.test("StructConstantStoredProperty") {
     let model = TF_319(x: 10)
     return model.applied(to: input)
   }
-  expectEqual(TF_319.CotangentVector(x: 6),
+  expectEqual(TF_319.TangentVector(x: 6),
               gradient(at: TF_319(x: 10), in: { $0.applied(to: 3) }))
   expectEqual(20, gradient(at: 3, in: testStructInit))
 }
@@ -282,7 +282,8 @@ SimpleMathTests.test("StructSideEffects") {
     }
   }
   let model = Add(bias: 1)
-  expectEqual(Add.CotangentVector(bias: 1), gradient(at: model) { m in m.applied(to: 1) })
+  expectEqual(Add.TangentVector(bias: 1),
+              gradient(at: model) { m in m.applied(to: 1) })
 }
 
 SimpleMathTests.test("StructGeneric") {
@@ -295,7 +296,7 @@ SimpleMathTests.test("StructGeneric") {
   let 𝛁generic = pullback(at: Float(3), in: { input -> Generic<Float> in
     var generic = Generic(x: input, y: input, z: input)
     return generic
-  })(Generic<Float>.CotangentVector(x: 1, y: 1, z: 1))
+  })(Generic<Float>.TangentVector(x: 1, y: 1, z: 1))
   expectEqual(3, 𝛁generic)
 
   func fifthPower(_ input: Float) -> Float {

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -21,7 +21,6 @@ struct DenseLayer : Equatable {
 
 extension DenseLayer : Differentiable, VectorNumeric {
   typealias TangentVector = DenseLayer
-  typealias CotangentVector = DenseLayer
   typealias Scalar = Float
   static var zero: DenseLayer {
     return DenseLayer(w: 0, b: 0)
@@ -68,7 +67,6 @@ struct Model : Equatable {
 
 extension Model : Differentiable, VectorNumeric {
   typealias TangentVector = Model
-  typealias CotangentVector = Model
   typealias Scalar = Float
   static var zero: Model {
     return Model(l1: DenseLayer.zero, l2: DenseLayer.zero, l3: DenseLayer.zero)

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -20,7 +20,6 @@ struct S : Proto, VectorNumeric {
   static func * (lhs: Float, rhs: S) -> S { return S(p: lhs * rhs.p) }
 
   typealias TangentVector = S
-  typealias CotangentVector = S
 
   @differentiable(wrt: (self), vjp: vjpP)
   let p: Float

--- a/test/Serialization/differentiating_attr.swift
+++ b/test/Serialization/differentiating_attr.swift
@@ -26,7 +26,7 @@ func generic<T : Numeric>(x: T) -> T {
   return x
 }
 @differentiating(generic)
-func vjpGeneric<T>(x: T) -> (value: T, pullback: (T.CotangentVector) -> T.CotangentVector)
+func vjpGeneric<T>(x: T) -> (value: T, pullback: (T.TangentVector) -> T.TangentVector)
   where T : Numeric, T : Differentiable
 {
   return (x, { v in v })
@@ -40,7 +40,7 @@ protocol InstanceMethod : Differentiable {
 }
 extension InstanceMethod {
   @differentiating(foo)
-  func vjpFoo(x: Self) -> (value: Self, pullback: (Self.CotangentVector) -> (Self.CotangentVector, Self.CotangentVector)) {
+  func vjpFoo(x: Self) -> (value: Self, pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)) {
     return (x, { ($0, $0) })
   }
 


### PR DESCRIPTION
https://github.com/apple/swift/pull/24825 follow-up.