### PR TITLE
[Documentation] Updated README to specify 'swift' directory for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,27 +141,26 @@ more environments.
 
 To build using Ninja, run:
 
-    cd swift
-    utils/build-script --release-debuginfo
+    swift/utils/build-script --release-debuginfo
 
 When developing Swift, it helps to build what you're working on in a debug
 configuration while building the rest of the project with optimizations. Below
 are some examples of using debug variants:
 
-    utils/build-script --release-debuginfo --debug-swift # Swift frontend built in debug
-    utils/build-script --release-debuginfo --debug-swift-stdlib # Standard library built in debug
-    utils/build-script --release-debuginfo --debug-swift --force-optimized-typechecker # Swift frontend sans type checker built in debug
+    swift/utils/build-script --release-debuginfo --debug-swift # Swift frontend built in debug
+    swift/utils/build-script --release-debuginfo --debug-swift-stdlib # Standard library built in debug
+    swift/utils/build-script --release-debuginfo --debug-swift --force-optimized-typechecker # Swift frontend sans type checker built in debug
 
 Limiting the amount of debug code in the compiler has a very large impact on
 Swift compile times, and in turn the test execution time. If you want to build
 the entire project in debug, you can run:
 
-    utils/build-script --debug
+    swift/utils/build-script --debug
 
 For documentation of all available arguments, as well as additional usage
 information, see the inline help:
 
-    utils/build-script -h
+    swift/utils/build-script -h
 
 #### Xcode
 
@@ -224,7 +223,7 @@ script is used by swift.org's CI to produce snapshots and can allow for one to
 locally reproduce such builds for development or distribution purposes. E.x.:
 
 ```
-  $ ./utils/build-toolchain $BUNDLE_PREFIX
+  $ ./swift/utils/build-toolchain $BUNDLE_PREFIX
 ```
 
 where ``$BUNDLE_PREFIX`` is a string that will be prepended to the build 


### PR DESCRIPTION
In a [previous PR](https://github.com/apple/swift/pull/25195), the README was updated to add a command to `cd swift` since a few other commands were based off of being in the `swift` folder. 

However, after the PR was merged, @gottesmm requested that instead of asking the user to go to to the `swift` directory, the proposed workflow was for the user to stay and the `swift-sources` directory and call commands from there.

As such, this current PR removes the line telling the user to `cd swift` and instead adds `swift/` in front of the appropriate commands in the README. 