### PR TITLE
Add '-emit-archive' option to mark modules as being part of static libraries

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -602,7 +602,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1,
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 
@@ -624,7 +624,10 @@ protected:
     ImplicitDynamicEnabled : 1,
 
     // Whether the module is a system module.
-    IsSystemModule : 1
+    IsSystemModule : 1,
+                        
+    // If the module is a static library.
+    IsStaticLibrary : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -64,6 +64,9 @@ ERROR(error_expected_frontend_command,none,
 ERROR(error_cannot_specify__o_for_multiple_outputs,none,
       "cannot specify -o when generating multiple output files", ())
 
+ERROR(error_static_emit_executable_disallowed,none,
+      "-static may not be used with -emit-executable", ())
+
 ERROR(error_unable_to_load_output_file_map, none,
       "unable to load output file map '%1': %0", (StringRef, StringRef))
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -338,6 +338,14 @@ public:
     return getResilienceStrategy() != ResilienceStrategy::Default;
   }
 
+  bool isStaticLibrary() const {
+    return Bits.ModuleDecl.IsStaticLibrary;
+  }
+
+  void setIsStaticLibrary(bool isStaticLibrary = true) {
+    Bits.ModuleDecl.IsStaticLibrary = isStaticLibrary;
+  }
+
   /// Look up a (possibly overloaded) value set at top-level scope
   /// (but with the specified access path, which may come from an import decl)
   /// within the current module.

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -333,8 +333,6 @@ public:
     assert(K == LinkKind::StaticLibrary);
   }
 
-  LinkKind getKind() const { return LinkKind::StaticLibrary; }
-
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::ArchiveJob;
   }

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -48,6 +48,7 @@ public:
     AutolinkExtractJob,
     REPLJob,
     LinkJob,
+    ArchiveJob,
     GenerateDSYMJob,
     VerifyDebugInfoJob,
     GeneratePCHJob,
@@ -313,13 +314,29 @@ public:
   LinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K)
       : JobAction(Action::Kind::LinkJob, Inputs, file_types::TY_Image),
         Kind(K) {
-    assert(Kind != LinkKind::None);
+    assert(Kind != LinkKind::None && Kind != LinkKind::StaticLibrary);
   }
 
   LinkKind getKind() const { return Kind; }
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::LinkJob;
+  }
+};
+
+class ArchiveJobAction : public JobAction {
+  virtual void anchor();
+
+public:
+  ArchiveJobAction(ArrayRef<const Action *> Inputs, LinkKind K)
+      : JobAction(Action::Kind::ArchiveJob, Inputs, file_types::TY_Image) {
+    assert(K == LinkKind::StaticLibrary);
+  }
+
+  LinkKind getKind() const { return LinkKind::StaticLibrary; }
+
+  static bool classof(const Action *A) {
+    return A->getKind() == Action::Kind::ArchiveJob;
   }
 };
 

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -161,6 +161,9 @@ protected:
   virtual InvocationInfo constructInvocation(const LinkJobAction &job,
                                              const JobContext &context) const;
 
+  virtual InvocationInfo constructInvocation(const ArchiveJobAction &job,
+                                             const JobContext &context) const;
+
   /// Searches for the given executable in appropriate paths relative to the
   /// Swift binary.
   ///

--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -34,7 +34,8 @@ namespace driver {
   enum class LinkKind {
     None,
     Executable,
-    DynamicLibrary
+    DynamicLibrary,
+    StaticLibrary
   };
 
   /// Used by a Job to request a "filelist": a file containing a list of all

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -228,6 +228,9 @@ public:
   /// the Objective-C half should implicitly be visible to the Swift sources.
   bool ImportUnderlyingModule = false;
 
+  /// If set, this module should be built and linked as a static library.
+  bool IsStaticLibrary = false;
+
   /// If set, the header provided in ImplicitObjCHeaderPath will be rewritten
   /// by the Clang importer as part of semantic analysis.
   bool SerializeBridgingHeader = false;

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1177,7 +1177,7 @@ public:
 
   static LinkInfo get(const UniversalLinkageInfo &linkInfo, StringRef name,
                       SILLinkage linkage, ForDefinition_t isDefinition,
-                      bool isWeakImported);
+                      bool isWeakImported, bool isStaticLibrary);
 
   StringRef getName() const {
     return Name.str();

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -368,9 +368,9 @@ def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
          ArgumentIsPath]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
