### PR TITLE
validation-test: avoid shell in ParseableInterface.verify_all_overlays

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -6,9 +6,11 @@
 # RUN: %empty-directory(%t)
 # RUN: %{python} %s %target-os %target-cpu %platform-sdk-overlay-dir %t \
 # RUN:   %target-swift-frontend -build-module-from-parseable-interface \
-# RUN:     -Fsystem %sdk/System/Library/PrivateFrameworks/ >> %t/failures.txt
+# RUN:     -Fsystem %sdk/System/Library/PrivateFrameworks/ \
+# RUN:     | sort > %t/failures.txt
+# RUN: grep '# %target-os:' %s > %t/filter.txt || true
 # RUN: test ! -e %t/failures.txt || \
-# RUN:   diff <(grep '# %target-os:' %s) <(sort -f %t/failures.txt)
+# RUN:   diff %t/filter.txt %t/failures.txt
 
 # REQUIRES: nonexecutable_test
 


### PR DESCRIPTION
Avoid using shell in the test as not all targets run with a POSIX shell
for the test executor.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
