### PR TITLE
[Diagnostics] Add a detailed diagnostic for generic argument mismatches

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -394,50 +394,42 @@ ERROR(cannot_convert_closure_result_protocol,none,
 ERROR(cannot_convert_closure_result_nil,none,
       "'nil' is not compatible with closure result type %0", (Type))
 
+NOTE(generic_argument_mismatch,none,
+     "arguments to generic parameter %0 (%1 and %2) are expected to be equal",
+     (Identifier, Type, Type))
 ERROR(cannot_convert_generic_type_argument,none,
-      "cannot convert %0 to expected argument type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to expected argument type %1, ",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_default_argument,none,
-      "default argument value of type %0 cannot be converted to type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "default argument value of type %0 cannot be converted to type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_return,none,
-      "cannot convert return expression of type %0 to return type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert return expression of type %0 to return type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_yield,none,
-      "cannot convert value of type %0 to expected yield type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to expected yield type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_closure_result,none,
-      "cannot convert value of type %0 to closure result type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to closure result type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_array_element,none,
-      "cannot convert value of type %0 to expected element type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to expected element type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_dict_key,none,
-      "cannot convert value of type %0 to expected dictionary key type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to expected dictionary key type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_dict_value,none,
-      "cannot convert value of type %0 to expected dictionary value type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to expected dictionary value type %1",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_coerce,none,
-      "cannot convert value of type %0 to type %1 in coercion, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to type %1 in coercion",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_assign,none,
-      "cannot convert value of type %0 to %1 in assignment, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert value of type %0 to %1 in assignment",
+      (Type, Type))
 ERROR(cannot_convert_generic_type_parent_type,none,
-      "cannot convert parent type %0 to expected type %1, "
-      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
-      (Type, Type, Identifier, Type, Type))
+      "cannot convert parent type %0 to expected type %1",
+      (Type, Type))
 
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -398,7 +398,10 @@ NOTE(generic_argument_mismatch,none,
      "arguments to generic parameter %0 (%1 and %2) are expected to be equal",
      (Identifier, Type, Type))
 ERROR(cannot_convert_generic_type_argument,none,
-      "cannot convert value of type %0 to expected argument type %1, ",
+      "cannot convert value of type %0 to expected argument type %1",
+      (Type, Type))
+ERROR(cannot_convert_generic_type_subscript_assign,none,
+      "cannot convert value of type %0 to expected subscript type %1",
       (Type, Type))
 ERROR(cannot_convert_generic_type_default_argument,none,
       "default argument value of type %0 cannot be converted to type %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -393,46 +393,13 @@ ERROR(cannot_convert_closure_result_protocol,none,
       (Type, Type))
 ERROR(cannot_convert_closure_result_nil,none,
       "'nil' is not compatible with closure result type %0", (Type))
+ERROR(cannot_convert_parent_type,none,
+      "cannot convert parent type %0 to expected type %1",
+      (Type, Type))
 
 NOTE(generic_argument_mismatch,none,
      "arguments to generic parameter %0 (%1 and %2) are expected to be equal",
      (Identifier, Type, Type))
