### PR TITLE
Basic: Use APInt to implement ClusteredBitVector

### DIFF
--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -11,15 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the ClusteredBitVector class, a bitset data
-// structure appropriate for situations meeting two criteria:
-//
-//   - Many vectors are no larger than a particular constant size, and
-//     such vectors should be stored as compactly as possible.  This
-//     constant size should be at least as large as any reasonable
-//     target's pointer size in bits (i.e. at least 64).
-//
-//   - Most vectors have no bits set, and those that do tend to have
-//     them set in coherent ranges.
+// structure.
 //
 // For example, this would be reasonable to use to describe the
 // unoccupied bits in a memory layout.
@@ -30,367 +22,101 @@
 //
 // Primary observers:
 //   - testing a specific bit
-//   - searching for set bits from the start
+//   - converting to llvm::APInt
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_CLUSTEREDBITVECTOR_H
 #define SWIFT_BASIC_CLUSTEREDBITVECTOR_H
 
-#include "swift/Basic/LLVM.h"
-#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Optional.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/MathExtras.h"
-#include <algorithm>
 #include <cassert>
-#include <climits>
-#include <cstdlib>
-#include <type_traits>
-
-namespace llvm {
-  class APInt;
-}
 
 namespace swift {
 
-/// A vector of bits.  This data structure is optimized to store an
-/// empty vector of any size without doing any allocation.
+/// A vector of bits.
 class ClusteredBitVector {
-  using ChunkType = uint64_t;
-  static_assert(std::is_unsigned<ChunkType>::value, "ChunkType must be unsigned");
-  enum {
-    ChunkSizeInBits = sizeof(ChunkType) * CHAR_BIT
-  };
-  static_assert(sizeof(ChunkType) >= sizeof(ChunkType*),
-                "ChunkType must be large enough to store a pointer");
+  using APInt = llvm::APInt;
 
-  /// Return the number of chunks required to store a vector of the
-  /// given number of bits.
-  static size_t getNumChunksForBits(size_t value) { 
-    return (value + ChunkSizeInBits - 1) / ChunkSizeInBits;
-  }
+  /// Represents the bit vector as an integer.
+  /// The least-significant bit of the integer corresponds to the bit
+  /// at index 0. If the optional does not have a value then the bit
+  /// vector has a length of 0 bits.
+  llvm::Optional<APInt> Bits;
 
-  /// Either:
-  ///   - a uint64_t * with at least enough storage for
-  ///     getNumChunksForBits(LengthInBits) or
-  ///   - inline storage for a single chunk
-  /// as determined by HasOutOfLineData.
-  ///
-  /// 1) When using out-of-line storage:
-  ///
-  /// Suppose chunk size = 8, length = 13, capacity = 24.
-  ///
-  ///   11010101 00011010 101010010
-  ///   ~~~~~~~~  ^ ~~~~~        ^
-  ///     data    |  data        |
-  ///             |              +---- bits in other chunks
-  ///    high bits in last chunk         are uninitialized
-  ///      are guaranteed zero
-  /// 
-  /// The capacity (in bits) is stored at index -1.
-  ///
-  /// 2) When using inline storage:
-  ///
-  ///  a) LengthInBits >= ChunkSizeInBits.  In this case, Data must be 0.
-  ///     All bits are considered to be zero in this case.
-  ///
-  ///  b) 0 == LengthInBits.  In this case, Data must be 0.
-  ///
-  ///  c) 0 < LengthInBits < ChunkSizeInBits.  In this case, Data contains
-  ///     a single chunk, with its unused high bits zeroed like in the
-  ///     out-of-line case.
-  ///
-  /// Therefore, an efficient way to test whether all bits are zero:
-  /// Data != 0.  (isInlineAndAllClear())  Not *guaranteed* to find
-  /// something, but still efficient.
-  ChunkType Data;
-  
-  size_t LengthInBits : sizeof(size_t) * CHAR_BIT - 1;
-  size_t HasOutOfLineData : 1;
+  /// Copy constructor from APInt.
+  ClusteredBitVector(const APInt &bits) : Bits(bits) {}
 
-  /// Is this vector using out-of-line storage?
-  bool hasOutOfLineData() const { return HasOutOfLineData; }
-
-  /// Return true if this vector is not using out-of-line storage and
-  /// does not have any bits set.  This is a special-case representation
-  /// where the capacity can be smaller than the length.
-  ///
-  /// This is a necessary condition for hasSufficientChunkStorage(),
-  /// and it's quicker to test, so a lot of routines in this class
-  /// that need to work on chunk data in the general case test this
-  /// first.
-  bool isInlineAndAllClear() const {
-    assert(!hasOutOfLineData() || Data != 0);
-    return Data == 0;
-  }
-
-  /// Return true if this vector is not in the special case where the
-  /// capacity is smaller than the length.  If this is true, then
-  /// it's safe to call routines like getChunks().
-  bool hasSufficientChunkStorage() const {
-    return !(isInlineAndAllClear() && LengthInBits > ChunkSizeInBits);
-  }
-
-  /// Return the number of chunks required in order to store the full
-  /// length (not capacity) of this bit vector.  This may be greater
-  /// than the capacity in exactly one case, (2a), i.e.
-  /// !hasSufficientChunkStorage().
-  size_t getLengthInChunks() const {
-    return getNumChunksForBits(LengthInBits);
-  }
-
-  /// Return the current capacity of this bit vector, in bits.  This
-  /// is a relatively important operation because it's needed on every
-  /// append.
-  size_t getCapacityInBits() const {
-    return hasOutOfLineData() ? getOutOfLineCapacityInBits() : ChunkSizeInBits;
-  }
-
-  /// Return the current capacity of this bit vector, in chunks.
-  size_t getCapacityInChunks() const {
-    return getCapacityInBits() / ChunkSizeInBits;
-  }
-
-  /// Return the current capacity of this bit vector, in bits, given
-  /// that it's using out-of-line storage.
-  size_t getOutOfLineCapacityInBits() const {
-    assert(hasOutOfLineData());
-    return (size_t) getOutOfLineChunksPtr()[-1];
-  }
-
-  /// Return the current capacity of this bit vector, in chunks, given
-  /// that it's using out-of-line storage.
-  size_t getOutOfLineCapacityInChunks() const {
-    return getOutOfLineCapacityInBits() / ChunkSizeInBits;
-  }
-
-  /// Return a pointer to the data storage of this bit vector.
-  ChunkType *getChunksPtr() {
-    assert(hasSufficientChunkStorage());
-    return hasOutOfLineData() ? getOutOfLineChunksPtr() : &Data;
-  }
-  const ChunkType *getChunksPtr() const {
-    assert(hasSufficientChunkStorage());
-    return hasOutOfLineData() ? getOutOfLineChunksPtr() : &Data;
-  }
-
-  MutableArrayRef<ChunkType> getChunks() {
-    assert(hasSufficientChunkStorage());
-    return { getChunksPtr(), getLengthInChunks() };
-  }
-  ArrayRef<ChunkType> getChunks() const {
-    assert(hasSufficientChunkStorage());
-    return { getChunksPtr(), getLengthInChunks() };
-  }
-
-  MutableArrayRef<ChunkType> getOutOfLineChunks() {
-    return { getOutOfLineChunksPtr(), getLengthInChunks() };
-  }
-  ArrayRef<ChunkType> getOutOfLineChunks() const {
-    return { getOutOfLineChunksPtr(), getLengthInChunks() };
-  }
-
-  /// Return a pointer to the data storage of this bit vector, given
-  /// that it's using out-of-line storage.
-  ChunkType *getOutOfLineChunksPtr() {
-    assert(hasOutOfLineData());
-    return reinterpret_cast<ChunkType*>(Data);
-  }
-  const ChunkType *getOutOfLineChunksPtr() const {
-    assert(hasOutOfLineData());
-    return reinterpret_cast<const ChunkType*>(Data);
-  }
-
+  /// Move constructor from APInt.
+  ClusteredBitVector(APInt &&bits) : Bits(std::move(bits)) {}
 public:
   /// Create a new bit vector of zero length.  This does not perform
   /// any allocations.
-  ClusteredBitVector() : Data(0), LengthInBits(0), HasOutOfLineData(0) {}
-
-  /// Return a constant bit-vector of the given size.
-  static ClusteredBitVector getConstant(size_t numBits, bool value) {
-    ClusteredBitVector result;
-    if (value) {
-      result.reserve(numBits);
-      result.appendSetBits(numBits);
-    } else {
-      result.appendClearBits(numBits);
-    }
-    return result;
-  }
+  ClusteredBitVector() = default;
 
   ClusteredBitVector(const ClusteredBitVector &other)
-    : Data(other.Data),
-      LengthInBits(other.LengthInBits),
-      HasOutOfLineData(other.HasOutOfLineData) {
-    if (hasOutOfLineData()) {
-      makeIndependentCopy();
-    }
-  }
+    : Bits(other.Bits) {}
 
   ClusteredBitVector(ClusteredBitVector &&other)
-    : Data(other.Data),
-      LengthInBits(other.LengthInBits),
-      HasOutOfLineData(other.HasOutOfLineData) {
-    other.dropData();
-  }
+    : Bits(std::move(other.Bits)) {}
 
   ClusteredBitVector &operator=(const ClusteredBitVector &other) {
-    // Do something with our current out-of-line storage.
-    if (hasOutOfLineData()) {
-      // Copy into our current storage if its capacity is adequate.
-      auto otherLengthInChunks = other.getLengthInChunks();
-      if (otherLengthInChunks <= getOutOfLineCapacityInChunks()) {
-        LengthInBits = other.LengthInBits;
-        if (other.isInlineAndAllClear()) {
-          memset(getOutOfLineChunksPtr(), 0,
-                 otherLengthInChunks * sizeof(ChunkType));
-        } else {
-          memcpy(getOutOfLineChunksPtr(), other.getChunksPtr(),
-                 otherLengthInChunks * sizeof(ChunkType));
-        }
-        return *this;
-      }
-
-      // Otherwise, destroy our current storage.
-      destroy();
-    }
-
-    Data = other.Data;
-    LengthInBits = other.LengthInBits;
-    HasOutOfLineData = other.HasOutOfLineData;
-    if (HasOutOfLineData) {
-      makeIndependentCopy();
-    }
-
+    this->Bits = other.Bits;
     return *this;
   }
 
   ClusteredBitVector &operator=(ClusteredBitVector &&other) {
-    // Just drop our current out-of-line storage.
-    if (hasOutOfLineData()) {
-      destroy();
-    }
-
-    Data = other.Data;
-    LengthInBits = other.LengthInBits;
-    HasOutOfLineData = other.HasOutOfLineData;
-    other.dropData();
+    this->Bits = std::move(other.Bits);
     return *this;
   }
 
-  ~ClusteredBitVector() {
-    if (hasOutOfLineData()) {
-      destroy();
-    }
-  }
+  ~ClusteredBitVector() = default;
 
   /// Return true if this vector is zero-length (*not* if it does not
   /// contain any set bits).
   bool empty() const {
-    return LengthInBits == 0;
+    return !Bits.hasValue();
   }
 
   /// Return the length of this bit-vector.
   size_t size() const {
-    return LengthInBits;
-  }
-
-  /// Reserve space for an extra N bits.  This may unnecessarily force
-  /// the vector to use an out-of-line representation.
-  void reserveExtra(size_t numBits) {
-    auto requiredBits = LengthInBits + numBits;
-    if (requiredBits > getCapacityInBits()) {
-      auto requiredChunks = getNumChunksForBits(requiredBits);
-      auto chunkCount = getCapacityInChunks();
-      assert(requiredChunks > chunkCount);
-      do {
-        // Growth curve: 1 (inline) -> 3 -> 7 -> 15 -> 31 -> ...
-        // This is a particularly nice sequence because we store the
-        // capacity in the chunk at index -1, so the actual allocation
-        // size is a power of 2.
-        chunkCount = chunkCount * 2 + 1;
-      } while (requiredChunks > chunkCount);
-
-      reallocate(chunkCount);
-    }
-    // Postcondition: hasSufficientChunkStorage().
-  }
-
-  /// Reserve space for a total of N bits.  This may unnecessarily
-  /// force the vector to use an out-of-line representation.
-  void reserve(size_t requiredSize) {
-    if (requiredSize > getCapacityInBits()) {
-      reallocate(getNumChunksForBits(requiredSize));
-    }
-    // Postcondition: hasSufficientChunkStorage().
+    return Bits ? Bits.getValue().getBitWidth() : 0;
   }
 
   /// Append the bits from the given vector to this one.
   void append(const ClusteredBitVector &other) {
     // Nothing to do if the other vector is empty.
-    if (other.empty()) return;
-
-    // Special case: don't allocate space for zero bits.
-    if (isInlineAndAllClear() && other.isInlineAndAllClear()) {
-      LengthInBits += other.LengthInBits;
+    if (!other.Bits) {
       return;
     }
-
-    // Okay, one or the other of these is using out-of-line storage.
-    // Assume that bits might be set.
-    reserveExtra(other.size());
-
-    if (other.isInlineAndAllClear()) {
-      appendConstantBitsReserved(other.size(), 0);
-    } else {
-      appendReserved(other.size(), other.getChunksPtr());
-    }
-  }
-
-  /// Append the bits from the given vector to this one.
-  void append(ClusteredBitVector &&other) {
-    // If this vector is empty, just move the other.
-    if (empty()) {
-      *this = std::move(other);
+    if (!Bits) {
+      Bits = other.Bits;
       return;
     }
-
-    // Otherwise, use copy-append.
-    append(other);
+    APInt &v = Bits.getValue();
+    unsigned w = v.getBitWidth();
+    v = v.zext(w + other.Bits.getValue().getBitWidth());
+    v.insertBits(other.Bits.getValue(), w);
+    return;
   }
 
   /// Add the low N bits from the given value to the vector.
   void add(size_t numBits, uint64_t value) {
-    assert(numBits <= 64);
-    if (numBits == 0) return;
-
-    if (value == 0 && isInlineAndAllClear()) {
-      LengthInBits += numBits;
-      return;
-    }
-
-    reserveExtra(numBits);
-    static_assert(sizeof(value) <= sizeof(ChunkType),
-                  "chunk too small for this, break 'value' up into "
-                  "multiple parts");
-    const ChunkType chunks[] = { value };
-    appendReserved(numBits, chunks);
+    append(fromAPInt(APInt(numBits, value)));
   }
 
   /// Append a number of clear bits to this vector.
   void appendClearBits(size_t numBits) {
-    if (numBits == 0) return;
-
-    if (isInlineAndAllClear()) {
-      LengthInBits += numBits;
+    if (numBits == 0) {
       return;
     }
-
-    reserveExtra(numBits);
-    appendConstantBitsReserved(numBits, 0);
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v = v.zext(v.getBitWidth() + numBits);
+      return;
+    }
+    Bits = APInt::getNullValue(numBits);
   }
 
   /// Extend the vector out to the given length with clear bits.
@@ -399,12 +125,20 @@ public:
     appendClearBits(newSize - size());
   }
 
-
   /// Append a number of set bits to this vector.
   void appendSetBits(size_t numBits) {
-    if (numBits == 0) return;
-    reserveExtra(numBits);
-    appendConstantBitsReserved(numBits, 1);
+    if (numBits == 0) {
+      return;
+    }
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      unsigned w = v.getBitWidth();
+      v = v.zext(w + numBits);
+      v.setBitsFrom(w);
+      return;
+    }
+    Bits = APInt::getAllOnesValue(numBits);
+    return;
   }
 
   /// Extend the vector out to the given length with set bits.
@@ -416,31 +150,15 @@ public:
   /// Test whether a particular bit is set.
   bool operator[](size_t i) const {
     assert(i < size());
-    if (isInlineAndAllClear()) return false;
-    return getChunks()[i / ChunkSizeInBits]
-             & (ChunkType(1) << (i % ChunkSizeInBits));
+    return Bits.getValue()[i];
   }
 
   /// Intersect a bit-vector of the same size into this vector.
   ClusteredBitVector &operator&=(const ClusteredBitVector &other) {
     assert(size() == other.size());
-
-    // If this vector is all-clear, this is a no-op.
-    if (isInlineAndAllClear())
-      return *this;
-
-    // If the other vector is all-clear, we need to wipe this one.
-    if (other.isInlineAndAllClear()) {
-      for (auto &chunk : getChunks())
-        chunk = 0;
-      return *this;
-    }
-
-    // Otherwise, &= the chunks pairwise.
-    auto chunks = getChunks();
-    auto oi = other.getChunksPtr();
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i, ++oi) {
-      *i &= *oi;
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v &= other.Bits.getValue();
     }
     return *this;
   }
@@ -448,21 +166,9 @@ public:
   /// Union a bit-vector of the same size into this vector.
   ClusteredBitVector &operator|=(const ClusteredBitVector &other) {
     assert(size() == other.size());
-
-    // If the other vector is all-clear, this is a no-op.
-    if (other.isInlineAndAllClear())
-      return *this;
-
-    // If this vector is all-clear, we just copy the other.
-    if (isInlineAndAllClear()) {
-      return (*this = other);
-    }
-
-    // Otherwise, |= the chunks pairwise.
-    auto chunks = getChunks();
-    auto oi = other.getChunksPtr();
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i, ++oi) {
-      *i |= *oi;
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v |= other.Bits.getValue();
     }
     return *this;
   }
