### PR TITLE
Removed uses of PointerUnion3

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -36,10 +36,10 @@ namespace swift {
   enum class DeclKind : uint8_t;
   enum class StmtKind;
 
-  struct ASTNode : public llvm::PointerUnion3<Expr*, Stmt*, Decl*> {
+  struct ASTNode : public llvm::PointerUnion<Expr*, Stmt*, Decl*> {
     // Inherit the constructors from PointerUnion.
-    using PointerUnion3::PointerUnion3;
-    
+    using PointerUnion::PointerUnion;
+
     SourceRange getSourceRange() const;
 
     /// Return the location of the start of the statement.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4773,7 +4773,7 @@ public:
   };
 
 protected:
-  PointerUnion3<PatternBindingDecl *, Stmt *, VarDecl *> Parent;
+  PointerUnion<PatternBindingDecl *, Stmt *, VarDecl *> Parent;
 
   VarDecl(DeclKind Kind, bool IsStatic, Specifier Sp, bool IsCaptureList,
           SourceLoc NameLoc, Identifier Name, DeclContext *DC)

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -92,10 +92,10 @@ public:
   class ResolvedType;
 
   using UnresolvedRequirementRHS =
-      llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
+      llvm::PointerUnion<Type, PotentialArchetype *, LayoutConstraint>;
 
   using RequirementRHS =
-    llvm::PointerUnion3<Type, PotentialArchetype *, LayoutConstraint>;
+    llvm::PointerUnion<Type, PotentialArchetype *, LayoutConstraint>;
 
   /// The location of a requirement as written somewhere in the source.
   typedef llvm::PointerUnion<const TypeRepr *, const RequirementRepr *>
@@ -1374,8 +1374,8 @@ class GenericSignatureBuilder::FloatingRequirementSource {
   } kind;
 
   using Storage =
-    llvm::PointerUnion3<const RequirementSource *, const TypeRepr *,
-                        const RequirementRepr *>;
+    llvm::PointerUnion<const RequirementSource *, const TypeRepr *,
+                       const RequirementRepr *>;
 
   Storage storage;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -301,7 +301,7 @@ struct WhereClauseOwner {
 
   /// The source of the where clause, which can be a generic parameter list
   /// or a declaration that can have a where clause.
-  llvm::PointerUnion3<GenericParamList *, Decl *, SpecializeAttr *> source;
+  llvm::PointerUnion<GenericParamList *, Decl *, SpecializeAttr *> source;
 
   WhereClauseOwner(Decl *decl);
 

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -42,8 +42,7 @@ namespace llvm {
   template<typename T> class MutableArrayRef;
   template<typename T> class TinyPtrVector;
   template<typename T> class Optional;
-  template <typename PT1, typename PT2> class PointerUnion;
-  template <typename PT1, typename PT2, typename PT3> class PointerUnion3;
+  template <typename ...PTs> class PointerUnion;
   class SmallBitVector;
 
   // Other common classes.
@@ -68,7 +67,6 @@ namespace swift {
   using llvm::None;
   using llvm::Optional;
   using llvm::PointerUnion;
-  using llvm::PointerUnion3;
   using llvm::SmallBitVector;
   using llvm::SmallPtrSet;
   using llvm::SmallPtrSetImpl;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -38,7 +38,7 @@
 #include "llvm/ADT/SetVector.h"
 
 namespace llvm {
-  template <typename PT1, typename PT2, typename PT3> class PointerUnion3;
+  template <typename...  PTs> class PointerUnion;
 }
 
 namespace swift {

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -384,7 +384,7 @@ public:
 private:
   /// A pointer to one of a Loop, Basic Block, or Function represented by this
   /// region.
-  llvm::PointerUnion3<FunctionTy *, LoopTy *, BlockTy *> Ptr;
+  llvm::PointerUnion<FunctionTy *, LoopTy *, BlockTy *> Ptr;
 
   /// The ID of this region.
   unsigned ID;

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -307,8 +307,8 @@ public:
   static bool contextRequiresName(ContextKind kind);
 
   /// A single entry referencing either a named declaration or a macro.
-  typedef llvm::PointerUnion3<clang::NamedDecl *, clang::MacroInfo *, 
-                              clang::ModuleMacro *>
+  typedef llvm::PointerUnion<clang::NamedDecl *, clang::MacroInfo *,
+                             clang::ModuleMacro *>
     SingleEntry;
 
   /// A stored version of the context of an entity, which is Clang


### PR DESCRIPTION
PointerUnion was generalized to be variadic. Replaced uses of
PointerUnion3 with PointerUnion

See also: git-svn-id:
https://llvm.org/svn/llvm-project/llvm/trunk@360962
91177308-0d34-0410-b5e6-96231b3b80d8

See also: https://github.com/apple/swift-llvm/commit/8a9a01614aae01c23bcfe473868ce54d7a50e161