### PR TITLE
Simpler fix for Foundation overlay ABI break

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1125,41 +1125,18 @@ deriveBodyHashable_hashValue(AbstractFunctionDecl *hashValueDecl, void *) {
 
   // return _hashValue(for: self)
   auto *hashFunc = C.getHashValueForDecl();
-  if (!hashFunc->hasInterfaceType())
-    C.getLazyResolver()->resolveDeclSignature(hashFunc);
-
-  auto selfType = hashValueDecl->mapTypeIntoContext(
-    parentDC->getSelfInterfaceType());
-  auto hashableProto = C.getProtocol(KnownProtocolKind::Hashable);
-  auto conformance = TypeChecker::conformsToProtocol(selfType, hashableProto,
-                                                     parentDC, None);
-  auto subs = SubstitutionMap::get(hashFunc->getGenericSignature(),
-                                   ArrayRef<Type>(selfType),
-                                   ArrayRef<ProtocolConformanceRef>(*conformance));
-  ConcreteDeclRef hashRef(hashFunc, subs);
-
-  auto hashExpr = new (C) DeclRefExpr(hashRef, DeclNameLoc(),
+  auto hashExpr = new (C) DeclRefExpr(hashFunc, DeclNameLoc(),
                                       /*implicit*/ true);
-
-  Type intType = C.getIntDecl()->getDeclaredType();
-  hashExpr->setType(FunctionType::get(AnyFunctionType::Param(selfType),
-                                      intType));
-
   auto selfDecl = hashValueDecl->getImplicitSelfDecl();
   auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
                                      /*implicit*/ true);
-  selfRef->setType(selfType);
-
-  auto callExpr = CallExpr::createImplicit(C, hashExpr, { selfRef }, { });
-  callExpr->setType(intType);
-  callExpr->setThrows(false);
-
+  auto callExpr = CallExpr::createImplicit(C, hashExpr,
+                                           { selfRef }, { C.Id_for });
   auto returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr);
 
   auto body = BraceStmt::create(C, SourceLoc(), {returnStmt}, SourceLoc(),
                                 /*implicit*/ true);
   hashValueDecl->setBody(body);
-  hashValueDecl->setBodyTypeCheckedIfPresent();
 }
 
 /// Derive a 'hashValue' implementation.

--- a/stdlib/public/Darwin/Foundation/NSError.swift
+++ b/stdlib/public/Darwin/Foundation/NSError.swift
@@ -568,6 +568,10 @@ public struct CocoaError : _BridgedStoredNSError {
 
   public static var errorDomain: String { return NSCocoaErrorDomain }
 
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
   /// The error code itself.
   public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
     public typealias _ErrorType = CocoaError
@@ -1795,6 +1799,10 @@ public struct URLError : _BridgedStoredNSError {
 
   public static var errorDomain: String { return NSURLErrorDomain }
 
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
   /// The error code itself.
   public struct Code : RawRepresentable, Hashable, _ErrorCodeProtocol {
     public typealias _ErrorType = URLError
@@ -2451,6 +2459,10 @@ public struct POSIXError : _BridgedStoredNSError {
 
   public static var errorDomain: String { return NSPOSIXErrorDomain }
 
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
+
   public typealias Code = POSIXErrorCode
 }
 
@@ -2936,6 +2948,10 @@ public struct MachError : _BridgedStoredNSError {
   }
 
   public static var errorDomain: String { return NSMachErrorDomain }
+
+  public var hashValue: Int {
+    return _nsError.hashValue
+  }
 
   public typealias Code = MachErrorCode
 }

--- a/stdlib/public/Darwin/Foundation/NSError.swift
+++ b/stdlib/public/Darwin/Foundation/NSError.swift
@@ -489,6 +489,10 @@ extension _BridgedStoredNSError {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_nsError)
   }
+
+  @_alwaysEmitIntoClient public var hashValue: Int {
+    return _nsError.hashValue
+  }
 }
 
 /// Describes the code of an error.


### PR DESCRIPTION
This reverts https://github.com/apple/swift/pull/25349 and adds explicit witnesses for the types that used to synthesize the accessor.

Imported types, or any new types we define, will continue to use the default implementation.