### PR TITLE
[CSDiagnostics] Add method to retrieve information about an argument application

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2697,7 +2697,11 @@ public:
   /// True if this is a C function that was imported as a member of a type in
   /// Swift.
   bool isImportAsMember() const;
-  
+
+  /// Returns true if the declaration's interface type is a function type with a
+  /// curried self parameter.
+  bool hasCurriedSelf() const;
+
   /// Get the decl for this value's opaque result type, if it has one.
   OpaqueTypeDecl *getOpaqueResultTypeDecl() const;
 
@@ -7165,6 +7169,14 @@ inline bool ValueDecl::isStatic() const {
 inline bool ValueDecl::isImportAsMember() const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))
     return func->isImportAsMember();
+  return false;
+}
+
+inline bool ValueDecl::hasCurriedSelf() const {
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(this))
+    return afd->hasImplicitSelfDecl();
+  if (isa<EnumElementDecl>(this))
+    return true;
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -115,11 +115,9 @@ Type FailureDiagnostic::resolveInterfaceType(Type type,
   auto &cs = getConstraintSystem();
   auto resolvedType = type.transform([&](Type type) -> Type {
     if (auto *tvt = type->getAs<TypeVariableType>()) {
-      auto *loc = tvt->getImpl().getLocator();
-
       // If this type variable is for a generic parameter, return that.
-      if (loc->isForGenericParameter())
-        return loc->getGenericParameter();
+      if (auto *gp = tvt->getImpl().getGenericParameter())
+        return gp;
 
       // Otherwise resolve its fixed type, mapped out of context.
       if (auto fixed = cs.getFixedType(tvt))

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -593,10 +593,6 @@ private:
   void offerDefaultValueUnwrapFixIt(DeclContext *DC, Expr *expr) const;
   /// Suggest a force optional unwrap via `!`
   void offerForceUnwrapFixIt(Expr *expr) const;
-
-  /// Determine whether given expression is an argument used in the
-  /// operator invocation, and if so return corresponding parameter.
-  Optional<AnyFunctionType::Param> getOperatorParameterFor(Expr *expr) const;
 };
 
 /// Diagnose errors associated with rvalues in positions

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -99,6 +99,10 @@ public:
                : resolvedType;
   }
 
+  /// Resolve type variables present in the raw type, using generic parameter
+  /// types where possible.
+  Type resolveInterfaceType(Type type, bool reconstituteSugar = false) const;
+
   template <typename... ArgTypes>
   InFlightDiagnostic emitDiagnostic(ArgTypes &&... Args) const;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -489,10 +489,6 @@ private:
   /// passing such parameter as an @escaping argument, or trying to
   /// assign it to a variable which expects @escaping function.
   bool diagnoseParameterUse() const;
-
-  /// Retrieve a type of the parameter at give index for call or
-  /// subscript invocation represented by given expression node.
-  Type getParameterTypeFor(Expr *expr, unsigned paramIdx) const;
 };
 
 class MissingForcedDowncastFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -67,16 +67,17 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
 
 bool ForceOptional::diagnose(Expr *root, bool asNote) const {
   MissingOptionalUnwrapFailure failure(root, getConstraintSystem(), BaseType,
-                                       UnwrappedType, getLocator());
+                                       UnwrappedType, FullLocator);
   return failure.diagnose(asNote);
 }
 
 ForceOptional *ForceOptional::create(ConstraintSystem &cs, Type baseType,
                                      Type unwrappedType,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator()) ForceOptional(
-      cs, baseType, unwrappedType,
-      cs.getConstraintLocator(simplifyLocatorToAnchor(cs, locator)));
+  auto *simplifiedLocator =
+      cs.getConstraintLocator(simplifyLocatorToAnchor(cs, locator));
+  return new (cs.getAllocator())
+      ForceOptional(cs, baseType, unwrappedType, simplifiedLocator, locator);
 }
 
 bool UnwrapOptionalBase::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -231,11 +231,14 @@ public:
 class ForceOptional final : public ConstraintFix {
   Type BaseType;
   Type UnwrappedType;
+  ConstraintLocator *FullLocator;
 
   ForceOptional(ConstraintSystem &cs, Type baseType, Type unwrappedType,
-                ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::ForceOptional, locator), BaseType(baseType),
-        UnwrappedType(unwrappedType) {
+                ConstraintLocator *simplifiedLocator,
+                ConstraintLocator *fullLocator)
+      : ConstraintFix(cs, FixKind::ForceOptional, simplifiedLocator),
+        BaseType(baseType), UnwrappedType(unwrappedType),
+        FullLocator(fullLocator) {
     assert(baseType && "Base type must not be null");
     assert(unwrappedType && "Unwrapped type must not be null");
   }

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -109,8 +109,11 @@ func foo(block: () -> (), other: () -> Int) {
 
 struct S {
   init<T>(_ x: T, _ y: T) {} // expected-note {{generic parameters are always considered '@escaping'}}
+  subscript<T>() -> (T, T) -> Void { { _, _ in } } // expected-note {{generic parameters are always considered '@escaping'}}
+
   init(fn: () -> Int) {
     self.init({ 0 }, fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T' may allow it to escape}}
+    _ = self[]({ 0 }, fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T' may allow it to escape}}
   }
 }
 

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -129,6 +129,79 @@ func test_passing_noescape_function_to_dependent_member() {
 
   func test(_ s: S<Q>, fn: () -> Int) {
     s.foo(fn)
-    // expected-error@-1 {{converting non-escaping parameter 'fn' to generic parameter 'Q.U' (aka '() -> Int') may allow it to escape}}
+    // expected-error@-1 {{converting non-escaping parameter 'fn' to generic parameter 'T.U' may allow it to escape}}
   }
+}
+
+protocol Q {
+  associatedtype U : P
+}
+
+func sr10811(_ fn: () -> Int) {
+  struct S1 : P {
+    typealias U = () -> Int
+  }
+
+  struct S2 : Q {
+    typealias U = S1
+  }
+
+  struct S<T : Q> { // expected-note {{generic parameters are always considered '@escaping'}}
+    func foo(_ x: T.U.U) {}
+  }
+
+  S<S2>().foo(fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T.U.U' may allow it to escape}}
+}
+
+struct Wrapper<U> {
+  var value: U
+  init(_ value: U) { self.value = value }
+}
+
+func with<T>(_ x: T, body: (T) -> Void) {}
+func takesGeneric<T>(_ x: T) {}
+func takesEscapingFn(_ fn: @escaping () -> Int) {}
+func returnsTakesEscapingFn() -> (@escaping () -> Int) -> Void { takesEscapingFn }
+
+prefix operator ^^^
+prefix func ^^^(_ x: Int) -> (@escaping () -> Int) -> Void { takesEscapingFn }
+
+func testWeirdFnExprs<T>(_ fn: () -> Int, _ cond: Bool, _ any: Any, genericArg: T) { // expected-note 11{{parameter 'fn' is implicitly non-escaping}}
+  (any as! (@escaping () -> Int) -> Void)(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  let wrapped = Wrapper<(@escaping () -> Int) -> Void>({ x in })
+  (wrapped[keyPath: \.value] as (@escaping () -> Int) -> Void)(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  (cond ? returnsTakesEscapingFn() : returnsTakesEscapingFn())(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  (^^^5)(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  var optFn: Optional = takesEscapingFn
+  optFn?(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  [takesEscapingFn][0](fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  (takesEscapingFn, "").0(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  with({ (x: @escaping () -> Int) in }) { y in
+    Wrapper(y).value(fn)
+    // expected-error @-1{{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+  }
+
+  _ = { x in (x({ 0 }), x(fn)) }(takesGeneric)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  _ = { (a: (@escaping () -> Int), b) in () }(fn, genericArg)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  func returnsVeryCurried() -> () throws -> (@escaping () -> Int) -> Void { { { x in } } }
+  (try? returnsVeryCurried()())?(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 }

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -255,7 +255,7 @@ func autoclosure_param_returning_func_type() {
 
   func bar_1(_ fn: @autoclosure @escaping () -> Int) { foo(fn) } // Ok
   func bar_2(_ fn: @autoclosure () -> Int) { foo(fn) } // expected-note {{parameter 'fn' is implicitly non-escaping}}
-  // expected-error@-1 {{using non-escaping parameter 'fn' in a context expecting an @escaping closure}}
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   func baz_1(_ fn: @autoclosure @escaping () -> Int) { generic_foo(fn) }   // Ok (T is inferred as () -> Int)
   func baz_2(_ fn: @autoclosure @escaping () -> Int) { generic_foo(fn()) } // Ok (T is inferred as Int)
   func baz_3(_ fn: @autoclosure () -> Int) { generic_foo(fn) } // Fails because fn is not marked as @escaping


### PR DESCRIPTION
This PR adds `FailureDiagnostic::getFunctionArgApplyInfo`, which retrieves information about an argument application at a given failure's locator. This method is then used to simplify the implementation of `NoEscapeFuncToTypeConversionFailure` and `MissingOptionalUnwrapFailure` and resolve a compiler crasher.


Resolves [SR-10811](https://bugs.swift.org/browse/SR-10811).

