### PR TITLE
[AutoDiff] Disable VJP/JVP labels in `@differentiating` when marked `linear`

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1500,6 +1500,8 @@ ERROR(attr_differentiable_missing_label,PointsToFirstBadToken,
 ERROR(attr_differentiable_expected_label,none,
       "expected either 'wrt:' or a function specifier label, e.g. 'jvp:', "
       "or 'vjp:'", ())
+ERROR(attr_differentiable_no_vjp_or_jvp_when_linear,none,
+      "can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'", ())
 
 // differentiating
 ERROR(attr_differentiating_expected_original_name,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1501,7 +1501,8 @@ ERROR(attr_differentiable_expected_label,none,
       "expected either 'wrt:' or a function specifier label, e.g. 'jvp:', "
       "or 'vjp:'", ())
 ERROR(attr_differentiable_no_vjp_or_jvp_when_linear,none,
-      "can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'", ())
+      "cannot specify 'vjp:' or 'jvp:' for linear functions; use "
+      "'transpose:' instead", ())
 
 // differentiating
 ERROR(attr_differentiating_expected_original_name,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1032,6 +1032,10 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Parse 'jvp: <func_name>' (optional).
   if (Tok.is(tok::identifier) && Tok.getText() == "jvp") {
+    if (linear) {
+      diagnose(Tok, diag::attr_differentiable_no_vjp_or_jvp_when_linear);
+      return errorAndSkipToEnd();
+    }
     SyntaxParsingContext JvpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
     jvpSpec = DeclNameWithLoc();
@@ -1045,6 +1049,10 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Parse 'vjp: <func_name>' (optional).
   if (Tok.is(tok::identifier) && Tok.getText() == "vjp") {
+    if (linear) {
+      diagnose(Tok, diag::attr_differentiable_no_vjp_or_jvp_when_linear);
+      return errorAndSkipToEnd();
+    }
     SyntaxParsingContext VjpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
     vjpSpec = DeclNameWithLoc();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1032,10 +1032,6 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Parse 'jvp: <func_name>' (optional).
   if (Tok.is(tok::identifier) && Tok.getText() == "jvp") {
-    if (linear) {
-      diagnose(Tok, diag::attr_differentiable_no_vjp_or_jvp_when_linear);
-      return errorAndSkipToEnd();
-    }
     SyntaxParsingContext JvpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
     jvpSpec = DeclNameWithLoc();
@@ -1049,10 +1045,6 @@ bool Parser::parseDifferentiableAttributeArguments(
 
   // Parse 'vjp: <func_name>' (optional).
   if (Tok.is(tok::identifier) && Tok.getText() == "vjp") {
-    if (linear) {
-      diagnose(Tok, diag::attr_differentiable_no_vjp_or_jvp_when_linear);
-      return errorAndSkipToEnd();
-    }
     SyntaxParsingContext VjpContext(
         SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
     vjpSpec = DeclNameWithLoc();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2882,6 +2882,14 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto &ctx = TC.Context;
   auto lookupConformance =
       LookUpConformanceInModule(D->getDeclContext()->getParentModule());
+  
+  // If functions is marked as linear, you cannot have a custom VJP and/or
+  // a JVP.
+  if (attr->isLinear() && (attr->getVJP() || attr->getJVP())) {
+    diagnoseAndRemoveAttr(attr,
+                          diag::attr_differentiable_no_vjp_or_jvp_when_linear);
+    return;
+  }
 
   AbstractFunctionDecl *original = dyn_cast<AbstractFunctionDecl>(D);
   if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {

--- a/test/AutoDiff/differentiable_attr_parse.swift
+++ b/test/AutoDiff/differentiable_attr_parse.swift
@@ -67,11 +67,6 @@ func slope2(_ x: Float) -> Float {
   return 2 * x
 }
 
-@differentiable(linear, wrt: x, vjp: const3) // okay
-func slope3(_ x: Float) -> Float {
-  return 3 * x
-}
-
 /// Bad
 
 @differentiable(3) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
@@ -127,6 +122,21 @@ func bar(_ x: Float, _: Float) -> Float {
 @differentiable(vjp: foo(_:_:), where T) // expected-error {{unexpected ',' separator}}
 func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
+}
+
+@differentiable(linear, wrt: x, vjp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
+func slope3(_ x: Float) -> Float {
+  return 3 * x
+}
+
+@differentiable(linear, wrt: x, jvp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
+func slope3(_ x: Float) -> Float {
+  return 3 * x
+}
+
+@differentiable(linear, vjp: const3, jvp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
+func slope3(_ x: Float) -> Float {
+  return 3 * x
 }
 
 @differentiable(wrt: x, linear) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}

--- a/test/AutoDiff/differentiable_attr_parse.swift
+++ b/test/AutoDiff/differentiable_attr_parse.swift
@@ -124,21 +124,6 @@ func bar<T : Numeric>(_ x: T, _: T) -> T {
     return 1 + x
 }
 
-@differentiable(linear, wrt: x, vjp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
-func slope3(_ x: Float) -> Float {
-  return 3 * x
-}
-
-@differentiable(linear, wrt: x, jvp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
-func slope3(_ x: Float) -> Float {
-  return 3 * x
-}
-
-@differentiable(linear, vjp: const3, jvp: const3) // expected-error {{can't define 'vjp:' and/or 'jvp:' on functions marked as 'linear'}}
-func slope3(_ x: Float) -> Float {
-  return 3 * x
-}
-
 @differentiable(wrt: x, linear) // expected-error {{expected either 'wrt:' or a function specifier label, e.g. 'jvp:', or 'vjp:'}}
 func slope4(_ x: Float) -> Float {
   return 4 * x

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -723,3 +723,18 @@ struct NonDiffableStruct {
     return a + b
   }
 }
+
+@differentiable(linear, wrt: x, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
+func slope1(_ x: Float) -> Float {
+  return 3 * x
+}
+
+ @differentiable(linear, wrt: x, jvp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
+func slope2(_ x: Float) -> Float {
+  return 3 * x
+}
+
+ @differentiable(linear, jvp: const3, vjp: const3) // expected-error {{cannot specify 'vjp:' or 'jvp:' for linear functions; use 'transpose:' instead}}
+func slope3(_ x: Float) -> Float {
+  return 3 * x
+}

--- a/test/Serialization/differentiable_attr.swift
+++ b/test/Serialization/differentiable_attr.swift
@@ -14,23 +14,16 @@ func simple(x: Float) -> Float {
   return x
 }
 
-// CHECK: @differentiable(linear, wrt: x, jvp: jvpSimple, vjp: vjpSimple)
+// CHECK: @differentiable(linear, wrt: x)
 // CHECK-NEXT: func simple2(x: Float) -> Float
-@differentiable(linear, jvp: jvpSimple, vjp: vjpSimple)
+@differentiable(linear)
 func simple2(x: Float) -> Float {
-  return x
-}
-
-// CHECK: @differentiable(linear, wrt: x, vjp: vjpSimple)
-// CHECK-NEXT: func simple3(x: Float) -> Float
-@differentiable(linear, vjp: vjpSimple)
-func simple3(x: Float) -> Float {
   return x
 }
 
 // CHECK: @differentiable(linear, wrt: x)
 // CHECK-NEXT: func simple4(x: Float) -> Float
-@differentiable(linear)
+@differentiable(linear, wrt: x)
 func simple4(x: Float) -> Float {
   return x
 }


### PR DESCRIPTION
When you mark a function as `linear`, you should not be able to specify a custom VJP or JVP function. Some time later this month, we are going to add a `transpose:` label in `@differentiable` that's parallel to `vjp:`. In 2-3 months, we are going to deprecate `jvp:`, `vjp`: and `transpose:` altogether to prefer `@differentiating`.

```swift
@differentiable(linear, transpose: myTransposeFunc)
func linearFunc(_ x: Float) -> Float {
    return 3 * x
}
```

This is part of an overhaul of our current AD system that will unify forward mode (will be implemented as a part of this overhaul) and reverse mode AD. 

**More info to come in the coming weeks!**