### PR TITLE
[5.1] Fix bounds check in bridged ASCII String comparison 5.1

### DIFF
--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -21,7 +21,7 @@ internal protocol _AbstractStringStorage : _NSCopying {
   var count: Int { get }
   var isASCII: Bool { get }
   var start: UnsafePointer<UInt8> { get }
-  var length: Int { get } // In UTF16 code units.
+  var UTF16Length: Int { get }
 }
 
 internal let _cocoaASCIIEncoding:UInt = 1 /* NSASCIIStringEncoding */
@@ -141,16 +141,26 @@ extension _AbstractStringStorage {
       }
       // At this point we've proven that it is an NSString of some sort, but not
       // one of ours.
-      if length != _stdlib_binary_CFStringGetLength(other) {
-        return 0
-      }
+
       defer { _fixLifetime(other) }
+      
+      let otherUTF16Length = _stdlib_binary_CFStringGetLength(other)
+      
       // CFString will only give us ASCII bytes here, but that's fine.
       // We already handled non-ASCII UTF8 strings earlier since they're Swift.
       if let otherStart = _cocoaUTF8Pointer(other) {
+        //We know that otherUTF16Length is also its byte count at this point
+        if count != otherUTF16Length {
+          return 0
+        }
         return (start == otherStart ||
           (memcmp(start, otherStart, count) == 0)) ? 1 : 0
       }
+      
+      if UTF16Length != otherUTF16Length {
+        return 0
+      }
+      
       /*
        The abstract implementation of -isEqualToString: falls back to -compare:
        immediately, so when we run out of fast options to try, do the same.
@@ -221,7 +231,7 @@ final internal class __StringStorage
 #if _runtime(_ObjC)
 
   @objc(length)
-  final internal var length: Int {
+  final internal var UTF16Length: Int {
     @_effects(readonly) @inline(__always) get {
       return asString.utf16.count // UTF16View special-cases ASCII for us.
     }
@@ -701,7 +711,7 @@ final internal class __SharedStringStorage
 #if _runtime(_ObjC)
 
   @objc(length)
-  final internal var length: Int {
+  final internal var UTF16Length: Int {
     @_effects(readonly) get {
       return asString.utf16.count // UTF16View special-cases ASCII for us.
     }

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -75,4 +75,14 @@ BOOL identityOfData(NSData *data);
 - (BOOL)verifyKeysInRange:(NSRange)range existInDictionary:(NSDictionary *)dictionary;
 @end
 
+#pragma mark - NSString bridging
+
+static inline NSString *getNSStringEqualTestString() {
+  return [NSString stringWithUTF8String:"2166002315@874404110.1042078977"];
+}
+
+static inline BOOL NSStringBridgeTestEqual(NSString * _Nonnull a, NSString * _Nonnull b) {
+  return [a isEqual:b];
+}
+
 NS_ASSUME_NONNULL_END

--- a/test/stdlib/TestNSString.swift
+++ b/test/stdlib/TestNSString.swift
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g
+// RUN: %target-build-swift %s -I %S/Inputs/FoundationBridge/ -Xlinker %t/FoundationBridgeObjC.o -sanitize=address -o %t/TestNSString
+// RUN: %target-codesign %t/TestNSString
+
+// RUN: %target-run %t/TestNSString > %t.txt
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+// REQUIRES: objc_interop
+
+import Foundation
+import FoundationBridgeObjC
+
+#if FOUNDATION_XCTEST
+    import XCTest
+    class TestNSStringSuper : XCTestCase { }
+#else
+    import StdlibUnittest
+    class TestNSStringSuper { }
+#endif
+
+class TestNSString : TestNSStringSuper {
+    
+    func test_equalOverflow() {
+      let cyrillic = "чебурашка@ящик-с-апельсинами.рф"
+      let other = getNSStringEqualTestString()
+      print(NSStringBridgeTestEqual(cyrillic, other))
+    }
+  
+}
+
+#if !FOUNDATION_XCTEST
+var NSStringTests = TestSuite("TestNSString")
+NSStringTests.test("test_equalOverflow") { TestNSString().test_equalOverflow() }
+runAllTests()
+#endif


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/24457

Fixes rdar://problem/50407214