### PR TITLE
Parameterized extensions

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -153,7 +153,7 @@ private:
   bool validateParentType(TypeDecl *decl, Type parent);
   CanGenericSignature demangleGenericSignature(
       NominalTypeDecl *nominalDecl,
-      NodePointer node);
+      NodePointer node, bool isParameterizedExtension);
   DeclContext *findDeclContext(NodePointer node);
   ModuleDecl *findModule(NodePointer node);
   Demangle::NodePointer findModuleNode(NodePointer node);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1216,6 +1216,7 @@ class ExtensionDecl final : public GenericContext, public Decl,
 
   ExtensionDecl(SourceLoc extensionLoc, TypeRepr *extendedType,
                 MutableArrayRef<TypeLoc> inherited,
+                GenericParamList *genericParams,
                 DeclContext *parent,
                 TrailingWhereClause *trailingWhereClause);
 
@@ -1241,6 +1242,7 @@ public:
   static ExtensionDecl *create(ASTContext &ctx, SourceLoc extensionLoc,
                                TypeRepr *extendedType,
                                MutableArrayRef<TypeLoc> inherited,
+                               GenericParamList *genericParams,
                                DeclContext *parent,
                                TrailingWhereClause *trailingWhereClause,
                                ClangNode clangNode = ClangNode());

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1347,6 +1347,10 @@ public:
   /// resiliently moved into the original protocol itself.
   bool isEquivalentToExtendedContext() const;
 
+  /// Whether this extension contains unique generic parameters that differ from
+  /// the extended nominal's generic signature.
+  bool isParameterized() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Extension;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -448,6 +448,15 @@ public:
         const_cast<DeclContext *>(this)->getInnermostSkippedFunctionContext();
   }
 
