### PR TITLE
[5.1][Diagnostics] Cherry-pick crasher fixes

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6545,16 +6545,20 @@ bool FailureDiagnosis::visitUnresolvedMemberExpr(UnresolvedMemberExpr *E) {
 
     // Depending on how we matched, produce tailored diagnostics.
     switch (candidateInfo.closeness) {
+    case CC_SelfMismatch:         // Self argument mismatches.
+      llvm_unreachable("These aren't produced by filterContextualMemberList");
+      return false;
+
     case CC_NonLValueInOut: // First argument is inout but no lvalue present.
     case CC_OneArgumentMismatch: // All arguments except one match.
     case CC_OneArgumentNearMismatch:
     case CC_OneGenericArgumentMismatch:
     case CC_OneGenericArgumentNearMismatch:
     case CC_GenericNonsubstitutableMismatch:
-    case CC_SelfMismatch:         // Self argument mismatches.
     case CC_ArgumentNearMismatch: // Argument list mismatch.
     case CC_ArgumentMismatch:     // Argument list mismatch.
-      llvm_unreachable("These aren't produced by filterContextualMemberList");
+      // Candidate filtering can produce these now, but they can't
+      // be properly diagnosed here at the moment.
       return false;
 
     case CC_ExactMatch: { // This is a perfect match for the arguments.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -833,8 +833,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
                              ? ConstraintLocator::SubscriptMember
                              : ConstraintLocator::Member;
       AllowTypeOrInstanceMemberFailure failure(
-          expr, CS, baseObjTy, memberName,
-          CS.getConstraintLocator(E, locatorKind), choice->getDecl());
+          expr, CS, baseObjTy, choice->getDecl(), memberName,
+          CS.getConstraintLocator(E, locatorKind));
       auto diagnosed = failure.diagnoseAsError();
       assert(diagnosed &&
              "Failed to produce missing or extraneous metatype diagnostic");

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2043,7 +2043,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   // comes up and is otherwise non-obvious what is going on.
 
   if (Name.isSimpleName(DeclBaseName::createConstructor()) &&
-      !BaseType->getRValueType()->is<AnyMetatypeType>()) {
+      !BaseType->is<AnyMetatypeType>()) {
     if (auto ctorRef = dyn_cast<UnresolvedDotExpr>(getRawAnchor())) {
       if (isa<SuperRefExpr>(ctorRef->getBase())) {
         emitDiagnostic(loc, diag::super_initializer_not_in_initializer);
@@ -2090,8 +2090,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   }
 
   if (BaseType->is<AnyMetatypeType>() && !member->isStatic()) {
-    auto instanceTy = BaseType->getRValueType();
-    
+    auto instanceTy = BaseType;
+
     if (auto *AMT = instanceTy->getAs<AnyMetatypeType>()) {
       instanceTy = AMT->getInstanceType();
     }
@@ -2174,11 +2174,11 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // to replace the metatype with 'Self'
     // error saying the lookup cannot be on a protocol metatype
     Optional<InFlightDiagnostic> Diag;
-    auto baseObjTy = BaseType->getRValueType();
-    
-    if (auto metatypeTy = baseObjTy->getAs<MetatypeType>()) {
+    auto baseObjTy = BaseType;
+
+    if (auto metatypeTy = baseObjTy->getAs<AnyMetatypeType>()) {
       auto instanceTy = metatypeTy->getInstanceType();
-      
+
       // This will only happen if we have an unresolved dot expression
       // (.foo) where foo is a protocol member and the contextual type is
       // an optional protocol metatype.
@@ -2186,40 +2186,41 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         instanceTy = objectTy;
         baseObjTy = MetatypeType::get(objectTy);
       }
-      assert(instanceTy->isExistentialType());
-      
-      // Give a customized message if we're accessing a member type
-      // of a protocol -- otherwise a diagnostic talking about
-      // static members doesn't make a whole lot of sense
-      if (auto TAD = dyn_cast<TypeAliasDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
-                                    TAD->getName()));
-      } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
-                                    ATD->getName()));
-      } else if (isa<ConstructorDecl>(member)) {
-        Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
-                                    instanceTy));
-      } else {
-        Diag.emplace(emitDiagnostic(loc,
-                                    diag::could_not_use_type_member_on_protocol_metatype,
-                                    baseObjTy, Name));
-      }
-      
-      Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
-      
-      // See through function decl context
-      if (auto parent = cs.DC->getInnermostTypeContext()) {
-        // If we are in a protocol extension of 'Proto' and we see
-        // 'Proto.static', suggest 'Self.static'
-        if (auto extensionContext = parent->getExtendedProtocolDecl()) {
-          if (extensionContext->getDeclaredType()->isEqual(instanceTy)) {
-            Diag->fixItReplace(getAnchor()->getSourceRange(), "Self");
+
+      if (instanceTy->isExistentialType()) {
+        // Give a customized message if we're accessing a member type
+        // of a protocol -- otherwise a diagnostic talking about
+        // static members doesn't make a whole lot of sense
+        if (auto TAD = dyn_cast<TypeAliasDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::typealias_outside_of_protocol,
+                                      TAD->getName()));
+        } else if (auto ATD = dyn_cast<AssociatedTypeDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::assoc_type_outside_of_protocol,
+                                      ATD->getName()));
+        } else if (isa<ConstructorDecl>(member)) {
+          Diag.emplace(emitDiagnostic(loc, diag::construct_protocol_by_name,
+                                      instanceTy));
+        } else {
+          Diag.emplace(emitDiagnostic(
+              loc, diag::could_not_use_type_member_on_protocol_metatype,
+              baseObjTy, Name));
+        }
+
+        Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
+
+        // See through function decl context
+        if (auto parent = cs.DC->getInnermostTypeContext()) {
+          // If we are in a protocol extension of 'Proto' and we see
+          // 'Proto.static', suggest 'Self.static'
+          if (auto extensionContext = parent->getExtendedProtocolDecl()) {
+            if (extensionContext->getDeclaredType()->isEqual(instanceTy)) {
+              Diag->fixItReplace(getAnchor()->getSourceRange(), "Self");
+            }
           }
         }
