### PR TITLE
[5.1][Sema] Treat static methods as always applying their curried self param

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -130,6 +130,9 @@ bool constraints::areConservativelyCompatibleArgumentLabels(
   bool hasCurriedSelf;
   if (isa<SubscriptDecl>(decl)) {
     hasCurriedSelf = false;
+  } else if (decl->isStatic() && isa<AbstractFunctionDecl>(decl)) {
+    // Static methods always have their Self.Type parameter applied.
+    hasCurriedSelf = true;
   } else if (!baseType || baseType->is<ModuleType>()) {
     hasCurriedSelf = false;
   } else if (baseType->is<AnyMetatypeType>() && decl->isInstanceMember()) {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -223,3 +223,17 @@ func rdar46459603() {
   _ = [arr.values] == [[e]]
   // expected-error@-1 {{protocol type 'Any' cannot conform to 'Equatable' because only concrete types can conform to protocols}}
 }
+
+// SR-10843
+infix operator ^^^
+func ^^^ (lhs: String, rhs: String) {}
+
+struct SR10843 {
+  static func ^^^ (lhs: SR10843, rhs: SR10843) {}
+}
+
+func sr10843() {
+  let s = SR10843()
+  (^^^)(s, s)
+  _ = (==)(0, 0)
+}


### PR DESCRIPTION
- **Explanation:** Currently `areConservativelyCompatibleArgumentLabels` treats a reference to a declaration as not having its curried self parameter applied if the choice doesn't have a base type. However this isn't correct for operators defined as static methods, which have their `Self.Type` parameter applied but their choice doesn't have a base type.

  This PR changes `areConservativelyCompatibleArgumentLabels` to always treat static methods as having their `Self.Type` parameters applied, as there's currently no way to form an unapplied curried reference to them.

- **Scope:** Resolves a 5.1 regression.

- **SR Issue:** [SR-10843].

- **Risk:** Low, the fix is fairly narrow.

- **Testing:** Added a regression test.

- **Reviewers:** @slavapestov @xedin.



  [SR-10843]: https://bugs.swift.org/browse/SR-10843
