### PR TITLE
[AutoDiff] TF-509: Make `Tensor.broadcast(to:)` differentiable

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -649,15 +649,6 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
       v.unbroadcast(toShape: origShape)
     })
   }
-  
-  @inlinable
-  func _vjpBroadcast(
-    to shape: TensorShape
-  ) -> (Tensor, (Tensor) -> Tensor) {
-    return (broadcast(to: shape), { [origShape = self.shape] v in
-      v.unbroadcast(to: origShape)
-    })
-  }
 
   @inlinable
   func _vjpUnbroadcast(
@@ -665,15 +656,6 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   ) -> (Tensor, (Tensor) -> Tensor) {
     return (unbroadcast(toShape: shape), { [origShape = self.shapeTensor] v in
       v.broadcast(toShape: origShape)
-    })
-  }
-  
-  @inlinable
-  func _vjpUnbroadcast(
-    to shape: TensorShape
-  ) -> (Tensor, (Tensor) -> Tensor) {
-    return (unbroadcast(to: shape), { [origShape = self.shape] v in
-      v.broadcast(to: origShape)
     })
   }
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -658,19 +658,7 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
       v.unbroadcast(to: origShape)
     })
   }
-  
-  @inlinable
-  func _vjpBroadcast<OtherScalar>(
-    like other: Tensor<OtherScalar>
-  ) -> (Tensor, (Tensor) -> Tensor)
-    where OtherScalar : TensorFlowScalar {
-    return (broadcast(like: other), { [origShape = self.shapeTensor] v in
-      v.unbroadcast(like: origShape)
-    })
-  }
-}
 
-extension Tensor where Scalar : Numeric {
   @inlinable
   func _vjpUnbroadcast(
     toShape shape: Tensor<Int32>
@@ -686,16 +674,6 @@ extension Tensor where Scalar : Numeric {
   ) -> (Tensor, (Tensor) -> Tensor) {
     return (unbroadcast(to: shape), { [origShape = self.shape] v in
       v.broadcast(to: origShape)
-    })
-  }
-  
-  @inlinable
-  func _vjpUnbroadcast<OtherScalar>(
-    like other: Tensor<OtherScalar>
-  ) -> (Tensor, (Tensor) -> Tensor)
-    where OtherScalar : TensorFlowScalar {
-    return (unbroadcast(like: other), { [origShape = self.shapeTensor] v in
-      v.broadcast(like: origShape)
     })
   }
 }

--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -635,3 +635,67 @@ func _vjpRelu<T : TensorFlowFloatingPoint>(
 ) -> (Tensor<T>, (Tensor<T>) -> Tensor<T>) {
   return (relu(x), { v in Tensor(x .> 0) * v })
 }
+
+//===----------------------------------------------------------------------===//
+// Broadcasting
+//===----------------------------------------------------------------------===//
+
+extension Tensor where Scalar : TensorFlowFloatingPoint {
+  @inlinable
+  func _vjpBroadcast(
+    toShape shape: Tensor<Int32>
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    return (broadcast(toShape: shape), { [origShape = self.shapeTensor] v in
+      v.unbroadcast(toShape: origShape)
+    })
+  }
+  
+  @inlinable
+  func _vjpBroadcast(
+    to shape: TensorShape
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    return (broadcast(to: shape), { [origShape = self.shape] v in
+      v.unbroadcast(to: origShape)
+    })
+  }
+  
+  @inlinable
+  func _vjpBroadcast<OtherScalar>(
+    like other: Tensor<OtherScalar>
+  ) -> (Tensor, (Tensor) -> Tensor)
+    where OtherScalar : TensorFlowScalar {
+    return (broadcast(like: other), { [origShape = self.shapeTensor] v in
+      v.unbroadcast(like: origShape)
+    })
+  }
+}
+
+extension Tensor where Scalar : Numeric {
+  @inlinable
+  func _vjpUnbroadcast(
+    toShape shape: Tensor<Int32>
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    return (unbroadcast(toShape: shape), { [origShape = self.shapeTensor] v in
+      v.broadcast(toShape: origShape)
+    })
+  }
+  
+  @inlinable
+  func _vjpUnbroadcast(
+    to shape: TensorShape
+  ) -> (Tensor, (Tensor) -> Tensor) {
+    return (unbroadcast(to: shape), { [origShape = self.shape] v in
+      v.broadcast(to: origShape)
+    })
+  }
+  
+  @inlinable
+  func _vjpUnbroadcast<OtherScalar>(
+    like other: Tensor<OtherScalar>
+  ) -> (Tensor, (Tensor) -> Tensor)
+    where OtherScalar : TensorFlowScalar {
+    return (unbroadcast(like: other), { [origShape = self.shapeTensor] v in
+      v.broadcast(like: origShape)
+    })
+  }
+}

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1600,11 +1600,17 @@ public extension Tensor {
 
 public extension Tensor {
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpBroadcast(toShape:)
+    where Scalar : TensorFlowFloatingPoint)
   func broadcast(toShape shape: Tensor<Int32>) -> Tensor {
     return Raw.broadcastTo(self, shape: shape)
   }
 
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpBroadcast(to:)
+    where Scalar : TensorFlowFloatingPoint)
   func broadcast(to shape: TensorShape) -> Tensor {
     return broadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
   }
@@ -1612,6 +1618,9 @@ public extension Tensor {
   /// Broadcast to the same shape as the specified `Tensor`.
   /// - Precondition: The specified shape must be compatible for broadcasting.
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpBroadcast(like:)
+    where Scalar : TensorFlowFloatingPoint)
   func broadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
     return broadcast(toShape: other.shapeTensor)
   }