-ERROR(cannot_convert_generic_type_argument,none,
-      "cannot convert value of type %0 to expected argument type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_subscript_assign,none,
-      "cannot convert value of type %0 to expected subscript type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_default_argument,none,
-      "default argument value of type %0 cannot be converted to type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_return,none,
-      "cannot convert return expression of type %0 to return type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_yield,none,
-      "cannot convert value of type %0 to expected yield type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_closure_result,none,
-      "cannot convert value of type %0 to closure result type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_array_element,none,
-      "cannot convert value of type %0 to expected element type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_dict_key,none,
-      "cannot convert value of type %0 to expected dictionary key type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_dict_value,none,
-      "cannot convert value of type %0 to expected dictionary value type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_coerce,none,
-      "cannot convert value of type %0 to type %1 in coercion",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_assign,none,
-      "cannot assign value of type %0 to type %1",
-      (Type, Type))
-ERROR(cannot_convert_generic_type_parent_type,none,
-      "cannot convert parent type %0 to expected type %1",
-      (Type, Type))
 
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -425,7 +425,7 @@ ERROR(cannot_convert_generic_type_coerce,none,
       "cannot convert value of type %0 to type %1 in coercion",
       (Type, Type))
 ERROR(cannot_convert_generic_type_assign,none,
-      "cannot convert value of type %0 to %1 in assignment",
+      "cannot assign value of type %0 to type %1",
       (Type, Type))
 ERROR(cannot_convert_generic_type_parent_type,none,
       "cannot convert parent type %0 to expected type %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -394,6 +394,56 @@ ERROR(cannot_convert_closure_result_protocol,none,
 ERROR(cannot_convert_closure_result_nil,none,
       "'nil' is not compatible with closure result type %0", (Type))
 
+ERROR(cannot_convert_generic_type_argument,none,
+      "cannot convert %0 to expected argument type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_default_argument,none,
+      "default argument value of type %0 cannot be converted to type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_return,none,
+      "cannot convert return expression of type %0 to return type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_yield,none,
+      "cannot convert value of type %0 to expected yield type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_closure_result,none,
+      "cannot convert value of type %0 to closure result type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_array_element,none,
+      "cannot convert value of type %0 to expected element type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_dict_key,none,
+      "cannot convert value of type %0 to expected dictionary key type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_dict_value,none,
+      "cannot convert value of type %0 to expected dictionary value type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_coerce,none,
+      "cannot convert value of type %0 to type %1 in coercion, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_assign,none,
+      "cannot convert value of type %0 to %1 in assignment, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+ERROR(cannot_convert_generic_type_parent_type,none,
+      "cannot convert parent type %0 to expected type %1, "
+      "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
+      (Type, Type, Identifier, Type, Type))
+      
+      
+
+
+
+
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -438,11 +438,6 @@ ERROR(cannot_convert_generic_type_parent_type,none,
       "cannot convert parent type %0 to expected type %1, "
       "arguments to generic parameter %2 (%3 and %4) are expected to be equal",
       (Type, Type, Identifier, Type, Type))
-      
-      
-
-
-
 
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -389,30 +389,30 @@ Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
   switch (context) {
   case CTP_Initialization:
   case CTP_AssignSource:
-    return diag::cannot_convert_generic_type_assign;
+    return diag::cannot_convert_assign;
   case CTP_ReturnStmt:
   case CTP_ReturnSingleExpr:
-    return diag::cannot_convert_generic_type_return;
+    return diag::cannot_convert_to_return_type;
   case CTP_DefaultParameter:
-    return diag::cannot_convert_generic_type_default_argument;
+    return diag::cannot_convert_default_arg_value;
   case CTP_YieldByValue:
-    return diag::cannot_convert_generic_type_yield;
+    return diag::cannot_convert_yield_value;
   case CTP_CallArgument:
-    return diag::cannot_convert_generic_type_argument;
+    return diag::cannot_convert_argument_value;
   case CTP_ClosureResult:
-    return diag::cannot_convert_generic_type_closure_result;
+    return diag::cannot_convert_closure_result;
   case CTP_ArrayElement:
-    return diag::cannot_convert_generic_type_array_element;
+    return diag::cannot_convert_array_element;
   // TODO(diagnostics): Make dictionary related diagnostics take prescedence
   // over CSDiag. Currently these won't ever be produced.
   case CTP_DictionaryKey:
-    return diag::cannot_convert_generic_type_dict_key;
+    return diag::cannot_convert_dict_key;
   case CTP_DictionaryValue:
-    return diag::cannot_convert_generic_type_dict_value;
+    return diag::cannot_convert_dict_value;
   case CTP_CoerceOperand:
-    return diag::cannot_convert_generic_type_coerce;
+    return diag::cannot_convert_coerce;
   case CTP_SubscriptAssignSource:
-    return diag::cannot_convert_generic_type_subscript_assign;
+    return diag::cannot_convert_subscript_assign;
 
   case CTP_ThrowStmt:
   case CTP_Unused:
@@ -463,18 +463,19 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
     }
 
     case ConstraintLocator::AutoclosureResult:
+    case ConstraintLocator::ApplyArgToParam:
     case ConstraintLocator::ApplyArgument: {
-      diagnostic = diag::cannot_convert_generic_type_argument;
+      diagnostic = diag::cannot_convert_argument_value;
       break;
     }
 
     case ConstraintLocator::ParentType: {
-      diagnostic = diag::cannot_convert_generic_type_parent_type;
+      diagnostic = diag::cannot_convert_parent_type;
       break;
     }
 
     case ConstraintLocator::ClosureResult: {
-      diagnostic = diag::cannot_convert_generic_type_closure_result;
+      diagnostic = diag::cannot_convert_closure_result;
       break;
     }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -411,6 +411,8 @@ Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
     return diag::cannot_convert_generic_type_dict_value;
   case CTP_CoerceOperand:
     return diag::cannot_convert_generic_type_coerce;
+  case CTP_SubscriptAssignSource:
+    return diag::cannot_convert_generic_type_subscript_assign;
 
   case CTP_ThrowStmt:
   case CTP_Unused:

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -429,13 +429,21 @@ void GenericArgumentsMismatchFailure::emitDiagnosticForMismatch(
   auto genericTypeDecl = getActual()->getCanonicalType()->getAnyGeneric();
   auto param = genericTypeDecl->getGenericParams()->getParams()[position];
 
-  auto lhs = resolveType(getActual()->getGenericArgs()[position]);
-  auto rhs = resolveType(getRequired()->getGenericArgs()[position]);
+  auto lhs = resolveType(getActual()->getGenericArgs()[position])
+                 ->reconstituteSugar(/*recursive=*/false);
+  auto rhs = resolveType(getRequired()->getGenericArgs()[position])
+                 ->reconstituteSugar(/*recursive=*/false);
 
-  emitDiagnostic(getAnchor()->getLoc(), diagnostic, resolveType(getActual()),
-                 resolveType(getRequired()), param->getName(), lhs, rhs);
-  emitDiagnostic(param->getLoc(), diag::kind_declname_declared_here,
-                 DescriptiveDeclKind::GenericTypeParam, param->getName());
+  emitDiagnostic(
+      getAnchor()->getLoc(), diagnostic,
+      resolveType(getActual())->reconstituteSugar(/*recursive=*/false),
+      resolveType(getRequired())->reconstituteSugar(/*recursive=*/false),
+      param->getName(), lhs, rhs);
+
+  if (param->getLoc().isValid()) {
+    emitDiagnostic(param->getLoc(), diag::kind_declname_declared_here,
+                   DescriptiveDeclKind::GenericTypeParam, param->getName());
+  }
 }
 
 bool GenericArgumentsMismatchFailure::diagnoseAsError() {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -384,8 +384,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
   return RequirementFailure::diagnoseAsError();
 }
 
-Optional<Diag<Type, Type>>
-GenericArgumentsMismatchFailure::getDiagnosticFor(
+Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
     ContextualTypePurpose context) {
   switch (context) {
   case CTP_Initialization:
@@ -434,7 +433,7 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
                  ->reconstituteSugar(/*recursive=*/false);
 
   auto noteLocation = param->getLoc();
-  
+
   if (!noteLocation.isValid()) {
     noteLocation = getAnchor()->getLoc();
   }
@@ -485,12 +484,10 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   if (!diagnostic)
     return false;
 
-  emitDiagnostic(getAnchor()->getLoc(), *diagnostic,
-                 resolveType(getActual())->reconstituteSugar(/*recursive=*/false),
-                 resolveType(getRequired())->reconstituteSugar(/*recursive=*/false));
-                 
-  
-  
+  emitDiagnostic(
+      getAnchor()->getLoc(), *diagnostic,
+      resolveType(getActual())->reconstituteSugar(/*recursive=*/false),
+      resolveType(getRequired())->reconstituteSugar(/*recursive=*/false));
   emitNotesForMismatches();
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -404,6 +404,8 @@ GenericArgumentsMismatchFailure::getDiagnosticFor(
     return diag::cannot_convert_generic_type_closure_result;
   case CTP_ArrayElement:
     return diag::cannot_convert_generic_type_array_element;
+  // TODO(diagnostics): Make dictionary related diagnostics take prescedence
+  // over CSDiag. Currently these won't ever be produced.
   case CTP_DictionaryKey:
     return diag::cannot_convert_generic_type_dict_key;
   case CTP_DictionaryValue:
@@ -459,17 +461,17 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       diagnostic = diag::cannot_convert_generic_type_argument;
       break;
     }
-    
+
     case ConstraintLocator::ParentType: {
       diagnostic = diag::cannot_convert_generic_type_parent_type;
       break;
     }
-    
+
     case ConstraintLocator::ClosureResult: {
       diagnostic = diag::cannot_convert_generic_type_closure_result;
       break;
     }
-    
+
     default:
       break;
     }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -364,10 +364,7 @@ protected:
 /// Diagnostics for mismatched generic arguments e.g
 /// ```swift
 /// struct F<G> {}
-/// extension F where G == Int {
-///  func foo() {}
-/// }
-/// F<Bool>().foo()
+/// let _:F<Int> = F<Bool>()
 /// ```
 class GenericArgumentsMismatchFailure final : public FailureDiagnostic {
   using GenericMismatchDiag = Diag<Type, Type, Identifier, Type, Type>;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -367,17 +367,15 @@ protected:
 /// let _:F<Int> = F<Bool>()
 /// ```
 class GenericArgumentsMismatchFailure final : public FailureDiagnostic {
-  using GenericMismatchDiag = Diag<Type, Type, Identifier, Type, Type>;
-
   BoundGenericType *Actual;
   BoundGenericType *Required;
-  llvm::SmallVector<int, 4> Mismatches;
+  ArrayRef<unsigned> Mismatches;
 
 public:
   GenericArgumentsMismatchFailure(Expr *expr, ConstraintSystem &cs,
                                   BoundGenericType *actual,
                                   BoundGenericType *required,
-                                  llvm::SmallVector<int, 4> mismatches,
+                                  ArrayRef<unsigned> mismatches,
                                   ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator), Actual(actual),
         Required(required), Mismatches(mismatches) {}
@@ -385,16 +383,15 @@ public:
   bool diagnoseAsError() override;
 
 private:
-  void emitDiagnosticForMismatches(GenericMismatchDiag diagnostic) {
-    for (int position : Mismatches) {
-      emitDiagnosticForMismatch(diagnostic, position);
+  void emitNotesForMismatches() {
+    for (unsigned position : Mismatches) {
+      emitNoteForMismatch(position);
     }
   }
 
-  void emitDiagnosticForMismatch(GenericMismatchDiag diagnostic,
-                                 int mismatchPosition);
+  void emitNoteForMismatch(int mismatchPosition);
 
-  Optional<GenericMismatchDiag> getDiagnosticFor(ContextualTypePurpose context);
+  Optional<Diag<Type, Type>> getDiagnosticFor(ContextualTypePurpose context);
 
   /// The actual type being used.
   BoundGenericType *getActual() const { return Actual; }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -228,6 +228,20 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
   return new (cs.getAllocator()) ContextualMismatch(cs, lhs, rhs, locator);
 }
 
+bool GenericArgumentsMismatch::diagnose(Expr *root, bool asNote) const {
+  auto failure = GenericArgumentsMismatchFailure(root, getConstraintSystem(),
+                                                 getActual(), getRequired(),
+                                                 getMismatches(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+GenericArgumentsMismatch *GenericArgumentsMismatch::create(
+    ConstraintSystem &cs, BoundGenericType *actual, BoundGenericType *required,
+    llvm::SmallVector<int, 4> mismatches, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      GenericArgumentsMismatch(cs, actual, required, mismatches, locator);
+}
+
 bool AutoClosureForwarding::diagnose(Expr *root, bool asNote) const {
   auto failure =
       AutoClosureForwardingFailure(getConstraintSystem(), getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -237,8 +237,10 @@ bool GenericArgumentsMismatch::diagnose(Expr *root, bool asNote) const {
 
 GenericArgumentsMismatch *GenericArgumentsMismatch::create(
     ConstraintSystem &cs, BoundGenericType *actual, BoundGenericType *required,
-    llvm::SmallVector<int, 4> mismatches, ConstraintLocator *locator) {
-  return new (cs.getAllocator())
+    llvm::ArrayRef<unsigned> mismatches, ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<unsigned>(mismatches.size());
+  void *mem = cs.getAllocator().Allocate(size, alignof(GenericArgumentsMismatch));
+  return new (mem)
       GenericArgumentsMismatch(cs, actual, required, mismatches, locator);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -239,7 +239,8 @@ GenericArgumentsMismatch *GenericArgumentsMismatch::create(
     ConstraintSystem &cs, BoundGenericType *actual, BoundGenericType *required,
     llvm::ArrayRef<unsigned> mismatches, ConstraintLocator *locator) {
   unsigned size = totalSizeToAlloc<unsigned>(mismatches.size());
-  void *mem = cs.getAllocator().Allocate(size, alignof(GenericArgumentsMismatch));
+  void *mem =
+      cs.getAllocator().Allocate(size, alignof(GenericArgumentsMismatch));
   return new (mem)
       GenericArgumentsMismatch(cs, actual, required, mismatches, locator);
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -88,8 +88,7 @@ enum class FixKind : uint8_t {
   /// like the types are aligned.
   ContextualMismatch,
 
-  /// Fix up the generic arguments of a type so they match
-  /// those enforced by a conditional requirement.
+  /// Fix up the generic arguments of two types so they match eachother.
   GenericArgumentsMismatch,
 
   /// Fix up @autoclosure argument to the @autoclosure parameter,
@@ -492,6 +491,13 @@ public:
                                     ConstraintLocator *locator);
 };
 
+/// Detect situations where two type's generic arguments must
+/// match but are not convertible e.g.
+///
+/// ```swift
+/// struct F<G> {}
+/// let _:F<Int> = F<Bool>()
+/// ```
 class GenericArgumentsMismatch : public ConstraintFix {
   BoundGenericType *Actual;
   BoundGenericType *Required;

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -167,7 +167,8 @@ enum class FixKind : uint8_t {
   /// associated with single declaration.
   ExplicitlySpecifyGenericArguments,
 
-  /// Skip any unhandled constructs that occur within a closure argument that matches up with a
+  /// Skip any unhandled constructs that occur within a closure argument that
+  /// matches up with a
   /// parameter that has a function builder.
   SkipUnhandledConstructInFunctionBuilder,
 };

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -500,13 +500,12 @@ public:
 /// ```
 class GenericArgumentsMismatch final
     : public ConstraintFix,
-      private llvm::TrailingObjects<GenericArgumentsMismatch,
-                                    unsigned> {
+      private llvm::TrailingObjects<GenericArgumentsMismatch, unsigned> {
   friend TrailingObjects;
-  
+
   BoundGenericType *Actual;
   BoundGenericType *Required;
-  
+
   unsigned NumMismatches;
 
 protected:
@@ -539,7 +538,7 @@ public:
                                           BoundGenericType *required,
                                           llvm::ArrayRef<unsigned> mismatches,
                                           ConstraintLocator *locator);
-                                          
+
 private:
   MutableArrayRef<unsigned> getMismatchesBuf() {
     return {getTrailingObjects<unsigned>(), NumMismatches};

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1613,7 +1613,7 @@ static ConstraintSystem::TypeMatchResult matchDeepTypeArguments(
     if (result.isFailure()) {
       if (!cs.shouldAttemptFixes())
         return result;
-        
+
       fullMatchResult = result;
       recordMismatch(i);
     }
@@ -1674,8 +1674,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
     if (result.isFailure())
       return result;
   }
-  
-  
+
   bool forRequirement = false;
   if (auto last = locator.last()) {
     forRequirement =
@@ -1688,17 +1687,19 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
   // new framework.
   bool isOptional = bound1->getDecl()->isOptionalDecl();
   bool isArray = isArrayType(bound1).hasValue();
-  
+
   auto args1 = bound1->getGenericArgs();
   auto args2 = bound2->getGenericArgs();
-  
+
   SmallVector<unsigned, 4> failedArguments;
-    // Match up the generic arguments, exactly.
-  auto result = matchDeepTypeArguments(*this, subflags, args1, args2, locator,
-                                       [&failedArguments, forRequirement, isOptional, isArray] (unsigned position) {
-                                         if (!(forRequirement || isOptional || isArray))
-                                           failedArguments.push_back(position); 
-                                        });
+  // Match up the generic arguments, exactly.
+  auto result =
+      matchDeepTypeArguments(*this, subflags, args1, args2, locator,
+                             [&failedArguments, forRequirement, isOptional,
+                              isArray](unsigned position) {
+                               if (!(forRequirement || isOptional || isArray))
+                                 failedArguments.push_back(position);
+                             });
   if (!failedArguments.empty()) {
     auto *fix = GenericArgumentsMismatch::create(
         *this, bound1, bound2, failedArguments, getConstraintLocator(locator));
@@ -2150,7 +2151,7 @@ bool ConstraintSystem::repairFailures(
 
     return false;
   }
-  
+
   auto hasConversionOrRestriction = [&](ConversionRestrictionKind kind) {
     return llvm::any_of(
         conversionsOrFixes, [](const RestrictionOrFix possibleRestriction) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -790,7 +790,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
       argLabels = component.getSubscriptLabels();
       hasTrailingClosure = false; // key paths don't support trailing closures
       break;
-      
+
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::Property:
@@ -851,7 +851,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
       break;
     }
   }
-  
+
   // If we didn't find any matching overloads, we're done.
   if (!choice)
     return std::make_tuple(nullptr, /*hasCurriedSelf=*/false, argLabels,
@@ -1594,25 +1594,58 @@ ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
   return getTypeMatchFailure(locator);
 }
 
-static ConstraintSystem::TypeMatchResult
-matchDeepTypeArguments(ConstraintSystem &cs,
-                       ConstraintSystem::TypeMatchOptions subflags,
-                       ArrayRef<Type> args1,
-                       ArrayRef<Type> args2,
-                       ConstraintLocatorBuilder locator) {
+static ConstraintSystem::TypeMatchResult matchDeepTypeArguments(
+    ConstraintSystem &cs, ConstraintSystem::TypeMatchOptions subflags,
+    BoundGenericType *base1, BoundGenericType *base2, ArrayRef<Type> args1,
+    ArrayRef<Type> args2, ConstraintLocatorBuilder locator) {
   if (args1.size() != args2.size()) {
     return cs.getTypeMatchFailure(locator);
   }
-  for (unsigned i = 0, n = args1.size(); i != n; ++i) {
-    auto result = cs.matchTypes(args1[i], args2[i], ConstraintKind::Bind,
-                                subflags, locator.withPathElement(
-                                        LocatorPathElt::getGenericArgument(i)));
 
-    if (result.isFailure())
-      return result;
+  SmallVector<int, 4> failedArguments;
+  ConstraintSystem::TypeMatchResult fullMatchResult = cs.getTypeMatchSuccess();
+
+  bool forRequirement = false;
+  if (auto last = locator.last()) {
+    forRequirement =
+        last->isTypeParameterRequirement() || last->isConditionalRequirement();
   }
 
-  return cs.getTypeMatchSuccess();
+  // Optionals have a lot of special diagnostics and only one generic
+  // argument, Wrapped, so if we're dealing with one, don't produce generic
+  // arguments mismatch fixes.
+  // TODO(diagnostics): Move Optional diagnostics over to the new diagnostic
+  // framework.
+  bool isOptional = !forRequirement && base1->getDecl()->isOptionalDecl();
+
+  for (unsigned i = 0, n = args1.size(); i != n; ++i) {
+    auto result = cs.matchTypes(
+        args1[i], args2[i], ConstraintKind::Bind, subflags,
+        locator.withPathElement(LocatorPathElt::getGenericArgument(i)));
+
+    if (result.isFailure()) {
+      if (!cs.shouldAttemptFixes() || forRequirement || isOptional)
+        return result;
+
+      fullMatchResult = result;
+      failedArguments.push_back(i);
+    }
+  }
+
+  if (!failedArguments.empty()) {
+    auto *fix = GenericArgumentsMismatch::create(
+        cs, base1, base2, failedArguments, cs.getConstraintLocator(locator));
+    // Increase the current solution's score for each mismatched argument.
+    for (unsigned i = 0; i < failedArguments.size(); ++i) {
+      cs.increaseScore(SK_Fix);
+    }
+
+    if (!cs.recordFix(fix)) {
+      return cs.getTypeMatchSuccess();
+    }
+  }
+
+  return fullMatchResult;
 }
 
 ConstraintSystem::TypeMatchResult
@@ -1630,13 +1663,14 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
         == arch2->getInterfaceType()->getCanonicalType(
                       opaque2->getGenericEnvironment()->getGenericSignature()));
     assert(opaque1->getDecl() == opaque2->getDecl());
-    
+
     auto args1 = opaque1->getSubstitutions().getReplacementTypes();
     auto args2 = opaque2->getSubstitutions().getReplacementTypes();
     // Match up the replacement types of the respective substitution maps.
-    return matchDeepTypeArguments(*this, subflags, args1, args2, locator);
+    return matchDeepTypeArguments(*this, subflags, nullptr, nullptr, args1,
+                                  args2, locator);
   }
-  
+
   // Handle nominal types that are not directly generic.
   if (auto nominal1 = type1->getAs<NominalType>()) {
     auto nominal2 = type2->castTo<NominalType>();
@@ -1671,7 +1705,8 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
   // Match up the generic arguments, exactly.
   auto args1 = bound1->getGenericArgs();
   auto args2 = bound2->getGenericArgs();
-  return matchDeepTypeArguments(*this, subflags, args1, args2, locator);
+  return matchDeepTypeArguments(*this, subflags, bound1, bound2, args1, args2,
+                                locator);
 }
 
 ConstraintSystem::TypeMatchResult
@@ -1814,7 +1849,7 @@ static bool isStringCompatiblePointerBaseType(TypeChecker &TC,
     return true;
   if (baseType->isEqual(TC.Context.TheEmptyTupleType))
     return true;
-  
+
   return false;
 }
 
@@ -2179,6 +2214,18 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::ClosureResult: {
+    // If we could record a generic arguments mismatch instead of this fix,
+    // don't record a ContextualMismatch here.
+    auto hasDeepEqualityRestriction =
+        llvm::any_of(conversionsOrFixes,
+                     [] (const RestrictionOrFix possibleRestriction) {
+                        auto restriction = possibleRestriction.getRestriction();
+                        if (!restriction) return false;
+                        return restriction == ConversionRestrictionKind::DeepEquality;
+                     });
+    if (hasDeepEqualityRestriction)
+      break;
+
     auto *fix = ContextualMismatch::create(*this, lhs, rhs,
                                            getConstraintLocator(locator));
     conversionsOrFixes.push_back(fix);
@@ -2532,7 +2579,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case TypeKind::DynamicSelf:
       // FIXME: Deep equality? What is the rule between two DynamicSelfs?
       break;
-       
+
     case TypeKind::Protocol:
       // Nothing to do here; try existential and user-defined conversions below.
       break;
@@ -2582,11 +2629,11 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                         ConstraintKind::Bind, subflags,
                         locator.withPathElement(
                           ConstraintLocator::LValueConversion));
-    
+
     case TypeKind::InOut:
       if (kind == ConstraintKind::BindParam)
         return getTypeMatchFailure(locator);
-      
+
       if (kind == ConstraintKind::OperatorArgumentConversion) {
         conversionsOrFixes.push_back(
             RemoveAddressOf::create(*this, getConstraintLocator(locator)));
@@ -2606,7 +2653,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case TypeKind::BoundGenericStruct: {
       auto bound1 = cast<BoundGenericType>(desugar1);
       auto bound2 = cast<BoundGenericType>(desugar2);
-      
+
       if (bound1->getDecl() == bound2->getDecl())
         conversionsOrFixes.push_back(ConversionRestrictionKind::DeepEquality);
       break;
@@ -2617,18 +2664,18 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case TypeKind::OpaqueTypeArchetype: {
       auto opaque1 = cast<OpaqueTypeArchetypeType>(desugar1);
       auto opaque2 = cast<OpaqueTypeArchetypeType>(desugar2);
-      
+
       if (opaque1->getDecl() == opaque2->getDecl()) {
         conversionsOrFixes.push_back(ConversionRestrictionKind::DeepEquality);
       }
       break;
     }
-    
+
     // Same for nested archetypes rooted in opaque types.
     case TypeKind::NestedArchetype: {
       auto nested1 = cast<NestedArchetypeType>(desugar1);
       auto nested2 = cast<NestedArchetypeType>(desugar2);
-      
+
       auto rootOpaque1 = dyn_cast<OpaqueTypeArchetypeType>(nested1->getRoot());
       auto rootOpaque2 = dyn_cast<OpaqueTypeArchetypeType>(nested2->getRoot());
       if (rootOpaque1 && rootOpaque2) {
@@ -2723,7 +2770,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     //
     // Class and protocol metatypes are interoperable with certain Objective-C
     // runtime classes, but only when ObjC interop is enabled.
-    
+
     if (TC.getLangOpts().EnableObjCInterop) {
       // These conversions are between concrete types that don't need further
       // resolution, so we can consider them immediately solved.
@@ -2733,7 +2780,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                                   type1, type2, locator);
           return getTypeMatchSuccess();
         };
-      
+
       if (auto meta1 = type1->getAs<MetatypeType>()) {
         if (meta1->getInstanceType()->mayHaveSuperclass()
             && type2->isAnyObject()) {
@@ -2751,7 +2798,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               return true;
           return false;
         };
-        
+
         if (auto protoTy = meta1->getInstanceType()->getAs<ProtocolType>()) {
           if (protoTy->getDecl()->isObjC()
               && isProtocolClassType(type2)) {
@@ -2771,7 +2818,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         }
       }
     }
-    
+
     // Special implicit nominal conversions.
     if (!type1->is<LValueType>() && kind >= ConstraintKind::Subtype) {
       // Array -> Array.
@@ -2788,7 +2835,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
     }
   }
-  
+
   if (kind == ConstraintKind::BindToPointerType) {
     if (desugar2->isEqual(getASTContext().TheEmptyTupleType))
       return getTypeMatchSuccess();
@@ -2873,7 +2920,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                 if (type1PointerKind != pointerKind)
                   increaseScore(ScoreKind::SK_ValueToPointerConversion);
                 conversionsOrFixes.push_back(
-                  ConversionRestrictionKind::PointerToPointer);              
+                    ConversionRestrictionKind::PointerToPointer);
               }
             }
             // UnsafePointer and UnsafeRawPointer can also be converted from an
@@ -2898,7 +2945,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                         ConversionRestrictionKind::StringToPointer);
                 }
               }
-              
+
               if (type1IsPointer && optionalityMatches &&
                   (type1PointerKind == PTK_UnsafePointer ||
                    type1PointerKind == PTK_AutoreleasingUnsafeMutablePointer)) {
@@ -2996,7 +3043,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           forceUnwrapPossible = false;
         }
       }
-      
+
       if (auto optTryExpr =
           dyn_cast_or_null<OptionalTryExpr>(locator.trySimplifyToExpr())) {
         auto subExprType = getType(optTryExpr->getSubExpr());
@@ -3168,7 +3215,7 @@ ConstraintSystem::simplifyConstructionConstraint(
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
       llvm_unreachable("artificial type in constraint");
-    
+
   case TypeKind::Unresolved:
   case TypeKind::Error:
     return SolutionKind::Error;
@@ -3239,14 +3286,11 @@ ConstraintSystem::simplifyConstructionConstraint(
   // The constructor will have function type T -> T2, for a fresh type
   // variable T. T2 is the result type provided via the construction
   // constraint itself.
-  addValueMemberConstraint(MetatypeType::get(valueType, TC.Context),
-                           DeclBaseName::createConstructor(),
-                           memberType,
-                           useDC, functionRefKind,
-                           /*outerAlternatives=*/{},
-                           getConstraintLocator(
-                             fnLocator, 
-                             ConstraintLocator::ConstructorMember));
+  addValueMemberConstraint(
+      MetatypeType::get(valueType, TC.Context),
+      DeclBaseName::createConstructor(), memberType, useDC, functionRefKind,
+      /*outerAlternatives=*/{},
+      getConstraintLocator(fnLocator, ConstraintLocator::ConstructorMember));
 
   // FIXME: Once TVO_PrefersSubtypeBinding is replaced with something
   // better, we won't need the second type variable at all.
@@ -3355,7 +3399,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   default:
     llvm_unreachable("bad constraint kind");
   }
-  
+
   if (!shouldAttemptFixes())
     return SolutionKind::Error;
 
@@ -3561,7 +3605,7 @@ ConstraintSystem::simplifyCheckedCastConstraint(
       addConstraint(ConstraintKind::Subtype, toType, fromType,
                     getConstraintLocator(locator));
     }
-      
+
     return SolutionKind::Solved;
   }
 
@@ -3595,7 +3639,6 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
 
     return SolutionKind::Unsolved;
   }
-  
 
   Type objectTy = optTy->getOptionalObjectType();
   // If the base type is not optional, let's attempt a fix (if possible)
@@ -3617,7 +3660,7 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
       return SolutionKind::Error;
     }
   }
-  
+
   // The object type is an lvalue if the optional was.
   if (optLValueTy->is<LValueType>())
     objectTy = LValueType::get(objectTy);
@@ -3718,10 +3761,10 @@ getArgumentLabels(ConstraintSystem &cs, ConstraintLocatorBuilder locator) {
       parts.pop_back();
       continue;
     }
-    
+
     break;
   }
-  
+
   if (!parts.empty())
     return None;
 
@@ -3781,18 +3824,18 @@ static bool hasDynamicMemberLookupAttribute(Type type,
     for (auto p : nominal->getAllProtocols())
       if (p->getAttrs().hasAttribute<DynamicMemberLookupAttr>())
         return true;
-    
+
     // Walk superclasses, if present.
     llvm::SmallPtrSet<const NominalTypeDecl*, 8> visitedDecls;
     while (1) {
       // If we found a circular parent class chain, reject this.
       if (!visitedDecls.insert(nominal).second)
         return false;
-      
+
       // If this type has the attribute on it, then yes!
       if (nominal->getAttrs().hasAttribute<DynamicMemberLookupAttr>())
         return true;
-      
+
       // If this is a class with a super class, check super classes as well.
       if (auto *cd = dyn_cast<ClassDecl>(nominal)) {
         if (auto superClass = cd->getSuperclassDecl()) {
@@ -3800,11 +3843,11 @@ static bool hasDynamicMemberLookupAttribute(Type type,
           continue;
         }
       }
-      
+
       return false;
     }
   };
-  
+
   auto result = calculate();
   // Cache the result if the type does not contain type variables.
   if (!type->hasTypeVariable())
@@ -3884,10 +3927,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     } else {
       fieldIdx = baseTuple->getNamedElementId(memberName.getBaseIdentifier());
     }
-    
+
     if (fieldIdx == -1)
       return result;    // No result.
-    
+
     // Add an overload set that selects this field.
     result.ViableCandidates.push_back(OverloadChoice(baseTy, fieldIdx));
     return result;
@@ -3958,7 +4001,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   // reasonable choice.
   auto addChoice = [&](OverloadChoice candidate) {
     auto decl = candidate.getDecl();
-    
+
     // If the result is invalid, skip it.
     TC.validateDecl(decl);
     if (decl->isInvalid()) {
@@ -4163,16 +4206,16 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // result was found via dynamic lookup.
     if (instanceTy->isAnyObject()) {
       assert(cand->getDeclContext()->isTypeContext() && "Dynamic lookup bug");
-      
+
       // We found this declaration via dynamic lookup, record it as such.
       return OverloadChoice::getDeclViaDynamic(baseTy, cand, functionRefKind);
     }
-    
+
     // If we have a bridged type, we found this declaration via bridging.
     if (isBridged)
       return OverloadChoice::getDeclViaBridge(bridgedType, cand,
                                               functionRefKind);
-    
+
     // If we got the choice by unwrapping an optional type, unwrap the base
     // type.
     if (isUnwrappedOptional) {
@@ -4206,7 +4249,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
 
     return OverloadChoice(baseTy, cand, functionRefKind);
   };
-  
+
   // Add all results from this lookup.
 retry_after_fail:
   labelMismatch = false;
@@ -4249,7 +4292,7 @@ retry_after_fail:
         foundationModule = module;
         continue;
       }
-      
+
       addChoice(getOverloadChoice(result.getValueDecl(),
                                   /*isBridged=*/true,
                                   /*isUnwrappedOptional=*/false));
@@ -4273,7 +4316,7 @@ retry_after_fail:
       }
     }
   }
-  
+
   // If we're about to fail lookup, but we are looking for members in a type
   // with the @dynamicMemberLookup attribute, then we resolve a reference
   // to a `subscript(dynamicMember:)` method and pass the member name as a
@@ -4328,13 +4371,13 @@ retry_after_fail:
   if (result.ViableCandidates.empty() && result.UnviableCandidates.empty() &&
       includeInaccessibleMembers) {
     NameLookupOptions lookupOptions = defaultMemberLookupOptions;
-    
+
     // Ignore access control so we get candidates that might have been missed
     // before.
     lookupOptions |= NameLookupFlags::IgnoreAccessControl;
     // This is only used for diagnostics, so always use KnownPrivate.
     lookupOptions |= NameLookupFlags::KnownPrivate;
-    
+
     auto lookup = TC.lookupMember(DC, instanceTy,
                                   memberName, lookupOptions);
     for (auto entry : lookup) {
@@ -4356,7 +4399,7 @@ retry_after_fail:
                          MemberLookupResult::UR_Inaccessible);
     }
   }
-  
+
   return result;
 }
 
@@ -4768,6 +4811,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
     // FIXME(diagnostics): If there were no viable results, but there are
     // unviable ones, we'd have to introduce fix for each specific problem.
+    // TODO(diagnostics): Remove this, see what happens (should be noop)
     if (!result.UnviableCandidates.empty())
       return SolutionKind::Error;
 
@@ -4904,7 +4948,7 @@ ConstraintSystem::simplifyOpaqueUnderlyingTypeConstraint(Type type1, Type type2,
   auto underlyingTyVar = openType(opaque2->getInterfaceType(),
                                   replacements);
   assert(underlyingTyVar);
-  
+
   if (auto dcSig = DC->getGenericSignatureOfContext()) {
     for (auto param : dcSig->getGenericParams()) {
       addConstraint(ConstraintKind::Bind,
@@ -4933,7 +4977,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
                            type2, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
-    
+
     return SolutionKind::Unsolved;
   };
 
@@ -5151,13 +5195,13 @@ ConstraintSystem::simplifyEscapableFunctionOfConstraint(
   if (!type2->isTypeVariableOrMember())
     // We definitely don't have a function, so bail.
     return SolutionKind::Error;
-  
+
   type1 = getFixedTypeRecursive(type1, flags, /*wantRValue=*/true);
   if (auto fn1 = type1->getAs<FunctionType>()) {
     // We should have the escaping end of the relation.
     if (fn1->getExtInfo().isNoEscape())
       return SolutionKind::Error;
-    
+
     // Solve backward by binding the other type variable to the noescape
     // variation of this type.
     auto fn2 = fn1->withExtInfo(fn1->getExtInfo().withNoEscape(true));
@@ -5195,13 +5239,13 @@ ConstraintSystem::simplifyOpenedExistentialOfConstraint(
   if (!type2->isTypeVariableOrMember())
     // We definitely don't have an existential, so bail.
     return SolutionKind::Error;
-  
+
   // If type1 is constrained to anything concrete, the constraint fails.
   // It can only be bound to a type we opened for it.
   type1 = getFixedTypeRecursive(type1, flags, /*wantRValue=*/true);
   if (!type1->isTypeVariableOrMember())
     return SolutionKind::Error;
-  
+
   if (flags.contains(TMF_GenerateConstraints)) {
     addUnsolvedConstraint(
       Constraint::create(*this, ConstraintKind::OpenedExistentialOf,
@@ -5220,7 +5264,7 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
   auto subflags = getDefaultDecompositionOptions(flags);
   // The constraint ought to have been anchored on a KeyPathExpr.
   auto keyPath = cast<KeyPathExpr>(locator.getBaseLocator()->getAnchor());
-  
+
   // Gather overload choices for any key path components associated with this
   // key path.
   SmallVector<OverloadChoice, 4> choices;
@@ -5234,12 +5278,12 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       choices[locator->getPath()[0].getValue()] = resolvedItem->Choice;
     }
   }
-  
+
   keyPathTy = getFixedTypeRecursive(keyPathTy, /*want rvalue*/ true);
   auto tryMatchRootAndValueFromKeyPathType =
     [&](BoundGenericType *bgt, bool allowPartial) -> SolutionKind {
       Type boundRoot, boundValue;
-      
+
       // We can get root and value from a concrete key path type.
       if (bgt->getDecl() == getASTContext().getKeyPathDecl()
           || bgt->getDecl() == getASTContext().getWritableKeyPathDecl()
@@ -5266,7 +5310,7 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
           && matchTypes(boundValue, valueTy,
                 ConstraintKind::Bind, subflags, locator).isFailure())
         return SolutionKind::Error;
-      
+
       return SolutionKind::Solved;
     };
 
@@ -5299,12 +5343,12 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
 
   for (unsigned i : indices(keyPath->getComponents())) {
     auto &component = keyPath->getComponents()[i];
-    
+
     switch (component.getKind()) {
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::Identity:
       break;
-      
+
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
@@ -5320,12 +5364,12 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
         }
         return SolutionKind::Unsolved;
       }
-      
+
       // tuple elements do not change the capability of the key path
       if (choices[i].getKind() == OverloadChoiceKind::TupleIndex) {
         continue;
       }
-        
+
       // Discarded unsupported non-decl member lookups.
       if (!choices[i].isDecl()) {
         return SolutionKind::Error;
@@ -5365,16 +5409,16 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       // Otherwise, the key path maintains its current capability.
       break;
     }
-    
+
     case KeyPathExpr::Component::Kind::OptionalChain:
       // Optional chains force the entire key path to be read-only.
       capability = ReadOnly;
       goto done;
-    
+
     case KeyPathExpr::Component::Kind::OptionalForce:
       // Forcing an optional preserves its lvalue-ness.
       break;
-    
+
     case KeyPathExpr::Component::Kind::OptionalWrap:
       // An optional chain should already have forced the entire key path to
       // be read-only.
@@ -5403,7 +5447,7 @@ done:
     kpDecl = getASTContext().getReferenceWritableKeyPathDecl();
     break;
   }
-  
+
   // FIXME: Allow the type to be upcast if the type system has a concrete
   // KeyPath type assigned to the expression already.
   if (keyPathBGT) {
@@ -5414,7 +5458,7 @@ done:
              capability >= Writable)
       kpDecl = getASTContext().getWritableKeyPathDecl();
   }
-  
+
   auto resolvedKPTy = BoundGenericType::get(kpDecl, nullptr,
                                             {rootTy, valueTy});
   // Let's check whether deduced key path type would match
@@ -5433,7 +5477,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
                                         ConstraintLocatorBuilder locator) {
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
   keyPathTy = getFixedTypeRecursive(keyPathTy, flags, /*wantRValue=*/true);
-  
+
   auto unsolved = [&]() -> SolutionKind {
     if (flags.contains(TMF_GenerateConstraints)) {
       addUnsolvedConstraint(Constraint::create(*this,
@@ -5455,11 +5499,11 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
                         subflags, locator);
     }
   }
-  
+
   if (auto bgt = keyPathTy->getAs<BoundGenericType>()) {
     // We have the key path type. Match it to the other ends of the constraint.
     auto kpRootTy = bgt->getGenericArgs()[0];
-    
+
     // Try to match the root type.
     rootTy = getFixedTypeRecursive(rootTy, flags, /*wantRValue=*/false);
 
@@ -5511,7 +5555,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
       return matchTypes(LValueType::get(kpValueTy), valueTy,
                         ConstraintKind::Bind, subflags, locator);
     };
-  
+
     if (bgt->getDecl() == getASTContext().getKeyPathDecl()) {
       // Read-only keypath.
       if (!matchRoot(ConstraintKind::Conversion))
@@ -5544,7 +5588,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
   }
   if (!keyPathTy->isTypeVariableOrMember())
     return SolutionKind::Error;
-  
+
   return unsolved();
 }
 
@@ -5741,7 +5785,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
                            type2, getConstraintLocator(locator)));
       return SolutionKind::Solved;
     }
-    
+
     return SolutionKind::Unsolved;
 
   };
@@ -6290,7 +6334,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     addContextualScore();
     return SolutionKind::Solved;
   }
-  
+
   // T <p U ===> T[] <a UnsafeMutablePointer<U>
   case ConversionRestrictionKind::ArrayToPointer: {
     addContextualScore();
@@ -6298,7 +6342,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     auto obj1 = type1->getInOutObjectType();
 
     obj1 = getFixedTypeRecursive(obj1, false);
-    
+
     auto t2 = type2->getDesugaredType();
 
     auto baseType1 = getFixedTypeRecursive(*isArrayType(obj1), false);
@@ -6309,13 +6353,13 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       ConstraintKind::BindToPointerType,
                       subflags, locator);
   }
-      
+
   // String ===> UnsafePointer<[U]Int8>
   case ConversionRestrictionKind::StringToPointer: {
     addContextualScore();
 
     auto baseType2 = getBaseTypeForPointer(*this, type2->getDesugaredType());
-    
+
     // The pointer element type must be void or a byte-sized type.
     // TODO: Handle different encodings based on pointer element type, such as
     // UTF16 for [U]Int16 or UTF32 for [U]Int32. For now we only interop with
@@ -6335,7 +6379,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
         auto voidCon = Constraint::create(*this, ConstraintKind::Bind,
                                         baseType2, TC.Context.TheEmptyTupleType,
                                         getConstraintLocator(locator));
-        
+
         Constraint *disjunctionChoices[] = {int8Con, uint8Con, voidCon};
         addDisjunctionConstraint(disjunctionChoices, locator);
         return SolutionKind::Solved;
@@ -6343,7 +6387,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
       return SolutionKind::Unsolved;
     }
-    
+
     if (!isStringCompatiblePointerBaseType(TC, DC, baseType2)) {
       return SolutionKind::Error;
     }
@@ -6351,16 +6395,16 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     increaseScore(ScoreKind::SK_ValueToPointerConversion);
     return SolutionKind::Solved;
   }
-      
+
   // T <p U ===> inout T <a UnsafeMutablePointer<U>
   case ConversionRestrictionKind::InoutToPointer: {
     addContextualScore();
 
     auto t2 = type2->getDesugaredType();
-    
+
     auto baseType1 = type1->getInOutObjectType();
     auto baseType2 = getBaseTypeForPointer(*this, t2);
-    
+
     // Set up the disjunction for the array or scalar cases.
 
     increaseScore(ScoreKind::SK_ValueToPointerConversion);
@@ -6368,20 +6412,20 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       ConstraintKind::BindToPointerType,
                       subflags, locator);
   }
-      
+
   // T <p U ===> UnsafeMutablePointer<T> <a UnsafeMutablePointer<U>
   case ConversionRestrictionKind::PointerToPointer: {
     auto t1 = type1->getDesugaredType();
     auto t2 = type2->getDesugaredType();
-    
+
     Type baseType1 = getBaseTypeForPointer(*this, t1);
     Type baseType2 = getBaseTypeForPointer(*this, t2);
-    
+
     return matchTypes(baseType1, baseType2,
                       ConstraintKind::BindToPointerType,
                       subflags, locator);
   }
-    
+
   // T < U or T is bridged to V where V < U ===> Array<T> <c Array<U>
   case ConversionRestrictionKind::ArrayUpcast: {
     Type baseType1 = *isArrayType(type1);
@@ -6396,10 +6440,10 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                         ConstraintLocator::PathElement::getGenericArgument(0)));
   }
 
-  // K1 < K2 && V1 < V2 || K1 bridges to K2 && V1 bridges to V2 ===> 
+  // K1 < K2 && V1 < V2 || K1 bridges to K2 && V1 bridges to V2 ===>
   //   Dictionary<K1, V1> <c Dictionary<K2, V2>
   case ConversionRestrictionKind::DictionaryUpcast: {
-    auto t1 = type1->getDesugaredType();    
+    auto t1 = type1->getDesugaredType();
     Type key1, value1;
     std::tie(key1, value1) = *isDictionaryType(t1);
 
@@ -6468,7 +6512,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     auto tv = createTypeVariable(constraintLocator,
                                  TVO_PrefersSubtypeBinding |
                                  TVO_CanBindToNoEscape);
-    
+
     addConstraint(ConstraintKind::ConformsTo, tv,
                   hashableProtocol->getDeclaredType(), constraintLocator);
 
@@ -6507,7 +6551,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       ConstraintKind::Subtype, subflags, locator);
   }
   }
