### PR TITLE
[GenDecl] XCOFF should be treated like COFF.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1331,6 +1331,7 @@ static std::string getDynamicReplacementSomeSection(IRGenModule &IGM) {
   case llvm::Triple::Wasm:
     sectionName = "swift5_replac2";
     break;
+  case llvm::Triple::XCOFF:
   case llvm::Triple::COFF:
     sectionName = ".sw5reps$B";
     break;


### PR DESCRIPTION
Fixes a build error:

/Users/local/swift/swift/lib/IRGen/GenDecl.cpp:1323:11: error: enumeration value 'XCOFF' not handled in switch [-Werror,-Wswitch]

All the other functions in this file group XCOFF and COFF together
so I guess this is a reasonable thing to do.
