### PR TITLE
[win][test] Make PathSanitizingFileCheck more aware of Windows.

### DIFF
--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -16,10 +16,10 @@
 
 print(app_function(1))
 
-// CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}app-bridging-header-to-pch.h {{.*}}SOURCE_DIR{{/|\\}}test{{/|\\}}ClangImporter{{/|\\}}Inputs{{/|\\}}chained-unit-test-bridging-header-to-pch.h
+// CHECK-DEPS: pch-bridging-header-deps.o : {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h {{.*}}SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h
 
 // CHECK-SWIFTDEPS: depends-external:
-// CHECK-SWIFTDEPS: - "SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}app-bridging-header-to-pch.h"
-// CHECK-SWIFTDEPS: - "SOURCE_DIR{{/|\\\\}}test{{/|\\\\}}ClangImporter{{/|\\\\}}Inputs{{/|\\\\}}chained-unit-test-bridging-header-to-pch.h"
+// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
+// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/chained-unit-test-bridging-header-to-pch.h"
 
 // CHECK-SWIFTDEPS2-NOT: {{.*}}.pch

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -2,7 +2,7 @@
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c main.swift | %FileCheck %s -check-prefix=INPUT
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
-// INPUT: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}main.swift
+// INPUT: SOURCE_DIR/test/Driver/Inputs/main.swift
 
 // Relative -working-directory...
 // RUN: cd %S && %swiftc_driver -driver-print-jobs -working-directory Inputs -c %/S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
@@ -13,11 +13,11 @@
 // In another driver mode.
 // RUN: cd %t && %swift_driver -driver-print-jobs -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
 // RUN: cd %t && %swift_driver -driver-print-jobs -deprecated-integrated-repl -working-directory %/S/Inputs -F. | %FileCheck %s -check-prefix=REPL
-// REPL: -F {{\\?"?}}SOURCE_DIR/test/Driver/Inputs{{(\\\\(\\\\)?)|/}}.
+// REPL: -F {{"?}}SOURCE_DIR/test/Driver/Inputs/.
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%/S/Inputs -c -module-name m main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
-// MULTI_INPUT: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}main.swift
-// MULTI_INPUT-SAME: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}lib.swift
+// MULTI_INPUT: SOURCE_DIR/test/Driver/Inputs/main.swift
+// MULTI_INPUT-SAME: SOURCE_DIR/test/Driver/Inputs/lib.swift
 
 // Using --
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%/S/Inputs -c -module-name m -- main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
@@ -25,37 +25,37 @@
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F . | %FileCheck %s -check-prefix=SEARCH_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F. | %FileCheck %s -check-prefix=SEARCH_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -F=. | %FileCheck %s -check-prefix=SEARCH_PATH
-// SEARCH_PATH: -F {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}.
+// SEARCH_PATH: -F {{"?}}SOURCE_DIR/test/Driver/Inputs/.
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L . | %FileCheck %s -check-prefix=L_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L. | %FileCheck %s -check-prefix=L_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -L=. | %FileCheck %s -check-prefix=L_PATH
-// L_PATH: -L {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}.
+// L_PATH: -L {{"?}}SOURCE_DIR/test/Driver/Inputs/.
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -disable-bridging-pch -import-objc-header bridging-header.h | %FileCheck %s -check-prefix=OBJC_HEADER1
-// OBJC_HEADER1: -import-objc-header {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}bridging-header.h
+// OBJC_HEADER1: -import-objc-header {{"?}}SOURCE_DIR/test/Driver/Inputs/bridging-header.h
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -enable-bridging-pch -import-objc-header bridging-header.h | %FileCheck %s -check-prefix=OBJC_HEADER2
-// OBJC_HEADER2: SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}bridging-header.h{{"? .*}}-emit-pch
+// OBJC_HEADER2: SOURCE_DIR/test/Driver/Inputs/bridging-header.h{{"?}} {{.*}}-emit-pch
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -o main.o | %FileCheck %s -check-prefix=OUTPUT_OBJ
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -o %/S/Inputs/main.o | %FileCheck %s -check-prefix=OUTPUT_OBJ
-// OUTPUT_OBJ: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{/|\\\\}}main.o
+// OUTPUT_OBJ: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main.o
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -module-cache-path mcp | %FileCheck %s -check-prefix=ARG_IS_PATH
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c %/s -module-cache-path %/S/Inputs/mcp | %FileCheck %s -check-prefix=ARG_IS_PATH
-// ARG_IS_PATH: -module-cache-path {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}mcp
+// ARG_IS_PATH: -module-cache-path {{"?}}SOURCE_DIR/test/Driver/Inputs/mcp
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -o main | %FileCheck %s -check-prefix=OUTPUT_EXE
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable %/s -o %/S/Inputs/main | %FileCheck %s -check-prefix=OUTPUT_EXE
-// OUTPUT_EXE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main
+// OUTPUT_EXE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-ir %/s -o - | %FileCheck %s -check-prefix=OUTPUT_STDOUT
 // OUTPUT_STDOUT: -o -
 
 // RUN: echo "{\"main.swift\": {\"object\": \"main-modified.o\"}}" > %t/ofmo.json
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c main.swift -output-file-map %t/ofmo.json | %FileCheck %s -check-prefix=OUTPUT_FILE_MAP_1
-// OUTPUT_FILE_MAP_1: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main-modified.o
+// OUTPUT_FILE_MAP_1: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main-modified.o
 
 // -output-file-map itself
 // RUN: echo "{\"main.swift\": {\"object\": \"main-modified.o\"}}" > %t/ofmo2.json