-  
+
   llvm_unreachable("bad conversion restriction");
 }
 
@@ -6684,6 +6728,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::TreatKeyPathSubscriptIndexAsHashable:
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::ExplicitlySpecifyGenericArguments:
+  case FixKind::GenericArgumentsMismatch:
     llvm_unreachable("handled elsewhere");
   }
 
@@ -6773,21 +6818,21 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   // connects the subscript's root type to the root type of the KeyPath.
   SmallVector<LocatorPathElt, 4> path;
   Expr *anchor = locator.getLocatorParts(path);
-  
+
   auto subscript = dyn_cast_or_null<SubscriptExpr>(anchor);
   if (!subscript)
     return;
-  
+
   assert(path.size() == 1 &&
          path[0].getKind() == ConstraintLocator::SubscriptMember);
   auto indexTuple = dyn_cast<TupleExpr>(subscript->getIndex());
   if (!indexTuple || indexTuple->getNumElements() != 1)
     return;
-  
+
   auto keyPathExpr = dyn_cast<KeyPathExpr>(indexTuple->getElement(0));
   if (!keyPathExpr)
     return;
-  
+
   auto typeVar = getType(keyPathExpr)->getAs<TypeVariableType>();
   if (!typeVar)
     return;
@@ -6813,7 +6858,7 @@ ConstraintSystem::addKeyPathApplicationConstraint(Type keypath,
                                               ConstraintLocatorBuilder locator,
                                               bool isFavored) {
   addKeyPathApplicationRootConstraint(root, locator);
-  
+
   switch (simplifyKeyPathApplicationConstraint(keypath, root, value,
                                                TMF_GenerateConstraints,
                                                locator)) {
@@ -6826,10 +6871,10 @@ ConstraintSystem::addKeyPathApplicationConstraint(Type keypath,
       addNewFailingConstraint(c);
     }
     return;
-  
+
   case SolutionKind::Solved:
     return;
-    
+
   case SolutionKind::Unsolved:
     llvm_unreachable("should have generated constraints");
   }
@@ -6852,10 +6897,10 @@ ConstraintSystem::addKeyPathConstraint(Type keypath,
       addNewFailingConstraint(c);
     }
     return;
-  
+
   case SolutionKind::Solved:
     return;
-    
+
   case SolutionKind::Unsolved:
     llvm_unreachable("should have generated constraints");
   }
