### PR TITLE
[Parser] Decouple the parser from AST creation (part 1)

### DIFF
--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -1,4 +1,4 @@
-//===--- SyntaxTransformer.h ----------------------------------------------===//
+//===--- ASTGen.h ---------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_PARSE_SYNTAXTRANSFORMER_H
-#define SWIFT_PARSE_SYNTAXTRANSFORMER_H
+#ifndef SWIFT_PARSE_ASTGEN_H
+#define SWIFT_PARSE_ASTGEN_H
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Expr.h"
@@ -19,8 +19,8 @@
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {
-/// Transforms Syntax nodes into AST nodes.
-class SyntaxTransformer {
+/// Generates AST nodes from Syntax nodes.
+class ASTGen {
   ASTContext &Context;
   // A stack of source locations of syntax constructs. Allows us to get the
   // SourceLoc necessary to create AST nodes for nodes in not-yet-complete
@@ -30,18 +30,18 @@ class SyntaxTransformer {
   llvm::SmallVector<SourceLoc, 16> LocStack;
 
 public:
-  explicit SyntaxTransformer(ASTContext &Context) : Context(Context) {}
+  explicit ASTGen(ASTContext &Context) : Context(Context) {}
 
-  IntegerLiteralExpr *transform(syntax::IntegerLiteralExprSyntax &Expr);
-  FloatLiteralExpr *transform(syntax::FloatLiteralExprSyntax &Expr);
-  NilLiteralExpr *transform(syntax::NilLiteralExprSyntax &Expr);
-  BooleanLiteralExpr *transform(syntax::BooleanLiteralExprSyntax &Expr);
-  MagicIdentifierLiteralExpr *transform(syntax::PoundFileExprSyntax &Expr);
-  MagicIdentifierLiteralExpr *transform(syntax::PoundLineExprSyntax &Expr);
-  MagicIdentifierLiteralExpr *transform(syntax::PoundColumnExprSyntax &Expr);
-  MagicIdentifierLiteralExpr *transform(syntax::PoundFunctionExprSyntax &Expr);
-  MagicIdentifierLiteralExpr *transform(syntax::PoundDsohandleExprSyntax &Expr);
-  Expr *transform(syntax::UnknownExprSyntax &Expr);
+  IntegerLiteralExpr *generate(syntax::IntegerLiteralExprSyntax &Expr);
+  FloatLiteralExpr *generate(syntax::FloatLiteralExprSyntax &Expr);
+  NilLiteralExpr *generate(syntax::NilLiteralExprSyntax &Expr);
+  BooleanLiteralExpr *generate(syntax::BooleanLiteralExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *generate(syntax::PoundFileExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *generate(syntax::PoundLineExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *generate(syntax::PoundColumnExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *generate(syntax::PoundFunctionExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *generate(syntax::PoundDsohandleExprSyntax &Expr);
+  Expr *generate(syntax::UnknownExprSyntax &Expr);
 
   /// Stores source location necessary for AST creation.
   void pushLoc(SourceLoc Loc);
@@ -56,7 +56,7 @@ private:
   SourceLoc topLoc();
 
   MagicIdentifierLiteralExpr *
-  transformMagicIdentifierLiteralExpr(const syntax::TokenSyntax &PoundToken);
+  generateMagicIdentifierLiteralExpr(const syntax::TokenSyntax &PoundToken);
 
   /// Map magic literal tokens such as #file to their MagicIdentifierLiteralExpr
   /// kind.
@@ -65,4 +65,4 @@ private:
 };
 } // namespace swift
 
-#endif // SWIFT_PARSE_SYNTAXTRANSFORMER_H
+#endif // SWIFT_PARSE_ASTGEN_H

--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -1,0 +1,71 @@
+//===--- HiddenLibSyntaxAction.h ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H
+#define SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H
+
+#include "swift/Parse/SyntaxParseActions.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace swift {
+/// Holds an explicitly provided action and uses it to handle all function
+/// calls. Also hides an implicit SyntaxTreeCreator and ensures libSyntax nodes
+/// are always created. Provides an interface to map results of the explicitly
+/// provided action to the hidden libSyntax action.
+// todo [gsoc]: remove when possible
+class HiddenLibSyntaxAction : public SyntaxParseActions {
+  std::shared_ptr<SyntaxParseActions> ExplicitAction;
+  std::shared_ptr<SyntaxTreeCreator> LibSyntaxAction;
+  llvm::DenseMap<OpaqueSyntaxNode, OpaqueSyntaxNode> OpaqueNodeMap;
+
+  bool areBothLibSyntax() {
+    return ExplicitAction->getOpaqueKind() == OpaqueSyntaxNodeKind::LibSyntax;
+  }
+
+public:
+  HiddenLibSyntaxAction(
+      const std::shared_ptr<SyntaxParseActions> &SPActions,
+      const std::shared_ptr<SyntaxTreeCreator> &LibSyntaxAction)
+      : ExplicitAction(SPActions != nullptr ? SPActions : LibSyntaxAction),
+        LibSyntaxAction(LibSyntaxAction){};
+
+  OpaqueSyntaxNode recordToken(tok tokenKind,
+                               ArrayRef<ParsedTriviaPiece> leadingTrivia,
+                               ArrayRef<ParsedTriviaPiece> trailingTrivia,
+                               CharSourceRange range) override;
+
+  OpaqueSyntaxNode recordMissingToken(tok tokenKind, SourceLoc loc) override;
+
+  OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
+                                   ArrayRef<OpaqueSyntaxNode> elements,
+                                   CharSourceRange range) override;
+
+  std::pair<size_t, OpaqueSyntaxNode>
+  lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
+
+  OpaqueSyntaxNodeKind getOpaqueKind() override {
+    return ExplicitAction->getOpaqueKind();
+  }
+
+  /// Returns the libSyntax node corresponding to the provided node that has
+  /// been created by the explicit action.
+  OpaqueSyntaxNode getLibSyntaxNodeFor(OpaqueSyntaxNode explicitNode);
+
+  /// Returns the underlying libSyntax SyntaxTreeCreator.
+  std::shared_ptr<SyntaxTreeCreator> getLibSyntaxAction() {
+    return LibSyntaxAction;
+  }
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_HIDDENLIBSYNTAXACTION_H

--- a/include/swift/Parse/LibSyntaxGenerator.h
+++ b/include/swift/Parse/LibSyntaxGenerator.h
@@ -1,0 +1,74 @@
+//===----------- LibSyntaxGenerator.h -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_LIBSYNTAXGENERATOR_H
+#define SWIFT_PARSE_LIBSYNTAXGENERATOR_H
+
+#include "swift/Parse/HiddenLibSyntaxAction.h"
+#include "swift/Parse/ParsedRawSyntaxNode.h"
+#include "swift/Parse/ParsedRawSyntaxRecorder.h"
+#include "swift/Parse/SyntaxParsingCache.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
+
+namespace swift {
+/// Generates libSyntax nodes either by looking them up using
+/// HiddenLibSyntaxAction (based on provided OpaqueSyntaxNode) or by recording
+/// them with ParsedRawSyntaxRecorder.
+// todo [gsoc]: remove when possible
+class LibSyntaxGenerator {
+  std::shared_ptr<HiddenLibSyntaxAction> Actions;
+  ParsedRawSyntaxRecorder Recorder;
+
+public:
+  explicit LibSyntaxGenerator(std::shared_ptr<HiddenLibSyntaxAction> TwoActions)
+      : Actions(std::move(TwoActions)),
+        Recorder(Actions->getLibSyntaxAction()) {}
+
+  TokenSyntax createToken(ParsedRawSyntaxNode Node) {
+    assert(Node.isDeferredToken());
+
+    auto Kind = Node.getTokenKind();
+    auto Range = Node.getDeferredTokenRangeWithTrivia();
+    auto LeadingTriviaPieces = Node.getDeferredLeadingTriviaPieces();
+    auto TrailingTriviaPieces = Node.getDeferredTrailingTriviaPieces();
+
+    auto Recorded = Recorder.recordToken(Kind, Range, LeadingTriviaPieces,
+                                         TrailingTriviaPieces);
+    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
+    return make<TokenSyntax>(Raw);
+  }
+
+  template <typename SyntaxNode>
+  SyntaxNode createNode(ParsedRawSyntaxNode Node) {
+    assert(Node.isDeferredLayout());
+    auto Kind = Node.getKind();
+    auto Children = Node.getDeferredChildren();
+
+    auto Recorded = Recorder.recordRawSyntax(Kind, Children);
+    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
+    return make<SyntaxNode>(Raw);
+  }
+
+  TokenSyntax getLibSyntaxTokenFor(OpaqueSyntaxNode Node) {
+    return getLibSyntaxNodeFor<TokenSyntax>(Node);
+  }
+
+  template <typename SyntaxNode>
+  SyntaxNode getLibSyntaxNodeFor(OpaqueSyntaxNode Node) {
+    auto Raw = static_cast<RawSyntax *>(Actions->getLibSyntaxNodeFor(Node));
+    return make<SyntaxNode>(Raw);
+  }
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_LIBSYNTAXGENERATOR_H

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -156,6 +156,19 @@ public:
 
   // Deferred Token Data =====================================================//
 
+  CharSourceRange getDeferredTokenRangeWithTrivia() const {
+    assert(DK == DataKind::DeferredToken);
+    auto leadTriviaPieces = getDeferredLeadingTriviaPieces();
+    auto trailTriviaPieces = getDeferredTrailingTriviaPieces();
+
+    auto leadTriviaLen = ParsedTriviaPiece::getTotalLength(leadTriviaPieces);
+    auto trailTriviaLen = ParsedTriviaPiece::getTotalLength(trailTriviaPieces);
+
+    SourceLoc begin = DeferredToken.TokLoc.getAdvancedLoc(-leadTriviaLen);
+    unsigned len = leadTriviaLen + DeferredToken.TokLength + trailTriviaLen;
+
+    return CharSourceRange{begin, len};
+  }
   CharSourceRange getDeferredTokenRangeWithoutBackticks() const {
     assert(DK == DataKind::DeferredToken);
     return CharSourceRange{DeferredToken.TokLoc, DeferredToken.TokLength};

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -66,10 +66,30 @@ public:
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
       SyntaxParsingContext &SPCtx);
+%   elif node.is_unknown():
+private:
+  static Parsed${node.name} record${node.syntax_kind}(
+      ArrayRef<ParsedSyntax> elts,
+      ParsedRawSyntaxRecorder &rec);
+
+public:
+  static Parsed${node.name} defer${node.syntax_kind}(
+      ArrayRef<ParsedSyntax> elts,
+      SyntaxParsingContext &SPCtx);
+
+  static Parsed${node.name} make${node.syntax_kind}(
+      ArrayRef<ParsedSyntax> elts,
+      SyntaxParsingContext &SPCtx);
 %   end
 % end
 
 #pragma mark - Convenience APIs
+
+public:
+  static ParsedTokenSyntax makeToken(const Token &Tok,
+                                     const ParsedTrivia &LeadingTrivia,
+                                     const ParsedTrivia &TrailingTrivia,
+                                     SyntaxParsingContext &SPCtx);
 
   /// Records an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -25,6 +25,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/OptionSet.h"
+#include "swift/Parse/ASTGen.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/PersistentParserState.h"
@@ -34,7 +35,6 @@
 #include "swift/Parse/ParserResult.h"
 #include "swift/Parse/SyntaxParserResult.h"
 #include "swift/Parse/SyntaxParsingContext.h"
-#include "swift/Parse/SyntaxTransformer.h"
 #include "swift/Syntax/References.h"
 #include "swift/Config.h"
 #include "llvm/ADT/SetVector.h"
@@ -378,8 +378,8 @@ public:
   /// Current syntax parsing context where call backs should be directed to.
   SyntaxParsingContext *SyntaxContext;
 
-  /// The libSyntax to AST transformer.
-  SyntaxTransformer Transformer;
+  /// The AST generator.
+  ASTGen Generator;
 
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -29,10 +29,12 @@
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Parse/Token.h"
+#include "swift/Parse/ParsedSyntaxNodes.h"
 #include "swift/Parse/ParserPosition.h"
 #include "swift/Parse/ParserResult.h"
 #include "swift/Parse/SyntaxParserResult.h"
 #include "swift/Parse/SyntaxParsingContext.h"
+#include "swift/Parse/SyntaxTransformer.h"
 #include "swift/Syntax/References.h"
 #include "swift/Config.h"
 #include "llvm/ADT/SetVector.h"
@@ -376,6 +378,9 @@ public:
   /// Current syntax parsing context where call backs should be directed to.
   SyntaxParsingContext *SyntaxContext;
 
+  /// The libSyntax to AST transformer.
+  SyntaxTransformer Transformer;
+
 public:
   Parser(unsigned BufferID, SourceFile &SF, DiagnosticEngine* LexerDiags,
          SILParserTUStateBase *SIL,
@@ -517,6 +522,12 @@ public:
   SourceLoc consumeToken(tok K) {
     assert(Tok.is(K) && "Consuming wrong token kind");
     return consumeToken();
+  }
+  /// Consume a token without providing it to the SyntaxParsingContext.
+  ParsedTokenSyntax consumeTokenSyntax();
+  ParsedTokenSyntax consumeTokenSyntax(tok K) {
+    assert(Tok.is(K) && "Consuming wrong token kind");
+    return consumeTokenSyntax();
   }
 
   SourceLoc consumeIdentifier(Identifier *Result = nullptr,
@@ -1320,6 +1331,15 @@ public:
   ParserResult<Expr> parseExprSelector();
   ParserResult<Expr> parseExprSuper();
   ParserResult<Expr> parseExprStringLiteral();
+
+  // todo [gsoc]: create new result type for ParsedSyntax
+  // todo [gsoc]: turn into proper non-templated methods later
+  template <typename SyntaxNode>
+  ParsedExprSyntax parseExprSyntax();
+
+  // todo [gsoc]: remove when possible
+  template <typename SyntaxNode>
+  ParserResult<Expr> parseExprAST();
 
   StringRef copyAndStripUnderscores(StringRef text);
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -33,6 +33,12 @@ namespace syntax {
 
 typedef void *OpaqueSyntaxNode;
 
+// todo [gsoc]: remove when possible
+enum class OpaqueSyntaxNodeKind {
+  SwiftSyntax,
+  LibSyntax,
+};
+
 class SyntaxParseActions {
   virtual void _anchor();
 
@@ -60,6 +66,9 @@ public:
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
     return std::make_pair(0, nullptr);
   }
+
+  /// Returns what kind of OpaqueSyntaxNode is created by `recordXXX` methods.
+  virtual OpaqueSyntaxNodeKind getOpaqueKind() = 0;
 };
 
 } // end namespace swift

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -15,8 +15,11 @@
 
 #include "llvm/ADT/PointerUnion.h"
 #include "swift/Basic/SourceLoc.h"
+#include "swift/Parse/HiddenLibSyntaxAction.h"
+#include "swift/Parse/LibSyntaxGenerator.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
+#include "swift/Parse/ParsedSyntaxNodes.h"
 
 namespace swift {
 
@@ -74,6 +77,7 @@ constexpr size_t SyntaxAlignInBits = 3;
 ///     // Now the context holds { '(' Expr ')' }.
 ///     // From these parts, it creates ParenExpr node and add it to the parent.
 ///   }
+// todo [gsoc]: remove when/if possible
 class alignas(1 << SyntaxAlignInBits) SyntaxParsingContext {
 public:
   /// The shared data for all syntax parsing contexts with the same root.
@@ -94,13 +98,15 @@ public:
 
     ParsedRawSyntaxRecorder Recorder;
 
+    LibSyntaxGenerator LibSyntaxCreator;
+
     llvm::BumpPtrAllocator ScratchAlloc;
 
     RootContextData(SourceFile &SF, DiagnosticEngine &Diags,
                     SourceManager &SourceMgr, unsigned BufferID,
-                    std::shared_ptr<SyntaxParseActions> spActions)
+                    const std::shared_ptr<HiddenLibSyntaxAction>& TwoActions)
         : SF(SF), Diags(Diags), SourceMgr(SourceMgr), BufferID(BufferID),
-          Recorder(std::move(spActions)) {}
+          Recorder(TwoActions), LibSyntaxCreator(TwoActions) {}
   };
 
 private:
@@ -162,9 +168,6 @@ private:
   /// true if it's in backtracking context.
   bool IsBacktracking = false;
 
-  // If false, context does nothing.
-  bool Enabled;
-
   /// Create a syntax node using the tail \c N elements of collected parts and
   /// replace those parts with the single result.
   void createNodeInPlace(SyntaxKind Kind, size_t N,
@@ -182,18 +185,19 @@ private:
   Optional<ParsedRawSyntaxNode> bridgeAs(SyntaxContextKind Kind,
                               ArrayRef<ParsedRawSyntaxNode> Parts);
 
+  ParsedRawSyntaxNode finalizeSourceFile();
+
 public:
   /// Construct root context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SourceFile &SF,
                        unsigned BufferID,
-                       std::shared_ptr<SyntaxParseActions> SPActions);
+                       std::shared_ptr<HiddenLibSyntaxAction> SPActions);
 
   /// Designated constructor for child context.
   SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder)
       : RootDataOrParent(CtxtHolder), CtxtHolder(CtxtHolder),
         RootData(CtxtHolder->RootData), Offset(RootData->Storage.size()),
-        IsBacktracking(CtxtHolder->IsBacktracking),
-        Enabled(CtxtHolder->isEnabled()) {
+        IsBacktracking(CtxtHolder->IsBacktracking) {
     assert(CtxtHolder->isTopOfContextStack() &&
            "SyntaxParsingContext cannot have multiple children");
     assert(CtxtHolder->Mode != AccumulationMode::SkippedForIncrementalUpdate &&
@@ -221,8 +225,6 @@ public:
   /// offset. If nothing is found \c 0 is returned.
   size_t lookupNode(size_t LexerOffset, SourceLoc Loc);
 
-  void disable() { Enabled = false; }
-  bool isEnabled() const { return Enabled; }
   bool isRoot() const { return RootDataOrParent.is<RootContextData*>(); }
   bool isTopOfContextStack() const { return this == CtxtHolder; }
 
@@ -238,6 +240,10 @@ public:
 
   const std::vector<ParsedRawSyntaxNode> &getStorage() const {
     return getRootData()->Storage;
+  }
+
+  LibSyntaxGenerator &getSyntaxCreator() {
+    return getRootData()->LibSyntaxCreator;
   }
 
   const SyntaxParsingContext *getRoot() const;
@@ -258,6 +264,21 @@ public:
   /// Add Syntax to the parts.
   void addSyntax(ParsedSyntax Node);
 
+  template <SyntaxKind Kind>
+  bool isTopNode() {
+    return getStorage().back().getKind() == Kind;
+  }
+
+  /// Returns the topmost Syntax node.
+  template <typename SyntaxNode> SyntaxNode topNode() {
+    ParsedRawSyntaxNode TopNode = getStorage().back();
+
+    if (IsBacktracking)
+      return getSyntaxCreator().createNode<SyntaxNode>(TopNode);
+
+    OpaqueSyntaxNode OpaqueNode = TopNode.getOpaqueNode();
+    return getSyntaxCreator().getLibSyntaxNodeFor<SyntaxNode>(OpaqueNode);
+  }
 
   template<typename SyntaxNode>
   llvm::Optional<SyntaxNode> popIf() {
@@ -298,6 +319,11 @@ public:
   void setDeferSyntax(SyntaxKind Kind) {
     Mode = AccumulationMode::DeferSyntax;
     SynKind = Kind;
+  }
+
+  /// On destruction, do not attempt to finalize the root node.
+  void setDiscard() {
+    Mode = AccumulationMode::Discard;
   }
 
   /// On destruction, if the parts size is 1 and it's kind of \c Kind, just

--- a/include/swift/Parse/SyntaxTransformer.h
+++ b/include/swift/Parse/SyntaxTransformer.h
@@ -1,0 +1,68 @@
+//===--- SyntaxTransformer.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PARSE_SYNTAXTRANSFORMER_H
+#define SWIFT_PARSE_SYNTAXTRANSFORMER_H
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Expr.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace swift {
+/// Transforms Syntax nodes into AST nodes.
+class SyntaxTransformer {
+  ASTContext &Context;
+  // A stack of source locations of syntax constructs. Allows us to get the
+  // SourceLoc necessary to create AST nodes for nodes in not-yet-complete
+  // Syntax tree. The topmost item should always correspond to the token/node
+  // that has been parsed/transformed most recently.
+  // todo [gsoc]: remove when possible
+  llvm::SmallVector<SourceLoc, 16> LocStack;
+
+public:
+  explicit SyntaxTransformer(ASTContext &Context) : Context(Context) {}
+
+  IntegerLiteralExpr *transform(syntax::IntegerLiteralExprSyntax &Expr);
+  FloatLiteralExpr *transform(syntax::FloatLiteralExprSyntax &Expr);
+  NilLiteralExpr *transform(syntax::NilLiteralExprSyntax &Expr);
+  BooleanLiteralExpr *transform(syntax::BooleanLiteralExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *transform(syntax::PoundFileExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *transform(syntax::PoundLineExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *transform(syntax::PoundColumnExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *transform(syntax::PoundFunctionExprSyntax &Expr);
+  MagicIdentifierLiteralExpr *transform(syntax::PoundDsohandleExprSyntax &Expr);
+  Expr *transform(syntax::UnknownExprSyntax &Expr);
+
+  /// Stores source location necessary for AST creation.
+  void pushLoc(SourceLoc Loc);
+
+  /// Copy a numeric literal value into AST-owned memory, stripping underscores
+  /// so the semantic part of the value can be parsed by APInt/APFloat parsers.
+  static StringRef copyAndStripUnderscores(StringRef Orig, ASTContext &Context);
+
+private:
+  StringRef copyAndStripUnderscores(StringRef Orig);
+
+  SourceLoc topLoc();
+
+  MagicIdentifierLiteralExpr *
+  transformMagicIdentifierLiteralExpr(const syntax::TokenSyntax &PoundToken);
+
+  /// Map magic literal tokens such as #file to their MagicIdentifierLiteralExpr
+  /// kind.
+  static MagicIdentifierLiteralExpr::Kind
+  getMagicIdentifierLiteralKind(tok Kind);
+};
+} // namespace swift
+
+#endif // SWIFT_PARSE_SYNTAXTRANSFORMER_H

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -53,7 +53,6 @@ public:
 
   void acceptSyntaxRoot(OpaqueSyntaxNode root, SourceFile &SF);
 
-private:
   OpaqueSyntaxNode recordToken(tok tokenKind,
                                ArrayRef<ParsedTriviaPiece> leadingTrivia,
                                ArrayRef<ParsedTriviaPiece> trailingTrivia,
@@ -67,6 +66,10 @@ private:
 
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
+
+  OpaqueSyntaxNodeKind getOpaqueKind() override {
+    return OpaqueSyntaxNodeKind::LibSyntax;
+  }
 };
 
 } // end namespace swift

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -5,6 +5,7 @@ else()
 endif()
 
 add_swift_host_library(swiftParse STATIC
+  ASTGen.cpp
   Confusables.cpp
   HiddenLibSyntaxAction.cpp
   Lexer.cpp
@@ -23,7 +24,6 @@ add_swift_host_library(swiftParse STATIC
   Scope.cpp
   SyntaxParsingCache.cpp
   SyntaxParsingContext.cpp
-  SyntaxTransformer.cpp
 
   GYB_SOURCES
     ParsedSyntaxBuilders.cpp.gyb

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 add_swift_host_library(swiftParse STATIC
   Confusables.cpp
+  HiddenLibSyntaxAction.cpp
   Lexer.cpp
   ParseDecl.cpp
   ParsedRawSyntaxNode.cpp
@@ -22,6 +23,7 @@ add_swift_host_library(swiftParse STATIC
   Scope.cpp
   SyntaxParsingCache.cpp
   SyntaxParsingContext.cpp
+  SyntaxTransformer.cpp
 
   GYB_SOURCES
     ParsedSyntaxBuilders.cpp.gyb
@@ -29,6 +31,7 @@ add_swift_host_library(swiftParse STATIC
     ParsedSyntaxRecorder.cpp.gyb)
 target_link_libraries(swiftParse PRIVATE
   swiftAST
-  swiftSyntax)
+  swiftSyntax
+  swiftSyntaxParse)
 
 add_dependencies(swiftParse swift-parse-syntax-generated-headers)

--- a/lib/Parse/HiddenLibSyntaxAction.cpp
+++ b/lib/Parse/HiddenLibSyntaxAction.cpp
@@ -1,0 +1,92 @@
+//===--- HiddenLibSyntaxAction.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/HiddenLibSyntaxAction.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/Module.h"
+#include "swift/Basic/OwnedString.h"
+#include "swift/Parse/ParsedTrivia.h"
+#include "swift/Parse/SyntaxParsingCache.h"
+#include "swift/Parse/Token.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/SyntaxVisitor.h"
+#include "swift/Syntax/Trivia.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace swift;
+using namespace swift::syntax;
+using namespace llvm;
+
+OpaqueSyntaxNode HiddenLibSyntaxAction::recordToken(
+    tok tokenKind, ArrayRef<ParsedTriviaPiece> leadingTrivia,
+    ArrayRef<ParsedTriviaPiece> trailingTrivia, CharSourceRange range) {
+  OpaqueSyntaxNode primaryNode = ExplicitAction->recordToken(
+      tokenKind, leadingTrivia, trailingTrivia, range);
+
+  if (!areBothLibSyntax()) {
+    OpaqueSyntaxNode secondaryNode = LibSyntaxAction->recordToken(
+        tokenKind, leadingTrivia, trailingTrivia, range);
+    OpaqueNodeMap[primaryNode] = secondaryNode;
+  }
+
+  return primaryNode;
+}
+
+OpaqueSyntaxNode HiddenLibSyntaxAction::recordMissingToken(tok tokenKind,
+                                                           SourceLoc loc) {
+  OpaqueSyntaxNode primaryNode =
+      ExplicitAction->recordMissingToken(tokenKind, loc);
+
+  if (!areBothLibSyntax()) {
+    OpaqueSyntaxNode secondaryNode =
+        LibSyntaxAction->recordMissingToken(tokenKind, loc);
+    OpaqueNodeMap[primaryNode] = secondaryNode;
+  }
+
+  return primaryNode;
+}
+
+OpaqueSyntaxNode
+HiddenLibSyntaxAction::recordRawSyntax(syntax::SyntaxKind kind,
+                                       ArrayRef<OpaqueSyntaxNode> elements,
+                                       CharSourceRange range) {
+  OpaqueSyntaxNode primaryNode =
+      ExplicitAction->recordRawSyntax(kind, elements, range);
+
+  if (!areBothLibSyntax()) {
+    SmallVector<OpaqueSyntaxNode, 4> secondaryElements;
+    secondaryElements.reserve(elements.size());
+    for (auto &&element : elements) {
+      secondaryElements.push_back(OpaqueNodeMap[element]);
+    }
+    OpaqueSyntaxNode secondaryNode =
+        LibSyntaxAction->recordRawSyntax(kind, secondaryElements, range);
+    OpaqueNodeMap[primaryNode] = secondaryNode;
+  }
+
+  return primaryNode;
+}
+
+std::pair<size_t, OpaqueSyntaxNode>
+HiddenLibSyntaxAction::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
+  return ExplicitAction->lookupNode(lexerOffset, kind);
+}
+
+OpaqueSyntaxNode
+HiddenLibSyntaxAction::getLibSyntaxNodeFor(OpaqueSyntaxNode explicitNode) {
+  if (!areBothLibSyntax())
+    return OpaqueNodeMap[explicitNode];
+
+  return explicitNode;
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -197,7 +197,7 @@ void PersistentParserState::parseMembers(IterableDeclContext *IDC) {
   // diagnostic engine here.
   Parser TheParser(BufferID, SF, /*No Lexer Diags*/nullptr, nullptr, this);
   // Disable libSyntax creation in the delayed parsing.
-  TheParser.SyntaxContext->disable();
+  TheParser.SyntaxContext->setDiscard();
   TheParser.parseDeclListDelayed(IDC);
 }
 
@@ -4483,11 +4483,9 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
   if (peekToken().is(tok::r_brace)) {
     accessors.LBLoc = consumeToken(tok::l_brace);
     // Give syntax node an empty accessor list.
-    if (SyntaxContext->isEnabled()) {
-      SourceLoc listLoc = accessors.LBLoc.getAdvancedLoc(1);
-      SyntaxContext->addSyntax(
-        ParsedSyntaxRecorder::makeBlankAccessorList(listLoc, *SyntaxContext));
-    }
+    SourceLoc listLoc = accessors.LBLoc.getAdvancedLoc(1);
+    SyntaxContext->addSyntax(
+      ParsedSyntaxRecorder::makeBlankAccessorList(listLoc, *SyntaxContext));
     accessors.RBLoc = consumeToken(tok::r_brace);
 
     // In the limited syntax, fall out and let the caller handle it.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -890,21 +890,8 @@ ParserResult<Expr> Parser::parseExprSuper() {
                                                      /*Implicit=*/false));
 }
 
-/// Copy a numeric literal value into AST-owned memory, stripping underscores
-/// so the semantic part of the value can be parsed by APInt/APFloat parsers.
 StringRef Parser::copyAndStripUnderscores(StringRef orig) {
-  char *start = static_cast<char*>(Context.Allocate(orig.size(), 1));
-  char *p = start;
-
-  if (p) {
-    for (char c : orig) {
-      if (c != '_') {
-        *p++ = c;
-      }
-    }
-  }
-  
-  return StringRef(start, p - start);
+  return SyntaxTransformer::copyAndStripUnderscores(orig, Context);
 }
 
 /// Disambiguate the parse after '{' token that is in a place that might be
@@ -1001,34 +988,6 @@ static bool isValidTrailingClosure(bool isExprBasic, Parser &P){
   // Recoverable case. Just return true here and Sema will emit a diagnostic
   // later. see: Sema/MiscDiagnostics.cpp#checkStmtConditionTrailingClosure
   return true;
-}
-
-
-
-/// Map magic literal tokens such as #file to their
-/// MagicIdentifierLiteralExpr kind.
-static MagicIdentifierLiteralExpr::Kind
-getMagicIdentifierLiteralKind(tok Kind) {
-  switch (Kind) {
-  case tok::kw___COLUMN__:
-  case tok::pound_column:
-    return MagicIdentifierLiteralExpr::Kind::Column;
-  case tok::kw___FILE__:
-  case tok::pound_file:
-    return MagicIdentifierLiteralExpr::Kind::File;
-  case tok::kw___FUNCTION__:
-  case tok::pound_function:
-    return MagicIdentifierLiteralExpr::Kind::Function;
-  case tok::kw___LINE__:
-  case tok::pound_line:
-    return MagicIdentifierLiteralExpr::Kind::Line;
-  case tok::kw___DSO_HANDLE__:
-  case tok::pound_dsohandle:
-    return MagicIdentifierLiteralExpr::Kind::DSOHandle;
-
-  default:
-    llvm_unreachable("not a magic literal");
-  }
 }
 
 ParserResult<Expr>
@@ -1198,12 +1157,10 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
           isa<TupleExpr>(callee))
         break;
 
-      if (SyntaxContext->isEnabled()) {
-        // Add dummy blank argument list to the call expression syntax.
-        SyntaxContext->addSyntax(
-            ParsedSyntaxRecorder::makeBlankFunctionCallArgumentList(
-                Tok.getLoc(), *SyntaxContext));
-      }
+      // Add dummy blank argument list to the call expression syntax.
+      SyntaxContext->addSyntax(
+          ParsedSyntaxRecorder::makeBlankFunctionCallArgumentList(
+              Tok.getLoc(), *SyntaxContext));
 
       ParserResult<Expr> closure =
           parseTrailingClosure(callee->getSourceRange());
@@ -1350,6 +1307,121 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
   return Result;
 }
 
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::integer_literal);
+  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<FloatLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::floating_literal);
+  return ParsedSyntaxRecorder::makeFloatLiteralExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<NilLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax(tok::kw_nil);
+  return ParsedSyntaxRecorder::makeNilLiteralExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<BooleanLiteralExprSyntax>() {
+  auto Token = consumeTokenSyntax();
+  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundFileExprSyntax>() {
+  if (Tok.getKind() == tok::kw___FILE__) {
+    StringRef fixit = "#file";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___FILE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_file);
+  return ParsedSyntaxRecorder::makePoundFileExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundLineExprSyntax>() {
+  if (Tok.getKind() == tok::kw___LINE__) {
+    StringRef fixit = "#line";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___LINE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  // FIXME: #line was renamed to #sourceLocation
+  auto Token = consumeTokenSyntax(tok::pound_line);
+  return ParsedSyntaxRecorder::makePoundLineExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundColumnExprSyntax>() {
+  if (Tok.getKind() == tok::kw___COLUMN__) {
+    StringRef fixit = "#column";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___COLUMN__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_column);
+  return ParsedSyntaxRecorder::makePoundColumnExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundFunctionExprSyntax>() {
+  if (Tok.getKind() == tok::kw___FUNCTION__) {
+    StringRef fixit = "#function";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___FUNCTION__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_function);
+  return ParsedSyntaxRecorder::makePoundFunctionExpr(Token, *SyntaxContext);
+}
+
+template <>
+ParsedExprSyntax Parser::parseExprSyntax<PoundDsohandleExprSyntax>() {
+  if (Tok.getKind() == tok::kw___DSO_HANDLE__) {
+    StringRef fixit = "#dsohandle";
+    diagnose(Tok.getLoc(), diag::snake_case_deprecated, Tok.getText(), fixit)
+        .fixItReplace(Tok.getLoc(), fixit);
+
+    auto Token = consumeTokenSyntax(tok::kw___DSO_HANDLE__);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+  }
+
+  auto Token = consumeTokenSyntax(tok::pound_dsohandle);
+  return ParsedSyntaxRecorder::makePoundDsohandleExpr(Token, *SyntaxContext);
+}
+
+template <typename SyntaxNode>
+ParserResult<Expr> Parser::parseExprAST() {
+  auto ParsedExpr = parseExprSyntax<SyntaxNode>();
+  SyntaxContext->addSyntax(ParsedExpr);
+  // todo [gsoc]: improve this somehow
+  if (SyntaxContext->isTopNode<SyntaxKind::UnknownExpr>()) {
+    auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
+    auto ExprAST = Transformer.transform(Expr);
+    return makeParserResult(ExprAST);
+  }
+  auto Expr = SyntaxContext->topNode<SyntaxNode>();
+  auto ExprAST = Transformer.transform(Expr);
+  return makeParserResult(ExprAST);
+}
+
 /// parseExprPrimary
 ///
 ///   expr-literal:
@@ -1383,23 +1455,27 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 ///     expr-selector
 ///
 ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
+  switch (Tok.getKind()) {
+  case tok::integer_literal: return parseExprAST<IntegerLiteralExprSyntax>();
+  case tok::floating_literal: return parseExprAST<FloatLiteralExprSyntax>();
+  case tok::kw_nil: return parseExprAST<NilLiteralExprSyntax>();
+  case tok::kw_true:
+  case tok::kw_false: return parseExprAST<BooleanLiteralExprSyntax>();
+  case tok::kw___FILE__:
+  case tok::pound_file: return parseExprAST<PoundFileExprSyntax>();
+  case tok::kw___LINE__:
+  case tok::pound_line: return parseExprAST<PoundLineExprSyntax>();
+  case tok::kw___COLUMN__:
+  case tok::pound_column: return parseExprAST<PoundColumnExprSyntax>();
+  case tok::kw___FUNCTION__:
+  case tok::pound_function: return parseExprAST<PoundFunctionExprSyntax>();
+  case tok::kw___DSO_HANDLE__:
+  case tok::pound_dsohandle: return parseExprAST<PoundDsohandleExprSyntax>();
+  default: break;
+  }
+
   SyntaxParsingContext ExprContext(SyntaxContext, SyntaxContextKind::Expr);
   switch (Tok.getKind()) {
-  case tok::integer_literal: {
-    StringRef Text = copyAndStripUnderscores(Tok.getText());
-    SourceLoc Loc = consumeToken(tok::integer_literal);
-    ExprContext.setCreateSyntax(SyntaxKind::IntegerLiteralExpr);
-    return makeParserResult(new (Context)
-                                IntegerLiteralExpr(Text, Loc,
-                                                   /*Implicit=*/false));
-  }
-  case tok::floating_literal: {
-    StringRef Text = copyAndStripUnderscores(Tok.getText());
-    SourceLoc Loc = consumeToken(tok::floating_literal);
-    ExprContext.setCreateSyntax(SyntaxKind::FloatLiteralExpr);
-    return makeParserResult(new (Context) FloatLiteralExpr(Text, Loc,
-                                                           /*Implicit=*/false));
-  }
   case tok::at_sign:
     // Objective-C programmers habitually type @"foo", so recover gracefully
     // with a fixit.  If this isn't @"foo", just handle it like an unknown
@@ -1414,62 +1490,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       
   case tok::string_literal:  // "foo"
     return parseExprStringLiteral();
-  
-  case tok::kw_nil:
-    ExprContext.setCreateSyntax(SyntaxKind::NilLiteralExpr);
-    return makeParserResult(new (Context)
-                                NilLiteralExpr(consumeToken(tok::kw_nil)));
 
-  case tok::kw_true:
-  case tok::kw_false: {
-    ExprContext.setCreateSyntax(SyntaxKind::BooleanLiteralExpr);
-    bool isTrue = Tok.is(tok::kw_true);
-    return makeParserResult(new (Context)
-                                BooleanLiteralExpr(isTrue, consumeToken()));
-  }
-
-  case tok::kw___FILE__:
-  case tok::kw___LINE__:
-  case tok::kw___COLUMN__:
-  case tok::kw___FUNCTION__:
-  case tok::kw___DSO_HANDLE__: {
-    StringRef replacement = "";
-    switch (Tok.getKind()) {
-    default: llvm_unreachable("can't get here");
-    case tok::kw___FILE__: replacement = "#file"; break;
-    case tok::kw___LINE__: replacement = "#line"; break;
-    case tok::kw___COLUMN__: replacement = "#column"; break;
-    case tok::kw___FUNCTION__:  replacement = "#function"; break;
-    case tok::kw___DSO_HANDLE__: replacement = "#dsohandle"; break;
-    }
-
-    diagnose(Tok.getLoc(), diag::snake_case_deprecated,
-             Tok.getText(), replacement)
-      .fixItReplace(Tok.getLoc(), replacement);
-    LLVM_FALLTHROUGH;
-  }
-  case tok::pound_column:
-  case tok::pound_file:
-  case tok::pound_function:
-  case tok::pound_line:
-  case tok::pound_dsohandle: {
-    SyntaxKind SKind = SyntaxKind::UnknownExpr;
-    switch (Tok.getKind()) {
-    case tok::pound_column: SKind = SyntaxKind::PoundColumnExpr; break;
-    case tok::pound_file: SKind = SyntaxKind::PoundFileExpr; break;
-    case tok::pound_function: SKind = SyntaxKind::PoundFunctionExpr; break;
-    // FIXME: #line was renamed to #sourceLocation
-    case tok::pound_line: SKind = SyntaxKind::PoundLineExpr; break;
-    case tok::pound_dsohandle: SKind = SyntaxKind::PoundDsohandleExpr; break;
-    default: break;
-    }
-    ExprContext.setCreateSyntax(SKind);
-    auto Kind = getMagicIdentifierLiteralKind(Tok.getKind());
-    SourceLoc Loc = consumeToken();
-    return makeParserResult(new (Context) MagicIdentifierLiteralExpr(
-        Kind, Loc, /*implicit=*/false));
-  }
-      
   case tok::identifier:  // foo
   case tok::kw_self:     // self
 
@@ -1491,15 +1512,13 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                      ? VarDecl::Specifier::Let
                      : VarDecl::Specifier::Var;
       auto pattern = createBindingFromPattern(loc, name, specifier);
-      if (SyntaxContext->isEnabled()) {
-        ParsedPatternSyntax PatternNode =
-            ParsedSyntaxRecorder::makeIdentifierPattern(
-                                    SyntaxContext->popToken(), *SyntaxContext);
-        ParsedExprSyntax ExprNode =
-            ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
-                                                             *SyntaxContext);
-        SyntaxContext->addSyntax(ExprNode);
-      }
+      ParsedPatternSyntax PatternNode =
+          ParsedSyntaxRecorder::makeIdentifierPattern(
+                                  SyntaxContext->popToken(), *SyntaxContext);
+      ParsedExprSyntax ExprNode =
+          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
+                                                           *SyntaxContext);
+      SyntaxContext->addSyntax(ExprNode);
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }
 
@@ -1602,12 +1621,10 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
 
     // Check for a trailing closure, if allowed.
     if (Tok.is(tok::l_brace) && isValidTrailingClosure(isExprBasic, *this)) {
-      if (SyntaxContext->isEnabled()) {
-        // Add dummy blank argument list to the call expression syntax.
-        SyntaxContext->addSyntax(
-            ParsedSyntaxRecorder::makeBlankFunctionCallArgumentList(
-                Tok.getLoc(), *SyntaxContext));
-      }
+      // Add dummy blank argument list to the call expression syntax.
+      SyntaxContext->addSyntax(
+          ParsedSyntaxRecorder::makeBlankFunctionCallArgumentList(
+              Tok.getLoc(), *SyntaxContext));
 
       ParserResult<Expr> closure =
         parseTrailingClosure(NameLoc.getSourceRange());
@@ -2115,10 +2132,9 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
   if (allowZeroArgCompoundNames && peekToken().is(tok::r_paren)) {
     SyntaxParsingContext ArgsCtxt(SyntaxContext, SyntaxKind::DeclNameArguments);
     consumeToken(tok::l_paren);
-    if (SyntaxContext->isEnabled())
-      SyntaxContext->addSyntax(
-          ParsedSyntaxRecorder::makeBlankDeclNameArgumentList(
-            Tok.getLoc(), *SyntaxContext));
+    SyntaxContext->addSyntax(
+        ParsedSyntaxRecorder::makeBlankDeclNameArgumentList(
+          Tok.getLoc(), *SyntaxContext));
     consumeToken(tok::r_paren);
     loc = DeclNameLoc(baseNameLoc);
     SmallVector<Identifier, 2> argumentLabels;
@@ -2306,7 +2322,7 @@ Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
       ConsumeTokenReceiver DisabledRec;
       llvm::SaveAndRestore<ConsumeTokenReceiver *> R(TokReceiver, &DisabledRec);
       SyntaxParsingContext SContext(SyntaxContext);
-      SContext.disable();
+      SContext.setDiscard();
 
       Tok.setKind(tok::unknown); // we might be at tok::eof now.
       consumeTokenWithoutFeedingReceiver();
@@ -3321,10 +3337,9 @@ ParserResult<Expr> Parser::parseExprCollection() {
 
   // [] is always an array.
   if (Tok.is(tok::r_square)) {
-    if (SyntaxContext->isEnabled())
-      SyntaxContext->addSyntax(
-          ParsedSyntaxRecorder::makeBlankArrayElementList(
-                                Tok.getLoc(), *SyntaxContext));
+    SyntaxContext->addSyntax(
+        ParsedSyntaxRecorder::makeBlankArrayElementList(
+                              Tok.getLoc(), *SyntaxContext));
     RSquareLoc = consumeToken(tok::r_square);
     ArrayOrDictContext.setCreateSyntax(SyntaxKind::ArrayExpr);
     return makeParserResult(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -891,7 +891,7 @@ ParserResult<Expr> Parser::parseExprSuper() {
 }
 
 StringRef Parser::copyAndStripUnderscores(StringRef orig) {
-  return SyntaxTransformer::copyAndStripUnderscores(orig, Context);
+  return ASTGen::copyAndStripUnderscores(orig, Context);
 }
 
 /// Disambiguate the parse after '{' token that is in a place that might be
@@ -1414,11 +1414,11 @@ ParserResult<Expr> Parser::parseExprAST() {
   // todo [gsoc]: improve this somehow
   if (SyntaxContext->isTopNode<SyntaxKind::UnknownExpr>()) {
     auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
-    auto ExprAST = Transformer.transform(Expr);
+    auto ExprAST = Generator.generate(Expr);
     return makeParserResult(ExprAST);
   }
   auto Expr = SyntaxContext->topNode<SyntaxNode>();
-  auto ExprAST = Transformer.transform(Expr);
+  auto ExprAST = Generator.generate(Expr);
   return makeParserResult(ExprAST);
 }
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -651,16 +651,11 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     SmallVector<ASTNode, 16> Elements;
     if (isActive || !isVersionCondition) {
       parseElements(Elements, isActive);
-    } else if (SyntaxContext->isEnabled()) {
-      // We shouldn't skip code if we are building syntax tree.
+    } else {
       // The parser will keep running and we just discard the AST part.
       DiagnosticSuppression suppression(Context.Diags);
       SmallVector<ASTNode, 16> dropedElements;
       parseElements(dropedElements, false);
-    } else {
-      DiagnosticTransaction DT(Diags);
-      skipUntilConditionalBlockClose();
-      DT.abort();
     }
 
     Clauses.emplace_back(ClauseLoc, Condition,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1166,12 +1166,10 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   if (subExpr.isNull())
     return status;
 
-  if (SyntaxContext->isEnabled()) {
-    if (auto UPES = PatternCtx.popIf<ParsedUnresolvedPatternExprSyntax>()) {
-      PatternCtx.addSyntax(UPES->getDeferredPattern());
-    } else {
-      PatternCtx.setCreateSyntax(SyntaxKind::ExpressionPattern);
-    }
+  if (auto UPES = PatternCtx.popIf<ParsedUnresolvedPatternExprSyntax>()) {
+    PatternCtx.addSyntax(UPES->getDeferredPattern());
+  } else {
+    PatternCtx.setCreateSyntax(SyntaxKind::ExpressionPattern);
   }
   // The most common case here is to parse something that was a lexically
   // obvious pattern, which will come back wrapped in an immediate

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -215,8 +215,6 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID,
   }
 
   auto makeMetatypeTypeSyntax = [&]() {
-    if (!SyntaxContext->isEnabled())
-      return;
     ParsedMetatypeTypeSyntaxBuilder Builder(*SyntaxContext);
     auto TypeOrProtocol = SyntaxContext->popToken();
     auto Period = SyntaxContext->popToken();
@@ -431,29 +429,27 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
     if (SecondHalf.isNull())
       return nullptr;
 
-    if (SyntaxContext->isEnabled()) {
-      ParsedFunctionTypeSyntaxBuilder Builder(*SyntaxContext);
-      Builder.useReturnType(SyntaxContext->popIf<ParsedTypeSyntax>().getValue());
-      Builder.useArrow(SyntaxContext->popToken());
-      if (throwsLoc.isValid())
-        Builder.useThrowsOrRethrowsKeyword(SyntaxContext->popToken());
+    ParsedFunctionTypeSyntaxBuilder Builder(*SyntaxContext);
+    Builder.useReturnType(SyntaxContext->popIf<ParsedTypeSyntax>().getValue());
+    Builder.useArrow(SyntaxContext->popToken());
+    if (throwsLoc.isValid())
+      Builder.useThrowsOrRethrowsKeyword(SyntaxContext->popToken());
 
-      auto InputNode = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
-      if (auto TupleTypeNode = InputNode.getAs<ParsedTupleTypeSyntax>()) {
-        // Decompose TupleTypeSyntax and repack into FunctionType.
-        auto LeftParen = TupleTypeNode->getDeferredLeftParen();
-        auto Arguments = TupleTypeNode->getDeferredElements();
-        auto RightParen = TupleTypeNode->getDeferredRightParen();
-        Builder
-          .useLeftParen(LeftParen)
-          .useArguments(Arguments)
-          .useRightParen(RightParen);
-      } else {
-        Builder.addArgumentsMember(ParsedSyntaxRecorder::makeTupleTypeElement(
-            InputNode, /*TrailingComma=*/None, *SyntaxContext));
-      }
-      SyntaxContext->addSyntax(Builder.build());
+    auto InputNode = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    if (auto TupleTypeNode = InputNode.getAs<ParsedTupleTypeSyntax>()) {
+      // Decompose TupleTypeSyntax and repack into FunctionType.
+      auto LeftParen = TupleTypeNode->getDeferredLeftParen();
+      auto Arguments = TupleTypeNode->getDeferredElements();
+      auto RightParen = TupleTypeNode->getDeferredRightParen();
+      Builder
+        .useLeftParen(LeftParen)
+        .useArguments(Arguments)
+        .useRightParen(RightParen);
+    } else {
+      Builder.addArgumentsMember(ParsedSyntaxRecorder::makeTupleTypeElement(
+          InputNode, /*TrailingComma=*/None, *SyntaxContext));
     }
+    SyntaxContext->addSyntax(Builder.build());
 
     TupleTypeRepr *argsTyR = nullptr;
     if (auto *TTArgs = dyn_cast<TupleTypeRepr>(tyR)) {
@@ -749,21 +745,17 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
   SyntaxContext->setCreateSyntax(SyntaxKind::CompositionType);
   assert(Tok.isContextualPunctuator("&"));
   do {
-    if (SyntaxContext->isEnabled()) {
-      auto Type = SyntaxContext->popIf<ParsedTypeSyntax>();
-      consumeToken(); // consume '&'
-      if (Type) {
-        ParsedCompositionTypeElementSyntaxBuilder Builder(*SyntaxContext);
-        auto Ampersand = SyntaxContext->popToken();
-        Builder
-          .useAmpersand(Ampersand)
-          .useType(Type.getValue());
-        SyntaxContext->addSyntax(Builder.build());
-      }
-    } else {
-      consumeToken(); // consume '&'
+    auto Type = SyntaxContext->popIf<ParsedTypeSyntax>();
+    consumeToken(); // consume '&'
+    if (Type) {
+      ParsedCompositionTypeElementSyntaxBuilder Builder(*SyntaxContext);
+      auto Ampersand = SyntaxContext->popToken();
+      Builder
+        .useAmpersand(Ampersand)
+        .useType(Type.getValue());
+      SyntaxContext->addSyntax(Builder.build());
     }
-    
+
     // Diagnose invalid `some` after an ampersand.
     if (Context.LangOpts.EnableOpaqueResultTypes
         && Tok.is(tok::identifier)
@@ -786,12 +778,10 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     addType(ty.getPtrOrNull());
   } while (Tok.isContextualPunctuator("&"));
 
-  if (SyntaxContext->isEnabled()) {
-    if (auto synType = SyntaxContext->popIf<ParsedTypeSyntax>()) {
-      auto LastNode = ParsedSyntaxRecorder::makeCompositionTypeElement(
-          synType.getValue(), None, *SyntaxContext);
-      SyntaxContext->addSyntax(LastNode);
-    }
+  if (auto synType = SyntaxContext->popIf<ParsedTypeSyntax>()) {
+    auto LastNode = ParsedSyntaxRecorder::makeCompositionTypeElement(
+        synType.getValue(), None, *SyntaxContext);
+    SyntaxContext->addSyntax(LastNode);
   }
   SyntaxContext->collectNodesInPlace(SyntaxKind::CompositionTypeElementList);
   
@@ -1198,35 +1188,31 @@ SyntaxParserResult<ParsedTypeSyntax, TypeRepr> Parser::parseTypeCollection() {
     // Form the dictionary type.
     TyR = new (Context)
         DictionaryTypeRepr(firstTy.get(), secondTy.get(), colonLoc, brackets);
-    if (SyntaxContext->isEnabled()) {
-      ParsedDictionaryTypeSyntaxBuilder Builder(*SyntaxContext);
-      auto RightSquareBracket = SyntaxContext->popToken();
-      auto ValueType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
-      auto Colon = SyntaxContext->popToken();
-      auto KeyType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
-      auto LeftSquareBracket = SyntaxContext->popToken();
-      Builder
-        .useRightSquareBracket(RightSquareBracket)
-        .useValueType(ValueType)
-        .useColon(Colon)
-        .useKeyType(KeyType)
-        .useLeftSquareBracket(LeftSquareBracket);
-      SyntaxNode.emplace(Builder.build());
-    }
+    ParsedDictionaryTypeSyntaxBuilder Builder(*SyntaxContext);
+    auto RightSquareBracket = SyntaxContext->popToken();
+    auto ValueType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    auto Colon = SyntaxContext->popToken();
+    auto KeyType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    auto LeftSquareBracket = SyntaxContext->popToken();
+    Builder
+      .useRightSquareBracket(RightSquareBracket)
+      .useValueType(ValueType)
+      .useColon(Colon)
+      .useKeyType(KeyType)
+      .useLeftSquareBracket(LeftSquareBracket);
+    SyntaxNode.emplace(Builder.build());
   } else {
     // Form the array type.
     TyR = new (Context) ArrayTypeRepr(firstTy.get(), brackets);
-    if (SyntaxContext->isEnabled()) {
-      ParsedArrayTypeSyntaxBuilder Builder(*SyntaxContext);
-      auto RightSquareBracket = SyntaxContext->popToken();
-      auto ElementType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
-      auto LeftSquareBracket = SyntaxContext->popToken();
-      Builder
-        .useRightSquareBracket(RightSquareBracket)
-        .useElementType(ElementType)
-        .useLeftSquareBracket(LeftSquareBracket);
-      SyntaxNode.emplace(Builder.build());
-    }
+    ParsedArrayTypeSyntaxBuilder Builder(*SyntaxContext);
+    auto RightSquareBracket = SyntaxContext->popToken();
+    auto ElementType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    auto LeftSquareBracket = SyntaxContext->popToken();
+    Builder
+      .useRightSquareBracket(RightSquareBracket)
+      .useElementType(ElementType)
+      .useLeftSquareBracket(LeftSquareBracket);
+    SyntaxNode.emplace(Builder.build());
   }
     
   return makeSyntaxResult(Status, SyntaxNode, TyR);
@@ -1279,18 +1265,16 @@ Parser::parseTypeOptional(TypeRepr *base) {
   SourceLoc questionLoc = consumeOptionalToken();
   auto TyR = new (Context) OptionalTypeRepr(base, questionLoc);
   llvm::Optional<ParsedTypeSyntax> SyntaxNode;
-  if (SyntaxContext->isEnabled()) {
-    auto QuestionMark = SyntaxContext->popToken();
-    if (auto WrappedType = SyntaxContext->popIf<ParsedTypeSyntax>()) {
-      ParsedOptionalTypeSyntaxBuilder Builder(*SyntaxContext);
-      Builder
-        .useQuestionMark(QuestionMark)
-        .useWrappedType(WrappedType.getValue());
-      SyntaxNode.emplace(Builder.build());
-    } else {
-      // Undo the popping of the question mark
-      SyntaxContext->addSyntax(QuestionMark);
-    }
+  auto QuestionMark = SyntaxContext->popToken();
+  if (auto WrappedType = SyntaxContext->popIf<ParsedTypeSyntax>()) {
+    ParsedOptionalTypeSyntaxBuilder Builder(*SyntaxContext);
+    Builder
+      .useQuestionMark(QuestionMark)
+      .useWrappedType(WrappedType.getValue());
+    SyntaxNode.emplace(Builder.build());
+  } else {
+    // Undo the popping of the question mark
+    SyntaxContext->addSyntax(QuestionMark);
   }
   return makeSyntaxResult(SyntaxNode, TyR);
 }
@@ -1303,15 +1287,13 @@ Parser::parseTypeImplicitlyUnwrappedOptional(TypeRepr *base) {
   auto TyR =
       new (Context) ImplicitlyUnwrappedOptionalTypeRepr(base, exclamationLoc);
   llvm::Optional<ParsedTypeSyntax> SyntaxNode;
-  if (SyntaxContext->isEnabled()) {
-    ParsedImplicitlyUnwrappedOptionalTypeSyntaxBuilder Builder(*SyntaxContext);
-    auto ExclamationMark = SyntaxContext->popToken();
-    auto WrappedType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
-    Builder
-      .useExclamationMark(ExclamationMark)
-      .useWrappedType(WrappedType);
-    SyntaxNode.emplace(Builder.build());
-  }
+  ParsedImplicitlyUnwrappedOptionalTypeSyntaxBuilder Builder(*SyntaxContext);
+  auto ExclamationMark = SyntaxContext->popToken();
+  auto WrappedType = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+  Builder
+    .useExclamationMark(ExclamationMark)
+    .useWrappedType(WrappedType);
+  SyntaxNode.emplace(Builder.build());
   return makeSyntaxResult(SyntaxNode, TyR);
 }
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -168,8 +168,57 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
   }
   return Parsed${node.name}(std::move(raw));
 }
+%   elif node.is_unknown():
+Parsed${node.name}
+ParsedSyntaxRecorder::record${node.syntax_kind}(
+    ArrayRef<ParsedSyntax> elements,
+    ParsedRawSyntaxRecorder &rec) {
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.getRaw());
+  }
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
+  return Parsed${node.name}(std::move(raw));
+}
+
+Parsed${node.name}
+ParsedSyntaxRecorder::defer${node.syntax_kind}(
+    ArrayRef<ParsedSyntax> elements,
+    SyntaxParsingContext &SPCtx) {
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.getRaw());
+  }
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
+  return Parsed${node.name}(std::move(raw));
+}
+
+Parsed${node.name}
+ParsedSyntaxRecorder::make${node.syntax_kind}(
+    ArrayRef<ParsedSyntax> elements,
+    SyntaxParsingContext &SPCtx) {
+  if (SPCtx.isBacktracking())
+    return defer${node.syntax_kind}(elements, SPCtx);
+  return record${node.syntax_kind}(elements, SPCtx.getRecorder());
+}
 %   end
 % end
+
+ParsedTokenSyntax
+ParsedSyntaxRecorder::makeToken(const Token &Tok,
+                                const ParsedTrivia &LeadingTrivia,
+                                const ParsedTrivia &TrailingTrivia,
+                                SyntaxParsingContext &SPCtx) {
+  ParsedRawSyntaxNode raw;
+  if (SPCtx.isBacktracking()) {
+    raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTrivia, TrailingTrivia, SPCtx);
+  } else {
+    raw = SPCtx.getRecorder().recordToken(Tok, LeadingTrivia, TrailingTrivia);
+  }
+  return ParsedTokenSyntax(std::move(raw));
+}
 
 ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -26,11 +26,15 @@
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
 #include "swift/Parse/DelayedParsingCallbacks.h"
+#include "swift/Parse/ParsedSyntaxNodes.h"
+#include "swift/Parse/ParsedSyntaxRecorder.h"
 #include "swift/Parse/ParseSILSupport.h"
 #include "swift/Parse/SyntaxParseActions.h"
 #include "swift/Parse/SyntaxParsingContext.h"
+#include "swift/Parse/HiddenLibSyntaxAction.h"
 #include "swift/Syntax/RawSyntax.h"
 #include "swift/Syntax/TokenSyntax.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -141,7 +145,7 @@ private:
     unsigned BufferID = SourceMgr.findBufferContainingLoc(AFD->getLoc());
     Parser TheParser(BufferID, SF, nullptr, &ParserState, nullptr,
                      /*DelayBodyParsing=*/false);
-    TheParser.SyntaxContext->disable();
+    TheParser.SyntaxContext->setDiscard();
     std::unique_ptr<CodeCompletionCallbacks> CodeCompletion;
     if (CodeCompletionFactory) {
       CodeCompletion.reset(
@@ -168,10 +172,7 @@ static void parseDelayedDecl(
     SourceMgr.findBufferContainingLoc(ParserState.getDelayedDeclLoc());
   Parser TheParser(BufferID, SF, nullptr, &ParserState, nullptr,
                    /*DelayBodyParsing=*/false);
-
-  // Disable libSyntax creation in the delayed parsing.
-  TheParser.SyntaxContext->disable();
-
+  TheParser.SyntaxContext->setDiscard();
   std::unique_ptr<CodeCompletionCallbacks> CodeCompletion;
   if (CodeCompletionFactory) {
     CodeCompletion.reset(
@@ -518,9 +519,16 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     TokReceiver(SF.shouldCollectToken() ?
                 new TokenRecorder(SF) :
                 new ConsumeTokenReceiver()),
-    SyntaxContext(new SyntaxParsingContext(SyntaxContext, SF,
-                                           L->getBufferID(),
-                                           std::move(SPActions))) {
+    SyntaxContext(new SyntaxParsingContext(
+                    SyntaxContext, SF, L->getBufferID(),
+                    std::make_shared<HiddenLibSyntaxAction>(
+                        SPActions,
+                        std::make_shared<SyntaxTreeCreator>(
+                            SF.getASTContext().SourceMgr,
+                            L->getBufferID(),
+                            SF.SyntaxParsingCache,
+                            SF.getASTContext().getSyntaxArena())))),
+    Transformer(SF.getASTContext()) {
   State = PersistentState;
   if (!State) {
     OwnedState.reset(new PersistentParserState(Context));
@@ -573,6 +581,19 @@ SourceLoc Parser::consumeToken() {
   TokReceiver->receive(Tok);
   SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
   return consumeTokenWithoutFeedingReceiver();
+}
+
+ParsedTokenSyntax Parser::consumeTokenSyntax() {
+  TokReceiver->receive(Tok);
+  ParsedTokenSyntax ParsedToken = ParsedSyntaxRecorder::makeToken(
+      Tok, LeadingTrivia, TrailingTrivia, *SyntaxContext);
+
+  // todo [gsoc]: remove when possible
+  // todo [gsoc]: handle backtracking properly
+  Transformer.pushLoc(Tok.getLoc());
+
+  consumeTokenWithoutFeedingReceiver();
+  return ParsedToken;
 }
 
 SourceLoc Parser::getEndOfPreviousLoc() {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -528,7 +528,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
                             L->getBufferID(),
                             SF.SyntaxParsingCache,
                             SF.getASTContext().getSyntaxArena())))),
-    Transformer(SF.getASTContext()) {
+    Generator(SF.getASTContext()) {
   State = PersistentState;
   if (!State) {
     OwnedState.reset(new PersistentParserState(Context));
@@ -590,7 +590,7 @@ ParsedTokenSyntax Parser::consumeTokenSyntax() {
 
   // todo [gsoc]: remove when possible
   // todo [gsoc]: handle backtracking properly
-  Transformer.pushLoc(Tok.getLoc());
+  Generator.pushLoc(Tok.getLoc());
 
   consumeTokenWithoutFeedingReceiver();
   return ParsedToken;

--- a/lib/Parse/SyntaxTransformer.cpp
+++ b/lib/Parse/SyntaxTransformer.cpp
@@ -1,0 +1,152 @@
+//===--- SyntaxTransformer.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/SyntaxTransformer.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+IntegerLiteralExpr *
+SyntaxTransformer::transform(IntegerLiteralExprSyntax &Expr) {
+  TokenSyntax Digits = Expr.getDigits();
+  StringRef Text = copyAndStripUnderscores(Digits.getText());
+  SourceLoc Loc = topLoc();
+  return new (Context) IntegerLiteralExpr(Text, Loc);
+}
+
+FloatLiteralExpr *SyntaxTransformer::transform(FloatLiteralExprSyntax &Expr) {
+  TokenSyntax FloatingDigits = Expr.getFloatingDigits();
+  StringRef Text = copyAndStripUnderscores(FloatingDigits.getText());
+  SourceLoc Loc = topLoc();
+  return new (Context) FloatLiteralExpr(Text, Loc);
+}
+
+NilLiteralExpr *SyntaxTransformer::transform(NilLiteralExprSyntax &Expr) {
+  TokenSyntax Nil = Expr.getNilKeyword();
+  SourceLoc Loc = topLoc();
+  return new (Context) NilLiteralExpr(Loc);
+}
+
+BooleanLiteralExpr *
+SyntaxTransformer::transform(BooleanLiteralExprSyntax &Expr) {
+  TokenSyntax Literal = Expr.getBooleanLiteral();
+  bool Value = Literal.getTokenKind() == tok::kw_true;
+  SourceLoc Loc = topLoc();
+  return new (Context) BooleanLiteralExpr(Value, Loc);
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transform(PoundFileExprSyntax &Expr) {
+  return transformMagicIdentifierLiteralExpr(Expr.getPoundFile());
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transform(PoundLineExprSyntax &Expr) {
+  return transformMagicIdentifierLiteralExpr(Expr.getPoundLine());
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transform(PoundColumnExprSyntax &Expr) {
+  return transformMagicIdentifierLiteralExpr(Expr.getPoundColumn());
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transform(PoundFunctionExprSyntax &Expr) {
+  return transformMagicIdentifierLiteralExpr(Expr.getPoundFunction());
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transform(PoundDsohandleExprSyntax &Expr) {
+  return transformMagicIdentifierLiteralExpr(Expr.getPoundDsohandle());
+}
+
+Expr* SyntaxTransformer::transform(UnknownExprSyntax& Expr) {
+  if (Expr.getNumChildren() == 1 && Expr.getChild(0)->isToken()) {
+    Syntax Token = *Expr.getChild(0);
+    tok Kind = Token.getRaw()->getTokenKind();
+    switch (Kind) {
+    case tok::kw___FILE__:
+    case tok::kw___LINE__:
+    case tok::kw___COLUMN__:
+    case tok::kw___FUNCTION__:
+    case tok::kw___DSO_HANDLE__: {
+      auto MagicKind = getMagicIdentifierLiteralKind(Kind);
+      SourceLoc Loc = topLoc();
+      return new (Context) MagicIdentifierLiteralExpr(MagicKind, Loc);
+    }
+    default:
+      return nullptr;
+    }
+  }
+  return nullptr;
+}
+
+void SyntaxTransformer::pushLoc(SourceLoc Loc) {
+  LocStack.push_back(Loc);
+}
+
+StringRef SyntaxTransformer::copyAndStripUnderscores(StringRef Orig,
+                                                     ASTContext &Context) {
+  char *start = static_cast<char *>(Context.Allocate(Orig.size(), 1));
+  char *p = start;
+
+  if (p) {
+    for (char c : Orig) {
+      if (c != '_') {
+        *p++ = c;
+      }
+    }
+  }
+
+  return StringRef(start, p - start);
+}
+
+StringRef SyntaxTransformer::copyAndStripUnderscores(StringRef Orig) {
+  return copyAndStripUnderscores(Orig, Context);
+}
+
+SourceLoc SyntaxTransformer::topLoc() {
+  // todo [gsoc]: create SourceLoc by pointing the offset of Syntax node into
+  // the source buffer
+  return LocStack.back();
+}
+
+MagicIdentifierLiteralExpr *
+SyntaxTransformer::transformMagicIdentifierLiteralExpr(
+    const TokenSyntax &PoundToken) {
+  auto Kind = getMagicIdentifierLiteralKind(PoundToken.getTokenKind());
+  SourceLoc Loc = topLoc();
+  return new (Context) MagicIdentifierLiteralExpr(Kind, Loc);
+}
+
+MagicIdentifierLiteralExpr::Kind
+SyntaxTransformer::getMagicIdentifierLiteralKind(tok Kind) {
+  switch (Kind) {
+  case tok::kw___COLUMN__:
+  case tok::pound_column:
+    return MagicIdentifierLiteralExpr::Kind::Column;
+  case tok::kw___FILE__:
+  case tok::pound_file:
+    return MagicIdentifierLiteralExpr::Kind::File;
+  case tok::kw___FUNCTION__:
+  case tok::pound_function:
+    return MagicIdentifierLiteralExpr::Kind::Function;
+  case tok::kw___LINE__:
+  case tok::pound_line:
+    return MagicIdentifierLiteralExpr::Kind::Line;
+  case tok::kw___DSO_HANDLE__:
+  case tok::pound_dsohandle:
+    return MagicIdentifierLiteralExpr::Kind::DSOHandle;
+  default:
+    llvm_unreachable("not a magic literal");
+  }
+}

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -156,6 +156,13 @@ static bool parseIntoSourceFileImpl(SourceFile &SF,
     *Done = P.Tok.is(tok::eof);
   } while (FullParse && !*Done);
 
+  if (!FullParse && !*Done) {
+    // Only parsed a part of the source file.
+    // Add artificial EOF to be able to finalize the tree.
+    P.SyntaxContext->addRawSyntax(
+      ParsedRawSyntaxNode::makeDeferredMissing(tok::eof, P.Tok.getLoc()));
+  }
+
   if (STreeCreator) {
     auto rawNode = P.finalizeSyntaxTree();
     STreeCreator->acceptSyntaxRoot(rawNode.getOpaqueNode(), SF);

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -39,9 +39,7 @@ bool isTokenTextDetermined(tok kind) {
 }
 
 StringRef getTokenText(tok kind) {
-  auto text = getTokenTextInternal(kind);
-  assert(!text.empty() && "token kind cannot be determined");
-  return text;
+  return getTokenTextInternal(kind);
 }
 
 bool parserShallOmitWhenNoChildren(syntax::SyntaxKind Kind) {

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -155,6 +155,7 @@ private:
     node.present = true;
   }
 
+public:
   OpaqueSyntaxNode recordToken(tok tokenKind,
                                ArrayRef<ParsedTriviaPiece> leadingTrivia,
                                ArrayRef<ParsedTriviaPiece> trailingTrivia,
@@ -200,6 +201,10 @@ private:
     assert(ckind == numValue && "syntax kind value is too large");
     auto result = NodeLookup(lexerOffset, ckind);
     return {result.length, result.node};
+  }
+
+  OpaqueSyntaxNodeKind getOpaqueKind() override {
+    return OpaqueSyntaxNodeKind::SwiftSyntax;
   }
 };
 


### PR DESCRIPTION
Instead of creating the AST directly in the parser (and libSyntax or SwiftSyntax via SyntaxParsingContext), make Parser to explicitly create a tree of ParsedSyntaxNodes. Their OpaqueSyntaxNodes can be either libSyntax or SwiftSyntax. If AST is needed, it can be generated from the libSyntax tree.
This PR contains the infrastructure to achieve the goal in an incremental way and also refactored literal parsing.

This PR is a part of a Google Summer of Code 2019 [project](https://swift.org/gsoc2019/#integration-of-libsyntax-with-the-rest-of-the-compiler-pipeline).