### PR TITLE
[Test] Add availability to the GenericMangled test in objc_getClass.swift

### DIFF
--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -179,6 +179,7 @@ testSuite.test("GenericMangled")
                 reason: "objc_getClass hook not present"))
   .requireOwnProcess()
   .code {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
   requireClass(named:   "_TtC4main24ConstrainedSwiftSubclass",
                demangledName: "main.ConstrainedSwiftSubclass")
   requireClass(named:   "_TtC4main26ConstrainedSwiftSuperclass",


### PR DESCRIPTION
This is a new test in Swift 5.1 that is not expected to pass when running
with the Swift 5.0 runtime library.

rdar://problem/50175915