### PR TITLE
Sema: Go back to synthesizing hashValue on _StoredBridgedNSError conformers

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1055,18 +1055,41 @@ deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl, void *) {
 
   // return _hashValue(for: self)
   auto *hashFunc = C.getHashValueForDecl();
-  auto hashExpr = new (C) DeclRefExpr(hashFunc, DeclNameLoc(),
+  if (!hashFunc->hasInterfaceType())
+    C.getLazyResolver()->resolveDeclSignature(hashFunc);
+
+  auto selfType = hashValueDecl->mapTypeIntoContext(
+    parentDC->getSelfInterfaceType());
+  auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
+  auto conformance = TypeChecker::conformsToProtocol(selfType, hashableProto,
+                                                     parentDC, None);
+  auto subs = SubstitutionMap::get(hashFunc->getGenericSignature(),
+                                   ArrayRef<Type>(selfType),
+                                   ArrayRef<ProtocolConformanceRef>(*conformance));
+  ConcreteDeclRef hashRef(hashFunc, subs);
+
+  auto hashExpr = new (C) DeclRefExpr(hashRef, DeclNameLoc(),
                                       /*implicit*/ true);
+
+  Type intType = C.getIntDecl()->getDeclaredType();
+  hashExpr->setType(FunctionType::get(AnyFunctionType::Param(selfType),
+                                      intType));
+
   auto selfDecl = hashValueDecl->getImplicitSelfDecl();
   auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
                                      /*implicit*/ true);
-  auto callExpr = CallExpr::createImplicit(C, hashExpr,
-                                           { selfRef }, { C.Id_for });
+  selfRef->setType(selfType);
+
+  auto callExpr = CallExpr::createImplicit(C, hashExpr, { selfRef }, { });
+  callExpr->setType(intType);
+  callExpr->setThrows(false);
+
   auto returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr);
 
   auto body = BraceStmt::create(C, SourceLoc(), {returnStmt}, SourceLoc(),
                                 /*implicit*/ true);
   hashValueDecl->setBody(body);
+  hashValueDecl->setBodyTypeCheckedIfPresent();
 }
 
 /// Derive a 'hashValue' implementation.

--- a/stdlib/public/Darwin/Foundation/NSError.swift
+++ b/stdlib/public/Darwin/Foundation/NSError.swift
@@ -489,10 +489,6 @@ extension _BridgedStoredNSError {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_nsError)
   }
-
-  @_alwaysEmitIntoClient public var hashValue: Int {
-    return _nsError.hashValue
-  }
 }
 
 /// Describes the code of an error.


### PR DESCRIPTION
Commit e0bba70 added a default implementation, however this is wrong
for non-imported types.

Instead, synthesize the body as before. Since this is one of the few
derived methods that can appear on an imported type, make sure to
build fully type-checked AST.

Fixes <rdar://problem/51322302>.