-def emit_archive : Flag<["-"], "emit-archive">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Emit module as a static archive">;
+def static_library : Flag<["-"], "static">,
+  Flags<[FrontendOption, ModuleInterfaceOption, NoInteractiveOption]>,
+  HelpText<"Make this module statically linkable and make the output of -emit-library a static library.">;
 
 def import_cf_types : Flag<["-"], "import-cf-types">,
   Flags<[FrontendOption, HelpHidden]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -368,7 +368,7 @@ def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
          ArgumentIsPath]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
-def static_library : Flag<["-"], "static">,
+def static : Flag<["-"], "static">,
   Flags<[FrontendOption, ModuleInterfaceOption, NoInteractiveOption]>,
   HelpText<"Make this module statically linkable and make the output of -emit-library a static library.">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -368,6 +368,10 @@ def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
          ArgumentIsPath]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
+def emit_archive : Flag<["-"], "emit-archive">,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit module as a static archive">;
+
 def import_cf_types : Flag<["-"], "import-cf-types">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Recognize and import CF types as class types">;

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -600,7 +600,8 @@ namespace options_block {
     IS_SIB,
     IS_TESTABLE,
     RESILIENCE_STRATEGY,
-    ARE_PRIVATE_IMPORTS_ENABLED
+    ARE_PRIVATE_IMPORTS_ENABLED,
+    IS_STATIC_LIBRARY
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -629,6 +630,10 @@ namespace options_block {
   using ResilienceStrategyLayout = BCRecordLayout<
     RESILIENCE_STRATEGY,
     BCFixed<2>
+  >;
+
+  using IsStaticLibraryLayout = BCRecordLayout<
+    IS_STATIC_LIBRARY
   >;
 }
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -98,6 +98,7 @@ class ExtendedValidationInfo {
     unsigned IsSIB : 1;
     unsigned IsTestable : 1;
     unsigned ResilienceStrategy : 2;
+    unsigned IsStaticLibrary : 1;
   } Bits;
 public:
   ExtendedValidationInfo() : Bits() {}
@@ -134,6 +135,11 @@ public:
   }
   void setResilienceStrategy(ResilienceStrategy resilience) {
     Bits.ResilienceStrategy = unsigned(resilience);
+  }
+
+  bool isStaticLibrary() const { return Bits.IsStaticLibrary; }
+  void setIsStaticLibrary(bool isStaticLibrary) {
+    Bits.IsStaticLibrary = isStaticLibrary;
   }
 };
 

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -29,6 +29,7 @@ const char *Action::getClassName(Kind AC) {
   case Kind::AutolinkExtractJob:  return "swift-autolink-extract";
   case Kind::REPLJob:  return "repl";
   case Kind::LinkJob:  return "link";
+  case Kind::ArchiveJob:  return "archive";
   case Kind::GenerateDSYMJob:  return "generate-dSYM";
   case Kind::VerifyDebugInfoJob:  return "verify-debug-info";
   case Kind::GeneratePCHJob:  return "generate-pch";
@@ -56,6 +57,8 @@ void AutolinkExtractJobAction::anchor() {}
 void REPLJobAction::anchor() {}
 
 void LinkJobAction::anchor() {}
+
+void ArchiveJobAction::anchor() {}
 
 void GenerateDSYMJobAction::anchor() {}
 

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -284,6 +284,9 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   case LinkKind::DynamicLibrary:
     Arguments.push_back("-dylib");
     break;
+  case LinkKind::StaticLibrary:
+    Arguments.push_back(".a");
+    break;
   }
 
   assert(Triple.isOSDarwin());

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -285,8 +285,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-dylib");
     break;
   case LinkKind::StaticLibrary:
