### PR TITLE
[Diagnostics] Add known member declaration to `invalid member ref` di…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -766,8 +766,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
                              ? ConstraintLocator::SubscriptMember
                              : ConstraintLocator::Member;
       AllowTypeOrInstanceMemberFailure failure(
-          expr, CS, baseObjTy, memberName,
-          CS.getConstraintLocator(E, locatorKind), choice->getDecl());
+          expr, CS, baseObjTy, choice->getDecl(), memberName,
+          CS.getConstraintLocator(E, locatorKind));
       auto diagnosed = failure.diagnoseAsError();
       assert(diagnosed &&
              "Failed to produce missing or extraneous metatype diagnostic");

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -738,6 +738,17 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
     instanceTy = MTT->getInstanceType();
   
   if (sameProblem) {
+    // If the problem is the same for all of the choices, let's
+    // just pick one which has a declaration.
+    auto choice = llvm::find_if(
+        result.UnviableCandidates,
+        [&](const OverloadChoice &choice) { return choice.isDecl(); });
+
+    // This code can't currently diagnose key path application
+    // related failures.
+    if (!choice)
+      return;
+
     switch (firstProblem) {
     case MemberLookupResult::UR_LabelMismatch:
     case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
@@ -755,8 +766,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
                              ? ConstraintLocator::SubscriptMember
                              : ConstraintLocator::Member;
       AllowTypeOrInstanceMemberFailure failure(
-          nullptr, CS, baseObjTy, memberName,
-          CS.getConstraintLocator(E, locatorKind));
+          expr, CS, baseObjTy, memberName,
+          CS.getConstraintLocator(E, locatorKind), choice->getDecl());
       auto diagnosed = failure.diagnoseAsError();
       assert(diagnosed &&
              "Failed to produce missing or extraneous metatype diagnostic");
@@ -778,7 +789,6 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
     }
         
     case MemberLookupResult::UR_Inaccessible: {
-      auto decl = result.UnviableCandidates[0].getDecl();
       // FIXME: What if the unviable candidates have different levels of access?
       //
       // If we found an inaccessible member of a protocol extension, it might
@@ -786,16 +796,20 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
       // visible to us, but the conforming type is. In this case, we need to
       // clamp the formal access for diagnostics purposes to the formal access
       // of the protocol itself.
-      InaccessibleMemberFailure failure(expr, CS, decl,
+      InaccessibleMemberFailure failure(expr, CS, choice->getDecl(),
                                         CS.getConstraintLocator(E));
       auto diagnosed = failure.diagnoseAsError();
       assert(diagnosed && "failed to produce expected diagnostic");
       for (auto cand : result.UnviableCandidates) {
-        auto *choice = cand.getDecl();
+        if (!cand.isDecl())
+          continue;
+
+        auto *candidate = cand.getDecl();
         // failure is going to highlight candidate given to it,
         // we just need to handle the rest here.
-        if (choice != decl)
-          diagnose(choice, diag::decl_declared_here, choice->getFullName());
+        if (candidate != choice->getDecl())
+          diagnose(candidate, diag::decl_declared_here,
+                   candidate->getFullName());
       }
       return;
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1974,32 +1974,6 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   Expr *expr = getParentExpr();
   SourceRange baseRange = expr ? expr->getSourceRange() : SourceRange();
 
-  ValueDecl *member = KnownChoice;
-  // If there is no known member, let's try to find it.
-  if (!member) {
-    auto overload = getOverloadChoiceIfAvailable(locator);
-    if (!overload)
-      return false;
-
-    const auto &choice = overload->choice;
-    if (choice.isDecl()) {
-      member = choice.getDecl();
-    } else {
-      auto baseTy = overload->choice.getBaseType();
-      if (!baseTy->is<MetatypeType>())
-        return false;
-
-      auto *MT = baseTy->castTo<MetatypeType>();
-      auto instanceTy = MT->getMetatypeInstanceType();
-      if (!instanceTy->getAnyNominal())
-        return false;
-
-      member = dyn_cast<ValueDecl>(instanceTy->getAnyNominal()->getAsDecl());
-      if (!member)
-        return false;
-    }
-  }
-
   // If the base is an implicit self type reference, and we're in a
   // an initializer, then the user wrote something like:
   //
@@ -2068,7 +2042,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
   }
 
-  if (BaseType->is<AnyMetatypeType>() && !member->isStatic()) {
+  if (BaseType->is<AnyMetatypeType>() && !Member->isStatic()) {
     auto instanceTy = BaseType;
 
     if (auto *AMT = instanceTy->getAs<AnyMetatypeType>()) {
@@ -2123,7 +2097,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
     // Check whether the instance member is declared on parent context and if so
     // provide more specialized message.
-    auto memberTypeContext = member->getDeclContext()->getInnermostTypeContext();
+    auto memberTypeContext =
+        Member->getDeclContext()->getInnermostTypeContext();
     auto currentTypeContext = cs.DC->getInnermostTypeContext();
     
     if (memberTypeContext && currentTypeContext &&
@@ -2133,7 +2108,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
                      currentTypeContext->getDeclaredInterfaceType(), Name,
                      memberTypeContext->getDeclaredInterfaceType(), true)
           .highlight(baseRange)
-          .highlight(member->getSourceRange());
+          .highlight(Member->getSourceRange());
       return true;
     }
 
@@ -2170,13 +2145,13 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         // Give a customized message if we're accessing a member type
         // of a protocol -- otherwise a diagnostic talking about
         // static members doesn't make a whole lot of sense
-        if (auto TAD = dyn_cast<TypeAliasDecl>(member)) {
+        if (auto TAD = dyn_cast<TypeAliasDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
                                       TAD->getName()));
-        } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
+        } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
                                       ATD->getName()));