+
+        return true;
       }
-      
-      return true;
     }
 
     // If this is a reference to a static member by one of the key path

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2001,25 +2001,31 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   Expr *expr = getParentExpr();
   SourceRange baseRange = expr ? expr->getSourceRange() : SourceRange();
 
-  auto overload = getOverloadChoiceIfAvailable(locator);
-  if (!overload)
-    return false;
+  ValueDecl *member = KnownChoice;
+  // If there is no known member, let's try to find it.
+  if (!member) {
+    auto overload = getOverloadChoiceIfAvailable(locator);
+    if (!overload)
+      return false;
 
-  ValueDecl *decl = nullptr;
-
-  if (!overload->choice.isDecl()) {
-    auto baseTy = overload->choice.getBaseType();
-    if (auto MT = baseTy->getAs<MetatypeType>()) {
-      if (auto VD = dyn_cast<ValueDecl>(
-              MT->getMetatypeInstanceType()->getAnyNominal()->getAsDecl())) {
-        decl = VD;
-      }
+    const auto &choice = overload->choice;
+    if (choice.isDecl()) {
+      member = choice.getDecl();
     } else {
-      return true;
+      auto baseTy = overload->choice.getBaseType();
+      if (!baseTy->is<MetatypeType>())
+        return false;
+
+      auto *MT = baseTy->castTo<MetatypeType>();
+      auto instanceTy = MT->getMetatypeInstanceType();
+      if (!instanceTy->getAnyNominal())
+        return false;
+
+      member = dyn_cast<ValueDecl>(instanceTy->getAnyNominal()->getAsDecl());
+      if (!member)
+        return false;
     }
   }
-
-  auto member = decl ? decl : overload->choice.getDecl();
 
   // If the base is an implicit self type reference, and we're in a
   // an initializer, then the user wrote something like:
@@ -2259,13 +2265,11 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
     
     // Try to provide a fix-it that only contains a '.'
-    if (contextualType) {
-      if (baseTy->isEqual(contextualType)) {
-        Diag->fixItInsert(loc, ".");
-        return true;
-      }
+    if (contextualType && baseTy->isEqual(contextualType)) {
+      Diag->fixItInsert(loc, ".");
+      return true;
     }
-    
+
     // Check if the expression is the matching operator ~=, most often used in
     // case statements. If so, try to provide a single dot fix-it
     const Expr *contextualTypeNode = nullptr;
@@ -2300,12 +2304,16 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     }
 
     // Fall back to a fix-it with a full type qualifier
-    auto nominal = member->getDeclContext()->getSelfNominalTypeDecl();
-    SmallString<32> typeName;
-    llvm::raw_svector_ostream typeNameStream(typeName);
-    typeNameStream << nominal->getSelfInterfaceType() << ".";
-    
-    Diag->fixItInsert(loc, typeNameStream.str());
+    if (auto *NTD = member->getDeclContext()->getSelfNominalTypeDecl()) {
+      auto typeName = NTD->getSelfInterfaceType()->getString();
+      if (auto *SE = dyn_cast<SubscriptExpr>(getRawAnchor())) {
+        auto *baseExpr = SE->getBase();
+        Diag->fixItReplace(baseExpr->getSourceRange(), typeName);
+      } else {
+        Diag->fixItInsert(loc, typeName + ".");
+      }
+    }
+
     return true;
   }
   

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2174,9 +2174,9 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // to replace the metatype with 'Self'
     // error saying the lookup cannot be on a protocol metatype
     Optional<InFlightDiagnostic> Diag;
-    auto baseObjTy = BaseType;
+    auto baseTy = BaseType;
 
-    if (auto metatypeTy = baseObjTy->getAs<AnyMetatypeType>()) {
+    if (auto metatypeTy = baseTy->getAs<AnyMetatypeType>()) {
       auto instanceTy = metatypeTy->getInstanceType();
 
       // This will only happen if we have an unresolved dot expression
@@ -2184,7 +2184,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
       // an optional protocol metatype.
       if (auto objectTy = instanceTy->getOptionalObjectType()) {
         instanceTy = objectTy;
-        baseObjTy = MetatypeType::get(objectTy);
+        baseTy = MetatypeType::get(objectTy);
       }
 
       if (instanceTy->isExistentialType()) {
@@ -2202,8 +2202,8 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
                                       instanceTy));
         } else {
           Diag.emplace(emitDiagnostic(
-              loc, diag::could_not_use_type_member_on_protocol_metatype,
-              baseObjTy, Name));
+              loc, diag::could_not_use_type_member_on_protocol_metatype, baseTy,
+              Name));
         }
 
         Diag->highlight(baseRange).highlight(getAnchor()->getSourceRange());
