### PR TITLE
rth: change the working directory on Windows

### DIFF
--- a/utils/rth
+++ b/utils/rth
@@ -15,6 +15,7 @@ import argparse
 import glob
 import os
 import pipes
+import platform
 import shlex
 import shutil
 import subprocess
@@ -224,6 +225,10 @@ class ResilienceTest(object):
                 os.path.join(self.tmp_dir, self.config_dir_map[config1], '*'))
             command = self.target_run + [output_obj] + tmp_dir_contents
             verbose_print_command(command)
+            # Windows does not have RPATH, make sure that we change the current
+            # working directory before we execute the test.
+            if platform.system() == 'Windows':
+                os.chdir(self.config_dir_map[config1])
             returncode = subprocess.call(command)
             assert returncode == 0, str(command)
 


### PR DESCRIPTION
The tests need to change the working directory when executing on Windows
as RPATH is not supported on the platform.  The current working
directory gets precedence over `PATH` for library lookup.  This allows
the last of the Evolution tests pass on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
