### PR TITLE
[AutoDiff] Diagnose duplicate `@differentiable` attributes on properties.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2709,7 +2709,9 @@ ERROR(differentiable_attr_overload_not_found,none,
 ERROR(differentiable_attr_no_currying,none,
       "'@differentiable' cannot be defined on functions that return functions", ())
 ERROR(differentiable_attr_duplicate,none,
-      "duplicate '@differentiable' attribute", ())
+      "duplicate '@differentiable' attribute with same parameter indices", ())
+NOTE(differentiable_attr_duplicate_note,none,
+     "other attribute declared here", ())
 ERROR(differentiable_attr_function_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclName))
 ERROR(differentiable_attr_specified_not_function,none,

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -96,7 +96,7 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       auto silDiffAttr = SILDifferentiableAttr::create(
           M, indices, A->getRequirements(), M.allocateCopy(jvpName),
           M.allocateCopy(vjpName));
-#if NDEBUG
+#ifndef NDEBUG
       // Verify that no existing attributes have the same indices.
       for (auto *existingAttr : F->getDifferentiableAttrs()) {
         bool sameAttributeConfig =

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -88,8 +88,7 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
         vjpName = SILDeclRef(vjpFn).mangle();
       // Get lowered argument indices.
       auto paramIndices = A->getParameterIndices();
-      if (!paramIndices)
-        continue;
+      assert(paramIndices && "Parameter indices should have been resolved");
       auto loweredParamIndices = paramIndices->getLowered(
           F->getASTContext(),
           decl->getInterfaceType()->castTo<AnyFunctionType>());
@@ -97,6 +96,15 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       auto silDiffAttr = SILDifferentiableAttr::create(
           M, indices, A->getRequirements(), M.allocateCopy(jvpName),
           M.allocateCopy(vjpName));
+#if NDEBUG
+      // Verify that no existing attributes have the same indices.
+      for (auto *existingAttr : F->getDifferentiableAttrs()) {
+        bool sameAttributeConfig =
+            silDiffAttr->getIndices() == existingAttr->getIndices();
+        assert(!sameAttributeConfig &&
+               "Duplicate `[differentiable]` attribute");
+      }
+#endif
       F->addDifferentiableAttr(silDiffAttr);
     }
   }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -209,7 +209,6 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
       // SWIFT_ENABLE_TENSORFLOW
       addFunctionAttributes(F, storage->getAttrs(), mod, constant);
     }
