### PR TITLE
[AutoDiff] Remove References to Deprecated `@autodiff` Attribute

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2533,9 +2533,6 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
     break;
   }
   // SWIFT_ENABLE_TENSORFLOW
-  // @autodiff(...) attribute.
-  case TAK_autodiff:
-  // SWIFT_ENABLE_TENSORFLOW
   // @differentiable(...) attribute.
   case TAK_differentiable:
     break;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2129,7 +2129,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
     TAK_convention, TAK_pseudogeneric,
     TAK_callee_owned, TAK_callee_guaranteed, TAK_noescape, TAK_autoclosure,
     // SWIFT_ENABLE_TENSORFLOW
-    TAK_escaping, TAK_autodiff, TAK_differentiable, TAK_yield_once, TAK_yield_many
+    TAK_escaping, TAK_differentiable, TAK_yield_once, TAK_yield_many
   };
 
   auto checkUnsupportedAttr = [&](TypeAttrKind attr) {
@@ -2230,7 +2230,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       SILFunctionType::ExtInfo extInfo(rep, attrs.has(TAK_pseudogeneric),
                                        // SWIFT_ENABLE_TENSORFLOW
                                        attrs.has(TAK_noescape),
-                                       attrs.has(TAK_autodiff) || attrs.has(TAK_differentiable));
+                                       attrs.has(TAK_differentiable));
 
       ty = resolveSILFunctionType(fnRepr, options, coroutineKind, extInfo,
                                   calleeConvention, witnessMethodProtocol);
@@ -2269,7 +2269,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
       FunctionType::ExtInfo extInfo(rep, /*noescape=*/false,
                                     // SWIFT_ENABLE_TENSORFLOW
                                     fnRepr->throws(),
-                                    attrs.has(TAK_autodiff) || attrs.has(TAK_differentiable));
+                                    attrs.has(TAK_differentiable));
 
       ty = resolveASTFunctionType(fnRepr, options, extInfo);
       if (!ty || ty->hasError())


### PR DESCRIPTION
There are other instances of the use of `autodiff` such as `autodiffApply_` and `autodiff_function`, however, as far as I can tell, these aren't related and are still required. Wanted to confirm.