### PR TITLE
[5.1][Diagnostics] Assignment diagnostic improvements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -451,6 +451,13 @@ ERROR(cannot_convert_assign_protocol,none,
 ERROR(cannot_convert_assign_nil,none,
       "'nil' cannot be assigned to type %0", (Type))
 
+// for ... in expression
+ERROR(cannot_convert_sequence_element_value,none,
+      "cannot convert sequence element type %0 to expected type %1",
+      (Type, Type))
+ERROR(cannot_convert_sequence_element_protocol,none,
+      "sequence element type %0 does not conform to expected type %1",
+      (Type, Type))
 
 ERROR(throws_functiontype_mismatch,none,
       "invalid conversion from throwing function of type %0 to "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -456,7 +456,7 @@ ERROR(cannot_convert_sequence_element_value,none,
       "cannot convert sequence element type %0 to expected type %1",
       (Type, Type))
 ERROR(cannot_convert_sequence_element_protocol,none,
-      "sequence element type %0 does not conform to expected type %1",
+      "sequence element type %0 does not conform to expected protocol %1",
       (Type, Type))
 
 ERROR(throws_functiontype_mismatch,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2378,8 +2378,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
 
   // When complaining about conversion to a protocol type, complain about
   // conformance instead of "conversion".
-  if (contextualType->is<ProtocolType>() ||
-      contextualType->is<ProtocolCompositionType>()) {
+  if (contextualType->isExistentialType()) {
     MissingContextualConformanceFailure failure(
         expr, CS, CTP, exprType, contextualType,
         CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2128,7 +2128,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   // system had a contextual type specified, we use it - it will have a purpose
   // indicator which allows us to give a very "to the point" diagnostic.
   Diag<Type, Type> diagID;
-  Diag<Type, Type> diagIDProtocol;
   Diag<Type> nilDiag;
   std::function<void(void)> nilFollowup;
 
@@ -2145,7 +2144,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
                      "contextual type");
   case CTP_Initialization:
     diagID = diag::cannot_convert_initializer_value;
-    diagIDProtocol = diag::cannot_convert_initializer_value_protocol;
     nilDiag = diag::cannot_convert_initializer_value_nil;
     nilFollowup = [this] {
       TypeRepr *patternTR = CS.getContextualTypeLoc().getTypeRepr();
@@ -2171,7 +2169,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     }
 
     diagID = diag::cannot_convert_to_return_type;
-    diagIDProtocol = diag::cannot_convert_to_return_type_protocol;
     nilDiag = diag::cannot_convert_to_return_type_nil;
     break;
   case CTP_ThrowStmt: {
@@ -2219,12 +2216,10 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
 
   case CTP_EnumCaseRawValue:
     diagID = diag::cannot_convert_raw_initializer_value;
-    diagIDProtocol = diag::cannot_convert_raw_initializer_value;
     nilDiag = diag::cannot_convert_raw_initializer_value_nil;
     break;
   case CTP_DefaultParameter:
     diagID = diag::cannot_convert_default_arg_value;
-    diagIDProtocol = diag::cannot_convert_default_arg_value_protocol;
     nilDiag = diag::cannot_convert_default_arg_value_nil;
     break;
 
@@ -2244,42 +2239,34 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     return true;
   case CTP_YieldByValue:
     diagID = diag::cannot_convert_yield_value;
-    diagIDProtocol = diag::cannot_convert_yield_value_protocol;
     nilDiag = diag::cannot_convert_yield_value_nil;
     break;
   case CTP_CallArgument:
     diagID = diag::cannot_convert_argument_value;
-    diagIDProtocol = diag::cannot_convert_argument_value_protocol;
     nilDiag = diag::cannot_convert_argument_value_nil;
     break;
   case CTP_ClosureResult:
     diagID = diag::cannot_convert_closure_result;
-    diagIDProtocol = diag::cannot_convert_closure_result_protocol;
     nilDiag = diag::cannot_convert_closure_result_nil;
     break;
   case CTP_ArrayElement:
     diagID = diag::cannot_convert_array_element;
-    diagIDProtocol = diag::cannot_convert_array_element_protocol;
     nilDiag = diag::cannot_convert_array_element_nil;
     break;
   case CTP_DictionaryKey:
     diagID = diag::cannot_convert_dict_key;
-    diagIDProtocol = diag::cannot_convert_dict_key_protocol;
     nilDiag = diag::cannot_convert_dict_key_nil;
     break;
   case CTP_DictionaryValue:
     diagID = diag::cannot_convert_dict_value;
-    diagIDProtocol = diag::cannot_convert_dict_value_protocol;
     nilDiag = diag::cannot_convert_dict_value_nil;
     break;
   case CTP_CoerceOperand:
     diagID = diag::cannot_convert_coerce;
-    diagIDProtocol = diag::cannot_convert_coerce_protocol;
     nilDiag = diag::cannot_convert_coerce_nil;
     break;
   case CTP_AssignSource:
     diagID = diag::cannot_convert_assign;
-    diagIDProtocol = diag::cannot_convert_assign_protocol;
     nilDiag = diag::cannot_convert_assign_nil;
     break;
   }
@@ -2392,9 +2379,13 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   // When complaining about conversion to a protocol type, complain about
   // conformance instead of "conversion".
   if (contextualType->is<ProtocolType>() ||
-      contextualType->is<ProtocolCompositionType>())
-    diagID = diagIDProtocol;
-  
+      contextualType->is<ProtocolCompositionType>()) {
+    MissingContextualConformanceFailure failure(
+        expr, CS, CTP, exprType, contextualType,
+        CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));
+    return failure.diagnoseAsError();
+  }
+
   // Try to simplify irrelevant details of function types.  For example, if
   // someone passes a "() -> Float" function to a "() throws -> Int"
   // parameter, then uttering the "throws" may confuse them into thinking that

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2766,6 +2766,7 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
 
 bool CollectionElementContextualFailure::diagnoseAsError() {
   auto *anchor = getAnchor();
+  auto *locator = getLocator();
 
   auto eltType = getFromType();
   auto contextualType = getToType();
@@ -2778,8 +2779,7 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
   }
 
   if (isa<DictionaryExpr>(getRawAnchor())) {
-    auto *locator = getLocator();
-    const auto eltLoc = locator->getPath().back();
+    const auto &eltLoc = locator->getPath().back();
 
     switch (eltLoc.getValue()) {
     case 0: // key
@@ -2797,6 +2797,15 @@ bool CollectionElementContextualFailure::diagnoseAsError() {
     default:
       break;
     }
+  }
+
+  if (locator->isForSequenceElementType()) {
+    diagnostic.emplace(
+        emitDiagnostic(anchor->getLoc(),
+                       contextualType->isExistentialType()
+                           ? diag::cannot_convert_sequence_element_protocol
+                           : diag::cannot_convert_sequence_element_value,
+                       eltType, contextualType));
   }
 
   if (!diagnostic)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2763,3 +2763,46 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
   emitDiagnostic(anchor->getLoc(), diag::cannot_return_value_from_void_func);
   return true;
 }
+
+bool CollectionElementContextualFailure::diagnoseAsError() {
+  auto *anchor = getAnchor();
+
+  auto eltType = getFromType();
+  auto contextualType = getToType();
+
+  Optional<InFlightDiagnostic> diagnostic;
+  if (isa<ArrayExpr>(getRawAnchor())) {
+    diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
+                                      diag::cannot_convert_array_element,
+                                      eltType, contextualType));
+  }
+
+  if (isa<DictionaryExpr>(getRawAnchor())) {
+    auto *locator = getLocator();
+    const auto eltLoc = locator->getPath().back();
+
+    switch (eltLoc.getValue()) {
+    case 0: // key
+      diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
+                                        diag::cannot_convert_dict_key, eltType,
+                                        contextualType));
+      break;
+
+    case 1: // value
+      diagnostic.emplace(emitDiagnostic(anchor->getLoc(),
+                                        diag::cannot_convert_dict_value,
+                                        eltType, contextualType));
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  if (!diagnostic)
+    return false;
+
+  (void)trySequenceSubsequenceFixIts(*diagnostic, getConstraintSystem(),
+                                     eltType, contextualType, anchor);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2831,10 +2831,28 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
       assert(Context != CTP_Unused);
       diagnostic = getDiagnosticFor(Context);
       break;
+
+    default:
+      break;
     }
   }
 
