### PR TITLE
[CodeCompletion] Context type analysis for default argument initializer

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -713,6 +713,31 @@ class ExprContextAnalyzer {
     }
   }
 
+  void analyzeInitializer(Initializer *initDC) {
+    switch (initDC->getInitializerKind()) {
+    case swift::InitializerKind::PatternBinding: {
+      auto initDC = cast<PatternBindingInitializer>(DC);
+      auto PBD = initDC->getBinding();
+      if (!PBD)
+        break;
+      auto pat = PBD->getPattern(initDC->getBindingIndex());
+      if (pat->hasType())
+        recordPossibleType(pat->getType());
+      break;
+    }
+    case InitializerKind::DefaultArgument: {
+      auto initDC = cast<DefaultArgumentInitializer>(DC);
+      auto AFD = dyn_cast<AbstractFunctionDecl>(initDC->getParent());
+      if (!AFD)
+        return;
+      auto param = AFD->getParameters()->get(initDC->getIndex());
+      if (param->hasInterfaceType())
+        recordPossibleType(AFD->mapTypeIntoContext(param->getInterfaceType()));
+      break;
+    }
+    }
+  }
+
   /// Whether the given \c BraceStmt, which must be the body of a function or
   /// closure, should be treated as a single-expression return for the purposes
   /// of code-completion.
@@ -808,13 +833,17 @@ public:
         return false;
     });
 
-    // For 'Initializer' context, we need to look into its parent because it
-    // might constrain the initializer's type.
+    // For 'Initializer' context, we need to look into its parent.
     auto analyzeDC = isa<Initializer>(DC) ? DC->getParent() : DC;
     analyzeDC->walkContext(Finder);
 
-    if (Finder.Ancestors.empty())
+    if (Finder.Ancestors.empty()) {
+      // There's no parent context in DC. But still, the parent of the
+      // initializer might constrain the initializer's type.
+      if (auto initDC = dyn_cast<Initializer>(DC))
+        analyzeInitializer(initDC);
       return;
+    }
 
     auto &P = Finder.Ancestors.back();
     if (auto Parent = P.getAsExpr()) {

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -18,9 +18,9 @@
 // RUN: %FileCheck %s -check-prefix=NEGATIVE_DEFAULT_ARGS_9 < %t
 //
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_1 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_2 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_2 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT_INTCONTEXT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_3 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_4 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_4 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT_INTCONTEXT
 
 func freeFuncWithDefaultArgs1(
     _ a: Int, b: Int = 42, file: String = #file, line: Int = #line,
@@ -140,3 +140,7 @@ func testDefaultArgInit4(_ x: Int = #^DEFAULT_ARG_INIT_4^#) { }
 // DEFAULT_ARG_INIT: Begin completions
 // DEFAULT_ARG_INIT: Decl[GlobalVar]/CurrModule:         globalVar[#Int#]{{; name=.+$}}
 // DEFAULT_ARG_INIT: End completions
+
+// DEFAULT_ARG_INIT_INTCONTEXT: Begin completions
+// DEFAULT_ARG_INIT_INTCONTEXT: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: globalVar[#Int#]{{; name=.+$}}
+// DEFAULT_ARG_INIT_INTCONTEXT: End completions

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -103,6 +103,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERICPARAM_21 | %FileCheck %s -check-prefix=GENERICPARAM_1
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DECL_MEMBER_INIT_1 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_1 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_2 | %FileCheck %s -check-prefix=UNRESOLVED_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 enum SomeEnum1 {
   case South
@@ -682,4 +685,10 @@ func testingGenericParam2<X>(obj: C<X>) {
 
 struct TestingStruct {
   var value: SomeEnum1 = .#^DECL_MEMBER_INIT_1^#
+}
+
+func testDefaultArgument(arg: SomeEnum1 = .#^DEFAULT_ARG_1^#) {}
+class TestDefalutArg {
+  func method(arg: SomeEnum1 = .#^DEFAULT_ARG_2^#) {}
+  init(arg: SomeEnum1 = .#^DEFAULT_ARG_3^#) {}
 }


### PR DESCRIPTION
This enables implicit member expression completion at default argument initializer position. e.g.

```swift
func foo(val: MyEnum = .<HERE>) {
```
rdar://problem/51037538