### PR TITLE
rth: quote the commandline properly on Windows (NFC)

### DIFF
--- a/utils/rth
+++ b/utils/rth
@@ -25,7 +25,10 @@ VERBOSE = True
 
 def verbose_print_command(command):
     if VERBOSE:
-        print(" ".join(pipes.quote(c) for c in command))
+        if platform.system() == 'Windows':
+            print(subprocess.list2cmdline(command))
+        else:
+            print(" ".join(pipes.quote(c) for c in command))
         sys.stdout.flush()
 
 


### PR DESCRIPTION
This is purely for debugging purposes.  Use the subprocess.list2cmd
function to get a command line quoted for Windows quoting rules.  NFC

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
