### PR TITLE
stdlib: permit builtin Collections and Unicode tests everywhere

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(swift_stdlib_unittest_compile_flags)
 
-# TODO: support this on non-POSIX platforms.  It cannot be currently as it
-# depends on pthreads.
 add_swift_target_library(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -24,8 +22,8 @@ add_swift_target_library(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BU
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc
   SWIFT_MODULE_DEPENDS_CYGWIN Glibc
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags}
-  TARGET_SDKS ALL_POSIX_PLATFORMS
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 

--- a/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(swift_stdlib_unittest_compile_flags)
 
-# TODO: support this on non-POSIX platforms.  It cannot be currently as it
-# depends on pthreads.
 add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -13,8 +11,8 @@ add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD
   SWIFT_MODULE_DEPENDS_FREEBSD Glibc
   SWIFT_MODULE_DEPENDS_CYGWIN Glibc
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_MODULE_DEPENDS_WINDOWS MSVCRT
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags}
-  TARGET_SDKS ALL_POSIX_PLATFORMS
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")
 


### PR DESCRIPTION
The pthread dependency has been lifted through the Windows port
generalising the SwiftThreadExtras.  Enable building these unit test
binaries which are needed for the validation test suite.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
