### PR TITLE
fix SourceKit injected VFS with .swiftinterface files

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -518,12 +518,6 @@ public:
   /// Returns true if there was an error during setup.
   bool setup(const CompilerInvocation &Invocation);
 
-  /// Returns true if there was an error during setup.
-  /// \param BaseFS Use this, instead of the real filesystem, as the vase
-  ///        filesystem.
-  bool setup(const CompilerInvocation &Invocation,
-             llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
-
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML
   /// files. If the process of validating VFS files failed, or the overlay

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -176,16 +176,7 @@ void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
 }
 
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
-  return setup(Invok, llvm::vfs::getRealFileSystem());
-}
-
-bool CompilerInstance::setup(
-    const CompilerInvocation &Invok,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS) {
-  assert(BaseFS);
   Invocation = Invok;
-
-  SourceMgr.setFileSystem(BaseFS);
 
   // If initializing the overlay file system fails there's no sense in
   // continuing because the compiler will read the wrong files.

--- a/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
+++ b/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
@@ -1,0 +1,14 @@
+import SwiftModule
+
+func foo(
+    _ structDefinedInSwiftModule: StructDefinedInSwiftModule
+) {
+    structDefinedInSwiftModule.
+}
+
+// CHECK: key.name: "methodDefinedInSwiftModule()"
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-parseable-module-interface-path %t/SwiftModule.swiftinterface -module-name SwiftModule -emit-module -o /dev/null %S/../Inputs/vfs/SwiftModule/SwiftModule.swift
+// RUN: ls %t
+// RUN: %sourcekitd-test -req=complete -pos=6:31 -vfs-files=/target_file1.swift=%s,/SwiftModule/SwiftModule.swiftinterface=%t/SwiftModule.swiftinterface /target_file1.swift -- /target_file1.swift -I /SwiftModule | %FileCheck %s

--- a/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
+++ b/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
@@ -10,5 +10,4 @@ func foo(
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-parseable-module-interface-path %t/SwiftModule.swiftinterface -module-name SwiftModule -emit-module -o /dev/null %S/../Inputs/vfs/SwiftModule/SwiftModule.swift
-// RUN: ls %t
 // RUN: %sourcekitd-test -req=complete -pos=6:31 -vfs-files=/target_file1.swift=%s,/SwiftModule/SwiftModule.swiftinterface=%t/SwiftModule.swiftinterface /target_file1.swift -- /target_file1.swift -I /SwiftModule | %FileCheck %s

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -927,7 +927,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
 
   Invocation.getLangOptions().CollectParsedToken = true;
 
-  if (CompIns.setup(Invocation, InvokRef->Impl.Opts.FileSystem)) {
+  CompIns.getSourceMgr().setFileSystem(InvokRef->Impl.Opts.FileSystem);
+  if (CompIns.setup(Invocation)) {
     // FIXME: Report the diagnostic.
     LOG_WARN_FUNC("Compilation setup failed!!!");
     Error = "compilation setup failed";

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -185,7 +185,8 @@ static bool swiftCodeCompleteImpl(
   // FIXME: We need to be passing the buffers from the open documents.
   // It is not a huge problem in practice because Xcode auto-saves constantly.
 
-  if (CI.setup(Invocation, FileSystem)) {
+  CI.getSourceMgr().setFileSystem(FileSystem);
+  if (CI.setup(Invocation)) {
     // FIXME: error?
     return true;
   }


### PR DESCRIPTION
The injected VFS (added in #24708) does not work with ".swiftinterface" files (see test that this PR adds).

The reason is that the ".swiftinterface" loader runs a "subcompilation" like this:
1. Initialize a `CompilerInstance SubInstance`: https://github.com/apple/swift/blob/tensorflow/lib/Frontend/ParseableInterfaceModuleLoader.cpp#L558
2. Propagate the current filesystem to the `SubInstance` using `SubInstance.getSourceMgr().setFileSystem(...)`: https://github.com/apple/swift/blob/tensorflow/lib/Frontend/ParseableInterfaceModuleLoader.cpp#L559
3. Calls `SubInstance.setup(...)`: https://github.com/apple/swift/blob/tensorflow/lib/Frontend/ParseableInterfaceModuleLoader.cpp#L566

The changes in #24708 make it so that `SubInstance.setup(...)` clobbers the FS set up in `SubInstance.getSourceMgr().setFileSystem(...)`, so the `SubInstance` gets a real filesystem instead of our injected filesystem.

This PR fixes things so that `SubInstance.setup(...)` does not clobber FS's that have been previously set.