### PR TITLE
[os_log][SIL Optimization] Make new os log APIs @_transparent and change OSLogOptimization pass so that inlining is not performed.

### DIFF
--- a/stdlib/private/OSLog/OSLog.swift
+++ b/stdlib/private/OSLog/OSLog.swift
@@ -38,8 +38,7 @@ public struct Logger {
 
   /// Log a string interpolation at a given level. The level is `default` if
   /// it is not specified.
-  @inlinable
-  @_semantics("oslog.log")
+  @_transparent
   @_optimize(none)
   public func log(level: OSLogType = .default, _ message: OSLogMessage) {
     osLog(logObject, level, message)
@@ -103,8 +102,7 @@ internal func osLog(
 ///   - message: An instance of `OSLogMessage` created from string interpolation
 ///   - assertion: A closure that takes a format string and a pointer to a
 ///     byte buffer and asserts a condition.
-@inlinable
-@_semantics("oslog.log.test_helper")
+@_transparent
 @_optimize(none)
 public // @testable
 func _checkFormatStringAndBuffer(

--- a/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileDiagnostics.swift
@@ -12,7 +12,9 @@ import OSLogPrototype
 if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
 
   func testDynamicLogMessage(h: Logger, message: OSLogMessage) {
-    h.log(level: .debug, message) // expected-error {{os log methods must be passed a string interpolation literal. 'OSLogMessage' must not be constructed explicitly}}
+    // FIXME: log APIs must always be passed a string interpolation literal.
+    // Diagnose this.
+    h.log(level: .debug, message)
   }
 
   func testNonconstantFormatOption(h: Logger, formatOpt: IntFormat) {

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -28,7 +28,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check integer constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
@@ -55,7 +55,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check integer constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
@@ -85,7 +85,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check integer constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 12
@@ -119,7 +119,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check integer constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 32
@@ -152,7 +152,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check other constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int{{[0-9]+}}, 2
@@ -223,7 +223,7 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // Check integer constants passed to the withCString closure: buffersize,
     // premable and argument count.
 
-    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @inout_aliasable OSLogArguments) -> ()
+    // CHECK-DAG: {{%.*}} = partial_apply [callee_guaranteed] [on_stack] [[OSLOGCLOSURE:%[0-9]+]]({{%.*}}, {{%.*}}, [[BUFFERSIZE:%[0-9]+]], [[PREAMBLE:%[0-9]+]], [[ARGCOUNT:%[0-9]+]], {{%.*}}) : $@convention(thin) (UnsafePointer<Int8>, @guaranteed OSLog, OSLogType, Int, UInt8, UInt8, @guaranteed OSLogArguments) -> ()
     // CHECK-DAG: [[OSLOGCLOSURE]] = function_ref @$s14OSLogPrototype5osLogyySo03OS_C4_logC_So0c1_F7_type_taAA0A7MessageVtFySPys4Int8VGXEfU_
     // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
     // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 482


### PR DESCRIPTION
@atrick  @eeckstein, I have made a change to the OSLogOptimization pass to address an issue raised by @gottesmm. Basically, I have removed inlining from the pass, which caused problems as the pass was in the mandatory pipeline but wasn't using Mandatory inlining (which happens earlier). The reason for that was that the pass used  @_semantics attribute to identify log calls, extract the custom string interpolation argument  of the call, and identify the instructions that must be constant evaluated. The call and the @_semantics attribute will be lost by mandatory inlining.

This commit changes how the instructions to constant evaluate are identified. The new approach uses the "initializer" calls of the custom string interpolation type: 'OSLogMessage' to drive the constant evaluation and folding. The initializer calls need not be inlined and are constant evaluable.   The main benefit of the current approach is that, it will kick in at every place where the type 'OSLogMessage' is instantiated using a string interpolation, regardless of whether or not it is passed to a os_log call.  E.g. the optimization will also apply to cases like the following.

```
    let x: OSLogMessage = "Hello \(1)"
    let y = x.formatString // This will be constant folded. 
```

A note: the diagnostics in this pass will be subsumed and enhanced by a new pass that will enforce the library implementation model (by checking if the implementation is constant evaluable etc.) and also the user model for the log calls (by checking if the log calls are passed a string interpolation).  The diagnostics in this pass will eventually become redundant and should just be asserts/noops.
