### PR TITLE
Update OSLogOptimization.cpp to fix warning.

### DIFF
--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -390,7 +390,7 @@ static SILValue emitCodeForSymbolicValue(SymbolicValue symVal,
     return newStructInst;
   }
   default: {
-    assert(false && "Symbolic value kind is not supported");
+    llvm_unreachable("Symbolic value kind is not supported");
   }
   }
 }


### PR DESCRIPTION
Fixes the following warning:
```console
swift/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp:396:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
```