### PR TITLE
[Frontend] Re-add FrontendObserver methods

### DIFF
--- a/include/swift/FrontendTool/FrontendTool.h
+++ b/include/swift/FrontendTool/FrontendTool.h
@@ -42,6 +42,19 @@ public:
 
   /// The frontend has configured the compiler instance.
   virtual void configuredCompiler(CompilerInstance &instance);
+
+  /// The frontend has performed semantic analysis.
+  virtual void performedSemanticAnalysis(CompilerInstance &instance);
+
+  /// The frontend has performed basic SIL generation.
+  /// SIL diagnostic passes have not yet been applied.
+  virtual void performedSILGeneration(SILModule &module);
+
+  /// The frontend has executed the SIL optimization and diagnostics pipelines.
+  virtual void performedSILProcessing(SILModule &module);
+
+  // TODO: maybe enhance this interface to hear about IRGen and LLVM
+  // progress.
 };
 
 namespace frontend {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1005,6 +1005,9 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::ActionType::ResolveImports)
     return Context.hadError();
 
+  if (observer)
+    observer->performedSemanticAnalysis(Instance);
+
   if (Stats)
     countStatsPostSema(*Stats, Instance);
 
@@ -1238,6 +1241,9 @@ static bool performCompileStepsPostSILGen(
   if (auto *SF = MSF.dyn_cast<SourceFile *>())
     ricd.emplace(*SF);
 
+  if (observer)
+    observer->performedSILGeneration(*SM);
+
   if (Stats)
     countStatsPostSILGen(*Stats, *SM);
 
@@ -1283,6 +1289,9 @@ static bool performCompileStepsPostSILGen(
   // Perform optimizations and mandatory/diagnostic passes.
   if (Instance.performSILProcessing(SM.get(), Stats))
     return true;
+
+  if (observer)
+    observer->performedSILProcessing(*SM);
 
   emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance, Invocation,
                                                       moduleIsPublic);
@@ -1847,3 +1856,6 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
 void FrontendObserver::parsedArgs(CompilerInvocation &invocation) {}
 void FrontendObserver::configuredCompiler(CompilerInstance &instance) {}
+void FrontendObserver::performedSemanticAnalysis(CompilerInstance &instance) {}
+void FrontendObserver::performedSILGeneration(SILModule &module) {}
+void FrontendObserver::performedSILProcessing(SILModule &module) {}


### PR DESCRIPTION
These observer methods were used by external clients. Since we no longer
have the granularity between diagnostics and optimization, they're
rolled into a new observer callback, `performedSILProcessing`.

This (effectively) reverts commit 7b43e1d04debfaea6ee2e75cac820c0b3cd95d85.