### PR TITLE
[AutoDiff] Revamp 'struct_extract' differentiation strategy.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -421,10 +421,8 @@ DECL_ATTR(differentiating, Differentiating,
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
                  OnAccessor | OnFunc | OnConstructor | OnSubscript,
                  /* Not serialized */ 90)
-SIMPLE_DECL_ATTR(_fieldwiseDifferentiable, FieldwiseDifferentiable,
-                 OnNominalType | UserInaccessible, 91)
 SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
-                 OnVar, 92)
+                 OnVar, 91)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -447,6 +447,9 @@ NOTE(autodiff_opaque_function_not_differentiable,none,
      "opaque non-'@differentiable' function is not differentiable", ())
 NOTE(autodiff_property_not_differentiable,none,
      "property is not differentiable", ())
+NOTE(autodiff_stored_property_no_corresponding_tangent,none,
+     "property cannot be differentiated because '%0.TangentVector' does not "
+     "have a member named '%1'", (StringRef, StringRef))
 NOTE(autodiff_value_defined_here,none,
      "value defined here", ())
 NOTE(autodiff_when_differentiating_function_call,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2734,7 +2734,7 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
 ERROR(differentiable_attr_stored_property_variable_unsupported,none,
-      "stored properties/variables cannot be marked with '@differentiable' with a custom VJP/JVP", ())
+      "'jvp:' or 'vjp:' cannot be specified for stored properties", ())
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,8 +2733,8 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by '@differentiable' attribute", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
-ERROR(differentiable_attr_stored_property_unsupported,none,
-      "stored properties cannot be marked with '@differentiable'", ())
+ERROR(differentiable_attr_stored_property_variable_unsupported,none,
+      "stored properties/variables cannot be marked with '@differentiable' with a custom VJP/JVP", ())
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2734,7 +2734,7 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
 ERROR(differentiable_attr_stored_property_unsupported,none,
-      "Stored properties cannot be marked with '@differentiable'", ())
+      "stored properties cannot be marked with '@differentiable'", ())
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2808,11 +2808,6 @@ ERROR(noderivative_only_on_stored_properties_in_differentiable_structs,none,
       "'@noDerivative' is only allowed on stored properties in structure types "
       "that declare a conformance to 'Differentiable'", ())
 
