### PR TITLE
IRGen: Generate spare bit mask lazily in StructLayoutBuilder

### DIFF
--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -78,7 +78,7 @@ StructLayout::StructLayout(IRGenModule &IGM,
   } else {
     MinimumAlign = builder.getAlignment();
     MinimumSize = builder.getSize();
-    SpareBits = std::move(builder.getSpareBits());
+    SpareBits = builder.getSpareBits();
     IsFixedLayout = builder.isFixedLayout();
     IsKnownPOD = builder.isPOD();
     IsKnownBitwiseTakable = builder.isBitwiseTakable();
@@ -263,9 +263,11 @@ void StructLayoutBuilder::addFixedSizeElement(ElementLayout &elt) {
     if (isFixedLayout()) {
       auto paddingTy = llvm::ArrayType::get(IGM.Int8Ty, paddingRequired);
       StructFields.push_back(paddingTy);
-      
+
       // The padding can be used as spare bits by enum layout.
-      CurSpareBits.appendSetBits(Size(paddingRequired).getValueInBits());
+      auto numBits = Size(paddingRequired).getValueInBits();
+      auto mask = llvm::APInt::getAllOnesValue(numBits);
+      CurSpareBits.push_back(SpareBitVector::fromAPInt(mask));
     }
   }
 
@@ -318,7 +320,7 @@ void StructLayoutBuilder::addElementAtFixedOffset(ElementLayout &elt) {
   StructFields.push_back(elt.getType().getStorageType());
   
   // Carry over the spare bits from the element.
-  CurSpareBits.append(eltTI.getSpareBits());
+  CurSpareBits.push_back(eltTI.getSpareBits());
 }
 
 /// Add an element at a non-fixed offset to the aggregate.
@@ -326,7 +328,7 @@ void StructLayoutBuilder::addElementAtNonFixedOffset(ElementLayout &elt) {
   assert(!isFixedLayout());
   elt.completeNonFixed(elt.getType().isPOD(ResilienceExpansion::Maximal),
                        NextNonFixedOffsetIndex);
-  CurSpareBits.clear();
+  CurSpareBits = SmallVector<SpareBitVector, 8>(); // clear spare bits
 }
 
 /// Add a non-fixed-size element to the aggregate at offset zero.
@@ -335,7 +337,7 @@ void StructLayoutBuilder::addNonFixedSizeElementAtOffsetZero(ElementLayout &elt)
   assert(!isa<FixedTypeInfo>(elt.getType()));
   assert(CurSize.isZero());
   elt.completeInitialNonFixedSize(elt.getType().isPOD(ResilienceExpansion::Maximal));
-  CurSpareBits.clear();
+  CurSpareBits = SmallVector<SpareBitVector, 8>(); // clear spare bits
 }
 
 /// Produce the current fields as an anonymous structure.
@@ -357,4 +359,28 @@ void StructLayoutBuilder::setAsBodyOfStruct(llvm::StructType *type) const {
           || IGM.DataLayout.getStructLayout(type)->getSizeInBytes()
             == CurSize.getValue())
          && "LLVM size of fixed struct type does not match StructLayout size");
+}
+
+/// Return the spare bit mask of the structure built so far.
+SpareBitVector StructLayoutBuilder::getSpareBits() const {
+  // Calculate the size up front to reduce possible allocations.
+  unsigned numBits = 0;
+  for (auto &v : CurSpareBits) {
+    numBits += v.size();
+  }
+  if (numBits == 0) {
+    return SpareBitVector();
+  }
+  // Assemble the spare bit mask.
+  auto mask = llvm::APInt::getNullValue(numBits);
+  unsigned offset = 0;
+  for (auto &v : CurSpareBits) {
+    if (v.size() == 0) {
+      continue;
+    }
+    mask.insertBits(v.asAPInt(), offset);
+    offset += v.size();
+  }
+  assert(offset == numBits);
+  return SpareBitVector::fromAPInt(std::move(mask));
 }

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -239,7 +239,7 @@ protected:
   Size CurSize = Size(0);
 private:
   Alignment CurAlignment = Alignment(1);
-  SpareBitVector CurSpareBits;
+  SmallVector<SpareBitVector, 8> CurSpareBits;
   unsigned NextNonFixedOffsetIndex = 0;
   bool IsFixedLayout = true;
   IsPOD_t IsKnownPOD = IsPOD;
@@ -300,12 +300,9 @@ public:
 
   /// Return the alignment of the structure built so far.
   Alignment getAlignment() const { return CurAlignment; }
-  
-  /// Return the spare bit mask of the structure built so far.
-  const SpareBitVector &getSpareBits() const { return CurSpareBits; }
 
   /// Return the spare bit mask of the structure built so far.
-  SpareBitVector &getSpareBits() { return CurSpareBits; }
+  SpareBitVector getSpareBits() const;
 
   /// Build the current elements as a new anonymous struct type.
   llvm::StructType *getAsAnonStruct() const;


### PR DESCRIPTION
Wait until we know the full size of the SpareBitVector before we
construct it from the spare bit masks of the individual elements
in the struct. This process mirrors the way we construct the rest
of the struct type.

This should reduce the number of short-lived allocations required
to build small struct types (especially after #25240). It also
provides a convenient place to insert code to handle the
construction of big-endian bit masks on when targeting big-endian
machines, assuming we decide to go down that route.