### PR TITLE
Runtime: Store a 32-bit offset in tuple metadata.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1495,7 +1495,7 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
     ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> Type;
 
     /// The offset of the tuple element within the tuple.
-    StoredSize Offset;
+    uint32_t Offset;
 
     OpaqueValue *findIn(OpaqueValue *tuple) const {
       return (OpaqueValue*) (((char*) tuple) + Offset);
@@ -1505,6 +1505,9 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
       return Type->getTypeLayout();
     }
   };
+  
+  static_assert(sizeof(Element) == sizeof(StoredSize) * 2,
+                "element size should be two words");
 
   Element *getElements() {
     return reinterpret_cast<Element*>(this + 1);


### PR DESCRIPTION
Key paths expect to do a 32-bit read here, which happens to work on little-endian systems but
breaks s390x. Make the field here 32-bit, which should have no practical effect on little
endian systems but fix big-endian.