### PR TITLE
syntax: silence MSVC warning about unreachable (NFC)

### DIFF
--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -516,6 +516,7 @@ struct MappingTraits<swift::syntax::TriviaPiece> {
     }
 % end
     }
+    llvm_unreachable("covered switch");
   }
 };
 


### PR DESCRIPTION
Add a llvm_unreachable to indicate to MSVC that the switch is covered.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