-  emitDiagnostic(anchor->getLoc(), *diagnostic, getFromType(), getToType());
+  if (!diagnostic)
+    return false;
+
+  auto srcType = getFromType();
+  auto dstType = getToType();
+
+  emitDiagnostic(anchor->getLoc(), *diagnostic, srcType, dstType);
+
+  if (isa<InOutExpr>(anchor))
+    return true;
+
+  if (srcType->isAny() && dstType->isAnyObject()) {
+    emitDiagnostic(anchor->getLoc(), diag::any_as_anyobject_fixit)
+        .fixItInsertAfter(anchor->getEndLoc(), " as AnyObject");
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2832,6 +2832,11 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
       diagnostic = getDiagnosticFor(Context);
       break;
 
+    case ConstraintLocator::SequenceElementType: {
+      diagnostic = diag::cannot_convert_sequence_element_protocol;
+      break;
+    }
+
     default:
       break;
     }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1202,6 +1202,27 @@ public:
   bool diagnoseAsError() override;
 };
 
+class MissingContextualConformanceFailure final : public ContextualFailure {
+  ContextualTypePurpose Context;
+
+public:
+  MissingContextualConformanceFailure(Expr *root, ConstraintSystem &cs,
+                                      ContextualTypePurpose context, Type type,
+                                      Type protocolType,
+                                      ConstraintLocator *locator)
+      : ContextualFailure(root, cs, type, protocolType, locator),
+        Context(context) {
+    assert(protocolType->is<ProtocolType>() ||
+           protocolType->is<ProtocolCompositionType>());
+  }
+
+  bool diagnoseAsError() override;
+
+private:
+  static Optional<Diag<Type, Type>>
+  getDiagnosticFor(ContextualTypePurpose purpose);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -324,14 +324,15 @@ private:
 /// ```
 class MissingConformanceFailure final : public RequirementFailure {
   Type NonConformingType;
-  ProtocolDecl *Protocol;
+  Type ProtocolType;
 
 public:
   MissingConformanceFailure(Expr *expr, ConstraintSystem &cs,
                             ConstraintLocator *locator,
-                            std::pair<Type, ProtocolDecl *> conformance)
+                            std::pair<Type, Type> conformance)
       : RequirementFailure(cs, expr, RequirementKind::Conformance, locator),
-        NonConformingType(conformance.first), Protocol(conformance.second) {}
+        NonConformingType(conformance.first), ProtocolType(conformance.second) {
+  }
 
   bool diagnoseAsError() override;
 
@@ -341,7 +342,7 @@ private:
   Type getLHS() const override { return NonConformingType; }
 
   /// The protocol generic requirement expected associated type to conform to.
-  Type getRHS() const override { return Protocol->getDeclaredType(); }
+  Type getRHS() const override { return ProtocolType; }
 
 protected:
   DiagOnDecl getDiagnosticOnDecl() const override {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -667,7 +667,7 @@ private:
 
 /// Intended to diagnose any possible contextual failure
 /// e.g. argument/parameter, closure result, conversions etc.
-class ContextualFailure final : public FailureDiagnostic {
+class ContextualFailure : public FailureDiagnostic {
   Type FromType, ToType;
 
 public:
@@ -675,6 +675,10 @@ public:
                     ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator), FromType(resolve(lhs)),
         ToType(resolve(rhs)) {}
+
+  Type getFromType() const { return resolveType(FromType); }
+
+  Type getToType() const { return resolveType(ToType); }
 
   bool diagnoseAsError() override;
 
@@ -1176,6 +1180,23 @@ public:
   ExtraneousReturnFailure(Expr *root, ConstraintSystem &cs,
                           ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
+/// Diagnose a contextual mismatch between expected collection element type
+/// and the one provided (e.g. source of the assignment or argument to a call)
+/// e.g.:
+///
+/// ```swift
+/// let _: [Int] = ["hello"]
+/// ```
+class CollectionElementContextualFailure final : public ContextualFailure {
+public:
+  CollectionElementContextualFailure(Expr *root, ConstraintSystem &cs,
+                                     Type eltType, Type contextualType,
+                                     ConstraintLocator *locator)
+      : ContextualFailure(root, cs, eltType, contextualType, locator) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -506,3 +506,18 @@ RemoveReturn *RemoveReturn::create(ConstraintSystem &cs,
                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) RemoveReturn(cs, locator);
 }
+
+bool CollectionElementContextualMismatch::diagnose(Expr *root,
+                                                   bool asNote) const {
+  CollectionElementContextualFailure failure(
+      root, getConstraintSystem(), getFromType(), getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+CollectionElementContextualMismatch *
+CollectionElementContextualMismatch::create(ConstraintSystem &cs, Type srcType,
+                                            Type dstType,
+                                            ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      CollectionElementContextualMismatch(cs, srcType, dstType, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -161,15 +161,15 @@ RelabelArguments::create(ConstraintSystem &cs,
 
 bool MissingConformance::diagnose(Expr *root, bool asNote) const {
   MissingConformanceFailure failure(root, getConstraintSystem(), getLocator(),
-                                    {NonConformingType, Protocol});
+                                    {NonConformingType, ProtocolType});
   return failure.diagnose(asNote);
 }
 
 MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
-                                               ProtocolDecl *protocol,
+                                               Type protocolType,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      MissingConformance(cs, type, protocol, locator);
+      MissingConformance(cs, type, protocolType, locator);
 }
 
 bool SkipSameTypeRequirement::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -890,6 +890,23 @@ public:
   static RemoveReturn *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
 
+class CollectionElementContextualMismatch final : public ContextualMismatch {
+  CollectionElementContextualMismatch(ConstraintSystem &cs, Type srcType,
+                                      Type dstType, ConstraintLocator *locator)
+      : ContextualMismatch(cs, srcType, dstType, locator) {}
+
+public:
+  std::string getName() const override {
+    return "fix collection element contextual mismatch";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static CollectionElementContextualMismatch *
+  create(ConstraintSystem &cs, Type srcType, Type dstType,
+         ConstraintLocator *locator);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -364,12 +364,13 @@ private:
 /// Add a new conformance to the type to satisfy a requirement.
 class MissingConformance final : public ConstraintFix {
   Type NonConformingType;
-  ProtocolDecl *Protocol;
+  // This could either be a protocol or protocol composition.
+  Type ProtocolType;
 
-  MissingConformance(ConstraintSystem &cs, Type type, ProtocolDecl *protocol,
+  MissingConformance(ConstraintSystem &cs, Type type, Type protocolType,
                      ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AddConformance, locator),
-        NonConformingType(type), Protocol(protocol) {}
+        NonConformingType(type), ProtocolType(protocolType) {}
 
 public:
   std::string getName() const override {
@@ -379,12 +380,12 @@ public:
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static MissingConformance *create(ConstraintSystem &cs, Type type,
-                                    ProtocolDecl *protocol,
+                                    Type protocolType,
                                     ConstraintLocator *locator);
 
   Type getNonConformingType() { return NonConformingType; }
 
-  ProtocolDecl *getProtocol() { return Protocol; }
+  Type getProtocolType() { return ProtocolType; }
 };
 
 /// Skip same-type generic requirement constraint,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -363,14 +363,19 @@ private:
 
 /// Add a new conformance to the type to satisfy a requirement.
 class MissingConformance final : public ConstraintFix {
+  // Determines whether given protocol type comes from the context e.g.
+  // assignment destination or argument comparison.
+  bool IsContextual;
+
   Type NonConformingType;
   // This could either be a protocol or protocol composition.
   Type ProtocolType;
 
-  MissingConformance(ConstraintSystem &cs, Type type, Type protocolType,
-                     ConstraintLocator *locator)
+  MissingConformance(ConstraintSystem &cs, bool isContextual, Type type,
+                     Type protocolType, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AddConformance, locator),
-        NonConformingType(type), ProtocolType(protocolType) {}
+        IsContextual(isContextual), NonConformingType(type),
+        ProtocolType(protocolType) {}
 
 public:
   std::string getName() const override {
@@ -379,9 +384,13 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static MissingConformance *create(ConstraintSystem &cs, Type type,
-                                    Type protocolType,
-                                    ConstraintLocator *locator);
+  static MissingConformance *forRequirement(ConstraintSystem &cs, Type type,
+                                            Type protocolType,
+                                            ConstraintLocator *locator);
+
+  static MissingConformance *forContextual(ConstraintSystem &cs, Type type,
+                                           Type protocolType,
+                                           ConstraintLocator *locator);
 
   Type getNonConformingType() { return NonConformingType; }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2148,6 +2148,14 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::TupleElement: {
+    if (anchor && (isa<ArrayExpr>(anchor) || isa<DictionaryExpr>(anchor))) {
+      conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
+          *this, lhs, rhs, getConstraintLocator(locator)));
+    }
+    break;
+  }
+
   default:
     break;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3335,8 +3335,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Error;
       }
 
-      auto *fix = MissingConformance::create(*this, type, protocol,
-                                             getConstraintLocator(locator));
+      auto *fix =
+          MissingConformance::create(*this, type, protocol->getDeclaredType(),
+                                     getConstraintLocator(locator));
       if (!recordFix(fix))
         return SolutionKind::Solved;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2003,6 +2003,19 @@ bool ConstraintSystem::repairFailures(
     return false;
   };
 
+  auto repairByAddingConformance = [&](Type lhs, Type rhs) -> bool {
+    if (lhs->isTypeVariableOrMember())
+      return false;
+
+    if (rhs->isAny() ||
+        !(rhs->is<ProtocolType>() || rhs->is<ProtocolCompositionType>()))
+      return false;
+
+    conversionsOrFixes.push_back(MissingConformance::forContextual(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+    return true;
+  };
+
   if (path.empty()) {
     if (!anchor)
       return false;
@@ -2020,6 +2033,9 @@ bool ConstraintSystem::repairFailures(
 
     if (auto *AE = dyn_cast<AssignExpr>(anchor)) {
       if (repairByInsertingExplicitCall(lhs, rhs))
+        return true;
+
+      if (repairByAddingConformance(lhs, rhs))
         return true;
 
       if (isa<InOutExpr>(AE->getSrc())) {
@@ -2111,6 +2127,9 @@ bool ConstraintSystem::repairFailures(
     }
 
     if (repairByInsertingExplicitCall(lhs, rhs))
+      return true;
+
+    if (repairByAddingConformance(lhs, rhs))
       return true;
 
     // If both types are key path, the only differences
@@ -3335,9 +3354,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Error;
       }
 
-      auto *fix =
-          MissingConformance::create(*this, type, protocol->getDeclaredType(),
-                                     getConstraintLocator(locator));
+      auto *fix = MissingConformance::forRequirement(
+          *this, type, protocol->getDeclaredType(),
+          getConstraintLocator(locator));
       if (!recordFix(fix))
         return SolutionKind::Solved;
     }
@@ -6552,6 +6571,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
 
   case FixKind::InsertCall:
   case FixKind::RemoveReturn:
+  case FixKind::AddConformance:
   case FixKind::RemoveAddressOf:
   case FixKind::SkipSameTypeRequirement:
   case FixKind::SkipSuperclassRequirement:
@@ -6564,7 +6584,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::ExplicitlyEscaping:
   case FixKind::CoerceToCheckedCast:
   case FixKind::RelabelArguments:
-  case FixKind::AddConformance:
   case FixKind::RemoveUnwrap:
   case FixKind::DefineMemberBasedOnUse:
   case FixKind::AllowTypeOrInstanceMember:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2156,6 +2156,12 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::SequenceElementType: {
+    conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
+        *this, lhs, rhs, getConstraintLocator(locator)));
+    break;
+  }
+
   default:
     break;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1731,8 +1731,28 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
       case SolutionKind::Unsolved:
         break;
 
-      case SolutionKind::Error:
-        return getTypeMatchFailure(locator);
+      case SolutionKind::Error: {
+        if (!shouldAttemptFixes())
+          return getTypeMatchFailure(locator);
+
+        if (auto last = locator.last()) {
+          // TODO(diagnostics): Diagnosing missing conformances
+          // associated with arguments requires having general
+          // conversion failures implemented first, otherwise
+          // we would be misdiagnosing ambiguous cases associated
+          // with overloaded declarations.
+          if (last->getKind() == ConstraintLocator::ApplyArgToParam)
+            return getTypeMatchFailure(locator);
+        }
+
+        auto *fix = MissingConformance::forContextual(
+            *this, type1, proto, getConstraintLocator(locator));
+
+        if (recordFix(fix))
+          return getTypeMatchFailure(locator);
+
+        break;
+      }
     }
   }
 
@@ -2003,12 +2023,8 @@ bool ConstraintSystem::repairFailures(
     return false;
   };
 
-  auto repairByAddingConformance = [&](Type lhs, Type rhs) -> bool {
-    if (lhs->isTypeVariableOrMember())
-      return false;
-
-    if (rhs->isAny() ||
-        !(rhs->is<ProtocolType>() || rhs->is<ProtocolCompositionType>()))
+  auto repairByAnyToAnyObjectCast = [&](Type lhs, Type rhs) -> bool {
+    if (!(lhs->isAny() && rhs->isAnyObject()))
       return false;
 
     conversionsOrFixes.push_back(MissingConformance::forContextual(
@@ -2035,14 +2051,14 @@ bool ConstraintSystem::repairFailures(
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;
 
-      if (repairByAddingConformance(lhs, rhs))
-        return true;
-
       if (isa<InOutExpr>(AE->getSrc())) {
         conversionsOrFixes.push_back(
             RemoveAddressOf::create(*this, getConstraintLocator(locator)));
         return true;
       }
+
+      if (repairByAnyToAnyObjectCast(lhs, rhs))
+        return true;
     }
 
     return false;
@@ -2129,7 +2145,7 @@ bool ConstraintSystem::repairFailures(
     if (repairByInsertingExplicitCall(lhs, rhs))
       return true;
 
-    if (repairByAddingConformance(lhs, rhs))
+    if (repairByAnyToAnyObjectCast(lhs, rhs))
       return true;
 
     // If both types are key path, the only differences

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2192,6 +2192,11 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::SequenceElementType: {
+    // This is going to be diagnosed as `missing conformance`,
+    // so no need to create duplicate fixes.
+    if (rhs->isExistentialType())
+      break;
+
     conversionsOrFixes.push_back(CollectionElementContextualMismatch::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
     break;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -64,8 +64,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case ClosureResult:
     case ParentType:
     case InstanceType:
-    case SequenceIteratorProtocol:
-    case GeneratorElementType:
+    case SequenceElementType:
     case AutoclosureResult:
     case GenericArgument:
     case NamedTupleElement:
@@ -256,8 +255,8 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       out << "function result";
       break;
 
-    case GeneratorElementType:
-      out << "generator element type";
+    case SequenceElementType:
+      out << "sequence element type";
       break;
 
     case GenericArgument:
@@ -298,10 +297,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case RValueAdjustment:
       out << "rvalue adjustment";
-      break;
-
-    case SequenceIteratorProtocol:
-      out << "sequence iterator type";
       break;
 
     case SubscriptMember:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -174,6 +174,12 @@ bool ConstraintLocator::isForGenericParameter() const {
          path.back().getKind() == ConstraintLocator::GenericParameter;
 }
 
+bool ConstraintLocator::isForSequenceElementType() const {
+  auto path = getPath();
+  return !path.empty() &&
+         path.back().getKind() == ConstraintLocator::SequenceElementType;
+}
+
 void ConstraintLocator::dump(SourceManager *sm) {
   dump(sm, llvm::errs());
   llvm::errs() << "\n";

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -98,10 +98,8 @@ public:
     ParentType,
     /// The instance of a metatype type.
     InstanceType,
-    /// The generic type of a sequence.
-    SequenceIteratorProtocol,
-    /// The element type of a generator.
-    GeneratorElementType,
+    /// The element type of a sequence in a for ... in ... loop.
+    SequenceElementType,
     /// An argument passed in an autoclosure parameter
     /// position, which must match the autoclosure return type.
     AutoclosureResult,
@@ -159,8 +157,7 @@ public:
     case ClosureResult:
     case ParentType:
     case InstanceType:
-    case SequenceIteratorProtocol:
-    case GeneratorElementType:
+    case SequenceElementType:
     case AutoclosureResult:
     case Requirement:
     case Witness:
@@ -208,8 +205,7 @@ public:
     case ApplyArgument:
     case ApplyFunction:
     case ApplyArgToParam:
-    case SequenceIteratorProtocol:
-    case GeneratorElementType:
+    case SequenceElementType:
     case ClosureResult:
     case ConstructorMember:
     case InstanceType:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -563,6 +563,10 @@ public:
   /// Determine whether this locator points to the generic parameter.
   bool isForGenericParameter() const;
 
+  /// Determine whether this locator points to the element type of a
+  /// sequence in a for ... in ... loop.
+  bool isForSequenceElementType() const;
+
   /// Produce a profile of this locator, for use in a folding set.
   static void Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
                       ArrayRef<PathElement> path);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2192,6 +2192,8 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
       // FIXME: It's kind of weird in general that we have to look
       // through lvalue, inout and IUO types here
       Type lookupBaseType = newBase->getWithoutSpecifierType();
+      if (auto selfType = lookupBaseType->getAs<DynamicSelfType>())
+        lookupBaseType = selfType->getSelfType();
 
       if (lookupBaseType->mayHaveMembers() ||
           lookupBaseType->is<DynamicSelfType>()) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2792,6 +2792,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         lookupOptions |= NameLookupFlags::KnownPrivate;
 
       auto sequenceType = cs.getType(expr)->getRValueType();
+      if (auto *selfType = sequenceType->getAs<DynamicSelfType>())
+        sequenceType = selfType->getSelfType();
 
       // Look through one level of optional; this improves recovery but doesn't
       // change the result.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2763,86 +2763,30 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         return true;
       }
 
+      auto elementAssocType =
+        cast<AssociatedTypeDecl>(
+          sequenceProto->lookupDirect(tc.Context.Id_Element).front());
+
       SequenceType = cs.createTypeVariable(Locator);
+
       cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
                        SequenceType, Locator);
       cs.addConstraint(ConstraintKind::ConformsTo, SequenceType,
                        sequenceProto->getDeclaredType(), Locator);
 
-      auto iteratorLocator =
-        cs.getConstraintLocator(Locator,
-                                ConstraintLocator::SequenceIteratorProtocol);
       auto elementLocator =
-        cs.getConstraintLocator(iteratorLocator,
-                                ConstraintLocator::GeneratorElementType);
+        cs.getConstraintLocator(Locator,
+                                ConstraintLocator::SequenceElementType);
 
       // Collect constraints from the element pattern.
       auto pattern = Stmt->getPattern();
       InitType = cs.generateConstraints(pattern, elementLocator);
       if (!InitType)
         return true;
-      
-      // Manually search for the iterator witness. If no iterator/element pair
-      // exists, solve for them.
-      Type iteratorType;
-      Type elementType;
-      
-      NameLookupOptions lookupOptions = defaultMemberTypeLookupOptions;
-      if (isa<AbstractFunctionDecl>(cs.DC))
-        lookupOptions |= NameLookupFlags::KnownPrivate;
-
-      auto sequenceType = cs.getType(expr)->getRValueType();
-      if (auto *selfType = sequenceType->getAs<DynamicSelfType>())
-        sequenceType = selfType->getSelfType();
-
-      // Look through one level of optional; this improves recovery but doesn't
-      // change the result.
-      if (auto sequenceObjectType = sequenceType->getOptionalObjectType())
-        sequenceType = sequenceObjectType;
-
-      // If the sequence type is an existential, we should not attempt to
-      // look up the member type at all, since we cannot represent associated
-      // types of existentials.
-      //
-      // We will diagnose it later.
-      if (!sequenceType->isExistentialType() &&
-          (sequenceType->mayHaveMembers() ||
-           sequenceType->isTypeVariableOrMember())) {
-        ASTContext &ctx = tc.Context;
-        auto iteratorAssocType =
-          cast<AssociatedTypeDecl>(
-            sequenceProto->lookupDirect(ctx.Id_Iterator).front());
-
-        auto subs = sequenceType->getContextSubstitutionMap(
-          cs.DC->getParentModule(),
-          sequenceProto);
-        iteratorType = iteratorAssocType->getDeclaredInterfaceType()
-          .subst(subs);
-
-        if (iteratorType) {
-          auto iteratorProto =
-            tc.getProtocol(Stmt->getForLoc(),
-                           KnownProtocolKind::IteratorProtocol);
-          if (!iteratorProto)
-            return true;
-
-          auto elementAssocType =
-            cast<AssociatedTypeDecl>(
-              iteratorProto->lookupDirect(ctx.Id_Element).front());
-
-          elementType = iteratorType->getTypeOfMember(
-                          cs.DC->getParentModule(),
-                          elementAssocType,
-                          elementAssocType->getDeclaredInterfaceType());
-        }
-      }
-
-      if (elementType.isNull()) {
-        elementType = cs.createTypeVariable(elementLocator);
-      }
 
       // Add a conversion constraint between the element type of the sequence
       // and the type of the element pattern.
+      auto elementType = DependentMemberType::get(SequenceType, elementAssocType);
       cs.addConstraint(ConstraintKind::Conversion, elementType, InitType,
                        elementLocator);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -708,7 +708,7 @@ static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
     auto missingConform = (MissingConformance *)fix;
     requirementKind = RequirementKind::Conformance;
     type = missingConform->getNonConformingType();
-    missingType = missingConform->getProtocol()->getDeclaredType();
+    missingType = missingConform->getProtocolType();
     break;
   }
   case FixKind::SkipSameTypeRequirement: {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -201,7 +201,7 @@ func testProtocols(_ b: B, bp: BProto) {
   var c1 : Cat1Proto = b
   var bcat1 = b.getAsProtoWithCat()!
   c1 = bcat1
-  bcat1 = c1 // expected-error{{value of type 'Cat1Proto' does not conform to 'BProto & Cat1Proto' in assignment}}
+  bcat1 = c1 // expected-error{{value of type 'Cat1Proto' does not conform to 'BProto' in assignment}}
 }
 
 // Methods only defined in a protocol

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -107,8 +107,7 @@ func longArray() {
 
 // <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to ArrayProtocol
 func rdar25563498<T : ExpressibleByArrayLiteral>(t: T) {
-  var x: T = [1] // expected-error {{cannot convert value of type '[Int]' to specified type 'T'}}
-  // expected-warning@-1{{variable 'x' was never used; consider replacing with '_' or removing it}}
+  var x: T = [1] // expected-error {{cannot convert value of type 'Int' to expected element type 'T.ArrayLiteralElement'}}
 }
 
 func rdar25563498_ok<T : ExpressibleByArrayLiteral>(t: T) -> T

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -349,7 +349,7 @@ func forceUniversalBridgeToAnyObject<T, U: KnownClassProtocol>(a: T, b: U, c: An
 
   z = a // expected-error{{does not conform to 'AnyObject'}}
   z = b
-  z = c // expected-error{{does not conform to 'AnyObject'}}
+  z = c // expected-error{{does not conform to 'AnyObject'}} expected-note {{cast 'Any' to 'AnyObject'}} {{8-8= as AnyObject}}
   z = d // expected-error{{does not conform to 'AnyObject'}}
   z = e
   z = f

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -603,7 +603,7 @@ func r22470302(_ c: r22470302Class) {
 // <rdar://problem/21928143> QoI: Pointfree reference to generic initializer in generic context does not compile
 extension String {
   @available(*, unavailable, message: "calling this is unwise")
-  func unavail<T : Sequence> // expected-note 2 {{'unavail' has been explicitly marked unavailable here}}
+  func unavail<T : Sequence> // expected-note {{'unavail' has been explicitly marked unavailable here}}
     (_ a : T) -> String where T.Iterator.Element == String {}
 }
 extension Array {
@@ -612,7 +612,7 @@ extension Array {
   }
   
   func h() -> String {
-    return "foo".unavail([0])  // expected-error {{'unavail' is unavailable: calling this is unwise}}
+    return "foo".unavail([0])  // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
   }
 }
 

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -19,13 +19,13 @@ func useDict<K, V>(_ d: MyDictionary<K,V>) {}
 useDictStringInt(["Hello" : 1])
 useDictStringInt(["Hello" : 1, "World" : 2])
 useDictStringInt(["Hello" : 1, "World" : 2.5])
-// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary value type 'DictStringInt.Value' (aka 'Int')}}
 useDictStringInt([4.5 : 2])
-// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'String'}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt([nil : 2])
 // expected-error@-1 {{'nil' is not compatible with expected dictionary key type 'String'}}
 useDictStringInt([7 : 1, "World" : 2])
-// expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+// expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt(["Hello" : nil])
 // expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'Int'}}
 

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -221,6 +221,5 @@ func rdar46459603() {
   // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Dictionary<String, E>.Values' and '[E]'}}
   // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
   _ = [arr.values] == [[e]]
-  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '[Dictionary<String, E>.Values]' and '[[E]]'}}
-  // expected-note@-2  {{expected an argument list of type '(Self, Self)'}}
+  // expected-error@-1 {{protocol type 'Any' cannot conform to 'Equatable' because only concrete types can conform to protocols}}
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -41,8 +41,8 @@ f0(f)
 f0(b)
 f1(i)
 
-f1(f) // expected-error{{argument type 'Float' does not conform to expected type 'Barable & Fooable'}}
-f1(b) // expected-error{{argument type 'Barable' does not conform to expected type 'Barable & Fooable'}}
+f1(f) // expected-error{{argument type 'Float' does not conform to expected type 'Fooable'}}
+f1(b) // expected-error{{argument type 'Barable' does not conform to expected type 'Fooable'}}
 
 //===----------------------------------------------------------------------===//
 // Subtyping

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -26,7 +26,7 @@ func arraySameType() {
 
     let _: SameType = [works]
     let _: SameType = [fails]
-    // expected-error@-1 {{value of type '[Fails]' does not conform to specified type 'SameType'}}
+    // expected-error@-1 {{cannot convert value of type 'Fails' to expected element type 'Works'}}
 
     let _: SameType = arrayWorks
     let _: SameType = arrayFails
@@ -51,7 +51,7 @@ func dictionarySameType() {
 
     let _: SameType = [0 : works]
     let _: SameType = [0 : fails]
-    // expected-error@-1 {{contextual type 'SameType' cannot be used with dictionary literal}}
+    // expected-error@-1 {{cannot convert value of type 'Fails' to expected dictionary value type 'Works'}}
 
     let _: SameType = dictWorks
     let _: SameType = dictFails

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -157,7 +157,8 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>${diag_suffix}'}}
   takesConstPointer([0, 1, 2])
   // <rdar://problem/22308330> QoI: CSDiags doesn't handle array -> pointer impl conversions well
-  takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type '[Double]' to expected argument type 'UnsafePointer<Int>}}
+  takesConstPointer([0.0, 1.0, 2.0])
+  // expected-error@-1 3 {{annot convert value of type 'Double' to expected element type 'Int'}}
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafePointer<Int> = &i // expected-error {{use of extraneous '&'}}

--- a/test/TypeCoercion/protocols.swift
+++ b/test/TypeCoercion/protocols.swift
@@ -43,9 +43,13 @@ func testPrintableCoercion(_ ip1: IsPrintable1,
                            inp2: IsNotPrintable2,
                            op: OtherPrintable) {
   var p : MyPrintable = ip1 // okay
+  let _: MyPrintable & Titled = Book(title: "")
+  // expected-error@-1 {{value of type 'Book' does not conform to specified type 'MyPrintable'}}
   p = ip1 // okay
   p = ip2 // okay
   p = inp1 // expected-error{{value of type 'IsNotPrintable1' does not conform to 'MyPrintable' in assignment}}
+  let _: MyPrintable = inp1
+  // expected-error@-1 {{value of type 'IsNotPrintable1' does not conform to specified type 'MyPrintable'}}
   p = inp2 // expected-error{{value of type 'IsNotPrintable2' does not conform to 'MyPrintable' in assignment}}
   p = op // expected-error{{value of type 'OtherPrintable' does not conform to 'MyPrintable' in assignment}}
   _ = p

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -419,3 +419,20 @@ func useSelfOperator() {
   let s = SelfOperator()
   _ = s + s
 }
+
+// for ... in loops
+
+struct DummyIterator : IteratorProtocol {
+  func next() -> Int? { return nil }
+}
+
+class Iterable : Sequence {
+  func returnsSelf() -> Self {
+    for _ in self {}
+    return self
+  }
+
+  func makeIterator() -> DummyIterator {
+    return DummyIterator()
+  }
+}

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -83,11 +83,14 @@ c3 as C4 // expected-error {{'C3' is not convertible to 'C4'; did you mean to us
 1 as Int as String // expected-error{{cannot convert value of type 'Int' to type 'String' in coercion}}
 Double(1) as Double as String // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
 ["awd"] as [Int] // expected-error{{cannot convert value of type 'String' to expected element type 'Int'}}
-([1, 2, 1.0], 1) as ([String], Int) // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
+([1, 2, 1.0], 1) as ([String], Int)
+// expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
+// expected-error@-2   {{cannot convert value of type 'Double' to expected element type 'String'}}
 [[1]] as [[String]] // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
 (1, 1.0) as (Int, Int) // expected-error{{cannot convert value of type 'Double' to type 'Int' in coercion}}
 (1.0, 1, "asd") as (String, Int, Float) // expected-error{{cannot convert value of type 'Double' to type 'String' in coercion}}
-(1, 1.0, "a", [1, 23]) as (Int, Double, String, [String]) // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
+(1, 1.0, "a", [1, 23]) as (Int, Double, String, [String])
+// expected-error@-1 2 {{cannot convert value of type 'Int' to expected element type 'String'}}
 
 _ = [1] as! [String] // expected-warning{{cast from '[Int]' to unrelated type '[String]' always fails}}
 _ = [(1, (1, 1))] as! [(Int, (String, Int))] // expected-warning{{cast from '[(Int, (Int, Int))]' to unrelated type '[(Int, (String, Int))]' always fails}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -739,8 +739,8 @@ func invalidDictionaryLiteral() {
 }
 
 
-[4].joined(separator: [1]) // expected-error {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'StringProtocol'}}
-[4].joined(separator: [[[1]]]) // expected-error {{referencing instance method 'joined(separator:)' on 'Sequence' requires that 'Int' conform to 'StringProtocol'}}
+[4].joined(separator: [1]) // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+[4].joined(separator: [[[1]]]) // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
 
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -53,12 +53,15 @@ struct GoodTupleIterator: Sequence, IteratorProtocol {
   func makeIterator() -> GoodTupleIterator {}
 }
 
+protocol ElementProtocol {}
+
 func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
   var sum : Int
   var sumf : Float
   for i : Int in gir { sum = sum + i }
   for i in gir { sum = sum + i }
-  for f : Float in gir { sum = sum + f } // expected-error{{'Int' is not convertible to 'Float'}}
+  for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'Int' to expected type 'Float'}}
+  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'Int' does not conform to expected type 'ElementProtocol'}}
 
   for (i, f) : (Int, Float) in gtr { sum = sum + i }
 
@@ -70,7 +73,7 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
 
   for (i, _) : (Int, Float) in gtr { sum = sum + i }
 
-  for (i, _) : (Int, Int) in gtr { sum = sum + i } // expected-error{{'GoodTupleIterator.Element' (aka '(Int, Float)') is not convertible to '(Int, Int)'}}
+  for (i, _) : (Int, Int) in gtr { sum = sum + i } // expected-error{{cannot convert sequence element type 'GoodTupleIterator.Element' (aka '(Int, Float)') to expected type '(Int, Int)'}}
 
   for (i, f) in gtr {}
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -61,7 +61,7 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
   for i : Int in gir { sum = sum + i }
   for i in gir { sum = sum + i }
   for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'Int' to expected type 'Float'}}
-  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'Int' does not conform to expected type 'ElementProtocol'}}
+  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'Int' does not conform to expected protocol 'ElementProtocol'}}
 
   for (i, f) : (Int, Float) in gtr { sum = sum + i }
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -111,7 +111,7 @@ func testConversion() {
 
   // Conversions among existential types.
   var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
-  x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'FooProtocol & SuperREPLPrintable' in assignment}}
+  x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'SuperREPLPrintable' in assignment}}
   x = x2
 
   // Subtyping

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -97,8 +97,8 @@ func basicSubtyping(
   anyObject: AnyObject) {
 
   // Errors
-  let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base & P2'}}
-  let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'Base<Int> & P2'}}
+  let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
+  let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
   let _: P3 = baseAndP1 // expected-error {{value of type 'Base<Int> & P1' does not conform to specified type 'P3'}}
   let _: P3 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'P3'}}
   let _: Derived = baseAndP1 // expected-error {{cannot convert value of type 'Base<Int> & P1' to specified type 'Derived'}}


### PR DESCRIPTION
- Detect and diagnose conversion failures related to collection element types;
-  Improve contextual mismatch diagnostics for `for ... in <expr>` loop;
- Extend use of missing protocol conformance fix to cover contextual failures, such as:
    - Assignment mismatches, where destination requires source to conform
       to certain protocol (or protocol composition);
    - Incorrect returns where returned type doesn't conform to the protocol specified in the signature.
    - Sequence element type mismatches in condition of for ... in <expr> loop.

Resolves: rdar://problem/49400007

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
