### PR TITLE
tests: disable backward deployment tests on Windows

### DIFF
--- a/validation-test/Evolution/test_backward_deploy_always_emit_into_client.swift
+++ b/validation-test/Evolution/test_backward_deploy_always_emit_into_client.swift
@@ -4,6 +4,9 @@
 // Uses swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_always_emit_into_client
 

--- a/validation-test/Evolution/test_backward_deploy_class.swift
+++ b/validation-test/Evolution/test_backward_deploy_class.swift
@@ -4,6 +4,9 @@
 // Uses swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_class
 

--- a/validation-test/Evolution/test_backward_deploy_enum.swift
+++ b/validation-test/Evolution/test_backward_deploy_enum.swift
@@ -4,6 +4,9 @@
 // Use swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_enum
 

--- a/validation-test/Evolution/test_backward_deploy_protocol.swift
+++ b/validation-test/Evolution/test_backward_deploy_protocol.swift
@@ -4,6 +4,9 @@
 // Use swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_protocol
 

--- a/validation-test/Evolution/test_backward_deploy_struct.swift
+++ b/validation-test/Evolution/test_backward_deploy_struct.swift
@@ -4,6 +4,9 @@
 // Use swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_struct
 

--- a/validation-test/Evolution/test_backward_deploy_top_level.swift
+++ b/validation-test/Evolution/test_backward_deploy_top_level.swift
@@ -4,6 +4,9 @@
 // Use swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import backward_deploy_top_level
 

--- a/validation-test/Evolution/test_protocol_add_requirements.swift
+++ b/validation-test/Evolution/test_protocol_add_requirements.swift
@@ -4,6 +4,9 @@
 // Use swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// SR-10913
+// UNSUPPORTED: OS=windows-msvc
+
 import StdlibUnittest
 import protocol_add_requirements
 


### PR DESCRIPTION
PE/COFF does not support weak linking semantics.  Disable the tests
until we can emulate the required behaviour.  This will allow us to
enable running the validation test suite on Windows in the mean time.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
