### PR TITLE
[5.1] IRGen: Work around JIT bug with GOT equivalents.

### DIFF
--- a/test/Interpreter/external_key_path_ref.swift
+++ b/test/Interpreter/external_key_path_ref.swift
@@ -1,0 +1,17 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+struct Container<Base, Value, Content>
+    where Base: Collection
+{
+    var base: Base
+    var elementPath: KeyPath<Base.Element, Value>
+    var content: (Value) -> Content
+}
+
+let x = Container(base: 1...10, elementPath: \.bitWidth) {
+    return String($0, radix: 2)
+} 
+
+// CHECK: i hope we passed the audition
+print("i hope we passed the audition")


### PR DESCRIPTION
SR-10590 | rdar://problem/50968433 appears to be caused by an LLVM JIT bug where GOT-equivalent
globals get emitted with incorrect alignment. Not marking the GOT equivalent as unnamed_addr
(which prevents it from getting folded into the GOT, or other equivalent constants) appears
to work around the issue.

rdar://problem/50971519