### PR TITLE
[windows] Fix Python tests in Windows.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -878,6 +878,14 @@ if run_vendor == 'apple':
 
 elif run_os in ['windows-msvc']:
     lit_config.note('Testing Windows ' + config.variant_triple)
+    config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
+    if 'PROCESSOR_ARCHITEW6432' in os.environ:
+        config.environment['PROCESSOR_ARCHITEW6432'] = os.environ['PROCESSOR_ARCHITEW6432']
+    if 'PROCESSOR_ARCHITECTURE' in os.environ:
+        config.environment['PROCESSOR_ARCHITECTURE'] = os.environ['PROCESSOR_ARCHITECTURE']
+    if 'PROCESSOR_IDENTIFIER' in os.environ:
+        config.environment['PROCESSOR_IDENTIFIER'] = os.environ['PROCESSOR_IDENTIFIER']
+    config.environment['PYTHON_EXECUTABLE'] = sys.executable
     config.target_object_format = 'coff'
     config.target_shared_library_prefix = ''
     config.target_shared_library_suffix = '.dll'

--- a/utils/build_swift/tests/test_driver_arguments.py
+++ b/utils/build_swift/tests/test_driver_arguments.py
@@ -8,6 +8,7 @@
 
 
 import os
+import platform
 import sys
 import unittest
 from contextlib import contextmanager
@@ -344,7 +345,10 @@ class TestDriverArgumentParserMeta(type):
     def generate_preset_test(cls, preset_name, preset_args):
         def test(self):
             try:
-                self.parse_default_args(preset_args, check_impl_args=True)
+                # Windows cannot run build-script-impl to check the impl args.
+                is_windows = platform.system() == 'Windows'
+                self.parse_default_args(preset_args,
+                                        check_impl_args=not is_windows)
             except ParserError as e:
                 self.fail('failed to parse preset "{}": {}'.format(
                     preset_name, e))

--- a/utils/swift_build_support/swift_build_support/tar.py
+++ b/utils/swift_build_support/swift_build_support/tar.py
@@ -25,7 +25,7 @@ def tar(source, destination):
     #  - We wish to explicitly set the owner and group of the archive.
     args = ['tar', '-c', '-z', '-f', destination]
 
-    if platform.system() != 'Darwin':
+    if platform.system() != 'Darwin' and platform.system() != 'Windows':
         args += ['--owner=0', '--group=0']
 
     # Discard stderr output such as 'tar: Failed to open ...'. We'll detect

--- a/utils/swift_build_support/swift_build_support/which.py
+++ b/utils/swift_build_support/swift_build_support/which.py
@@ -35,7 +35,8 @@ def which(cmd):
     been backported to Python 2.7, which we support.
     """
     out = shell.capture(['which', cmd],
-                        dry_run=False, echo=False, optional=True)
+                        dry_run=False, echo=False,
+                        optional=True, stderr=shell.DEVNULL)
     if out is None:
         return None
     return out.rstrip()

--- a/utils/swift_build_support/tests/mock-distcc.cmd
+++ b/utils/swift_build_support/tests/mock-distcc.cmd
@@ -1,0 +1,3 @@
+@ echo off
+IF NOT DEFINED PYTHON_EXECUTABLE SET PYTHON_EXECUTABLE=python
+"%PYTHON_EXECUTABLE%" "%~dp0\mock-distcc" %*

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -119,7 +119,15 @@ class NinjaTestCase(unittest.TestCase):
 + pushd {build_dir}
 + {expect_env}{python} configure.py --bootstrap
 + popd
-""".format(source_dir=self.workspace.source_dir('ninja'),
-           build_dir=self.workspace.build_dir('build', 'ninja'),
+""".format(source_dir=self._platform_quote(
+            self.workspace.source_dir('ninja')),
+           build_dir=self._platform_quote(
+            self.workspace.build_dir('build', 'ninja')),
            expect_env=expect_env,
-           python=sys.executable))
+           python=self._platform_quote(sys.executable)))
+
+    def _platform_quote(self, path):
+        if platform.system() == 'Windows':
+            return "'{}'".format(path)
+        else:
+            return path

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -12,6 +12,7 @@
 
 import argparse
 import os
+import platform
 import sys
 import unittest
 try:
@@ -85,6 +86,9 @@ class ArgumentsTypeTestCase(unittest.TestCase):
             "1..2")
 
     def test_executable(self):
+        if platform.system() == 'Windows':
+            self.skipTest('Every file is considered executable in Windows')
+
         python = sys.executable
         self.assertTrue(os.path.isabs(argtype.executable(python)))
 

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -9,6 +9,7 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import os
+import platform
 import unittest
 from argparse import Namespace
 
@@ -22,8 +23,11 @@ class CMakeTestCase(unittest.TestCase):
     def mock_distcc_path(self):
         """Return a path string of mock distcc executable
         """
-        return os.path.join(os.path.dirname(__file__),
-                            'mock-distcc')
+        if platform.system() == 'Windows':
+            executable = 'mock-distcc.cmd'
+        else:
+            executable = 'mock-distcc'
+        return os.path.join(os.path.dirname(__file__), executable)
 
     def default_args(self):
         """Return new args object with default values

--- a/utils/swift_build_support/tests/test_migration.py
+++ b/utils/swift_build_support/tests/test_migration.py
@@ -10,6 +10,7 @@
 
 import argparse
 import os
+import platform
 import unittest
 
 from swift_build_support import migration
@@ -54,6 +55,10 @@ class MigrateImplArgsTestCase(unittest.TestCase):
                 build_script_impl_args=[]))
 
     def test_check_impl_args(self):
