### PR TITLE
[AutoDiff] Enable control flow AD by default.

### DIFF
--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -120,8 +120,6 @@ func calls_grad_of_nested(_ x: Float) -> Float {
 
 func if_else(_ x: Float, _ flag: Bool) -> Float {
   let y: Float
-  // expected-error @+2 {{expression is not differentiable}}
-  // expected-note @+1 {{differentiating control flow is not yet supported}}
   if flag {
     y = x + 1
   } else {

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift-control-flow-differentiation
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/control_flow_diagnostics.swift
+++ b/test/AutoDiff/control_flow_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -differentiation-enable-control-flow %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
 
 // Test supported `br` and `cond_br` terminators.
 

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -differentiation-enable-control-flow %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
-// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -differentiation-enable-control-flow %s | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 // TODO: Add adjoint SIL FileCheck tests.
 

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift-control-flow-differentiation
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
 // Test differentiation-related memory leaks.

--- a/test/TensorFlowRuntime/tensor_autodiff_control_flow.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift-control-flow-differentiation
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
 // FIXME(TF-326): Re-enable `-O` after deserialization failure fix.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1419,14 +1419,6 @@ if not getattr(config, 'target_run_simple_swift', None):
                             '%s %%t/a.out' % (config.target_build_swift,
                                               mcp_opt, config.target_codesign,
                                               config.target_run)))
-    # SWIFT_ENABLE_TENSORFLOW
-    # TODO: Remove when differentiation control flow support is robust.
-    config.target_run_simple_swift_control_flow_differentiation = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -differentiation-enable-control-flow -o %%t/a.out %s -module-name main  && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out %s -module-name main  && '
@@ -1484,9 +1476,6 @@ config.substitutions.append(('%target-swift-frontend', config.target_swift_front
 
 
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
-# SWIFT_ENABLE_TENSORFLOW
-# TODO: Remove when differentiation control flow support is robust.
-config.substitutions.append(('%target-run-simple-swift-control-flow-differentiation', config.target_run_simple_swift_control_flow_differentiation))
 config.substitutions.append(('%target-run-simple-swift\(([^)]+)\)', config.target_run_simple_swift_parameterized))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))


### PR DESCRIPTION
Preemptively remove `-Xllvm -differentiation-enable-control-flow` flag.

Note that limited control flow AD support is not yet robust:
- Memory leaks: [TF-552](https://bugs.swift.org/browse/TF-552). (*work in progress*)
- Incorrect zero gradients involving buffers + recursion: [TF-554](https://bugs.swift.org/browse/TF-554).