### PR TITLE
[stdlib] Rename `VectorProtocol.*` to `VectorProtocol.scaled(by:)`.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -134,6 +134,7 @@ IDENTIFIER_(typeList)
 // AdditiveArithmetic, VectorProtocol
 IDENTIFIER(zero)
 IDENTIFIER(VectorSpaceScalar)
+IDENTIFIER(scaled)
 // Differentiable
 IDENTIFIER(AllDifferentiableVariables)
 IDENTIFIER(TangentVector)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -27,7 +27,8 @@ add_swift_host_library(swiftSema STATIC
   DerivedConformanceEquatableHashable.cpp
   DerivedConformanceError.cpp
   # SWIFT_ENABLE_TENSORFLOW
-  DerivedConformanceAdditiveArithmeticVectorProtocol.cpp
+  DerivedConformanceAdditiveArithmetic.cpp
+  DerivedConformanceVectorProtocol.cpp
   DerivedConformanceDifferentiable.cpp
   DerivedConformanceKeyPathIterable.cpp
   DerivedConformanceTensorArrayProtocol.cpp

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -326,7 +326,7 @@ static void deriveBodyDifferentiable_method(AbstractFunctionDecl *funcDecl,
     memberMethodCallExprs.push_back(createMemberMethodCallExpr(member));
     memberNames.push_back(member->getName());
   }
-  // Call memberwise initialier with member method call expressions.
+  // Call memberwise initializer with member method call expressions.
   auto *callExpr =
       CallExpr::createImplicit(C, initExpr, memberMethodCallExprs, memberNames);
   ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);

