### PR TITLE
Revert "[build-czar] Disable broken test."

### DIFF
--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// REQUIRES: rdar51080373
-
 struct X {
   var i : Int, j : Int
 }


### PR DESCRIPTION
This reverts commit a7870128cbaa223d3e1ba2b8c414ce07192b3841.

Turns out this only fails on the internal CI.