@@ -6875,7 +6920,7 @@ void ConstraintSystem::addConstraint(Requirement req,
     kind = ConstraintKind::Subtype;
     break;
   case RequirementKind::SameType:
-    kind = ConstraintKind::Bind;
+    kind = ConstraintKind::Equal;
     break;
   case RequirementKind::Layout:
     // Only a class constraint can be modeled as a constraint, and only that can
@@ -7081,7 +7126,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                             constraint.getSecondType(),
                                             TMF_GenerateConstraints,
                                             constraint.getLocator());
-      
+
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
     return simplifyMemberConstraint(constraint.getKind(),

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -30,10 +30,8 @@ class Demo {
   var here: (() -> Void)?
 }
 
-// FIXME: This error is better than it was, but the diagnosis should break it down more specifically to 'here's type.
-// TODO(diagnostics): Fix this regression, we want the following error message ideally
-// "cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'"
 let some = Some(keyPath: \Demo.here)
-// expected-error@-1 {{generic parameter 'V' could not be inferred}}
-// expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
-
+// expected-error@-1 {{cannot convert value of type 'KeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<Demo, ((Any) -> Void)?>'}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('(() -> Void)?' and '((Any) -> Void)?') are expected to be equal}}
+// expected-error@-3 {{generic parameter 'V' could not be inferred}}
+// expected-note@-4 {{explicitly specify the generic arguments to fix this issue}}

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -21,7 +21,7 @@ func test() {
 }
 
 // SR-7339
-class Some<T, V> {
+class Some<T, V> { // expected-note {{'V' declared as parameter to type 'Some'}}
   init(keyPath: KeyPath<T, ((V) -> Void)?>) {
   }
 }
@@ -31,6 +31,9 @@ class Demo {
 }
 
 // FIXME: This error is better than it was, but the diagnosis should break it down more specifically to 'here's type.
+// TODO(diagnostics): Fix this regression, we want the following error message ideally
+// "cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'"
 let some = Some(keyPath: \Demo.here)
-// expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'}}
+// expected-error@-1 {{generic parameter 'V' could not be inferred}}
+// expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
 

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -24,12 +24,13 @@ struct Lunch<T> {
 }
 
 class Deli<Spices> { // expected-note {{'Spices' declared as parameter to type 'Deli'}}
+// expected-note@-1 {{arguments to generic parameter 'Spices' ('Pepper' and 'ChiliFlakes') are expected to be equal}}
 
   class Pepperoni {}
   struct Sausage {}
 }
 
-struct Pizzas<Spices> { // expected-note {{generic parameter 'Spices' declared here}}
+struct Pizzas<Spices> { // expected-note {{arguments to generic parameter 'Spices' ('ChiliFlakes' and 'Pepper') are expected to be equal}}
   class NewYork {
   }
 
@@ -69,7 +70,7 @@ func badDiagnostic2() {
   let topping = Deli<Pepper>.Pepperoni()
 
   eatDinnerConcrete(d: firstCourse, t: topping)
-  // expected-error@-1 {{cannot convert parent type 'Deli<Pepper>' to expected type 'Deli<ChiliFlakes>', arguments to generic parameter 'Spices' ('Pepper' and 'ChiliFlakes') are expected to be equal}}
+  // expected-error@-1 {{cannot convert parent type 'Deli<Pepper>' to expected type 'Deli<ChiliFlakes>'}}
 
 }
 
@@ -130,39 +131,32 @@ struct X<A> : Hashable {
   class Foo {}
   class Bar {}
 }
-// expected-note@-4 {{generic parameter 'A' declared here}}
-// expected-note@-5 {{generic parameter 'A' declared here}}
-// expected-note@-6 {{generic parameter 'A' declared here}}
-// expected-note@-7 {{generic parameter 'A' declared here}}
-// expected-note@-8 {{generic parameter 'A' declared here}}
-// expected-note@-9 {{generic parameter 'A' declared here}}
-// expected-note@-10 {{generic parameter 'A' declared here}}
-// expected-note@-11 {{generic parameter 'A' declared here}}
-// expected-note@-12 {{generic parameter 'A' declared here}}
+// expected-note@-4 3 {{arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
+// expected-note@-5 2 {{arguments to generic parameter 'A' ('Bool' and 'Int') are expected to be equal}}
+// expected-note@-6 4 {{arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
 
-struct Y<A, B, C>{} // expected-note {{generic parameter 'A' declared here}}
-// expected-note@-1 {{generic parameter 'C' declared here}}
+struct Y<A, B, C>{} // expected-note {{arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
+// expected-note@-1 {{arguments to generic parameter 'C' ('Int' and 'Float') are expected to be equal}}
 
 struct YieldValue {
   var property: X<Bool> {
     _read {
-      yield X<Int>() // expected-error {{cannot convert value of type 'X<Int>' to expected yield type 'X<Bool>', arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
+      yield X<Int>() // expected-error {{cannot convert value of type 'X<Int>' to expected yield type 'X<Bool>'}}
     }
   }
 }
 
 func multipleArguments(y: Y<Int, Int, Int>) {
-  let _: Y<Bool, Int, Float> = y // expected-error {{cannot convert value of type 'Y<Int, Int, Int>' to 'Y<Bool, Int, Float>' in assignment, arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
-  // expected-error@-1 {{cannot convert value of type 'Y<Int, Int, Int>' to 'Y<Bool, Int, Float>' in assignment, arguments to generic parameter 'C' ('Int' and 'Float') are expected to be equal}}
+  let _: Y<Bool, Int, Float> = y // expected-error {{cannot assign value of type 'Y<Int, Int, Int>' to type 'Y<Bool, Int, Float>'}}
 }
 
 func errorMessageVariants(x: X<Int>, x2: X<Bool> = X<Int>()) -> X<Bool> {
   // expected-error@-1 {{default argument value of type 'X<Int>' cannot be converted to type 'X<Bool>'}}
-  let _: X<Bool> = x // expected-error {{cannot convert value of type 'X<Int>' to 'X<Bool>' in assignment, arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
-  errorMessageVariants(x: x2, x2: x2) // expected-error {{cannot convert 'X<Bool>' to expected argument type 'X<Int>', arguments to generic parameter 'A' ('Bool' and 'Int') are expected to be equal}}
-  let _: X<Bool> = { return x }() // expected-error {{cannot convert value of type 'X<Int>' to closure result type 'X<Bool>', arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
-  let _: [X<Bool>] = [x] // expected-error {{cannot convert value of type 'X<Int>' to expected element type 'X<Bool>', arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
-  let _ = x as X<Bool> // expected-error {{cannot convert value of type 'X<Int>' to type 'X<Bool>' in coercion, arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
-  let _: X<Int>.Foo = X<Bool>.Foo() // expected-error {{cannot convert parent type 'X<Bool>' to expected type 'X<Int>', arguments to generic parameter 'A' ('Bool' and 'Int') are expected to be equal}}
-  return x // expected-error {{cannot convert return expression of type 'X<Int>' to return type 'X<Bool>', arguments to generic parameter 'A' ('Int' and 'Bool') are expected to be equal}}
+  let _: X<Bool> = x // expected-error {{cannot assign value of type 'X<Int>' to type 'X<Bool>'}}
+  errorMessageVariants(x: x2, x2: x2) // expected-error {{cannot convert value of type 'X<Bool>' to expected argument type 'X<Int>'}}
+  let _: X<Bool> = { return x }() // expected-error {{cannot convert value of type 'X<Int>' to closure result type 'X<Bool>'}}
+  let _: [X<Bool>] = [x] // expected-error {{cannot convert value of type 'X<Int>' to expected element type 'X<Bool>'}}
+  let _ = x as X<Bool> // expected-error {{cannot convert value of type 'X<Int>' to type 'X<Bool>' in coercion}}
+  let _: X<Int>.Foo = X<Bool>.Foo() // expected-error {{cannot convert parent type 'X<Bool>' to expected type 'X<Int>'}}
+  return x // expected-error {{cannot convert return expression of type 'X<Int>' to return type 'X<Bool>'}}
 }

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -29,7 +29,7 @@ class Deli<Spices> { // expected-note {{'Spices' declared as parameter to type '
   struct Sausage {}
 }
 
-struct Pizzas<Spices> {
+struct Pizzas<Spices> { // expected-note {{generic parameter 'Spices' declared here}}
   class NewYork {
   }
 
@@ -54,7 +54,7 @@ func eatDinnerConcrete(d: Pizzas<Pepper>.DeepDish,
 func badDiagnostic1() {
 
   _ = Lunch<Pizzas<Pepper>.NewYork>.Dinner<HotDog>(
-      leftovers: Pizzas<ChiliFlakes>.NewYork(),  // expected-error {{cannot convert value of type 'Pizzas<ChiliFlakes>.NewYork' to expected argument type 'Pizzas<Pepper>.NewYork'}}
+      leftovers: Pizzas<ChiliFlakes>.NewYork(),  // expected-error {{cannot convert parent type 'Pizzas<ChiliFlakes>' to expected type 'Pizzas<Pepper>'}}
       transformation: { _ in HotDog() })
 }
 
@@ -69,8 +69,7 @@ func badDiagnostic2() {
   let topping = Deli<Pepper>.Pepperoni()
 
   eatDinnerConcrete(d: firstCourse, t: topping)
-  // expected-error@-1 {{cannot invoke 'eatDinnerConcrete' with an argument list of type '(d: Pizzas<ChiliFlakes>.NewYork, t: Deli<Pepper>.Pepperoni)'}}
-  // expected-note@-2 {{overloads for 'eatDinnerConcrete' exist with these partially matching parameter lists: (d: Pizzas<ChiliFlakes>.NewYork, t: Deli<ChiliFlakes>.Pepperoni), (d: Pizzas<Pepper>.DeepDish, t: Deli<Pepper>.Pepperoni)}}
+  // expected-error@-1 {{cannot convert parent type 'Deli<Pepper>' to expected type 'Deli<ChiliFlakes>', arguments to generic parameter 'Spices' ('Pepper' and 'ChiliFlakes') are expected to be equal}}
 
 }
 

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -345,13 +345,14 @@ class Runce : Runcible {
 // ----------------------------------------------------------------------------
 // Forming a type with 'Self' in invariant position
 
-struct Generic<T> { init(_: T) {} }
+struct Generic<T> { init(_: T) {} } // expected-note {{generic parameter 'T' declared here}}
+// expected-note@-1 {{generic parameter 'T' declared here}}
 
 class InvariantSelf {
   func me() -> Self {
     let a = Generic(self)
     let _: Generic<InvariantSelf> = a
-    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to specified type 'Generic<InvariantSelf>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to 'Generic<InvariantSelf>' in assignment, arguments to generic parameter 'T' ('Self' and 'InvariantSelf') are expected to be equal}}
 
     return self
   }
@@ -363,7 +364,7 @@ final class FinalInvariantSelf {
   func me() -> Self {
     let a = Generic(self)
     let _: Generic<FinalInvariantSelf> = a
-    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to specified type 'Generic<FinalInvariantSelf>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to 'Generic<FinalInvariantSelf>' in assignment, arguments to generic parameter 'T' ('Self' and 'FinalInvariantSelf') are expected to be equal}}
 
     return self
   }

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -345,14 +345,14 @@ class Runce : Runcible {
 // ----------------------------------------------------------------------------
 // Forming a type with 'Self' in invariant position
 
-struct Generic<T> { init(_: T) {} } // expected-note {{generic parameter 'T' declared here}}
-// expected-note@-1 {{generic parameter 'T' declared here}}
+struct Generic<T> { init(_: T) {} } // expected-note {{arguments to generic parameter 'T' ('Self' and 'InvariantSelf') are expected to be equal}}
+// expected-note@-1 {{arguments to generic parameter 'T' ('Self' and 'FinalInvariantSelf') are expected to be equal}}
 
 class InvariantSelf {
   func me() -> Self {
     let a = Generic(self)
     let _: Generic<InvariantSelf> = a
-    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to 'Generic<InvariantSelf>' in assignment, arguments to generic parameter 'T' ('Self' and 'InvariantSelf') are expected to be equal}}
+    // expected-error@-1 {{cannot assign value of type 'Generic<Self>' to type 'Generic<InvariantSelf>'}}
 
     return self
   }
@@ -364,7 +364,7 @@ final class FinalInvariantSelf {
   func me() -> Self {
     let a = Generic(self)
     let _: Generic<FinalInvariantSelf> = a
-    // expected-error@-1 {{cannot convert value of type 'Generic<Self>' to 'Generic<FinalInvariantSelf>' in assignment, arguments to generic parameter 'T' ('Self' and 'FinalInvariantSelf') are expected to be equal}}
+    // expected-error@-1 {{cannot assign value of type 'Generic<Self>' to type 'Generic<FinalInvariantSelf>'}}
 
     return self
   }

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -69,15 +69,15 @@ func fooT(_ callback: () throws -> Bool) {} //OK
 func fooT(_ callback: () -> Bool) {}
 
 // Throwing and non-throwing types are not equivalent.
-struct X<T> { } // expected-note {{generic parameter 'T' declared here}}
-// expected-note@-1 {{generic parameter 'T' declared here}}
+struct X<T> { } // expected-note {{arguments to generic parameter 'T' ('(String) -> Int' and '(String) throws -> Int') are expected to be equal}}
+// expected-note@-1 {{arguments to generic parameter 'T' ('(String) throws -> Int' and '(String) -> Int') are expected to be equal}}
 func specializedOnFuncType1(_ x: X<(String) throws -> Int>) { }
 func specializedOnFuncType2(_ x: X<(String) -> Int>) { }
 func testSpecializedOnFuncType(_ xThrows: X<(String) throws -> Int>,
                                xNonThrows: X<(String) -> Int>) {
   specializedOnFuncType1(xThrows) // ok
-  specializedOnFuncType1(xNonThrows) // expected-error{{cannot convert 'X<(String) -> Int>' to expected argument type 'X<(String) throws -> Int>', arguments to generic parameter 'T' ('(String) -> Int' and '(String) throws -> Int') are expected to be equal}}
-  specializedOnFuncType2(xThrows)  // expected-error{{cannot convert 'X<(String) throws -> Int>' to expected argument type 'X<(String) -> Int>', arguments to generic parameter 'T' ('(String) throws -> Int' and '(String) -> Int') are expected to be equal}}
+  specializedOnFuncType1(xNonThrows) // expected-error{{cannot convert value of type 'X<(String) -> Int>' to expected argument type 'X<(String) throws -> Int>'}}
+  specializedOnFuncType2(xThrows)  // expected-error{{cannot convert value of type 'X<(String) throws -> Int>' to expected argument type 'X<(String) -> Int>'}}
   specializedOnFuncType2(xNonThrows) // ok
 }
 

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -69,14 +69,15 @@ func fooT(_ callback: () throws -> Bool) {} //OK
 func fooT(_ callback: () -> Bool) {}
 
 // Throwing and non-throwing types are not equivalent.
-struct X<T> { }
+struct X<T> { } // expected-note {{generic parameter 'T' declared here}}
+// expected-note@-1 {{generic parameter 'T' declared here}}
 func specializedOnFuncType1(_ x: X<(String) throws -> Int>) { }
 func specializedOnFuncType2(_ x: X<(String) -> Int>) { }
 func testSpecializedOnFuncType(_ xThrows: X<(String) throws -> Int>,
                                xNonThrows: X<(String) -> Int>) {
   specializedOnFuncType1(xThrows) // ok
-  specializedOnFuncType1(xNonThrows) // expected-error{{cannot convert value of type 'X<(String) -> Int>' to expected argument type 'X<(String) throws -> Int>'}}
-  specializedOnFuncType2(xThrows)  // expected-error{{cannot convert value of type 'X<(String) throws -> Int>' to expected argument type 'X<(String) -> Int>'}}
+  specializedOnFuncType1(xNonThrows) // expected-error{{cannot convert 'X<(String) -> Int>' to expected argument type 'X<(String) throws -> Int>', arguments to generic parameter 'T' ('(String) -> Int' and '(String) throws -> Int') are expected to be equal}}
+  specializedOnFuncType2(xThrows)  // expected-error{{cannot convert 'X<(String) throws -> Int>' to expected argument type 'X<(String) -> Int>', arguments to generic parameter 'T' ('(String) throws -> Int' and '(String) -> Int') are expected to be equal}}
   specializedOnFuncType2(xNonThrows) // ok
 }
 

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -228,7 +228,8 @@ extension GS {
   }
 }
 
-struct HasNested<T> {
+struct HasNested<T> { // expected-note {{generic parameter 'T' declared here}}
+// expected-note@-1 {{generic parameter 'T' declared here}}
   init<U>(_ t: T, _ u: U) {}
   func f<U>(_ t: T, u: U) -> (T, U) {}
 
@@ -250,7 +251,7 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   typealias InnerI = HasNested<Int>.Inner
   var innerI = InnerI(5)
   typealias InnerF = HasNested<Float>.Inner
-  var innerF : InnerF = innerI // expected-error{{cannot convert value of type 'InnerI' (aka 'HasNested<Int>.Inner') to specified type 'InnerF' (aka 'HasNested<Float>.Inner')}}
+  var innerF : InnerF = innerI // expected-error{{cannot convert parent type 'HasNested<Int>' to expected type 'HasNested<Float>', arguments to generic parameter 'T' ('Int' and 'Float') are expected to be equal}}
 
   _ = innerI.identity(i)
   i = innerI.identity(i)
@@ -270,7 +271,7 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   var ids = xis.g(1, u: "Hello", v: 3.14159)
   ids = (2, "world", 2.71828)
 
-  xis = xfs // expected-error{{cannot assign value of type 'HasNested<Float>.InnerGeneric<String>' to type 'HasNested<Int>.InnerGeneric<String>'}}
+  xis = xfs // expected-error{{cannot convert parent type 'HasNested<Float>' to expected type 'HasNested<Int>', arguments to generic parameter 'T' ('Float' and 'Int') are expected to be equal}}
 }
 
 // Extensions of nested generic types

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -228,8 +228,8 @@ extension GS {
   }
 }
 
-struct HasNested<T> { // expected-note {{generic parameter 'T' declared here}}
-// expected-note@-1 {{generic parameter 'T' declared here}}
+struct HasNested<T> { // expected-note {{arguments to generic parameter 'T' ('Int' and 'Float') are expected to be equal}}
+// expected-note@-1 {{arguments to generic parameter 'T' ('Float' and 'Int') are expected to be equal}}
   init<U>(_ t: T, _ u: U) {}
   func f<U>(_ t: T, u: U) -> (T, U) {}
 
@@ -251,7 +251,7 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   typealias InnerI = HasNested<Int>.Inner
   var innerI = InnerI(5)
   typealias InnerF = HasNested<Float>.Inner
-  var innerF : InnerF = innerI // expected-error{{cannot convert parent type 'HasNested<Int>' to expected type 'HasNested<Float>', arguments to generic parameter 'T' ('Int' and 'Float') are expected to be equal}}
+  var innerF : InnerF = innerI // expected-error{{cannot convert parent type 'HasNested<Int>' to expected type 'HasNested<Float>'}}
 
   _ = innerI.identity(i)
   i = innerI.identity(i)
@@ -271,7 +271,7 @@ func useNested(_ ii: Int, hni: HasNested<Int>,
   var ids = xis.g(1, u: "Hello", v: 3.14159)
   ids = (2, "world", 2.71828)
 
-  xis = xfs // expected-error{{cannot convert parent type 'HasNested<Float>' to expected type 'HasNested<Int>', arguments to generic parameter 'T' ('Float' and 'Int') are expected to be equal}}
+  xis = xfs // expected-error{{cannot convert parent type 'HasNested<Float>' to expected type 'HasNested<Int>'}}
 }
 
 // Extensions of nested generic types

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -13,6 +13,12 @@ class Generic<T> : Concrete {
 
   func genericMethod(_: GenericAlias) {}
 }
+// expected-note@-5 {{generic parameter 'T' declared here}}
+// expected-note@-6 {{generic parameter 'T' declared here}}
+// expected-note@-7 {{generic parameter 'T' declared here}}
+// expected-note@-8 {{generic parameter 'T' declared here}}
+// expected-note@-9 {{generic parameter 'T' declared here}}
+// expected-note@-10 {{generic parameter 'T' declared here}}
 
 protocol BaseProto {}
 
@@ -44,7 +50,7 @@ extension ProtoRefinesClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   }
 }
 
@@ -68,7 +74,7 @@ func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesClass' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
@@ -91,7 +97,7 @@ func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 class BadConformingClass1 : ProtoRefinesClass {
@@ -147,7 +153,7 @@ extension ProtoRefinesProtoWithClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   }
 }
 
@@ -171,7 +177,7 @@ func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesProtoWithClass' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
@@ -194,7 +200,7 @@ func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 class ClassWithInits<T> {

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -8,17 +8,11 @@ class Concrete {
   func concreteMethod(_: ConcreteAlias) {}
 }
 
-class Generic<T> : Concrete {
+class Generic<T> : Concrete { // expected-note 6 {{arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   typealias GenericAlias = (T, T)
 
   func genericMethod(_: GenericAlias) {}
 }
-// expected-note@-5 {{generic parameter 'T' declared here}}
-// expected-note@-6 {{generic parameter 'T' declared here}}
-// expected-note@-7 {{generic parameter 'T' declared here}}
-// expected-note@-8 {{generic parameter 'T' declared here}}
-// expected-note@-9 {{generic parameter 'T' declared here}}
-// expected-note@-10 {{generic parameter 'T' declared here}}
 
 protocol BaseProto {}
 
@@ -49,8 +43,8 @@ extension ProtoRefinesClass {
     let _: BaseProto & Generic<Int> = self
     let _: BaseProto & Concrete = self
 
-    let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+    let _: Generic<String> = self;
+    // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
   }
 }
 
@@ -74,7 +68,7 @@ func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
@@ -97,7 +91,7 @@ func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 class BadConformingClass1 : ProtoRefinesClass {
@@ -153,7 +147,7 @@ extension ProtoRefinesProtoWithClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+    // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
   }
 }
 
@@ -177,7 +171,7 @@ func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
@@ -200,7 +194,7 @@ func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 class ClassWithInits<T> {

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -43,7 +43,7 @@ extension ProtoRefinesClass {
     let _: BaseProto & Generic<Int> = self
     let _: BaseProto & Concrete = self
 
-    let _: Generic<String> = self;
+    let _: Generic<String> = self
     // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
   }
 }

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -8,17 +8,12 @@ class Concrete {
   func concreteMethod(_: ConcreteAlias) {}
 }
 
-class Generic<T> : Concrete {
+class Generic<T> : Concrete { // expected-note 6 {{arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   typealias GenericAlias = (T, T)
 
   func genericMethod(_: GenericAlias) {}
 }
-// expected-note@-5 {{generic parameter 'T' declared here}}
-// expected-note@-6 {{generic parameter 'T' declared here}}
-// expected-note@-7 {{generic parameter 'T' declared here}}
-// expected-note@-8 {{generic parameter 'T' declared here}}
-// expected-note@-9 {{generic parameter 'T' declared here}}
-// expected-note@-10 {{generic parameter 'T' declared here}}
+
 
 protocol BaseProto {}
 
@@ -50,7 +45,7 @@ extension ProtoRefinesClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+    // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
   }
 }
 
@@ -74,7 +69,7 @@ func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
@@ -97,7 +92,7 @@ func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 class BadConformingClass1 : ProtoRefinesClass {
@@ -153,7 +148,7 @@ extension ProtoRefinesProtoWithClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+    // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
   }
 }
 
@@ -177,7 +172,7 @@ func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
@@ -200,7 +195,7 @@ func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+  // expected-error@-1 {{cannot assign value of type 'Generic<Int>' to type 'Generic<String>'}}
 }
 
 class ClassWithInits<T> {

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -13,6 +13,12 @@ class Generic<T> : Concrete {
 
   func genericMethod(_: GenericAlias) {}
 }
+// expected-note@-5 {{generic parameter 'T' declared here}}
+// expected-note@-6 {{generic parameter 'T' declared here}}
+// expected-note@-7 {{generic parameter 'T' declared here}}
+// expected-note@-8 {{generic parameter 'T' declared here}}
+// expected-note@-9 {{generic parameter 'T' declared here}}
+// expected-note@-10 {{generic parameter 'T' declared here}}
 
 protocol BaseProto {}
 
@@ -44,7 +50,7 @@ extension ProtoRefinesClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   }
 }
 
@@ -68,7 +74,7 @@ func usesProtoRefinesClass1(_ t: ProtoRefinesClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesClass' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
@@ -91,7 +97,7 @@ func usesProtoRefinesClass2<T : ProtoRefinesClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 class BadConformingClass1 : ProtoRefinesClass {
@@ -147,7 +153,7 @@ extension ProtoRefinesProtoWithClass {
     let _: BaseProto & Concrete = self
 
     let _: Generic<String> = self
-    // expected-error@-1 {{cannot convert value of type 'Self' to specified type 'Generic<String>'}}
+    // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
   }
 }
 
@@ -171,7 +177,7 @@ func usesProtoRefinesProtoWithClass1(_ t: ProtoRefinesProtoWithClass) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'ProtoRefinesProtoWithClass' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
@@ -194,7 +200,7 @@ func usesProtoRefinesProtoWithClass2<T : ProtoRefinesProtoWithClass>(_ t: T) {
   let _: BaseProto & Concrete = t
 
   let _: Generic<String> = t
-  // expected-error@-1 {{cannot convert value of type 'T' to specified type 'Generic<String>'}}
+  // expected-error@-1 {{cannot convert value of type 'Generic<Int>' to 'Generic<String>' in assignment, arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
 }
 
 class ClassWithInits<T> {

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,13 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
 struct MyType<TyA, TyB> { // expected-note {{generic type 'MyType' declared here}}
+  // expected-note @-1 {{arguments to generic parameter 'TyB' ('S' and 'Int') are expected to be equal}}
+  // expected-note @-2 4 {{arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
   var a : TyA, b : TyB
 }
-// expected-note@-3 {{generic parameter 'TyA' declared here}}
-// expected-note@-4 {{generic parameter 'TyA' declared here}}
-// expected-note@-5 {{generic parameter 'TyA' declared here}}
-// expected-note@-6 {{generic parameter 'TyA' declared here}}
-// expected-note@-7 {{generic parameter 'TyB' declared here}}
 
 //
 // Type aliases that reference unbound generic types -- not really generic,
@@ -157,7 +154,7 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
-    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'MyType<T, Int>', arguments to generic parameter 'TyB' ('S' and 'Int') are expected to be equal}}
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'MyType<T, Int>'}}
   }
 
   func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {
@@ -265,8 +262,8 @@ let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA'}}
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to 'MyType<Int, Int>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot convert value of type 'MyType<Float, Double>' to 'MyType<Int, Double>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot assign value of type 'MyType<Float, Int>' to type 'MyType<Int, Int>'}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot assign value of type 'MyType<Float, Double>' to type 'MyType<Int, Double>'}}
 
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
@@ -277,8 +274,8 @@ let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Float>' to 'MyType<Int, Float>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot convert value of type 'MyType<Float, Float>' to 'MyType<Int, Float>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot assign value of type 'MyType<Float, Float>' to type 'MyType<Int, Float>'}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot assign value of type 'MyType<Float, Float>' to type 'MyType<Int, Float>'}}
 
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 1, b: 4.0)

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -3,6 +3,11 @@
 struct MyType<TyA, TyB> { // expected-note {{generic type 'MyType' declared here}}
   var a : TyA, b : TyB
 }
