### PR TITLE
[IRGen] Remove SetBitEnumerator from ClusteredBitVector

### DIFF
--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -29,9 +29,8 @@ static unsigned getNumLowObjCReservedBits(const IRGenModule &IGM) {
     return 0;
 
   // Get the index of the first non-reserved bit.
-  SpareBitVector ObjCMask = IGM.TargetInfo.ObjCPointerReservedBits;
-  ObjCMask.flipAll();
-  return ObjCMask.enumerateSetBits().findNext().getValue();
+  auto &mask = IGM.TargetInfo.ObjCPointerReservedBits;
+  return mask.asAPInt().countTrailingOnes();
 }
 
 /*****************************************************************************/

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6778,62 +6778,141 @@ void irgen::emitStoreEnumTagToAddress(IRGenFunction &IGF,
     .storeTag(IGF, enumTy, enumAddr, theCase);
 }
 
-/// Scatter spare bits from the low bits of an integer value.
-llvm::Value *irgen::emitScatterSpareBits(IRGenFunction &IGF,
-                                         const SpareBitVector &spareBitMask,
-                                         llvm::Value *packedBits,
-                                         unsigned packedLowBit) {
-  auto destTy
-    = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), spareBitMask.size());
-  llvm::Value *result = nullptr;
-  unsigned usedBits = packedLowBit;
+/// Extract the rightmost run of contiguous set bits from the
+/// provided integer or zero if there are no set bits in the
+/// provided integer. For example:
+///
+///   rightmostMask(0x0f0f_0f0f) = 0x0000_000f
+///   rightmostMask(0xf0f0_f0f0) = 0x0000_00f0
+///   rightmostMask(0xffff_ff10) = 0x0000_0010
+///   rightmostMask(0xffff_ff80) = 0xffff_ff80
+///   rightmostMask(0x0000_0000) = 0x0000_0000
+///
+static inline llvm::APInt rightmostMask(const llvm::APInt& mask) {
+  if (mask.isShiftedMask()) {
+    return mask;
+  }
+  // This formula is derived from the formula to "turn off the
+  // rightmost contiguous string of 1's" in Chapter 2-1 of
+  // Hacker's Delight (Second Edition) by Henry S. Warren and
+  // attributed to Luther Woodrum.
+  llvm::APInt result = -mask;
+  result &= mask; // isolate rightmost set bit
+  result += mask; // clear rightmost contiguous set bits
+  result &= mask; // mask out carry bit leftover from add
+  result ^= mask; // extract desired bits
+  return result;
+}
 
