### PR TITLE
[Diagnostic] Improve diagnostic for trailing closures in statement conditions

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1045,23 +1045,40 @@ static bool isValidTrailingClosure(bool isExprBasic, Parser &P){
   // the token after the { is on the same line as the {.
   if (P.peekToken().isAtStartOfLine())
     return false;
-  
-  
+
   // Determine if the {} goes with the expression by eating it, and looking
-  // to see if it is immediately followed by '{', 'where', or comma.  If so,
-  // we consider it to be part of the proceeding expression.
+  // to see if it is immediately followed by a token which indicates we should
+  // consider it part of the preceding expression
   Parser::BacktrackingScope backtrack(P);
   P.consumeToken(tok::l_brace);
   P.skipUntil(tok::r_brace);
   SourceLoc endLoc;
-  if (!P.consumeIf(tok::r_brace, endLoc) ||
-      P.Tok.isNot(tok::l_brace, tok::kw_where, tok::comma)) {
+  if (!P.consumeIf(tok::r_brace, endLoc))
+    return false;
+
+  switch (P.Tok.getKind()) {
+  case tok::l_brace:
+  case tok::kw_where:
+  case tok::comma:
+    return true;
+  case tok::l_square:
+  case tok::l_paren:
+  case tok::period:
+  case tok::period_prefix:
+  case tok::kw_is:
+  case tok::kw_as:
+  case tok::question_postfix:
+  case tok::question_infix:
+  case tok::exclaim_postfix:
+  case tok::colon:
+  case tok::equal:
+  case tok::oper_postfix:
+  case tok::oper_binary_spaced:
+  case tok::oper_binary_unspaced:
+    return !P.Tok.isAtStartOfLine();
+  default:
     return false;
   }
-
-  // Recoverable case. Just return true here and Sema will emit a diagnostic
-  // later. see: Sema/MiscDiagnostics.cpp#checkStmtConditionTrailingClosure
-  return true;
 }
 
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2957,7 +2957,7 @@ void swift::fixItEncloseTrailingClosure(TypeChecker &TC,
 static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Expr *E) {
   if (E == nullptr || isa<ErrorExpr>(E)) return;
 
-  // Shallow walker. just dig into implicit expression.
+  // Walk into expressions which might have invalid trailing closures
   class DiagnoseWalker : public ASTWalker {
     TypeChecker &TC;
 
@@ -2992,13 +2992,22 @@ static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Expr *E) {
     bool shouldWalkIntoNonSingleExpressionClosure() override { return false; }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-      // Dig into implicit expression.
-      if (E->isImplicit()) return { true, E };
-      // Diagnose call expression.
-      if (auto CE = dyn_cast<CallExpr>(E))
-        diagnoseIt(CE);
-      // Don't dig any further.
-      return { false, E };
+      switch (E->getKind()) {
+      case ExprKind::Paren:
+      case ExprKind::Tuple:
+      case ExprKind::Array:
+      case ExprKind::Dictionary:
+      case ExprKind::InterpolatedStringLiteral:
+        // If a trailing closure appears as a child of one of these types of
+        // expression, don't diagnose it as there is no ambiguity.
+        return {E->isImplicit(), E};
+      case ExprKind::Call:
+        diagnoseIt(cast<CallExpr>(E));
+        break;
+      default:
+        break;
+      }
+      return {true, E};
     }
   };
 
@@ -3018,9 +3027,12 @@ static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Expr *E) {
 static void checkStmtConditionTrailingClosure(TypeChecker &TC, const Stmt *S) {
   if (auto LCS = dyn_cast<LabeledConditionalStmt>(S)) {
     for (auto elt : LCS->getCond()) {
-      if (elt.getKind() == StmtConditionElement::CK_PatternBinding)
+      if (elt.getKind() == StmtConditionElement::CK_PatternBinding) {
         checkStmtConditionTrailingClosure(TC, elt.getInitializer());
-      else if (elt.getKind() == StmtConditionElement::CK_Boolean)
+        if (auto *exprPattern = dyn_cast<ExprPattern>(elt.getPattern())) {
+          checkStmtConditionTrailingClosure(TC, exprPattern->getMatchExpr());
+        }
+      } else if (elt.getKind() == StmtConditionElement::CK_Boolean)
         checkStmtConditionTrailingClosure(TC, elt.getBoolean());
       // No trailing closure for CK_Availability: e.g. `if #available() {}`.
     }


### PR DESCRIPTION
This improves the diagnostic for trailing closures in statement conditions to catch cases where one or more trailing closures are used within a chain composed of multiple calls (this is currently only diagnosed if the trailing closure appears at the very end)

For example:
```swift
let x: [Int]? = nil
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
  print(sumOfSquares)
}
```

Used to result in these errors:
```
error: anonymous closure argument not contained in a closure
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
                             ^
error: anonymous closure argument not contained in a closure
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
                                ^
error: consecutive statements on a line must be separated by ';'
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
                                   ^
                                   ;
error: expression type '(((Int) throws -> _) throws -> [_])?' is ambiguous without more context
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
                      ~~~^~~
error: use of unresolved identifier 'sumOfSquares'
  print(sumOfSquares)
        ^~~~~~~~~~~~
```
but now can be diagnosed as follows:
```
error: trailing closure requires parentheses for disambiguation in this context
if let sumOfSquares = x?.map{$0*$0}.reduce(0, +) {
                            ^
                            (      )
```

Resolves [SR8736](https://bugs.swift.org/browse/SR-8736)