### PR TITLE
validation-test: avoid shell in HashingRandomization

### DIFF
--- a/validation-test/stdlib/HashingRandomization.swift
+++ b/validation-test/stdlib/HashingRandomization.swift
@@ -1,8 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -disable-access-control -module-name main %s -o %t/hash
 // RUN: %target-codesign %t/hash
-// RUN: (export -n %env-SWIFT_DETERMINISTIC_HASHING; %target-run %t/hash && %target-run %t/hash) | %FileCheck --check-prefixes=RANDOM %s
-// RUN: (export %env-SWIFT_DETERMINISTIC_HASHING=1; %target-run %t/hash && %target-run %t/hash) | %FileCheck --check-prefixes=STABLE %s
+// RUN: env -u %env-SWIFT_DETERMINISTIC_HASHING %target-run %t/hash > %t/nondeterministic.log
+// RUN: env -u %env-SWIFT_DETERMINISTIC_HASHING %target-run %t/hash >> %t/nondeterministic.log
+// RUN: %FileCheck --check-prefixes=RANDOM %s < %t/nondeterministic.log
+// RUN: env %env-SWIFT_DETERMINISTIC_HASHING=1 %target-run %t/hash > %t/deterministic.log
+// RUN: env %env-SWIFT_DETERMINISTIC_HASHING=1 %target-run %t/hash >> %t/deterministic.log
+// RUN: %FileCheck --check-prefixes=STABLE %s < %t/deterministic.log
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Split up the commands into multiple RUN lines.  Use a temporary to
actually capture the output of multiple invocations to compose them into
a single stream.

Replace the `export` usage with `env` which the lit interpreter is able
to process even on Windows.

This makes HashingRandomization pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
