### PR TITLE
vim: improve syntax highlighting for `typealias`

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -82,6 +82,8 @@ syn keyword swiftTypeDefinition skipwhite skipempty nextgroup=swiftTypeName
       \ extension
       \ protocol
       \ struct
+
+syn keyword swiftTypeAliasDefinition skipwhite skipempty nextgroup=swiftTypeAliasName
       \ typealias
 
 syn match swiftMultiwordTypeDefinition skipwhite skipempty nextgroup=swiftTypeName
@@ -109,6 +111,8 @@ syn match swiftImportModule contained nextgroup=swiftImportComponent
 syn match swiftImportComponent contained nextgroup=swiftImportComponent
       \ /\.\<[A-Za-z_][A-Za-z_0-9]*\>/
 
+syn match swiftTypeAliasName contained skipwhite skipempty nextgroup=swiftTypeAliasValue
+      \ /\<[A-Za-z_][A-Za-z_0-9]*\>/
 syn match swiftTypeName contained skipwhite skipempty nextgroup=swiftTypeParameters
       \ /\<[A-Za-z_][A-Za-z_0-9\.]*\>/
 syn match swiftVarName contained skipwhite skipempty nextgroup=swiftTypeDeclaration
@@ -136,6 +140,8 @@ syn region swiftTypeParameters contained contains=swiftVarName,swiftConstraint
 syn keyword swiftConstraint contained
       \ where
 
+syn match swiftTypeAliasValue skipwhite skipempty nextgroup=swiftType
+      \ /=/
 syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType,swiftInOutKeyword
       \ /:/
 syn match swiftTypeDeclaration skipwhite skipempty nextgroup=swiftType
@@ -195,6 +201,7 @@ hi def link swiftTypeDefinition Define
 hi def link swiftMultiwordTypeDefinition Define
 hi def link swiftType Type
 hi def link swiftTypePair Type
+hi def link swiftTypeAliasName Identifier
 hi def link swiftTypeName Function
 hi def link swiftConstraint Special
 hi def link swiftFuncDefinition Define
@@ -202,10 +209,12 @@ hi def link swiftDefinitionModifier Define
 hi def link swiftInOutKeyword Define
 hi def link swiftFuncKeyword Function
 hi def link swiftFuncKeywordGeneral Function
+hi def link swiftTypeAliasDefinition Define
 hi def link swiftVarDefinition Define
 hi def link swiftVarName Identifier
 hi def link swiftImplicitVarName Identifier
 hi def link swiftIdentifierKeyword Identifier
+hi def link swiftTypeAliasValue Delimiter
 hi def link swiftTypeDeclaration Delimiter
 hi def link swiftTypeParameters Delimiter
 hi def link swiftBoolean Boolean


### PR DESCRIPTION
This improves the detection of syntax so that the identifier for a
typealias is identified as an identifier, the `=` is identified as a
delimiter, and the type that is aliased is identified as a type.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