@@ -2227,8 +2227,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // components, let's provide a tailored diagnostic and return because
     // that is unsupported so there is no fix-it.
     if (locator->isForKeyPathComponent()) {
-      InvalidStaticMemberRefInKeyPath failure(expr, getConstraintSystem(),
-                                              member, locator);
+      InvalidStaticMemberRefInKeyPath failure(expr, cs, member, locator);
       return failure.diagnoseAsError();
     }
 
@@ -2237,13 +2236,13 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
           loc, diag::could_not_use_enum_element_on_instance, Name));
     } else {
       Diag.emplace(emitDiagnostic(
-          loc, diag::could_not_use_type_member_on_instance, baseObjTy, Name));
+          loc, diag::could_not_use_type_member_on_instance, baseTy, Name));
     }
 
     Diag->highlight(getAnchor()->getSourceRange());
 
     if (Name.isSimpleName(DeclBaseName::createConstructor()) &&
-        !baseObjTy->is<AnyMetatypeType>()) {
+        !baseTy->is<AnyMetatypeType>()) {
       if (auto ctorRef = dyn_cast<UnresolvedDotExpr>(getRawAnchor())) {
         SourceRange fixItRng = ctorRef->getNameLoc().getSourceRange();
         Diag->fixItInsert(fixItRng.Start, "type(of: ");
@@ -2261,7 +2260,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     
     // Try to provide a fix-it that only contains a '.'
     if (contextualType) {
-      if (baseObjTy->isEqual(contextualType)) {
+      if (baseTy->isEqual(contextualType)) {
         Diag->fixItInsert(loc, ".");
         return true;
       }
@@ -2291,7 +2290,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
             // since the type can be inferred
             Type secondArgType =
             lastCS->getType(binaryExpr->getArg()->getElement(1));
-            if (secondArgType->isEqual(baseObjTy)) {
+            if (secondArgType->isEqual(baseTy)) {
               Diag->fixItInsert(loc, ".");
               return true;
             }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -802,12 +802,17 @@ class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   Type BaseType;
   DeclName Name;
 
+  /// The choice associated with given member name, if known.
+  ValueDecl *KnownChoice;
+
 public:
   AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
                                    Type baseType, DeclName memberName,
-                                   ConstraintLocator *locator)
+                                   ConstraintLocator *locator,
+                                   ValueDecl *choice = nullptr)
       : FailureDiagnostic(root, cs, locator),
-        BaseType(baseType->getRValueType()), Name(memberName) {}
+        BaseType(baseType->getRValueType()), Name(memberName),
+        KnownChoice(choice) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -803,11 +803,12 @@ class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   DeclName Name;
 
 public:
-  AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs, Type baseType,
-                                   DeclName memberName, ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), BaseType(baseType),
-        Name(memberName) {}
-    
+  AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
+                                   Type baseType, DeclName memberName,
+                                   ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator),
+        BaseType(baseType->getRValueType()), Name(memberName) {}
+
   bool diagnoseAsError() override;
 };
 class PartialApplicationFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -800,22 +800,21 @@ private:
 /// ```
 class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
   Type BaseType;
