### PR TITLE
[5.1] [ModuleInterface] Change swift-tools-version to swift-compiler-version

### DIFF
--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/Regex.h"
 
 #define SWIFT_INTERFACE_FORMAT_VERSION_KEY "swift-interface-format-version"
-#define SWIFT_TOOLS_VERSION_KEY "swift-tools-version"
+#define SWIFT_COMPILER_VERSION_KEY "swift-compiler-version"
 #define SWIFT_MODULE_FLAGS_KEY "swift-module-flags"
 
 namespace swift {

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -66,7 +66,7 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
       Ctx.LangOpts.EffectiveLanguageVersion);
   out << "// " SWIFT_INTERFACE_FORMAT_VERSION_KEY ": "
       << InterfaceFormatVersion << "\n";
-  out << "// " SWIFT_TOOLS_VERSION_KEY ": "
+  out << "// " SWIFT_COMPILER_VERSION_KEY ": "
       << ToolsVersion << "\n";
   out << "// " SWIFT_MODULE_FLAGS_KEY ": "
       << Opts.ParseableInterfaceFlags << "\n";

--- a/test/ParseableInterface/Conformances.swiftinterface
+++ b/test/ParseableInterface/Conformances.swiftinterface
@@ -1,4 +1,4 @@
-// swift-tools-version: 4.0
+// swift-compiler-version: Swift 4.0
 // swift-module-flags: 
 
 // RUN: %empty-directory(%t)

--- a/test/ParseableInterface/DefaultArgs.swiftinterface
+++ b/test/ParseableInterface/DefaultArgs.swiftinterface
@@ -1,4 +1,4 @@
-// swift-tools-version: 4.0
+// swift-compiler-version: Swift 4.0
 // swift-module-flags: 
 
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s


### PR DESCRIPTION
Cherry-pick of #25160 to the 5.1 branch. Reviewed by @harlanhaskins.