### PR TITLE
optimize keypath instructions

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -226,6 +226,7 @@ public:
   SILInstruction *visitRetainValueAddrInst(RetainValueAddrInst *CI);
   SILInstruction *visitPartialApplyInst(PartialApplyInst *AI);
   SILInstruction *visitApplyInst(ApplyInst *AI);
+  SILInstruction *visitBeginApplyInst(BeginApplyInst *BAI);
   SILInstruction *visitTryApplyInst(TryApplyInst *AI);
   SILInstruction *optimizeStringObject(BuiltinInst *BI);
   SILInstruction *visitBuiltinInst(BuiltinInst *BI);
@@ -299,6 +300,10 @@ public:
 
   SILInstruction *optimizeApplyOfConvertFunctionInst(FullApplySite AI,
                                                      ConvertFunctionInst *CFI);
+
+  bool tryOptimizeKeypath(ApplyInst *AI);
+  bool tryOptimizeInoutKeypath(BeginApplyInst *AI);
+
   // Optimize concatenation of string literals.
   // Constant-fold concatenation of string literals known at compile-time.
   SILInstruction *optimizeConcatenationOfStringLiterals(ApplyInst *AI);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -30,9 +30,12 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
 
 using namespace swift;
 using namespace swift::PatternMatch;
+
+STATISTIC(NumOptimizedKeypaths, "Number of optimized keypath instructions");
 
 /// Remove pointless reabstraction thunk closures.
 ///   partial_apply %reabstraction_thunk_typeAtoB(
@@ -546,6 +549,189 @@ SILCombiner::optimizeApplyOfConvertFunctionInst(FullApplySite AI,
              AI.getSubstCalleeType()->getAllResultsType() &&
          "Function types should be the same");
   return NAI;