+        if platform.system() == 'Windows':
+            self.skipTest("build-script-impl cannot run in Windows")
+            return
+
         # Assuming file locations:
         #   utils/swift_build_support/tests/test_migration.py
         #   utils/build-script-impl

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -11,6 +11,7 @@
 
 import os
 import os.path
+import platform
 import shutil
 import sys
 import tempfile
@@ -61,7 +62,8 @@ class ShellTestCase(unittest.TestCase):
         self.assertEqual(self.stdout.getvalue(), "")
         self.assertEqual(self.stderr.getvalue(), '''\
 + cp {foo_file} {bar_file}
-'''.format(foo_file=foo_file, bar_file=bar_file))
+'''.format(foo_file=self._platform_quote(foo_file),
+           bar_file=self._platform_quote(bar_file)))
 
     def test_capture(self):
         self.assertEqual(shell.capture(["echo", "hi"]), "hi\n")
@@ -97,7 +99,7 @@ class ShellTestCase(unittest.TestCase):
         self.assertEqual(self.stderr.getvalue(), '''\
 + mkdir -p {path}
 + rm -rf {path}
-'''.format(path=path))
+'''.format(path=self._platform_quote(path)))
 
     def test_pushd(self):
         shell.dry_run = False
@@ -138,7 +140,7 @@ class ShellTestCase(unittest.TestCase):
 + pushd {tmpdir}
 + rm -rf foo
 + popd
-'''.format(tmpdir=self.tmpdir))
+'''.format(tmpdir=self._platform_quote(self.tmpdir)))
 
     def test_dry_run(self):
         shell.dry_run = True
@@ -167,6 +169,13 @@ class ShellTestCase(unittest.TestCase):
 + touch testfile
 + popd
 + rm -rf {tmpdir}
-'''.format(foobar_dir=foobar_dir, tmpdir=self.tmpdir))
+'''.format(foobar_dir=self._platform_quote(foobar_dir),
+           tmpdir=self._platform_quote(self.tmpdir)))
         self.assertEqual(self.stderr.getvalue(), "")
         self.dry_run = False
+
+    def _platform_quote(self, path):
+        if platform.system() == 'Windows':
+            return "'{}'".format(path)
+        else:
+            return path

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -36,23 +36,36 @@ class TarTestCase(unittest.TestCase):
 
     def test_tar_this_file_succeeds(self):
         # `tar` complains about absolute paths, so use a relative path here.
-        source = os.path.relpath(__file__)
+        if platform.system() != 'Windows':
+            source = os.path.relpath(__file__)
+        else:
+            # Windows can use absolute paths, specially because the relative
+            # path might not exist because the file and the current directory
+            # might be in different drives.
+            source = __file__
         _, destination = tempfile.mkstemp()
         tar(source=source, destination=destination)
 