--- a/lib/Sema/DerivedConformanceVectorProtocol.cpp
+++ b/lib/Sema/DerivedConformanceVectorProtocol.cpp
@@ -1,0 +1,295 @@
+//===--- DerivedConformanceVectorProtocol.cpp -----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements explicit derivation of the VectorProtocol protocol for
+// struct types.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CodeSynthesis.h"
+#include "TypeChecker.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Stmt.h"
+#include "swift/AST/Types.h"
+#include "DerivedConformances.h"
+
+using namespace swift;
+
+// Return the protocol requirement with the specified name.
+static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
+  auto lookup = proto->lookupDirect(name);
+  lookup.erase(std::remove_if(lookup.begin(), lookup.end(),
+                              [](ValueDecl *v) {
+                                return !isa<ProtocolDecl>(
+                                           v->getDeclContext()) ||
+                                       !v->isProtocolRequirement();
+                              }),
+               lookup.end());
+  assert(lookup.size() == 1 && "Ambiguous protocol requirement");
+  return lookup.front();
+}
+
+// Return the `VectorSpaceScalar` associated type for the given `ValueDecl` if
+// it conforms to `VectorProtocol` in the given context. Otherwise, return
+// `nullptr`.
+static Type getVectorProtocolVectorSpaceScalarAssocType(
+    VarDecl *varDecl, DeclContext *DC) {
+  auto &C = varDecl->getASTContext();
+  auto *vectorProto = C.getProtocol(KnownProtocolKind::VectorProtocol);
+  if (!varDecl->hasInterfaceType())
+    C.getLazyResolver()->resolveDeclSignature(varDecl);
+  if (!varDecl->hasInterfaceType())
+    return nullptr;
+  auto varType = DC->mapTypeIntoContext(varDecl->getValueInterfaceType());
+  auto conf = TypeChecker::conformsToProtocol(varType, vectorProto, DC, None);
+  if (!conf)
+    return nullptr;
+  return conf->getTypeWitnessByName(varType, C.Id_VectorSpaceScalar);
+}
+
+// Return the `VectorSpaceScalar` associated type for the given nominal type in
+// the given context, or `nullptr` if `VectorSpaceScalar` cannot be derived.
+static Type deriveVectorProtocol_VectorSpaceScalar(NominalTypeDecl *nominal,
+                                                   DeclContext *DC) {
+  auto &C = DC->getASTContext();
+  // Nominal type must be a struct. (Zero stored properties is okay.)
+  if (!isa<StructDecl>(nominal))
+    return nullptr;
+  // If all stored properties conform to `VectorProtocol` and have the same
+  // `VectorSpaceScalar` associated type, return that `VectorSpaceScalar`
+  // associated type. Otherwise, the `VectorSpaceScalar` type cannot be derived.
+  Type sameScalarType;
+  for (auto member : nominal->getStoredProperties()) {
+    if (!member->hasInterfaceType())
+      C.getLazyResolver()->resolveDeclSignature(member);
+    if (!member->hasInterfaceType())
+      return nullptr;
+    auto scalarType = getVectorProtocolVectorSpaceScalarAssocType(member, DC);
+    // If stored property does not conform to `VectorProtocol`, return nullptr.
+    if (!scalarType)
+      return nullptr;
+    // If same `VectorSpaceScalar` type has not been set, set it for the first
+    // time.
+    if (!sameScalarType) {
+      sameScalarType = scalarType;
+      continue;
+    }
+    // If stored property `VectorSpaceScalar` types do not match, return
+    // nullptr.
+    if (!scalarType->isEqual(sameScalarType))
+      return nullptr;
+  }
+  return sameScalarType;
+}
+
+// Return true if given nominal type has a `let` stored with an initial value.
+static bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
+  return llvm::any_of(nominal->getStoredProperties(), [&](VarDecl *v) {
+    return v->isLet() && v->hasInitialValue();
+  });
+}
+
+bool DerivedConformance::canDeriveVectorProtocol(NominalTypeDecl *nominal,
+                                                 DeclContext *DC) {
+  // Must not have any `let` stored properties with an initial value.
+  // - This restriction may be lifted later with support for "true" memberwise
+  //   initializers that initialize all stored properties, including initial
+  //   value information.
+  if (hasLetStoredPropertyWithInitialValue(nominal))
+    return false;
+  // Must be able to derive `VectorSpaceScalar` associated type.
+  return bool(deriveVectorProtocol_VectorSpaceScalar(nominal, DC));
+}
+
+// Synthesize body for a `VectorProtocol` method requirement.
+static void deriveBodyVectorProtocol_method(AbstractFunctionDecl *funcDecl,
+                                            Identifier methodName,
+                                            Identifier methodParamLabel) {
+  auto *parentDC = funcDecl->getParent();
+  auto *nominal = parentDC->getSelfNominalTypeDecl();
+  auto &C = nominal->getASTContext();
+
+  // Create memberwise initializer: `Nominal.init(...)`.
+  auto *memberwiseInitDecl = nominal->getEffectiveMemberwiseInitializer();
+  assert(memberwiseInitDecl && "Memberwise initializer must exist");
+  auto *initDRE =
+      new (C) DeclRefExpr(memberwiseInitDecl, DeclNameLoc(), /*Implicit*/ true);
+  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+  auto *nominalTypeExpr = TypeExpr::createForDecl(SourceLoc(), nominal,
+                                                  funcDecl, /*Implicit*/ true);
+  auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, nominalTypeExpr);
+
+  // Get method protocol requirement.
+  auto *vectorProto = C.getProtocol(KnownProtocolKind::VectorProtocol);
+  auto *methodReq = getProtocolRequirement(vectorProto, methodName);
+
+  // Get references to `self` and parameter declarations.
+  auto *selfDecl = funcDecl->getImplicitSelfDecl();
+  auto *selfDRE =
+      new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
+  auto *paramDecl = funcDecl->getParameters()->get(0);
+  auto *paramDRE =
+      new (C) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit*/ true);
+
+  // Create call expression applying a member method to the parameter.
+  // Format: `<member>.method(<parameter>)`.
+  // Example: `x.scaled(by: scalar)`.
+  auto createMemberMethodCallExpr = [&](VarDecl *member) -> Expr * {
+    auto *module = nominal->getModuleContext();
+    auto memberType =
+        parentDC->mapTypeIntoContext(member->getValueInterfaceType());
+    auto confRef = module->lookupConformance(memberType, vectorProto);
+    assert(confRef && "Member does not conform to `VectorNumeric`");
+
+    // Get member type's method, e.g. `Member.scaled(by:)`.
+    // Use protocol requirement declaration for the method by default: this
+    // will be dynamically dispatched.
+    ValueDecl *memberMethodDecl = methodReq;
+    // If conformance reference is concrete, then use concrete witness
+    // declaration for the operator.
+    if (confRef->isConcrete()) {
+      if (auto *concreteMemberMethodDecl =
+              confRef->getConcrete()->getWitnessDecl(methodReq,
+                                                     C.getLazyResolver()))
+        memberMethodDecl = concreteMemberMethodDecl;
+      assert(memberMethodDecl);
+    }
+    assert(memberMethodDecl && "Member method declaration must exist");
+    auto memberMethodDRE =
+        new (C) DeclRefExpr(memberMethodDecl, DeclNameLoc(), /*Implicit*/ true);
+    memberMethodDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
+
+    // Create reference to member method: `x.scaled(by:)`.
+    auto memberExpr =
+        new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
+                              /*Implicit*/ true);
+    auto memberMethodExpr =
+        new (C) DotSyntaxCallExpr(memberMethodDRE, SourceLoc(), memberExpr);
+
+    // Create expression: `x.scaled(by: scalar)`.
+    return CallExpr::createImplicit(C, memberMethodExpr, {paramDRE},
+                                    {methodParamLabel});
+  };
+
+  // Create array of member method call expressions.
+  llvm::SmallVector<Expr *, 2> memberMethodCallExprs;
+  llvm::SmallVector<Identifier, 2> memberNames;
+  for (auto *member : nominal->getStoredProperties()) {
+    memberMethodCallExprs.push_back(createMemberMethodCallExpr(member));
+    memberNames.push_back(member->getName());
+  }
+  // Call memberwise initializer with member method call expressions.
+  auto *callExpr =
+      CallExpr::createImplicit(C, initExpr, memberMethodCallExprs, memberNames);
+  ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);
+  funcDecl->setBody(
+      BraceStmt::create(C, SourceLoc(), returnStmt, SourceLoc(), true));
+}
+
+// Synthesize body for `scaled(by:)`.
+static void deriveBodyVectorProtocol_scalarMultiply(
+    AbstractFunctionDecl *funcDecl, void *) {
+  auto &C = funcDecl->getASTContext();
+  deriveBodyVectorProtocol_method(funcDecl, C.Id_scaled, C.getIdentifier("by"));
+}
+
+// Synthesize function declaration for a `VectorProtocol` method requirement.
+static ValueDecl *deriveVectorProtocol_method(
+    DerivedConformance &derived, Identifier methodName, Identifier argumentName,
+    Identifier parameterName, Type parameterType, Type returnType,
+    AbstractFunctionDecl::BodySynthesizer bodySynthesizer) {
+  auto nominal = derived.Nominal;
+  auto &TC = derived.TC;
+  auto &C = derived.TC.Context;
+  auto parentDC = derived.getConformanceContext();
+
+  auto *param =
+      new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
+                        argumentName, SourceLoc(), parameterName, parentDC);
+  param->setInterfaceType(parameterType);
+  ParameterList *params = ParameterList::create(C, {param});
+
+  DeclName declName(C, methodName, params);
+  auto funcDecl = FuncDecl::create(C, SourceLoc(), StaticSpellingKind::None,
+                                   SourceLoc(), declName, SourceLoc(),
+                                   /*Throws*/ false, SourceLoc(),
+                                   /*GenericParams*/ nullptr, params,
+                                   TypeLoc::withoutLoc(returnType), parentDC);
+  funcDecl->setImplicit();
+  funcDecl->setBodySynthesizer(bodySynthesizer.Fn, bodySynthesizer.Context);
+
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    funcDecl->setGenericEnvironment(env);
+  funcDecl->computeType();
+  funcDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
+  funcDecl->setValidationToChecked();
+
+  derived.addMembersToConformanceContext({funcDecl});
+  C.addSynthesizedDecl(funcDecl);
+
+  // Returned nominal type must define a memberwise initializer.
+  // Add memberwise initializer if necessary.
+  if (!nominal->getEffectiveMemberwiseInitializer()) {
+    // The implicit memberwise constructor must be explicitly created so that
+    // it can called in `VectorProtocol` methods. Normally, the memberwise
+    // constructor is synthesized during SILGen, which is too late.
+    auto *initDecl = createImplicitConstructor(
+        TC, nominal, ImplicitConstructorKind::Memberwise);
+    nominal->addMember(initDecl);
+    C.addSynthesizedDecl(initDecl);
+  }
+
+  return funcDecl;
+}
+
+// Synthesize the `scaled(by:)` function declaration.
+static ValueDecl *deriveVectorProtocol_scaled(DerivedConformance &derived) {
+  auto &C = derived.TC.Context;
+  auto *nominal = derived.Nominal;
+  auto *parentDC = derived.getConformanceContext();
+
+  auto selfInterfaceType = parentDC->getDeclaredInterfaceType();
+  auto scalarType = deriveVectorProtocol_VectorSpaceScalar(nominal, parentDC)
+      ->mapTypeOutOfContext();
+
+  return deriveVectorProtocol_method(
+      derived, C.Id_scaled, C.getIdentifier("by"), C.getIdentifier("scalar"),
+      scalarType, selfInterfaceType,
+      {deriveBodyVectorProtocol_scalarMultiply, nullptr});
+}
+
+ValueDecl *DerivedConformance::deriveVectorProtocol(ValueDecl *requirement) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.Id_scaled)
+    return deriveVectorProtocol_scaled(*this);
+  TC.diagnose(requirement->getLoc(), diag::broken_vector_protocol_requirement);
+  return nullptr;
+}
+
+Type DerivedConformance::deriveVectorProtocol(AssociatedTypeDecl *requirement) {
+  // Diagnose conformances in disallowed contexts.
+  if (checkAndDiagnoseDisallowedContext(requirement))
+    return nullptr;
+  if (requirement->getBaseName() == TC.Context.Id_VectorSpaceScalar)
+    return deriveVectorProtocol_VectorSpaceScalar(
+        Nominal, getConformanceContext());
+  TC.diagnose(requirement->getLoc(), diag::broken_vector_protocol_requirement);
+  return nullptr;
+}

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -279,12 +279,12 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
     }
 
     // SWIFT_ENABLE_TENSORFLOW
