### PR TITLE
SIL: Replace uses of getReferencedFunction() by getReferencedFunction…

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -149,9 +149,13 @@ public:
 
   /// Return the referenced function if the callee is a function_ref like
   /// instruction.
+  ///
   /// WARNING: This not necessarily the function that will be called at runtime.
-  /// If the callee is a (prev_)dynamic_function_ref the actuall function called
-  /// might be different.
+  /// If the callee is a (prev_)dynamic_function_ref the actual function called
+  /// might be different because it could be dynamically replaced at runtime.
+  ///
+  /// If the client of this API wants to look at the content of the returned SIL
+  /// function it should call getReferencedFunctionOrNull() instead.
   SILFunction *getInitiallyReferencedFunction() const {
     FOREACH_IMPL_RETURN(getInitiallyReferencedFunction());
   }

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -143,8 +143,17 @@ public:
 
   /// Return the referenced function if the callee is a function_ref
   /// instruction.
-  SILFunction *getReferencedFunction() const {
-    FOREACH_IMPL_RETURN(getReferencedFunction());
+  SILFunction *getReferencedFunctionOrNull() const {
+    FOREACH_IMPL_RETURN(getReferencedFunctionOrNull());
+  }
+
+  /// Return the referenced function if the callee is a function_ref like
+  /// instruction.
+  /// WARNING: This not necessarily the function that will be called at runtime.
+  /// If the callee is a (prev_)dynamic_function_ref the actuall function called
+  /// might be different.
+  SILFunction *getInitiallyReferencedFunction() const {
+    FOREACH_IMPL_RETURN(getInitiallyReferencedFunction());
   }
 
   /// Should we optimize this call.

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -518,7 +518,7 @@ struct Callee_match<SILFunction &> {
     if (!AI)
       return false;
 
-    return AI->getReferencedFunction() == &Fun;
+    return AI->getReferencedFunctionOrNull() == &Fun;
   }
 };
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -950,7 +950,8 @@ SILCloner<ImplClass>::visitEndApplyInst(EndApplyInst *Inst) {
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitFunctionRefInst(FunctionRefInst *Inst) {
-  SILFunction *OpFunction = getOpFunction(Inst->getReferencedFunction());
+  SILFunction *OpFunction =
+      getOpFunction(Inst->getInitiallyReferencedFunction());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createFunctionRef(
                                     getOpLocation(Inst->getLoc()), OpFunction));
@@ -959,7 +960,8 @@ SILCloner<ImplClass>::visitFunctionRefInst(FunctionRefInst *Inst) {
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitDynamicFunctionRefInst(DynamicFunctionRefInst *Inst) {
-  SILFunction *OpFunction = getOpFunction(Inst->getReferencedFunction());
+  SILFunction *OpFunction =
+      getOpFunction(Inst->getInitiallyReferencedFunction());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createDynamicFunctionRef(
                                     getOpLocation(Inst->getLoc()), OpFunction));
@@ -968,7 +970,8 @@ SILCloner<ImplClass>::visitDynamicFunctionRefInst(DynamicFunctionRefInst *Inst) 
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitPreviousDynamicFunctionRefInst(
     PreviousDynamicFunctionRefInst *Inst) {
-  SILFunction *OpFunction = getOpFunction(Inst->getReferencedFunction());
+  SILFunction *OpFunction =
+      getOpFunction(Inst->getInitiallyReferencedFunction());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createPreviousDynamicFunctionRef(
                                     getOpLocation(Inst->getLoc()), OpFunction));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1854,9 +1854,13 @@ public:
 
   /// Return the referenced function if the callee is a function_ref like
   /// instruction.
+  ///
   /// WARNING: This not necessarily the function that will be called at runtime.
-  /// If this is a (prev_)dynamic_function_ref the actuall function called might
-  /// be different.
+  /// If the callee is a (prev_)dynamic_function_ref the actual function called
+  /// might be different because it could be dynamically replaced at runtime.
+  ///
+  /// If the client of this API wants to look at the content of the returned SIL
+  /// function it should call getReferencedFunctionOrNull() instead.
   SILFunction *getInitiallyReferencedFunction() const {
     if (auto *FRI = dyn_cast<FunctionRefBaseInst>(getCallee()))
       return FRI->getInitiallyReferencedFunction();
@@ -2319,10 +2323,14 @@ public:
     return nullptr;
   }
 
-  /// Return the referenced function.
+  /// Return the initially referenced function.
+  ///
   /// WARNING: This not necessarily the function that will be called at runtime.
-  /// If this is a (prev_)dynamic_function_ref the actuall function called might
-  /// be different.
+  /// If the callee is a (prev_)dynamic_function_ref the actual function called
+  /// might be different because it could be dynamically replaced at runtime.
+  ///
+  /// If the client of this API wants to look at the content of the returned SIL
+  /// function it should call getReferencedFunctionOrNull() instead.
   SILFunction *getInitiallyReferencedFunction() const { return f; }
 
   void dropReferencedFunction();

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1844,9 +1844,22 @@ public:
   bool isCalleeDynamicallyReplaceable() const;
 
   /// Gets the referenced function if the callee is a function_ref instruction.
-  SILFunction *getReferencedFunction() const {
+  /// Returns null if the callee is dynamic or a (prev_)dynamic_function_ref
+  /// instruction.
+  SILFunction *getReferencedFunctionOrNull() const {
     if (auto *FRI = dyn_cast<FunctionRefBaseInst>(getCallee()))
-      return FRI->getReferencedFunction();
+      return FRI->getReferencedFunctionOrNull();
+    return nullptr;
+  }
+
+  /// Return the referenced function if the callee is a function_ref like
+  /// instruction.
+  /// WARNING: This not necessarily the function that will be called at runtime.
+  /// If this is a (prev_)dynamic_function_ref the actuall function called might
+  /// be different.
+  SILFunction *getInitiallyReferencedFunction() const {
+    if (auto *FRI = dyn_cast<FunctionRefBaseInst>(getCallee()))
+      return FRI->getInitiallyReferencedFunction();
     return nullptr;
   }
 
@@ -2294,8 +2307,23 @@ protected:
 public:
   ~FunctionRefBaseInst();
 
+  /// Return the referenced function if this is a function_ref instruction and
+  /// therefore a client can rely on the dynamically called function being equal
+  /// to the returned value and null otherwise.
+  SILFunction *getReferencedFunctionOrNull() const {
+    auto kind = getKind();
+    if (kind == SILInstructionKind::FunctionRefInst)
+      return f;
+    assert(kind == SILInstructionKind::DynamicFunctionRefInst ||
+           kind == SILInstructionKind::PreviousDynamicFunctionRefInst);
+    return nullptr;
+  }
+
   /// Return the referenced function.
-  SILFunction *getReferencedFunction() const { return f; }
+  /// WARNING: This not necessarily the function that will be called at runtime.
+  /// If this is a (prev_)dynamic_function_ref the actuall function called might
+  /// be different.
+  SILFunction *getInitiallyReferencedFunction() const { return f; }
 
   void dropReferencedFunction();
 
@@ -7805,7 +7833,7 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
     // previous_dynamic_function_ref as the target of those functions is not
     // statically known.
     if (auto *FRI = dyn_cast<FunctionRefInst>(Callee))
-      return FRI->getReferencedFunction();
+      return FRI->getReferencedFunctionOrNull();
 
     if (auto *PAI = dyn_cast<PartialApplyInst>(Callee)) {
       Callee = PAI->getCalleeOrigin();

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -69,7 +69,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
 
       if (!Cloner.Inlining) {
         FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(AI.getCallee());
-        if (FRI && FRI->getReferencedFunction() == AI.getFunction() &&
+        if (FRI && FRI->getInitiallyReferencedFunction() == AI.getFunction() &&
             Subs == Cloner.SubsMap) {
           // Handle recursions by replacing the apply to the callee with an
           // apply to the newly specialized function, but only if substitutions

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -352,7 +352,7 @@ bool indicatesDynamicAvailabilityCheckUse(SILInstruction *I) {
     return false;
   if (Apply->hasSemantics("availability.osversion"))
     return true;
-  auto *FunRef = Apply->getReferencedFunction();
+  auto *FunRef = Apply->getReferencedFunctionOrNull();
   if (!FunRef)
     return false;
   if (FunRef->getName().equals("_swift_stdlib_operatingSystemVersion"))

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1842,7 +1842,7 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
 }
 
 void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
-  auto fn = i->getReferencedFunction();
+  auto fn = i->getInitiallyReferencedFunction();
 
   llvm::Constant *fnPtr = IGM.getAddrOfSILFunction(
       fn, NotForDefinition, false /*isDynamicallyReplaceableImplementation*/,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2790,7 +2790,7 @@ void LoadableByAddress::run() {
     for (SILBasicBlock &BB : CurrF) {
       for (SILInstruction &I : BB) {
         if (auto *FRI = dyn_cast<FunctionRefBaseInst>(&I)) {
-          SILFunction *RefF = FRI->getReferencedFunction();
+          SILFunction *RefF = FRI->getInitiallyReferencedFunction();
           if (modFuncs.count(RefF) != 0) {
             // Go over the uses and add them to lists to modify
             //
@@ -2895,7 +2895,7 @@ void LoadableByAddress::run() {
   // They just contain a pointer to the function
   // The pointer does not change
   for (auto *instr : funcRefs) {
-    SILFunction *F = instr->getReferencedFunction();
+    SILFunction *F = instr->getInitiallyReferencedFunction();
     SILBuilderWithScope refBuilder(instr);
     SingleValueInstruction *newInstr =
         refBuilder.createFunctionRef(instr->getLoc(), F, instr->getKind());

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -358,7 +358,7 @@ SILValue swift::isPartialApplyOfReabstractionThunk(PartialApplyInst *PAI) {
       PAI->getNumArguments() != 2)
     return SILValue();
 
-  auto *Fun = PAI->getReferencedFunction();
+  auto *Fun = PAI->getReferencedFunctionOrNull();
   if (!Fun)
     return SILValue();
 

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -170,17 +170,17 @@ void SILLinkerVisitor::visitPartialApplyInst(PartialApplyInst *PAI) {
 }
 
 void SILLinkerVisitor::visitFunctionRefInst(FunctionRefInst *FRI) {
-  maybeAddFunctionToWorklist(FRI->getReferencedFunction());
+  maybeAddFunctionToWorklist(FRI->getInitiallyReferencedFunction());
 }
 
 void SILLinkerVisitor::visitDynamicFunctionRefInst(
     DynamicFunctionRefInst *FRI) {
-  maybeAddFunctionToWorklist(FRI->getReferencedFunction());
+  maybeAddFunctionToWorklist(FRI->getInitiallyReferencedFunction());
 }
 
 void SILLinkerVisitor::visitPreviousDynamicFunctionRefInst(
     PreviousDynamicFunctionRefInst *FRI) {
-  maybeAddFunctionToWorklist(FRI->getReferencedFunction());
+  maybeAddFunctionToWorklist(FRI->getInitiallyReferencedFunction());
 }
 
 // Eagerly visiting all used conformances leads to a large blowup

--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -33,7 +33,7 @@ AccessedStorage::Kind AccessedStorage::classify(SILValue base) {
     return Global;
   case ValueKind::ApplyInst: {
     FullApplySite apply(cast<ApplyInst>(base));
-    if (auto *funcRef = apply.getReferencedFunction()) {
+    if (auto *funcRef = apply.getReferencedFunctionOrNull()) {
       if (getVariableOfGlobalInit(funcRef))
         return Global;
     }
@@ -91,7 +91,7 @@ AccessedStorage::AccessedStorage(SILValue base, Kind kind) {
       global = GAI->getReferencedGlobal();
     else {
       FullApplySite apply(cast<ApplyInst>(base));
-      auto *funcRef = apply.getReferencedFunction();
+      auto *funcRef = apply.getReferencedFunctionOrNull();
       assert(funcRef);
       global = getVariableOfGlobalInit(funcRef);
       assert(global);
@@ -197,7 +197,7 @@ void AccessedStorage::dump() const { print(llvm::dbgs()); }
 // module.
 static bool isExternalGlobalAddressor(ApplyInst *AI) {
   FullApplySite apply(AI);
-  auto *funcRef = apply.getReferencedFunction();
+  auto *funcRef = apply.getReferencedFunctionOrNull();
   if (!funcRef)
     return false;
   

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -233,7 +233,7 @@ SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
          "Expected C function representation!");
 
   if (auto *FR = dyn_cast<FunctionRefInst>(Callee))
-    return FR->getReferencedFunction();
+    return FR->getReferencedFunctionOrNull();
 
   return nullptr;
 }

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -158,7 +158,7 @@ void SILInstruction::dropAllReferences() {
   // If we have a function ref inst, we need to especially drop its function
   // argument so that it gets a proper ref decrement.
   if (auto *FRI = dyn_cast<FunctionRefBaseInst>(this)) {
-    if (!FRI->getReferencedFunction())
+    if (!FRI->getInitiallyReferencedFunction())
       return;
     FRI->dropReferencedFunction();
     return;
@@ -465,16 +465,19 @@ namespace {
 
     bool visitFunctionRefInst(const FunctionRefInst *RHS) {
       auto *X = cast<FunctionRefInst>(LHS);
-      return X->getReferencedFunction() == RHS->getReferencedFunction();
+      return X->getInitiallyReferencedFunction() ==
+             RHS->getInitiallyReferencedFunction();
     }
     bool visitDynamicFunctionRefInst(const DynamicFunctionRefInst *RHS) {
       auto *X = cast<DynamicFunctionRefInst>(LHS);
-      return X->getReferencedFunction() == RHS->getReferencedFunction();
+      return X->getInitiallyReferencedFunction() ==
+             RHS->getInitiallyReferencedFunction();
     }
     bool visitPreviousDynamicFunctionRefInst(
         const PreviousDynamicFunctionRefInst *RHS) {
       auto *X = cast<PreviousDynamicFunctionRefInst>(LHS);
-      return X->getReferencedFunction() == RHS->getReferencedFunction();
+      return X->getInitiallyReferencedFunction() ==
+             RHS->getInitiallyReferencedFunction();
     }
 
     bool visitAllocGlobalInst(const AllocGlobalInst *RHS) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -489,7 +489,7 @@ BeginApplyInst::create(SILDebugLocation loc, SILValue callee,
 
 bool swift::doesApplyCalleeHaveSemantics(SILValue callee, StringRef semantics) {
   if (auto *FRI = dyn_cast<FunctionRefBaseInst>(callee))
-    if (auto *F = FRI->getReferencedFunction())
+    if (auto *F = FRI->getReferencedFunctionOrNull())
       return F->hasSemanticsAttr(semantics);
   return false;
 }
@@ -573,14 +573,14 @@ FunctionRefBaseInst::FunctionRefBaseInst(SILInstructionKind Kind,
 }
 
 void FunctionRefBaseInst::dropReferencedFunction() {
-  if (auto *Function = getReferencedFunction())
+  if (auto *Function = getInitiallyReferencedFunction())
     Function->decrementRefCount();
   f = nullptr;
 }
 
 FunctionRefBaseInst::~FunctionRefBaseInst() {
-  if (getReferencedFunction())
-    getReferencedFunction()->decrementRefCount();
+  if (getInitiallyReferencedFunction())
+    getInitiallyReferencedFunction()->decrementRefCount();
 }
 
 FunctionRefInst::FunctionRefInst(SILDebugLocation Loc, SILFunction *F)

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -834,15 +834,15 @@ public:
   void print(const SILInstruction *I) {
     if (auto *FRI = dyn_cast<FunctionRefInst>(I))
       *this << "  // function_ref "
-            << demangleSymbol(FRI->getReferencedFunction()->getName())
+            << demangleSymbol(FRI->getInitiallyReferencedFunction()->getName())
             << "\n";
     else if (auto *FRI = dyn_cast<DynamicFunctionRefInst>(I))
       *this << "  // dynamic_function_ref "
-            << demangleSymbol(FRI->getReferencedFunction()->getName())
+            << demangleSymbol(FRI->getInitiallyReferencedFunction()->getName())
             << "\n";
     else if (auto *FRI = dyn_cast<PreviousDynamicFunctionRefInst>(I))
       *this << "  // prev_dynamic_function_ref "
-            << demangleSymbol(FRI->getReferencedFunction()->getName())
+            << demangleSymbol(FRI->getInitiallyReferencedFunction()->getName())
             << "\n";
 
     *this << "  ";
@@ -1141,16 +1141,16 @@ public:
   }
 
   void visitFunctionRefInst(FunctionRefInst *FRI) {
-    FRI->getReferencedFunction()->printName(PrintState.OS);
+    FRI->getInitiallyReferencedFunction()->printName(PrintState.OS);
     *this << " : " << FRI->getType();
   }
   void visitDynamicFunctionRefInst(DynamicFunctionRefInst *FRI) {
-    FRI->getReferencedFunction()->printName(PrintState.OS);
+    FRI->getInitiallyReferencedFunction()->printName(PrintState.OS);
     *this << " : " << FRI->getType();
   }
   void
   visitPreviousDynamicFunctionRefInst(PreviousDynamicFunctionRefInst *FRI) {
-    FRI->getReferencedFunction()->printName(PrintState.OS);
+    FRI->getInitiallyReferencedFunction()->printName(PrintState.OS);
     *this << " : " << FRI->getType();
   }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1642,7 +1642,7 @@ public:
     // Note: in SingleFunction mode, we relax some of these checks because
     // we may not have linked everything yet.
 
-    SILFunction *RefF = FRI->getReferencedFunction();
+    SILFunction *RefF = FRI->getInitiallyReferencedFunction();
 
     if (isa<FunctionRefInst>(FRI))
       require(

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -28,7 +28,7 @@ static bool isAutoreleasePoolCall(SILInstruction *I) {
   if (!AI)
     return false;
 
-  auto *Fn = AI->getReferencedFunction();
+  auto *Fn = AI->getReferencedFunctionOrNull();
   if (!Fn)
     return false;
 

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -24,7 +24,7 @@ using namespace swift;
 static ParameterConvention
 getSelfParameterConvention(ApplyInst *SemanticsCall) {
   FunctionRefInst *FRI = cast<FunctionRefInst>(SemanticsCall->getCallee());
-  SILFunction *F = FRI->getReferencedFunction();
+  SILFunction *F = FRI->getInitiallyReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
 
   return FnTy->getSelfParameter().getConvention();
@@ -36,7 +36,7 @@ bool swift::ArraySemanticsCall::isValidSignature() {
   assert(SemanticsCall && getKind() != ArrayCallKind::kNone &&
          "Need an array semantic call");
   FunctionRefInst *FRI = cast<FunctionRefInst>(SemanticsCall->getCallee());
-  SILFunction *F = FRI->getReferencedFunction();
+  SILFunction *F = FRI->getInitiallyReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
   auto &Mod = F->getModule();
 
@@ -84,7 +84,7 @@ bool swift::ArraySemanticsCall::isValidSignature() {
       auto *AllocBufferAI = dyn_cast<ApplyInst>(Arg0);
       if (!AllocBufferAI)
         return false;
-      auto *AllocFn = AllocBufferAI->getReferencedFunction();
+      auto *AllocFn = AllocBufferAI->getReferencedFunctionOrNull();
       if (!AllocFn || AllocFn->getName() != "swift_bufferAllocate" ||
           !hasOneNonDebugUse(AllocBufferAI))
         return false;
@@ -132,7 +132,7 @@ swift::ArraySemanticsCall::ArraySemanticsCall(ApplyInst *AI,
 
 void ArraySemanticsCall::initialize(ApplyInst *AI, StringRef semanticName,
                                     bool matchPartialName) {
-  auto *fn = AI->getReferencedFunction();
+  auto *fn = AI->getReferencedFunctionOrNull();
   if (!fn)
     return;
 
@@ -159,7 +159,7 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
     return ArrayCallKind::kNone;
 
   auto F = cast<FunctionRefInst>(SemanticsCall->getCallee())
-               ->getReferencedFunction();
+               ->getInitiallyReferencedFunction();
 
   ArrayCallKind Kind = ArrayCallKind::kNone;
 
@@ -773,7 +773,7 @@ bool swift::ArraySemanticsCall::replaceByAppendingValues(
     }
   }
   CanSILFunctionType AppendContentsOfFnTy =
-    SemanticsCall->getReferencedFunction()->getLoweredFunctionType();
+      SemanticsCall->getReferencedFunctionOrNull()->getLoweredFunctionType();
   if (AppendContentsOfFnTy->getParameters()[0].getConvention() ==
         ParameterConvention::Direct_Owned) {
     SILValue SrcArray = SemanticsCall->getArgument(0);

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -239,7 +239,8 @@ CalleeList CalleeCache::getCalleeListForCalleeKind(SILValue Callee) const {
     return CalleeList();
 
   case ValueKind::FunctionRefInst:
-    return CalleeList(cast<FunctionRefInst>(Callee)->getReferencedFunction());
+    return CalleeList(
+        cast<FunctionRefInst>(Callee)->getInitiallyReferencedFunction());
 
   case ValueKind::DynamicFunctionRefInst:
   case ValueKind::PreviousDynamicFunctionRefInst:

--- a/lib/SILOptimizer/Analysis/CFG.cpp
+++ b/lib/SILOptimizer/Analysis/CFG.cpp
@@ -50,7 +50,7 @@ static bool isSafeNonExitTerminator(TermInst *TI) {
 static bool isTrapNoReturnFunction(ApplyInst *AI) {
   const char *fatalName =
     MANGLE_AS_STRING(MANGLE_SYM(s18_fatalErrorMessageyys12StaticStringV_AcCSutF));
-  auto *Fn = AI->getReferencedFunction();
+  auto *Fn = AI->getReferencedFunctionOrNull();
 
   // We use endswith here since if we specialize fatal error we will always
   // prepend the specialization records to fatalName.

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -32,7 +32,8 @@ CallerAnalysis::FunctionInfo::FunctionInfo(SILFunction *f)
     : callerStates(),
       // TODO: Make this more aggressive by considering
       // final/visibility/etc.
-      mayHaveIndirectCallers(canBeCalledIndirectly(f->getRepresentation())) {}
+      mayHaveIndirectCallers(f->getDynamicallyReplacedFunction() ||
+                             canBeCalledIndirectly(f->getRepresentation())) {}
 
 //===----------------------------------------------------------------------===//
 //                   CallerAnalysis::ApplySiteFinderVisitor
@@ -113,7 +114,7 @@ CallerAnalysis::ApplySiteFinderVisitor::~ApplySiteFinderVisitor() {
 bool CallerAnalysis::ApplySiteFinderVisitor::visitFunctionRefBaseInst(
     FunctionRefBaseInst *fri) {
   auto optResult = findLocalApplySites(fri);
-  auto *calleeFn = fri->getReferencedFunction();
+  auto *calleeFn = fri->getInitiallyReferencedFunction();
   FunctionInfo &calleeInfo = analysis->unsafeGetFunctionInfo(calleeFn);
 
   // First make an edge from our callerInfo to our calleeState for invalidation

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -79,7 +79,7 @@ ColdBlockInfo::BranchHint ColdBlockInfo::getBranchHint(SILValue Cond,
   if (!AI)
     return BranchHint::None;
 
-  if (auto *F = AI->getReferencedFunction()) {
+  if (auto *F = AI->getReferencedFunctionOrNull()) {
     if (F->hasSemanticsAttrs()) {
       // fastpath/slowpath attrs are untested because the inliner luckily
       // inlines them before the downstream calls.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1305,12 +1305,12 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         break;
     }
 
-    if (FAS.getReferencedFunction()
-        && FAS.getReferencedFunction()->hasSemanticsAttr(
-               "self_no_escaping_closure")
-        && ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3)
-            || (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 2))
-        && FAS.hasSelfArgument()) {
+    if (FAS.getReferencedFunctionOrNull() &&
+        FAS.getReferencedFunctionOrNull()->hasSemanticsAttr(
+            "self_no_escaping_closure") &&
+        ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3) ||
+         (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 2)) &&
+        FAS.hasSelfArgument()) {
       // The programmer has guaranteed that the closure will not capture the
       // self pointer passed to it or anything that is transitively reachable
       // from the pointer.
@@ -1320,12 +1320,12 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       return;
     }
 
-    if (FAS.getReferencedFunction()
-        && FAS.getReferencedFunction()->hasSemanticsAttr(
-               "pair_no_escaping_closure")
-        && ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 4)
-            || (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3))
-        && FAS.hasSelfArgument()) {
+    if (FAS.getReferencedFunctionOrNull() &&
+        FAS.getReferencedFunctionOrNull()->hasSemanticsAttr(
+            "pair_no_escaping_closure") &&
+        ((FAS.hasIndirectSILResults() && FAS.getNumArguments() == 4) ||
+         (!FAS.hasIndirectSILResults() && FAS.getNumArguments() == 3)) &&
+        FAS.hasSelfArgument()) {
       // The programmer has guaranteed that the closure will not capture the
       // self pointer passed to it or anything that is transitively reachable
       // from the pointer.
@@ -1342,7 +1342,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         return;
     }
 
-    if (auto *Fn = FAS.getReferencedFunction()) {
+    if (auto *Fn = FAS.getReferencedFunctionOrNull()) {
       if (Fn->getName() == "swift_bufferAllocate")
         // The call is a buffer allocation, e.g. for Array.
         return;

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -471,7 +471,7 @@ bool FunctionSideEffects::summarizeCall(FullApplySite fullApply) {
     }
   }
 
-  if (SILFunction *SingleCallee = fullApply.getReferencedFunction()) {
+  if (SILFunction *SingleCallee = fullApply.getReferencedFunctionOrNull()) {
     // Does the function have any @_effects?
     if (setDefinedEffects(SingleCallee))
       return true;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -137,7 +137,7 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
     FullApplySite &Apply,
     llvm::SmallDenseMap<int, ExistentialTransformArgumentDescriptor>
         &ExistentialArgDescriptor) {
-  auto *F = Apply.getReferencedFunction();
+  auto *F = Apply.getReferencedFunctionOrNull();
   auto CalleeArgs = F->begin()->getFunctionArguments();
   bool returnFlag = false;
 
@@ -215,7 +215,7 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
 bool ExistentialSpecializer::canSpecializeCalleeFunction(FullApplySite &Apply) {
 
   /// Determine the caller of the apply.
-  auto *Callee = Apply.getReferencedFunction();
+  auto *Callee = Apply.getReferencedFunctionOrNull();
   if (!Callee)
     return false;
 
@@ -278,7 +278,7 @@ void ExistentialSpecializer::specializeExistentialArgsInAppliesWithinFunction(
         continue;
       }
 
-      auto *Callee = Apply.getReferencedFunction();
+      auto *Callee = Apply.getReferencedFunctionOrNull();
 
       /// Handle recursion! Do not modify F right now.
       if (Callee == &F) {

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -632,7 +632,8 @@ bool FunctionSignatureTransform::run(bool hasCaller) {
     return false;
   }
 
-  if (!hasCaller && canBeCalledIndirectly(F->getRepresentation())) {
+  if (!hasCaller && (F->getDynamicallyReplacedFunction() ||
+                     canBeCalledIndirectly(F->getRepresentation()))) {
     LLVM_DEBUG(llvm::dbgs() << "  function has no caller -> abort\n");
     return false;
   }

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -976,7 +976,7 @@ bool isPartialApplyNonEscapingUser(Operand *CurrentOp, PartialApplyInst *PAI,
   // index so is not stored separately);
   unsigned Index = OpNo - 1 + closureConv.getNumSILArguments();
 
-  auto *Fn = PAI->getReferencedFunction();
+  auto *Fn = PAI->getReferencedFunctionOrNull();
 
   // It is not safe to look at the content of dynamically replaceable functions
   // since this pass looks at the content of Fn.
@@ -1153,7 +1153,7 @@ constructClonedFunction(SILOptFunctionBuilder &FuncBuilder,
   SILFunction *F = PAI->getFunction();
 
   // Create the Cloned Name for the function.
-  SILFunction *Orig = FRI->getReferencedFunction();
+  SILFunction *Orig = FRI->getReferencedFunctionOrNull();
 
   IsSerialized_t Serialized = IsNotSerialized;
   if (F->isSerialized() && Orig->isSerialized())

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -373,7 +373,7 @@ static SILFunction *getSpecializedWithDeadParams(
       if (Specialized)
         return nullptr;
 
-      Specialized = FAS.getReferencedFunction();
+      Specialized = FAS.getReferencedFunctionOrNull();
       if (!Specialized)
         return nullptr;
 
@@ -440,7 +440,7 @@ static SILFunction *getSpecializedWithDeadParams(
 }
 
 bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
-  SILFunction *SubstF = PAI->getReferencedFunction();
+  SILFunction *SubstF = PAI->getReferencedFunctionOrNull();
   if (!SubstF)
     return false;
   if (SubstF->isExternalDeclaration())

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -183,15 +183,18 @@ public:
   CallSiteDescriptor &operator=(CallSiteDescriptor &&) =default;
 
   SILFunction *getApplyCallee() const {
-    return cast<FunctionRefInst>(AI.getCallee())->getReferencedFunction();
+    return cast<FunctionRefInst>(AI.getCallee())
+        ->getInitiallyReferencedFunction();
   }
 
   SILFunction *getClosureCallee() const {
     if (auto *PAI = dyn_cast<PartialApplyInst>(getClosure()))
-      return cast<FunctionRefInst>(PAI->getCallee())->getReferencedFunction();
+      return cast<FunctionRefInst>(PAI->getCallee())
+          ->getInitiallyReferencedFunction();
 
     auto *TTTFI = cast<ThinToThickFunctionInst>(getClosure());
-    return cast<FunctionRefInst>(TTTFI->getCallee())->getReferencedFunction();
+    return cast<FunctionRefInst>(TTTFI->getCallee())
+        ->getInitiallyReferencedFunction();
   }
 
   bool closureHasRefSemanticContext() const {
@@ -553,7 +556,7 @@ static bool isSupportedClosure(const SILInstruction *Closure) {
   // function_ref).
   //
   // TODO: We can probably handle other partial applies here.
-  auto *FRI = dyn_cast<FunctionRefInst>(Callee);
+  auto *FRI = dyn_cast_or_null<FunctionRefInst>(Callee);
   if (!FRI)
     return false;
 
@@ -561,7 +564,7 @@ static bool isSupportedClosure(const SILInstruction *Closure) {
     // Bail if any of the arguments are passed by address and
     // are not @inout.
     // This is a temporary limitation.
-    auto ClosureCallee = FRI->getReferencedFunction();
+    auto ClosureCallee = FRI->getReferencedFunctionOrNull();
     assert(ClosureCallee);
     auto ClosureCalleeConv = ClosureCallee->getConventions();
     unsigned ClosureArgIdx =
@@ -730,8 +733,9 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
     SILValue origCalleeValue = calleeValue;
     calleeValue = cloneCalleeConversion(PAI->getArgument(0), NewClosure,
                                         Builder, NeedsRelease, CapturedMap);
-    auto FunRef = Builder.createFunctionRef(CallSiteDesc.getLoc(),
-                                            PAI->getReferencedFunction());
+    auto origRef = PAI->getReferencedFunctionOrNull();
+    assert(origRef);
+    auto FunRef = Builder.createFunctionRef(CallSiteDesc.getLoc(), origRef);
     auto NewPA = Builder.createPartialApply(
         CallSiteDesc.getLoc(), FunRef, {}, {calleeValue},
         PAI->getType().getAs<SILFunctionType>()->getCalleeConvention(),
@@ -1022,12 +1026,12 @@ static bool isClosureAppliedIn(SILFunction *Callee, unsigned closureArgIdx,
       assert(UserAI.isArgumentOperand(*ArgUse) &&
              "any other non-argument operands than the callee?");
 
-      SILFunction *ApplyCallee = UserAI.getReferencedFunction();
+      SILFunction *ApplyCallee = UserAI.getReferencedFunctionOrNull();
       if (ApplyCallee && !ApplyCallee->isExternalDeclaration() &&
           HandledFuncs.count(ApplyCallee) == 0 &&
           HandledFuncs.size() < RecursionBudget) {
         HandledFuncs.insert(ApplyCallee);
-        if (isClosureAppliedIn(UserAI.getReferencedFunction(),
+        if (isClosureAppliedIn(UserAI.getReferencedFunctionOrNull(),
                                UserAI.getCalleeArgIndex(*ArgUse), HandledFuncs))
           return true;
       }
@@ -1166,7 +1170,7 @@ bool SILClosureSpecializerTransform::gatherCallSites(
 
         // If AI does not have a function_ref definition as its callee, we can
         // not do anything here... so continue...
-        SILFunction *ApplyCallee = AI.getReferencedFunction();
+        SILFunction *ApplyCallee = AI.getReferencedFunctionOrNull();
         if (!ApplyCallee || ApplyCallee->isExternalDeclaration())
           continue;
 

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -97,6 +97,12 @@ protected:
     if (F->isPossiblyUsedExternally())
       return true;
 
+    if (F->getDynamicallyReplacedFunction())
+      return true;
+
+    if (F->isDynamicallyReplaceable())
+      return true;
+
     // ObjC functions are called through the runtime and are therefore alive
     // even if not referenced inside SIL.
     if (F->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
@@ -350,11 +356,11 @@ protected:
           MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ false);
           ensureAliveClassMethod(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {
-          ensureAlive(FRI->getReferencedFunction());
+          ensureAlive(FRI->getInitiallyReferencedFunction());
         } else if (auto *FRI = dyn_cast<DynamicFunctionRefInst>(&I)) {
-          ensureAlive(FRI->getReferencedFunction());
+          ensureAlive(FRI->getInitiallyReferencedFunction());
         } else if (auto *FRI = dyn_cast<PreviousDynamicFunctionRefInst>(&I)) {
-          ensureAlive(FRI->getReferencedFunction());
+          ensureAlive(FRI->getInitiallyReferencedFunction());
         } else if (auto *KPI = dyn_cast<KeyPathInst>(&I)) {
           for (auto &component : KPI->getPattern()->getComponents())
             ensureKeyPathComponentIsAlive(component);

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -68,7 +68,7 @@ bool UsePrespecialized::replaceByPrespecialized(SILFunction &F) {
   collectApplyInst(F, NewApplies);
 
   for (auto &AI : NewApplies) {
-    auto *ReferencedF = AI.getReferencedFunction();
+    auto *ReferencedF = AI.getReferencedFunctionOrNull();
     if (!ReferencedF)
       continue;
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -309,7 +309,7 @@ static bool isRelease(SILInstruction *Inst, SILValue RetainedValue,
       }
 
   if (auto *AI = dyn_cast<ApplyInst>(Inst)) {
-    if (auto *F = AI->getReferencedFunction()) {
+    if (auto *F = AI->getReferencedFunctionOrNull()) {
       auto Params = F->getLoweredFunctionType()->getParameters();
       auto Args = AI->getArguments();
       for (unsigned ArgIdx = 0, ArgEnd = Params.size(); ArgIdx != ArgEnd;

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1229,7 +1229,7 @@ static bool isSuperInitUse(SILInstruction *User) {
     // super.init call as a hack to allow us to write testcases.
     auto *AI = dyn_cast<ApplyInst>(User);
     if (AI && AI->getLoc().isSILFile())
-      if (auto *Fn = AI->getReferencedFunction())
+      if (auto *Fn = AI->getReferencedFunctionOrNull())
         if (Fn->getName() == "superinit")
           return true;
     return false;
@@ -1311,7 +1311,7 @@ static bool isSelfInitUse(SILInstruction *I) {
   // self.init call as a hack to allow us to write testcases.
   if (I->getLoc().isSILFile()) {
     if (auto *AI = dyn_cast<ApplyInst>(I))
-      if (auto *Fn = AI->getReferencedFunction())
+      if (auto *Fn = AI->getReferencedFunctionOrNull())
         if (Fn->getName().startswith("selfinit"))
           return true;
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1128,7 +1128,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
         FD = dyn_cast<FuncDecl>(WMI->getMember().getDecl());
       
       // If this is a direct/devirt method application, check the location info.
-      if (auto *Fn = Apply.getReferencedFunction()) {
+      if (auto *Fn = Apply.getReferencedFunctionOrNull()) {
         if (Fn->hasLocation()) {
           auto SILLoc = Fn->getLocation();
           FD = SILLoc.getAsASTNode<FuncDecl>();
@@ -1406,7 +1406,7 @@ findMethodForStoreInitializationOfTemporary(const DIMemoryObjectInfo &TheMemory,
 
   // Otherwise, try to get the func decl from the referenced function if we can
   // find one.
-  auto *Fn = TheApply->getReferencedFunction();
+  auto *Fn = TheApply->getReferencedFunctionOrNull();
   if (!Fn->hasLocation())
     return nullptr;
 
@@ -1544,7 +1544,7 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
       Method = dyn_cast<FuncDecl>(OMI->getMember().getDecl());
 
     // If this is a direct/devirt method application, check the location info.
-    if (auto *Fn = cast<ApplyInst>(Inst)->getReferencedFunction()) {
+    if (auto *Fn = cast<ApplyInst>(Inst)->getReferencedFunctionOrNull()) {
       if (Fn->hasLocation())
         Method = Fn->getLocation().getAsASTNode<FuncDecl>();
     }

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -127,7 +127,9 @@ static bool checkNoEscapePartialApplyUse(Operand *oper, FollowUse followUses) {
     if (isPartialApplyOfReabstractionThunk(PAI)) {
       // However, first check for withoutActuallyEscaping, which is always
       // a valid non-escaping use.
-      SILFunction *thunkDef = PAI->getReferencedFunction();
+      SILFunction *thunkDef = PAI->getReferencedFunctionOrNull();
+      if (!thunkDef)
+        return true;
       if (!thunkDef->isWithoutActuallyEscapingThunk())
         followUses(PAI);
       return false;

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -594,7 +594,7 @@ static AccessedStorage findValidAccessedStorage(SILValue Source) {
 /// Used for fix-its to suggest replacing with Collection.swapAt()
 /// on exclusivity violations.
 static bool isCallToStandardLibrarySwap(ApplyInst *AI, ASTContext &Ctx) {
-  SILFunction *SF = AI->getReferencedFunction();
+  SILFunction *SF = AI->getReferencedFunctionOrNull();
   if (!SF)
     return false;
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -680,7 +680,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   if (!FRI)
     return nullptr;
 
-  SILFunction *CalleeFunction = FRI->getReferencedFunction();
+  SILFunction *CalleeFunction = FRI->getReferencedFunctionOrNull();
 
   switch (CalleeFunction->getRepresentation()) {
   case SILFunctionTypeRepresentation::Thick:

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -617,7 +617,7 @@ class OSLogOptimization : public SILFunctionTransform {
   /// \param oslogCall log call instruction to inline.
   /// \returns last instruction of the callee after inlining.
   SILBasicBlock::iterator inlineLogCallAndGetLast(ApplyInst *oslogCall) {
-    SILFunction *callee = oslogCall->getReferencedFunction();
+    SILFunction *callee = oslogCall->getReferencedFunctionOrNull();
     assert(callee);
 
     // Load and link the called os log function before inlining. This is needed

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -633,7 +633,7 @@ static SILValue createKeypathProjections(SILValue keyPath, SILValue root,
 ///   ...
 ///   load/store %addr
 bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
-  SILFunction *callee = AI->getReferencedFunction();
+  SILFunction *callee = AI->getReferencedFunctionOrNull();
   if (!callee)
     return false;
 
@@ -687,7 +687,7 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
 ///   %addr = struct_element_addr/ref_element_addr %root_object
 ///   // use %inout_addr
 bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
-  SILFunction *callee = AI->getReferencedFunction();
+  SILFunction *callee = AI->getReferencedFunctionOrNull();
   if (!callee)
     return false;
 
@@ -1367,7 +1367,7 @@ static bool knowHowToEmitReferenceCountInsts(ApplyInst *Call) {
   FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(Call->getCallee());
   if (!FRI)
     return false;
-  SILFunction *F = FRI->getReferencedFunction();
+  SILFunction *F = FRI->getReferencedFunctionOrNull();
   auto FnTy = F->getLoweredFunctionType();
 
   // Look at the result type.
@@ -1390,7 +1390,7 @@ static bool knowHowToEmitReferenceCountInsts(ApplyInst *Call) {
 /// Add reference counting operations equal to the effect of the call.
 static void emitMatchingRCAdjustmentsForCall(ApplyInst *Call, SILValue OnX) {
   FunctionRefInst *FRI = cast<FunctionRefInst>(Call->getCallee());
-  SILFunction *F = FRI->getReferencedFunction();
+  SILFunction *F = FRI->getReferencedFunctionOrNull();
   auto FnTy = F->getLoweredFunctionType();
   assert(FnTy->getNumResults() == 1);
   auto ResultInfo = FnTy->getResults()[0];
@@ -1521,7 +1521,7 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
     return nullptr;
 
   // Optimize readonly functions with no meaningful users.
-  SILFunction *SF = AI->getReferencedFunction();
+  SILFunction *SF = AI->getReferencedFunctionOrNull();
   if (SF && SF->getEffectsKind() < EffectsKind::ReleaseNone) {
     UserListTy Users;
     if (recursivelyCollectARCUsers(Users, AI)) {
@@ -1652,7 +1652,7 @@ SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
   }
 
   // Optimize readonly functions with no meaningful users.
-  SILFunction *Fn = AI->getReferencedFunction();
+  SILFunction *Fn = AI->getReferencedFunctionOrNull();
   if (Fn && Fn->getEffectsKind() < EffectsKind::ReleaseNone) {
     UserListTy Users;
     if (isTryApplyResultNotUsed(Users, AI)) {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -206,7 +206,7 @@ static bool partialApplyEscapes(SILValue V, bool examineApply);
 /// Could this operand to an apply escape that function by being
 /// stored or returned?
 static bool applyArgumentEscapes(FullApplySite Apply, Operand *O) {
-  SILFunction *F = Apply.getReferencedFunction();
+  SILFunction *F = Apply.getReferencedFunctionOrNull();
   // If we cannot examine the function body, assume the worst.
   if (!F || F->empty())
     return true;
@@ -283,7 +283,7 @@ static SILInstruction *findUnexpectedBoxUse(SILValue Box,
 /// disqualify it from being promoted to a stack location.  Return
 /// true if this partial apply will not block our promoting the box.
 static bool checkPartialApplyBody(Operand *O) {
-  SILFunction *F = ApplySite(O->getUser()).getReferencedFunction();
+  SILFunction *F = ApplySite(O->getUser()).getReferencedFunctionOrNull();
   // If we cannot examine the function body, assume the worst.
   if (!F || F->empty())
     return false;
@@ -743,7 +743,7 @@ specializePartialApply(SILOptFunctionBuilder &FuncBuilder,
                        AllocBoxToStackState &pass) {
   auto *FRI = cast<FunctionRefInst>(PartialApply->getCallee());
   assert(FRI && "Expected a direct partial_apply!");
-  auto *F = FRI->getReferencedFunction();
+  auto *F = FRI->getReferencedFunctionOrNull();
   assert(F && "Expected a referenced function!");
 
   IsSerialized_t Serialized = IsNotSerialized;

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -122,7 +122,8 @@ public:
   }
 
   hash_code visitFunctionRefInst(FunctionRefInst *X) {
-    return llvm::hash_combine(X->getKind(), X->getReferencedFunction());
+    return llvm::hash_combine(X->getKind(),
+                              X->getInitiallyReferencedFunction());
   }
 
   hash_code visitGlobalAddrInst(GlobalAddrInst *X) {
@@ -934,6 +935,8 @@ bool CSE::canHandle(SILInstruction *Inst) {
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::OpenExistentialRefInst:
   case SILInstructionKind::WitnessMethodInst:
+    // Intentionally we don't handle (prev_)dynamic_function_ref.
+    // They change at runtime.
 #define LOADABLE_REF_STORAGE(Name, ...) \
   case SILInstructionKind::RefTo##Name##Inst: \
   case SILInstructionKind::Name##ToRefInst:

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -89,7 +89,7 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
   while (!NewApplies.empty()) {
     auto Apply = NewApplies.pop_back_val();
 
-    auto *CalleeFn = Apply.getReferencedFunction();
+    auto *CalleeFn = Apply.getInitiallyReferencedFunction();
     assert(CalleeFn && "Expected devirtualized callee!");
 
     // We need to ensure that we link after devirtualizing in order to pull in

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -75,7 +75,7 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
       if (!Apply || !Apply.hasSubstitutions())
         continue;
 
-      auto *Callee = Apply.getReferencedFunction();
+      auto *Callee = Apply.getReferencedFunctionOrNull();
       if (!Callee)
         continue;
       if (!Callee->isDefinition()) {
@@ -99,7 +99,7 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
       auto *I = Applies.pop_back_val();
       auto Apply = ApplySite::isa(I);
       assert(Apply && "Expected an apply!");
-      SILFunction *Callee = Apply.getReferencedFunction();
+      SILFunction *Callee = Apply.getReferencedFunctionOrNull();
       assert(Callee && "Expected to have a known callee");
 
       if (!Apply.canOptimize() || !Callee->shouldOptimize())

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -492,7 +492,7 @@ static bool matchSwitch(SwitchInfo &SI, SILInstruction *Inst,
 
   // Check that we call the _unconditionallyBridgeFromObjectiveC witness.
   auto NativeType = Apply->getType().getASTType();
-  auto *BridgeFun = FunRef->getReferencedFunction();
+  auto *BridgeFun = FunRef->getInitiallyReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   auto bridgeWitness = getBridgeFromObjectiveC(NativeType, SwiftModule);
   if (BridgeFun->getName() != bridgeWitness.mangle())
@@ -780,7 +780,7 @@ BridgedArgument BridgedArgument::match(unsigned ArgIdx, SILValue Arg,
 
   // Make sure we are calling the actual bridge witness.
   auto NativeType = BridgedValue->getType().getASTType();
-  auto *BridgeFun = FunRef->getReferencedFunction();
+  auto *BridgeFun = FunRef->getInitiallyReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   auto bridgeWitness = getBridgeToObjectiveC(NativeType, SwiftModule);
   if (BridgeFun->getName() != bridgeWitness.mangle())

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -258,7 +258,8 @@ bool SILPerformanceInliner::isProfitableToInline(
     FullApplySite AI, Weight CallerWeight, ConstantTracker &callerTracker,
     int &NumCallerBlocks,
     const llvm::DenseMap<SILBasicBlock *, uint64_t> &BBToWeightMap) {
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
+  assert(Callee);
   bool IsGeneric = AI.hasSubstitutions();
 
   assert(EnableSILInliningOfGenerics || !IsGeneric);
@@ -535,7 +536,7 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   assert(AI.hasSubstitutions() &&
          "Expected a generic apply");
 
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
 
   // Do not inline @_semantics functions when compiling the stdlib,
   // because they need to be preserved, so that the optimizer
@@ -580,7 +581,7 @@ bool SILPerformanceInliner::decideInWarmBlock(
       return ShouldInlineGeneric.getValue();
   }
 
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
 
   if (Callee->getInlineStrategy() == AlwaysInline || Callee->isTransparent()) {
     LLVM_DEBUG(dumpCaller(AI.getFunction());
@@ -634,7 +635,7 @@ bool SILPerformanceInliner::decideInColdBlock(FullApplySite AI,
 /// callee.
 static void addWeightCorrection(FullApplySite FAS,
                         llvm::DenseMap<FullApplySite, int> &WeightCorrections) {
-  SILFunction *Callee = FAS.getReferencedFunction();
+  SILFunction *Callee = FAS.getReferencedFunctionOrNull();
   if (Callee && Callee->hasSemanticsAttr("array.uninitialized")) {
     // We want to inline the argument to an array.uninitialized call, because
     // this argument is most likely a call to a function which contains the
@@ -848,7 +849,7 @@ void SILPerformanceInliner::collectAppliesToInline(
   // Calculate how many times a callee is called from this caller.
   llvm::DenseMap<SILFunction *, unsigned> CalleeCount;
   for (auto AI : InitialCandidates) {
-    SILFunction *Callee = AI.getReferencedFunction();
+    SILFunction *Callee = AI.getReferencedFunctionOrNull();
     assert(Callee && "apply_inst does not have a direct callee anymore");
     CalleeCount[Callee]++;
   }
@@ -856,7 +857,7 @@ void SILPerformanceInliner::collectAppliesToInline(
   // Now copy each candidate callee that has a small enough number of
   // call sites into the final set of call sites.
   for (auto AI : InitialCandidates) {
-    SILFunction *Callee = AI.getReferencedFunction();
+    SILFunction *Callee = AI.getReferencedFunctionOrNull();
     assert(Callee && "apply_inst does not have a direct callee anymore");
 
     const unsigned CallsToCalleeThreshold = 1024;
@@ -885,7 +886,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
 
   // Second step: do the actual inlining.
   for (auto AI : AppliesToInline) {
-    SILFunction *Callee = AI.getReferencedFunction();
+    SILFunction *Callee = AI.getReferencedFunctionOrNull();
     assert(Callee && "apply_inst does not have a direct callee anymore");
 
     if (!Callee->shouldOptimize()) {

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -129,8 +129,8 @@ class BugReducerTester : public SILFunctionTransform {
         }
 
         auto *FRI = dyn_cast<FunctionRefInst>(FAS.getCallee());
-        if (!FRI ||
-            !FRI->getReferencedFunction()->getName().equals(FunctionTarget)) {
+        if (!FRI || !FRI->getInitiallyReferencedFunction()->getName().equals(
+                        FunctionTarget)) {
           ++II;
           continue;
         }

--- a/lib/SILOptimizer/UtilityPasses/ConstantEvaluatorTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ConstantEvaluatorTester.cpp
@@ -43,7 +43,7 @@ class ConstantEvaluatorTester : public SILFunctionTransform {
     if (!applyInst)
       return false;
 
-    auto *callee = applyInst->getReferencedFunction();
+    auto *callee = applyInst->getReferencedFunctionOrNull();
     if (!callee)
       return false;
 

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -214,7 +214,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
     return SymbolicValue::getString(sli->getValue(), evaluator.getAllocator());
 
   if (auto *fri = dyn_cast<FunctionRefInst>(value))
-    return SymbolicValue::getFunction(fri->getReferencedFunction());
+    return SymbolicValue::getFunction(fri->getInitiallyReferencedFunction());
 
   // If we have a reference to a metatype, constant fold any substitutable
   // types.

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1411,7 +1411,7 @@ static bool isApplyOfBuiltin(SILInstruction &I, BuiltinValueKind kind) {
 
 static bool isApplyOfStringConcat(SILInstruction &I) {
   if (auto *AI = dyn_cast<ApplyInst>(&I))
-    if (auto *Fn = AI->getReferencedFunction())
+    if (auto *Fn = AI->getReferencedFunctionOrNull())
       if (Fn->hasSemanticsAttr("string.concat"))
         return true;
   return false;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2360,7 +2360,8 @@ void swift::trySpecializeApplyOfGeneric(
     OptRemark::Emitter &ORE) {
   assert(Apply.hasSubstitutions() && "Expected an apply with substitutions!");
   auto *F = Apply.getFunction();
-  auto *RefF = cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunction();
+  auto *RefF =
+      cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunctionOrNull();
 
   LLVM_DEBUG(llvm::dbgs() << "\n\n*** ApplyInst in function " << F->getName()
                           << ":\n";

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -208,15 +208,15 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
       // If we have a function ref inst, we need to especially drop its function
       // argument so that it gets a proper ref decrement.
       auto *FRI = dyn_cast<FunctionRefInst>(I);
-      if (FRI && FRI->getReferencedFunction())
+      if (FRI && FRI->getInitiallyReferencedFunction())
         FRI->dropReferencedFunction();
 
       auto *DFRI = dyn_cast<DynamicFunctionRefInst>(I);
-      if (DFRI && DFRI->getReferencedFunction())
+      if (DFRI && DFRI->getInitiallyReferencedFunction())
         DFRI->dropReferencedFunction();
 
       auto *PFRI = dyn_cast<PreviousDynamicFunctionRefInst>(I);
-      if (PFRI && PFRI->getReferencedFunction())
+      if (PFRI && PFRI->getInitiallyReferencedFunction())
         PFRI->dropReferencedFunction();
     }
 
@@ -740,7 +740,7 @@ public:
 /// Returns false if optimization is not possible.
 /// Returns true and initializes internal fields if optimization is possible.
 bool StringConcatenationOptimizer::extractStringConcatOperands() {
-  auto *Fn = AI->getReferencedFunction();
+  auto *Fn = AI->getReferencedFunctionOrNull();
   if (!Fn)
     return false;
 
@@ -760,8 +760,8 @@ bool StringConcatenationOptimizer::extractStringConcatOperands() {
   if (!FRILeft || !FRIRight)
     return false;
 
-  auto *FRILeftFun = FRILeft->getReferencedFunction();
-  auto *FRIRightFun = FRIRight->getReferencedFunction();
+  auto *FRILeftFun = FRILeft->getReferencedFunctionOrNull();
+  auto *FRIRightFun = FRIRight->getReferencedFunctionOrNull();
 
   if (FRILeftFun->getEffectsKind() >= EffectsKind::ReleaseNone ||
       FRIRightFun->getEffectsKind() >= EffectsKind::ReleaseNone)

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -551,7 +551,7 @@ static bool calleeIsSelfRecursive(SILFunction *Callee) {
   for (auto &BB : *Callee)
     for (auto &I : BB)
       if (auto Apply = FullApplySite::isa(&I))
-        if (Apply.getReferencedFunction() == Callee)
+        if (Apply.getReferencedFunctionOrNull() == Callee)
           return true;
   return false;
 }
@@ -563,7 +563,9 @@ static bool calleeHasPartialApplyWithOpenedExistentials(FullApplySite AI) {
   if (!AI.hasSubstitutions())
     return false;
 
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
+  assert(Callee && "Trying to optimize a dynamic function?!");
+
   auto SubsMap = AI.getSubstitutionMap();
 
   // Bail if there are no open existentials in the list of substitutions.
@@ -610,7 +612,7 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
   if (ASC && !ASC.canInlineEarly())
     return true;
 
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
   if (!Callee)
     return false;
 
@@ -628,7 +630,9 @@ static bool shouldSkipApplyDuringEarlyInlining(FullApplySite AI) {
 
 /// Checks if a generic callee and caller have compatible layout constraints.
 static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
+  assert(Callee && "Trying to optimize a dynamic function!?");
+
   auto CalleeSig = Callee->getLoweredFunctionType()->getGenericSignature();
   auto AISubs = AI.getSubstitutionMap();
 
@@ -665,7 +669,7 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
 // Returns the callee of an apply_inst if it is basically inlinable.
 SILFunction *swift::getEligibleFunction(FullApplySite AI,
                                         InlineSelection WhatToInline) {
-  SILFunction *Callee = AI.getReferencedFunction();
+  SILFunction *Callee = AI.getReferencedFunctionOrNull();
 
   if (!Callee) {
     return nullptr;

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -50,7 +50,7 @@ static bool canInlineBeginApply(BeginApplyInst *BA) {
   // potentially after the resumption site when there are un-mergeable
   // values alive across it.
   bool hasYield = false;
-  for (auto &B : BA->getReferencedFunction()->getBlocks()) {
+  for (auto &B : BA->getReferencedFunctionOrNull()->getBlocks()) {
     if (isa<YieldInst>(B.getTerminator())) {
       if (hasYield) return false;
       hasYield = true;
@@ -341,6 +341,7 @@ std::pair<SILBasicBlock::iterator, SILBasicBlock *>
 SILInliner::inlineFullApply(FullApplySite apply,
                             SILInliner::InlineKind inlineKind,
                             SILOptFunctionBuilder &funcBuilder) {
+  assert(apply.canOptimize());
   SmallVector<SILValue, 8> appliedArgs;
   for (const auto &arg : apply.getArguments())
     appliedArgs.push_back(arg);
@@ -355,7 +356,7 @@ SILInliner::inlineFullApply(FullApplySite apply,
 
   SILInliner Inliner(funcBuilder, inlineKind, apply.getSubstitutionMap(),
                      OpenedArchetypesTracker);
-  return Inliner.inlineFunction(apply.getReferencedFunction(), apply,
+  return Inliner.inlineFunction(apply.getReferencedFunctionOrNull(), apply,
                                 appliedArgs);
 }
 

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -202,14 +202,11 @@ FunctionSignatureSpecializationMangler::mangleConstantProp(LiteralInst *LI) {
   switch (LI->getKind()) {
   default:
     llvm_unreachable("unknown literal");
-  case SILInstructionKind::DynamicFunctionRefInst: {
-    SILFunction *F = cast<DynamicFunctionRefInst>(LI)->getReferencedFunction();
-    ArgOpBuffer << 'f';
-    appendIdentifier(F->getName());
-    break;
-  }
+  case SILInstructionKind::PreviousDynamicFunctionRefInst:
+  case SILInstructionKind::DynamicFunctionRefInst:
   case SILInstructionKind::FunctionRefInst: {
-    SILFunction *F = cast<FunctionRefInst>(LI)->getReferencedFunction();
+    SILFunction *F =
+        cast<FunctionRefBaseInst>(LI)->getInitiallyReferencedFunction();
     ArgOpBuffer << 'f';
     appendIdentifier(F->getName());
     break;
@@ -264,12 +261,12 @@ FunctionSignatureSpecializationMangler::mangleClosureProp(SILInstruction *Inst) 
   // restriction is removed, the assert here will fire.
   if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(Inst)) {
     auto *FRI = cast<FunctionRefInst>(TTTFI->getCallee());
-    appendIdentifier(FRI->getReferencedFunction()->getName());
+    appendIdentifier(FRI->getInitiallyReferencedFunction()->getName());
     return;
   }
   auto *PAI = cast<PartialApplyInst>(Inst);
   auto *FRI = cast<FunctionRefInst>(PAI->getCallee());
-  appendIdentifier(FRI->getReferencedFunction()->getName());
+  appendIdentifier(FRI->getInitiallyReferencedFunction()->getName());
 
   // Then we mangle the types of the arguments that the partial apply is
   // specializing.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1310,7 +1310,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // Use SILOneOperandLayout to specify the function type and the function
     // name (IdentifierID).
     const FunctionRefInst *FRI = cast<FunctionRefInst>(&SI);
-    SILFunction *ReferencedFunction = FRI->getReferencedFunction();
+    SILFunction *ReferencedFunction = FRI->getInitiallyReferencedFunction();
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,
@@ -1324,7 +1324,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // Use SILOneOperandLayout to specify the function type and the function
     // name (IdentifierID).
     const auto *FRI = cast<DynamicFunctionRefInst>(&SI);
-    SILFunction *ReferencedFunction = FRI->getReferencedFunction();
+    SILFunction *ReferencedFunction = FRI->getInitiallyReferencedFunction();
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,
@@ -1338,7 +1338,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // Use SILOneOperandLayout to specify the function type and the function
     // name (IdentifierID).
     const auto *FRI = cast<PreviousDynamicFunctionRefInst>(&SI);
-    SILFunction *ReferencedFunction = FRI->getReferencedFunction();
+    SILFunction *ReferencedFunction = FRI->getInitiallyReferencedFunction();
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,


### PR DESCRIPTION
…OrNull() and getInitialReferencedFunction()

With the advent of dynamic_function_ref the actual callee of such a ref
my vary. Optimizations should not assume to know the content of a
function referenced by dynamic_function_ref. Introduce
getReferencedFunctionOrNull which will return null for such function
refs. And getInitialReferencedFunction to return the referenced
function.
Use as appropriate.

rdar://50959798