### PR TITLE
Improve warning message for defer_stmt_at_block_end

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3150,7 +3150,7 @@ ERROR(jump_out_of_defer,none,
       (StringRef))
 
 WARNING(defer_stmt_at_block_end,none,
-     "'defer' statement before end of scope always executes immediately; "
+     "'defer' statement at end of scope always executes immediately; "
      "replace with 'do' statement to silence this warning", ())
 
 ERROR(return_invalid_outside_func,none,

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -518,7 +518,7 @@ func defer_in_closure_in_generic<T>(_ x: T) {
   // CHECK-LABEL: sil private [ossa] @$s10statements017defer_in_closure_C8_genericyyxlFyycfU_ : $@convention(thin) <T> () -> ()
   _ = {
     // CHECK-LABEL: sil private [ossa] @$s10statements017defer_in_closure_C8_genericyyxlFyycfU_6$deferL_yylF : $@convention(thin) <T> () -> ()
-    defer { generic_callee_1(T.self) } // expected-warning {{'defer' statement before end of scope always executes immediately}}{{5-10=do}}
+    defer { generic_callee_1(T.self) } // expected-warning {{'defer' statement at end of scope always executes immediately}}{{5-10=do}}
   }
 }
 
@@ -531,7 +531,7 @@ func defer_mutable(_ x: Int) {
   // CHECK: function_ref @$s10statements13defer_mutableyySiF6$deferL_yyF : $@convention(thin) (@inout_aliasable Int) -> ()
   // CHECK-NOT: [[BOX]]
   // CHECK: destroy_value [[BOX]]
-  defer { _ = x } // expected-warning {{'defer' statement before end of scope always executes immediately}}{{3-8=do}}
+  defer { _ = x } // expected-warning {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
 }
 
 protocol StaticFooProtocol { static func foo() }

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -21,7 +21,7 @@ defer { print(y) } // expected-error {{constant 'y' used in defer before being i
 // Test top-level functions.
 
 func testFunc() {       // expected-error {{variable 'x' used by function definition before being initialized}}
-  defer { print(x) }    // expected-warning {{'defer' statement before end of scope always executes immediately}}{{3-8=do}}
+  defer { print(x) }    // expected-warning {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
 }
 
 // Test top-level closures.

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -328,7 +328,7 @@ func deferTryNoReturn() throws {
 }
 
 func noReturnInDefer() {
-  defer { // expected-warning {{'defer' statement before end of scope always executes immediately}}{{3-8=do}}
+  defer { // expected-warning {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
     _ = Lisp()
     die() // expected-note {{a call to a never-returning function}}
     die() // expected-warning {{will never be executed}}

--- a/test/Sema/diag_defer_block_end.swift
+++ b/test/Sema/diag_defer_block_end.swift
@@ -3,14 +3,14 @@
 let x = 1
 let y = 2
 if (x > y) {
-    defer { // expected-warning {{'defer' statement before end of scope always executes immediately}}{{5-10=do}}
+    defer { // expected-warning {{'defer' statement at end of scope always executes immediately}}{{5-10=do}}
         print("not so useful defer stmt.")
     }
 }
 
 func sr7307(_ value: Bool) {
     let negated = !value 
-    defer { // expected-warning {{'defer' statement before end of scope always executes immediately}}{{5-10=do}}
+    defer { // expected-warning {{'defer' statement at end of scope always executes immediately}}{{5-10=do}}
         print("negated value is {negated}")
     }
 }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -350,9 +350,9 @@ func test_defer(_ a : Int) {
 
   // Not ok.
   while false { defer { break } }   // expected-error {{'break' cannot transfer control out of a defer statement}}
-  // expected-warning@-1 {{'defer' statement before end of scope always executes immediately}}{{17-22=do}}
+  // expected-warning@-1 {{'defer' statement at end of scope always executes immediately}}{{17-22=do}}
   defer { return }  // expected-error {{'return' cannot transfer control out of a defer statement}}
-  // expected-warning@-1 {{'defer' statement before end of scope always executes immediately}}{{3-8=do}}
+  // expected-warning@-1 {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
 }
 
 class SomeTestClass {
@@ -360,7 +360,7 @@ class SomeTestClass {
  
   func method() {
     defer { x = 97 }  // self. not required here!
-    // expected-warning@-1 {{'defer' statement before end of scope always executes immediately}}{{5-10=do}}
+    // expected-warning@-1 {{'defer' statement at end of scope always executes immediately}}{{5-10=do}}
   }
 }
 

--- a/test/stmt/yield.swift
+++ b/test/stmt/yield.swift
@@ -82,7 +82,7 @@ func call_yield() {
 struct YieldInDefer {
   var property: String {
     _read {
-      defer { // expected-warning {{'defer' statement before end of scope always executes immediately}}{{7-12=do}}
+      defer { // expected-warning {{'defer' statement at end of scope always executes immediately}}{{7-12=do}}
         // FIXME: this recovery is terrible
         yield ""
         // expected-error@-1 {{expression resolves to an unused function}}


### PR DESCRIPTION
To make the reason for the warning more obvious, I changed the warning message for `defer_stmt_at_block_end` as follows:

```
'defer' statement at end of scope always executes immediately; replace with 'do' statement to silence this warning
```
(replace "before" with "at").

Resolves [SR-10581](https://bugs.swift.org/browse/SR-10581).
