### PR TITLE
[build-script-impl] When skipping building LLVM in toolchain only mod…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2150,8 +2150,18 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
                     # We can't skip the build completely because the standalone
-                    # build of Swift depend on these for testing etc.
-                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets FileCheck not)
+                    # build of Swift depend on these for building and testing.
+                    build_targets=(llvm-tblgen clang-headers intrinsics_gen clang-tablegen-targets)
+                    # If we are not performing a toolchain only build, then we
+                    # also want to include FileCheck and not for testing
+                    # purposes.
+                    if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
+                      build_targets=(
+                          "${build_targets[@]}"
+                          FileCheck
+                          not
+                      )
+                    fi
                 fi
 
                 if [ "${HOST_LIBTOOL}" ] ; then


### PR DESCRIPTION
…e, do not include FileCheck and not.

The reason why is that we will not generate targets for them causing the build
to fail.
