### PR TITLE
Fix a bug in root and add a test case for it.

### DIFF
--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -95,7 +95,7 @@ extension ${Self}: ElementaryFunctions {
     guard x >= 0 || n % 2 != 0 else { return .nan }
     // TODO: this implementation isn't quite right for n so large that
     // the conversion to `${Self}` rounds.
-    return ${Self}(signOf: x, magnitudeOf: pow(x, 1/${Self}(n)))
+    return ${Self}(signOf: x, magnitudeOf: pow(x.magnitude, 1/${Self}(n)))
   }
 
   @_alwaysEmitIntoClient

--- a/test/stdlib/MathFunctions.swift.gyb
+++ b/test/stdlib/MathFunctions.swift.gyb
@@ -72,7 +72,7 @@ internal extension ElementaryFunctions where Self: BinaryFloatingPoint {
     expectEqualWithTolerance(-1.415037499278843818546261056052183491, Self.log2(0.375))
     expectEqualWithTolerance(0.3184537311185346158102472135905995955, Self.log1p(0.375))
     expectEqualWithTolerance(-0.425968732272281148346188780918363771, Self.log10(0.375))
-    expectEqualWithTolerance(0.7211247851537041911608191553900547941, Self.root(0.375, 3))
+    expectEqualWithTolerance(-0.7211247851537041911608191553900547941, Self.root(-0.375, 3))
     expectEqualWithTolerance(0.6123724356957945245493210186764728479, Self.sqrt(0.375))
     expectEqualWithTolerance(0.54171335479545025876069682133938570, Self.pow(0.375, 0.625))
     expectEqualWithTolerance(-0.052734375, Self.pow(-0.375, 3))


### PR DESCRIPTION
For odd roots of negative values, we need to take the root of the *magnitude* of the number to avoid a NaN from the platform's implementation of `pow`, then restore the sign afterwards. We had the basic logic in place already, but were missing the step of taking the magnitude first. Also modified a test case to find this error.