### PR TITLE
[Tests] Make sure FrontendObserver methods are not removed

### DIFF
--- a/unittests/FrontendTool/CMakeLists.txt
+++ b/unittests/FrontendTool/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_unittest(SwiftFrontendTests
   FrontendToolTests.cpp
+  FrontendObserverTests.cpp
   ModuleLoadingTests.cpp)
 
 target_link_libraries(SwiftFrontendTests

--- a/unittests/FrontendTool/FrontendObserverTests.cpp
+++ b/unittests/FrontendTool/FrontendObserverTests.cpp
@@ -10,16 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// This file exists to make sure methods of FrontendObserver are not removed
+/// This test exists to make sure methods of FrontendObserver are not removed
 /// because external clients may be using them.
-///
-/// Successful compilation -> successful test.
 ///
 //===----------------------------------------------------------------------===//
 
 #include "gtest/gtest.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/AST/Module.h"
 #include "swift/FrontendTool/FrontendTool.h"
 
 using namespace swift;
@@ -30,20 +29,72 @@ class TestObserver : public testing::Test, public FrontendObserver {
 
 public:
 
-  void parsedArgs(CompilerInvocation &invocation) override { }
+  // convenient fields are grabbed from the given object at each method
+  // to assert that the passed object is valid and usable
 
-  void configuredCompiler(CompilerInstance &instance) override { }
+  // fields to assert
+  std::string parsedArgsTest = "";
+  std::string configuredCompilerTest = "";
+  std::string performedSemanticAnalysisTest = "";
+  bool performedSILGenerationTest = true;
+  bool performedSILProcessingTest = true;
 
-  void performedSemanticAnalysis(CompilerInstance &instance) override { }
+  void parsedArgs(CompilerInvocation &invocation) override {
+    parsedArgsTest = invocation.getModuleName();
+  }
 
-  void performedSILGeneration(SILModule &module) override { }
+  void configuredCompiler(CompilerInstance &instance) override {
+    configuredCompilerTest = instance.getMainModule()->getName().str();
+  }
 
-  void performedSILProcessing(SILModule &module) override { }
+  void performedSemanticAnalysis(CompilerInstance &instance) override {
+    performedSemanticAnalysisTest = instance.getMainModule()->getName().str();
+  }
+
+  void performedSILGeneration(SILModule &module) override {
+    performedSILGenerationTest = module.isSerialized();
+  }
+
+  void performedSILProcessing(SILModule &module) override {
+    performedSILProcessingTest = module.hasFunction("random");
+  }
 
 };
 
 TEST_F(TestObserver, MethodsExistTest) {
-  // If this file compiles, then the "test" is successful.
+  std::string testName = "testName";
+
+  // set up CompilerInvocation
+  CompilerInvocation TestCompilerInovcation;
+  TestCompilerInovcation.setModuleName(testName);
+
+  // set up CompilerInstance
+  CompilerInstance TestCompilerInstance;
+  if (TestCompilerInstance.setup(TestCompilerInovcation))
+    FAIL() << "Failed to setup CompilerInstance.";
+  TestCompilerInstance.performSema();
+  TestCompilerInstance.setSILModule(SILModule::createEmptyModule(
+      TestCompilerInstance.getMainModule(),
+      TestCompilerInstance.getSILOptions()));
+
+  // perform calls, then assert that appropriate TestObserver property has been
+  // set from given object, for each method
+
+  parsedArgs(TestCompilerInovcation);
+  ASSERT_EQ(parsedArgsTest, testName);
+
+  configuredCompiler(TestCompilerInstance);
+  ASSERT_EQ(configuredCompilerTest, testName);
+
+  performedSemanticAnalysis(TestCompilerInstance);
+  ASSERT_EQ(performedSemanticAnalysisTest, testName);
+
+  performedSILGeneration(*TestCompilerInstance.getSILModule());
+  ASSERT_EQ(performedSILGenerationTest, false);
+
+  performedSILProcessing(*TestCompilerInstance.getSILModule());
+  ASSERT_EQ(performedSILProcessingTest, false);
+
 }
 
 } // end anonymous namespace

--- a/unittests/FrontendTool/FrontendObserverTests.cpp
+++ b/unittests/FrontendTool/FrontendObserverTests.cpp
@@ -1,0 +1,49 @@
+//===--- FrontendObserverTests.cpp ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file exists to make sure methods of FrontendObserver are not removed
+/// because external clients may be using them.
+///
+/// Successful compilation -> successful test.
+///
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/FrontendTool/FrontendTool.h"
+
+using namespace swift;
+
+namespace {
+
+class TestObserver : public testing::Test, public FrontendObserver {
+
+public:
+
+  void parsedArgs(CompilerInvocation &invocation) override { }
+
+  void configuredCompiler(CompilerInstance &instance) override { }
+
+  void performedSemanticAnalysis(CompilerInstance &instance) override { }
+
+  void performedSILGeneration(SILModule &module) override { }
+
+  void performedSILProcessing(SILModule &module) override { }
+
+};
+
+TEST_F(TestObserver, MethodsExistTest) {
+  // If this file compiles, then the "test" is successful.
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
Per @jrose-apple's request, I have added a simple unit test (more of a compilation test) to make sure FrontendObserver methods are not removed again in the future. Related commit: https://github.com/apple/swift/commit/ca5b94f7d9cfced17c884ff999aed01ed65f4611.

<!-- What's in this pull request? -->
**Background:** In [this](https://forums.swift.org/t/re-adding-frontendobserver-methods-for-the-sake-of-external-static-analysis-tools/24672?u=tiganov) forum post, I asked for the methods of `FrontendObserver` removed in [this](https://github.com/apple/swift/commit/7b43e1d04debfaea6ee2e75cac820c0b3cd95d85) commit to be re-added. This has been [done](https://github.com/apple/swift/commit/ca5b94f7d9cfced17c884ff999aed01ed65f4611) (Thank you!). 