### PR TITLE
Fix update checkout for building toolchains.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -338,7 +338,7 @@
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
-                "swift-syntax": "swift-DEVELOPMENT-SNAPSHOT-2019-05-12-a",
+                "swift-syntax": "ce19fd53c3137baa1c3370d9577c18f125934a04",
                 "swift-stress-tester": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "compiler-rt": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "swift-corelibs-xctest": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",


### PR DESCRIPTION
`swift-syntax` does not have tag `swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a`,
and `swift-DEVELOPMENT-SNAPSHOT-2019-05-12-a` causes an error.

Use untagged working commit instead.