### PR TITLE
Disable crash_without_backtrace.swift.

### DIFF
--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -6,6 +6,8 @@
 // doesn't pass through the crash, and `not` may not be available when running
 // on a remote host.
 
+// REQUIRES: rdar51076215
+
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos


### PR DESCRIPTION
rdar://51076215
(cherry picked from commit 195672a2014a056fd8cff532469cc2a2ba02620f)
