### PR TITLE
[AutoDiff] Revisit differentiation of `struct` instruction with aggregate adjoint value.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4541,8 +4541,11 @@ public:
       break;
     }
     case AdjointValueKind::Aggregate: {
-      llvm_unreachable("Unhandled. Are you trying to differentiate a "
-                       "memberwise initializer?");
+      // Note: All user-called initializations go through the calls to the
+      // initializer, and synthesized initializers only have one level of struct
+      // formation which will not result into any aggregate adjoint valeus.
+      llvm_unreachable("Aggregate adjoint values should not occur for `struct` "
+                       "instructions");
     }
     }
   }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -184,7 +184,8 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
 
   let 𝛁foo = pullback(at: Float(4), in: { input -> Foo in
     let foo = Foo(stored: input)
-    return foo + foo
+    let foo2 = foo + foo
+    return Foo(stored: foo2.stored)
   })(Foo.TangentVector(stored: 1))
   expectEqual(2, 𝛁foo)
 


### PR DESCRIPTION
In the latest Swift, no calls to an initializer will emit a `struct` instruction, so differentiation of the `struct` instruction will only be for differentiating struct initializer functions themselves. In struct initializer functions, since there's only one `struct` operation, `AdjointEmitter::visitStructInst` will never get an adjoint value of kind `AdjointValueKind::Aggregate`. This PR marks that case unreachable.