### PR TITLE
 [SE-0258] Ensure that we fully check the property type vs. wrapper's value type

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5444,9 +5444,6 @@ PropertyWrapperTypeInfo VarDecl::getAttachedPropertyWrapperTypeInfo() const {
 
 Type VarDecl::getAttachedPropertyWrapperType() const {
   auto &ctx = getASTContext();
-  if (!ctx.getLazyResolver())
-    return nullptr;
-
   auto mutableThis = const_cast<VarDecl *>(this);
   return evaluateOrDefault(ctx.evaluator,
                            AttachedPropertyWrapperTypeRequest{mutableThis},
@@ -5455,9 +5452,6 @@ Type VarDecl::getAttachedPropertyWrapperType() const {
 
 Type VarDecl::getPropertyWrapperBackingPropertyType() const {
   ASTContext &ctx = getASTContext();
-  if (!ctx.getLazyResolver())
-    return nullptr;
-
   auto mutableThis = const_cast<VarDecl *>(this);
   return evaluateOrDefault(
       ctx.evaluator, PropertyWrapperBackingPropertyTypeRequest{mutableThis},
@@ -5467,9 +5461,6 @@ Type VarDecl::getPropertyWrapperBackingPropertyType() const {
 PropertyWrapperBackingPropertyInfo
 VarDecl::getPropertyWrapperBackingPropertyInfo() const {
   auto &ctx = getASTContext();
-  if (!ctx.getLazyResolver())
-    return PropertyWrapperBackingPropertyInfo();
-
   auto mutableThis = const_cast<VarDecl *>(this);
   return evaluateOrDefault(
       ctx.evaluator,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -648,6 +648,7 @@ void PropertyWrapperBackingPropertyTypeRequest::noteCycleStep(
     DiagnosticEngine &diags) const {
   std::get<0>(getStorage())->diagnose(diag::circular_reference_through);
 }
+
 bool PropertyWrapperBackingPropertyInfoRequest::isCached() const {
   auto var = std::get<0>(getStorage());
   return !var->getAttrs().isEmpty();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -371,12 +371,15 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (!customAttr)
     return Type();
 
+  ASTContext &ctx = var->getASTContext();
+  if (!ctx.getLazyResolver())
+    return nullptr;
+
   auto resolution =
       TypeResolution::forContextual(var->getDeclContext());
   TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
 
-  ASTContext &ctx = var->getASTContext();
   auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
   if (tc.validateType(customAttr->getTypeLoc(), resolution, options))
     return ErrorType::get(ctx);
@@ -409,10 +412,13 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!binding)
     return Type();
 
+  ASTContext &ctx = var->getASTContext();
+  if (!ctx.getLazyResolver())
+    return Type();
+
   // If there's an initializer of some sort, checking it will determine the
   // property wrapper type.
   unsigned index = binding->getPatternEntryIndexForVarDecl(var);
-  ASTContext &ctx = var->getASTContext();
   TypeChecker &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
   if (binding->isInitialized(index)) {
     tc.validateDecl(var);

--- a/test/Serialization/Inputs/def_property_wrappers.swift
+++ b/test/Serialization/Inputs/def_property_wrappers.swift
@@ -10,3 +10,32 @@ public struct SomeWrapper<T> {
 public struct HasWrappers {
   @SomeWrapper public var x: Int = 17
 }
+
+// SR-10844
+@_propertyWrapper
+class A<T: Equatable> {
+
+  private var _value: T
+
+  var value: T {
+    get { _value }
+    set { _value = newValue }
+  }
+
+  init(initialValue: T) {
+    _value = initialValue
+  }
+}
+
+@_propertyWrapper
+class B: A<Double> {
+  override var value: Double {
+    get { super.value }
+    set { super.value = newValue }
+  }
+}
+
+class Holder {
+  // @A var b = 10.0 // ok
+  @B var b = 10.0 // crash in test target
+}

--- a/test/Serialization/property_wrappers.swift
+++ b/test/Serialization/property_wrappers.swift
@@ -1,8 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_property_wrappers.swift
+// RUN: %empty-directory(%t-scratch)
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_property_wrappers~partial.swiftmodule -primary-file %S/Inputs/def_property_wrappers.swift -module-name def_property_wrappers -enable-testing
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -enable-testing %t-scratch/def_property_wrappers~partial.swiftmodule -module-name def_property_wrappers -o %t/def_property_wrappers.swiftmodule
 // RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown
 
-import def_property_wrappers
+@testable import def_property_wrappers
+
+// SR-10844
+func testSR10844() {
+  let holder = Holder()
+  holder.b = 100
+}
 
 func useWrappers(hd: HasWrappers) {
   // Access the original properties

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -758,3 +758,13 @@ struct UsesWrapperRequiringP {
   // expected-error@-2{{expected declaration}}
   // expected-error@-3{{type annotation missing in pattern}}
 }
+
+// SR-10899 / rdar://problem/51588022
+@_propertyWrapper
+struct SR_10899_Wrapper { // expected-note{{property wrapper type 'SR_10899_Wrapper' declared here}}
+  var value: String { "hi" }
+}
+
+struct SR_10899_Usage {
+  @SR_10899_Wrapper var thing: Bool // expected-error{{property type 'Bool' does not match that of the 'value' property of its wrapper type 'SR_10899_Wrapper'}}
+}


### PR DESCRIPTION
Various optimizations / shortcuts in type checking property wrappers meant
that we weren't consistently verifying that a wrapped property type is
identical to the type of the 'value' property of the wrapper. Do so.

Fixes SR-10899 / rdar://problem/51588022.