### PR TITLE
[NameLookup: ASTScope] Add trailing quote location to interpolated string literal.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -954,8 +954,10 @@ class InterpolatedStringLiteralExpr : public LiteralExpr {
   /// Points at the beginning quote.
   SourceLoc Loc;
   /// Points at the ending quote.
-  /// Needed for the upcoming ASTScope subsystem because lookups can be targeted
-  /// to inside an InterpolatedStringLiteralExpr.
+  /// Needed for the upcoming \c ASTScope subsystem because lookups can be
+  /// targeted to inside an \c InterpolatedStringLiteralExpr. It would be nicer
+  /// to use \c EndLoc for this value, but then \c Lexer::getLocForEndOfToken()
+  /// would not work for \c stringLiteral->getEndLoc().
   SourceLoc TrailingQuoteLoc;
   TapExpr *AppendingExpr;
   Expr *SemanticExpr;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1930,7 +1930,19 @@ public:
   }
   void visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *E) {
     printCommon(E, "interpolated_string_literal_expr");
-    PrintWithColorRAII(OS, LiteralValueColor) << " literal_capacity=" 
+    
+    // Print the trailing quote location
+    if (auto Ty = GetTypeOfExpr(E)) {
+      auto &Ctx = Ty->getASTContext();
+      auto TQL = E->getTrailingQuoteLoc();
+      if (TQL.isValid()) {
+        PrintWithColorRAII(OS, LocationColor) << " trailing_quote_loc=";
+        TQL.print(PrintWithColorRAII(OS, LocationColor).getOS(),
+                  Ctx.SourceMgr);
+      }
+    }
+    PrintWithColorRAII(OS, LiteralValueColor)
+      << " literal_capacity="
       << E->getLiteralCapacity() << " interpolation_count="
       << E->getInterpolationCount() << '\n';
     printRec(E->getAppendingExpr());

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -813,6 +813,7 @@ static LiteralExpr *
 shallowCloneImpl(const InterpolatedStringLiteralExpr *E, ASTContext &Ctx,
                  llvm::function_ref<Type(const Expr *)> getType) {
   auto res = new (Ctx) InterpolatedStringLiteralExpr(E->getLoc(),
+                                                     E->getTrailingQuoteLoc(),
                                                      E->getLiteralCapacity(),
                                                      E->getInterpolationCount(),
                                                      E->getAppendingExpr());

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2040,7 +2040,9 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     // so that parseDeclPoundDiagnostic() can figure out why this string
     // literal was bad.
     return makeParserErrorResult(
-        new (Context) InterpolatedStringLiteralExpr(Loc, 0, 0, nullptr));
+        new (Context) InterpolatedStringLiteralExpr(Loc,
+                                                    EndLoc.getAdvancedLoc(-1),
+                                                    0, 0, nullptr));
   }
 
   unsigned LiteralCapacity = 0;
@@ -2093,7 +2095,8 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
   }
 
   return makeParserResult(Status, new (Context) InterpolatedStringLiteralExpr(
-                                      Loc, LiteralCapacity, InterpolationCount,
+                                      Loc, EndLoc.getAdvancedLoc(-1),
+                                      LiteralCapacity, InterpolationCount,
                                       AppendingExpr));
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2039,10 +2039,8 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     // Return an error, but include an empty InterpolatedStringLiteralExpr
     // so that parseDeclPoundDiagnostic() can figure out why this string
     // literal was bad.
-    return makeParserErrorResult(
-        new (Context) InterpolatedStringLiteralExpr(Loc,
-                                                    EndLoc.getAdvancedLoc(-1),
-                                                    0, 0, nullptr));
+    return makeParserErrorResult(new (Context) InterpolatedStringLiteralExpr(
+        Loc, Loc.getAdvancedLoc(CloseQuoteBegin), 0, 0, nullptr));
   }
 
   unsigned LiteralCapacity = 0;
@@ -2095,7 +2093,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
   }
 
   return makeParserResult(Status, new (Context) InterpolatedStringLiteralExpr(
-                                      Loc, EndLoc.getAdvancedLoc(-1),
+                                      Loc, Loc.getAdvancedLoc(CloseQuoteBegin),
                                       LiteralCapacity, InterpolationCount,
                                       AppendingExpr));
 }

--- a/test/Parse/interpolated_trailing_quote.swift
+++ b/test/Parse/interpolated_trailing_quote.swift
@@ -1,6 +1,0 @@
-// Check the trailingQuoteLoc field of InterpolatedStringLiteral
-
-"\("abc")"
-
-// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
-// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc={{.*}}:3:10 {{.*}}

--- a/test/Parse/interpolated_trailing_quote.swift
+++ b/test/Parse/interpolated_trailing_quote.swift
@@ -1,0 +1,6 @@
+// Check the trailingQuoteLoc field of InterpolatedStringLiteral
+
+"\("abc")"
+
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc={{.*}}:3:10 {{.*}}

--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -1,0 +1,8 @@
+// Check source locations (only InterpolatedStringLiteral for now).
+
+func string_interpolation() {
+  "\("abc")"
+}
+
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR/test/Parse/source_locs.swift:4:12 {{.*}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add an instance variable to `InterpolatedStringLiteral` holding the location of the trailing quote. This information will be needed for the upcoming `ASTScope` code.
Also add a test to ensure the information is there and correct.