### PR TITLE
[ConstraintSystem] Deplay opening generic requirements until after co…

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2376,6 +2376,9 @@ public:
   /// \param skipProtocolSelfConstraint Whether to skip the constraint on a
   /// protocol's 'Self' type.
   ///
+  /// \param skipGenericRequirements Whether to skip opening generic
+  /// requirements asscoiated with given function type.
+  ///
   /// \returns The opened type, or \c type if there are no archetypes in it.
   Type openFunctionType(
       AnyFunctionType *funcType,
@@ -2384,16 +2387,18 @@ public:
       OpenedTypeMap &replacements,
       DeclContext *innerDC,
       DeclContext *outerDC,
-      bool skipProtocolSelfConstraint);
+      bool skipProtocolSelfConstraint,
+      bool skipGenericRequirements = false);
 
-  /// Open the generic parameter list and its requirements, creating
-  /// type variables for each of the type parameters.
+  /// Open the generic parameter list and (if requested) its requirements,
+  /// creating type variables for each of the type parameters.
   void openGeneric(DeclContext *innerDC,
                    DeclContext *outerDC,
                    GenericSignature *signature,
                    bool skipProtocolSelfConstraint,
                    ConstraintLocatorBuilder locator,
-                   OpenedTypeMap &replacements);
+                   OpenedTypeMap &replacements,
+                   bool skipGenericRequirements = false);
 
   /// Given generic signature open its generic requirements,
   /// using substitution function, and record them in the

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -751,6 +751,14 @@ static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
   Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
   if (type->isEqual(selfTy)) {
     type = conformance->getType();
+
+    // e.g. `extension P where Self == C { func foo() { ... } }`
+    // and `C` doesn't actually conform to `P`.
+    if (type->isEqual(missingType)) {
+      requirementKind = RequirementKind::Conformance;
+      missingType = proto->getDeclaredType();
+    }
+
     if (auto agt = type->getAs<AnyGenericType>())
       type = agt->getDecl()->getDeclaredInterfaceType();
     return missingRequirementMatch(type);

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -627,3 +627,30 @@ func rdar_50467583_and_50909555() {
     s[1] // expected-error {{static member 'subscript' cannot be used on instance of type 'S'}} {{5-6=S}}
   }
 }
+
+// SR-9396 (rdar://problem/46427500) - Nonsensical error message related to constrained extensions
+struct SR_9396<A, B> {}
+
+extension SR_9396 where A == Bool {  // expected-note {{where 'A' = 'Int'}}
+  func foo() {}
+}
+
+func test_sr_9396(_ s: SR_9396<Int, Double>) {
+  s.foo() // expected-error {{referencing instance method 'foo()' on 'SR_9396' requires the types 'Int' and 'Bool' be equivalent}}
+}
+
+// rdar://problem/34770265 - Better diagnostic needed for constrained extension method call
+extension Dictionary where Key == String { // expected-note {{where 'Key' = 'Int'}}
+  func rdar_34770265_key() {}
+}
+
+extension Dictionary where Value == String { // expected-note {{where 'Value' = 'Int'}}
+  func rdar_34770265_val() {}
+}
+
+func test_34770265(_ dict: [Int: Int]) {
+  dict.rdar_34770265_key()
+  // expected-error@-1 {{referencing instance method 'rdar_34770265_key()' on 'Dictionary' requires the types 'Int' and 'String' be equivalent}}
+  dict.rdar_34770265_val()
+  // expected-error@-1 {{referencing instance method 'rdar_34770265_val()' on 'Dictionary' requires the types 'Int' and 'String' be equivalent}}
+}

--- a/test/Serialization/extension-of-typealias.swift
+++ b/test/Serialization/extension-of-typealias.swift
@@ -41,7 +41,7 @@ func test(x: Int) {
   x.addedMember()
   [x].addedMember()
   [x].addedMemberInt()
-  ([] as [Bool]).addedMemberInt() // expected-error {{'[Bool]' is not convertible to 'Array<Int>'}}
+  ([] as [Bool]).addedMemberInt() // expected-error {{referencing instance method 'addedMemberInt()' on 'Array' requires the types 'Bool' and 'Int' be equivalent}}
 }
 
 #endif

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -377,8 +377,8 @@ protocol ExpressibleByDogLiteral {}
 struct Kitten : ExpressibleByCatLiteral {}
 struct Puppy : ExpressibleByDogLiteral {}
 
-struct Claws<A: ExpressibleByCatLiteral> { // expected-note {{'A' declared as parameter to type 'Claws'}}
-  struct Fangs<B: ExpressibleByDogLiteral> { }
+struct Claws<A: ExpressibleByCatLiteral> {
+  struct Fangs<B: ExpressibleByDogLiteral> { } // expected-note {{where 'B' = 'NotADog'}}
 }
 
 struct NotADog {}
@@ -401,9 +401,8 @@ func test() {
   // expected-error@-1 {{cannot convert value of type 'Claws<_>.Fangs<_>' to specified type 'Claws.Fangs<Puppy>'}}
   let _: Claws.Fangs<NotADog> = something()
   // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
-  _ = Claws.Fangs<NotADog>()
-  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
-  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+  _ = Claws.Fangs<NotADog>() // TODO(diagnostics): There should be two errors here - "cannot infer A" and "NotADog conformance to ExpressibleByDogLiteral"
+  // expected-error@-1 {{referencing initializer 'init()' on 'Claws.Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
 }
 
 // https://bugs.swift.org/browse/SR-4379

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -50,7 +50,7 @@ protocol HasDefault {
 
 extension HasDefault where Self == SillyClass {
   func foo() {}
-  // expected-note@-1 {{candidate has non-matching type '<Self> () -> ()'}}
+  // expected-note@-1 {{candidate would match if 'SillyClass' conformed to 'HasDefault'}}
 }
 
 extension SillyClass : HasDefault {}


### PR DESCRIPTION
…ntextual self has been applied

While computing a type of member via `getTypeOfMemberReference`
let's delay opening generic requirements associated with function
type until after self constraint has been created, that would give
a chance for contextual types to get propagated and make mismatch
originated in generic requirements much easier to diagnose.

Consider following example:

```swift
struct S<T> {}

extension S where T == Int {
  func foo() {}
}

func test(_ s: S<String>) {
  s.foo()
}
```

`foo` would get opened as `(S<$T>) -> () -> Void` and contextual `self`
type is going to be `S<String>`, so applying that before generic requirement
`$T == Int` would make sure that `$T` gets bound to a contextual
type of `String` and later fails requirement constraint `$T == Int`.

This is much easier to diagnose comparing to `$T` being bound to
`Int` right away due to same-type generic requirement and then
failing an attempt to convert `S<String>` to `S<Int>` while simplifying
self constraint.

Resolves: rdar://problem/46427500
Resolves: rdar://problem/34770265

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
