### PR TITLE
Replace two #ifs with #if/#else in new integer random algorithm

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -104,8 +104,7 @@ extension RandomNumberGenerator {
     } while random < range
 
     return random % upperBound
-#endif
-#if arch(x86_64) || arch(arm64)
+#else
     var random: T = next()
     var m = random.multipliedFullWidth(by: upperBound)
     if m.low < upperBound {


### PR DESCRIPTION
Swift gets used on archs other than 32 and 64b Intel and ARM (IBM's systems, for instance); this would fail to compile.