### PR TITLE
[test] Mark mandatory_inlining.swift as executable.

### DIFF
--- a/test/Interpreter/mandatory_inlining.swift
+++ b/test/Interpreter/mandatory_inlining.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift
 
+// REQUIRES: executable_test
+
 func test(reportError: ((String) -> (Void))? = nil) {
   let reportError = reportError ?? { error in
     print(error)


### PR DESCRIPTION
Otherwise the Android CI will fail this test, since no device is
actually attached.
