### PR TITLE
Don't use implicit dynamic on declarations if they are transparent or…

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2706,6 +2706,14 @@ TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D) {
   return None;
 }
 
+static bool shouldBlockImplicitDynamic(Decl *D) {
+  if (D->getAttrs().hasAttribute<NonObjCAttr>() ||
+      D->getAttrs().hasAttribute<SILGenNameAttr>() ||
+      D->getAttrs().hasAttribute<TransparentAttr>() ||
+      D->getAttrs().hasAttribute<InlinableAttr>())
+    return true;
+  return false;
+}
 void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
   if (!D->getModuleContext()->isImplicitDynamicEnabled())
     return;
@@ -2716,10 +2724,9 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
       isa<AccessorDecl>(D))
     return;
 
-  if (D->getAttrs().hasAttribute<NonObjCAttr>() ||
-      D->getAttrs().hasAttribute<TransparentAttr>() ||
-      D->getAttrs().hasAttribute<InlinableAttr>())
-    return;
+  // Don't add dynamic if decl is inlinable or tranparent.
+  if (shouldBlockImplicitDynamic(D))
+   return;
 
   if (auto *FD = dyn_cast<FuncDecl>(D)) {
     // Don't add dynamic to defer bodies.
@@ -2728,6 +2735,14 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     // Don't add dynamic to functions with a cdecl.
     if (FD->getAttrs().hasAttribute<CDeclAttr>())
       return;
+  }
+
+  // Don't add dynamic if accessor is inlinable or tranparent.
+  if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
+    for (auto *accessor : asd->getAllAccessors()) {
+      if (!accessor->isImplicit() && shouldBlockImplicitDynamic(accessor))
+        return;
+    }
   }
 
   if (auto *VD = dyn_cast<VarDecl>(D)) {

--- a/test/attr/implicit_dynamic.swift
+++ b/test/attr/implicit_dynamic.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -swift-version 5 -enable-implicit-dynamic  -I %t -emit-silgen %s | %FileCheck %s
+
+// Make sure that these functions are not implicitly marked dynamic.
+
+public struct NotImplicitDynamic {
+  @inlinable
+  public var x : Int {
+// CHECK: sil [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV1xSivg
+// CHECK: sil [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV1xSivs
+    get {
+      return 1
+    }
+    set {
+    }
+  }
+
+  @inlinable
+  public var y : Int {
+// CHECK: sil [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV1ySivg
+    return 1
+  }
+
+  public var z : Int {
+// CHECK: sil [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV1zSivg
+// CHECK: sil [ossa] @$s16implicit_dynamic18NotImplicitDynamicV1zSivs
+    @inlinable
+    get {
+      return 1
+    }
+    set {
+    }
+  }
+
+  @_transparent
+  public var x2 : Int {
+// CHECK: sil [transparent] [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV2x2Sivg
+// CHECK: sil [transparent] [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicV2x2Sivs
+    get {
+      return 1
+    }
+    set {
+    }
+  }
+
+  public subscript() -> Int {
+// CHECK: sil [transparent] [serialized] [ossa] @$s16implicit_dynamic18NotImplicitDynamicVSiycig
+    @_transparent
+    get{
+      return 1
+    }
+  }
+}
+
+// CHECK: sil [ossa] @foobar
+@_silgen_name("foobar")
+public func noImplicitDynamicFunc() {
+}


### PR DESCRIPTION
… inlinable, or have the silgen_name attribute

The first two are contratictory and the last is a current implementation
limitation.

rdar://51031462