### PR TITLE
[stdlib] Improve error messages when snake case conversion is used.

### DIFF
--- a/stdlib/public/Darwin/Foundation/JSONEncoder.swift
+++ b/stdlib/public/Darwin/Foundation/JSONEncoder.swift
@@ -1376,10 +1376,13 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
             // In this case we can attempt to recover the original value by reversing the transform
             let original = key.stringValue
             let converted = JSONEncoder.KeyEncodingStrategy._convertToSnakeCase(original)
+            let roundtrip = JSONDecoder.KeyDecodingStrategy._convertFromSnakeCase(converted)
             if converted == original {
                 return "\(key) (\"\(original)\")"
-            } else {
+            } else if roundtrip == original {
                 return "\(key) (\"\(original)\"), converted to \(converted)"
+            } else {
+                return "\(key) (\"\(original)\"), with divergent representation \(roundtrip), converted to \(converted)"
             }
         default:
             // Otherwise, just report the converted string


### PR DESCRIPTION
`convertFromSnakeCase` and `convertToSnakeCase` are not inverses of each other for keys like "pictureURL" (which roundtrips to "pictureUrl").
This does not fix the underlying issue, but improves the error message if this situation is detected.

Discussions of the underlying issue, which this PR does not address:
https://forums.swift.org/t/handling-edge-cases-in-jsonencoder-jsondecoder-key-conversion-strategies-sr-6629/12384
https://github.com/apple/swift/pull/14039
