### PR TITLE
[5.1][GenEnum] Fix getBitMaskForNoPayloadElements.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3229,11 +3229,31 @@ namespace {
     getBitMaskForNoPayloadElements() const override {
       // Use the extra inhabitants mask from the payload.
       auto &payloadTI = getFixedPayloadTypeInfo();
-      ClusteredBitVector extraInhabitantsMask;
+      APInt extraInhabitantsMaskInt;
+
+      // If we used extra inhabitants from the payload, then we can use the
+      // payload's mask to find the bits we need to test.
+      auto extraDiscriminatorBits = (~APInt(8, 0));
+      if (payloadTI.getFixedSize().getValueInBits() != 0)
+        extraDiscriminatorBits =
+          extraDiscriminatorBits.zextOrTrunc(
+              payloadTI.getFixedSize().getValueInBits());
+      if (getNumExtraInhabitantTagValues() > 0) {
+        extraInhabitantsMaskInt = payloadTI.getFixedExtraInhabitantMask(IGM);
+        // If we have more no-payload cases than extra inhabitants, also
+        // mask in up to four bytes for discriminators we generate using
+        // extra tag bits.
+        if (ExtraTagBitCount > 0) {
+          extraInhabitantsMaskInt |= extraDiscriminatorBits;
+        }
+      } else {
+        // If we only use extra tag bits, then we need that extra tag plus
+        // up to four bytes of discriminator.
+        extraInhabitantsMaskInt = extraDiscriminatorBits;
+      }
+      auto extraInhabitantsMask
+        = getBitVectorFromAPInt(extraInhabitantsMaskInt);
       
-      if (!payloadTI.isKnownEmpty(ResilienceExpansion::Maximal))
-        extraInhabitantsMask =
-          getBitVectorFromAPInt(payloadTI.getFixedExtraInhabitantMask(IGM));
       // Extend to include the extra tag bits, which are always significant.
       unsigned totalSize
         = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();


### PR DESCRIPTION
Based on a patch from Joe Groff. This is only triggered in
lldb so I'll add a test there.

<rdar://problem/51211938>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
