### PR TITLE
[SourceKit] Fail requests when an error occurs

### DIFF
--- a/test/SourceKit/CompileNotifications/arg-parsing.swift
+++ b/test/SourceKit/CompileNotifications/arg-parsing.swift
@@ -1,6 +1,26 @@
-// RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
+// RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s -no-such-arg 2>&1 | %FileCheck %s -check-prefix=ARG_PARSE_0
+// ARG_PARSE_0: (Request Failed): error: unknown argument: '-no-such-arg'
+// ARG_PARSE_0: {
+// ARG_PARSE_0:  key.notification: source.notification.compile-will-start
+// ARG_PARSE_0:  key.compileid: [[CID1:".*"]]
+// ARG_PARSE_0:  key.compilerargs-string: "{{.*}}.swift -no-such-arg"
+// ARG_PARSE_0: }
+// ARG_PARSE_0: {
+// ARG_PARSE_0:   key.notification: source.notification.compile-did-finish
+// ARG_PARSE_0:   key.diagnostics: [
+// ARG_PARSE_0:     {
+// ARG_PARSE_0:       key.filepath: "<unknown>",
+// ARG_PARSE_0:       key.severity: source.diagnostic.severity.error,
+// ARG_PARSE_0:       key.description: "unknown argument: '-no-such-arg'"
+// ARG_PARSE_0:     }
+// ARG_PARSE_0:   ]
+// ARG_PARSE_0:   key.compileid: [[CID1]]
+// ARG_PARSE_0: }
+// ARG_PARSE_0-NOT: compile-will-start
+// ARG_PARSE_0-NOT: compile-did-finish
+
 // RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -print-raw-response -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
-// RUN: %sourcekitd-test -req=track-compiles == -req=cursor -offset=0 %s -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
+// RUN: not %sourcekitd-test -req=track-compiles == -req=cursor -offset=0 %s -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
 // ARG_PARSE_1: {
 // ARG_PARSE_1:  key.notification: source.notification.compile-will-start
 // ARG_PARSE_1:  key.compileid: [[CID1:".*"]]
@@ -20,8 +40,8 @@
 // ARG_PARSE_1-NOT: compile-will-start
 // ARG_PARSE_1-NOT: compile-did-finish
 
-// RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 | %FileCheck %s -check-prefix=ARG_PARSE_2
-// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -print-raw-response | %FileCheck %s -check-prefix=ARG_PARSE_2
+//  %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 | %FileCheck %s -check-prefix=ARG_PARSE_2
+//  %sourcekitd-test -req=track-compiles == -req=sema %s -print-raw-response | %FileCheck %s -check-prefix=ARG_PARSE_2
 // ARG_PARSE_2: {
 // ARG_PARSE_2:  key.notification: source.notification.compile-will-start
 // ARG_PARSE_2:  key.compileid: [[CID1:".*"]]

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -8,6 +8,6 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
-// COMPILE_1: <diagnostic "Unable to resolve cursor info.">
+// COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1-NOT: compile-will-start
 // COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,5 +1,4 @@
-// RUN: not %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s 2>&1 | %FileCheck %s -check-prefix=COMPILE_1 -dump-input-on-failure
-// COMPILE_1: error response (Request Failed): Unable to resolve cursor info.
+// RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",
@@ -9,5 +8,6 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
+// COMPILE_1: <diagnostic "Unable to resolve cursor info.">
 // COMPILE_1-NOT: compile-will-start
 // COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,4 +1,5 @@
-// RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: not %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s 2>&1 | %FileCheck %s -check-prefix=COMPILE_1 -dump-input-on-failure
+// COMPILE_1: error response (Request Failed): Unable to resolve cursor info.
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",