+  /// Returns the outermost context based off syntactic depth, right below the
+  /// module context. E.g. for a nested type in a nested type in an extension,
+  /// this returns that extension.
+  LLVM_READONLY
+  DeclContext *getOutermostSyntacticContext();
+  const DeclContext *getOutermostSyntacticContext() const {
+    return const_cast<DeclContext *>(this)->getOutermostSyntacticContext();
+  }
+
   /// Returns the semantic parent of this context.  A context has a
   /// parent if and only if it is not a module context.
   DeclContext *getParent() const {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1797,9 +1797,6 @@ ERROR(extension_access_with_conformances,none,
       "protocol conformances", (DeclAttribute))
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
-ERROR(extension_specialization,none,
-      "constrained extension must be declared on the unspecialized generic "
-      "type %0 with constraints specified by a 'where' clause", (Identifier))
 ERROR(extension_stored_property,none,
       "extensions must not contain stored properties", ())
 NOTE(extension_stored_property_fixit,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1787,6 +1787,10 @@ ERROR(inferred_opaque_type,none,
 // Extensions
 ERROR(non_nominal_extension,none,
       "non-nominal type %0 cannot be extended", (Type))
+ERROR(generic_param_extension,none,
+      "cannot extend generic parameter type %0", (Identifier))
+ERROR(concrete_generic_extension,none,
+      "cannot have generic parameters when extending a concrete type", ())
 WARNING(composition_in_extended_type,none,
         "extending a protocol composition is not supported; extending %0 "
         "instead", (Type))

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -297,6 +297,7 @@ NODE(NoncanonicalSpecializedGenericTypeMetadataCache)
 NODE(GlobalVariableOnceFunction)
 NODE(GlobalVariableOnceToken)
 NODE(GlobalVariableOnceDeclList)
+CONTEXT_NODE(GenericExtension)
 
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -503,7 +503,7 @@ protected:
   NodePointer popTypeAndGetAnyGeneric();
   NodePointer demangleBuiltinType();
   NodePointer demangleAnyGenericType(Node::Kind kind);
-  NodePointer demangleExtensionContext();
+  NodePointer demangleExtensionContext(bool isParameterized);
   NodePointer demanglePlainFunction();
   NodePointer popFunctionType(Node::Kind kind);
   NodePointer popFunctionParams(Node::Kind kind);

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -1078,6 +1078,7 @@ private:
       case Node::Kind::Module:
         break;
       case Node::Kind::Extension:
+      case Node::Kind::GenericExtension:
         // Decode the type being extended.
         if (parentContext->getNumChildren() < 2)
           return MAKE_NODE_TYPE_ERROR(parentContext,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -630,6 +630,9 @@ namespace {
 
     void visitExtensionDecl(ExtensionDecl *ED) {
       printCommon(ED, "extension_decl", ExtensionColor);
+      if (ED->isParameterized()) {
+        printGenericParameters(OS, ED->getParsedGenericParams());
+      }
       OS << ' ';
       ED->getExtendedType().print(OS);
       printCommonPost(ED);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2315,9 +2315,15 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
   if (Options.BracketOptions.shouldOpenExtension(decl)) {
     printDocumentationComment(decl);
     printAttributes(decl);
-    Printer << "extension ";
+    Printer << tok::kw_extension;
+
+    if (decl->isParameterized()) {
+      printGenericDeclGenericParams(decl);
+    }
+
+    Printer << " ";
+
     recordDeclLoc(decl, [&]{
-      // We cannot extend sugared types.
       Type extendedType = decl->getExtendedType();
       if (!extendedType) {
         // Fallback to TypeRepr.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1103,9 +1103,10 @@ NominalTypeDecl::takeConformanceLoaderSlow() {
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
                              TypeRepr *extendedType,
                              MutableArrayRef<TypeLoc> inherited,
+                             GenericParamList *genericParams,
                              DeclContext *parent,
                              TrailingWhereClause *trailingWhereClause)
-  : GenericContext(DeclContextKind::ExtensionDecl, parent, nullptr),
+  : GenericContext(DeclContextKind::ExtensionDecl, parent, genericParams),
     Decl(DeclKind::Extension, parent),
     IterableDeclContext(IterableDeclContextKind::ExtensionDecl),
     ExtensionLoc(extensionLoc),
@@ -1120,6 +1121,7 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
 ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,
                                      TypeRepr *extendedType,
                                      MutableArrayRef<TypeLoc> inherited,
+                                     GenericParamList *genericParams,
                                      DeclContext *parent,
                                      TrailingWhereClause *trailingWhereClause,
                                      ClangNode clangNode) {
@@ -1130,8 +1132,8 @@ ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,
 
   // Construct the extension.
   auto result = ::new (declPtr) ExtensionDecl(extensionLoc, extendedType,
-                                              inherited, parent,
-                                              trailingWhereClause);
+                                              inherited, genericParams,
+                                              parent, trailingWhereClause);
   if (clangNode)
     result->setClangNode(clangNode);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1231,6 +1231,20 @@ bool ExtensionDecl::isEquivalentToExtendedContext() const {
     && !getDeclaredInterfaceType()->isExistentialType();
 }
 
+bool ExtensionDecl::isParameterized() const {
+  if (!hasBeenBound())
+    return getParsedGenericParams();
+
+  auto nominal = getExtendedNominal();
+  if (!nominal && getParsedGenericParams())
+    return true;
+
+  if (!nominal)
+    return false;
+
+  return getGenericContextDepth() != nominal->getGenericContextDepth();
+}
+
 AccessLevel ExtensionDecl::getDefaultAccessLevel() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -247,6 +247,17 @@ DeclContext *DeclContext::getInnermostSkippedFunctionContext() {
   return nullptr;
 }
 
+DeclContext *DeclContext::getOutermostSyntacticContext() {
+  auto depth = getSyntacticDepth() - 1;
+  auto dc = this;
+
+  for (auto i = 0; i != depth; i += 1) {
+    dc = dc->getParent();
+  }
+
+  return dc;
+}
+
 DeclContext *DeclContext::getParentForLookup() const {
   if (isa<ProtocolDecl>(this) || isa<ExtensionDecl>(this)) {
     // If we are inside a protocol or an extension, skip directly

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -96,7 +96,12 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   if (auto proto = dyn_cast<ProtocolDecl>(this)) {
     genericParams = proto->getGenericParams();
   } else {
-    genericParams = cast<ExtensionDecl>(this)->getGenericParams();
+    auto ext = cast<ExtensionDecl>(this);
+    genericParams = ext->getGenericParams();
+
+    if (ext->isParameterized()) {
+      genericParams = genericParams->getOuterParameters();
+    }
   }
 
   if (genericParams == nullptr)

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -212,6 +212,13 @@ void GetDestructorRequest::cacheResult(DestructorDecl *value) const {
 
 Optional<GenericParamList *> GenericParamListRequest::getCachedResult() const {
   auto *decl = std::get<0>(getStorage());
+
+  // If this is an extension and we can get the parsed generic params, go ahead
+  // and go through the request evaluation because we still need to clone the
+  // nominal's generic param list.
+  if (isa<ExtensionDecl>(decl) && decl->getParsedGenericParams())
+    return None;
+
   if (auto *params = decl->GenericParamsAndBit.getPointer())
     return params;
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -538,10 +538,11 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
   // The extension signature should be a superset of the type signature, meaning
   // every thing in the type signature either is included too or is implied by
   // something else. The most important bit is having the same type
-  // parameters. (NB. if/when Swift gets parameterized extensions, this needs to
-  // change.)
-  assert(typeSig->getCanonicalSignature().getGenericParams() ==
+  // parameters. If the extension is parameterized however, this is untrue.
+  if (!ext->isParameterized()) {
+    assert(typeSig->getCanonicalSignature().getGenericParams() ==
          extensionSig->getCanonicalSignature().getGenericParams());
+  }
 
   // Find the requirements in the extension that aren't proved by the original
   // type, these are the ones that make the conformance conditional.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4679,7 +4679,7 @@ namespace {
       auto result = ExtensionDecl::create(
                       Impl.SwiftContext, loc,
                       nullptr,
-                      { }, dc, nullptr, decl);
+                      { }, nullptr, dc, nullptr, decl);
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedTypeRequest{result},
                                               objcClass->getDeclaredType());
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{result},
@@ -8382,7 +8382,8 @@ ClangImporter::Implementation::importDeclContextOf(
 
   // Create a new extension for this nominal type/Clang submodule pair.
   auto ext = ExtensionDecl::create(SwiftContext, SourceLoc(), nullptr, {},
-                                   getClangModuleForDecl(decl), nullptr);
+                                   nullptr, getClangModuleForDecl(decl),
+                                   nullptr);
   SwiftContext.evaluator.cacheOutput(ExtendedTypeRequest{ext},
                                      nominal->getDeclaredType());
   SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{ext},

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -556,6 +556,7 @@ private:
     case Node::Kind::GlobalVariableOnceDeclList:
     case Node::Kind::GlobalVariableOnceFunction:
     case Node::Kind::GlobalVariableOnceToken:
+    case Node::Kind::GenericExtension:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -1166,6 +1167,7 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     }
     return nullptr;
   case Node::Kind::Extension:
+  case Node::Kind::GenericExtension:
     assert((Node->getNumChildren() == 2 || Node->getNumChildren() == 3)
            && "Extension expects 2 or 3 children.");
     if (Options.QualifyEntities && Options.DisplayExtensionContexts) {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1576,12 +1576,20 @@ void Remangler::mangleExtension(Node *node, EntityContext &ctx) {
   } else {
     Buffer << 'E';
   }
-  mangleEntityContext(node->begin()[0], ctx); // module
+  mangleEntityContext(node->getChild(0), ctx); // module
   if (node->getNumChildren() == 3) {
-    mangleDependentGenericSignature(node->begin()[2]); // generic sig
+    mangleDependentGenericSignature(node->getChild(2)); // generic sig
   }
 
-  mangleEntityContext(node->begin()[1], ctx); // context
+  mangleEntityContext(node->getChild(1), ctx); // context
+}
+
+void Remangler::mangleGenericExtension(Node *node, EntityContext &ctx) {
+  assert(node->getNumChildren() == 3);
+  Buffer << 'J';
+  mangleEntityContext(node->getChild(0), ctx); // module
+  mangleDependentGenericSignature(node->getChild(2)); // generic sig
+  mangleEntityContext(node->getChild(1), ctx); // context
 }
 
 void Remangler::mangleAnonymousContext(Node *node, EntityContext &ctx) {
@@ -1734,7 +1742,8 @@ void Remangler::mangleGenericArgs(Node *node, EntityContext &ctx) {
   }
 
   case Node::Kind::AnonymousContext:
-  case Node::Kind::Extension: {
+  case Node::Kind::Extension:
+  case Node::Kind::GenericExtension: {
     mangleGenericArgs(node->getChild(1), ctx);
     break;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4648,6 +4648,19 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   
   DebuggerContextChange DCC (*this);
 
+  // Parse the generic params, if present.
+  Optional<Scope> genericScope;
+  genericScope.emplace(this, ScopeKind::Generics);
+  GenericParamList *genericParams;
+  bool gpHasCodeCompletion = false;
+
+  auto genericResult = maybeParseGenericParams();
+  genericParams = genericResult.getPtrOrNull();
+  gpHasCodeCompletion |= genericResult.hasCodeCompletion();
+
+  if (gpHasCodeCompletion && !CodeCompletion)
+    return makeParserCodeCompletionStatus();
+
   // Parse the type being extended.
   ParserStatus status;
   ParserResult<TypeRepr> extendedType = parseType(diag::extension_type_expected);
@@ -4681,9 +4694,12 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     status |= whereStatus;
   }
 
+  diagnoseWhereClauseInGenericParamList(genericParams);
+
   ExtensionDecl *ext = ExtensionDecl::create(Context, ExtensionLoc,
                                              extendedType.getPtrOrNull(),
                                              Context.AllocateCopy(Inherited),
+                                             genericParams,
                                              CurDeclContext,
                                              trailingWhereClause);
   ext->getAttrs() = Attributes;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2408,6 +2408,18 @@ public:
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
+    // First, if this extension is parameterized and isn't invalid, go ahead and
+    // compute the generic signature. This is important because the interface
+    // type could contain a generic parameter and we need to set depths of each
+    // parameter.
+    if (ED->isParameterized()) {
+      if (!ED->isInvalid()) {
+        (void) ED->getGenericSignature();
+      } else {
+        return;
+      }
+    }
+
     // Produce any diagnostics for the extended type.
     auto extType = ED->getExtendedType();
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -531,6 +531,10 @@ static Type formExtensionInterfaceType(
   } else {
     auto currentBoundType = type->getAs<BoundGenericType>();
 
+    if (ext->isParameterized()) {
+      genericParams = genericParams->getOuterParameters();
+    }
+
     // Form the bound generic type with the type parameters provided.
     unsigned gpIndex = 0;
     for (auto gp : *genericParams) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3929,7 +3929,7 @@ public:
       return declOrOffset;
 
     auto extension = ExtensionDecl::create(ctx, SourceLoc(), nullptr, { },
-                                           DC, nullptr);
+                                           nullptr, DC, nullptr);
     declOrOffset = extension;
 
     // Generic parameter lists are written from outermost to innermost.

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -370,3 +370,5 @@ $s7example1fyyYF -> example.f() async -> ()
 $s7example1fyyYKF -> example.f() async throws -> ()
 $s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
 $s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
+_TtCJ4mainRxzGSqqd___rVS_4Pair6Nested ---> (extension in main):main.Pair<A where A == A1?>.Nested
+$s4main4PairVAAqd__SgRszlJ6NestedC ---> (extension in main):main.Pair<A where A == A1?>.Nested

--- a/test/TypeDecoder/extensions.swift
+++ b/test/TypeDecoder/extensions.swift
@@ -58,3 +58,24 @@ extension Generic where T: AnyObject {
 // DEMANGLE-DECL: $s10extensions7GenericVAARlzClE18NestedViaAnyObjectV
 // CHECK-DECL: extensions.(file).Generic extension.NestedViaAnyObject
 
+// Parameterized Extensions
+
+extension<U> Generic<U?> {
+  struct Nested3 {}
+}
+
+extension<U: Proto> Generic<U> {
+  struct Nested4 {}
+}
+
+// DEMANGLE-TYPE: $s10extensions7GenericVAAqd__SgRszlJ7Nested3VyAD_GD
+// CHECK-TYPE: Generic<Optional<τ_1_0>>.Nested3
+
+// DEMANGLE-TYPE: $s10extensions7GenericVA2A5ProtoRzqd__RszlJ7Nested4Vyx_GD
+// CHECK-TYPE: Generic<τ_0_0>.Nested4
+
+// DEMANGLE-DECL: $s10extensions7GenericVAAqd__SgRszlJ7Nested3V
+// CHECK-DECL: extensions.(file).Generic extension.Nested3
+
+// DEMANGLE-DECL: $s10extensions7GenericVA2A5ProtoRzqd__RszlJ7Nested4V
+// CHECK-DECL: extensions.(file).Generic extension.Nested4

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -339,7 +339,8 @@ extension Tree.LimbContent.Contents {
 }
 
 extension Tree.BoughPayload.Contents {
- // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
+ // expected-error@-1 {{extension of type 'Tree.BoughPayload.Contents' (aka 'Nest<Int>') must be declared as an extension of 'Nest<Int>'}}
+ // expected-note@-2 {{did you mean to extend 'Nest<Int>' instead?}} {{11-37=Nest<Int>}}
 }
 
 // SR-10466 Check 'where' clause when referencing type defined inside extension

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -19,11 +19,9 @@ extension Double : P2 {
 }
 
 extension X<Int, Double, String> {
-// expected-error@-1{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
   let x = 0
   // expected-error@-1 {{extensions must not contain stored properties}}
   static let x = 0
-  // expected-error@-1 {{static stored properties not supported in generic types}}
   func f() -> Int {}
   class C<T> {}
 }

--- a/test/decl/ext/parameterized.swift
+++ b/test/decl/ext/parameterized.swift
@@ -128,3 +128,32 @@ _ = m.compacted() // ok
 let n = [1, 2, 3, 4]
 _ = n.compacted() // expected-error {{referencing instance method 'compacted()' on 'Collection' requires the types 'Int' and 'T?' be equivalent}}
                   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+// Cannot extend generic type parameters
+
+extension<T> T { // expected-error {{cannot extend generic parameter type 'T'}}
+  func sayHello() {
+    print("Hello!")
+  }
+}
+
+protocol X {}
+protocol Y {}
+
+extension<T: X> T: Y { // expected-error {{cannot extend generic parameter type 'T'}}
+  func sayGoodbye() {
+    print("Goodbye!")
+  }
+}
+
+// Cannot extend concrete types (also specialized types)
+
+extension<T> Int {} // expected-error {{cannot have generic parameters when extending a concrete type}}
+
+extension<T> [Int] {} // expected-error {{cannot have generic parameters when extending a concrete type}}
+
+extension<T> [Int] where Element == T? {} // expected-error {{cannot have generic parameters when extending a concrete type}}
+
+extension<T> [T?] {} // ok
+
+extension<T> [[[T?]]] {} // ok

--- a/test/decl/ext/parameterized.swift
+++ b/test/decl/ext/parameterized.swift
@@ -1,0 +1,130 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Pair<Element> {
+  var first: Element
+  var second: Element
+}
+
+// Reject invalid extensions
+
+struct BadScope {
+  extension<T> Pair<T> {} // expected-error {{declaration is only valid at file scope}}
+}
+
+// Basic parameterized extensions
+
+// Extend Pair where Element == Optional<T>
+extension<T> Pair where Element == T? {
+  var firstUnwrapped: T {
+    first!
+  }
+}
+
+let a = Pair<Int?>(first: 316, second: nil)
+_ = a.firstUnwrapped // ok
+
+let b = Pair<Int>(first: 316, second: 128)
+_ = b.firstUnwrapped // expected-error {{type of expression is ambiguous without more context}}
+
+// Ensure we can extend types with same type requirements
+
+// Extend Pair where Element == T, T: FixedWidthInteger
+extension<T: FixedWidthInteger> Pair<T> { // expected-note {{where 'Element' = 'Double'}}
+  var sum: T {
+    first + second
+  }
+}
+
+let c = Pair<Int>(first: 316, second: 128)
+_ = c.sum // ok
+
+let d = Pair<Double>(first: .pi, second: .zero)
+_ = d.sum // expected-error {{property 'sum' requires that 'Double' conform to 'FixedWidthInteger'}}
+
+// Extend Pair where Element == Optional<T>
+extension<T> Pair<T?> {
+  var secondUnwrapped: T {
+    second!
+  }
+}
+
+let e = Pair<Int?>(first: nil, second: 128)
+_ = e.secondUnwrapped // ok
+
+let f = Pair<Int>(first: 316, second: 128)
+_ = f.secondUnwrapped // expected-error {{type of expression is ambiguous without more context}}
+
+// Extend Pair where Element == Array<T>
+extension<T> Pair<[T]> { // expected-note {{where 'Element' = 'Set<Int>'}}
+                         // expected-note@-1 {{'T' declared as parameter to type 'Pair'}}
+  var concatenated: [T] {
+    first + second
+  }
+}
+
+let g = Pair<[Int]>(first: [1, 2, 3], second: [4, 5, 6])
+_ = g.concatenated // ok
+
+let h = Pair<Set<Int>>(first: [1, 2, 3], second: [4, 5, 6])
+_ = h.concatenated // expected-error {{generic parameter 'T' could not be inferred}}
+                   // expected-error@-1 {{property 'concatenated' requires the types 'Set<Int>' and '[T]' be equivalent}}
+
+// Ensure we can extend specialized types
+
+// Extend Pair where Element == String
+extension Pair<String> { // expected-note {{where 'Element' = '[Character]'}}
+                         // expected-note@-1 {{where 'Element' = '[Character]'}}
+  var firstLowered: String {
+    first.lowercased()
+  }
+
+  var secondLowered: String {
+    second.lowercased()
+  }
+}
+
+let i = Pair<String>(first: "Hello", second: "Hey")
+_ = i.firstLowered // ok
+_ = i.secondLowered // ok
+
+let j = Pair<[Character]>(first: ["H", "e", "l", "l", "o"], second: ["H", "e", "y"])
+_ = j.firstLowered // expected-error {{property 'firstLowered' requires the types '[Character]' and 'String' be equivalent}}
+_ = j.secondLowered // expected-error {{property 'secondLowered' requires the types '[Character]' and 'String' be equivalent}}
+
+// Ensure we can extend sugar types
+
+// Extend Array where Element == Optional<T>
+extension<T> [T?] { // expected-note {{where 'Element' = 'Int'}}
+                    // expected-note@-1 {{'T' declared as parameter to type 'Array'}}
+  var someValues: [T] {
+    var result = [T]()
+    for opt in self {
+      if let value = opt { result.append(value) }
+    }
+
+    return result
+  }
+}
+
+let k = [1, 2, nil, 4]
+_ = k.someValues // ok
+
+let l = [1, 2, 3, 4]
+_ = l.someValues // expected-error {{generic parameter 'T' could not be inferred}}
+                 // expected-error@-1 {{property 'someValues' requires the types 'Int' and 'T?' be equivalent}}
+
+// Protocol Extensions
+
+extension<T> Collection where Element == T? { // expected-note {{where 'Self.Element' = 'Int'}}
+                                              // expected-note@-1 {{'T' declared as parameter to type 'Collection'}}
+  func compacted() -> [T] {
+    compactMap { $0 }
+  }
+}
+
+let m = [1, 2, nil, 4]
+_ = m.compacted() // ok
+
+let n = [1, 2, 3, 4]
+_ = n.compacted() // expected-error {{referencing instance method 'compacted()' on 'Collection' requires the types 'Int' and 'T?' be equivalent}}
+                  // expected-error@-1 {{generic parameter 'T' could not be inferred}}

--- a/test/decl/ext/parameterized.swift
+++ b/test/decl/ext/parameterized.swift
@@ -173,3 +173,18 @@ _ = o == p // ok
 let q = Pair<Wrapped<Int>>(first: .init(value: 316), second: .init(value: 128))
 let r = Pair<Wrapped<Int>>(first: .init(value: 316), second: .init(value: 128))
 _ = q == r // expected-error {{binary operator '==' cannot be applied to two 'Pair<Wrapped<Int>>' operands}}
+
+// Nested Types in Parameterized Extensions
+
+extension<T> Pair<T?> { // expected-note {{requirement specified as 'Element' == 'T?' [with Element = Int, T = T]}}
+  struct NestedPair {
+    let first: T
+    let second: T
+  }
+}
+
+let s = Pair<Int?>.NestedPair(first: 128, second: 316) // ok
+
+let t = Pair<Int>.NestedPair(first: 128, second: 316) // expected-error {{'Pair<Element>.NestedPair' requires the types 'Int' and 'T?' be equivalent}}
+
+let u = Pair<Int?>.NestedPair(first: nil, second: 316) //expected-error {{'nil' is not compatible with expected argument type 'Int'}}

--- a/test/decl/ext/parameterized.swift
+++ b/test/decl/ext/parameterized.swift
@@ -157,3 +157,19 @@ extension<T> [Int] where Element == T? {} // expected-error {{cannot have generi
 extension<T> [T?] {} // ok
 
 extension<T> [[[T?]]] {} // ok
+
+// Conditional Conformance (!!!)
+
+struct Wrapped<T> {
+  let value: T
+}
+
+extension<T: Equatable> Pair<T>: Equatable {}
+
+let o = Pair<Int>(first: 316, second: 128)
+let p = Pair<Int>(first: 316, second: 128)
+_ = o == p // ok
+
+let q = Pair<Wrapped<Int>>(first: .init(value: 316), second: .init(value: 128))
+let r = Pair<Wrapped<Int>>(first: .init(value: 316), second: .init(value: 128))
+_ = q == r // expected-error {{binary operator '==' cannot be applied to two 'Pair<Wrapped<Int>>' operands}}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -302,9 +302,9 @@ func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {
 extension A {}
 
 extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
-extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension A<Float,Int> {}
 extension C<T> {}  // expected-error {{cannot find type 'T' in scope}}
-extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension C<Int> {}
 
 
 protocol ErrorQ {

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -263,8 +263,8 @@ DECL_NODES = [
          ]),
 
     # extension-declaration -> attributes? access-level-modifier?
-    #                            'extension' extended-type
-    #                              type-inheritance-clause?
+    #                            'extension' generic-parameter-clause?
+    #                             extended-type type-inheritance-clause?
     #                            generic-where-clause?
     #                            '{' extension-members '}'
     # extension-name -> identifier
@@ -275,6 +275,8 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList',
                    collection_element_name='Modifier', is_optional=True),
              Child('ExtensionKeyword', kind='ExtensionToken'),
+             Child('GenericParameterClause', kind='GenericParameterClause',
+                   is_optional=True),
              Child('ExtendedType', kind='Type'),
              Child('InheritanceClause', kind='TypeInheritanceClause',
                    is_optional=True),


### PR DESCRIPTION
Refer to: [Generics Manifesto](https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#parameterized-extensions).

I'm not really sure exactly what to discuss here, but right now this is a bare implementation of parameterized extensions. There might be some more that this needs, but this successfully implements all the examples from the manifesto. This also piggybacks on some of Doug's work with extending specialized typealiases, but now you can extend specialized nominal types as well.

```swift
extension<T> Array where Element == T? {}
extension<T> Array<T?> {} // equivalent to Array where Element == T?
extension Array<String> {} // equivalent to Array where Element == String
```

You can also extend sugar types now like:

```swift
extension<T> [T?] {} // equivalent to Array where Element == T?
extension [String] {} // equivalent to Array where Element == String
```

Right now this has basic tests, but I'd really appreciate any test cases that I should add.

cc: @slavapestov @DougGregor 