### PR TITLE
[5.1][CodeCompletion] '#file', '#line', et al. after '#'

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1481,6 +1481,7 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   ASTContext &Ctx;
   LazyResolver *TypeResolver = nullptr;
   const DeclContext *CurrDeclContext;
+  ModuleDecl *CurrModule;
   ClangImporter *Importer;
   CodeCompletionContext *CompletionContext;
 
@@ -1629,6 +1630,8 @@ public:
                    const DeclContext *CurrDeclContext,
                    CodeCompletionContext *CompletionContext = nullptr)
       : Sink(Sink), Ctx(Ctx), CurrDeclContext(CurrDeclContext),
+        CurrModule(CurrDeclContext ? CurrDeclContext->getParentModule()
+                                   : nullptr),
         Importer(static_cast<ClangImporter *>(CurrDeclContext->getASTContext().
           getClangModuleLoader())),
         CompletionContext(CompletionContext) {
@@ -3514,9 +3517,73 @@ public:
         addPostfixBang(ValueT);
   }
 
+  void addTypeRelationFromProtocol(CodeCompletionResultBuilder &builder,
+                                   CodeCompletionLiteralKind kind,
+                                   StringRef defaultTypeName) {
+    // Check for matching ExpectedTypes.
+    auto *P = Ctx.getProtocol(protocolForLiteralKind(kind));
+    for (auto T : expectedTypeContext.possibleTypes) {
+      if (!T)
+        continue;
+
+      auto typeRelation = CodeCompletionResult::Identical;
+      // Convert through optional types unless we're looking for a protocol
+      // that Optional itself conforms to.
+      if (kind != CodeCompletionLiteralKind::NilLiteral) {
+        if (auto optionalObjT = T->getOptionalObjectType()) {
+          T = optionalObjT;
+          typeRelation = CodeCompletionResult::Convertible;
+        }
+      }
+
+      // Check for conformance to the literal protocol.
+      if (auto *NTD = T->getAnyNominal()) {
+        SmallVector<ProtocolConformance *, 2> conformances;
+        if (NTD->lookupConformance(CurrModule, P, conformances)) {
+          addTypeAnnotation(builder, T);
+          builder.setExpectedTypeRelation(typeRelation);
+          return;
+        }
+      }
+    }
+
+    // Fallback to showing the default type.
+    if (!defaultTypeName.empty())
+      builder.addTypeAnnotation(defaultTypeName);
+  }
+
+  /// Add '#file', '#line', et at.
+  void addPoundLiteralCompletions(bool needPound) {
+    auto addFromProto = [&](StringRef name, CodeCompletionKeywordKind kwKind,
+                            CodeCompletionLiteralKind literalKind,
+                            StringRef defaultTypeName) {
+      if (!needPound)
+        name = name.substr(1);
+
+      CodeCompletionResultBuilder builder(
+          Sink, CodeCompletionResult::ResultKind::Keyword,
+          SemanticContextKind::None, {});
+      builder.setLiteralKind(literalKind);
+      builder.setKeywordKind(kwKind);
+      builder.addTextChunk(name);
+      addTypeRelationFromProtocol(builder, literalKind, defaultTypeName);
+    };
+
+    addFromProto("#function", CodeCompletionKeywordKind::pound_function,
+                 CodeCompletionLiteralKind::StringLiteral, "String");
+    addFromProto("#file", CodeCompletionKeywordKind::pound_file,
+                 CodeCompletionLiteralKind::StringLiteral, "String");
+    addFromProto("#line", CodeCompletionKeywordKind::pound_line,
+                 CodeCompletionLiteralKind::IntegerLiteral, "Int");
+    addFromProto("#column", CodeCompletionKeywordKind::pound_column,
+                 CodeCompletionLiteralKind::IntegerLiteral, "Int");
+
+    addKeyword(needPound ? "#dsohandle" : "dsohandle", "UnsafeRawPointer",
+               CodeCompletionKeywordKind::pound_dsohandle);
+  }
+
   void addValueLiteralCompletions() {
     auto &context = CurrDeclContext->getASTContext();
-    auto *module = CurrDeclContext->getParentModule();
 
     auto addFromProto = [&](
         CodeCompletionLiteralKind kind, StringRef defaultTypeName,
@@ -3528,38 +3595,7 @@ public:
       builder.setLiteralKind(kind);
 
       consumer(builder);
-
-      // Check for matching ExpectedTypes.
-      auto *P = context.getProtocol(protocolForLiteralKind(kind));
-      bool foundConformance = false;
-      for (auto T : expectedTypeContext.possibleTypes) {
-        if (!T)
-          continue;
-
-        auto typeRelation = CodeCompletionResult::Identical;
-        // Convert through optional types unless we're looking for a protocol
-        // that Optional itself conforms to.
-        if (kind != CodeCompletionLiteralKind::NilLiteral) {
-          if (auto optionalObjT = T->getOptionalObjectType()) {
-            T = optionalObjT;
-            typeRelation = CodeCompletionResult::Convertible;
-          }
-        }
-
-        // Check for conformance to the literal protocol.
-        if (auto *NTD = T->getAnyNominal()) {
-          SmallVector<ProtocolConformance *, 2> conformances;
-          if (NTD->lookupConformance(module, P, conformances)) {
-            foundConformance = true;
-            addTypeAnnotation(builder, T);
-            builder.setExpectedTypeRelation(typeRelation);
-          }
-        }
-      }
-
-      // Fallback to showing the default type.
-      if (!foundConformance && !defaultTypeName.empty())
-        builder.addTypeAnnotation(defaultTypeName);
+      addTypeRelationFromProtocol(builder, kind, defaultTypeName);
     };
 
     // FIXME: the pedantically correct way is to resolve Swift.*LiteralType.
@@ -3708,8 +3744,11 @@ public:
           });
     }
 
