### PR TITLE
test: plumb `--triple` to the resilience test helper

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1341,11 +1341,11 @@ if swift_execution_tests_extra_flags:
 config.target_resilience_test = (
      '%s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S --s %%s '
      '--lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
-     '--additional-compile-flags "%s"'
+     '--additional-compile-flags "%s" --triple "%s"'
      % (config.rth, config.target_build_swift, config.target_run,
         config.target_shared_library_prefix,
         config.target_shared_library_suffix, config.target_codesign,
-        rth_flags))
+        rth_flags, config.variant_triple))
 
 # FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
 # different.

--- a/utils/rth
+++ b/utils/rth
@@ -33,7 +33,7 @@ class ResilienceTest(object):
 
     def __init__(self, target_build_swift, target_run, target_codesign,
                  target_nm, tmp_dir, test_dir, test_src, lib_prefix,
-                 lib_suffix, additional_compile_flags,
+                 lib_suffix, additional_compile_flags, triple,
                  backward_deployment, no_symbol_diff):
         self.target_build_swift = shlex.split(target_build_swift)
         self.target_run = shlex.split(target_run)
@@ -45,6 +45,7 @@ class ResilienceTest(object):
         self.lib_prefix = lib_prefix
         self.lib_suffix = lib_suffix
         self.additional_compile_flags = shlex.split(additional_compile_flags)
+        self.triple = triple
 
         self.before_dir = os.path.join(self.tmp_dir, 'before')
         self.after_dir = os.path.join(self.tmp_dir, 'after')
@@ -229,6 +230,7 @@ def main():
                         action='store_true')
     parser.add_argument('--no-symbol-diff', default=False,
                         action='store_true')
+    parser.add_argument('--triple', required=True)
 
     args = parser.parse_args()
 
@@ -236,7 +238,7 @@ def main():
                                      args.target_codesign, args.target_nm,
                                      args.t, args.S, args.s, args.lib_prefix,
                                      args.lib_suffix,
-                                     args.additional_compile_flags,
+                                     args.additional_compile_flags, args.triple,
                                      args.backward_deployment,
                                      args.no_symbol_diff)
 

--- a/validation-test/Evolution/test_keypaths.swift.gyb
+++ b/validation-test/Evolution/test_keypaths.swift.gyb
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t/rth)
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %s > %t/test_keypaths.swift
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %S/Inputs/keypaths.swift.gyb > %t/Inputs/keypaths.swift
-// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix "%{target-shared-library-suffix}" --target-codesign "%target-codesign" --no-symbol-diff
+// RUN: %target-resilience-test --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --no-symbol-diff
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
The resilience test helper builds up invocations of the tooling.  In
order to do this, we need to know what host we are building for.  Plumb
the value for `-triple` from the test harness into the utility.  This
will be used subsequently to enable additional testing for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
