### PR TITLE
[CodeCompletion] '#file', '#line', et al. after '#'

### DIFF
--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -128,10 +128,10 @@ typealias FooTypealias = Int
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:    Int32[#Int32#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:    Int64[#Int64#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:      Bool[#Bool#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 // COMMON: End completions
 
 // NO_SELF-NOT: {{[[:<:]][Ss]elf[[:>:]]}}

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -191,10 +191,10 @@
 // KW_DECL_STMT-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // Literals
 //
@@ -211,10 +211,10 @@
 // KW_EXPR-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // let and var
 //

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -93,6 +93,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SWITCH_TOP | %FileCheck %s -check-prefix=KW_CASE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SWITCH_IN_CASE | %FileCheck %s -check-prefix=KW_CASE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_UINT32 | %FileCheck %s -check-prefix=CONTEXT_UINT32
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_STATICSTRING | %FileCheck %s -check-prefix=CONTEXT_STATICSTRING
+
 // KW_RETURN: Keyword[return]/None: return{{; name=.+$}}
 // KW_NO_RETURN-NOT: Keyword[return]
 
@@ -412,8 +415,27 @@ func inSwitch(val: Int) {
     foo()
   #^SWITCH_IN_CASE^#
   }
-// Begin completions
+// KW_CASE: Begin completions
 // KW_CASE-DAG: Keyword[case]/None:                 case; name=case
 // KW_CASE-DAG: Keyword[default]/None:              default; name=default
-// End completions
+// KW_CASE: End completions
+}
+func testContextualType() {
+  let _: UInt32 = #^CONTEXT_UINT32^#
+// CONTEXT_UINT32: Begin completions
+// CONTEXT_UINT32-DAG: Keyword[#function]/None:            #function[#String#]; name=#function
+// CONTEXT_UINT32-DAG: Keyword[#file]/None:                #file[#String#]; name=#file
+// CONTEXT_UINT32-DAG: Keyword[#line]/None/TypeRelation[Identical]: #line[#UInt32#]; name=#line
+// CONTEXT_UINT32-DAG: Keyword[#column]/None/TypeRelation[Identical]: #column[#UInt32#]; name=#column
+// CONTEXT_UINT32-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
+// CONTEXT_UINT32: End completions
+
+  let _: StaticString = #^CONTEXT_STATICSTRING^#
+// CONTEXT_STATICSTRING: Begin completions
+// CONTEXT_STATICSTRING-DAG: Keyword[#function]/None/TypeRelation[Identical]: #function[#StaticString#]; name=#function
+// CONTEXT_STATICSTRING-DAG: Keyword[#file]/None/TypeRelation[Identical]: #file[#StaticString#]; name=#file
+// CONTEXT_STATICSTRING-DAG: Keyword[#line]/None:                #line[#Int#]; name=#line
+// CONTEXT_STATICSTRING-DAG: Keyword[#column]/None:              #column[#Int#]; name=#column
+// CONTEXT_STATICSTRING-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
+// CONTEXT_STATICSTRING: End completions
 }

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -7,8 +7,13 @@ func test1() {
   _ = use(##^POUND_EXPR_1^#)
 }
 
-// POUND_EXPR_STRINGCONTEXT: Begin completions, 2 items
+// POUND_EXPR_STRINGCONTEXT: Begin completions, 7 items
 // POUND_EXPR_STRINGCONTEXT-NOT: available
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: selector({#@objc method#}); name=selector(@objc method)
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: keyPath({#@objc property sequence#}); name=keyPath(@objc property sequence)
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               selector({#@objc method#});
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               keyPath({#@objc property sequence#});
 // POUND_EXPR_STRINGCONTEXT: End completions

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -1,19 +1,42 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_1 | %FileCheck %s -check-prefix=POUND_EXPR_STRINGCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_1 | %FileCheck %s -check-prefix=POUND_EXPR_INTCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_2 | %FileCheck %s -check-prefix=POUND_EXPR_STRINGCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_3 | %FileCheck %s -check-prefix=POUND_EXPR_SELECTORCONTEXT
 // REQUIRES: objc_interop
 
-func use(_ str: String) -> Bool {}
+import ObjectiveC
+
+func useInt(_ str: Int) -> Bool {}
+func useString(_ str: String) -> Bool {}
+func useSelector(_ sel: Selector) -> Bool {}
 
 func test1() {
-  _ = use(##^POUND_EXPR_1^#)
+  let _ = useInt(##^POUND_EXPR_1^#)
+  let _ = useString(##^POUND_EXPR_2^#)
+  let _ = useSelector(##^POUND_EXPR_3^#)
 }
 
-// POUND_EXPR_STRINGCONTEXT: Begin completions, 7 items
-// POUND_EXPR_STRINGCONTEXT-NOT: available
+// POUND_EXPR_INTCONTEXT: Begin completions, 5 items
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#function]/None:            function[#String#]; name=function
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#file]/None:                file[#String#]; name=file
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#line]/None/TypeRelation[Identical]: line[#Int#]; name=line
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#column]/None/TypeRelation[Identical]: column[#Int#]; name=column
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#]; name=dsohandle
+// POUND_EXPR_INTCONTEXT: End completions
+
+// POUND_EXPR_STRINGCONTEXT: Begin completions, 6 items
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               selector({#@objc method#});
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               keyPath({#@objc property sequence#});
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: keyPath({#@objc property sequence#})[#String#];
 // POUND_EXPR_STRINGCONTEXT: End completions
+
+// POUND_EXPR_SELECTORCONTEXT: Begin completions, 6 items
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: selector({#@objc method#})[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT: End completions

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -34,9 +34,9 @@ func completeInKeyPath2() {
   _ = #keyPath(ObjCClass.#^IN_KEYPATH_2^#
 }
 
-// CHECK-AFTER_POUND: Keyword/ExprSpecific:               keyPath({#@objc property sequence#}); name=keyPath(@objc property sequence)
+// CHECK-AFTER_POUND-NOT: keyPath
 
-// CHECK-KEYPATH_ARG: Keyword/None:                       #keyPath({#@objc property sequence#}); name=#keyPath(@objc property sequence)
+// CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Identical]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath(@objc property sequence)
 
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2

--- a/test/IDE/complete_pound_selector.swift
+++ b/test/IDE/complete_pound_selector.swift
@@ -71,10 +71,10 @@ class Subclass : NSObject {
 }
 
 
+// CHECK-AFTER_POUND-NOT: selector
 // CHECK-AFTER_POUND: Keyword/ExprSpecific:               available({#Platform...#}, *); name=available(Platform..., *)
-// CHECK-AFTER_POUND: Keyword/ExprSpecific:               selector({#@objc method#}); name=selector(@objc method)
 
-// CHECK-CONTEXT_SELECTOR: Keyword/None:                  #selector({#@objc method#}); name=#selector(@objc method)
+// CHECK-CONTEXT_SELECTOR: Keyword/None/TypeRelation[Identical]: #selector({#@objc method#})[#Selector#]; name=#selector(@objc method)
 
 // CHECK-SELECTOR_BASIC: Keyword/None:                       getter: {#@objc property#}; name=getter: @objc property
 // CHECK-SELECTOR_BASIC: Keyword/None:                       setter: {#@objc property#}; name=setter: @objc property


### PR DESCRIPTION
* Implement completion for `#file`, `#line`, et al. after `#` in expression context
* Polymorphic type annotation for `#file`, `#line`, et al. depending on context types
* Suggest `#selector` and `#keyPath` only if the context type matches
* Add `CompletionLookup::CurrModule` instance field to avoid recurring computation for `CurrDeclContext->getParentModule()`

rdar://problem/47169238