### PR TITLE
Remove `validateDeclForNameLookup` and related logic

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -60,9 +60,6 @@ public:
   /// consistency and provides the value a type.
   virtual void resolveDeclSignature(ValueDecl *VD) = 0;
 
-  /// Resolve the generic environment of the given protocol.
-  virtual void resolveProtocolEnvironment(ProtocolDecl *proto) = 0;
-
   /// Resolve the type of an extension.
   ///
   /// This can be called to ensure that the members of an extension can be

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3624,7 +3624,10 @@ UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {
 
 Type TypeAliasDecl::getStructuralType() const {
   assert(!getGenericParams());
-  
+
+  if (auto resolved = this->getUnderlyingTypeLoc().getType())
+    return resolved;
+
   auto &context = getASTContext();
   return evaluateOrDefault(context.evaluator,
                            StructuralTypeRequest { const_cast<TypeAliasDecl *>(this) },

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3785,9 +3785,6 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
 
 static Type getStructuralType(TypeDecl *typeDecl) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    if (auto resolved = typealias->getUnderlyingTypeLoc().getType())
-      return resolved;
-
     return typealias->getStructuralType();
   }
 

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -594,7 +594,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
                                             CS.DC, instanceType, NameLookupFlags::IgnoreAccessControl);
       for (auto ctor : ctors) {
         if (!ctor.getValueDecl()->hasInterfaceType())
-          CS.getTypeChecker().validateDeclForNameLookup(ctor.getValueDecl());
+          CS.getTypeChecker().validateDecl(ctor.getValueDecl());
         if (ctor.getValueDecl()->hasInterfaceType())
           candidates.push_back({ ctor.getValueDecl(), 1 });
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1069,7 +1069,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   //    `ExpressibleByStringLiteral`.
   //    `D.Value` and the return type can be arbitrary.
 
-  TC.validateDeclForNameLookup(decl);
+  TC.validateDecl(decl);
   auto paramList = decl->getParameters();
   if (paramList->size() != 1 || paramList->get(0)->isVariadic()) return false;
   auto argType = paramList->get(0)->getType();
@@ -1235,7 +1235,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   auto oneCandidate = candidates.front();
   candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    TC.validateDeclForNameLookup(cand);
+    TC.validateDecl(cand);
     return isValidDynamicMemberLookupSubscript(cand, decl, TC);
   });
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2930,7 +2930,10 @@ public:
       PD->dumpRef(llvm::errs());
       llvm::errs() << "\n";
       llvm::errs() << "Requirement signature: ";
-      requirementsSig->print(llvm::errs());
+
+      PrintOptions opts;
+      opts.PrintTypeAliasUnderlyingType = true;
+      requirementsSig->print(llvm::errs(), opts);
       llvm::errs() << "\n";
 
       // Note: One cannot canonicalize a requirement signature, because

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2912,6 +2912,16 @@ public:
         TC.inferDefaultWitnesses(PD);
 
     if (TC.Context.LangOpts.DebugGenericSignatures) {
+      auto *sig = PD->getGenericSignature();
+      PD->printContext(llvm::errs());
+      llvm::errs() << "\n";
+      llvm::errs() << "Generic signature: ";
+      sig->print(llvm::errs());
+      llvm::errs() << "\n";
+      llvm::errs() << "Canonical generic signature: ";
+      sig->getCanonicalSignature()->print(llvm::errs());
+      llvm::errs() << "\n";
+
       auto requirementsSig =
         GenericSignature::get({PD->getProtocolSelfType()},
                               PD->getRequirementSignature());

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3640,10 +3640,6 @@ static Type buildAddressorResultType(TypeChecker &TC,
 }
 
 void TypeChecker::validateDecl(ValueDecl *D) {
-  // Generic parameters are validated as part of their context.
-  if (isa<GenericTypeParamDecl>(D))
-    return;
-
   // Handling validation failure due to re-entrancy is left
   // up to the caller, who must call hasValidSignature() to
   // check that validateDecl() returned a fully-formed decl.
@@ -3680,6 +3676,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     if (!ext->hasValidSignature())
       return;
   }
+
+  // Generic parameters are validated as part of their context.
+  if (isa<GenericTypeParamDecl>(D))
+    return;
 
   // Validating the parent may have triggered validation of this declaration,
   // so just return if that was the case.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1030,5 +1030,17 @@ swift::StructuralTypeRequest::evaluate(Evaluator &evaluator,
 
   auto typeRepr = D->getUnderlyingTypeLoc().getTypeRepr();
   auto resolution = TypeResolution::forStructural(D);
-  return resolution.resolveType(typeRepr, options);
+  auto resolvedType = resolution.resolveType(typeRepr, options);
+
+  // Wrap the resolved type in a TypeAliasType
+  auto *genericSig = D->getGenericSignature();
+  SubstitutionMap subs;
+  if (genericSig)
+    subs = genericSig->getIdentitySubstitutionMap();
+
+  Type parent;
+  auto parentDC = D->getDeclContext();
+  if (parentDC->isTypeContext())
+    parent = parentDC->getSelfInterfaceType();
+  return TypeAliasType::get(D, parent, subs, resolvedType);
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -759,22 +759,6 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
     // The generic signature and environment is created lazily by
     // GenericContext::getGenericSignature(), so there is nothing we
     // need to do.
-
-    // Debugging of the generic signature builder and generic signature
-    // generation.
-    if (Context.LangOpts.DebugGenericSignatures) {
-      auto *sig = proto->getGenericSignature();
-
-      proto->printContext(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "Generic signature: ";
-      sig->print(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "Canonical generic signature: ";
-      sig->getCanonicalSignature()->print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-
     return;
   }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1497,7 +1497,7 @@ recur:
     }
 
     // If there is a subpattern, push the enum element type down onto it.
-    validateDeclForNameLookup(elt);
+    validateDecl(elt);
     if (EEP->hasSubPattern()) {
       Pattern *sub = EEP->getSubPattern();
       if (!elt->hasAssociatedValues()) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -645,10 +645,11 @@ Type TypeChecker::resolveTypeInContext(
       }
     }
   }
-  
+
   // Finally, substitute the base type into the member type.
   return substMemberTypeWithBase(fromDC->getParentModule(), typeDecl,
-                                 selfType, resolution.usesArchetypes());
+                                 selfType, resolution.usesArchetypes(),
+                                 resolution.getStage());
 }
 
 static TypeResolutionOptions
