### PR TITLE
[Frontend] Add an option to emit XCTest methods to a file

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -70,5 +70,6 @@ TYPE("opt-record",          OptRecord,                 "opt.yaml",        "")
 TYPE("pcm",                 ClangModuleFile,           "pcm",             "")
 TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
+TYPE("xctest-methods",      XCTestMethodsFile,         "xctest.json",     "")
 
 #undef TYPE

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -124,6 +124,18 @@ struct SupplementaryOutputPaths {
   /// \sa swift::emitParseableInterface
   std::string ParseableInterfaceOutputPath;
 
+  /// The path to which we should emit XCTest test methods in JSON format.
+  ///
+  /// This is useful for build systems to generate entry point for corelibs-xctest
+  /// that is used on Linux. Eventually, this can be removed once we have runtime
+  /// reflection support on Linux.
+  ///
+  /// While it is possible to emit this on a per-file basis, the current implementation only
+  /// works for the whole-module.
+  ///
+  /// \sa swift::emitXCTestMethods
+  std::string XCTestMethodsFilePath;
+
   SupplementaryOutputPaths() = default;
   SupplementaryOutputPaths(const SupplementaryOutputPaths &) = default;
 
@@ -132,7 +144,8 @@ struct SupplementaryOutputPaths {
            ModuleDocOutputPath.empty() && DependenciesFilePath.empty() &&
            ReferenceDependenciesFilePath.empty() &&
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
-           TBDPath.empty() && ParseableInterfaceOutputPath.empty();
+           TBDPath.empty() && ParseableInterfaceOutputPath.empty() &&
+           XCTestMethodsFilePath.empty();
   }
 };
 } // namespace swift

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -359,6 +359,11 @@ private:
                                     llvm::SmallString<128> &buffer,
                                     CommandOutput *output) const;
 
+  void chooseXCTestMethodsPath(Compilation &C, const JobAction *JA,
+                               StringRef workingDirectory,
+                               llvm::SmallString<128> &buffer,
+                               CommandOutput *output) const;
+
   void chooseRemappingOutputPath(Compilation &C, const TypeToPathMap *OutputMap,
                                  CommandOutput *Output) const;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -348,6 +348,9 @@ public:
   /// fail an assert if not in that mode.
   std::string getParseableInterfaceOutputPathForWholeModule() const;
 
+  /// The current implementation requires the whole module.
+  std::string getXCTestMethodsFilePathForWholeModule() const;
+
   SerializationOptions
   computeSerializationOptions(const SupplementaryOutputPaths &outs,
                               bool moduleIsPublic);

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -236,6 +236,7 @@ public:
   bool hasModuleOutputPath() const;
   bool hasModuleDocOutputPath() const;
   bool hasParseableInterfaceOutputPath() const;
+  bool hasXCTestMethodsFilePath() const;
   bool hasTBDPath() const;
 
   bool hasDependencyTrackerPath() const;

--- a/include/swift/Frontend/XCTestMethodsEmitter.h
+++ b/include/swift/Frontend/XCTestMethodsEmitter.h
@@ -1,0 +1,34 @@
+//===--- ParseableInterfaceSupport.h - swiftinterface files -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_XCTESTMETHODEMITTER_H
+#define SWIFT_FRONTEND_XCTESTMETHODEMITTER_H
+
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+
+class ModuleDecl;
+
+/// Emit a JSON containing XCTest test methods for \p M.
+///
+/// This is useful for build systems to generate entry point for corelibs-xctest
+/// that is used on Linux. Eventually, this can be removed once we have runtime
+/// reflection support on Linux.
+///
+///
+/// \return true if an error occurred
+bool emitXCTestMethods(raw_ostream &out, ModuleDecl *M);
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -368,6 +368,11 @@ def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
          ArgumentIsPath]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
