### PR TITLE
[5.1] [SE-0258] More property wrapper fixes

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1110,7 +1110,7 @@ ERROR(numeric_literal_numeric_member,none,
 ERROR(standalone_dollar_identifier,none,
      "'$' is not an identifier; use backticks to escape it", ())
 ERROR(dollar_identifier_decl,none,
-     "'cannot declare entity named %0; the '$' prefix is reserved for "
+     "cannot declare entity named %0; the '$' prefix is reserved for "
      "implicitly-synthesized declarations", (Identifier))
 
 ERROR(anon_closure_arg_not_in_closure,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1110,7 +1110,8 @@ ERROR(numeric_literal_numeric_member,none,
 ERROR(standalone_dollar_identifier,none,
      "'$' is not an identifier; use backticks to escape it", ())
 ERROR(dollar_identifier_decl,none,
-     "cannot declare entity %0 with a '$' prefix", (Identifier))
+     "'cannot declare entity named %0; the '$' prefix is reserved for "
+     "implicitly-synthesized declarations", (Identifier))
 
 ERROR(anon_closure_arg_not_in_closure,none,
       "anonymous closure argument not contained in a closure", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4370,8 +4370,6 @@ ERROR(property_wrapper_type_requirement_not_accessible,none,
       "more restrictive access than its enclosing property wrapper type %3 "
       "(which is %select{private|fileprivate|internal|public|open}4)",
       (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
-ERROR(property_wrapper_reserved_name,none,
-      "property wrapper type name must start with an uppercase letter", ())
 
 ERROR(property_wrapper_attribute_not_on_property, none,
       "property wrapper attribute %0 can only be applied to a property",

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1559,7 +1559,7 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
                                                      VarDecl *var) const {
   // Determine the type of the backing property.
   auto wrapperType = var->getPropertyWrapperBackingPropertyType();
-  if (!wrapperType)
+  if (!wrapperType || wrapperType->hasError())
     return PropertyWrapperBackingPropertyInfo();
 
   auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -723,25 +723,6 @@ void TypeChecker::checkDeclAttributesEarly(Decl *D) {
   }
 }
 
-/// Determine whether the given string is an attribute name that is
-/// reserved for the implementation.
-static bool isReservedAttributeName(StringRef name) {
-  for (unsigned i : indices(name)) {
-    if (name[i] == '_')
-      continue;
-
-    // First character is lowercase; reserved.
-    if (clang::isLowercase(name[i]))
-      return true;
-
-    // Everything else is reserved.
-    return false;
-  }
-
-  // All underscores is reserved.
-  return true;
-}
-
 namespace {
 class AttributeChecker : public AttributeVisitor<AttributeChecker> {
   TypeChecker &TC;
@@ -2569,11 +2550,6 @@ void AttributeChecker::visitPropertyWrapperAttr(PropertyWrapperAttr *attr) {
 
   // Force checking of the property wrapper type.
   (void)nominal->getPropertyWrapperTypeInfo();
-
-  // Make sure the name isn't reserved.
-  if (isReservedAttributeName(nominal->getName().str())) {
-    nominal->diagnose(diag::property_wrapper_reserved_name);
-  }
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -62,10 +62,10 @@ func escapedDollarAnd() {
   `$abc` = 3
 }
 
-func $declareWithDollar() { // expected-error{{cannot declare entity '$declareWithDollar' with a '$' prefix}}
-  var $foo = 17 // expected-error{{cannot declare entity '$foo' with a '$' prefix}}
-  func $bar() { } // expected-error{{cannot declare entity '$bar' with a '$' prefix}}
+func $declareWithDollar() { // expected-error{{cannot declare entity named '$declareWithDollar'}}
+  var $foo = 17 // expected-error{{cannot declare entity named '$foo'}}
+  func $bar() { } // expected-error{{cannot declare entity named '$bar'}}
   func wibble(
-    $a: Int, // expected-error{{cannot declare entity '$a' with a '$' prefix}}
-    $b c: Int) { } // expected-error{{cannot declare entity '$b' with a '$' prefix}}
+    $a: Int, // expected-error{{cannot declare entity named '$a'}}
+    $b c: Int) { } // expected-error{{cannot declare entity named '$b'}}
 }

--- a/test/PlaygroundTransform/import_error.swift
+++ b/test/PlaygroundTransform/import_error.swift
@@ -2,4 +2,4 @@
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -typecheck -playground %t/main.swift -verify
 
-var $a = 2 // expected-error {{cannot declare entity '$a' with a '$' prefix}}
+var $a = 2 // expected-error {{cannot declare entity named '$a'}}

--- a/test/SourceKit/Sema/sema_playground.swift.response
+++ b/test/SourceKit/Sema/sema_playground.swift.response
@@ -11,7 +11,7 @@
     key.column: 5,
     key.filepath: sema_playground.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "cannot declare entity '$blah' with a '$' prefix",
+    key.description: "cannot declare entity named '$blah'; the '$' prefix is reserved for implicitly-synthesized declarations",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema
   }
 ]

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -108,7 +108,7 @@ struct InitialValueFailableIUO<Value> {
 // Property wrapper type definitions
 // ---------------------------------------------------------------------------
 @_propertyWrapper
-struct _lowercaseWrapper<T> { // expected-error{{property wrapper type name must start with an uppercase letter}}
+struct _lowercaseWrapper<T> {
   var value: T
 }
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -714,3 +714,20 @@ struct TestPD {
   @PD(a: "foo") var foo: Int = 42 // expected-error{{property 'foo' with attached wrapper cannot initialize both the wrapper type and the property}}
   // expected-error@-1{{missing argument for parameter 'initialValue' in call}}
 }
+
+protocol P { }
+
+@_propertyWrapper
+struct WrapperRequiresP<T: P> {
+  var value: T
+  var wrapperValue: T { return value }
+}
+
+struct UsesWrapperRequiringP {
+  // expected-note@-1{{in declaration of}}
+  
+  @WrapperRequiresP var x.: UsesWrapperRequiringP
+  // expected-error@-1{{expected member name following '.'}}
+  // expected-error@-2{{expected declaration}}
+  // expected-error@-3{{type annotation missing in pattern}}
+}


### PR DESCRIPTION
Bring over a few fixes for property wrappers:
* Clarify diagnostic banning '$' identifiers.
* Drop the lowercasing restriction on property wrapper names.
* Fix crash-on-invalid involving some wrappers with `wrapperValue` (rdar://problem/51193573)