### PR TITLE
DNM: stdlib: Add backward deployment versions for the dynamic-replacement runtime functions - version 2

### DIFF
--- a/include/swift/Runtime/DynamicReplaceable.h
+++ b/include/swift/Runtime/DynamicReplaceable.h
@@ -1,0 +1,40 @@
+//===--- DynamicReplaceable.h - dynamic replaceable support -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift runtime support for dynamic replaceable functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_DYNAMIC_REPLACEABLE_H
+#define SWIFT_RUNTIME_DYNAMIC_REPLACEABLE_H
+
+#include "swift/Runtime/Config.h"
+
+namespace swift {
+
+/// Loads the replacement function pointer from \p ReplFnPtr and returns the
+/// replacement function if it should be called.
+/// Returns null if the original function (which is passed in \p CurrFn) should
+/// be called.
+SWIFT_RUNTIME_EXPORT
+char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
+
+/// Returns the original function of a replaced function, which is loaded from
+/// \p OrigFnPtr.
+/// This function is called from a replacement function to call the original
+/// function.
+SWIFT_RUNTIME_EXPORT
+char *swift_getOrigOfReplaceable(char **OrigFnPtr);
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -40,20 +40,6 @@ SWIFT_RUNTIME_EXPORT
 void swift_beginAccess(void *pointer, ValueBuffer *buffer,
                        ExclusivityFlags flags, void *pc);
 
-/// Loads the replacement function pointer from \p ReplFnPtr and returns the
-/// replacement function if it should be called.
-/// Returns null if the original function (which is passed in \p CurrFn) should
-/// be called.
-SWIFT_RUNTIME_EXPORT
-char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
-
-/// Returns the original function of a replaced function, which is loaded from
-/// \p OrigFnPtr.
-/// This function is called from a replacement function to call the original
-/// function.
-SWIFT_RUNTIME_EXPORT
-char *swift_getOrigOfReplaceable(char **OrigFnPtr);
-
 /// Stop dynamically tracking an access.
 SWIFT_RUNTIME_EXPORT
 void swift_endAccess(ValueBuffer *buffer);

--- a/stdlib/public/Compatibility50/CMakeLists.txt
+++ b/stdlib/public/Compatibility50/CMakeLists.txt
@@ -3,6 +3,7 @@ set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
 
 add_swift_target_library(swiftCompatibility50 TARGET_LIBRARY STATIC INSTALL_WITH_SHARED
   ProtocolConformance.cpp
+  DynamicReplaceable.cpp
   Overrides.cpp
   C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}

--- a/stdlib/public/Compatibility50/DynamicReplaceable.cpp
+++ b/stdlib/public/Compatibility50/DynamicReplaceable.cpp
@@ -1,0 +1,88 @@
+//===--- ProtocolConformance.cpp - Swift protocol conformance checking ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Runtime support for dynamic replaceable functions.
+//
+// This implementation is intended to be backward-deployed into Swift 5.0
+// runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Overrides.h"
+#include "swift/Runtime/Exclusivity.h"
+#include "swift/Runtime/Metadata.h"
+#include "../runtime/ThreadLocalStorage.h"
+
+using namespace swift;
+
+// Mirror the SwiftTLSContext, which is defined in the runtime.
+// This is a hack: the layout must match with SwiftTLSContext defined in
+// Exclusivity.cpp. Fortunately it contains only a single pointer (the head of
+// the access list).
+class SwiftTLSContext {
+  void *AccessHead;
+
+public:
+  void *getHead() const { return AccessHead; }
+
+  void setExtraBit() {
+    AccessHead = (void *)((intptr_t)AccessHead | 1);
+  }
+
+  void clearExtraBit() {
+    AccessHead = (void *)((intptr_t)AccessHead & ~1);
+  }
+
+  bool testExtraBit() const {
+    return (bool)((intptr_t)AccessHead & 1);
+  }
+};
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
+  char *ReplFn = *ReplFnPtr;
+  char *RawReplFn = ReplFn;
+
+  if (RawReplFn == CurrFn)
+    return nullptr;
+
+  void *tlsStorage = SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY);
+  if (tlsStorage) {
+    SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(tlsStorage);
+
+    if (ctx->testExtraBit()) {
+      ctx->clearExtraBit();
+      return nullptr;
+    }
+  }
+  return ReplFn;
+}
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getOrigOfReplaceable(char **OrigFnPtr) {
+  void *tlsStorage = SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY);
+  if (!tlsStorage) {
+    ValueBuffer dummyAccess;
+    int dummyValue = 0;
+    swift_beginAccess(&dummyValue, &dummyAccess, ExclusivityFlags::Read, nullptr);
+    swift_endAccess(&dummyAccess);
+    tlsStorage = SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY);
+    if (!tlsStorage)
+      abort();
+  }
+  SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(tlsStorage);
+  void *pr = ctx->getHead();
+  ctx->setExtraBit();
+  char *OrigFn = *OrigFnPtr;
+  return OrigFn;
+}
+


### PR DESCRIPTION
This will allow backward deployment to a swift 5.0 runtime.
It also needs a different mechanism to pass the "implicit" boolean parameter in the thread local storage: Instead storing it in a boolean field, we use bit 0 of the AccessSet Head.
This avoids changing the layout of the thread local storage and makes it compatible with the swift 5.0 runtime.

rdar://problem/51601233

This PR is another possibility to implement this feature. The first version is https://github.com/apple/swift/pull/25340