### PR TITLE
api-digester: keep track of the introduced platforms and language versions for all APIs

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -148,6 +148,11 @@ KEY_STRING(EnumRawTypeName, enumRawTypeName)
 KEY_STRING(GenericSig, genericSig)
 KEY_STRING(FuncSelfKind, funcSelfKind)
 KEY_STRING(ParamValueOwnership, paramValueOwnership)
+KEY_STRING(IntromacOS, intro_Macosx)
+KEY_STRING(IntroiOS, intro_iOS)
+KEY_STRING(IntrotvOS, intro_tvOS)
+KEY_STRING(IntrowatchOS, intro_watchOS)
+KEY_STRING(Introswift, intro_swift)
 
 KEY_STRING_ARR(SuperclassNames, superclassNames)
 

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -117,3 +117,9 @@ public class FutureContainer {
 extension FutureContainer: P1 {}
 
 extension FutureContainer: P2 {}
+
+@available(macOS 10.1, iOS 10.2, tvOS 10.3, watchOS 3.4, *)
+public class PlatformIntroClass {}
+
+@available(swift, introduced: 5)
+public class SwiftIntroClass {}

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1203,6 +1203,10 @@
           "usr": "s:4cake15FutureContainerC9futureFooyyF",
           "moduleName": "cake",
           "isABIPlaceholder": true,
+          "intro_Macosx": "9999",
+          "intro_iOS": "9999",
+          "intro_tvOS": "9999",
+          "intro_watchOS": "9999",
           "declAttributes": [
             "Available",
             "Available",
@@ -1225,6 +1229,7 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC12NotfutureFooyyF",
           "moduleName": "cake",
+          "intro_Macosx": "9999",
           "declAttributes": [
             "Available"
           ],
@@ -1248,6 +1253,36 @@
           "printedName": "P2",
           "usr": "s:4cake2P2P"
         }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "PlatformIntroClass",
+      "printedName": "PlatformIntroClass",
+      "declKind": "Class",
+      "usr": "s:4cake18PlatformIntroClassC",
+      "moduleName": "cake",
+      "intro_Macosx": "10.1",
+      "intro_iOS": "10.2",
+      "intro_tvOS": "10.3",
+      "intro_watchOS": "3.4",
+      "declAttributes": [
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "SwiftIntroClass",
+      "printedName": "SwiftIntroClass",
+      "declKind": "Class",
+      "usr": "s:4cake15SwiftIntroClassC",
+      "moduleName": "cake",
+      "intro_swift": "5",
+      "declAttributes": [
+        "Available"
       ]
     },
     {

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1092,6 +1092,10 @@
           "usr": "s:4cake15FutureContainerC9futureFooyyF",
           "moduleName": "cake",
           "isABIPlaceholder": true,
+          "intro_Macosx": "9999",
+          "intro_iOS": "9999",
+          "intro_tvOS": "9999",
+          "intro_watchOS": "9999",
           "declAttributes": [
             "Available",
             "Available",
@@ -1114,6 +1118,7 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC12NotfutureFooyyF",
           "moduleName": "cake",
+          "intro_Macosx": "9999",
           "declAttributes": [
             "Available"
           ],
@@ -1137,6 +1142,36 @@
           "printedName": "P2",
           "usr": "s:4cake2P2P"
         }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "PlatformIntroClass",
+      "printedName": "PlatformIntroClass",
+      "declKind": "Class",
+      "usr": "s:4cake18PlatformIntroClassC",
+      "moduleName": "cake",
+      "intro_Macosx": "10.1",
+      "intro_iOS": "10.2",
+      "intro_tvOS": "10.3",
+      "intro_watchOS": "3.4",
+      "declAttributes": [
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "SwiftIntroClass",
+      "printedName": "SwiftIntroClass",
+      "declKind": "Class",
+      "usr": "s:4cake15SwiftIntroClassC",
+      "moduleName": "cake",
+      "intro_swift": "5",
+      "declAttributes": [
+        "Available"
       ]
     },
     {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -187,6 +187,8 @@ public:
   DiagnosticEngine &getDiags() {
     return Diags;
   }
+  StringRef getPlatformIntroVersion(Decl *D, PlatformKind Kind);
+  StringRef getLanguageIntroVersion(Decl *D);
   bool isEqual(const SDKNode &Left, const SDKNode &Right);
   bool checkingABI() const { return Opts.ABI; }
   AccessLevel getAccessLevel(const ValueDecl *VD) const;
@@ -285,6 +287,14 @@ public:
   }
 };
 
+struct PlatformIntroVersion {
+  StringRef macos;
+  StringRef ios;
+  StringRef tvos;
+  StringRef watchos;
+  StringRef swift;
+};
+
 class SDKNodeDecl: public SDKNode {
   DeclKind DKind;
   StringRef Usr;
@@ -302,6 +312,7 @@ class SDKNodeDecl: public SDKNode {
   uint8_t ReferenceOwnership;
   StringRef GenericSig;
   Optional<uint8_t> FixedBinaryOrder;
+  PlatformIntroVersion introVersions;
 
 protected:
   SDKNodeDecl(SDKNodeInitInfo Info, SDKNodeKind Kind);


### PR DESCRIPTION
These fields will be used to diagnose the missing of available
attributes for newly added APIs.

rdar://51089418