### PR TITLE
[AutoDiff] Adjoint buffer optimization for address projections.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4141,6 +4141,11 @@ public:
       auto addActiveValue = [&](SILValue v) {
         if (visited.count(v))
           return;
+        // Skip address projections.
+        // Address projections do not need their own adjoint buffers; they
+        // become projections into their adjoint base buffer.
+        if (Projection::isAddressProjection(v))
+          return;
         visited.insert(v);
         bbActiveValues.push_back(v);
       };

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -68,6 +68,22 @@ ControlFlowTests.test("Conditionals") {
   expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple))
   expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple))
 
+  func cond_tuple2(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y: (Float, Float) = (x, x)
+    let y0 = y.0
+    if x > 0 {
+      let y1 = y.1
+      return y0 + y1
+    }
+    let y0_double = y0 + y.0
+    let y1 = y.1
+    return y0_double - y1 + y.0
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple2))
+
   func cond_tuple_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
     var y: (Float, Float) = (x, x)
@@ -134,6 +150,22 @@ ControlFlowTests.test("Conditionals") {
   expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct))
   expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct))
   expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct))
+
+  func cond_struct2(_ x: Float) -> Float {
+    // Convoluted function returning `x + x`.
+    let y = FloatPair(x, x)
+    let y0 = y.first
+    if x > 0 {
+      let y1 = y.second
+      return y0 + y1
+    }
+    let y0_double = y0 + y.first
+    let y1 = y.second
+    return y0_double - y1 + y.first
+  }
+  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct2))
 
   func cond_struct_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
-// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -sil-print-after=differentiation -o /dev/null 2>&1 %s | %FileCheck %s -check-prefix=CHECK-SIL
 
-// TODO: Add adjoint SIL FileCheck tests.
+// TODO: Add FileCheck tests.
 
-// Test conditional: a simple if-diamond.
+//===----------------------------------------------------------------------===//
+// Conditionals
+//===----------------------------------------------------------------------===//
 
 @differentiable
 @_silgen_name("cond")
@@ -40,7 +42,7 @@ func cond(_ x: Float) -> Float {
 // CHECK-DATA-STRUCTURES:   @_hasStorage var predecessor: _AD__cond_bb3__Pred__src_0_wrt_0 { get set }
 // CHECK-DATA-STRUCTURES: }
 
-// CHECK-SIL-LABEL: sil hidden @AD__cond__vjp_src_0_wrt_0
+// CHECK-SIL-LABEL: sil hidden @AD__cond__vjp_src_0_wrt_0 : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[INPUT_ARG:%.*]] : $Float):
 // CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__cond_bb0__PB__src_0_wrt_0 ()
 // CHECK-SIL:   [[BB1_PRED:%.*]] = enum $_AD__cond_bb1__Pred__src_0_wrt_0, #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt.1, [[BB0_PB_STRUCT]]
@@ -63,6 +65,40 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[ADJOINT_REF]]([[BB3_PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]]
+
+// CHECK-SIL-LABEL: sil hidden @AD__cond__adjoint_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_bb3__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = struct_extract %1 : $_AD__cond_bb3__PB__src_0_wrt_0, #_AD__cond_bb3__PB__src_0_wrt_0.predecessor
+// CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
+
+// CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+
+// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL:   [[BB1_PB:%.*]] = struct_extract [[BB1_PB_STRUCT]]
+// CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
+// CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
+// CHECK-SIL:   [[BB1_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB1_PRED]]
+// CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+
+// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL:   [[BB2_PB:%.*]] = struct_extract [[BB2_PB_STRUCT]]
+// CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
+// CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
+// CHECK-SIL:   [[BB2_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB2_PRED]]
+// CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+
+// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL:   return {{%.*}} : $Float
 
 @differentiable
 @_silgen_name("nested_cond")
@@ -89,3 +125,52 @@ func nested_cond_generic<T : Differentiable & FloatingPoint>(_ x: T, _ y: T) -> 
   }
   return y
 }
+
+// Test control flow + tuple buffer.
+// Verify that adjoint buffers are not allocated for address projections.
+
+@differentiable
+@_silgen_name("cond_tuple_var")
+func cond_tuple_var(_ x: Float) -> Float {
+  // expected-warning @+1 {{variable 'y' was never mutated; consider changing to 'let' constant}}
+  var y = (x, x)
+  if x > 0 {
+    return y.0
+  }
+  return y.1
+}
+// CHECK-SIL-LABEL: sil hidden @AD__cond_tuple_var__adjoint_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_tuple_var_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = struct_extract %1 : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0, #_AD__cond_tuple_var_bb3__PB__src_0_wrt_0.predecessor
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
+
+// CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+
+// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   [[BB1_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB1_PRED]]
+// CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+
+// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
+// CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
+// CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
+// CHECK-SIL:   [[BB2_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB2_PRED]]
+// CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+
+// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL:   return {{%.*}} : $Float


### PR DESCRIPTION
Do not allocate adjoint buffers for address projections; they become
projections into their adjoint base buffer.

---

This reduces unnecessary adjoint buffer logic (allocation/initialization/copying/cleanup).
Quick experiments (based on `struct_element_addr`):
```swift
struct FloatPair : Differentiable {
  var first, second: Float
  init(_ first: Float, _ second: Float) {
    self.first = first
    self.second = second
  }
}

struct Pair<T : Differentiable, U : Differentiable> : Differentiable {
  var first: T
  var second: U
  init(_ first: T, _ second: U) {
    self.first = first
    self.second = second
  }
}

func cond_struct_var(_ x: Float) -> Float {
  // Convoluted function returning `x + x`.
  var y = FloatPair(x, x)
  var z = FloatPair(x + x, x - x)
  if x > 0 {
    var w = y
    y.first = w.second
    y.second = w.first
    z.first = z.first - y.first
    z.second = z.second + y.first
  } else {
    z = FloatPair(x, x)
  }
  return y.first + y.second - z.first + z.second
}
print((8, 2), valueWithGradient(at: 4, in: cond_struct_var))
print((-20, 2), valueWithGradient(at: -10, in: cond_struct_var))
print((-2674, 2), valueWithGradient(at: -1337, in: cond_struct_var))

func cond_nestedstruct_var(_ x: Float) -> Float {
  // Convoluted function returning `x + x`.
  var y = FloatPair(x + x, x - x)
  var z = Pair(y, x)
  if x > 0 {
    var w = FloatPair(x, x)
    y.first = w.second
    y.second = w.first
    z.first.first = z.first.first - y.first
    z.first.second = z.first.second + y.first
  } else {
    z = Pair(FloatPair(y.first - x, y.second + x), x)
  }
  return y.first + y.second - z.first.first + z.first.second
}
print((8, 2), valueWithGradient(at: 4, in: cond_nestedstruct_var))
```
```
Debugging active values for $s6struct05cond_A4_varyS2fF (before vs after):
Active values in bb0 (7 vs 7)
Active values in bb1 (27 vs 37)
Active values in bb2 (9 vs 9)
Active values in bb3 (18 vs 22)

Debugging active values for $s6nested21cond_nestedstruct_varyS2fF (before vs after):
Active values in bb0 (10 vs 10)
Active values in bb1 (44 vs 30)
Active values in bb2 (24 vs 22)
Active values in bb3 (27 vs 21)
```

Similar improvements for `tuple_element_addr`.