### PR TITLE
Add default implementations for AdditiveArithmetic.{+=, -=}.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -128,6 +128,16 @@ public protocol AdditiveArithmetic : Equatable {
   static func -=(lhs: inout Self, rhs: Self)
 }
 
+public extension AdditiveArithmetic {
+  static func +=(lhs: inout Self, rhs: Self) {
+    lhs = lhs + rhs
+  }
+
+  static func -=(lhs: inout Self, rhs: Self) {
+    lhs = lhs - rhs
+  }
+}
+
 public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
   /// The zero value.
   ///

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -129,10 +129,12 @@ public protocol AdditiveArithmetic : Equatable {
 }
 
 public extension AdditiveArithmetic {
+  @_alwaysEmitIntoClient
   static func +=(lhs: inout Self, rhs: Self) {
     lhs = lhs + rhs
   }
 
+  @_alwaysEmitIntoClient
   static func -=(lhs: inout Self, rhs: Self) {
     lhs = lhs - rhs
   }


### PR DESCRIPTION
This patch defines a default implementation for `+=` and `-=` in `extension AdditiveArithmetic` implemented in terms of `+` and `-`.