### PR TITLE
[stdlib] Rename `VectorProtocol.Scalar` to `VectorSpaceScalar`.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -133,7 +133,7 @@ IDENTIFIER_(tensorHandleCount)
 IDENTIFIER_(typeList)
 // AdditiveArithmetic, VectorProtocol
 IDENTIFIER(zero)
-IDENTIFIER(Scalar)
+IDENTIFIER(VectorSpaceScalar)
 // Differentiable
 IDENTIFIER(AllDifferentiableVariables)
 IDENTIFIER(TangentVector)

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -369,8 +369,8 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
       return getRequirement(KnownProtocolKind::Differentiable);
 
     // SWIFT_ENABLE_TENSORFLOW
-    // VectorProtocol.Scalar
-    if (name.isSimpleName(ctx.Id_Scalar))
+    // VectorProtocol.VectorSpaceScalar
+    if (name.isSimpleName(ctx.Id_VectorSpaceScalar))
       return getRequirement(KnownProtocolKind::VectorProtocol);
 
     return nullptr;

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -24,18 +24,18 @@
 /// elements in this vector space and have either no shape or a static shape.
 public protocol VectorProtocol : AdditiveArithmetic {
   /// The type of scalars in the vector space.
-  associatedtype Scalar : AdditiveArithmetic
+  associatedtype VectorSpaceScalar : AdditiveArithmetic
 
-  static func * (lhs: Scalar, rhs: Self) -> Self
-  static func *= (lhs: inout Self, rhs: Scalar)
+  static func * (lhs: VectorSpaceScalar, rhs: Self) -> Self
+  static func *= (lhs: inout Self, rhs: VectorSpaceScalar)
 }
 
 public extension VectorProtocol {
-  static func * (lhs: Self, rhs: Scalar) -> Self {
+  static func * (lhs: Self, rhs: VectorSpaceScalar) -> Self {
     return rhs * lhs
   }
 
-  static func *= (lhs: inout Self, rhs: Scalar) {
+  static func *= (lhs: inout Self, rhs: VectorSpaceScalar) {
     lhs = rhs * lhs
   }
 }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1877,7 +1877,7 @@ extension ${Self} : Strideable {
 //===----------------------------------------------------------------------===//
 
 extension ${Self} : VectorProtocol {
-  public typealias Scalar = ${Self}
+  public typealias VectorSpaceScalar = ${Self}
 }
 
 extension ${Self} : Differentiable {

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -349,7 +349,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
-                "tensorflow-swift-apis": "b9bcebc7dfd1497e324c24f4c0d8c0b212580d1f",
+                "tensorflow-swift-apis": "55ddd7ccedf46a3a480ded0affa067eadd91bae0",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a"
             }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -349,7 +349,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
-                "tensorflow-swift-apis": "55ddd7ccedf46a3a480ded0affa067eadd91bae0",
+                "tensorflow-swift-apis": "eea90b71a7bf01ad031e11bb4a753c40e19e55d9",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a"
             }


### PR DESCRIPTION
A step towards machine learning optimizer revamp.

The next step is to make `Tensor.VectorSpaceScalar = Float`.
This makes `Tensor` scalar multiplication always work with `Float`
instead of `Scalar`.

Renaming `VectorProtocol.Scalar` is necessary. Otherwise, `Scalar`
is ambiguous within `Tensor`'s type context: it may refer to either:
- The witness type of `VectorProtocol.Scalar`, or
- The `Scalar` generic parameter.