### PR TITLE
[Diagnostics] Clarify diagnostic for failed type conversion in subscript assignment

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -447,6 +447,16 @@ ERROR(cannot_convert_assign_protocol,none,
 ERROR(cannot_convert_assign_nil,none,
       "'nil' cannot be assigned to type %0", (Type))
 
+// Subscript Assign Expr
+ERROR(cannot_convert_subscript_assign,none,
+      "cannot assign value of type %0 to subscript of type %1",
+      (Type,Type))
+ERROR(cannot_convert_subscript_assign_protocol,none,
+      "value of type %0 does not conform to %1 in subscript assignment",
+      (Type, Type))
+ERROR(cannot_convert_subscript_assign_nil,none,
+      "'nil' cannot be assigned to subscript of type %0", (Type))
+
 // for ... in expression
 ERROR(cannot_convert_sequence_element_value,none,
       "cannot convert sequence element type %0 to expected type %1",

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2804,7 +2804,11 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
   Optional<Diag<Type, Type>> diagnostic;
   if (path.empty()) {
     assert(isa<AssignExpr>(anchor));
-    diagnostic = getDiagnosticFor(CTP_AssignSource);
+    if (isa<SubscriptExpr>(cast<AssignExpr>(anchor)->getDest())) {
+      diagnostic = getDiagnosticFor(CTP_SubscriptAssignSource);
+    } else {
+      diagnostic = getDiagnosticFor(CTP_AssignSource);
+    }
   } else {
     const auto &last = path.back();
     switch (last.getKind()) {
@@ -2871,6 +2875,8 @@ MissingContextualConformanceFailure::getDiagnosticFor(
     return diag::cannot_convert_coerce_protocol;
   case CTP_AssignSource:
     return diag::cannot_convert_assign_protocol;
+  case CTP_SubscriptAssignSource:
+    return diag::cannot_convert_subscript_assign_protocol;
 
   case CTP_ThrowStmt:
   case CTP_Unused:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -217,6 +217,8 @@ enum ContextualTypePurpose {
   CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
   CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
   CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
+  CTP_SubscriptAssignSource, ///< AssignExpr source operand coerced to subscript
+                             ///< result type.
 
   CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
 };

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -2,6 +2,7 @@
 
 struct X { }
 struct Y { }
+protocol Z { }
 
 struct WithOverloadedSubscript {
   subscript(i: Int) -> X {
@@ -9,6 +10,13 @@ struct WithOverloadedSubscript {
     set {}
   }
   subscript(i: Int) -> Y {
+    get {}
+    set {}
+  }
+}
+
+struct WithProtocolSubscript {
+  subscript(i: Int) -> Z {
     get {}
     set {}
   }
@@ -26,6 +34,7 @@ var f: Y
 func getXY() -> (X, Y) {}
 var ift : (X, Y)
 var ovl = WithOverloadedSubscript()
+var ps = WithProtocolSubscript()
 
 var slice: [X]
 
@@ -40,7 +49,11 @@ i = j
 _ = (i, f)
 slice[7] = i
 
-slice[7] = f // expected-error{{cannot assign value of type 'Y' to type 'X'}}
+slice[7] = f // expected-error{{cannot assign value of type 'Y' to subscript of type 'X'}}
+
+slice[7] = nil // expected-error{{'nil' cannot be assigned to subscript of type 'X'}}
+
+ps[7] = i // expected-error{{value of type 'X' does not conform to 'Z' in subscript assignment}}
 
 slice[7] = _ // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
 


### PR DESCRIPTION

Addresses [SR-6340](https://bugs.swift.org/browse/SR-6340)

Currently,

```swift
var d: [Int: String] = [:]
d[0]=0
```

results in the error,
```
error: cannot assign value of type 'Int' to type 'String?'
```

This PR changes the error message for subscript assignment so it now reads,
```
error: cannot assign value of type 'Int' to subscript of type 'String?
```

It's kind of unfortunate the new, subscript-specific messages don't use the existing assignment diagnostic definitions, but it keeps the `diagnoseContextualConversionError` additions much simpler