-    // SWIFT_ENABLE_TENSORFLOW
     addFunctionAttributes(F, decl->getAttrs(), mod, constant);
   }
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2010,6 +2010,9 @@ emitAssociatedFunctionReference(
     auto substMap = getSubstitutionMap(original);
     // Attempt to look up a `[differentiable]` attribute that minimally
     // satisfies the specified indices.
+    // TODO(TF-482): Change `lookupMinimalDifferentiableAttr` to additionally
+    // check whether `[differentiable]` attribute generic requirements are
+    // satisfied.
     auto *minimalAttr =
         context.lookUpMinimalDifferentiableAttr(originalFn, desiredIndices);
     if (!minimalAttr) {
@@ -2061,7 +2064,8 @@ emitAssociatedFunctionReference(
       minimalAttr = newAttr;
     }
     assert(minimalAttr);
-    // TODO(TF-482): Change `lookupMinimalDifferentiableAttr`.
+    // TODO(TF-482): Move generic requirement checking logic to
+    // `lookupMinimalDifferentiableAttr`.
     if (!checkRequirementsSatisfied(
             minimalAttr->getRequirements(),
             substMap, originalFn, context.getModule().getSwiftModule())) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3173,7 +3173,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   // `@differentiable` attributes are uniqued by their parameter indices.
   // Reject duplicate attributes for the same decl and parameter indices pair.
   if (!insertion.second && insertion.first->getSecond() != attr) {
-    TC.diagnose(attr->getLocation(), diag::differentiable_attr_duplicate);
+    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
     TC.diagnose(insertion.first->getSecond()->getLocation(),
                 diag::differentiable_attr_duplicate_note);
     return;
@@ -3191,7 +3191,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     // indices. Reject duplicate attributes for the same decl and parameter
     // indices pair.
     if (!insertion.second) {
-      TC.diagnose(attr->getLocation(), diag::differentiable_attr_duplicate);
+      diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
       TC.diagnose(insertion.first->getSecond()->getLocation(),
                   diag::differentiable_attr_duplicate_note);
       return;
@@ -3491,7 +3491,7 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     // indices. Reject duplicate attributes for the same decl and parameter
     // indices pair.
     if (!insertion.second && insertion.first->getSecond() != da) {
-      TC.diagnose(da->getLocation(), diag::differentiable_attr_duplicate);
+      diagnoseAndRemoveAttr(da, diag::differentiable_attr_duplicate);
       TC.diagnose(insertion.first->getSecond()->getLocation(),
                   diag::differentiable_attr_duplicate_note);
       return;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2894,7 +2894,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     // When used directly on a storage decl (stored/computed property or
     // subscript), the getter is currently inferred to be `@differentiable`.
     // TODO(TF-129): Infer setter to also be `@differentiable` after
-    // differentiation supports inout parameters.
+    // differentiation supports inout parameters. This requires refactoring to
+    // handle multiple `original` functions (both getter and setter).
     original = asd->getGetter();
   }
   // Setters are not yet supported.
@@ -3167,13 +3168,37 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     attr->setVJPFunction(vjp);
   }
 
-  auto insertion =
-      ctx.DifferentiableAttrs.try_emplace({D, checkedWrtParamIndices}, attr);
+  auto insertion = ctx.DifferentiableAttrs.try_emplace(
+      {D, attr->getParameterIndices()}, attr);
   // `@differentiable` attributes are uniqued by their parameter indices.
   // Reject duplicate attributes for the same decl and parameter indices pair.
   if (!insertion.second && insertion.first->getSecond() != attr) {
-    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_duplicate);
+    TC.diagnose(attr->getLocation(), diag::differentiable_attr_duplicate);
+    TC.diagnose(insertion.first->getSecond()->getLocation(),
+                diag::differentiable_attr_duplicate_note);
     return;
+  }
+  // Transfer `@differentiable` attribute from storage declaration to
+  // getter accessor.
+  if (auto *asd = dyn_cast<AbstractStorageDecl>(D)) {
+    auto *newAttr = DifferentiableAttr::create(
+        ctx, /*implicit*/ true, attr->AtLoc, attr->getRange(), attr->isLinear(),
+        attr->getParameterIndices(), attr->getJVP(), attr->getVJP(),
+        attr->getRequirements());
+    auto insertion = ctx.DifferentiableAttrs.try_emplace(
+        {asd->getGetter(), attr->getParameterIndices()}, newAttr);
+    // Valid `@differentiable` attributes are uniqued by their parameter
+    // indices. Reject duplicate attributes for the same decl and parameter
+    // indices pair.
+    if (!insertion.second) {
+      TC.diagnose(newAttr->getLocation(), diag::differentiable_attr_duplicate);
+      TC.diagnose(insertion.first->getSecond()->getLocation(),
+                  diag::differentiable_attr_duplicate_note);
+      return;
+    }
+    // Remove `@differentiable` attribute from storage declaration to prevent
+    // duplicate attribute registration during SILGen.
+    D->getAttrs().removeAttribute(attr);
   }
 }
 
@@ -3469,7 +3494,9 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     // indices. Reject duplicate attributes for the same decl and parameter
     // indices pair.
     if (!insertion.second && insertion.first->getSecond() != da) {
-      diagnoseAndRemoveAttr(da, diag::differentiable_attr_duplicate);
+      TC.diagnose(da->getLocation(), diag::differentiable_attr_duplicate);
+      TC.diagnose(insertion.first->getSecond()->getLocation(),
+                  diag::differentiable_attr_duplicate_note);
       return;
     }
     originalFn->getAttrs().add(da);

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-testing -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-testing -verify %s | %FileCheck %s -check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -emit-silgen -enable-testing -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 //===----------------------------------------------------------------------===//
 // Normal types
@@ -10,14 +11,14 @@ public func foo(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dfoo] [ossa] @foo
+// CHECK-SIL-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dfoo] [ossa] @foo
 
 @_silgen_name("dfoo")
 public func dfoo(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)) {
   return (foo(x, y), { _ in (1, 1) })
 }
 
-// CHECK-LABEL: sil [ossa] @dfoo
+// CHECK-SIL-LABEL: sil [ossa] @dfoo
 
 //===----------------------------------------------------------------------===//
 // Indirect returns
