### PR TITLE
[Sema] Always consider outer alternatives when resolving a decl ref.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2660,10 +2660,7 @@ namespace {
         //
         // The only way to get here is via an UnresolvedDotExpr with outer
         // alternatives.
-        auto UDE = cast<UnresolvedDotExpr>(expr);
-        cs.diagnoseDeprecatedConditionalConformanceOuterAccess(
-            UDE, selected.choice.getDecl());
-
+        assert(isa<UnresolvedDotExpr>(expr));
         return buildDeclRef(selected.choice, nameLoc, selected.openedFullType,
                             memberLocator, implicit,
                             selected.choice.getFunctionRefKind(),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4604,16 +4604,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         [&](unsigned, const OverloadChoice &choice) {
           return fixMemberRef(*this, baseTy, member, choice, locator);
         });
+  }
 
-    if (!outerAlternatives.empty()) {
-      // If local scope has a single choice,
-      // it should always be preferred.
-      if (candidates.size() == 1)
-        candidates.front()->setFavored();
+  if (!outerAlternatives.empty()) {
+    // If local scope has a single choice,
+    // it should always be preferred.
+    if (candidates.size() == 1)
+      candidates.front()->setFavored();
 
-      generateConstraints(candidates, memberTy, outerAlternatives,
-                          useDC, locator);
-    }
+    generateConstraints(candidates, memberTy, outerAlternatives,
+                        useDC, locator);
   }
 
   if (!result.UnviableCandidates.empty()) {


### PR DESCRIPTION
Currently, when a type member has the same base name as a global declaration, one cannot refer to the global member from a method context, and the current diagnostics force the user to use a fully qualified name. This is a long-standing issue with the use of top-level `min` and `max` in an extension, and is causing unnecessarily verbosity in math algorithms in extensions for `ElementaryFunctions`-conforming types.

More context:
1. [Forum thread](https://forums.swift.org/t/elementaryfunctions-and-ambiguity-in-extensions/25297): `ElementaryFunctions` and ambiguity in extensions
2. [SR-456](https://bugs.swift.org/browse/SR-456): Confusing build error when calling 'max' function within 'extension Int'.
3. [SR-1772](https://bugs.swift.org/browse/SR-1772): File-level function with the same name as instance function not picked up by compiler.

This PR makes `UnresolvedDeclRefExpr` resolution always consider alternative candidates from the outer context. The following code will no longer trigger any error or warning.

```swift
import Foundation // which exports a top-level `sin(_:)`.

extension Float {
    func foo() {
        // Refers to top-level `sin(_:)`, not static method `Float.sin(_:)`.
        _ = sin(self)
        _ = sin(_:) as (Float) -> Float
    }
}

extension Sequence {
    func foo() {
        // Refers to top-level `max(_:_:)`.
        _ = max(1, 2)
    }
}
```