### PR TITLE
[Runtime] swift_demangle: Update buffer size after copying

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -666,13 +666,14 @@ char *swift_demangle(const char *mangledName,
     return strdup(result.c_str());
   }
 
-  // Indicate a failure if the result does not fit and will be truncated
-  // and set the required outputBufferSize.
+  // Copy into the provided buffer.
+  _swift_strlcpy(outputBuffer, result.c_str(), *outputBufferSize);
+
+  // Indicate a failure if the result did not fit and was truncated
+  // by setting the required outputBufferSize.
   if (*outputBufferSize < result.length() + 1) {
     *outputBufferSize = result.length() + 1;
   }
 
-  // Copy into the provided buffer.
-  _swift_strlcpy(outputBuffer, result.c_str(), *outputBufferSize);
   return outputBuffer;
 }

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -375,6 +375,37 @@ Runtime.test("demangleName") {
   expectEqual("Foobar", _stdlib_demangleName("$s13__lldb_expr_46FoobarCD"))
 }
 
+Runtime.test("demangleTruncate") {
+  // Swift.Int requires 10 bytes to be fully demangled.
+  let buffer = UnsafeMutableBufferPointer<Int8>.allocate(capacity: 10)
+
+  defer { buffer.deallocate() }
+
+  // Set last byte to a custom number, that way when we call swift_demangle
+  // the last byte should be unchanged rather than it being set to 0.
+  buffer[buffer.count - 1] = 16
+
+  // Only give 9 bytes though to exercise that swift_demangle doesn't write past
+  // the buffer.
+  var bufferSize = UInt(buffer.count - 1)
+
+  let mangled = "$sSi"
+
+  mangled.utf8CString.withUnsafeBufferPointer {
+    _ = _stdlib_demangleImpl(
+      mangledName: $0.baseAddress,
+      mangledNameLength: UInt($0.count - 1),
+      outputBuffer: buffer.baseAddress,
+      outputBufferSize: &bufferSize,
+      flags: 0
+    )
+  }
+
+  expectEqual(String(cString: buffer.baseAddress!), "Swift.In")
+  expectEqual(bufferSize, 10)
+  expectEqual(buffer[buffer.count - 1], 16)
+}
+
 % for optionality in ['', '?']:
 Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
   typealias IntPtr = UnsafeMutablePointer<Int>


### PR DESCRIPTION
Previously this would update buffer size before copying if the given buffer size was smaller than the result size. This lead to writing past the given buffer rather than truncating like the comment states. Update it after copying so that we get truncation along with error indication.

cc: @jckarter @rjmccall 