### PR TITLE
[5.1 04-24-2019] Allow non-@objc ‘dynamic’ in all language modes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3921,17 +3921,9 @@ ERROR(borrowed_on_objc_protocol_requirement,none,
 // MARK: dynamic
 //------------------------------------------------------------------------------
 
-ERROR(dynamic_not_in_class,none,
-      "only members of classes may be dynamic", ())
-ERROR(dynamic_with_nonobjc,none,
-      "a declaration cannot be both '@nonobjc' and 'dynamic'",
-      ())
 ERROR(dynamic_with_transparent,none,
       "a declaration cannot be both '@_tranparent' and 'dynamic'",
       ())
-ERROR(dynamic_requires_objc,none,
-      "'dynamic' %0 %1 must also be '@objc'",
-      (DescriptiveDeclKind, DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: @_dynamicReplacement(for:)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -324,13 +324,8 @@ void AttributeEarlyChecker::visitMutationAttr(DeclAttribute *attr) {
 }
 
 void AttributeEarlyChecker::visitDynamicAttr(DynamicAttr *attr) {
-  // Members cannot be both dynamic and @nonobjc.
-  if (D->getAttrs().hasAttribute<NonObjCAttr>())
-    diagnoseAndRemoveAttr(attr, diag::dynamic_with_nonobjc);
-
   // Members cannot be both dynamic and @_transparent.
-  if (D->getASTContext().LangOpts.isSwiftVersionAtLeast(5) &&
-      D->getAttrs().hasAttribute<TransparentAttr>())
+  if (D->getAttrs().hasAttribute<TransparentAttr>())
     diagnoseAndRemoveAttr(attr, diag::dynamic_with_transparent);
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1093,36 +1093,14 @@ static void inferFinalAndDiagnoseIfNeeded(TypeChecker &TC, ValueDecl *D,
   makeFinal(TC.Context, D);
 }
 
-/// Try to make the given declaration 'dynamic', checking any semantic
-/// constraints before doing so.
-///
-/// \returns true if it can be made dynamic, false otherwise.
-static bool makeObjCDynamic(ValueDecl *decl) {
-  // Only  members of classes can be dynamic.
-  auto classDecl = decl->getDeclContext()->getSelfClassDecl();
-  if (!classDecl) {
-    auto attr = decl->getAttrs().getAttribute<DynamicAttr>();
-    decl->diagnose(diag::dynamic_not_in_class)
-      .fixItRemove(attr ? SourceRange(attr->getLocation()) : SourceRange());
-    return false;
-  }
-
-  // '@objc dynamic' is only supported through the Objective-C runtime.
-  if (!decl->isObjC()) {
-    decl->diagnose(diag::dynamic_requires_objc,
-                   decl->getDescriptiveKind(), decl->getFullName())
-      .fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/false),
-                   "@objc ");
-    return false;
-  }
-
+/// Make the given declaration 'dynamic', if it isn't already marked as such.
+static void makeDynamic(ValueDecl *decl) {
   // If there isn't already a 'dynamic' attribute, add an inferred one.
-  if (!decl->getAttrs().hasAttribute<DynamicAttr>()) {
-    auto attr = new (decl->getASTContext()) DynamicAttr(/*implicit=*/true);
-    decl->getAttrs().add(attr);
-  }
-
-  return true;
+  if (decl->getAttrs().hasAttribute<DynamicAttr>())
+    return;
+  
+  auto attr = new (decl->getASTContext()) DynamicAttr(/*implicit=*/true);
+  decl->getAttrs().add(attr);
 }
 
 static llvm::Expected<bool> isStorageDynamic(Evaluator &evaluator,
@@ -1199,9 +1177,7 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
 
   // If 'dynamic' was explicitly specified, check it.
   if (decl->getAttrs().hasAttribute<DynamicAttr>()) {
-    if (decl->getASTContext().LangOpts.isSwiftVersionAtLeast(5))
-      return true;
-    return makeObjCDynamic(decl);
+    return true;
   }
 
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
@@ -1217,15 +1193,11 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     case AccessorKind::Get:
     case AccessorKind::Set: {
       auto isDynamicResult = evaluator(
-        IsDynamicRequest{accessor->getStorage()});
-
-      if (!isDynamicResult)
-        return isDynamicResult;
-
-      if (*isDynamicResult)
-        return makeObjCDynamic(decl);
-
-      return false;
+          IsDynamicRequest{accessor->getStorage()});
+      if (isDynamicResult && *isDynamicResult)
+        makeDynamic(decl);
+      
+      return isDynamicResult;  
     }
 
 #define OBJC_ACCESSOR(ID, KEYWORD)
@@ -1240,7 +1212,8 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // FIXME: Use a semantic check for NSManaged rather than looking for the
   // attribute (which could be ill-formed).
   if (decl->getAttrs().hasAttribute<NSManagedAttr>()) {
-    return makeObjCDynamic(decl);
+    makeDynamic(decl);
+    return true;
   }
 
   // The presence of 'final' blocks the inference of 'dynamic'.
@@ -1259,7 +1232,8 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // This is intended to enable overriding the declarations.
   auto dc = decl->getDeclContext();
   if (isa<ExtensionDecl>(dc) && dc->getSelfClassDecl()) {
-    return makeObjCDynamic(decl);
+    makeDynamic(decl);
+    return true;
   }
 
   // If any of the declarations overridden by this declaration are dynamic
@@ -1270,13 +1244,10 @@ IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   auto overriddenDecls = evaluateOrDefault(evaluator,
     OverriddenDeclsRequest{decl}, {});
   for (auto overridden : overriddenDecls) {
-    if (overridden->isDynamic() &&
-        (!decl->getASTContext().LangOpts.isSwiftVersionAtLeast(5) ||
-         overridden->isObjC()))
-      return makeObjCDynamic(decl);
-
-    if (overridden->hasClangNode())
-      return makeObjCDynamic(decl);
+    if (overridden->isDynamic() || overridden->hasClangNode()) {
+      makeDynamic(decl);
+      return true;
+    }
   }
 
   return false;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1233,15 +1233,6 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
 
       return ObjCReason(ObjCReason::ExplicitlyDynamic);
     }
-    if (!ctx.isSwiftVersionAtLeast(5)) {
-      // Complain that 'dynamic' requires '@objc', but (quietly) infer @objc
-      // anyway for better recovery.
-      VD->diagnose(diag::dynamic_requires_objc, VD->getDescriptiveKind(),
-                   VD->getFullName())
-          .fixItInsert(VD->getAttributeInsertionLoc(/*forModifier=*/false),
-                       "@objc ");
-      return ObjCReason(ObjCReason::ImplicitlyObjC);
-    }
   }
 
   // If we aren't provided Swift 3's @objc inference rules, we're done.

--- a/test/attr/attr_dynamic.swift
+++ b/test/attr/attr_dynamic.swift
@@ -12,23 +12,19 @@ dynamic prefix operator +!+  // expected-error{{'dynamic' modifier cannot be app
 class Foo {
   @objc dynamic init() {}
   @objc dynamic init(x: NotObjCAble) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-1{{'dynamic' initializer 'init(x:)' must also be '@objc}}
   
   @objc dynamic var x: Int
   
   @objc dynamic var nonObjcVar: NotObjCAble // expected-error{{property cannot be marked @objc because its type cannot be represented in Objective-C}} expected-note{{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-1{{'dynamic' property 'nonObjcVar' must also be '@objc'}}
 
   @objc dynamic func foo(x: Int) {}
   @objc dynamic func bar(x: Int) {}
 
   @objc dynamic func nonObjcFunc(x: NotObjCAble) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-1{{'dynamic' instance method 'nonObjcFunc(x:)' must also be '@objc'}}
   
   @objc dynamic subscript(x: Int) -> ObjCClass { get {} }
 
   @objc dynamic subscript(x: Int) -> NotObjCAble { get {} } // expected-error{{subscript cannot be marked @objc because its type cannot be represented in Objective-C}} expected-note{{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-1{{'dynamic' subscript 'subscript(_:)' must also be '@objc'}}
   
   dynamic deinit {} // expected-error{{'dynamic' modifier cannot be applied to this declaration}} {{3-11=}}
 
@@ -38,13 +34,13 @@ class Foo {
 }
 
 struct Bar {
-  dynamic init() {} // expected-error{{only members of classes may be dynamic}} {{3-11=}}
+  dynamic init() {}
 
-  dynamic var x: Int // expected-error{{only members of classes may be dynamic}} {{3-11=}}
+  dynamic var x: Int
 
-  dynamic subscript(x: Int) -> ObjCClass { get {} } // expected-error{{only members of classes may be dynamic}} {{3-11=}}
+  dynamic subscript(x: Int) -> ObjCClass { get {} }
 
-  dynamic func foo(x: Int) {} // expected-error{{only members of classes may be dynamic}} {{3-11=}}
+  dynamic func foo(x: Int) {}
 }
 
 // CHECK-LABEL: class InheritsDynamic : Foo {
@@ -61,5 +57,5 @@ class InheritsDynamic: Foo {
 // SR-5317
 @objcMembers
 class ObjCMemberCheck {
-  dynamic var s = NotObjCAble(c: Foo()) // expected-error{{'dynamic' property 's' must also be '@objc'}}
+  dynamic var s = NotObjCAble(c: Foo())
 }

--- a/test/attr/attr_nonobjc.swift
+++ b/test/attr/attr_nonobjc.swift
@@ -67,8 +67,8 @@ class ObjCAndNonObjCNotAllowed {
   @objc @nonobjc func redundantAttributes() { } // expected-error {{declaration is marked @objc, and cannot be marked @nonobjc}}
 }
 
-class DynamicAndNonObjCNotAllowed {
-  @nonobjc dynamic func redundantAttributes() { } // expected-error {{a declaration cannot be both '@nonobjc' and 'dynamic'}}
+class DynamicAndNonObjCAreFineNow {
+  @nonobjc dynamic func someAttributes() { }
 }
 
 class IBOutletAndNonObjCNotAllowed {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1724,8 +1724,7 @@ class HasNSManaged {
   var badManaged: PlainStruct
   // expected-error@-1 {{property cannot be marked @NSManaged because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-3{{'dynamic' property 'badManaged' must also be '@objc'}}
-  // CHECK-LABEL: {{^}}  @NSManaged var badManaged: PlainStruct {
+  // CHECK-LABEL: {{^}}  @NSManaged dynamic var badManaged: PlainStruct {
   // CHECK-NEXT: {{^}} get
   // CHECK-NEXT: {{^}} set
   // CHECK-NEXT: {{^}} }

--- a/test/attr/attr_objc_swift4.swift
+++ b/test/attr/attr_objc_swift4.swift
@@ -9,10 +9,9 @@ class ObjCSubclass : NSObject {
 }
 
 class DynamicMembers {
-  dynamic func foo() { } // expected-error{{'dynamic' instance method 'foo()' must also be '@objc'}}{{3-3=@objc }}
+  @objc dynamic func foo() { }
   
-  dynamic var bar: NSObject? = nil
- // expected-error@-1{{'dynamic' property 'bar' must also be '@objc'}}{{3-3=@objc }}
+  @objc dynamic var bar: NSObject? = nil
 }
 
 func test(sc: ObjCSubclass, dm: DynamicMembers) {

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -13,8 +13,8 @@ class A {
   @objc var v2: Int { return 0 } // expected-note{{overri}}
   @objc var v3: Int = 0 // expected-note{{overri}}
 
-  dynamic func f3D() { } // expected-error{{'dynamic' instance method 'f3D()' must also be '@objc'}}{{3-3=@objc }}
-  dynamic func f4D() -> ObjCClassA { } // expected-error{{'dynamic' instance method 'f4D()' must also be '@objc'}}{{3-3=@objc }}
+  @objc dynamic func f3D() { }
+  @objc dynamic func f4D() -> ObjCClassA { }
 }
 
 extension A {

--- a/test/decl/var/NSManaged_properties.swift
+++ b/test/decl/var/NSManaged_properties.swift
@@ -38,7 +38,6 @@ class SwiftGizmo : A {
 
   // expected-error@+1{{property cannot be marked @NSManaged because its type cannot be represented in Objective-C}}
   @NSManaged var nonobjc_var: SwiftProto?
-  // expected-error@-1{{'dynamic' property 'nonobjc_var' must also be '@objc'}}
 
   // expected-error@+4 {{@NSManaged only allowed on an instance property or method}}
   // expected-error@+3 {{@NSManaged property cannot have an initial value}}


### PR DESCRIPTION
Non-‘@objc’ ‘dynamic’ has been allowed since Swift 5, but there’s no
reason to tie it to the language mode (Swift >= 5).

Fixes rdar://problem/50348013.