--- a/test/SourceKit/CursorInfo/cursor_getter.swift
+++ b/test/SourceKit/CursorInfo/cursor_getter.swift
@@ -21,4 +21,4 @@ struct S1 {
 // RUN: %sourcekitd-test -req=cursor -pos=3:41 %s -- %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=cursor -pos=6:29 %s -- %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=cursor -pos=6:31 %s -- %s | %FileCheck %s
-// CHECK: <diagnostic "Unable to resolve cursor info.">
+// CHECK: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">

--- a/test/SourceKit/CursorInfo/cursor_getter.swift
+++ b/test/SourceKit/CursorInfo/cursor_getter.swift
@@ -7,18 +7,18 @@ struct S1 {
 }
 
 // Checks that we don't crash.
-// RUN: not %sourcekitd-test -req=cursor -pos=1:15 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=1:17 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=2:15 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=2:17 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=2:21 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=2:23 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:15 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:17 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:21 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:23 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:37 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=3:41 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=6:29 %s -- %s 2>&1 | %FileCheck %s
-// RUN: not %sourcekitd-test -req=cursor -pos=6:31 %s -- %s 2>&1 | %FileCheck %s
-// CHECK: (Request Failed): Unable to resolve cursor info
+// RUN: %sourcekitd-test -req=cursor -pos=1:15 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=1:17 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:15 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:17 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:21 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:23 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:15 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:17 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:21 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:23 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:37 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:41 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=6:29 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=6:31 %s -- %s | %FileCheck %s
+// CHECK: <diagnostic "Unable to resolve cursor info.">

--- a/test/SourceKit/CursorInfo/cursor_getter.swift
+++ b/test/SourceKit/CursorInfo/cursor_getter.swift
@@ -7,18 +7,18 @@ struct S1 {
 }
 
 // Checks that we don't crash.
-// RUN: %sourcekitd-test -req=cursor -pos=1:15 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=1:17 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=2:15 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=2:17 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=2:21 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=2:23 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:15 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:17 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:21 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:23 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:37 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=3:41 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=6:29 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=cursor -pos=6:31 %s -- %s | %FileCheck %s
-// CHECK: <empty cursor info>
+// RUN: not %sourcekitd-test -req=cursor -pos=1:15 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=1:17 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=2:15 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=2:17 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=2:21 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=2:23 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:15 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:17 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:21 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:23 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:37 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=3:41 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=6:29 %s -- %s 2>&1 | %FileCheck %s
+// RUN: not %sourcekitd-test -req=cursor -pos=6:31 %s -- %s 2>&1 | %FileCheck %s
+// CHECK: (Request Failed): Unable to resolve cursor info

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -379,17 +379,17 @@ enum E7: String {
 // CHECK22: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>
 
 // RUN: %sourcekitd-test -req=cursor -pos=56:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK23 %s
-// CHECK23: <diagnostic "Unavailable in the current compilation context.">
+// CHECK23: <empty cursor info; internal diagnostic: "Unavailable in the current compilation context.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=57:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK24 %s
-// CHECK24: <diagnostic "Unavailable in the current compilation context.">
+// CHECK24: <empty cursor info; internal diagnostic: "Unavailable in the current compilation context.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=58:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK25 %s
 // CHECK25: <Declaration>func availabilityIntroducedMsg()</Declaration>
 // CHECK25: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>
 
 // RUN: %sourcekitd-test -req=cursor -pos=59:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK26 %s
-// CHECK26: <diagnostic "Unavailable in the current compilation context.">
+// CHECK26: <empty cursor info; internal diagnostic: "Unavailable in the current compilation context.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=69:14 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK27 %s
 // CHECK27: <Declaration>public subscript(i: <Type usr="s:Si">Int</Type>) -&gt; <Type usr="s:Si">Int</Type> { get }</Declaration>

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -378,21 +378,18 @@ enum E7: String {
 // CHECK22: <Declaration>func availabilityIntroduced()</Declaration>
 // CHECK22: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>
 
-// RUN: %sourcekitd-test -req=cursor -pos=56:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK23 %s
-// CHECK23-NOT: <Declaration>func swiftUnavailable()</Declaration>
-// CHECK23-NOT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>
+// RUN: not %sourcekitd-test -req=cursor -pos=56:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK23 %s
+// CHECK23: (Request Failed): Unavailable in the current compilation context
 
-// RUN: %sourcekitd-test -req=cursor -pos=57:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK24 %s
-// CHECK24-NOT: <Declaration>func unavailable()</Declaration>
-// CHECK24-NOT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>
+// RUN: not %sourcekitd-test -req=cursor -pos=57:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK24 %s
+// CHECK24: (Request Failed): Unavailable in the current compilation context
 
 // RUN: %sourcekitd-test -req=cursor -pos=58:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK25 %s
 // CHECK25: <Declaration>func availabilityIntroducedMsg()</Declaration>
 // CHECK25: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>
 
-// RUN: %sourcekitd-test -req=cursor -pos=59:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK26 %s
-// CHECK26-NOT: <Declaration>func availabilityDeprecated()</Declaration>
-// CHECK26-NOT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>
+// RUN: not %sourcekitd-test -req=cursor -pos=59:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK26 %s
+// CHECK26: (Request Failed): Unavailable in the current compilation context
 
 // RUN: %sourcekitd-test -req=cursor -pos=69:14 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK27 %s
 // CHECK27: <Declaration>public subscript(i: <Type usr="s:Si">Int</Type>) -&gt; <Type usr="s:Si">Int</Type> { get }</Declaration>

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -378,18 +378,18 @@ enum E7: String {
 // CHECK22: <Declaration>func availabilityIntroduced()</Declaration>
 // CHECK22: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>
 
-// RUN: not %sourcekitd-test -req=cursor -pos=56:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK23 %s
-// CHECK23: (Request Failed): Unavailable in the current compilation context
+// RUN: %sourcekitd-test -req=cursor -pos=56:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK23 %s
+// CHECK23: <diagnostic "Unavailable in the current compilation context.">
 
-// RUN: not %sourcekitd-test -req=cursor -pos=57:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK24 %s
-// CHECK24: (Request Failed): Unavailable in the current compilation context
+// RUN: %sourcekitd-test -req=cursor -pos=57:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK24 %s
+// CHECK24: <diagnostic "Unavailable in the current compilation context.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=58:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK25 %s
 // CHECK25: <Declaration>func availabilityIntroducedMsg()</Declaration>
 // CHECK25: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>
 
-// RUN: not %sourcekitd-test -req=cursor -pos=59:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK26 %s
-// CHECK26: (Request Failed): Unavailable in the current compilation context
+// RUN: %sourcekitd-test -req=cursor -pos=59:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK26 %s
+// CHECK26: <diagnostic "Unavailable in the current compilation context.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=69:14 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK27 %s
 // CHECK27: <Declaration>public subscript(i: <Type usr="s:Si">Int</Type>) -&gt; <Type usr="s:Si">Int</Type> { get }</Declaration>

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -46,7 +46,7 @@ func resyncParser2() {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=7:12 %s -- %s | %FileCheck -check-prefix=DIAG %s
 // RUN: %sourcekitd-test -req=cursor -pos=9:7 %s -- %s | %FileCheck -check-prefix=DIAG %s
-// DIAG: <diagnostic "Unable to resolve cursor info.">
+// DIAG: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s
 // RUN: %sourcekitd-test -req=cursor -pos=19:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -44,9 +44,9 @@ func resyncParser2() {}
 // CHECK4: bad
 // CHECK4: <Declaration>var bad: IDontExist</Declaration>
 
-// RUN: not %sourcekitd-test -req=cursor -pos=7:12 %s -- %s 2>&1 | %FileCheck -check-prefix=FAIL %s
-// RUN: not %sourcekitd-test -req=cursor -pos=9:7 %s -- %s 2>&1 | %FileCheck -check-prefix=FAIL %s
-// FAIL: (Request Failed): Unable to resolve cursor info
+// RUN: %sourcekitd-test -req=cursor -pos=7:12 %s -- %s | %FileCheck -check-prefix=DIAG %s
+// RUN: %sourcekitd-test -req=cursor -pos=9:7 %s -- %s | %FileCheck -check-prefix=DIAG %s
+// DIAG: <diagnostic "Unable to resolve cursor info.">
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s
 // RUN: %sourcekitd-test -req=cursor -pos=19:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -44,9 +44,9 @@ func resyncParser2() {}
 // CHECK4: bad
 // CHECK4: <Declaration>var bad: IDontExist</Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=7:12 %s -- %s | %FileCheck -check-prefix=EMPTY %s
-// RUN: %sourcekitd-test -req=cursor -pos=9:7 %s -- %s | %FileCheck -check-prefix=EMPTY %s
-// EMPTY: <empty cursor info>
+// RUN: not %sourcekitd-test -req=cursor -pos=7:12 %s -- %s 2>&1 | %FileCheck -check-prefix=FAIL %s
+// RUN: not %sourcekitd-test -req=cursor -pos=9:7 %s -- %s 2>&1 | %FileCheck -check-prefix=FAIL %s
+// FAIL: (Request Failed): Unable to resolve cursor info
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s
 // RUN: %sourcekitd-test -req=cursor -pos=19:6 %s -- %s | %FileCheck -check-prefix=EQEQ1 %s

--- a/test/SourceKit/CursorInfo/cursor_unavailable.swift
+++ b/test/SourceKit/CursorInfo/cursor_unavailable.swift
@@ -2,7 +2,7 @@ print("")
 find([1,2,3],1)
 
 // RUN: %sourcekitd-test -req=cursor -pos=1:1 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: not %sourcekitd-test -req=cursor -pos=2:1 %s -- %s 2>&1 | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:1 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
 
 // CHECK1: source.lang.swift.ref.function.free
-// CHECK2: (Request Failed): Resolved to incomplete expression or statement
+// CHECK2: <diagnostic "Resolved to incomplete expression or statement.">

--- a/test/SourceKit/CursorInfo/cursor_unavailable.swift
+++ b/test/SourceKit/CursorInfo/cursor_unavailable.swift
@@ -5,4 +5,4 @@ find([1,2,3],1)
 // RUN: %sourcekitd-test -req=cursor -pos=2:1 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
 
 // CHECK1: source.lang.swift.ref.function.free
-// CHECK2: <diagnostic "Resolved to incomplete expression or statement.">
+// CHECK2: <empty cursor info; internal diagnostic: "Resolved to incomplete expression or statement.">

--- a/test/SourceKit/CursorInfo/cursor_unavailable.swift
+++ b/test/SourceKit/CursorInfo/cursor_unavailable.swift
@@ -2,7 +2,7 @@ print("")
 find([1,2,3],1)
 
 // RUN: %sourcekitd-test -req=cursor -pos=1:1 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=cursor -pos=2:1 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: not %sourcekitd-test -req=cursor -pos=2:1 %s -- %s 2>&1 | %FileCheck -check-prefix=CHECK2 %s
 
 // CHECK1: source.lang.swift.ref.function.free
-// CHECK2-NOT: source.lang.swift.ref.function.free
+// CHECK2: (Request Failed): Resolved to incomplete expression or statement

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -28,11 +28,11 @@ func foo(x: FooStruct1) -> S1 {}
 // RUN: %sourcekitd-test -req=cursor -usr "s:blahblahblah" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=RESOLVE
 // Missing s: prefix.
 // RUN: %sourcekitd-test -req=cursor -usr "10cursor_usr6globalSivp" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=RESOLVE
-// RESOLVE: <diagnostic "Unable to resolve type from USR.">
+// RESOLVE: <empty cursor info; internal diagnostic: "Unable to resolve type from USR.">
 
 // FIXME: no support for clang USRs.
 // RUN: %sourcekitd-test -req=cursor -usr "c:@S@FooStruct1" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=CSUPPORT
-// CSUPPORT: <diagnostic "Lookup for C/C++/ObjC USRs not implemented.">
+// CSUPPORT: <empty cursor info; internal diagnostic: "Lookup for C/C++/ObjC USRs not implemented.">
 
 // RUN: %sourcekitd-test -req=cursor -usr "s:10cursor_usr2S1V" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: source.lang.swift.decl.struct (5:8-5:10)

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -25,12 +25,15 @@ func foo(x: FooStruct1) -> S1 {}
 // CHECK_SANITY1-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>
 
 // Bogus USR.
-// RUN: %sourcekitd-test -req=cursor -usr "s:blahblahblah" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=EMPTY
+// RUN: not %sourcekitd-test -req=cursor -usr "s:blahblahblah" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=RESOLVE
 // Missing s: prefix.
-// RUN: %sourcekitd-test -req=cursor -usr "10cursor_usr6globalSivp" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=EMPTY
+// RUN: not %sourcekitd-test -req=cursor -usr "10cursor_usr6globalSivp" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=RESOLVE
+// RESOLVE: (Request Failed): Unable to resolve type from USR.
+
 // FIXME: no support for clang USRs.
-// RUN: %sourcekitd-test -req=cursor -usr "c:@S@FooStruct1" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=EMPTY
-// EMPTY: <empty cursor info>
+// RUN: not %sourcekitd-test -req=cursor -usr "c:@S@FooStruct1" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=CSUPPORT
+// CSUPPORT: (Request Failed): Lookup for C/C++/ObjC USRs not implemented.
+
 // RUN: %sourcekitd-test -req=cursor -usr "s:10cursor_usr2S1V" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: source.lang.swift.decl.struct (5:8-5:10)
 // CHECK1: s1

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -25,14 +25,14 @@ func foo(x: FooStruct1) -> S1 {}
 // CHECK_SANITY1-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>
 
 // Bogus USR.
-// RUN: not %sourcekitd-test -req=cursor -usr "s:blahblahblah" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=RESOLVE
+// RUN: %sourcekitd-test -req=cursor -usr "s:blahblahblah" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=RESOLVE
 // Missing s: prefix.
-// RUN: not %sourcekitd-test -req=cursor -usr "10cursor_usr6globalSivp" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=RESOLVE
-// RESOLVE: (Request Failed): Unable to resolve type from USR.
+// RUN: %sourcekitd-test -req=cursor -usr "10cursor_usr6globalSivp" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=RESOLVE
+// RESOLVE: <diagnostic "Unable to resolve type from USR.">
 
 // FIXME: no support for clang USRs.
-// RUN: not %sourcekitd-test -req=cursor -usr "c:@S@FooStruct1" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s 2>&1 | %FileCheck %s -check-prefix=CSUPPORT
-// CSUPPORT: (Request Failed): Lookup for C/C++/ObjC USRs not implemented.
+// RUN: %sourcekitd-test -req=cursor -usr "c:@S@FooStruct1" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=CSUPPORT
+// CSUPPORT: <diagnostic "Lookup for C/C++/ObjC USRs not implemented.">
 
 // RUN: %sourcekitd-test -req=cursor -usr "s:10cursor_usr2S1V" %s -- -I %t -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %s | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: source.lang.swift.decl.struct (5:8-5:10)

--- a/test/SourceKit/CursorInfo/ignore-llvm-args.swift
+++ b/test/SourceKit/CursorInfo/ignore-llvm-args.swift
@@ -3,4 +3,4 @@ _ = ""
 // rdar://problem/38314383
 // RUN: %sourcekitd-test -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
 
-// CHECK: <diagnostic "Resolved to incomplete expression or statement.">
+// CHECK: <empty cursor info; internal diagnostic: "Resolved to incomplete expression or statement.">

--- a/test/SourceKit/CursorInfo/ignore-llvm-args.swift
+++ b/test/SourceKit/CursorInfo/ignore-llvm-args.swift
@@ -1,6 +1,6 @@
 _ = ""
 
 // rdar://problem/38314383
-// RUN: not %sourcekitd-test 2>&1 -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
 
-// CHECK: (Request Failed): Resolved to incomplete expression or statement.
+// CHECK: <diagnostic "Resolved to incomplete expression or statement.">

--- a/test/SourceKit/CursorInfo/ignore-llvm-args.swift
+++ b/test/SourceKit/CursorInfo/ignore-llvm-args.swift
@@ -1,6 +1,6 @@
 _ = ""
 
 // rdar://problem/38314383
-// RUN: %sourcekitd-test -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
+// RUN: not %sourcekitd-test 2>&1 -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
 
-// CHECK: <empty cursor info>
+// CHECK: (Request Failed): Resolved to incomplete expression or statement.

--- a/test/SourceKit/CursorInfo/invalid_offset.swift
+++ b/test/SourceKit/CursorInfo/invalid_offset.swift
@@ -3,7 +3,7 @@ let a = 12
 // rdar://problem/30346106
 // Invalid offset should trigger a crash.
 
-// RUN: %sourcekitd-test \
+// RUN: not %sourcekitd-test 2>&1 \
 // RUN:   -req=open %s -- %s == \
 // RUN:   -req=edit -async -offset=0 -length=200 -replace='' %s -- %s == \
 // RUN:   -req=cursor -offset=250 %s -- %s \
@@ -12,4 +12,4 @@ let a = 12
 // rdar://problem/38162017
 // REQUIRES: OS=macosx
 
-// CHECK: <empty cursor info>
+// CHECK: (Request Failed): Unable to resolve the start of the token

--- a/test/SourceKit/CursorInfo/rdar_18677108-1.swift
+++ b/test/SourceKit/CursorInfo/rdar_18677108-1.swift
@@ -1,6 +1,6 @@
 // Checks that we don't crash.
-// RUN: not %sourcekitd-test -req=cursor -pos=7:5 %s -- %s 2>&1 | %FileCheck %s
-// CHECK: (Request Failed): Unable to resolve cursor info
+// RUN: %sourcekitd-test -req=cursor -pos=7:5 %s -- %s | %FileCheck %s
+// CHECK: <diagnostic "Unable to resolve cursor info.">
 
 class CameraViewController
 {

--- a/test/SourceKit/CursorInfo/rdar_18677108-1.swift
+++ b/test/SourceKit/CursorInfo/rdar_18677108-1.swift
@@ -1,6 +1,6 @@
 // Checks that we don't crash.
 // RUN: %sourcekitd-test -req=cursor -pos=7:5 %s -- %s | %FileCheck %s
-// CHECK: <diagnostic "Unable to resolve cursor info.">
+// CHECK: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 
 class CameraViewController
 {

--- a/test/SourceKit/CursorInfo/rdar_18677108-1.swift
+++ b/test/SourceKit/CursorInfo/rdar_18677108-1.swift
@@ -1,6 +1,6 @@
 // Checks that we don't crash.
-// RUN: %sourcekitd-test -req=cursor -pos=7:5 %s -- %s | %FileCheck %s
-// CHECK: <empty cursor info>
+// RUN: not %sourcekitd-test -req=cursor -pos=7:5 %s -- %s 2>&1 | %FileCheck %s
+// CHECK: (Request Failed): Unable to resolve cursor info
 
 class CameraViewController
 {

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -31,7 +31,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1: -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 
 // RUN: %sourcekitd-test -req=translate -objc-selector fooBaseInstanceFuncOverridden1 -pos=12:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK4 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=13:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
@@ -39,7 +39,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc2:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty11 -pos=16:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB:withC: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB:withC: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKFEWER1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector :withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING2 %s
@@ -47,7 +47,7 @@ class MyDerived: FooClassDerived {
 
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK12 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 // RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector iit: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector NAME -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
@@ -56,7 +56,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=23:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
 
 // CHECK1: FooClassDerived2
-// CHECK-NONE: <empty name translation info>
+// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
 // CHECK2: fooProperty2
 // CHECK3: fooInstanceFunc1
 // CHECK4: fooBaseInstanceFuncOverridden1

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -56,7 +56,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=23:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
 
 // CHECK1: FooClassDerived2
-// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
+// CHECK-DIAG: <empty name translation info; internal diagnostic: "Unable to resolve ObjC declaration name.">
 // CHECK2: fooProperty2
 // CHECK3: fooInstanceFunc1
 // CHECK4: fooBaseInstanceFuncOverridden1

--- a/test/SourceKit/NameTranslation/basic.swift
+++ b/test/SourceKit/NameTranslation/basic.swift
@@ -31,7 +31,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty2 -pos=6:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1 -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc1: -pos=7:16 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
-// RUN: not %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooFunc3:d:d:d: -pos=8:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 
 // RUN: %sourcekitd-test -req=translate -objc-selector fooBaseInstanceFuncOverridden1 -pos=12:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK4 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=13:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
@@ -39,7 +39,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc2:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
 // RUN: %sourcekitd-test -req=translate -objc-name fooProperty11 -pos=16:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
-// RUN: not %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB:withC: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:withBB:withC: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKFEWER1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21:: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector :withBB: -pos=15:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECKMISSING2 %s
@@ -47,7 +47,7 @@ class MyDerived: FooClassDerived {
 
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc21: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK12 %s
-// RUN: not %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithfloat2:D: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -objc-selector init: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector iit: -pos=17:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK13 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector NAME -pos=18:13 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK14 %s
@@ -56,7 +56,7 @@ class MyDerived: FooClassDerived {
 // RUN: %sourcekitd-test -req=translate -objc-selector fooInstanceFunc01 -pos=23:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK5 %s
 
 // CHECK1: FooClassDerived2
-// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
+// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
 // CHECK2: fooProperty2
 // CHECK3: fooInstanceFunc1
 // CHECK4: fooBaseInstanceFuncOverridden1

--- a/test/SourceKit/NameTranslation/enum.swift
+++ b/test/SourceKit/NameTranslation/enum.swift
@@ -17,6 +17,6 @@ func foo1() {
 // RUN: %sourcekitd-test -req=translate -objc-name FooRinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 
 // CHECK1: orderedSome
-// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
+// CHECK-DIAG: <empty name translation info; internal diagnostic: "Unable to resolve ObjC declaration name.">
 // CHECK2: enableThird
 // CHECK3: inEnableThird

--- a/test/SourceKit/NameTranslation/enum.swift
+++ b/test/SourceKit/NameTranslation/enum.swift
@@ -10,13 +10,13 @@ func foo1() {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-name orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: not %sourcekitd-test -req=translate -objc-selector orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -objc-selector orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -objc-name enableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRuncingEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRuncinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 
 // CHECK1: orderedSome
-// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
+// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
 // CHECK2: enableThird
 // CHECK3: inEnableThird

--- a/test/SourceKit/NameTranslation/enum.swift
+++ b/test/SourceKit/NameTranslation/enum.swift
@@ -10,13 +10,13 @@ func foo1() {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=translate -objc-name orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -objc-selector orderedSome -pos=4:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 // RUN: %sourcekitd-test -req=translate -objc-name enableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRuncingEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRuncinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=translate -objc-name FooRinEnableThird -pos=7:30 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK3 %s
 
 // CHECK1: orderedSome
-// CHECK-NONE: <empty name translation info>
+// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
 // CHECK2: enableThird
 // CHECK3: inEnableThird

--- a/test/SourceKit/NameTranslation/init.swift
+++ b/test/SourceKit/NameTranslation/init.swift
@@ -12,6 +12,6 @@ func foo2 () {
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 
-// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
+// CHECK-DIAG: <empty name translation info; internal diagnostic: "Unable to resolve ObjC declaration name.">
 // CHECK1: init(float2:)
 // CHECK2: init(float2:second2:)

--- a/test/SourceKit/NameTranslation/init.swift
+++ b/test/SourceKit/NameTranslation/init.swift
@@ -9,9 +9,9 @@ func foo2 () {
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2: -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2 -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
-// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 
-// CHECK-NONE: <empty name translation info>
+// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
 // CHECK1: init(float2:)
 // CHECK2: init(float2:second2:)

--- a/test/SourceKit/NameTranslation/init.swift
+++ b/test/SourceKit/NameTranslation/init.swift
@@ -9,9 +9,9 @@ func foo2 () {
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2: -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2 -pos=4:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
-// RUN: not %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -objc-selector initWithFloat2:second2:third: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -objc-selector initFloat2:second2: -pos=5:15 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK2 %s
 
-// CHECK-FAIL: (Request Failed): Unable to resolve ObjC declaration name
+// CHECK-DIAG: <diagnostic "Unable to resolve ObjC declaration name.">
 // CHECK1: init(float2:)
 // CHECK2: init(float2:second2:)

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -69,7 +69,7 @@ class C3: NSObject {
 // RUN: %sourcekitd-test -req=translate -swift-name "foo2(_:_:_:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW8 %s
-// RUN: not %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-DIAG %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=1:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
 
 // RUN: %sourcekitd-test -req=translate -swift-name "init(a1:b2:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
@@ -86,7 +86,7 @@ class C3: NSObject {
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK17 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW17 %s
 
-// CHECK-FAIL: (Request Failed): Unable to resolve Swift declaration name
+// CHECK-DIAG: <diagnostic "Unable to resolve Swift declaration name.">
 // CHECK1: fooWithA:b:c:
 // CHECK2: fooWithA1:b1:c1:
 // CHECK3: foo:b1:c1:

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -86,7 +86,7 @@ class C3: NSObject {
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK17 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW17 %s
 
-// CHECK-DIAG: <diagnostic "Unable to resolve Swift declaration name.">
+// CHECK-DIAG: <empty name translation info; internal diagnostic: "Unable to resolve Swift declaration name.">
 // CHECK1: fooWithA:b:c:
 // CHECK2: fooWithA1:b1:c1:
 // CHECK3: foo:b1:c1:

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -69,7 +69,7 @@ class C3: NSObject {
 // RUN: %sourcekitd-test -req=translate -swift-name "foo2(_:_:_:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK7 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK8 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW8 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK-NONE %s
+// RUN: not %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s 2>&1 | %FileCheck -check-prefix=CHECK-FAIL %s
 // RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=1:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK9 %s
 
 // RUN: %sourcekitd-test -req=translate -swift-name "init(a1:b2:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK10 %s
@@ -86,7 +86,7 @@ class C3: NSObject {
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK17 %s
 // RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK_RAW17 %s
 
-// CHECK-NONE: <empty name translation info>
+// CHECK-FAIL: (Request Failed): Unable to resolve Swift declaration name
 // CHECK1: fooWithA:b:c:
 // CHECK2: fooWithA1:b1:c1:
 // CHECK3: foo:b1:c1:

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -310,6 +310,11 @@ struct RefactoringInfo {
 
 struct CursorInfoData {
   bool IsCancelled = false;
+  // If nonempty, a proper Info could not be resolved (and the rest of the Info
+  // will be empty). Clients can potentially use this to show a diagnostic
+  // message to the user in lieu of using the empty response.
+  StringRef InternalDiagnostic;
+
   UIdent Kind;
   StringRef Name;
   StringRef USR;
@@ -358,6 +363,11 @@ struct RangeInfo {
 
 struct NameTranslatingInfo {
   bool IsCancelled = false;
+  // If nonempty, a proper Info could not be resolved (and the rest of the Info
+  // will be empty). Clients can potentially use this to show a diagnostic
+  // message to the user in lieu of using the empty response.
+  StringRef InternalDiagnostic;
+
   UIdent NameKind;
   StringRef BaseName;
   std::vector<StringRef> ArgNames;

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -302,13 +302,17 @@ public:
 struct Statistic;
 typedef std::function<void(ArrayRef<Statistic *> stats)> StatisticsReceiver;
 
-// Used to wrap the result of a request. There are three possibilities:
-// - The request succeeded (`value` is valid)
-// - The request was cancelled
-// - The request failed (with an `error`)
+/// Used to wrap the result of a request. There are three possibilities:
+/// - The request succeeded (`value` is valid)
+/// - The request was cancelled
+/// - The request failed (with an `error`)
+///
+/// NOTE: This type does not own its `value` or `error`. Therefore, it's not
+/// safe to store this type, nor is it safe to store its `value` or `error`.
+/// Instead, any needed information should be fetched and stored (e.g. reading
+/// properties from `value` or getting a `std::string` from `error`).
 template <typename T>
 class RequestResult {
-private:
   enum Type {
     Value,
     Error,

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -386,8 +386,6 @@ struct RelatedIdentsInfo {
 
 /// Filled out by LangSupport::findInterfaceDocument().
 struct InterfaceDocInfo {
-  /// Non-empty if an error occurred.
-  StringRef Error;
   /// Non-empty if a generated interface editor document has previously been
   /// opened for the requested module name.
   StringRef ModuleInterfaceName;
@@ -666,37 +664,43 @@ public:
                              unsigned Length, bool Actionables,
                              bool CancelOnSubsequentRequest,
                              ArrayRef<const char *> Args,
-                      std::function<void(const CursorInfoData &)> Receiver) = 0;
+                      std::function<void(const CursorInfoData &,
+                                         StringRef Error)> Receiver) = 0;
 
 
   virtual void getNameInfo(StringRef Filename, unsigned Offset,
                            NameTranslatingInfo &Input,
                            ArrayRef<const char *> Args,
-                std::function<void(const NameTranslatingInfo &)> Receiver) = 0;
+                std::function<void(const NameTranslatingInfo &,
+                                   StringRef Error)> Receiver) = 0;
 
   virtual void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
                             bool CancelOnSubsequentRequest,
                             ArrayRef<const char *> Args,
-                            std::function<void(const RangeInfo&)> Receiver) = 0;
+                            std::function<void(const RangeInfo&,
+                                               StringRef Error)> Receiver) = 0;
 
   virtual void
   getCursorInfoFromUSR(StringRef Filename, StringRef USR,
                        bool CancelOnSubsequentRequest,
                        ArrayRef<const char *> Args,
-                     std::function<void(const CursorInfoData &)> Receiver) = 0;
+                     std::function<void(const CursorInfoData &,
+                                        StringRef Error)> Receiver) = 0;
 
   virtual void findRelatedIdentifiersInFile(StringRef Filename,
                                             unsigned Offset,
                                             bool CancelOnSubsequentRequest,
                                             ArrayRef<const char *> Args,
-                   std::function<void(const RelatedIdentsInfo &)> Receiver) = 0;
+                   std::function<void(const RelatedIdentsInfo &,
+                                      StringRef Error)> Receiver) = 0;
 
   virtual llvm::Optional<std::pair<unsigned, unsigned>>
       findUSRRange(StringRef DocumentName, StringRef USR) = 0;
 
   virtual void findInterfaceDocument(StringRef ModuleName,
                                      ArrayRef<const char *> Args,
-                    std::function<void(const InterfaceDocInfo &)> Receiver) = 0;
+                    std::function<void(const InterfaceDocInfo &,
+                                       StringRef Error)> Receiver) = 0;
 
   virtual void findModuleGroups(StringRef ModuleName,
                                 ArrayRef<const char *> Args,
@@ -724,7 +728,8 @@ public:
   virtual void collectExpressionTypes(StringRef FileName,
                                       ArrayRef<const char *> Args,
                                       ArrayRef<const char *> ExpectedProtocols,
-                                      std::function<void(const ExpressionTypesInFile&)> Receiver) = 0;
+                                      std::function<void(const ExpressionTypesInFile&,
+                                                         StringRef Error)> Receiver) = 0;
 
   virtual void getDocInfo(llvm::MemoryBuffer *InputBuf,
                           StringRef ModuleName,

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1127,7 +1127,7 @@ public:
     Receiver(std::move(Receiver)), OS(ErrBuffer), DiagConsumer(OS) {}
   ~Implementation() {
     if (DiagConsumer.didErrorOccur()) {
-      Receiver({}, OS.str());
+      Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromError(OS.str()));
       return;
     }
     assert(UIds.size() == StartEnds.size());
@@ -1138,7 +1138,7 @@ public:
                          llvm::makeArrayRef(AllEdits.data() + Pair.first,
                                              Pair.second - Pair.first)});
     }
-    Receiver(Results, "");
+    Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromResult(Results));
   }
   void accept(SourceManager &SM, RegionType RegionType,
               ArrayRef<Replacement> Replacements) {
@@ -1205,10 +1205,10 @@ public:
 
   ~Implementation() {
     if (DiagConsumer.didErrorOccur()) {
-      Receiver({}, OS.str());
+      Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::fromError(OS.str()));
       return;
     }
-    Receiver(CategorizedRanges, "");
+    Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::fromResult(CategorizedRanges));
   }
 
   void accept(SourceManager &SM, RegionType RegionType,
@@ -1277,7 +1277,7 @@ syntacticRename(llvm::MemoryBuffer *InputBuf,
   ParseCI.addDiagnosticConsumer(&PrintDiags);
   SourceFile *SF = getSyntacticSourceFile(InputBuf, Args, ParseCI, Error);
   if (!SF) {
-    Receiver({}, Error);
+    Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromError(Error));
     return;
   }
 
@@ -1295,7 +1295,7 @@ void SwiftLangSupport::findRenameRanges(
   ParseCI.addDiagnosticConsumer(&PrintDiags);
   SourceFile *SF = getSyntacticSourceFile(InputBuf, Args, ParseCI, Error);
   if (!SF) {
-    Receiver({}, Error);
+    Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::fromError(Error));
     return;
   }
 
@@ -1310,9 +1310,8 @@ void SwiftLangSupport::findLocalRenameRanges(
   std::string Error;
   SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, Filename, Error);
   if (!Invok) {
-    // FIXME: Report it as failed request.
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
-    Receiver({}, Error);
+    Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::fromError(Error));
     return;
   }
 
@@ -1332,9 +1331,13 @@ void SwiftLangSupport::findLocalRenameRanges(
       swift::ide::findLocalRenameRanges(&SF, Range, Consumer, Consumer);
     }
 
-    void cancelled() override { Receiver({}, "The refactoring is canceled."); }
+    void cancelled() override {
+      Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::cancelled());
+    }
 
-    void failed(StringRef Error) override { Receiver({}, Error); }
+    void failed(StringRef Error) override {
+      Receiver(RequestResult<ArrayRef<CategorizedRenameRanges>>::fromError(Error));
+    }
   };
 
   auto ASTConsumer = std::make_shared<LocalRenameRangeASTConsumer>(
@@ -1429,8 +1432,7 @@ void SwiftLangSupport::getDocInfo(llvm::MemoryBuffer *InputBuf,
 
 void SwiftLangSupport::
 findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
-                 std::function<void(ArrayRef<StringRef>,
-                                    StringRef Error)> Receiver) {
+                 std::function<void(const RequestResult<ArrayRef<StringRef>> &)> Receiver) {
   CompilerInvocation Invocation;
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
@@ -1443,12 +1445,12 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   std::string Error;
   if (getASTManager()->initCompilerInvocationNoInputs(Invocation, Args,
                                                      CI.getDiags(), Error)) {
-    Receiver(Groups, Error);
+    Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
   if (CI.setup(Invocation)) {
     Error = "Compiler invocation set up fails.";
-    Receiver(Groups, Error);
+    Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
 
@@ -1460,15 +1462,16 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   auto *Stdlib = getModuleByFullName(Ctx, Ctx.StdlibModuleName);
   if (!Stdlib) {
     Error = "Cannot load stdlib.";
-    Receiver(Groups, Error);
+    Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
   auto *M = getModuleByFullName(Ctx, ModuleName);
   if (!M) {
     Error = "Cannot find the module.";
-    Receiver(Groups, Error);
+    Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
   std::vector<StringRef> Scratch;
-  Receiver(collectModuleGroups(M, Scratch), Error);
+  Receiver(RequestResult<ArrayRef<StringRef>>::fromResult(
+      collectModuleGroups(M, Scratch)));
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -834,8 +834,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
 
 void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
                                              ArrayRef<const char *> Args,
-                       std::function<void(const InterfaceDocInfo &,
-                                          StringRef Error)> Receiver) {
+                       std::function<void(const RequestResult<InterfaceDocInfo> &)> Receiver) {
   InterfaceDocInfo Info;
 
   CompilerInstance CI;
@@ -847,7 +846,7 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   std::string Error;
   if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
                                              StringRef(), Error)) {
-    return Receiver({}, Error);
+    return Receiver(RequestResult<InterfaceDocInfo>::fromError(Error));
   }
 
   if (auto IFaceGenRef = IFaceGenContexts.find(ModuleName, Invocation))
@@ -905,5 +904,5 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   }
   Info.CompilerArgs = NewArgs;
 
-  return Receiver(Info, "");
+  return Receiver(RequestResult<InterfaceDocInfo>::fromResult(Info));
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -834,7 +834,8 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
 
 void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
                                              ArrayRef<const char *> Args,
-                       std::function<void(const InterfaceDocInfo &)> Receiver) {
+                       std::function<void(const InterfaceDocInfo &,
+                                          StringRef Error)> Receiver) {
   InterfaceDocInfo Info;
 
   CompilerInstance CI;
@@ -846,8 +847,7 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   std::string Error;
   if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
                                              StringRef(), Error)) {
-    Info.Error = Error;
-    return Receiver(Info);
+    return Receiver({}, Error);
   }
 
   if (auto IFaceGenRef = IFaceGenContexts.find(ModuleName, Invocation))
@@ -905,5 +905,5 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   }
   Info.CompilerArgs = NewArgs;
 
-  return Receiver(Info);
+  return Receiver(Info, "");
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -490,31 +490,26 @@ public:
                      unsigned Length, bool Actionables,
                      bool CancelOnSubsequentRequest,
                      ArrayRef<const char *> Args,
-                 std::function<void(const CursorInfoData &,
-                                    StringRef Error)> Receiver) override;
+                 std::function<void(const RequestResult<CursorInfoData> &)> Receiver) override;
 
   void getNameInfo(StringRef Filename, unsigned Offset,
                    NameTranslatingInfo &Input,
                    ArrayRef<const char *> Args,
-                   std::function<void(const NameTranslatingInfo &,
-                                      StringRef Error)> Receiver) override;
+                   std::function<void(const RequestResult<NameTranslatingInfo> &)> Receiver) override;
 
   void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
                     bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
-                    std::function<void(const RangeInfo&,
-                                       StringRef Error)> Receiver) override;
+                    std::function<void(const RequestResult<RangeInfo> &)> Receiver) override;
 
   void getCursorInfoFromUSR(
       StringRef Filename, StringRef USR, bool CancelOnSubsequentRequest,
       ArrayRef<const char *> Args,
-      std::function<void(const CursorInfoData &,
-                         StringRef Errro)> Receiver) override;
+      std::function<void(const RequestResult<CursorInfoData> &)> Receiver) override;
 
   void findRelatedIdentifiersInFile(StringRef Filename, unsigned Offset,
                                     bool CancelOnSubsequentRequest,
                                     ArrayRef<const char *> Args,
-              std::function<void(const RelatedIdentsInfo &,
-                                 StringRef Errror)> Receiver) override;
+              std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver) override;
 
   void syntacticRename(llvm::MemoryBuffer *InputBuf,
                        ArrayRef<RenameLocations> RenameLocations,
@@ -532,8 +527,7 @@ public:
 
   void collectExpressionTypes(StringRef FileName, ArrayRef<const char *> Args,
                               ArrayRef<const char *> ExpectedProtocols,
-                              std::function<void(const ExpressionTypesInFile&,
-                                                 StringRef Errror)> Receiver) override;
+                              std::function<void(const RequestResult<ExpressionTypesInFile> &)> Receiver) override;
 
   void semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,
                            ArrayRef<const char*> Args,
@@ -548,12 +542,10 @@ public:
       findUSRRange(StringRef DocumentName, StringRef USR) override;
 
   void findInterfaceDocument(StringRef ModuleName, ArrayRef<const char *> Args,
-               std::function<void(const InterfaceDocInfo &,
-                                  StringRef Error)> Receiver) override;
+               std::function<void(const RequestResult<InterfaceDocInfo> &)> Receiver) override;
 
   void findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
-               std::function<void(ArrayRef<StringRef>,
-                                  StringRef Error)> Receiver) override;
+               std::function<void(const RequestResult<ArrayRef<StringRef>> &)> Receiver) override;
 
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                 ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -490,26 +490,31 @@ public:
                      unsigned Length, bool Actionables,
                      bool CancelOnSubsequentRequest,
                      ArrayRef<const char *> Args,
-                 std::function<void(const CursorInfoData &)> Receiver) override;
+                 std::function<void(const CursorInfoData &,
+                                    StringRef Error)> Receiver) override;
 
   void getNameInfo(StringRef Filename, unsigned Offset,
                    NameTranslatingInfo &Input,
                    ArrayRef<const char *> Args,
-                   std::function<void(const NameTranslatingInfo &)> Receiver) override;
+                   std::function<void(const NameTranslatingInfo &,
+                                      StringRef Error)> Receiver) override;
 
   void getRangeInfo(StringRef Filename, unsigned Offset, unsigned Length,
                     bool CancelOnSubsequentRequest, ArrayRef<const char *> Args,
-                    std::function<void(const RangeInfo&)> Receiver) override;
+                    std::function<void(const RangeInfo&,
+                                       StringRef Error)> Receiver) override;
 
   void getCursorInfoFromUSR(
       StringRef Filename, StringRef USR, bool CancelOnSubsequentRequest,
       ArrayRef<const char *> Args,
-      std::function<void(const CursorInfoData &)> Receiver) override;
+      std::function<void(const CursorInfoData &,
+                         StringRef Errro)> Receiver) override;
 
   void findRelatedIdentifiersInFile(StringRef Filename, unsigned Offset,
                                     bool CancelOnSubsequentRequest,
                                     ArrayRef<const char *> Args,
-              std::function<void(const RelatedIdentsInfo &)> Receiver) override;
+              std::function<void(const RelatedIdentsInfo &,
+                                 StringRef Errror)> Receiver) override;
 
   void syntacticRename(llvm::MemoryBuffer *InputBuf,
                        ArrayRef<RenameLocations> RenameLocations,
@@ -527,7 +532,8 @@ public:
 
   void collectExpressionTypes(StringRef FileName, ArrayRef<const char *> Args,
                               ArrayRef<const char *> ExpectedProtocols,
-                              std::function<void(const ExpressionTypesInFile&)> Receiver) override;
+                              std::function<void(const ExpressionTypesInFile&,
+                                                 StringRef Errror)> Receiver) override;
 
   void semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,
                            ArrayRef<const char*> Args,
