### PR TITLE
test/Interpreter/SDK/archive_attributes.swift only work on the host or simulator

### DIFF
--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -8,6 +8,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: CPU=i386 || CPU=x86_64
 
 // See also archive_attributes_stable_abi.swift, for the stable ABI
 // deployment target test.

--- a/test/Interpreter/SDK/archive_attributes_stable_abi.swift
+++ b/test/Interpreter/SDK/archive_attributes_stable_abi.swift
@@ -9,3 +9,4 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: swift_stable_abi
+// REQUIRES: CPU=i386 || CPU=x86_64


### PR DESCRIPTION
Fixes <rdar://problem/50897246>.