### PR TITLE
Fix a potential race condition in StdlibUnittest

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -117,6 +117,10 @@ fileprivate struct AtomicBool {
     func orAndFetch(_ b: Bool) -> Bool {
         return _value.orAndFetch(b ? 1 : 0) != 0
     }
+
+    func fetchAndClear() -> Bool {
+        return _value.fetchAndAnd(0) != 0
+    }
 }
 
 func _printStackTrace(_ stackTrace: SourceLocStack?) {
@@ -139,11 +143,9 @@ public func expectFailure(
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line, invoking body: () -> Void) {
-  let startAnyExpectFailed = _anyExpectFailed.load()
-  _anyExpectFailed.store(false)
+  let startAnyExpectFailed = _anyExpectFailed.fetchAndClear()
   body()
-  let endAnyExpectFailed = _anyExpectFailed.load()
-  _anyExpectFailed.store(false)
+  let endAnyExpectFailed = _anyExpectFailed.fetchAndClear()
   expectTrue(
     endAnyExpectFailed, "running `body` should produce an expected failure",
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)


### PR DESCRIPTION
`StdlibUnittest` uses an `AtomicBool` to track whether a failure has ocurred in a test. Without these changes, `expectFailure` could have a false-positive failure due to a race condition on the `_anyExpectFailed` variable.

I believe the following interleaving of two threads `A` and `B` would trigger the issue:
```
A: loads false
A: stores false
B: loads false
A: stores true
B: stores false
A: loads false (after body)
```
which causes A to see a false-positive failure.

Fixes rdar://51247527
CC @lorentey 