### PR TITLE
[TypeChecker] Don't try to validate generic requirements when unbound…

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -805,7 +805,10 @@ Type TypeChecker::applyUnboundGenericArguments(
   // generic arguments.
   auto resultType = decl->getDeclaredInterfaceType();
 
-  bool hasTypeVariable = false;
+  // If types involved in requirements check have either type variables
+  // or unbound generics, let's skip the check here, and let the solver
+  // do it when missing types are deduced.
+  bool skipRequirementsCheck = false;
 
   // Get the substitutions for outer generic parameters from the parent
   // type.
@@ -822,7 +825,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     }
 
     subs = parentType->getContextSubstitutions(decl->getDeclContext());
-    hasTypeVariable |= parentType->hasTypeVariable();
+    skipRequirementsCheck |= parentType->hasTypeVariable();
   }
 
   SourceLoc noteLoc = decl->getLoc();
@@ -839,13 +842,14 @@ Type TypeChecker::applyUnboundGenericArguments(
     subs[origTy->getCanonicalType()->castTo<GenericTypeParamType>()] =
       substTy;
 
-    hasTypeVariable |= substTy->hasTypeVariable();
+    skipRequirementsCheck |=
+        substTy->hasTypeVariable() || substTy->hasUnboundGenericType();
   }
 
   // Check the generic arguments against the requirements of the declaration's
   // generic signature.
   auto dc = resolution.getDeclContext();
-  if (!hasTypeVariable &&
+  if (!skipRequirementsCheck &&
       resolution.getStage() > TypeResolutionStage::Structural) {
     auto result =
       checkGenericArguments(dc, loc, noteLoc, unboundType,

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -452,7 +452,6 @@ class GenericClass<A> {}
 func genericFunc<T>(t: T) {
   _ = [T: GenericClass] // expected-error {{generic parameter 'A' could not be inferred}}
   // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
-  // expected-error@-2 {{type 'T' does not conform to protocol 'Hashable'}}
 }
 
 struct SR_3525<T> {}

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -377,3 +377,27 @@ func testClonableExistential(_ v: Clonable, _ vv: Clonable.Type) {
   let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; use a generic constraint instead}}
 
 }
+
+
+// rdar://problem/50099849
+
+protocol Trivial {
+  associatedtype T
+}
+
+func rdar_50099849() {
+  struct A : Trivial {
+    typealias T = A
+  }
+
+  struct B<C : Trivial> : Trivial { // expected-note {{'C' declared as parameter to type 'B'}}
+    typealias T = C.T
+  }
+
+  struct C<W: Trivial, Z: Trivial> : Trivial where W.T == Z.T {
+    typealias T = W.T
+  }
+
+  let _ = C<A, B>() // expected-error {{generic parameter 'C' could not be inferred}}
+  // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{17-17=<<#C: Trivial#>>}}
+}


### PR DESCRIPTION
… generic types are involved

If one of the generic parameters is missing let's give solver a
chance to diagnose the problem, otherwise there is a risk of failing
type resolution and not producing any diagnostics.

Resolves: rdar://problem/50099849

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
