### PR TITLE
[5.1] SourceKit/Indentation: align function names in chained trailing closures

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -481,6 +481,24 @@ public:
       }
     }
 
+    // Chained trailing closures shouldn't require additional indentation.
+    // a.map {
+    //  ...
+    // }.filter { <--- No indentation here.
+    //  ...
+    // }.map { <--- No indentation here.
+    //  ...
+    // }
+    if (AtExprEnd && AtCursorExpr && isa<CallExpr>(AtExprEnd)) {
+      if (auto *UDE = dyn_cast<UnresolvedDotExpr>(AtCursorExpr)) {
+        if (auto *Base = UDE->getBase()) {
+          if (exprEndAtLine(Base, Line))
+            return false;
+        }
+      }
+    }
+
+
     // Indent another level from the outer context by default.
     return true;
   }

--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -52,6 +52,16 @@ func foo8() {
   })
 }
 
+func foo9(input: [Int]){
+    input.map { (ele) in
+        ele + 1
+    }.filter{(ele) in
+        return ele > 10
+    }.map {(ele) in
+        return ele + 1
+    }
+}
+
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
@@ -68,6 +78,17 @@ func foo8() {
 // RUN: %sourcekitd-test -req=format -line=32 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=42 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=50 -length=1 %s >>%t.response
+
+// RUN: %sourcekitd-test -req=format -line=55 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=56 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=57 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=58 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=59 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=60 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=61 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=62 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=63 -length=1 %s >>%t.response
+
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "        var abc = 1"
@@ -94,3 +115,13 @@ func foo8() {
 // CHECK: key.sourcetext: "  })"
 
 // CHECK: key.sourcetext: "  }, B: {"
+
+// CHECK: key.sourcetext: "func foo9(input: [Int]){"
+// CHECK: key.sourcetext: "    input.map { (ele) in"
+// CHECK: key.sourcetext: "        ele + 1"
+// CHECK: key.sourcetext: "    }.filter{(ele) in"
+// CHECK: key.sourcetext: "        return ele > 10"
+// CHECK: key.sourcetext: "    }.map {(ele) in"
+// CHECK: key.sourcetext: "        return ele + 1"
+// CHECK: key.sourcetext: "    }"
+// CHECK: key.sourcetext: "}"


### PR DESCRIPTION
Chained trailing closures are sibling-like thus they should be aligned.

rdar://22205716
