### PR TITLE
test: fix the path separator for Evolution.test_rth

### DIFF
--- a/validation-test/Evolution/test_rth.swift
+++ b/validation-test/Evolution/test_rth.swift
@@ -12,8 +12,11 @@ let clientIsAfter = true
 #endif
 
 let execPath = CommandLine.arguments.first!
-// FIXME: Don't hardcode "/" here.
+#if os(Windows)
+let execName = execPath.split(separator: "\\").last!
+#else
 let execName = execPath.split(separator: "/").last!
+#endif
 switch execName {
 case "after_after":
   precondition(clientIsAfter)


### PR DESCRIPTION
Windows uses `\` for the path separator while other targets use `/`
Use the correct seprator for calculating the basename of the executable
to enable the test on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
