### PR TITLE
fix sourcekit vfs test on macos

### DIFF
--- a/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
+++ b/test/SourceKit/CodeComplete/injected_vfs_swiftinterface.swift
@@ -11,3 +11,5 @@ func foo(
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-parseable-module-interface-path %t/SwiftModule.swiftinterface -module-name SwiftModule -emit-module -o /dev/null %S/../Inputs/vfs/SwiftModule/SwiftModule.swift
 // RUN: %sourcekitd-test -req=complete -pos=6:31 -vfs-files=/target_file1.swift=%s,/SwiftModule/SwiftModule.swiftinterface=%t/SwiftModule.swiftinterface /target_file1.swift -- /target_file1.swift -I /SwiftModule | %FileCheck %s
+
+// REQUIRES: sourcekit_use_inproc_library


### PR DESCRIPTION
The MacOS build runs sourcekit tests in a way that the VFS tests don't work, so this disables the test when run that way.