### PR TITLE
[AutoDiff] Differentiation transform cleanup.

### DIFF
--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
 //===----------------------------------------------------------------------===//
-// Top-level (before primal/adjoint synthesis)
+// Top-level (before VJP/adjoint synthesis)
 //===----------------------------------------------------------------------===//
 
 // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}

--- a/test/AutoDiff/autodiff_function_inst_irgen.sil
+++ b/test/AutoDiff/autodiff_function_inst_irgen.sil
@@ -5,11 +5,11 @@ sil_stage raw
 import Swift
 import Builtin
 
-// The pullback function emitted by the compiler. Parameter are a vector, as in
-// vector-Jacobian products, and primal values. The function is not itself a
-// pullback, but to be partially applied to form a pullback, which takes a
-// vector and returns vector-Jacobian products evaluated at the original
-// parameter.
+// The adjoint function emitted by the compiler. Parameters are a vector, as in
+// vector-Jacobian products, and pullback struct value. The function is not
+// itself a pullback, but to be partially applied to form a pullback, which
+// takes a vector and returns vector-Jacobian products evaluated at the
+// original parameter.
 sil hidden @foo_adj : $@convention(thin) (Float, Float, Float) -> Float {
 bb0(%0 : $Float, %1 : $Float, %2 : $Float):
   return %0 : $Float

--- a/test/AutoDiff/existential.swift
+++ b/test/AutoDiff/existential.swift
@@ -16,7 +16,7 @@ struct B : A {
   func a(_ x: Float) -> Float { return x * 5.0 }
 }
 
-ExistentialTests.test("primal/adjoint constructed with existentials.") {
+ExistentialTests.test("vjp/adjoint constructed with existentials.") {
   expectEqual(5.0, b(g: B()))
 }
 

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -70,7 +70,7 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK:   release_value [[SEED:%.*]] : $Vector
 // CHECK: }
 
-// The vjp should not release primal values.
+// The vjp should not release pullback values.
 //
 // CHECK-LABEL: sil hidden @{{.*}}testOwnedVector{{.*}}__vjp_src_0_wrt_0 : $@convention(thin) (@guaranteed Vector) -> (@owned Vector, @owned @callee_guaranteed (@guaranteed Vector) -> @owned Vector)
 // CHECK:   [[ADD:%.*]] = function_ref @Vector_plus
@@ -83,13 +83,13 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK-NOT:   release_value [[ADD_VJP_RESULT]]
 // CHECK-NOT:   release_value [[ADD_PULLBACK]]
 
-// The adjoint should not release primal values because they are passed in as @guaranteed.
+// The adjoint should not release pullback struct argument because it has @guaranteed convention.
 //
 // CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
-// CHECK: bb0({{%.*}} : $Vector, [[PRIMAL_VALUES:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0):
-// CHECK:   [[PULLBACK0:%.*]] = struct_extract [[PRIMAL_VALUES]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
+// CHECK: bb0({{%.*}} : $Vector, [[PULLBACKS_ARG:%.*]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0):
+// CHECK:   [[PULLBACK0:%.*]] = struct_extract [[PULLBACKS_ARG]] : ${{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__Type__src_0_wrt_0.pullback_0
 // CHECK-NOT:   release_value [[PULLBACK0]]
-// CHECK-NOT:   release_value [[PRIMAL_VALUES]]
+// CHECK-NOT:   release_value [[PULLBACKS_ARG]]
 // CHECK: }
 
 

--- a/test/AutoDiff/tbdgen.swift
+++ b/test/AutoDiff/tbdgen.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -O
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -enable-testing -O
 
-// TODO: These tests are disabled because the primal value struct makes the TBDGen be different before/after SILGen.
+// TODO: These tests are disabled because the pullback struct makes the TBDGen be different before/after SILGen.
 // UN: %empty-directory(%t)
 // UN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
 // UN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd

--- a/test/AutoDiff/witness_table_irgen.sil
+++ b/test/AutoDiff/witness_table_irgen.sil
@@ -57,12 +57,6 @@ bb0(%0 : $Float, %1 : $*DifferentiableConformance):
   return undef : $(Float, @callee_guaranteed (Float) -> Float)
 } // end sil function 'AD__$s23witness_tables_autodiff25DifferentiableConformanceVAA0D11RequirementA2aDP1fyS2fFTW_vjp_SU'
 
-// AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__primal_src_0_wrt_0
-sil hidden @AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__primal_src_0_wrt_0 : $@convention(method) (Float, DifferentiableConformance) -> (@owned AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__Type__src_0_wrt_0, Float) {
-bb0(%0 : $Float, %1 : $DifferentiableConformance):
-  return undef : $(AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__Type__src_0_wrt_0, Float)
-} // end sil function 'AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__primal_src_0_wrt_0'
-
 // AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__adjoint_src_0_wrt_0
 sil hidden @AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__adjoint_src_0_wrt_0 : $@convention(method) (Float, AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__Type__src_0_wrt_0, Float, Float, DifferentiableConformance) -> Float {
 bb0(%0 : $Float, %1 : $AD__$s23witness_tables_autodiff25DifferentiableConformanceV1fyS2fF__Type__src_0_wrt_0, %2 : $Float, %3 : $Float, %4 : $DifferentiableConformance):


### PR DESCRIPTION
- Remove all mentions of "primal".
  - Rename "primal value struct" to "pullback struct".
- Simplify/optimize `VJPEmitter` and `AdjointEmitter` members.
  - Unuseful `VJPEmitter` getter methods are removed.
  - `AdjointEmitter` now stores a reference to the parent `VJPEmitter`.
    `AdjointEmitter` getter methods forward `VJPEmitter` members.
- Use `SmallPtrSet` to track processed `autodiff_function` instructions
  to avoid reprocessing invalidated instructions.
- Redefine `foldAutoDiffFunctionExtraction` as a method on `ADContext`.