### PR TITLE
[ConstraintSystem] Fix metatype matching optimization to account for …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2531,14 +2531,18 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // P.Type < Q.Type if P < Q, both P and Q are protocols, and P.Type
       // and Q.Type are both existential metatypes
       auto subKind = std::min(kind, ConstraintKind::Subtype);
-      // If instance types can't have a subtype relationship
-      // it means that such types can be simply equated.
       auto instanceType1 = meta1->getInstanceType();
       auto instanceType2 = meta2->getInstanceType();
+
       if (isa<MetatypeType>(meta1) &&
-          !(instanceType1->mayHaveSuperclass() &&
-            instanceType2->getClassOrBoundGenericClass())) {
-        subKind = ConstraintKind::Bind;
+          !(instanceType1->isTypeVariableOrMember() ||
+            instanceType2->isTypeVariableOrMember())) {
+        // If instance types can't have a subtype relationship
+        // it means that such types can be simply equated.
+        if (!(instanceType1->mayHaveSuperclass() &&
+              instanceType2->getClassOrBoundGenericClass())) {
+          subKind = ConstraintKind::Bind;
+        }
       }
 
       return matchTypes(

--- a/test/Constraints/class.swift
+++ b/test/Constraints/class.swift
@@ -39,3 +39,15 @@ class X {
 var x0 = X()
 var x1 = X(x: 1, y: "2")
 
+func rdar_51528927() {
+  class A {}
+
+  class B : A {}
+  class C : A {}
+  class D : B {}
+
+  func test<T: A>(_ arr: [T.Type]) {}
+
+  test([B.self, C.self]) // Ok (since B and C have a common supertype A)
+  test([B.self, C.self, D.self]) // Ok
+}


### PR DESCRIPTION
…type variables

Currently we have a check which would bind instance types while
matching metatypes if subtype relationship between them could not
be established, but that logic also needs to account for instance
types being type variables or not-yet-resolved dependent members.

Resolves: rdar://problem/51528927

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
