### PR TITLE
[5.1] Introduce -runtime-compatibility-version flag as a no-op.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -883,4 +883,8 @@ def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,
 def vfsoverlay_EQ : Joined<["-"], "vfsoverlay=">,
   Alias<vfsoverlay>;
 
+// Runtime compatibility version
+def runtime_compatibility_version : Separate<["-"], "runtime-compatibility-version">,
+  Flags<[FrontendOption]>,
+  HelpText<"Link compatibility library for Swift runtime version, or 'none'">;
 include "FrontendOptions.td"


### PR DESCRIPTION
Stage in part of apple/swift#25030 so that build systems can start using it.