### PR TITLE
Sema: Fix crash-on-invalid with 'let' property in protocol

### DIFF
--- a/test/multifile/Inputs/protocol-conformance-let-other.swift
+++ b/test/multifile/Inputs/protocol-conformance-let-other.swift
@@ -1,0 +1,4 @@
+public protocol P {
+  let x: Int
+  // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+}

--- a/test/multifile/protocol-conformance-let.swift
+++ b/test/multifile/protocol-conformance-let.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/protocol-conformance-let-other.swift
+
+public struct S : P {
+  public var x: Int
+}


### PR DESCRIPTION
The protocol requirement storage declaration might not have accessors
created for it if it was incorrectly declared as a 'let' property
inside the protocol.

There might be other cases where we had failed to synthesize the
requirement's accessors, and crash here; this should hopefully make
all of those more robust.

Fixes <rdar://problem/48994271>.