### PR TITLE
[5.1] [clang-importer] Fix option -disable-modules-validate-system-headers

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -636,7 +636,9 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     invocationArgStrs.back().append(moduleCachePath);
   }
 
-  if (!importerOpts.DisableModulesValidateSystemHeaders) {
+  if (importerOpts.DisableModulesValidateSystemHeaders) {
+    invocationArgStrs.push_back("-fno-modules-validate-system-headers");
+  } else {
     invocationArgStrs.push_back("-fmodules-validate-system-headers");
   }
 

--- a/test/ClangImporter/disable-modules-validate-system-headers.swift
+++ b/test/ClangImporter/disable-modules-validate-system-headers.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -parse -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix=DEFAULT
+// DEFAULT: -fmodules-validate-system-headers
+// DEFAULT-NOT: -fno-modules-validate-system-headers
+
+// RUN: %target-swift-frontend %s -parse -dump-clang-diagnostics -disable-modules-validate-system-headers 2>&1 | %FileCheck %s -check-prefix=DISABLE
+// DISABLE: -fno-modules-validate-system-headers
+// DISABLE-NOT: -fmodules-validate-system-headers


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/24877 to swift-5.1-branch
Reviewed by: @jrose-apple 

---

This option stopped working when clang changed its default behaviour to
-fmodules-validate-system-headers; we now need to explicitly disable it
to preserve the behaviour of our flag.

rdar://problem/50908762