### PR TITLE
[TF] TF-416: Produce error if `PythonLibrary.useVersion` is called after Python sy…

### DIFF
--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -88,8 +88,8 @@ public struct PythonLibrary {
 public extension PythonLibrary {
   static func useVersion(_ major: Int, _ minor: Int? = nil) {
     precondition(!librarySymbolsLoaded, """
-      Error: \(#function) should not be called after any Python library
-      symbols have already been loaded.
+      Error: \(#function) should not be called after any Python library \
+      has already been loaded.
       """)
     let version = PythonVersion(major: major, minor: minor)
     PythonLibrary.Environment.version.set(version.versionString)

--- a/stdlib/public/Python/PythonLibrary.swift
+++ b/stdlib/public/Python/PythonLibrary.swift
@@ -30,6 +30,7 @@ import WinSDK
 public struct PythonLibrary {
   private static let shared = PythonLibrary()
   private static let pythonLegacySymbolName = "PyString_AsString"
+  private static var librarySymbolsLoaded = false
 
   private let pythonLibraryHandle: UnsafeMutableRawPointer
   private let isLegacyPython: Bool
@@ -51,6 +52,7 @@ public struct PythonLibrary {
       PythonLibrary.log(
         "Loaded legacy Python library, using legacy symbols...")
     }
+    PythonLibrary.librarySymbolsLoaded = true
   }
 
   static func loadSymbol(
@@ -82,9 +84,13 @@ public struct PythonLibrary {
   }
 }
 
-// Methods of `PythonLibrary` required to set a given the Python version.
+// Methods of `PythonLibrary` required to set a given Python version.
 public extension PythonLibrary {
   static func useVersion(_ major: Int, _ minor: Int? = nil) {
+    precondition(!librarySymbolsLoaded, """
+      Error: \(#function) should not be called after any Python library
+      symbols have already been loaded.
+      """)
     let version = PythonVersion(major: major, minor: minor)
     PythonLibrary.Environment.version.set(version.versionString)
   }

--- a/test/Python/python_runtime.swift
+++ b/test/Python/python_runtime.swift
@@ -6,6 +6,9 @@
 import Python
 import StdlibUnittest
 
+var PythonRuntimeTestSuite = TestSuite("PythonRuntime")
+PythonLibrary.useVersion(2, 7)
+
 /// The gc module is an interface to the Python garbage collector.
 let gc = Python.import("gc")
 /// The tracemalloc module is a debug tool to trace memory blocks allocated by
@@ -33,14 +36,16 @@ extension TestSuite {
   }
 }
 
-var PythonRuntimeTestSuite = TestSuite("PythonRuntime")
-PythonLibrary.useVersion(2, 7)
-
 PythonRuntimeTestSuite.testWithLeakChecking("CheckVersion") {
   expectEqual("2.7.", String(Python.version)!.prefix(4))
   let versionInfo = Python.versionInfo
   expectEqual(2, versionInfo.major)
   expectEqual(7, versionInfo.minor)
+
+  expectCrash(executing: {
+    // Expect crash when setting version if any Python symbols are already loaded.
+    PythonLibrary.useVersion(2, 7)
+  })
 }
 
 // Python.repr() in lists produces some static values that stay referenced for


### PR DESCRIPTION
Resolves [TF-416](https://bugs.swift.org/browse/TF-416).

Produce a precondition error if [`PythonLibrary.useVersion(_:_:)`](https://www.tensorflow.org/swift/api_docs/Structs/PythonLibrary#useversion_:_:) is called after any Python library symbols have been loaded. The Swift bug tracker issue suggested producing an error if this method is called a second time, but really it appears the core idea is to prevent users from calling it after Python symbols have been initially loaded.