### PR TITLE
Add CLI option to warn when a public decl has no intro version

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4112,6 +4112,9 @@ ERROR(availability_protocol_requires_version,
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
 
+WARNING(public_decl_needs_availability, none,
+     "public declarations should have an availability attribute with -require-explicit-availability", ())
+
 // This doesn't display as an availability diagnostic, but it's
 // implemented there and fires when these subscripts are marked
 // unavailable, so it seems appropriate to put it here.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -96,6 +96,13 @@ namespace swift {
     /// Enable 'availability' restrictions for App Extensions.
     bool EnableAppExtensionRestrictions = false;
 
+    /// Require public declarations to declare an introduction OS version.
+    bool RequireExplicitAvailability = false;
+
+    /// Introduction platform and version to suggest as fix-it
+    /// when using RequireExplicitAvailability.
+    std::string RequireExplicitAvailabilityTarget;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -312,6 +312,14 @@ def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Build the module to allow binary-compatible library evolution">;
 
+def require_explicit_availability : Flag<["-"], "require-explicit-availability">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Require explicit availability on public declarations">;
+def require_explicit_availability_target : Separate<["-"], "require-explicit-availability-target">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Suggest fix-its adding @available(<target>, *) to public declarations without availability">,
+  MetaVarName<"<target>">;
+
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Name of the module to build">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -386,6 +386,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.RequestEvaluatorGraphVizPath = A->getValue();
   }
 
+  if (Args.getLastArg(OPT_require_explicit_availability, OPT_require_explicit_availability_target)) {
+    Opts.RequireExplicitAvailability = true;
+    if (const Arg *A = Args.getLastArg(OPT_require_explicit_availability_target)) {
+      Opts.RequireExplicitAvailabilityTarget = A->getValue();
+    }
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_solver_memory_threshold)) {
     unsigned threshold;
     if (StringRef(A->getValue()).getAsInteger(10, threshold)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2788,3 +2788,60 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *Decl,
   AvailabilityWalker AW(TC, DC);
   return AW.diagAvailability(const_cast<ValueDecl *>(Decl), R, nullptr, Flags);
 }
+
+void swift::checkExplicitAvailability(Decl *decl) {
+  // Check only if the command line option was set.
+  if (!decl->getASTContext().LangOpts.RequireExplicitAvailability)
+    return;
+
+  // Skip nominal type members as the type should be annotated.
+  auto declContext = decl->getDeclContext();
+  if (isa<NominalTypeDecl>(declContext))
+    return;
+
+  ValueDecl *valueDecl = dyn_cast<ValueDecl>(decl);
+  if (valueDecl == nullptr) {
+    // decl should be either a ValueDecl or an ExtensionDecl
+    auto extension = cast<ExtensionDecl>(decl);
+    valueDecl = extension->getExtendedNominal();
+    if (!valueDecl)
+      return;
+  }
+
+  // Skip decls that are not public and not usable from inline.
+  AccessScope scope =
+    valueDecl->getFormalAccessScope(/*useDC*/nullptr,
+                                  /*treatUsableFromInlineAsPublic*/true);
+  if (!scope.isPublic() ||
+      decl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+    return;
+
+  // Warn on decls without an introduction version.
+  auto &ctx = decl->getASTContext();
+  auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl, ctx);
+  if (!safeRangeUnderApprox.getOSVersion().hasLowerEndpoint()) {
+    auto diag = decl->diagnose(diag::public_decl_needs_availability);
+
+    auto suggestPlatform = decl->getASTContext().LangOpts.RequireExplicitAvailabilityTarget;
+    if (!suggestPlatform.empty()) {
+      auto InsertLoc = decl->getAttrs().getStartLoc(/*forModifiers=*/false);
+      if (InsertLoc.isInvalid())
+        InsertLoc = decl->getStartLoc();
+
+      if (InsertLoc.isInvalid())
+        return;
+
+      std::string AttrText;
+      {
+         llvm::raw_string_ostream Out(AttrText);
+
+         StringRef OriginalIndent = Lexer::getIndentationForLine(
+           ctx.SourceMgr, InsertLoc);
+         Out << "@available(" << suggestPlatform << ", *)\n"
+             << OriginalIndent;
+      }
+
+      diag.fixItInsert(InsertLoc, AttrText);
+    }
+  }
+}

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -28,6 +28,7 @@ namespace swift {
   class Expr;
   class InFlightDiagnostic;
   class TypeChecker;
+  class Decl;
   class ValueDecl;
 
 /// Diagnose uses of unavailable declarations.
@@ -81,6 +82,9 @@ bool diagnoseExplicitUnavailability(
     SourceRange R,
     const DeclContext *DC,
     llvm::function_ref<void(InFlightDiagnostic &)> attachRenameFixIts);
+
+/// Check if \p decl has a introduction version required by -require-explicit-availability
+void checkExplicitAvailability(Decl *decl);
 
 } // namespace swift
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -19,6 +19,7 @@
 #include "DerivedConformances.h"
 #include "TypeChecker.h"
 #include "TypeCheckAccess.h"
+#include "TypeCheckAvailability.h"
 #include "TypeCheckType.h"
 #include "MiscDiagnostics.h"
 #include "swift/AST/AccessScope.h"
@@ -2738,6 +2739,8 @@ public:
       checkEnumRawValues(TC, ED);
     }
 
