### PR TITLE
Introduce a backward-deployment library for SR-10600. 

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -888,4 +888,8 @@ def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,
 def vfsoverlay_EQ : Joined<["-"], "vfsoverlay=">,
   Alias<vfsoverlay>;
 
+// Runtime compatibility version
+def runtime_compatibility_version : Separate<["-"], "runtime-compatibility-version">,
+  Flags<[FrontendOption]>,
+  HelpText<"Link compatibility library for Swift runtime version, or 'none'">;
 include "FrontendOptions.td"

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -61,6 +61,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stubs)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
+  add_subdirectory(Compatibility50)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
+set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
+
+add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC
+  ProtocolConformance.cpp
+  Overrides.cpp
+  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+  LINK_FLAGS ${swift_runtime_linker_flags}
+  TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
+  INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/Compatibility50/Overrides.cpp
+++ b/stdlib/public/Compatibility50/Overrides.cpp
@@ -1,0 +1,33 @@
+//===--- Overrides.cpp - Compat override table for Swift 5.0 runtime ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file provides compatibility override hooks for Swift 5.0 runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "../runtime/CompatibilityOverride.h"
+
+using namespace swift;
+
+struct OverrideSection {
+  uintptr_t version;
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  Override_ ## name name;
+#include "../runtime/CompatibilityOverride.def"
+};
+  
+OverrideSection Overrides
+__attribute__((used, section("__DATA,__swift_hooks"))) = {
+  .version = 0,
+  .conformsToProtocol = swift50override_conformsToProtocol,
+};

--- a/stdlib/public/Compatibility50/Overrides.h
+++ b/stdlib/public/Compatibility50/Overrides.h
@@ -1,0 +1,30 @@
+//===--- Overrides.cpp - Compat overrides for Swift 5.0 runtime ----s------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file provides compatibility override hooks for Swift 5.0 runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Runtime/Metadata.h"
+
+namespace swift {
+
+using ConformsToProtocol_t =
+  const WitnessTable *(const Metadata *, const ProtocolDescriptor *);
+
+const WitnessTable *
+swift50override_conformsToProtocol(const Metadata * const type,
+  const ProtocolDescriptor *protocol,
+  ConformsToProtocol_t *original);
+
+}

