### PR TITLE
[redux][Foundation] Fix availability of NSValue.value(of:)

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
+++ b/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
@@ -42,7 +42,11 @@ extension NSValue {
             }
             let allocated = UnsafeMutablePointer<StoredType>.allocate(capacity: 1)
             defer { allocated.deallocate() }
-            getValue(allocated, size: storedSize)
+            if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
+                getValue(allocated, size: storedSize)
+            } else {
+                getValue(allocated)
+            }
             return allocated.pointee
         }
         return nil

--- a/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
+++ b/stdlib/public/Darwin/Foundation/NSValue.swift.gyb
@@ -24,6 +24,7 @@ ${ ObjectiveCBridgeableImplementationForNSValue("CGSize") }
 ${ ObjectiveCBridgeableImplementationForNSValue("CGAffineTransform") }
 
 extension NSValue {
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     public func value<StoredType>(of type: StoredType.Type) -> StoredType? {
         if StoredType.self is AnyObject.Type {
             let encoding = String(cString: objCType)
@@ -41,11 +42,7 @@ extension NSValue {
             }
             let allocated = UnsafeMutablePointer<StoredType>.allocate(capacity: 1)
             defer { allocated.deallocate() }
-            if #available(OSX 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *) {
-            	getValue(allocated, size: storedSize)
-        	} else {
-        		getValue(allocated)
-        	}
+            getValue(allocated, size: storedSize)
             return allocated.pointee
         }
         return nil

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -92,6 +92,8 @@ nsValueBridging.test("NSValue can only be cast back to its original type") {
 }
 
 nsValueBridging.test("NSValue fetching method should be able to convert constructed values safely") {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+
   let range = NSRange(location: 17, length: 38)
   let value = NSValue(range: range)
   expectEqual(value.value(of: NSRange.self)?.location, range.location)


### PR DESCRIPTION
This reapplies #24498 with an additional commit that will work around the 9999-availability issue uncovered by the previous PR.

Original PR description:

`NSValue.value(of:)` is a new public method in 5.1; it needs an explicit availability attribute.

rdar://problem/50151221