### PR TITLE
[TF-519] Set up infrastructure to connect to TPU on top of eager execution

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -515,6 +515,17 @@ private func configureRuntimeFromEnvironment() {
         protocol: "\(`protocol`)"
         """)
       debugLog("Setting TF server address to \(address) from env.")
+
+      // At the moment, without TF_EAGER_REMOTE_USE_SEND_TENSOR_RPC=1,
+      // running on TPUs freezes. Therefore, we set this environment variable
+      // to 1 unless it's set explicitly.
+      if let value = getenv("TF_EAGER_REMOTE_USE_SEND_TENSOR_RPC") {
+        debugLog("TF_EAGER_REMOTE_USE_SEND_TENSOR_RPC already set:")
+        debugLog(String(cString: value))
+      } else {
+        setenv("TF_EAGER_REMOTE_USE_SEND_TENSOR_RPC", "1", /*override*/ 0)
+        debugLog("Setting TF_EAGER_REMOTE_USE_SEND_TENSOR_RPC to 1")
+      }
     }
   }
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1071,7 +1071,12 @@ func _TFCEagerExecute(_ op: CTFEOp,
                       _ status: CTFStatus) {
   if _RuntimeConfig.printsDebugLog {
     debugLog("Calling _TFCEagerExecute() over: ")
-    TFE_OpPrintDebugString(op)
+    if let value = getenv("TF_CPP_MIN_LOG_LEVEL"),
+      String(cString: value) == "0" {
+        TFE_OpPrintDebugString(op)
+    } else {
+      debugLog("[Run with TF_CPP_MIN_LOG_LEVEL=0 to have TFEOps printed out]")
+    }
   }
   if let traceContext = _RuntimeConfig.traceState.context {
     // convert this eager op into a trace graph node

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -1101,7 +1101,7 @@ func _TFCEagerExecute(_ op: CTFEOp,
     debugLog("Calling _TFCEagerExecute() over: ")
     if let value = getenv("TF_CPP_MIN_LOG_LEVEL"),
       String(cString: value) == "0" {
-        TFE_OpPrintDebugString(op)
+      TFE_OpPrintDebugString(op)
     } else {
       debugLog("[Run with TF_CPP_MIN_LOG_LEVEL=0 to have TFEOps printed out]")
     }

--- a/stdlib/public/TensorFlow/Execution.swift
+++ b/stdlib/public/TensorFlow/Execution.swift
@@ -20,6 +20,8 @@ public enum DeviceKind {
   case cpu
   /// The GPU device kind.
   case gpu
+  /// The TPU device kind.
+  case tpu
 }
 
 /// Executes a closure, making TensorFlow operations run on a specific kind of


### PR DESCRIPTION
With this PR, I've been able to run the following code on TPU:

```swift
import TensorFlow
withDevice(.tpu, 0) {
  let x = Tensor<Float>([1, 2, 3, 4, 5])
  print(x + x)
}
```

This required setting the `SWIFT_TENSORFLOW_SERVER_ADDRESS` environment variable to something that can communicate with a TPU machine. Details of configuring that are currently Google3-specific, so I won't be posting them here. In TF-520, we'll be figuring out how to arrange this in a manner compatible with public CI.