### PR TITLE
[5.1] SILGen: Add an option to disable the previous implementation in…

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -132,6 +132,16 @@ public:
   /// Enable the mandatory semantic arc optimizer.
   bool EnableMandatorySemanticARCOpts = false;
 
+  /// Calls to the replaced method inside of the replacement method will call
+  /// the previous implementation.
+  ///
+  /// @_dynamicReplacement(for: original())
+  /// func replacement() {
+  ///   if (...)
+  ///     original() // calls original() implementation if true
+  /// }
+  bool EnableDynamicReplacementCanCallPreviousImplementation = true;
+
   /// Enable large loadable types IRGen pass.
   bool EnableLargeLoadableTypes = true;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -353,6 +353,11 @@ def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Add 'dynamic' to all declarations">;
 
+def disable_previous_implementation_calls_in_dynamic_replacements :
+  Flag<["-"], "disable-previous-implementation-calls-in-dynamic-replacements">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Disable calling the previous implementation in dynamic replacements">;
+
 def enable_dynamic_replacement_chaining :
   Flag<["-"], "enable-dynamic-replacement-chaining">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -798,6 +798,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EnableMandatorySemanticARCOpts |=
       Args.hasArg(OPT_enable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
+  Opts.EnableDynamicReplacementCanCallPreviousImplementation = !Args.hasArg(
+      OPT_disable_previous_implementation_calls_in_dynamic_replacements);
 
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))
     Opts.OptRecordFile = A->getValue();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1044,7 +1044,9 @@ public:
     // Directly dispatch to calls of the replaced function inside of
     // '@_dynamicReplacement(for:)' methods.
     bool isObjCReplacementCall = false;
