### PR TITLE
Revert "Update tensorflow-swift-bindings to one with virtualized interface"

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -57,10 +57,9 @@ set(GYB_SOURCES
 
 # Copy TensorFlow bindings file, if it exists.
 if (TENSORFLOW_SWIFT_BINDINGS)
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_BINDINGS}/TensorOperation.swift")
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_BINDINGS}/TFTensorOperation.swift")
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_BINDINGS}/EagerExecution.swift")
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_BINDINGS}/RawOpsGenerated.swift")
+  file(GLOB_RECURSE TENSORFLOW_SWIFT_BINDINGS_SOURCES
+    "${TENSORFLOW_SWIFT_BINDINGS}/*.swift")
+  list(APPEND SOURCES "${TENSORFLOW_SWIFT_BINDINGS_SOURCES}")
 endif()
 
 # Copy TensorFlow high-level API sources, if they exist.

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -351,7 +351,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "tensorflow": "447e512d332ab86172a3b13119900b4d021d0c65",
-                "tensorflow-swift-bindings": "f217f40dab006c7de57f64cc3e0cbff86794bff9",
+                "tensorflow-swift-bindings": "330ea66bd06ad9df911673bd263a787c63a51597",
                 "tensorflow-swift-apis": "5883af609ff29b06bb6b415dd9be0724a70174eb",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-05-15-a"


### PR DESCRIPTION
Reverts apple/swift#24948, which causes compilation to fail on macOS.
```
/Users/danielzheng/swift-dev/tensorflow-swift-bindings/RawOpsGenerated.swift:20:49: error: 'some' return types are only available in macOS 9999.0.0 or newer
func makeOp(_ name: String, _ nOutputs: Int) -> some TFTensorOperation {
                                                ^
/Users/danielzheng/swift-dev/tensorflow-swift-bindings/RawOpsGenerated.swift:20:6: note: add @available attribute to enclosing global function
func makeOp(_ name: String, _ nOutputs: Int) -> some TFTensorOperation {
     ^
/Users/danielzheng/swift-dev/tensorflow-swift-bindings/TFTensorOperation.swift:5:65: error: 'some' return types are only available in macOS 9999.0.0 or newer
  public static func makeOp(_ name: String, _ nOutputs: Int) -> some TFTensorOperation {
                                                                ^
/Users/danielzheng/swift-dev/tensorflow-swift-bindings/TFTensorOperation.swift:5:22: note: add @available attribute to enclosing static method
  public static func makeOp(_ name: String, _ nOutputs: Int) -> some TFTensorOperation {
                     ^
/Users/danielzheng/swift-dev/tensorflow-swift-bindings/TFTensorOperation.swift:1:1: note: add @available attribute to enclosing extension
extension _ExecutionContext {
^
```