### PR TITLE
[ConstraintSystem] Replace special locator for return of single expr …

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2239,7 +2239,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
         CS.TC.isConvertibleTo(srcFT->getResult(), contextualType, CS.DC)) {
 
       auto locator =
-          CS.getConstraintLocator(expr, ConstraintLocator::ContextualType);
+          CS.getConstraintLocator(expr, LocatorPathElt::getContextualType());
       ContextualFailure failure =
           ContextualFailure(nullptr, CS, srcFT, contextualType, locator);
       auto diagnosed = failure.diagnoseAsError();
@@ -2320,7 +2320,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   if (contextualType->isExistentialType()) {
     MissingContextualConformanceFailure failure(
         expr, CS, CTP, exprType, contextualType,
-        CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));
+        CS.getConstraintLocator(expr, LocatorPathElt::getContextualType()));
     return failure.diagnoseAsError();
   }
 
@@ -5687,7 +5687,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
 
       MissingArgumentsFailure failure(
           expr, CS, fnType, inferredArgCount - actualArgCount,
-          CS.getConstraintLocator(CE, ConstraintLocator::ContextualType));
+          CS.getConstraintLocator(CE, LocatorPathElt::getContextualType()));
       return failure.diagnoseAsError();
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2935,8 +2935,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // literals and expressions representing an implicit return type of the single
   // expression functions.
   if (auto elt = locator.last()) {
-    if (elt->getKind() == ConstraintLocator::ClosureResult ||
-        elt->getKind() == ConstraintLocator::SingleExprFuncResultType) {
+    if (elt->isClosureResult() || elt->isResultOfSingleExprFunction()) {
       if (kind >= ConstraintKind::Subtype &&
           (type1->isUninhabited() || type2->isVoid())) {
         increaseScore(SK_FunctionConversion);
@@ -5405,8 +5404,9 @@ done:
                                             {rootTy, valueTy});
   // Let's check whether deduced key path type would match
   // expected contextual one.
-  return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
-                    locator.withPathElement(ConstraintLocator::ContextualType));
+  return matchTypes(
+      resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
+      locator.withPathElement(LocatorPathElt::getContextualType()));
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1176,10 +1176,10 @@ ConstraintSystem::solveImpl(Expr *&expr,
     if (getContextualTypePurpose() == CTP_YieldByReference)
       constraintKind = ConstraintKind::Bind;
 
+    bool isForSingleExprFunction =
+        getContextualTypePurpose() == CTP_ReturnSingleExpr;
     auto *convertTypeLocator = getConstraintLocator(
-        expr, getContextualTypePurpose() == CTP_ReturnSingleExpr
-                  ? ConstraintLocator::SingleExprFuncResultType
-                  : ConstraintLocator::ContextualType);
+        expr, LocatorPathElt::getContextualType(isForSingleExprFunction));
 
     if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
       convertType = convertType.transform([&](Type type) -> Type {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -82,7 +82,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
-    case SingleExprFuncResultType:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -364,7 +363,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       break;
 
     case ContextualType:
-      out << "contextual type";
+      if (elt.isResultOfSingleExprFunction())
+        out << "expected result type of the function with a single expression";
+      else
+        out << "contextual type";
       break;
 
     case SynthesizedArgument:
@@ -389,9 +391,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case KeyPathComponentResult:
       out << "key path component result";
-      break;
-    case SingleExprFuncResultType:
-      out << " expected result type of the function with a single expression";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -135,8 +135,6 @@ public:
     KeyPathValue,
     /// The result type of a key path component. Not used for subscripts.
     KeyPathComponentResult,
-    /// The expected type of the function with a single expression body.
-    SingleExprFuncResultType,
   };
 
   /// Determine the number of numeric values used for the given path
@@ -165,14 +163,13 @@ public:
     case Witness:
     case ImplicitlyUnwrappedDisjunctionChoice:
     case DynamicLookupResult:
-    case ContextualType:
     case KeyPathType:
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
-    case SingleExprFuncResultType:
       return 0;
 
+    case ContextualType:
     case OpenedGeneric:
     case GenericArgument:
     case NamedTupleElement:
@@ -240,7 +237,6 @@ public:
     case KeyPathRoot:
     case KeyPathValue:
     case KeyPathComponentResult:
-    case SingleExprFuncResultType:
       return 0;
 
     case FunctionArgument:
@@ -398,6 +394,10 @@ public:
       return PathElement(base);
     }
 
+    static PathElement getContextualType(bool isForSingleExprFunction = false) {
+      return PathElement(ContextualType, isForSingleExprFunction);
+    }
+
     /// Retrieve the kind of path element.
     PathElementKind getKind() const {
       switch (static_cast<StoredKind>(storedKind)) {
@@ -505,6 +505,17 @@ public:
 
     bool isKeyPathComponent() const {
       return getKind() == PathElementKind::KeyPathComponent;
+    }
+
+    bool isClosureResult() const {
+      return getKind() == PathElementKind::ClosureResult;
+    }
+
+    /// Determine whether this element points to the contextual type
+    /// associated with result of a single expression function.
+    bool isResultOfSingleExprFunction() const {
+      return getKind() == PathElementKind::ContextualType ? bool(getValue())
+                                                          : false;
     }
   };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2219,8 +2219,8 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   Type convertTo = convertType.getType();
   if (options.contains(TypeCheckExprFlags::ExpressionTypeMustBeOptional)) {
     assert(!convertTo && "convertType and type check options conflict");
-    auto *convertTypeLocator = cs.getConstraintLocator(
-        cs.getConstraintLocator(expr), ConstraintLocator::ContextualType);
+    auto *convertTypeLocator =
+        cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
     Type var = cs.createTypeVariable(convertTypeLocator, TVO_CanBindToNoEscape);
     convertTo = getOptionalType(expr->getLoc(), var);
   }
@@ -2604,7 +2604,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
       // Save the locator we're using for the expression.
       Locator =
-          cs.getConstraintLocator(expr, ConstraintLocator::ContextualType);
+          cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
 
       // Collect constraints from the pattern.
       Type patternType = cs.generateConstraints(pattern, Locator);

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -365,3 +365,18 @@ struct OtherGeneric<X, Y, Z> {
   var y: GenericWithOpaqueAssoc<Y>.Assoc
   var z: GenericWithOpaqueAssoc<Z>.Assoc
 }
+
+
+protocol P_51641323 {
+  associatedtype T
+
+  var foo: Self.T { get }
+}
+
+func rdar_51641323() {
+  struct Foo: P_51641323 {
+    var foo: some P_51641323 { {} }
+    // expected-error@-1 {{return type of property 'foo' requires that '() -> ()' conform to 'P_51641323'}}
+    // expected-note@-2 {{opaque return type declared here}}
+  }
+}


### PR DESCRIPTION
…function with a flag on contextual type locator

It's only needed in one place in the constraint solver to allow
`() -> T` to `() -> ()` and `() -> Never` to `() -> T` for expressions
representing return of a single expression functions, so to simplify
contextual type handling in diagnostic and other places it would be
better to replace dedicated locator kind with a flag on existing `ContextualType`.

Resolves: rdar://problem/51641323

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
