### PR TITLE
test: add a workaround for `rth` invocation

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1338,12 +1338,13 @@ rth_flags = ''
 if swift_execution_tests_extra_flags:
     rth_flags = swift_execution_tests_extra_flags + ' -wmo'
 
+# FIXME: why can we not use %rth and have that be expanded out?
 config.target_resilience_test = (
-     '%s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S --s %%s '
-     '--lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
+     '%r %s --target-build-swift "%s" --target-run "%s" --t %%t --S %%S '
+     '--s %%s --lib-prefix "%s" --lib-suffix "%s" --target-codesign "%s" '
      '--additional-compile-flags "%s" --triple "%s"'
-     % (config.rth, config.target_build_swift, config.target_run,
-        config.target_shared_library_prefix,
+     % (sys.executable, config.rth, config.target_build_swift,
+        config.target_run, config.target_shared_library_prefix,
         config.target_shared_library_suffix, config.target_codesign,
         rth_flags, config.variant_triple))
 


### PR DESCRIPTION
The `rth` tool is a python script and relied on the execution via the
shebang.  However, not all targets support the shebang to invoke the
interpreter.  Explicitly launch the resilience test helper with the
interpreter (python).  Ideally, we would use the `%rth` substitution,
but that does not seem to function for the nested case here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
