### PR TITLE
[Property delegates] Fix crash involving generic uses of delegateValue.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1794,7 +1794,7 @@ PropertyDelegateBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   VarDecl *storageVar = nullptr;
   if (delegateInfo.delegateValueVar) {
     storageVar = synthesizePropertyDelegateStorageDelegateProperty(
-        ctx, var, delegateType, delegateInfo.delegateValueVar);
+        ctx, var, storageType, delegateInfo.delegateValueVar);
   }
 
   // Get the property delegate information.

--- a/test/decl/var/property_delegates.swift
+++ b/test/decl/var/property_delegates.swift
@@ -667,6 +667,26 @@ func testStorageRef(tsr: TestStorageRef) {
   _ = tsr.$$x // expected-error{{'$$x' is inaccessible due to 'private' protection level}}
 }
 
+// rdar://problem/50873275 - crash when using wrapper with delegateValue in
+// generic type.
+@_propertyDelegate
+struct InitialValueWrapperWithStorageRef<T> {
+  var value: T
+
+  init(initialValue: T) {
+    value = initialValue
+  }
+
+  var delegateValue: Wrapper<T> {
+    return Wrapper(value: value)
+  }
+}
+
+struct TestGenericStorageRef<T> {
+  struct Inner { }
+  @InitialValueWrapperWithStorageRef var inner: Inner = Inner()
+}
+
 // ---------------------------------------------------------------------------
 // Misc. semantic issues
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes rdar://problem/50873275.
