### PR TITLE
[AutoDiff] Refactor 'AutoDiffIndexSubset' to take a 'SmallBitVector' in the base factory method.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -296,8 +296,7 @@ public:
   static AutoDiffIndexSubset *get(ASTContext &ctx,
                                   const SmallBitVector &indices);
 
-  static AutoDiffIndexSubset *get(ASTContext &ctx,
-                                  unsigned capacity,
+  static AutoDiffIndexSubset *get(ASTContext &ctx, unsigned capacity,
                                   ArrayRef<unsigned> indices) {
     SmallBitVector indicesBitVec(capacity, false);
     for (auto index : indices)
@@ -305,14 +304,12 @@ public:
     return AutoDiffIndexSubset::get(ctx, indicesBitVec);
   }
 
-  static AutoDiffIndexSubset *getDefault(ASTContext &ctx,
-                                         unsigned capacity,
+  static AutoDiffIndexSubset *getDefault(ASTContext &ctx, unsigned capacity,
                                          bool includeAll = false) {
     return get(ctx, SmallBitVector(capacity, includeAll));
   }
 
-  static AutoDiffIndexSubset *getFromRange(ASTContext &ctx,
-                                           unsigned capacity,
+  static AutoDiffIndexSubset *getFromRange(ASTContext &ctx, unsigned capacity,
                                            unsigned start, unsigned end) {
     assert(start < capacity);
     assert(end <= capacity);

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -385,17 +385,16 @@ AutoDiffIndexSubset *AutoDiffIndexSubset::adding(unsigned index,
   assert(index < getCapacity());
   if (contains(index))
     return const_cast<AutoDiffIndexSubset *>(this);
-  SmallVector<unsigned, 8> newIndices;
-  newIndices.reserve(capacity + 1);
+  SmallBitVector newIndices(capacity);
   bool inserted = false;
   for (auto curIndex : getIndices()) {
     if (!inserted && curIndex > index) {
-      newIndices.push_back(index);
+      newIndices.set(index);
       inserted = true;
     }
-    newIndices.push_back(curIndex);
+    newIndices.set(curIndex);
   }
-  return get(ctx, capacity, newIndices);
+  return get(ctx, newIndices);
 }
 
 AutoDiffIndexSubset *AutoDiffIndexSubset::extendingCapacity(
@@ -403,10 +402,10 @@ AutoDiffIndexSubset *AutoDiffIndexSubset::extendingCapacity(
   assert(newCapacity >= capacity);
   if (newCapacity == capacity)
     return const_cast<AutoDiffIndexSubset *>(this);
-  SmallVector<unsigned, 8> indices;
+  SmallBitVector indices(newCapacity);
   for (auto index : getIndices())
-    indices.push_back(index);
-  return AutoDiffIndexSubset::get(ctx, newCapacity, indices);
+    indices.set(index);
+  return AutoDiffIndexSubset::get(ctx, indices);
 }
 
 int AutoDiffIndexSubset::findNext(int startIndex) const {


### PR DESCRIPTION
Change the base implementation of `AutoDiffIndexSubset::get` to take a `const SmallBitVector &` instead of an `ArrayRef<unsigned>` because bit vectors are far more efficient.