### PR TITLE
[tests] Add support for running executable tests when SWIFT_INCLUDE_T…

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,22 +39,28 @@ function(get_test_dependencies SDK result_var_name)
     list(APPEND deps SwiftUnitTests)
   endif()
 
-  set(deps_binaries
+  set(deps_binaries)
+
+  if (SWIFT_INCLUDE_TOOLS)
+    list(APPEND deps_binaries
       swift swift-ide-test swift-syntax-test sil-opt swift-llvm-opt swift-demangle
       sil-func-extractor sil-llvm-gen sil-nm sil-passpipeline-dumper
       lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
       swift-api-digester swift-refactor swift-demangle-yamldump)
+
+    if(SWIFT_BUILD_SYNTAXPARSERLIB)
+      list(APPEND deps_binaries swift-syntax-parser-test)
+    endif()
+    if(SWIFT_BUILD_SOURCEKIT)
+      list(APPEND deps_binaries sourcekitd-test complete-test)
+    endif()
+  endif()
+
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
          clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-dis
          llvm-bcanalyzer llvm-nm llvm-readobj llvm-profdata count not
          llvm-strings dsymutil)
-  endif()
-  if(SWIFT_BUILD_SYNTAXPARSERLIB)
-    list(APPEND deps_binaries swift-syntax-parser-test)
-  endif()
-  if(SWIFT_BUILD_SOURCEKIT)
-    list(APPEND deps_binaries sourcekitd-test complete-test)
   endif()
 
   if(("${SDK}" STREQUAL "IOS") OR

--- a/test/DebugInfo/ASTSection.swift
+++ b/test/DebugInfo/ASTSection.swift
@@ -4,6 +4,7 @@
 // RUN: %lldb-moduleimport-test -verbose %t/ASTSection | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
 
 // The test ASTSection_linker.swift builds this code with separate
 // compile and link steps.

--- a/test/IDE/complete_cache.swift
+++ b/test/IDE/complete_cache.swift
@@ -47,7 +47,9 @@
 // Ensure the testable import showed up mangled correctly.
 // RUN: ls %t.ccp/Darwin-testable*
 // RUN: ls %t.ccp/AppKit-private*
+
 // REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
 
 import macros
 import ctypes

--- a/test/IDE/print_ast_overlay.swift
+++ b/test/IDE/print_ast_overlay.swift
@@ -12,6 +12,7 @@
 // RUN: %FileCheck %s -check-prefix=PASS_ANNOTATED -strict-whitespace < %t.annotated.txt
 
 // REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
 
 @_exported import Foo
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -112,6 +112,9 @@ else:
     # even if SWIFT_ENABLE_GOLD_LINKER isn't set, we cannot use BFD for Android
     config.android_linker_name = "gold"
 
+if '@SWIFT_INCLUDE_TOOLS@' == 'TRUE':
+    config.available_features.add('swift_tools_extra')
+
 # Let the main config do the real work.
 if config.test_exec_root is None:
     config.test_exec_root = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
…OOLS is set to false.

The two changes here are that:

1. We do not create dependencies from lit on the non-existant swift tools.
2. I added a lit feature called 'swift_tools_extra' that marks some executable
tests that use extra tools that we build normally but that are not put in
toolchains.
