### PR TITLE
[5.1] Doc-serialization: skip declarations with double-underscore as name prefix

### DIFF
--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -97,7 +97,8 @@ public:
 
   const ParamDecl *operator[](unsigned i) const { return get(i); }
   ParamDecl *&operator[](unsigned i) { return get(i); }
-  
+  bool hasInternalParameter(StringRef prefix) const;
+
   /// Change the DeclContext of any contained parameters to the specified
   /// DeclContext.
   void setDeclContextOfParamDecls(DeclContext *DC);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -521,6 +521,17 @@ bool AbstractFunctionDecl::isTransparent() const {
   return false;
 }
 
+bool ParameterList::hasInternalParameter(StringRef Prefix) const {
+  for (auto param : *this) {
+    if (param->hasName() && param->getNameStr().startswith(Prefix))
+      return true;
+    auto argName = param->getArgumentName();
+    if (!argName.empty() && argName.str().startswith(Prefix))
+      return true;
+  }
+  return false;
+}
+
 bool Decl::isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic) const {
   const Decl *D = this;
   if (auto ExtD = dyn_cast<ExtensionDecl>(D)) {
@@ -542,26 +553,15 @@ bool Decl::isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic) const {
       FU->getKind() != FileUnitKind::SerializedAST)
     return false;
 
-  auto hasInternalParameter = [](const ParameterList *params) -> bool {
-    for (auto param : *params) {
-      if (param->hasName() && param->getNameStr().startswith("_"))
-        return true;
-      auto argName = param->getArgumentName();
-      if (!argName.empty() && argName.str().startswith("_"))
-        return true;
-    }
-    return false;
-  };
-
   if (auto AFD = dyn_cast<AbstractFunctionDecl>(D)) {
     // If it's a function with a parameter with leading underscore, it's a
     // private function.
-    if (hasInternalParameter(AFD->getParameters()))
+    if (AFD->getParameters()->hasInternalParameter("_"))
       return true;
   }
 
   if (auto SubscriptD = dyn_cast<SubscriptDecl>(D)) {
-    if (hasInternalParameter(SubscriptD->getIndices()))
+    if (SubscriptD->getIndices()->hasInternalParameter("_"))
       return true;
   }
 

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -18,10 +18,29 @@
 public class PublicClass {
   /// Public Function Documentation
   public func f_public() { }
+  /// Public Init Documentation
+  public init(_ name: String) {}
+  /// Public Subscript Documentation
+  public subscript(_ name: String) -> Int { return 0 }
   /// Internal Function Documentation NotForNormal
   internal func f_internal() { }
   /// Private Function Documentation NotForNormal NotForTesting
   private func f_private() { }
+  /// Public Filter Function Documentation NotForNormal NotForTesting
+  public func __UnderscoredPublic() {}
+  /// Public Filter Init Documentation NotForNormal NotForTesting
+  public init(__label name: String) {}
+  /// Public Filter Subscript Documentation NotForNormal NotForFiltering
+  public subscript(__label name: String) -> Int { return 0 }
+  /// Public Filter Init Documentation NotForNormal NotForTesting
+  public init(label __name: String) {}
+  /// Public Filter Subscript Documentation NotForNormal NotForTesting
+  public subscript(label __name: String) -> Int { return 0 }
+}
+
+public extension PublicClass {
+  /// Public Filter Operator Documentation NotForNormal NotForTesting
+  static func -=(__lhs: inout PublicClass, __rhs: PublicClass) {}
 }
 
 /// InternalClass Documentation NotForNormal
@@ -42,10 +61,14 @@ private class PrivateClass {
 // NORMAL-NEGATIVE-NOT: NotForTesting
 // NORMAL: PublicClass Documentation
 // NORMAL: Public Function Documentation
+// NORMAL: Public Init Documentation
+// NORMAL: Public Subscript Documentation
 
 // TESTING-NEGATIVE-NOT: NotForTesting
 // TESTING: PublicClass Documentation
 // TESTING: Public Function Documentation
+// TESTINH: Public Init Documentation
+// TESTING: Public Subscript Documentation
 // TESTING: Internal Function Documentation
 // TESTING: InternalClass Documentation
 // TESTING: Internal Function Documentation


### PR DESCRIPTION
Double-underscored names suggest the symbols aren't supposed to be used by framework
clients. This patch excludes the doc-comments of these symbols in swiftdoc files.

rdar://51468650
