### PR TITLE
[ownership] Update the ownership utils infrastructure to treat mark_d…

### DIFF
--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -876,7 +876,7 @@ OperandOwnershipKindMap OperandOwnershipKindClassifier::visitMarkDependenceInst(
     MarkDependenceInst *mdi) {
   // If we are analyzing "the value", we forward ownership.
   if (getValue() == mdi->getValue()) {
-    auto kind = getValue().getOwnershipKind();
+    auto kind = mdi->getOwnershipKind();
     if (kind == ValueOwnershipKind::Any)
       return Map::allLive();
     auto lifetimeConstraint = kind.getForwardingLifetimeConstraint();

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -43,6 +43,7 @@ bool swift::isOwnershipForwardingValueKind(SILNodeKind kind) {
   case SILNodeKind::CondBranchInst:
   case SILNodeKind::DestructureStructInst:
   case SILNodeKind::DestructureTupleInst:
+  case SILNodeKind::MarkDependenceInst:
     return true;
   default:
     return false;

--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -292,7 +292,7 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitSILFunctionArgument(
 // This is a forwarding instruction through only one of its arguments.
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitMarkDependenceInst(MarkDependenceInst *MDI) {
-  return MDI->getValue().getOwnershipKind();
+  return MDI->getOwnershipKind();
 }
 
 ValueOwnershipKind ValueOwnershipKindClassifier::visitApplyInst(ApplyInst *ai) {

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1156,3 +1156,11 @@ bb0:
   %9999 = tuple()
   return %9999 : $()
 }
+
+sil [ossa] @mark_dependence_test_guaranteed : $@convention(thin) (@guaranteed Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %2 = mark_dependence %0 : $Builtin.NativeObject on %1 : $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…ependence as forwarding.

We have already been forwarding ownership in terms of ValueOwnership and
OwnershipUtils, I just had not setup certain parts of the ownership utils to
recognize mark_dependence as forwarding of guaranteed values. We did not hit
this before since we have not had been late enough in the pipeline to get
mark_dependence on guaranteed values. I am fixing a problem with closure
lifetime fixup that exposed this issue.
