### PR TITLE
Fix `DataProtocol.lastRange(of:)` (and cherry-pick Data.swift changes from swift-5.0-branch)

### DIFF
--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -688,7 +688,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                 return Int(length)
             }
             set(newValue) {
-                precondition(newValue <= MemoryLayout<Buffer>.size)
+                assert(newValue <= MemoryLayout<Buffer>.size)
                 length = UInt8(newValue)
             }
         }
@@ -777,7 +777,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             assert(subrange.upperBound <= MemoryLayout<Buffer>.size)
             assert(count - (subrange.upperBound - subrange.lowerBound) + replacementLength <= MemoryLayout<Buffer>.size)
             precondition(subrange.lowerBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
-            precondition(subrange.upperBound <= length, "index \(subrange.lowerBound) is out of bounds of 0..<\(length)")
+            precondition(subrange.upperBound <= length, "index \(subrange.upperBound) is out of bounds of 0..<\(length)")
             let currentLength = count
             let resultingLength = currentLength - (subrange.upperBound - subrange.lowerBound) + replacementLength
             let shift = resultingLength - currentLength
@@ -2194,7 +2194,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     @inlinable // This is @inlinable as trivially forwarding.
     internal func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Int>) {
-        if range.upperBound - range.lowerBound == 0 { return }
+        if range.isEmpty { return }
         _representation.copyBytes(to: pointer, from: range)
     }
     

--- a/stdlib/public/Darwin/Foundation/DataProtocol.swift
+++ b/stdlib/public/Darwin/Foundation/DataProtocol.swift
@@ -86,7 +86,7 @@ extension DataProtocol {
     }
 
     public func lastRange<D: DataProtocol>(of data: D) -> Range<Index>? {
-        return self.firstRange(of: data, in: self.startIndex ..< self.endIndex)
+        return self.lastRange(of: data, in: self.startIndex ..< self.endIndex)
     }
 
     @discardableResult


### PR DESCRIPTION
`DataProtocol.lastRange(of:)` is correct in swift-5.0-branch, but not in master and swift-5.1-branch.

The changes are from #21292 (d7fcb87cec67796b4843eb2e9c55c6e3a7888d15).