### PR TITLE
Build TensorFlowUnittest only if we are also building tensorflow-swift-apis.

### DIFF
--- a/stdlib/private/CMakeLists.txt
+++ b/stdlib/private/CMakeLists.txt
@@ -20,7 +20,8 @@ if(SWIFT_BUILD_SDK_OVERLAY)
   add_subdirectory(OSLog)
 
   # SWIFT_ENABLE_TENSORFLOW
-  if(SWIFT_ENABLE_TENSORFLOW)
+  # Only build unittest if we are also building swift apis.
+  if(SWIFT_ENABLE_TENSORFLOW AND TENSORFLOW_SWIFT_APIS)
     add_subdirectory(TensorFlowUnittest)
   endif()
 


### PR DESCRIPTION
This is necessary to build a test-only toolchain. See https://github.com/tensorflow/swift-apis/issues/161