### PR TITLE
[windows] Fix module-cache-bad-version.swift in Windows.

### DIFF
--- a/test/ParseableInterface/ModuleCache/module-cache-bad-version.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-bad-version.swift
@@ -19,7 +19,8 @@
 //
 // RUN: not %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module  -o %t/TestModule.swiftmodule -module-name TestModule %s >%t/err.txt 2>&1
 // RUN: test ! -f %t/TestModule.swiftmodule
-// RUN: test ! -f %t/modulecache/LeafModule-*.swiftmodule
+// This avoids a problem in Windows with test ! -f 'foo*' for a file that doesn't exist
+// RUN: %{python} -c "import sys; import glob; sys.exit(len(glob.glob('%t/modulecache/LeafModule-*.swiftmodule')) != 0)"
 // RUN: %FileCheck %s -check-prefix=CHECK-ERR <%t/err.txt
 // CHECK-ERR: {{error: unsupported version of module interface '.*[/\\]LeafModule.swiftinterface': '9999.999'}}
 // CHECK-ERR: error: no such module 'LeafModule


### PR DESCRIPTION
In Windows, the expansion of globs is not performed by the shell, and
might happen (or not) in each process. Seems that some versions of `test`
(like the one used in CI) do their own expansion. Since the test is
testing for the inexistence of a file, the asterisk ends up in the
process argv, then the expansion happen, which finds no files, and test
fails saying that -f needs an argument. This doesn't happen in Unix
because the asterisk is not expanded in process.

Quoting or other tricks were defeated by lit own parsing of the
commands.

The solution involves using Python own globbing to find out if there's a
file that matches the glob or not.
