### PR TITLE
Change the overflow behavior of floating-point inits from String

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -31,17 +31,15 @@ SWIFT_RUNTIME_STDLIB_API
 void *_swift_objCMirrorSummary(const void * nsObject);
 
 /// Call strtold_l with the C locale, swapping argument and return
-/// types so we can operate on Float80.  Return NULL on overflow.
+/// types so we can operate on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult);
 /// Call strtod_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.  Return NULL on
-/// overflow.
+/// types so we can operate consistently on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtod_clocale(const char *nptr, double *outResult);
 /// Call strtof_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.  Return NULL on
-/// overflow.
+/// types so we can operate consistently on Float80.
 SWIFT_RUNTIME_STDLIB_API
 const char *_swift_stdlib_strtof_clocale(const char *nptr, float *outResult);
 

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -459,10 +459,6 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   errno = 0;
   const auto result = posixImpl(nptr, &EndPtr, getCLocale());
   *outResult = result;
-  if (result == huge || result == -huge || result == 0.0 || result == -0.0) {
-      if (errno == ERANGE)
-          EndPtr = nullptr;
-  }
   return EndPtr;
 }
     

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -180,17 +180,11 @@ tests.test("${Self}/Basics") {
   expectNil(${Self}("0 "))  // Trailing whitespace
   expectNil(${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
 
-  // Overflow and underflow.  Interleave with other checks to make
-  // sure we're not abusing errno
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("2e99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("2e-99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("-2e99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
-  expectNil(${Self}("-2e-99999999999999"))
-  expectEqual(0.0, ${Self}("0"))
+  // Overflow and underflow.
+  expectEqual(.infinity, ${Self}("2e99999999999999"))
+  expectEqual(-.infinity, ${Self}("-2e99999999999999"))
+  expectEqual(0, ${Self}("2e-99999999999999"))
+  expectEqual(0, ${Self}("-2e-99999999999999"))
 }
 
 % if Self == 'Float80':


### PR DESCRIPTION
All other floating-point inits round out-of-range inputs to the nearest representable value. The conversions from string currently do not match this behavior, and return nil instead. This change makes it so only invalid character sequences produce nil; with overflow producing infinity and underflow producing zero, matching the behavior of literals.

Fixes <rdar://problem/36990878>