### PR TITLE
[5.1] De-underscore @frozen, apply it to structs

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -364,10 +364,11 @@ SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
   OnNominalType | OnAssociatedType | OnFunc | OnAccessor | OnVar |
   OnSubscript | OnConstructor | OnEnumElement | OnExtension | UserInaccessible,
   75)
-SIMPLE_DECL_ATTR(_frozen, Frozen,
-  OnEnum |
+SIMPLE_DECL_ATTR(frozen, Frozen,
+  OnEnum | OnStruct |
   UserInaccessible,
   76)
+DECL_ATTR_ALIAS(_frozen, Frozen)
 SIMPLE_DECL_ATTR(_forbidSerializingReference, ForbidSerializingReference,
   OnAnyDecl |
   LongAttribute | RejectByParser | UserInaccessible | NotSerialized,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5017,7 +5017,7 @@ public:
   /// exposed to clients.
   /// There's a very narrow case when we would: if the decl is an instance
   /// member with an initializer expression and the parent type is
-  /// @_fixed_layout and resides in a resilient module.
+  /// @frozen and resides in a resilient module.
   bool isInitExposedToClients() const;
   
   /// Is this a special debugger variable?

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1387,8 +1387,8 @@ WARNING(pattern_type_not_usable_from_inline_warn,none,
         "%select{%select{variable|constant}0|property}1 "
         "should be '@usableFromInline' or public",
         (bool, bool))
-ERROR(pattern_type_not_usable_from_inline_fixed_layout,none,
-      "type referenced from a stored property in a '@_fixed_layout' struct must "
+ERROR(pattern_type_not_usable_from_inline_frozen,none,
+      "type referenced from a stored property in a '@frozen' struct must "
       "be '@usableFromInline' or public",
       (/*ignored*/bool, /*ignored*/bool))
 ERROR(pattern_type_not_usable_from_inline_inferred,none,
@@ -1403,9 +1403,9 @@ WARNING(pattern_type_not_usable_from_inline_inferred_warn,none,
         "with inferred type %2 "
         "should be '@usableFromInline' or public",
         (bool, bool, Type))
-ERROR(pattern_type_not_usable_from_inline_inferred_fixed_layout,none,
+ERROR(pattern_type_not_usable_from_inline_inferred_frozen,none,
       "type referenced from a stored property with inferred type %2 in a "
-      "'@_fixed_layout' struct must be '@usableFromInline' or public",
+      "'@frozen' struct must be '@usableFromInline' or public",
       (/*ignored*/bool, /*ignored*/bool, Type))
 
 ERROR(pattern_binds_no_variables,none,
@@ -4133,6 +4133,15 @@ ERROR(fixed_layout_attr_on_internal_type,
       "%select{private|fileprivate|internal|%error|%error}1",
       (DeclName, AccessLevel))
 
+WARNING(fixed_layout_struct,
+      none, "'@frozen' attribute is now used for fixed-layout structs", ())
+
+ERROR(frozen_attr_on_internal_type,
+      none, "'@frozen' attribute can only be applied to '@usableFromInline' "
+      "or public declarations, but %0 is "
+      "%select{private|fileprivate|internal|%error|%error}1",
+      (DeclName, AccessLevel))
+
 ERROR(usable_from_inline_attr_with_explicit_access,
       none, "'@usableFromInline' attribute can only be applied to internal "
       "declarations, but %0 is %select{private|fileprivate|%error|public|open}1",
@@ -4149,7 +4158,7 @@ ERROR(usable_from_inline_attr_in_protocol,none,
   "an '@inlinable' function|" \
   "an '@_alwaysEmitIntoClient' function|" \
   "a default argument value|" \
-  "a property initializer in a '@_fixed_layout' type}"
+  "a property initializer in a '@frozen' type}"
 
 #define DECL_OR_ACCESSOR "%select{%0|%0 for}"
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1488,7 +1488,8 @@ bool VarDecl::isInitExposedToClients() const {
   if (!parent) return false;
   if (!hasInitialValue()) return false;
   if (isStatic()) return false;
-  return parent->getAttrs().hasAttribute<FixedLayoutAttr>();
+  return parent->getAttrs().hasAttribute<FrozenAttr>() ||
+         parent->getAttrs().hasAttribute<FixedLayoutAttr>();
 }
 
 /// Check whether the given type representation will be
@@ -3109,7 +3110,7 @@ bool NominalTypeDecl::isFormallyResilient() const {
                             /*treatUsableFromInlineAsPublic=*/true).isPublic())
     return false;
 
-  // Check for an explicit @_fixed_layout or @_frozen attribute.
+  // Check for an explicit @_fixed_layout or @frozen attribute.
   if (getAttrs().hasAttribute<FixedLayoutAttr>() ||
       getAttrs().hasAttribute<FrozenAttr>()) {
     return false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2614,7 +2614,7 @@ namespace {
           errorWrapper->setAddedImplicitInitializers();
           errorWrapper->setAccess(AccessLevel::Public);
           errorWrapper->getAttrs().add(
-            new (Impl.SwiftContext) FixedLayoutAttr(/*IsImplicit*/true));
+            new (Impl.SwiftContext) FrozenAttr(/*IsImplicit*/true));
 
           StringRef nameForMangling;
           ClangImporterSynthesizedTypeAttr::Kind relatedEntityKind;

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -93,7 +93,7 @@ StructLayout::StructLayout(IRGenModule &IGM,
 
   assert(typeToFill == nullptr || Ty == typeToFill);
 
-  // If the struct is not @_fixed_layout, it will have a dynamic
+  // If the struct is not @frozen, it will have a dynamic
   // layout outside of its resilience domain.
   if (decl) {
     if (IGM.isResilient(decl, ResilienceExpansion::Minimal))

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -317,13 +317,14 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   if (isStoredPropertyInitializer()) {
     // Three cases:
     //
-    // 1) Type is formally @_fixed_layout. Root initializers can be declared
-    //    @inlinable. The property initializer must only reference
+    // 1) Type is formally @_fixed_layout/@frozen. Root initializers can be
+    //    declared @inlinable. The property initializer must only reference
     //    public symbols, and is serialized, so we give it PublicNonABI linkage.
     //
-    // 2) Type is not formally @_fixed_layout and the module is not resilient.
-    //    Root initializers can be declared @inlinable. This is the annoying
-    //    case. We give the initializer public linkage if the type is public.
+    // 2) Type is not formally @_fixed_layout/@frozen and the module is not
+    //    resilient. Root initializers can be declared @inlinable. This is the 
+    //    annoying case. We give the initializer public linkage if the type is
+    //    public.
     //
     // 3) Type is resilient. The property initializer is never public because
     //    root initializers cannot be @inlinable.
@@ -497,7 +498,7 @@ IsSerialized_t SILDeclRef::isSerialized() const {
   }
 
   // Stored property initializers are inlinable if the type is explicitly
-  // marked as @_fixed_layout.
+  // marked as @frozen.
   if (isStoredPropertyInitializer()) {
     auto *nominal = cast<NominalTypeDecl>(d->getDeclContext());
     auto scope =

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1032,7 +1032,8 @@ public:
     auto *parentStruct = dyn_cast<StructDecl>(PBD->getDeclContext());
     if (!parentStruct)
       return nullptr;
-    if (!parentStruct->getAttrs().hasAttribute<FixedLayoutAttr>() ||
+    if (!(parentStruct->getAttrs().hasAttribute<FrozenAttr>() ||         
+          parentStruct->getAttrs().hasAttribute<FixedLayoutAttr>()) ||
         PBD->isStatic() || !PBD->hasStorage()) {
       return nullptr;
     }
@@ -1064,7 +1065,7 @@ public:
       auto diagID = diag::pattern_type_not_usable_from_inline_inferred;
       if (fixedLayoutStructContext) {
         diagID =
-            diag::pattern_type_not_usable_from_inline_inferred_fixed_layout;
+            diag::pattern_type_not_usable_from_inline_inferred_frozen;
       } else if (!TC.Context.isSwiftVersionAtLeast(5)) {
         diagID = diag::pattern_type_not_usable_from_inline_inferred_warn;
       }
@@ -1100,7 +1101,7 @@ public:
                         DowngradeToWarning downgradeToWarning) {
       auto diagID = diag::pattern_type_not_usable_from_inline;
       if (fixedLayoutStructContext)
-        diagID = diag::pattern_type_not_usable_from_inline_fixed_layout;
+        diagID = diag::pattern_type_not_usable_from_inline_frozen;
       else if (!TC.Context.isSwiftVersionAtLeast(5))
         diagID = diag::pattern_type_not_usable_from_inline_warn;
       auto diag = TC.diagnose(TP->getLoc(), diagID, anyVar->isLet(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1931,6 +1931,11 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 }
 
 void AttributeChecker::visitFixedLayoutAttr(FixedLayoutAttr *attr) {
+  if (isa<StructDecl>(D)) {
+    TC.diagnose(attr->getLocation(), diag::fixed_layout_struct)
+      .fixItReplace(attr->getRange(), "@frozen");
+  }  
+
   auto *VD = cast<ValueDecl>(D);
 
   if (VD->getFormalAccess() < AccessLevel::Public &&
@@ -2436,16 +2441,25 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 }
 
 void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
-  auto *ED = cast<EnumDecl>(D);
+  if (auto *ED = dyn_cast<EnumDecl>(D)) {
+    if (!ED->getModuleContext()->isResilient()) {
+      diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonresilient, attr);
+      return;
+    }
 
-  if (!ED->getModuleContext()->isResilient()) {
-    diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonresilient, attr);
-    return;
+    if (ED->getFormalAccess() < AccessLevel::Public &&
+        !ED->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
+      diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonpublic, attr);
+      return;
+    }
   }
 
-  if (ED->getFormalAccess() < AccessLevel::Public &&
-      !ED->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
-    diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonpublic, attr);
+  auto *VD = cast<ValueDecl>(D);
+
+  if (VD->getFormalAccess() < AccessLevel::Public &&
+      !VD->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
+    diagnoseAndRemoveAttr(attr, diag::frozen_attr_on_internal_type,
+                          VD->getFullName(), VD->getFormalAccess());
   }
 }
 

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -268,7 +268,7 @@ public func _isStdlibDebugConfiguration() -> Bool {
 #endif
 }
 
-@_fixed_layout
+@frozen
 public struct LinearCongruentialGenerator: RandomNumberGenerator {
 
   @usableFromInline

--- a/stdlib/public/Darwin/ARKit/ARKit.swift
+++ b/stdlib/public/Darwin/ARKit/ARKit.swift
@@ -17,7 +17,7 @@ extension ARCamera {
     /**
      A value describing the camera's tracking state.
      */
-    @_frozen
+    @frozen
     public enum TrackingState {
         public enum Reason {
             /** Tracking is limited due to initialization in progress. */

--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -22,7 +22,7 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 @_exported import CoreGraphics
 import Darwin
 
-@_fixed_layout
+@frozen
 public struct CGFloat {
 #if arch(i386) || arch(arm)
   /// The native type used to store the CGFloat, which is Float on

--- a/stdlib/public/Darwin/Dispatch/Dispatch.swift
+++ b/stdlib/public/Darwin/Dispatch/Dispatch.swift
@@ -121,7 +121,7 @@ public struct DispatchQoS : Equatable {
 }
 
 /// 
-@_frozen
+@frozen
 public enum DispatchTimeoutResult {
 	case success
 	case timedOut

--- a/stdlib/public/Darwin/Foundation/Data.swift
+++ b/stdlib/public/Darwin/Foundation/Data.swift
@@ -602,7 +602,7 @@ internal class __NSSwiftData : NSData {
 #endif
 }
 
-@_fixed_layout
+@frozen
 public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessCollection, MutableCollection, RangeReplaceableCollection, MutableDataProtocol, ContiguousBytes {
     public typealias ReferenceType = NSData
 
@@ -618,7 +618,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // A small inline buffer of bytes suitable for stack-allocation of small data.
     // Inlinability strategy: everything here should be inlined for direct operation on the stack wherever possible.
     @usableFromInline
-    @_fixed_layout
+    @frozen
     internal struct InlineData {
 #if arch(x86_64) || arch(arm64) || arch(s390x) || arch(powerpc64) || arch(powerpc64le)
         @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
@@ -839,7 +839,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // A buffer of bytes too large to fit in an InlineData, but still small enough to fit a storage pointer + range in two words.
     // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
     @usableFromInline
-    @_fixed_layout
+    @frozen
     internal struct InlineSlice {
         // ***WARNING***
         // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
@@ -1085,7 +1085,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // A buffer of bytes whose range is too large to fit in a signle word. Used alongside a RangeReference to make it fit into _Representation's two-word size.
     // Inlinability strategy: everything here should be easily inlinable as large _DataStorage methods should not inline into here.
     @usableFromInline
-    @_fixed_layout
+    @frozen
     internal struct LargeSlice {
         // ***WARNING***
         // These ivars are specifically laid out so that they cause the enum _Representation to be 16 bytes on 64 bit platforms. This means we _MUST_ have the class type thing last
@@ -1261,7 +1261,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     // The actual storage for Data's various representations.
     // Inlinability strategy: almost everything should be inlinable as forwarding the underlying implementations. (Inlining can also help avoid retain-release traffic around pulling values out of enums.)
     @usableFromInline
-    @_frozen
+    @frozen
     internal enum _Representation {
         case empty
         case inline(InlineData)

--- a/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
@@ -23,7 +23,7 @@ import _SwiftObjectiveCOverlayShims
 /// On 64-bit iOS, the Objective-C BOOL type is a typedef of C/C++
 /// bool. Elsewhere, it is "signed char". The Clang importer imports it as
 /// ObjCBool.
-@_fixed_layout
+@frozen
 public struct ObjCBool : ExpressibleByBooleanLiteral {
 #if os(macOS) || (os(iOS) && (arch(i386) || arch(arm)))
   // On OS X and 32-bit iOS, Objective-C's BOOL type is a "signed char".
@@ -95,7 +95,7 @@ func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
 /// convert between C strings and selectors.
 ///
 /// The compiler has special knowledge of this type.
-@_fixed_layout
+@frozen
 public struct Selector : ExpressibleByStringLiteral {
   var ptr: OpaquePointer
 
@@ -144,7 +144,7 @@ extension Selector : CustomReflectable {
 // NSZone
 //===----------------------------------------------------------------------===//
 
-@_fixed_layout
+@frozen
 public struct NSZone {
   var pointer: OpaquePointer
 }

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -28,7 +28,7 @@ public var noErr: OSStatus { return 0 }
 /// Foundation.
 ///
 /// The C type is a typedef for `unsigned char`.
-@_fixed_layout
+@frozen
 public struct DarwinBoolean : ExpressibleByBooleanLiteral {
   var _value: UInt8
 

--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen
+  @frozen
   public enum ASCII {}
 }
 
@@ -68,7 +68,7 @@ extension Unicode.ASCII : Unicode.Encoding {
     return encode(FromEncoding.decode(content))
   }
 
-  @_fixed_layout
+  @frozen
   public struct Parser {
     @inlinable
     public init() { }

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -91,7 +91,7 @@ public func max<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 ///     }
 ///     // Prints "0: foo"
 ///     // Prints "1: bar"
-@_fixed_layout
+@frozen
 public struct EnumeratedSequence<Base: Sequence> {
   @usableFromInline
   internal var _base: Base
@@ -118,7 +118,7 @@ extension EnumeratedSequence {
   ///
   /// To create an instance, call
   /// `enumerated().makeIterator()` on a sequence or collection.
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal var _base: Base.Iterator

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -123,7 +123,7 @@ internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
 ///     print(descriptions[AnyHashable(43)])       // prints "nil"
 ///     print(descriptions[AnyHashable(Int8(43))]!) // prints "an Int8"
 ///     print(descriptions[AnyHashable(Set(["a", "b"]))]!) // prints "a set of strings"
-@_fixed_layout
+@frozen
 public struct AnyHashable {
   internal var _box: _AnyHashableBox
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -296,7 +296,7 @@
 /// - Note: The `ContiguousArray` and `ArraySlice` types are not bridged;
 ///   instances of those types always have a contiguous block of memory as
 ///   their storage.
-@_fixed_layout
+@frozen
 public struct Array<Element>: _DestructorSafeContainer {
   #if _runtime(_ObjC)
   @usableFromInline

--- a/stdlib/public/core/ArrayBody.swift
+++ b/stdlib/public/core/ArrayBody.swift
@@ -17,7 +17,7 @@
 
 import SwiftShims
 
-@_fixed_layout
+@frozen
 @usableFromInline
 internal struct _ArrayBody {
   @usableFromInline

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -23,7 +23,7 @@ internal typealias _ArrayBridgeStorage
   = _BridgeStorage<__ContiguousArrayStorageBase>
 
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
 
   /// Create an empty buffer.

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -11,7 +11,7 @@
 
 /// This type is used as a result of the _checkSubscript call to associate the
 /// call with the array access call it guards.
-@_fixed_layout
+@frozen
 public struct _DependenceToken {
   @inlinable
   public init() {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -113,7 +113,7 @@
 /// - Note: To safely reference the starting and ending indices of a slice,
 ///   always use the `startIndex` and `endIndex` properties instead of
 ///   specific values.
-@_fixed_layout
+@frozen
 public struct ArraySlice<Element>: _DestructorSafeContainer {
   @usableFromInline
   internal typealias _Buffer = _SliceBuffer<Element>

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -16,7 +16,7 @@
 /// Because `_UnsafeBitset` implements a flat bit vector, it isn't suitable for
 /// holding arbitrarily large integers. The maximal element a bitset can store
 /// is fixed at its initialization.
-@_fixed_layout
+@frozen
 @usableFromInline // @testable
 internal struct _UnsafeBitset {
   @usableFromInline
@@ -146,7 +146,7 @@ extension _UnsafeBitset: Sequence {
   }
 
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct Iterator: IteratorProtocol {
     @usableFromInline
     internal let bitset: _UnsafeBitset
@@ -182,7 +182,7 @@ extension _UnsafeBitset: Sequence {
 ////////////////////////////////////////////////////////////////////////////////
 
 extension _UnsafeBitset {
-  @_fixed_layout
+  @frozen
   @usableFromInline
   internal struct Word {
     @usableFromInline

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -60,7 +60,7 @@
 /// bridged into Swift as `Bool`. The single `Bool` type in Swift guarantees
 /// that functions, methods, and properties imported from C and Objective-C
 /// have a consistent type interface.
-@_fixed_layout
+@frozen
 public struct Bool {
   @usableFromInline
   internal var _value: Builtin.Int1

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -356,7 +356,7 @@ public func _getBridgedNonVerbatimObjectiveCType<T>(_: T.Type) -> Any.Type?
 /// This type does not carry an owner pointer unlike the other C*Pointer types
 /// because it only needs to reference the results of inout conversions, which
 /// already have writeback-scoped lifetime.
-@_fixed_layout
+@frozen
 public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   :  _Pointer {
 

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -20,7 +20,7 @@
 //===----------------------------------------------------------------------===//
 import SwiftShims
 
-@_fixed_layout
+@frozen
 @usableFromInline
 internal struct _BridgeStorage<NativeClass: AnyObject> {
   @usableFromInline

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -109,7 +109,7 @@ public typealias CBool = Bool
 ///
 /// Opaque pointers are used to represent C pointers to types that
 /// cannot be represented in Swift, such as incomplete struct types.
-@_fixed_layout
+@frozen
 public struct OpaquePointer {
   @usableFromInline
   internal var _rawValue: Builtin.RawPointer
@@ -220,7 +220,7 @@ extension UInt {
 
 /// A wrapper around a C `va_list` pointer.
 #if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
-@_fixed_layout
+@frozen
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
   internal var _value: (__stack: UnsafeMutablePointer<Int>?,
@@ -252,7 +252,7 @@ extension CVaListPointer : CustomDebugStringConvertible {
 
 #else
 
-@_fixed_layout
+@frozen
 public struct CVaListPointer {
   @usableFromInline // unsafe-performance
   internal var _value: UnsafeMutableRawPointer

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -61,7 +61,7 @@
 /// [glossary]: http://www.unicode.org/glossary/
 /// [clusters]: http://www.unicode.org/glossary/#extended_grapheme_cluster
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
-@_fixed_layout
+@frozen
 public struct Character {
   @usableFromInline
   internal var _str: String

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -60,7 +60,7 @@
 /// `Stride` types, they cannot be used as the bounds of a countable range. If
 /// you need to iterate over consecutive floating-point values, see the
 /// `stride(from:through:by:)` function.
-@_fixed_layout
+@frozen
 public struct ClosedRange<Bound: Comparable> {
   /// The range's lower bound.
   public let lowerBound: Bound
@@ -127,7 +127,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger {
 }
 
 extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
-  @_frozen // FIXME(resilience)
+  @frozen // FIXME(resilience)
   public enum Index {
     case pastEnd
     case inRange(Bound)

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -25,7 +25,7 @@ import SwiftShims
 /// `Collection` conformance.  Why not make `_NSArrayCore` conform directly?
 /// It's a class, and I don't want to pay for the dynamic dispatch overhead.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _CocoaArrayWrapper : RandomAccessCollection {
   @usableFromInline
   typealias Indices = Range<Int>

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -65,7 +65,7 @@
 ///     }
 ///     // Prints "15.0"
 ///     // Prints "20.0"
-@_fixed_layout
+@frozen
 public struct IndexingIterator<Elements : Collection> {
   @usableFromInline
   internal let _elements: Elements

--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -15,7 +15,7 @@
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) // FIXME(availability-5.1)
 public struct CollectionDifference<ChangeElement> {
   /// A single change to a collection.
-  @_frozen
+  @frozen
   public enum Change {
     /// An insertion.
     ///
@@ -227,7 +227,7 @@ extension CollectionDifference: Collection {
   public typealias Element = Change
 
   /// The position of a collection difference.
-  @_fixed_layout
+  @frozen
   public struct Index {
     // Opaque index type is isomorphic to Int
     @usableFromInline

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -21,7 +21,7 @@
 ///     let toAdd = 100
 ///     let b = a + CollectionOfOne(toAdd)
 ///     // b == [1, 2, 3, 4, 100]
-@_fixed_layout // trivial-implementation
+@frozen // trivial-implementation
 public struct CollectionOfOne<Element> {
   @usableFromInline // trivial-implementation
   internal var _element: Element
@@ -39,7 +39,7 @@ extension CollectionOfOne {
   /// An iterator that produces one or zero instances of an element.
   ///
   /// `IteratorOverOne` is the iterator for the `CollectionOfOne` type.
-  @_fixed_layout // trivial-implementation
+  @frozen // trivial-implementation
   public struct Iterator {
     @usableFromInline // trivial-implementation
     internal var _elements: Element?

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -13,7 +13,7 @@
 import SwiftShims
 
 /// Command-line arguments for the current process.
-@_frozen // namespace
+@frozen // namespace
 public enum CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -33,7 +33,7 @@
 ///
 /// For more information about using arrays, see `Array` and `ArraySlice`, with
 /// which `ContiguousArray` shares most properties and methods.
-@_fixed_layout
+@frozen
 public struct ContiguousArray<Element>: _DestructorSafeContainer {
   @usableFromInline
   internal typealias _Buffer = _ContiguousArrayBuffer<Element>

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -171,7 +171,7 @@ internal final class _ContiguousArrayStorage<
 }
 
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
 
   /// Make a buffer with uninitialized elements.  After using this
@@ -652,7 +652,7 @@ internal func _copyCollectionToContiguousArray<
 /// element-by-element. The type is unsafe because it cannot be deinitialized
 /// until the buffer has been finalized by a call to `finish`.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
   @usableFromInline
   internal var result: _ContiguousArrayBuffer<Element>

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -12,7 +12,7 @@
 
 import SwiftShims
 
-@_frozen // namespace
+@frozen // namespace
 public enum _DebuggerSupport {
   private enum CollectionStatus {
     case notACollection

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -385,7 +385,7 @@
 /// `NSDictionary` and `Dictionary` share buffer using the same copy-on-write
 /// optimization that is used when two instances of `Dictionary` share
 /// buffer.
-@_fixed_layout
+@frozen
 public struct Dictionary<Key: Hashable, Value> {
   /// The element type of a dictionary: a tuple containing an individual
   /// key-value pair.
@@ -1280,7 +1280,7 @@ extension Dictionary {
   }
 
   /// A view of a dictionary's keys.
-  @_fixed_layout
+  @frozen
   public struct Keys
     : Collection, Equatable,
       CustomStringConvertible, CustomDebugStringConvertible {
@@ -1407,7 +1407,7 @@ extension Dictionary {
   }
 
   /// A view of a dictionary's values.
-  @_fixed_layout
+  @frozen
   public struct Values
     : MutableCollection, CustomStringConvertible, CustomDebugStringConvertible {
     public typealias Element = Value
@@ -1505,7 +1505,7 @@ extension Dictionary {
 }
 
 extension Dictionary.Keys {
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _base: Dictionary<Key, Value>.Iterator
@@ -1538,7 +1538,7 @@ extension Dictionary.Keys {
 }
 
 extension Dictionary.Values {
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _base: Dictionary<Key, Value>.Iterator
@@ -1713,7 +1713,7 @@ extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 @usableFromInline
-@_frozen
+@frozen
 internal enum _MergeError: Error {
   case keyCollision
 }
@@ -1730,7 +1730,7 @@ extension Dictionary {
   /// 2. Subscripting with an index, yielding a key-value pair:
   ///
   ///        (k, v) = d[i]
-  @_fixed_layout
+  @frozen
   public struct Index {
     // Index for native dictionary is efficient.  Index for bridged NSDictionary
     // is not, because neither NSEnumerator nor fast enumeration support moving
@@ -1739,7 +1739,7 @@ extension Dictionary {
     // safe to copy the state.  So, we cannot implement Index that is a value
     // type for bridged NSDictionary in terms of Cocoa enumeration facilities.
 
-    @_frozen
+    @frozen
     @usableFromInline
     internal enum _Variant {
       case native(_HashTable.Index)
@@ -1908,7 +1908,7 @@ extension Dictionary.Index: Hashable {
 
 extension Dictionary {
   /// An iterator over the members of a `Dictionary<Key, Value>`.
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     // Dictionary has a separate IteratorProtocol and Index because of
     // efficiency and implementability reasons.
@@ -1921,7 +1921,7 @@ extension Dictionary {
     // IteratorProtocol, which is being consumed as iteration proceeds.
 
     @usableFromInline
-    @_frozen
+    @frozen
     internal enum _Variant {
       case native(_NativeDictionary<Key, Value>.Iterator)
 #if _runtime(_ObjC)

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -424,7 +424,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 // classes, so it was renamed. The old names must not be used in the new
 // runtime.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct __CocoaDictionary {
   @usableFromInline
   internal let object: AnyObject
@@ -567,7 +567,7 @@ extension __CocoaDictionary {
 }
 
 extension __CocoaDictionary {
-  @_fixed_layout
+  @frozen
   @usableFromInline
   internal struct Index {
     internal var _storage: Builtin.BridgeObject

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -14,7 +14,7 @@
 ///
 /// Using a builder can be faster than inserting members into an empty
 /// `Dictionary`.
-@_fixed_layout
+@frozen
 public // SPI(Foundation)
 struct _DictionaryBuilder<Key: Hashable, Value> {
   @usableFromInline

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -32,7 +32,7 @@ internal protocol _DictionaryBuffer {
 
 extension Dictionary {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct _Variant {
     @usableFromInline
     internal var object: _BridgeStorage<__RawDictionaryStorage>

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -12,7 +12,7 @@
 
 /// A sequence whose elements consist of the elements that follow the initial
 /// consecutive elements of some base sequence that satisfy a given predicate.
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct LazyDropWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
   
@@ -37,7 +37,7 @@ extension LazyDropWhileSequence {
   /// This is the associated iterator for the `LazyDropWhileSequence`,
   /// `LazyDropWhileCollection`, and `LazyDropWhileBidirectionalCollection`
   /// types.
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Iterator {
     public typealias Element = Base.Element
     

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -18,7 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A collection whose element type is `Element` but that is always empty.
-@_fixed_layout // trivial-implementation
+@frozen // trivial-implementation
 public struct EmptyCollection<Element> {
   // no properties
 
@@ -29,7 +29,7 @@ public struct EmptyCollection<Element> {
 
 extension EmptyCollection {
   /// An iterator that never produces an element.
-  @_fixed_layout // trivial-implementation
+  @frozen // trivial-implementation
   public struct Iterator {
     // no properties
   

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -41,7 +41,7 @@ internal func _abstract(
 /// This iterator forwards its `next()` method to an arbitrary underlying
 /// iterator having the same `Element` type, hiding the specifics of the
 /// underlying `IteratorProtocol`.
-@_fixed_layout
+@frozen
 public struct AnyIterator<Element> {
   @usableFromInline
   internal let _box: _AnyIteratorBoxBase<Element>
@@ -115,7 +115,7 @@ extension AnyIterator: IteratorProtocol {
 extension AnyIterator: Sequence { }
 
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
   @inlinable
   internal init(_ body: @escaping () -> Element?) {
@@ -672,7 +672,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
 % end
 
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _ClosureBasedSequence<Iterator : IteratorProtocol> {
   @usableFromInline
   internal var _makeUnderlyingIterator: () -> Iterator
@@ -695,7 +695,7 @@ extension _ClosureBasedSequence: Sequence {
 /// An instance of `AnySequence` forwards its operations to an underlying base
 /// sequence having the same `Element` type, hiding the specifics of the
 /// underlying sequence.
-@_fixed_layout
+@frozen
 public struct AnySequence<Element> {
   @usableFromInline
   internal let _box: _AnySequenceBox<Element>
@@ -889,7 +889,7 @@ internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
 }
 
 /// A wrapper over an underlying index that hides the specific underlying type.
-@_fixed_layout
+@frozen
 public struct AnyIndex {
   @usableFromInline
   internal var _box: _AnyIndexBox
@@ -960,7 +960,7 @@ protocol _AnyCollectionProtocol : Collection {
 /// An `${Self}` instance forwards its operations to a base collection having the
 /// same `Element` type, hiding the specifics of the underlying
 /// collection.
-@_fixed_layout
+@frozen
 public struct ${Self}<Element> {
   @usableFromInline
   internal let _box: _${Self}Box<Element>

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -16,7 +16,7 @@
 ///
 /// - Note: `s.lazy.filter { ... }`, for an arbitrary sequence `s`,
 ///   is a `LazyFilterSequence`.
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct LazyFilterSequence<Base: Sequence> {
   @usableFromInline // lazy-performance
   internal var _base: Base
@@ -42,7 +42,7 @@ extension LazyFilterSequence {
   ///
   /// - Note: This is the associated `Iterator` of `LazyFilterSequence`
   /// and `LazyFilterCollection`.
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Iterator {
     /// The underlying iterator whose elements are being filtered.
     public var base: Base.Iterator { return _base }

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -23,7 +23,7 @@
 /// * `s.joined()` does not create new storage
 /// * `s.joined().map(f)` maps eagerly and returns a new array
 /// * `s.lazy.joined().map(f)` maps lazily and returns a `LazyMapSequence`
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct FlattenSequence<Base: Sequence> where Base.Element: Sequence {
 
   @usableFromInline // lazy-performance
@@ -39,7 +39,7 @@ public struct FlattenSequence<Base: Sequence> where Base.Element: Sequence {
 }
 
 extension FlattenSequence {
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Iterator {
     @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
@@ -138,7 +138,7 @@ public typealias FlattenCollection<T: Collection> = FlattenSequence<T> where T.E
 
 extension FlattenSequence where Base: Collection, Base.Element: Collection {
   /// A position in a FlattenCollection
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Index {
     /// The position in the outer collection of collections.
     @usableFromInline // lazy-performance

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1211,7 +1211,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
 }
 
 /// The sign of a floating-point value.
-@_frozen // FIXME(sil-serialize-all)
+@frozen
 public enum FloatingPointSign: Int {
   /// The sign for a positive value.
   case plus
@@ -1260,7 +1260,7 @@ public enum FloatingPointSign: Int {
 }
 
 /// The IEEE 754 floating-point classes.
-@_frozen // FIXME(sil-serialize-all)
+@frozen
 public enum FloatingPointClassification {
   /// A signaling NaN ("not a number").
   ///

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -58,7 +58,7 @@ else:
 % end
 
 ${SelfDocComment}
-@_fixed_layout
+@frozen
 public struct ${Self} {
   public // @testable
   var _value: Builtin.FPIEEE${bits}
@@ -318,7 +318,7 @@ extension ${Self}: BinaryFloatingPoint {
   }
 %else:
   // Internal implementation details of x86 Float80
-  @_fixed_layout
+  @frozen
   @usableFromInline
   internal struct _Representation {
     @usableFromInline
@@ -1900,7 +1900,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 #else
 
 ${SelfDocComment}
-@_fixed_layout
+@frozen
 @available(*, unavailable, message: "Float80 is only available on non-Windows x86 targets.")
 public struct ${Self} {
   /// Creates a value initialized to zero.

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -17,7 +17,7 @@ internal protocol _HashTableDelegate {
 }
 
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _HashTable {
   @usableFromInline
   internal typealias Word = _UnsafeBitset.Word
@@ -118,7 +118,7 @@ extension _HashTable {
 }
 
 extension _HashTable {
-  @_fixed_layout
+  @frozen
   @usableFromInline
   internal struct Bucket {
     @usableFromInline
@@ -172,7 +172,7 @@ extension _HashTable.Bucket: Comparable {
 
 extension _HashTable {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct Index {
     @usableFromInline
     let bucket: Bucket
@@ -217,7 +217,7 @@ extension _HashTable.Index: Comparable {
 
 extension _HashTable: Sequence {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct Iterator: IteratorProtocol {
     @usableFromInline
     let hashTable: _HashTable

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -58,9 +58,9 @@ extension Hasher {
   /// trailing bytes, while the most significant 8 bits hold the count of bytes
   /// appended so far, modulo 256. The count of bytes currently stored in the
   /// buffer is in the lower three bits of the byte count.)
-  // FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+  // FIXME: Remove @usableFromInline and @frozen once Hasher is resilient.
   // rdar://problem/38549901
-  @usableFromInline @_fixed_layout
+  @usableFromInline @frozen
   internal struct _TailBuffer {
     // msb                                                             lsb
     // +---------+-------+-------+-------+-------+-------+-------+-------+
@@ -135,9 +135,9 @@ extension Hasher {
 }
 
 extension Hasher {
-  // FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+  // FIXME: Remove @usableFromInline and @frozen once Hasher is resilient.
   // rdar://problem/38549901
-  @usableFromInline @_fixed_layout
+  @usableFromInline @frozen
   internal struct _Core {
     private var _buffer: _TailBuffer
     private var _state: Hasher._State
@@ -272,7 +272,7 @@ extension Hasher {
 ///   different values on every new execution of your program. The hash
 ///   algorithm implemented by `Hasher` may itself change between any two
 ///   versions of the standard library.
-@_fixed_layout // FIXME: Should be resilient (rdar://problem/38549901)
+@frozen // FIXME: Should be resilient (rdar://problem/38549901)
 public struct Hasher {
   internal var _core: _Core
 

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A collection of indices for an arbitrary collection
-@_fixed_layout
+@frozen
 public struct DefaultIndices<Elements: Collection> {
   @usableFromInline
   internal var _elements: Elements

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1085,7 +1085,7 @@ def unsafeOperationComment(operator):
 /// ${Article} ${bits}-bit ${'' if signed else 'un'}signed integer value
 /// type.
 %   end
-@_fixed_layout
+@frozen
 public struct ${Self}
   : FixedWidthInteger, ${Unsigned}Integer,
     _ExpressibleByBuiltinIntegerLiteral {
@@ -1383,7 +1383,7 @@ ${assignmentOperatorComment(x.operator, True)}
   }
 
   /// A type that represents the words of this integer.
-  @_fixed_layout
+  @frozen
   public struct Words : RandomAccessCollection {
     public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -12,7 +12,7 @@
 
 /// A sequence that presents the elements of a base sequence of sequences
 /// concatenated using a given separator.
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
 
   public typealias Element = Base.Element.Element
@@ -37,7 +37,7 @@ public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
 extension JoinedSequence {
   /// An iterator that presents the elements of the sequences traversed
   /// by a base iterator, concatenated using a given separator.
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Iterator {
     @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
@@ -48,7 +48,7 @@ extension JoinedSequence {
     @usableFromInline // lazy-performance
     internal var _separator: ContiguousArray<Element>.Iterator?
     
-    @_frozen // lazy-performance
+    @frozen // lazy-performance
     @usableFromInline // lazy-performance
     internal enum _JoinIteratorState {
       case start

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -72,7 +72,7 @@
 ///     let pairs = IntPairs([1: 2, 1: 1, 3: 4, 2: 1])
 ///     print(pairs.elements)
 ///     // Prints "[(1, 2), (1, 1), (3, 4), (2, 1)]"
-@_fixed_layout // trivial-implementation
+@frozen // trivial-implementation
 public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
   @usableFromInline // trivial-implementation
   internal let _elements: [(Key, Value)]

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -176,7 +176,7 @@ extension LazySequenceProtocol where Elements: LazySequenceProtocol {
 /// implemented lazily.
 ///
 /// - See also: `LazySequenceProtocol`
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct LazySequence<Base : Sequence> {
   @usableFromInline
   internal var _base: Base

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -171,7 +171,7 @@ extension ManagedBuffer {
 ///        }
 ///      }
 ///
-@_fixed_layout
+@frozen
 public struct ManagedBufferPointer<Header, Element> {
 
   @usableFromInline

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -14,7 +14,7 @@
 /// `Sequence` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
-@_fixed_layout
+@frozen
 public struct LazyMapSequence<Base : Sequence, Element> {
 
   public typealias Elements = LazyMapSequence
@@ -34,7 +34,7 @@ public struct LazyMapSequence<Base : Sequence, Element> {
 }
 
 extension LazyMapSequence {
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal var _base: Base.Iterator

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -39,7 +39,7 @@
 ///     let pointPointer = UnsafeMutableRawPointer.allocate(
 ///             bytes: count * MemoryLayout<Point>.stride,
 ///             alignedTo: MemoryLayout<Point>.alignment)
-@_frozen // namespace
+@frozen // namespace
 public enum MemoryLayout<T> {
   /// The contiguous memory footprint of `T`, in bytes.
   ///

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -607,7 +607,7 @@ extension Zip2Sequence {
 @available(swift, deprecated: 4.2, message: "PlaygroundQuickLook will be removed in a future Swift version. For customizing how types are presented in playgrounds, use CustomPlaygroundDisplayConvertible instead.")
 public typealias PlaygroundQuickLook = _PlaygroundQuickLook
 
-@_frozen // rdar://problem/38719739 - needed by LLDB
+@frozen // rdar://problem/38719739 - needed by LLDB
 public enum _PlaygroundQuickLook {
   case text(String)
   case int(Int64)

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -13,7 +13,7 @@
 /// A wrapper around __RawDictionaryStorage that provides most of the
 /// implementation of Dictionary.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _NativeDictionary<Key: Hashable, Value> {
   @usableFromInline
   internal typealias Element = (key: Key, value: Value)
@@ -777,7 +777,7 @@ extension _NativeDictionary { // High-level operations
 
 extension _NativeDictionary: Sequence {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct Iterator {
     // The iterator is iterating over a frozen view of the collection state, so
     // it keeps its own reference to the dictionary.

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -13,7 +13,7 @@
 /// A wrapper around __RawSetStorage that provides most of the
 /// implementation of Set.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct _NativeSet<Element: Hashable> {
   /// See the comments on __RawSetStorage and its subclasses to understand why we
   /// store an untyped storage here.
@@ -546,7 +546,7 @@ extension _NativeSet { // Deletion
 
 extension _NativeSet: Sequence {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct Iterator {
     // The iterator is iterating over a frozen view of the collection state, so
     // it keeps its own reference to the set.

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -14,7 +14,7 @@
 ///
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
-@_fixed_layout // trivial-implementation
+@frozen // trivial-implementation
 public struct ObjectIdentifier {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -118,7 +118,7 @@
 ///
 /// Unconditionally unwrapping a `nil` instance with `!` triggers a runtime
 /// error.
-@_frozen
+@frozen
 public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   // The compiler has special knowledge of Optional<Wrapped>, including the fact
   // that it is an `enum` with cases named `none` and `some`.
@@ -390,7 +390,7 @@ extension Optional: Hashable where Wrapped: Hashable {
 
 // Enable pattern matching against the nil literal, even if the element type
 // isn't equatable.
-@_fixed_layout
+@frozen
 public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
   /// Create an instance initialized with `nil`.
   @_transparent

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -25,7 +25,7 @@
 ///     func crashAndBurn() -> Never {
 ///         fatalError("Something very, very bad happened")
 ///     }
-@_frozen
+@frozen
 public enum Never {}
 
 extension Never: Error {}

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -13,7 +13,7 @@
 
 /// A sequence whose elements consist of the initial consecutive elements of
 /// some base sequence that satisfy a given predicate.
-@_fixed_layout // lazy-performance
+@frozen // lazy-performance
 public struct LazyPrefixWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
   
@@ -37,7 +37,7 @@ extension LazyPrefixWhileSequence {
   /// This is the associated iterator for the `LazyPrefixWhileSequence`,
   /// `LazyPrefixWhileCollection`, and `LazyPrefixWhileBidirectionalCollection`
   /// types.
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Iterator {
     public typealias Element = Base.Element
 
@@ -112,7 +112,7 @@ public typealias LazyPrefixWhileCollection<T: Collection> = LazyPrefixWhileSeque
 extension LazyPrefixWhileCollection {
   /// A position in the base collection of a `LazyPrefixWhileCollection` or the
   /// end of that collection.
-  @_frozen // lazy-performance
+  @frozen // lazy-performance
   @usableFromInline
   internal enum _IndexRepresentation {
     case index(Base.Index)
@@ -121,7 +121,7 @@ extension LazyPrefixWhileCollection {
   
   /// A position in a `LazyPrefixWhileCollection` or
   /// `LazyPrefixWhileBidirectionalCollection` instance.
-  @_fixed_layout // lazy-performance
+  @frozen // lazy-performance
   public struct Index {
     /// The position corresponding to `self` in the underlying collection.
     @usableFromInline // lazy-performance

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -131,7 +131,7 @@ extension RandomNumberGenerator {
 /// - Apple platforms use `arc4random_buf(3)`.
 /// - Linux platforms use `getrandom(2)` when available; otherwise, they read
 ///   from `/dev/urandom`.
-@_fixed_layout
+@frozen
 public struct SystemRandomNumberGenerator : RandomNumberGenerator {
   /// Creates a new instance of the system's default random number generator.
   @inlinable

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -125,7 +125,7 @@ extension RangeExpression {
 /// `Stride` types, they cannot be used as the bounds of a countable range. If
 /// you need to iterate over consecutive floating-point values, see the
 /// `stride(from:to:by:)` function.
-@_fixed_layout
+@frozen
 public struct Range<Bound : Comparable> {
   /// The range's lower bound.
   ///
@@ -449,7 +449,7 @@ extension Range: Encodable where Bound: Encodable {
 ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
 ///     print(numbers[..<3])
 ///     // Prints "[10, 20, 30]"
-@_fixed_layout
+@frozen
 public struct PartialRangeUpTo<Bound: Comparable> {
   public let upperBound: Bound
   
@@ -505,7 +505,7 @@ extension PartialRangeUpTo: Encodable where Bound: Encodable {
 ///     let numbers = [10, 20, 30, 40, 50, 60, 70]
 ///     print(numbers[...3])
 ///     // Prints "[10, 20, 30, 40]"
-@_fixed_layout
+@frozen
 public struct PartialRangeThrough<Bound: Comparable> {  
   public let upperBound: Bound
   
@@ -620,7 +620,7 @@ extension PartialRangeThrough: Encodable where Bound: Encodable {
 /// `Bound`. For example, iterating over an instance of
 /// `PartialRangeFrom<Int>` traps when the sequence's next value would be
 /// above `Int.max`.
-@_fixed_layout
+@frozen
 public struct PartialRangeFrom<Bound: Comparable> {
   public let lowerBound: Bound
 
@@ -647,7 +647,7 @@ extension PartialRangeFrom: Sequence
   public typealias Element = Bound
 
   /// The iterator for a `PartialRangeFrom` instance.
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _current: Bound
@@ -827,7 +827,7 @@ extension Comparable {
 ///     let word2 = "grisly"
 ///     let changes = countLetterChanges(word1[...], word2[...])
 ///     // changes == 2
-@_frozen // namespace
+@frozen // namespace
 public enum UnboundedRange_ {
   // FIXME: replace this with a computed var named `...` when the language makes
   // that possible.

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -25,7 +25,7 @@
 ///     // "Humperdinck"
 ///     // "Humperdinck"
 ///     // "Humperdinck"
-@_fixed_layout
+@frozen
 public struct Repeated<Element> {
   /// The number of elements in this collection.
   public let count: Int

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -12,7 +12,7 @@
 
 /// A value that represents either a success or a failure, including an
 /// associated value in each case.
-@_frozen
+@frozen
 public enum Result<Success, Failure: Error> {
   /// A success, storing a `Success` value.
   case success(Success)

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -49,7 +49,7 @@ extension MutableCollection where Self: BidirectionalCollection {
 /// * `c.reversed()` does not create new storage
 /// * `c.reversed().map(f)` maps eagerly and returns a new array
 /// * `c.lazy.reversed().map(f)` maps lazily and returns a `LazyMapCollection`
-@_fixed_layout
+@frozen
 public struct ReversedCollection<Base: BidirectionalCollection> {
   public let _base: Base
 
@@ -65,7 +65,7 @@ public struct ReversedCollection<Base: BidirectionalCollection> {
 
 extension ReversedCollection {
   // An iterator that can be much faster than the iterator of a reversed slice.
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal let _base: Base
@@ -112,7 +112,7 @@ extension ReversedCollection: Sequence {
 extension ReversedCollection {
   /// An index that traverses the same positions as an underlying index,
   /// with inverted traversal direction.
-  @_fixed_layout
+  @frozen
   public struct Index {
     /// The position after this position in the underlying collection.
     ///

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -607,7 +607,7 @@ where Scalar: BinaryFloatingPoint, Scalar.RawSignificand: FixedWidthInteger {
   }
 }
 
-@_fixed_layout
+@frozen
 public struct SIMDMask<Storage>: SIMD
                   where Storage: SIMD,
                  Storage.Scalar: FixedWidthInteger & SignedInteger {

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -25,7 +25,7 @@ ordinalPositions = ['first', 'second', 'third', 'fourth']
 %for n in vectorscalarCounts:
 % storageN = 4 if n == 3 else n
 /// A vector of ${spelledNumbers[n]} scalar values.
-@_fixed_layout
+@frozen
 public struct SIMD${n}<Scalar>: SIMD where Scalar: SIMDScalar {
 
   public var _storage: Scalar.SIMD${storageN}Storage
@@ -214,7 +214,7 @@ extension ${Self}: SIMDScalar {
 % for n in storagescalarCounts:
 %  bytes = n * self_type.bits / 8
   /// Storage for a vector of ${spelledNumbers[n]} integers.
-  @_fixed_layout
+  @frozen
   @_alignment(${bytes if bytes <= 16 else 16})
   public struct SIMD${n}Storage: SIMDStorage {
 
@@ -259,7 +259,7 @@ extension ${Self}: SIMDScalar {
 % for n in storagescalarCounts:
 %  bytes = n * bits / 8
   /// Storage for a vector of ${spelledNumbers[n]} floating-point values.
-  @_fixed_layout
+  @frozen
   @_alignment(${bytes if bytes <= 16 else 16})
   public struct SIMD${n}Storage: SIMDStorage {
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -389,7 +389,7 @@ extension Sequence where Self.Iterator == Self {
 /// `Base` iterator before possibly returning the first available element.
 ///
 /// The underlying iterator's sequence may be infinite.
-@_fixed_layout
+@frozen
 public struct DropFirstSequence<Base: Sequence> {
   @usableFromInline
   internal let _base: Base
@@ -433,7 +433,7 @@ extension DropFirstSequence: Sequence {
 /// `Base` iterator.
 ///
 /// The underlying iterator's sequence may be infinite.
-@_fixed_layout
+@frozen
 public struct PrefixSequence<Base: Sequence> {
   @usableFromInline
   internal var _base: Base
@@ -449,7 +449,7 @@ public struct PrefixSequence<Base: Sequence> {
 }
 
 extension PrefixSequence {
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal var _base: Base.Iterator
@@ -496,7 +496,7 @@ extension PrefixSequence: Sequence {
 /// `Base` iterator before possibly returning the first available element.
 ///
 /// The underlying iterator's sequence may be infinite.
-@_fixed_layout
+@frozen
 public struct DropWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
   
@@ -522,7 +522,7 @@ public struct DropWhileSequence<Base: Sequence> {
 }
 
 extension DropWhileSequence {
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal var _iterator: Base.Iterator
@@ -1122,7 +1122,7 @@ extension Sequence {
 /// given just an iterator `i`:
 ///
 ///     for x in IteratorSequence(i) { ... }
-@_fixed_layout
+@frozen
 public struct IteratorSequence<Base : IteratorProtocol> {
   @usableFromInline
   internal var _base: Base

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -146,7 +146,7 @@
 /// unspecified. The instances of `NSSet` and `Set` share buffer using the
 /// same copy-on-write optimization that is used when two instances of `Set`
 /// share buffer.
-@_fixed_layout
+@frozen
 public struct Set<Element: Hashable> {
   @usableFromInline
   internal var _variant: _Variant
@@ -1265,7 +1265,7 @@ extension Set {
 
 extension Set {
   /// The position of an element in a set.
-  @_fixed_layout
+  @frozen
   public struct Index {
     // Index for native buffer is efficient.  Index for bridged NSSet is
     // not, because neither NSEnumerator nor fast enumeration support moving
@@ -1274,7 +1274,7 @@ extension Set {
     // safe to copy the state.  So, we cannot implement Index that is a value
     // type for bridged NSSet in terms of Cocoa enumeration facilities.
 
-    @_frozen
+    @frozen
     @usableFromInline
     internal enum _Variant {
       case native(_HashTable.Index)
@@ -1451,7 +1451,7 @@ extension Set.Index: Hashable {
 
 extension Set {
   /// An iterator over the members of a `Set<Element>`.
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     // Set has a separate IteratorProtocol and Index because of efficiency
     // and implementability reasons.
@@ -1463,7 +1463,7 @@ extension Set {
     // IteratorProtocol, which is being consumed as iteration proceeds.
 
     @usableFromInline
-    @_frozen
+    @frozen
     internal enum _Variant {
       case native(_NativeSet<Element>.Iterator)
 #if _runtime(_ObjC)

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -292,7 +292,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
 // classes, so it was renamed. The old names must not be used in the new
 // runtime.
 @usableFromInline
-@_fixed_layout
+@frozen
 internal struct __CocoaSet {
   @usableFromInline
   internal let object: AnyObject
@@ -411,7 +411,7 @@ extension __CocoaSet: _SetBuffer {
 }
 
 extension __CocoaSet {
-  @_fixed_layout
+  @frozen
   @usableFromInline
   internal struct Index {
     internal var _storage: Builtin.BridgeObject

--- a/stdlib/public/core/SetBuilder.swift
+++ b/stdlib/public/core/SetBuilder.swift
@@ -14,7 +14,7 @@
 ///
 /// Using a builder can be faster than inserting members into an empty
 /// `Set`.
-@_fixed_layout
+@frozen
 public // SPI(Foundation)
 struct _SetBuilder<Element: Hashable> {
   @usableFromInline

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -28,7 +28,7 @@ internal protocol _SetBuffer {
 
 extension Set {
   @usableFromInline
-  @_fixed_layout
+  @frozen
   internal struct _Variant {
     @usableFromInline
     internal var object: _BridgeStorage<__RawSetStorage>

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -20,9 +20,9 @@
 //===----------------------------------------------------------------------===//
 
 extension Hasher {
-  // FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+  // FIXME: Remove @usableFromInline and @frozen once Hasher is resilient.
   // rdar://problem/38549901
-  @usableFromInline @_fixed_layout
+  @usableFromInline @frozen
   internal struct _State {
     // "somepseudorandomlygeneratedbytes"
     private var v0: UInt64 = 0x736f6d6570736575

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -79,7 +79,7 @@
 ///   collection type, don't use `Slice` as its subsequence type. Instead,
 ///   define your own subsequence type that takes your index invalidation
 ///   requirements into account.
-@_fixed_layout // generic-performance
+@frozen // generic-performance
 public struct Slice<Base: Collection> {
   public var _startIndex: Base.Index
   public var _endIndex: Base.Index

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Buffer type for `ArraySlice<Element>`.
-@_fixed_layout
+@frozen
 @usableFromInline
 internal struct _SliceBuffer<Element>
   : _ArrayBufferProtocol,

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -23,7 +23,7 @@
 //  ↑                             ↑
 //  first (leftmost) code unit    discriminator (incl. count)
 //
-@_fixed_layout @usableFromInline
+@frozen @usableFromInline
 internal struct _SmallString {
   @usableFromInline
   internal typealias RawBitPattern = (UInt64, UInt64)

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -24,7 +24,7 @@
 /// commonly used `String` type. A static string can store its value as a
 /// pointer to an ASCII code unit sequence, as a pointer to a UTF-8 code unit
 /// sequence, or as a single Unicode scalar value.
-@_fixed_layout
+@frozen
 public struct StaticString
   : _ExpressibleByBuiltinUnicodeScalarLiteral,
     _ExpressibleByBuiltinExtendedGraphemeClusterLiteral,

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -203,7 +203,7 @@ extension Strideable where Self : FloatingPoint, Self == Stride {
 }
 
 /// An iterator for a `StrideTo` instance.
-@_fixed_layout
+@frozen
 public struct StrideToIterator<Element : Strideable> {
   @usableFromInline
   internal let _start: Element
@@ -246,7 +246,7 @@ extension StrideToIterator: IteratorProtocol {
 /// A sequence of values formed by striding over a half-open interval.
 ///
 /// Use the `stride(from:to:by:)` function to create `StrideTo` instances.
-@_fixed_layout
+@frozen
 public struct StrideTo<Element : Strideable> {
   @usableFromInline
   internal let _start: Element
@@ -404,7 +404,7 @@ public func stride<T>(
 }
 
 /// An iterator for a `StrideThrough` instance.
-@_fixed_layout
+@frozen
 public struct StrideThroughIterator<Element : Strideable> {
   @usableFromInline
   internal let _start: Element
@@ -458,7 +458,7 @@ extension StrideThroughIterator: IteratorProtocol {
 ///
 /// Use the `stride(from:through:by:)` function to create `StrideThrough` 
 /// instances.
-@_fixed_layout
+@frozen
 public struct StrideThrough<Element: Strideable> {
   @usableFromInline
   internal let _start: Element

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -348,7 +348,7 @@ internal func unimplemented_utf8_32bit(
 /// [clusters]: http://www.unicode.org/glossary/#extended_grapheme_cluster
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [equivalence]: http://www.unicode.org/glossary/#canonical_equivalent
-@_fixed_layout
+@frozen
 public struct String {
   public // @SPI(Foundation)
   var _guts: _StringGuts

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -214,7 +214,7 @@ extension String: BidirectionalCollection {
 }
 
 extension String {
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -253,7 +253,7 @@ private func _findBoundary(
   }
 }
 
-@_frozen
+@frozen
 @usableFromInline
 internal enum _StringComparisonResult {
   case equal

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -16,7 +16,7 @@ import SwiftShims
 // StringGuts is a parameterization over String's representations. It provides
 // functionality and guidance for efficiently working with Strings.
 //
-@_fixed_layout
+@frozen
 public // SPI(corelibs-foundation)
 struct _StringGuts {
   @usableFromInline

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -35,7 +35,7 @@ the default value being `0`.
 */
 extension String {
   /// A position of a character or code unit in a string.
-  @_fixed_layout
+  @frozen
   public struct Index {
     @usableFromInline
     internal var _rawBits: UInt64

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -59,7 +59,7 @@
 /// 
 /// `DefaultStringInterpolation` extensions should add only `mutating` members
 /// and should not copy `self` or capture it in an escaping closure.
-@_fixed_layout
+@frozen
 public struct DefaultStringInterpolation: StringInterpolationProtocol {
   /// The string contents accumulated by this instance.
   @usableFromInline

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -61,14 +61,14 @@
   `_discriminator`'s `b6`.
 */
 
-@_fixed_layout @usableFromInline
+@frozen @usableFromInline
 internal struct _StringObject {
   // Namespace to hold magic numbers
-  @usableFromInline @_frozen
+  @usableFromInline @frozen
   enum Nibbles {}
 
   // Abstract the count and performance-flags containing word
-  @_fixed_layout @usableFromInline
+  @frozen @usableFromInline
   struct CountAndFlags {
     @usableFromInline
     var _storage: UInt64
@@ -78,7 +78,7 @@ internal struct _StringObject {
   }
 
 #if arch(i386) || arch(arm)
-  @usableFromInline @_frozen
+  @usableFromInline @frozen
   internal enum Variant {
     case immortal(UInt)
     case native(AnyObject)

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -32,7 +32,7 @@ func _findStringSwitchCase(
   return -1
 }
 
-@_fixed_layout // needs known size for static allocation
+@frozen // needs known size for static allocation
 public // used by COMPILER_INTRINSIC
 struct _OpaqueStringSwitchCache {
   var a: Builtin.Word

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -98,7 +98,7 @@ extension String {
   ///         print(snowy[range])
   ///     }
   ///     // Prints "Let it snow!"
-  @_fixed_layout
+  @frozen
   public struct UTF16View {
     @usableFromInline
     internal var _guts: _StringGuts
@@ -256,7 +256,7 @@ extension String.UTF16View: BidirectionalCollection {
 }
 
 extension String.UTF16View {
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -88,7 +88,7 @@ extension String {
   ///     // Prints "-17"
   ///     print(String(s1.utf8.prefix(15)))
   ///     // Prints "They call me 'B"
-  @_fixed_layout
+  @frozen
   public struct UTF8View {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -60,7 +60,7 @@ extension String {
   ///         print(asciiPrefix)
   ///     }
   ///     // Prints "My favorite emoji is "
-  @_fixed_layout
+  @frozen
   public struct UnicodeScalarView {
     @usableFromInline
     internal var _guts: _StringGuts
@@ -161,7 +161,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
 }
 
 extension String.UnicodeScalarView {
-  @_fixed_layout
+  @frozen
   public struct Iterator: IteratorProtocol {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -92,7 +92,7 @@ extension String {
 ///   when there is no other reference to the original string. Storing
 ///   substrings may, therefore, prolong the lifetime of string data that is
 ///   no longer otherwise accessible, which can appear to be memory leakage.
-@_fixed_layout
+@frozen
 public struct Substring {
   @usableFromInline
   internal var _slice: Slice<String>
@@ -322,7 +322,7 @@ extension Substring : LosslessStringConvertible {
 }
 
 extension Substring {
-  @_fixed_layout
+  @frozen
   public struct UTF8View {
     @usableFromInline
     internal var _slice: Slice<String.UTF8View>
@@ -448,7 +448,7 @@ extension String {
   }
 }
 extension Substring {
-  @_fixed_layout
+  @frozen
   public struct UTF16View {
     @usableFromInline
     internal var _slice: Slice<String.UTF16View>
@@ -574,7 +574,7 @@ extension String {
   }
 }
 extension Substring {
-  @_fixed_layout
+  @frozen
   public struct UnicodeScalarView {
     @usableFromInline
     internal var _slice: Slice<String.UnicodeScalarView>

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -14,7 +14,7 @@
 //  255 elements.
 //
 //===----------------------------------------------------------------------===//
-@_fixed_layout
+@frozen
 public struct _UIntBuffer<Element: UnsignedInteger & FixedWidthInteger> {
   public typealias Storage = UInt32
   public var _storage: Storage
@@ -38,7 +38,7 @@ public struct _UIntBuffer<Element: UnsignedInteger & FixedWidthInteger> {
 extension _UIntBuffer : Sequence {
   public typealias SubSequence = Slice<_UIntBuffer>
   
-  @_fixed_layout
+  @frozen
   public struct Iterator : IteratorProtocol, Sequence {
     @inlinable
     @inline(__always)
@@ -66,7 +66,7 @@ extension _UIntBuffer : Sequence {
 }
 
 extension _UIntBuffer : Collection {  
-  @_fixed_layout
+  @frozen
   public struct Index : Comparable {
     @usableFromInline
     internal var bitOffset: UInt8

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen
+  @frozen
   public enum UTF16 {
   case _swift3Buffer(Unicode.UTF16.ForwardParser)
   }
@@ -369,7 +369,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
     return encode(FromEncoding.decode(content))
   }
   
-  @_fixed_layout
+  @frozen
   public struct ForwardParser {
     public typealias _Buffer = _UIntBuffer<UInt16>
     @inlinable
@@ -377,7 +377,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
     public var _buffer: _Buffer
   }
   
-  @_fixed_layout
+  @frozen
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt16>
     @inlinable

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen
+  @frozen
   public enum UTF32 {
   case _swift3Codec
   }
@@ -56,7 +56,7 @@ extension Unicode.UTF32 : Unicode.Encoding {
     return EncodedScalar(source.value)
   }
   
-  @_fixed_layout
+  @frozen
   public struct Parser {
     @inlinable
     public init() { }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_frozen
+  @frozen
   public enum UTF8 {
   case _swift3Buffer(Unicode.UTF8.ForwardParser)
   }
@@ -161,7 +161,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
     return encode(FromEncoding.decode(content))
   }
 
-  @_fixed_layout
+  @frozen
   public struct ForwardParser {
     public typealias _Buffer = _UIntBuffer<UInt8>
     @inline(__always)
@@ -170,7 +170,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
     public var _buffer: _Buffer
   }
   
-  @_fixed_layout
+  @frozen
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt8>
     @inline(__always)

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -100,7 +100,7 @@ public typealias UnfoldFirstSequence<T> = UnfoldSequence<T, (T?, Bool)>
 ///
 /// Instances of `UnfoldSequence` are created with the functions
 /// `sequence(first:next:)` and `sequence(state:next:)`.
-@_fixed_layout // generic-performance
+@frozen // generic-performance
 public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
   @inlinable // generic-performance
   public mutating func next() -> Element? {

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -20,7 +20,7 @@ import SwiftShims
 /// Each `UnicodeDecodingResult` instance can represent a Unicode scalar value,
 /// an indication that no more Unicode scalars are available, or an indication
 /// of a decoding error.
-@_frozen
+@frozen
 public enum UnicodeDecodingResult : Equatable {
   /// A decoded Unicode scalar value.
   case scalarValue(Unicode.Scalar)
@@ -671,6 +671,6 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 }
 
 /// A namespace for Unicode utilities.
-@_frozen
+@frozen
 public enum Unicode {}
 

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   /// The result of attempting to parse a `T` from some input.
-  @_frozen
+  @frozen
   public enum ParseResult<T> {
   /// A `T` was parsed successfully
   case valid(T)

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -32,7 +32,7 @@ extension Unicode {
   ///     let airplane = Unicode.Scalar(9992)
   ///     print(airplane)
   ///     // Prints "✈︎"
-  @_fixed_layout
+  @frozen
   public struct Scalar {
     @inlinable
     internal init(_value: UInt32) {
@@ -386,7 +386,7 @@ extension Unicode.Scalar : Comparable {
 }
 
 extension Unicode.Scalar {
-  @_fixed_layout
+  @frozen
   public struct UTF16View {
     @inlinable
     internal init(value: Unicode.Scalar) {
@@ -436,7 +436,7 @@ extension Unicode.Scalar.UTF16View : RandomAccessCollection {
 
 extension Unicode.Scalar {
   @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
-  @_fixed_layout
+  @frozen
   public struct UTF8View {
     @inlinable
     internal init(value: Unicode.Scalar) {

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -14,7 +14,7 @@
 ///
 /// When you use this type, you become partially responsible for
 /// keeping the object alive.
-@_fixed_layout
+@frozen
 public struct Unmanaged<Instance : AnyObject> {
   @usableFromInline
   internal unowned(unsafe) var _value: Instance

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -32,7 +32,7 @@
 // FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
 // to avoid a hang in Foundation, which has the following setup:
 // struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
-@_fixed_layout // unsafe-performance
+@frozen // unsafe-performance
 public struct Unsafe${Mutable}BufferPointer<Element> {
 
   @usableFromInline
@@ -49,7 +49,7 @@ public struct Unsafe${Mutable}BufferPointer<Element> {
 extension UnsafeBufferPointer {
   /// An iterator for the elements in the buffer referenced by an
   /// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance.
-  @_fixed_layout // unsafe-performance
+  @frozen // unsafe-performance
   public struct Iterator {
     @usableFromInline
     internal var _position, _end: UnsafePointer<Element>?

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -204,7 +204,7 @@
 ///       var number = 5
 ///       let numberPointer = UnsafePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
-@_fixed_layout // unsafe-performance
+@frozen // unsafe-performance
 public struct UnsafePointer<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.
@@ -510,7 +510,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
 ///       var number = 5
 ///       let numberPointer = UnsafeMutablePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
-@_fixed_layout // unsafe-performance
+@frozen // unsafe-performance
 public struct UnsafeMutablePointer<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -92,7 +92,7 @@
 ///
 ///     destBytes[0..<n] = someBytes[n..<(n + n)]
 % end
-@_fixed_layout
+@frozen
 public struct Unsafe${Mutable}RawBufferPointer {
   @usableFromInline
   internal let _position, _end: Unsafe${Mutable}RawPointer?
@@ -101,7 +101,7 @@ public struct Unsafe${Mutable}RawBufferPointer {
 %if not mutable:
 extension UnsafeRawBufferPointer {
   /// An iterator over the bytes viewed by a raw buffer pointer.
-  @_fixed_layout
+  @frozen
   public struct Iterator {
     @usableFromInline
     internal var _position, _end: UnsafeRawPointer?

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -168,7 +168,7 @@
 ///       var number = 5
 ///       let numberPointer = UnsafeRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
-@_fixed_layout
+@frozen
 public struct UnsafeRawPointer: _Pointer {
   
   public typealias Pointee = UInt8
@@ -520,7 +520,7 @@ extension UnsafeRawPointer: Strideable {
 ///       var number = 5
 ///       let numberPointer = UnsafeMutableRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
-@_fixed_layout
+@frozen
 public struct UnsafeMutableRawPointer: _Pointer {
   
   public typealias Pointee = UInt8

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -16,7 +16,7 @@
 //  0xFF
 //
 //===----------------------------------------------------------------------===//
-@_fixed_layout
+@frozen
 public struct _ValidUTF8Buffer {
   public typealias Element = Unicode.UTF8.CodeUnit
 
@@ -39,7 +39,7 @@ public struct _ValidUTF8Buffer {
 extension _ValidUTF8Buffer : Sequence {
   public typealias SubSequence = Slice<_ValidUTF8Buffer>
 
-  @_fixed_layout
+  @frozen
   public struct Iterator : IteratorProtocol, Sequence {
     @inlinable
     public init(_ x: _ValidUTF8Buffer) { _biasedBits = x._biasedBits }
@@ -61,7 +61,7 @@ extension _ValidUTF8Buffer : Sequence {
 }
 
 extension _ValidUTF8Buffer : Collection {
-  @_fixed_layout
+  @frozen
   public struct Index : Comparable {
     @usableFromInline
     internal var _biasedBits: UInt32

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -430,7 +430,7 @@ extension Float80 : CVarArg, _CVarArgAligned {
 @usableFromInline // c-abi
 final internal class __VaListBuilder {
   #if arch(x86_64) || arch(s390x)
-  @_fixed_layout // c-abi
+  @frozen // c-abi
   @usableFromInline
   internal struct Header {
     @inlinable // c-abi

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -67,7 +67,7 @@ public func zip<Sequence1, Sequence2>(
 ///     // Prints "two: 2
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
-@_fixed_layout // generic-performance
+@frozen // generic-performance
 public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
   @usableFromInline // generic-performance
   internal let _sequence1: Sequence1
@@ -84,7 +84,7 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
 
 extension Zip2Sequence {
   /// An iterator for `Zip2Sequence`.
-  @_fixed_layout // generic-performance
+  @frozen // generic-performance
   public struct Iterator {
     @usableFromInline // generic-performance
     internal var _baseStream1: Sequence1.Iterator

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -7,7 +7,7 @@
 // CHECK-NEXT: case B
 // CHECK-NEXT: {{^}$}}
 
-// Note that we don't print '@_frozen' here yet.
+// Note that we don't print '@frozen' here yet.
 // CHECK-LABEL: {{^}}enum ExhaustiveEnum : {{.+}} {
 // CHECK:      case A
 // CHECK-NEXT: case B

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -827,7 +827,7 @@ public enum NonExhaustivePayload {
   case a(Int), b(Bool)
 }
 
-@_frozen public enum TemporalProxy {
+@frozen public enum TemporalProxy {
   case seconds(Int)
   case milliseconds(Int)
   case microseconds(Int)

--- a/test/DebugInfo/patternvars.swift
+++ b/test/DebugInfo/patternvars.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 
-@_fixed_layout
+@frozen
 public struct UnicodeScalar {
   var _value: UInt32
   public var value: UInt32 { return _value }

--- a/test/FixCode/fixits-switch-nonfrozen.swift
+++ b/test/FixCode/fixits-switch-nonfrozen.swift
@@ -141,7 +141,7 @@ public enum NonExhaustivePayload {
   case a(Int), b(Bool)
 }
 
-@_frozen public enum TemporalProxy {
+@frozen public enum TemporalProxy {
   case seconds(Int)
   case milliseconds(Int)
   case microseconds(Int)

--- a/test/FixCode/fixits-switch-nonfrozen.swift.result
+++ b/test/FixCode/fixits-switch-nonfrozen.swift.result
@@ -673,7 +673,7 @@ public enum NonExhaustivePayload {
   case a(Int), b(Bool)
 }
 
-@_frozen public enum TemporalProxy {
+@frozen public enum TemporalProxy {
   case seconds(Int)
   case milliseconds(Int)
   case microseconds(Int)

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -20,7 +20,7 @@ public func inlinableFunction() {
   fn()
 }
 
-@_fixed_layout
+@frozen
 public struct Rectangle : Shape {
   @inlinable
   public func draw() {

--- a/test/IRGen/Inputs/type_layout_dumper_other.swift
+++ b/test/IRGen/Inputs/type_layout_dumper_other.swift
@@ -2,19 +2,19 @@ public class SomeClass {}
 
 public protocol SomeProtocol {}
 
-@_fixed_layout
+@frozen
 public struct ConcreteFragileStruct {
   var field: Int32
 
   public struct NestedResilientStruct {}
 }
 
-@_fixed_layout
+@frozen
 public struct NonDependentFragileStruct<T : AnyObject> {
   var field: T
 }
 
-@_fixed_layout
+@frozen
 public struct DependentFragileStruct<T> {
   var field: T
 }

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -255,7 +255,7 @@ extension ResilientGenericOutsideParent {
 // to their best-known value and made non-constant if that value might
 // disagree with the dynamic value.
 
-@_fixed_layout
+@frozen
 public struct Empty {}
 
 public class ClassWithEmptyThenResilient {

--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -98,7 +98,7 @@ func testConstantIndirectFieldAccess<T>(_ o: GenericObjCSubclass<T>) {
   o.field = 10
 }
 
-@_fixed_layout
+@frozen
 public struct Empty {}
 
 public class ClassWithEmptyThenResilient : DummyClass {

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -64,7 +64,7 @@ public struct Reference {
   public var n: Class
 }
 
-@_frozen public enum Either {
+@frozen public enum Either {
   case Left(Reference)
   case Right(Reference)
 }
@@ -79,11 +79,11 @@ enum InternalEither {
   case Right(Reference)
 }
 
-@_fixed_layout public struct ReferenceFast {
+@frozen public struct ReferenceFast {
   public var n: Class
 }
 
-@_frozen public enum EitherFast {
+@frozen public enum EitherFast {
   case Left(ReferenceFast)
   case Right(ReferenceFast)
 }

--- a/test/Inputs/resilient_enum.swift
+++ b/test/Inputs/resilient_enum.swift
@@ -1,25 +1,25 @@
 import resilient_struct
 
 // Fixed-layout enum with resilient members
-@_frozen public enum SimpleShape {
+@frozen public enum SimpleShape {
   case KleinBottle
   case Triangle(Size)
 }
 
 // Fixed-layout enum with resilient members
-@_frozen public enum Shape {
+@frozen public enum Shape {
   case Point
   case Rect(Size)
   case RoundedRect(Size, Size)
 }
 
 // Fixed-layout enum with indirect resilient members
-@_frozen public enum FunnyShape {
+@frozen public enum FunnyShape {
   indirect case Parallelogram(Size)
   indirect case Trapezoid(Size)
 }
 
-@_frozen public enum FullyFixedLayout {
+@frozen public enum FullyFixedLayout {
   case noPayload
   case hasPayload(Int)
 }
@@ -38,7 +38,7 @@ public struct Color {
   }
 }
 
-@_frozen public enum CustomColor {
+@frozen public enum CustomColor {
   case Black
   case White
   case Custom(Color)

--- a/test/Inputs/resilient_struct.swift
+++ b/test/Inputs/resilient_struct.swift
@@ -1,5 +1,5 @@
 // Fixed-layout struct
-@_fixed_layout public struct Point {
+@frozen public struct Point {
   public var x: Int // read-write stored property
   public let y: Int // read-only stored property
 
@@ -27,7 +27,7 @@ public struct Size {
 }
 
 // Fixed-layout struct with resilient members
-@_fixed_layout public struct Rectangle {
+@frozen public struct Rectangle {
   public let p: Point
   public let s: Size
   public let color: Int
@@ -64,7 +64,7 @@ public struct ResilientDouble {
   }
 }
 
-@_fixed_layout public struct ResilientLayoutRuntimeTest {
+@frozen public struct ResilientLayoutRuntimeTest {
   public let b1: ResilientBool
   public let i: ResilientInt
   public let b2: ResilientBool

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -288,7 +288,7 @@ ResilientClassTestSuite.test("TypeByName") {
              == ChildOfOutsideParentWithResilientStoredProperty.self)
 }
 
-@_fixed_layout
+@frozen
 public struct Empty {}
 
 // rdar://48031465

--- a/test/ParseableInterface/Conformances.swiftinterface
+++ b/test/ParseableInterface/Conformances.swiftinterface
@@ -23,7 +23,7 @@ extension MyProto {
 // NEGATIVE-MODULE-NOT: sil_default_witness_table{{.+}}MyProto
 
 
-@_fixed_layout // allow conformance devirtualization
+@frozen // allow conformance devirtualization
 public struct FullStructImpl: MyProto {
   public init()
   public func method()
@@ -37,7 +37,7 @@ public struct FullStructImpl: MyProto {
 // CHECK: function_ref @$s12Conformances14FullStructImplVyS2icig
 // CHECK: end sil function '$s16ConformancesUser8testFullSiyF'
 
-@_fixed_layout // allow conformance devirtualization
+@frozen // allow conformance devirtualization
 public struct OpaqueStructImpl: MyProto {}
 
 // CHECK-LABEL: sil @$s16ConformancesUser10testOpaqueSiyF

--- a/test/ParseableInterface/attrs.swift
+++ b/test/ParseableInterface/attrs.swift
@@ -7,8 +7,8 @@
 // CHECK: @_effects(readnone) public func illiterate(){{$}}
 @_effects(readnone) public func illiterate() {}
 
-// CHECK-LABEL: @_fixed_layout public struct Point {
-@_fixed_layout public struct Point {
+// CHECK-LABEL: @frozen public struct Point {
+@frozen public struct Point {
   // CHECK-NEXT: public var x: Int
   public var x: Int
   // CHECK-NEXT: public var y: Int

--- a/test/ParseableInterface/fixed-layout-property-initializers.swift
+++ b/test/ParseableInterface/fixed-layout-property-initializers.swift
@@ -12,8 +12,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-library-evolution %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-library-evolution -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix RESILIENT --check-prefix COMMON
 
-// COMMON: @_fixed_layout public struct MyStruct {
-@_fixed_layout
+// COMMON: @frozen public struct MyStruct {
+@frozen
 public struct MyStruct {
   // COMMON: public var publicVar: [[BOOL:(Swift\.)?Bool]] = false
   public var publicVar: Bool = false

--- a/test/ParseableInterface/lazy-vars.swift
+++ b/test/ParseableInterface/lazy-vars.swift
@@ -11,7 +11,7 @@
 // RUN: %target-swift-frontend -build-module-from-parseable-interface %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-parseable-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
 
-// CHECK: @_fixed_layout public struct HasLazyVarsFixedLayout {
+// CHECK: @frozen public struct HasLazyVarsFixedLayout {
 // CHECK-NEXT: public var foo: [[INT:(Swift\.)?Int]] {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
@@ -20,7 +20,7 @@
 // CHECK-NOT: private var bar
 // CHECK: private var $__lazy_storage_$_bar: [[INT]]?
 // CHECK-NEXT: }
-@_fixed_layout
+@frozen
 public struct HasLazyVarsFixedLayout {
   public lazy var foo: Int = 0
   private lazy var bar: Int = 0

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -74,8 +74,8 @@ public struct HasStoredProperties {
 // COMMON: }
 }
 
-// COMMON: @_fixed_layout public struct BagOfVariables {
-@_fixed_layout
+// COMMON: @frozen public struct BagOfVariables {
+@frozen
 public struct BagOfVariables {
   // COMMON: public let a: [[INT]] = 0
   public let a: Int = 0
@@ -92,8 +92,8 @@ public struct BagOfVariables {
 // COMMON: }
 }
 
-// COMMON: @_fixed_layout public struct HasStoredPropertiesFixedLayout {
-@_fixed_layout
+// COMMON: @frozen public struct HasStoredPropertiesFixedLayout {
+@frozen
 public struct HasStoredPropertiesFixedLayout {
   // COMMON: public var simpleStoredMutable: [[BAGOFVARIABLES:.*BagOfVariables]]
   public var simpleStoredMutable: BagOfVariables

--- a/test/PrintAsObjC/enums-frozen.swift
+++ b/test/PrintAsObjC/enums-frozen.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 // CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, FrozenEnum, closed) {
-@objc @_frozen public enum FrozenEnum: Int {
+@objc @frozen public enum FrozenEnum: Int {
   case yes
   case no
 }

--- a/test/Prototypes/UnicodeDecoders.swift
+++ b/test/Prototypes/UnicodeDecoders.swift
@@ -37,7 +37,7 @@ extension Unicode.Scalar {
 //===----------------------------------------------------------------------===//
 
 extension Unicode {
-  @_fixed_layout
+  @frozen
   public // @testable
   struct _ParsingIterator<
     CodeUnitIterator : IteratorProtocol, 

--- a/test/SIL/Serialization/Inputs/nontransparent.swift
+++ b/test/SIL/Serialization/Inputs/nontransparent.swift
@@ -5,7 +5,7 @@ public enum Optional<T> {
   case some(T)
 }
 
-@_fixed_layout
+@frozen
 public struct B {
   @inlinable
   public func amIConfused() {}
@@ -13,7 +13,7 @@ public struct B {
   public init() {}
 }
 
-@_fixed_layout
+@frozen
 public struct A {
   public var b : B
 

--- a/test/SIL/Serialization/Inputs/shared_function_serialization_input.swift
+++ b/test/SIL/Serialization/Inputs/shared_function_serialization_input.swift
@@ -1,4 +1,4 @@
-@_fixed_layout
+@frozen
 public struct X {
   @inlinable
   public init() { }

--- a/test/SIL/Serialization/Inputs/specializer_input.swift
+++ b/test/SIL/Serialization/Inputs/specializer_input.swift
@@ -1,7 +1,7 @@
 
 public typealias Int = Builtin.Int32
 
-@_fixed_layout
+@frozen
 public struct Container<V> {
   @inlinable
   @inline(never)

--- a/test/SILGen/fixed_layout_attribute.swift
+++ b/test/SILGen/fixed_layout_attribute.swift
@@ -27,7 +27,7 @@ public struct NonFixedStruct {
 // CHECK: function_ref @$s22fixed_layout_attribute6globalSivau
 // CHECK: return
 
-@_fixed_layout
+@frozen
 public struct FixedStruct {
   public var storedProperty = global
 }
@@ -52,7 +52,7 @@ struct AnotherInternalStruct {
 
 // Static properties in fixed-layout type is still resilient
 
-@_fixed_layout
+@frozen
 public struct HasStaticProperty {
   public static var staticProperty: Int = 0
 }

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -52,7 +52,7 @@ public class MyCls {
 // CHECK-LABEL: sil non_abi [transparent] [serialized] [ossa] @$s19inlinable_attribute15HasInitializersV1xSivpfi : $@convention(thin) () -> Int
 // CHECK-LABEL: sil non_abi [transparent] [serialized] [ossa] @$s19inlinable_attribute15HasInitializersV1ySivpfi : $@convention(thin) () -> Int
 
-@_fixed_layout
+@frozen
 public struct HasInitializers {
   public let x = 1234
   internal let y = 4321

--- a/test/Sema/Inputs/exhaustive_switch_testable_helper.swift
+++ b/test/Sema/Inputs/exhaustive_switch_testable_helper.swift
@@ -1,4 +1,4 @@
-@_frozen public enum FrozenEnum {
+@frozen public enum FrozenEnum {
   case a, b, c
 }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -360,7 +360,7 @@ enum MyNever {}
 func ~= (_ : MyNever, _ : MyNever) -> Bool { return true }
 func myFatalError() -> MyNever { fatalError() }
 
-@_frozen public enum UninhabitedT4<A> {
+@frozen public enum UninhabitedT4<A> {
   case x(A)
 }
 
@@ -786,7 +786,7 @@ public enum NonExhaustivePayload {
   case a(Int), b(Bool)
 }
 
-@_frozen public enum TemporalProxy {
+@frozen public enum TemporalProxy {
   case seconds(Int)
   case milliseconds(Int)
   case microseconds(Int)

--- a/test/Sema/implementation-only-import-library-evolution.swift
+++ b/test/Sema/implementation-only-import-library-evolution.swift
@@ -41,7 +41,7 @@ public class PublicClassStoredProperties {
 
 // MARK: Frozen types
 
-@_fixed_layout
+@frozen
 public struct FrozenPublicStructStoredProperties {
   public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
   internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
@@ -53,8 +53,34 @@ public struct FrozenPublicStructStoredProperties {
   @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
 }
 
-@_fixed_layout
+@frozen
 @usableFromInline internal struct FrozenUFIStructStoredProperties {
+  @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@_fixed_layout
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+public struct FixedLayoutPublicStructStoredProperties {
+  public var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  private let letIsLikeVar: [BadStruct] = [] // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+  
+  private var computedIsOkay: BadStruct? { return nil } // okay
+  private static var staticIsOkay: BadStruct? // okay
+  @usableFromInline internal var computedUFIIsNot: BadStruct? { return nil } // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
+}
+
+@_fixed_layout
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+@usableFromInline internal struct FixedLayoutUFIStructStoredProperties {
   @usableFromInline var publiclyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
   internal var internallyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}
   private var privatelyBad: BadStruct? // expected-error {{cannot use struct 'BadStruct' here; 'BADLibrary' has been imported as implementation-only}}

--- a/test/Serialization/Inputs/def_always_inline.swift
+++ b/test/Serialization/Inputs/def_always_inline.swift
@@ -2,7 +2,7 @@
   return x
 }
 
-@_fixed_layout
+@frozen
 public struct AlwaysInlineInitStruct {
   @usableFromInline
   var x: Bool

--- a/test/Serialization/Inputs/def_enum.swift
+++ b/test/Serialization/Inputs/def_enum.swift
@@ -38,4 +38,4 @@ public enum Breakfast<Champions> : Int {
   case Coffee
 }
 
-@_frozen public enum Exhaustive {}
+@frozen public enum Exhaustive {}

--- a/test/Serialization/Inputs/def_noinline.swift
+++ b/test/Serialization/Inputs/def_noinline.swift
@@ -3,7 +3,7 @@
   return x
 }
 
-@_fixed_layout
+@frozen
 public struct NoInlineInitStruct {
   @usableFromInline
   var x: Bool

--- a/test/Serialization/Inputs/def_transparent.swift
+++ b/test/Serialization/Inputs/def_transparent.swift
@@ -60,7 +60,7 @@ public func do_switch(u u: MaybePair) {
   e()
 }
 
-@_fixed_layout
+@frozen
 public struct Wrapper {
   public var value: Int32
   

--- a/test/Serialization/attr-invalid.swift
+++ b/test/Serialization/attr-invalid.swift
@@ -8,7 +8,7 @@
 // CHECK-RESILIENT: Frozen_DECL_ATTR
 // CHECK-NON-RESILIENT-NOT: Frozen_DECL_ATTR
 
-@_frozen // expected-warning {{@_frozen has no effect without -enable-library-evolution}}
+@frozen // expected-warning {{@frozen has no effect without -enable-library-evolution}}
 public enum SomeEnum {
   case x
 }

--- a/test/Serialization/early-serialization.swift
+++ b/test/Serialization/early-serialization.swift
@@ -6,7 +6,7 @@
 // - it happens before the performance inlining and thus preserves @_semantics functions
 // - it happens after generic specialization
 
-@_fixed_layout
+@frozen
 public struct Int {
   @inlinable
   public init() {}
@@ -24,7 +24,7 @@ public func userOfSemanticsAnnotatedFunc(_ a: Array<Int>) -> Int {
   return a._getCapacity()
 }
 
-@_fixed_layout
+@frozen
 public struct Array<T> {
   @inlinable
   public init() {}

--- a/test/Serialization/enum.swift
+++ b/test/Serialization/enum.swift
@@ -8,7 +8,7 @@
 
 // CHECK-NOT: UnknownCode
 
-// CHECK-PRINT-DAG: @_frozen enum Exhaustive {
+// CHECK-PRINT-DAG: @frozen enum Exhaustive {
 
 import def_enum
 

--- a/test/SourceKit/Indexing/rdar_21602898.swift.response
+++ b/test/SourceKit/Indexing/rdar_21602898.swift.response
@@ -57,7 +57,7 @@
           ],
           key.attributes: [
             {
-              key.attribute: source.decl.attribute._fixed_layout
+              key.attribute: source.decl.attribute.frozen
             }
           ]
         },

--- a/test/SourceKit/InterfaceGen/gen_stdlib.swift
+++ b/test/SourceKit/InterfaceGen/gen_stdlib.swift
@@ -38,7 +38,7 @@ var x: Int
 // CHECK1-NEXT: <Group>Math/Integers</Group>
 // CHECK1-NEXT: /<interface-gen>{{$}}
 // CHECK1-NEXT: SYSTEM
-// CHECK1-NEXT: <Declaration>struct Int : <Type usr="s:s17FixedWidthIntegerP">FixedWidthInteger</Type>{{.*}}<Type usr="s:SZ">SignedInteger</Type>{{.*}}</Declaration>
+// CHECK1-NEXT: <Declaration>@frozen struct Int : <Type usr="s:s17FixedWidthIntegerP">FixedWidthInteger</Type>{{.*}}<Type usr="s:SZ">SignedInteger</Type>{{.*}}</Declaration>
 
 // RUN: %sourcekitd-test -req=module-groups -module Swift | %FileCheck -check-prefix=GROUP1 %s
 // GROUP1: <GROUPS>

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -3,7 +3,7 @@
 public protocol P1 {}
 public protocol P2 {}
 public protocol P3: P2, P1 {}
-@_fixed_layout
+@frozen
 public struct S1: P1 {
   public static func foo1() {}
   mutating public func foo2() {}
@@ -46,7 +46,7 @@ public extension Int {
   public func foo() {}
 }
 
-@_fixed_layout
+@frozen
 public struct fixedLayoutStruct {
   public var a = 1
   private var b = 2 { didSet {} willSet(value) {} }

--- a/test/api-digester/Inputs/cake1.swift
+++ b/test/api-digester/Inputs/cake1.swift
@@ -37,7 +37,7 @@ public class C5 {
 
 public struct C6 {}
 
-@_frozen
+@frozen
 public enum IceKind {}
 
 public protocol P1 {}
@@ -48,7 +48,7 @@ public extension P1 where Self: P2 {
   func P1Constraint() {}
 }
 
-@_fixed_layout
+@frozen
 public struct fixedLayoutStruct {
   public var b = 2
   public func foo() {}
@@ -56,13 +56,13 @@ public struct fixedLayoutStruct {
 }
 
 @usableFromInline
-@_fixed_layout
+@frozen
 struct fixedLayoutStruct2 {
   public private(set) var NoLongerWithFixedBinaryOrder = 1
   public var BecomeFixedBinaryOrder: Int { return 1 }
 }
 
-@_frozen
+@frozen
 public enum FrozenKind {
   case Unchanged
   case Fixed

--- a/test/api-digester/Inputs/cake2.swift
+++ b/test/api-digester/Inputs/cake2.swift
@@ -35,7 +35,7 @@ public class C5 {
   public dynamic func dy_foo() {}
 }
 
-@_fixed_layout
+@frozen
 public struct C6 {}
 
 public enum IceKind {}
@@ -48,7 +48,7 @@ public extension P1 {
   func P1Constraint() {}
 }
 
-@_fixed_layout
+@frozen
 public struct fixedLayoutStruct {
   public var a = 1
   public func OKChange() {}
@@ -60,13 +60,13 @@ public struct fixedLayoutStruct {
 }
 
 @usableFromInline
-@_fixed_layout
+@frozen
 struct fixedLayoutStruct2 {
   public var NoLongerWithFixedBinaryOrder: Int { return 1 }
   public var BecomeFixedBinaryOrder = 1
 }
 
-@_frozen
+@frozen
 public enum FrozenKind {
   case Unchanged
   case Rigid

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -42,7 +42,7 @@ cake1: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
 
 /* Decl Attribute changes */
 cake1: Class C5 is now without @objc
-cake1: Enum IceKind is now without @_frozen
+cake1: Enum IceKind is now without @frozen
 cake1: Func C1.foo1() is now not static
 cake1: Func C5.dy_foo() is now with dynamic
 cake1: Func FinalFuncContainer.NewFinalFunc() is now with final
@@ -51,7 +51,7 @@ cake1: Func HasMutatingMethodClone.foo() has self access kind changing from Muta
 cake1: Func S1.foo1() has self access kind changing from NonMutating to Mutating
 cake1: Func S1.foo3() is now static
 cake1: Func _NoResilientClass.NoLongerFinalFunc() is now without final
-cake1: Struct C6 is now with @_fixed_layout
+cake1: Struct C6 is now with @frozen
 cake1: Var C1.CIIns1 changes from weak to strong
 cake1: Var C1.CIIns2 changes from strong to weak
 cake1: Var GlobalLetChangedToVar changes from let to var

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -134,7 +134,7 @@
       "usr": "s:4cake2S1V",
       "moduleName": "cake",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ],
       "conformances": [
         {
@@ -838,7 +838,7 @@
       "usr": "s:4cake17fixedLayoutStructV",
       "moduleName": "cake",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ]
     },
     {
@@ -1292,7 +1292,7 @@
       "usr": "s:Si",
       "moduleName": "Swift",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ],
       "conformances": [
         {

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -141,7 +141,7 @@
       "usr": "s:4cake2S1V",
       "moduleName": "cake",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ],
       "conformances": [
         {
@@ -768,7 +768,7 @@
       "usr": "s:4cake17fixedLayoutStructV",
       "moduleName": "cake",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ]
     },
     {
@@ -1181,7 +1181,7 @@
       "usr": "s:Si",
       "moduleName": "Swift",
       "declAttributes": [
-        "FixedLayout"
+        "Frozen"
       ],
       "conformances": [
         {

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -4,18 +4,25 @@
 // RUN: not %target-swift-frontend -typecheck -swift-version 4.2 -dump-ast %s -enable-testing | %FileCheck --check-prefix=RESILIENCE-OFF %s
 
 //
-// Public types with @_fixed_layout are always fixed layout
+// Public types with @frozen are always fixed layout
 //
 
 // RESILIENCE-ON: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
 // RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
-@_fixed_layout public struct Point {
+@frozen public struct Point {
+  let x, y: Int
+}
+
+// RESILIENCE-ON: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non-resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"FixedPoint" interface type='FixedPoint.Type' access=public non-resilient
+@_fixed_layout public struct FixedPoint {
+  // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   let x, y: Int
 }
 
 // RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
 // RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
-@_frozen public enum ChooseYourOwnAdventure {
+@frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
 }
@@ -32,7 +39,12 @@ public struct Size {
 
 // RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non-resilient
 // RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineStruct" interface type='UsableFromInlineStruct.Type' access=internal non-resilient
-@_fixed_layout @usableFromInline struct UsableFromInlineStruct {}
+@frozen @usableFromInline struct UsableFromInlineStruct {}
+
+// RESILIENCE-ON: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non-resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"UsableFromInlineFixedStruct" interface type='UsableFromInlineFixedStruct.Type' access=internal non-resilient
+@_fixed_layout @usableFromInline struct UsableFromInlineFixedStruct {}
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
 
 // RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public resilient
 // RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public non-resilient
@@ -56,48 +68,112 @@ struct Rectangle {
 // Diagnostics
 //
 
-@_fixed_layout struct InternalStruct { // expected-note * {{declared here}}
-// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'InternalStruct' is internal}}
+@frozen struct InternalStruct { // expected-note * {{declared here}}
+// expected-error@-1 {{'@frozen' attribute can only be applied to '@usableFromInline' or public declarations, but 'InternalStruct' is internal}}
+
+  @frozen public struct NestedStruct {}
+}
+
+@_fixed_layout struct FixedInternalStruct { // expected-note * {{declared here}}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'FixedInternalStruct' is internal}}
+// expected-warning@-2 {{'@frozen' attribute is now used for fixed-layout structs}}
 
   @_fixed_layout public struct NestedStruct {}
+  // expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
 }
 
-@_fixed_layout fileprivate struct FileprivateStruct {}
-// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'FileprivateStruct' is fileprivate}}
+@frozen fileprivate struct FileprivateStruct {}
+// expected-error@-1 {{'@frozen' attribute can only be applied to '@usableFromInline' or public declarations, but 'FileprivateStruct' is fileprivate}}
 
-@_fixed_layout private struct PrivateStruct {} // expected-note * {{declared here}}
-// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'PrivateStruct' is private}}
+@_fixed_layout fileprivate struct FixedFileprivateStruct {}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'FixedFileprivateStruct' is fileprivate}}
+// expected-warning@-2 {{'@frozen' attribute is now used for fixed-layout structs}}
+
+@frozen private struct PrivateStruct {} // expected-note * {{declared here}}
+// expected-error@-1 {{'@frozen' attribute can only be applied to '@usableFromInline' or public declarations, but 'PrivateStruct' is private}}
+
+@_fixed_layout private struct FixedPrivateStruct {} // expected-note * {{declared here}}
+// expected-error@-1 {{'@_fixed_layout' attribute can only be applied to '@usableFromInline' or public declarations, but 'FixedPrivateStruct' is private}}
+// expected-warning@-2 {{'@frozen' attribute is now used for fixed-layout structs}}
 
 
-@_fixed_layout public struct BadFields1 {
-  private var field: PrivateStruct // expected-error {{type referenced from a stored property in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@frozen public struct BadFields1 {
+  private var field: PrivateStruct // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 }
 
-@_fixed_layout public struct BadFields2 {
-  private var field: PrivateStruct? // expected-error {{type referenced from a stored property in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@_fixed_layout public struct FixedBadFields1 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateStruct // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 }
 
-@_fixed_layout public struct BadFields3 {
-  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@frozen public struct BadFields2 {
+  private var field: PrivateStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 }
 
-@_fixed_layout @usableFromInline struct BadFields4 {
-  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@_fixed_layout public struct FixedBadFields2 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
 }
 
-@_fixed_layout public struct BadFields5 {
-  private var field: PrivateStruct? { // expected-error {{type referenced from a stored property in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@frozen public struct BadFields3 {
+  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout public struct FixedBadFields3 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen @usableFromInline struct BadFields4 {
+  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@_fixed_layout @usableFromInline struct FixedBadFields4 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  internal var field: InternalStruct? // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct BadFields5 {
+  private var field: PrivateStruct? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
     didSet {}
+    
+    
+  }
+}
+
+@_fixed_layout public struct FixedBadFields5 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field: PrivateStruct? { // expected-error {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+    didSet {}
+    
+    
   }
 }
 
 // expected-warning@+1 {{the result of a '@usableFromInline' function should be '@usableFromInline' or public}}
 @usableFromInline func notReallyUsableFromInline() -> InternalStruct? { return nil }
-@_fixed_layout public struct BadFields6 {
-  private var field = notReallyUsableFromInline() // expected-error {{type referenced from a stored property with inferred type 'InternalStruct?' in a '@_fixed_layout' struct must be '@usableFromInline' or public}}
+@frozen public struct BadFields6 {
+  private var field = notReallyUsableFromInline() // expected-error {{type referenced from a stored property with inferred type 'InternalStruct?' in a '@frozen' struct must be '@usableFromInline' or public}}
 }
 
-@_fixed_layout public struct OKFields {
+// expected-warning@+1 {{the result of a '@usableFromInline' function should be '@usableFromInline' or public}}
+@usableFromInline func notReallyUsableFromInlineFixed() -> FixedInternalStruct? { return nil }
+@_fixed_layout public struct FrozenBadFields6 {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
+  private var field = notReallyUsableFromInlineFixed() // expected-error {{type referenced from a stored property with inferred type 'FixedInternalStruct?' in a '@frozen' struct must be '@usableFromInline' or public}}
+}
+
+@frozen public struct OKFields {
+  private var publicTy: Size
+  internal var ufiTy: UsableFromInlineStruct?
+
+  internal static var staticProp: InternalStruct?
+
+  private var computed: PrivateStruct? { return nil }
+}
+
+@_fixed_layout public struct FixedOKFields {
+// expected-warning@-1 {{'@frozen' attribute is now used for fixed-layout structs}}
   private var publicTy: Size
   internal var ufiTy: UsableFromInlineStruct?
 

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -231,9 +231,9 @@ public struct PublicResilientStructWithInit {
 private func privateIntReturningFunc() -> Int { return 0 }
 internal func internalIntReturningFunc() -> Int { return 0 }
 
-@_fixed_layout
+@frozen
 public struct PublicFixedStructWithInit {
-  var x = internalGlobal // expected-error {{let 'internalGlobal' is internal and cannot be referenced from a property initializer in a '@_fixed_layout' type}}
+  var x = internalGlobal // expected-error {{let 'internalGlobal' is internal and cannot be referenced from a property initializer in a '@frozen' type}}
   var y = publicGlobal // OK
   static var z = privateIntReturningFunc() // OK
   static var a = internalIntReturningFunc() // OK

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-@_frozen public enum Exhaustive {} // expected-warning {{@_frozen has no effect without -enable-library-evolution}} {{1-10=}}
+@frozen public enum Exhaustive {} // expected-warning {{@frozen has no effect without -enable-library-evolution}} {{1-9=}}
 
-@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect without -enable-library-evolution}} {{1-10=}}
+@frozen enum NotPublic {} // expected-warning {{@frozen has no effect without -enable-library-evolution}} {{1-9=}}

--- a/test/decl/enum/frozen.swift
+++ b/test/decl/enum/frozen.swift
@@ -1,11 +1,15 @@
 // RUN: %target-typecheck-verify-swift -enable-library-evolution
 
-@_frozen public enum Exhaustive {} // no-warning
+@frozen public enum Exhaustive {} // no-warning
 
-@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect on non-public enums}} {{1-10=}}
+@frozen enum NotPublic {} // expected-warning {{@frozen has no effect on non-public enums}} {{1-9=}}
 
 internal enum Outer {
-  @_frozen public enum ButThisIsOK {} // no-warning
+  @frozen public enum ButThisIsOK {} // no-warning
 }
 
-@_frozen @usableFromInline enum NotPublicButVersioned {} // no-warning
+@frozen @usableFromInline enum NotPublicButVersioned {} // no-warning
+
+@frozen enum DeprecationWarning {} // expected-warning {{@frozen has no effect on non-public enums}} {{1-9=}}
+
+@_frozen public enum UnderscoredFrozen {}

--- a/test/decl/init/resilience-cross-module.swift
+++ b/test/decl/init/resilience-cross-module.swift
@@ -12,7 +12,7 @@
 import resilient_struct
 import resilient_protocol
 
-// Size is not @_fixed_layout, so we cannot define a new designated initializer
+// Size is not @frozen, so we cannot define a new designated initializer
 extension Size {
   init(ww: Int, hh: Int) {
     self.w = ww

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %s
 // RUN: %target-swift-frontend -typecheck -swift-version 5 %s
 
-// Animal is not @_fixed_layout, so we cannot define an @inlinable
+// Animal is not @frozen, so we cannot define an @inlinable
 // designated initializer
 public struct Animal {
   public let name: String // expected-note 2 {{declared here}}

--- a/test/sil-opt/sil-opt.swift
+++ b/test/sil-opt/sil-opt.swift
@@ -55,7 +55,7 @@
 @_silgen_name("unknown")
 public func unknown() -> ()
 
-@_fixed_layout
+@frozen
 public struct X {
   @inlinable
   public func test() {

--- a/validation-test/Evolution/Inputs/backward_deploy_struct.swift
+++ b/validation-test/Evolution/Inputs/backward_deploy_struct.swift
@@ -25,7 +25,7 @@ public func getVersion() -> Int {
   }
 }
 
-@_weakLinked @_fixed_layout public struct FixedLayoutStruct {
+@_weakLinked @frozen public struct FixedLayoutStruct {
   public init() {}
 
   public func fn(_ x: Int) {}

--- a/validation-test/Evolution/Inputs/enum_change_size.swift
+++ b/validation-test/Evolution/Inputs/enum_change_size.swift
@@ -33,7 +33,7 @@ public struct ChangeSize {
 #endif
 }
 
-@_frozen public enum SingletonEnum {
+@frozen public enum SingletonEnum {
   case X(ChangeSize)
 }
 
@@ -42,7 +42,7 @@ public func getSingletonEnumValues(_ c: ChangeSize)
   return [.X(c), nil]
 }
 
-@_frozen public enum SinglePayloadEnum {
+@frozen public enum SinglePayloadEnum {
   case X(ChangeSize)
   case Y
   case Z
@@ -53,7 +53,7 @@ public func getSinglePayloadEnumValues(_ c: ChangeSize)
   return [.X(c), .Y, .Z, nil]
 }
 
-@_frozen public enum MultiPayloadEnum {
+@frozen public enum MultiPayloadEnum {
   case X(ChangeSize)
   case Y(ChangeSize)
   case Z

--- a/validation-test/Evolution/Inputs/struct_add_initializer.swift
+++ b/validation-test/Evolution/Inputs/struct_add_initializer.swift
@@ -9,7 +9,7 @@ public func getVersion() -> Int {
 
 #if BEFORE
 
-@_fixed_layout
+@frozen
 public struct AddInitializer {
   public var x: Int
 
@@ -23,7 +23,7 @@ public struct AddInitializer {
 
 #else
 
-@_fixed_layout
+@frozen
 public struct AddInitializer {
   public var x: Int = 0
 

--- a/validation-test/Evolution/Inputs/struct_change_size.swift
+++ b/validation-test/Evolution/Inputs/struct_change_size.swift
@@ -18,7 +18,7 @@ public struct ChangeSize {
   private var _version: T
 }
 
-@_fixed_layout public struct ChangeFieldOffsetsOfFixedLayout {
+@frozen public struct ChangeFieldOffsetsOfFixedLayout {
   public init(major: Int32, minor: Int32, patch: Int32) {
     self.major = ChangeSize(version: major)
     self.minor = ChangeSize(version: minor)

--- a/validation-test/Evolution/Inputs/struct_change_stored_to_computed_static.swift
+++ b/validation-test/Evolution/Inputs/struct_change_stored_to_computed_static.swift
@@ -1,7 +1,7 @@
 
 #if BEFORE
 
-@_fixed_layout
+@frozen
 public struct ChangeStoredToComputed {
   public static var celsius: Int = 0
 
@@ -17,7 +17,7 @@ public struct ChangeStoredToComputed {
 
 #else
 
-@_fixed_layout
+@frozen
 public struct ChangeStoredToComputed {
   public static var celsius: Int {
     get {

--- a/validation-test/Evolution/Inputs/struct_fixed_layout_add_conformance.swift
+++ b/validation-test/Evolution/Inputs/struct_fixed_layout_add_conformance.swift
@@ -7,7 +7,7 @@ public func getVersion() -> Int {
 #endif
 }
 
-@_fixed_layout public struct AddConformance {
+@frozen public struct AddConformance {
   public init() {
     x = 0
     y = 0

--- a/validation-test/Evolution/Inputs/struct_fixed_layout_remove_conformance.swift
+++ b/validation-test/Evolution/Inputs/struct_fixed_layout_remove_conformance.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout public struct RemoveConformance {
+@frozen public struct RemoveConformance {
   public init() {
     x = 0
     y = 0

--- a/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
@@ -12,7 +12,7 @@ extension UnicodeScalar {
   }
 }
 //===----------------------------------------------------------------------===//
-@_fixed_layout
+@frozen
 public struct _UIntBuffer<
   Storage: UnsignedInteger & FixedWidthInteger, 
   Element: UnsignedInteger & FixedWidthInteger
@@ -37,7 +37,7 @@ public struct _UIntBuffer<
 }
 
 extension _UIntBuffer : Sequence {
-  @_fixed_layout
+  @frozen
   public struct Iterator : IteratorProtocol, Sequence {
     @inline(__always)
     public init(_ x: _UIntBuffer) { _impl = x }
@@ -412,7 +412,7 @@ extension Unicode.DefaultScalarView : Collection {
 // This should go in the standard library; see
 // https://github.com/apple/swift/pull/9074 and
 // https://bugs.swift.org/browse/SR-4721
-@_fixed_layout
+@frozen
 public struct ReverseIndexingIterator<
   Elements : BidirectionalCollection
 > : IteratorProtocol, Sequence {

--- a/validation-test/compiler_crashers_fixed/28660-false-encountered-error-in-diagnostic-text.swift
+++ b/validation-test/compiler_crashers_fixed/28660-false-encountered-error-in-diagnostic-text.swift
@@ -6,4 +6,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
-class C{@_fixed_layout public struct P
+class C{@frozen public struct P


### PR DESCRIPTION
5.1 version of #24185 

There is some follow-up cleanup to be done in a subsequent PR to make enums and structs warn similarly, for now this leaves the previous inconsistency.