### PR TITLE
[5.1] swift-api-digester: avoid adding MissingMemberDecl to the json file

### DIFF
--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1553,6 +1553,8 @@ SwiftDeclCollector::addMembersToRoot(SDKNode *Root, IterableDeclContext *Context
       // All containing variables should have been handled.
     } else if (isa<DestructorDecl>(Member)) {
       // deinit has no impact.
+    } else if (isa<MissingMemberDecl>(Member)) {
+      // avoid adding MissingMemberDecl
     } else {
       llvm_unreachable("unhandled member decl kind.");
     }

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -34,7 +34,7 @@ def check_call(cmd, cwd=None, env=os.environ, verbose=False, output=None):
     if verbose:
         print(' '.join([escapeCmdArg(arg) for arg in cmd]))
     return subprocess.check_call(cmd, cwd=cwd, env=env,
-                                 stderr=subprocess.STDOUT, stdout=output)
+                                 stderr=None, stdout=output)
 
 
 def check_output(cmd, verbose=False):


### PR DESCRIPTION
We explicitly ignore these ABI placeholders to fix an unreachable hit.
