### PR TITLE
[TF] install_name_dir workaround for Python and TensorFlow modules.

### DIFF
--- a/stdlib/public/Python/CMakeLists.txt
+++ b/stdlib/public/Python/CMakeLists.txt
@@ -40,4 +40,7 @@ add_swift_target_library(swiftPython ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   SWIFT_MODULE_DEPENDS_CYGWIN Glibc
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
-  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  # NOTE: This is a workaround for https://github.com/apple/swift/pull/24382,
+  # which changed the default install_name_dir to `/usr/bin/swift`.
+  DARWIN_INSTALL_NAME_DIR "@rpath")

--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -67,4 +67,7 @@ add_swift_target_library(swiftTensorFlow ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_
   SWIFT_COMPILE_FLAGS "${swift_stdlib_compile_flags}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib
-  EXTRA_RPATHS "${SWIFT_TENSORFLOW_TARGET_LIB_DIR}")
+  EXTRA_RPATHS "${SWIFT_TENSORFLOW_TARGET_LIB_DIR}"
+  # NOTE: This is a workaround for https://github.com/apple/swift/pull/24382,
+  # which changed the default install_name_dir to `/usr/bin/swift`.
+  DARWIN_INSTALL_NAME_DIR "@rpath")


### PR DESCRIPTION
`install_name_dir` for the standard library has been changed from `@rpath` to `/usr/lib/swift` in https://github.com/apple/swift/pull/24382.

This patch may resolve `Library not loaded: /usr/lib/swift/libswiftTensorFlow.dylib` linker issues: https://github.com/tensorflow/swift-apis/pull/136