### PR TITLE
Platform: attempt to split out the bionic modulemap

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -95,7 +95,11 @@ foreach(sdk ${SWIFT_SDKS})
       set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_ARCH_INCLUDE_PATH}")
     endif()
 
-    set(glibc_modulemap_source "glibc.modulemap.gyb")
+    if(sdk STREQUAL ANDROID)
+      set(glibc_modulemap_source "bionic.modulemap.gyb")
+    else()
+      set(glibc_modulemap_source "glibc.modulemap.gyb")
+    endif()
     set(glibc_modulemap_out "${module_dir}/glibc.modulemap")
 
     # Configure the module map based on the target. Each platform needs to

--- a/stdlib/public/Platform/bionic.modulemap.gyb
+++ b/stdlib/public/Platform/bionic.modulemap.gyb
@@ -1,4 +1,4 @@
-//===--- glibc.modulemap.gyb ----------------------------------------------===//
+//===--- bionic.modulemap -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,50 +10,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// This is a semi-complete modulemap that maps glibc's headers in a roughly
+/// This is a semi-complete modulemap that maps bionics's headers in a roughly
 /// similar way to the Darwin SDK modulemap. We do not take care to list every
 /// single header which may be included by a particular submodule, so there can
 /// still be issues if imported into the same context as one in which someone
 /// included those headers directly.
 ///
