### PR TITLE
[5.1] SourceKit/Indentation: avoid indenting the end of subscript expressions in call chain.

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -489,7 +489,8 @@ public:
     // }.map { <--- No indentation here.
     //  ...
     // }
-    if (AtExprEnd && AtCursorExpr && isa<CallExpr>(AtExprEnd)) {
+    if (AtExprEnd && AtCursorExpr &&
+        (isa<CallExpr>(AtExprEnd) || isa<SubscriptExpr>(AtExprEnd))) {
       if (auto *UDE = dyn_cast<UnresolvedDotExpr>(AtCursorExpr)) {
         if (auto *Base = UDE->getBase()) {
           if (exprEndAtLine(Base, Line))

--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -62,6 +62,11 @@ func foo9(input: [Int]){
     }
 }
 
+func foo10() {
+    Something() [
+    ].whatever
+}
+
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
@@ -88,6 +93,9 @@ func foo9(input: [Int]){
 // RUN: %sourcekitd-test -req=format -line=61 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=62 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=63 -length=1 %s >>%t.response
+
+// RUN: %sourcekitd-test -req=format -line=66 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=67 -length=1 %s >>%t.response
 
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
@@ -125,3 +133,6 @@ func foo9(input: [Int]){
 // CHECK: key.sourcetext: "        return ele + 1"
 // CHECK: key.sourcetext: "    }"
 // CHECK: key.sourcetext: "}"
+
+// CHECK: key.sourcetext: "    Something() ["
+// CHECK: key.sourcetext: "    ].whatever"


### PR DESCRIPTION
rdar://50591281
