### PR TITLE
[SE-0258] Infer generic arguments of wrapper type from original property type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4377,6 +4377,8 @@ ERROR(property_wrapper_type_requirement_not_accessible,none,
 ERROR(property_wrapper_attribute_not_on_property, none,
       "property wrapper attribute %0 can only be applied to a property",
       (DeclName))
+NOTE(property_wrapper_declared_here,none,
+     "property wrapper type %0 declared here", (DeclName))
 
 ERROR(property_wrapper_multiple,none,
       "only one property wrapper can be attached to a given property", ())
@@ -4416,9 +4418,9 @@ NOTE(property_wrapper_direct_init,none,
      "initialize the property wrapper type directly with "
      "'(...') on the attribute", ())
 
-ERROR(property_wrapper_incompatible_unbound, none,
-      "property wrapper type %0 must either specify all generic arguments "
-      "or require only a single generic argument", (Type))
+ERROR(property_wrapper_incompatible_property, none,
+      "property type %0 does not match that of the 'value' property of "
+      "its wrapper type %1", (Type, Type))
 
 ERROR(property_wrapper_type_access,none,
       "%select{%select{variable|constant}0|property}1 "

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -13,6 +13,7 @@
 // This file implements semantic analysis for property wrappers.
 //
 //===----------------------------------------------------------------------===//
+#include "ConstraintSystem.h"
 #include "TypeChecker.h"
 #include "TypeCheckType.h"
 #include "swift/AST/ASTContext.h"
@@ -423,43 +424,39 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     return type;
   }
 
-  // Compose the type of property wrapper with the type of the property.
-
-  // We expect an unbound generic type here that refers to a single-parameter
-  // generic type.
-  auto wrapperAttr = var->getAttachedPropertyWrapper();
-  auto nominal = rawType->getAnyNominal();
-  auto unboundGeneric = rawType->getAs<UnboundGenericType>();
-  if (!unboundGeneric ||
-      unboundGeneric->getDecl() != nominal ||
-      !nominal->getGenericParams() ||
-      nominal->getGenericParams()->size() != 1) {
-    ctx.Diags.diagnose(wrapperAttr->getLocation(),
-                       diag::property_wrapper_incompatible_unbound,
-                       rawType)
-      .highlight(wrapperAttr->getTypeLoc().getSourceRange());
+  // Get information about the wrapper type itself.
+  auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo();
+  if (!wrapperInfo)
     return Type();
-  }
 
   // Compute the type of the property to plug in to the wrapper type.
   tc.validateDecl(var);
   Type propertyType = var->getType();
+  if (!propertyType || propertyType->hasError())
+    return Type();
 
-  // Form the specialized type.
-  Type wrapperType = tc.applyUnboundGenericArguments(
-      unboundGeneric, nominal, wrapperAttr->getLocation(),
-      TypeResolution::forContextual(var->getDeclContext()), { propertyType });
+  using namespace constraints;
+  auto dc = var->getInnermostDeclContext();
+  ConstraintSystem cs(tc, dc, None);
+  auto emptyLocator = cs.getConstraintLocator(nullptr);
+  Type openedWrapperType =
+    cs.openUnboundGenericType(rawType, emptyLocator);
+  Type valueMemberType = openedWrapperType->getTypeOfMember(
+      dc->getParentModule(), wrapperInfo.valueVar);
+  cs.addConstraint(ConstraintKind::Equal, valueMemberType,
+                   propertyType, emptyLocator);
 
-  // Make sure no unbound types remain; this could happen if there are outer
-  // unbound types that weren't resolved by the application of the property
-  // type.
-  if (wrapperType->hasUnboundGenericType()) {
-    ctx.Diags.diagnose(wrapperAttr->getLocation(),
-                       diag::property_wrapper_incompatible_unbound,
-                       wrapperType)
-      .highlight(wrapperAttr->getTypeLoc().getSourceRange());
+  SmallVector<Solution, 4> solutions;
+  if (cs.solve(nullptr, solutions) || solutions.size() != 1) {
+    var->diagnose(diag::property_wrapper_incompatible_property,
+                  propertyType, rawType);
+    if (auto nominalWrapper = rawType->getAnyNominal()) {
+      nominalWrapper->diagnose(diag::property_wrapper_declared_here,
+                               nominalWrapper->getFullName());
+    }
     return Type();
   }
 
+  Type wrapperType = solutions.front().simplifyType(openedWrapperType);
   return wrapperType->mapTypeOutOfContext();
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -241,7 +241,7 @@ struct IntWrapper {
 }
 
 @_propertyWrapper
-struct WrapperForHashable<T: Hashable> {
+struct WrapperForHashable<T: Hashable> { // expected-note{{property wrapper type 'WrapperForHashable' declared here}}
   var value: T
 }
 
@@ -256,31 +256,58 @@ struct UseWrappersWithDifferentForm {
   @IntWrapper
   var x: Int
 
-  @WrapperForHashable // expected-error{{type 'NotHashable' does not conform to protocol 'Hashable'}}
-  var y: NotHashable
+  // FIXME: Diagnostic should be better here
+  @WrapperForHashable
+  var y: NotHashable // expected-error{{property type 'NotHashable' does not match that of the 'value' property of its wrapper type 'WrapperForHashable'}}
 
   @WrapperForHashable
   var yOkay: Int
 
-  @WrapperWithTwoParams // expected-error{{property wrapper type 'WrapperWithTwoParams' must either specify all generic arguments or require only a single generic argument}}
-  var z: Int
+  @WrapperWithTwoParams
+  var zOkay: (Int, Float)
 
-  @HasNestedWrapper.NestedWrapper // expected-error{{property wrapper type 'HasNestedWrapper.NestedWrapper<Int>' must either specify all generic arguments or require only a single generic argument}}
-  var w: Int
+  // FIXME: Need a better diagnostic here
+  @HasNestedWrapper.NestedWrapper
+  var w: Int // expected-error{{property type 'Int' does not match that of the 'value' property of its wrapper type 'HasNestedWrapper.NestedWrapper'}}
 
   @HasNestedWrapper<Double>.NestedWrapper
   var wOkay: Int
+
+  @HasNestedWrapper.ConcreteNestedWrapper
+  var wOkay2: Int
 }
 
+@_propertyWrapper
+struct Function<T, U> { // expected-note{{property wrapper type 'Function' declared here}}
+  var value: (T) -> U?
+}
+
+struct TestFunction {
+  @Function var f: (Int) -> Float?
+  
+  @Function var f2: (Int) -> Float // expected-error{{property type '(Int) -> Float' does not match that of the 'value' property of its wrapper type 'Function'}}
+
+  func test() {
+    let _: Int = $f // expected-error{{cannot convert value of type 'Function<Int, Float>' to specified type 'Int'}}
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Nested wrappers
 // ---------------------------------------------------------------------------
 struct HasNestedWrapper<T> {
   @_propertyWrapper
-  struct NestedWrapper<U> {
+  struct NestedWrapper<U> { // expected-note{{property wrapper type 'NestedWrapper' declared here}}
     var value: U
     init(initialValue: U) {
+      self.value = initialValue
+    }
+  }
+
+  @_propertyWrapper
+  struct ConcreteNestedWrapper {
+    var value: T
+    init(initialValue: T) {
       self.value = initialValue
     }
   }


### PR DESCRIPTION
Implement the revised type inference rules that allow the type checker to
infer the generic arguments of a wrapper type from the original property type,
including in various structural positions. Fixes rdar://problem/51266744.
