### PR TITLE
Address infinite loop with floating point inf to Decimal

### DIFF
--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -316,6 +316,8 @@ extension Decimal {
     public init(_ value: Double) {
         if value.isNaN {
             self = Decimal.nan
+        } else if value == Double.infinity || value == -Double.infinity {
+            preconditionFailure("Decimal does not support infinities")
         } else if value == 0.0 {
             self = Decimal(_exponent: 0, _length: 0, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
         } else {

--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -314,7 +314,8 @@ extension Decimal {
     }
     
     public init(_ value: Double) {
-        if value.isNaN {
+        if value.isNaN || value == Double.infinity || value == -Double.infinity {
+            // Note: Decimal does not have infinities yet.
             self = Decimal.nan
         } else if value == 0.0 {
             self = Decimal(_exponent: 0, _length: 0, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))

--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -314,8 +314,7 @@ extension Decimal {
     }
     
     public init(_ value: Double) {
-        if value.isNaN || value == Double.infinity || value == -Double.infinity {
-            // Note: Decimal does not have infinities yet.
+        if value.isNaN {
             self = Decimal.nan
         } else if value == 0.0 {
             self = Decimal(_exponent: 0, _length: 0, _isNegative: 0, _isCompact: 0, _reserved: 0, _mantissa: (0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -594,15 +594,6 @@ class TestDecimal : TestDecimalSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(Decimal(), Decimal._unconditionallyBridgeFromObjectiveC(nil))
     }
-    
-    func test_floatingPointInfinityToDecimal() {
-        let inf = Double.infinity
-        var conversion = Decimal(floatLiteral: inf)
-        expectTrue(conversion.nan.isNaN)
-        
-        conversion = Decimal(floatLiteral: -inf)
-        expectTrue(conversion.nan.isNaN)
-    }
 }
 
 
@@ -625,7 +616,5 @@ DecimalTests.test("test_Round") { TestDecimal().test_Round() }
 DecimalTests.test("test_ScanDecimal") { TestDecimal().test_ScanDecimal() }
 DecimalTests.test("test_SimpleMultiplication") { TestDecimal().test_SimpleMultiplication() }
 DecimalTests.test("test_unconditionallyBridgeFromObjectiveC") { TestDecimal().test_unconditionallyBridgeFromObjectiveC() }
-DecimalTests.test("test_floatingPointInfinityToDecimal") { TestDecimal().test_floatingPointInfinityToDecimal() }
-
 runAllTests()
 #endif

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -594,6 +594,15 @@ class TestDecimal : TestDecimalSuper {
     func test_unconditionallyBridgeFromObjectiveC() {
         expectEqual(Decimal(), Decimal._unconditionallyBridgeFromObjectiveC(nil))
     }
+    
+    func test_floatingPointInfinityToDecimal() {
+        let inf = Double.infinity
+        var conversion = Decimal(floatLiteral: inf)
+        expectTrue(conversion.nan.isNaN)
+        
+        conversion = Decimal(floatLiteral: -inf)
+        expectTrue(conversion.nan.isNaN)
+    }
 }
 
 
@@ -616,5 +625,7 @@ DecimalTests.test("test_Round") { TestDecimal().test_Round() }
 DecimalTests.test("test_ScanDecimal") { TestDecimal().test_ScanDecimal() }
 DecimalTests.test("test_SimpleMultiplication") { TestDecimal().test_SimpleMultiplication() }
 DecimalTests.test("test_unconditionallyBridgeFromObjectiveC") { TestDecimal().test_unconditionallyBridgeFromObjectiveC() }
+DecimalTests.test("test_floatingPointInfinityToDecimal") { TestDecimal().test_floatingPointInfinityToDecimal() }
+
 runAllTests()
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
Swift currently does not support infinites for the `Decimal` class. Because of this, any code that tries to convert a floating point value of `Inf` or `-Inf` to `Decimal` will cause the compiler to go into an infinite loop due to the existing implementation of the `Decimal` class. 

**Repro**
```
let inf= Double.infinity
let decimal = Decimal(floatLiteral: inf) // <-- Infinite loop
```

As an alternative till infinity is properly defined in the `Decimal` class, one is to catch these infinity conversions and turn them into `Decimal.nan`



<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3126](https://bugs.swift.org/browse/SR-3126).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->