### PR TITLE
Make allCases tests more strict

### DIFF
--- a/test/stdlib/CaseIterableTests.swift
+++ b/test/stdlib/CaseIterableTests.swift
@@ -13,9 +13,9 @@ CaseIterableTests.test("Simple Enums") {
   }
 
   expectEqual(SimpleEnum.allCases.count, 3)
-  expectTrue(SimpleEnum.allCases.contains(.bar))
-  expectTrue(SimpleEnum.allCases.contains(.baz))
-  expectTrue(SimpleEnum.allCases.contains(.quux))
+  expectTrue(SimpleEnum.allCases[0] == .bar)
+  expectTrue(SimpleEnum.allCases[1] == .baz)
+  expectTrue(SimpleEnum.allCases[2] == .quux)
 }
 
 runAllTests()


### PR DESCRIPTION
`allCases` provides the cases in order of their declaration, so I think this test case should be stricter.

> The synthesized allCases collection provides the cases in order of their declaration.
https://developer.apple.com/documentation/swift/caseiterable

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