+    checkExplicitAvailability(ED);
+
     TC.checkDeclCircularity(ED);
     TC.ConformanceContexts.push_back(ED);
   }
@@ -2760,6 +2763,8 @@ public:
     checkInheritanceClause(SD);
 
     checkAccessControl(TC, SD);
+
+    checkExplicitAvailability(SD);
 
     TC.checkDeclCircularity(SD);
     TC.ConformanceContexts.push_back(SD);
@@ -2983,6 +2988,8 @@ public:
 
     checkAccessControl(TC, CD);
 
+    checkExplicitAvailability(CD);
+
     TC.checkDeclCircularity(CD);
     TC.ConformanceContexts.push_back(CD);
   }
@@ -3057,6 +3064,8 @@ public:
 
     // Explicity compute the requirement signature to detect errors.
     (void) PD->getRequirementSignature();
+
+    checkExplicitAvailability(PD);
   }
 
   void visitVarDecl(VarDecl *VD) {
@@ -3140,6 +3149,8 @@ public:
     }
 
     TC.checkParameterAttributes(FD->getParameters());
+
+    checkExplicitAvailability(FD);
   }
 
   void visitModuleDecl(ModuleDecl *) { }
@@ -3206,6 +3217,8 @@ public:
       TC.checkDeclAttributes(ED);
 
     checkAccessControl(TC, ED);
+
+    checkExplicitAvailability(ED);
   }
 
   void visitTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
+
+public struct S { // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}}
+  public func method() { }
+}
+
+public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+@usableFromInline
+func bar() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+@available(macOS 10.1, *)
+public func ok() { }
+
+@available(macOS, deprecated: 10.10)
+public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+func privateFunc() { }
+
+@_alwaysEmitIntoClient
+public func alwaysEmitted() { }
+
+@available(macOS 10.1, *)
+struct SOk {
+  public func okMethod() { }
+}
+
+precedencegroup MediumPrecedence {}
+infix operator + : MediumPrecedence
+
+public func +(lhs: S, rhs: S) -> S { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+public enum E { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+public class C { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+public protocol P { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+extension S { // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+  func ok() { }
+}
+
+open class OpenClass { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+private class PrivateClass { }
+
+extension PrivateClass { }


### PR DESCRIPTION
Add the command line option `-require-explicit-availability` to detect public or `@usableFromInline` declarations and warn if they don't declare an introduction OS version. This option should catch forgotten `@available` attributes in frameworks where all services are expected to be introduced by an OS version.

The option `-require-explicit-availability-target "macOS 10.14, iOS 12.0"` can be specified for the compiler to suggest fix-its with the missing attributes `@available(macOS 10.14, iOS 12.0, *)`.

This is a similar check than #25104 warning of the same problem early on, but this option must be set by the developer.