### PR TITLE
[benchmark] ReportFormatter: Improved single_table headers

### DIFF
--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -614,22 +614,22 @@ class ReportFormatter(object):
         ]
 
         def max_widths(maximum, widths):
-            return tuple(map(max, zip(maximum, widths)))
+            return map(max, zip(maximum, widths))
 
-        return reduce(max_widths, widths, tuple([0] * 5))
+        return reduce(max_widths, widths, [0] * 5)
 
     def _formatted_text(self, ROW, HEADER_SEPARATOR, DETAIL):
         widths = self._column_widths()
         self.header_printed = False
 
         def justify_columns(contents):
-            return tuple([c.ljust(w) for w, c in zip(widths, contents)])
+            return [c.ljust(w) for w, c in zip(widths, contents)]
 
         def row(contents):
             return ROW.format(*justify_columns(contents))
 
         def header(header):
-            return '\n' + row(header) + row(tuple([HEADER_SEPARATOR] * 5))
+            return '\n' + row(header) + row([HEADER_SEPARATOR] * 5)
 
         def format_columns(r, strong):
             return (r if not strong else

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -631,7 +631,9 @@ class ReportFormatter(object):
         def header(title, column_labels):
             h = ''
             if not self.header_printed:
-                h = '\n' + row(column_labels) + row([HEADER_SEPARATOR] * 5)
+                h = '\n' + row(column_labels)
+                h += row([':' + HEADER_SEPARATOR] +  # left align 1st column
+                         ([HEADER_SEPARATOR + ':']) * 4)  # right align rest
             if self.single_table:
                 h += row(('**' + title + '**', '', '', '', ''))
             if self.single_table and not self.header_printed:

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -589,14 +589,14 @@ class ReportFormatter(object):
     def markdown(self):
         """Report results of benchmark comparisons in Markdown format."""
         return self._formatted_text(
-            ROW='{0} | {1} | {2} | {3} | {4} \n',
+            COLUMN_SEPARATOR=' | ',
             HEADER_SEPARATOR='---',
             DETAIL=self.MARKDOWN_DETAIL)
 
     def git(self):
         """Report results of benchmark comparisons in 'git' format."""
         return self._formatted_text(
-            ROW='{0}   {1}   {2}   {3}   {4} \n',
+            COLUMN_SEPARATOR='   ',
             HEADER_SEPARATOR='   ',
             DETAIL=self.GIT_DETAIL)
 
@@ -618,7 +618,7 @@ class ReportFormatter(object):
 
         return reduce(max_widths, widths, [0] * 5)
 
-    def _formatted_text(self, ROW, HEADER_SEPARATOR, DETAIL):
+    def _formatted_text(self, COLUMN_SEPARATOR, HEADER_SEPARATOR, DETAIL):
         widths = self._column_widths()
         self.header_printed = False
 
@@ -626,14 +626,14 @@ class ReportFormatter(object):
             return [c.ljust(w) for w, c in zip(widths, contents)]
 
         def row(contents):
-            return ROW.format(*justify_columns(contents))
+            return COLUMN_SEPARATOR.join(justify_columns(contents)) + ' \n'
 
         def header(header):
             return '\n' + row(header) + row([HEADER_SEPARATOR] * 5)
 
-        def format_columns(r, strong):
-            return (r if not strong else
-                    r[:-1] + ('**{0}**'.format(r[-1]), ))
+        def format_columns(r, is_strong):
+            return (r if not is_strong else
+                    r[:-1] + ('**' + r[-1] + '**', ))
 
         def table(title, results, is_strong=False, is_open=False):
             rows = [

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -648,10 +648,8 @@ class ReportFormatter(object):
         def table(title, results, is_strong=False, is_open=False):
             if not results:
                 return ''
-            rows = [
-                row(format_columns(ReportFormatter.values(r), is_strong))
-                for r in results
-            ]
+            rows = [row(format_columns(ReportFormatter.values(r), is_strong))
+                    for r in results]
             table = (header(title if self.single_table else '',
                             ReportFormatter.header_for(results[0])) +
                      ''.join(rows))

--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -88,7 +88,7 @@ def main():
         help='In addition to stdout, write the results into a markdown file')
     argparser.add_argument(
         '-threshold', type=float,
-        help='The performance threshold in % which triggers a re-run',
+        help='The performance threshold in %% which triggers a re-run',
         default=5)
     argparser.add_argument(
         '-num-samples', type=int,

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -856,7 +856,7 @@ class TestReportFormatter(OldAndNewLog):
         self.assertNotIn('AngryPhonebook', html)
 
     def test_single_table_report(self):
-        """Single table report has bold inline headers and no sections."""
+        """Single table report has inline headers and no elaborate sections."""
         self.tc.removed = []  # test handling empty section
         rf = ReportFormatter(self.tc, changes_only=True, single_table=True)
         markdown = rf.markdown()

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -759,7 +759,7 @@ class TestReportFormatter(OldAndNewLog):
         )
         self.assert_markdown_contains([
             'TEST                  | OLD    | NEW    | DELTA   | RATIO',
-            '---                   | ---    | ---    | ---     | ---    ',
+            ':---                  | ---:   | ---:   | ---:    | ---:   ',
             'TEST                  | MIN    | MAX    | MEAN    | MAX_RSS'])
         self.assert_git_contains([
             'TEST                    OLD      NEW      DELTA     RATIO',
@@ -864,8 +864,8 @@ class TestReportFormatter(OldAndNewLog):
             '**Regression**', '**Added**',
             '| OLD', '| NEW', '| DELTA', '| RATIO'
         ], markdown)
-        self.assertIn('\n--- ', markdown)  # first column
-        self.assertEqual(markdown.count('| ---'), 4)
+        self.assertIn('\n:---', markdown)  # first column is left aligned
+        self.assertEqual(markdown.count('| ---:'), 4)  # other, right aligned
 
 
 class Test_parse_args(unittest.TestCase):

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -855,6 +855,18 @@ class TestReportFormatter(OldAndNewLog):
         self.assertNotIn('No Changes', html)
         self.assertNotIn('AngryPhonebook', html)
 
+    def test_single_table_report(self):
+        """Single table report has bold inline headers and no sections."""
+        rf = ReportFormatter(self.tc, changes_only=True, single_table=True)
+        markdown = rf.markdown()
+        self.assertNotIn('<details', markdown)
+        self.assert_report_contains([
+            '**Regression**', '**Added**',
+            '| OLD', '| NEW', '| DELTA', '| RATIO'
+        ], markdown)
+        self.assertIn('\n--- ', markdown)  # first column
+        self.assertEqual(markdown.count('| ---'), 4)
+
 
 class Test_parse_args(unittest.TestCase):
     required = ['--old-file', 'old.log', '--new-file', 'new.log']


### PR DESCRIPTION
This PR improves `single_table` mode of `ReportFormatter`:
* Add unit test coverage.
* Print labels for the numeric columns on inline headers.
* Visually distinguish sections by a separator row preceding the the inline headers.
* Separate header label styles for `git` and `markdown` modes with UPPERCASE and **Bold**  formatting respectively.