### PR TITLE
Basic: silence MSVC pedantic warning (NFC)

### DIFF
--- a/lib/Basic/Default/Task.inc
+++ b/lib/Basic/Default/Task.inc
@@ -84,7 +84,10 @@ bool Task::execute() {
   }
 
   Optional<StringRef> Redirects[] = {
-      None, {StdoutPath}, {SeparateErrors ? StderrPath : StdoutPath}};
+      None,
+      StringRef{StdoutPath},
+      StringRef{SeparateErrors ? StderrPath : StdoutPath},
+  };
 
   bool ExecutionFailed = false;
   PI = llvm::sys::ExecuteNoWait(ExecPath, llvm::toStringRefArray(Argv.data()),


### PR DESCRIPTION
The constructor here required multiple user-defined conversions which is
not exactly pedantically correct.  Add an explicit indicator that the
constructor being invoked is the `StringRef` constructor to convert the
`SmallString` to a `StringRef` which can then be implicitly converted to
the `Optional<StringRef>`.  This silences a MSVC warning (clang should
catch this with `-pedantic`).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