-// @_fieldwiseDifferentiable attribute
-ERROR(fieldwise_differentiable_only_on_differentiable_structs,none,
-      "'@_fieldwiseDifferentiable' is only allowed on structure types that "
-      "conform to 'Differentiable'", ())
-
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,8 +2733,8 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by '@differentiable' attribute", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
-ERROR(differentiable_attr_stored_prop_unsupported,none,
-"Stored properties cannot be marked with '@differentiable'", ())
+ERROR(differentiable_attr_stored_property_unsupported,none,
+      "Stored properties cannot be marked with '@differentiable'", ())
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2733,6 +2733,8 @@ ERROR(differentiable_attr_unsupported_req_kind,none,
       "layout requirement are not supported by '@differentiable' attribute", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
+ERROR(differentiable_attr_stored_prop_unsupported,none,
+"Stored properties cannot be marked with '@differentiable'", ())
 NOTE(protocol_witness_missing_specific_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3235,7 +3235,8 @@ public:
     // This instruction is active. Determine the appropriate differentiation
     // strategy, and use it.
     auto *structDecl = sei->getStructDecl();
-    if (structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
+    if (structDecl->getEffectiveAccess() <= AccessLevel::Internal
+        || structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
       strategies[sei] = StructExtractDifferentiationStrategy::Fieldwise;
       SILClonerWithScopes::visitStructExtractInst(sei);
       return;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3305,7 +3305,8 @@ public:
     // This instruction is active. Determine the appropriate differentiation
     // strategy, and use it.
     auto *structDecl = seai->getStructDecl();
-    if (structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
+    if (structDecl->getEffectiveAccess() <= AccessLevel::Internal ||
+        structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
       strategies[seai] = StructExtractDifferentiationStrategy::Fieldwise;
       SILClonerWithScopes::visitStructElementAddrInst(seai);
       return;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3235,8 +3235,8 @@ public:
     // This instruction is active. Determine the appropriate differentiation
     // strategy, and use it.
     auto *structDecl = sei->getStructDecl();
-    if (structDecl->getEffectiveAccess() <= AccessLevel::Internal
-        || structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
+    if (structDecl->getEffectiveAccess() <= AccessLevel::Internal ||
+        structDecl->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>()) {
       strategies[sei] = StructExtractDifferentiationStrategy::Fieldwise;
       SILClonerWithScopes::visitStructExtractInst(sei);
       return;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4570,10 +4570,6 @@ public:
       break;
     }
     case AdjointValueKind::Aggregate: {
-      // FIXME(TF-21): If `TangentVector` is not marked
-      // `@_fieldwiseProductSpace`, call the VJP of the memberwise initializer.
-      // for (auto pair : llvm::zip(si->getElements(), av.getAggregateElements()))
-      //   addAdjointValue(std::get<0>(pair), std::get<1>(pair));
       llvm_unreachable("Unhandled. Are you trying to differentiate a "
                        "memberwise initializer?");
     }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1250,7 +1250,6 @@ ADContext::emitNondifferentiabilityError(SourceLoc loc,
     }
     diagnose(loc, diag::autodiff_expression_not_differentiable_error);
     return diagnose(loc, diag, std::forward<U>(args)...);
-        //diag.getValueOr(diag::autodiff_expression_not_differentiable_note),
   }
 
   // For `[differentiable]` attributes, try to find an AST function declaration

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -690,8 +690,6 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   auto *structDecl = new (C) StructDecl(SourceLoc(), id, SourceLoc(),
                                         /*Inherited*/ C.AllocateCopy(inherited),
                                         /*GenericParams*/ {}, parentDC);
-  structDecl->getAttrs().add(
-      new (C) FieldwiseDifferentiableAttr(/*implicit*/ true));
   structDecl->setImplicit();
   structDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
 
@@ -959,12 +957,6 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
   for (auto *member : diffProperties)
     if (!getAssociatedType(member, parentDC, id))
       return nullptr;
-
-  // Since associated types will be derived, we make this struct a fieldwise
-  // differentiable type.
-  if (!nominal->getAttrs().hasAttribute<FieldwiseDifferentiableAttr>())
-    nominal->getAttrs().add(
-        new (C) FieldwiseDifferentiableAttr(/*implicit*/ true));
 
   // Prevent re-synthesis during repeated calls.
   // FIXME: Investigate why this is necessary to prevent duplicate synthesis.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -135,7 +135,6 @@ public:
   IGNORED_ATTR(Differentiable)
   IGNORED_ATTR(Differentiating)
   IGNORED_ATTR(CompilerEvaluable)
-  IGNORED_ATTR(FieldwiseDifferentiable)
   IGNORED_ATTR(NoDerivative)
 #undef IGNORED_ATTR
 
@@ -872,7 +871,6 @@ public:
   void visitDifferentiableAttr(DifferentiableAttr *attr);
   void visitDifferentiatingAttr(DifferentiatingAttr *attr);
   void visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr);
-  void visitFieldwiseDifferentiableAttr(FieldwiseDifferentiableAttr *attr);
   void visitNoDerivativeAttr(NoDerivativeAttr *attr);
 };
 } // end anonymous namespace
@@ -3574,23 +3572,6 @@ void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
   // follow certain rules. We can only check these rules after the body is type
   // checked, and it's not type checked yet, so we check these rules later in
   // TypeChecker::checkFunctionBodyCompilerEvaluable().
-}
-
-// SWIFT_ENABLE_TENSORFLOW
-void AttributeChecker::visitFieldwiseDifferentiableAttr(
-    FieldwiseDifferentiableAttr *attr) {
-  auto *structDecl = dyn_cast<StructDecl>(D);
-  if (!structDecl) {
-    diagnoseAndRemoveAttr(attr,
-        diag::fieldwise_differentiable_only_on_differentiable_structs);
-    return;
-  }
-  if (!conformsToDifferentiableInModule(
-          structDecl->getDeclaredInterfaceType(), D->getModuleContext())) {
-    diagnoseAndRemoveAttr(attr,
-        diag::fieldwise_differentiable_only_on_differentiable_structs);
-    return;
-  }
 }
 
 // SWIFT_ENABLE_TENSORFLOW

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2887,8 +2887,10 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
   AbstractFunctionDecl *original = dyn_cast<AbstractFunctionDecl>(D);
   if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
-    if (asd->getImplInfo().isSimpleStored()) {
-      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_stored_property_unsupported);
+    if (asd->getImplInfo().isSimpleStored() &&
+        (attr->getJVP() || attr->getVJP())) {
+      diagnoseAndRemoveAttr(attr,
+          diag::differentiable_attr_stored_property_variable_unsupported);
 	  return;
     }
     // When used directly on a storage decl (stored/computed property or

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2887,6 +2887,9 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
 
   AbstractFunctionDecl *original = dyn_cast<AbstractFunctionDecl>(D);
   if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
+    if (asd->getImplInfo().isSimpleStored()) {
+      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_stored_prop_unsupported);
+    }
     // When used directly on a storage decl (stored/computed property or
     // subscript), the getter is currently inferred to be `@differentiable`.
     // TODO(TF-129): Infer setter to also be `@differentiable` after

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2891,7 +2891,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
         (attr->getJVP() || attr->getVJP())) {
       diagnoseAndRemoveAttr(attr,
           diag::differentiable_attr_stored_property_variable_unsupported);
-	  return;
+      return;
     }
     // When used directly on a storage decl (stored/computed property or
     // subscript), the getter is currently inferred to be `@differentiable`.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2888,7 +2888,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   AbstractFunctionDecl *original = dyn_cast<AbstractFunctionDecl>(D);
   if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
     if (asd->getImplInfo().isSimpleStored()) {
-      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_stored_prop_unsupported);
+      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_stored_property_unsupported);
+	  return;
     }
     // When used directly on a storage decl (stored/computed property or
     // subscript), the getter is currently inferred to be `@differentiable`.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1303,7 +1303,6 @@ namespace  {
     UNINTERESTING_ATTR(Differentiable)
     UNINTERESTING_ATTR(Differentiating)
     UNINTERESTING_ATTR(CompilerEvaluable)