@@ -470,66 +176,41 @@ public:
   /// Set bit i.
   void setBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    getChunks()[i / ChunkSizeInBits] |= (ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().setBit(i);
   }
 
   /// Clear bit i.
   void clearBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) return;
-    getChunksPtr()[i / ChunkSizeInBits] &= ~(ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().clearBit(i);
   }
 
   /// Toggle bit i.
   void flipBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    getChunksPtr()[i / ChunkSizeInBits] ^= (ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().flipBit(i);
   }
 
   /// Toggle all the bits in this vector.
   void flipAll() {
-    if (empty()) return;
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    for (auto &chunk : getChunks()) {
-      chunk = ~chunk;
-    }
-    if (auto tailBits = size() % ChunkSizeInBits) {
-      getChunks().back() &= ((ChunkType(1) << tailBits) - 1);
+    if (Bits) {
+      Bits.getValue().flipAllBits();
     }
   }
 
-  /// Set the length of this vector to zero, but do not release any capacity.
+  /// Set the length of this vector to zero.
   void clear() {
-    LengthInBits = 0;
-    if (!hasOutOfLineData())
-      Data = 0;
+    Bits.reset();
   }
 
   /// Count the number of set bits in this vector.
   size_t count() const {
-    if (isInlineAndAllClear()) return 0;
-    size_t count = 0;
-    for (ChunkType chunk : getChunks()) {
-      count += llvm::countPopulation(chunk);
-    }
-    return count;
+    return Bits ? Bits.getValue().countPopulation() : 0;
   }
 
   /// Determine if there are any bits set in this vector.
   bool any() const {
-    if (isInlineAndAllClear()) return false;
-    for (ChunkType chunk : getChunks()) {
-      if (chunk) return true;
-    }
-    return false;
+    return Bits && Bits.getValue() != 0;
   }
 
   /// Determine if there are no bits set in this vector.
@@ -541,16 +222,13 @@ public:
 
   friend bool operator==(const ClusteredBitVector &lhs,
                          const ClusteredBitVector &rhs) {
-    if (lhs.size() != rhs.size())
+    if (lhs.size() != rhs.size()) {
       return false;
-    if (lhs.empty())
-      return true;
-
-    if (!lhs.hasOutOfLineData() && !rhs.hasOutOfLineData()) {
-      return lhs.Data == rhs.Data;
-    } else {
-      return equalsSlowCase(lhs, rhs);
     }
+    if (lhs.size() == 0) {
+      return true;
+    }
+    return lhs.Bits.getValue() == rhs.Bits.getValue();
   }
   friend bool operator!=(const ClusteredBitVector &lhs,
                          const ClusteredBitVector &rhs) {
@@ -559,73 +237,36 @@ public:
 
   /// Return this bit-vector as an APInt, with low indices becoming
   /// the least significant bits of the number.
-  llvm::APInt asAPInt() const;
+  APInt asAPInt() const {
+    // Return 1-bit wide zero APInt for a 0-bit vector.
+    return Bits ? Bits.getValue() : APInt();
+  }
 
   /// Construct a bit-vector from an APInt.
-  static ClusteredBitVector fromAPInt(const llvm::APInt &value);
+  static ClusteredBitVector fromAPInt(const APInt &value) {
+    return ClusteredBitVector(value);
+  }
+
+  /// Construct a bit-vector from an APInt.
+  static ClusteredBitVector fromAPInt(APInt &&value) {
+    return ClusteredBitVector(std::move(value));
+  }
+
+  /// Return a constant bit-vector of the given size.
+  static ClusteredBitVector getConstant(size_t numBits, bool value) {
+    if (numBits == 0) {
+      return ClusteredBitVector();
+    }
+    auto vec = APInt::getNullValue(numBits);
+    if (value) {
+      vec.flipAllBits();
+    }
+    return ClusteredBitVector(vec);
+  }
 
   /// Pretty-print the vector.
   void print(llvm::raw_ostream &out) const;
   void dump() const;
-
-private:
-  /// Make this object store an independent copy of the out of line
-  /// data it currently stores, simply overwriting the current pointer
-  /// without deleting it.
-  void makeIndependentCopy() {
-    assert(hasOutOfLineData());
-    auto lengthToCopy = getLengthInChunks();
-    allocateAndCopyFrom(getOutOfLineChunksPtr(), lengthToCopy, lengthToCopy);
-  }
-
-  /// Reallocate this vector, copying the current data into the new space.
-  void reallocate(size_t newCapacityInChunks);
-
-  ChunkType *allocate(size_t newCapacityInChunks) {
-    assert(HasOutOfLineData && "bit should already be set");
-    ChunkType *newData = new ChunkType[newCapacityInChunks + 1] + 1;
-    newData[-1] = newCapacityInChunks * ChunkSizeInBits;
-    Data = reinterpret_cast<ChunkType>(newData);
-    assert(!isInlineAndAllClear());
-    assert(getCapacityInChunks() == newCapacityInChunks);
-    return newData;
-  }
-
-  void allocateAndCopyFrom(const ChunkType *oldData,
-                           size_t newCapacityInChunks,
-                           size_t numChunksToCopy) {
-    auto newData = allocate(newCapacityInChunks);
-    memcpy(newData, oldData, numChunksToCopy * sizeof(ChunkType));
-  }
-
-  /// Drop references to the current data.
-  void dropData() {
-    LengthInBits = 0;
-    HasOutOfLineData = false;
-    Data = 0;
-  }
-
-  /// Destroy the out of line data currently stored in this object.
-  void destroy() {
-    assert(hasOutOfLineData());
-    delete[] (getOutOfLineChunksPtr() - 1);
-  }
-
-  /// Append a certain number of constant bits to this vector, given
-  /// that it's known to contain enough capacity for them.
-  void appendConstantBitsReserved(size_t numBits, bool addOnes);
-
-  /// Append bits from the given array to this vector.
-  void appendReserved(size_t numBits, const ChunkType *nextChunk);
-
-  /// Append bits to this vector, given that it's known to contain
-  /// enough capacity for them all.
-  void appendReserved(size_t numBits,
-                llvm::function_ref<ChunkType(size_t numBitsWanted)> generator);
-
-  /// The slow case of equality-checking.
-  static bool equalsSlowCase(const ClusteredBitVector &lhs,
-                             const ClusteredBitVector &rhs);
 };
 
 } // end namespace swift

--- a/lib/Basic/ClusteredBitVector.cpp
+++ b/lib/Basic/ClusteredBitVector.cpp
@@ -16,192 +16,9 @@
 
 #include "swift/Basic/ClusteredBitVector.h"
 
-#include "llvm/ADT/APInt.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
-
-ClusteredBitVector ClusteredBitVector::fromAPInt(const llvm::APInt &bits) {
-  // This is not a very efficient algorithm.
-  ClusteredBitVector result;
-  for (unsigned i = 0, e = bits.getBitWidth(); i != e; ++i) {
-    if (bits[i]) {
-      result.appendSetBits(1);
-    } else {
-      result.appendClearBits(1);
-    }
-  }
-  return result;
-}
-
-llvm::APInt ClusteredBitVector::asAPInt() const {
-  if (size() == 0) {
-    // APInt doesn't like zero-bit values.
-    return llvm::APInt(1, 0);
-  }
-
-  if (isInlineAndAllClear()) {
-    return llvm::APInt(size(), 0);
-  } else {
-    // This assumes that the chunk size is the same as APInt's.
-    // TODO: it'd be nice to be able to do this without copying.
-    return llvm::APInt(size(), getChunks());
-  }
-}
-
-void ClusteredBitVector::reallocate(size_t newCapacityInChunks) {
-  // If we already have out-of-line storage, the padding invariants
-  // will still apply, and we just need to copy the old data into
-  // the new allocation.
-  if (hasOutOfLineData()) {
-    auto oldData = getOutOfLineChunksPtr();
-    allocateAndCopyFrom(oldData, newCapacityInChunks, getLengthInChunks());
-    delete[] (oldData - 1);
-    return;
-  }
-
-  // Otherwise, we might need to establish the invariants.  If we
-  // were in inline-and-all-clear mode, the vector might logically
-  // be much longer than a single chunk, but all-zero.
-  HasOutOfLineData = true;
-  auto oldDataValue = Data;
-  auto newData = allocate(newCapacityInChunks);
-
-  // All of these cases initialize 'length' chunks in newData.
-  switch (auto length = getLengthInChunks()) {
-  case 0:
-    break;
-  case 1:
-    newData[0] = oldDataValue;
-    break;
-  default:
-    assert(oldDataValue == 0 && "not previously in inline-and-all-clear?");
-    memset(newData, 0, length * sizeof(ChunkType));
-    break;
-  }
-}
-
-void ClusteredBitVector::appendReserved(size_t numBits,
-                llvm::function_ref<ChunkType(size_t numBitsWanted)> generator) {
-  assert(LengthInBits + numBits <= getCapacityInBits());
-  assert(numBits > 0);
-
-  auto getMoreBits =
-    [&](size_t numBitsWanted) -> ChunkType {
-    auto result = generator(numBitsWanted);
-    assert((numBitsWanted == ChunkSizeInBits ||
-            result <= (ChunkType(1) << numBitsWanted)) &&
-           "generator returned out-of-range value!");
-    return result;
-  };
-
-  // Check whether the current end of the vector is a clean multiple
-  // of the chunk size.
-  auto offset = LengthInBits % ChunkSizeInBits;
-  ChunkType *nextChunk = &getChunksPtr()[LengthInBits / ChunkSizeInBits];
-
-  // Now we can go ahead and add in the right number of extra bits.
-  LengthInBits += numBits;
-
-  // If not, we need to combine the generator result with that last chunk.
-  if (offset) {
-    auto claimedBits = std::min(numBits, size_t(ChunkSizeInBits - offset));
-
-    // The extra bits in data[chunkIndex] are guaranteed to be zero.
-    *nextChunk++ |= (getMoreBits(claimedBits) << offset);
-    
-    numBits -= claimedBits;
-    if (numBits == 0) return;
-  }
-
-  // For the rest, just generator chunks one at a time.
-  do {
-    auto claimedBits = std::min(numBits, size_t(ChunkSizeInBits));
-    *nextChunk++ = getMoreBits(claimedBits);
-    numBits -= claimedBits;
-  } while (numBits);
-}
-
-void ClusteredBitVector::appendConstantBitsReserved(size_t numBits,
-                                                    bool addOnes) {
-  assert(LengthInBits + numBits <= getCapacityInBits());
-  assert(numBits > 0);
-
-  ChunkType pattern = (addOnes ? ~ChunkType(0) : ChunkType(0));
-  appendReserved(numBits, [=](size_t numBitsWanted) -> ChunkType {
-    return (pattern >> (ChunkSizeInBits - numBitsWanted));
-  });
-}
-
-void ClusteredBitVector::appendReserved(size_t numBits,
-                                        const ChunkType *nextChunk) {
-  // This is easy if we're not currently at an offset.
-  // (Note that this special case generator relies on the exact
-  // implementation of the main appendReserved routine.)
-  auto offset = LengthInBits % ChunkSizeInBits;
-  if (!offset) {
-    appendReserved(numBits, [&](size_t numBitsWanted) -> ChunkType {
-      return *nextChunk++;
-    });
-    return;
-  }
-
-  // But if we are, we need to be constantly mixing values.
-  ChunkType prevChunk = 0;
-  size_t bitsRemaining = 0;
-  appendReserved(numBits, [&](size_t numBitsWanted) -> ChunkType {
-    auto resultMask = (numBitsWanted == ChunkSizeInBits
-                         ? ~ChunkType(0)
-                         : ((ChunkType(1) << numBitsWanted) - 1));
-
-    // If we can resolve the desired bits out of the current chunk,
-    // all the better.
-    if (numBitsWanted <= bitsRemaining) {
-      assert(numBitsWanted != ChunkSizeInBits);
-      auto result = prevChunk & resultMask;
-      bitsRemaining -= numBitsWanted;
-      prevChunk >>= numBitsWanted;
-      return result;
-    }
-
-    // |-- bitsRemaining --|-------- ChunkSizeInBits --------|
-    // |     prevChunk     |             nextChunk           |
-    // |------ numBitsWanted ------|----- bitsRemaining' ----|
-    //                             |        prevChunk'       |
-
-    auto newChunk = *nextChunk++;
-    auto result = (prevChunk | (newChunk << bitsRemaining)) & resultMask;
-    prevChunk = newChunk >> (numBitsWanted - bitsRemaining);
-    bitsRemaining = ChunkSizeInBits + bitsRemaining - numBitsWanted;
-    return result;
-  });
-}
-
-bool ClusteredBitVector::equalsSlowCase(const ClusteredBitVector &lhs,
-                                        const ClusteredBitVector &rhs) {
-  assert(lhs.size() == rhs.size());
-  assert(!lhs.empty() && !rhs.empty());
-  assert(lhs.hasOutOfLineData() || rhs.hasOutOfLineData());
-
-  if (!lhs.hasOutOfLineData()) {
-    assert(lhs.Data == 0 || lhs.getLengthInChunks() == 1);
-    for (auto chunk : rhs.getOutOfLineChunks())
-      if (chunk != lhs.Data)
-        return false;
-    return true;
-  } else if (!rhs.hasOutOfLineData()) {
-    assert(rhs.Data == 0 || rhs.getLengthInChunks() == 1);
-    for (auto chunk : lhs.getOutOfLineChunks())
-      if (chunk != rhs.Data)
-        return false;
-    return true;
-  } else {
-    auto lhsChunks = lhs.getOutOfLineChunks();
-    auto rhsChunks = rhs.getOutOfLineChunks();
-    assert(lhsChunks.size() == rhsChunks.size());
-    return lhsChunks == rhsChunks;
-  }
-}
 
 void ClusteredBitVector::dump() const {
   print(llvm::errs());
@@ -210,8 +27,12 @@ void ClusteredBitVector::dump() const {
 /// Pretty-print the vector.
 void ClusteredBitVector::print(llvm::raw_ostream &out) const {
   // Print in 8 clusters of 8 bits per row.
+  if (!Bits) {
+    return;
+  }
+  auto &v = Bits.getValue();
   for (size_t i = 0, e = size(); ; ) {
-    out << ((*this)[i++] ? '1' : '0');
+    out << (v[i++] ? '1' : '0');
     if (i == e) {
       return;
     } else if ((i & 64) == 0) {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -626,7 +626,6 @@ public:
       TotalStride(Size(ClangLayout.getSize().getQuantity())),
       TotalAlignment(IGM.getCappedAlignment(
                                        Alignment(ClangLayout.getAlignment()))) {
-    SpareBits.reserve(TotalStride.getValue() * 8);
   }
 
   void collectRecordFields() {

--- a/unittests/Basic/ClusteredBitVectorTest.cpp
+++ b/unittests/Basic/ClusteredBitVectorTest.cpp
@@ -115,22 +115,6 @@ TEST(ClusteredBitVector, AssignAfterGrowth) {
   EXPECT_EQ(false, vec[64]);
 }
 
-/// define == on llvm::Optional, you jerks
-template <class T> struct ComparableOptional {
-  Optional<T> Value;
-  ComparableOptional(const T &value) : Value(value) {}
-  ComparableOptional() : Value() {}
-
-  bool operator==(const Optional<T> &other) const {
-    if (Value.hasValue()) {
-      return other.hasValue()
-          && Value.getValue() == other.getValue();
-    } else {
-      return !other.hasValue();
-    }
-  }
-};
-
 TEST(ClusteredBitVector, SetClearBit) {
   ClusteredBitVector vec;
   vec.appendClearBits(64);


### PR DESCRIPTION
Simplify the implementation of ClusteredBitVector by using an APInt
to represent the raw bits. This simplification will make it easier
to incrementally move to a representation of bit vectors that works
on both big- and little-endian machines.

This commit also removes reserve and reserveExtra from the API
since they were only used in one place and no longer have any effect
because memory allocation is now handled by the APInt class.