### PR TITLE
[test] Disable inherits_NSObject.swift on watchOS.

### DIFF
--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -7,6 +7,10 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// REQUIRES: OS=macosx || OS=ios || OS=tvos
+// NOTE: Test is temporarily disabled for watchOS until we can figure out why
+// it's failing there. rdar://problem/50898688
+
 import Foundation
 import simd
 


### PR DESCRIPTION
This was failing alongside inherits_ObjCClasses.swift (they were failing at the
same time).

Until MikeA has time to look at this disable this as well.

rdar://problem/50898688
(cherry picked from commit 6f42934462b471657e22f4e15d59c817ba60ccac)
