### PR TITLE
SILOptimizer: Fix crash on invalid in invalid escaping captures pass [5.1]

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -146,6 +146,28 @@ const ParamDecl *getParamDeclFromOperand(SILValue value) {
   return nullptr;
 }
 
+bool isUseOfSelfInInitializer(Operand *oper) {
+  if (auto *PBI = dyn_cast<ProjectBoxInst>(oper->get())) {
+    if (auto *MUI = dyn_cast<MarkUninitializedInst>(PBI->getOperand())) {
+      switch (MUI->getKind()) {
+      case MarkUninitializedInst::Kind::Var:
+        return false;
+      case MarkUninitializedInst::Kind::RootSelf:
+      case MarkUninitializedInst::Kind::CrossModuleRootSelf:
+      case MarkUninitializedInst::Kind::DerivedSelf:
+      case MarkUninitializedInst::Kind::DerivedSelfOnly:
+      case MarkUninitializedInst::Kind::DelegatingSelf:
+      case MarkUninitializedInst::Kind::DelegatingSelfAllocated:
+        return true;
+      }
+
+      llvm_unreachable("Bad MarkUninitializedInst::Kind");
+    }
+  }
+
+  return false;
+}
+
 static bool checkForEscapingPartialApplyUses(PartialApplyInst *PAI) {
   // Avoid exponential path exploration.
   SmallVector<Operand *, 8> uses;
@@ -301,14 +323,18 @@ static void checkPartialApply(ASTContext &Context, DeclContext *DC,
 
   // First, diagnose the inout captures, if any.
   for (auto inoutCapture : inoutCaptures) {
-    auto *param = getParamDeclFromOperand(inoutCapture->get());
-    if (param->isSelfParameter())
+    if (isUseOfSelfInInitializer(inoutCapture)) {
       diagnose(Context, PAI->getLoc(), diag::escaping_mutable_self_capture);
-    else {
-      diagnose(Context, PAI->getLoc(), diag::escaping_inout_capture,
-                param->getName());
-      diagnose(Context, param->getLoc(), diag::inout_param_defined_here,
-                param->getName());
+    } else {
+      auto *param = getParamDeclFromOperand(inoutCapture->get());
+      if (param->isSelfParameter())
+        diagnose(Context, PAI->getLoc(), diag::escaping_mutable_self_capture);
+      else {
+        diagnose(Context, PAI->getLoc(), diag::escaping_inout_capture,
+                  param->getName());
+        diagnose(Context, param->getLoc(), diag::inout_param_defined_here,
+                  param->getName());
+      }
     }
 
     diagnoseCaptureLoc(Context, DC, PAI, inoutCapture);

--- a/test/SILOptimizer/invalid_escaping_captures.swift
+++ b/test/SILOptimizer/invalid_escaping_captures.swift
@@ -176,3 +176,15 @@ func ~> (x: inout Int, f: @escaping (_: inout Int, _: Target) -> Target) -> (Tar
   return { f(&x, $0) } // expected-note {{captured here}}
   // expected-error@-1 {{escaping closure captures 'inout' parameter 'x'}}
 }
+
+func addHandler(_: @escaping () -> ()) {}
+
+public struct SelfEscapeFromInit {
+  public init() {
+    addHandler { self.handler() }
+    // expected-error@-1 {{escaping closure captures mutating 'self' parameter}}
+    // expected-note@-2 {{captured here}}
+  }
+
+  public mutating func handler() {}
+}


### PR DESCRIPTION
An inout capture of 'self' is not lowered as a SIL argument inside
an initializer, so add a new check to handle this case.

Fixes <rdar://problem/50412872>.