### PR TITLE
[5.1] IRGen: Fix getLocalSelfMetadata

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1703,8 +1703,11 @@ llvm::Value *IRGenFunction::getLocalSelfMetadata() {
   // with the correct value.
 
   llvm::IRBuilderBase::InsertPointGuard guard(Builder);
-  Builder.SetInsertPoint(&CurFn->getEntryBlock(),
-                         CurFn->getEntryBlock().begin());
+  auto insertPt = isa<llvm::Instruction>(LocalSelf)
+                      ? std::next(llvm::BasicBlock::iterator(
+                            cast<llvm::Instruction>(LocalSelf)))
+                      : CurFn->getEntryBlock().begin();
+  Builder.SetInsertPoint(&CurFn->getEntryBlock(), insertPt);
 
   switch (SelfKind) {
   case SwiftMetatype:

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -112,3 +112,18 @@ bb0(%0 :  $@objc_metatype K<P>.Type):
   %3 = apply %2<P>() : $@convention(thin) <τ_0_0 > () -> ()
   return undef : $()
 }
+
+public class D {
+}
+
+// CHECK: define void @testDynamicSelfMetatype(i8*, i8*)
+// CHECK:   [[C:%.*]] = bitcast i8* %0 to %T27objc_generic_class_metadata1DC*
+// CHECK:   [[O:%.*]] = bitcast %T27objc_generic_class_metadata1DC* [[C]] to %objc_object*
+// CHECK:   call %swift.type* @swift_getObjectType(%objc_object* [[O]]
+sil @testDynamicSelfMetatype : $@convention(objc_method) (@owned D) -> () {
+bb0(%0 : $D):
+  %1 = metatype $@thick @dynamic_self D.Type
+  return undef : $()
+}
+
+sil_vtable D {}


### PR DESCRIPTION
Don't use the beginning of the basic block as insertion point if 'local
self' is an llvm::Instruction (i.e a cast from the argument llvm::Value
has been insterted) rather use the 'local self' value as insertion point.

Fixes a dominance issue because we inserted at the beginning of the
basic block.

rdar://51186963
