### PR TITLE
Add build-script -a/-A to control assertions

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -663,12 +663,12 @@ def create_argument_parser():
         set_defaults(assertions=True)
 
         # TODO: Convert to store_true
-        option('--assertions', store,
+        option(['-a', '--assertions'], store,
                const=True,
                help='enable assertions in all projects')
 
         # TODO: Convert to store_false
-        option('--no-assertions', store('assertions'),
+        option(['-A', '--no-assertions'], store('assertions'),
                const=False,
                help='disable assertions in all projects')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -386,9 +386,11 @@ EXPECTED_OPTIONS = [
     SetOption('-s', dest='test_optimize_for_size', value=True),
     SetOption('-y', dest='test_optimize_none_implicit_dynamic', value=True),
     SetOption('-t', dest='test', value=True),
+    SetOption('-a', dest='assertions', value=True),
 
     # FIXME: Convert these options to set_false actions
     SetOption('--no-assertions', dest='assertions', value=False),
+    SetOption('-A', dest='assertions', value=False),
     SetOption('--no-lldb-assertions', dest='lldb_assertions', value=False),
     SetOption('--no-llvm-assertions', dest='llvm_assertions', value=False),
     SetOption('--no-llbuild-assertions',


### PR DESCRIPTION
This PR adds two short equivalents of current long flags: `-a` is short for `--assertions`, while `-A` is short for `--no-assertions`. The assertion setting is critical for testing performance, so it really ought to be easy to specify.

With this change, common configurations like "release-debug, no assertions" can be specified with `build-script -rA`.