### PR TITLE
validation-test: correct typo in ParseableInterface.verify_all_overlays

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -4,7 +4,7 @@
 # generated.
 
 # RUN: %empty-directory(%t)
-# RUN: ${python} %s %target-os %target-cpu %platform-sdk-overlay-dir %t \
+# RUN: %{python} %s %target-os %target-cpu %platform-sdk-overlay-dir %t \
 # RUN:   %target-swift-frontend -build-module-from-parseable-interface \
 # RUN:     -Fsystem %sdk/System/Library/PrivateFrameworks/ >> %t/failures.txt
 # RUN: test ! -e %t/failures.txt || \


### PR DESCRIPTION
The `%{python}` substitution was typoed with the `%` sigil being
replaced with `$`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