-    // VectorProtocol.*
-    if (func->isOperator() && name.getBaseName() == "*") {
+    // VectorProtocol.scaled(by:)
+    if (name.isCompoundName() && name.getBaseName() == ctx.Id_scaled) {
       auto argumentNames = name.getArgumentNames();
-      if (argumentNames.size() == 2) {
+      if (argumentNames.size() == 1 &&
+          argumentNames[0] == ctx.getIdentifier("by"))
         return getRequirement(KnownProtocolKind::VectorProtocol);
-      }
     }
 
     // SWIFT_ENABLE_TENSORFLOW

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -26,17 +26,28 @@ public protocol VectorProtocol : AdditiveArithmetic {
   /// The type of scalars in the vector space.
   associatedtype VectorSpaceScalar : AdditiveArithmetic
 
-  static func * (lhs: VectorSpaceScalar, rhs: Self) -> Self
-  static func *= (lhs: inout Self, rhs: VectorSpaceScalar)
+  /// Returns `self` multiplied by the given scalar.
+  func scaled(by scalar: VectorSpaceScalar) -> Self
+
+  /// Multiplies `self` by the given scalar.
+  mutating func scale(by scalar: VectorSpaceScalar)
 }
 
 public extension VectorProtocol {
+  mutating func scale(by scalar: VectorSpaceScalar) {
+    self = scaled(by: scalar)
+  }
+
   static func * (lhs: Self, rhs: VectorSpaceScalar) -> Self {
-    return rhs * lhs
+    return lhs.scaled(by: rhs)
+  }
+
+  static func * (lhs: VectorSpaceScalar, rhs: Self) -> Self {
+    return rhs.scaled(by: lhs)
   }
 
   static func *= (lhs: inout Self, rhs: VectorSpaceScalar) {
-    lhs = rhs * lhs
+    lhs.scale(by: rhs)
   }
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1878,6 +1878,10 @@ extension ${Self} : Strideable {
 
 extension ${Self} : VectorProtocol {
   public typealias VectorSpaceScalar = ${Self}
+
+  public func scaled(by scalar: ${Self}) -> ${Self} {
+    return self * scalar
+  }
 }
 
 extension ${Self} : Differentiable {

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -23,7 +23,7 @@ public struct Vector : AdditiveArithmetic, VectorProtocol, Differentiable, Equat
   @differentiable(vjp: fakeVJP)
   public static func - (lhs: Vector, rhs: Vector) -> Vector { abort() }
 
-  public static func * (lhs: Float, rhs: Vector) -> Vector { abort() }
+  public func scaled(by scalar: Float) -> Vector { abort() }
 
   public static func fakeVJP(lhs: Vector, rhs: Vector) -> (Vector, (Vector) -> (Vector, Vector)) { abort() }
 }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -349,7 +349,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
-                "tensorflow-swift-apis": "b6955d19340a6823de8f63095226dbc32c900261",
+                "tensorflow-swift-apis": "fb3135cc8113639d74070e019105a129dcb74e7b",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-06-02-a"
             }


### PR DESCRIPTION
Rename `VectorProtocol` scalar multiplication.
- `VectorProtocol.*` -> `VectorProtocol.scaled(by:)`
- `VectorProtocol.*=` -> `VectorProtocol.scale(by:)`

Update `VectorProtocol` derived conformances.