### PR TITLE
MSVC: litter the code with `llvm_unreachable` (NFC)

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -102,6 +102,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       return ApplySite(cast<PartialApplyInst>(node));
     }
+    llvm_unreachable("covered switch");
   }
 
   ApplySiteKind getKind() const { return ApplySiteKind(Inst->getKind()); }
@@ -126,6 +127,7 @@ public:
     case ApplySiteKind::TryApplyInst:                                          \
       return cast<TryApplyInst>(Inst)->OPERATION;                              \
     }                                                                          \
+    llvm_unreachable("covered switch");                                        \
   } while (0)
 
   /// Return the callee operand.
@@ -293,6 +295,7 @@ public:
       // apply pa2(a)
       return getSubstCalleeConv().getNumSILArguments() - getNumArguments();
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return the callee's function argument index corresponding to the given
@@ -325,6 +328,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       llvm_unreachable("unhandled case");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return the applied 'self' argument value.
@@ -339,6 +343,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       llvm_unreachable("unhandled case");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return the 'self' apply operand.
@@ -353,6 +358,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       llvm_unreachable("Unhandled cast");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return a list of applied arguments without self.
@@ -367,6 +373,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       llvm_unreachable("Unhandled case");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return whether the given apply is of a formally-throwing function
@@ -466,6 +473,7 @@ public:
     case FullApplySiteKind::TryApplyInst:
       return FullApplySite(cast<TryApplyInst>(node));
     }
+    llvm_unreachable("covered switch");
   }
 
   FullApplySiteKind getKind() const {

--- a/include/swift/SIL/Consumption.h
+++ b/include/swift/SIL/Consumption.h
@@ -66,6 +66,7 @@ inline bool shouldDestroyOnFailure(CastConsumptionKind kind) {
   case CastConsumptionKind::BorrowAlways:
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Should the source value be taken if the cast succeeds?
@@ -78,6 +79,7 @@ inline IsTake_t shouldTakeOnSuccess(CastConsumptionKind kind) {
   case CastConsumptionKind::BorrowAlways:
     return IsNotTake;
   }
+  llvm_unreachable("covered switch");
 }
 
 } // end namespace swift

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -198,6 +198,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   CastConsumptionKind getConsumptionKind() const {
@@ -226,6 +227,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   Optional<ProfileCounter> getSuccessBlockCount() {
@@ -242,6 +244,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   const SILBasicBlock *getSuccessBlock() const {
@@ -262,6 +265,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   Optional<ProfileCounter> getFailureBlockCount() {
@@ -278,6 +282,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   const SILBasicBlock *getFailureBlock() const {
@@ -299,6 +304,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   // Returns the success value.
@@ -320,6 +326,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unimplemented");
     }
+    llvm_unreachable("covered switch");
   }
 
   CanType getSourceType() const {
@@ -337,6 +344,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   SILType getLoweredSourceType() const {
@@ -371,6 +379,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unimplemented");
     }
+    llvm_unreachable("covered switch");
   }
 
   SILType getLoweredTargetType() const {
@@ -391,6 +400,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   bool isSourceTypeExact() const {
@@ -404,6 +414,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   SILLocation getLocation() const { return inst->getLoc(); }
@@ -475,6 +486,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       llvm_unreachable("unsupported");
     }
+    llvm_unreachable("covered switch");
   }
 
   bool canUseScalarCheckedCastInstructions() const {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -239,6 +239,7 @@ public:
       return value == other.value
              && getElementIndex() == other.getElementIndex();
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return true if the storage is guaranteed local.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -174,6 +174,7 @@ struct ValueOwnershipKind {
     case ValueOwnershipKind::Owned:
       return UseLifetimeConstraint::MustBeInvalidated;
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Returns true if \p Other can be merged successfully with this, implying

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4470,6 +4470,7 @@ VarDecl *VarDecl::getOriginalWrappedProperty(
   case PropertyWrapperSynthesizedPropertyKind::StorageWrapper:
     return this == wrapperInfo.storageWrapperVar ? original : nullptr;
   }
+  llvm_unreachable("covered switch");
 }
 
 void VarDecl::setOriginalWrappedProperty(VarDecl *originalProperty) {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -428,6 +428,7 @@ getParameterConvention(ImplParameterConvention conv) {
   case Demangle::ImplParameterConvention::Direct_Guaranteed:
     return ParameterConvention::Direct_Guaranteed;
   }
+  llvm_unreachable("covered switch");
 }
 
 static ResultConvention getResultConvention(ImplResultConvention conv) {
@@ -443,6 +444,7 @@ static ResultConvention getResultConvention(ImplResultConvention conv) {
   case Demangle::ImplResultConvention::Autoreleased:
     return ResultConvention::Autoreleased;
   }
+  llvm_unreachable("covered switch");
 }
 
 Type ASTBuilder::createImplFunctionType(
@@ -539,6 +541,7 @@ getMetatypeRepresentation(ImplMetatypeRepresentation repr) {
   case Demangle::ImplMetatypeRepresentation::ObjC:
     return MetatypeRepresentation::ObjC;
   }
+  llvm_unreachable("covered switch");
 }
 
 Type ASTBuilder::createExistentialMetatypeType(Type instance,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6472,6 +6472,7 @@ bool AbstractFunctionDecl::hasInlinableBodyText() const {
   case BodyKind::MemberwiseInitializer:
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 
 StringRef AbstractFunctionDecl::getInlinableBodyText(

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -207,6 +207,7 @@ FileSpecificDiagnosticConsumer::findSubconsumer(
   case DiagnosticKind::Note:
     return SubconsumerForSubsequentNotes;
   }
+  llvm_unreachable("covered switch");
 }
 
 Optional<FileSpecificDiagnosticConsumer::Subconsumer *>

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -159,6 +159,7 @@ getDynamicCastArguments(IRGenFunction &IGF,
     return llvm::makeArrayRef(argsBuf, n-3);
     break;
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Emit a checked unconditional downcast of a class value.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1721,6 +1721,7 @@ namespace {
       case SILLinkage::PublicNonABI:
         return false;
       }
+      llvm_unreachable("covered switch");
     }
     
     GenericSignature *getGenericSignature() {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -356,6 +356,7 @@ static LexerMode sourceFileKindToLexerMode(SourceFileKind kind) {
     case swift::SourceFileKind::REPL:
       return LexerMode::Swift;
   }
+  llvm_unreachable("covered switch");
 }
 
 Parser::Parser(unsigned BufferID, SourceFile &SF, SILParserTUStateBase *SIL,

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -139,6 +139,7 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
   case RK_DerivedAddress:
     return Address;
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Clone this SymbolicValue into the specified ASTContext and return the new
@@ -179,6 +180,7 @@ SymbolicValue::cloneInto(SymbolicValueAllocator &allocator) const {
     return getAddress(newMemObject, accessPath, allocator);
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1372,6 +1372,7 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
 #include "swift/AST/AccessorKinds.def"
         llvm_unreachable("not an opaque accessor");
       }
+      llvm_unreachable("covered switch");
     }();
     if (!shouldEmit) return;
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -985,6 +985,7 @@ SILGenFunction::emitOpenExistential(
   case ExistentialRepresentation::None:
     llvm_unreachable("not existential");
   }
+  llvm_unreachable("covered switch");
 }
 
 ManagedValue SILGenFunction::manageOpaqueValue(ManagedValue value,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3240,6 +3240,7 @@ static ProtocolConformance *mapConformanceOutOfContext(
                .mapReplacementTypesOutOfContext());
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Map the given protocol conformance out of context, replacing archetypes

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1370,6 +1370,7 @@ getManagedSubobject(SILGenFunction &SGF, SILValue value,
   case CastConsumptionKind::TakeOnSuccess:
     return {SGF.emitManagedRValueWithCleanup(value, valueTL), consumption};
   }
+  llvm_unreachable("covered switch");
 }
 
 static ConsumableManagedValue
@@ -1539,6 +1540,7 @@ emitTupleDispatch(ArrayRef<RowToSpecialize> rows, ConsumableManagedValue src,
             "Borrow always can only occur along object only code paths");
       }
       }
+      llvm_unreachable("covered switch");
     }());
 
     // If we aren't loadable, add to the unforward array.

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -1048,6 +1048,7 @@ static bool canSpecializeFullApplySite(FullApplySiteKind kind) {
   case FullApplySiteKind::BeginApplyInst:
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 
 bool SILClosureSpecializerTransform::gatherCallSites(

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -310,6 +310,7 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
           case StoreOwnershipQualifier::Trivial:
             return PMOUseKind::InitOrAssign;
           }
+          llvm_unreachable("covered switch");
         })();
         Uses.emplace_back(si, kind);
         continue;

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -388,6 +388,7 @@ static bool isWrittenTo(SILFunction &f, SILValue value) {
   case AccessedStorage::Argument:
     return mayFunctionMutateArgument(storage, f);
   }
