### PR TITLE
Add benchmarks for string operations.

### DIFF
--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -28,13 +28,17 @@ let words = [
   "Joshua", "Kevin", "Ronald", "Timothy", "Jason", "Jeffrey", "Gary", "Ryan",
   "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Frank"]
 
+let emojis = [
+  "🏄", "🍔", "🎽", "🐟", "😔", "🚓", "🚼", "🍣", "🏃", "🚲", "😼", "🎷", "🙇", "👩", "🙉", "🍲", "😨", "🚃", "🎾", "🚫", "🐰", "😖", "🍫", "💄", "👹", "🚏", "🍢", "🎭", "😌", "🚍", "🍕", "🙈", "👧"]
+
+
 @inline(never)
 public func run_AngryPhonebook(_ N: Int) {
   // Permute the names.
   for _ in 1...N {
     for firstname in words {
       for lastname in words {
-        _ = (firstname.uppercased(), lastname.lowercased())
+        blackHole((firstname.uppercased(), lastname.lowercased()))
       }
     }
   }

--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -15,11 +15,23 @@
 import TestsUtils
 import Foundation
 
-public let AngryPhonebook = BenchmarkInfo(
-  name: "AngryPhonebook",
-  runFunction: run_AngryPhonebook,
-  tags: [.validation, .api, .String],
-  legacyFactor: 7)
+public let AngryPhonebook = [
+  BenchmarkInfo(
+    name: "AngryPhonebook",
+    runFunction: run_AngryPhonebook,
+    tags: [.validation, .api, .String],
+    legacyFactor: 7),
+  BenchmarkInfo(
+    name: "AngryNonAsciiPhonebook",
+    runFunction: run_AngryNonAsciiPhonebook,
+    tags: [.validation, .api, .String],
+    legacyFactor: 7),
+  BenchmarkInfo(
+    name: "AngryEmojiPhonebook",
+    runFunction: run_AngryEmojiPhonebook,
+    tags: [.validation, .api, .String])
+]
+
 
 let words = [
   "James", "John", "Robert", "Michael", "William", "David", "Richard", "Joseph",
@@ -27,10 +39,13 @@ let words = [
   "Paul", "Mark", "George", "Steven", "Kenneth", "Andrew", "Edward", "Brian",
   "Joshua", "Kevin", "Ronald", "Timothy", "Jason", "Jeffrey", "Gary", "Ryan",
   "Nicholas", "Eric", "Stephen", "Jacob", "Larry", "Frank"]
-
+let nonAsciWords = [
+  "Michał", "Łucja", "Władysław", "Elżbieta", "Dobrosława", "Bożena", "Żaneta",
+  "Rafał", "Günter", "Jürgen", "Jörg", "Jürgen"]
 let emojis = [
-  "🏄", "🍔", "🎽", "🐟", "😔", "🚓", "🚼", "🍣", "🏃", "🚲", "😼", "🎷", "🙇", "👩", "🙉", "🍲", "😨", "🚃", "🎾", "🚫", "🐰", "😖", "🍫", "💄", "👹", "🚏", "🍢", "🎭", "😌", "🚍", "🍕", "🙈", "👧"]
-
+  "🏄", "🍔", "🎽", "🐟", "😔", "🚓", "🚼", "🍣", "🏃", "🚲", "😼", "🎷",
+  "🙇", "👩", "🙉", "🍲", "😨", "🚃", "🎾", "🚫", "🐰", "😖", "🍫", "💄",
+  "👹", "🚏", "🍢", "🎭", "😌", "🚍", "🍕", "🙈", "👧"]
 
 @inline(never)
 public func run_AngryPhonebook(_ N: Int) {
@@ -40,6 +55,28 @@ public func run_AngryPhonebook(_ N: Int) {
       for lastname in words {
         blackHole((firstname.uppercased(), lastname.lowercased()))
       }
+    }
+  }
+}
+
+@inline(never)
+public func run_AngryNonAsciiPhonebook(_ N: Int) {
+  // Permute the names.
+  for _ in 1...N {
+    for firstname in nonAsciWords {
+      for lastname in nonAsciWords {
+        blackHole((firstname.uppercased(), lastname.lowercased()))
+      }
+    }
+  }
+}
+
+@inline(never)
+public func run_AngryEmojiPhonebook(_ N: Int) {
+  // Permute the names.
+  for _ in 1...N {
+    for emoji in emojis {
+      blackHole((emoji.uppercased(), emoji.lowercased()))
     }
   }
 }

--- a/benchmark/single-source/RemoveWhere.swift
+++ b/benchmark/single-source/RemoveWhere.swift
@@ -25,7 +25,7 @@ public let RemoveWhere = [
   BenchmarkInfo(name: "RemoveWhereMoveInts", runFunction: run_RemoveWhereMoveInts, tags: [.validation, .api], setUpFunction: buildWorkload),
   BenchmarkInfo(name: "RemoveWhereSwapStrings", runFunction: run_RemoveWhereSwapStrings, tags: [.validation, .api], setUpFunction: buildWorkload),
   BenchmarkInfo(name: "RemoveWhereSwapInts", runFunction: run_RemoveWhereSwapInts, tags: [.validation, .api], setUpFunction: buildWorkload),
-  // these test performance of filter, character iteration/comparison 
+  // these test performance of filter, character iteration/comparison
   BenchmarkInfo(name: "RemoveWhereFilterString", runFunction: run_RemoveWhereFilterString, tags: [.validation, .api], setUpFunction: buildWorkload),
   BenchmarkInfo(name: "RemoveWhereQuadraticString", runFunction: run_RemoveWhereQuadraticString, tags: [.validation, .api], setUpFunction: buildWorkload),
 ]


### PR DESCRIPTION
This PR adds two benchmarks for `String` operations (`lowercased()` and `uppercased()`) for non-ASCII strings and emojis.

Resolves [SR-10857](https://bugs.swift.org/browse/SR-10857).
