### PR TITLE
test: make the StdlibUnittest.Common pass on Windows

### DIFF
--- a/validation-test/StdlibUnittest/Common.swift
+++ b/validation-test/StdlibUnittest/Common.swift
@@ -353,7 +353,7 @@ TestSuiteWithSetUp.test("passes") {
 
 // CHECK: [ RUN      ] TestSuiteWithSetUp.fails
 // CHECK: stdout>>> setUp
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> test body
 // CHECK: [     FAIL ] TestSuiteWithSetUp.fails
 TestSuiteWithSetUp.test("fails") {
@@ -366,7 +366,7 @@ TestSuiteWithSetUp.test("fails") {
 // CHECK: [       OK ] TestSuiteWithSetUp.passesFails/parameterized/0
 // CHECK: [ RUN      ] TestSuiteWithSetUp.passesFails/parameterized/1
 // CHECK: stdout>>> setUp
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> test body
 // CHECK: [     FAIL ] TestSuiteWithSetUp.passesFails/parameterized/1
 TestSuiteWithSetUp.test("passesFails/parameterized")
@@ -398,7 +398,7 @@ TestSuiteWithTearDown.test("passes") {
 // CHECK: [ RUN      ] TestSuiteWithTearDown.fails
 // CHECK: stdout>>> test body
 // CHECK: stdout>>> tearDown
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: [     FAIL ] TestSuiteWithTearDown.fails
 TestSuiteWithTearDown.test("fails") {
   print("test body")
@@ -412,7 +412,7 @@ TestSuiteWithTearDown.test("fails") {
 // CHECK: [ RUN      ] TestSuiteWithTearDown.passesFails/parameterized/1
 // CHECK: stdout>>> test body
 // CHECK: stdout>>> tearDown
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: [     FAIL ] TestSuiteWithTearDown.passesFails/parameterized/1
 TestSuiteWithTearDown.test("passesFails/parameterized")
   .forEach(in: [1010, 2020]) {
@@ -437,7 +437,7 @@ AssertionsTestSuite.test("expectFailure/Pass") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/Pass
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 1 (of type Swift.Int)
 // CHECK: stdout>>> actual: 2 (of type Swift.Int)
 // CHECK: [       OK ] Assertions.expectFailure/Pass
@@ -451,7 +451,7 @@ AssertionsTestSuite.test("expectFailure/UXPass")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/UXPass ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 1 (of type Swift.Int)
 // CHECK: stdout>>> actual: 2 (of type Swift.Int)
 // CHECK: [   UXPASS ] Assertions.expectFailure/UXPass
@@ -462,7 +462,7 @@ AssertionsTestSuite.test("expectFailure/Fail") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/Fail
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: true
 // CHECK: stdout>>> running `body` should produce an expected failure
 // CHECK: [     FAIL ] Assertions.expectFailure/Fail
@@ -475,7 +475,7 @@ AssertionsTestSuite.test("expectFailure/XFail")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/XFail ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: true
 // CHECK: stdout>>> running `body` should produce an expected failure
 // CHECK: [    XFAIL ] Assertions.expectFailure/XFail
@@ -488,10 +488,10 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/Fail") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/Fail
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 1 (of type Swift.Int)
 // CHECK: stdout>>> actual: 2 (of type Swift.Int)
-// CHECK: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 3 (of type Swift.Int)
 // CHECK: stdout>>> actual: 4 (of type Swift.Int)
 // CHECK: [     FAIL ] Assertions.expectFailure/AfterFailure/Fail
@@ -506,10 +506,10 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/XFail")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/XFail ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 1 (of type Swift.Int)
 // CHECK: stdout>>> actual: 2 (of type Swift.Int)
-// CHECK: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> expected: 3 (of type Swift.Int)
 // CHECK: stdout>>> actual: 4 (of type Swift.Int)
 // CHECK: [    XFAIL ] Assertions.expectFailure/AfterFailure/XFail
@@ -518,7 +518,7 @@ AssertionsTestSuite.test("expectUnreachable") {
   expectUnreachable()
 }
 // CHECK: [ RUN      ] Assertions.expectUnreachable
-// CHECK-NEXT: stdout>>> check failed at {{.*}}/StdlibUnittest/Common.swift, line
+// CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
 // CHECK: stdout>>> this code should not be executed
 // CHECK: [     FAIL ] Assertions.expectUnreachable
 
@@ -582,7 +582,8 @@ AssertionsTestSuite.test("expectTrapping(_: Bound, in: RangeProtocol)") {
   expectTrapping(0, in: 1..<10)
 }
 // CHECK: [ RUN      ] Assertions.expectTrapping(_: Bound, in: RangeProtocol)
-// CHECK-NEXT: stdout>>> check failed at {{.*}}.swift, line [[@LINE-3]]
+// stderr>>> CRASHED: SIGABRT
+// CHECK: stdout>>> check failed at {{.*}}.swift, line [[@LINE-4]]
 // CHECK: stdout>>> 0 in 1..<10{{$}}
 // CHECK: the test crashed unexpectedly
 // CHECK: [     FAIL ] Assertions.expectTrapping(_: Bound, in: RangeProtocol)
@@ -591,7 +592,8 @@ AssertionsTestSuite.test("expectTrapping(_: RangeProtocol, in: RangeProtocol)") 
   expectTrapping(0..<5, in: 1..<10)
 }
 // CHECK: [ RUN      ] Assertions.expectTrapping(_: RangeProtocol, in: RangeProtocol)
-// CHECK-NEXT: stdout>>> check failed at {{.*}}.swift, line [[@LINE-3]]
+// stderr>>> CRASHED: SIGABRT
+// CHECK: stdout>>> check failed at {{.*}}.swift, line [[@LINE-4]]
 // CHECK: stdout>>> 0..<5 in 1..<10{{$}}
 // CHECK: the test crashed unexpectedly
 // CHECK: [     FAIL ] Assertions.expectTrapping(_: RangeProtocol, in: RangeProtocol)


### PR DESCRIPTION
This adjusts the paths in the test to support the Linux and Windows path
separators.  Loosen the test to accept the interleaved stdout output on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
