### PR TITLE
validation-test: make stdlib.string compile on Win32

### DIFF
--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -20,6 +20,10 @@ import NSSlowString
 import Foundation  // For NSRange
 #endif
 
+#if os(Windows)
+import ucrt
+#endif
+
 extension Collection {
   internal func index(_nth n: Int) -> Index {
     precondition(n >= 0)


### PR DESCRIPTION
The C library functions used here do not appear without the C runtime
being imported (ucrt or MSVCRT).  Adjust the test as such.  This exposes
a stack corruption in the test which needs to be resolved.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
