### PR TITLE
[5.1] IRGen/runtime: change the code generation for dynamically replaceable functions

### DIFF
--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -40,6 +40,20 @@ SWIFT_RUNTIME_EXPORT
 void swift_beginAccess(void *pointer, ValueBuffer *buffer,
                        ExclusivityFlags flags, void *pc);
 
+/// Loads the replacement function pointer from \p ReplFnPtr and returns the
+/// replacement function if it should be called.
+/// Returns null if the original function (which is passed in \p CurrFn) should
+/// be called.
+SWIFT_RUNTIME_EXPORT
+char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
+
+/// Returns the original function of a replaced function, which is loaded from
+/// \p OrigFnPtr.
+/// This function is called from a replacement function to call the original
+/// function.
+SWIFT_RUNTIME_EXPORT
+char *swift_getOrigOfReplaceable(char **OrigFnPtr);
+
 /// Stop dynamically tracking an access.
 SWIFT_RUNTIME_EXPORT
 void swift_endAccess(ValueBuffer *buffer);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1225,6 +1225,16 @@ FUNCTION(EndAccess, swift_endAccess, C_CC, AlwaysAvailable,
          ARGS(getFixedBufferTy()->getPointerTo()),
          ATTRS(NoUnwind))
 
+FUNCTION(GetOrigOfReplaceable, swift_getOrigOfReplaceable, C_CC, AlwaysAvailable,
+         RETURNS(FunctionPtrTy),
+         ARGS(FunctionPtrTy->getPointerTo()),
+         ATTRS(NoUnwind))
+
+FUNCTION(GetReplacement, swift_getFunctionReplacement, C_CC, AlwaysAvailable,
+         RETURNS(FunctionPtrTy),
+         ARGS(FunctionPtrTy->getPointerTo(), FunctionPtrTy),
+         ATTRS(NoUnwind))
+
 FUNCTION(InstantiateObjCClass, swift_instantiateObjCClass,
          C_CC, AlwaysAvailable,
          RETURNS(VoidTy),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2174,6 +2174,71 @@ static llvm::GlobalVariable *createGlobalForDynamicReplacementFunctionKey(
   return key;
 }
 
+/// Creates the prolog for a dynamically replaceable function.
+/// It checks if the replaced function or the original function should be called
+/// (by calling the swift_getFunctionReplacement runtime function). In case of
+/// the original function, it just jumps to the "real" code of the function,
+/// otherwise it tail calls the replacement.
+void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
+  LinkEntity varEntity =
+      LinkEntity::forDynamicallyReplaceableFunctionVariable(f);
+  LinkEntity keyEntity =
+      LinkEntity::forDynamicallyReplaceableFunctionKey(f);
+  Signature signature = getSignature(f->getLoweredFunctionType());
+
+  // Create and initialize the first link entry for the chain of replacements.
+  // The first implementation is initialized with 'implFn'.
+  auto linkEntry = getChainEntryForDynamicReplacement(*this, varEntity, IGF.CurFn);
+
+  // Create the key data structure. This is used from other modules to refer to
+  // the chain of replacements.
+  createGlobalForDynamicReplacementFunctionKey(*this, keyEntity, linkEntry);
+
+  llvm::Constant *indices[] = {llvm::ConstantInt::get(Int32Ty, 0),
+                               llvm::ConstantInt::get(Int32Ty, 0)};
+
+  auto *fnPtrAddr =
+      llvm::ConstantExpr::getInBoundsGetElementPtr(nullptr, linkEntry, indices);
+
+  auto *ReplAddr =
+    llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(fnPtrAddr,
+      FunctionPtrTy->getPointerTo());
+
+  auto *FnAddr = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
+      IGF.CurFn, FunctionPtrTy);
+
+  // Call swift_getFunctionReplacement to check which function to call.
+  auto *ReplFn = IGF.Builder.CreateCall(getGetReplacementFn(),
+                                        { ReplAddr, FnAddr });
+  ReplFn->setDoesNotThrow();
+  auto *hasReplFn = IGF.Builder.CreateICmpEQ(ReplFn,
+          llvm::ConstantExpr::getNullValue(ReplFn->getType()));
+
+  auto *replacedBB = IGF.createBasicBlock("forward_to_replaced");
+  auto *origEntryBB = IGF.createBasicBlock("original_entry");
+  IGF.Builder.CreateCondBr(hasReplFn, origEntryBB, replacedBB);
+
+  IGF.Builder.emitBlock(replacedBB);
+
+  // Call the replacement function.
+  SmallVector<llvm::Value *, 16> forwardedArgs;
+  for (auto &arg : IGF.CurFn->args())
+    forwardedArgs.push_back(&arg);
+  auto *fnType = signature.getType()->getPointerTo();
+  auto *realReplFn = IGF.Builder.CreateBitCast(ReplFn, fnType);
+
+  auto *Res = IGF.Builder.CreateCall(FunctionPointer(realReplFn, signature),
+                                     forwardedArgs);
+  Res->setTailCall();
+  if (IGF.CurFn->getReturnType()->isVoidTy())
+    IGF.Builder.CreateRetVoid();
+  else
+    IGF.Builder.CreateRet(Res);
+
+  IGF.Builder.emitBlock(origEntryBB);
+
+}
+
 /// Emit the thunk that dispatches to the dynamically replaceable function.
 static void emitDynamicallyReplaceableThunk(IRGenModule &IGM,
                                             LinkEntity varEntity,
@@ -2304,10 +2369,17 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
   llvm::Constant *indices[] = {llvm::ConstantInt::get(Int32Ty, 0),
                                llvm::ConstantInt::get(Int32Ty, 0)};
 
-  auto *fnPtr = B.CreateLoad(
+  auto *fnPtrAddr =
+    llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
       llvm::ConstantExpr::getInBoundsGetElementPtr(nullptr, linkEntry, indices),
-      getPointerAlignment());
-  auto *typeFnPtr = B.CreateBitOrPointerCast(fnPtr, implFn->getType());
+      FunctionPtrTy->getPointerTo());
+
+  auto *OrigFn = B.CreateCall(getGetOrigOfReplaceableFn(),
+                                        { fnPtrAddr });
+  OrigFn->setDoesNotThrow();
+
+  auto *typeFnPtr =
+      B.CreateBitOrPointerCast(OrigFn, implFn->getType());
 
   SmallVector<llvm::Value *, 16> forwardedArgs;
   for (auto &arg : implFn->args())
