### PR TITLE
Update documentation for CommandLine.arguments

### DIFF
--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -43,8 +43,9 @@ public enum CommandLine {
     return _unsafeArgv
   }
 
-  /// Access to the swift arguments, also use lazy initialization of static
-  /// properties to safely initialize the swift arguments.
+  /// Access to the Swift command line arguments.
+  // Use lazy initialization of static properties to 
+  // safely initialize the swift arguments.
   public static var arguments: [String]
     = (0..<Int(argc)).map { String(cString: _unsafeArgv[$0]!) }
 }


### PR DESCRIPTION
Addresses SR-6776 Documentation comment for CommandLine.arguments contains implementation remarks.

Resolves [SR-6776](https://bugs.swift.org/browse/SR-6776).
