### PR TITLE
[5.1] Sourcekit/Indentation: avoid indenting the end of array/dictionary literals if they appear at the argument end

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -456,7 +456,9 @@ public:
     auto AtCursorExpr = Cursor->getAsExpr();
     if (AtExprEnd && AtCursorExpr && (isa<ParenExpr>(AtCursorExpr) ||
                                       isa<TupleExpr>(AtCursorExpr))) {
-      if (isa<CallExpr>(AtExprEnd)) {
+      if (isa<CallExpr>(AtExprEnd) ||
+          isa<ArrayExpr>(AtExprEnd) ||
+          isa<DictionaryExpr>(AtExprEnd)) {
         if (exprEndAtLine(AtExprEnd, Line) &&
             exprEndAtLine(AtCursorExpr, Line)) {
           return false;

--- a/test/SourceKit/CodeFormat/indent-closing-array.swift
+++ b/test/SourceKit/CodeFormat/indent-closing-array.swift
@@ -15,12 +15,26 @@ struct Foo {
             "b": 2
         ]
     }
+    func foo() {
+        print([
+            "Hello, World!",
+            "Hello, World!",
+])
+        print([
+            "Hello, World!": 1,
+            "Hello, World!": 2,
+])
+    }
 }
 
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=11 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=16 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=22 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=26 -length=1 %s >>%t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 // CHECK: key.sourcetext: "    ]"
 // CHECK: key.sourcetext: "        ]"
 // CHECK: key.sourcetext: "        ]"
+// CHECK: key.sourcetext: "        ])"
+// CHECK: key.sourcetext: "        ])"


### PR DESCRIPTION
rdar://40093469