+def emit_xctest_methods_path : Separate<["-"], "emit-xctest-methods-path">,
+Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+ArgumentIsPath]>,
+MetaVarName<"<path>">, HelpText<"Emit a file containing XCTest test methods to <path>">;
+
 def import_cf_types : Flag<["-"], "import-cf-types">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Recognize and import CF types as class types">;

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -80,6 +80,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_ModuleTrace:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_XCTestMethodsFile:
     return true;
   case file_types::TY_Image:
   case file_types::TY_Object:
@@ -137,6 +138,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_ModuleTrace:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_XCTestMethodsFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -178,6 +180,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_IndexData:
   case file_types::TY_ModuleTrace:
   case file_types::TY_OptRecord:
+  case file_types::TY_XCTestMethodsFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -508,6 +508,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_TBD:
   case file_types::TY_OptRecord:
   case file_types::TY_SwiftParseableInterfaceFile:
+  case file_types::TY_XCTestMethodsFile:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -639,6 +640,9 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
                    "-emit-loaded-module-trace-path");
   addOutputsOfType(arguments, Output, Args, file_types::TY_TBD,
                    "-emit-tbd-path");
+  addOutputsOfType(arguments, Output, Args,
+                   file_types::ID::TY_XCTestMethodsFile,
+                   "-emit-xctest-methods-path");
 }
 
 ToolChain::InvocationInfo
@@ -747,6 +751,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ModuleTrace:
     case file_types::TY_OptRecord:
     case file_types::TY_SwiftParseableInterfaceFile:
+    case file_types::TY_XCTestMethodsFile:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");
@@ -887,6 +892,9 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::ID::TY_SwiftParseableInterfaceFile,
                    "-emit-parseable-module-interface-path");
+  addOutputsOfType(Arguments, context.Output, context.Args,
+                   file_types::ID::TY_XCTestMethodsFile,
+                   "-emit-xctest-methods-path");
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::TY_SerializedDiagnostics,
                    "-serialize-diagnostics-path");

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -296,11 +296,13 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
   auto TBD = getSupplementaryFilenamesFromArguments(options::OPT_emit_tbd_path);
   auto parseableInterfaceOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_module_interface_path);
+  auto xctestMethodsFilePath = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_xctest_methods_path);
 
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
-      !parseableInterfaceOutput) {
+      !parseableInterfaceOutput || !xctestMethodsFilePath) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -319,6 +321,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.LoadedModuleTracePath = (*loadedModuleTrace)[i];
     sop.TBDPath = (*TBD)[i];
     sop.ParseableInterfaceOutputPath = (*parseableInterfaceOutput)[i];
+    sop.XCTestMethodsFilePath = (*xctestMethodsFilePath)[i];
 
     result.push_back(sop);
   }
@@ -398,6 +401,9 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   auto parseableInterfaceOutputPath =
       pathsFromArguments.ParseableInterfaceOutputPath;
 
+  // There is no non-path form of -emit-xctest-methods-path
+  auto xctestMethodsFilePath = pathsFromArguments.XCTestMethodsFilePath;
+
   ID emitModuleOption;
   std::string moduleExtension;
   std::string mainOutputIfUsableForModule;
@@ -420,6 +426,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.LoadedModuleTracePath = loadedModuleTracePath;
   sop.TBDPath = tbdPath;
   sop.ParseableInterfaceOutputPath = parseableInterfaceOutputPath;
+  sop.XCTestMethodsFilePath = xctestMethodsFilePath;
   return sop;
 }
 
@@ -516,6 +523,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_serialize_diagnostics_path,
         options::OPT_emit_loaded_module_trace_path,
         options::OPT_emit_module_interface_path,
