### PR TITLE
swift-reflection-test: silence tautological warning

### DIFF
--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -575,11 +575,16 @@ int main(int argc, char *argv[]) {
     printUsageAndExit();
 
   const char *BinaryFilename = argv[1];
-  
+
+#if defined(_WIN32)
+  // FIXME(compnerd) weak linking is not permitted on PE/COFF, we should fall
+  // back to GetProcAddress to see if the symbol is present.
+#else
   // swift_reflection_classIsSwiftMask is weak linked so we can work
   // with older Remote Mirror dylibs.
   if (&swift_reflection_classIsSwiftMask != NULL)
     swift_reflection_classIsSwiftMask = computeClassIsSwiftMask();
+#endif
 
   uint16_t Version = swift_reflection_getSupportedMetadataVersion();
   printf("Metadata version: %u\n", Version);


### PR DESCRIPTION
PE/COFF does not permit weak linking semantics.  This means that the
expression `&symbol == NULL` is tautologically false.  In order to
support this semantic, the symbol needs to be dynamically looked up at
runtime.  Since the ObjC runtime is not in use on Windows currently,
just ignore this for the time being.  Silences a warning from clang
about the tautological comparison.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