-    UNINTERESTING_ATTR(FieldwiseDifferentiable)
     UNINTERESTING_ATTR(NoDerivative)
 
     // These can't appear on overridable declarations.

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -38,8 +38,6 @@ extension S : Differentiable, VectorNumeric {
   typealias TangentVector = S
 }
 
-// expected-error @+2 {{function is not differentiable}}
-// expected-note @+1 {{property is not differentiable}}
 _ = gradient(at: S(p: 0)) { s in 2 * s.p }
 
 struct NoDerivativeProperty : Differentiable {

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -29,15 +29,23 @@ struct S {
 }
 
 extension S : Differentiable, VectorNumeric {
+  struct TangentVector: Differentiable, VectorNumeric {
+    var dp: Float
+  }
+  typealias AllDifferentiableVariables = S
   static var zero: S { return S(p: 0) }
   typealias Scalar = Float
   static func + (lhs: S, rhs: S) -> S { return S(p: lhs.p + rhs.p) }
   static func - (lhs: S, rhs: S) -> S { return S(p: lhs.p - rhs.p) }
   static func * (lhs: Float, rhs: S) -> S { return S(p: lhs * rhs.p) }
 
-  typealias TangentVector = S
+  func moved(along direction: TangentVector) -> S {
+    return S(p: p + direction.dp)
+  }
 }
 
+// expected-error @+2 {{function is not differentiable}}
+// expected-note @+1 {{property cannot be differentiated because 'S.TangentVector' does not have a member named 'p'}}
 _ = gradient(at: S(p: 0)) { s in 2 * s.p }
 
 struct NoDerivativeProperty : Differentiable {

--- a/test/AutoDiff/derived_differentiable_properties.swift
+++ b/test/AutoDiff/derived_differentiable_properties.swift
@@ -6,11 +6,11 @@ public struct Foo : Differentiable {
   public var a: Float
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct Foo : Differentiable {
+// CHECK-AST-LABEL: public struct Foo : Differentiable {
 // CHECK-AST:   @differentiable
 // CHECK-AST:   public var a: Float
 // CHECK-AST:   internal init(a: Float)
-// CHECK-AST:   @_fieldwiseDifferentiable public struct AllDifferentiableVariables
+// CHECK-AST:   public struct AllDifferentiableVariables
 // CHECK-AST:     public typealias AllDifferentiableVariables = Foo.AllDifferentiableVariables
 // CHECK-AST:     public typealias TangentVector = Foo.AllDifferentiableVariables
 // CHECK-AST:   public typealias TangentVector = Foo.AllDifferentiableVariables
@@ -25,7 +25,7 @@ let _: @differentiable (AdditiveTangentIsSelf) -> Float = { x in
   x.a + x.a
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
+// CHECK-AST-LABEL: internal struct AdditiveTangentIsSelf : AdditiveArithmetic, Differentiable {
 // CHECK-AST:         internal var a: Float
 // CHECK-AST:         internal init(a: Float)
 // CHECK-AST:         internal typealias TangentVector = AdditiveTangentIsSelf
@@ -36,11 +36,11 @@ struct TestNoDerivative : Differentiable {
   @noDerivative var technicallyDifferentiable: Float
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct TestNoDerivative : Differentiable {
+// CHECK-AST-LABEL: internal struct TestNoDerivative : Differentiable {
 // CHECK-AST:         var w: Float
 // CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
 // CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
-// CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, VectorNumeric
+// CHECK-AST:         internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, VectorNumeric
 // CHECK-AST:           internal typealias AllDifferentiableVariables = TestNoDerivative.AllDifferentiableVariables
 // CHECK-AST:           internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
 // CHECK-AST:         internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
@@ -50,11 +50,11 @@ struct TestKeyPathIterable : Differentiable, KeyPathIterable {
   @noDerivative var technicallyDifferentiable: Float
 }
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct TestKeyPathIterable : Differentiable, KeyPathIterable {
+// CHECK-AST-LABEL: internal struct TestKeyPathIterable : Differentiable, KeyPathIterable {
 // CHECK-AST:         var w: Float
 // CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
 // CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
-// CHECK-AST:         @_fieldwiseDifferentiable internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, VectorNumeric
+// CHECK-AST:         internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, VectorNumeric
 // CHECK-AST:           internal typealias AllDifferentiableVariables = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:           internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
 // CHECK-AST:         internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
@@ -66,7 +66,7 @@ struct GenericTanMember<T : Differentiable> : Differentiable, AdditiveArithmetic
 // TODO(TF-316): Revisit after `Differentiable` derived conformances behavior is standardized.
 // `AllDifferentiableVariables` and `TangentVector` structs need not both be synthesized.
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable internal struct GenericTanMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable
+// CHECK-AST-LABEL: internal struct GenericTanMember<T> : Differentiable, AdditiveArithmetic where T : Differentiable
 // CHECK-AST:   internal var x: T.TangentVector
 // CHECK-AST:   internal init(x: T.TangentVector)
 // CHECK-AST:   internal typealias TangentVector = GenericTanMember<T>
@@ -81,7 +81,7 @@ public struct ConditionallyDifferentiable<T> {
 }
 extension ConditionallyDifferentiable : Differentiable where T : Differentiable {}
 
-// CHECK-AST-LABEL: @_fieldwiseDifferentiable public struct ConditionallyDifferentiable<T> {
+// CHECK-AST-LABEL: public struct ConditionallyDifferentiable<T> {
 // CHECK-AST:         @differentiable(wrt: self where T : Differentiable)
 // CHECK-AST:         public let x: T
 // CHECK-AST:         internal init(x: T)

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -77,43 +77,6 @@ public func dhasvjp(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)
 // CHECK-LABEL: sil [ossa] @dhasvjp
 
 //===----------------------------------------------------------------------===//
-// Stored property
-//===----------------------------------------------------------------------===//
-
-struct DiffStoredProp {
-  @differentiable(wrt: (self), jvp: storedPropJVP, vjp: storedPropVJP)
-  let storedProp: Float
-
-  @_silgen_name("storedPropJVP")
-  func storedPropJVP() -> (Float, (DiffStoredProp) -> Float) {
-    fatalError("unimplemented")
-  }
-
-  @_silgen_name("storedPropVJP")
-  func storedPropVJP() -> (Float, (Float) -> DiffStoredProp) {
-    fatalError("unimplemented")
-  }
-}
-
-extension DiffStoredProp : VectorNumeric {
-  static var zero: DiffStoredProp { fatalError("unimplemented") }
-  static func + (lhs: DiffStoredProp, rhs: DiffStoredProp) -> DiffStoredProp {
-    fatalError("unimplemented")
-  }
-  static func - (lhs: DiffStoredProp, rhs: DiffStoredProp) -> DiffStoredProp {
-    fatalError("unimplemented")
-  }
-  typealias Scalar = Float
-  static func * (lhs: Float, rhs: DiffStoredProp) -> DiffStoredProp {
-    fatalError("unimplemented")
-  }
-}
-
-extension DiffStoredProp : Differentiable {
-  typealias TangentVector = DiffStoredProp
-}
-
-//===----------------------------------------------------------------------===//
 // Computed property
 //===----------------------------------------------------------------------===//
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -1,7 +1,10 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
 @differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
-let global: Float = 1
+let globalConst: Float = 1
+
+@differentiable // expected-error {{'@differentiable' attribute cannot be applied to this declaration}}
+var globalVar: Float = 1
 
 func testLocalVariables() {
   // expected-error @+1 {{'_' has no parameters to differentiate with respect to}}
@@ -225,25 +228,18 @@ class Foo {
 }
 
 struct JVPStruct {
+  @differentiable
   let p: Float
 
-  @differentiable(wrt: (self), jvp: storedPropJVP)
-  let storedImmutableOk: Float
-
-  // expected-error @+1 {{'storedPropJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
-  @differentiable(wrt: (self), jvp: storedPropJVP)
-  let storedImmutableWrongType: Double
-
-  @differentiable(wrt: (self), jvp: storedPropJVP)
-  var storedMutableOk: Float
-
-  // expected-error @+1 {{'storedPropJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
-  @differentiable(wrt: (self), jvp: storedPropJVP)
-  var storedMutableWrongType: Double
+  // expected-error @+1 {{'funcJVP' does not have expected type '(JVPStruct) -> () -> (Double, (JVPStruct.TangentVector) -> Double.TangentVector)' (aka '(JVPStruct) -> () -> (Double, (JVPStruct) -> Double)'}}
+  @differentiable(wrt: (self), jvp: funcJVP)
+  func funcWrongType() -> Double {
+    fatalError("unimplemented")
+  }
 }
 
 extension JVPStruct {
-  func storedPropJVP() -> (Float, (JVPStruct) -> Float) {
+  func funcJVP() -> (Float, (JVPStruct) -> Float) {
     fatalError("unimplemented")
   }
 }
@@ -383,23 +379,15 @@ func vjpNonDiffResult2(x: Float) -> (Float, Int) {
 struct VJPStruct {
   let p: Float
 
-  @differentiable(vjp: storedPropVJP)
-  let storedImmutableOk: Float
-
-  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
-  @differentiable(vjp: storedPropVJP)
-  let storedImmutableWrongType: Double
-
-  @differentiable(vjp: storedPropVJP)
-  var storedMutableOk: Float
-
-  // expected-error @+1 {{'storedPropVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
-  @differentiable(vjp: storedPropVJP)
-  var storedMutableWrongType: Double
+  // expected-error @+1 {{'funcVJP' does not have expected type '(VJPStruct) -> () -> (Double, (Double.TangentVector) -> VJPStruct.TangentVector)' (aka '(VJPStruct) -> () -> (Double, (Double) -> VJPStruct)'}}
+  @differentiable(vjp: funcVJP)
+  func funcWrongType() -> Double {
+    fatalError("unimplemented")
+  }
 }
 
 extension VJPStruct {
-  func storedPropVJP() -> (Float, (Float) -> VJPStruct) {
+  func funcVJP() -> (Float, (Float) -> VJPStruct) {
     fatalError("unimplemented")
   }
 }

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -295,3 +295,23 @@ func jvpConsistent(_ x: Float) -> (value: Float, differential: (Float) -> Float)
 func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
   return (x, { $0 })
 }
+
+// Test usage of `@differentiable` on a stored property
+struct PropertyDiff : Differentiable & AdditiveArithmetic {
+	// expected-error @+1 {{Stored properties cannot be marked with '@differentiable'}}
+    @differentiable(vjp: vjpPropertyA)
+    var a: Float = 1
+    typealias TangentVector = PropertyDiff
+    typealias AllDifferentiableVariables = PropertyDiff
+    func vjpPropertyA() -> (Float, (Float) -> PropertyDiff) {
+        (.zero, { _ in .zero })
+    }
+}
+
+@differentiable
+func f(_ x: PropertyDiff) -> Float {
+    return x.a
+}
+
+let a = gradient(at: PropertyDiff(), in: f)
+print(a)

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -298,7 +298,7 @@ func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
 
 // Test usage of `@differentiable` on a stored property
 struct PropertyDiff : Differentiable & AdditiveArithmetic {
-    // expected-error @+1 {{stored properties cannot be marked with '@differentiable'}}
+    // expected-error @+1 {{'jvp:' or 'vjp:' cannot be specified for stored properties}}
     @differentiable(vjp: vjpPropertyA)
     var a: Float = 1
     typealias TangentVector = PropertyDiff

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -298,7 +298,7 @@ func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
 
 // Test usage of `@differentiable` on a stored property
 struct PropertyDiff : Differentiable & AdditiveArithmetic {
-	// expected-error @+1 {{Stored properties cannot be marked with '@differentiable'}}
+    // expected-error @+1 {{Stored properties cannot be marked with '@differentiable'}}
     @differentiable(vjp: vjpPropertyA)
     var a: Float = 1
     typealias TangentVector = PropertyDiff

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -30,10 +30,9 @@ struct Space {
   }
 
   private let storedX: Float
-
-  /// `y` is a stored property with a custom vjp for its getter.
-  @differentiable(vjp: vjpY)
-  let y: Float
+  
+  @differentiable
+  var y: Float
 
   func vjpY() -> (Float, (Float) -> TangentSpace) {
     return (y, { v in TangentSpace(dx: 0, dy: v) })
@@ -70,7 +69,7 @@ E2EDifferentiablePropertyTests.test("stored property") {
 
 struct GenericMemberWrapper<T : Differentiable> : Differentiable {
   // Stored property.
-  @differentiable(vjp: vjpX)
+  @differentiable
   var x: T
 
   func vjpX() -> (T, (T.TangentVector) -> GenericMemberWrapper.TangentVector) {

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -9,7 +9,7 @@ import StdlibUnittest
 var E2EDifferentiablePropertyTests = TestSuite("E2EDifferentiableProperty")
 
 struct TangentSpace : VectorNumeric {
-  let dx, dy: Float
+  let x, y: Float
 }
 
 extension TangentSpace : Differentiable {
@@ -26,17 +26,13 @@ struct Space {
   }
 
   func vjpX() -> (Float, (Float) -> TangentSpace) {
-    return (x, { v in TangentSpace(dx: v, dy: 0) } )
+    return (x, { v in TangentSpace(x: v, y: 0) } )
   }
 
   private let storedX: Float
-  
+
   @differentiable
   var y: Float
-
-  func vjpY() -> (Float, (Float) -> TangentSpace) {
-    return (y, { v in TangentSpace(dx: 0, dy: v) })
-  }
 
   init(x: Float, y: Float) {
     self.storedX = x
@@ -47,7 +43,7 @@ struct Space {
 extension Space : Differentiable {
   typealias TangentVector = TangentSpace
   func moved(along: TangentSpace) -> Space {
-    return Space(x: x + along.dx, y: y + along.dy)
+    return Space(x: x + along.x, y: y + along.y)
   }
 }
 
@@ -55,7 +51,7 @@ E2EDifferentiablePropertyTests.test("computed property") {
   let actualGrad = gradient(at: Space(x: 0, y: 0)) { (point: Space) -> Float in
     return 2 * point.x
   }
-  let expectedGrad = TangentSpace(dx: 2, dy: 0)
+  let expectedGrad = TangentSpace(x: 2, y: 0)
   expectEqual(expectedGrad, actualGrad)
 }
 
@@ -63,7 +59,7 @@ E2EDifferentiablePropertyTests.test("stored property") {
   let actualGrad = gradient(at: Space(x: 0, y: 0)) { (point: Space) -> Float in
     return 3 * point.y
   }
-  let expectedGrad = TangentSpace(dx: 0, dy: 3)
+  let expectedGrad = TangentSpace(x: 0, y: 3)
   expectEqual(expectedGrad, actualGrad)
 }
 
@@ -85,7 +81,6 @@ E2EDifferentiablePropertyTests.test("generic stored property") {
   expectEqual(expectedGrad, actualGrad)
 }
 
-@_fieldwiseDifferentiable
 struct ProductSpaceSelfTangent : VectorNumeric {
   let x, y: Float
 }
@@ -110,7 +105,6 @@ extension ProductSpaceOtherTangentTangentSpace : Differentiable {
   typealias TangentVector = ProductSpaceOtherTangentTangentSpace
 }
 
-@_fieldwiseDifferentiable
 struct ProductSpaceOtherTangent {
   let x, y: Float
 }

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -128,4 +128,16 @@ func TF_508_func(x: TF_508_Struct<Float>, y: TF_508_Struct<Float>)
 }
 let TF_508_bp = pullback(at: TF_508_inst, TF_508_inst, in: TF_508_func)
 
+// TF-523
+struct A : Differentiable & AdditiveArithmetic {
+  var a: Float = 1
+  typealias TangentVector = A
+  typealias AllDifferentiableVariables = A
+}
+
+@differentiable
+func f(_ x: A) -> Float {
+  return x.a * 2
+}
+
 // TODO: add more tests.

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -129,14 +129,14 @@ func TF_508_func(x: TF_508_Struct<Float>, y: TF_508_Struct<Float>)
 let TF_508_bp = pullback(at: TF_508_inst, TF_508_inst, in: TF_508_func)
 
 // TF-523
-struct A : Differentiable & AdditiveArithmetic {
+struct TF_523_Struct : Differentiable & AdditiveArithmetic {
   var a: Float = 1
-  typealias TangentVector = A
-  typealias AllDifferentiableVariables = A
+  typealias TangentVector = TF_523_Struct
+  typealias AllDifferentiableVariables = TF_523_Struct
 }
 
 @differentiable
-func f(_ x: A) -> Float {
+func TF_523_f(_ x: TF_523_Struct) -> Float {
   return x.a * 2
 }
 

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -8,8 +8,15 @@ var MethodTests = TestSuite("Method")
 // ==== Tests with generated adjoint ====
 
 struct Parameter : Equatable {
+  private let storedX: Float
   @differentiable(wrt: (self), jvp: jvpX, vjp: vjpX)
-  let x: Float
+  var x: Float {
+      return storedX
+  }
+  
+  init(x: Float) {
+    storedX = x
+  }
 
   func vjpX() -> (Float, (Float) -> Parameter) {
     return (x, { dx in Parameter(x: dx) } )
@@ -155,8 +162,15 @@ struct DiffWrtSelf : Differentiable {
 }
 
 struct CustomParameter : Equatable {
+  let storedX: Float
   @differentiable(wrt: (self), vjp: vjpX)
-  let x: Float
+  var x: Float {
+      return storedX
+  }
+  
+  init(x: Float) {
+    storedX = x
+  }
 
   func vjpX() -> (Float, (Float) -> CustomParameter) {
     return (x, { dx in CustomParameter(x: dx) })

--- a/test/AutoDiff/protocol_requirement_autodiff.swift
+++ b/test/AutoDiff/protocol_requirement_autodiff.swift
@@ -18,23 +18,14 @@ extension DiffReq where TangentVector : AdditiveArithmetic {
 struct Quadratic : DiffReq, Equatable {
   typealias TangentVector = Quadratic
 
-  @differentiable(wrt: (self), vjp: vjpA)
+  @differentiable
   let a: Float
-  func vjpA() -> (Float, (Float) -> Quadratic) {
-    return (a, { da in Quadratic(da, 0, 0) } )
-  }
 
-  @differentiable(wrt: (self), vjp: vjpB)
+  @differentiable
   let b: Float
-  func vjpB() -> (Float, (Float) -> Quadratic) {
-    return (b, { db in Quadratic(0, db, 0) } )
-  }
 
-  @differentiable(wrt: (self), vjp: vjpC)
+  @differentiable
   let c: Float
-  func vjpC() -> (Float, (Float) -> Quadratic) {
-    return (c, { dc in Quadratic(0, 0, dc) } )
-  }
 
   init(_ a: Float, _ b: Float, _ c: Float) {
     self.a = a

--- a/test/AutoDiff/separate_cotangent_type.swift
+++ b/test/AutoDiff/separate_cotangent_type.swift
@@ -10,7 +10,6 @@ import Glibc
 
 var SeparateTangentTypeTests = TestSuite("SeparateTangentType")
 
-@_fieldwiseDifferentiable
 struct DifferentiableSubset : Differentiable {
   @differentiable(wrt: self)
   var w: Float
@@ -18,7 +17,6 @@ struct DifferentiableSubset : Differentiable {
   var b: Float
   @noDerivative var flag: Bool
 
-  @_fieldwiseDifferentiable
   struct TangentVector : Differentiable, VectorNumeric {
     typealias TangentVector = DifferentiableSubset.TangentVector
     var w: Float
@@ -41,12 +39,10 @@ SeparateTangentTypeTests.test("Initialization") {
   expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
 }
 
-// FIXME(SR-9602): If `TangentVector` is not marked
-// `@_fieldwiseProductSpace`, call the VJP of the memberwise initializer.
-// SeparateTangentTypeTests.test("SomeArithmetics") {
-//   let x = DifferentiableSubset(w: 0, b: 1, flag: false)
-//   let pb = pullback(at: x) { x in DifferentiableSubset(w: x.w * x.w, b: x.b * x.b, flag: true) }
-//   expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
-// }
+SeparateTangentTypeTests.test("SomeArithmetics") {
+  let x = DifferentiableSubset(w: 0, b: 1, flag: false)
+  let pb = pullback(at: x) { x in DifferentiableSubset(w: x.w * x.w, b: x.b * x.b, flag: true) }
+  expectEqual(pb(DifferentiableSubset.TangentVector.zero), DifferentiableSubset.TangentVector.zero)
+}
 
 runAllTests()

--- a/test/AutoDiff/simple_model.swift
+++ b/test/AutoDiff/simple_model.swift
@@ -6,17 +6,11 @@ import StdlibUnittest
 var SimpleModelTests = TestSuite("SimpleModel")
 
 struct DenseLayer : Equatable {
-  @differentiable(wrt: self, vjp: vjpW)
+  @differentiable
   let w: Float
-  func vjpW() -> (Float, (Float) -> DenseLayer) {
-    return (w, { dw in DenseLayer(w: dw, b: 0) } )
-  }
 
-  @differentiable(wrt: self, vjp: vjpB)
+  @differentiable
   let b: Float
-  func vjpB() -> (Float, (Float) -> DenseLayer) {
-    return (b, { db in DenseLayer(w: 0, b: db) } )
-  }
 }
 
 extension DenseLayer : Differentiable, VectorNumeric {
@@ -46,23 +40,14 @@ extension DenseLayer {
 }
 
 struct Model : Equatable {
-  @differentiable(wrt: self, vjp: vjpL1)
+  @differentiable
   let l1: DenseLayer
-  func vjpL1() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l1, { dl1 in Model(l1: dl1, l2: DenseLayer.zero, l3: DenseLayer.zero) } )
-  }
 
-  @differentiable(wrt: self, vjp: vjpL2)
+  @differentiable
   let l2: DenseLayer
-  func vjpL2() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l2, { dl2 in Model(l1: DenseLayer.zero, l2: dl2, l3: DenseLayer.zero) } )
-  }
 
-  @differentiable(wrt: self, vjp: vjpL3)
+  @differentiable
   let l3: DenseLayer
-  func vjpL3() -> (DenseLayer, (DenseLayer) -> Model) {
-    return (l3, { dl3 in Model(l1: DenseLayer.zero, l2: DenseLayer.zero, l3: dl3) } )
-  }
 }
 
 extension Model : Differentiable, VectorNumeric {

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -11,7 +11,6 @@ protocol Proto : Differentiable {
   func function3(_ x: Float, _ y: Double) -> Double
 }
 
-@_fieldwiseDifferentiable
 struct S : Proto, VectorNumeric {
   static var zero: S { return S(p: 0) }
   typealias Scalar = Float

--- a/test/AutoDiff/witness_table_silgen.swift
+++ b/test/AutoDiff/witness_table_silgen.swift
@@ -21,11 +21,8 @@ struct S : Proto, VectorNumeric {
 
   typealias TangentVector = S
 
-  @differentiable(wrt: (self), vjp: vjpP)
+  @differentiable
   let p: Float
-  func vjpP() -> (Float, (Float) -> S) {
-    return (p, { dp in S(p: dp) })
-  }
 
   @differentiable(wrt: (x, y))
   func function1(_ x: Float, _ y: Double) -> Float {


### PR DESCRIPTION
Resolves [TF-523](https://bugs.swift.org/browse/TF-523).

## The Bug

SILGen sometimes does not create a getter for a stored property. User-defined derivatives (VJPs) for such properties are not attached to the original function, causing the differentiation transform unable to find or use any custom derivative through the SIL `[differentiable]` attribute on the original getter function. Lots of property differentiation issues arose because of this. 

## History/Reason Why Bug Exists

Previously, the semantics of automatic differentiation treated stored properties exactly as if they were computed properties. In particular, we allowed stored properties to have user-defined derivatives. This was also required because `TangentVector` could be entirely user-defined, in which case the compiler would not be able to figure out which stored property in a `T.TangentVector` corresponds to a stored property in `T`. As such, we made it so that all differentiation of stored property accesses semantically go through a derivative function defined for the property (#21567), with an efficient shortcut which does not go through derivative functions but uses a `struct` instruction to create a `TangentVector` when the structure is marked with `@_fieldwiseDifferentiable` (#21575, #21737, #21863, and #22009).

For functions, initializer and computed properties, a reference to the user-defined derivative is attached to the original function in SIL. However, for stored properties, a getter function may not exist. Also, it is quite cumbersome for a user to define a custom VJP for a stored property and it's unclear anyone would want to do it.

## Solution

The solution can be broken into two parts:

1. Ban user-defined derivatives for stored properties. This both prevents potential user-introduced errors and reduces the compiler implementation complexity.
2. When differentiating a stored property access, require that the `TangentVector` contains a stored property of the same name.

### Ban user-defined derivatives for stored properties

This step makes it possible to use the fieldwise `struct_extract` differentiation strategy (i.e. forming a `TangentVector` using a `struct` instruction) for all `TangentVector`s that are mathematically the tangent space of the original product space.

Previously, in order to support user-defined derivatives for properties in the same module, we had another `struct_extract` differentiation strategy that worked by replacing the `struct_extract` call with a call to the derivative of the synthesized property getter. However, we had to add a lot of _hacky_ if statements to make this work, and even then it didn't work perfectly. A bunch of bugs and unknown SIL modifications came up like:
- The VJP of the getter ended up calling itself when a property is marked `@differentiable` and when the struct is not `@_fieldwiseDifferentiable`. 
- Getters are not SILGen'd if the property's access level is than or equal to `fileprivate`, or when `swift` is run instead of `swiftc`.

### Require `T.TangentVector` fields to correspond to fields in `T`

In [this commit](https://github.com/apple/swift/pull/25151/commits/d0f77e73a8a54b556ac25f0d471afe12811a7dfd),  we changed so now we require a name correspondence between fields in `T.TangentVector` and fields in `T`, and deprecated the `@_fieldwiseProductSpace` attribute. From now on, in order to differentiate a property access `foo.x`, `type(of: foo).TangentVector` must contain a corresponding property named `x`. If not, a diagnostic will be emitted. This is easier to reason about than the existing behavior, and is significantly easier for the user to define custom tangent spaces.

Case where a user defined `TangentVector` makes it possible to differentiate `foo.x`:

```swift
struct Foo: Differentiable {
    var x: Float
    struct TangentVector: Differentiable, AdditiveArithmetic {
        var x: Float
    }
    ...
}

@differentiable
func funcToDiff(_ foo: Foo) -> Float {
    foo.x
}
```

Case where a user defined `TangentVector` does not allow differentiating `foo.x` because it does not have a field named `x`.

```swift
struct Foo: Differentiable {
    var x: Float

    // No field named "x"!
    struct TangentVector: Differentiable, AdditiveArithmetic {
        var y: Float
    }
    ...
}

@differentiable
func funcToDiff(_ foo: Foo) -> Float {
    foo.x
}
// error: function is not differentiable
// note: property cannot be differentiated because 'Foo.TangentVector' does not have a member named 'x'
```

## Implementation

- Reject `vjp:` or `jvp:` in a `@differentiable` attribute on a stored property.
- Make `AdjointEmitter::visitStructExtractInst` and `AdjointEmitter::visitStructElementAddrInst` differentiate fieldwise, forming a `TangentVector` using a `struct` instruction.
- Eliminate `@_fieldwiseDifferentiable` everywhere.
- Remove `StructExtractDifferentiationStrategy` and all related logic.
- When a `TangentVector` does not contain a property with the requested name that corresponds to a property in the original type, emit a diagnostic `property cannot be differentiated because 'Foo.TangentVector' does not have a member named 'x'`.
- Turn `ADContext::emitNondifferentiabilityError` methods into templates that take diagnostics with arbitrary arguments. This makes it possible for us to emit finer-grained diagnostics in the future.

This change resulted in a 300-LOC code removal, which we should celebrate.

## Tests

Had to fix a lot of tests, since a lot of them were relying on defining a custom VJP on stored properties. 

## Other Tickets/PRs

This fix would unblock me on the [Complex Number PR](https://github.com/tensorflow/swift-apis/pull/129) and also fix [TF-262](https://bugs.swift.org/browse/TF-262).