### PR TITLE
[C++ Interop] Handle importing nested types and namespaces better.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1485,10 +1485,16 @@ ASTMangler::getSpecialManglingContext(const ValueDecl *decl,
       else
         hasNameForLinkage = !clangDecl->getDeclName().isEmpty();
       if (hasNameForLinkage) {
-        auto *clangDC = clangDecl->getDeclContext();
-        assert(clangDC->getRedeclContext()->isTranslationUnit() &&
-               "non-top-level Clang types not supported yet");
-        (void)clangDC;
+        if (!decl->getASTContext().LangOpts.EnableCXXInterop) {
+          // TODO: Mangle namespaces into these ObjC names.
+          // TODO: https://bugs.swift.org/browse/TF-560
+          // Skip checks for c++ interop. This doesn't mangle the names right
+          // though.
+          auto *clangDC = clangDecl->getDeclContext();
+          assert(clangDC->getRedeclContext()->isTranslationUnit() &&
+                 "non-top-level Clang types not supported yet");
+          (void)clangDC;
+        }
         return ASTMangler::ObjCContext;
       }
     }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1405,7 +1405,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   case clang::DeclarationName::CXXUsingDirective:
   case clang::DeclarationName::CXXDeductionGuideName:
     // Handling these is part of C++ interoperability.
-    llvm_unreachable("unhandled C++ interoperability");
+    return ImportedName();
 
   case clang::DeclarationName::Identifier:
     // Map the identifier.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -196,6 +196,8 @@ public:
       DC = omDecl->getCanonicalDecl();
     } else if (auto fDecl = dyn_cast<clang::FunctionDecl>(dc)) {
       DC = fDecl->getCanonicalDecl();
+    } else if (auto nsDecl = dyn_cast<clang::NamespaceDecl>(dc)) {
+      DC = nsDecl->getCanonicalDecl();
     } else {
       assert(isa<clang::TranslationUnitDecl>(dc) ||
              isa<clang::ObjCContainerDecl>(dc) &&

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace ns {
+
+struct Basic {
+  int a;
+};
+
+}  // namespace ns
+
+ns::Basic makeA();
+
+using ns_Basic = ns::Basic;
+
+namespace nested_struct_problem {
+
+// Because of cycles in the importing process,
+// importing NextedStruct directly would get into an infinite loop importing
+// WrapperClass which would in turn import NestedStruct.
+class WrapperClass {
+ public:
+  struct NestedStruct {
+    int a;
+  };
+};
+
+}  // namespace nested_struct_problem
+
+using NestedStruct = nested_struct_problem::WrapperClass::NestedStruct;
+NestedStruct MakeNestedStruct();

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -229,3 +229,7 @@ module ConditionallyFoo {
 module ForwardDeclarationsHelper {
   header "ForwardDeclarationsHelper.h"
 }
+
+module CXXInterop {
+  header "cxx_interop.h"
+}

--- a/test/ClangImporter/cxx_interop.swift
+++ b/test/ClangImporter/cxx_interop.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop
+
+import CXXInterop
+
+// Basic structs
+do {
+  var tmp: ns_Basic = makeA()
+  tmp.a = 3
+}
+
+var tmp: NestedStruct = MakeNestedStruct()
+


### PR DESCRIPTION
Note that namespaces should require mangling support in the future for
the generated swift wrapping type.