### PR TITLE
[TF] Reimplement unbroadcast using on-host axis calculation for performance.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -645,16 +645,14 @@ extension Tensor where Scalar : TensorFlowFloatingPoint {
   func _vjpBroadcast(
     toShape shape: Tensor<Int32>
   ) -> (Tensor, (Tensor) -> Tensor) {
-    return (broadcast(toShape: shape), { [origShape = self.shapeTensor] v in
+    return (broadcast(toShape: shape), { [origShape = shapeTensor] v in
       v.unbroadcast(toShape: origShape)
     })
   }
 
   @inlinable
-  func _vjpUnbroadcast(
-    toShape shape: Tensor<Int32>
-  ) -> (Tensor, (Tensor) -> Tensor) {
-    return (unbroadcast(toShape: shape), { [origShape = self.shapeTensor] v in
+  func _vjpUnbroadcast(to shape: TensorShape) -> (Tensor, (Tensor) -> Tensor) {
+    return (unbroadcast(to: shape), { [origShape = shapeTensor] v in
       v.broadcast(toShape: origShape)
     })
   }


### PR DESCRIPTION
The inefficiency of `unbroadcast(toShape:)`, `unbroadcast(to:)`, and `unbroadcast(like:)` has caused significant performance problems during model training because it's performing a lot of TensorFlow operations to achieve axis calculation. We were forced to implement it this way in the early GPE era when neither send/receive nor per-op dispatch was available.

This PR reimplements the unbroadcast operations in terms of host-side logic to compute axes to reduce along. This significantly reduces the TensorFlow opreation dispatch overhead. The base implementation changed from `broadcast(toShape:)` to `broadcast(to:)`.

With the new implementation, differentiating broadcasting operators is **37% faster** (see simple test script [here](https://gist.github.com/rxwei/e1488cac5379ba2bc3aff7490e18158f)).

Note:
- Since we now rely on the TensorFlow runtime less, more precondition checks and assertions are added to the newly implemented `unbroadcast(to:)` method.
- The part of #24408 that uses `Raw.broadcastGradientArgs(s0:s1:)` is still necessary for broadcasting binary operations to become faster.

TODO:
- Change `unbroadcast(toShape:)` tests added by #24899 to use `unbroadcast(to:)`, since `unbroadcast(to:)` is now the base implementation.