### PR TITLE
[AutoDiff] Diagnose only unfulfilled `@differentiable` attributes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2526,8 +2526,6 @@ WARNING(differentiable_constant_property_implicit_noderivative_fixit,none,
       "'let' properties with a default value do not have a derivative; add "
       "'@noDerivative' to make it explicit, or change it to 'var' to allow "
       "derivatives", ())
-NOTE(protocol_witness_missing_differentiable_attr,none,
-     "candidate is missing attribute '%0'", (StringRef))
 
 NOTE(codable_extraneous_codingkey_case_here,none,
      "CodingKey case %0 does not match any stored properties", (Identifier))
@@ -2739,7 +2737,7 @@ ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
 ERROR(differentiable_attr_stored_property_variable_unsupported,none,
       "'jvp:' or 'vjp:' cannot be specified for stored properties", ())
-NOTE(protocol_witness_missing_specific_differentiable_attr,none,
+NOTE(protocol_witness_missing_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 
 // @differentiating

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2790,13 +2790,11 @@ static AutoDiffParameterIndices *computeDifferentiationParameters(
     // conform to `Differentiable`.
     else {
       auto selfType = function->getImplicitSelfDecl()->getInterfaceType();
-      if (derivativeGenEnv) {
-        auto selfInterfaceType = selfType->hasTypeParameter()
-            ? selfType
-            : selfType->mapTypeOutOfContext();
-        selfType =
-            derivativeGenEnv->mapTypeIntoContext(selfInterfaceType);
-      }
+      if (derivativeGenEnv)
+        selfType = derivativeGenEnv->mapTypeIntoContext(selfType);
+      // FIXME(TF-568): `Differentiable`-conforming protocols cannot define
+      // `@differentiable` computed properties because the check below returns
+      // false.
       if (!conformsToDifferentiable(selfType, function)) {
         TC.diagnose(attrLoc, diag::diff_function_no_parameters,
                     function->getFullName())

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -359,6 +359,15 @@ struct RequirementMatch {
     assert(!hasWitnessType() && "Should have witness type");
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  RequirementMatch(ValueDecl *witness, MatchKind kind,
+                   const DeclAttribute *attr)
+    : Witness(witness), Kind(kind), WitnessType(), UnmetAttribute(attr),
+      ReqEnv(None) {
+    assert(!hasWitnessType() && "Should have witness type");
+    assert(UnmetAttribute);
+  }
+
   RequirementMatch(ValueDecl *witness, MatchKind kind,
                    Type witnessType,
                    Optional<RequirementEnvironment> env = None,
@@ -394,6 +403,10 @@ struct RequirementMatch {
 
   /// Requirement not met.
   Optional<Requirement> MissingRequirement;
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Attribute not met.
+  const DeclAttribute * UnmetAttribute = nullptr;
 
   /// The requirement environment to use for the witness thunk.
   Optional<RequirementEnvironment> ReqEnv;
@@ -469,6 +482,10 @@ struct RequirementMatch {
 
   /// Determine whether this requirement match has a requirement.
   bool hasRequirement() { return Kind == MatchKind::MissingRequirement; }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Determine whether this requirement match has an unmet attribute.
+  bool hasUnmetAttribute() { return Kind == MatchKind::DifferentiableConflict; }
 
   swift::Witness getWitness(ASTContext &ctx) const;
 };

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -406,7 +406,7 @@ struct RequirementMatch {
 
   // SWIFT_ENABLE_TENSORFLOW
   /// Attribute not met.
-  const DeclAttribute * UnmetAttribute = nullptr;
+  const DeclAttribute *UnmetAttribute = nullptr;
 
   /// The requirement environment to use for the witness thunk.
   Optional<RequirementEnvironment> ReqEnv;

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -722,8 +722,6 @@ protocol TF285 : Differentiable {
 struct TF285MissingOneDiffAttr : TF285 {
   // Requirement is missing an attribute.
   @differentiable(wrt: x)
-  // FIXME(TF-564): Do not diagnose fulfilled `@differentiable(wrt: x)` attribute.
-  // expected-note @+2 {{candidate is missing attribute '@differentiable(wrt: x)}}
   // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: (x, y))}}
   func foo(x: Float, y: Float) -> Float {
     return x


### PR DESCRIPTION
For protocol witness, diagnose only unfulfilled requirement `@differentiable` attributes.

Resolves [TF-564](https://bugs.swift.org/browse/TF-564).