@@ -542,10 +548,12 @@ public:
       findUSRRange(StringRef DocumentName, StringRef USR) override;
 
   void findInterfaceDocument(StringRef ModuleName, ArrayRef<const char *> Args,
-               std::function<void(const InterfaceDocInfo &)> Receiver) override;
+               std::function<void(const InterfaceDocInfo &,
+                                  StringRef Error)> Receiver) override;
 
   void findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
-               std::function<void(ArrayRef<StringRef>, StringRef Error)> Receiver) override;
+               std::function<void(ArrayRef<StringRef>,
+                                  StringRef Error)> Receiver) override;
 
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                 ArrayRef<const char *> Args,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1306,7 +1306,8 @@ static void printNameTranslationInfo(sourcekitd_variant_t Info,
   const char *InternalDiagnostic =
       sourcekitd_variant_dictionary_get_string(Info, KeyInternalDiagnostic);
   if (InternalDiagnostic) {
-    OS << "<diagnostic \"" << InternalDiagnostic << "\">\n";
+    OS << "<empty name translation info; internal diagnostic: \""
+       << InternalDiagnostic << "\">\n";
     return;
   }
   sourcekitd_uid_t KindUID = sourcekitd_variant_dictionary_get_uid(Info,
@@ -1371,7 +1372,8 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
   const char *InternalDiagnostic =
       sourcekitd_variant_dictionary_get_string(Info, KeyInternalDiagnostic);
   if (InternalDiagnostic) {
-    OS << "<diagnostic \"" << InternalDiagnostic << "\">\n";
+    OS << "<empty cursor info; internal diagnostic: \""
+       << InternalDiagnostic << "\">\n";
     return;
   }
   sourcekitd_uid_t KindUID = sourcekitd_variant_dictionary_get_uid(Info,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1303,6 +1303,12 @@ static void notification_receiver(sourcekitd_response_t resp) {
 
 static void printNameTranslationInfo(sourcekitd_variant_t Info,
                                      llvm::raw_ostream &OS) {
+  const char *InternalDiagnostic =
+      sourcekitd_variant_dictionary_get_string(Info, KeyInternalDiagnostic);
+  if (InternalDiagnostic) {
+    OS << "<diagnostic \"" << InternalDiagnostic << "\">\n";
+    return;
+  }
   sourcekitd_uid_t KindUID = sourcekitd_variant_dictionary_get_uid(Info,
                                                                    KeyNameKind);
   if (KindUID == nullptr) {
@@ -1362,6 +1368,12 @@ static void printNameTranslationInfo(sourcekitd_variant_t Info,
 
 static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                             llvm::raw_ostream &OS) {
+  const char *InternalDiagnostic =
+      sourcekitd_variant_dictionary_get_string(Info, KeyInternalDiagnostic);
+  if (InternalDiagnostic) {
+    OS << "<diagnostic \"" << InternalDiagnostic << "\">\n";
+    return;
+  }
   sourcekitd_uid_t KindUID = sourcekitd_variant_dictionary_get_uid(Info,
                                       sourcekitd_uid_get_from_cstr("key.kind"));
   if (KindUID == nullptr) {

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -160,9 +160,9 @@ void handleRequest(sourcekitd_object_t Request, ResponseReceiver Receiver);
 void printRequestObject(sourcekitd_object_t Obj, llvm::raw_ostream &OS);
 void printResponse(sourcekitd_response_t Resp, llvm::raw_ostream &OS);
 
-sourcekitd_response_t createErrorRequestInvalid(const char *Description);
+sourcekitd_response_t createErrorRequestInvalid(llvm::StringRef Description);
 sourcekitd_response_t createErrorRequestFailed(llvm::StringRef Description);
-sourcekitd_response_t createErrorRequestInterrupted(const char *Description);
+sourcekitd_response_t createErrorRequestInterrupted(llvm::StringRef Descr);
 sourcekitd_response_t createErrorRequestCancelled();
 
 /// Send notification object.

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -161,7 +161,7 @@ void printRequestObject(sourcekitd_object_t Obj, llvm::raw_ostream &OS);
 void printResponse(sourcekitd_response_t Resp, llvm::raw_ostream &OS);
 
 sourcekitd_response_t createErrorRequestInvalid(const char *Description);
-sourcekitd_response_t createErrorRequestFailed(const char *Description);
+sourcekitd_response_t createErrorRequestFailed(llvm::StringRef Description);
 sourcekitd_response_t createErrorRequestInterrupted(const char *Description);
 sourcekitd_response_t createErrorRequestCancelled();
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1625,6 +1625,11 @@ static void reportCursorInfo(const CursorInfoData &Info, ResponseReceiver Rec,
     return Rec(createErrorRequestFailed(Error.str().c_str()));
 
   ResponseBuilder RespBuilder;
+  if (!Info.InternalDiagnostic.empty()) {
+    auto Elem = RespBuilder.getDictionary();
+    Elem.set(KeyInternalDiagnostic, Info.InternalDiagnostic);
+    return Rec(RespBuilder.createResponse());
+  }
   if (Info.Kind.isInvalid())
     return Rec(RespBuilder.createResponse());
 
@@ -1732,6 +1737,11 @@ static void reportNameInfo(const NameTranslatingInfo &Info,
     return Rec(createErrorRequestFailed(Error.str().c_str()));
 
   ResponseBuilder RespBuilder;
+  if (!Info.InternalDiagnostic.empty()) {
+    auto Elem = RespBuilder.getDictionary();
+    Elem.set(KeyInternalDiagnostic, Info.InternalDiagnostic);
+    return Rec(RespBuilder.createResponse());
+  }
   if (Info.NameKind.isInvalid())
     return Rec(RespBuilder.createResponse());
   if (Info.BaseName.empty() && Info.ArgNames.empty())

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -798,9 +798,9 @@ sourcekitd::createErrorRequestInvalid(const char *Description) {
 }
 
 sourcekitd_response_t
-sourcekitd::createErrorRequestFailed(const char *Description) {
+sourcekitd::createErrorRequestFailed(StringRef Description) {
   return retained(new SKDError(SOURCEKITD_ERROR_REQUEST_FAILED, 
-                      StringRef(Description)));
+                      Description));
 }
 
 sourcekitd_response_t

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -792,15 +792,15 @@ Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) {
 }
 
 sourcekitd_response_t
-sourcekitd::createErrorRequestInvalid(const char *Description) {
+sourcekitd::createErrorRequestInvalid(StringRef Description) {
   return retained(new SKDError(SOURCEKITD_ERROR_REQUEST_INVALID, 
-                               StringRef(Description)));
+                               Description));
 }
 
 sourcekitd_response_t
 sourcekitd::createErrorRequestFailed(StringRef Description) {
   return retained(new SKDError(SOURCEKITD_ERROR_REQUEST_FAILED, 
-                      Description));
+                               Description));
 }
 
 sourcekitd_response_t

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -380,8 +380,8 @@ sourcekitd::createErrorRequestInvalid(const char *Description) {
 }
 sourcekitd_response_t
 sourcekitd::createErrorRequestFailed(StringRef DescRef) {
-  const char *Description = DescRef.str().c_str();
-  return CustomXPCData::createErrorRequestFailed(Description).getXObj();
+  std::string Desc = DescRef.str();
+  return CustomXPCData::createErrorRequestFailed(Desc.c_str()).getXObj();
 }
 sourcekitd_response_t
 sourcekitd::createErrorRequestInterrupted(const char *Description) {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -379,7 +379,8 @@ sourcekitd::createErrorRequestInvalid(const char *Description) {
   return CustomXPCData::createErrorRequestInvalid(Description).getXObj();
 }
 sourcekitd_response_t
-sourcekitd::createErrorRequestFailed(const char *Description) {
+sourcekitd::createErrorRequestFailed(StringRef DescRef) {
+  const char *Description = DescRef.str().c_str();
   return CustomXPCData::createErrorRequestFailed(Description).getXObj();
 }
 sourcekitd_response_t

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -69,24 +69,25 @@ public:
     return getPtr()+1;
   }
 
-  static CustomXPCData createErrorRequestInvalid(const char *Description) {
+  static CustomXPCData createErrorRequestInvalid(StringRef Description) {
     return createKindAndString(Kind::ErrorRequestInvalid, Description);
   }
-  static CustomXPCData createErrorRequestFailed(const char *Description) {
+  static CustomXPCData createErrorRequestFailed(StringRef Description) {
     return createKindAndString(Kind::ErrorRequestFailed, Description);
   }
-  static CustomXPCData createErrorRequestInterrupted(const char *Description) {
+  static CustomXPCData createErrorRequestInterrupted(StringRef Description) {
     return createKindAndString(Kind::ErrorRequestInterrupted, Description);
   }
-  static CustomXPCData createErrorRequestCancelled(const char *Description) {
+  static CustomXPCData createErrorRequestCancelled(StringRef Description) {
     return createKindAndString(Kind::ErrorRequestCancelled, Description);
   }
 
 private:
-  static CustomXPCData createKindAndString(Kind K, const char *Str) {
+  static CustomXPCData createKindAndString(Kind K, StringRef Str) {
     llvm::SmallVector<char, 128> Buf;
     Buf.push_back((char)K);
-    Buf.append(Str, Str+strlen(Str)+1);
+    Buf.append(Str.begin(), Str.end());
+    Buf.push_back('\0');
     return CustomXPCData(xpc_data_create(Buf.begin(), Buf.size()));
   }
 
@@ -375,21 +376,20 @@ Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) {
 }
 
 sourcekitd_response_t
-sourcekitd::createErrorRequestInvalid(const char *Description) {
+sourcekitd::createErrorRequestInvalid(StringRef Description) {
   return CustomXPCData::createErrorRequestInvalid(Description).getXObj();
 }
 sourcekitd_response_t
-sourcekitd::createErrorRequestFailed(StringRef DescRef) {
-  std::string Desc = DescRef.str();
-  return CustomXPCData::createErrorRequestFailed(Desc.c_str()).getXObj();
+sourcekitd::createErrorRequestFailed(StringRef Description) {
+  return CustomXPCData::createErrorRequestFailed(Description).getXObj();
 }
 sourcekitd_response_t
-sourcekitd::createErrorRequestInterrupted(const char *Description) {
+sourcekitd::createErrorRequestInterrupted(StringRef Description) {
   return CustomXPCData::createErrorRequestInterrupted(Description).getXObj();
 }
 sourcekitd_response_t
 sourcekitd::createErrorRequestCancelled() {
-  return CustomXPCData::createErrorRequestCancelled("").getXObj();
+  return CustomXPCData::createErrorRequestCancelled(StringRef("")).getXObj();
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -148,8 +148,14 @@ public:
 
     TestCursorInfo TestInfo;
     getLang().getCursorInfo(DocName, Offset, 0, false, false, Args,
-      [&](const CursorInfoData &Info, StringRef Error) {
-        TestInfo.Error = Error;
+      [&](const RequestResult<CursorInfoData> &Result) {
+        assert(!Result.isCancelled());
+        if (Result.isError()) {
+          TestInfo.Error = Result.getError();
+          sema.signal();
+          return;
+        }
+        const CursorInfoData &Info = Result.value();
         TestInfo.Name = Info.Name;
         TestInfo.Typename = Info.TypeName;
         TestInfo.Filename = Info.Filename;

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -90,6 +90,8 @@ public:
 };
 
 struct TestCursorInfo {
+  // Empty if no error.
+  std::string Error;
   std::string Name;
   std::string Typename;
   std::string Filename;
@@ -146,7 +148,8 @@ public:
 
     TestCursorInfo TestInfo;
     getLang().getCursorInfo(DocName, Offset, 0, false, false, Args,
-      [&](const CursorInfoData &Info) {
+      [&](const CursorInfoData &Info, StringRef Error) {
+        TestInfo.Error = Error;
         TestInfo.Name = Info.Name;
         TestInfo.Typename = Info.TypeName;
         TestInfo.Filename = Info.Filename;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -169,6 +169,7 @@ UID_KEYS = [
     KEY('ExpressionOffset', 'key.expression_offset'),
     KEY('ExpressionLength', 'key.expression_length'),
     KEY('ExpressionType', 'key.expression_type'),
+    KEY('InternalDiagnostic', "key.internal_diagnostic"),
 ]
 
 


### PR DESCRIPTION
Roll forward of #24124 (reverted in #24993) with fix.

Original description:


Previously, requests would fail silently by returning an empty struct
in the response.

With this change, responses will properly report fail with the internal
error.

This allows IDEs to:

- Properly identify errors when they occur
- Choose to display the error to the user or perhaps handle it