### PR TITLE
build: improve libedit handling for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -915,14 +915,11 @@ else()
   find_package(LibXml2)
 endif()
 
-# You need libedit linked in order to check if you have el_wgets.
-cmake_push_check_state()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "edit")
-check_symbol_exists(el_wgets "histedit.h" HAVE_EL_WGETS)
-if(HAVE_EL_WGETS)
-  set(HAVE_UNICODE_LIBEDIT 1)
+if(LLVM_ENABLE_LIBEDIT)
+  find_package(LibEdit REQUIRED)
+else()
+  find_package(LibEdit)
 endif()
-cmake_pop_check_state()
 
 check_symbol_exists(wait4 "sys/wait.h" HAVE_WAIT4)
 

--- a/cmake/modules/FindLibEdit.cmake
+++ b/cmake/modules/FindLibEdit.cmake
@@ -1,0 +1,62 @@
+#.rst:
+# FindLibEdit
+# -----------
+#
+# Find libedit library and headers
+#
+# The module defines the following variables:
+#
+# ::
+#
+#   libedit_FOUND         - true if libedit was found
+#   libedit_INCLUDE_DIRS  - include search path
+#   libedit_LIBRARIES     - libraries to link
+#   libedit_VERSION       - version number
+
+if(libedit_INCLUDE_DIRS AND libedit_LIBRARIES)
+  set(libedit_FOUND TRUE)
+else()
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_LIBEDIT QUIET libedit)
+
+  find_path(libedit_INCLUDE_DIRS
+            NAMES
+              histedit.h
+            HINTS
+              ${PC_LIBEDIT_INCLUDEDIR}
+              ${PC_LIBEDIT_INCLUDE_DIRS}
+              ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  find_library(libedit_LIBRARIES
+               NAMES
+                 edit libedit
+               HINTS
+                 ${PC_LIBEDIT_LIBDIR}
+                 ${PC_LIBEDIT_LIBRARY_DIRS}
+                 ${CMAKE_INSTALL_FULL_LIBDIR})
+
+  if(libedit_INCLUDE_DIRS AND EXISTS "${libedit_INCLUDE_DIRS}/histedit.h")
+    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_major_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MAJOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MAJOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MAJOR_VERSION "${libedit_major_version_str}")
+
+    file(STRINGS "${libedit_INCLUDE_DIRS}/histedit.h"
+         libedit_minor_version_str
+         REGEX "^#define[ \t]+LIBEDIT_MINOR[ \t]+[0-9]+")
+    string(REGEX REPLACE "^#define[ \t]+LIBEDIT_MINOR[ \t]+([0-9]+)" "\\1"
+           LIBEDIT_MINOR_VERSION "${libedit_minor_version_str}")
+
+    set(libedit_VERSION_STRING "${libedit_major_version}.${libedit_minor_version}")
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(libedit
+                                    REQUIRED_VARS
+                                      libedit_INCLUDE_DIRS
+                                      libedit_LIBRARIES
+                                    VERSION_VAR
+                                      libedit_VERSION_STRING)
+  mark_as_advanced(libedit_INCLUDE_DIRS libedit_LIBRARIES)
+endif()
+

--- a/include/swift/CMakeLists.txt
+++ b/include/swift/CMakeLists.txt
@@ -5,6 +5,9 @@ if(SWIFT_BUILD_REMOTE_MIRROR)
 endif()
 
 if(SWIFT_INCLUDE_TOOLS)
+  if(libedit_FOUND)
+    set(HAVE_UNICODE_LIBEDIT TRUE)
+  endif()
   configure_file(Config.h.in ${CMAKE_CURRENT_BINARY_DIR}/Config.h
                 ESCAPE_QUOTES @ONLY)
   add_subdirectory(Option)

--- a/tools/SourceKit/tools/CMakeLists.txt
+++ b/tools/SourceKit/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
 
 add_swift_lib_subdirectory(sourcekitd)
 add_swift_tool_subdirectory(sourcekitd-test)
-if(HAVE_UNICODE_LIBEDIT)
+if(libedit_FOUND)
   add_swift_tool_subdirectory(sourcekitd-repl)
 endif()
 add_swift_tool_subdirectory(complete-test)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -1,7 +1,4 @@
-set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} edit)
-check_symbol_exists(el_wgets "histedit.h" HAVE_UNICODE_LIBEDIT)
-
-if(HAVE_UNICODE_LIBEDIT)
+if(libedit_FOUND)
   if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
     set(SOURCEKITD_REPL_LINK_LIBS sourcekitdInProc)
   else()
@@ -10,9 +7,13 @@ if(HAVE_UNICODE_LIBEDIT)
 
   add_sourcekit_executable(sourcekitd-repl
     sourcekitd-repl.cpp
-    LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS} edit
+    LINK_LIBS ${SOURCEKITD_REPL_LINK_LIBS}
     LLVM_LINK_COMPONENTS support coverage lto
   )
+  target_include_directories(sourcekitd-repl PRIVATE
+    ${libedit_INCLUDE_DIRS})
+  target_link_libraries(sourcekitd-repl PRIVATE
+    ${libedit_LIBRARIES})
   if(SWIFT_NEED_EXPLICIT_LIBDISPATCH)
     target_link_libraries(sourcekitd-repl PRIVATE dispatch BlocksRuntime)
   endif()

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -9,8 +9,9 @@ target_link_libraries(swift
                       PRIVATE
                         swiftDriver
                         swiftFrontendTool)
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift PRIVATE edit)
+if(libedit_FOUND)
+  target_link_libraries(swift PRIVATE
+    ${libedit_LIBRARIES})
 endif()
 
 swift_create_post_build_symlink(swift

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -7,8 +7,9 @@ target_link_libraries(swift-remoteast-test
                         swiftFrontendTool
                         swiftRemoteAST)
 set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
-if(HAVE_UNICODE_LIBEDIT)
-  target_link_libraries(swift-remoteast-test PRIVATE edit)
+if(libedit_FOUND)
+  target_link_libraries(swift-remoteast-test PRIVATE
+    ${libedit_LIBRARIES})
 endif()
 
 # If building as part of clang, make sure the headers are installed.


### PR DESCRIPTION
Use the `FindLibEdit.cmake` module from LLDB to properly control where
the libedit libraries are searched for and linked from as well as where
the headers come from.  This uses the standard mechanisms which allows
users to control where libedit is pulled from (which is important for
cross-compilation).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
