### PR TITLE
[ClangImporter] Update now that APValue::Uninitialized was split.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8185,10 +8185,11 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   case clang::APValue::ComplexFloat:
   case clang::APValue::ComplexInt:
   case clang::APValue::FixedPoint:
+  case clang::APValue::Indeterminate:
   case clang::APValue::LValue:
   case clang::APValue::MemberPointer:
+  case clang::APValue::None:
   case clang::APValue::Struct:
-  case clang::APValue::Uninitialized:
   case clang::APValue::Union:
   case clang::APValue::Vector:
     llvm_unreachable("Unhandled APValue kind");


### PR DESCRIPTION
The two new states are None & Indeterminate.
The former means "no such object", and "indeterminate" represents
an uninitialized object.

As the clang importer was using these only to cover a switch of
unhandled case, this should be functionally equivalent to what
was there before.