+  llvm_unreachable("covered switch");
 }
 
 // Convert a load [copy] from unique storage [read] that has all uses that can

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -636,6 +636,7 @@ static ApplySite replaceApplySite(SILBuilder &B, SILLocation Loc,
     return replacePartialApplyInst(B, Loc, OldPAI, NewFn, NewSubs, NewArgs);
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Delete an apply site that's been successfully devirtualized.

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -345,6 +345,7 @@ bool AllowInvalidInitRef::diagnose(Expr *root, bool asNote) const {
     return failure.diagnose(asNote);
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 AllowInvalidInitRef *AllowInvalidInitRef::dynamicOnMetatype(
@@ -478,6 +479,7 @@ bool AllowInvalidRefInKeyPath::diagnose(Expr *root, bool asNote) const {
     return failure.diagnose(asNote);
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 AllowInvalidRefInKeyPath *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -895,6 +895,7 @@ public:
     case RefKind::Method:
       return "allow reference to a method as a key path component";
     }
+    llvm_unreachable("covered switch");
   }
 
   bool diagnose(Expr *root, bool asNote = false) const override;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1998,6 +1998,7 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   case RequirementKind::Conformance:
     return MissingConformance::forRequirement(cs, type1, type2, reqLoc);
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Attempt to repair typing failures and record fixes if needed.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2035,6 +2035,7 @@ static Constraint *tryOptimizeGenericDisjunction(
   case Comparison::Unordered:
     return nullptr;
   }
+  llvm_unreachable("covered switch");
 }
 
 void ConstraintSystem::partitionDisjunction(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1181,6 +1181,7 @@ doesAccessorNeedDynamicAttribute(AccessorDecl *accessor, Evaluator &evaluator) {
       return isStorageDynamic(evaluator, accessor);
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 
 llvm::Expected<bool>

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -230,6 +230,7 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
       return None;
     }
     }
+    llvm_unreachable("covered switch");
   });
 }
 
@@ -474,6 +475,7 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
           return findTargetSpecificModuleFiles();
         }
         }
+        llvm_unreachable("covered switch");
       });
   return result.getValueOr(false);
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -522,6 +522,7 @@ static bool isValidProtocolMemberForTBDGen(const Decl *D) {
   case DeclKind::PostfixOperator:
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 #endif
 


### PR DESCRIPTION
Add `llvm_unreachable` to mark covered switches which MSVC does not
analyze correctly and believes that there exists a path through the
function without a return value.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