-/// It's not named just Glibc so that it doesn't conflict in the event of a
-/// future official glibc modulemap.
+/// It's not named just Bionic so that it doesn't conflict in the event of a
+/// future official bionic modulemap.
 module SwiftGlibc [system] {
-% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
-  link "pthread"
-  // FIXME: util contains rarely used functions and not usually needed. Unfortunately
-  // link directive doesn't work in the submodule yet.
+  // FIXME: util contains rarely used functions and not usually needed.
+  // Unfortunately link directive doesn't work in the submodule yet.
   link "util"
-% end
 
-% if CMAKE_SDK != "FREEBSD" and CMAKE_SDK != "HAIKU":
   link "dl"
-% end
-
-% if CMAKE_SDK == "HAIKU":
-  link "network"
-  link "bsd"
-  link "execinfo"
-% end
 
   // C standard library
   module C {
-% if CMAKE_SDK in ["LINUX", "CYGWIN"]:
-    module features {
-% if CMAKE_SDK == "LINUX":
-      header "${GLIBC_INCLUDE_PATH}/stdc-predef.h"
-% end
       header "${GLIBC_INCLUDE_PATH}/features.h"
       export *
     }
-% end
-% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
+
     module complex {
       header "${GLIBC_INCLUDE_PATH}/complex.h"
       export *
     }
-% end
-% if CMAKE_SDK in ["LINUX", "CYGWIN"]:
+
     module pty {
       header "${GLIBC_INCLUDE_PATH}/pty.h"
       export *
@@ -62,23 +44,6 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/utmp.h"
       export *
     }
-% end
-% if CMAKE_SDK == "FREEBSD":
-    module pty {
-      header "${GLIBC_INCLUDE_PATH}/libutil.h"
-      export *
-    }
-    module utmp {
-      header "${GLIBC_INCLUDE_PATH}/utmpx.h"
-      export *
-    }
-% end
-% if CMAKE_SDK == "HAIKU":
-    module pty {
-      header "${GLIBC_INCLUDE_PATH}/../bsd/pty.h"
-      export *
-    }
-% end
 
     module ctype {
       header "${GLIBC_INCLUDE_PATH}/ctype.h"
@@ -120,9 +85,6 @@ module SwiftGlibc [system] {
       export *
     }
     module math {
-% if CMAKE_SDK == "LINUX":
-      link "m"
-% end
       header "${GLIBC_INCLUDE_PATH}/math.h"
       export *
     }
@@ -181,37 +143,20 @@ module SwiftGlibc [system] {
 
   // POSIX
   module POSIX {
-% if CMAKE_SDK in ["LINUX", "CYGWIN"]:
     module wait {
       header "${GLIBC_INCLUDE_PATH}/wait.h"
       export *
     }
-% end
 
-% if CMAKE_SDK in ["LINUX", "FREEBSD"]:
-    module aio {
-      header "${GLIBC_INCLUDE_PATH}/aio.h"
-      export *
-    }
     module cpio {
       header "${GLIBC_INCLUDE_PATH}/cpio.h"
-      export *
-    }
-    module fmtmsg {
-      header "${GLIBC_INCLUDE_PATH}/fmtmsg.h"
       export *
     }
     module nl_types {
       header "${GLIBC_INCLUDE_PATH}/nl_types.h"
       export *
     }
-    module ulimit {
-      header "${GLIBC_INCLUDE_PATH}/ulimit.h"
-      export *
-    }
-% end
 
-% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
     module ftw {
       header "${GLIBC_INCLUDE_PATH}/ftw.h"
       export *
@@ -226,10 +171,6 @@ module SwiftGlibc [system] {
     }
     module langinfo {
       header "${GLIBC_INCLUDE_PATH}/langinfo.h"
-      export *
-    }
-    module monetary {
-      header "${GLIBC_INCLUDE_PATH}/monetary.h"
       export *
     }
     module netdb {
@@ -256,58 +197,7 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/tar.h"
       export *
     }
-    module utmpx {
-      header "${GLIBC_INCLUDE_PATH}/utmpx.h"
-      export *
-    }
-    module wordexp {
-      header "${GLIBC_INCLUDE_PATH}/wordexp.h"
-      export *
-    }
-% end
 
-% if CMAKE_SDK == "HAIKU":
-    module ftw {
-      header "${GLIBC_INCLUDE_PATH}/ftw.h"
-      export *
-    }
-    module glob {
-      header "${GLIBC_INCLUDE_PATH}/glob.h"
-      export *
-    }
-    module iconv {
-      header "${GLIBC_INCLUDE_PATH}/../iconv.h"
-      export *
-    }
-    module langinfo {
-      header "${GLIBC_INCLUDE_PATH}/langinfo.h"
-      export *
-    }
-    module monetary {
-      header "${GLIBC_INCLUDE_PATH}/monetary.h"
-      export *
-    }
-    module netdb {
-      header "${GLIBC_INCLUDE_PATH}/netdb.h"
-      export *
-    }
-    module ifaddrs {
-      header "${GLIBC_INCLUDE_PATH}/../bsd/ifaddrs.h"
-      export *
-    }
-    module search {
-      header "${GLIBC_INCLUDE_PATH}/search.h"
-      export *
-    }
-    module syslog {
-      header "${GLIBC_INCLUDE_PATH}/syslog.h"
-      export *
-    }
-    module tar {
-      header "${GLIBC_INCLUDE_PATH}/tar.h"
-      export *
-    }
-% end
     module arpa {
       module inet {
         header "${GLIBC_INCLUDE_PATH}/arpa/inet.h"
@@ -393,7 +283,6 @@ module SwiftGlibc [system] {
     module sys {
       export *
 
-% if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
       module file {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/file.h"
         export *
@@ -402,7 +291,6 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sem.h"
         export *
       }
-% if CMAKE_SDK != "HAIKU":
       module shm {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/shm.h"
         export *
@@ -411,12 +299,10 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/inotify.h"
         export *
       }
-% end
       module statvfs {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/statvfs.h"
         export *
       }
-% end
 
       module ipc {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ipc.h"
@@ -438,12 +324,10 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/select.h"
         export *
       }
-% if CMAKE_SDK != "FREEBSD" and CMAKE_SDK != "HAIKU":
       module sendfile {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sendfile.h"
         export *
       }
-% end
       module socket {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
         export *
@@ -464,12 +348,6 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/types.h"
         export *
       }
-% if CMAKE_SDK in ["FREEBSD"]:
-      module event {
-        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/event.h"
-        export *
-      }
-% end
       module uio {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
         export *
@@ -478,12 +356,10 @@ module SwiftGlibc [system] {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/un.h"
         export *
       }
-% if CMAKE_SDK in ["LINUX"]:
       module user {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/user.h"
         export *
       }
-% end
       module utsname {
         header "${GLIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
         export *
@@ -493,12 +369,10 @@ module SwiftGlibc [system] {
         export *
       }
     }
-% if CMAKE_SDK in ["LINUX", "FREEBSD"]:
     module sysexits {
       header "${GLIBC_INCLUDE_PATH}/sysexits.h"
       export *
     }
-% end
     module termios {
       header "${GLIBC_INCLUDE_PATH}/termios.h"
       export *
@@ -514,8 +388,3 @@ module SwiftGlibc [system] {
   }
 }
 
-module CUUID [system] {
-  header "${GLIBC_INCLUDE_PATH}/uuid/uuid.h"
-  link "uuid"
-  export *
-}


### PR DESCRIPTION
This splits out the bionic modulemap from the glibc modulemap.  They are
sufficiently different that the duplication is worth it.  Furthermore,
it will enable properly identifying the libc on android.  Once fully
detangled, this will enable the use of bionic on non-android platforms.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
