### PR TITLE
[TF] Tensor.replacing: unit test and implicit broadcast

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -972,7 +972,7 @@ public extension Tensor {
                   vjp: _vjpReplacing where Scalar : TensorFlowFloatingPoint)
   func replacing(with other: Tensor,
                  where mask: Tensor<Bool>) -> Tensor {
-    return Raw.select(condition: mask, t: other, e: self)
+    return Raw.select(condition: mask, t: other.broadcast(like: self), e: self)
   }
 }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -778,6 +778,15 @@ func testShapeGetter4() {
 }
 TensorTests.testAllBackends("ShapeGetter4", testShapeGetter4)
 
+@inline(never)
+func testReplacing1() {
+  let original = Tensor<Float>([[1.0, 0.0], [3.0, 0.0], [2.0, 3.0], [1.0, 0.0]])
+  let modified = original.replacing(with: Tensor<Float>(-1).broadcast(like: original), where: original.<3)
+  let expected = Tensor<Float>([[-1.0, -1.0], [3.0, -1.0], [-1.0, 3.0], [-1.0, -1.0]])
+  expectEqual(expected, modified)
+}
+TensorTests.testAllBackends("Replacing1", testReplacing1)
+
 // For now it is sufficient to run remote tests with test cases in this file
 // only. When creating new test files, consider simply calling runAllTests().
 #if CUDA

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -787,6 +787,16 @@ func testReplacing1() {
 }
 TensorTests.testAllBackends("Replacing1", testReplacing1)
 
+@inline(never)
+func testReplacing2() {
+  // Implicit broadcast
+  let original = Tensor<Float>([[1.0, 0.0], [3.0, 0.0], [2.0, 3.0], [1.0, 0.0]])
+  let modified = original.replacing(with: Tensor<Float>(-1), where: original.<3)
+  let expected = Tensor<Float>([[-1.0, -1.0], [3.0, -1.0], [-1.0, 3.0], [-1.0, -1.0]])
+  expectEqual(expected, modified)
+}
+TensorTests.testAllBackends("Replacing2", testReplacing2)
+
 // For now it is sufficient to run remote tests with test cases in this file
 // only. When creating new test files, consider simply calling runAllTests().
 #if CUDA

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -778,24 +778,23 @@ func testShapeGetter4() {
 }
 TensorTests.testAllBackends("ShapeGetter4", testShapeGetter4)
 
-@inline(never)
-func testReplacing1() {
+TensorTests.testAllBackends("replacing(with:where:) no broadcasting") {
   let original = Tensor<Float>([[1.0, 0.0], [3.0, 0.0], [2.0, 3.0], [1.0, 0.0]])
-  let modified = original.replacing(with: Tensor<Float>(-1).broadcast(like: original), where: original.<3)
-  let expected = Tensor<Float>([[-1.0, -1.0], [3.0, -1.0], [-1.0, 3.0], [-1.0, -1.0]])
+  let modified = original.replacing(
+                with: Tensor<Float>(-1).broadcast(like: original), 
+                where: original.<3)
+  let expected = Tensor<Float>([[-1.0,-1.0],[3.0, -1.0], 
+                                [-1.0, 3.0], [-1.0, -1.0]])
   expectEqual(expected, modified)
 }
-TensorTests.testAllBackends("Replacing1", testReplacing1)
 
-@inline(never)
-func testReplacing2() {
-  // Implicit broadcast
+TensorTests.testAllBackends("replacing(with:where:) with broadcasting") {
   let original = Tensor<Float>([[1.0, 0.0], [3.0, 0.0], [2.0, 3.0], [1.0, 0.0]])
   let modified = original.replacing(with: Tensor<Float>(-1), where: original.<3)
-  let expected = Tensor<Float>([[-1.0, -1.0], [3.0, -1.0], [-1.0, 3.0], [-1.0, -1.0]])
+  let expected = Tensor<Float>([[-1.0, -1.0], [3.0, -1.0], 
+                                [-1.0, 3.0], [-1.0, -1.0]])
   expectEqual(expected, modified)
 }
-TensorTests.testAllBackends("Replacing2", testReplacing2)
 
 // For now it is sufficient to run remote tests with test cases in this file
 // only. When creating new test files, consider simply calling runAllTests().


### PR DESCRIPTION
This pull request contains the following additions:
1) Unit test for tensor.replacing(with,where) fix (#24635)
1) Implicit broadcast for `with` parameter, with relative unit test.

Example:
```swift
// You can write this:
let modified = orig.replacing(with: Tensor<Float>(-1), where: orig.<3)

// Instead of this:
let modified_no_bst = orig.replacing(with: Tensor<Float>(-1).broadcast(like: orig), where: orig.<3)
```