### PR TITLE
Add `tensorflow_osx,no_test,installer` build preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2116,6 +2116,12 @@ mixin-preset=
     mixin_codesigning
 darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
 
+[preset: tensorflow_osx,no_test,installer]
+mixin-preset=
+    tensorflow_osx,no_test
+    mixin_codesigning
+darwin-toolchain-installer-package=%(darwin_toolchain_installer_package)s
+
 [preset: tensorflow_linux]
 mixin-preset=buildbot_linux
 enable-tensorflow

--- a/utils/build-toolchain-tensorflow
+++ b/utils/build-toolchain-tensorflow
@@ -85,7 +85,6 @@ while [ $# -ne 0 ]; do
     INSTALLER_PACKAGE=1
     if [ "$(uname -s)" == "Darwin" ]; then
       SWIFT_PACKAGE_INSTALLER=,installer
-      SWIFT_PACKAGE_NOTEST=
     else
       echo "--pkg is not supported on \"$(uname -s)\". See --help"
       exit 1


### PR DESCRIPTION
Add preset to build macOS toolchain without running tests.

```console
utils/build-toolchain-tensorflow --pkg        # build pkg, no test
utils/build-toolchain-tensorflow --pkg --test # build pkg, test
```