### PR TITLE
[build-script] Add support for passing --reconfigure to arbitrary presets and remove --reconfigure from stdlib standalone presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2057,7 +2057,6 @@ build-subdir=stdlib_RA_standalone
 release
 assertions
 
-reconfigure
 verbose-build
 
 [preset: stdlib_RA_standalone,build,test]
@@ -2074,7 +2073,6 @@ build-subdir=stdlib_RDA_standalone
 release-debuginfo
 assertions
 
-reconfigure
 verbose-build
 
 [preset: stdlib_RDA_standalone,build,test]
@@ -2091,7 +2089,6 @@ build-subdir=stdlib_DA_standalone
 debug
 assertions
 
-reconfigure
 verbose-build
 
 [preset: stdlib_DA_standalone,build,test]

--- a/utils/build-script
+++ b/utils/build-script
@@ -887,6 +887,11 @@ def main_preset():
              "various values used to build in this configuration",
         action="store_true",
         default=False)
+    parser.add_argument(
+        "--reconfigure",
+        help="Reconfigure all projects as we build",
+        action="store_true",
+        default=False)
     args = parser.parse_args()
     if len(args.preset_file_names) == 0:
         args.preset_file_names = [
@@ -954,14 +959,17 @@ def main_preset():
         build_script_args += ["--cmake-c-launcher", args.cmake_c_launcher]
     if args.cmake_cxx_launcher:
         build_script_args += ["--cmake-cxx-launcher", args.cmake_cxx_launcher]
-
     printable_command = shell.quote_command(build_script_args)
     if args.expand_invocation:
         print(printable_command)
-    else:
-        diagnostics.note('using preset "{}", which expands to \n\n{}\n'.format(
-            args.preset, printable_command))
-        shell.call_without_sleeping(build_script_args)
+        return 0
+
+    if args.reconfigure:
+        build_script_args += ["--reconfigure"]
+
+    diagnostics.note('using preset "{}", which expands to \n\n{}\n'.format(
+        args.preset, printable_command))
+    shell.call_without_sleeping(build_script_args)
     return 0
 
 


### PR DESCRIPTION
I realized that if one reconfigures the standalone presets, we seem to always rebuild everything. To work around this, I added a --reconfigure option to build-script's preset code to allow one to add --reconfigure to arbitrary build-script-impl lines. This then lets me make the default behavior of the standalone stdlib be to /not/ reconfigure.