-    Arguments.push_back(".a");
-    break;
+    llvm_unreachable("invalid link kind");
   }
 
   assert(Triple.isOSDarwin());

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1368,18 +1368,20 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
 
     switch (OutputModeArg->getOption().getID()) {
     case options::OPT_emit_executable:
+      assert(!Args.hasArg(options::OPT_static) &&
+             "-static may not be used with -emit-executable.");
       OI.LinkAction = LinkKind::Executable;
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 
     case options::OPT_emit_library:
-      OI.LinkAction = Args.hasArg(options::OPT_static_library) ?
+      OI.LinkAction = Args.hasArg(options::OPT_static) ?
                       LinkKind::StaticLibrary :
                       LinkKind::DynamicLibrary;
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 
-    case options::OPT_static_library:
+    case options::OPT_static:
       break;
 
     case options::OPT_emit_object:
@@ -1959,12 +1961,13 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
   if (OI.shouldLink() && !AllLinkerInputs.empty()) {
     JobAction *LinkAction = nullptr;
 
-    if (OI.LinkAction == LinkKind::StaticLibrary)
+    if (OI.LinkAction == LinkKind::StaticLibrary) {
       LinkAction = C.createAction<ArchiveJobAction>(AllLinkerInputs,
                                                     OI.LinkAction);
-    else
+    } else {
       LinkAction = C.createAction<LinkJobAction>(AllLinkerInputs,
                                                  OI.LinkAction);
+    }
 
     // On ELF platforms there's no built in autolinking mechanism, so we
     // pull the info we need from the .o files directly and pass them as an

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1368,8 +1368,10 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
 
     switch (OutputModeArg->getOption().getID()) {
     case options::OPT_emit_executable:
-      assert(!Args.hasArg(options::OPT_static) &&
-             "-static may not be used with -emit-executable.");
+      if (Args.hasArg(options::OPT_static))
+        Diags.diagnose(SourceLoc(),
+                       diag::error_static_emit_executable_disallowed);
+                       
       OI.LinkAction = LinkKind::Executable;
       OI.CompilerOutputType = file_types::TY_Object;
       break;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1373,14 +1373,13 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       break;
 
     case options::OPT_emit_library:
-      if (OI.LinkAction != LinkKind::StaticLibrary)
-        OI.LinkAction = LinkKind::DynamicLibrary;
+      OI.LinkAction = Args.hasArg(options::OPT_static_library) ?
+                      LinkKind::StaticLibrary :
+                      LinkKind::DynamicLibrary;
       OI.CompilerOutputType = file_types::TY_Object;
       break;
 
-    case options::OPT_emit_archive:
-      OI.LinkAction = LinkKind::StaticLibrary;
-      OI.CompilerOutputType = file_types::TY_Object;
+    case options::OPT_static_library:
       break;
 
     case options::OPT_emit_object:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1959,12 +1959,10 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
   if (OI.shouldLink() && !AllLinkerInputs.empty()) {
     JobAction *LinkAction = nullptr;
 
-    if (OI.LinkAction == LinkKind::StaticLibrary) {
+    if (OI.LinkAction == LinkKind::StaticLibrary)
       LinkAction = C.createAction<ArchiveJobAction>(AllLinkerInputs,
                                                     OI.LinkAction);
-                                                  
-      llvm::errs() << "LinkAction is an ArchiveJobAction\n";
-    } else
+    else
       LinkAction = C.createAction<LinkJobAction>(AllLinkerInputs,
                                                  OI.LinkAction);
 

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -100,6 +100,7 @@ std::unique_ptr<Job> ToolChain::constructJob(
       CASE(MergeModuleJob)
       CASE(ModuleWrapJob)
       CASE(LinkJob)
+      CASE(ArchiveJob)
       CASE(GenerateDSYMJob)
       CASE(VerifyDebugInfoJob)
       CASE(GeneratePCHJob)

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -208,6 +208,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_warnings_as_errors);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
+  inputArgs.AddLastArg(arguments, options::OPT_static_library);
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1101,14 +1101,12 @@ ToolChain::constructInvocation(const ArchiveJobAction &job,
       isLLVMAR = true;
     }
 
-    // Look for binutils in the toolchain folder.
-    Arguments.push_back("-B");
-    Arguments.push_back(context.Args.MakeArgString(A->getValue()));
   }
   if (AR == nullptr) {
-    if (auto pathAR = llvm::sys::findProgramByName("llvm-ar", None))
+    if (auto pathAR = llvm::sys::findProgramByName("llvm-ar", None)) {
       AR = context.Args.MakeArgString(pathAR.get());
       isLLVMAR = true;
+    }
   }
   if (AR == nullptr) {
     if (auto pathAR = llvm::sys::findProgramByName("ar", None))

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -208,7 +208,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_warnings_as_errors);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
-  inputArgs.AddLastArg(arguments, options::OPT_static_library);
+  inputArgs.AddLastArg(arguments, options::OPT_static);
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
@@ -1084,7 +1084,6 @@ ToolChain::constructInvocation(const ArchiveJobAction &job,
                                const JobContext &context) const {
    assert(context.Output.getPrimaryOutputType() == file_types::TY_Image &&
          "Invalid linker output type.");
-  assert(job.getKind() == LinkKind::StaticLibrary);
 
   ArgStringList Arguments;
 
@@ -1118,17 +1117,17 @@ ToolChain::constructInvocation(const ArchiveJobAction &job,
 
   if (isLLVMAR) {
     switch (getTriple().getOS()) {
-      case llvm::Triple::Darwin:
-        Arguments.push_back("--format=darwin");
-        break;
-      case llvm::Triple::FreeBSD:
-        Arguments.push_back("--format=bsd");
-        break;
-      case llvm::Triple::Linux:
-        Arguments.push_back("--format=gnu");
-        break;
-      default:
-        break;
+    case llvm::Triple::Darwin:
+      Arguments.push_back("--format=darwin");
+      break;
+    case llvm::Triple::FreeBSD:
+      Arguments.push_back("--format=bsd");
+      break;
+    case llvm::Triple::Linux:
+      Arguments.push_back("--format=gnu");
+      break;
+    default:
+      break;
     }
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1121,6 +1121,9 @@ ToolChain::constructInvocation(const ArchiveJobAction &job,
       case llvm::Triple::Darwin:
         Arguments.push_back("--format=darwin");
         break;
+      case llvm::Triple::FreeBSD:
+        Arguments.push_back("--format=bsd");
+        break;
       case llvm::Triple::Linux:
         Arguments.push_back("--format=gnu");
         break;

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -130,6 +130,9 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   case LinkKind::DynamicLibrary:
     Arguments.push_back("-shared");
     break;
+  case LinkKind::StaticLibrary:
+    // Nothing extra needed.
+    break;
   }
 
   // Select the linker to use.

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -131,8 +131,7 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-shared");
     break;
   case LinkKind::StaticLibrary:
-    // Nothing extra needed.
-    break;
+    llvm_unreachable("invalid link kind");
   }
 
   // Select the linker to use.

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -61,6 +61,9 @@ toolchains::Windows::constructInvocation(const LinkJobAction &job,
   case LinkKind::DynamicLibrary:
     Arguments.push_back("-shared");
     break;
+  case LinkKind::StaticLibrary:
+    // Nothing extra needed.
+    break;
   }
 
   // Select the linker to use.

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -62,8 +62,7 @@ toolchains::Windows::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-shared");
     break;
   case LinkKind::StaticLibrary:
-    // Nothing extra needed.
-    break;
+    llvm_unreachable("invalid link kind");
   }
 
   // Select the linker to use.

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -73,7 +73,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_library_evolution);
   
-  Opts.IsStaticLibrary |= Args.hasArg(OPT_emit_archive);
+  Opts.IsStaticLibrary |= Args.hasArg(OPT_static_library);
 
   // FIXME: Remove this flag
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_resilience);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -73,7 +73,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_library_evolution);
   
-  Opts.IsStaticLibrary |= Args.hasArg(OPT_static_library);
+  Opts.IsStaticLibrary |= Args.hasArg(OPT_static);
 
   // FIXME: Remove this flag
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_resilience);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -72,6 +72,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnablePrivateImports |= Args.hasArg(OPT_enable_private_imports);
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_library_evolution);
+  
+  Opts.IsStaticLibrary |= Args.hasArg(OPT_emit_archive);
 
   // FIXME: Remove this flag
   Opts.EnableLibraryEvolution |= Args.hasArg(OPT_enable_resilience);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -535,6 +535,8 @@ ModuleDecl *CompilerInstance::getMainModule() {
       MainModule->setPrivateImportsEnabled();
     if (Invocation.getFrontendOptions().EnableImplicitDynamic)
       MainModule->setImplicitDynamicEnabled();
+    if (Invocation.getFrontendOptions().IsStaticLibrary)
+      MainModule->setIsStaticLibrary();
 
     if (Invocation.getFrontendOptions().EnableLibraryEvolution)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1612,12 +1612,12 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
             llvm::GlobalValue::VISIBILITY##Visibility,                         \
             llvm::GlobalValue::DLL_STORAGE##StorageClass}
 
+  bool useDLLStorage = info.UseDLLStorage && !isStaticLibrary;
+
   // Use protected visibility for public symbols we define on ELF.  ld.so
   // doesn't support relative relocations at load time, which interferes with
   // our metadata formats.  Default visibility should suffice for other object
   // formats.
-  bool useDLLStorage = info.UseDLLStorage && !isStaticLibrary;
-
   llvm::GlobalValue::VisibilityTypes PublicDefinitionVisibility =
       info.IsELFObject ? llvm::GlobalValue::ProtectedVisibility
                        : llvm::GlobalValue::DefaultVisibility;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -120,6 +120,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       options_block::ResilienceStrategyLayout::readRecord(scratch, Strategy);
       extendedInfo.setResilienceStrategy(ResilienceStrategy(Strategy));
       break;
+    case options_block::IS_STATIC_LIBRARY:
+      extendedInfo.setIsStaticLibrary(true);
+      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -828,6 +828,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, IS_TESTABLE);
   BLOCK_RECORD(options_block, ARE_PRIVATE_IMPORTS_ENABLED);
   BLOCK_RECORD(options_block, RESILIENCE_STRATEGY);
