### PR TITLE
[AutoDiff] Expose failing control flow + recursion + buffer AD test.

### DIFF
--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -338,21 +338,47 @@ ControlFlowTests.test("Recursion") {
   expectEqual(26, gradient(at: 4, in: factorial))
   expectEqual(154, gradient(at: 5, in: factorial))
 
-  func factorial_var(_ x: Float) -> Float {
+  func factorial_var1(_ x: Float) -> Float {
+    var y: Float = x
+    if x == 1 {
+      y = 1
+    } else {
+      y = x
+      y = y * factorial_var1(y - 1)
+    }
+    return y
+  }
+  expectEqual(0, gradient(at: 1, in: factorial_var1))
+  expectEqual(1, gradient(at: 2, in: factorial_var1))
+  expectEqual(5, gradient(at: 3, in: factorial_var1))
+  expectEqual(26, gradient(at: 4, in: factorial_var1))
+  expectEqual(154, gradient(at: 5, in: factorial_var1))
+
+  func factorial_var2(_ x: Float) -> Float {
+    // Next line is the only difference with `factorial_var1`.
     var y: Float = 1
     if x == 1 {
       y = 1
     } else {
       y = x
-      y = y * factorial(y - 1)
+      y = y * factorial_var2(y - 1)
     }
     return y
   }
-  expectEqual(0, gradient(at: 1, in: factorial))
-  expectEqual(1, gradient(at: 2, in: factorial))
-  expectEqual(5, gradient(at: 3, in: factorial))
-  expectEqual(26, gradient(at: 4, in: factorial))
-  expectEqual(154, gradient(at: 5, in: factorial))
+  // FIXME: Fix zero gradients (related to activity analysis).
+  // See `factorial_var1` for the working version.
+  /*
+  expectEqual(0, gradient(at: 1, in: factorial_var2))
+  expectEqual(1, gradient(at: 2, in: factorial_var2))
+  expectEqual(5, gradient(at: 3, in: factorial_var2))
+  expectEqual(26, gradient(at: 4, in: factorial_var2))
+  expectEqual(154, gradient(at: 5, in: factorial_var2))
+  */
+  expectEqual(0, gradient(at: 1, in: factorial_var2))
+  expectEqual(0, gradient(at: 2, in: factorial_var2))
+  expectEqual(0, gradient(at: 3, in: factorial_var2))
+  expectEqual(0, gradient(at: 4, in: factorial_var2))
+  expectEqual(0, gradient(at: 5, in: factorial_var2))
 
   func product(_ x: Float, count: Int) -> Float {
     precondition(count > 0)


### PR DESCRIPTION
Filed [TF-554](https://bugs.swift.org/browse/TF-554).