### PR TITLE
Apply Override Fixit to Variable Declarations

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1634,18 +1634,19 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
       overrideRequiresKeyword(base) != OverrideRequiresKeyword::Never &&
       !override->isImplicit() &&
       override->getDeclContext()->getParentSourceFile()) {
-    // FIXME: rdar://16320042 - For properties, we don't have a useful
-    // location for the 'var' token.  Instead of emitting a bogus fixit, only
-    // emit the fixit for 'func's.
     auto theDiag =
       overrideRequiresKeyword(base) == OverrideRequiresKeyword::Always
         ? diag::missing_override
         : diag::missing_override_warn;
-    if (!isa<VarDecl>(override))
-      diags.diagnose(override, theDiag)
-          .fixItInsert(override->getStartLoc(), "override ");
-    else
-      diags.diagnose(override, theDiag);
+
+    auto diagLoc = override->getStartLoc();
+    // If dynamic cast to VarDecl succeeds, use the location of its parent
+    // pattern binding which will return the VarLoc.
+    if (auto VD = dyn_cast<VarDecl>(override)) {
+      diagLoc = VD->getParentPatternBinding()->getLoc();
+    }
+
+    diags.diagnose(override, theDiag).fixItInsert(diagLoc, "override ");
     diags.diagnose(base, diag::overridden_here);
   }
 

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -29,6 +29,7 @@ class A {
 
   var v1: Int { return 5 }
   var v2: Int { return 5 } // expected-note{{overridden declaration is here}}
+  internal var v21: Int { return 5 } // expected-note{{overridden declaration is here}}
   var v4: String { return "hello" }// expected-note{{attempt to override property here}}
   var v5: A { return self }
   var v6: A { return self }
@@ -93,9 +94,9 @@ class B : A {
   override func f0() { }
   func f1() { } // expected-error{{overriding declaration requires an 'override' keyword}}{{3-3=override }}
   override func f2() { } // expected-error{{method does not override any method from its superclass}}
-
   override var v1: Int { return 5 }
-  var v2: Int { return 5 } // expected-error{{overriding declaration requires an 'override' keyword}}
+  var v2: Int { return 5 } // expected-error{{overriding declaration requires an 'override' keyword}}{{3-3=override }}
+  internal var v21: Int { return 5 } // expected-error{{overriding declaration requires an 'override' keyword}}{{12-12=override }}
   override var v3: Int { return 5 } // expected-error{{property does not override any property from its superclass}}
   override var v4: Int { return 5 } // expected-error{{property 'v4' with type 'Int' cannot override a property with type 'String'}}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently when an `override` is missing for a variable declaration, no fix-it is applied but a fix-it is applied for function declarations.

This PR:

- Inserts an `override` fix-it at the location of the `var` keyword using the location of the Parent Pattern Binding.
- Updates the `attr_override.swift` tests to verify that the override fix-it is inserted at the correct location.
- Adds test case to `attr_override.swift` for `internal` access modifier keyword scenario.

Note: I looked into adding more test cases but couldn't think of any other valid scenarios that should be tested (lazy vars can't be overridden, multiple vars can't be overridden on a single line). If anyone has suggestions for more test cases, I'd be happy to add them.

cc @theblixguy

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10292](https://bugs.swift.org/browse/SR-10292). 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
