### PR TITLE
[stdlib-standalone] Always configure with lit-args=--filter=stdlib/

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2049,6 +2049,7 @@ native-llvm-tools-path=%(toolchain_path)s
 native-clang-tools-path=%(toolchain_path)s
 
 build-ninja
+lit-args=--filter=stdlib/
 
 [preset: stdlib_RA_standalone,build]
 mixin-preset=stdlib_base_standalone
@@ -2064,7 +2065,6 @@ mixin-preset=stdlib_RA_standalone,build
 
 test
 validation-test
-lit-args=-v --filter=stdlib/
 
 [preset: stdlib_RDA_standalone,build]
 mixin-preset=stdlib_base_standalone
@@ -2080,7 +2080,6 @@ mixin-preset=stdlib_RDA_standalone,build
 
 test
 validation-test
-lit-args=-v --filter=stdlib/
 
 [preset: stdlib_DA_standalone,build]
 mixin-preset=stdlib_base_standalone
@@ -2096,4 +2095,3 @@ mixin-preset=stdlib_DA_standalone,build
 
 test
 validation-test
-lit-args=-v --filter=stdlib/


### PR DESCRIPTION
Otherwise, we will need to reconfigure when someone uses the build vs test
preset. Because the reconfiguring forces a rebuild, this is unfortunate.
Luckily, we want to make it so we always only build stdlib tests, so this works
around the problem.