+}
+
+/// Ends the begin_access "scope" if a begin_access was inserted for optimizing
+/// a keypath pattern.
+static void insertEndAccess(BeginAccessInst *&beginAccess, bool isModify,
+                            SILBuilder &builder) {
+  if (beginAccess) {
+    builder.createEndAccess(beginAccess->getLoc(), beginAccess,
+                            /*aborted*/ false);
+    if (isModify)
+      beginAccess->setAccessKind(SILAccessKind::Modify);
+    beginAccess = nullptr;
+  }
+}
+
+/// Creates the projection pattern for a keypath instruction.
+///
+/// Currently only the StoredProperty pattern is handled.
+/// TODO: handle other patterns, like getters/setters, optional chaining, etc.
+///
+/// Returns false if \p keyPath is not a keypath instruction or if there is any
+/// other reason why the optimization cannot be done.
+static SILValue createKeypathProjections(SILValue keyPath, SILValue root,
+                                         SILLocation loc,
+                                         BeginAccessInst *&beginAccess,
+                                         SILBuilder &builder) {
+  if (auto *upCast = dyn_cast<UpcastInst>(keyPath))
+    keyPath = upCast->getOperand();
+
+  // Is it a keypath instruction at all?
+  auto *kpInst = dyn_cast<KeyPathInst>(keyPath);
+  if (!kpInst || !kpInst->hasPattern())
+    return SILValue();
+
+  auto components = kpInst->getPattern()->getComponents();
+
+  // Check if the keypath only contains patterns which we support.
+  for (const KeyPathPatternComponent &comp : components) {
+    if (comp.getKind() != KeyPathPatternComponent::Kind::StoredProperty)
+      return SILValue();
+  }
+
+  SILValue addr = root;
+  for (const KeyPathPatternComponent &comp : components) {
+    assert(comp.getKind() == KeyPathPatternComponent::Kind::StoredProperty);
+    VarDecl *storedProperty = comp.getStoredPropertyDecl();
+    SILValue elementAddr;
+    if (addr->getType().getStructOrBoundGenericStruct()) {
+      addr = builder.createStructElementAddr(loc, addr, storedProperty);
+    } else if (addr->getType().getClassOrBoundGenericClass()) {
+      LoadInst *Ref = builder.createLoad(loc, addr,
+                                         LoadOwnershipQualifier::Unqualified);
+      insertEndAccess(beginAccess, /*isModify*/ false, builder);
+      addr = builder.createRefElementAddr(loc, Ref, storedProperty);
+
+      // Class members need access enforcement.
+      if (builder.getModule().getOptions().EnforceExclusivityDynamic) {
+        beginAccess = builder.createBeginAccess(loc, addr, SILAccessKind::Read,
+                                                SILAccessEnforcement::Dynamic,
+                                                /*noNestedConflict*/ false,
+                                                /*fromBuiltin*/ false);
+        addr = beginAccess;
+      }
+    } else {
+      // This should never happen, as a stored-property pattern can only be
+      // applied to classes and structs. But to be safe - and future prove -
+      // let's handle this case and bail.
+      insertEndAccess(beginAccess, /*isModify*/ false, builder);
+      return SILValue();
+    }
+  }
+  return addr;
+}
+
+/// Try to optimize a keypath application with an apply instruction.
+///
+/// Replaces (simplified SIL):
+///   %kp = keypath ...
+///   apply %keypath_runtime_function(%addr, %kp, %root_object)
+/// with:
+///   %addr = struct_element_addr/ref_element_addr %root_object
+///   ...
+///   load/store %addr
+bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
+  SILFunction *callee = AI->getReferencedFunction();
+  if (!callee)
+    return false;
+
+  if (AI->getNumArguments() != 3)
+    return false;
+
+  SILValue keyPath, rootAddr, valueAddr;
+  bool isModify = false;
+  if (callee->getName() == "swift_setAtWritableKeyPath" ||
+      callee->getName() == "swift_setAtReferenceWritableKeyPath") {
+    keyPath = AI->getArgument(1);
+    rootAddr = AI->getArgument(0);
+    valueAddr = AI->getArgument(2);
+    isModify = true;
+  } else if (callee->getName() == "swift_getAtKeyPath") {
+    keyPath = AI->getArgument(2);
+    rootAddr = AI->getArgument(1);
+    valueAddr = AI->getArgument(0);
+  } else {
+    return false;
+  }
+
+  BeginAccessInst *beginAccess = nullptr;
+  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr,
+                                                    AI->getLoc(), beginAccess,
+                                                    Builder);
+  if (!projectedAddr)
+    return false;
+
+  if (isModify) {
+    Builder.createCopyAddr(AI->getLoc(), valueAddr, projectedAddr,
+                           IsTake, IsNotInitialization);
+  } else {
+    Builder.createCopyAddr(AI->getLoc(), projectedAddr, valueAddr,
+                           IsNotTake, IsInitialization);
+  }
+  insertEndAccess(beginAccess, isModify, Builder);
+  eraseInstFromFunction(*AI);
+  ++NumOptimizedKeypaths;
+  return true;
+}
+
+/// Try to optimize a keypath application with an apply instruction.
+///
+/// Replaces (simplified SIL):
+///   %kp = keypath ...
+///   %inout_addr = begin_apply %keypath_runtime_function(%kp, %root_object)
+///   // use %inout_addr
+///   end_apply
+/// with:
+///   %addr = struct_element_addr/ref_element_addr %root_object
+///   // use %inout_addr
+bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
+  SILFunction *callee = AI->getReferencedFunction();
+  if (!callee)
+    return false;
+
+  if (AI->getNumArguments() != 2)
+    return false;
+
+  SILValue keyPath = AI->getArgument(1);
+  SILValue rootAddr = AI->getArgument(0);
+  bool isModify = false;
+  if (callee->getName() == "swift_modifyAtWritableKeyPath" ||
+      callee->getName() == "swift_modifyAtReferenceWritableKeyPath") {
+    isModify = true;
+  } else if (callee->getName() != "swift_readAtKeyPath") {
+    return false;
+  }
+
+  SILInstructionResultArray yields = AI->getYieldedValues();
+  if (yields.size() != 1)
+    return false;
+
+  SILValue valueAddr = yields[0];
+  Operand *AIUse = AI->getTokenResult()->getSingleUse();
+  if (!AIUse)
+    return false;
+  EndApplyInst *endApply = dyn_cast<EndApplyInst>(AIUse->getUser());
+  if (!endApply)
+    return false;
+
+  BeginAccessInst *beginAccess = nullptr;
+  SILValue projectedAddr = createKeypathProjections(keyPath, rootAddr,
+                                                    AI->getLoc(), beginAccess,
+                                                    Builder);
+  if (!projectedAddr)
+    return false;
+
+  // Replace the projected address.
+  valueAddr->replaceAllUsesWith(projectedAddr);
+
+  Builder.setInsertionPoint(endApply);
+  insertEndAccess(beginAccess, isModify, Builder);
+  eraseInstFromFunction(*endApply);
+  eraseInstFromFunction(*AI);
+  ++NumOptimizedKeypaths;
+  return true;
 }
 
 bool
