### PR TITLE
[Doc] Added instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ more environments.
 
 To build using Ninja, run:
 
+    cd swift
     utils/build-script --release-debuginfo
 
 When developing Swift, it helps to build what you're working on in a debug


### PR DESCRIPTION
**Description**

Hi! I recently went through the build process described in the README, and found that telling the user to change into the swift directory could be helpful. 

The build instructions [start by putting the user in a swift-source directory](https://github.com/apple/swift#getting-sources-for-swift-and-related-projects) (and has the user run a script where the path goes into the `swift` directory, in the Via HTTPS and Via SSH section), but the next section for [Building Swift](https://github.com/apple/swift#getting-sources-for-swift-and-related-projects) has the user using scripts from the `utils` folder without telling them to switch into the `swift` directory (or prefixing `swift/` to the commands).

This is a tiny bit of documentation change for hopefully a bit more clear instructions. 