### PR TITLE
Add TrailingAngleBrackLoc to EditorPlaceholder for upcoming scope code.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4666,16 +4666,19 @@ public:
 class EditorPlaceholderExpr : public Expr {
   Identifier Placeholder;
   SourceLoc Loc;
+  SourceLoc TrailingAngleBracketLoc;
   TypeLoc PlaceholderTy;
   TypeRepr *ExpansionTyR;
   Expr *SemanticExpr;
 
 public:
   EditorPlaceholderExpr(Identifier Placeholder, SourceLoc Loc,
+                        SourceLoc TrailingAngleBracketLoc,
                         TypeLoc PlaceholderTy,
                         TypeRepr *ExpansionTyR)
     : Expr(ExprKind::EditorPlaceholder, /*Implicit=*/false),
       Placeholder(Placeholder), Loc(Loc),
+      TrailingAngleBracketLoc(TrailingAngleBracketLoc),
       PlaceholderTy(PlaceholderTy),
       ExpansionTyR(ExpansionTyR),
       SemanticExpr(nullptr) {
@@ -4685,6 +4688,9 @@ public:
   SourceRange getSourceRange() const { return Loc; }
   TypeLoc &getTypeLoc() { return PlaceholderTy; }
   TypeLoc getTypeLoc() const { return PlaceholderTy; }
+  SourceLoc getTrailingAngleBracketLoc() const {
+    return TrailingAngleBracketLoc;
+  }
 
   /// The TypeRepr to be considered for placeholder expansion.
   TypeRepr *getTypeForExpansion() const { return ExpansionTyR; }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4666,19 +4666,16 @@ public:
 class EditorPlaceholderExpr : public Expr {
   Identifier Placeholder;
   SourceLoc Loc;
-  SourceLoc TrailingAngleBracketLoc;
   TypeLoc PlaceholderTy;
   TypeRepr *ExpansionTyR;
   Expr *SemanticExpr;
 
 public:
   EditorPlaceholderExpr(Identifier Placeholder, SourceLoc Loc,
-                        SourceLoc TrailingAngleBracketLoc,
                         TypeLoc PlaceholderTy,
                         TypeRepr *ExpansionTyR)
     : Expr(ExprKind::EditorPlaceholder, /*Implicit=*/false),
       Placeholder(Placeholder), Loc(Loc),
-      TrailingAngleBracketLoc(TrailingAngleBracketLoc),
       PlaceholderTy(PlaceholderTy),
       ExpansionTyR(ExpansionTyR),
       SemanticExpr(nullptr) {
@@ -4689,7 +4686,7 @@ public:
   TypeLoc &getTypeLoc() { return PlaceholderTy; }
   TypeLoc getTypeLoc() const { return PlaceholderTy; }
   SourceLoc getTrailingAngleBracketLoc() const {
-    return TrailingAngleBracketLoc;
+    return Loc.getAdvancedLoc(Placeholder.getLength() - 1);
   }
 
   /// The TypeRepr to be considered for placeholder expansion.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2635,7 +2635,19 @@ public:
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {
-    printCommon(E, "editor_placeholder_expr") << '\n';
+    printCommon(E, "editor_placeholder_expr") << ' ';
+
+    // Print the trailing angle bracket location
+    if (auto Ty = GetTypeOfExpr(E)) {
+      auto &Ctx = Ty->getASTContext();
+      auto TABL = E->getTrailingAngleBracketLoc();
+      if (TABL.isValid()) {
+        PrintWithColorRAII(OS, LocationColor) << " trailing_angle_bracket_loc=";
+        TABL.print(PrintWithColorRAII(OS, LocationColor).getOS(),
+                   Ctx.SourceMgr);
+      }
+    }
+    OS << '\n';
     auto *TyR = E->getTypeLoc().getTypeRepr();
     auto *ExpTyR = E->getTypeForExpansion();
     if (TyR)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2385,7 +2385,6 @@ Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
   parseTypeForPlaceholder(TyLoc, ExpansionTyR);
   return new (Context) EditorPlaceholderExpr(PlaceholderId,
                                              PlaceholderTok.getLoc(),
-                                             PlaceholderTok.getRange().getEnd(),
                                              TyLoc, ExpansionTyR);
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2385,6 +2385,7 @@ Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
   parseTypeForPlaceholder(TyLoc, ExpansionTyR);
   return new (Context) EditorPlaceholderExpr(PlaceholderId,
                                              PlaceholderTok.getLoc(),
+                                             PlaceholderTok.getRange().getEnd(),
                                              TyLoc, ExpansionTyR);
 }
 

--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -2,7 +2,10 @@
 
 func string_interpolation() {
   "\("abc")"
+  <#Int#>
 }
 
-// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+// RUN: not %target-swift-frontend -dump-ast %s | %FileCheck %s
 // CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:4:12 {{.*}}
+// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:5:10
+

--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -7,5 +7,5 @@ func string_interpolation() {
 
 // RUN: not %target-swift-frontend -dump-ast %s | %FileCheck %s
 // CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:4:12 {{.*}}
-// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:5:10
+// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc=SOURCE_DIR{{/|\\}}test{{/|\\}}Parse{{/|\\}}source_locs.swift:5:9
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds an instance variable to track the location of the trailing angle bracket of an editor place holder.
Will be needed by the upcoming scope code. Also adds a test.