@@ -2338,25 +2410,6 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   if (fn) {
     if (forDefinition) {
       updateLinkageForDefinition(*this, fn, entity);
-      if (isDynamicallyReplaceableImplementation) {
-        // Create the dynamically replacement thunk.
-        LinkEntity implEntity = LinkEntity::forSILFunction(f, true);
-        auto existingImpl = Module.getFunction(implEntity.mangleAsString());
-        assert(!existingImpl);
-        (void) existingImpl;
-        Signature signature = getSignature(f->getLoweredFunctionType());
-        addLLVMFunctionAttributes(f, signature);
-        LinkInfo implLink = LinkInfo::get(*this, implEntity, forDefinition);
-        auto implFn = createFunction(*this, implLink, signature, fn,
-                                     f->getOptimizationMode());
-        LinkEntity varEntity =
-            LinkEntity::forDynamicallyReplaceableFunctionVariable(f);
-        LinkEntity keyEntity =
-            LinkEntity::forDynamicallyReplaceableFunctionKey(f);
-        emitDynamicallyReplaceableThunk(*this, varEntity, keyEntity, fn, implFn,
-                                        signature);
-        return implFn;
-      }
     }
     return fn;
   }
@@ -2430,20 +2483,6 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   // If we have an order number for this function, set it up as appropriate.
   if (hasOrderNumber) {
     EmittedFunctionsByOrder.insert(orderNumber, fn);
-  }
-
-  if (isDynamicallyReplaceableImplementation && forDefinition) {
-    LinkEntity implEntity = LinkEntity::forSILFunction(f, true);
-    LinkInfo implLink = LinkInfo::get(*this, implEntity, forDefinition);
-    auto implFn = createFunction(*this, implLink, signature, insertBefore,
-                                 f->getOptimizationMode());
-
-    LinkEntity varEntity =
-        LinkEntity::forDynamicallyReplaceableFunctionVariable(f);
-    LinkEntity keyEntity = LinkEntity::forDynamicallyReplaceableFunctionKey(f);
-    emitDynamicallyReplaceableThunk(*this, varEntity, keyEntity, fn, implFn,
-                                    signature);
-    return implFn;
   }
   return fn;
 }

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -56,4 +56,6 @@ namespace irgen {
 }
 }
 
+extern llvm::cl::opt<bool> UseBasicDynamicReplacement;
+
 #endif

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1437,6 +1437,8 @@ public:
   llvm::Function *getAddrOfOpaqueTypeDescriptorAccessFunction(
       OpaqueTypeDecl *decl, ForDefinition_t forDefinition, bool implementation);
 
