### PR TITLE
tests: add swift_addNewDSOImage to the stubs

### DIFF
--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -18,3 +18,4 @@ void swift_retain(){}
 void swift_allocBox(){}
 void swift_getWitnessTable(void) {}
 void swift_getObjCClassMetadata(void) {}
+void swift_addNewDSOImage(void) {}


### PR DESCRIPTION
This is needed particularly on Windows which does not permit unresolved
symbols and the startup stub (swiftrt.obj) references the runtime
function.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