-    if (LiteralCompletions)
+    if (LiteralCompletions) {
       addValueLiteralCompletions();
+      addPoundLiteralCompletions(/*needPound=*/true);
+    }
+
 
     // If the expected type is ObjectiveC.Selector, add #selector. If
     // it's String, add #keyPath.
@@ -4842,14 +4881,6 @@ static void addExprKeywords(CodeCompletionResultSink &Sink) {
   addKeyword(Sink, "try", CodeCompletionKeywordKind::kw_try);
   addKeyword(Sink, "try!", CodeCompletionKeywordKind::kw_try);
   addKeyword(Sink, "try?", CodeCompletionKeywordKind::kw_try);
-  // FIXME: The pedantically correct way to find the type is to resolve the
-  // Swift.StringLiteralType type.
-  addKeyword(Sink, "#function", CodeCompletionKeywordKind::pound_function, "String");
-  addKeyword(Sink, "#file", CodeCompletionKeywordKind::pound_file, "String");
-  // Same: Swift.IntegerLiteralType.
-  addKeyword(Sink, "#line", CodeCompletionKeywordKind::pound_line, "Int");
-  addKeyword(Sink, "#column", CodeCompletionKeywordKind::pound_column, "Int");
-  addKeyword(Sink, "#dsohandle", CodeCompletionKeywordKind::pound_dsohandle, "UnsafeMutableRawPointer");
 }
 
 static void addOpaqueTypeKeyword(CodeCompletionResultSink &Sink) {
@@ -5448,7 +5479,12 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
 
   case CompletionKind::AfterPoundExpr: {
+    ExprContextInfo ContextInfo(CurDeclContext, CodeCompleteTokenExpr);
+    Lookup.setExpectedTypes(ContextInfo.getPossibleTypes(),
+                            ContextInfo.isSingleExpressionBody());
+
     Lookup.addPoundAvailable(ParentStmtKind);
+    Lookup.addPoundLiteralCompletions(/*needPound=*/false);
     Lookup.addPoundSelector(/*needPound=*/false);
     Lookup.addPoundKeyPath(/*needPound=*/false);
     break;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1765,7 +1765,7 @@ public:
     llvm::StringSet<> ImportedModules;
     collectImportedModules(ImportedModules);
 
-    auto mainModuleName = CurrDeclContext->getParentModule()->getName();
+    auto mainModuleName = CurrModule->getName();
     for (auto ModuleName : ModuleNames) {
       if (ModuleName.str().startswith("_") ||
           ModuleName == mainModuleName ||
@@ -1822,8 +1822,7 @@ public:
       return SemanticContextKind::OutsideNominal;
 
     case DeclVisibilityKind::VisibleAtTopLevel:
-      if (CurrDeclContext &&
-          D->getModuleContext() == CurrDeclContext->getParentModule()) {
+      if (CurrDeclContext && D->getModuleContext() == CurrModule) {
         // Treat global variables from the same source file as local when
         // completing at top-level.
         if (isa<VarDecl>(D) && isTopLevelContext(CurrDeclContext) &&
@@ -1936,7 +1935,7 @@ public:
   /// protocol compositions.
   ///
   /// FIXME: Perhaps this should be an option in PrintOptions instead.
-  Type eraseArchetypes(ModuleDecl *M, Type type, GenericSignature *genericSig) {
+  Type eraseArchetypes(Type type, GenericSignature *genericSig) {
     if (!genericSig)
       return type;
 
@@ -1944,20 +1943,20 @@ public:
       SmallVector<Type, 2> types;
       for (auto proto : protos)
         types.push_back(proto->getDeclaredInterfaceType());
-      return ProtocolCompositionType::get(M->getASTContext(), types,
+      return ProtocolCompositionType::get(Ctx, types,
                                           /*HasExplicitAnyObject=*/false);
     };
 
     if (auto *genericFuncType = type->getAs<GenericFunctionType>()) {
       SmallVector<AnyFunctionType::Param, 8> erasedParams;
       for (const auto &param : genericFuncType->getParams()) {
-        auto erasedTy = eraseArchetypes(M, param.getPlainType(), genericSig);
+        auto erasedTy = eraseArchetypes(param.getPlainType(), genericSig);
         erasedParams.emplace_back(erasedTy, param.getLabel(),
                                   param.getParameterFlags());
       }
       return GenericFunctionType::get(genericSig,
           erasedParams,
-          eraseArchetypes(M, genericFuncType->getResult(), genericSig),
+          eraseArchetypes(genericFuncType->getResult(), genericSig),
           genericFuncType->getExtInfo());
     }
 
@@ -1996,7 +1995,6 @@ public:
   }
 
   Type getTypeOfMember(const ValueDecl *VD, Type ExprType) {
-    auto *M = CurrDeclContext->getParentModule();
     auto *GenericSig = VD->getInnermostDeclContext()
         ->getGenericSignatureOfContext();
 
@@ -2037,7 +2035,7 @@ public:
           return T;
 
         // For everything else, substitute in the base type.
-        auto Subs = MaybeNominalType->getMemberSubstitutionMap(M, VD);
+        auto Subs = MaybeNominalType->getMemberSubstitutionMap(CurrModule, VD);
 
         // Pass in DesugarMemberTypes so that we see the actual
         // concrete type witnesses instead of type alias types.
@@ -2047,7 +2045,7 @@ public:
       }
     }
 
-    return eraseArchetypes(M, T, GenericSig);
+    return eraseArchetypes(T, GenericSig);
   }
 
   Type getAssociatedTypeType(const AssociatedTypeDecl *ATD) {
@@ -2307,7 +2305,7 @@ public:
 
     if (calleeDC->isLocalContext())
       return SemanticContextKind::Local;
-    if (calleeDC->getParentModule() == CurrDeclContext->getParentModule())
+    if (calleeDC->getParentModule() == CurrModule)
       return SemanticContextKind::CurrentModule;
 
     return SemanticContextKind::OtherModule;
@@ -2318,8 +2316,7 @@ public:
     foundFunction(AFT);
     auto genericSig =
         SD->getInnermostDeclContext()->getGenericSignatureOfContext();
-    AFT = eraseArchetypes(CurrDeclContext->getParentModule(),
-                          const_cast<AnyFunctionType *>(AFT), genericSig)
+    AFT = eraseArchetypes(const_cast<AnyFunctionType *>(AFT), genericSig)
               ->castTo<AnyFunctionType>();
 
     CommandWordsPairs Pairs;
@@ -2349,8 +2346,7 @@ public:
     if (AFD) {
       auto genericSig =
           AFD->getInnermostDeclContext()->getGenericSignatureOfContext();
-      AFT = eraseArchetypes(CurrDeclContext->getParentModule(),
-                            const_cast<AnyFunctionType *>(AFT), genericSig)
+      AFT = eraseArchetypes(const_cast<AnyFunctionType *>(AFT), genericSig)
                 ->castTo<AnyFunctionType>();
     }
 
@@ -3173,7 +3169,7 @@ public:
   bool tryModuleCompletions(Type ExprType) {
     if (auto MT = ExprType->getAs<ModuleType>()) {
       ModuleDecl *M = MT->getModule();
-      if (CurrDeclContext->getParentModule() != M) {
+      if (CurrModule != M) {
         // Only use the cache if it is not the current module.
         RequestedCachedResults.push_back(
           RequestedResultsTy::fromModule(M).needLeadingDot(needDot()));
@@ -3721,7 +3717,7 @@ public:
       if (auto NT = T->getAs<NominalType>()) {
         if (auto NTD = NT->getDecl()) {
           if (!isa<ProtocolDecl>(NTD) &&
-              NTD->getModuleContext() != CurrDeclContext->getParentModule()) {
+              NTD->getModuleContext() != CurrModule) {
             addNominalTypeRef(NT->getDecl(),
                               DeclVisibilityKind::VisibleAtTopLevel, {});
           }
@@ -3782,7 +3778,6 @@ public:
     if (!T->mayHaveMembers())
       return;
 
-    ModuleDecl *CurrModule = CurrDeclContext->getParentModule();
     DeclContext *DC = const_cast<DeclContext *>(CurrDeclContext);
 
     // We can only say .foo where foo is a static member of the contextual
@@ -3925,10 +3920,8 @@ public:
   void collectPrecedenceGroups() {
     assert(CurrDeclContext);
 
-    auto M = CurrDeclContext->getParentModule();
-
-    if (M) {
-      for (auto FU: M->getFiles()) {
+    if (CurrModule) {
+      for (auto FU: CurrModule->getFiles()) {
         // We are looking through the current module,
         // inspect only source files.
         if (FU->getKind() != FileUnitKind::Source)
@@ -3944,7 +3937,7 @@ public:
     CurrDeclContext->getParentSourceFile()
       ->forAllVisibleModules([&](ModuleDecl::ImportedModule Import) {
       auto Module = Import.second;
-      if (Module == M)
+      if (Module == CurrModule)
         return;
 
       RequestedCachedResults.push_back(
@@ -3998,9 +3991,9 @@ public:
     Kind = OnlyTypes ? LookupKind::TypeInDeclContext
                      : LookupKind::ValueInDeclContext;
     NeedLeadingDot = false;
-    ModuleDecl *M = CurrDeclContext->getParentModule();
     AccessFilteringDeclConsumer FilteringConsumer(CurrDeclContext, *this);
-    M->lookupVisibleDecls({}, FilteringConsumer, NLKind::UnqualifiedLookup);
+    CurrModule->lookupVisibleDecls({}, FilteringConsumer,
+                                   NLKind::UnqualifiedLookup);
   }
 
   void getVisibleDeclsOfModule(const ModuleDecl *TheModule,

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -128,10 +128,10 @@ typealias FooTypealias = Int
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:    Int32[#Int32#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:    Int64[#Int64#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]:      Bool[#Bool#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 // COMMON: End completions
 
 // NO_SELF-NOT: {{[[:<:]][Ss]elf[[:>:]]}}

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -191,10 +191,10 @@
 // KW_DECL_STMT-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // Literals
 //
@@ -211,10 +211,10 @@
 // KW_EXPR-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#function]/None: #function[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#file]/None: #file[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#line]/None: #line[#Int#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // let and var
 //

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -93,6 +93,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SWITCH_TOP | %FileCheck %s -check-prefix=KW_CASE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SWITCH_IN_CASE | %FileCheck %s -check-prefix=KW_CASE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_UINT32 | %FileCheck %s -check-prefix=CONTEXT_UINT32
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_STATICSTRING | %FileCheck %s -check-prefix=CONTEXT_STATICSTRING
+
 // KW_RETURN: Keyword[return]/None: return{{; name=.+$}}
 // KW_NO_RETURN-NOT: Keyword[return]
 
@@ -412,8 +415,27 @@ func inSwitch(val: Int) {
     foo()
   #^SWITCH_IN_CASE^#
   }
-// Begin completions
+// KW_CASE: Begin completions
 // KW_CASE-DAG: Keyword[case]/None:                 case; name=case
 // KW_CASE-DAG: Keyword[default]/None:              default; name=default
-// End completions
+// KW_CASE: End completions
+}
+func testContextualType() {
+  let _: UInt32 = #^CONTEXT_UINT32^#
+// CONTEXT_UINT32: Begin completions
+// CONTEXT_UINT32-DAG: Keyword[#function]/None:            #function[#String#]; name=#function
+// CONTEXT_UINT32-DAG: Keyword[#file]/None:                #file[#String#]; name=#file
+// CONTEXT_UINT32-DAG: Keyword[#line]/None/TypeRelation[Identical]: #line[#UInt32#]; name=#line
+// CONTEXT_UINT32-DAG: Keyword[#column]/None/TypeRelation[Identical]: #column[#UInt32#]; name=#column
+// CONTEXT_UINT32-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
+// CONTEXT_UINT32: End completions
+
+  let _: StaticString = #^CONTEXT_STATICSTRING^#
+// CONTEXT_STATICSTRING: Begin completions
+// CONTEXT_STATICSTRING-DAG: Keyword[#function]/None/TypeRelation[Identical]: #function[#StaticString#]; name=#function
+// CONTEXT_STATICSTRING-DAG: Keyword[#file]/None/TypeRelation[Identical]: #file[#StaticString#]; name=#file
+// CONTEXT_STATICSTRING-DAG: Keyword[#line]/None:                #line[#Int#]; name=#line
+// CONTEXT_STATICSTRING-DAG: Keyword[#column]/None:              #column[#Int#]; name=#column
+// CONTEXT_STATICSTRING-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
+// CONTEXT_STATICSTRING: End completions
 }

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -7,8 +7,13 @@ func test1() {
   _ = use(##^POUND_EXPR_1^#)
 }
 
-// POUND_EXPR_STRINGCONTEXT: Begin completions, 2 items
+// POUND_EXPR_STRINGCONTEXT: Begin completions, 7 items
 // POUND_EXPR_STRINGCONTEXT-NOT: available
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: selector({#@objc method#}); name=selector(@objc method)
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: keyPath({#@objc property sequence#}); name=keyPath(@objc property sequence)
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               selector({#@objc method#});
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               keyPath({#@objc property sequence#});
 // POUND_EXPR_STRINGCONTEXT: End completions

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -1,19 +1,42 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_1 | %FileCheck %s -check-prefix=POUND_EXPR_STRINGCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_1 | %FileCheck %s -check-prefix=POUND_EXPR_INTCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_2 | %FileCheck %s -check-prefix=POUND_EXPR_STRINGCONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_3 | %FileCheck %s -check-prefix=POUND_EXPR_SELECTORCONTEXT
 // REQUIRES: objc_interop
 
-func use(_ str: String) -> Bool {}
+import ObjectiveC
+
+func useInt(_ str: Int) -> Bool {}
+func useString(_ str: String) -> Bool {}
+func useSelector(_ sel: Selector) -> Bool {}
 
 func test1() {
-  _ = use(##^POUND_EXPR_1^#)
+  let _ = useInt(##^POUND_EXPR_1^#)
+  let _ = useString(##^POUND_EXPR_2^#)
+  let _ = useSelector(##^POUND_EXPR_3^#)
 }
 
-// POUND_EXPR_STRINGCONTEXT: Begin completions, 7 items
-// POUND_EXPR_STRINGCONTEXT-NOT: available
+// POUND_EXPR_INTCONTEXT: Begin completions, 5 items
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#function]/None:            function[#String#]; name=function
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#file]/None:                file[#String#]; name=file
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#line]/None/TypeRelation[Identical]: line[#Int#]; name=line
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#column]/None/TypeRelation[Identical]: column[#Int#]; name=column
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#]; name=dsohandle
+// POUND_EXPR_INTCONTEXT: End completions
+
+// POUND_EXPR_STRINGCONTEXT: Begin completions, 6 items
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               selector({#@objc method#});
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific:               keyPath({#@objc property sequence#});
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: keyPath({#@objc property sequence#})[#String#];
 // POUND_EXPR_STRINGCONTEXT: End completions
+
+// POUND_EXPR_SELECTORCONTEXT: Begin completions, 6 items
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: selector({#@objc method#})[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT: End completions

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -34,9 +34,9 @@ func completeInKeyPath2() {
   _ = #keyPath(ObjCClass.#^IN_KEYPATH_2^#
 }
 
-// CHECK-AFTER_POUND: Keyword/ExprSpecific:               keyPath({#@objc property sequence#}); name=keyPath(@objc property sequence)
+// CHECK-AFTER_POUND-NOT: keyPath
 
-// CHECK-KEYPATH_ARG: Keyword/None:                       #keyPath({#@objc property sequence#}); name=#keyPath(@objc property sequence)
+// CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Identical]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath(@objc property sequence)
 
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2

--- a/test/IDE/complete_pound_selector.swift
+++ b/test/IDE/complete_pound_selector.swift
@@ -71,10 +71,10 @@ class Subclass : NSObject {
 }
 
 
+// CHECK-AFTER_POUND-NOT: selector
 // CHECK-AFTER_POUND: Keyword/ExprSpecific:               available({#Platform...#}, *); name=available(Platform..., *)
-// CHECK-AFTER_POUND: Keyword/ExprSpecific:               selector({#@objc method#}); name=selector(@objc method)
 
-// CHECK-CONTEXT_SELECTOR: Keyword/None:                  #selector({#@objc method#}); name=#selector(@objc method)
+// CHECK-CONTEXT_SELECTOR: Keyword/None/TypeRelation[Identical]: #selector({#@objc method#})[#Selector#]; name=#selector(@objc method)
 
 // CHECK-SELECTOR_BASIC: Keyword/None:                       getter: {#@objc property#}; name=getter: @objc property
 // CHECK-SELECTOR_BASIC: Keyword/None:                       setter: {#@objc property#}; name=setter: @objc property


### PR DESCRIPTION
Cherry-pick of #24969 to `swift-5.1-branch` reviewed by @benlangmuir 

rdar://problem/47169238