### PR TITLE
IRGen: Fix handling of singleton aggregate projections and tuple types

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2291,14 +2291,9 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
     auto field = allFields.begin();
     if (!allFields.empty() && std::next(field) == allFields.end()) {
       auto fieldTy = t.getFieldType(*field, IGM.getSILModule());
-      if (auto fieldDecl = fieldTy.getNominalOrBoundGenericNominal()) {
-        // The field's access level must be higher or equal to the enclosing
-        // struct's.
-        if (fieldDecl->getEffectiveAccess() >= structDecl->getEffectiveAccess())
-          return fieldTy;
-      } else {
-        return fieldTy;
-      }
+      if (!IGM.isTypeABIAccessible(fieldTy))
+        return SILType();
+      return fieldTy;
     }
 
     return SILType();
@@ -2316,14 +2311,9 @@ SILType irgen::getSingletonAggregateFieldType(IRGenModule &IGM, SILType t,
     if (!allCases.empty() && std::next(theCase) == allCases.end()
         && (*theCase)->hasAssociatedValues()) {
       auto enumEltTy = t.getEnumElementType(*theCase, IGM.getSILModule());
-      if (auto eltDecl = enumEltTy.getNominalOrBoundGenericNominal()) {
-        // The enum element's access level must be higher or equal to the
-        // enclosing struct's.
-        if (eltDecl->getEffectiveAccess() >= enumDecl->getEffectiveAccess())
-          return enumEltTy;
-      } else {
-        return enumEltTy;
-      }
+      if (!IGM.isTypeABIAccessible(enumEltTy))
+        return SILType();
+      return enumEltTy;
     }
 
     return SILType();

--- a/test/IRGen/Inputs/metadata2.swift
+++ b/test/IRGen/Inputs/metadata2.swift
@@ -24,3 +24,66 @@ struct InternalContainer {
         self.type = SomeEnumType(item: item)
     }
 }
+
+struct InternalContainer2 {
+
+    fileprivate enum SomeEnumType {
+        case none
+        case single(Item)
+
+        init(item: [Item]) {
+            if item.count >= 1 {
+                self = .single(item.first!)
+            } else {
+                self = .none
+            }
+        }
+    }
+
+    private var type: (SomeEnumType, SomeEnumType)
+
+    init(item: [Item]) {
+        self.type = SomeEnumType(item: item)
+    }
+}
+
+enum InternalSingletonEnum {
+  fileprivate enum SomeEnumType {
+       case none
+       case single(Item)
+
+       init(item: [Item]) {
+           if item.count >= 1 {
+               self = .single(item.first!)
+           } else {
+               self = .none
+           }
+       }
+  }
+  case first(SomeEnumType)
+
+  init() {
+    return .first(.none)
+  }
+}
+
+enum InternalSingletonEnum2 {
+  fileprivate enum SomeEnumType {
+       case none
+       case single(Item)
+
+       init(item: [Item]) {
+           if item.count >= 1 {
+               self = .single(item.first!)
+           } else {
+               self = .none
+           }
+       }
+  }
+
+  case first(SomeEnumType, SomeEnumType)
+
+  init() {
+    return .first(.none, .none)
+  }
+}

--- a/test/IRGen/metadata.swift
+++ b/test/IRGen/metadata.swift
@@ -8,6 +8,9 @@
 // CHECK:  ret
 class MyController {
   var c = InternalContainer(item: [])
+  var c2 = InternalContainer2(item: [])
+  var e = InternalSingletonEnum()
+  var e2 = InternalSingletonEnum2()
   func update(_ n: InternalContainer) {
     c = n
   }


### PR DESCRIPTION
Follow up to "IRGen: getSingletonAggregateFieldType must not return field if
its access level does not match"

rdar://50554717