### PR TITLE
DNM: stdlib: Add backward deployment versions for the dynamic-replacement runtime functions.

### DIFF
--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -3,6 +3,7 @@ set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
 
 add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC INSTALL_WITH_SHARED
   ProtocolConformance.cpp
+  DynamicReplaceable.cpp
   Overrides.cpp
   C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}

--- a/stdlib/public/Compatibility50/DynamicReplaceable.cpp
+++ b/stdlib/public/Compatibility50/DynamicReplaceable.cpp
@@ -1,0 +1,63 @@
+//===--- ProtocolConformance.cpp - Swift protocol conformance checking ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Runtime support for dynamic replaceable functions.
+//
+// This implementation is intended to be backward-deployed into Swift 5.0
+// runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "swift/Runtime/Once.h"
+#include "../runtime/ThreadLocalStorage.h"
+
+using namespace swift;
+
+// The thread-local key must be weak so that it is shared between different
+// binaries (e.g. shared libraries).
+__attribute__((weak)) __swift_thread_key_t _swift_dr_key;
+__attribute__((weak)) swift_once_t _swift_dr_Predicate;
+
+static void createSwiftThreadKey(void *) {
+  int result = SWIFT_THREAD_KEY_CREATE(&_swift_dr_key, nullptr);
+  if (result != 0)
+    abort();
+}
+
+static __swift_thread_key_t &getTLSKey() {
+  swift_once(&_swift_dr_Predicate, createSwiftThreadKey, nullptr);
+  return _swift_dr_key;
+}
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
+  char *ReplFn = *ReplFnPtr;
+  char *RawReplFn = ReplFn;
+
+  if (RawReplFn == CurrFn)
+    return nullptr;
+
+  __swift_thread_key_t key = getTLSKey();
+  if ((intptr_t)SWIFT_THREAD_GETSPECIFIC(key) != 0) {
+    SWIFT_THREAD_SETSPECIFIC(key, (void *)0);
+    return nullptr;
+  }
+  return ReplFn;
+}
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getOrigOfReplaceable(char **OrigFnPtr) {
+  char *OrigFn = *OrigFnPtr;
+  SWIFT_THREAD_SETSPECIFIC(getTLSKey(), (void *)-1);
+  return OrigFn;
+}

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -19,3 +19,4 @@ void swift_allocBox(){}
 void swift_getWitnessTable(void) {}
 void swift_getObjCClassMetadata(void) {}
 void swift_addNewDSOImage(void) {}
+void swift_once() {}


### PR DESCRIPTION
This will allow backward deployment to a swift 5.0 runtime.

rdar://problem/51601233
