### PR TITLE
Fix for KeyPathMultiModule test failure

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2507,7 +2507,7 @@ internal enum KeyPathPatternStoredOffset {
   case inline(UInt32)
   case outOfLine(UInt32)
   case unresolvedFieldOffset(UInt32)
-  case unresolvedIndirectOffset(UnsafePointer<UInt32>)
+  case unresolvedIndirectOffset(UnsafePointer<UInt>)
 }
 internal struct KeyPathPatternComputedArguments {
   var getLayout: KeyPathComputedArgumentLayoutFn
@@ -2602,7 +2602,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
                                 as: Int32.self)
       let ptr = _resolveRelativeIndirectableAddress(base, relativeOffset)
       offset = .unresolvedIndirectOffset(
-                                       ptr.assumingMemoryBound(to: UInt32.self))
+                                       ptr.assumingMemoryBound(to: UInt.self))
     default:
       offset = .inline(header.storedOffsetPayload)
     }
@@ -3151,7 +3151,8 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
       case .unresolvedIndirectOffset(let pointerToOffset):
         // Look up offset in the indirectly-referenced variable we have a
         // pointer.
-        let offset = UInt32(pointerToOffset.pointee)
+        assert(pointerToOffset.pointee <= UInt32.max)
+        let offset = UInt32(truncatingIfNeeded: pointerToOffset.pointee)
         let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
                                                 mutable: mutable)
         pushDest(header)


### PR DESCRIPTION
This commit changes the pointer of `unresolvedIndirectOffset` from size UInt32 to size UInt64, so that it is compatible on both big (s390x) and little endian platforms. It resolves the failure of `stdlib/KeyPathMultiModule.swift` on big-endian platform.  The related discussion can be found at https://forums.swift.org/t/keypath-test-case-v5-0-failed-on-big-endian-platform/19529