### PR TITLE
[5.1] -build-module-from-parseable-interface: Don't make an extra ASTContext

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -535,6 +535,7 @@ private:
   }
 
   bool setUpInputs();
+  bool setUpASTContextIfNeeded();
   Optional<unsigned> setUpCodeCompletionBuffer();
 
   /// Set up all state in the CompilerInstance to process the given input file.

--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -116,6 +116,9 @@ namespace unittest {
 
 namespace swift {
 
+  class LangOptions;
+  class SearchPathOptions;
+
 /// A ModuleLoader that runs a subordinate \c CompilerInvocation and
 /// \c CompilerInstance to convert .swiftinterface files to .swiftmodule
 /// files on the fly, caching the resulting .swiftmodules in the module cache
@@ -162,10 +165,11 @@ public:
   /// Unconditionally build \p InPath (a swiftinterface file) to \p OutPath (as
   /// a swiftmodule file).
   ///
-  /// A simplified version of the core logic in #openModuleFiles, mostly for
-  /// testing purposes.
+  /// A simplified version of the core logic in #openModuleFiles.
   static bool buildSwiftModuleFromSwiftInterface(
-    ASTContext &Ctx, StringRef CacheDir, StringRef PrebuiltCacheDir,
+    SourceManager &SourceMgr, DiagnosticEngine &Diags,
+    const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
+    StringRef CacheDir, StringRef PrebuiltCacheDir,
     StringRef ModuleName, StringRef InPath, StringRef OutPath,
     bool SerializeDependencyHashes, bool TrackSystemDependencies,
     bool RemarkOnRebuildFromInterface);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -175,6 +175,26 @@ void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
     recordPrimaryInputBuffer(SF->getBufferID().getValue());
 }
 
+bool CompilerInstance::setUpASTContextIfNeeded() {
+  if (Invocation.getFrontendOptions().RequestedAction ==
+      FrontendOptions::ActionType::CompileModuleFromInterface) {
+    // Compiling a module interface from source uses its own CompilerInstance
+    // with options read from the input file. Don't bother setting up an
+    // ASTContext at this level.
+    return false;
+  }
+
+  Context.reset(ASTContext::get(Invocation.getLangOptions(),
+                                Invocation.getSearchPathOptions(), SourceMgr,
+                                Diagnostics));
+  registerTypeCheckerRequestFunctions(Context->evaluator);
+
+  if (setUpModuleLoaders())
+    return true;
+
+  return false;
+}
+
 bool CompilerInstance::setup(const CompilerInvocation &Invok) {
   Invocation = Invok;
 
@@ -196,20 +216,18 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     Invocation.getLangOptions().AttachCommentsToDecls = true;
   }
 
-  Context.reset(ASTContext::get(Invocation.getLangOptions(),
-                                Invocation.getSearchPathOptions(), SourceMgr,
-                                Diagnostics));
-  registerTypeCheckerRequestFunctions(Context->evaluator);
-
-  if (setUpModuleLoaders())
-    return true;
-
   assert(Lexer::isIdentifier(Invocation.getModuleName()));
 
   if (isInSILMode())
     Invocation.getLangOptions().EnableAccessControl = false;
 
-  return setUpInputs();
+  if (setUpInputs())
+    return true;
+
+  if (setUpASTContextIfNeeded())
+    return true;
+
+  return false;
 }
 
 static bool loadAndValidateVFSOverlay(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -599,7 +599,9 @@ static bool buildModuleFromParseableInterface(CompilerInvocation &Invocation,
   StringRef InputPath = FEOpts.InputsAndOutputs.getFilenameOfFirstInput();
   StringRef PrebuiltCachePath = FEOpts.PrebuiltModuleCachePath;
   return ParseableInterfaceModuleLoader::buildSwiftModuleFromSwiftInterface(
-      Instance.getASTContext(), Invocation.getClangModuleCachePath(),
+      Instance.getSourceMgr(), Instance.getDiags(),
+      Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
+      Invocation.getClangModuleCachePath(),
       PrebuiltCachePath, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,

--- a/test/ParseableInterface/NoWrongSDKWarning.swiftinterface
+++ b/test/ParseableInterface/NoWrongSDKWarning.swiftinterface
@@ -1,0 +1,13 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9
+
+// Deliberately pass the wrong target at the command line and see what happens.
+// RUN: %empty-directory(%t)
+// RUN: %swift -sdk %sdk -target arm64-apple-ios10 -build-module-from-parseable-interface %s -o %t/NoWrongSDKWarning.swiftmodule 2>&1 | %FileCheck -allow-empty %s
+
+// REQUIRES: OS=macosx
+
+public func empty()
+
+// CHECK-NOT: warning:
+// CHECK-NOT: error:


### PR DESCRIPTION
Cherry-pick of #25185 to the 5.1 branch. Reviewed by @nathawes and @harlanhaskins.