### PR TITLE
[preset] Fix macOS full test preset to include sourcekit-lsp

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1359,6 +1359,13 @@ llbuild
 swiftpm
 swiftsyntax
 
+# Build sourcekit-lsp & indexstore-db
+indexstore-db
+sourcekit-lsp
+install-swift
+install-llbuild
+install-swiftpm
+
 # Build Playground support
 playgroundsupport
 


### PR DESCRIPTION
The smoke test preset tests sourcekit-lsp, and the full test should too.
Note: on Linux this was already working.