### PR TITLE
[test] Mark SR-10600.swift as executable.

### DIFF
--- a/test/Interpreter/SR-10600.swift
+++ b/test/Interpreter/SR-10600.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
+// REQUIRES: executable_test
+
 public class BaseView { }
 public class GenericView<T>: BaseView { }
 public class FinalView: GenericView<ContentForTheView> { }


### PR DESCRIPTION
Android CI do not run the executable tests because there's no device
attached, but this test was not marked to be skipped, and it broke the
Android CI.

See https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/918/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/2699/