### PR TITLE
[Profiler] Separate profiler instances for property inits and constructors

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILPrintContext.h"
 #include "llvm/ADT/StringMap.h"
@@ -362,7 +363,8 @@ public:
     Profiler = InheritedProfiler;
   }
 
-  void createProfiler(ASTNode Root, ForDefinition_t forDefinition);
+  void createProfiler(ASTNode Root, SILDeclRef forDecl,
+                      ForDefinition_t forDefinition);
 
   void discardProfiler() { Profiler = nullptr; }
 

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -41,6 +41,8 @@ private:
 
   ASTNode Root;
 
+  SILDeclRef forDecl;
+
   bool EmitCoverageMapping;
 
   SILCoverageMap *CovMap = nullptr;
@@ -61,12 +63,14 @@ private:
 
   std::vector<std::tuple<std::string, uint64_t, std::string>> CoverageData;
 
-  SILProfiler(SILModule &M, ASTNode Root, bool EmitCoverageMapping)
-      : M(M), Root(Root), EmitCoverageMapping(EmitCoverageMapping) {}
+  SILProfiler(SILModule &M, ASTNode Root, SILDeclRef forDecl,
+              bool EmitCoverageMapping)
+      : M(M), Root(Root), forDecl(forDecl),
+        EmitCoverageMapping(EmitCoverageMapping) {}
 
 public:
   static SILProfiler *create(SILModule &M, ForDefinition_t forDefinition,
-                             ASTNode N);
+                             ASTNode N, SILDeclRef forDecl);
 
   /// Check if the function is set up for profiling.
   bool hasRegionCounters() const { return NumRegionCounters != 0; }

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -151,9 +151,10 @@ SILFunction::~SILFunction() {
          "Function cannot be deleted while function_ref's still exist");
 }
 
