### PR TITLE
IRGen: Work around JIT bug with GOT equivalents.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2396,7 +2396,8 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
 
 static llvm::GlobalVariable *createGOTEquivalent(IRGenModule &IGM,
                                                  llvm::Constant *global,
-                                                 LinkEntity entity) {
+                                                 LinkEntity entity)
+{
   // Determine the name of this entity.
   llvm::SmallString<64> globalName;
   entity.mangle(globalName);
@@ -2419,7 +2420,17 @@ static llvm::GlobalVariable *createGOTEquivalent(IRGenModule &IGM,
                                       llvm::GlobalValue::PrivateLinkage,
                                       global,
                                       llvm::Twine("got.") + globalName);
-  gotEquivalent->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  
+  // rdar://problem/50968433: Unnamed_addr constants appear to get emitted
+  // with incorrect alignment by the LLVM JIT in some cases. Don't use
+  // unnamed_addr as a workaround.
+  if (!IGM.getOptions().UseJIT) {
+    gotEquivalent->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  } else {
+    ApplyIRLinkage(IRLinkage::InternalLinkOnceODR)
+      .to(gotEquivalent);
+  }
+  
   return gotEquivalent;
 }
 

--- a/test/Interpreter/external_key_path_ref.swift
+++ b/test/Interpreter/external_key_path_ref.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+struct Container<Base, Value, Content>
+    where Base: Collection
+{
+    var base: Base
+    var elementPath: KeyPath<Base.Element, Value>
+    var content: (Value) -> Content
+}
+
+let x = Container(base: 1...10, elementPath: \.bitWidth) {
+    return String($0, radix: 2)
+} 
+
+// CHECK: i hope we passed the audition
+print("i hope we passed the audition")


### PR DESCRIPTION
SR-10590 | rdar://problem/50968433 appears to be caused by an LLVM JIT bug where GOT-equivalent
globals get emitted with incorrect alignment. Not marking the GOT equivalent as unnamed_addr
(which prevents it from getting folded into the GOT, or other equivalent constants) appears
to work around the issue.

rdar://problem/50971519