### PR TITLE
[AutoDiff] Fix subset parameters thunk linkage.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -5721,9 +5721,9 @@ ADContext::getOrCreateSubsetParametersThunkForAssociatedFunction(
 
   auto loc = origFnOperand.getLoc();
   SILOptFunctionBuilder fb(getTransform());
-  auto *thunk = fb.getOrCreateFunction(
-      loc, thunkName, SILLinkage::Hidden, thunkType, IsBare, IsTransparent,
-      caller->isSerialized(), IsNotDynamic, ProfileCounter(), IsThunk);
+  auto *thunk = fb.getOrCreateSharedFunction(
+      loc, thunkName, thunkType, IsBare, IsTransparent, caller->isSerialized(),
+      ProfileCounter(), IsThunk, IsNotDynamic);
 
   if (!thunk->empty())
     return {thunk, interfaceSubs};


### PR DESCRIPTION
Use shared linkage to prevent `duplicate symbol` error for thunks.

---

Todo: add a test involving multiple Swift source files (i.e. SIL modules).

Patching ASAP to unblock `swift test` for `swift-apis`, which fails with a `duplicate symbol` linker error as of https://github.com/tensorflow/swift-apis/commit/76f5ee6e520dc6cc973119efbf676cda1b801a13:
```
duplicate symbol _AD__orig_$s10TensorFlow0A0VAASjRzrlE1moiyACyxGAE_AEtFZ_$s10TensorFlow0A0VyxGA2DXMtA4DIegggo_Iegggyoo_A3DXMtA3DIeggo_Iegggyoo_AA0aB13FloatingPointRzlTR_src_0_wrt_0_jvp_thunk in:
    /Users/danielzheng/swift-apis/.build/x86_64-apple-macosx/debug/DeepLearning.build/Layer.swift.o
    /Users/danielzheng/swift-apis/.build/x86_64-apple-macosx/debug/DeepLearning.build/Loss.swift.o
duplicate symbol _AD__orig_$s10TensorFlow0A0VAASjRzrlE1moiyACyxGAE_AEtFZ_$s10TensorFlow0A0VyxGA2DXMtA4DIeggoo_Iegggyoo_A3DXMtA3DIeggo_Iegggyoo_AA0aB13FloatingPointRzlTR_src_0_wrt_0_vjp_thunk in:
    /Users/danielzheng/swift-apis/.build/x86_64-apple-macosx/debug/DeepLearning.build/Layer.swift.o
    /Users/danielzheng/swift-apis/.build/x86_64-apple-macosx/debug/DeepLearning.build/Loss.swift.o
ld: 2 duplicate symbols for architecture x86_64
error: link command failed with exit code 1 (use -v to see invocation)
[0/1] Linking DeepLearningPackageTests
```