### PR TITLE
[diagnose-unreachable] Ignore/eliminate end_borrows after noreturn fu…

### DIFF
--- a/test/SILOptimizer/return_ownership.swift
+++ b/test/SILOptimizer/return_ownership.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend %s -enable-ownership-stripping-after-serialization -emit-sil -verify
+
+class TuringMachine {
+  func halt() -> Never {
+    repeat { } while true
+  }
+}
+
+func diagnose_missing_return_no_error_after_noreturn_method() -> Int {
+  TuringMachine().halt()
+} // no error
+
+func testUnreachableAfterNoReturnMethod() -> Int {
+  TuringMachine().halt(); // expected-note{{a call to a never-returning function}}
+  return 0; // expected-warning {{will never be executed}}
+}
+


### PR DESCRIPTION
…nctions.

This seems to happen more often when we strip ownership after diagnose
unreachable.