-  // Expand the packed bits to the destination type.
-  packedBits = IGF.Builder.CreateZExtOrTrunc(packedBits, destTy);
+/// Pack masked bits into the low bits of an integer value.
+/// Equivalent to a parallel bit extract instruction (PEXT),
+/// although we don't currently emit PEXT directly.
+llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
+                                   llvm::APInt mask,
+                                   llvm::Value *source,
+                                   unsigned resultLowBit,
+                                   unsigned resultBitWidth) {
+  auto &builder = IGF.Builder;
+  auto &context = IGF.IGM.getLLVMContext();
+  assert(mask.getBitWidth() == source->getType()->getIntegerBitWidth()
+    && "source and mask must have same width");
 
-  auto spareBitEnumeration = spareBitMask.enumerateSetBits();
-  for (auto nextSpareBit = spareBitEnumeration.findNext();
-       nextSpareBit.hasValue();
-       nextSpareBit = spareBitEnumeration.findNext()) {
-    unsigned u = nextSpareBit.getValue(), startBit = u;
-    assert(u >= usedBits - packedLowBit
-           && "used more bits than we've processed?!");
-
-    // Shift the selected bits into place.
-    llvm::Value *newBits;
-    if (u > usedBits)
-      newBits = IGF.Builder.CreateShl(packedBits, u - usedBits);
-    else if (u < usedBits)
-      newBits = IGF.Builder.CreateLShr(packedBits, usedBits - u);
-    else
-      newBits = packedBits;
-
-    // See how many consecutive bits we have.
-    unsigned numBits = 1;
-    ++u;
-    for (unsigned e = spareBitMask.size(); u < e && spareBitMask[u]; ++u) {
-      ++numBits;
-      auto nextBit = spareBitEnumeration.findNext(); (void) nextBit;
-      assert(nextBit.hasValue());
-    }
-
-    // Mask out the selected bits.
-    auto val = APInt::getAllOnesValue(numBits);
-    if (numBits < spareBitMask.size())
-      val = val.zext(spareBitMask.size());
-    val = val.shl(startBit);
-    auto mask = llvm::ConstantInt::get(IGF.IGM.getLLVMContext(), val);
-    newBits = IGF.Builder.CreateAnd(newBits, mask);
-
-    // Accumulate the result.
-    if (result)
-      result = IGF.Builder.CreateOr(result, newBits);
-    else
-      result = newBits;
-
-    usedBits += numBits;
+  // The source and mask need to be at least as wide as the result so
+  // that bits can be shifted into the correct position.
+  auto destTy = llvm::IntegerType::get(context, resultBitWidth);
+  if (mask.getBitWidth() < resultBitWidth) {
+    source = builder.CreateZExt(source, destTy);
+    mask = mask.zext(resultBitWidth);
   }
 
+  // Shift each set of contiguous set bits into position and
+  // accumulate them into the result.
+  int64_t usedBits = resultLowBit;
+  llvm::Value *result = nullptr;
+  while (mask != 0) {
+    // Isolate the rightmost run of contiguous set bits.
+    // Example: 0b0011_01101_1100 -> 0b0000_0001_1100
+    llvm::APInt partMask = rightmostMask(mask);
+
+    // Update the bits we need to mask next.
+    mask ^= partMask;
+
+    // Shift the selected bits into position.
+    llvm::Value *part = source;
+    int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
+    if (offset > 0) {
+      uint64_t shift = uint64_t(offset);
+      part = builder.CreateLShr(part, shift);
+      partMask.lshrInPlace(shift);
+    } else if (offset < 0) {
+      uint64_t shift = uint64_t(-offset);
+      part = builder.CreateShl(part, shift);
+      partMask <<= shift;
+    }
+
+    // Truncate the output to the result size.
+    if (partMask.getBitWidth() > resultBitWidth) {
+      partMask = partMask.trunc(resultBitWidth);
+      part = builder.CreateTrunc(part, destTy);
+    }
+
+    // Mask out selected bits.
+    part = builder.CreateAnd(part, partMask);
+
+    // Accumulate the result.
+    result = result ? builder.CreateOr(result, part) : part;
+
+    // Update the offset and remaining mask.
+    usedBits += partMask.countPopulation();
+  }
+  return result;
+}
+
+/// Unpack bits from the low bits of an integer value and
+/// move them to the bit positions indicated by the mask.
+/// Equivalent to a parallel bit deposit instruction (PDEP),
+/// although we don't currently emit PDEP directly.
+llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
+                                    llvm::APInt mask,
+                                    llvm::Value *source,
+                                    unsigned packedLowBit) {
+  auto &builder = IGF.Builder;
+  auto &context = IGF.IGM.getLLVMContext();
+
+  // Expand the packed bits to the destination type.
+  auto destTy = llvm::IntegerType::get(context, mask.getBitWidth());
+  source = builder.CreateZExtOrTrunc(source, destTy);
+
+  // Shift each set of contiguous set bits into position and
+  // accumulate them into the result.
+  int64_t usedBits = packedLowBit;
+  llvm::Value *result = nullptr;
+  while (mask != 0) {
+    // Isolate the rightmost run of contiguous set bits.
+    // Example: 0b0011_01101_1100 -> 0b0000_0001_1100
+    llvm::APInt partMask = rightmostMask(mask);
+
+    // Update the bits we need to mask next.
+    mask ^= partMask;
+
+    // Shift the selected bits into position.
+    llvm::Value *part = source;
+    int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
+    if (offset > 0) {
+      part = builder.CreateShl(part, uint64_t(offset));
+    } else if (offset < 0) {
+      part = builder.CreateLShr(part, uint64_t(-offset));
+    }
+
+    // Mask out selected bits.
+    part = builder.CreateAnd(part, partMask);
+
+    // Accumulate the result.
+    result = result ? builder.CreateOr(result, part) : part;
+
+    // Update the offset and remaining mask.
+    usedBits += partMask.countPopulation();
+  }
   return result;
 }
 
