### PR TITLE
[cfg] Make the docs for splitBasicBlockAndBranch clearer.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -96,8 +96,9 @@ bool rotateLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI,
                 bool RotateSingleBlockLoops, SILBasicBlock *UpTo,
                 bool ShouldVerify);
 
-/// Splits the basic block before the instruction with an unconditional
-/// branch and updates the dominator tree and loop info.
+/// Splits the basic block before the instruction with an unconditional branch
+/// and updates the dominator tree and loop info. Returns the new, branched to
+/// block that contains the end of \p SplitBeforeInst's block.
 SILBasicBlock *splitBasicBlockAndBranch(SILBuilder &B,
                                         SILInstruction *SplitBeforeInst,
                                         DominanceInfo *DT, SILLoopInfo *LI);


### PR DESCRIPTION
I found myself worrying about the return type, so this just makes the semantics
of the return type explicit.