+// expected-note@-3 {{generic parameter 'TyA' declared here}}
+// expected-note@-4 {{generic parameter 'TyA' declared here}}
+// expected-note@-5 {{generic parameter 'TyA' declared here}}
+// expected-note@-6 {{generic parameter 'TyA' declared here}}
+// expected-note@-7 {{generic parameter 'TyB' declared here}}
 
 //
 // Type aliases that reference unbound generic types -- not really generic,
@@ -152,7 +157,7 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
-    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'GenericClass<T>.TA<S>' (aka 'MyType<T, S>') to return type 'MyType<T, Int>'}}
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'MyType<T, Int>', arguments to generic parameter 'TyB' ('S' and 'Int') are expected to be equal}}
   }
 
   func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {
@@ -260,8 +265,8 @@ let _: GenericClass.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA'}}
 let _: GenericClass<Int>.TA = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'GenericClass<Int>.TA'}}
-let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'GenericClass<Int>.TA'}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to 'MyType<Int, Int>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
+let _: GenericClass<Int>.TA = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot convert value of type 'MyType<Float, Double>' to 'MyType<Int, Double>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
 
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA = GenericClass<Int>.TA(a: 1, b: 4.0)
@@ -272,8 +277,8 @@ let _: GenericClass<Int>.TA = GenericClass<Int>.TA<Float>(a: 1, b: 4.0)
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Double, Int>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
 let _: GenericClass<Int>.TA<Float> = GenericClass.TA(a: 1, b: 4.0)
 
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Int>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
-let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // FIXME // expected-error {{cannot convert value of type 'MyType<Float, Double>' to specified type 'GenericClass<Int>.TA<Float>' (aka 'MyType<Int, Float>')}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'MyType<Float, Float>' to 'MyType<Int, Float>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
+let _: GenericClass<Int>.TA<Float> = GenericClass.TA<Float>(a: 1, b: 4.0) // expected-error {{cannot convert value of type 'MyType<Float, Float>' to 'MyType<Int, Float>' in assignment, arguments to generic parameter 'TyA' ('Float' and 'Int') are expected to be equal}}
 
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 4.0, b: 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: GenericClass<Int>.TA<Float> = GenericClass<Int>.TA(a: 1, b: 4.0)

