### PR TITLE
[TF] Enable optimizations on the TensorFlow module.

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -27,7 +27,6 @@ list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
 list(APPEND swift_stdlib_compile_flags "-force-single-frontend-invocation")
 list(APPEND swift_stdlib_compile_flags "-O" "-whole-module-optimization")
-list(APPEND swift_stdlib_compile_flags "-Onone")
 list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_MODULE")
 
 set(SOURCES "")

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -26,8 +26,7 @@ set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
 list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
 list(APPEND swift_stdlib_compile_flags "-force-single-frontend-invocation")
-# FIXME(SR-7972): Some tests fail when TensorFlow is optimized.
-# list(APPEND swift_stdlib_compile_flags "-O" "-whole-module-optimization")
+list(APPEND swift_stdlib_compile_flags "-O" "-whole-module-optimization")
 list(APPEND swift_stdlib_compile_flags "-Onone")
 list(APPEND swift_stdlib_compile_flags "-DCOMPILING_TENSORFLOW_MODULE")
 


### PR DESCRIPTION
Enable optimizations when building the TensorFlow module.

Resolves [TF-95](https://bugs.swift.org/browse/TF-95).