### PR TITLE
[Diagnostics] Add a fix-it for misplaced throws in function types

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -417,6 +417,12 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   if (Tok.is(tok::arrow)) {
     // Handle type-function if we have an arrow.
     SourceLoc arrowLoc = consumeToken();
+    if(Tok.is(tok::kw_throws)) {
+     Diag<> DiagID = diag::throws_in_wrong_position;
+     diagnose(Tok.getLoc(), DiagID).fixItInsert(arrowLoc, "throws ")
+	     .fixItRemove(Tok.getLoc());
+     consumeToken();
+    }
     ParserResult<TypeRepr> SecondHalf =
       parseType(diag::expected_type_function_result);
     if (SecondHalf.hasCodeCompletion())

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -422,7 +422,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       diagnose(Tok.getLoc(), DiagID)
           .fixItInsert(arrowLoc, "throws ")
           .fixItRemove(Tok.getLoc());
-      consumeToken();
+      throwsLoc = consumeToken();
     }
     ParserResult<TypeRepr> SecondHalf =
         parseType(diag::expected_type_function_result);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -417,14 +417,15 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   if (Tok.is(tok::arrow)) {
     // Handle type-function if we have an arrow.
     SourceLoc arrowLoc = consumeToken();
-    if(Tok.is(tok::kw_throws)) {
-     Diag<> DiagID = diag::throws_in_wrong_position;
-     diagnose(Tok.getLoc(), DiagID).fixItInsert(arrowLoc, "throws ")
-	     .fixItRemove(Tok.getLoc());
-     consumeToken();
+    if (Tok.is(tok::kw_throws)) {
+      Diag<> DiagID = diag::throws_in_wrong_position;
+      diagnose(Tok.getLoc(), DiagID)
+          .fixItInsert(arrowLoc, "throws ")
+          .fixItRemove(Tok.getLoc());
+      consumeToken();
     }
     ParserResult<TypeRepr> SecondHalf =
-      parseType(diag::expected_type_function_result);
+        parseType(diag::expected_type_function_result);
     if (SecondHalf.hasCodeCompletion())
       return makeParserCodeCompletionResult<TypeRepr>();
     if (SecondHalf.isNull())

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -125,3 +125,5 @@ func fixitThrow2() throws {
   throw MSV.Foo
   var _: (Int) throw -> Int // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{16-21=throws}}
 }
+
+let fn: () -> throws Void  // expected-error{{'throws' may only occur before '->'}} {{12-12=throws }} {{15-22=}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adds a diagnostic error for misplaced throws in function types. For e.g:
```swift
let fn: () -> throws Void  // expected-error{{'throws' may only occur before '->'}} {{12-12=throws }} {{15-22=}}
```
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10703](https://bugs.swift.org/browse/SR-10703).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
