### PR TITLE
[Diagnostics] Fix incorrect metatype check which leads to crashes

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2016,7 +2016,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   // comes up and is otherwise non-obvious what is going on.
 
   if (Name.isSimpleName(DeclBaseName::createConstructor()) &&
-      !BaseType->getRValueType()->is<AnyMetatypeType>()) {
+      !BaseType->is<AnyMetatypeType>()) {
     if (auto ctorRef = dyn_cast<UnresolvedDotExpr>(getRawAnchor())) {
       if (isa<SuperRefExpr>(ctorRef->getBase())) {
         emitDiagnostic(loc, diag::super_initializer_not_in_initializer);
@@ -2063,8 +2063,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   }
 
   if (BaseType->is<AnyMetatypeType>() && !member->isStatic()) {
-    auto instanceTy = BaseType->getRValueType();
-    
+    auto instanceTy = BaseType;
+
     if (auto *AMT = instanceTy->getAs<AnyMetatypeType>()) {
       instanceTy = AMT->getInstanceType();
     }
@@ -2147,11 +2147,11 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // to replace the metatype with 'Self'
     // error saying the lookup cannot be on a protocol metatype
     Optional<InFlightDiagnostic> Diag;
-    auto baseObjTy = BaseType->getRValueType();
-    
-    if (auto metatypeTy = baseObjTy->getAs<MetatypeType>()) {
+    auto baseObjTy = BaseType;
+
+    if (auto metatypeTy = baseObjTy->getAs<AnyMetatypeType>()) {
       auto instanceTy = metatypeTy->getInstanceType();
-      
+
       // This will only happen if we have an unresolved dot expression
       // (.foo) where foo is a protocol member and the contextual type is
       // an optional protocol metatype.
@@ -2159,40 +2159,41 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         instanceTy = objectTy;
         baseObjTy = MetatypeType::get(objectTy);
       }
-      assert(instanceTy->isExistentialType());
-      
-      // Give a customized message if we're accessing a member type
-      // of a protocol -- otherwise a diagnostic talking about
-      // static members doesn't make a whole lot of sense
-      if (auto TAD = dyn_cast<TypeAliasDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
-                                    TAD->getName()));
-      } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
-                                    ATD->getName()));
-      } else if (isa<ConstructorDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
-                                    instanceTy));
-      } else {
-        Diag.emplace(emitDiagnostic(loc,
-                                    diag::could_not_use_type_member_on_protocol_metatype,
-                                    baseObjTy, Name));
-      }
-      
-      Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
-      
-      // See through function decl context
-      if (auto parent = cs.DC->getInnermostTypeContext()) {
-        // If we are in a protocol extension of 'Proto' and we see
-        // 'Proto.static', suggest 'Self.static'
-        if (auto extensionContext = parent->getExtendedProtocolDecl()) {
-          if (extensionContext->getDeclaredType()->isEqual(instanceTy)) {
-            Diag->fixItReplace(getAnchor()->getSourceRange(), "Self");
+
+      if (instanceTy->isExistentialType()) {
+        // Give a customized message if we're accessing a member type
+        // of a protocol -- otherwise a diagnostic talking about
+        // static members doesn't make a whole lot of sense
+        if (auto TAD = dyn_cast<TypeAliasDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
+                                      TAD->getName()));
+        } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
+                                      ATD->getName()));
+        } else if (isa<ConstructorDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
+                                      instanceTy));
+        } else {
+          Diag.emplace(emitDiagnostic(
+              loc, diag::could_not_use_type_member_on_protocol_metatype,
+              baseObjTy, Name));
+        }
+
+        Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
+
+        // See through function decl context
+        if (auto parent = cs.DC->getInnermostTypeContext()) {
+          // If we are in a protocol extension of 'Proto' and we see
+          // 'Proto.static', suggest 'Self.static'
+          if (auto extensionContext = parent->getExtendedProtocolDecl()) {
+            if (extensionContext->getDeclaredType()->isEqual(instanceTy)) {
+              Diag->fixItReplace(getAnchor()->getSourceRange(), "Self");
+            }
           }
         }
+
+        return true;
       }
-      
-      return true;
     }
 
     // If this is a reference to a static member by one of the key path

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -810,11 +810,12 @@ class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   DeclName Name;
 
 public:
-  AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs, Type baseType,
-                                   DeclName memberName, ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), BaseType(baseType),
-        Name(memberName) {}
-    
+  AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
+                                   Type baseType, DeclName memberName,
+                                   ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator),
+        BaseType(baseType->getRValueType()), Name(memberName) {}
+
   bool diagnoseAsError() override;
 };
 class PartialApplicationFailure final : public FailureDiagnostic {

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -577,3 +577,35 @@ extension S_Min : CustomStringConvertible {
     return "\(min)" // Ok
   }
 }
+
+// rdar://problem/50679161
+
+func rdar50679161() {
+  struct Point {}
+
+  struct S {
+    var w, h: Point
+  }
+
+  struct Q {
+    init(a: Int, b: Int) {}
+    init(a: Point, b: Point) {}
+  }
+
+  func foo() {
+    _ = { () -> Void in
+      var foo = S
+      // expected-error@-1 {{expected member name or constructor call after type name}}
+      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+      // expected-note@-3 {{use '.self' to reference the type object}}
+      if let v = Int?(1) {
+        var _ = Q(
+          a: v + foo.w,
+          // expected-error@-1 {{instance member 'w' cannot be used on type 'S'}}
+          b: v + foo.h
+          // expected-error@-1 {{instance member 'h' cannot be used on type 'S'}}
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Incorrect member reference diagnostic tailed for protocols
should cover existential metatypes as well.

Resolves: rdar://problem/50679161

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
