### PR TITLE
[5.1] IRGen: Map type into context before asking for class layout.

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -761,8 +761,13 @@ emitKeyPathComponent(IRGenModule &IGM,
       assert(currentBaseTy->getClassOrBoundGenericClass() == propertyBaseDecl);
       loweredBaseTy =
           IGM.getLoweredType(AbstractionPattern::getOpaque(), currentBaseTy);
+      
+      auto loweredBaseContextTy = SILType::getPrimitiveObjectType(
+            GenericEnvironment::mapTypeIntoContext(genericEnv,
+                                                   loweredBaseTy.getASTType())
+              ->getCanonicalType());
 
-      switch (getClassFieldAccess(IGM, loweredBaseTy, property)) {
+      switch (getClassFieldAccess(IGM, loweredBaseContextTy, property)) {
       case FieldAccess::ConstantDirect: {
         // Known constant fixed offset.
         auto offset = tryEmitConstantClassFragilePhysicalMemberOffset(IGM,

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -27,6 +27,9 @@ public class C: Hashable {
   public func hash(into hasher: inout Hasher)
   public static func ==(_: C, _: C) -> Bool
 }
+public class GC<T> {
+  public final var x: T
+}
 
 public struct G<T> {
   public var x: T { get set }
@@ -299,6 +302,14 @@ sil_vtable C2 {}
 // CHECK-32-SAME: i32 24 }>
 // CHECK-64-SAME: i32 48 }>
 
+// -- %gcx: GC<T>.x
+// CHECK: [[KP_GCX:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
+// CHECK-SAME: @"generic environment l"
+// CHECK-SAME: @"symbolic 8keypaths2GCCyxG"
+// CHECK-SAME: @"symbolic x"
+//             -- class with runtime-resolved offset, mutable
+// CHECK-SAME: <i32 0x3fffffe>
+
 // CHECK-LABEL: @"generic environment SHRzSHR_r0_l" = linkonce_odr hidden constant
 // CHECK-SAME: i32 8193, i16 2, i8 -128, i8 -128, i32 128
 
@@ -420,6 +431,14 @@ entry:
 
   return undef : $()
 }
+
+sil @generic_class_stored_final : $@convention(thin) <T> () -> () {
+entry:
+  %gcx = keypath $ReferenceWritableKeyPath<GC<T>, T>, <T> (root $GC<T>; stored_property #GC.x: $T) <T>
+
+  return undef : $()
+}
+
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @computed_property_generics
 sil @computed_property_generics : $@convention(thin) <T, U> () -> () {


### PR DESCRIPTION
Asking for the layout of the interface type apparently gives the wrong answer,
causing key paths to access stored properties of generic classes using the wrong
strategy.

Fixes SR-10167 | rdar://problem/49230751.