-        } else if (isa<ConstructorDecl>(member)) {
+        } else if (isa<ConstructorDecl>(Member)) {
           Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
                                       instanceTy));
         } else {
@@ -2206,11 +2181,11 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // components, let's provide a tailored diagnostic and return because
     // that is unsupported so there is no fix-it.
     if (locator->isForKeyPathComponent()) {
-      InvalidStaticMemberRefInKeyPath failure(expr, cs, member, locator);
+      InvalidStaticMemberRefInKeyPath failure(expr, cs, Member, locator);
       return failure.diagnoseAsError();
     }
 
-    if (isa<EnumElementDecl>(member)) {
+    if (isa<EnumElementDecl>(Member)) {
       Diag.emplace(emitDiagnostic(
           loc, diag::could_not_use_enum_element_on_instance, Name));
     } else {
@@ -2277,7 +2252,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
 
     // Fall back to a fix-it with a full type qualifier
-    if (auto *NTD = member->getDeclContext()->getSelfNominalTypeDecl()) {
+    if (auto *NTD = Member->getDeclContext()->getSelfNominalTypeDecl()) {
       auto typeName = NTD->getSelfInterfaceType()->getString();
       if (auto *SE = dyn_cast<SubscriptExpr>(getRawAnchor())) {
         auto *baseExpr = SE->getBase();
@@ -2289,9 +2264,10 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
     return true;
   }
-  
+
   return false;
 }
+
 bool PartialApplicationFailure::diagnoseAsError() {
   auto &cs = getConstraintSystem();
   auto *anchor = cast<UnresolvedDotExpr>(getRawAnchor());

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -807,22 +807,21 @@ private:
 /// ```
 class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   Type BaseType;
+  ValueDecl *Member;
   DeclName Name;
-
-  /// The choice associated with given member name, if known.
-  ValueDecl *KnownChoice;
 
 public:
   AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
-                                   Type baseType, DeclName memberName,
-                                   ConstraintLocator *locator,
-                                   ValueDecl *choice = nullptr)
+                                   Type baseType, ValueDecl *member,
+                                   DeclName name, ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator),
-        BaseType(baseType->getRValueType()), Name(memberName),
-        KnownChoice(choice) {}
+        BaseType(baseType->getRValueType()), Member(member), Name(name) {
+    assert(member);
+  }
 
   bool diagnoseAsError() override;
 };
+
 class PartialApplicationFailure final : public FailureDiagnostic {
   enum RefKind : unsigned {
     MutatingMethod,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -809,12 +809,17 @@ class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   Type BaseType;
   DeclName Name;
 
+  /// The choice associated with given member name, if known.
+  ValueDecl *KnownChoice;
+
 public:
   AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
                                    Type baseType, DeclName memberName,
-                                   ConstraintLocator *locator)
+                                   ConstraintLocator *locator,
+                                   ValueDecl *choice = nullptr)
       : FailureDiagnostic(root, cs, locator),
-        BaseType(baseType->getRValueType()), Name(memberName) {}
+        BaseType(baseType->getRValueType()), Name(memberName),
+        KnownChoice(choice) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -284,17 +284,19 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
 }
 
 bool AllowTypeOrInstanceMember::diagnose(Expr *root, bool asNote) const {
-  auto failure = AllowTypeOrInstanceMemberFailure(root, getConstraintSystem(),
-                                                  BaseType, Name, getLocator());
+  auto failure = AllowTypeOrInstanceMemberFailure(
+      root, getConstraintSystem(), BaseType, Member, UsedName, getLocator());
   return failure.diagnose(asNote);
 }
 
-AllowTypeOrInstanceMember *AllowTypeOrInstanceMember::create(ConstraintSystem &cs,
-                                                             Type baseType,
-                                                             DeclName member,
-                                                             ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AllowTypeOrInstanceMember(cs, baseType, member, locator);
+AllowTypeOrInstanceMember *
+AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
+                                  ValueDecl *member, DeclName usedName,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
 }
+
 bool AllowInvalidPartialApplication::diagnose(Expr *root, bool asNote) const {
   auto failure = PartialApplicationFailure(root, isWarning(),
                                            getConstraintSystem(), getLocator());

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -595,13 +595,17 @@ public:
 	
 class AllowTypeOrInstanceMember final : public ConstraintFix {
   Type BaseType;
-  DeclName Name;
+  ValueDecl *Member;
+  DeclName UsedName;
 
 public:
-  AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType, DeclName member,
+  AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType,
+                            ValueDecl *member, DeclName name,
                             ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowTypeOrInstanceMember, locator),
-        BaseType(baseType), Name(member) {}
+        BaseType(baseType), Member(member), UsedName(name) {
+    assert(member);
+  }
 
   std::string getName() const override {
     return "allow access to instance member on type or a type member on instance";
@@ -610,7 +614,7 @@ public:
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static AllowTypeOrInstanceMember *create(ConstraintSystem &cs, Type baseType,
-                                           DeclName member,
+                                           ValueDecl *member, DeclName usedName,
                                            ConstraintLocator *locator);
 };
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4530,8 +4530,12 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
   if (reason) {
     switch (*reason) {
     case MemberLookupResult::UR_InstanceMemberOnType:
-    case MemberLookupResult::UR_TypeMemberOnInstance:
-      return AllowTypeOrInstanceMember::create(cs, baseTy, memberName, locator);
+    case MemberLookupResult::UR_TypeMemberOnInstance: {
+      return choice.isDecl()
+                 ? AllowTypeOrInstanceMember::create(
+                       cs, baseTy, choice.getDecl(), memberName, locator)
+                 : nullptr;
+    }
 
     case MemberLookupResult::UR_Inaccessible:
       assert(choice.isDecl());

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -609,3 +609,21 @@ func rdar50679161() {
     }
   }
 }
+
+
+func rdar_50467583_and_50909555() {
+  // rdar://problem/50467583
+  let _: Set = [Int][]
+  // expected-error@-1 {{instance member 'subscript' cannot be used on type '[Int]'}}
+
+  // rdar://problem/50909555
+  struct S {
+    static subscript(x: Int, y: Int) -> Int {
+      return 1
+    }
+  }
+
+  func test(_ s: S) {
+    s[1] // expected-error {{static member 'subscript' cannot be used on instance of type 'S'}} {{5-6=S}}
+  }
+}


### PR DESCRIPTION
…agnostic

This is useful for `CSDiag` when it detects that all
overload choices have the same problem. Since there
are going to be no solutions, choice declaration could
be supplied to `invalid ref` diagnostic directly.

Resolves: rdar://problem/50467583
Resolves: rdar://problem/50682022
Resolves: rdar://problem/50909555

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
