### PR TITLE
class method differentiation prototype

### DIFF
--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -88,6 +88,20 @@ template <class T> class SILVTableVisitor {
 
     SILDeclRef constant(fd, SILDeclRef::Kind::Func);
     maybeAddEntry(constant, constant.requiresNewVTableEntry());
+
+    if (auto *DA = fd->getAttrs().getAttribute<DifferentiableAttr>()) {
+      auto jvpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+          AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
+          DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(jvpConstant, jvpConstant.requiresNewVTableEntry());
+
+      auto vjpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+          AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
+          DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(vjpConstant, vjpConstant.requiresNewVTableEntry());
+    }
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -841,7 +841,7 @@ SILDeclRef SILDeclRef::getOverridden() const {
   if (!overridden)
     return SILDeclRef();
 
-  return SILDeclRef(overridden, kind, isCurried);
+  return SILDeclRef(overridden, kind, isCurried, isForeign, autoDiffAssociatedFunctionIdentifier);
 }
 
 SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
@@ -899,7 +899,7 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
 SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
   auto bestOverridden =
     getOverriddenWitnessTableEntry(cast<AbstractFunctionDecl>(getDecl()));
-  return SILDeclRef(bestOverridden, kind, isCurried);
+  return SILDeclRef(bestOverridden, kind, isCurried, isForeign, autoDiffAssociatedFunctionIdentifier);
 }
 
 AbstractFunctionDecl *SILDeclRef::getOverriddenWitnessTableEntry(

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -135,6 +135,9 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
   if (!name.empty()) {
     entry = &*M.FunctionTable.insert(std::make_pair(name, nullptr)).first;
     PrettyStackTraceSILFunction trace("creating", entry->getValue());
+    if (entry->getValue()) {
+      entry->getValue()->dump();
+    }
     assert(!entry->getValue() && "function already exists");
     name = entry->getKey();
   }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1943,11 +1943,39 @@ emitAssociatedFunctionReference(
   }
 
   // Reject class methods.
-  if (auto *classMethod =
+  if (auto *classMethodInst =
           peerThroughFunctionConversions<ClassMethodInst>(original)) {
-    context.emitNondifferentiabilityError(original, invoker,
-        diag::autodiff_class_member_not_supported);
-    return None;
+    auto loc = classMethodInst->getLoc();
+    auto methodRef = classMethodInst->getMember();
+    auto methodDecl = methodRef.getDecl();
+    auto *diffAttr = methodDecl->getAttrs().getAttribute<DifferentiableAttr>();
+    if (!diffAttr) {
+      context.emitNondifferentiabilityError(original, invoker,
+          diag::autodiff_protocol_member_not_differentiable);  // TODO: change to a class method diagnostic
+      return None;
+    }
+
+    auto *methodParameterIndices = diffAttr->getParameterIndices();
+
+    // TODO: need to check that the method parameter indices are compatible with
+    // the desired ones.
+
+    auto originalType = classMethodInst->getType().castTo<SILFunctionType>();
+    auto assocType = originalType->getAutoDiffAssociatedFunctionType(
+        desiredIndices.parameters, desiredIndices.source,  // TODO: using desired here is very dangerous. should use the ones from the method declaration
+        /*differentiationOrder*/ 1, kind, builder.getModule(),
+        LookUpConformanceInModule(builder.getModule().getSwiftModule()));
+
+    // Emit a class_method instruction pointing at the associated function.
+    auto *autoDiffFuncId = AutoDiffAssociatedFunctionIdentifier::get(
+        kind, /*differentiationOrder*/ 1, methodParameterIndices,
+        context.getASTContext());
+    auto *ref = builder.createClassMethod(
+        loc, classMethodInst->getOperand(),
+        methodRef.asAutoDiffAssociatedFunction(autoDiffFuncId), SILType::getPrimitiveObjectType(assocType));
+    auto convertedRef =
+        reapplyFunctionConversion(ref, classMethodInst, original, builder, loc);
+    return std::make_pair(convertedRef, desiredIndices);  // TODO: using desired here is very dangerous. should use the ones from the method declaration
   }
 
   // Emit the general opaque function error.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2911,12 +2911,12 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  // Class members are not supported by differentiation yet.
-  if (original->getInnermostTypeContext() &&
-      isa<ClassDecl>(original->getInnermostTypeContext())) {
-    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
-    return;
-  }
+  // // Class members are not supported by differentiation yet.
+  // if (original->getInnermostTypeContext() &&
+  //     isa<ClassDecl>(original->getInnermostTypeContext())) {
+  //   diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
+  //   return;
+  // }
 
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->eraseDynamicSelfType()


### PR DESCRIPTION
Just a proof of concept that includes some terrible shortcuts and workarounds.

Long explanation: https://gist.github.com/marcrasi/182c7059212fb75a0fa61b8a1d5ee0ac

But it works! For example,
```swift
class Superclass {
  @differentiable(jvp: jvpf, vjp: vjpf)
  func f(_ x: Float) -> Float {
    return 2 * x
  }

  final func jvpf(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 2 * v })
  }

  final func vjpf(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 2 * v })
  }
}

class Subclass : Superclass {
  @differentiable(jvp: jvpf2, vjp: vjpf2)
  override func f(_ x: Float) -> Float {
    return 3 * x
  }

  final func jvpf2(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 3 * v })
  }

  final func vjpf2(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 3 * v })
  }
}

func gimmeAGradientDynamically(_ c: Superclass) {
  let g = gradient(at: 0) { c.f($0) }
  print(g)
}

gimmeAGradientDynamically(Superclass())
gimmeAGradientDynamically(Subclass())
```
outputs:
```
2.0
3.0
```