### PR TITLE
test: invoke scale-test with the interpreter

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1490,8 +1490,9 @@ config.substitutions.append(('%round-trip-syntax-test',
                                         config.round_trip_syntax_test)))
 config.substitutions.append(('%rth', '%r %s' % (sys.executable, config.rth)))
 config.substitutions.append(('%scale-test',
-                             '{} --swiftc-binary={} --tmpdir=%t'.format(
-                                 config.scale_test, config.swiftc)))
+                             '{} {} --swiftc-binary={} --tmpdir=%t'.format(
+                                 sys.executable, config.scale_test,
+                                 config.swiftc)))
 config.substitutions.append(('%empty-directory\(([^)]+)\)',
                              SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
 


### PR DESCRIPTION
The scale-test utility is a python script which was relying on the
shebang to invoke the interpreter.  However, not all targets support
such an invocation mechanism (i.e. Windows doesn't support this).
Explicitly invoke the interpreter to ensure that the tool is executed
properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
