### PR TITLE
[5.1 04-24-2019] Opaque types require a newer Swift runtime.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -50,6 +50,7 @@ namespace clang {
 namespace swift {
   class ASTContext;
   enum class Associativity : unsigned char;
+  class AvailabilityContext;
   class BoundGenericType;
   class ClangNode;
   class ConstructorDecl;
@@ -593,6 +594,9 @@ public:
   void addDestructorCleanup(T &object) {
     addCleanup([&object]{ object.~T(); });
   }
+  
+  /// Get the runtime availability of the opaque types language feature for the target platform.
+  AvailabilityContext getOpaqueTypeAvailability();
 
   //===--------------------------------------------------------------------===//
   // Diagnostics Helper functions

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4041,6 +4041,10 @@ ERROR(availability_decl_only_version_newer, none,
       "%0 is only available on %1 %2 or newer",
       (DeclName, StringRef, llvm::VersionTuple))
 
+ERROR(availability_opaque_types_only_version_newer, none,
+      "'some' return types are only available in %0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -297,7 +297,7 @@ namespace swift {
     
     /// Enable the experimental opaque result types feature.
     bool EnableOpaqueResultTypes = true;
-
+    
     /// To mimic existing system, set to false.
     /// To experiment with including file-private and private dependency info,
     /// set to true.

--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -20,6 +20,8 @@
 #include "llvm/ADT/ArrayRef.h"
 
 namespace swift {
+  
+class AvailabilityContext;
 
 /// Generate an llvm declaration for a runtime entry with a
 /// given name, return types, argument types, attributes and
@@ -28,6 +30,7 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module,
                       llvm::Constant *&cache,
                       char const *name,
                       llvm::CallingConv::ID cc,
+                      bool isWeakLinked,
                       llvm::ArrayRef<llvm::Type*> retTypes,
                       llvm::ArrayRef<llvm::Type*> argTypes,
                       llvm::ArrayRef<llvm::Attribute::AttrKind> attrs);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -15,7 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// FUNCTION(Id, Name, ReturnTys, ArgTys, CC, Attrs)
+/// FUNCTION(Id, Name, CC, Availability, ReturnTys, ArgTys, Attrs)
 ///   Makes available as "Id" the following runtime function:
 ///     ReturnTy Name(ArgTys...);
 ///   ReturnTys is a call to RETURNS, which takes a non-empty list
@@ -35,10 +35,10 @@
 ///     ATTRS
 ///     NO_ATTRS
 #ifndef FUNCTION
-#define FUNCTION(Id, Name, CC, ReturnTys, ArgTys, Attrs) FUNCTION_ID(Id)
+#define FUNCTION(Id, Name, CC, Availability, ReturnTys, ArgTys, Attrs) FUNCTION_ID(Id)
 #endif
 
-FUNCTION(AllocBox, swift_allocBox, SwiftCC,
+FUNCTION(AllocBox, swift_allocBox, SwiftCC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind))
@@ -46,340 +46,362 @@ FUNCTION(AllocBox, swift_allocBox, SwiftCC,
 //  BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata *type, size_t alignMask);
 FUNCTION(MakeBoxUnique,
          swift_makeBoxUnique,
-         SwiftCC,
+         SwiftCC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy, OpaquePtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, SizeTy),
          ATTRS(NoUnwind))
 
-FUNCTION(DeallocBox, swift_deallocBox, C_CC,
+FUNCTION(DeallocBox, swift_deallocBox, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-FUNCTION(ProjectBox, swift_projectBox, C_CC,
+FUNCTION(ProjectBox, swift_projectBox, C_CC, AlwaysAvailable,
          RETURNS(OpaquePtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-FUNCTION(AllocEmptyBox, swift_allocEmptyBox, C_CC,
+FUNCTION(AllocEmptyBox, swift_allocEmptyBox, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(),
          ATTRS(NoUnwind))
 
 // RefCounted *swift_allocObject(Metadata *type, size_t size, size_t alignMask);
-FUNCTION(AllocObject, swift_allocObject, C_CC,
+FUNCTION(AllocObject, swift_allocObject, C_CC,  AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // HeapObject *swift_initStackObject(HeapMetadata const *metadata,
 //                                   HeapObject *object);
-FUNCTION(InitStackObject, swift_initStackObject, C_CC,
+FUNCTION(InitStackObject, swift_initStackObject, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // HeapObject *swift_initStaticObject(HeapMetadata const *metadata,
 //                                    HeapObject *object);
-FUNCTION(InitStaticObject, swift_initStaticObject, C_CC,
+FUNCTION(InitStaticObject, swift_initStaticObject, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(TypeMetadataPtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_verifyEndOfLifetime(HeapObject *object);
-FUNCTION(VerifyEndOfLifetime, swift_verifyEndOfLifetime, C_CC,
+FUNCTION(VerifyEndOfLifetime, swift_verifyEndOfLifetime, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_deallocObject(HeapObject *obj, size_t size, size_t alignMask);
-FUNCTION(DeallocObject, swift_deallocObject, C_CC,
+FUNCTION(DeallocObject, swift_deallocObject, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void swift_deallocUninitializedObject(HeapObject *obj, size_t size, size_t alignMask);
 FUNCTION(DeallocUninitializedObject, swift_deallocUninitializedObject,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void swift_deallocClassInstance(HeapObject *obj, size_t size, size_t alignMask);
-FUNCTION(DeallocClassInstance, swift_deallocClassInstance, C_CC,
+FUNCTION(DeallocClassInstance, swift_deallocClassInstance, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void swift_deallocPartialClassInstance(HeapObject *obj, HeapMetadata *type, size_t size, size_t alignMask);
-FUNCTION(DeallocPartialClassInstance, swift_deallocPartialClassInstance, C_CC,
+FUNCTION(DeallocPartialClassInstance, swift_deallocPartialClassInstance,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, TypeMetadataPtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void *swift_slowAlloc(size_t size, size_t alignMask);
-FUNCTION(SlowAlloc, swift_slowAlloc, C_CC,
+FUNCTION(SlowAlloc, swift_slowAlloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void swift_slowDealloc(void *ptr, size_t size, size_t alignMask);
-FUNCTION(SlowDealloc, swift_slowDealloc, C_CC,
+FUNCTION(SlowDealloc, swift_slowDealloc, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, SizeTy, SizeTy),
          ATTRS(NoUnwind))
 
 // void swift_willThrow(error *ptr);
-FUNCTION(WillThrow, swift_willThrow, SwiftCC,
+FUNCTION(WillThrow, swift_willThrow, SwiftCC,  AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, ErrorPtrTy->getPointerTo()),
          ATTRS(NoUnwind))
 
 // void swift_errorInMain(error *ptr);
-FUNCTION(ErrorInMain, swift_errorInMain, SwiftCC,
+FUNCTION(ErrorInMain, swift_errorInMain, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_unexpectedError(error *ptr);
-FUNCTION(UnexpectedError, swift_unexpectedError, SwiftCC,
+FUNCTION(UnexpectedError, swift_unexpectedError, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind, NoReturn))
 
 // void *swift_copyPOD(void *dest, void *src, Metadata *self);
-FUNCTION(CopyPOD, swift_copyPOD, C_CC,
+FUNCTION(CopyPOD, swift_copyPOD, C_CC, AlwaysAvailable,
          RETURNS(OpaquePtrTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_retain(void *ptr);
-FUNCTION(NativeStrongRetain, swift_retain, C_CC,
+FUNCTION(NativeStrongRetain, swift_retain, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_release(void *ptr);
-FUNCTION(NativeStrongRelease, swift_release, C_CC,
+FUNCTION(NativeStrongRelease, swift_release, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_retain_n(void *ptr, int32_t n);
-FUNCTION(NativeStrongRetainN, swift_retain_n, C_CC,
+FUNCTION(NativeStrongRetainN, swift_retain_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void *swift_release_n(void *ptr, int32_t n);
-FUNCTION(NativeStrongReleaseN, swift_release_n, C_CC,
+FUNCTION(NativeStrongReleaseN, swift_release_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_setDeallocating(void *ptr);
 FUNCTION(NativeSetDeallocating, swift_setDeallocating,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_nonatomic_retain_n(void *ptr, int32_t n);
-FUNCTION(NativeNonAtomicStrongRetainN, swift_nonatomic_retain_n, C_CC,
+FUNCTION(NativeNonAtomicStrongRetainN, swift_nonatomic_retain_n, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_release_n(void *ptr, int32_t n);
-FUNCTION(NativeNonAtomicStrongReleaseN, swift_nonatomic_release_n, C_CC,
+FUNCTION(NativeNonAtomicStrongReleaseN, swift_nonatomic_release_n, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // void *swift_unknownObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(UnknownObjectRetainN, swift_unknownObjectRetain_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unknownObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(UnknownObjectReleaseN, swift_unknownObjectRelease_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // void *swift_nonatomic_unknownObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownObjectRetainN, swift_nonatomic_unknownObjectRetain_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_unknownObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicUnknownObjectReleaseN, swift_nonatomic_unknownObjectRelease_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // void swift_bridgeObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(BridgeObjectRetainN, swift_bridgeObjectRetain_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_bridgeObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(BridgeObjectReleaseN, swift_bridgeObjectRelease_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // void swift_nonatomic_bridgeObjectRetain_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicBridgeObjectRetainN, swift_nonatomic_bridgeObjectRetain_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_bridgeObjectRelease_n(void *ptr, int32_t n);
 FUNCTION(NonAtomicBridgeObjectReleaseN, swift_nonatomic_bridgeObjectRelease_n,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
 // void *swift_nonatomic_retain(void *ptr);
-FUNCTION(NativeNonAtomicStrongRetain, swift_nonatomic_retain, C_CC,
+FUNCTION(NativeNonAtomicStrongRetain, swift_nonatomic_retain,
+         C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_release(void *ptr);
-FUNCTION(NativeNonAtomicStrongRelease, swift_nonatomic_release, C_CC,
+FUNCTION(NativeNonAtomicStrongRelease, swift_nonatomic_release,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_tryRetain(void *ptr);
-FUNCTION(NativeTryRetain, swift_tryRetain, C_CC,
+FUNCTION(NativeTryRetain, swift_tryRetain, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // bool swift_isDeallocating(void *ptr);
-FUNCTION(IsDeallocating, swift_isDeallocating, C_CC,
+FUNCTION(IsDeallocating, swift_isDeallocating, C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
 
 // void *swift_unknownObjectRetain(void *ptr);
-FUNCTION(UnknownObjectRetain, swift_unknownObjectRetain, C_CC,
+FUNCTION(UnknownObjectRetain, swift_unknownObjectRetain, C_CC, AlwaysAvailable,
          RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_unknownObjectRelease(void *ptr);
-FUNCTION(UnknownObjectRelease, swift_unknownObjectRelease, C_CC,
+FUNCTION(UnknownObjectRelease, swift_unknownObjectRelease,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_nonatomic_unknownObjectRetain(void *ptr);
-FUNCTION(NonAtomicUnknownObjectRetain, swift_nonatomic_unknownObjectRetain, C_CC,
+FUNCTION(NonAtomicUnknownObjectRetain, swift_nonatomic_unknownObjectRetain,
+         C_CC, AlwaysAvailable,
          RETURNS(UnknownRefCountedPtrTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_unknownObjectRelease(void *ptr);
-FUNCTION(NonAtomicUnknownObjectRelease, swift_nonatomic_unknownObjectRelease, C_CC,
+FUNCTION(NonAtomicUnknownObjectRelease, swift_nonatomic_unknownObjectRelease,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_bridgeObjectRetain(void *ptr);
-FUNCTION(BridgeObjectStrongRetain, swift_bridgeObjectRetain, C_CC,
+FUNCTION(BridgeObjectStrongRetain, swift_bridgeObjectRetain,
+         C_CC, AlwaysAvailable,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_bridgeRelease(void *ptr);
-FUNCTION(BridgeObjectStrongRelease, swift_bridgeObjectRelease, C_CC,
+FUNCTION(BridgeObjectStrongRelease, swift_bridgeObjectRelease,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind))
 
 // void *swift_nonatomic_bridgeObjectRetain(void *ptr);
-FUNCTION(NonAtomicBridgeObjectStrongRetain, swift_nonatomic_bridgeObjectRetain, C_CC,
+FUNCTION(NonAtomicBridgeObjectStrongRetain, swift_nonatomic_bridgeObjectRetain,
+         C_CC, AlwaysAvailable,
          RETURNS(BridgeObjectPtrTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, FirstParamReturned))
 
 // void swift_nonatomic_bridgeRelease(void *ptr);
-FUNCTION(NonAtomicBridgeObjectStrongRelease, swift_nonatomic_bridgeObjectRelease, C_CC,
+FUNCTION(NonAtomicBridgeObjectStrongRelease,
+         swift_nonatomic_bridgeObjectRelease,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind))
 
 
 // error *swift_errorRetain(error *ptr);
-FUNCTION(ErrorStrongRetain, swift_errorRetain, C_CC,
+FUNCTION(ErrorStrongRetain, swift_errorRetain,
+         C_CC, AlwaysAvailable,
          RETURNS(ErrorPtrTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_errorRelease(void *ptr);
-FUNCTION(ErrorStrongRelease, swift_errorRelease, C_CC,
+FUNCTION(ErrorStrongRelease, swift_errorRelease,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind))
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Nativeness, SymName, UnknownPrefix) \
   /* void swift_##SymName##Destroy(Name##Reference *object); */ \
-  FUNCTION(Nativeness##Name##Destroy, swift_##SymName##Destroy, C_CC, \
+  FUNCTION(Nativeness##Name##Destroy, swift_##SymName##Destroy, \
+           C_CC, AlwaysAvailable, \
            RETURNS(VoidTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind)) \
   /* void swift_##SymName##Init(Name##Reference *object, void *value); */ \
-  FUNCTION(Nativeness##Name##Init, swift_##SymName##Init, C_CC, \
+  FUNCTION(Nativeness##Name##Init, swift_##SymName##Init, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, UnknownPrefix##RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* Name##Reference *swift_##SymName##Assign(Name##Reference *object, void *value); */ \
-  FUNCTION(Nativeness##Name##Assign, swift_##SymName##Assign, C_CC, \
+  FUNCTION(Nativeness##Name##Assign, swift_##SymName##Assign, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, UnknownPrefix##RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* void *swift_##SymName##Load(Name##Reference *object); */ \
-  FUNCTION(Nativeness##Name##LoadStrong, swift_##SymName##LoadStrong,C_CC, \
+  FUNCTION(Nativeness##Name##LoadStrong, swift_##SymName##LoadStrong, \
+           C_CC, AlwaysAvailable, \
            RETURNS(UnknownPrefix##RefCountedPtrTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind)) \
   /* void *swift_##SymName##Take(Name##Reference *object); */ \
-  FUNCTION(Nativeness##Name##TakeStrong, swift_##SymName##TakeStrong,C_CC, \
+  FUNCTION(Nativeness##Name##TakeStrong, swift_##SymName##TakeStrong, \
+           C_CC, AlwaysAvailable, \
            RETURNS(UnknownPrefix##RefCountedPtrTy), \
            ARGS(Name##ReferencePtrTy), \
            ATTRS(NoUnwind)) \
   /* Name##Reference *swift_##SymName##CopyInit(Name##Reference *dest, Name##Reference *src); */ \
-  FUNCTION(Nativeness##Name##CopyInit, swift_##SymName##CopyInit, C_CC, \
+  FUNCTION(Nativeness##Name##CopyInit, swift_##SymName##CopyInit, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* void *swift_##SymName##TakeInit(Name##Reference *dest, Name##Reference *src); */ \
-  FUNCTION(Nativeness##Name##TakeInit, swift_##SymName##TakeInit, C_CC, \
+  FUNCTION(Nativeness##Name##TakeInit, swift_##SymName##TakeInit, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* Name##Reference *swift_##SymName##CopyAssign(Name##Reference *dest, Name##Reference *src); */ \
-  FUNCTION(Nativeness##Name##CopyAssign, swift_##SymName##CopyAssign, C_CC, \
+  FUNCTION(Nativeness##Name##CopyAssign, swift_##SymName##CopyAssign, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* Name##Reference *swift_##SymName##TakeAssign(Name##Reference *dest, Name##Reference *src); */ \
-  FUNCTION(Nativeness##Name##TakeAssign, swift_##SymName##TakeAssign, C_CC, \
+  FUNCTION(Nativeness##Name##TakeAssign, swift_##SymName##TakeAssign, \
+           C_CC, AlwaysAvailable, \
            RETURNS(Name##ReferencePtrTy), \
            ARGS(Name##ReferencePtrTy, Name##ReferencePtrTy), \
            ATTRS(NoUnwind, FirstParamReturned))
@@ -388,24 +410,27 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease, C_CC,
   NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Unknown, unknownObject##Name, Unknown)
 #define LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name, Prefix, prefix) \
   /* void *swift_##prefix##name##Retain(void *ptr); */ \
-  FUNCTION(Prefix##Name##Retain, swift_##prefix##name##Retain, C_CC, \
+  FUNCTION(Prefix##Name##Retain, swift_##prefix##name##Retain, \
+           C_CC, AlwaysAvailable, \
            RETURNS(RefCountedPtrTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* void swift_##prefix##name##Release(void *ptr); */ \
-  FUNCTION(Prefix##Name##Release, swift_##prefix##name##Release, C_CC, \
+  FUNCTION(Prefix##Name##Release, swift_##prefix##name##Release, \
+           C_CC, AlwaysAvailable, \
            RETURNS(VoidTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind)) \
   /* void *swift_##prefix##name##RetainStrong(void *ptr); */ \
   FUNCTION(Prefix##StrongRetain##Name, swift_##prefix##name##RetainStrong, \
-           C_CC, \
+           C_CC, AlwaysAvailable, \
            RETURNS(RefCountedPtrTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind, FirstParamReturned)) \
   /* void swift_##prefix##name##RetainStrongAndRelease(void *ptr); */ \
   FUNCTION(Prefix##StrongRetainAnd##Name##Release, \
-           swift_##prefix##name##RetainStrongAndRelease, C_CC, \
+           swift_##prefix##name##RetainStrongAndRelease, \
+           C_CC, AlwaysAvailable, \
            RETURNS(VoidTy), \
            ARGS(RefCountedPtrTy), \
            ATTRS(NoUnwind))
@@ -422,7 +447,7 @@ FUNCTION(ErrorStrongRelease, swift_errorRelease, C_CC,
 
 // bool swift_isUniquelyReferencedNonObjC(const void *);
 FUNCTION(IsUniquelyReferencedNonObjC, swift_isUniquelyReferencedNonObjC,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
@@ -430,7 +455,7 @@ FUNCTION(IsUniquelyReferencedNonObjC, swift_isUniquelyReferencedNonObjC,
 // bool swift_isUniquelyReferencedNonObjC_nonNull(const void *);
 FUNCTION(IsUniquelyReferencedNonObjC_nonNull,
          swift_isUniquelyReferencedNonObjC_nonNull,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
@@ -439,14 +464,14 @@ FUNCTION(IsUniquelyReferencedNonObjC_nonNull,
 //   uintptr_t bits);
 FUNCTION(IsUniquelyReferencedNonObjC_nonNull_bridgeObject,
          swift_isUniquelyReferencedNonObjC_nonNull_bridgeObject,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind, ZExt))
 
 // bool swift_isUniquelyReferenced_native(const struct HeapObject *);
 FUNCTION(IsUniquelyReferenced_native, swift_isUniquelyReferenced_native,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
@@ -454,7 +479,7 @@ FUNCTION(IsUniquelyReferenced_native, swift_isUniquelyReferenced_native,
 // bool swift_isUniquelyReferenced_nonNull_native(const struct HeapObject *);
 FUNCTION(IsUniquelyReferenced_nonNull_native,
          swift_isUniquelyReferenced_nonNull_native,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
@@ -466,66 +491,68 @@ FUNCTION(IsUniquelyReferenced_nonNull_native,
 //                                            int32_t col,
 //                                            unsigned type);
 FUNCTION(IsEscapingClosureAtFileLocation, swift_isEscapingClosureAtFileLocation,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(RefCountedPtrTy, Int8PtrTy, Int32Ty, Int32Ty, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ZExt))
 
 // void swift_arrayInitWithCopy(opaque*, opaque*, size_t, type*);
-FUNCTION(ArrayInitWithCopy, swift_arrayInitWithCopy, C_CC,
+FUNCTION(ArrayInitWithCopy, swift_arrayInitWithCopy,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayInitWithTakeNoAlias(opaque*, opaque*, size_t, type*);
-FUNCTION(ArrayInitWithTakeNoAlias, swift_arrayInitWithTakeNoAlias, C_CC,
+FUNCTION(ArrayInitWithTakeNoAlias, swift_arrayInitWithTakeNoAlias,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayInitWithTakeFrontToBack(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithTakeFrontToBack, swift_arrayInitWithTakeFrontToBack,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayInitWithTakeBackToFront(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayInitWithTakeBackToFront, swift_arrayInitWithTakeBackToFront,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayAssignWithCopyNoAlias(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyNoAlias, swift_arrayAssignWithCopyNoAlias,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayAssignWithCopyFrontToBack(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyFrontToBack, swift_arrayAssignWithCopyFrontToBack,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayAssignWithCopyBackToFront(opaque*, opaque*, size_t, type*);
 FUNCTION(ArrayAssignWithCopyBackToFront, swift_arrayAssignWithCopyBackToFront,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayAssignWithTake(opaque*, opaque*, size_t, type*);
-FUNCTION(ArrayAssignWithTake, swift_arrayAssignWithTake, C_CC,
+FUNCTION(ArrayAssignWithTake, swift_arrayAssignWithTake, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_arrayDestroy(opaque*, size_t, type*);
-FUNCTION(ArrayDestroy, swift_arrayDestroy, C_CC,
+FUNCTION(ArrayDestroy, swift_arrayDestroy, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
@@ -534,7 +561,8 @@ FUNCTION(ArrayDestroy, swift_arrayDestroy, C_CC,
 //                                         const Metadata **parameters,
 //                                         const uint32_t *parameterFlags,
 //                                         const Metadata *result);
-FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, C_CC,
+FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy,
               TypeMetadataPtrTy->getPointerTo(0),
@@ -544,7 +572,8 @@ FUNCTION(GetFunctionMetadata, swift_getFunctionTypeMetadata, C_CC,
 
 // Metadata *swift_getFunctionTypeMetadata0(unsigned long flags,
 //                                          const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata0, swift_getFunctionTypeMetadata0, C_CC,
+FUNCTION(GetFunctionMetadata0, swift_getFunctionTypeMetadata0,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
@@ -552,7 +581,8 @@ FUNCTION(GetFunctionMetadata0, swift_getFunctionTypeMetadata0, C_CC,
 // Metadata *swift_getFunctionTypeMetadata1(unsigned long flags,
 //                                          const Metadata *arg0,
 //                                          const Metadata *resultMetadata);
-FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, C_CC,
+FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1,
+        C_CC, AlwaysAvailable,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
@@ -562,7 +592,7 @@ FUNCTION(GetFunctionMetadata1, swift_getFunctionTypeMetadata1, C_CC,
 //                                          const Metadata *arg1,
 //                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
-        C_CC,
+        C_CC, AlwaysAvailable,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
@@ -573,21 +603,23 @@ FUNCTION(GetFunctionMetadata2, swift_getFunctionTypeMetadata2,
 //                                          const Metadata *arg2,
 //                                          const Metadata *resultMetadata);
 FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
-        C_CC,
+        C_CC, AlwaysAvailable,
         RETURNS(TypeMetadataPtrTy),
         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
              TypeMetadataPtrTy),
         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);
-FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, SwiftCC,
+FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata,
+         SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone)) // only writes to runtime-private fields
 
 // MetadataResponse swift_getSingletonMetadata(MetadataRequest request,
 //                                             TypeContextDescriptor *type);
-FUNCTION(GetSingletonMetadata, swift_getSingletonMetadata, SwiftCC,
+FUNCTION(GetSingletonMetadata, swift_getSingletonMetadata,
+         SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone))
@@ -595,7 +627,8 @@ FUNCTION(GetSingletonMetadata, swift_getSingletonMetadata, SwiftCC,
 // MetadataResponse swift_getGenericMetadata(MetadataRequest request,
 //                                           const void * const *arguments,
 //                                           TypeContextDescriptor *type);
-FUNCTION(GetGenericMetadata, swift_getGenericMetadata, SwiftCC,
+FUNCTION(GetGenericMetadata, swift_getGenericMetadata,
+         SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, TypeContextDescriptorPtrTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -604,7 +637,8 @@ FUNCTION(GetGenericMetadata, swift_getGenericMetadata, SwiftCC,
 //                                     const void * const *arguments,
 //                                     const OpaqueTypeDescriptor *descriptor,
 //                                     uintptr_t index);
-FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata, SwiftCC,
+FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata,
+         SwiftCC, OpaqueTypeAvailability,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -612,7 +646,8 @@ FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata, SwiftCC,
 // const WitnessTable *swift_getOpaqueTypeConformance(const void * const *arguments,
 //                                     const OpaqueTypeDescriptor *descriptor,
 //                                     uintptr_t index);
-FUNCTION(GetOpaqueTypeConformance, swift_getOpaqueTypeConformance, SwiftCC,
+FUNCTION(GetOpaqueTypeConformance, swift_getOpaqueTypeConformance,
+         SwiftCC, OpaqueTypeAvailability,
          RETURNS(WitnessTablePtrTy),
          ARGS(Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -621,7 +656,8 @@ FUNCTION(GetOpaqueTypeConformance, swift_getOpaqueTypeConformance, SwiftCC,
 //                                              const void * const *arguments,
 //                                              const void *template);
 FUNCTION(AllocateGenericClassMetadata, swift_allocateGenericClassMetadata,
-         C_CC, RETURNS(TypeMetadataPtrTy),
+         C_CC, AlwaysAvailable,
+         RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
@@ -630,13 +666,15 @@ FUNCTION(AllocateGenericClassMetadata, swift_allocateGenericClassMetadata,
 //                                              const void *template,
 //                                              size_t extraSize);
 FUNCTION(AllocateGenericValueMetadata, swift_allocateGenericValueMetadata,
-         C_CC, RETURNS(TypeMetadataPtrTy),
+         C_CC, AlwaysAvailable,
+         RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind))
 
 // MetadataResponse swift_checkMetadataState(MetadataRequest request,
 //                                           const Metadata *type);
-FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
+FUNCTION(CheckMetadataState, swift_checkMetadataState,
+         SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -645,7 +683,7 @@ FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
 // swift_getWitnessTable(const ProtocolConformanceDescriptor *conf,
 //                       const Metadata *type,
 //                       const void * const *instantiationArgs);
-FUNCTION(GetWitnessTable, swift_getWitnessTable, C_CC,
+FUNCTION(GetWitnessTable, swift_getWitnessTable, C_CC, AlwaysAvailable,
          RETURNS(WitnessTablePtrTy),
          ARGS(ProtocolConformanceDescriptorPtrTy,
               TypeMetadataPtrTy,
@@ -658,7 +696,8 @@ FUNCTION(GetWitnessTable, swift_getWitnessTable, C_CC,
 //                                            const Metadata *conformingType,
 //                                            ProtocolRequirement *reqBase,
 //                                            ProtocolRequirement *assocType);
-FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness, SwiftCC,
+FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness,
+         SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy,
               WitnessTablePtrTy,
@@ -675,7 +714,7 @@ FUNCTION(GetAssociatedTypeWitness, swift_getAssociatedTypeWitness, SwiftCC,
 //                                 const ProtocolRequirement *reqBase,
 //                                 const ProtocolRequirement *assocConformance);
 FUNCTION(GetAssociatedConformanceWitness,
-         swift_getAssociatedConformanceWitness, SwiftCC,
+         swift_getAssociatedConformanceWitness, SwiftCC, AlwaysAvailable,
          RETURNS(WitnessTablePtrTy),
          ARGS(WitnessTablePtrTy,
               TypeMetadataPtrTy,
@@ -685,32 +724,35 @@ FUNCTION(GetAssociatedConformanceWitness,
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getMetatypeMetadata(Metadata *instanceTy);
-FUNCTION(GetMetatypeMetadata, swift_getMetatypeMetadata, C_CC,
+FUNCTION(GetMetatypeMetadata, swift_getMetatypeMetadata, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getExistentialMetatypeMetadata(Metadata *instanceTy);
 FUNCTION(GetExistentialMetatypeMetadata,
-         swift_getExistentialMetatypeMetadata, C_CC,
+         swift_getExistentialMetatypeMetadata, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjCClassMetadata(objc_class *theClass);
-FUNCTION(GetObjCClassMetadata, swift_getObjCClassMetadata, C_CC,
+FUNCTION(GetObjCClassMetadata, swift_getObjCClassMetadata,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjCClassFromMetadata(objc_class *theClass);
-FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata, C_CC,
+FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjCClassFromObject(id object);
-FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject, C_CC,
+FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind, ReadNone))
@@ -720,7 +762,7 @@ FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject, C_CC,
 //                                             Metadata * const *elts,
 //                                             const char *labels,
 //                                             value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, SwiftCC,
+FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, SizeTy, TypeMetadataPtrTy->getPointerTo(0),
               Int8PtrTy, WitnessTablePtrTy),
@@ -730,7 +772,7 @@ FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, SwiftCC,
 //                                              Metadata *elt0, Metadata *elt1,
 //                                              const char *labels,
 //                                              value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, SwiftCC,
+FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
@@ -741,7 +783,7 @@ FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, SwiftCC,
 //                                              Metadata *elt2,
 //                                              const char *labels,
 //                                              value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC,
+FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
@@ -751,7 +793,7 @@ FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC,
 //                               uint32_t offsets,
 //                               TupleTypeFlags flags,
 //                               const TypeLayout * const *elts);
-FUNCTION(GetTupleLayout, swift_getTupleTypeLayout, SwiftCC,
+FUNCTION(GetTupleLayout, swift_getTupleTypeLayout, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(FullTypeLayoutTy->getPointerTo(0), Int32Ty->getPointerTo(0),
               SizeTy, Int8PtrPtrTy->getPointerTo(0)),
@@ -760,7 +802,7 @@ FUNCTION(GetTupleLayout, swift_getTupleTypeLayout, SwiftCC,
 // size_t swift_getTupleTypeLayout2(TypeLayout *layout,
 //                                  const TypeLayout *elt0,
 //                                  const TypeLayout *elt1);
-FUNCTION(GetTupleLayout2, swift_getTupleTypeLayout2, SwiftCC,
+FUNCTION(GetTupleLayout2, swift_getTupleTypeLayout2, SwiftCC, AlwaysAvailable,
          RETURNS(SizeTy),
          ARGS(FullTypeLayoutTy->getPointerTo(0), Int8PtrPtrTy, Int8PtrPtrTy),
          ATTRS(NoUnwind))
@@ -769,7 +811,7 @@ FUNCTION(GetTupleLayout2, swift_getTupleTypeLayout2, SwiftCC,
 //                                      const TypeLayout *elt0,
 //                                      const TypeLayout *elt1,
 //                                      const TypeLayout *elt2);
-FUNCTION(GetTupleLayout3, swift_getTupleTypeLayout3, SwiftCC,
+FUNCTION(GetTupleLayout3, swift_getTupleTypeLayout3, SwiftCC, AlwaysAvailable,
          RETURNS(OffsetPairTy),
          ARGS(FullTypeLayoutTy->getPointerTo(0),
               Int8PtrPtrTy, Int8PtrPtrTy, Int8PtrPtrTy),
@@ -783,7 +825,8 @@ FUNCTION(GetTupleLayout3, swift_getTupleTypeLayout3, SwiftCC,
 //
 // Note: ProtocolClassConstraint::Class is 0, ::Any is 1.
 FUNCTION(GetExistentialMetadata,
-         swift_getExistentialTypeMetadata, C_CC,
+         swift_getExistentialTypeMetadata,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int1Ty, TypeMetadataPtrTy, SizeTy,
               ProtocolDescriptorRefTy->getPointerTo()),
@@ -792,7 +835,7 @@ FUNCTION(GetExistentialMetadata,
 // Metadata *swift_relocateClassMetadata(TypeContextDescriptor *descriptor,
 //                                       const void *pattern);
 FUNCTION(RelocateClassMetadata,
-         swift_relocateClassMetadata, C_CC,
+         swift_relocateClassMetadata, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
@@ -803,7 +846,7 @@ FUNCTION(RelocateClassMetadata,
 //                              TypeLayout * const *fieldTypes,
 //                              size_t *fieldOffsets);
 FUNCTION(InitClassMetadata,
-         swift_initClassMetadata, C_CC,
+         swift_initClassMetadata, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
@@ -816,7 +859,7 @@ FUNCTION(InitClassMetadata,
 //                                TypeLayout * const *fieldTypes,
 //                                size_t *fieldOffsets);
 FUNCTION(UpdateClassMetadata,
-         swift_updateClassMetadata, C_CC,
+         swift_updateClassMetadata, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
@@ -829,7 +872,7 @@ FUNCTION(UpdateClassMetadata,
 //                                             TypeLayout * const *fieldTypes,
 //                                             size_t *fieldOffsets);
 FUNCTION(InitClassMetadata2,
-         swift_initClassMetadata2, SwiftCC,
+         swift_initClassMetadata2, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataDependencyTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
@@ -842,7 +885,7 @@ FUNCTION(InitClassMetadata2,
 //                                               TypeLayout * const *fieldTypes,
 //                                               size_t *fieldOffsets);
 FUNCTION(UpdateClassMetadata2,
-         swift_updateClassMetadata2, SwiftCC,
+         swift_updateClassMetadata2, SwiftCC, AlwaysAvailable,
          RETURNS(TypeMetadataDependencyTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(),
@@ -853,7 +896,7 @@ FUNCTION(UpdateClassMetadata2,
 //                               ClassDescriptor *description,
 //                               MethodDescriptor *method);
 FUNCTION(LookUpClassMethod,
-         swift_lookUpClassMethod, C_CC,
+         swift_lookUpClassMethod, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(TypeMetadataPtrTy,
               MethodDescriptorStructTy->getPointerTo(),
@@ -866,7 +909,7 @@ FUNCTION(LookUpClassMethod,
 //                               TypeLayout * const *fieldTypes,
 //                               uint32_t *fieldOffsets);
 FUNCTION(InitStructMetadata,
-         swift_initStructMetadata, C_CC,
+         swift_initStructMetadata, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(0),
@@ -878,7 +921,7 @@ FUNCTION(InitStructMetadata,
 //                                       TypeLayout *payload);
 FUNCTION(InitEnumMetadataSingleCase,
          swift_initEnumMetadataSingleCase,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind))
@@ -889,7 +932,7 @@ FUNCTION(InitEnumMetadataSingleCase,
 //                                          unsigned num_empty_cases);
 FUNCTION(InitEnumMetadataSinglePayload,
          swift_initEnumMetadataSinglePayload,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy, Int32Ty),
          ATTRS(NoUnwind))
@@ -899,7 +942,7 @@ FUNCTION(InitEnumMetadataSinglePayload,
 //                                         TypeLayout * const *payloadTypes);
 FUNCTION(InitEnumMetadataMultiPayload,
          swift_initEnumMetadataMultiPayload,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy, Int8PtrPtrTy->getPointerTo(0)),
          ATTRS(NoUnwind))
@@ -907,7 +950,7 @@ FUNCTION(InitEnumMetadataMultiPayload,
 // int swift_getEnumCaseMultiPayload(opaque_t *obj, Metadata *enumTy);
 FUNCTION(GetEnumCaseMultiPayload,
          swift_getEnumCaseMultiPayload,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int32Ty),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -920,7 +963,7 @@ FUNCTION(GetEnumCaseMultiPayload,
 //                                                        Metadata *payload));
 FUNCTION(GetEnumTagSinglePayloadGeneric,
          swift_getEnumTagSinglePayloadGeneric,
-         SwiftCC,
+         SwiftCC, AlwaysAvailable,
          RETURNS(Int32Ty),
          ARGS(OpaquePtrTy, Int32Ty, TypeMetadataPtrTy,
               llvm::FunctionType::get(Int32Ty, {OpaquePtrTy, Int32Ty,
@@ -939,7 +982,7 @@ FUNCTION(GetEnumTagSinglePayloadGeneric,
 //                                                        Metadata *payload));
 FUNCTION(StoreEnumTagSinglePayloadGeneric,
          swift_storeEnumTagSinglePayloadGeneric,
-         SwiftCC,
+         SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, Int32Ty, Int32Ty, TypeMetadataPtrTy,
               llvm::FunctionType::get(VoidTy, {OpaquePtrTy, Int32Ty, Int32Ty,
@@ -951,7 +994,7 @@ FUNCTION(StoreEnumTagSinglePayloadGeneric,
 //                                     int case_index);
 FUNCTION(StoreEnumTagMultiPayload,
          swift_storeEnumTagMultiPayload,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, Int32Ty),
          ATTRS(NoUnwind))
@@ -960,103 +1003,109 @@ FUNCTION(StoreEnumTagMultiPayload,
 //
 // This is readonly instead of readnone because isa-rewriting can have
 // a noticeable effect.
-FUNCTION(GetObjectClass, object_getClass, C_CC,
+FUNCTION(GetObjectClass, object_getClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // id object_dispose(id object);
-FUNCTION(ObjectDispose, object_dispose, C_CC,
+FUNCTION(ObjectDispose, object_dispose, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind))
 
 // Class objc_lookUpClass(const char *name);
-FUNCTION(LookUpClass, objc_lookUpClass, C_CC,
+FUNCTION(LookUpClass, objc_lookUpClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjectType(id object);
-FUNCTION(GetObjectType, swift_getObjectType, C_CC,
+FUNCTION(GetObjectType, swift_getObjectType, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(ObjCPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getDynamicType(opaque_t *obj, Metadata *self);
-FUNCTION(GetDynamicType, swift_getDynamicType, C_CC,
+FUNCTION(GetDynamicType, swift_getDynamicType, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(OpaquePtrTy, TypeMetadataPtrTy, Int1Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastClass(void*, void*);
-FUNCTION(DynamicCastClass, swift_dynamicCastClass, C_CC,
+FUNCTION(DynamicCastClass, swift_dynamicCastClass, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastClassUnconditional(void*, void*);
 FUNCTION(DynamicCastClassUnconditional, swift_dynamicCastClassUnconditional,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastObjCClass(void*, void*);
-FUNCTION(DynamicCastObjCClass, swift_dynamicCastObjCClass, C_CC,
+FUNCTION(DynamicCastObjCClass, swift_dynamicCastObjCClass,
+         C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastObjCClassUnconditional(void*, void*);
 FUNCTION(DynamicCastObjCClassUnconditional,
-         swift_dynamicCastObjCClassUnconditional, C_CC,
+         swift_dynamicCastObjCClassUnconditional, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastUnknownClass(void*, void*);
-FUNCTION(DynamicCastUnknownClass, swift_dynamicCastUnknownClass, C_CC,
+FUNCTION(DynamicCastUnknownClass, swift_dynamicCastUnknownClass,
+         C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // void *swift_dynamicCastUnknownClassUnconditional(void*, void*);
 FUNCTION(DynamicCastUnknownClassUnconditional,
-         swift_dynamicCastUnknownClassUnconditional, C_CC,
+         swift_dynamicCastUnknownClassUnconditional,
+         C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // type *swift_dynamicCastMetatype(type*, type*);
-FUNCTION(DynamicCastMetatype, swift_dynamicCastMetatype, C_CC,
+FUNCTION(DynamicCastMetatype, swift_dynamicCastMetatype,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // type *swift_dynamicCastMetatypeUnconditional(type*, type*);
 FUNCTION(DynamicCastMetatypeUnconditional,
-         swift_dynamicCastMetatypeUnconditional, C_CC,
+         swift_dynamicCastMetatypeUnconditional,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // objc_class *swift_dynamicCastObjCClassMetatype(objc_class*, objc_class*);
 FUNCTION(DynamicCastObjCClassMetatype, swift_dynamicCastObjCClassMetatype,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy, ObjCClassPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // objc_class *swift_dynamicCastObjCClassMetatypeUnconditional(objc_class*, objc_class*);
 FUNCTION(DynamicCastObjCClassMetatypeUnconditional,
-         swift_dynamicCastObjCClassMetatypeUnconditional, C_CC,
+         swift_dynamicCastObjCClassMetatypeUnconditional,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy, ObjCClassPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadOnly))
 
 // bool swift_dynamicCast(opaque*, opaque*, type*, type*, size_t);
-FUNCTION(DynamicCast, swift_dynamicCast, C_CC,
+FUNCTION(DynamicCast, swift_dynamicCast, C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(OpaquePtrTy, OpaquePtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               SizeTy),
@@ -1066,7 +1115,8 @@ FUNCTION(DynamicCast, swift_dynamicCast, C_CC,
 //                                               size_t numProtocols,
 //                                               Protocol * const *protocols);
 FUNCTION(DynamicCastTypeToObjCProtocolUnconditional,
-         swift_dynamicCastTypeToObjCProtocolUnconditional, C_CC,
+         swift_dynamicCastTypeToObjCProtocolUnconditional,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind))
@@ -1075,7 +1125,8 @@ FUNCTION(DynamicCastTypeToObjCProtocolUnconditional,
 //                                             size_t numProtocols,
 //                                             Protocol * const *protocols);
 FUNCTION(DynamicCastTypeToObjCProtocolConditional,
-         swift_dynamicCastTypeToObjCProtocolConditional, C_CC,
+         swift_dynamicCastTypeToObjCProtocolConditional,
+         C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),
          ARGS(TypeMetadataPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind))
@@ -1084,7 +1135,7 @@ FUNCTION(DynamicCastTypeToObjCProtocolConditional,
 //                                               size_t numProtocols,
 //                                               Protocol * const *protocols);
 FUNCTION(DynamicCastObjCProtocolUnconditional,
-         swift_dynamicCastObjCProtocolUnconditional, C_CC,
+         swift_dynamicCastObjCProtocolUnconditional, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind))
@@ -1093,42 +1144,42 @@ FUNCTION(DynamicCastObjCProtocolUnconditional,
 //                                             size_t numProtocols,
 //                                             Protocol * const *protocols);
 FUNCTION(DynamicCastObjCProtocolConditional,
-         swift_dynamicCastObjCProtocolConditional, C_CC,
+         swift_dynamicCastObjCProtocolConditional, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(ObjCPtrTy, SizeTy, Int8PtrPtrTy),
          ATTRS(NoUnwind))
 
 // id swift_dynamicCastMetatypeToObjectUnconditional(type *type);
 FUNCTION(DynamicCastMetatypeToObjectUnconditional,
-         swift_dynamicCastMetatypeToObjectUnconditional, C_CC,
+         swift_dynamicCastMetatypeToObjectUnconditional, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(TypeMetadataPtrTy, Int8PtrTy, Int32Ty, Int32Ty),
          ATTRS(NoUnwind, ReadNone))
 
 // id swift_dynamicCastMetatypeToObjectConditional(type *type);
 FUNCTION(DynamicCastMetatypeToObjectConditional,
-         swift_dynamicCastMetatypeToObjectConditional, C_CC,
+         swift_dynamicCastMetatypeToObjectConditional, C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // witness_table* swift_conformsToProtocol(type*, protocol*);
 FUNCTION(ConformsToProtocol,
-         swift_conformsToProtocol, C_CC,
+         swift_conformsToProtocol, C_CC, AlwaysAvailable,
          RETURNS(WitnessTablePtrTy),
          ARGS(TypeMetadataPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
 // bool swift_isClassType(type*);
 FUNCTION(IsClassType,
-         swift_isClassType, C_CC,
+         swift_isClassType, C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(TypeMetadataPtrTy),
          ATTRS(ZExt, NoUnwind, ReadNone))
 
 // bool swift_isOptionalType(type*);
 FUNCTION(IsOptionalType,
-         swift_isOptionalType, C_CC,
+         swift_isOptionalType, C_CC, AlwaysAvailable,
          RETURNS(Int1Ty),
          ARGS(TypeMetadataPtrTy),
          ATTRS(ZExt, NoUnwind, ReadNone))
@@ -1136,7 +1187,7 @@ FUNCTION(IsOptionalType,
 // void swift_once(swift_once_t *predicate,
 //                 void (*function_code)(RefCounted*),
 //                 void *context);
-FUNCTION(Once, swift_once, C_CC,
+FUNCTION(Once, swift_once, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(OnceTy->getPointerTo(), Int8PtrTy, Int8PtrTy),
          ATTRS())
@@ -1144,7 +1195,7 @@ FUNCTION(Once, swift_once, C_CC,
 // void swift_registerProtocols(const ProtocolRecord *begin,
 //                              const ProtocolRecord *end)
 FUNCTION(RegisterProtocols,
-         swift_registerProtocols, C_CC,
+         swift_registerProtocols, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolRecordPtrTy, ProtocolRecordPtrTy),
          ATTRS(NoUnwind))
@@ -1152,170 +1203,185 @@ FUNCTION(RegisterProtocols,
 // void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
 //                                         const ProtocolConformanceRecord *end)
 FUNCTION(RegisterProtocolConformances,
-         swift_registerProtocolConformances, C_CC,
+         swift_registerProtocolConformances, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(RelativeAddressPtrTy, RelativeAddressPtrTy),
          ATTRS(NoUnwind))
 FUNCTION(RegisterTypeMetadataRecords,
-         swift_registerTypeMetadataRecords, C_CC,
+         swift_registerTypeMetadataRecords, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataRecordPtrTy, TypeMetadataRecordPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_beginAccess(void *pointer, ValueBuffer *scratch, size_t flags);
-FUNCTION(BeginAccess, swift_beginAccess, C_CC,
+FUNCTION(BeginAccess, swift_beginAccess, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, getFixedBufferTy()->getPointerTo(), SizeTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 // void swift_endAccess(ValueBuffer *scratch);
-FUNCTION(EndAccess, swift_endAccess, C_CC,
+FUNCTION(EndAccess, swift_endAccess, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(getFixedBufferTy()->getPointerTo()),
          ATTRS(NoUnwind))
 
-FUNCTION(InstantiateObjCClass, swift_instantiateObjCClass, C_CC,
+FUNCTION(InstantiateObjCClass, swift_instantiateObjCClass,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ObjCAllocWithZone, objc_allocWithZone, C_CC,
+FUNCTION(ObjCAllocWithZone, objc_allocWithZone,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCPtrTy), ARGS(ObjCClassPtrTy), ATTRS(NoUnwind))
-FUNCTION(ObjCMsgSend, objc_msgSend, C_CC,
+FUNCTION(ObjCMsgSend, objc_msgSend,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCMsgSendStret, objc_msgSend_stret, C_CC,
+FUNCTION(ObjCMsgSendStret, objc_msgSend_stret,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCMsgSendSuper, objc_msgSendSuper, C_CC,
+FUNCTION(ObjCMsgSendSuper, objc_msgSendSuper,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCMsgSendSuperStret, objc_msgSendSuper_stret, C_CC,
+FUNCTION(ObjCMsgSendSuperStret, objc_msgSendSuper_stret,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCMsgSendSuper2, objc_msgSendSuper2, C_CC,
+FUNCTION(ObjCMsgSendSuper2, objc_msgSendSuper2,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCMsgSendSuperStret2, objc_msgSendSuper2_stret, C_CC,
+FUNCTION(ObjCMsgSendSuperStret2, objc_msgSendSuper2_stret,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy), NO_ARGS, NO_ATTRS)
-FUNCTION(ObjCSelRegisterName, sel_registerName, C_CC,
+FUNCTION(ObjCSelRegisterName, sel_registerName,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCSELTy), ARGS(Int8PtrTy), ATTRS(NoUnwind, ReadNone))
-FUNCTION(ClassReplaceMethod, class_replaceMethod, C_CC,
+FUNCTION(ClassReplaceMethod, class_replaceMethod,
+         C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(ObjCClassPtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ClassAddProtocol, class_addProtocol, C_CC,
+FUNCTION(ClassAddProtocol, class_addProtocol,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ObjCClassPtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ObjCGetClass, objc_getClass, C_CC,
+FUNCTION(ObjCGetClass, objc_getClass, C_CC,  AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ObjCGetMetaClass, objc_getMetaClass, C_CC,
+FUNCTION(ObjCGetMetaClass, objc_getMetaClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ObjCClassGetName, class_getName, C_CC,
+FUNCTION(ObjCClassGetName, class_getName, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind))
 
-FUNCTION(GetObjCProtocol, objc_getProtocol, C_CC,
+FUNCTION(GetObjCProtocol, objc_getProtocol, C_CC, AlwaysAvailable,
          RETURNS(ProtocolDescriptorPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(AllocateObjCProtocol, objc_allocateProtocol, C_CC,
+FUNCTION(AllocateObjCProtocol, objc_allocateProtocol, C_CC, AlwaysAvailable,
          RETURNS(ProtocolDescriptorPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(RegisterObjCProtocol, objc_registerProtocol, C_CC,
+FUNCTION(RegisterObjCProtocol, objc_registerProtocol, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind))
-FUNCTION(ProtocolAddMethodDescription, protocol_addMethodDescription, C_CC,
+FUNCTION(ProtocolAddMethodDescription, protocol_addMethodDescription,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy, Int8PtrTy, Int8PtrTy,
               ObjCBoolTy, ObjCBoolTy),
          ATTRS(NoUnwind))
-FUNCTION(ProtocolAddProtocol, protocol_addProtocol, C_CC,
+FUNCTION(ProtocolAddProtocol, protocol_addProtocol,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ProtocolDescriptorPtrTy, ProtocolDescriptorPtrTy),
          ATTRS(NoUnwind))
 
-FUNCTION(Malloc, malloc, C_CC,
+FUNCTION(Malloc, malloc, C_CC, AlwaysAvailable,
          RETURNS(Int8PtrTy),
          ARGS(SizeTy),
          NO_ATTRS)
-FUNCTION(Free, free, C_CC,
+FUNCTION(Free, free, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy),
          NO_ATTRS)
 
 // void *_Block_copy(void *block);
-FUNCTION(BlockCopy, _Block_copy, C_CC,
+FUNCTION(BlockCopy, _Block_copy, C_CC, AlwaysAvailable,
          RETURNS(ObjCBlockPtrTy),
          ARGS(ObjCBlockPtrTy),
          NO_ATTRS)
 // void _Block_release(void *block);
-FUNCTION(BlockRelease, _Block_release, C_CC,
+FUNCTION(BlockRelease, _Block_release, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ObjCBlockPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_deletedMethodError();
-FUNCTION(DeletedMethodError, swift_deletedMethodError, C_CC,
+FUNCTION(DeletedMethodError, swift_deletedMethodError, C_CC, AlwaysAvailable,
         RETURNS(VoidTy),
         ARGS(),
         ATTRS(NoUnwind))
 
-FUNCTION(AllocError, swift_allocError, SwiftCC,
+FUNCTION(AllocError, swift_allocError, SwiftCC, AlwaysAvailable,
          RETURNS(ErrorPtrTy, OpaquePtrTy),
          ARGS(TypeMetadataPtrTy, WitnessTablePtrTy, OpaquePtrTy, Int1Ty),
          ATTRS(NoUnwind))
-FUNCTION(DeallocError, swift_deallocError, C_CC,
+FUNCTION(DeallocError, swift_deallocError, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind))
-FUNCTION(GetErrorValue, swift_getErrorValue, C_CC,
+FUNCTION(GetErrorValue, swift_getErrorValue, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy, Int8PtrPtrTy, OpenedErrorTriplePtrTy),
          ATTRS(NoUnwind))
 
 // void __tsan_external_write(void *addr, void *caller_pc, void *tag);
 // This is a Thread Sanitizer instrumentation entry point in compiler-rt.
-FUNCTION(TSanInoutAccess, __tsan_external_write, C_CC,
+FUNCTION(TSanInoutAccess, __tsan_external_write, C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
-FUNCTION(GetKeyPath, swift_getKeyPath, C_CC,
+FUNCTION(GetKeyPath, swift_getKeyPath, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
          ARGS(Int8PtrTy, Int8PtrTy),
          ATTRS(NoUnwind))
-FUNCTION(CopyKeyPathTrivialIndices, swift_copyKeyPathTrivialIndices, C_CC,
+FUNCTION(CopyKeyPathTrivialIndices, swift_copyKeyPathTrivialIndices,
+         C_CC,  AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(Int8PtrTy, Int8PtrTy, SizeTy),
          ATTRS(NoUnwind))
 
-FUNCTION(GetInitializedObjCClass, swift_getInitializedObjCClass, C_CC,
+FUNCTION(GetInitializedObjCClass, swift_getInitializedObjCClass,
+         C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCClassPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector)
 FUNCTION(Swift3ImplicitObjCEntrypoint, swift_objc_swift3ImplicitObjCEntrypoint,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ObjCPtrTy, ObjCSELTy, Int8PtrTy, SizeTy, SizeTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 FUNCTION(VerifyTypeLayoutAttribute, _swift_debug_verifyTypeLayoutAttribute,
-         C_CC,
+         C_CC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, Int8PtrTy, Int8PtrTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
 // float swift_intToFloat32(const size_t *data, IntegerLiteralFlags flags);
-FUNCTION(IntToFloat32, swift_intToFloat32, SwiftCC,
+FUNCTION(IntToFloat32, swift_intToFloat32, SwiftCC, AlwaysAvailable,
          RETURNS(FloatTy),
          ARGS(SizeTy->getPointerTo(), SizeTy),
          ATTRS(NoUnwind, ReadOnly))
-FUNCTION(IntToFloat64, swift_intToFloat64, SwiftCC,
+FUNCTION(IntToFloat64, swift_intToFloat64, SwiftCC, AlwaysAvailable,
          RETURNS(DoubleTy),
          ARGS(SizeTy->getPointerTo(), SizeTy),
          ATTRS(NoUnwind, ReadOnly))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -216,3 +216,17 @@ AvailabilityContext AvailabilityInference::inferForType(Type t) {
   t.walk(walker);
   return walker.AvailabilityInfo;
 }
+
+AvailabilityContext ASTContext::getOpaqueTypeAvailability() {
+  auto target = LangOpts.Target;
+  
+  if (target.isMacOSX()
+      || target.isiOS()
+      || target.isWatchOS()) {
+    // TODO: Update with OS versions that ship with runtime support
+    return AvailabilityContext(
+                            VersionRange::allGTE(llvm::VersionTuple(9999,0,0)));
+  }
+  
+  return AvailabilityContext::alwaysAvailable();
+}

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -220,7 +220,7 @@ private:
     Retain = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain" : "swift_retain",
-        DefaultCC, {ObjectPtrTy}, {ObjectPtrTy},
+        DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy},
         {NoUnwind, FirstParamReturned});
 
     return Retain.get();
@@ -237,7 +237,7 @@ private:
     Release = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_release" : "swift_release",
-        DefaultCC, {VoidTy}, {ObjectPtrTy}, {NoUnwind});
+        DefaultCC, false, {VoidTy}, {ObjectPtrTy}, {NoUnwind});
 
     return Release.get();
   }
@@ -272,7 +272,7 @@ private:
     RetainN = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain_n" : "swift_retain_n",
-        DefaultCC, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
+        DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
         {NoUnwind, FirstParamReturned});
 
     return RetainN.get();
@@ -290,7 +290,7 @@ private:
     ReleaseN = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_release_n" : "swift_release_n",
-        DefaultCC, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+        DefaultCC, false, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return ReleaseN.get();
   }
@@ -309,7 +309,7 @@ private:
                      isNonAtomic(OrigI)
                        ? "swift_nonatomic_unknownObjectRetain_n"
                        : "swift_unknownObjectRetain_n",
-                     DefaultCC, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
+                     DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
                      {NoUnwind, FirstParamReturned});
 
     return UnknownObjectRetainN.get();
@@ -329,7 +329,8 @@ private:
                      isNonAtomic(OrigI)
                        ? "swift_nonatomic_unknownObjectRelease_n"
                        : "swift_unknownObjectRelease_n",
-                     DefaultCC, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+                     DefaultCC, false,
+                     {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return UnknownObjectReleaseN.get();
   }
@@ -346,7 +347,7 @@ private:
         getRuntimeFn(getModule(), cache,
                      isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRetain_n"
                                         : "swift_bridgeObjectRetain_n",
-                     DefaultCC, {BridgeObjectPtrTy},
+                     DefaultCC, false, {BridgeObjectPtrTy},
                      {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeRetainN.get();
   }
@@ -365,7 +366,7 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRelease_n"
                            : "swift_bridgeObjectRelease_n",
-        DefaultCC, {VoidTy}, {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
+        DefaultCC, false, {VoidTy}, {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeReleaseN.get();
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2007,6 +2007,10 @@ public:
                                        const DeclContext *ReferenceDC,
                                        const UnavailabilityReason &Reason);
 
+  void diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
+                                           const DeclContext *ReferenceDC,
+                                           const UnavailabilityReason &Reason);
+  
   /// Emits a diagnostic for a reference to a storage accessor that is
   /// potentially unavailable.
   void diagnosePotentialAccessorUnavailability(

--- a/test/IRGen/dynamic_replaceable_opaque_return.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/lazy_opaque_result_type.swift
+++ b/test/IRGen/lazy_opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll
 
 protocol P { }

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
-// RUN: %target-swift-frontend -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
 public protocol O {
   func bar()

--- a/test/IRGen/opaque_result_type_access_path.swift
+++ b/test/IRGen/opaque_result_type_access_path.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64 || CPU=x86_64
 
-// Check that the IRGenMangler does not crashq when mangling a conformance
+// Check that the IRGenMangler does not crash when mangling a conformance
 // access path with an opaque result type as root.
 // As a bonus, also do a runtime test to check that there is no miscompile.
 

--- a/test/IRGen/opaque_result_type_availability.swift
+++ b/test/IRGen/opaque_result_type_availability.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -Onone -emit-ir %s | %FileCheck --check-prefix=MAYBE-AVAILABLE %s
+// TODO: Build with a macos deployment target that unconditionally supports opaque result types
+// R/UN: %target-swift-frontend -target x86_64-apple-macosx10.9999 -Onone -emit-ir %s | %FileCheck --check-prefix=ALWAYS-AVAILABLE %s
+// REQUIRES: OS=macosx
+
+protocol P {}
+extension Int: P {}
+
+@available(macOS 9999, *)
+func foo() -> some P {
+  return 1738
+}
+
+@_silgen_name("external")
+func generic<T: P>(x: T, y: T)
+
+@available(macOS 9999, *)
+public func main() {
+  generic(x: foo(), y: foo())
+}
+
+// MAYBE-AVAILABLE: declare{{.*}} extern_weak {{.*}} @swift_getOpaqueTypeMetadata
+// MAYBE-AVAILABLE: declare{{.*}} extern_weak {{.*}} @swift_getOpaqueTypeConformance
+// ALWAYS-AVAILABLE-NOT: declare{{.*}} extern_weak {{.*}} @swift_getOpaqueTypeMetadata
+// ALWAYS-AVAILABLE-NOT: declare{{.*}} extern_weak {{.*}} @swift_getOpaqueTypeConformance

--- a/test/IRGen/opaque_result_type_debug.swift
+++ b/test/IRGen/opaque_result_type_debug.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -g -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -g -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s
 
 public protocol P {}
 extension Int: P {} 

--- a/test/IRGen/opaque_result_type_global.swift
+++ b/test/IRGen/opaque_result_type_global.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
 
 // rdar://problem/49818962
 func foo() -> some Collection {

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
@@ -9,15 +9,18 @@ extension Int: P {
 
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func bar(_ x: Int) -> some P {
   return x
 }
 
 struct Container {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   func bar(_ x: Int) -> some P {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   var computedProperty : some P {
     get {
       return 2
@@ -27,6 +30,7 @@ struct Container {
     }
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   subscript(_ x: Int) -> some P {
     get {
       return 2

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
@@ -8,17 +8,20 @@ struct Pair : P {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @_dynamicReplacement(for:bar(_:))
 func _replacement_bar(y x: Int) -> some P {
   return Pair()
 }
 
 extension Container {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for:bar(_:))
   func _replacement_bar(y x: Int) -> some P {
     return Pair()
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for: computedProperty)
   var _replacement_computedProperty : some P {
      get {
@@ -28,6 +31,8 @@ extension Container {
       print("replacement \(newValue)")
      }
   }
+
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   @_dynamicReplacement(for: subscript(_:))
   subscript(y x: Int) -> some P {
     get {

--- a/test/Interpreter/dynamic_replacement_opaque_result.swift
+++ b/test/Interpreter/dynamic_replacement_opaque_result.swift
@@ -7,7 +7,8 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize_none
-// REQUIRES: CPU=arm64 || CPU=arm64e || CPU=x86_64
+
+// REQUIRES: CPU=arm64 || CPU=x86_64
 
 @_private(sourceFile: "TestOpaque1.swift") import TestOpaque1
 
@@ -32,6 +33,7 @@ private func target_library_name(_ name: String) -> String {
 #endif
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func test() {
   print(MemoryLayout.size(ofValue: bar(5)))
   print(MemoryLayout.size(ofValue: Container().bar(5)))
@@ -51,7 +53,11 @@ func test() {
 // CHECK: 2
 // CHECK: 8
 // CHECK: 2
-test()
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  test()
+} else {
+  print("8 8 5 5 8 2 8 2")
+}
 
 var executablePath = CommandLine.arguments[0]
 executablePath.removeLast(4)
@@ -72,4 +78,8 @@ executablePath.removeLast(4)
 // CHECK: 1
 // CHECK: 16
 // CHECK: 1
-test()
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  test()
+} else {
+  print("16 16 1 1 16 1 16 1")
+}

--- a/test/ParseableInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ParseableInterface/Inputs/opaque-result-types-client.swift
@@ -13,6 +13,7 @@ func getAssocSubscriptType<T: AssocTypeInference>(_ x: T) -> T.AssocSubscript {
 struct MyFoo: Foo {}
 struct YourFoo: Foo {}
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func someTypeIsTheSame() {
   var a = foo(0)
   a = foo(0)

--- a/test/ParseableInterface/opaque-result-types.swift
+++ b/test/ParseableInterface/opaque-result-types.swift
@@ -7,16 +7,19 @@ public protocol Foo {}
 extension Int: Foo {}
 
 // CHECK-LABEL: public func foo(_: Int) -> some Foo
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
 // CHECK-LABEL: @inlinable public func foo(_: String) -> some Foo {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
 // CHECK-LABEL: public func foo<T>(_ x: T) -> some Foo where T : OpaqueResultTypes.Foo
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
@@ -32,43 +35,53 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
   // CHECK-LABEL: public func foo(_: Int) -> some Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Bas: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -78,30 +91,37 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo(_ x: U) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -111,9 +131,11 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T, U>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public var prop: some Foo {
     return 123
   }
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public subscript() -> some Foo {
     return 123
   }
@@ -123,70 +145,87 @@ public struct Bar<T>: AssocTypeInference {
   // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct Zim: AssocTypeInference {
   public init() {}
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Zang: AssocTypeInference {
     public init() {}
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
 
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public var prop: some Foo {
       return 123
     }
+    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -196,9 +235,11 @@ public struct Zim: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<U>
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public var prop: some Foo {
     return 123
   }
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public subscript() -> some Foo {
     return 123
   }

--- a/test/SIL/Serialization/opaque_return_type_serialize.sil
+++ b/test/SIL/Serialization/opaque_return_type_serialize.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OpaqueReturnTypeExporter.swiftmodule -module-name OpaqueReturnTypeExporter %S/Inputs/OpaqueReturnTypeExporter.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module -emit-module-path %t/OpaqueReturnTypeExporter.swiftmodule -module-name OpaqueReturnTypeExporter %S/Inputs/OpaqueReturnTypeExporter.swift
 // RUN: %target-sil-opt -I %t %s -emit-sib -module-name test -o %t/test.sib
-// RUN: %target-swift-frontend -I %t -emit-ir %t/test.sib
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir %t/test.sib
 
 import OpaqueReturnTypeExporter
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s | %FileCheck %s
 
 protocol P {}
 protocol Q: AnyObject {}

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
-// RUN: %target-swift-frontend -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
+// RUN: %target-swift-frontend -disable-availability-checking -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -Onone -emit-sil %s | %FileCheck %s --check-prefix=MANDATORY
 // We want to check two things here:
 // - Correctness
 // - That certain "is" checks are eliminated based on static analysis at compile-time

--- a/test/Serialization/opaque_circularity.swift
+++ b/test/Serialization/opaque_circularity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -emit-module %s
+// RUN: %target-swiftc_driver -Xfrontend -disable-availability-checking -emit-module %s
 
 // rdar://problem/49829836
 

--- a/test/Serialization/opaque_cross_file.swift
+++ b/test/Serialization/opaque_cross_file.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -verify %s | %FileCheck %s
 
 import OpaqueCrossFileB
 

--- a/test/TBD/opaque_result_type.swift
+++ b/test/TBD/opaque_result_type.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
 
 public protocol O {
   func bar()

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -enable-opaque-result-types %s
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify -enable-opaque-result-types %s
 
 protocol P {
   func paul()

--- a/test/type/opaque_constraint_order.swift
+++ b/test/type/opaque_constraint_order.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
 
 // rdar://problem/50309983, make sure that the generic signature built for
 // an opaque return type is correct when there are associated type constraints

--- a/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
+++ b/validation-test/compiler_crashers_2_fixed/0194-rdar50309503.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -o /dev/null %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null %s
 
 protocol P {
   associatedtype AT


### PR DESCRIPTION
Check the availability of decls that declare an opaque return type to ensure they deploy to a
runtime that supports opaque types.

rdar://problem/50731151
