### PR TITLE
[android] Fix Bionic modulemap file syntax.

### DIFF
--- a/stdlib/public/Platform/bionic.modulemap.gyb
+++ b/stdlib/public/Platform/bionic.modulemap.gyb
@@ -27,6 +27,7 @@ module SwiftGlibc [system] {
 
   // C standard library
   module C {
+    module features {
       header "${GLIBC_INCLUDE_PATH}/features.h"
       export *
     }


### PR DESCRIPTION
A line was forgotten in the rewrite which break the Android builds.
