### PR TITLE
[SR-7320] Update the build instrunction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ several hours. Naturally, incremental builds are much faster.
 macOS, Ubuntu Linux LTS, and the latest Ubuntu Linux release are the current
 supported host development operating systems.
 
-Please make sure you use Python 2.x. Python 3.x is not supported currently.
+Please make sure you use Python 2.x and your path setting is appropriate. Python 3.x is not supported currently.
 
 #### macOS
 
@@ -161,8 +161,6 @@ For documentation of all available arguments, as well as additional usage
 information, see the inline help:
 
     utils/build-script -h
-
-**Note:**  If you get an error when using Anaconda, you should temporarily set a path to Python 2 to be higher priority, or change PythonInterp to Python2 and PYTHON_EXECUTABLE to Python2_EXECUTABLE in the build system.
 
 #### Xcode
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ information, see the inline help:
 
     utils/build-script -h
 
+**Note:**  If you get an error when using Anaconda, you should temporarily set a path to Python 2 to be higher priority, or change PythonInterp to Python2 and PYTHON_EXECUTABLE to Python2_EXECUTABLE in the build system.
+
 #### Xcode
 
 To build using Xcode, specify the `--xcode` argument on any of the above commands.


### PR DESCRIPTION
<!-- What's in this pull request? -->
I got some errors when building as below.

```
:
:
File "/Users/moatom/Documents/prg/GitHub/swift-source/swift/stdlib/public/core/IntegerTypes.swift.gyb", line 20, in <module>
    from string import maketrans, capitalize
ImportError: cannot import name 'maketrans'
ninja: build stopped: subcommand failed.
utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```

According to my research, in the case of using PythonInterp module for find_module, CMake could't get any path to Python 2 in my environment whether find_module's version operand is 2.7 [EXACT] or not.

Although it seems good to chenge them to use Python2 module, it is supported only since CMake's version 3.12 (see: https://cmake.org/cmake/help/latest/module/FindPythonInterp.html .)

So I think writing them to README.md is the best choice.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7320](https://bugs.swift.org/browse/SR-7320).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
