### PR TITLE
[AutoDiff] Modify non-`@differentiable` external function diagnostic.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -409,8 +409,8 @@ ERROR(autodiff_expression_not_differentiable_error,none,
 NOTE(autodiff_expression_not_differentiable_note,none,
      "expression is not differentiable", ())
 NOTE(autodiff_external_nondifferentiable_function,none,
-     "cannot differentiate an external function that has not been marked "
-     "'@differentiable'", ())
+     "cannot differentiate functions that have not been marked "
+     "'@differentiable' and that are defined in other files", ())
 NOTE(autodiff_nondifferentiable_argument,none,
      "cannot differentiate through a non-differentiable argument; do you want "
      "to add '.withoutDerivative()'?", ())

--- a/test/AutoDiff/Inputs/nondifferentiable_function_other_module.swift
+++ b/test/AutoDiff/Inputs/nondifferentiable_function_other_module.swift
@@ -1,0 +1,5 @@
+// A public function that is not marked with `@differentiable`.
+// Differentiation of `externalFunction` in other modules should fail.
+public func externalFunction(_ x: Float) -> Float {
+  return x + x
+}

--- a/test/AutoDiff/nondifferentiable_function_cross_module.swift
+++ b/test/AutoDiff/nondifferentiable_function_cross_module.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -primary-file %S/Inputs/nondifferentiable_function_other_module.swift -emit-module-path %t/nondifferentiable_function_other_module.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -I %t -primary-file %s -verify
+
+import nondifferentiable_function_other_module
+
+func test() {
+  // expected-error @+2 {{function is not differentiable}}
+  // expected-note @+1 {{cannot differentiate functions that have not been marked '@differentiable' and that are defined in other files}}
+  _ = gradient(at: Float(1), in: externalFunction)
+}


### PR DESCRIPTION
Change diagnostic text from "external function" to "functions from other modules".
Add test.