### PR TITLE
[TF] Add derivative for `Tensor(concatenating:alongAxis:)`.

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -161,12 +161,25 @@ TensorADTests.testAllBackends("Tensor.init(concatenating:)") {
   let c = Tensor<Float>([8,  9, 10, 11])
   let d = Tensor<Float>([12, 13, 14, 15])
 
-  let grads = gradient(at: [a, b], [c, d]) { xs, ys in
-    return (Tensor(concatenating: xs) * Tensor(concatenating: ys)).sum()
+  do {
+    let grads = gradient(at: [a, b], [c, d]) { xs, ys in
+      return (Tensor(concatenating: xs) * Tensor(concatenating: ys)).sum()
+    }
+    expectEqual([[8, 9, 10, 11], [12, 13, 14, 15]], grads.0.base)
+    expectEqual([[0, 1, 2, 3], [4, 5, 6, 7]], grads.1.base)
   }
 
-  expectEqual([[8, 9, 10, 11], [12, 13, 14, 15]], grads.0.base)
-  expectEqual([[0, 1, 2, 3], [4, 5, 6, 7]], grads.1.base)
+  // TODO(TF-462): Re-enable test when differentiation supports array literal initialization.
+  /*
+  do {
+    let grads = gradient(at: a, b, c) { a, b, c in
+      return (Tensor(concatenating: [a, b]) * Tensor(concatenating: [c])).sum()
+    }
+    expectEqual([8, 9, 10, 11], grads.0)
+    expectEqual([12, 13, 14, 15], grads.1)
+    expectEqual([0, 1, 2, 3], grads.2)
+  }
+  */
 }
 
 TensorADTests.testAllBackends("concatenation (++)") {

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -155,6 +155,20 @@ TensorADTests.testAllBackends("reshaped") {
   expectEqual(input, reshapedPullback(reshaped))
 }
 
+TensorADTests.testAllBackends("Tensor.init(concatenating:)") {
+  let a = Tensor<Float>([0,  1,  2,  3])
+  let b = Tensor<Float>([4,  5,  6,  7])
+  let c = Tensor<Float>([8,  9, 10, 11])
+  let d = Tensor<Float>([12, 13, 14, 15])
+
+  let grads = gradient(at: [a, b], [c, d]) { xs, ys in
+    return (Tensor(concatenating: xs) * Tensor(concatenating: ys)).sum()
+  }
+
+  expectEqual([[8, 9, 10, 11], [12, 13, 14, 15]], grads.0.base)
+  expectEqual([[0, 1, 2, 3], [4, 5, 6, 7]], grads.1.base)
+}
+
 TensorADTests.testAllBackends("concatenation (++)") {
   let a1 = Tensor<Float>([1,2,3,4])
   let b1 = Tensor<Float>([5,6,7,8,9,10])


### PR DESCRIPTION
Potential stepping stone toward fixing `UpSampling3D` ([TF-525](https://bugs.swift.org/browse/TF-525)) following the Keras implementation (manual broadcasting for high dimensional tensors).