+  ValueDecl *Member;
   DeclName Name;
-
-  /// The choice associated with given member name, if known.
-  ValueDecl *KnownChoice;
 
 public:
   AllowTypeOrInstanceMemberFailure(Expr *root, ConstraintSystem &cs,
-                                   Type baseType, DeclName memberName,
-                                   ConstraintLocator *locator,
-                                   ValueDecl *choice = nullptr)
+                                   Type baseType, ValueDecl *member,
+                                   DeclName name, ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator),
-        BaseType(baseType->getRValueType()), Name(memberName),
-        KnownChoice(choice) {}
+        BaseType(baseType->getRValueType()), Member(member), Name(name) {
+    assert(member);
+  }
 
   bool diagnoseAsError() override;
 };
+
 class PartialApplicationFailure final : public FailureDiagnostic {
   enum RefKind : unsigned {
     MutatingMethod,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -265,17 +265,19 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
 }
 
 bool AllowTypeOrInstanceMember::diagnose(Expr *root, bool asNote) const {
-  auto failure = AllowTypeOrInstanceMemberFailure(root, getConstraintSystem(),
-                                                  BaseType, Name, getLocator());
+  auto failure = AllowTypeOrInstanceMemberFailure(
+      root, getConstraintSystem(), BaseType, Member, UsedName, getLocator());
   return failure.diagnose(asNote);
 }
 
-AllowTypeOrInstanceMember *AllowTypeOrInstanceMember::create(ConstraintSystem &cs,
-                                                             Type baseType,
-                                                             DeclName member,
-                                                             ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AllowTypeOrInstanceMember(cs, baseType, member, locator);
+AllowTypeOrInstanceMember *
+AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
+                                  ValueDecl *member, DeclName usedName,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowTypeOrInstanceMember(cs, baseType, member, usedName, locator);
 }
+
 bool AllowInvalidPartialApplication::diagnose(Expr *root, bool asNote) const {
   auto failure = PartialApplicationFailure(root, isWarning(),
                                            getConstraintSystem(), getLocator());

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -585,13 +585,17 @@ public:
 	
 class AllowTypeOrInstanceMember final : public ConstraintFix {
   Type BaseType;
-  DeclName Name;
+  ValueDecl *Member;
+  DeclName UsedName;
 
 public:
-  AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType, DeclName member,
+  AllowTypeOrInstanceMember(ConstraintSystem &cs, Type baseType,
+                            ValueDecl *member, DeclName name,
                             ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowTypeOrInstanceMember, locator),
-        BaseType(baseType), Name(member) {}
+        BaseType(baseType), Member(member), UsedName(name) {
+    assert(member);
+  }
 
   std::string getName() const override {
     return "allow access to instance member on type or a type member on instance";
@@ -600,7 +604,7 @@ public:
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static AllowTypeOrInstanceMember *create(ConstraintSystem &cs, Type baseType,
-                                           DeclName member,
+                                           ValueDecl *member, DeclName usedName,
                                            ConstraintLocator *locator);
 };
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4460,8 +4460,12 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
   if (reason) {
     switch (*reason) {
     case MemberLookupResult::UR_InstanceMemberOnType:
-    case MemberLookupResult::UR_TypeMemberOnInstance:
-      return AllowTypeOrInstanceMember::create(cs, baseTy, memberName, locator);
+    case MemberLookupResult::UR_TypeMemberOnInstance: {
+      return choice.isDecl()
+                 ? AllowTypeOrInstanceMember::create(
+                       cs, baseTy, choice.getDecl(), memberName, locator)
+                 : nullptr;
+    }
 
     case MemberLookupResult::UR_Inaccessible:
       assert(choice.isDecl());

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -209,3 +209,14 @@ func rdar_45535925() {
     // expected-error@-1 {{'bar' is inaccessible due to 'private' protection level}}
   }
 }
+
+// rdar://problem/50668864
+func rdar_50668864() {
+  struct Foo {
+    init(anchors: [Int]) {
+      // TODO: This would be improved when argument conversions are diagnosed via new diagnostic framework,
+      // actual problem here is that `[Int]` cannot be converted to function type represented by a closure.
+      self = .init { _ in [] } // expected-error {{cannot convert value of type '(_) -> [Any]' to expected argument type '[Int]'}}
+    }
+  }
+}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -609,3 +609,21 @@ func rdar50679161() {
     }
   }
 }
+
+
+func rdar_50467583_and_50909555() {
+  // rdar://problem/50467583
+  let _: Set = [Int][]
+  // expected-error@-1 {{instance member 'subscript' cannot be used on type '[Int]'}}
+
+  // rdar://problem/50909555
+  struct S {
+    static subscript(x: Int, y: Int) -> Int {
+      return 1
+    }
+  }
+
+  func test(_ s: S) {
+    s[1] // expected-error {{static member 'subscript' cannot be used on instance of type 'S'}} {{5-6=S}}
+  }
+}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -577,3 +577,35 @@ extension S_Min : CustomStringConvertible {
     return "\(min)" // Ok
   }
 }
+
+// rdar://problem/50679161
+
+func rdar50679161() {
+  struct Point {}
+
+  struct S {
+    var w, h: Point
+  }
+
+  struct Q {
+    init(a: Int, b: Int) {}
+    init(a: Point, b: Point) {}
+  }
+
+  func foo() {
+    _ = { () -> Void in
+      var foo = S
+      // expected-error@-1 {{expected member name or constructor call after type name}}
+      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+      // expected-note@-3 {{use '.self' to reference the type object}}
+      if let v = Int?(1) {
+        var _ = Q(
+          a: v + foo.w,
+          // expected-error@-1 {{instance member 'w' cannot be used on type 'S'}}
+          b: v + foo.h
+          // expected-error@-1 {{instance member 'h' cannot be used on type 'S'}}
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Fix incorrect metatype check which leads to crashes
- Adjust assert to account for changes in `filterContextualMemberList`
- Add known member declaration to `invalid member ref` diagnostic

Resolves: rdar://problem/50679161
Resolves: rdar://problem/50668864
Resolves: rdar://problem/50467583
Resolves: rdar://problem/50682022
Resolves: rdar://problem/50909555

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
