### PR TITLE
[5.1] Introduce a backward-deployment library for SR-10600.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -705,7 +705,8 @@ function(_add_swift_library_single target name)
         OBJECT_LIBRARY
         SHARED
         STATIC
-        TARGET_LIBRARY)
+        TARGET_LIBRARY
+        INSTALL_WITH_SHARED)
   set(SWIFTLIB_SINGLE_single_parameter_options
         ARCHITECTURE
         DEPLOYMENT_VERSION_IOS
@@ -1072,18 +1073,24 @@ function(_add_swift_library_single target name)
         BINARY_DIR ${SWIFT_RUNTIME_OUTPUT_INTDIR}
         LIBRARY_DIR ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 
+    if(SWIFTLIB_INSTALL_WITH_SHARED)
+      set(swift_lib_dir ${SWIFTLIB_DIR})
+    else()
+      set(swift_lib_dir ${SWIFTSTATICLIB_DIR})
+    endif()
+
     foreach(config ${CMAKE_CONFIGURATION_TYPES})
       string(TOUPPER ${config} config_upper)
       escape_path_for_xcode(
-          "${config}" "${SWIFTSTATICLIB_DIR}" config_lib_dir)
+          "${config}" "${swift_lib_dir}" config_lib_dir)
       set_target_properties(${target_static} PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY_${config_upper} ${config_lib_dir}/${SWIFTLIB_SINGLE_SUBDIR}
         ARCHIVE_OUTPUT_DIRECTORY_${config_upper} ${config_lib_dir}/${SWIFTLIB_SINGLE_SUBDIR})
     endforeach()
 
     set_target_properties(${target_static} PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY ${SWIFTSTATICLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}
-      ARCHIVE_OUTPUT_DIRECTORY ${SWIFTSTATICLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR})
+      LIBRARY_OUTPUT_DIRECTORY ${swift_lib_dir}/${SWIFTLIB_SINGLE_SUBDIR}
+      ARCHIVE_OUTPUT_DIRECTORY ${swift_lib_dir}/${SWIFTLIB_SINGLE_SUBDIR})
   endif()
 
   set_target_properties(${target}
@@ -1342,8 +1349,14 @@ function(_add_swift_library_single target name)
     set_property(TARGET "${target_static}" APPEND_STRING PROPERTY
         COMPILE_FLAGS " ${c_compile_flags}")
     # FIXME: The fallback paths here are going to be dynamic libraries.
+
+    if(SWIFTLIB_INSTALL_WITH_SHARED)
+      set(search_base_dir ${SWIFTLIB_DIR})
+    else()
+      set(search_base_dir ${SWIFTSTATICLIB_DIR})
+    endif()
     set(library_search_directories
-        "${SWIFTSTATICLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}"
+        "${search_base_dir}/${SWIFTLIB_SINGLE_SUBDIR}"
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFTLIB_SINGLE_SUBDIR}"
         "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib/swift/${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_LIB_SUBDIR}")
     swift_target_link_search_directories("${target_static}" "${library_search_directories}")
@@ -1492,6 +1505,7 @@ endfunction()
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
 #     [TARGET_LIBRARY]
+#     [INSTALL_WITH_SHARED]
 #     INSTALL_IN_COMPONENT comp
 #     DEPLOYMENT_VERSION_OSX version
 #     DEPLOYMENT_VERSION_IOS version
@@ -1598,6 +1612,9 @@ endfunction()
 # DEPLOYMENT_VERSION_WATCHOS
 #   The minimum deployment version to build for if this is an WATCHOS library.
 #
+# INSTALL_WITH_SHARED
+#   Install a static library target alongside shared libraries
+#
 # source1 ...
 #   Sources to add into this library.
 function(add_swift_target_library name)
@@ -1612,7 +1629,8 @@ function(add_swift_target_library name)
         OBJECT_LIBRARY
         SHARED
         STATIC