-        if platform.system() == "Darwin":
+        if platform.system() == "Darwin" or platform.system() == 'Windows':
             expect = "+ tar -c -z -f {dest} {source}\n"
         else:
             expect = "+ tar -c -z -f {dest} --owner=0 --group=0 {source}\n"
 
         self.assertEqual(self.stdout.getvalue(), "")
         self.assertEqual(self.stderr.getvalue(),
-                         expect.format(dest=destination, source=source))
+                         expect.format(dest=self._platform_quote(destination),
+                                       source=self._platform_quote(source)))
 
     def test_tar_nonexistent_file_raises(self):
         with self.assertRaises(SystemExit):
             tar(source='/path/to/something/that/surely/doesnt/exist',
                 destination='/another/path/that/shouldnt/exist')
+
+    def _platform_quote(self, path):
+        if platform.system() == 'Windows':
+            return "'{}'".format(path)
+        else:
+            return path
 
 
 if __name__ == '__main__':

--- a/utils/swift_build_support/tests/test_toolchain.py
+++ b/utils/swift_build_support/tests/test_toolchain.py
@@ -10,6 +10,7 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import os
+import platform
 import unittest
 
 from swift_build_support import toolchain
@@ -31,10 +32,10 @@ class ToolchainTestCase(unittest.TestCase):
 
         self.assertTrue(
             os.path.isabs(tc.cc) and
-            os.path.basename(tc.cc).startswith('clang'))
+            os.path.basename(tc.cc).startswith(self._platform_cc_name()))
         self.assertTrue(
             os.path.isabs(tc.cxx) and
-            os.path.basename(tc.cxx).startswith('clang++'))
+            os.path.basename(tc.cxx).startswith(self._platform_cxx_name()))
 
     def test_llvm_tools(self):
         tc = host_toolchain()
@@ -86,8 +87,8 @@ class ToolchainTestCase(unittest.TestCase):
         tc = host_toolchain()
 
         # CC and CXX must have consistent suffix
-        cc_suffix = get_suffix(tc.cc, 'clang')
-        cxx_suffix = get_suffix(tc.cxx, 'clang++')
+        cc_suffix = get_suffix(tc.cc, self._platform_cc_name())
+        cxx_suffix = get_suffix(tc.cxx, self._platform_cxx_name())
         self.assertEqual(cc_suffix, cxx_suffix)
 
     def test_tools_llvm_suffix(self):
@@ -104,7 +105,7 @@ class ToolchainTestCase(unittest.TestCase):
             self.assertEqual(profdata_suffix, cov_suffix)
 
         # If we have suffixed clang, llvm tools must have the same suffix.
-        cc_suffix = get_suffix(tc.cc, 'clang')
+        cc_suffix = get_suffix(tc.cc, self._platform_cc_name())
         if cc_suffix != '':
             if cov_suffix is not None:
                 self.assertEqual(cc_suffix, cov_suffix)
@@ -118,6 +119,18 @@ class ToolchainTestCase(unittest.TestCase):
         toolchain.Linux()
         toolchain.FreeBSD()
         toolchain.Cygwin()
+
+    def _platform_cc_name(self):
+        if platform.system() == 'Windows':
+            return 'clang-cl'
+        else:
+            return 'clang'
+
+    def _platform_cxx_name(self):
+        if platform.system() == 'Windows':
+            return 'clang-cl'
+        else:
+            return 'clang++'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Forward several environment variables to the test environment because
Windows uses them to inform the processes about things like the number
of processors and the architecture.
- Normalize some literal Unix paths to be the same as the results in
Windows, that will have forward slashes and the drive letter.
- Skip some test that use build-script-impl and tests that check for
files being executable (everything is executable in Windows).
- Don't use the owner and group arguments for tar on Windows.
- Hide the stderr output of which. In Windows it prints the full PATH in
case of failures, which is disrupting.
- Quote many paths in Windows in the output of build-script results.
- Provide a version of mock-distcc that can be executed in Windows. The
raw Python script cannot.
- Change the expected results for clang/clang++ to the right values in
Windows (clang-cl in both cases).