### PR TITLE
[build-script] Add a presets for building/testing the stdlib standalo…

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2026,3 +2026,34 @@ debug-foundation
 
 [preset: buildbot_linux,foundation=release]
 mixin-preset=buildbot_linux
+
+#===------------------------------------------------------------------------===#
+# Standalone Stdlib
+#===------------------------------------------------------------------------===#
+
+[preset: stdlib_RA,standalone,notest]
+release
+assertions
+
+# We do not want to build llvm, cmark, or benchmarks. We will still build a
+# small part of llvm and configure both llvm/cmark.
+skip-build-llvm
+skip-build-cmark
+skip-build-benchmarks
+
+# Then we inject two cmake arguments that cause us not to build tools and to
+# assume we are working with the host compiler.
+extra-cmake-options=-DSWIFT_INCLUDE_TOOLS=NO -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=YES
+
+# Then set the paths to our native tools. If compiling against a toolchain,
+# these should all be the ./usr/bin directory.
+native-swift-tools-path=%(toolchain_path)s
+native-llvm-tools-path=%(toolchain_path)s
+native-clang-tools-path=%(toolchain_path)s
+
+[preset: stdlib_RA,standalone]
+mixin-preset=stdlib_RA,standalone,notest
+
+test
+validation-test
+only-executable-test

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -42,6 +42,7 @@ PRESET_DEFAULTS = {
     'symbols_package': '/path/to/symbols/package',
     'ndk_path': '/path/to/ndk',
     'arm_dir': '/path/to/arm',
+    'toolchain_path': '/tmp/toolchain',
 }
 
 SAMPLE_PRESET = """


### PR DESCRIPTION
…ne against a swift.org toolchain

This hopefully provides an example for other people on how to do this sort of
thing.

The presets are called "stdlib_RDA,standalone{,[,]notest}". It requires one parameter:
toolchain_path which should be the bin directory of your toolchain. Example:

```
build-script --preset=stdlib_RDA,standalone toolchain_path=$MY_TOOLCHAIN/usr/bin
build-script --preset=stdlib_RDA,standalone,notest toolchain_path=$MY_TOOLCHAIN/usr/bin
```