--- a/test/expr/cast/array_coerce.swift
+++ b/test/expr/cast/array_coerce.swift
@@ -34,12 +34,12 @@ das = cas // expected-error{{cannot assign value of type '[C]' to type '[D]'}}
 var cs = ca[0...0]
 var ds = da[0...0]
 
-cs = ds // expected-error{{cannot assign value of type 'ArraySlice<D>' to type 'ArraySlice<C>'}}
-ds = cs // expected-error{{cannot assign value of type 'ArraySlice<C>' to type 'ArraySlice<D>'}}
+cs = ds // expected-error{{cannot convert value of type 'ArraySlice<D>' to 'ArraySlice<C>' in assignment, arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
+ds = cs // expected-error{{cannot convert value of type 'ArraySlice<C>' to 'ArraySlice<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
 
 // ContiguousArray<T>
 var cna: ContiguousArray<C> = [c1]
 var dna: ContiguousArray<D> = [d1]
 
-cna = dna // expected-error{{cannot assign value of type 'ContiguousArray<D>' to type 'ContiguousArray<C>'}}
-dna = cna // expected-error{{cannot assign value of type 'ContiguousArray<C>' to type 'ContiguousArray<D>'}}
+cna = dna // expected-error{{cannot convert value of type 'ContiguousArray<D>' to 'ContiguousArray<C>' in assignment, arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
+dna = cna // expected-error{{cannot convert value of type 'ContiguousArray<C>' to 'ContiguousArray<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}

