### PR TITLE
[build-script-impl] When building parts of Swift without LLVM, always…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2150,8 +2150,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
                     # We can't skip the build completely because the standalone
-                    # build of Swift depend on these.
-                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets)
+                    # build of Swift depend on these for testing etc.
+                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets FileCheck not)
                 fi
 
                 if [ "${HOST_LIBTOOL}" ] ; then


### PR DESCRIPTION
… at least build FileCheck/not from LLVM.

These are common utilities used when testing with lit, so it makes sense to
always include them so in these cases we can use them for testing purposes.