--- a/stdlib/public/Compatibility50/ProtocolConformance.cpp
+++ b/stdlib/public/Compatibility50/ProtocolConformance.cpp
@@ -1,0 +1,71 @@
+//===--- ProtocolConformance.cpp - Swift protocol conformance checking ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Checking and caching of Swift protocol conformances.
+//
+// This implementation is intended to be backward-deployed into Swift 5.0
+// runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "../runtime/Private.h"
+#include "swift/Basic/Lazy.h"
+#include <objc/runtime.h>
+
+using namespace swift;
+
+// Clone of private function getRootSuperclass. This returns the SwiftObject
+// class in the ABI-stable dylib, regardless of what the local runtime build
+// does, since we're always patching an ABI-stable dylib.
+__attribute__((visibility("hidden"), weak))
+const ClassMetadata *swift::getRootSuperclass() {
+  auto theClass = SWIFT_LAZY_CONSTANT(objc_getClass("_TtCs12_SwiftObject"));
+  return (const ClassMetadata *)theClass;
+}
+
+// Clone of private helper swift::_swiftoverride_class_getSuperclass
+// for use in the override implementation.
+static const Metadata *_swift50override_class_getSuperclass(
+                                                    const Metadata *theClass) {
+  if (const ClassMetadata *classType = theClass->getClassObject()) {
+    if (classHasSuperclass(classType))
+      return getMetadataForClass(classType->Superclass);
+  }
+  
+  if (const ForeignClassMetadata *foreignClassType
+      = dyn_cast<ForeignClassMetadata>(theClass)) {
+    if (const Metadata *superclass = foreignClassType->Superclass)
+      return superclass;
+  }
+  
+  return nullptr;
+}
+
+const WitnessTable *
+swift::swift50override_conformsToProtocol(const Metadata *type,
+  const ProtocolDescriptor *protocol,
+  ConformsToProtocol_t *original_conformsToProtocol)
+{
+  // The implementation of swift_conformsToProtocol in Swift 5.0 would return
+  // a false negative answer when asking whether a subclass conforms using
+  // a conformance from a superclass. Work around this by walking up the
+  // superclass chain in cases where the original implementation returns
+  // null.
+  do {
+    auto result = original_conformsToProtocol(type, protocol);
+    if (result)
+      return result;
+  } while ((type = _swift50override_class_getSuperclass(type)));
+  
+  return nullptr;
+}

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3850,24 +3850,6 @@ static const WitnessTable *_getForeignWitnessTable(
 /*** Other metadata routines ***********************************************/
 /***************************************************************************/
 
-template<> const ClassMetadata *
-Metadata::getClassObject() const {
-  switch (getKind()) {
-  case MetadataKind::Class: {
-    // Native Swift class metadata is also the class object.
-    return static_cast<const ClassMetadata *>(this);
-  }
-  case MetadataKind::ObjCClassWrapper: {
-    // Objective-C class objects are referenced by their Swift metadata wrapper.
-    auto wrapper = static_cast<const ObjCClassWrapperMetadata *>(this);
-    return wrapper->Class;
-  }
-  // Other kinds of types don't have class objects.
-  default:
-    return nullptr;
-  }
-}
-
 template <> OpaqueValue *Metadata::allocateBoxForExistentialIn(ValueBuffer *buffer) const {
   auto *vwt = getValueWitnesses();
   if (vwt->isValueInline())

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -463,6 +463,24 @@ public:
     return c;
 #endif
   }
+  
+  template<> inline const ClassMetadata *
+  Metadata::getClassObject() const {
+    switch (getKind()) {
+    case MetadataKind::Class: {
+      // Native Swift class metadata is also the class object.
+      return static_cast<const ClassMetadata *>(this);
+    }
+    case MetadataKind::ObjCClassWrapper: {
+      // Objective-C class objects are referenced by their Swift metadata wrapper.
+      auto wrapper = static_cast<const ObjCClassWrapperMetadata *>(this);
+      return wrapper->Class;
+    }
+    // Other kinds of types don't have class objects.
+    default:
+      return nullptr;
+    }
+  }
 
   void *allocateMetadata(size_t size, size_t align);
 

--- a/test/Interpreter/SR-10600.swift
+++ b/test/Interpreter/SR-10600.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+public class BaseView { }
+public class GenericView<T>: BaseView { }
+public class FinalView: GenericView<ContentForTheView> { }
+
+
+public class ContentForTheView { }
+extension ContentForTheView: InfoNeededByControllers { }
+
+public protocol ConditionallyConformed { }
+public protocol InfoNeededByControllers { }
+
+extension GenericView: ConditionallyConformed where T: InfoNeededByControllers { }
+
+open class BaseGenericController<T> where T: BaseView & ConditionallyConformed { }
+
+
+open class FinalController: BaseGenericController<FinalView> { public override init() { } }
+
+// CHECK: FinalController
+print(FinalController())

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -17,3 +17,4 @@ void swift_storeEnumTagSinglePayloadGeneric(void) {}
 void swift_retain(){}
 void swift_allocBox(){}
 void swift_getWitnessTable(void) {}
+void swift_getObjCClassMetadata(void) {}


### PR DESCRIPTION
Build a static archive that can be linked into executables and take advantage of the Swift runtime's
hooking mechanism to work around the issue Doug fixed in #24759.
The Swift 5.0 version of swift_conformsToProtocol would return a false negative in some cases where
a subclass conforms using an inherited conformance, so work around this by successively retrying
the original implementation up the superclass chain to try to find a match.

rdar://problem/50057445