### PR TITLE
[AutoDiff] Re-add `@differentiable` attribute deserialization hack.

### DIFF
--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -88,7 +88,10 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
         vjpName = SILDeclRef(vjpFn).mangle();
       // Get lowered argument indices.
       auto paramIndices = A->getParameterIndices();
-      assert(paramIndices && "Parameter indices should have been resolved");
+      // NOTE: If `A->getParameterIndices()` is `nullptr`, continue. This is a
+      // necessary hack regarding deserialization.
+      if (!paramIndices)
+        continue;
       auto loweredParamIndices = paramIndices->getLowered(
           F->getASTContext(),
           decl->getInterfaceType()->castTo<AnyFunctionType>());


### PR DESCRIPTION
Reverts change in https://github.com/apple/swift/pull/25293.