### PR TITLE
[AutoDiff] Partially fix AD control flow memory leaks

### DIFF
--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -72,9 +72,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB1_PB:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
@@ -82,9 +82,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB2_PB:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
@@ -92,12 +92,12 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
 // CHECK-SIL:   return {{%.*}} : $Float
 
 @differentiable
@@ -147,9 +147,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -157,9 +157,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -167,10 +167,10 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
 // CHECK-SIL:   return {{%.*}} : $Float

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -78,6 +78,11 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   [[BB1_PB:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   [[BB1_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB1_PRED]]
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
@@ -88,6 +93,10 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   [[BB2_PB:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   [[BB2_PB_STRUCT_DATA:%.*]] = unchecked_enum_data [[BB2_PRED]]
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
@@ -98,6 +107,8 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL:   release_value {{%.*}} : $Float
+// CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   return {{%.*}} : $Float
 
 @differentiable

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -92,7 +92,7 @@ LeakCheckingTests.test("ControlFlow") {
   // FIXME: Fix control flow AD memory leaks.
   // See related FIXME comments in adjoint value/buffer propagation in
   // lib/SILOptimizer/Mandatory/Differentiation.cpp.
-  testWithLeakChecking(expectedLeakCount: 105) {
+  testWithLeakChecking(expectedLeakCount: 74) {
     func cond_nestedtuple_var(_ x: Tracked<Float>) -> Tracked<Float> {
       // Convoluted function returning `x + x`.
       var y = (x + x, x - x)
@@ -116,7 +116,7 @@ LeakCheckingTests.test("ControlFlow") {
   // FIXME: Fix control flow AD memory leaks.
   // See related FIXME comments in adjoint value/buffer propagation in
   // lib/SILOptimizer/Mandatory/Differentiation.cpp.
-  testWithLeakChecking(expectedLeakCount: 379) {
+  testWithLeakChecking(expectedLeakCount: 300) {
     func cond_nestedstruct_var(_ x: Tracked<Float>) -> Tracked<Float> {
       // Convoluted function returning `x + x`.
       var y = FloatPair(x + x, x - x)
@@ -140,7 +140,7 @@ LeakCheckingTests.test("ControlFlow") {
   // FIXME: Fix control flow AD memory leaks.
   // See related FIXME comments in adjoint value/buffer propagation in
   // lib/SILOptimizer/Mandatory/Differentiation.cpp.
-  testWithLeakChecking(expectedLeakCount: 9) {
+  testWithLeakChecking(expectedLeakCount: 3) {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
     _ = model.gradient(at: x) { m, x in
@@ -157,7 +157,7 @@ LeakCheckingTests.test("ControlFlow") {
   // FIXME: Fix control flow AD memory leaks.
   // See related FIXME comments in adjoint value/buffer propagation in
   // lib/SILOptimizer/Mandatory/Differentiation.cpp.
-  testWithLeakChecking(expectedLeakCount: 14) {
+  testWithLeakChecking(expectedLeakCount: 6) {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
     _ = model.gradient(at: x) { m, x in


### PR DESCRIPTION
This PR partially fixes the incorrect omission of memory cleanup in `AdjointEmitter`.

Cleanups should be created per basic block in an adjoint function, starting with its arguments. Like function parameter arguments in the adjoint entry block, every phi argument except the pullback struct in a non-entry adjoint block also needs to possess a cleanup. We let the existing adjoint emission logic accumulate the cleanups until we are about to branch, where we disable the top-level cleanup for arguments in the terminator instruction and apply all of their child cleanups recursively. This logic is more general than the original single-block differentiation logic, and we should refactor `AdjointEmitter::run()` to eliminate special logic for adjoint entry and exit blocks as much as possible.

```
bb1(x, y, pbs):
    v0 = pbs.0(x, y)
    v1 = pbs.1(v0)
    release_value x
    release_value y
    release_value v0
    switch pbs.predessor, case #case1: bb2, case #case2: bb3
bb2_tramp(...):
    br bb2(v1)
bb2(...):
    ...
bb3_tramp(...):
    br bb3(v1)
bb3(...):
    ...
```

This PR also unifies the argument order of the adjoint entry block with that of other adjoint blocks, making the pullback struct always the last argument. This helps us reduce special logic for the adjoint entry block later.