### PR TITLE
[Sema] Add notes to explain why Equatable/Hashable conformance couldn't be synthesized

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2518,6 +2518,12 @@ NOTE(decodable_suggest_overriding_init_here,none,
 NOTE(codable_suggest_overriding_init_here,none,
      "did you mean to override 'init(from:)' and 'encode(to:)'?", ())
 
+NOTE(missing_member_type_conformance_prevents_synthesis, none,
+     "%select{associated value|stored property}0 type %1 does not conform to "
+     "protocol %2, preventing synthesized conformance "
+     "of %3 to %2",
+     (unsigned, Type, Type, Type))
+
 // Dynamic Self
 ERROR(dynamic_self_non_method,none,
       "%select{global|local}0 function cannot return 'Self'", (bool))

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -137,6 +137,22 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
   return false;
 }
 
+void DerivedConformance::tryDiagnoseFailedDerivation(DeclContext *DC,
+                                                     NominalTypeDecl *nominal,
+                                                     ProtocolDecl *protocol) {
+  auto knownProtocol = protocol->getKnownProtocolKind();
+  if (!knownProtocol)
+    return;
+
+  if (*knownProtocol == KnownProtocolKind::Equatable) {
+    tryDiagnoseFailedEquatableDerivation(DC, nominal);
+  }
+
+  if (*knownProtocol == KnownProtocolKind::Hashable) {
+    tryDiagnoseFailedHashableDerivation(DC, nominal);
+  }
+}
+
 ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
                                                        NominalTypeDecl *nominal,
                                                        ValueDecl *requirement) {

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -69,6 +69,18 @@ public:
                                          NominalTypeDecl *nominal,
                                          ProtocolDecl *protocol);
 
+  /// Diagnose problems, if any, preventing automatic derivation of protocol
+  /// requirements
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  ///
+  /// \param protocol The protocol with requirements we would like to diagnose
+  /// derivation failures for
+  static void tryDiagnoseFailedDerivation(DeclContext *DC,
+                                          NominalTypeDecl *nominal,
+                                          ProtocolDecl *protocol);
+
   /// Determine the derivable requirement that would satisfy the given
   /// requirement, if there is one.
   ///
@@ -128,6 +140,14 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveEquatable(ValueDecl *requirement);
 
+  /// Diagnose problems, if any, preventing automatic derivation of Equatable
+  /// requirements
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  static void tryDiagnoseFailedEquatableDerivation(DeclContext *DC,
+                                                   NominalTypeDecl *nominal);
+
   /// Determine if a Hashable requirement can be derived for a type.
   ///
   /// This is implemented for enums without associated values or all-Hashable
