### PR TITLE
[Test] Disable inherits_ObjCClasses.swift on watchOS.

### DIFF
--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -9,6 +9,9 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios || OS=tvos
+// NOTE: Test is temporarily disabled for watchOS until we can figure out why
+// it's failing there. rdar://problem/50898688
 
 import simd
 import ObjCClasses


### PR DESCRIPTION
It's failing and it's going to take some more time to figure out why.

rdar://problem/50898688