### PR TITLE
Doc-serialization: add a front-end option to filter out unwanted symbols

### DIFF
--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -97,7 +97,8 @@ public:
 
   const ParamDecl *operator[](unsigned i) const { return get(i); }
   ParamDecl *&operator[](unsigned i) { return get(i); }
-  
+  bool hasInternalParameter(StringRef prefix) const;
+
   /// Change the DeclContext of any contained parameters to the specified
   /// DeclContext.
   void setDeclContextOfParamDecls(DeclContext *DC);

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -18,10 +18,29 @@
 public class PublicClass {
   /// Public Function Documentation
   public func f_public() { }
+  /// Public Init Documentation
+  public init(_ name: String) {}
+  /// Public Subscript Documentation
+  public subscript(_ name: String) -> Int { return 0 }
   /// Internal Function Documentation NotForNormal
   internal func f_internal() { }
   /// Private Function Documentation NotForNormal NotForTesting
   private func f_private() { }
+  /// Public Filter Function Documentation NotForNormal NotForTesting
+  public func __UnderscoredPublic() {}
+  /// Public Filter Init Documentation NotForNormal NotForTesting
+  public init(__label name: String) {}
+  /// Public Filter Subscript Documentation NotForNormal NotForFiltering
+  public subscript(__label name: String) -> Int { return 0 }
+  /// Public Filter Init Documentation NotForNormal NotForTesting
+  public init(label __name: String) {}
+  /// Public Filter Subscript Documentation NotForNormal NotForTesting
+  public subscript(label __name: String) -> Int { return 0 }
+}
+
+public extension PublicClass {
+  /// Public Filter Operator Documentation NotForNormal NotForTesting
+  static func -=(__lhs: inout PublicClass, __rhs: PublicClass) {}
 }
 
 /// InternalClass Documentation NotForNormal
@@ -42,10 +61,14 @@ private class PrivateClass {
 // NORMAL-NEGATIVE-NOT: NotForTesting
 // NORMAL: PublicClass Documentation
 // NORMAL: Public Function Documentation
+// NORMAL: Public Init Documentation
+// NORMAL: Public Subscript Documentation
 
 // TESTING-NEGATIVE-NOT: NotForTesting
 // TESTING: PublicClass Documentation
 // TESTING: Public Function Documentation
+// TESTINH: Public Init Documentation
+// TESTING: Public Subscript Documentation
 // TESTING: Internal Function Documentation
 // TESTING: InternalClass Documentation
 // TESTING: Internal Function Documentation


### PR DESCRIPTION
The front-end option specifies a prefix of those public symbols whose
doc-comments should be skipped during doc-comment serialization. A common filter is "__".

rdar://51468650