### PR TITLE
[AutoDiff] Do not differentiate an 'apply' when there's no active arguments.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2511,8 +2511,6 @@ static void collectMinimalIndicesForFunctionCall(
       paramIndices.push_back(currentParamIdx);
     ++currentParamIdx;
   }
-  assert((currentParamIdx > 0 || !paramIndices.empty())
-         && "Parameter indices cannot be empty");
   // Result indices are indices (in the type signature) of results that are
   // useful.
   //

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2511,6 +2511,8 @@ static void collectMinimalIndicesForFunctionCall(
       paramIndices.push_back(currentParamIdx);
     ++currentParamIdx;
   }
+  assert((currentParamIdx > 0 || !paramIndices.empty())
+         && "Parameter indices cannot be empty");
   // Result indices are indices (in the type signature) of results that are
   // useful.
   //
@@ -2963,8 +2965,13 @@ public:
     allResults.push_back(ai);
     allResults.append(ai->getIndirectSILResults().begin(),
                       ai->getIndirectSILResults().end());
-    auto hasActiveResults = llvm::any_of(allResults, [&](SILValue result) {
-      return activityInfo.isActive(result, getIndices());
+    auto hasActiveResults = llvm::any_of(
+        allResults, [this](SILValue res) {
+      return activityInfo.isActive(res, getIndices());
+    });
+    auto hasActiveArguments = llvm::any_of(
+        ai->getArgumentsWithoutIndirectResults(), [this](SILValue arg) {
+      return activityInfo.isActive(arg, getIndices());
     });
     // Check for active 'inout' arguments.
     auto paramInfos = ai->getSubstCalleeConv().getParameters();
@@ -2983,7 +2990,7 @@ public:
     }
     // If there's no active results, this function should not be differentiated.
     // Do standard cloning.
-    if (!hasActiveResults) {
+    if (!hasActiveResults || !hasActiveArguments) {
       LLVM_DEBUG(getADDebugStream() << "No active results:\n" << *ai << '\n');
       SILClonerWithScopes::visitApplyInst(ai);
       return;

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -57,4 +57,16 @@ func noEscapePartialApplyTest() {
   }
 }
 
+// TF-529: Crash when apply's result is active but arguments aren't.
+struct Vector<T: Numeric & Differentiable>: AdditiveArithmetic & Differentiable {
+  var x, y: T
+}
+
+@differentiable
+func TF_529<T>(x: Vector<T>) -> Vector<T> {
+  var zero = Vector<T>.zero
+  zero = x
+  return zero
+}
+
 // TODO: Add file checks.

--- a/test/AutoDiff/side_effects.swift
+++ b/test/AutoDiff/side_effects.swift
@@ -58,13 +58,13 @@ func noEscapePartialApplyTest() {
 }
 
 // TF-529: Crash when apply's result is active but arguments aren't.
-struct Vector<T: Numeric & Differentiable>: AdditiveArithmetic & Differentiable {
+struct TF_529_Vector<T: Numeric & Differentiable>: AdditiveArithmetic & Differentiable {
   var x, y: T
 }
 
 @differentiable
-func TF_529<T>(x: Vector<T>) -> Vector<T> {
-  var zero = Vector<T>.zero
+func TF_529<T>(x: TF_529_Vector<T>) -> TF_529_Vector<T> {
+  var zero = TF_529_Vector<T>.zero
   zero = x
   return zero
 }


### PR DESCRIPTION
There are cases where an `apply` has active results while no arguments are active, specifically when the result is a buffer that is being modified by later instructions, for example:

```swift
@differentiable
func TF_529<T>(x: Vector<T>) -> Vector<T> {
  var zero = Vector<T>.zero
  zero = x
  return zero
}
```

This is now fixed by checking whether the function has any active arguments before attempting to differentiate the function.

Resolves [TF-529](https://bugs.swift.org/browse/TF-529).