### PR TITLE
[TF] Update commit hash for tensorflow/swift-apis for v0.4

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -349,7 +349,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-05-26-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-05-26-a",
                 "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
-                "tensorflow-swift-apis": "e9092254c8135202a813a6cab727fbca691010e8",
+                "tensorflow-swift-apis": "2c7a1909bc42db91ba0e0032a3a1f395f684b16c",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-05-26-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-05-26-a"
             }


### PR DESCRIPTION
Adds the following [commit](https://github.com/tensorflow/swift-apis/commit/2c7a1909bc42db91ba0e0032a3a1f395f684b16c) that includes the renaming of convolutional and pooling layers.