-        TARGET_LIBRARY)
+        TARGET_LIBRARY
+        INSTALL_WITH_SHARED)
   set(SWIFTLIB_single_parameter_options
         DEPLOYMENT_VERSION_IOS
         DEPLOYMENT_VERSION_OSX
@@ -1897,6 +1915,7 @@ function(add_swift_target_library name)
         ${SWIFTLIB_SHARED_keyword}
         ${SWIFTLIB_STATIC_keyword}
         ${SWIFTLIB_OBJECT_LIBRARY_keyword}
+        ${SWIFTLIB_INSTALL_WITH_SHARED_keyword}
         ${SWIFTLIB_SOURCES}
         MODULE_TARGET ${MODULE_VARIANT_NAME}
         SDK ${sdk}
@@ -1996,7 +2015,7 @@ function(add_swift_target_library name)
       set(resource_dir_sdk_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
       precondition(resource_dir_sdk_subdir)
 
-      if(SWIFTLIB_SHARED)
+      if(SWIFTLIB_SHARED OR SWIFTLIB_INSTALL_WITH_SHARED)
         set(resource_dir "swift")
         set(file_permissions
             OWNER_READ OWNER_WRITE OWNER_EXECUTE
@@ -2058,10 +2077,18 @@ function(add_swift_target_library name)
           list(APPEND THIN_INPUT_TARGETS_STATIC "${TARGET}-static")
         endforeach()
 
+        if(SWIFTLIB_INSTALL_WITH_SHARED)
+          set(install_subdir "swift")
+          set(universal_subdir ${SWIFTLIB_DIR})
+        else()
+          set(install_subdir "swift_static")
+          set(universal_subdir ${SWIFTSTATICLIB_DIR})
+        endif()
+
         set(lipo_target_static
             "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-static")
         set(UNIVERSAL_LIBRARY_NAME
-            "${SWIFTSTATICLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            "${universal_subdir}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
         _add_swift_lipo_target(SDK
                                  ${sdk}
                                TARGET
@@ -2071,7 +2098,7 @@ function(add_swift_target_library name)
                                ${THIN_INPUT_TARGETS_STATIC})
         swift_install_in_component("${SWIFTLIB_INSTALL_IN_COMPONENT}"
             FILES "${UNIVERSAL_LIBRARY_NAME}"
-            DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift_static/${resource_dir_sdk_subdir}"
+            DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${install_subdir}/${resource_dir_sdk_subdir}"
             PERMISSIONS
               OWNER_READ OWNER_WRITE
               GROUP_READ

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -258,18 +258,22 @@ function(_compile_swift_files
     list(APPEND swift_flags "-module-name" "${SWIFTFILE_MODULE_NAME}")
   endif()
 
-  # Force swift 5 mode for Standard Library.
+  # Force swift 5 mode for Standard Library and overlays.
   if (SWIFTFILE_IS_STDLIB)
     list(APPEND swift_flags "-swift-version" "5")
   endif()
-
-  # Force swift 4 compatibility mode for overlays.
   if (SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-swift-version" "5")
   endif()
 
   if(SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-autolink-force-load")
+  endif()
+
+  # Don't need to link runtime compatibility libraries for older runtimes 
+  # into the new runtime.
+  if (SWIFTFILE_IS_STDLIB OR SWIFTFILE_IS_SDK_OVERLAY)
+    list(APPEND swift_flags "-runtime-compatibility-version" "none")
   endif()
 
   if (SWIFTFILE_IS_STDLIB_CORE OR SWIFTFILE_IS_SDK_OVERLAY)

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -26,6 +26,7 @@
 // FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
 // split the header upstream so we don't include so much.
 #include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Support/VersionTuple.h"
 #include <string>
 #include <vector>
 
@@ -224,6 +225,9 @@ public:
   };
 
   TypeInfoDumpFilter TypeInfoFilter;
+  
+  /// Pull in runtime compatibility shim libraries by autolinking.
+  Optional<llvm::VersionTuple> AutolinkRuntimeCompatibilityLibraryVersion;
 
   IRGenOptions()
       : DWARFVersion(2), OutputKind(IRGenOutputKind::LLVMAssembly),

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -19,6 +19,7 @@
 
 namespace llvm {
   class Triple;
+  class VersionTuple;
 }
 
 namespace swift {
@@ -85,6 +86,12 @@ namespace swift {
   /// The input triple should already be "normalized" in the sense that
   /// llvm::Triple::normalize() would not affect it.
   llvm::Triple getTargetSpecificModuleTriple(const llvm::Triple &triple);
+  
+  
+  /// Get the Swift runtime version to deploy back to, given a deployment target expressed as an
+  /// LLVM target triple.
+  Optional<llvm::VersionTuple>
+  getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple);
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PLATFORM_H

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -887,4 +887,9 @@ def vfsoverlay_EQ : Joined<["-"], "vfsoverlay=">,
 def runtime_compatibility_version : Separate<["-"], "runtime-compatibility-version">,
   Flags<[FrontendOption]>,
   HelpText<"Link compatibility library for Swift runtime version, or 'none'">;
+
+def disable_autolinking_runtime_compatibility : Flag<["-"], "disable-autolinking-runtime-compatibility">,
+  Flags<[FrontendOption]>,
+  HelpText<"Do not use autolinking for runtime compatibility libraries">;
+
 include "FrontendOptions.td"

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
+#include "llvm/Support/VersionTuple.h"
 
 using namespace swift;
 
@@ -311,5 +312,39 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
 
   // Other platforms get no normalization.
   return triple;
+}
+
+Optional<llvm::VersionTuple>
+swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
+  unsigned Major, Minor, Micro;
+  
+  if (Triple.isMacOSX()) {
+    Triple.getMacOSXVersion(Major, Minor, Micro);
+    if (Major == 10) {
+      if (Minor <= 14) {
+        return llvm::VersionTuple(5, 0);
+      } else {
+        return None;
+      }
+    } else {
+      return None;
+    }
+  } else if (Triple.isiOS()) { // includes tvOS
+    Triple.getiOSVersion(Major, Minor, Micro);
+    if (Major <= 12) {
+      return llvm::VersionTuple(5, 0);
+    } else {
+      return None;
+    }
+  } else if (Triple.isWatchOS()) {
+    Triple.getWatchOSVersion(Major, Minor, Micro);
+    if (Major <= 5) {
+      return llvm::VersionTuple(5, 0);
+    } else {
+      return None;
+    }
+  } else {
+    return None;
+  }
 }
 

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -228,9 +228,46 @@ static bool wantsObjCRuntime(const llvm::Triple &triple) {
   llvm_unreachable("unknown Darwin OS");
 }
 
+/// Return the earliest backward deployment compatibility version we need to
+/// link in for the given target triple, if any.
+static Optional<std::pair<unsigned, unsigned>>
+getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple) {
+  unsigned Major, Minor, Micro;
+  
+  if (Triple.isMacOSX()) {
+    Triple.getMacOSXVersion(Major, Minor, Micro);
+    if (Major == 10) {
+      if (Minor <= 14) {
+        return std::make_pair(5u, 0u);
+      } else {
+        return None;
+      }
+    } else {
+      return None;
+    }
+  } else if (Triple.isiOS()) { // includes tvOS
+    Triple.getiOSVersion(Major, Minor, Micro);
+    if (Major <= 12) {
+      return std::make_pair(5u, 0u);
+    } else {
+      return None;
+    }
+  } else if (Triple.isWatchOS()) {
+    Triple.getWatchOSVersion(Major, Minor, Micro);
+    if (Major <= 5) {
+      return std::make_pair(5u, 0u);
+    } else {
+      return None;
+    }
+  } else {
+    return None;
+  }
+}
+
 ToolChain::InvocationInfo
 toolchains::Darwin::constructInvocation(const LinkJobAction &job,
-                                        const JobContext &context) const {
+                                        const JobContext &context) const
+{
   assert(context.Output.getPrimaryOutputType() == file_types::TY_Image &&
          "Invalid linker output type.");
 
@@ -399,6 +436,38 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   SmallString<128> RuntimeLibPath;
   getRuntimeLibraryPath(RuntimeLibPath, context.Args, /*Shared=*/true);
 
+  // Link compatibility libraries, if we're deploying back to OSes that
+  // have an older Swift runtime.
+  Optional<std::pair<unsigned, unsigned>> runtimeCompatibilityVersion;
+  
+  if (context.Args.hasArg(options::OPT_runtime_compatibility_version)) {
+    auto value = context.Args.getLastArgValue(options::OPT_runtime_compatibility_version);
+    if (value.equals("5.0")) {
+      runtimeCompatibilityVersion = std::make_pair(5u, 0u);
+    } else if (value.equals("none")) {
+      runtimeCompatibilityVersion = None;
+    } else {
+      // TODO: diagnose unknown runtime compatibility version?
+    }
+  } else if (job.getKind() == LinkKind::Executable) {
+    runtimeCompatibilityVersion
+                         = getSwiftRuntimeCompatibilityVersionForTarget(Triple);
+  }
+  
+  if (runtimeCompatibilityVersion) {
+    if (*runtimeCompatibilityVersion <= std::make_pair(5u, 0u)) {
+      // Swift 5.0 compatibility library
+      SmallString<128> BackDeployLib;
+      BackDeployLib.append(RuntimeLibPath);
+      llvm::sys::path::append(BackDeployLib, "libswiftCompatibility50.a");
+      
+      if (llvm::sys::fs::exists(BackDeployLib)) {
+        Arguments.push_back("-force_load");
+        Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+      }
+    }
+  }
+    
   // Link the standard library.
   Arguments.push_back("-L");
   if (context.Args.hasFlag(options::OPT_static_stdlib,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Program.h"
+#include "llvm/Support/VersionTuple.h"
 
 using namespace swift;
 using namespace swift::driver;
@@ -228,42 +229,6 @@ static bool wantsObjCRuntime(const llvm::Triple &triple) {
   llvm_unreachable("unknown Darwin OS");
 }
 
-/// Return the earliest backward deployment compatibility version we need to
-/// link in for the given target triple, if any.
-static Optional<std::pair<unsigned, unsigned>>
-getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple) {
-  unsigned Major, Minor, Micro;
-  
-  if (Triple.isMacOSX()) {
-    Triple.getMacOSXVersion(Major, Minor, Micro);
-    if (Major == 10) {
-      if (Minor <= 14) {
-        return std::make_pair(5u, 0u);
-      } else {
-        return None;
-      }
-    } else {
-      return None;
-    }
-  } else if (Triple.isiOS()) { // includes tvOS
-    Triple.getiOSVersion(Major, Minor, Micro);
-    if (Major <= 12) {
-      return std::make_pair(5u, 0u);
-    } else {
-      return None;
-    }
-  } else if (Triple.isWatchOS()) {
-    Triple.getWatchOSVersion(Major, Minor, Micro);
-    if (Major <= 5) {
-      return std::make_pair(5u, 0u);
-    } else {
-      return None;
-    }
-  } else {
-    return None;
-  }
-}
-
 ToolChain::InvocationInfo
 toolchains::Darwin::constructInvocation(const LinkJobAction &job,
                                         const JobContext &context) const
@@ -438,12 +403,13 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   // Link compatibility libraries, if we're deploying back to OSes that
   // have an older Swift runtime.
-  Optional<std::pair<unsigned, unsigned>> runtimeCompatibilityVersion;
+  Optional<llvm::VersionTuple> runtimeCompatibilityVersion;
   
   if (context.Args.hasArg(options::OPT_runtime_compatibility_version)) {
-    auto value = context.Args.getLastArgValue(options::OPT_runtime_compatibility_version);
+    auto value = context.Args.getLastArgValue(
+                                    options::OPT_runtime_compatibility_version);
     if (value.equals("5.0")) {
-      runtimeCompatibilityVersion = std::make_pair(5u, 0u);
+      runtimeCompatibilityVersion = llvm::VersionTuple(5, 0);
     } else if (value.equals("none")) {
       runtimeCompatibilityVersion = None;
     } else {
@@ -455,7 +421,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   }
   
   if (runtimeCompatibilityVersion) {
-    if (*runtimeCompatibilityVersion <= std::make_pair(5u, 0u)) {
+    if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
       // Swift 5.0 compatibility library
       SmallString<128> BackDeployLib;
       BackDeployLib.append(RuntimeLibPath);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -391,6 +391,17 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-debug-info-store-invocation");
   }
 
+  if (context.Args.hasArg(
+                      options::OPT_disable_autolinking_runtime_compatibility)) {
+    Arguments.push_back("-disable-autolinking-runtime-compatibility");
+  }
+                                 
+  if (auto arg = context.Args.getLastArg(
+                                  options::OPT_runtime_compatibility_version)) {
+    Arguments.push_back("-runtime-compatibility-version");
+    Arguments.push_back(arg->getValue());
+  }
+                                 
   return II;
 }
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -61,6 +61,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stubs)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
+  add_subdirectory(Compatibility50)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
+set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
+
+add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC
+  ProtocolConformance.cpp
+  Overrides.cpp
+  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+  LINK_FLAGS ${swift_runtime_linker_flags}
+  TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
+  INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -7,4 +7,4 @@ add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC
   C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}
   TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
-  INSTALL_IN_COMPONENT stdlib)
+  INSTALL_IN_COMPONENT compiler)

--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
 
-add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC
+add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC INSTALL_WITH_SHARED
   ProtocolConformance.cpp
   Overrides.cpp
   C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}
   TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
   INSTALL_IN_COMPONENT compiler)
+
+

--- a/stdlib/public/Compatibility50/Overrides.cpp
+++ b/stdlib/public/Compatibility50/Overrides.cpp
@@ -1,0 +1,33 @@
+//===--- Overrides.cpp - Compat override table for Swift 5.0 runtime ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file provides compatibility override hooks for Swift 5.0 runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "../runtime/CompatibilityOverride.h"
+
+using namespace swift;
+
+struct OverrideSection {
+  uintptr_t version;
+#define OVERRIDE(name, ret, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  Override_ ## name name;
+#include "../runtime/CompatibilityOverride.def"
+};
+  
+OverrideSection Overrides
+__attribute__((used, section("__DATA,__swift_hooks"))) = {
+  .version = 0,
+  .conformsToProtocol = swift50override_conformsToProtocol,
+};

--- a/stdlib/public/Compatibility50/Overrides.cpp
+++ b/stdlib/public/Compatibility50/Overrides.cpp
@@ -31,3 +31,8 @@ __attribute__((used, section("__DATA,__swift_hooks"))) = {
   .version = 0,
   .conformsToProtocol = swift50override_conformsToProtocol,
 };
+
+// Allow this library to get force-loaded by autolinking
+__attribute__((weak, visibility("hidden")))
+extern "C"
+char _swift_FORCE_LOAD_$_swiftCompatibility50 = 0;

--- a/stdlib/public/Compatibility50/Overrides.h
+++ b/stdlib/public/Compatibility50/Overrides.h
@@ -1,0 +1,30 @@
+//===--- Overrides.cpp - Compat overrides for Swift 5.0 runtime ----s------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file provides compatibility override hooks for Swift 5.0 runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Runtime/Metadata.h"
+
+namespace swift {
+
+using ConformsToProtocol_t =
+  const WitnessTable *(const Metadata *, const ProtocolDescriptor *);
+
+const WitnessTable *
+swift50override_conformsToProtocol(const Metadata * const type,
+  const ProtocolDescriptor *protocol,
+  ConformsToProtocol_t *original);
+
+}

--- a/stdlib/public/Compatibility50/ProtocolConformance.cpp
+++ b/stdlib/public/Compatibility50/ProtocolConformance.cpp
@@ -1,0 +1,71 @@
+//===--- ProtocolConformance.cpp - Swift protocol conformance checking ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Checking and caching of Swift protocol conformances.
+//
+// This implementation is intended to be backward-deployed into Swift 5.0
+// runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "../runtime/Private.h"
+#include "swift/Basic/Lazy.h"
+#include <objc/runtime.h>
+
+using namespace swift;
+
+// Clone of private function getRootSuperclass. This returns the SwiftObject
+// class in the ABI-stable dylib, regardless of what the local runtime build
+// does, since we're always patching an ABI-stable dylib.
+__attribute__((visibility("hidden"), weak))
+const ClassMetadata *swift::getRootSuperclass() {
+  auto theClass = SWIFT_LAZY_CONSTANT(objc_getClass("_TtCs12_SwiftObject"));
+  return (const ClassMetadata *)theClass;
+}
+
+// Clone of private helper swift::_swiftoverride_class_getSuperclass
+// for use in the override implementation.
+static const Metadata *_swift50override_class_getSuperclass(
+                                                    const Metadata *theClass) {
+  if (const ClassMetadata *classType = theClass->getClassObject()) {
+    if (classHasSuperclass(classType))
+      return getMetadataForClass(classType->Superclass);
+  }
+  
+  if (const ForeignClassMetadata *foreignClassType
+      = dyn_cast<ForeignClassMetadata>(theClass)) {
+    if (const Metadata *superclass = foreignClassType->Superclass)
+      return superclass;
+  }
+  
+  return nullptr;
+}
+
+const WitnessTable *
+swift::swift50override_conformsToProtocol(const Metadata *type,
+  const ProtocolDescriptor *protocol,
+  ConformsToProtocol_t *original_conformsToProtocol)
+{
+  // The implementation of swift_conformsToProtocol in Swift 5.0 would return
+  // a false negative answer when asking whether a subclass conforms using
+  // a conformance from a superclass. Work around this by walking up the
+  // superclass chain in cases where the original implementation returns
+  // null.
+  do {
+    auto result = original_conformsToProtocol(type, protocol);
+    if (result)
+      return result;
+  } while ((type = _swift50override_class_getSuperclass(type)));
+  
+  return nullptr;
+}

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3851,24 +3851,6 @@ static const WitnessTable *_getForeignWitnessTable(
 /*** Other metadata routines ***********************************************/
 /***************************************************************************/
 
-template<> const ClassMetadata *
-Metadata::getClassObject() const {
-  switch (getKind()) {
-  case MetadataKind::Class: {
-    // Native Swift class metadata is also the class object.
-    return static_cast<const ClassMetadata *>(this);
-  }
-  case MetadataKind::ObjCClassWrapper: {
-    // Objective-C class objects are referenced by their Swift metadata wrapper.
-    auto wrapper = static_cast<const ObjCClassWrapperMetadata *>(this);
-    return wrapper->Class;
-  }
-  // Other kinds of types don't have class objects.
-  default:
-    return nullptr;
-  }
-}
-
 template <> OpaqueValue *Metadata::allocateBoxForExistentialIn(ValueBuffer *buffer) const {
   auto *vwt = getValueWitnesses();
   if (vwt->isValueInline())

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -463,6 +463,24 @@ public:
     return c;
 #endif
   }
+  
+  template<> inline const ClassMetadata *
+  Metadata::getClassObject() const {
+    switch (getKind()) {
+    case MetadataKind::Class: {
+      // Native Swift class metadata is also the class object.
+      return static_cast<const ClassMetadata *>(this);
+    }
+    case MetadataKind::ObjCClassWrapper: {
+      // Objective-C class objects are referenced by their Swift metadata wrapper.
+      auto wrapper = static_cast<const ObjCClassWrapperMetadata *>(this);
+      return wrapper->Class;
+    }
+    // Other kinds of types don't have class objects.
+    default:
+      return nullptr;
+    }
+  }
 
   void *allocateMetadata(size_t size, size_t align);
 

--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -1,0 +1,25 @@
+// REQUIRES: OS=macosx
+
+// Doesn't autolink compatibility library because autolinking is disabled
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+
+// Doesn't autolink compatibility library because runtime compatibility library is disabled
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+
+// Doesn't autolink compatibility library because target OS doesn't need it
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.24 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+
+// Autolinks because compatibility library was explicitly asked for
+// RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD %s
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.24 -runtime-compatibility-version 5.0 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD %s
+
+public func foo() {}
+
+// NO-FORCE-LOAD-NOT: FORCE_LOAD
+// NO-FORCE-LOAD-NOT: !{!"-lswiftCompatibility50"}
+
+// FORCE-LOAD: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibility50"
+
+// FORCE-LOAD-DAG: [[AUTOLINK_SWIFT_COMPAT:![0-9]+]] = !{!"-lswiftCompatibility50"}
+// FORCE-LOAD-DAG: !llvm.linker.options = !{{{.*}}[[AUTOLINK_SWIFT_COMPAT]]{{[,}]}}

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
+// RUN: %target-swift-frontend -runtime-compatibility-version none -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/Interpreter/SR-10600.swift
+++ b/test/Interpreter/SR-10600.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+public class BaseView { }
+public class GenericView<T>: BaseView { }
+public class FinalView: GenericView<ContentForTheView> { }
+
+
+public class ContentForTheView { }
+extension ContentForTheView: InfoNeededByControllers { }
+
+public protocol ConditionallyConformed { }
+public protocol InfoNeededByControllers { }
+
+extension GenericView: ConditionallyConformed where T: InfoNeededByControllers { }
+
+open class BaseGenericController<T> where T: BaseView & ConditionallyConformed { }
+
+
+open class FinalController: BaseGenericController<FinalView> { public override init() { } }
+
+// CHECK: FinalController
+print(FinalController())

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -1,23 +1,23 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name someModule -module-link-name module %S/../Inputs/empty.swift
-// RUN: %target-swift-frontend -emit-ir -lmagic %s -I %t > %t/out.txt
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -lmagic %s -I %t > %t/out.txt
 // RUN: %FileCheck %s < %t/out.txt
 // RUN: %FileCheck -check-prefix=NO-FORCE-LOAD %s < %t/out.txt
 
 // RUN: %empty-directory(%t/someModule.framework/Modules/someModule.swiftmodule)
 // RUN: mv %t/someModule.swiftmodule %t/someModule.framework/Modules/someModule.swiftmodule/%target-swiftmodule-name
-// RUN: %target-swift-frontend -emit-ir -lmagic %s -F %t > %t/framework.txt
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -lmagic %s -F %t > %t/framework.txt
 // RUN: %FileCheck -check-prefix=FRAMEWORK %s < %t/framework.txt
 // RUN: %FileCheck -check-prefix=NO-FORCE-LOAD %s < %t/framework.txt
 
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load
-// RUN: %target-swift-frontend -emit-ir -lmagic %s -I %t > %t/force-load.txt
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -lmagic %s -I %t > %t/force-load.txt
 // RUN: %FileCheck %s < %t/force-load.txt
 // RUN: %FileCheck -check-prefix FORCE-LOAD-CLIENT -check-prefix FORCE-LOAD-CLIENT-%target-object-format %s < %t/force-load.txt
 
-// RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
-// RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD %s
-// RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name someModule -module-link-name 0module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD-HEX %s
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD %s
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name 0module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD-HEX %s
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3814,11 +3814,12 @@ for host in "${ALL_HOSTS[@]}"; do
 
             # Run dsymutil on executables and shared libraries.
             #
-            # Exclude shell scripts.
+            # Exclude shell scripts and static archives.
             (cd "${INSTALL_SYMROOT}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
                grep -v crashlog.py | \
                grep -v symbolication.py | \
+               grep -v '.a$' | \
                xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
 
             # Strip executables, shared libraries and static libraries in

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -17,3 +17,4 @@ void swift_storeEnumTagSinglePayloadGeneric(void) {}
 void swift_retain(){}
 void swift_allocBox(){}
 void swift_getWitnessTable(void) {}
+void swift_getObjCClassMetadata(void) {}


### PR DESCRIPTION
Build a static archive that can be linked into executables and take advantage of the Swift runtime's
hooking mechanism to work around the issue Doug fixed in #24759.
The Swift 5.0 version of swift_conformsToProtocol would return a false negative in some cases where
a subclass conforms using an inherited conformance, so work around this by successively retrying
the original implementation up the superclass chain to try to find a match.

rdar://problem/50057445