-    if (isCallToReplacedInDynamicReplacement(SGF, afd, isObjCReplacementCall) &&
+    if (SGF.getOptions()
+            .EnableDynamicReplacementCanCallPreviousImplementation &&
+        isCallToReplacedInDynamicReplacement(SGF, afd, isObjCReplacementCall) &&
         thisCallSite->getArg()->isSelfExprOf(
             cast<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl()), false)) {
       auto constant = SILDeclRef(afd).asForeign(
@@ -1115,6 +1117,8 @@ public:
     ApplyExpr *thisCallSite = callSites.back();
     bool isObjCReplacementSelfCall = false;
     bool isSelfCallToReplacedInDynamicReplacement =
+        SGF.getOptions()
+            .EnableDynamicReplacementCanCallPreviousImplementation &&
         isCallToReplacedInDynamicReplacement(
             SGF, cast<AbstractFunctionDecl>(constant.getDecl()),
             isObjCReplacementSelfCall) &&
@@ -1449,6 +1453,8 @@ public:
 
     bool isObjCReplacementSelfCall = false;
     bool isSelfCallToReplacedInDynamicReplacement =
+        SGF.getOptions()
+            .EnableDynamicReplacementCanCallPreviousImplementation &&
         isCallToReplacedInDynamicReplacement(
             SGF, cast<AbstractFunctionDecl>(constant.getDecl()),
             isObjCReplacementSelfCall) &&
@@ -5691,8 +5697,11 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
 
   bool isObjCReplacementSelfCall = false;
-  if (isOnSelfParameter && isCallToReplacedInDynamicReplacement(
-                               SGF, decl, isObjCReplacementSelfCall)) {
+  if (isOnSelfParameter &&
+      SGF.getOptions()
+          .EnableDynamicReplacementCanCallPreviousImplementation &&
+      isCallToReplacedInDynamicReplacement(SGF, decl,
+                                           isObjCReplacementSelfCall)) {
     return Callee::forDirect(
         SGF,
         SILDeclRef(cast<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl()),

--- a/test/Interpreter/Inputs/dynamic_replacement_without_previous_calls1.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_without_previous_calls1.swift
@@ -1,0 +1,17 @@
+public dynamic func selfRec(_ x: Int, _ acc: Int) -> Int {
+  return 0
+}
+
+public class AClass {
+  public init() {}
+  public dynamic func selfRec(_ x: Int, _ acc: Int) -> Int {
+    return 0
+  }
+}
+
+public class AStruct {
+  public init() {}
+  public dynamic func selfRec(_ x: Int, _ acc: Int) -> Int {
+    return 0
+  }
+}

--- a/test/Interpreter/Inputs/dynamic_replacement_without_previous_calls2.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_without_previous_calls2.swift
@@ -1,0 +1,29 @@
+import Module1
+
+@_dynamicReplacement(for: selfRec(_: _:))
+func selfRec_r(_ x: Int, _ acc: Int) -> Int {
+  if x <= 0 {
+    return acc
+  }
+  return selfRec(x - 1, acc + 1)
+}
+
+extension AStruct {
+  @_dynamicReplacement(for: selfRec(_: _:))
+  func selfRec_r(_ x: Int, _ acc: Int) -> Int {
+    if x <= 0 {
+      return acc
+    }
+    return selfRec(x - 1, acc + 1)
+  }
+}
+
+extension AClass {
+  @_dynamicReplacement(for: selfRec(_: _:))
+  func selfRec_r(_ x: Int, _ acc: Int) -> Int {
+    if x <= 0 {
+      return acc
+    }
+    return selfRec(x - 1, acc + 1)
+  }
+}

--- a/test/Interpreter/dynamic_replacement_without_previous_calls.swift
+++ b/test/Interpreter/dynamic_replacement_without_previous_calls.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module1)) -module-name Module1 -emit-module -emit-module-path %t/Module1.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_without_previous_calls1.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module2)) -I%t -L%t -lModule1 %target-rpath(%t) -module-name Module2 -emit-module -emit-module-path %t/Module2.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_without_previous_calls2.swift -Xfrontend -disable-previous-implementation-calls-in-dynamic-replacements
+// RUN: %target-build-swift -I%t -L%t -lModule1 -o %t/main %target-rpath(%t) %s -swift-version 5
+// RUN: %target-codesign %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+// RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
+
+// REQUIRES: executable_test
+
+import Module1
+
+import StdlibUnittest
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Darwin
+#elseif os(Linux) || os(FreeBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
+  import Glibc
+#elseif os(Windows)
+  import MSVCRT
+  import WinSDK
+#else
+#error("Unsupported platform")
+#endif
+
+private func target_library_name(_ name: String) -> String {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+  return "lib\(name).dylib"
+#elseif os(Windows)
+  return "\(name).dll"
+#else
+  return "lib\(name).so"
+#endif
+}
+
+var DynamicallyReplaceable = TestSuite("DynamicallyReplaceable")
+
+DynamicallyReplaceable.test("DynamicallyReplaceable") {
+  var executablePath = CommandLine.arguments[0]
+  executablePath.removeLast(4)
+
+  // First, test with only the original module.
+  expectEqual(0, selfRec(2, 0))
+  expectEqual(0, AClass().selfRec(2, 0))
+  expectEqual(0, AStruct().selfRec(2, 0))
+
+  // Now, test with the module containing the replacements.
+#if os(Linux)
+	_ = dlopen(target_library_name("Module2"), RTLD_NOW)
+#elseif os(Windows)
+        _ = LoadLibraryA(target_library_name("Module2"))
+#else
+	_ = dlopen(executablePath+target_library_name("Module2"), RTLD_NOW)
+#endif
+  expectEqual(2, selfRec(2, 0))
+  expectEqual(2, AClass().selfRec(2, 0))
+  expectEqual(2, AStruct().selfRec(2, 0))
+}
+
+runAllTests()

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -swift-version 5 %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -swift-version 5 %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=IMPLICIT
+// RUN: %target-swift-emit-silgen -swift-version 5 %s -disable-previous-implementation-calls-in-dynamic-replacements | %FileCheck %s --check-prefix=NOPREVIOUS
 
 // CHECK-LABEL: sil hidden [ossa] @$s23dynamically_replaceable014maybe_dynamic_B0yyF : $@convention(thin) () -> () {
 // IMPLICIT-LABEL: sil hidden [dynamically_replacable] [ossa] @$s23dynamically_replaceable014maybe_dynamic_B0yyF : $@convention(thin) () -> () {
@@ -122,6 +123,12 @@ extension Klass {
   // CHECK: [[METHOD:%.*]] = class_method %0 : $Klass, #Klass.dynamic_replaceable2!1
   // CHECK: = apply [[METHOD]](%0) : $@convention(method) (@guaranteed Klass) -> ()
   // CHECK: return
+  // NOPREVIOUS-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC08dynamic_B0yyF"] [ossa] @$s23dynamically_replaceable5KlassC11replacementyyF : $@convention(method) (@guaranteed Klass) -> () {
+  // NOPREVIOUS: [[FN:%.*]] = class_method %0 : $Klass, #Klass.dynamic_replaceable
+  // NOPREVIOUS: apply [[FN]](%0) : $@convention(method) (@guaranteed Klass) -> ()
+  // NOPREVIOUS: [[METHOD:%.*]] = class_method %0 : $Klass, #Klass.dynamic_replaceable2!1
+  // NOPREVIOUS: = apply [[METHOD]](%0) : $@convention(method) (@guaranteed Klass) -> ()
+  // NOPREVIOUS: return
   @_dynamicReplacement(for: dynamic_replaceable())
   func replacement() {
     dynamic_replaceable()
@@ -131,6 +138,9 @@ extension Klass {
   // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1cACSi_tcfC"] [ossa] @$s23dynamically_replaceable5KlassC2crACSi_tcfC : $@convention(method) (Int, @thick Klass.Type) -> @owned Klass {
   // CHECK:  [[FUN:%.*]] = prev_dynamic_function_ref @$s23dynamically_replaceable5KlassC2crACSi_tcfC
   // CHECK:  apply [[FUN]]({{.*}}, %1)
+  // NOPREVIOUS-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1cACSi_tcfC"] [ossa] @$s23dynamically_replaceable5KlassC2crACSi_tcfC : $@convention(method) (Int, @thick Klass.Type) -> @owned Klass {
+  // NOPREVIOUS:  [[FUN:%.*]] = dynamic_function_ref @$s23dynamically_replaceable5KlassC1cACSi_tcfC
+  // NOPREVIOUS:  apply [[FUN]]({{.*}}, %1)
   @_dynamicReplacement(for: init(c:))
   convenience init(cr: Int) {
     self.init(c: cr + 1)
@@ -140,7 +150,11 @@ extension Klass {
   // CHECK: // dynamic_function_ref Klass.__allocating_init(c:)
   // CHECK: [[FUN:%.*]] = dynamic_function_ref @$s23dynamically_replaceable5KlassC1cACSi_tcfC
   // CHECK: apply [[FUN]]({{.*}}, %2)
-  @_dynamicReplacement(for: init(a: b:))
+  // NOPREVIOUS-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC1a1bACSi_SitcfC"] [ossa] @$s23dynamically_replaceable5KlassC2ar2brACSi_SitcfC
+  // NOPREVIOUS: // dynamic_function_ref Klass.__allocating_init(c:)
+  // NOPREVIOUS: [[FUN:%.*]] = dynamic_function_ref @$s23dynamically_replaceable5KlassC1cACSi_tcfC
+  // NOPREVIOUS: apply [[FUN]]({{.*}}, %2)
+	@_dynamicReplacement(for: init(a: b:))
   convenience init(ar: Int, br: Int) {
     self.init(c: ar + br)
   }
@@ -153,11 +167,19 @@ extension Klass {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Klass):
 // CHECK:   [[ORIG:%.*]] = prev_dynamic_function_ref  @$s23dynamically_replaceable5KlassC1rSivg
 // CHECK:   apply [[ORIG]]([[ARG]]) : $@convention(method) (@guaranteed Klass) -> Int
+// NOPREVIOUS-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC08dynamic_B4_varSivg"] [ossa] @$s23dynamically_replaceable5KlassC1rSivg : $@convention(method) (@guaranteed Klass) -> Int {
+// NOPREVIOUS: bb0([[ARG:%.*]] : @guaranteed $Klass):
+// NOPREVIOUS:   [[ORIG:%.*]] = class_method [[ARG]] : $Klass, #Klass.dynamic_replaceable_var!getter.1
+// NOPREVIOUS:   apply [[ORIG]]([[ARG]]) : $@convention(method) (@guaranteed Klass) -> Int
 
 // CHECK-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC08dynamic_B4_varSivs"] [ossa] @$s23dynamically_replaceable5KlassC1rSivs : $@convention(method) (Int, @guaranteed Klass) -> () {
 // CHECK: bb0({{.*}} : $Int, [[SELF:%.*]] : @guaranteed $Klass):
 // CHECK:   [[ORIG:%.*]] = prev_dynamic_function_ref @$s23dynamically_replaceable5KlassC1rSivs
 // CHECK:   apply [[ORIG]]({{.*}}, [[SELF]]) : $@convention(method)
+// NOPREVIOUS-LABEL: sil hidden [dynamic_replacement_for "$s23dynamically_replaceable5KlassC08dynamic_B4_varSivs"] [ossa] @$s23dynamically_replaceable5KlassC1rSivs : $@convention(method) (Int, @guaranteed Klass) -> () {
+// NOPREVIOUS: bb0({{.*}} : $Int, [[SELF:%.*]] : @guaranteed $Klass):
+// NOPREVIOUS:   [[ORIG:%.*]] = class_method [[SELF]] : $Klass, #Klass.dynamic_replaceable_var!setter
+// NOPREVIOUS:   apply [[ORIG]]({{.*}}, [[SELF]]) : $@convention(method)
   @_dynamicReplacement(for: dynamic_replaceable_var)
   var r : Int {
     get {


### PR DESCRIPTION
…side of dynamic replacement thunks

 @_dynamicReplacement(for: selfRec(x: acc:))
  func selfRec_r(x: Int, acc: Int) -> Int {
    if x <= 0 {
      return acc
    }
    // Normally, this will call selfRec(x: acc:)'s implementation.
    // With the option, this will call to selfRec_r(x: acc:).
    return selfRec(x: x - 1, acc: acc + 1)
  }

rdar://51229650