@@ -3362,7 +3363,8 @@ Type TypeResolver::buildProtocolType(
 Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
                                           TypeDecl *member,
                                           Type baseTy,
-                                          bool useArchetypes) {
+                                          bool useArchetypes,
+                                          TypeResolutionStage stage) {
   Type sugaredBaseTy = baseTy;
 
   // For type members of a base class, make sure we use the right
@@ -3422,8 +3424,9 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   }
 
   Type resultType;
-  auto memberType = aliasDecl ? aliasDecl->getUnderlyingTypeLoc().getType()
+  auto memberType = aliasDecl ? aliasDecl->getStructuralType()
                               : member->getDeclaredInterfaceType();
+
   SubstitutionMap subs;
   if (baseTy) {
     // Cope with the presence of unbound generic types, which are ill-formed

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3422,15 +3422,6 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
           aliasDecl, baseTy,
           aliasDecl->getASTContext());
     }
-
-    // FIXME: If this is a protocol typealias and we haven't built the
-    // protocol's generic environment yet, do so now, to ensure the
-    // typealias's underlying type has fully resolved dependent
-    // member types.
-    if (auto *protoDecl = dyn_cast<ProtocolDecl>(aliasDecl->getDeclContext())) {
-      ASTContext &ctx = protoDecl->getASTContext();
-      ctx.getLazyResolver()->resolveProtocolEnvironment(protoDecl);
-    }
   }
 
   Type resultType;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -26,6 +26,7 @@
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/TypeRefinementContext.h"
+#include "swift/AST/TypeResolutionStage.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Config.h"
@@ -865,8 +866,11 @@ public:
   /// member.
   /// \param useArchetypes Whether to use context archetypes for outer generic
   /// parameters if the class is nested inside a generic function.
+  /// \param stage The type resolution stage for type validation,
+  /// defaults to Interface.
   static Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member,
-                                      Type baseTy, bool useArchetypes = true);
+                                      Type baseTy, bool useArchetypes = true,
+                                      TypeResolutionStage stage = TypeResolutionStage::Interface);
 
   /// Determine whether one type is a subtype of another.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -788,9 +788,6 @@ public:
   void validateDecl(OperatorDecl *decl);
   void validateDecl(PrecedenceGroupDecl *decl);
 
-  /// Perform just enough validation for looking up names using the Decl.
-  void validateDeclForNameLookup(ValueDecl *D);
-
   /// Validate the given extension declaration, ensuring that it
   /// properly extends the nominal type it names.
   void validateExtension(ExtensionDecl *ext);
@@ -999,7 +996,7 @@ public:
   void checkDefaultArguments(ParameterList *params, ValueDecl *VD);
 
   virtual void resolveDeclSignature(ValueDecl *VD) override {
-    validateDeclForNameLookup(VD);
+    validateDecl(VD);
   }
 
   virtual void resolveProtocolEnvironment(ProtocolDecl *proto) override {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -999,10 +999,6 @@ public:
     validateDecl(VD);
   }
 
-  virtual void resolveProtocolEnvironment(ProtocolDecl *proto) override {
-    validateDecl(proto);
-  }
-
   virtual void resolveExtension(ExtensionDecl *ext) override {
     validateExtension(ext);
   }

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -178,3 +178,10 @@ takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift
 typealias T08 = P1 & inout P2 // expected-error {{'inout' may only be used on parameters}}
 typealias T09 = P1 & __shared P2 // expected-error {{'__shared' may only be used on parameters}}
 typealias T10 = P1 & __owned P2 // expected-error {{'__owned' may only be used on parameters}}
+
+// Using a typealias of a protocol composition in a protocol composition
+protocol C { }
+protocol DA { }
+protocol DB { }
+typealias DD = DA & DB
+func composeTypealiasOfComposition<T: C & DD>(x: T) {}


### PR DESCRIPTION
`validateDeclForNameLookup` was a phase executed before `validateDecl` on some decls to avoid cycles. We already moved its work to be lazier, so we don't need this phase anymore. Calling `validateDecl` is enough as it relies on the new lazy services to avoid cycles.

The next goal is to make lazy more of the logic in `validateDecl` so it is evaluated only when it is actually needed.