### PR TITLE
[Build System: CMake] Darwin Supported Archs and Modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,14 @@ option(SWIFT_STDLIB_ENABLE_SIB_TARGETS
        "Should we generate sib targets for the stdlib or not?"
        FALSE)
 
+
+set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
+  "Space-separated list of architectures to configure on Darwin platforms. \
+If left empty all default architectures are configured.")
+
+separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
+
+
 #
 # User-configurable Android specific options.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,16 +225,13 @@ option(SWIFT_STDLIB_ENABLE_SIB_TARGETS
 
 
 set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
-  "Space-separated list of architectures to configure on Darwin platforms. \
+  "Semicolon-separated list of architectures to configure on Darwin platforms. \
 If left empty all default architectures are configured.")
 
 set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
-  "Space-separated list of architectures to configure Swift module-only \
+  "Semicolon-separated list of architectures to configure Swift module-only \
 targets on Darwin platforms. These targets are in addition to the full \
 library targets.")
-
-separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
-separate_arguments(SWIFT_DARWIN_MODULE_ARCHS)
 
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,13 @@ set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
   "Space-separated list of architectures to configure on Darwin platforms. \
 If left empty all default architectures are configured.")
 
+set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
+  "Space-separated list of architectures to configure Swift module-only \
+targets on Darwin platforms. These targets are in addition to the full \
+library targets.")
+
 separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