@@ -1327,6 +1513,9 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
   if (auto *CFI = dyn_cast<ConvertFunctionInst>(AI->getCallee()))
     return optimizeApplyOfConvertFunctionInst(AI, CFI);
 
+  if (tryOptimizeKeypath(AI))
+    return nullptr;
+
   // Optimize readonly functions with no meaningful users.
   SILFunction *SF = AI->getReferencedFunction();
   if (SF && SF->getEffectsKind() < EffectsKind::ReleaseNone) {
@@ -1390,6 +1579,12 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
                                       "convertFromObjectiveC"))
     return nullptr;
 
+  return nullptr;
+}
+
+SILInstruction *SILCombiner::visitBeginApplyInst(BeginApplyInst *BAI) {
+  if (tryOptimizeInoutKeypath(BAI))
+    return nullptr;
   return nullptr;
 }
 

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -52,6 +52,9 @@ STATISTIC(DeadAllocRefEliminated,
 STATISTIC(DeadAllocStackEliminated,
           "number of AllocStack instructions removed");
 
+STATISTIC(DeadKeyPathEliminated,
+          "number of keypath instructions removed");
+
 STATISTIC(DeadAllocApplyEliminated,
           "number of allocating Apply instructions removed");
 
@@ -206,6 +209,9 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts,
     return acceptRefCountInsts;
 
   if (isa<InjectEnumAddrInst>(Inst))
+    return true;
+
+  if (isa<KeyPathInst>(Inst))
     return true;
 
   // We know that the destructor has no side effects so we can remove the
@@ -643,17 +649,20 @@ class DeadObjectElimination : public SILFunctionTransform {
   llvm::SmallVector<SILInstruction*, 16> Allocations;
 
   void collectAllocations(SILFunction &Fn) {
-    for (auto &BB : Fn)
+    for (auto &BB : Fn) {
       for (auto &II : BB) {
-        if (isa<AllocationInst>(&II))
+        if (isa<AllocationInst>(&II) ||
+            isAllocatingApply(&II) ||
+            isa<KeyPathInst>(&II)) {
           Allocations.push_back(&II);
-        else if (isAllocatingApply(&II))
-          Allocations.push_back(&II);
+        }
       }
+    }
   }
 
   bool processAllocRef(AllocRefInst *ARI);
   bool processAllocStack(AllocStackInst *ASI);
+  bool processKeyPath(KeyPathInst *KPI);
   bool processAllocBox(AllocBoxInst *ABI){ return false;}
   bool processAllocApply(ApplyInst *AI, DeadEndBlocks &DEBlocks);
 
@@ -668,6 +677,8 @@ class DeadObjectElimination : public SILFunctionTransform {
         Changed |= processAllocRef(A);
       else if (auto *A = dyn_cast<AllocStackInst>(II))
         Changed |= processAllocStack(A);
+      else if (auto *KPI = dyn_cast<KeyPathInst>(II))
+        Changed |= processKeyPath(KPI);
       else if (auto *A = dyn_cast<AllocBoxInst>(II))
         Changed |= processAllocBox(A);
       else if (auto *A = dyn_cast<ApplyInst>(II))
@@ -746,6 +757,30 @@ bool DeadObjectElimination::processAllocStack(AllocStackInst *ASI) {
   LLVM_DEBUG(llvm::dbgs() << "    Success! Eliminating alloc_stack.\n");
 
   ++DeadAllocStackEliminated;
+  return true;
+}
+
+bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
+  UserList UsersToRemove;
+  if (hasUnremovableUsers(KPI, UsersToRemove, /*acceptRefCountInsts=*/ true,
+      /*onlyAcceptTrivialStores*/ false)) {
+    LLVM_DEBUG(llvm::dbgs() << "    Found a use that cannot be zapped...\n");
+    return false;
+  }
+
+  // For simplicity just bail if the keypath has a non-trivial operands.
+  // TODO: don't bail but insert compensating destroys for such operands.
+  for (const Operand &Op : KPI->getAllOperands()) {
+    if (!Op.get()->getType().isTrivial(*KPI->getFunction()))
+      return false;
+  }
+
+  // Remove the keypath and all of its users.
+  removeInstructions(
+    ArrayRef<SILInstruction*>(UsersToRemove.begin(), UsersToRemove.end()));
+  LLVM_DEBUG(llvm::dbgs() << "    Success! Eliminating keypath.\n");
+
+  ++DeadKeyPathEliminated;
   return true;
 }
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -1,0 +1,269 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -emit-sil >%t/output.sil
+// RUN: %FileCheck %s < %t/output.sil
+// RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output.sil
+
+// RUN: %target-build-swift -O %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+protocol P {
+  func modifyIt()
+}
+
+struct GenStruct<T : P> : P {
+  var st: T
+  
+  init(_ st: T) { self.st = st }
+
+  func modifyIt() {
+    st.modifyIt()
+  }
+}
+
+var numGenClassObjs = 0
+
+final class GenClass<T : P> : P {
+  var ct: T
+
+  init(_ ct: T) {
+    self.ct = ct
+    numGenClassObjs += 1
+  }
+
+  deinit {
+    numGenClassObjs -= 1
+  }
+
+  func modifyIt() {
+    ct.modifyIt()
+  }
+}
+
+final class SimpleClass : P {
+  var i: Int
+  static var numObjs = 0
+
+  init(_ i: Int) {
+    self.i = i
+    Self.numObjs += 1
+  }
+
+  deinit {
+    Self.numObjs -= 1
+  }
+
+  func modifyIt() {
+    i += 10
+  }
+}
+
+// Check if all keypath instructions have been optimized away
+// CHECK-ALL-NOT: = keypath
+
+// CHECK-LABEL: sil {{.*}}testGenStructRead
+// CHECK: [[A:%[0-9]+]] = struct_element_addr %1
+// CHECK: copy_addr [[A]] to [initialization] %0
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenStructRead<T>(_ s: GenStruct<T>) -> T {
+  let kp = \GenStruct<T>.st
+  return s[keyPath: kp]
+}
+
+// CHECK-LABEL: sil {{.*}}testGenStructWrite
+// CHECK: [[A:%[0-9]+]] = struct_element_addr %0
+// CHECK: copy_addr %1 to [[A]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenStructWrite<T>(_ s: inout GenStruct<T>, _ t: T) {
+  let kp = \GenStruct<T>.st
+  s[keyPath: kp] = t
+}
+
+// CHECK-LABEL: sil {{.*}}testGenClassRead
+// CHECK: [[E:%[0-9]+]] = ref_element_addr %1
+// CHECK: [[A:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E]]
+// CHECK: copy_addr [[A]] to [initialization] %0
+// CHECK: end_access [[A]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenClassRead<T>(_ c: GenClass<T>) -> T {
+  let kp = \GenClass<T>.ct
+  return c[keyPath: kp]
+}
+
+// CHECK-LABEL: sil {{.*}}testGenClassWrite
+// CHECK: [[S:%[0-9]+]] = alloc_stack $T
+// CHECK: [[E:%[0-9]+]] = ref_element_addr %0
+// CHECK: [[A:%[0-9]+]] = begin_access [modify] [dynamic] [[E]]
+// CHECK: copy_addr [take] [[S]] to [[A]]
+// CHECK: end_access [[A]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenClassWrite<T>(_ c: GenClass<T>, _ t: T) {
+  let kp = \GenClass<T>.ct
+  c[keyPath: kp] = t
+}
+
+
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func modifyGeneric<T : P>(_ t: inout T) {
+  t.modifyIt()
+}
+
+// CHECK-LABEL: sil {{.*}}testGenStructModify
+// CHECK: [[A:%[0-9]+]] = struct_element_addr %0
+// CHECK: [[F:%[0-9]+]] = function_ref {{.*}}modifyGeneric
+// CHECK: apply [[F]]<T>([[A]])
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenStructModify<T : P>(_ s: inout GenStruct<T>) {
+  let kp = \GenStruct<T>.st
+  modifyGeneric(&s[keyPath: kp])
+}
+
+// CHECK-LABEL: sil {{.*}}testGenClassModify
+// CHECK: [[E:%[0-9]+]] = ref_element_addr %0
+// CHECK: [[A:%[0-9]+]] = begin_access [modify] [dynamic] [[E]]
+// CHECK: [[F:%[0-9]+]] = function_ref {{.*}}modifyGeneric
+// CHECK: apply [[F]]<T>([[A]])
+// CHECK: end_access [[A]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testGenClassModify<T : P>(_ c: GenClass<T>) {
+  let kp = \GenClass<T>.ct
+  modifyGeneric(&c[keyPath: kp])
+}
+
+// CHECK-LABEL: sil {{.*}}testNestedRead1
+// CHECK: [[R1:%[0-9]+]] = struct_extract %0
+// CHECK: [[E1:%[0-9]+]] = ref_element_addr [[R1]]
+// CHECK: [[A1:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]]
+// CHECK: [[E2:%[0-9]+]] = struct_element_addr [[A1]]
+// CHECK: [[R2:%[0-9]+]] = load [[E2]]
+// CHECK: end_access [[A1]]
+// CHECK: [[E3:%[0-9]+]] = ref_element_addr [[R2]]
+// CHECK: [[A2:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E3]]
+// CHECK: [[I:%[0-9]+]] = load [[A2]]
+// CHECK: end_access [[A2]]
+// CHECK: return [[I]]
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testNestedRead1(_ s: GenStruct<GenClass<GenStruct<SimpleClass>>>) -> Int {
+  let kp = \GenStruct<GenClass<GenStruct<SimpleClass>>>.st.ct.st.i
+  return s[keyPath: kp]
+}
+
+// CHECK-LABEL: sil {{.*}}testNestedRead2
+// CHECK: [[R:%[0-9]+]] = struct_extract %1
+// CHECK: [[E1:%[0-9]+]] = ref_element_addr [[R]]
+// CHECK: [[A:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]]
+// CHECK: [[E2:%[0-9]+]] = struct_element_addr [[A]]
+// CHECK: copy_addr [[E2]] to [initialization] %0
+// CHECK: end_access [[A]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testNestedRead2<T>(_ s: GenStruct<GenClass<GenStruct<T>>>) -> T {
+  let kp = \GenStruct<GenClass<GenStruct<T>>>.st.ct.st
+  return s[keyPath: kp]
+}
+
+// CHECK-LABEL: sil {{.*}}testNestedWrite
+// CHECK: [[E1:%[0-9]+]] = ref_element_addr %0
+// CHECK: [[A1:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]]
+// CHECK: [[E2:%[0-9]+]] = struct_element_addr [[A1]]
+// CHECK: [[R1:%[0-9]+]] = load [[E2]]
+// CHECK: end_access [[A1]]
+// CHECK: [[E3:%[0-9]+]] = ref_element_addr [[R1]]
+// CHECK: [[A2:%[0-9]+]] = begin_access [modify] [dynamic] [no_nested_conflict] [[E3]]
+// CHECK: store %1 to [[A2]]
+// CHECK: end_access [[A2]]
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testNestedWrite(_ s: GenClass<GenStruct<SimpleClass>>, _ i: Int) {
+  let kp = \GenClass<GenStruct<SimpleClass>>.ct.st.i
+  s[keyPath: kp] = i
+}
+
+// CHECK-LABEL: sil {{.*}}testNestedModify
+// CHECK: [[E1:%[0-9]+]] = struct_element_addr %0
+// CHECK: [[R1:%[0-9]+]] = load [[E1]]
+// CHECK: [[E2:%[0-9]+]] = ref_element_addr [[R1]]
+// CHECK: [[A1:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E2]]
+// CHECK: [[R2:%[0-9]+]] = load [[A1]]
+// CHECK: end_access [[A1]]
+// CHECK: [[E3:%[0-9]+]] = ref_element_addr [[R2]]
+// CHECK: [[A2:%[0-9]+]] = begin_access [modify] [dynamic] [[E3]]
+// CHECK: [[F:%[0-9]+]] = function_ref {{.*}}modifyGeneric
+// CHECK: apply [[F]]<T>([[A2]])
+// CHECK: end_access [[A2]]
+// CHECK: return
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func testNestedModify<T : P>(_ s: inout GenStruct<GenClass<GenClass<T>>>) {
+  let kp = \GenStruct<GenClass<GenClass<T>>>.st.ct.ct
+  modifyGeneric(&s[keyPath: kp])
+}
+
+
+// CHECK-LABEL: sil {{.*}}testit
+func testit() {
+  // CHECK-OUTPUT: GenStructRead: 27
+  print("GenStructRead: \(testGenStructRead(GenStruct(SimpleClass(27))).i)")
+
+  // CHECK-OUTPUT: GenStructWrite: 28
+  var s = GenStruct(SimpleClass(0))
+  testGenStructWrite(&s, SimpleClass(28))
+  print("GenStructWrite: \(s.st.i)")
+
+  // CHECK-OUTPUT: GenStructModify: 38
+  testGenStructModify(&s)
+  print("GenStructModify: \(s.st.i)")
+
+  // CHECK-OUTPUT: GenClassRead: 29
+  print("GenClassRead: \(testGenClassRead(GenClass(SimpleClass(29))).i)")
+
+  // CHECK-OUTPUT: GenClassWrite: 30
+  let c = GenClass(SimpleClass(0))
+  testGenClassWrite(c, SimpleClass(30))
+  print("GenClassWrite: \(c.ct.i)")
+
+  // CHECK-OUTPUT: GenClassModify: 40
+  testGenClassModify(c)
+  print("GenClassModify: \(c.ct.i)")
+
+  // CHECK-OUTPUT: NestedRead1: 31
+  print("NestedRead1: \(testNestedRead1(GenStruct(GenClass(GenStruct(SimpleClass(31))))))")
+
+  // CHECK-OUTPUT: NestedRead2: 32
+  print("NestedRead2: \(testNestedRead2(GenStruct(GenClass(GenStruct(SimpleClass(32))))).i)")
+
+  // CHECK-OUTPUT: NestedWrite: 33
+  let c2 = GenClass(GenStruct(SimpleClass(0)))
+  testNestedWrite(c2, 33)
+  print("NestedWrite: \(c2.ct.st.i)")
+
+  // CHECK-OUTPUT: NestedModify: 44
+  var s2 = GenStruct(GenClass(GenClass(SimpleClass(34))))
+  testNestedModify(&s2)
+  print("NestedModify: \(s2.st.ct.ct.i)")
+}
+
+testit()
+
+// CHECK-OUTPUT: SimpleClass obj count: 0
+print("SimpleClass obj count: \(SimpleClass.numObjs)")
+// CHECK-OUTPUT: GenClass obj count: 0
+print("GenClass obj count: \(numGenClassObjs)")
+
+


### PR DESCRIPTION
If the keypath argument of a keypath access function is a keypath literal instruction, generate the projection inline and remove the access function.

For example, replaces (simplified SIL):
   %kp = keypath ... stored_property #Foo.bar
   apply %keypath_runtime_function(%root_object, %kp, %addr)
with:
   %addr = struct_element_addr %root_object, #Foo.bar
   load/store %addr

Currently this only handles stored property patterns.

rdar://problem/36244734