### PR TITLE
[5.1][Diagnostics] Clarify requirement failure source when it's anchored a…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -131,9 +131,17 @@ Optional<SelectedOverload> FailureDiagnostic::getChoiceFor(Expr *expr) {
 }
 
 Type RequirementFailure::getOwnerType() const {
-  return getType(getRawAnchor())
-      ->getInOutObjectType()
-      ->getMetatypeInstanceType();
+  auto *anchor = getRawAnchor();
+
+  // If diagnostic is anchored at assignment expression
+  // it means that requirement failure happend while trying
+  // to convert source to destination, which means that
+  // owner type is actually not an assignment expression
+  // itself but its source.
+  if (auto *assignment = dyn_cast<AssignExpr>(anchor))
+    anchor = assignment->getSrc();
+
+  return getType(anchor)->getInOutObjectType()->getMetatypeInstanceType();
 }
 
 const GenericContext *RequirementFailure::getGenericContext() const {

--- a/test/Constraints/sr10906.swift
+++ b/test/Constraints/sr10906.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol ViewDataSource: class {
+  func foo<T>() -> [T]
+}
+
+class View {
+  weak var delegate: ViewDataSource?
+}
+
+final class ViewController<T> {
+  let view = View()
+  init() {
+    view.delegate = self
+    // expected-error@-1 {{generic class 'ViewController' requires the types 'T' and 'String' be equivalent}}
+  }
+}
+
+extension ViewController: ViewDataSource where T == String {
+// expected-note@-1 {{requirement from conditional conformance of 'ViewController<T>' to 'ViewDataSource'}}
+  func foo<T>() -> [T] {
+    return []
+  }
+}


### PR DESCRIPTION
…t assignment

While trying to fetch owner type for generic requirement failures
anchored at assignment expression, use assignment source as an anchor
because that's where requirements come from - conversion from source
type to destination.

Resolves: rdar://problem/51587755
(cherry picked from commit 4bd5a1e4e1d0288b5a13746bc68a8855c6c9af86)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
