### PR TITLE
[5.1][ConstraintSystem] Make sure that read-only keypath is preferred for …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4108,8 +4108,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       if (auto *storage = dyn_cast<AbstractStorageDecl>(decl)) {
         // If this is an attempt to access read-only member via
         // writable key path, let's fail this choice early.
+        auto &ctx = getASTContext();
         if (isReadOnlyKeyPathComponent(storage) &&
-            keyPath == getASTContext().getWritableKeyPathDecl()) {
+            (keyPath == ctx.getWritableKeyPathDecl() ||
+             keyPath == ctx.getReferenceWritableKeyPathDecl())) {
           result.addUnviable(
               candidate,
               MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember);
@@ -4120,7 +4122,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
         // on the other hand if setter is mutating there is no point
         // of attempting `ReferenceWritableKeyPath` overload.
         if (storage->isSetterMutating() &&
-            keyPath == getASTContext().getReferenceWritableKeyPathDecl()) {
+            keyPath == ctx.getReferenceWritableKeyPathDecl()) {
           result.addUnviable(
               candidate,
               MemberLookupResult::UR_ReferenceWritableKeyPathOnMutatingMember);


### PR DESCRIPTION
…read-only properties

This fixes an oversight related to `ReferenceWritableKeyPath` overloads
of the KeyPath dynamic member lookup. Original check filtered out only
`WritableKeyPath` if the storage is read-only, but it should check for
both `WritableKeyPath` and `ReferenceWritableKeyPath`, otherwise program
is going to crash at run time.

Resolves: rdar://problem/51456614
(cherry picked from commit 329ed30b71e6955b8466d69a9f5974255163f382)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
