### PR TITLE
Sema: Port member access on existentials diagnostic to new diagnostic framework

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -757,8 +757,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
       break;
 
     case MemberLookupResult::UR_UnavailableInExistential: {
-      AllowProtocolTypeMemberFailure failure(baseExpr, CS, instanceTy, memberName,
-                                             CS.getConstraintLocator(E));
+      InvalidMemberRefOnExistential failure(baseExpr, CS, instanceTy, memberName,
+                                            CS.getConstraintLocator(E));
       failure.diagnoseAsError();
       return;
     }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -754,12 +754,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
     case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
     case MemberLookupResult::UR_ReferenceWritableKeyPathOnMutatingMember:
     case MemberLookupResult::UR_KeyPathWithAnyObjectRootType:
-      break;
     case MemberLookupResult::UR_UnavailableInExistential:
-      diagnose(loc, diag::could_not_use_member_on_existential,
-               instanceTy, memberName)
-        .highlight(baseRange).highlight(nameLoc.getSourceRange());
-      return;
+      break;
     case MemberLookupResult::UR_InstanceMemberOnType:
     case MemberLookupResult::UR_TypeMemberOnInstance: {
       auto locatorKind = isa<SubscriptExpr>(E)
@@ -6671,7 +6667,7 @@ bool FailureDiagnosis::diagnoseMemberFailures(
       locator = simplifyLocator(CS, locator, memberRange);
 
     BaseLoc = baseExpr->getLoc();
-    NameLoc = DeclNameLoc(memberRange.Start);
+    NameLoc =   DeclNameLoc(memberRange.Start);
 
     // Retypecheck the anchor type, which is the base of the member expression.
     baseExpr =

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -757,8 +757,8 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
       break;
 
     case MemberLookupResult::UR_UnavailableInExistential: {
-      InvalidMemberRefOnExistential failure(baseExpr, CS, instanceTy, memberName,
-                                            CS.getConstraintLocator(E));
+      InvalidMemberRefOnExistential failure(
+          baseExpr, CS, instanceTy, memberName, CS.getConstraintLocator(E));
       failure.diagnoseAsError();
       return;
     }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6667,7 +6667,7 @@ bool FailureDiagnosis::diagnoseMemberFailures(
       locator = simplifyLocator(CS, locator, memberRange);
 
     BaseLoc = baseExpr->getLoc();
-    NameLoc =   DeclNameLoc(memberRange.Start);
+    NameLoc = DeclNameLoc(memberRange.Start);
 
     // Retypecheck the anchor type, which is the base of the member expression.
     baseExpr =

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -754,8 +754,15 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
     case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
     case MemberLookupResult::UR_ReferenceWritableKeyPathOnMutatingMember:
     case MemberLookupResult::UR_KeyPathWithAnyObjectRootType:
-    case MemberLookupResult::UR_UnavailableInExistential:
       break;
+
+    case MemberLookupResult::UR_UnavailableInExistential: {
+      AllowProtocolTypeMemberFailure failure(baseExpr, CS, instanceTy, memberName,
+                                             CS.getConstraintLocator(E));
+      failure.diagnoseAsError();
+      return;
+    }
+
     case MemberLookupResult::UR_InstanceMemberOnType:
     case MemberLookupResult::UR_TypeMemberOnInstance: {
       auto locatorKind = isa<SubscriptExpr>(E)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1963,7 +1963,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 
 bool AllowProtocolTypeMemberFailure::diagnoseAsError() {
   auto *anchor = getRawAnchor();
-  
+
   Expr *baseExpr = getAnchor();
   DeclNameLoc nameLoc;
   if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
@@ -1976,10 +1976,10 @@ bool AllowProtocolTypeMemberFailure::diagnoseAsError() {
   } else if (auto *call = dyn_cast<CallExpr>(anchor)) {
     baseExpr = call->getFn();
   }
-  
+
   emitDiagnostic(getAnchor()->getLoc(),
-                  diag::could_not_use_member_on_existential,
-                  getBaseType(), getName())
+                 diag::could_not_use_member_on_existential, getBaseType(),
+                 getName())
       .highlight(nameLoc.getSourceRange())
       .highlight(baseExpr->getSourceRange());
   return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1978,7 +1978,7 @@ bool InvalidMemberRefOnExistential::diagnoseAsError() {
   }
 
   emitDiagnostic(getAnchor()->getLoc(),
-                 diag::could_not_use_member_on_existential, getBaseType()->getRValueType(),
+                 diag::could_not_use_member_on_existential, getBaseType(),
                  getName())
       .highlight(nameLoc.getSourceRange())
       .highlight(baseExpr->getSourceRange());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1978,7 +1978,7 @@ bool AllowProtocolTypeMemberFailure::diagnoseAsError() {
   }
 
   emitDiagnostic(getAnchor()->getLoc(),
-                 diag::could_not_use_member_on_existential, getBaseType(),
+                 diag::could_not_use_member_on_existential, getBaseType()->getRValueType(),
                  getName())
       .highlight(nameLoc.getSourceRange())
       .highlight(baseExpr->getSourceRange());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1961,6 +1961,30 @@ bool MissingMemberFailure::diagnoseAsError() {
   return true;
 }
 
+bool AllowProtocolTypeMemberFailure::diagnoseAsError() {
+  auto *anchor = getRawAnchor();
+  
+  Expr *baseExpr = getAnchor();
+  DeclNameLoc nameLoc;
+  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
+    baseExpr = UDE->getBase();
+    nameLoc = UDE->getNameLoc();
+  } else if (auto *UME = dyn_cast<UnresolvedMemberExpr>(anchor)) {
+    nameLoc = UME->getNameLoc();
+  } else if (auto *SE = dyn_cast<SubscriptExpr>(anchor)) {
+    baseExpr = SE->getBase();
+  } else if (auto *call = dyn_cast<CallExpr>(anchor)) {
+    baseExpr = call->getFn();
+  }
+  
+  emitDiagnostic(getAnchor()->getLoc(),
+                  diag::could_not_use_member_on_existential,
+                  getBaseType(), getName())
+      .highlight(nameLoc.getSourceRange())
+      .highlight(baseExpr->getSourceRange());
+  return true;
+}
+
 bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
   auto loc = getAnchor()->getLoc();
   auto &cs = getConstraintSystem();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1844,7 +1844,7 @@ bool MissingMemberFailure::diagnoseAsError() {
   if (!anchor || !baseExpr)
     return false;
 
-  if (auto *typeVar = BaseType->getAs<TypeVariableType>()) {
+  if (auto *typeVar = getBaseType()->getAs<TypeVariableType>()) {
     auto &CS = getConstraintSystem();
     auto *memberLoc = typeVar->getImpl().getLocator();
     // Don't try to diagnose anything besides first missing
@@ -1856,7 +1856,7 @@ bool MissingMemberFailure::diagnoseAsError() {
       return false;
   }
 
-  auto baseType = resolveType(BaseType)->getWithoutSpecifierType();
+  auto baseType = resolveType(getBaseType())->getWithoutSpecifierType();
 
   DeclNameLoc nameLoc(anchor->getStartLoc());
   if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
@@ -1876,22 +1876,22 @@ bool MissingMemberFailure::diagnoseAsError() {
     if (baseType->is<TupleType>())
       diagnostic = diag::could_not_find_tuple_member;
 
-    emitDiagnostic(anchor->getLoc(), diagnostic, baseType, Name)
+    emitDiagnostic(anchor->getLoc(), diagnostic, baseType, getName())
         .highlight(baseExpr->getSourceRange())
         .highlight(nameLoc.getSourceRange());
   };
 
-  TypoCorrectionResults corrections(TC, Name, nameLoc);
+  TypoCorrectionResults corrections(TC, getName(), nameLoc);
   auto tryTypoCorrection = [&] {
     TC.performTypoCorrection(getDC(), DeclRefKind::Ordinary, baseType,
                              defaultMemberLookupOptions, corrections);
   };
 
-  if (Name.getBaseName().getKind() == DeclBaseName::Kind::Subscript) {
+  if (getName().getBaseName().getKind() == DeclBaseName::Kind::Subscript) {
     emitDiagnostic(anchor->getLoc(), diag::could_not_find_value_subscript,
                    baseType)
         .highlight(baseExpr->getSourceRange());
-  } else if (Name.getBaseName() == "deinit") {
+  } else if (getName().getBaseName() == "deinit") {
     // Specialised diagnostic if trying to access deinitialisers
     emitDiagnostic(anchor->getLoc(), diag::destructor_not_accessible)
         .highlight(baseExpr->getSourceRange());
@@ -1900,9 +1900,9 @@ bool MissingMemberFailure::diagnoseAsError() {
     tryTypoCorrection();
 
     if (DeclName rightName =
-            findCorrectEnumCaseName(instanceTy, corrections, Name)) {
+            findCorrectEnumCaseName(instanceTy, corrections, getName())) {
       emitDiagnostic(anchor->getLoc(), diag::could_not_find_enum_case,
-                     instanceTy, Name, rightName)
+                     instanceTy, getName(), rightName)
           .fixItReplace(nameLoc.getBaseNameLoc(),
                         rightName.getBaseIdentifier().str());
       return true;
@@ -1911,7 +1911,7 @@ bool MissingMemberFailure::diagnoseAsError() {
     if (auto correction = corrections.claimUniqueCorrection()) {
       auto diagnostic = emitDiagnostic(
           anchor->getLoc(), diag::could_not_find_type_member_corrected,
-          instanceTy, Name, correction->CorrectedName);
+          instanceTy, getName(), correction->CorrectedName);
       diagnostic.highlight(baseExpr->getSourceRange())
           .highlight(nameLoc.getSourceRange());
       correction->addFixits(diagnostic);
@@ -1920,14 +1920,14 @@ bool MissingMemberFailure::diagnoseAsError() {
     }
   } else if (auto moduleTy = baseType->getAs<ModuleType>()) {
     emitDiagnostic(baseExpr->getLoc(), diag::no_member_of_module,
-                   moduleTy->getModule()->getName(), Name)
+                   moduleTy->getModule()->getName(), getName())
         .highlight(baseExpr->getSourceRange())
         .highlight(nameLoc.getSourceRange());
     return true;
   } else {
     // Check for a few common cases that can cause missing members.
     auto *ED = baseType->getEnumOrBoundGenericEnum();
-    if (ED && Name.isSimpleName("rawValue")) {
+    if (ED && getName().isSimpleName("rawValue")) {
       auto loc = ED->getNameLoc();
       if (loc.isValid()) {
         emitBasicError(baseType);
@@ -1947,7 +1947,7 @@ bool MissingMemberFailure::diagnoseAsError() {
     if (auto correction = corrections.claimUniqueCorrection()) {
       auto diagnostic = emitDiagnostic(
           anchor->getLoc(), diag::could_not_find_value_member_corrected,
-          baseType, Name, correction->CorrectedName);
+          baseType, getName(), correction->CorrectedName);
       diagnostic.highlight(baseExpr->getSourceRange())
           .highlight(nameLoc.getSourceRange());
       correction->addFixits(diagnostic);
@@ -1961,7 +1961,7 @@ bool MissingMemberFailure::diagnoseAsError() {
   return true;
 }
 
-bool AllowProtocolTypeMemberFailure::diagnoseAsError() {
+bool InvalidMemberRefOnExistential::diagnoseAsError() {
   auto *anchor = getRawAnchor();
 
   Expr *baseExpr = getAnchor();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -771,7 +771,7 @@ public:
 ///   let _: Int = s.foo(1, 2) // expected type is `(Int, Int) -> Int`
 /// }
 /// ```
-class MissingMemberFailure final : public FailureDiagnostic {
+class MissingMemberFailure : public FailureDiagnostic {
   Type BaseType;
   DeclName Name;
 
@@ -787,6 +787,10 @@ private:
   static DeclName findCorrectEnumCaseName(Type Ty,
                                           TypoCorrectionResults &corrections,
                                           DeclName memberName);
+
+protected:
+  Type getBaseType() const { return BaseType; }
+  DeclName getName() const { return Name; }
 };
 
 /// Diagnose cases where a member only accessible on generic constraints
@@ -797,29 +801,19 @@ private:
 /// protocol P {
 ///   var foo: Self { get }
 /// }
-/// 
+///
 /// func bar<X : P>(p: X) {
 ///   p.foo
 /// }
 /// ```
-class AllowProtocolTypeMemberFailure final : public FailureDiagnostic {
-  Type BaseType;
-  ValueDecl *Member;
-  DeclName Name;
-  
-  public:
-    AllowProtocolTypeMemberFailure(Expr *root, ConstraintSystem &cs,
-                                   Type baseType, ValueDecl *member, DeclName memberName,
-                                   ConstraintLocator *locator)
-            : FailureDiagnostic(root, cs, locator), BaseType(baseType),
-              Member(member), Name(memberName) {}
-  
-    bool diagnoseAsError() override;
-    
-  private:
-    Type getBaseType() const { return BaseType; }
-    ValueDecl *getMember() const { return Member; }
-    DeclName getName() const { return Name; }
+class AllowProtocolTypeMemberFailure final : public MissingMemberFailure {
+public:
+  AllowProtocolTypeMemberFailure(Expr *root, ConstraintSystem &cs,
+                                 Type baseType, DeclName memberName,
+                                 ConstraintLocator *locator)
+      : MissingMemberFailure(root, cs, baseType, memberName, locator) {}
+
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose situations when we use an instance member on a type

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -765,13 +765,13 @@ public:
 class InvalidMemberRefFailure : public FailureDiagnostic {
   Type BaseType;
   DeclName Name;
-  
+
 public:
   InvalidMemberRefFailure(Expr *root, ConstraintSystem &cs, Type baseType,
                           DeclName memberName, ConstraintLocator *locator)
-          : FailureDiagnostic(root, cs, locator),
-            BaseType(baseType), Name(memberName) {}
-            
+      : FailureDiagnostic(root, cs, locator), BaseType(baseType->getRValueType()),
+        Name(memberName) {}
+
 protected:
   Type getBaseType() const { return BaseType; }
   DeclName getName() const { return Name; }
@@ -815,9 +815,8 @@ private:
 /// ```
 class InvalidMemberRefOnExistential final : public InvalidMemberRefFailure {
 public:
-  InvalidMemberRefOnExistential(Expr *root, ConstraintSystem &cs,
-                                Type baseType, DeclName memberName,
-                                ConstraintLocator *locator)
+  InvalidMemberRefOnExistential(Expr *root, ConstraintSystem &cs, Type baseType,
+                                DeclName memberName, ConstraintLocator *locator)
       : InvalidMemberRefFailure(root, cs, baseType, memberName, locator) {}
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -789,6 +789,39 @@ private:
                                           DeclName memberName);
 };
 
+/// Diagnose cases where a member only accessible on generic constraints
+/// requiring conformance to a protocol is used on a value of the
+/// existential protocol type e.g.
+///
+/// ```swift
+/// protocol P {
+///   var foo: Self { get }
+/// }
+/// 
+/// func bar<X : P>(p: X) {
+///   p.foo
+/// }
+/// ```
+class AllowProtocolTypeMemberFailure final : public FailureDiagnostic {
+  Type BaseType;
+  ValueDecl *Member;
+  DeclName Name;
+  
+  public:
+    AllowProtocolTypeMemberFailure(Expr *root, ConstraintSystem &cs,
+                                   Type baseType, ValueDecl *member, DeclName memberName,
+                                   ConstraintLocator *locator)
+            : FailureDiagnostic(root, cs, locator), BaseType(baseType),
+              Member(member), Name(memberName) {}
+  
+    bool diagnoseAsError() override;
+    
+  private:
+    Type getBaseType() const { return BaseType; }
+    ValueDecl *getMember() const { return Member; }
+    DeclName getName() const { return Name; }
+};
+
 /// Diagnose situations when we use an instance member on a type
 /// or a type member on an instance
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -285,14 +285,15 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
 
 AllowProtocolTypeMember *
 AllowProtocolTypeMember::create(ConstraintSystem &cs, Type baseType,
-                                ValueDecl *member, DeclName memberName, ConstraintLocator *locator) {
+                                ValueDecl *member, DeclName memberName,
+                                ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowProtocolTypeMember(cs, baseType, memberName, member, locator);
 }
 
 bool AllowProtocolTypeMember::diagnose(Expr *root, bool asNote) const {
   auto failure = AllowProtocolTypeMemberFailure(root, getConstraintSystem(),
-                                                BaseType, Member, Name, getLocator());
+                                                BaseType, Name, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -283,17 +283,17 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
       DefineMemberBasedOnUse(cs, baseType, member, locator);
 }
 
-AllowProtocolTypeMember *
-AllowProtocolTypeMember::create(ConstraintSystem &cs, Type baseType,
+AllowMemberRefOnExistential *
+AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
                                 ValueDecl *member, DeclName memberName,
                                 ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowProtocolTypeMember(cs, baseType, memberName, member, locator);
+      AllowMemberRefOnExistential(cs, baseType, memberName, member, locator);
 }
 
-bool AllowProtocolTypeMember::diagnose(Expr *root, bool asNote) const {
-  auto failure = AllowProtocolTypeMemberFailure(root, getConstraintSystem(),
-                                                BaseType, Name, getLocator());
+bool AllowMemberRefOnExistential::diagnose(Expr *root, bool asNote) const {
+  auto failure = InvalidMemberRefOnExistential(root, getConstraintSystem(),
+                                               BaseType, Name, getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -283,6 +283,19 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
       DefineMemberBasedOnUse(cs, baseType, member, locator);
 }
 
+AllowProtocolTypeMember *
+AllowProtocolTypeMember::create(ConstraintSystem &cs, Type baseType,
+                                ValueDecl *member, DeclName memberName, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowProtocolTypeMember(cs, baseType, memberName, member, locator);
+}
+
+bool AllowProtocolTypeMember::diagnose(Expr *root, bool asNote) const {
+  auto failure = AllowProtocolTypeMemberFailure(root, getConstraintSystem(),
+                                                BaseType, Member, Name, getLocator());
+  return failure.diagnose(asNote);
+}
+
 bool AllowTypeOrInstanceMember::diagnose(Expr *root, bool asNote) const {
   auto failure = AllowTypeOrInstanceMemberFailure(
       root, getConstraintSystem(), BaseType, Member, UsedName, getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -285,8 +285,8 @@ DefineMemberBasedOnUse::create(ConstraintSystem &cs, Type baseType,
 
 AllowMemberRefOnExistential *
 AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
-                                ValueDecl *member, DeclName memberName,
-                                ConstraintLocator *locator) {
+                                    ValueDecl *member, DeclName memberName,
+                                    ConstraintLocator *locator) {
   return new (cs.getAllocator())
       AllowMemberRefOnExistential(cs, baseType, memberName, member, locator);
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -124,7 +124,7 @@ enum class FixKind : uint8_t {
   /// derived (rather than an arbitrary value of metatype type) or the
   /// referenced constructor must be required.
   AllowInvalidInitRef,
-  
+
   /// Allow an invalid member access on a value of protocol type as if
   /// that protocol type were a generic constraint requiring conformance
   /// to that protocol.
@@ -600,30 +600,29 @@ public:
 
 class AllowProtocolTypeMember final : public ConstraintFix {
   Type BaseType;
-  ValueDecl *Member;
   DeclName Name;
-  
+
   AllowProtocolTypeMember(ConstraintSystem &cs, Type baseType,
                           DeclName memberName, ValueDecl *member,
                           ConstraintLocator *locator)
-          : ConstraintFix(cs, FixKind::AllowProtocolTypeMember,
-                          locator), BaseType(baseType), Member(member), Name(memberName) {}
-  
-  public:
-    std::string getName() const override {
-      llvm::SmallVector<char, 16> scratch;
-      auto memberName = Name.getString(scratch);
-      return "allow access to invalid member '" + memberName.str() +
-            "' on value of protocol type";
-    }
-    
-    bool diagnose(Expr *root, bool asNote = false) const override;
-    
-    static AllowProtocolTypeMember *create(ConstraintSystem &cs,
-                                           Type baseType, ValueDecl *member, DeclName memberName,
-                                           ConstraintLocator *locator);
+      : ConstraintFix(cs, FixKind::AllowProtocolTypeMember, locator),
+        BaseType(baseType), Name(memberName) {}
+
+public:
+  std::string getName() const override {
+    llvm::SmallVector<char, 16> scratch;
+    auto memberName = Name.getString(scratch);
+    return "allow access to invalid member '" + memberName.str() +
+           "' on value of protocol type";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static AllowProtocolTypeMember *create(ConstraintSystem &cs, Type baseType,
+                                         ValueDecl *member, DeclName memberName,
+                                         ConstraintLocator *locator);
 };
-	
+
 class AllowTypeOrInstanceMember final : public ConstraintFix {
   Type BaseType;
   ValueDecl *Member;

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -603,8 +603,8 @@ class AllowMemberRefOnExistential final : public ConstraintFix {
   DeclName Name;
 
   AllowMemberRefOnExistential(ConstraintSystem &cs, Type baseType,
-                          DeclName memberName, ValueDecl *member,
-                          ConstraintLocator *locator)
+                              DeclName memberName, ValueDecl *member,
+                              ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowMemberRefOnExistential, locator),
         BaseType(baseType), Name(memberName) {}
 
@@ -618,9 +618,10 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static AllowMemberRefOnExistential *create(ConstraintSystem &cs, Type baseType,
-                                         ValueDecl *member, DeclName memberName,
-                                         ConstraintLocator *locator);
+  static AllowMemberRefOnExistential *create(ConstraintSystem &cs,
+                                             Type baseType, ValueDecl *member,
+                                             DeclName memberName,
+                                             ConstraintLocator *locator);
 };
 
 class AllowTypeOrInstanceMember final : public ConstraintFix {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -128,7 +128,7 @@ enum class FixKind : uint8_t {
   /// Allow an invalid member access on a value of protocol type as if
   /// that protocol type were a generic constraint requiring conformance
   /// to that protocol.
-  AllowProtocolTypeMember,
+  AllowMemberRefOnExistential,
 
   /// If there are fewer arguments than parameters, let's fix that up
   /// by adding new arguments to the list represented as type variables.
@@ -598,14 +598,14 @@ public:
                                         ConstraintLocator *locator);
 };
 
-class AllowProtocolTypeMember final : public ConstraintFix {
+class AllowMemberRefOnExistential final : public ConstraintFix {
   Type BaseType;
   DeclName Name;
 
-  AllowProtocolTypeMember(ConstraintSystem &cs, Type baseType,
+  AllowMemberRefOnExistential(ConstraintSystem &cs, Type baseType,
                           DeclName memberName, ValueDecl *member,
                           ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AllowProtocolTypeMember, locator),
+      : ConstraintFix(cs, FixKind::AllowMemberRefOnExistential, locator),
         BaseType(baseType), Name(memberName) {}
 
 public:
@@ -618,7 +618,7 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static AllowProtocolTypeMember *create(ConstraintSystem &cs, Type baseType,
+  static AllowMemberRefOnExistential *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclName memberName,
                                          ConstraintLocator *locator);
 };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4528,11 +4528,17 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
     case MemberLookupResult::UR_Inaccessible:
       assert(choice.isDecl());
       return AllowInaccessibleMember::create(cs, choice.getDecl(), locator);
+      
+    case MemberLookupResult::UR_UnavailableInExistential: {
+      return choice.isDecl()
+             ? AllowProtocolTypeMember::create(
+                    cs, baseTy, choice.getDecl(), memberName, locator)
+             : nullptr;
+    }
 
     case MemberLookupResult::UR_MutatingMemberOnRValue:
     case MemberLookupResult::UR_MutatingGetterOnRValue:
     case MemberLookupResult::UR_LabelMismatch:
-    case MemberLookupResult::UR_UnavailableInExistential:
     // TODO(diagnostics): Add a new fix that is suggests to
     // add `subscript(dynamicMember: {Writable}KeyPath<T, U>)`
     // overload here, that would help if such subscript has
@@ -6637,6 +6643,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::RelabelArguments:
   case FixKind::RemoveUnwrap:
   case FixKind::DefineMemberBasedOnUse:
+  case FixKind::AllowProtocolTypeMember:
   case FixKind::AllowTypeOrInstanceMember:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4528,12 +4528,12 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
     case MemberLookupResult::UR_Inaccessible:
       assert(choice.isDecl());
       return AllowInaccessibleMember::create(cs, choice.getDecl(), locator);
-      
+
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()
-             ? AllowProtocolTypeMember::create(
-                    cs, baseTy, choice.getDecl(), memberName, locator)
-             : nullptr;
+                 ? AllowProtocolTypeMember::create(cs, baseTy, choice.getDecl(),
+                                                   memberName, locator)
+                 : nullptr;
     }
 
     case MemberLookupResult::UR_MutatingMemberOnRValue:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4531,7 +4531,7 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
 
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()
-                 ? AllowProtocolTypeMember::create(cs, baseTy, choice.getDecl(),
+                 ? AllowMemberRefOnExistential::create(cs, baseTy, choice.getDecl(),
                                                    memberName, locator)
                  : nullptr;
     }
@@ -6643,7 +6643,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::RelabelArguments:
   case FixKind::RemoveUnwrap:
   case FixKind::DefineMemberBasedOnUse:
-  case FixKind::AllowProtocolTypeMember:
+  case FixKind::AllowMemberRefOnExistential:
   case FixKind::AllowTypeOrInstanceMember:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4531,8 +4531,8 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
 
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()
-                 ? AllowMemberRefOnExistential::create(cs, baseTy, choice.getDecl(),
-                                                   memberName, locator)
+                 ? AllowMemberRefOnExistential::create(
+                       cs, baseTy, choice.getDecl(), memberName, locator)
                  : nullptr;
     }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -267,7 +267,7 @@ struct WrongIsEqual : IsEqualComparable { // expected-error{{type 'WrongIsEqual'
 //===----------------------------------------------------------------------===//
 
 func existentialSequence(_ e: Sequence) { // expected-error{{has Self or associated type requirements}}
-  var x = e.makeIterator() // expected-error{{value of type 'Sequence' has no member 'makeIterator'}}
+  var x = e.makeIterator() // expected-error{{member 'makeIterator' cannot be used on value of protocol type 'Sequence'; use a generic constraint instead}}
   x.next()
   x.nonexistent()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Ported the diagnostic for member accesses on values of protocol type that require the protocol to be used as a generic constraint to the new diagnostic framework and removed the old implementation in CSDiag.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