@@ -1619,6 +1628,8 @@ public extension Tensor {
 
 public extension Tensor where Scalar : Numeric {
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpUnbroadcast(toShape:))
   func unbroadcast(toShape otherShape: Tensor<Int32>) -> Tensor {
     let rankDiff = (rankTensor - otherShape.scalarCountTensor).rankLifted()
     let ones: Tensor<Int32> = Raw.fill(dims: rankDiff, value: Tensor<Int32>(1))
@@ -1631,11 +1642,15 @@ public extension Tensor where Scalar : Numeric {
   }
 
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpUnbroadcast(like:))
   func unbroadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
     return unbroadcast(toShape: other.shapeTensor)
   }
 
   @inlinable
+  // SWIFT_ENABLE_TENSORFLOW
+  @differentiable(wrt: self, vjp: _vjpUnbroadcast(to:))
   func unbroadcast(to shape: TensorShape) -> Tensor {
     return unbroadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
   }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1607,10 +1607,9 @@ public extension Tensor {
   }
 
   @inlinable
-  @differentiable(wrt: self, vjp: _vjpBroadcast(to:)
-    where Scalar : TensorFlowFloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func broadcast(to shape: TensorShape) -> Tensor {
-    return broadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
+    return broadcast(toShape: Tensor<Int32>({ shape.dimensions.map(Int32.init) }()))
   }
 
   /// Broadcast to the same shape as the specified `Tensor`.
@@ -1645,10 +1644,9 @@ public extension Tensor where Scalar : Numeric {
   }
 
   @inlinable
-  @differentiable(wrt: self, vjp: _vjpUnbroadcast(to:)
-    where Scalar : TensorFlowFloatingPoint)
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func unbroadcast(to shape: TensorShape) -> Tensor {
-    return unbroadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
+    return unbroadcast(toShape: Tensor<Int32>({ shape.dimensions.map(Int32.init) }()))
   }
 
   @inlinable

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1600,7 +1600,6 @@ public extension Tensor {
 
 public extension Tensor {
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
   @differentiable(wrt: self, vjp: _vjpBroadcast(toShape:)
     where Scalar : TensorFlowFloatingPoint)
   func broadcast(toShape shape: Tensor<Int32>) -> Tensor {
@@ -1608,7 +1607,6 @@ public extension Tensor {
   }
 
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
   @differentiable(wrt: self, vjp: _vjpBroadcast(to:)
     where Scalar : TensorFlowFloatingPoint)
   func broadcast(to shape: TensorShape) -> Tensor {
@@ -1618,8 +1616,7 @@ public extension Tensor {
   /// Broadcast to the same shape as the specified `Tensor`.
   /// - Precondition: The specified shape must be compatible for broadcasting.
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: self, vjp: _vjpBroadcast(like:)
+  @differentiable(wrt: self
     where Scalar : TensorFlowFloatingPoint)
   func broadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
     return broadcast(toShape: other.shapeTensor)
@@ -1628,8 +1625,8 @@ public extension Tensor {
 
 public extension Tensor where Scalar : Numeric {
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: self, vjp: _vjpUnbroadcast(toShape:))
+  @differentiable(wrt: self, vjp: _vjpUnbroadcast(toShape:)
+    where Scalar : TensorFlowFloatingPoint)
   func unbroadcast(toShape otherShape: Tensor<Int32>) -> Tensor {
     let rankDiff = (rankTensor - otherShape.scalarCountTensor).rankLifted()
     let ones: Tensor<Int32> = Raw.fill(dims: rankDiff, value: Tensor<Int32>(1))
@@ -1642,15 +1639,14 @@ public extension Tensor where Scalar : Numeric {
   }
 
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: self, vjp: _vjpUnbroadcast(like:))
+  @differentiable(wrt: self where Scalar : TensorFlowFloatingPoint)
   func unbroadcast<OtherScalar>(like other: Tensor<OtherScalar>) -> Tensor {
     return unbroadcast(toShape: other.shapeTensor)
   }
 
   @inlinable
-  // SWIFT_ENABLE_TENSORFLOW
-  @differentiable(wrt: self, vjp: _vjpUnbroadcast(to:))
+  @differentiable(wrt: self, vjp: _vjpUnbroadcast(to:)
+    where Scalar : TensorFlowFloatingPoint)
   func unbroadcast(to shape: TensorShape) -> Tensor {
     return unbroadcast(toShape: Tensor<Int32>(shape.dimensions.map(Int32.init)))
   }

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -262,4 +262,135 @@ TensorADTests.testAllBackends("Side effects") {
   expectEqual(Tensor(48), gradient(at: Tensor(4), in: bar))
 }
 
+TensorADTests.testAllBackends("broadcast(toShape:)") {
+  func foo(tensor: Tensor<Float>, shape: Tensor<Int32>) -> Tensor<Float> {
+    tensor.broadcast(toShape: shape)
+  }
+
+  var inputTensor: Tensor<Float>
+  var expected: Tensor<Float>
+  var pb: (Tensor<Float>) -> Tensor<Float>
+
+  // [3,] -> [3,3]
+  pb = pullback(at: Tensor([99, 33, 55])) { x in 
+    foo(tensor: x, shape: Tensor([3, 3])) 
+  }
+
+  // Test 1: same shape as parameter of pullback
+  inputTensor = Tensor([
+    [1, 2, 3], 
+    [1, 2, 3], 
+    [1, 2, 3]]
+  )
+  expected = Tensor([3, 6, 9])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 2: different shape than parameter of pullback
+  inputTensor = Tensor([
+    [1, 2, 3], 
+    [1, 2, 3], 
+    [1, 2, 3],
+    [1, 2, 3]]
+  )
+  expected = Tensor([4, 8, 12])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 3: same shape as tensor we are differentiating at
+  inputTensor = Tensor([1, 2, 3])
+  expected = Tensor([1, 2, 3])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 4: extremely padded shape as tensor we are differentiating at
+  inputTensor = Tensor([[[[[[1, 2, 3]]]]]])
+  expected = Tensor([1, 2, 3])
+  expectEqual(expected, pb(inputTensor))
+
+  // [3,1] -> [3x3]
+  pb = pullback(at: Tensor([[99, 33, 55]])) { x in 
+    foo(tensor: x, shape: Tensor([3, 3])) 
+  }
+
+  // Test 5: same shape as parameter of pullback
+  inputTensor = Tensor([
+    [1, 2, 3], 
+    [1, 2, 3], 
+    [1, 2, 3]]
+  )
+  expected = Tensor([[3, 6, 9]])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 6: different shape than parameter of pullback
+  inputTensor = Tensor([
+    [1, 2, 3], 
+    [1, 2, 3], 
+    [1, 2, 3],
+    [1, 2, 3]]
+  )
+  expected = Tensor([[4, 8, 12]])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 7: same shape as tensor we are differentiating at
+  inputTensor = Tensor([[1, 2, 3]])
+  expected = Tensor([[1, 2, 3]])
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 8: extremely padded shape of tensor we are differentiating at
+  inputTensor = Tensor([[[[[[1, 2, 3]]]]]])
+  expected = Tensor([[1, 2, 3]])
+  expectEqual(expected, pb(inputTensor))
+}
+
+TensorADTests.testAllBackends("unbroadcast(toShape:") {
+  func foo(tensor: Tensor<Float>, shape: Tensor<Int32>) -> Tensor<Float> {
+    tensor.unbroadcast(toShape: shape)
+  }
+
+  var inputTensor: Tensor<Float>
+  var expected: Tensor<Float>
+  var pb: (Tensor<Float>) -> Tensor<Float>
+
+  // [3,3] -> [1,3]
+  let atTensor: Tensor<Float> = Tensor([
+    [1, 2, 3], 
+    [1, 2, 3], 
+    [1, 2, 3]]
+  )
+  pb = pullback(at: atTensor) { x in 
+    foo(tensor: x, shape: Tensor([1, 3])) 
+  }
+
+  // Test 1: same shape as parameter of pullback
+  inputTensor = Tensor([[1, 2, 3]])
+  expected = atTensor
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 2: different shape than parameter of pullback
+  inputTensor = Tensor([2])
+  expected = Tensor([
+    [2, 2, 2], 
+    [2, 2, 2], 
+    [2, 2, 2]]
+  )
+  expectEqual(expected, pb(inputTensor))
+
+  // Test 3: same shape as tensor we are differentiating at
+  inputTensor = Tensor([
+    [8, 1, 3], 
+    [8, 1, 3], 
+    [8, 1, 3]]
+  )
+  expected = inputTensor
+  expectEqual(expected, pb(inputTensor))
+
+  // TODO
+  // Test 4: extremely padded shape as tensor we are differentiating at
+  // inputTensor = Tensor([
+  //   [[8, 1, 3]], 
+  //   [[8, 1, 3]], 
+  //   [[8, 1, 3]]]
+  // )
+  // expected = Tensor([1, 2, 3])
+  // expectEqual(expected, pb(inputTensor))
+}
+
 runAllTests()


### PR DESCRIPTION
Resolves the following [JIRA ticket](https://bugs.swift.org/browse/TF-509).

For background info, refer to the [S4TF Group](https://groups.google.com/a/google.com/forum/#!msg/s4tf-users/dkiowBModZQ/2IsQfSURAwAJ).

I still need to add tests, but wanted to slowly begin the review for my implementation.