### PR TITLE
[5.1-04-24-2019][Test] Fix backtrace.swift to use %target-run.

### DIFF
--- a/test/Inputs/not.py
+++ b/test/Inputs/not.py
@@ -1,0 +1,14 @@
+import shlex
+import subprocess
+import sys
+
+if len(sys.argv) < 2:
+    print("Too few args to " + sys.argv[0])
+    sys.exit(0)
+
+try:
+    isPosix = (sys.platform != "win32")
+    subprocess.check_call(shlex.split(sys.argv[1], posix=isPosix))
+    sys.exit(1)
+except subprocess.CalledProcessError as e:
+    sys.exit(0)

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | %{python} %utils/backtrace-check
+// RUN: not --crash %target-run %t/a.out 2>&1 | %{python} %utils/backtrace-check
 
 // This is not supported on watchos, ios, or tvos
 // UNSUPPORTED: OS=watchos

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %target-run %t/a.out 2>&1 | %{python} %utils/backtrace-check
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | %{python} %utils/backtrace-check
+
+// NOTE: not.py is used above instead of "not --crash" because %target-run
+// doesn't pass through the crash, and `not` may not be available when running
+// on a remote host.
 
 // This is not supported on watchos, ios, or tvos
 // UNSUPPORTED: OS=watchos

--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/out
-// RUN: not --crash %t/out 2>&1 | %FileCheck %s
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/out" 2>&1 | %FileCheck %s
+
+// NOTE: not.py is used above instead of "not --crash" because %target-run
+// doesn't pass through the crash, and `not` may not be available when running
+// on a remote host.
 
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios

--- a/test/Runtime/crash_without_backtrace_optimized.swift
+++ b/test/Runtime/crash_without_backtrace_optimized.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -O %s -o %t/out
-// RUN: not --crash %t/out 2>&1 | %FileCheck %s
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/out" 2>&1 | %FileCheck %s
+
+// NOTE: not.py is used above instead of "not --crash" because %target-run
+// doesn't pass through the crash, and `not` may not be available when running
+// on a remote host.
 
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,9 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
+// RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
+
+// NOTE: not.py is used above instead of "not --crash" because %target-run
+// doesn't pass through the crash, and `not` may not be available when running
+// on a remote host.
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24864 to 5.1-04-24-2019.

rdar://problem/50863395