+  void createReplaceableProlog(IRGenFunction &IGF, SILFunction *f);
+
   void emitOpaqueTypeDescriptorAccessor(OpaqueTypeDecl *);
 
 private:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1244,6 +1244,10 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
   if (f->getDynamicallyReplacedFunction()) {
     IGM.emitDynamicReplacementOriginalFunctionThunk(f);
   }
+
+  if (f->isDynamicallyReplaceable()) {
+    IGM.createReplaceableProlog(*this, f);
+  }
 }
 
 IRGenSILFunction::~IRGenSILFunction() {
@@ -1646,7 +1650,7 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.DebugInfo->emitFunction(*CurSILFn, CurFn);
 
   // Map the entry bb.
-  LoweredBBs[&*CurSILFn->begin()] = LoweredBB(&*CurFn->begin(), {});
+  LoweredBBs[&*CurSILFn->begin()] = LoweredBB(&CurFn->back(), {});
   // Create LLVM basic blocks for the other bbs.
   for (auto bi = std::next(CurSILFn->begin()), be = CurSILFn->end(); bi != be;
        ++bi) {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -60,6 +60,7 @@
 #include "GenCast.h"
 #include "GenClass.h"
 #include "GenConstant.h"
+#include "GenDecl.h"
 #include "GenEnum.h"
 #include "GenExistential.h"
 #include "GenFunc.h"
@@ -1874,6 +1875,11 @@ void IRGenSILFunction::visitDynamicFunctionRefInst(DynamicFunctionRefInst *i) {
 
 void IRGenSILFunction::visitPreviousDynamicFunctionRefInst(
     PreviousDynamicFunctionRefInst *i) {
+  if (UseBasicDynamicReplacement) {
+    IGM.unimplemented(i->getLoc().getSourceLoc(),
+      ": calling the original implementation of a dynamic function is not "
+      "supported with -Xllvm -basic-dynamic-replacement");
+  }
   visitFunctionRefBaseInst(i);
 }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -197,8 +197,6 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
     addSymbol(LinkEntity::forDynamicallyReplaceableFunctionVariable(
         AFD, useAllocator));
     addSymbol(
-        LinkEntity::forDynamicallyReplaceableFunctionImpl(AFD, useAllocator));
-    addSymbol(
         LinkEntity::forDynamicallyReplaceableFunctionKey(AFD, useAllocator));
 
   }

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -157,16 +157,8 @@ static_assert(sizeof(Access) <= sizeof(ValueBuffer) &&
               "Access doesn't fit in a value buffer!");
 
 /// A set of accesses that we're tracking.  Just a singly-linked list.
-/// TODO: rename this class to something like SwiftTLSContext, because it also
-/// contains fields not related to access tracking.
 class AccessSet {
   Access *Head = nullptr;
-
-  // Not related to access tracking: The "implicit" boolean parameter which is
-  // passed to a dynamically replaceable function.
-  // If true, the original function should be executed instead of the
-  // replacement function.
-  bool CallOriginalOfReplacedFunction = false;
 public:
   constexpr AccessSet() {}
 
@@ -229,21 +221,18 @@ public:
     }
   }
 #endif
+};
 
-  /// Called immediately before a replacement function calls its original
-  /// function.
-  void aboutToCallOriginalOfReplacedFunction() {
-    CallOriginalOfReplacedFunction = true;
-  }
+class SwiftTLSContext {
+public:
+  /// The set of tracked accesses.
+  AccessSet accessSet;
 
-  /// Checked in the prolog of a replaceable function. Returns true if the
-  /// original function should be called instead of the replacement function.
-  /// Also clears the CallOriginalOfReplacedFunction flag.
-  bool shouldCallOriginalOfReplacedFunction() {
-    bool callOrig = CallOriginalOfReplacedFunction;
-    CallOriginalOfReplacedFunction = false;
-    return callOrig;
-  }
+  // The "implicit" boolean parameter which is passed to a dynamically
+  // replaceable function.
+  // If true, the original function should be executed instead of the
+  // replacement function.
+  bool CallOriginalOfReplacedFunction = false;
 };
 
 } // end anonymous namespace
@@ -254,40 +243,40 @@ public:
 #if SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC
 // Use the reserved TSD key if possible.
 
