### PR TITLE
Remove libTensorFlow forced linking.

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -267,36 +267,6 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   } else {
     Arguments.push_back(context.Args.MakeArgString(SharedRuntimeLibPath));
     Arguments.push_back("-lswiftCore");
-
-    // SWIFT_ENABLE_TENSORFLOW
-    // On Linux, the REPL fails with "Couldn't lookup symbols" errors when:
-    // - Linking an external Swift shared library (produced by `swift build`)
-    //   and importing the corresponding Swift module.
-    // - Importing the `TensorFlow` and `Python` modules, without manually
-    //   linking `libswiftPython.so` and `libswiftTensorFlow.so`.
-    //
-    // A manual workaround involves specifying the `-lswiftPython` and
-    // `-lswiftTensorFlow` flags (in that specific order) when invoking the
-    // REPL. Also, `Python` and `TensorFlow` must be imported before the
-    // external Swift module to avoid the error.
-    //
-    // Conditionally adding the linker flags here seems to solve the issue.
-    // This is robust assuming that toolchain artifacts are not manipulated
-    // (so that somehow Python.swiftmodule exists while libswiftPython.so
-    // doesn't).
-    //
-    // https://github.com/google/swift/issues/4
-    SmallString<128> swiftPythonLibPath = SharedRuntimeLibPath;
-    llvm::sys::path::append(swiftPythonLibPath, "libswiftPython.so");
-    if (llvm::sys::fs::exists(swiftPythonLibPath))
-      Arguments.push_back("-lswiftPython");
-
-    SmallString<128> swiftTensorFlowLibPath = SharedRuntimeLibPath;
-    llvm::sys::path::append(swiftTensorFlowLibPath, "libswiftTensorFlow.so");
-    if (llvm::sys::fs::exists(swiftTensorFlowLibPath)) {
-      Arguments.push_back("-lswiftTensorFlow");
-      Arguments.push_back("-ltensorflow");
-    }
   }
 
   // Explicitly pass the target to the linker

--- a/stdlib/public/CTensorFlow/module.modulemap
+++ b/stdlib/public/CTensorFlow/module.modulemap
@@ -3,4 +3,6 @@ module CTensorFlow {
   header "c_api_experimental.h"
   header "c_api_eager.h"
   header "ctensorflow_init.h"
+
+  link "tensorflow"
 }


### PR DESCRIPTION
I seem to be able to run `swift test.swift` without these linked in, so I think that they're unnecessary. Also, fixed the "-ltensorflow" problem in a different way. This may break some things I'm not able to test on mac, but I think we should fix-forward that.