### PR TITLE
[5.1] [CodeSynthesis] Reset TypeLoc when synthesizing overridden designated inits

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2476,6 +2476,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
     auto paramTy = decl->getInterfaceType();
     auto substTy = paramTy.subst(subMap);
     decl->setInterfaceType(substTy);
+    decl->getTypeLoc() = TypeLoc::withoutLoc(substTy);
   }
 
   // Create the initializer declaration, inheriting the name,

--- a/test/ParseableInterface/default-args.swift
+++ b/test/ParseableInterface/default-args.swift
@@ -28,7 +28,7 @@ public class Derived: Base {
   }
 
   // CHECK-NOT: init(convInit: Int = super)
-  // CHECK: override {{(public )?}}init(x: Int = super)
+  // CHECK: override {{(public )?}}init(x: {{(Swift.)?}}Int = super)
   // CHECK-NOT: init(convInit: Int = super)
 }
 

--- a/test/ParseableInterface/inherited-generic-parameters.swift
+++ b/test/ParseableInterface/inherited-generic-parameters.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// RUN: %target-build-swift %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// RUN: %target-build-swift %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -wmo
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// This test makes sure that we substitute uses of the superclass's generic
+// parameters when we inherit initializers.
+
+// CHECK: public class Base<In, Out> {
+public class Base<In, Out> {
+// CHECK-NEXT: public init(x: @escaping (In) -> Out)
+  public init(x: @escaping (In) -> Out) {}
+// CHECK: }
+}
+
+// CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
+public class Derived<T> : Base<T, T> {
+// CHECK-NEXT: override public init(x: @escaping (T) -> T)
+// CHECK: }
+}
+

--- a/test/ParseableInterface/modifiers.swift
+++ b/test/ParseableInterface/modifiers.swift
@@ -69,7 +69,7 @@ public class Base {
 // CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
 public class SubImplicit: Base {
   // CHECK-NEXT: @objc override public init(){{$}}
-  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 


### PR DESCRIPTION
Previously, we'd clone the superclass's initializer and update its
interface type, but we didn't reset the TypeLoc. This meant the
synthesized overridden initializer's parameter typeLocs would still be in
the parent decl context, which caused the ASTPrinter to print the
unsubstituted type.

rdar://50914733

Reviewed by @jrose-apple and @slavapestov