### PR TITLE
AST: Fix crash when calling subst() on types involving member types of UnresolvedType [5.1]

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2945,8 +2945,11 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
   }
 
   // If the parent is a type variable or a member rooted in a type variable,
-  // we're done.
-  if (substBase->isTypeVariableOrMember())
+  // or if the parent is a type parameter, we're done. Also handle
+  // UnresolvedType here, which can come up in diagnostics.
+  if (substBase->isTypeVariableOrMember() ||
+      substBase->isTypeParameter() ||
+      substBase->is<UnresolvedType>())
     return getDependentMemberType(substBase);
 
   // Retrieve the member type with the given name.
@@ -2954,10 +2957,6 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
   // Tuples don't have member types.
   if (substBase->is<TupleType>())
     return failed();
-
-  // If the parent is dependent, create a dependent member type.
-  if (substBase->isTypeParameter())
-    return getDependentMemberType(substBase);
 
   // If we know the associated type, look in the witness table.
   LazyResolver *resolver = substBase->getASTContext().getLazyResolver();

--- a/test/Constraints/sr10595.swift
+++ b/test/Constraints/sr10595.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+protocol Nested {
+    associatedtype U // expected-note {{protocol requires nested type 'U'; do you want to add it?}}
+}
+
+class A<M> {
+    func f<T : Nested>(_ t: T, _ keyPath: WritableKeyPath<M, T.U>) {}
+}
+
+class B<Y> : Nested { // expected-error {{type 'B<Y>' does not conform to protocol 'Nested'}}
+    var i: Y?
+}
+
+
+class C<M> {
+    func cFunc(_ a: A<M>) {
+        let function: (B<Int>, ReferenceWritableKeyPath<M, Int>) -> Void = a.f // expected-error {{cannot convert value of type '(_, WritableKeyPath<M, _.U>) -> ()' to specified type '(B<Int>, ReferenceWritableKeyPath<M, Int>) -> Void'}}
+    }
+}


### PR DESCRIPTION
UnresolvedType needs to go away, but for now, don't crash.

Fixes <rdar://problem/50370326>, <https://bugs.swift.org/browse/SR-10595>.