+        options::OPT_emit_xctest_methods_path,
         options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -10,7 +10,8 @@ add_swift_host_library(swiftFrontend STATIC
   ParseableInterfaceModuleLoader.cpp
   ParseableInterfaceSupport.cpp
   PrintingDiagnosticConsumer.cpp
-  SerializedDiagnosticConsumer.cpp)
+  SerializedDiagnosticConsumer.cpp
+  XCTestMethodsEmitter.cpp)
 add_dependencies(swiftFrontend
   SwiftOptions)
 target_link_libraries(swiftFrontend PRIVATE

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -124,6 +124,15 @@ CompilerInvocation::getParseableInterfaceOutputPathForWholeModule() const {
       .SupplementaryOutputs.ParseableInterfaceOutputPath;
 }
 
+std::string
+CompilerInvocation::getXCTestMethodsFilePathForWholeModule() const {
+  assert(getFrontendOptions().InputsAndOutputs.isWholeModule() &&
+         "XCTestMethodsFilePath only makes sense when the whole module "
+         "can be seen");
+  return getPrimarySpecificPathsForAtMostOnePrimary()
+  .SupplementaryOutputs.XCTestMethodsFilePath;
+}
+
 SerializationOptions CompilerInvocation::computeSerializationOptions(
     const SupplementaryOutputPaths &outs, bool moduleIsPublic) {
   const FrontendOptions &opts = getFrontendOptions();

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -441,6 +441,12 @@ bool FrontendInputsAndOutputs::hasParseableInterfaceOutputPath() const {
         return outs.ParseableInterfaceOutputPath;
       });
 }
