### PR TITLE
[5.1][ConstraintSystem] Use lightweight conformance check in determining w…

### DIFF
--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -686,3 +686,16 @@ func member_ref_with_explicit_init() {
   _ = S.init(42)
   // expected-error@-1 {{generic struct 'S' requires that 'Int' conform to 'P'}}
 }
+
+func rdar_50007727() {
+  struct A<T> { // expected-note {{'T' declared as parameter to type 'A'}}
+    struct B<U> : ExpressibleByStringLiteral {
+      init(stringLiteral value: String) {}
+    }
+  }
+
+  struct S {}
+  let _ = A.B<S>("hello")
+  // expected-error@-1 {{generic parameter 'T' could not be inferred in cast to 'A<_>.B<S>'}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{12-12=<Any>}}
+}


### PR DESCRIPTION
…hether literal could be initialized via coercion

Currently logic to transform call into coercion uses `conformsToProtocol`
to validate that type conforms to one of the ExpressibleBy*Literal protocols.

That function doesn't handle unbound generic parameters and would result in
an infinite loop or a crash when not all of the generic parameters were
explicitly specified for one of the types in the chain e.g. `A.B(42)`
where `A` has at least one generic parameter.

Resolves: rdar://problem/50007727
(cherry picked from commit a80fa91c3bd081b30f8f64214c53e066e96a07ad)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