--- a/test/expr/cast/array_coerce.swift
+++ b/test/expr/cast/array_coerce.swift
@@ -34,12 +34,17 @@ das = cas // expected-error{{cannot assign value of type '[C]' to type '[D]'}}
 var cs = ca[0...0]
 var ds = da[0...0]
 
-cs = ds // expected-error{{cannot convert value of type 'ArraySlice<D>' to 'ArraySlice<C>' in assignment, arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
-ds = cs // expected-error{{cannot convert value of type 'ArraySlice<C>' to 'ArraySlice<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
+cs = ds // expected-error{{cannot assign value of type 'ArraySlice<D>' to type 'ArraySlice<C>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
+
+ds = cs // expected-error{{cannot assign value of type 'ArraySlice<C>' to type 'ArraySlice<D>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
 
 // ContiguousArray<T>
 var cna: ContiguousArray<C> = [c1]
 var dna: ContiguousArray<D> = [d1]
 
-cna = dna // expected-error{{cannot convert value of type 'ContiguousArray<D>' to 'ContiguousArray<C>' in assignment, arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
-dna = cna // expected-error{{cannot convert value of type 'ContiguousArray<C>' to 'ContiguousArray<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
+cna = dna // expected-error{{cannot assign value of type 'ContiguousArray<D>' to type 'ContiguousArray<C>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('D' and 'C') are expected to be equal}}
+dna = cna // expected-error{{cannot assign value of type 'ContiguousArray<C>' to type 'ContiguousArray<D>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -82,9 +82,12 @@ func testUpcastBridge() {
   dictBB = dictBO // expected-error{{cannot assign value of type '[BridgedToObjC : ObjC]' to type '[BridgedToObjC : BridgedToObjC]'}}
   dictBB = dictOB // expected-error{{cannot assign value of type '[ObjC : BridgedToObjC]' to type '[BridgedToObjC : BridgedToObjC]'}}
 