-static AccessSet &getAccessSet() {
-  AccessSet *set = static_cast<AccessSet*>(
-    SWIFT_THREAD_GETSPECIFIC(SWIFT_EXCLUSIVITY_TLS_KEY));
-  if (set)
-    return *set;
+static SwiftTLSContext &getTLSContext() {
+  SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(
+    SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY));
+  if (ctx)
+    return *ctx;
   
   static OnceToken_t setupToken;
   SWIFT_ONCE_F(setupToken, [](void *) {
-    pthread_key_init_np(SWIFT_EXCLUSIVITY_TLS_KEY, [](void *pointer) {
-      delete static_cast<AccessSet*>(pointer);
+    pthread_key_init_np(SWIFT_RUNTIME_TLS_KEY, [](void *pointer) {
+      delete static_cast<SwiftTLSContext*>(pointer);
     });
   }, nullptr);
   
-  set = new AccessSet();
-  SWIFT_THREAD_SETSPECIFIC(SWIFT_EXCLUSIVITY_TLS_KEY, set);
-  return *set;
+  ctx = new SwiftTLSContext();
+  SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME_TLS_KEY, ctx);
+  return *ctx;
 }
 
 #elif SWIFT_TLS_HAS_THREADLOCAL
 // Second choice is direct language support for thread-locals.
 
-static LLVM_THREAD_LOCAL AccessSet ExclusivityAccessSet;
+static LLVM_THREAD_LOCAL SwiftTLSContext TLSContext;
 
-static AccessSet &getAccessSet() {
-  return ExclusivityAccessSet;
+static SwiftTLSContext &getTLSContext() {
+  return TLSContext;
 }
 
 #else
 // Use the platform thread-local data API.
 
-static __swift_thread_key_t createAccessSetThreadKey() {
+static __swift_thread_key_t createSwiftThreadKey() {
   __swift_thread_key_t key;
   int result = SWIFT_THREAD_KEY_CREATE(&key, [](void *pointer) {
-    delete static_cast<AccessSet*>(pointer);
+    delete static_cast<SwiftTLSContext*>(pointer);
   });
 
   if (result != 0) {
@@ -297,15 +286,15 @@ static __swift_thread_key_t createAccessSetThreadKey() {
   return key;
 }
 
-static AccessSet &getAccessSet() {
-  static __swift_thread_key_t key = createAccessSetThreadKey();
+static SwiftTLSContext &getTLSContext() {
+  static __swift_thread_key_t key = createSwiftThreadKey();
 
-  AccessSet *set = static_cast<AccessSet*>(SWIFT_THREAD_GETSPECIFIC(key));
-  if (!set) {
-    set = new AccessSet();
-    SWIFT_THREAD_SETSPECIFIC(key, set);
+  SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(SWIFT_THREAD_GETSPECIFIC(key));
+  if (!ctx) {
+    ctx = new SwiftTLSContext();
+    SWIFT_THREAD_SETSPECIFIC(key, ctx);
   }
-  return *set;
+  return *ctx;
 }
 
 #endif
@@ -332,7 +321,7 @@ void swift::swift_beginAccess(void *pointer, ValueBuffer *buffer,
   if (!pc)
     pc = get_return_address();
 
-  if (!getAccessSet().insert(access, pc, pointer, flags))
+  if (!getTLSContext().accessSet.insert(access, pc, pointer, flags))
     access->Pointer = nullptr;
 }
 
@@ -347,14 +336,16 @@ void swift::swift_endAccess(ValueBuffer *buffer) {
     return;
   }
 
-  getAccessSet().remove(access);
+  getTLSContext().accessSet.remove(access);
 }
 
 char *swift::swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
   char *ReplFn = *ReplFnPtr;
   if (ReplFn == CurrFn)
     return nullptr;
-  if (getAccessSet().shouldCallOriginalOfReplacedFunction()) {
+  SwiftTLSContext &ctx = getTLSContext();
+  if (ctx.CallOriginalOfReplacedFunction) {
+    ctx.CallOriginalOfReplacedFunction = false;
     return nullptr;
   }
   return ReplFn;
@@ -362,7 +353,7 @@ char *swift::swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
 
 char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
   char *OrigFn = *OrigFnPtr;
-  getAccessSet().aboutToCallOriginalOfReplacedFunction();
+  getTLSContext().CallOriginalOfReplacedFunction = true;
   return OrigFn;
 }
 
@@ -372,7 +363,7 @@ char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
 //
 // This is only intended to be used in the debugger.
 void swift::swift_dumpTrackedAccesses() {
-  getAccessSet().forEach([](Access *a) {
+  getTLSContext().accessSet.forEach([](Access *a) {
       fprintf(stderr, "Access. Pointer: %p. PC: %p. AccessAction: %s\n",
               a->Pointer, a->PC, getAccessName(a->getAccessAction()));
   });

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -54,7 +54,7 @@ extern "C" int pthread_key_init_np(int key, void (*destructor)(void *));
 #  define __PTK_FRAMEWORK_SWIFT_KEY1 101
 # endif
 
-# define SWIFT_EXCLUSIVITY_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY0
+# define SWIFT_RUNTIME_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY0
 # define SWIFT_STDLIB_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY1
 
 #endif

--- a/test/IRGen/dynamic_replaceable.sil
+++ b/test/IRGen/dynamic_replaceable.sil
@@ -2,7 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// CHECK: @test_dynamically_replaceableTX = global %swift.dyn_repl_link_entry { i8* bitcast (void ()* @test_dynamically_replaceableTI to i8*), %swift.dyn_repl_link_entry* null }
+// CHECK: @test_dynamically_replaceableTX = global %swift.dyn_repl_link_entry { i8* bitcast (void ()* @test_dynamically_replaceable to i8*), %swift.dyn_repl_link_entry* null }
 // CHECK: @test_dynamically_replaceableTx = constant %swift.dyn_repl_key { i32{{.*}}%swift.dyn_repl_link_entry* @test_dynamically_replaceableTX{{.*}}, i32 0 }, section "__TEXT,__const"
 // CHECK: @test_replacementTX = global %swift.dyn_repl_link_entry zeroinitializer
 
@@ -23,16 +23,16 @@
 
 // CHECK-LABEL: define swiftcc void @test_dynamically_replaceable()
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   [[FUN_PTR:%.*]] = load i8*, i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_dynamically_replaceableTX, i32 0, i32 0)
+// CHECK-NEXT:   [[FUN_PTR:%.*]] =  call i8* @swift_getFunctionReplacement(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_dynamically_replaceableTX, i32 0, i32 0), i8* bitcast (void ()* @test_dynamically_replaceable to i8*))
+// CHECK-NEXT:   [[CMP:%.*]] = icmp eq i8* [[FUN_PTR]], null
+// CHECK-NEXT:   br i1 [[CMP]], label %[[ORIGBB:[a-z_]*]], label %[[FWBB:[a-z_]*]]
+// CHECK:      [[FWBB]]:
 // CHECK-NEXT:   [[TYPED_PTR:%.*]] = bitcast i8* [[FUN_PTR]] to void ()*
 // CHECK-NEXT:   tail call swiftcc void [[TYPED_PTR]]()
 // CHECK-NEXT:   ret void
+// CHECK:      [[ORIGBB]]:
+// CHECK-NEXT:   ret void
 // CHECK-NEXT: }
-
-// CHECK-LABEL: define swiftcc void @test_dynamically_replaceableTI()
-// CHECK: entry:
-// CHECK:   ret void
-// CHECK: }
 
 sil [dynamically_replacable] @test_dynamically_replaceable : $@convention(thin) () -> () {
 bb0:
@@ -49,7 +49,7 @@ bb0:
 // The thunk that implement the prev_dynamic_function_ref lookup.
 // CHECK-LABEL: define swiftcc void @test_replacementTI()
 // CHECK: entry:
-// CHECK:   [[FUN_PTR:%.*]] = load i8*, i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_replacementTX, i32 0, i32 0)
+// CHECK:   [[FUN_PTR:%.*]] = call i8* @swift_getOrigOfReplaceable(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_replacementTX, i32 0, i32 0))
 // CHECK:   [[TYPED_PTR:%.*]] = bitcast i8* [[FUN_PTR]] to void ()*
 // CHECK:   call swiftcc void [[TYPED_PTR]]()
 // CHECK:   ret void

--- a/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
+++ b/validation-test/stdlib/MicroStdlib/MicroStdlib.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -parse-stdlib -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule -o %t/Swift.o %S/Inputs/Swift.swift
+// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -parse-stdlib -Xllvm -basic-dynamic-replacement -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule -o %t/Swift.o %S/Inputs/Swift.swift
 // RUN: ls %t/Swift.swiftmodule
 // RUN: ls %t/Swift.swiftdoc
 // RUN: ls %t/Swift.o


### PR DESCRIPTION
Instead of a thunk insert the dispatch into the original function.
If the original function should be executed the prolog just jumps to the "real" code in the function. Otherwise the replacement function is called.
There is one little complication here: when the replacement function calls the original function, the original function should not dispatch to the replacement again.
To pass this information, we use a flag in thread local storage.
The setting and reading of the flag is done in two new runtime functions.

rdar://problem/51043781