@@ -6900,8 +6979,8 @@ EnumPayload irgen::interleaveSpareBits(IRGenFunction &IGF,
         payloadValue = IGF.Builder.CreateLShr(payloadValue,
                        llvm::ConstantInt::get(IGF.IGM.Int32Ty, usedBits));
       }
-      payloadValue = emitScatterSpareBits(IGF, spareBitsChunk,
-                                          payloadValue, 0);
+      payloadValue = emitScatterBits(IGF, spareBitsChunk.asAPInt(),
+                                     payloadValue, 0);
       if (payloadValue->getType() != type) {
         if (type->isPointerTy())
           payloadValue = IGF.Builder.CreateIntToPtr(payloadValue, type);

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -103,17 +103,22 @@ EnumPayload interleaveSpareBits(IRGenFunction &IGF,
                                 const SpareBitVector &spareBitVector,
                                 llvm::Value *value);
 
-/// Gather spare bits into the low bits of a smaller integer value.
-llvm::Value *emitGatherSpareBits(IRGenFunction &IGF,
-                                 const SpareBitVector &spareBitMask,
-                                 llvm::Value *spareBits,
-                                 unsigned resultLowBit,
-                                 unsigned resultBitWidth);
-/// Scatter spare bits from the low bits of a smaller integer value.
-llvm::Value *emitScatterSpareBits(IRGenFunction &IGF,
-                                  const SpareBitVector &spareBitMask,
-                                  llvm::Value *packedBits,
-                                  unsigned packedLowBit);
+/// Pack masked bits into the low bits of an integer value.
+/// Equivalent to a parallel bit extract instruction (PEXT),
+/// although we don't currently emit PEXT directly.
+llvm::Value *emitGatherBits(IRGenFunction &IGF,
+                            llvm::APInt mask,
+                            llvm::Value *source,
+                            unsigned resultLowBit,
+                            unsigned resultBitWidth);
+/// Unpack bits from the low bits of an integer value and
+/// move them to the bit positions indicated by the mask.
+/// Equivalent to a parallel bit deposit instruction (PDEP),
+/// although we don't currently emit PDEP directly.
+llvm::Value *emitScatterBits(IRGenFunction &IGF,
+                             llvm::APInt mask,
+                             llvm::Value *packedBits,
+                             unsigned packedLowBit);
   
 /// An implementation strategy for an enum, which handles how the enum is
 /// laid out and how to perform TypeInfo operations on values of the enum.

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -328,7 +328,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   // Gather the occupied bits.
   auto OccupiedBits = SpareBits;
   OccupiedBits.flipAll();
-  llvm::Value *idx = emitGatherSpareBits(IGF, OccupiedBits, val, 0, 31);
+  llvm::Value *idx = emitGatherBits(IGF, OccupiedBits.asAPInt(), val, 0, 31);
   
   // See if spare bits fit into the 31 bits of the index.
   unsigned numSpareBits = SpareBits.count();
@@ -336,7 +336,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   if (numOccupiedBits < 31) {
     // Gather the spare bits.
     llvm::Value *spareIdx
-      = emitGatherSpareBits(IGF, SpareBits, val, numOccupiedBits, 31);
+      = emitGatherBits(IGF, SpareBits.asAPInt(), val, numOccupiedBits, 31);
     // Unbias by subtracting one.
 
     uint64_t shifted = static_cast<uint64_t>(1) << numOccupiedBits;
@@ -830,13 +830,13 @@ FixedTypeInfo::storeSpareBitExtraInhabitant(IRGenFunction &IGF,
   }
   
   // Scatter the occupied bits.
-  auto OccupiedBits = SpareBits;
-  OccupiedBits.flipAll();
-  llvm::Value *occupied = emitScatterSpareBits(IGF, OccupiedBits,
-                                               occupiedIndex, 0);
+  auto OccupiedBits = ~SpareBits.asAPInt();
+  llvm::Value *occupied = emitScatterBits(IGF, OccupiedBits,
+                                          occupiedIndex, 0);
   
   // Scatter the spare bits.
-  llvm::Value *spare = emitScatterSpareBits(IGF, SpareBits, spareIndex, 0);
+  llvm::Value *spare = emitScatterBits(IGF, SpareBits.asAPInt(),
+                                       spareIndex, 0);
   
   // Combine the values and store to the destination.
   llvm::Value *inhabitant = IGF.Builder.CreateOr(occupied, spare);

--- a/unittests/Basic/ClusteredBitVectorTest.cpp
+++ b/unittests/Basic/ClusteredBitVectorTest.cpp
@@ -131,28 +131,6 @@ template <class T> struct ComparableOptional {
   }
 };
 
-TEST(ClusteredBitVector, Enumeration) {
-  ClusteredBitVector temp;
-  temp.appendClearBits(256);
-  temp.setBit(64);
-  temp.setBit(40);
-  temp.setBit(39);
-  temp.setBit(63);
-  temp.setBit(201);
-
-  using Opt = ComparableOptional<size_t>;
-
-  auto enumerator = temp.enumerateSetBits();
-  EXPECT_EQ(Opt(39), enumerator.findNext());
-  EXPECT_EQ(Opt(40), enumerator.findNext());
-  EXPECT_EQ(Opt(63), enumerator.findNext());
-  EXPECT_EQ(Opt(64), enumerator.findNext());
-  EXPECT_EQ(Opt(201), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-}
-
 TEST(ClusteredBitVector, SetClearBit) {
   ClusteredBitVector vec;
   vec.appendClearBits(64);

--- a/utils/test-clustered-bit-vector/generator.cpp
+++ b/utils/test-clustered-bit-vector/generator.cpp
@@ -175,26 +175,6 @@ static void run() {
     // Validate that everything's still okay.
     for (auto i = 0; i != NV; ++i) {
       checkConsistency("cbvs[" + Twine(i) + "]", cbvs[i], vecs[i], 1);
-
-      auto enumerator = cbvs[i].enumerateSetBits();
-      auto nextIndex = enumerator.findNext();
-      for (unsigned j = 0, je = cbvs[i].size(); j != je; ++j) {
-        assert((!nextIndex || nextIndex.getValue() >= j) && "going in reverse?");
-        if (cbvs[i][j]) {
-          if (!nextIndex || nextIndex.getValue() != j) {
-            llvm::outs() << "  cbvs[" << i << "][" << j
-                         << "] is set but was not found by enumerator\n";
-            abort();
-          }
-          nextIndex = enumerator.findNext();
-        } else {
-          if (nextIndex && nextIndex.getValue() == j) {
-            llvm::outs() << "  cbvs[" << i << "][" << j
-                         << "] is not set but was found by enumerator\n";
-            abort();
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
The change replaces 'set bit enumeration' with arithmetic
and bitwise operations. For example, the formula
'(((x & -x) + x) & x) ^ x' can be used to find the rightmost
contiguous bit mask. This is essentially the operation that
SetBitEnumerator.findNext() performed.

Removing this functionality reduces the complexity of the
ClusteredBitVector (a.k.a. SpareBitVector) implementation and,
more importantly, API which will make it easier to modify
the implementation of spare bit masks going forward. My end
goal being to make spare bit operations work more reliably on
big endian systems.

Side note:

This change modifies the emit gather/scatter functions so that
they work with an APInt, rather than a SpareBitVector, which
makes these functions a bit more generic. These functions emit
instructions that are essentially equivalent to the parallel bit
extract/deposit (PEXT and PDEP) instructions in BMI2 on x86_64
(although we don't emit those directly currently). They also map
well to bitwise manipulation instructions on other platforms (e.g.
RISBG on IBM Z). So we might find uses for them outside spare bit
manipulation in the future.
