### PR TITLE
Add a comment in ClosureScopeAnalysis.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -107,6 +107,10 @@ public:
   void recordCapture(AddressCapture capture) {
     LLVM_DEBUG(llvm::dbgs() << "Dynamic Capture: " << capture);
 
+    // *NOTE* For dynamically replaceable local functions, getCalleeFunction()
+    // returns nullptr. This assert verifies the assumption that a captured
+    // local variable can never be promoted to capture-by-address for
+    // dynamically replaceable local functions.
     auto callee = capture.site.getCalleeFunction();
     assert(callee && "cannot locate function ref for nonescaping closure");
 


### PR DESCRIPTION
As a follow-up to reviewing the dynamically replaceable
implementation, document the place where this analysis would otherwise
crash once we start optimizing non-escaping closure
captures, unless we properly restrict those optimizations in the presence of
dynamically replaceable calls.