### PR TITLE
[ownership] Add a cmake flag to enable ownership stripping after diag…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,10 @@ option(SWIFT_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING
   "Build stdlibCore with exclusivity checking enabled"
   FALSE)
 
+option(SWIFT_ENABLE_OWNERSHIP_STRIPPING_AFTER_DIAGNOSTIC_PASSES
+  "Build the stdlib with ownership stripping after the diagnostic passes run."
+  FALSE)
+
 #
 # End of user-configurable options.
 #

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1715,6 +1715,10 @@ function(add_swift_target_library name)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
   endif()
 
+  if (SWIFTLIB_IS_STDLIB AND SWIFT_ENABLE_OWNERSHIP_STRIPPING_AFTER_DIAGNOSTICS)
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-enable-ownership-stripping-after-diagnostics")
+  endif()
+
   if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE)
     list(APPEND SWIFTLIB_DEPENDS clang)
   endif()

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -134,7 +134,7 @@ public:
 
   /// Should the default pass pipelines strip ownership during the diagnostic
   /// pipeline or after serialization.
-  bool StripOwnershipAfterSerialization = false;
+  bool StripOwnershipAfterDiagnosticPasses = false;
 
   /// The name of the file to which the backend should save YAML optimization
   /// records.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -232,9 +232,9 @@ def disable_arc_opts : Flag<["-"], "disable-arc-opts">,
 def disable_sil_partial_apply : Flag<["-"], "disable-sil-partial-apply">,
   HelpText<"Disable use of partial_apply in SIL generation">;
 
-def enable_ownership_stripping_after_serialization
-  : Flag<["-"], "enable-ownership-stripping-after-serialization">,
-  HelpText<"Strip ownership after serialization">;
+def enable_ownership_stripping_after_diagnostics
+  : Flag<["-"], "enable-ownership-stripping-after-diagnostics">,
+  HelpText<"Strip ownership after the diagnostic passes run">;
 
 def disable_access_control : Flag<["-"], "disable-access-control">,
   HelpText<"Don't respect access control restrictions">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -806,7 +806,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     Args.hasArg(OPT_disable_sil_partial_apply);
   Opts.VerifySILOwnership &= !Args.hasArg(OPT_disable_sil_ownership_verifier);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
-  Opts.StripOwnershipAfterSerialization |= Args.hasArg(OPT_enable_ownership_stripping_after_serialization);
+  Opts.StripOwnershipAfterDiagnosticPasses |=
+      Args.hasArg(OPT_enable_ownership_stripping_after_diagnostics);
 
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))
     Opts.OptRecordFile = A->getValue();

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -105,7 +105,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   if (Options.shouldOptimize()) {
     P.addSemanticARCOpts();
   }
-  if (!Options.StripOwnershipAfterSerialization)
+  if (!Options.StripOwnershipAfterDiagnosticPasses)
     P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
   P.addMandatorySILLinker();
@@ -309,7 +309,7 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
     P.addSerializeSILPass();
 
     // Now strip any transparent functions that still have ownership.
-    if (P.getOptions().StripOwnershipAfterSerialization)
+    if (P.getOptions().StripOwnershipAfterDiagnosticPasses)
       P.addOwnershipModelEliminator();
 
     if (P.getOptions().StopOptimizationAfterSerialization)
@@ -390,7 +390,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   P.addDeadFunctionElimination();
 
   // Strip ownership from non-transparent functions.
-  if (P.getOptions().StripOwnershipAfterSerialization)
+  if (P.getOptions().StripOwnershipAfterDiagnosticPasses)
     P.addNonTransparentFunctionOwnershipModelEliminator();
 
   // Start by cloning functions from stdlib.
@@ -655,7 +655,7 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   P.addSerializeSILPass();
 
   // And then strip ownership...
-  if (Options.StripOwnershipAfterSerialization)
+  if (Options.StripOwnershipAfterDiagnosticPasses)
     P.addOwnershipModelEliminator();
 
   // Finally perform some small transforms.

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil -enforce-exclusivity=unchecked %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -O -emit-sil -enforce-exclusivity=unchecked %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-diagnostics -O -emit-sil -enforce-exclusivity=unchecked %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/bridged_casts_folding_ownership.sil
+++ b/test/SILOptimizer/bridged_casts_folding_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -module-name bridged_casts_folding -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-diagnostics -module-name bridged_casts_folding -O -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -O -emit-sil %s | %FileCheck %s
 // RUN: %target-swift-frontend -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-serialization -disable-availability-checking -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -enable-ownership-stripping-after-serialization -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-diagnostics -disable-availability-checking -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-ownership-stripping-after-diagnostics -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
 
 // We want to check two things here:
 // - Correctness

--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-serialization -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-diagnostics -emit-sil %s | %FileCheck %s
 
 // We want to check two things here:
 // - Correctness

--- a/test/SILOptimizer/cast_folding_objc_generics.swift
+++ b/test/SILOptimizer/cast_folding_objc_generics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name cast_folding_objc_generics -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name cast_folding_objc_generics -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-serialization -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name cast_folding_objc_generics -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=PerfInliner -enable-ownership-stripping-after-diagnostics -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
…nostics on the stdlib and rename the flag from stripping after serialization => stripping after diagnostics.

This fits more with the meaning of the option. We care that we are serializing
after the diagnostic passes. The stuff around serialization is just a
side-effect of making that work with -Onone and -O.

