### PR TITLE
[diagnostics] Add the llvm option swift-diagnostics-assert-on-warning…

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -622,10 +622,14 @@ static DiagnosticKind toDiagnosticKind(DiagnosticState::Behavior behavior) {
   llvm_unreachable("Unhandled DiagnosticKind in switch.");
 }
 
-/// A special option only for compiler writers that causes Diagnostics to assert
-/// when a failure diagnostic is emitted. Intended for use in the debugger.
+// A special option only for compiler writers that causes Diagnostics to assert
+// when a failure diagnostic is emitted. Intended for use in the debugger.
 llvm::cl::opt<bool> AssertOnError("swift-diagnostics-assert-on-error",
                                   llvm::cl::init(false));
+// A special option only for compiler writers that causes Diagnostics to assert
+// when a warning diagnostic is emitted. Intended for use in the debugger.
+llvm::cl::opt<bool> AssertOnWarning("swift-diagnostics-assert-on-warning",
+                                    llvm::cl::init(false));
 
 DiagnosticState::Behavior DiagnosticState::determineBehavior(DiagID id) {
   auto set = [this](DiagnosticState::Behavior lvl) {
@@ -637,6 +641,8 @@ DiagnosticState::Behavior DiagnosticState::determineBehavior(DiagID id) {
     }
 
     assert((!AssertOnError || !anyErrorOccurred) && "We emitted an error?!");
+    assert((!AssertOnWarning || (lvl != Behavior::Warning)) &&
+           "We emitted a warning?!");
     previousBehavior = lvl;
     return lvl;
   };


### PR DESCRIPTION
… to cause the diagnostics engine to assert upon triggering a warning.

This is an option only intending to help compiler developers triage/track down
why a warning is being emitted in a quick manner. It will only be in asserts
builds since it is an LLVM option.
