### PR TITLE
tests: improve resilience test helper for Windows

### DIFF
--- a/utils/rth
+++ b/utils/rth
@@ -74,7 +74,10 @@ class ResilienceTest(object):
         os.makedirs(self.before_dir)
 
     def is_apple_platform(self):
-        return any('-apple-' in arg for arg in self.target_build_swift)
+        return self.triple.split('-')[1] == 'apple'
+
+    def is_windows_host(self):
+        return self.triple.split('-')[2] == 'windows'
 
     def compile_library(self):
         for config in self.config_dir_map:
@@ -172,7 +175,10 @@ class ResilienceTest(object):
                                       config1_lower + '_' + config2_lower)
             if self.is_apple_platform():
                 rpath_origin = '@executable_path'
+            elif self.is_windows_host():
+                pass
             else:
+                # assume it is an ELF host
                 rpath_origin = '$ORIGIN'
 
             compiler_flags = [
@@ -180,12 +186,20 @@ class ResilienceTest(object):
                 '-l' + self.lib_name,
                 os.path.join(self.config_dir_map[config2],
                              'main.o'),
-                '-Xlinker', '-rpath', '-Xlinker',
-                os.path.join(rpath_origin,
-                             os.path.relpath(self.config_dir_map[config1],
-                                             self.tmp_dir)),
                 '-o', output_obj
             ]
+
+            if self.is_windows_host():
+                # Emulate RPATH by changing to the location as `PATH` is what
+                # drives library searching on Windows
+                os.chdir(self.config_dir_map[config1])
+            else:
+                compiler_flags.extend([
+                    '-Xlinker', '-rpath', '-Xlinker',
+                    os.path.join(rpath_origin,
+                                 os.path.relpath(self.config_dir_map[config1],
+                                                 self.tmp_dir)),
+                ])
 
             if self.is_apple_platform():
                 compiler_flags += ['-Xlinker', '-bind_at_load']


### PR DESCRIPTION
Windows does not support the concept of RPATH.  As a result, we must
change the working directory for the test.  This extends the support
for the tests to work with PE/COFF on Windows.  Use the newly minted
`self.triple` property to drive the host detection.  This means that
the test coverage on Windows is able to test most of the resilience
functionality.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
