### PR TITLE
[win] Fix path separators for Windows.

### DIFF
--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -5,4 +5,4 @@ func string_interpolation() {
 }
 
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
-// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR/test/Parse/source_locs.swift:4:12 {{.*}}
+// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:4:12 {{.*}}


### PR DESCRIPTION
The Windows CI added another broken test with the changes in d37fd2f85dae7f375ad2b84af052038689834bcc. This should fix it.

It should happen sooner or later in the Azure CI.