-void SILFunction::createProfiler(ASTNode Root, ForDefinition_t forDefinition) {
+void SILFunction::createProfiler(ASTNode Root, SILDeclRef forDecl,
+                                 ForDefinition_t forDefinition) {
   assert(!Profiler && "Function already has a profiler");
-  Profiler = SILProfiler::create(Module, forDefinition, Root);
+  Profiler = SILProfiler::create(Module, forDefinition, Root, forDecl);
 }
 
 bool SILFunction::hasForeignBody() const {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -573,29 +573,6 @@ static bool haveProfiledAssociatedFunction(SILDeclRef constant) {
          constant.isCurried;
 }
 
-SILProfiler *
-SILGenModule::getOrCreateProfilerForConstructors(DeclContext *ctx,
-                                                 ConstructorDecl *cd) {
-  const auto &Opts = M.getOptions();
-  if (!Opts.GenerateProfile && Opts.UseProfile.empty())
-    return nullptr;
-
-  // Profile nominal types and extensions separately, as they may live in
-  // distinct files. For extensions, just pass in the constructor, because
-  // there are no stored property initializers to visit.
-  Decl *decl = nullptr;
-  if (isa<ExtensionDecl>(ctx))
-    decl = cd;
-  else
-    decl = ctx->getSelfNominalTypeDecl();
-  assert(decl && "No decl available for profiling in this context");
-
-  SILProfiler *&profiler = constructorProfilers[decl];
-  if (!profiler)
-    profiler = SILProfiler::create(M, ForDefinition, decl);
-  return profiler;
-}
-
 /// Set up the function for profiling instrumentation.
 static void setUpForProfiling(SILDeclRef constant, SILFunction *F,
                               ForDefinition_t forDefinition) {
@@ -607,12 +584,12 @@ static void setUpForProfiling(SILDeclRef constant, SILFunction *F,
     if (constant.hasDecl()) {
       if (auto *fd = constant.getFuncDecl()) {
         if (fd->hasBody()) {
-          F->createProfiler(fd, forDefinition);
+          F->createProfiler(fd, constant, forDefinition);
           profiledNode = fd->getBody(/*canSynthesize=*/false);
         }
       }
     } else if (auto *ace = constant.getAbstractClosureExpr()) {
-      F->createProfiler(ace, forDefinition);
+      F->createProfiler(ace, constant, forDefinition);
       profiledNode = ace;
     }
     // Set the function entry count for PGO.
@@ -915,12 +892,11 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
         SILDeclRef initConstant(decl, SILDeclRef::Kind::Initializer);
         emitOrDelayFunction(
             *this, initConstant,
-            [this, initConstant, decl, declCtx](SILFunction *initF) {
+            [this, initConstant, decl](SILFunction *initF) {
               preEmitFunction(initConstant, decl, initF, decl);
               PrettyStackTraceSILFunction X("silgen constructor initializer",
                                             initF);
-              initF->setProfiler(
-                  getOrCreateProfilerForConstructors(declCtx, decl));
+              initF->createProfiler(decl, initConstant, ForDefinition);
               SILGenFunction(*this, *initF, decl)
                 .emitClassConstructorInitializer(decl);
               postEmitFunction(initConstant, initF);
@@ -935,10 +911,10 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
   // non-@objc convenience initializers for classes.
   if (decl->hasBody()) {
     emitOrDelayFunction(
-        *this, constant, [this, constant, decl, declCtx](SILFunction *f) {
+        *this, constant, [this, constant, decl](SILFunction *f) {
           preEmitFunction(constant, decl, f, decl);
           PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->setProfiler(getOrCreateProfilerForConstructors(declCtx, decl));
+          f->createProfiler(decl, constant, ForDefinition);
           SILGenFunction(*this, *f, decl).emitValueConstructor(decl);
           postEmitFunction(constant, f);
         });
@@ -1026,7 +1002,7 @@ void SILGenModule::emitObjCAllocatorDestructor(ClassDecl *cd,
     SILFunction *f = getFunction(dealloc, ForDefinition);
     preEmitFunction(dealloc, dd, f, dd);
     PrettyStackTraceSILFunction X("silgen emitDestructor -dealloc", f);
-    f->createProfiler(dd, ForDefinition);
+    f->createProfiler(dd, dealloc, ForDefinition);
     SILGenFunction(*this, *f, dd).emitObjCDestructor(dealloc);
     postEmitFunction(dealloc, f);
   }
@@ -1096,7 +1072,7 @@ void SILGenModule::emitDestructor(ClassDecl *cd, DestructorDecl *dd) {
     SILFunction *f = getFunction(deallocator, ForDefinition);
     preEmitFunction(deallocator, dd, f, dd);
     PrettyStackTraceSILFunction X("silgen emitDeallocatingDestructor", f);
-    f->createProfiler(dd, ForDefinition);
+    f->createProfiler(dd, deallocator, ForDefinition);
     SILGenFunction(*this, *f, dd).emitDeallocatingDestructor(dd);
     f->setDebugScope(new (M) SILDebugScope(dd, f));
     postEmitFunction(deallocator, f);
@@ -1169,15 +1145,12 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
 
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
   emitOrDelayFunction(*this, constant,
-                      [this,constant,init,initDC,var](SILFunction *f) {
+                      [this,constant,init,initDC](SILFunction *f) {
     preEmitFunction(constant, init, f, init);
     PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
-
-    // Inherit a profiler instance from the constructor.
-    f->setProfiler(
-        getOrCreateProfilerForConstructors(var->getDeclContext(), nullptr));
-
-    SILGenFunction(*this, *f, initDC).emitGeneratorFunction(constant, init);
+    f->createProfiler(init, constant, ForDefinition);
+    SILGenFunction(*this, *f, initDC)
+        .emitGeneratorFunction(constant, init, /*EmitProfilerIncrement=*/true);
     postEmitFunction(constant, f);
   });
 }
@@ -1530,7 +1503,7 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
   // A single SILFunction may be used to lower multiple top-level decls. When
   // this happens, fresh profile counters must be assigned to the new decl.
   TopLevelSGF->F.discardProfiler();
-  TopLevelSGF->F.createProfiler(td, ForDefinition);
+  TopLevelSGF->F.createProfiler(td, SILDeclRef(), ForDefinition);
 
   TopLevelSGF->emitProfilerIncrement(td->getBody());
  

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -88,11 +88,6 @@ public:
   /// Set of delayed conformances that have already been forced.
   llvm::DenseSet<NormalProtocolConformance *> forcedConformances;
 
-  /// Profiler instances for constructors, grouped by associated decl.
-  /// Each profiler is shared by all member initializers for a nominal type.
-  /// Constructors within extensions are profiled separately.
-  llvm::DenseMap<Decl *, SILProfiler *> constructorProfilers;
-
   SILFunction *emitTopLevelFunction(SILLocation Loc);
 
   size_t anonymousSymbolCounter = 0;
@@ -454,12 +449,6 @@ public:
 
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
-
-  /// Get or create the shared profiler instance for a type's constructors.
-  /// This takes care to create separate profilers for extensions, which may
-  /// reside in a different file than the one where the base type is defined.
-  SILProfiler *getOrCreateProfilerForConstructors(DeclContext *ctx,
-                                                  ConstructorDecl *cd);
 
 private:
   /// Emit the deallocator for a class that uses the objc allocator.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -612,7 +612,8 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
   }
 }
 
-void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value) {
+void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,
+                                           bool EmitProfilerIncrement) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(function);
 
   RegularLocation Loc(value);
@@ -635,6 +636,8 @@ void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value) {
   auto interfaceType = value->getType()->mapTypeOutOfContext();
   emitProlog(/*paramList=*/nullptr, /*selfParam=*/nullptr, interfaceType,
              dc, false);
+  if (EmitProfilerIncrement)
+    emitProfilerIncrement(value);
   prepareEpilog(value->getType(), false, CleanupLocation::get(Loc));
   emitReturnExpr(Loc, value);
   emitEpilog(Loc);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -627,7 +627,10 @@ public:
   void emitNativeToForeignThunk(SILDeclRef thunk);
   
   /// Generate a nullary function that returns the given value.
-  void emitGeneratorFunction(SILDeclRef function, Expr *value);
+  /// If \p emitProfilerIncrement is set, emit a profiler increment for
+  /// \p value.
+  void emitGeneratorFunction(SILDeclRef function, Expr *value,
+                             bool emitProfilerIncrement = false);
 
   /// Generate a nullary function that returns the value of the given variable's
   /// expression initializer.

--- a/test/Profiler/coverage_class.swift
+++ b/test/Profiler/coverage_class.swift
@@ -1,32 +1,43 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_class %s | %FileCheck %s
 
 class C {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.foo
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.foo() -> ()
+  // CHECK-NEXT: [[@LINE+1]]:14 -> [[@LINE+1]]:16 : 0
   func foo() {}
-  // CHECK: sil_coverage_map {{.*}}// __ntd_C_line:[[@LINE-3]]:1
+
+  // CHECK: sil_coverage_map {{.*}}// coverage_class.C.init() -> coverage_class.C
   // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:12
   init() {}
+
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.__deallocating_deinit
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:12
   deinit {}
 }
 
 extension C {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.bar
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.bar() -> ()
+  // CHECK-NEXT: [[@LINE+1]]:14 -> [[@LINE+1]]:16 : 0
   func bar() {}
 }
 
 struct S {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.foo
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.foo() -> ()
+  // CHECK-NEXT: [[@LINE+1]]:14 -> [[@LINE+1]]:16 : 0
   func foo() {}
-  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-3]]:1
+
+  // CHECK: sil_coverage_map {{.*}}// coverage_class.S.init() -> coverage_class.S
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:12
   init() {}
 }
 
 enum E {
   case X, Y, Z
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.foo
+
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.foo() -> ()
+  // CHECK-NEXT: [[@LINE+1]]:14 -> [[@LINE+1]]:16 : 0
   func foo() {}
-  // CHECK: sil_coverage_map {{.*}}// __ntd_E_line:[[@LINE-4]]:1
+
+  // CHECK: sil_coverage_map {{.*}}// coverage_class.E.init() -> coverage_class.E
   // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:23
   init() { self = .Y }
 }
@@ -34,9 +45,10 @@ enum E {
 var g1: Bool = true
 
 struct S2 {
-  // CHECK: sil_coverage_map {{.*}}// __ntd_S2_line:[[@LINE-1]]:1
-  // CHECK-NEXT: [[@LINE+2]]:22 -> [[@LINE+2]]:23 : 0
-  // CHECK-NEXT: [[@LINE+1]]:26 -> [[@LINE+1]]:27 : (1 - 0)
+  // CHECK: sil_coverage_map {{.*}}// variable initialization expression of coverage_class.S2.m1 : Swift.Int
+  // CHECK-NEXT: [[@LINE+3]]:22 -> [[@LINE+3]]:23 : 1
+  // CHECK-NEXT: [[@LINE+2]]:26 -> [[@LINE+2]]:27 : (0 - 1)
+  // CHECK-NEXT: [[@LINE+1]]:17 -> [[@LINE+1]]:27 : 0
   var m1: Int = g1 ? 0 : 1
 }
 

--- a/test/Profiler/coverage_closures.swift
+++ b/test/Profiler/coverage_closures.swift
@@ -34,9 +34,10 @@ func foo() {
   f1 { left, right in left == 0 || right == 1 }
 }
 
-// SR-2615: Implicit constructor decl has no body, and shouldn't be mapped
+// SR-2615: Display coverage for implicit member initializers without crashing
 struct C1 {
-// CHECK-NOT: sil_coverage_map{{.*}}errors
+  // CHECK-LABEL: sil_coverage_map{{.*}}// variable initialization expression of coverage_closures.C1
+  // CHECK-NEXT: [[@LINE+1]]:24 -> [[@LINE+1]]:34 : 0
   private var errors = [String]()
 }
 

--- a/test/Profiler/coverage_exceptions.swift
+++ b/test/Profiler/coverage_exceptions.swift
@@ -1,5 +1,16 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_catch %s | %FileCheck %s
 
+struct S {
+  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.S.init() -> coverage_catch.S
+  init() {     // CHECK: [[@LINE]]:10 -> [[@LINE+6]]:4 : 0
+    do {       // CHECK: [[@LINE]]:8 -> [[@LINE+2]]:6 : 0
+      throw SomeErr.Err1
+    } catch {
+      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 1
+    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 0
+  }
+}
+
 enum SomeErr : Error {
   case Err1
   case Err2
@@ -108,15 +119,4 @@ func joo() -> Int {
 
   } while false // CHECK: [[@LINE]]:11 {{.*}} : (1 - 2)
   return 1
-}
-
-struct S {
-  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-1]]
-  init() {
-    do {
-      throw SomeErr.Err1
-    } catch {
-      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 1
-    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 0
-  }
 }

--- a/test/Profiler/coverage_primary_file.swift
+++ b/test/Profiler/coverage_primary_file.swift
@@ -4,8 +4,8 @@
 // ALL: sil_coverage_map {{.*}} // closure #1 () -> Swift.Int in coverage_primary_file.Box.x.getter : Swift.Int
 // ALL: sil_coverage_map {{.*}} // coverage_primary_file.Box.init(y: Swift.Int) -> coverage_primary_file.Box
 // ALL: sil_coverage_map {{.*}} // coverage_primary_file.Box.init(z: Swift.String) -> coverage_primary_file.Box
+// ALL: sil_coverage_map {{.*}} // coverage_primary_file.Box.init() -> coverage_primary_file.Box
 // ALL: sil_coverage_map {{.*}} // coverage_primary_file.main() -> ()
-// ALL: sil_coverage_map {{.*}} // __ntd_Box
 
 // PRIMARY-NOT: sil_coverage_map
 // PRIMARY: sil_coverage_map {{.*}} // coverage_primary_file.Box.init(y: Swift.Int) -> coverage_primary_file.Box

--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -133,9 +133,9 @@ extension Struct1 {
 var g2: Int = 0
 
 class Class3 {
-  var m1 = g2 == 0
-             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
-             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  var m1 = g2 == 0     // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
+             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
+             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
 }
 
 // rdar://34244637: Wrong coverage for do/catch sequence

--- a/test/Profiler/coverage_ternary.swift
+++ b/test/Profiler/coverage_ternary.swift
@@ -1,17 +1,25 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_ternary %s | %FileCheck %s
 
+// coverage_ternary.bar.init() -> coverage_ternary.bar
 // CHECK-LABEL: sil hidden @$s16coverage_ternary3barCACycfc
 // CHECK-NOT: return
 // CHECK: builtin "int_instrprof_increment"
 
-// CHECK-LABEL: sil hidden @$s16coverage_ternary3barCfD
-// CHECK-NOT: return
-// CHECK: builtin "int_instrprof_increment"
+// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
+// CHECK: sil_coverage_map {{.*}}// variable initialization expression of coverage_ternary.bar.m1 : Swift.String
+class bar {
+  var m1 = flag == 0   // CHECK: [[@LINE]]:12 -> [[@LINE+2]]:22 : 0
+             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 1
+             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : (0 - 1)
+}
+
+// Note: We didn't instantiate bar, but we still expect to see instrumentation
+// for its *structors, and coverage mapping information for it.
 
 var flag: Int = 0
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.foo
-func foo(_ x : Int32) -> Int32 {
+func foo(_ x : Int32) -> Int32 { // CHECK: [[@LINE]]:32 -> [[@LINE+4]]:2 : 0
   return x == 3
              ? 9000 // CHECK: [[@LINE]]:16 -> [[@LINE]]:20 : 1
              : 1234 // CHECK: [[@LINE]]:16 -> [[@LINE]]:20 : (0 - 1)
@@ -20,14 +28,3 @@ func foo(_ x : Int32) -> Int32 {
 foo(1)
 foo(2)
 foo(3)
-
-// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
-// CHECK: sil_coverage_map {{.*}}// __ntd_bar_line:[[@LINE+1]]
-class bar {
-  var m1 = flag == 0
-             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 0
-             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : (1 - 0)
-}
-
-// Note: We didn't instantiate bar, but we still expect to see instrumentation
-// for its *structors, and coverage mapping information for it.


### PR DESCRIPTION
Assign separate SILProfiler instances to stored property initializers
and constructors.

Starting with rdar://39460313, coverage reporting for these constructs
was bundled up into a single SILProfiler uniqued by the NominalTypeDecl.
There are two problems with doing this.

First, the shared SILProfiler is given a fake name that can't be
demangled. That breaks Xcode's reports.  Second, the relationship
between SILProfiler and SILFunction is supposed to be 1:1. Having a
shared SILProfiler muddies things a bit and requires extra bookkeeping.

rdar://47467864