### PR TITLE
test: make StdlibUnittest.CrashingTests pass on Windows

### DIFF
--- a/validation-test/StdlibUnittest/CrashingTests.swift
+++ b/validation-test/StdlibUnittest/CrashingTests.swift
@@ -19,8 +19,8 @@ TestSuiteCrashes.test("crashesUnexpectedly1") {
   print("crashesUnexpectedly1")
   fatalError("This should crash")
 }
-// CHECK: stdout>>> crashesUnexpectedly1
-// CHECK: stderr>>> Fatal error: This should crash:
+// CHECK-DAG: stdout>>> crashesUnexpectedly1
+// CHECK-DAG: stderr>>> Fatal error: This should crash:
 // CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly1
 


### PR DESCRIPTION
The output can be interleaved differently.  Accept either ordering.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
