### PR TITLE
[TypeContextInfo/ConformingMethods] Map type out of context

### DIFF
--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -87,6 +87,10 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (!T || T->is<ErrorType>() || T->is<UnresolvedType>())
     return;
 
+  T = T->getRValueType();
+  if (T->hasArchetype())
+    T = T->mapTypeOutOfContext();
+
   llvm::MapVector<ProtocolDecl*, StringRef> expectedProtocols;
   resolveProtocolNames(CurDeclContext, ExpectedTypeNames, expectedProtocols);
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -104,11 +104,16 @@ void ContextInfoCallbacks::doneParsing() {
   for (auto T : Info.getPossibleTypes()) {
     if (T->is<ErrorType>() || T->is<UnresolvedType>())
       continue;
-    if (auto env = CurDeclContext->getGenericEnvironmentOfContext())
-      T = env->mapTypeIntoContext(T);
+
+    T = T->getRValueType();
+    if (T->hasArchetype())
+      T = T->mapTypeOutOfContext();
 
     // TODO: Do we need '.none' for Optionals?
     auto objT = T->lookThroughAllOptionalTypes();
+
+    if (auto env = CurDeclContext->getGenericEnvironmentOfContext())
+      objT = env->mapTypeIntoContext(T);
 
     if (!seenTypes.insert(objT->getCanonicalType()).second)
       continue;

--- a/test/SourceKit/ConformingMethods/generics.swift
+++ b/test/SourceKit/ConformingMethods/generics.swift
@@ -1,0 +1,23 @@
+protocol Proto {}
+struct ConcreteProto : Proto {}
+struct ConcreteProtoGen<T> : Proto {}
+
+struct S<T> : Proto {
+  func methodForProto1(x: T) -> ConcreteProto {}
+  func methodForProto2<U>(x: U) -> ConcreteProtoGen<U> {}
+  func methodForProto3(x: Self) -> ConcreteProtoGen<T> {}
+  func methodForProto4() -> Self {}
+  func methodForInt() -> Int { return 1 }
+  mutating func test() {
+    self.
+  }
+}
+
+func test<X>(value: S<X>) {
+  value.
+}
+
+// RUN: %sourcekitd-test -req=conformingmethods -pos=12:10 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.1
+// RUN: diff -u %s.response.1 %t.response.1
+// RUN: %sourcekitd-test -req=conformingmethods -pos=17:8 %s -req-opts=expectedtypes='$s8MyModule5ProtoPD' -- -module-name MyModule %s > %t.response.2
+// RUN: diff -u %s.response.2 %t.response.2

--- a/test/SourceKit/ConformingMethods/generics.swift.response.1
+++ b/test/SourceKit/ConformingMethods/generics.swift.response.1
@@ -1,0 +1,34 @@
+{
+  key.typename: "S<T>",
+  key.typeusr: "$s8MyModule1SVyxGD",
+  key.members: [
+    {
+      key.name: "methodForProto1(x:)",
+      key.sourcetext: "methodForProto1(x: <#T##T#>)",
+      key.description: "methodForProto1(x: T)",
+      key.typename: "ConcreteProto",
+      key.typeusr: "$s8MyModule13ConcreteProtoVD"
+    },
+    {
+      key.name: "methodForProto2(x:)",
+      key.sourcetext: "methodForProto2(x: <#T##U#>)",
+      key.description: "methodForProto2(x: U)",
+      key.typename: "ConcreteProtoGen<U>",
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD"
+    },
+    {
+      key.name: "methodForProto3(x:)",
+      key.sourcetext: "methodForProto3(x: <#T##S<T>#>)",
+      key.description: "methodForProto3(x: S<T>)",
+      key.typename: "ConcreteProtoGen<T>",
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD"
+    },
+    {
+      key.name: "methodForProto4()",
+      key.sourcetext: "methodForProto4()",
+      key.description: "methodForProto4()",
+      key.typename: "S<T>",
+      key.typeusr: "$s8MyModule1SVyxGD"
+    }
+  ]
+}

--- a/test/SourceKit/ConformingMethods/generics.swift.response.2
+++ b/test/SourceKit/ConformingMethods/generics.swift.response.2
@@ -1,0 +1,34 @@
+{
+  key.typename: "S<X>",
+  key.typeusr: "$s8MyModule1SVyxGD",
+  key.members: [
+    {
+      key.name: "methodForProto1(x:)",
+      key.sourcetext: "methodForProto1(x: <#T##X#>)",
+      key.description: "methodForProto1(x: X)",
+      key.typename: "ConcreteProto",
+      key.typeusr: "$s8MyModule13ConcreteProtoVD"
+    },
+    {
+      key.name: "methodForProto2(x:)",
+      key.sourcetext: "methodForProto2(x: <#T##U#>)",
+      key.description: "methodForProto2(x: U)",
+      key.typename: "ConcreteProtoGen<U>",
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD"
+    },
+    {
+      key.name: "methodForProto3(x:)",
+      key.sourcetext: "methodForProto3(x: <#T##S<X>#>)",
+      key.description: "methodForProto3(x: S<X>)",
+      key.typename: "ConcreteProtoGen<X>",
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD"
+    },
+    {
+      key.name: "methodForProto4()",
+      key.sourcetext: "methodForProto4()",
+      key.description: "methodForProto4()",
+      key.typename: "S<X>",
+      key.typeusr: "$s8MyModule1SVyxGD"
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift
@@ -1,0 +1,34 @@
+struct S<T> {
+  func foo<U>(x: U) {}
+  func bar<V>(x: S<V>) {}
+  func baz(x: Self) {}
+
+  func test() {
+    foo(x: )
+    bar(x: )
+    self.baz(x: )
+  }
+
+  func test2<X>(x: X) {
+    var value = S<X>()
+    value.foo(x: )
+    value.bar(x: )
+    value.baz(x: )
+  }
+
+  static var instance: Self = S<T>()
+}
+
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=7:12 %s -- %s > %t.response.1
+// RUN: diff -u %s.response.1 %t.response.1
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=8:12 %s -- %s > %t.response.2
+// RUN: diff -u %s.response.2 %t.response.2
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=9:17 %s -- %s > %t.response.3
+// RUN: diff -u %s.response.3 %t.response.3
+
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=14:18 %s -- %s > %t.response.4
+// RUN: diff -u %s.response.4 %t.response.4
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=15:18 %s -- %s > %t.response.5
+// RUN: diff -u %s.response.5 %t.response.5
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=16:18 %s -- %s > %t.response.6
+// RUN: diff -u %s.response.6 %t.response.6

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.1
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.1
@@ -1,0 +1,10 @@
+{
+  key.results: [
+    {
+      key.typename: "U",
+      key.typeusr: "$sqd__D",
+      key.implicitmembers: [
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.2
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.2
@@ -1,0 +1,15 @@
+{
+  key.results: [
+    {
+      key.typename: "S<V>",
+      key.typeusr: "$s20typecontext_generics1SVyqd__GD",
+      key.implicitmembers: [
+        {
+          key.name: "instance",
+          key.sourcetext: "instance",
+          key.description: "instance"
+        }
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.3
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.3
@@ -1,0 +1,15 @@
+{
+  key.results: [
+    {
+      key.typename: "S<T>",
+      key.typeusr: "$s20typecontext_generics1SVyxGD",
+      key.implicitmembers: [
+        {
+          key.name: "instance",
+          key.sourcetext: "instance",
+          key.description: "instance"
+        }
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.4
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.4
@@ -1,0 +1,10 @@
+{
+  key.results: [
+    {
+      key.typename: "U",
+      key.typeusr: "$sqd__D",
+      key.implicitmembers: [
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.5
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.5
@@ -1,0 +1,15 @@
+{
+  key.results: [
+    {
+      key.typename: "S<V>",
+      key.typeusr: "$s20typecontext_generics1SVyqd__GD",
+      key.implicitmembers: [
+        {
+          key.name: "instance",
+          key.sourcetext: "instance",
+          key.description: "instance"
+        }
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.6
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.6
@@ -1,0 +1,15 @@
+{
+  key.results: [
+    {
+      key.typename: "S<X>",
+      key.typeusr: "$s20typecontext_generics1SVyqd__GD",
+      key.implicitmembers: [
+        {
+          key.name: "instance",
+          key.sourcetext: "instance",
+          key.description: "instance"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
To print mangling names. Otherwise, they hit [assertion](https://github.com/apple/swift/blob/9821d462005366ebaaf2e821c778bb4f05f2cc6c/lib/AST/USRGeneration.cpp#L36):
```
Assertion failed: (!Ty->hasArchetype() && "cannot have contextless archetypes mangled.")
```

rdar://problem/51198887
rdar://problem/51227338