+separate_arguments(SWIFT_DARWIN_MODULE_ARCHS)
 
 
 #

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2092,6 +2092,9 @@ function(add_swift_target_library name)
       # Add the arch-specific library targets to the global exports.
       foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
         set(_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+        if(NOT TARGET "${_variant_name}")
+          continue()
+        endif()
 
         if(is_installing)
           set_property(GLOBAL APPEND
@@ -2104,13 +2107,12 @@ function(add_swift_target_library name)
 
       # Add the swiftmodule-only targets to the lipo target depdencies.
       foreach(arch ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
-        set(_variant_name
-          "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-
-        if(TARGET "${_variant_name}")
-          add_dependencies("${lipo_target}"
-            "${_variant_name}")
+        set(_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+        if(NOT TARGET "${_variant_name}")
+          continue()
         endif()
+
+        add_dependencies("${lipo_target}" "${_variant_name}")
       endforeach()
 
       # If we built static variants of the library, create a lipo target for

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2042,12 +2042,22 @@ function(add_swift_target_library name)
         endforeach()
       endif()
 
-      swift_is_installing_component("${SWIFTLIB_INSTALL_IN_COMPONENT}" is_installing)
-      if(NOT is_installing)
-        set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${VARIANT_NAME})
-      else()
-        set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${VARIANT_NAME})
-      endif()
+      swift_is_installing_component(
+        "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+        is_installing)
+
+      # Add the arch-specific library targets to the global exports.
+      foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+        set(_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+
+        if(is_installing)
+          set_property(GLOBAL APPEND
+            PROPERTY SWIFT_EXPORTS ${_variant_name})
+        else()
+          set_property(GLOBAL APPEND
+            PROPERTY SWIFT_BUILDTREE_EXPORTS ${_variant_name})
+        endif()
+      endforeach()
 
       # If we built static variants of the library, create a lipo target for
       # them.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -922,6 +922,17 @@ function(_add_swift_library_single target name)
     endif()
   endif()
 
+  # Only build the modules for any arch listed in the *_MODULE_ARCHITECTURES.
+  if(SWIFTLIB_SINGLE_SDK IN_LIST SWIFT_APPLE_PLATFORMS
+      AND SWIFTLIB_SINGLE_ARCHITECTURE IN_LIST SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_MODULE_ARCHITECTURES)
+    # Create dummy target to hook up the module target dependency.
+    add_custom_target("${target}"
+      DEPENDS
+        "${swift_module_dependency_target}")
+
+    return()
+  endif()
+
   set(SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS)
   foreach(object_library ${SWIFTLIB_SINGLE_INCORPORATE_OBJECT_LIBRARIES})
     list(APPEND SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
@@ -1826,7 +1837,10 @@ function(add_swift_target_library name)
     endif()
 
     # For each architecture supported by this SDK
-    foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+    set(sdk_supported_archs
+      ${SWIFT_SDK_${sdk}_ARCHITECTURES}
+      ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
+    foreach(arch ${sdk_supported_archs})
       # Configure variables for this subdirectory.
       set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
       set(VARIANT_NAME "${name}${VARIANT_SUFFIX}")
@@ -1947,10 +1961,37 @@ function(add_swift_target_library name)
           endforeach()
         endif()
 
-        # Note this thin library.
-        list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
+        if(arch IN_LIST SWIFT_SDK_${sdk}_ARCHITECTURES)
+          # Note this thin library.
+          list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
+        endif()
       endif()
     endforeach()
+
+    # Configure module-only targets
+    if(NOT SWIFT_SDK_${sdk}_ARCHITECTURES
+        AND SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES)
+      set(_target "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+
+      # Create unified sdk target
+      add_custom_target("${_target}")
+
+      foreach(_arch ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
+        set(_variant_suffix "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${_arch}")
+        set(_module_variant_name "${name}-swiftmodule-${_variant_suffix}")
+
+        add_dependencies("${_target}" ${_module_variant_name})
+
+        # Add Swift standard library targets as dependencies to the top-level
+        # convenience target.
+        if(TARGET "swift-stdlib${_variant_suffix}")
+          add_dependencies("swift-stdlib${_variant_suffix}"
+            "${_target}")
+        endif()
+      endforeach()
+
+      return()
+    endif()
 
     if(NOT SWIFTLIB_OBJECT_LIBRARY)
       # Determine the name of the universal library.
@@ -2056,6 +2097,17 @@ function(add_swift_target_library name)
         else()
           set_property(GLOBAL APPEND
             PROPERTY SWIFT_BUILDTREE_EXPORTS ${_variant_name})
+        endif()
+      endforeach()
+
+      # Add the swiftmodule-only targets to the lipo target depdencies.
+      foreach(arch ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
+        set(_variant_name
+          "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+
+        if(TARGET "${_variant_name}")
+          add_dependencies("${lipo_target}"
+            "${_variant_name}")
         endif()
       endforeach()
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1836,10 +1836,12 @@ function(add_swift_target_library name)
       list(APPEND swiftlib_link_flags_all "-Wl,-z,defs")
     endif()
 
-    # For each architecture supported by this SDK
     set(sdk_supported_archs
       ${SWIFT_SDK_${sdk}_ARCHITECTURES}
       ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})
+    list(REMOVE_DUPLICATES sdk_supported_archs)
+
+    # For each architecture supported by this SDK
     foreach(arch ${sdk_supported_archs})
       # Configure variables for this subdirectory.
       set(VARIANT_SUFFIX "-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -66,16 +66,13 @@ set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
   "Build type for the Swift standard library and SDK overlays.")
 
 set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
-  "Space-separated list of architectures to configure on Darwin platforms. \
+  "Semicolon-separated list of architectures to configure on Darwin platforms. \
 If left empty all default architectures are configured.")
 
 set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
-  "Space-separated list of architectures to configure Swift module-only \
+  "Semicolon-separated list of architectures to configure Swift module-only \
 targets on Darwin platforms. These targets are in addition to the full \
 library targets.")
-
-separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
-separate_arguments(SWIFT_DARWIN_MODULE_ARCHS)
 
 
 # -----------------------------------------------------------------------------

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -69,7 +69,13 @@ set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
   "Space-separated list of architectures to configure on Darwin platforms. \
 If left empty all default architectures are configured.")
 
+set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
+  "Space-separated list of architectures to configure Swift module-only \
+targets on Darwin platforms. These targets are in addition to the full \
+library targets.")
+
 separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
+separate_arguments(SWIFT_DARWIN_MODULE_ARCHS)
 
 
 # -----------------------------------------------------------------------------

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -65,6 +65,13 @@ option(SWIFT_ENABLE_PARSEABLE_MODULE_INTERFACES
 set(SWIFT_STDLIB_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
   "Build type for the Swift standard library and SDK overlays.")
 
+set(SWIFT_DARWIN_SUPPORTED_ARCHS "" CACHE STRING
+  "Space-separated list of architectures to configure on Darwin platforms. \
+If left empty all default architectures are configured.")
+
+separate_arguments(SWIFT_DARWIN_SUPPORTED_ARCHS)
+
+
 # -----------------------------------------------------------------------------
 # Constants
 

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -159,6 +159,13 @@ macro(configure_sdk_darwin
     "${architectures}"                        # rhs
     SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES) # result
 
+  # Ensure the architectures and module-only architectures lists are mutually
+  # exclusive.
+  list_subtract(
+    "${SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES}" # lhs
+    "${SWIFT_SDK_${prefix}_ARCHITECTURES}"        # rhs
+    SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES)     # result
+
   # Configure variables for _all_ architectures even if we aren't "building"
   # them because they aren't supported.
   foreach(arch ${architectures})

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -141,9 +141,18 @@ macro(configure_sdk_darwin
   set(SWIFT_SDK_${prefix}_LIB_SUBDIR "${xcrun_name}")
   set(SWIFT_SDK_${prefix}_VERSION_MIN_NAME "${version_min_name}")
   set(SWIFT_SDK_${prefix}_TRIPLE_NAME "${triple_name}")
-  set(SWIFT_SDK_${prefix}_ARCHITECTURES "${architectures}")
   set(SWIFT_SDK_${prefix}_OBJECT_FORMAT "MACHO")
 
+  set(SWIFT_SDK_${prefix}_ARCHITECTURES ${architectures})
+  if(SWIFT_DARWIN_SUPPORTED_ARCHS)
+    list_intersect(
+      "${architectures}"                  # lhs
+      "${SWIFT_DARWIN_SUPPORTED_ARCHS}"   # rhs
+      SWIFT_SDK_${prefix}_ARCHITECTURES)  # result
+  endif()
+
+  # Configure variables for _all_ architectures even if we aren't "building"
+  # them because they aren't supported.
   foreach(arch ${architectures})
     # On Darwin, all archs share the same SDK path.
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "${SWIFT_SDK_${prefix}_PATH}")

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -51,6 +51,9 @@ function(_report_sdk prefix)
     message(STATUS "  Triple name: ${SWIFT_SDK_${prefix}_TRIPLE_NAME}")
   endif()
   message(STATUS "  Architectures: ${SWIFT_SDK_${prefix}_ARCHITECTURES}")
+  if(SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES)
+    message(STATUS "  Module Architectures: ${SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES}")
+  endif()
   if(NOT prefix IN_LIST SWIFT_APPLE_PLATFORMS)
     if(SWIFT_BUILD_STDLIB)
       foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
@@ -150,6 +153,11 @@ macro(configure_sdk_darwin
       "${SWIFT_DARWIN_SUPPORTED_ARCHS}"   # rhs
       SWIFT_SDK_${prefix}_ARCHITECTURES)  # result
   endif()
+
+  list_intersect(
+    "${SWIFT_DARWIN_MODULE_ARCHS}"            # lhs
+    "${architectures}"                        # rhs
+    SWIFT_SDK_${prefix}_MODULE_ARCHITECTURES) # result
 
   # Configure variables for _all_ architectures even if we aren't "building"
   # them because they aren't supported.

--- a/utils/build-script
+++ b/utils/build-script
@@ -420,6 +420,31 @@ class BuildScriptInvocation(object):
             args.android = True
             args.build_android = False
 
+        # Include the Darwin supported architectures in the CMake options.
+        if args.swift_darwin_supported_archs:
+            args.extra_cmake_options.append(
+                '-DSWIFT_DARWIN_SUPPORTED_ARCHS:STRING={}'.format(
+                    args.swift_darwin_supported_archs))
+
+            # Remove unsupported Darwin archs from the standard library
+            # deployment targets.
+            supported_archs = args.swift_darwin_supported_archs.split(';')
+            targets = StdlibDeploymentTarget.get_targets_by_name(
+                args.stdlib_deployment_targets)
+
+            args.stdlib_deployment_targets = [
+                target.name
+                for target in targets
+                if (target.platform.is_darwin and
+                    target.arch in supported_archs)
+            ]
+
+        # Include the Darwin module-only architectures in the CMake options.
+        if args.swift_darwin_module_archs:
+            args.extra_cmake_options.append(
+                '-DSWIFT_DARWIN_MODULE_ARCHS:STRING={}'.format(
+                    args.swift_darwin_module_archs))
+
 # ---
 
     def __init__(self, toolchain, args):

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -522,6 +522,18 @@ def create_argument_parser():
            help='A space-separated list that filters which of the configured '
                 'targets to build the Swift standard library for, or "all".')
 
+    option('--swift-darwin-supported-archs', store,
+           metavar='ARCHS',
+           help='Semicolon-separated list of architectures to configure on '
+                'Darwin platforms. If left empty all default architectures '
+                'are configured.')
+
+    option('--swift-darwin-module-archs', store,
+           metavar='ARCHS',
+           help='Semicolon-separated list of architectures to configure Swift '
+                'module-only targets on Darwin platforms. These targets are '
+                'in addition to the full library targets.')
+
     # -------------------------------------------------------------------------
     in_group('Options to select projects')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -171,6 +171,8 @@ EXPECTED_DEFAULTS = {
     'swift_assertions': True,
     'swift_build_variant': 'Debug',
     'swift_compiler_version': None,
+    'swift_darwin_module_archs': None,
+    'swift_darwin_supported_archs': None,
     'swift_stdlib_assertions': True,
     'swift_stdlib_build_variant': 'Debug',
     'swift_tools_max_parallel_lto_link_jobs':
@@ -532,6 +534,8 @@ EXPECTED_OPTIONS = [
     StrOption('--host-target'),
     StrOption('--lit-args'),
     StrOption('--llvm-targets-to-build'),
+    StrOption('--swift-darwin-module-archs'),
+    StrOption('--swift-darwin-supported-archs'),
 
     PathOption('--android-deploy-device-path'),
     PathOption('--android-icu-i18n'),

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -258,6 +258,10 @@ class StdlibDeploymentTarget(object):
     def get_target_for_name(cls, name):
         return cls._targets_by_name.get(name)
 
+    @classmethod
+    def get_targets_by_name(cls, names):
+        return [cls.get_target_for_name(name) for name in names]
+
 
 def install_prefix():
     """


### PR DESCRIPTION
This PR adds the ability for users to override the complete list of supported architectures when building for Darwin platforms. Setting the CMake cache variable `SWIFT_DARWIN_SUPPORTED_ARCHS` to a space separated list of architectures (e.g. `armv7 arm64 x86_46`) will exclude all other supported architectures across all the Darwin platforms. Leaving this option blank will configure _all_ the default architectures specified in `cmake/modules/DarwinSDKs.cmake`.

Additionally users are able to set `SWIFT_DARWIN_MODULE_ARCHS` to configure and build _only_ the `.swiftmodule` content for architectures that have been excluded by `SWIFT_DARWIN_SUPPORTED_ARCHS`. If architectures are listed in both of these cache variables then the supported architectures list takes precedence. The SDK output will now optionally include a `Module Architectures` section if any have been selected.

rdar://50561574