+bool FrontendInputsAndOutputs::hasXCTestMethodsFilePath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+    return outs.XCTestMethodsFilePath;
+  });
+}
 bool FrontendInputsAndOutputs::hasTBDPath() const {
   return hasSupplementaryOutputPath(
       [](const SupplementaryOutputPaths &outs) -> const std::string & {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -127,6 +127,7 @@ void FrontendOptions::forAllOutputPaths(
   const std::string *outputs[] = {&outs.ModuleOutputPath,
                                   &outs.ModuleDocOutputPath,
                                   &outs.ParseableInterfaceOutputPath,
+                                  &outs.XCTestMethodsFilePath,
                                   &outs.ObjCHeaderOutputPath};
   for (const std::string *next : outputs) {
     if (!next->empty())

--- a/lib/Frontend/XCTestMethodsEmitter.cpp
+++ b/lib/Frontend/XCTestMethodsEmitter.cpp
@@ -1,0 +1,135 @@
+//===--- ParseableInterfaceSupport.cpp - swiftinterface files ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Frontend/XCTestMethodsEmitter.h"
+#include "swift/Basic/JSONSerialization.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+
+using namespace swift;
+
+// Copied from lib/Index/IndexSymbol.cpp
+static NominalTypeDecl *getNominalParent(const ValueDecl *D) {
+  return D->getDeclContext()->getSelfNominalTypeDecl();
+}
+static bool isUnitTestCase(const ClassDecl *D) {
+  if (!D)
+    return false;
+  
+  return D->walkSuperclasses([D](ClassDecl *SuperD) {
+    if (SuperD != D && // Do not treate XCTestCase itself as a test.
+        SuperD->getNameStr() == "XCTestCase")
+      return TypeWalker::Action::Stop; // Found test; stop and return true.
+    return TypeWalker::Action::Continue;
+  });
+}
+static bool isUnitTest(const ValueDecl *D) {
+  if (!D->hasName())
+    return false;
+  
+  // A 'test candidate' is:
+  // 1. An instance method...
+  auto FD = dyn_cast<FuncDecl>(D);
+  if (!FD)
+    return false;
+  if (!D->isInstanceMember())
+    return false;
+  
+  // 2. ...on a class or extension (not a struct) subclass of XCTestCase...
+  auto parentNTD = getNominalParent(D);
+  if (!parentNTD)
+    return false;
+  if (!isa<ClassDecl>(parentNTD))
+    return false;
+  if (!isUnitTestCase(cast<ClassDecl>(parentNTD)))
+    return false;
+  
+  // 3. ...that returns void...
+  Type RetTy = FD->getResultInterfaceType();
+  if (RetTy && !RetTy->isVoid())
+    return false;
+  
+  // 4. ...takes no parameters...
+  if (FD->getParameters()->size() != 0)
+    return false;
+  
+  // 5. ...is of at least 'internal' access (unless we can use
+  //    Objective-C reflection)...
+  if (!D->getASTContext().LangOpts.EnableObjCInterop &&
+      (D->getFormalAccess() < AccessLevel::Internal ||
+       parentNTD->getFormalAccess() < AccessLevel::Internal))
+    return false;
+  
+  // 6. ...and starts with "test".
+  if (FD->getName().str().startswith("test"))
+    return true;
+  
+  return false;
+}
+
+namespace {
+  struct XCTestClass {
+    std::string Name;
+    std::vector<std::string> Methods;
+  };
+} // namespace
+
+namespace swift {
+namespace json {
+
+template <> struct ObjectTraits<XCTestClass> {
+  static void mapping(Output &out, XCTestClass &value) {
+    out.mapRequired("testClass", value.Name);
+    out.mapRequired("testMethods", value.Methods);
+  }
+};
+
+} // namespace json
+} // namespace swift
+
+bool swift::emitXCTestMethods(raw_ostream &out, ModuleDecl *M) {
+  assert(M);
+
+  std::vector<XCTestClass> xctestClasses;
+  SmallVector<Decl *, 16> topLevelDecls;
+  M->getTopLevelDecls(topLevelDecls);
+
+  for (const Decl *D : topLevelDecls) {
+    auto CD = dyn_cast<ClassDecl>(D);
+    if (CD && isUnitTestCase(CD)) {
+        std::vector<std::string> Methods;
+        for (auto member : CD->getMembers()) {
+          auto VD = dyn_cast<ValueDecl>(member);
+          if (VD && isUnitTest(VD)) {
+            SmallString<32> scratch;
+            VD->getFullName().getString(scratch);
+            Methods.push_back(std::string(scratch.str()));
+          }
+        }
+
+        XCTestClass klass = XCTestClass();
+        SmallString<32> scratch;
+        CD->getFullName().getString(scratch);
+        klass.Name = std::string(scratch.str());
+        klass.Methods = Methods;
+
+        xctestClasses.push_back(klass);
+    }
+  }
+
+  swift::json::Output Out(out);
+  Out << xctestClasses;
+
+  return false;
+}

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -53,6 +53,7 @@
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
 #include "swift/Frontend/ParseableInterfaceModuleLoader.h"
 #include "swift/Frontend/ParseableInterfaceSupport.h"
+#include "swift/Frontend/XCTestMethodsEmitter.h"
 #include "swift/Immediate/Immediate.h"
 #include "swift/Index/IndexRecord.h"
 #include "swift/Option/Options.h"
@@ -380,6 +381,16 @@ printParseableInterfaceIfNeeded(StringRef outputPath,
   return withOutputFile(diags, outputPath,
                         [M, Opts](raw_ostream &out) -> bool {
     return swift::emitParseableInterface(out, Opts, M);
+  });
+}
+
+static bool printXCTestMethodsIfNeeded(StringRef outputPath, ModuleDecl *M) {
+  if (outputPath.empty())
+    return false;
+
+  return withOutputFile(M->getDiags(), outputPath,
+                        [&](raw_ostream &out) -> bool {
+    return swift::emitXCTestMethods(out, M);
   });
 }
 
@@ -942,6 +953,12 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
 
   {
     hadAnyError |= writeTBDIfNeeded(Invocation, Instance);
+  }
+
+  if (opts.InputsAndOutputs.hasXCTestMethodsFilePath()) {
+    hadAnyError |= printXCTestMethodsIfNeeded(
+        Invocation.getXCTestMethodsFilePathForWholeModule(),
+        Instance.getMainModule());
   }
 
   return hadAnyError;


### PR DESCRIPTION
This adds an option "-emit-xctest-methods-path" to the driver and
frontend for emitting a list of XCTest methods in a JSON file. This will
be used by SwiftPM (and potentially other build systems) to
automatically generate LinuxMain.swift file during the build process so
users don't have to manually maintain the file on Linux.

This is a much easier solution than other alternatives like invoking
SourceKit during a build. Eventually, XCTest on Linux should be able to
use runtime reflection to query the test methods but we don't have that
yet.