### PR TITLE
Add isDecl check.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -733,12 +733,6 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
         return problem == firstProblem;
       });
 
-  ValueDecl *member = nullptr;
-  for (auto cand : result.UnviableCandidates) {
-    if (member == nullptr && cand.isDecl())
-      member = cand.getDecl();
-  }
-
   auto instanceTy = baseObjTy;
   if (auto *MTT = instanceTy->getAs<AnyMetatypeType>())
     instanceTy = MTT->getInstanceType();

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -735,7 +735,7 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
 
   ValueDecl *member = nullptr;
   for (auto cand : result.UnviableCandidates) {
-    if (member == nullptr)
+    if (member == nullptr && cand.isDecl())
       member = cand.getDecl();
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
During ASTScope testing, the compiler crashed because `member` was null but `cand` was not a `Decl`. Add a conjunct to prevent the crash.