### PR TITLE
StdlibUnittest: consume the carriage return on stdout

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -934,7 +934,10 @@ class _ParentProcess {
     let (_, stdoutThread) = _stdlib_thread_create_block({
       while !self._childStdout.isEOF {
         self._childStdout.read()
-        while let line = self._childStdout.getline() {
+        while var line = self._childStdout.getline() {
+          if let cr = line.firstIndex(of: "\r") {
+            line.remove(at: cr)
+          }
           var done: Bool
           (done: done, ()) = onStdoutLine(line)
           if done { return }


### PR DESCRIPTION
This was already being done for the stderr, but not for stdout.  Doing
this means that we no longer get spurious carriage returns on the stdout
output stream on Windows.  This is needed for supporting the
validation test suite on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