+  BLOCK_RECORD(options_block, IS_STATIC_LIBRARY);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -991,6 +992,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
       if (M->getResilienceStrategy() != ResilienceStrategy::Default) {
         options_block::ResilienceStrategyLayout Strategy(Out);
         Strategy.emit(ScratchRecord, unsigned(M->getResilienceStrategy()));
+      }
+
+      if (M->isStaticLibrary()) {
+        options_block::IsStaticLibraryLayout IsStaticLibrary(Out);
+        IsStaticLibrary.emit(ScratchRecord);
       }
 
       if (options.SerializeOptionsForDebugging) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -552,6 +552,8 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
       M.setTestingEnabled();
     if (extendedInfo.arePrivateImportsEnabled())
       M.setPrivateImportsEnabled();
+    if (extendedInfo.isStaticLibrary())
+      M.setIsStaticLibrary();
 
     auto diagLocOrInvalid = diagLoc.getValueOr(SourceLoc());
     loadInfo.status =


### PR DESCRIPTION
Following discussion [here](https://forums.swift.org/t/spm-windows-link-issues-during-build/24921/), this is a draft PR to add a `-emit-archive` option to Swift that controls the linkage of symbols within Swift modules (and potentially more in the future).

The core problem is that Windows needs different linkage – DLL import vs. default – for shared vs. static libraries. For Swift, cache whether a module is built as a static or shared library on a per-module basis, and use that to determine what linkage should be applied.

cc @compnerd