@@ -29,8 +30,8 @@ public func foo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> T {
   return y
 }
 
-// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dfoo_indir_ret] [ossa] @foo_indir_ret : $@convention(thin) <T where T : Differentiable> (Float, @in_guaranteed T) -> @out T {
-// CHECK: bb0(%0 : $*T, %1 : $Float, %2 : $*T):
+// CHECK-SIL-LABEL: sil [differentiable source 0 wrt 0, 1 vjp @dfoo_indir_ret] [ossa] @foo_indir_ret : $@convention(thin) <T where T : Differentiable> (Float, @in_guaranteed T) -> @out T {
+// CHECK-SIL: bb0(%0 : $*T, %1 : $Float, %2 : $*T):
 
 @_silgen_name("dfoo_indir_ret")
 public func dfoo_indir_ret<T: Differentiable>(_ x: Float, _ y: T) -> (T, (T.TangentVector) -> (Float, T.TangentVector)) {
@@ -47,14 +48,14 @@ public func hasjvp(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [differentiable source 0 wrt 0, 1 jvp @dhasjvp] [ossa] @hasjvp
+// CHECK-SIL-LABEL: sil [differentiable source 0 wrt 0, 1 jvp @dhasjvp] [ossa] @hasjvp
 
 @_silgen_name("dhasjvp")
 public func dhasjvp(_ x: Float, _ y: Float) -> (Float, (Float, Float) -> Float) {
   return (1, { _, _ in 1 })
 }
 
-// CHECK-LABEL: sil [ossa] @dhasjvp
+// CHECK-SIL-LABEL: sil [ossa] @dhasjvp
 
 //===----------------------------------------------------------------------===//
 // VJP
@@ -67,20 +68,20 @@ public func hasvjp(_ x: Float, _ y: Float) -> Float {
   return 1
 }
 
-// CHECK-LABEL: sil [serialized] [differentiable source 0 wrt 0, 1 vjp @dhasvjp] [ossa] @hasvjp
+// CHECK-SIL-LABEL: sil [serialized] [differentiable source 0 wrt 0, 1 vjp @dhasvjp] [ossa] @hasvjp
 
 @_silgen_name("dhasvjp")
 public func dhasvjp(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float, Float)) {
   return (1, { _ in (1, 1) })
 }
 
-// CHECK-LABEL: sil [ossa] @dhasvjp
+// CHECK-SIL-LABEL: sil [ossa] @dhasvjp
 
 //===----------------------------------------------------------------------===//
 // Computed property
 //===----------------------------------------------------------------------===//
 
-struct DiffComputedProp {
+struct DiffComputedProp : Differentiable & AdditiveArithmetic {
   @differentiable(wrt: (self), jvp: computedPropJVP, vjp: computedPropVJP)
   var computedProp: Float {
     return 0
@@ -97,31 +98,20 @@ struct DiffComputedProp {
   }
 }
 
-extension DiffComputedProp : VectorNumeric {
-  static var zero: DiffComputedProp { fatalError("unimplemented") }
-  static func + (lhs: DiffComputedProp, rhs: DiffComputedProp) -> DiffComputedProp {
-    fatalError("unimplemented")
-  }
-  static func - (lhs: DiffComputedProp, rhs: DiffComputedProp) -> DiffComputedProp {
-    fatalError("unimplemented")
-  }
-  typealias Scalar = Float
-  static func * (lhs: Float, rhs: DiffComputedProp) -> DiffComputedProp {
-    fatalError("unimplemented")
-  }
-}
+// Check that `@differentiable` attribute is transferred from computed property
+// storage declaration to getter accessor.
 
-extension DiffComputedProp : Differentiable {
-  typealias TangentVector = DiffComputedProp
-}
+// CHECK-AST: struct DiffComputedProp : AdditiveArithmetic & Differentiable {
+// CHECK-AST-NEXT:   var computedProp: Float { get }
+// CHECK-AST: }
 
-// CHECK-LABEL: DiffComputedProp.computedProp.getter
-// CHECK-NEXT: [differentiable source 0 wrt 0 jvp @computedPropJVP vjp @computedPropVJP]
+// CHECK-SIL-LABEL: DiffComputedProp.computedProp.getter
+// CHECK-SIL-NOT: [differentiable source 0 wrt 0 jvp @computedPropJVP vjp @computedPropVJP]
 
 public struct MyLayer: Differentiable {
   @differentiable
   var x: Float = 10
 }
 
-// CHECK-LABEL: initialization expression of MyLayer.x
-// CHECK-NEXT: sil [transparent] [ossa] @$s26differentiable_attr_silgen7MyLayerV1xSfvpfi : $@convention(thin) () -> Float
+// CHECK-SIL-LABEL: initialization expression of MyLayer.x
+// CHECK-SIL-NEXT: sil [transparent] [ossa] @$s26differentiable_attr_silgen7MyLayerV1xSfvpfi : $@convention(thin) () -> Float

--- a/test/AutoDiff/differentiable_attr_silgen.swift
+++ b/test/AutoDiff/differentiable_attr_silgen.swift
@@ -106,7 +106,7 @@ struct DiffComputedProp : Differentiable & AdditiveArithmetic {
 // CHECK-AST: }
 
 // CHECK-SIL-LABEL: DiffComputedProp.computedProp.getter
-// CHECK-SIL-NOT: [differentiable source 0 wrt 0 jvp @computedPropJVP vjp @computedPropVJP]
+// CHECK-SIL-NEXT: [differentiable source 0 wrt 0 jvp @computedPropJVP vjp @computedPropVJP]
 
 public struct MyLayer: Differentiable {
   @differentiable

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -29,15 +29,34 @@ func no_jvp_or_vjp(_ x: Float) -> Float {
   return x * x
 }
 
+// Test duplicated `@differentiable` attributes.
+
 @differentiable // expected-error {{duplicate '@differentiable' attribute}}
-@differentiable
+@differentiable // expected-note {{other attribute declared here}}
 func dupe_attributes(arg: Float) -> Float { return arg }
 
-@differentiable(wrt: arg1) // expected-error {{duplicate '@differentiable' attribute}}
 @differentiable(wrt: arg1)
 @differentiable(wrt: arg2) // expected-error {{duplicate '@differentiable' attribute}}
-@differentiable(wrt: arg2)
+@differentiable(wrt: arg2) // expected-note {{other attribute declared here}}
 func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
+
+struct ComputedPropertyDupeAttributes<T : Differentiable> : Differentiable {
+  var value: T
+
+  @differentiable // expected-error {{duplicate '@differentiable' attribute}}
+  var computed1: T {
+    @differentiable // expected-note {{other attribute declared here}}
+    get { value }
+    set { value = newValue }
+  }
+
+  @differentiable(where T == Float) // expected-error {{duplicate '@differentiable' attribute}}
+  @differentiable(where T == Double) // expected-note {{other attribute declared here}}
+  var computed2: T {
+    get { value }
+    set { value = newValue }
+  }
+}
 
 class Class {}
 // expected-error @+1 {{class objects and protocol existentials ('Class') cannot be differentiated with respect to}}

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -50,6 +50,8 @@ struct ComputedPropertyDupeAttributes<T : Differentiable> : Differentiable {
     set { value = newValue }
   }
 
+  // TODO(TF-482): Remove diagnostics when `@differentiable` attributes are
+  // also uniqued based on generic requirements.
   @differentiable(where T == Float) // expected-error {{duplicate '@differentiable' attribute}}
   @differentiable(where T == Double) // expected-note {{other attribute declared here}}
   var computed2: T {

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -124,4 +124,20 @@ E2EDifferentiablePropertyTests.test("fieldwise product space, other tangent") {
   expectEqual(expectedGrad, actualGrad)
 }
 
+E2EDifferentiablePropertyTests.test("computed property") {
+  struct TF_544 : Differentiable {
+    var value: Float
+    @differentiable
+    var computed: Float {
+      get { value }
+      set { value = newValue }
+    }
+  }
+  let actualGrad = gradient(at: TF_544(value: 2.4)) { x in
+    return x.computed * x.computed
+  }
+  let expectedGrad = TF_544.AllDifferentiableVariables(value: 4.8)
+  expectEqual(expectedGrad, actualGrad)
+}
+
 runAllTests()


### PR DESCRIPTION
- Diagnose duplicate `@differentiable` attributes on computed property
  and getter. Resolves [TF-544](https://bugs.swift.org/browse/TF-544).
- During SILGen, assert no duplicate `@differentiable` attributes.
- Improve duplicate `@differentiable` attribute diagnostics.