-  dictDO = dictBB // expected-error{{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[DerivesObjC : ObjC]'}}
-  dictOD = dictBB // expected-error{{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[ObjC : DerivesObjC]'}}
-  dictDD = dictBB // expected-error{{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[DerivesObjC : DerivesObjC]'}}
+  dictDO = dictBB // expected-error{{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : ObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  //expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : ObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
+  dictOD = dictBB // expected-error {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[ObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
+  // expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[ObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  dictDD = dictBB // expected-error {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  // expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
   
   _ = dictDD; _ = dictDO; _ = dictOD; _ = dictOO; _ = dictOR; _ = dictOR; _ = dictRR; _ = dictRO
 }

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -82,12 +82,15 @@ func testUpcastBridge() {
   dictBB = dictBO // expected-error{{cannot assign value of type '[BridgedToObjC : ObjC]' to type '[BridgedToObjC : BridgedToObjC]'}}
   dictBB = dictOB // expected-error{{cannot assign value of type '[ObjC : BridgedToObjC]' to type '[BridgedToObjC : BridgedToObjC]'}}
 
-  dictDO = dictBB // expected-error{{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : ObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
-  //expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : ObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
-  dictOD = dictBB // expected-error {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[ObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
-  // expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[ObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
-  dictDD = dictBB // expected-error {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
-  // expected-error@-1 {{cannot convert value of type '[BridgedToObjC : BridgedToObjC]' to '[DerivesObjC : DerivesObjC]' in assignment, arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  dictDO = dictBB // expected-error{{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[DerivesObjC : ObjC]'}}
+  //expected-note@-1 {{arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  //expected-note@-2 {{arguments to generic parameter 'Value' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
+  dictOD = dictBB // expected-error {{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[ObjC : DerivesObjC]'}}
+  //expected-note@-1 {{arguments to generic parameter 'Key' ('BridgedToObjC' and 'ObjC') are expected to be equal}}
+  //expected-note@-2 {{arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  dictDD = dictBB // expected-error {{cannot assign value of type '[BridgedToObjC : BridgedToObjC]' to type '[DerivesObjC : DerivesObjC]'}}
+  //expected-note@-1 {{arguments to generic parameter 'Key' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  //expected-note@-2 {{arguments to generic parameter 'Value' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
   
   _ = dictDD; _ = dictDO; _ = dictOD; _ = dictOO; _ = dictOR; _ = dictOR; _ = dictRR; _ = dictRO
 }

--- a/test/expr/cast/dictionary_coerce.swift
+++ b/test/expr/cast/dictionary_coerce.swift
@@ -24,13 +24,15 @@ dictCC = dictDC
 dictCC = dictDD
 
 dictCD = dictDD
-dictCD = dictCC // expected-error{{cannot convert value of type '[C : C]' to '[C : D]' in assignment, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
+dictCD = dictCC // expected-error{{cannot assign value of type '[C : C]' to type '[C : D]'}}
+// expected-note@-1 {{arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
 
 
 dictDC = dictDD
-dictDC = dictCD // expected-error {{cannot convert value of type '[C : D]' to '[D : C]' in assignment, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
-// expected-error@-1 {{cannot convert value of type '[C : D]' to '[D : C]' in assignment, arguments to generic parameter 'Value' ('D' and 'C') are expected to be equal}}
+dictDC = dictCD // expected-error {{cannot assign value of type '[C : D]' to type '[D : C]'}}
+// expected-note@-1 {{arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('D' and 'C') are expected to be equal}}
 
-dictDD = dictCC // expected-error{{cannot convert value of type '[C : C]' to '[D : D]' in assignment, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
-// expected-error@-1 {{cannot convert value of type '[C : C]' to '[D : D]' in assignment, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
-
+dictDD = dictCC // expected-error{{cannot assign value of type '[C : C]' to type '[D : D]'}}
+// expected-note@-1 {{arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}

--- a/test/expr/cast/dictionary_coerce.swift
+++ b/test/expr/cast/dictionary_coerce.swift
@@ -24,11 +24,13 @@ dictCC = dictDC
 dictCC = dictDD
 
 dictCD = dictDD
-dictCD = dictCC // expected-error{{cannot assign value of type '[C : C]' to type '[C : D]'}}
+dictCD = dictCC // expected-error{{cannot convert value of type '[C : C]' to '[C : D]' in assignment, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
 
 
 dictDC = dictDD
-dictDC = dictCD // expected-error{{cannot assign value of type '[C : D]' to type '[D : C]'}}
+dictDC = dictCD // expected-error {{cannot convert value of type '[C : D]' to '[D : C]' in assignment, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-error@-1 {{cannot convert value of type '[C : D]' to '[D : C]' in assignment, arguments to generic parameter 'Value' ('D' and 'C') are expected to be equal}}
 
-dictDD = dictCC // expected-error{{cannot assign value of type '[C : C]' to type '[D : D]'}}
+dictDD = dictCC // expected-error{{cannot convert value of type '[C : C]' to '[D : D]' in assignment, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-error@-1 {{cannot convert value of type '[C : C]' to '[D : D]' in assignment, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
 

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -32,9 +32,12 @@ if let _ = dictCC as? Dictionary<D, C> { }
 if let _ = dictCC as? Dictionary<D, D> { }
 
 // Test dictionary downcasts to unrelated types.
-dictCC as Dictionary<D, U> // expected-error{{cannot convert value of type '[C : C]' to type 'Dictionary<D, U>' in coercion}}
-dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type '[C : C]' to type 'Dictionary<U, D>' in coercion}}
-dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type '[C : C]' to type 'Dictionary<U, U>' in coercion}}
+dictCC as Dictionary<D, U> // expected-error{{cannot convert value of type '[C : C]' to type '[D : U]' in coercion, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[D : U]' in coercion, arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
+dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type '[C : C]' to type '[U : D]' in coercion, arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
+// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[U : D]' in coercion, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
+dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type '[C : C]' to type '[U : U]' in coercion, arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
+// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[U : U]' in coercion, arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
 
 // Test dictionary conditional downcasts to unrelated types
 if let _ = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from '[C : C]' to unrelated type 'Dictionary<D, U>' always fails}}

--- a/test/expr/cast/dictionary_downcast.swift
+++ b/test/expr/cast/dictionary_downcast.swift
@@ -32,12 +32,15 @@ if let _ = dictCC as? Dictionary<D, C> { }
 if let _ = dictCC as? Dictionary<D, D> { }
 
 // Test dictionary downcasts to unrelated types.
-dictCC as Dictionary<D, U> // expected-error{{cannot convert value of type '[C : C]' to type '[D : U]' in coercion, arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
-// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[D : U]' in coercion, arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
-dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type '[C : C]' to type '[U : D]' in coercion, arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
-// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[U : D]' in coercion, arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
-dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type '[C : C]' to type '[U : U]' in coercion, arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
-// expected-error@-1 {{cannot convert value of type '[C : C]' to type '[U : U]' in coercion, arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
+dictCC as Dictionary<D, U> // expected-error{{cannot convert value of type '[C : C]' to type '[D : U]' in coercion}}
+// expected-note@-1 {{arguments to generic parameter 'Key' ('C' and 'D') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
+dictCC as Dictionary<U, D> // expected-error{{cannot convert value of type '[C : C]' to type '[U : D]' in coercion}}
+// expected-note@-1 {{arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('C' and 'D') are expected to be equal}}
+dictCC as Dictionary<U, U> // expected-error{{cannot convert value of type '[C : C]' to type '[U : U]' in coercion}}
+// expected-note@-1 {{arguments to generic parameter 'Key' ('C' and 'U') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Value' ('C' and 'U') are expected to be equal}}
 
 // Test dictionary conditional downcasts to unrelated types
 if let _ = dictCC as? Dictionary<D, U> { } // expected-warning{{cast from '[C : C]' to unrelated type 'Dictionary<D, U>' always fails}}

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -61,7 +61,8 @@ func testUpcastBridge() {
   setB = setO // expected-error{{cannot assign value of type 'Set<ObjC>' to type 'Set<BridgedToObjC>'}}
 
   // Failed upcast
-  setD = setB // expected-error{{cannot convert value of type 'Set<BridgedToObjC>' to 'Set<DerivesObjC>' in assignment, arguments to generic parameter 'Element' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
+  setD = setB // expected-error{{cannot assign value of type 'Set<BridgedToObjC>' to type 'Set<DerivesObjC>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
 }
 
 func testForcedDowncastBridge() {

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -61,8 +61,7 @@ func testUpcastBridge() {
   setB = setO // expected-error{{cannot assign value of type 'Set<ObjC>' to type 'Set<BridgedToObjC>'}}
 
   // Failed upcast
-  setD = setB // expected-error{{cannot assign value of type 'Set<BridgedToObjC>' to type 'Set<DerivesObjC>'}}
-  _ = setD
+  setD = setB // expected-error{{cannot convert value of type 'Set<BridgedToObjC>' to 'Set<DerivesObjC>' in assignment, arguments to generic parameter 'Element' ('BridgedToObjC' and 'DerivesObjC') are expected to be equal}}
 }
 
 func testForcedDowncastBridge() {

--- a/test/expr/cast/set_coerce.swift
+++ b/test/expr/cast/set_coerce.swift
@@ -18,4 +18,5 @@ var setD = Set<D>()
 
 // Test set upcasts
 setC = setD
-setD = setC // expected-error{{cannot convert value of type 'Set<C>' to 'Set<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
+setD = setC // expected-error{{cannot assign value of type 'Set<C>' to type 'Set<D>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}

--- a/test/expr/cast/set_coerce.swift
+++ b/test/expr/cast/set_coerce.swift
@@ -18,4 +18,4 @@ var setD = Set<D>()
 
 // Test set upcasts
 setC = setD
-setD = setC // expected-error{{cannot assign value of type 'Set<C>' to type 'Set<D>'}}
+setD = setC // expected-error{{cannot convert value of type 'Set<C>' to 'Set<D>' in assignment, arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -684,7 +684,8 @@ func testSubtypeKeypathClass(_ keyPath: ReferenceWritableKeyPath<Base, Int>) {
 
 func testSubtypeKeypathProtocol(_ keyPath: ReferenceWritableKeyPath<PP, Int>) {
   testSubtypeKeypathProtocol(\Base.i)
-  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to specified type 'ReferenceWritableKeyPath<PP, Int>'}}
+  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to expected argument type 'ReferenceWritableKeyPath<PP, Int>'}}
+  // expected-note@-2 {{arguments to generic parameter 'Root' ('Base' and 'PP') are expected to be equal}}
 }
 
 // rdar://problem/32057712

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -87,9 +87,11 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>', arguments to generic parameter 'Pointee' ('String' and '_') are expected to be equal}}
+  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and '_') are expected to be equal}}
   _ = UnsafePointer<String>(upi) // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>', arguments to generic parameter 'Pointee' ('Int' and '_') are expected to be equal}}
+  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and '_') are expected to be equal}}
 }
 
 func unsafeRawBufferPointerConversions(

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -87,9 +87,9 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>'}}
+  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>', arguments to generic parameter 'Pointee' ('String' and '_') are expected to be equal}}
   _ = UnsafePointer<String>(upi) // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>'}}
+  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>', arguments to generic parameter 'Pointee' ('Int' and '_') are expected to be equal}}
 }
 
 func unsafeRawBufferPointerConversions(

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -86,12 +86,14 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'RawPointer'}}
   _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
 
-  _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<_>'}}
-  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and '_') are expected to be equal}}
-  _ = UnsafePointer<String>(upi) // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'RawPointer'}}
-  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<_>'}}
-  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and '_') are expected to be equal}}
+  _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'UnsafePointer<Int>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}
+  _ = UnsafeMutablePointer<Int>(umps) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<String>' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}
+  _ = UnsafePointer<String>(upi) // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafePointer<String>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'String') are expected to be equal}}
+  _ = UnsafeMutablePointer<String>(umpi) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<String>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'String') are expected to be equal}}
 }
 
 func unsafeRawBufferPointerConversions(


### PR DESCRIPTION
Adds a detailed diagnostic for generic argument mismatches. The new diagnostic covers both existing cases that would have been diagnosed as `cannot convert X<Y> to X<Z>`, providing more information, and takes the place of some diagnostics generated by CSDiag which provided little help.

The new diagnostic has a few forms depending on the context it's used in, but here's an example of it with assignment:

```swift
struct A<X, Y, Z> {}

let a: A<Int, Int, Int> = A<Int, Int, Int>()
let b: A<Bool, Int, Float> = a
```
Which produces the following diagnostics:

```
example.swift:4:30: error: cannot convert value of type 'A<Int, Int, Int>' to 'A<Bool, Int, Float>' in assignment, arguments to generic parameter 'X' ('Int' and 'Bool') are expected to be equal
let b: A<Bool, Int, Float> = a
                             ^
example.swift:1:10: note: generic parameter 'X' declared here
struct A<X, Y, Z> {}
         ^
example.swift:4:30: error: cannot convert value of type 'A<Int, Int, Int>' to 'A<Bool, Int, Float>' in assignment, arguments to generic parameter 'Z' ('Int' and 'Float') are expected to be equal
let b: A<Bool, Int, Float> = a
                             ^
example.swift:1:16: note: generic parameter 'Z' declared here
struct A<X, Y, Z> {}
```

Resolves: [SR-10790](https://bugs.swift.org/browse/SR-10790)
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
