### PR TITLE
[CSDiag] Adjust assert to account for changes in `filterContextualMem…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6497,16 +6497,20 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
 
     // Depending on how we matched, produce tailored diagnostics.
     switch (candidateInfo.closeness) {
+    case CC_SelfMismatch:         // Self argument mismatches.
+      llvm_unreachable("These aren't produced by filterContextualMemberList");
+      return false;
+
     case CC_NonLValueInOut: // First argument is inout but no lvalue present.
     case CC_OneArgumentMismatch: // All arguments except one match.
     case CC_OneArgumentNearMismatch:
     case CC_OneGenericArgumentMismatch:
     case CC_OneGenericArgumentNearMismatch:
     case CC_GenericNonsubstitutableMismatch:
-    case CC_SelfMismatch:         // Self argument mismatches.
     case CC_ArgumentNearMismatch: // Argument list mismatch.
     case CC_ArgumentMismatch:     // Argument list mismatch.
-      llvm_unreachable("These aren't produced by filterContextualMemberList");
+      // Candidate filtering can produce these now, but they can't
+      // be properly diagnosed here at the moment.
       return false;
 
     case CC_ExactMatch: { // This is a perfect match for the arguments.

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -209,3 +209,14 @@ func rdar_45535925() {
     // expected-error@-1 {{'bar' is inaccessible due to 'private' protection level}}
   }
 }
+
+// rdar://problem/50668864
+func rdar_50668864() {
+  struct Foo {
+    init(anchors: [Int]) {
+      // TODO: This would be improved when argument conversions are diagnosed via new diagnostic framework,
+      // actual problem here is that `[Int]` cannot be converted to function type represented by a closure.
+      self = .init { _ in [] } // expected-error {{type of expression is ambiguous without more context}}
+    }
+  }
+}


### PR DESCRIPTION
…berList`.

Originally `filterContextualMemberList` would only return a limited
set of closeness kinds `CC_GeneralMismatch`, `CC_Argument{Label, Count}Mismatch`,
and unavailable/inaccessible. At some point later it also started
matching almost everything besides `CC_SelfMismatch` and logic in
`visitUnresolvedMemberExpr` needs to get adjusted to account for that.

Resolves: rdar://problem/50668864

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
