### PR TITLE
[SE-0258] Minor adjustments to bring implementation closer to the proposal

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4379,6 +4379,9 @@ ERROR(property_delegate_local,none,
 ERROR(property_delegate_let, none,
       "property delegate can only be applied to a 'var'",
       ())
+ERROR(property_delegate_computed, none,
+      "property delegate cannot be applied to a computed property",
+      ())
 
 ERROR(property_with_delegate_conflict_attribute,none,
       "property %0 with a delegate cannot also be "

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -136,6 +136,14 @@ static CodableConformanceType varConformsToCodable(TypeChecker &tc,
                                isIUO, proto);
 }
 
+/// Retrieve the variable name for the purposes of encoding/decoding.
+static Identifier getVarNameForCoding(VarDecl *var) {
+  if (auto originalVar = var->getOriginalDelegatedProperty())
+    return originalVar->getName();
+
+  return var->getName();
+}
+
 /// Validates the given CodingKeys enum decl by ensuring its cases are a 1-to-1
 /// match with the stored vars of the given type.
 ///
@@ -162,7 +170,7 @@ static bool validateCodingKeysEnum(DerivedConformance &derived,
     if (varDecl->getAttrs().hasAttribute<LazyAttr>())
       continue;
 
-    properties[varDecl->getName()] = varDecl;
+    properties[getVarNameForCoding(varDecl)] = varDecl;
   }
 
   bool propertiesAreValid = true;
@@ -365,7 +373,8 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
     switch (conformance) {
       case Conforms:
       {
-        auto *elt = new (C) EnumElementDecl(SourceLoc(), varDecl->getName(),
+        auto *elt = new (C) EnumElementDecl(SourceLoc(),
+                                            getVarNameForCoding(varDecl),
                                             nullptr, SourceLoc(), nullptr,
                                             enumDecl);
         elt->setImplicit();
@@ -518,6 +527,11 @@ lookupVarDeclForCodingKeysCase(DeclContext *conformanceDC,
                                NominalTypeDecl *targetDecl) {
   for (auto decl : targetDecl->lookupDirect(DeclName(elt->getName()))) {
     if (auto *vd = dyn_cast<VarDecl>(decl)) {
+      // If we found a property with an attached delegate, retrieve the
+      // backing property.
+      if (auto backingVar = vd->getPropertyDelegateBackingProperty())
+        vd = backingVar;
+
       if (!vd->isStatic()) {
         // This is the VarDecl we're looking for.
 

--- a/lib/Sema/TypeCheckPropertyDelegate.cpp
+++ b/lib/Sema/TypeCheckPropertyDelegate.cpp
@@ -343,6 +343,12 @@ AttachedPropertyDelegateRequest::evaluate(Evaluator &evaluator,
       }
     }
 
+    // Properties with delegates must not declare a getter or setter.
+    if (!var->hasStorage()) {
+      ctx.Diags.diagnose(attr->getLocation(), diag::property_delegate_computed);
+      return nullptr;
+    }
+
     return mutableAttr;
   }
 

--- a/lib/Sema/TypeCheckPropertyDelegate.cpp
+++ b/lib/Sema/TypeCheckPropertyDelegate.cpp
@@ -265,7 +265,8 @@ AttachedPropertyDelegateRequest::evaluate(Evaluator &evaluator,
 
     // If the declaration came from a module file, we've already done all of
     // the semantic checking required.
-    if (!dc->getParentSourceFile())
+    auto sourceFile = dc->getParentSourceFile();
+    if (!sourceFile)
       return mutableAttr;
 
     // Check various restrictions on which properties can have delegates
@@ -344,7 +345,7 @@ AttachedPropertyDelegateRequest::evaluate(Evaluator &evaluator,
     }
 
     // Properties with delegates must not declare a getter or setter.
-    if (!var->hasStorage()) {
+    if (!var->hasStorage() && sourceFile->Kind != SourceFileKind::Interface) {
       ctx.Diags.diagnose(attr->getLocation(), diag::property_delegate_computed);
       return nullptr;
     }

--- a/test/SILGen/property_delegates.swift
+++ b/test/SILGen/property_delegates.swift
@@ -142,17 +142,12 @@ struct HasDefaultInit {
 
 struct DelegateWithAccessors {
   @Wrapper
-  var x: Int {
-    // CHECK-LABEL: sil hidden [ossa] @$s18property_delegates21DelegateWithAccessorsV1xSivg
-    // CHECK-NOT: return
-    // CHECK: integer_literal $Builtin.IntLiteral, 42
-    return 42
+  var x: Int
 
-    // Synthesized setter
-    // CHECK-LABEL: sil hidden [transparent] [ossa] @$s18property_delegates21DelegateWithAccessorsV1xSivs : $@convention(method) (Int, @inout DelegateWithAccessors) -> ()
-    // CHECK-NOT: return
-    // CHECK: struct_element_addr {{%.*}} : $*DelegateWithAccessors, #DelegateWithAccessors.$x
-  }
+  // Synthesized setter
+  // CHECK-LABEL: sil hidden [transparent] [ossa] @$s18property_delegates21DelegateWithAccessorsV1xSivs : $@convention(method) (Int, @inout DelegateWithAccessors) -> ()
+  // CHECK-NOT: return
+  // CHECK: struct_element_addr {{%.*}} : $*DelegateWithAccessors, #DelegateWithAccessors.$x
 
   mutating func test() {
     x = 17

--- a/test/decl/protocol/special/coding/property_delegate_codable.swift
+++ b/test/decl/protocol/special/coding/property_delegate_codable.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+@_propertyDelegate
+struct Wrapper<T: Codable> {
+  var value: T
+}
+
+@_propertyDelegate
+struct WrapperWithInitialValue<T: Codable> {
+  var value: T
+
+  init(initialValue: T) {
+    self.value = initialValue
+  }
+}
+
+extension WrapperWithInitialValue: Codable { }
+
+struct X: Codable {
+  @WrapperWithInitialValue var foo = 17
+
+  // Make sure the generated key is named 'foo', like the original property.
+  private func getFooKey() -> CodingKeys {
+    return .foo
+  }
+}
+
+
+
+// expected-error@+2{{type 'Y' does not conform to protocol 'Encodable'}}
+// expected-error@+1{{type 'Y' does not conform to protocol 'Decodable'}}
+struct Y: Codable {
+  @Wrapper var foo: Int
+  // expected-note@-1{{cannot automatically synthesize 'Encodable' because 'Wrapper<Int>' does not conform to 'Encodable'}}
+  // expected-note@-2{{cannot automatically synthesize 'Decodable' because 'Wrapper<Int>' does not conform to 'Decodable'}}
+  
+}

--- a/test/decl/var/property_delegates.swift
+++ b/test/decl/var/property_delegates.swift
@@ -169,6 +169,13 @@ class Superclass {
   var x: Int = 0
 }
 
+class SubclassOfClassWithDelegates: ClassWithDelegates {
+  override var x: Int {
+    get { return $x.value }
+    set { $x.value = newValue }
+  }
+}
+
 class SubclassWithDelegate: Superclass {
   @Wrapper(value: 17)
   override var x: Int { get { return 0 } set { } } // expected-error{{property 'x' with attached delegate cannot override another property}}
@@ -593,7 +600,7 @@ struct NoDefaultInitializerStruct { // expected-note{{'init(x:)' declared here}}
 
 class DefaultInitializerClass {
   @Wrapper(value: true)
-  final var x
+  var x
 
   @WrapperWithInitialValue
   final var y: Int = 10

--- a/test/decl/var/property_delegates.swift
+++ b/test/decl/var/property_delegates.swift
@@ -322,25 +322,9 @@ func testBackingStore<T>(bs: BackingStore<T>) {
 // Explicitly-specified accessors
 // ---------------------------------------------------------------------------
 struct DelegateWithAccessors {
-  @Wrapper
+  @Wrapper  // expected-error{{property delegate cannot be applied to a computed property}}
   var x: Int {
-    return $x.value * 2
-  }
-
-  @WrapperWithInitialValue
-  var y: Int {
-    get {
-      return $y.value
-    }
-
-    set {
-      $y.value = newValue / 2
-    }
-  }
-
-  mutating func test() {
-    x = y
-    y = x
+    return 17
   }
 }
 
@@ -520,24 +504,13 @@ class Box<Value> {
 struct UseBox {
   @Box
   var x = 17
-
-  @Box
-  var y: Int {
-    get { return $y.value }
-    set { }
-  }
 }
 
 func testBox(ub: UseBox) {
   _ = ub.x
   ub.x = 5 // expected-error{{cannot assign to property: 'x' is a get-only property}}
 
-  _ = ub.y
-  ub.y = 20 // expected-error{{cannot assign to property: 'ub' is a 'let' constant}}
-
   var mutableUB = ub
-  _ = mutableUB.y
-  mutableUB.y = 20
   mutableUB = ub
 }
 


### PR DESCRIPTION
Three minor adjustments to the property delegates^Wwrappers implementation to bring it closer to the proposal:

* Ensure that non-`final` properties can have attached delegates/wrappers
* Adjust the name of the synthesized enum case in `CodingKeys` for synthesized `Codable` support
* Ban `get` / `set` on properties with attached delegates/wrappers