@@ -143,6 +163,14 @@ public:
   ///
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveHashable(ValueDecl *requirement);
+
+  /// Diagnose problems, if any, preventing automatic derivation of Hashable
+  /// requirements
+  ///
+  /// \param nominal The nominal type for which we would like to diagnose
+  /// derivation failures
+  static void tryDiagnoseFailedHashableDerivation(DeclContext *DC,
+                                                  NominalTypeDecl *nominal);
 
   /// Derive a _BridgedNSError requirement for an @objc enum type.
   ///

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3305,8 +3305,11 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     // Save the missing requirement for later diagnosis.
     GlobalMissingWitnesses.insert(requirement);
     diagnoseOrDefer(requirement, true,
-      [requirement, matches](NormalProtocolConformance *conformance) {
+      [requirement, matches, nominal](NormalProtocolConformance *conformance) {
         auto dc = conformance->getDeclContext();
+        auto *protocol = conformance->getProtocol();
+        // Possibly diagnose reason for automatic derivation failure
+        DerivedConformance::tryDiagnoseFailedDerivation(dc, nominal, protocol);
         // Diagnose each of the matches.
         for (const auto &match : matches)
           diagnoseMatch(dc->getParentModule(), conformance, requirement, match);

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -147,7 +147,8 @@ func enumWithHashablePayload() {
 // Enums with non-hashable payloads don't derive conformance.
 struct NotHashable {}
 enum EnumWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
-  case A(NotHashable)
+  case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Hashable'}}
+  // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'EnumWithNonHashablePayload' to 'Equatable'}}
 }
 
 // Enums should be able to derive conformances based on the conformances of
@@ -164,7 +165,7 @@ func genericHashable() {
 // But it should be an error if the generic argument doesn't have the necessary
 // constraints to satisfy the conditions for derivation.
 enum GenericNotHashable<T: Equatable>: Hashable { // expected-error 2 {{does not conform to protocol 'Hashable'}}
-  case A(T)
+  case A(T) //expected-note 2 {{associated value type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'GenericNotHashable<T>' to 'Hashable'}}
   case B
 }
 func genericNotHashable() {
@@ -228,7 +229,8 @@ extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatic
 
 // No explicit conformance and it cannot be derived.
 enum NotExplicitlyHashableAndCannotDerive {
-  case A(NotHashable)
+  case A(NotHashable) //expected-note {{associated value type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
+  // expected-note@-1 {{associated value type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
 extension NotExplicitlyHashableAndCannotDerive : Hashable {} // expected-error 2 {{does not conform}}
 extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-error {{does not conform}}
@@ -282,7 +284,7 @@ case only([Int])
 struct NotEquatable { }
 
 enum ArrayOfNotEquatables : Equatable { // expected-error{{type 'ArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
-case only([NotEquatable])
+case only([NotEquatable]) //expected-note {{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'ArrayOfNotEquatables' to 'Equatable'}}
 }
 
 // Conditional conformances should be able to be synthesized
@@ -294,7 +296,8 @@ extension GenericDeriveExtension: Hashable where T: Hashable {}
 
 // Incorrectly/insufficiently conditional shouldn't work
 enum BadGenericDeriveExtension<T> {
-    case A(T)
+    case A(T) //expected-note {{associated value type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Hashable'}}
+  //expected-note@-1 {{associated value type 'T' does not conform to protocol 'Equatable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Equatable'}}
 }
 extension BadGenericDeriveExtension: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -3,11 +3,11 @@
 struct NotEquatable { }
 
 enum WithArrayOfNotEquatables : Equatable { // expected-error{{type 'WithArrayOfNotEquatables' does not conform to protocol 'Equatable'}}
-case only([NotEquatable])
+  case only([NotEquatable]) // expected-note{{associated value type '[NotEquatable]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables' to 'Equatable'}}
 }
 
 enum WithArrayOfNotEquatables2<T> : Equatable { // expected-error{{type 'WithArrayOfNotEquatables2<T>' does not conform to protocol 'Equatable'}}
-case only([T])
+  case only([T]) // expected-note{{associated value type '[T]' does not conform to protocol 'Equatable', preventing synthesized conformance of 'WithArrayOfNotEquatables2<T>' to 'Equatable'}}
 }
 
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -121,7 +121,8 @@ func structWithoutExplicitConformance() {
 // Structs with non-hashable/equatable stored properties don't derive conformance.
 struct NotHashable {}
 struct StructWithNonHashablePayload: Hashable { // expected-error 2 {{does not conform}}
-  let a: NotHashable
+  let a: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Hashable'}}
+  // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'StructWithNonHashablePayload' to 'Equatable'}}
 }
 
 // ...but computed properties and static properties are not considered.
@@ -151,7 +152,7 @@ func genericHashable() {
 // But it should be an error if the generic argument doesn't have the necessary
 // constraints to satisfy the conditions for derivation.
 struct GenericNotHashable<T: Equatable>: Hashable { // expected-error 2 {{does not conform to protocol 'Hashable'}}
-  let value: T
+  let value: T // expected-note 2 {{stored property type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'GenericNotHashable<T>' to 'Hashable'}}
 }
 func genericNotHashable() {
   if GenericNotHashable<String>(value: "a") == GenericNotHashable<String>(value: "b") { }
@@ -178,7 +179,8 @@ extension StructConformsAndImplementsInExtension : Equatable {
 
 // No explicit conformance and it cannot be derived.
 struct NotExplicitlyHashableAndCannotDerive {
-  let v: NotHashable
+  let v: NotHashable // expected-note {{stored property type 'NotHashable' does not conform to protocol 'Hashable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Hashable'}}
+  // expected-note@-1 {{stored property type 'NotHashable' does not conform to protocol 'Equatable', preventing synthesized conformance of 'NotExplicitlyHashableAndCannotDerive' to 'Equatable'}}
 }
 extension NotExplicitlyHashableAndCannotDerive : Hashable {}  // expected-error 2 {{does not conform}}
 
@@ -233,7 +235,8 @@ extension GenericDeriveExtension: Hashable where T: Hashable {}
 
 // Incorrectly/insufficiently conditional shouldn't work
 struct BadGenericDeriveExtension<T> {
-    let value: T
+    let value: T // expected-note {{stored property type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Hashable'}}
+// expected-note@-1 {{stored property type 'T' does not conform to protocol 'Equatable', preventing synthesized conformance of 'BadGenericDeriveExtension<T>' to 'Equatable'}}
 }
 extension BadGenericDeriveExtension: Equatable {}
 // expected-error@-1 {{type 'BadGenericDeriveExtension<T>' does not conform to protocol 'Equatable'}}


### PR DESCRIPTION
If a struct/enum cannot have Equatable/Hashable conformance automatically synthesized because a member's type is not Equatable/Hashable, add a note to the existing 'does not conform' diagnostic pointing out the type that blocked synthesis.

Addresses issues raised in [SR-6801](https://bugs.swift.org/browse/SR-6801)

Given a simple example like this:
```swift
struct Foo {}

struct Bar: Equatable {
  let baz: Foo
}
```

The new output diagnostic will look like this:
```
test.swift:3:8: error: type 'Bar' does not conform to protocol 'Equatable'
struct Bar: Equatable {
       ^
test.swift:4:12: note: Stored property type 'Foo' does not conform to protocol 'Equatable'; prevents automatic conformance synthesis
  let baz: Foo
           ^
Swift.==:1:24: note: candidate would match if 'Bar' conformed to 'RawRepresentable'
@inlinable public func == <T>(lhs: T, rhs: T) -> Bool where T : RawRepresentable, T.RawValue : Equatable

// Followed by all of the other candidates
```

Note: I'm not entirely sure `diagnoseConformanceFailure` is the right place to be calling the new diagnostics code. I'd be happy to hear any suggestions on how to organize this better.