@@ -76,21 +76,21 @@
 // CLANG-SAME: -Xcc -working-directory -Xcc BUILD_DIR
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -c main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_OBJ
-// OUTPUT_IMPLICIT_OBJ: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.o
+// OUTPUT_IMPLICIT_OBJ: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main.o
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-module main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_MODULE
-// OUTPUT_IMPLICIT_MODULE: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.swiftdoc
-// OUTPUT_IMPLICIT_MODULE-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.swiftmodule
+// OUTPUT_IMPLICIT_MODULE: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs/main.swiftdoc
+// OUTPUT_IMPLICIT_MODULE-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main.swiftmodule
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-executable main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXE
-// OUTPUT_IMPLICIT_EXE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main
+// OUTPUT_IMPLICIT_EXE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-module -emit-executable main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXE_AND_MODULE
-// OUTPUT_IMPLICIT_EXE_AND_MODULE: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.swiftdoc
-// OUTPUT_IMPLICIT_EXE_AND_MODULE-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main.swiftmodule
-// OUTPUT_IMPLICIT_EXE_AND_MODULE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}main
+// OUTPUT_IMPLICIT_EXE_AND_MODULE: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs/main.swiftdoc
+// OUTPUT_IMPLICIT_EXE_AND_MODULE-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main.swiftmodule
+// OUTPUT_IMPLICIT_EXE_AND_MODULE: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/main
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %/S/Inputs -emit-module -emit-executable main.swift -o not_main | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXPLICIT
-// OUTPUT_IMPLICIT_EXPLICIT: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}not_main.swiftdoc
-// OUTPUT_IMPLICIT_EXPLICIT-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}not_main.swiftmodule
-// OUTPUT_IMPLICIT_EXPLICIT: -o {{"?}}SOURCE_DIR/test/Driver/Inputs{{\\\\|/}}not_main
+// OUTPUT_IMPLICIT_EXPLICIT: -emit-module-doc-path {{"?}}SOURCE_DIR/test/Driver/Inputs/not_main.swiftdoc
+// OUTPUT_IMPLICIT_EXPLICIT-SAME: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/not_main.swiftmodule
+// OUTPUT_IMPLICIT_EXPLICIT: -o {{"?}}SOURCE_DIR/test/Driver/Inputs/not_main

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1544,12 +1544,12 @@ config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 
 config.substitutions.append(('%FileCheck',
-                             '%r %r --sanitize BUILD_DIR=%r --sanitize SOURCE_DIR=%r --use-filecheck %r %s' % (
-        sys.executable,
-        config.PathSanitizingFileCheck,
-        swift_obj_root,
-        config.swift_src_root,
-        config.filecheck,
+                             '%s %s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s' % (
+        pipes.quote(sys.executable),
+        pipes.quote(config.PathSanitizingFileCheck),
+        pipes.quote(swift_obj_root),
+        pipes.quote(config.swift_src_root),
+        pipes.quote(config.filecheck),
         '--enable-windows-compatibility' if kIsWindows else '')))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -60,9 +60,11 @@ constants.""")
 
     if args.enable_windows_compatibility:
         if args.enable_yaml_compatibility:
-            slashes_re = r'(/|\\\\|\\\\\\\\)'
+            slashes_re = r'(/|\\\\\\\\|\\\\)'
+            undo_slashes_re = re.compile(r'\\\\|\\')
         else:
             slashes_re = r'(/|\\\\)'
+            undo_slashes_re = re.compile(r'\\')
     else:
         slashes_re = r'/'
 
@@ -72,7 +74,18 @@ constants.""")
         # We are replacing the Unix path separators in the paths passed as
         # arguments with a broader pattern to also allow forward slashes and
         # double escaped slashes in the result that we are checking. Sigh.
-        stdin = re.sub(re.sub(r'/', slashes_re, pattern), replacement, stdin)
+        pattern = re.sub(r'/', slashes_re, pattern)
+        stdin = re.sub(pattern, replacement, stdin)
+
+        if args.enable_windows_compatibility:
+            # For making easier to write the tests, we also look in the
+            # possible subpath attached to the replacement.
+            extended_replacement = replacement + r'[^\s\'"]+'
+
+            def replace_slashes(matchobj):
+                return re.sub(undo_slashes_re, r'/', matchobj.group(0))
+
+            stdin = re.sub(extended_replacement, replace_slashes, stdin)
 
     p = subprocess.Popen(
         [args.file_check_path] + unknown_args, stdin=subprocess.PIPE)


### PR DESCRIPTION
Besides being smart about directory separators in Windows for the
replacements, the PathSanitizingFileCheck will also look into the path
attached to the replacements, and try to do the same trick there, to
avoid littering every test with checks for both directory separators.

The change in `lit.cfg` avoids using Python '%r' since it is supposed to be used only for getting serialized Python objects, so the escaping is right for Python, but not for the shell, since it does more than needed (like escaping \ Windows separators). `pipes.quote` is used instead to escape it properly. All those %r should be removed, but for the time being, I only removed the ones related to path sanitizing.

This removes a few of those `{{/|\\}}` and their variants, but not all. I think all of them can be removed being more aggressive, but I have to work more on that. At least this should avoid problems like #24931. I tested all those changes in my Windows installation.