### PR TITLE
[SE-0258] Improve backward compatibility of the newer property wrappers implementation

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -401,11 +401,9 @@ SIMPLE_DECL_ATTR(_implementationOnly, ImplementationOnly,
 DECL_ATTR(_custom, Custom,
   OnAnyDecl | UserInaccessible,
   85)
-SIMPLE_DECL_ATTR(_propertyWrapper, PropertyWrapper,
+SIMPLE_DECL_ATTR(propertyWrapper, PropertyWrapper,
   OnStruct | OnClass | OnEnum,
   86)
-DECL_ATTR_ALIAS(propertyDelegate, PropertyWrapper)
-DECL_ATTR_ALIAS(propertyWrapper, PropertyWrapper)
 SIMPLE_DECL_ATTR(_disfavoredOverload, DisfavoredOverload,
   OnAbstractFunction | OnVar | OnSubscript | UserInaccessible,
   87)

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -404,6 +404,8 @@ DECL_ATTR(_custom, Custom,
 SIMPLE_DECL_ATTR(_propertyWrapper, PropertyWrapper,
   OnStruct | OnClass | OnEnum,
   86)
+DECL_ATTR_ALIAS(propertyDelegate, PropertyWrapper)
+DECL_ATTR_ALIAS(propertyWrapper, PropertyWrapper)
 SIMPLE_DECL_ATTR(_disfavoredOverload, DisfavoredOverload,
   OnAbstractFunction | OnVar | OnSubscript | UserInaccessible,
   87)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5150,6 +5150,10 @@ public:
   /// \end
   bool isPropertyWrapperInitializedWithInitialValue() const;
 
+  /// Whether the memberwise initializer parameter for a property with a property wrapper type
+  /// uses the wrapped type.
+  bool isPropertyMemberwiseInitializedWithWrappedType() const;
+
   /// If this property is the backing storage for a property with an attached
   /// property wrapper, return the original property.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4462,6 +4462,9 @@ ERROR(property_wrapper_type_not_usable_from_inline,none,
       "%select{%select{variable|constant}0|property}1 "
       "must be '@usableFromInline' or public",
       (bool, bool))
+WARNING(property_wrapper_delegateValue,none,
+        "property wrapper's `delegateValue` property should be renamed to "
+        "'wrapperValue'; use of 'delegateValue' is deprecated", ())
 
 //------------------------------------------------------------------------------
 // MARK: function builder diagnostics

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1800,6 +1800,12 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
     checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable);
   }
 
+  // Other names of property wrappers...
+  checkInvalidAttrName("propertyDelegate", "propertyWrapper",
+                       DAK_PropertyWrapper, diag::attr_renamed_warning);
+  checkInvalidAttrName("_propertyWrapper", "propertyWrapper",
+                       DAK_PropertyWrapper, diag::attr_renamed_warning);
+
   if (DK == DAK_Count && Tok.getText() == "warn_unused_result") {
     // The behavior created by @warn_unused_result is now the default. Emit a
     // Fix-It to remove.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1137,10 +1137,13 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   // If this is the backing storage for a property with an attached wrapper
   // that was initialized with `=`, use that expression as the initializer.
   if (auto originalProperty = var->getOriginalWrappedProperty()) {
-    auto wrapperInfo =
-        originalProperty->getPropertyWrapperBackingPropertyInfo();
-    if (wrapperInfo.originalInitialValue)
-      init = wrapperInfo.originalInitialValue;
+    if (originalProperty
+            ->isPropertyMemberwiseInitializedWithWrappedType()) {
+      auto wrapperInfo =
+          originalProperty->getPropertyWrapperBackingPropertyInfo();
+      if (wrapperInfo.originalInitialValue)
+        init = wrapperInfo.originalInitialValue;
+    }
   }
 
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2247,12 +2247,18 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   if (!var->getParentPattern()->getSingleVar())
     return;
 
-  // If we don't have an expression initializer or silgen can't assign a default
-  // initializer, then we can't generate a default value. An example of where
-  // silgen can assign a default is var x: Int? where the default is nil.
-  // If the variable is lazy, go ahead and give it a default value.
-  if (!var->getAttrs().hasAttribute<LazyAttr>() &&
-      !var->getParentPatternBinding()->isDefaultInitializable())
+  // Determine whether this variable will be 'nil' initialized.
+  bool isNilInitialized =
+    (isa<OptionalType>(var->getValueInterfaceType().getPointer()) &&
+     !var->isParentInitialized()) ||
+    var->getAttrs().hasAttribute<LazyAttr>();
+
+  // Whether we have explicit initialization.
+  bool isExplicitlyInitialized = var->isParentInitialized();
+
+  // If this is neither nil-initialized nor explicitly initialized, don't add
+  // anything.
+  if (!isNilInitialized && !isExplicitlyInitialized)
     return;
 
   // We can add a default value now.
@@ -2268,12 +2274,13 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   // default arg. All lazy variables return a nil literal as well. *Note* that
   // the type will always be a sugared T? because we don't default init an
   // explicit Optional<T>.
-  if ((isa<OptionalType>(var->getValueInterfaceType().getPointer()) &&
-      !var->isParentInitialized()) ||
-      var->getAttrs().hasAttribute<LazyAttr>()) {
+  if (isNilInitialized) {
     arg->setDefaultArgumentKind(DefaultArgumentKind::NilLiteral);
     return;
   }
+
+ // Explicitly initialize.
+ assert(isExplicitlyInitialized);
 
   // If there's a backing storage property, the memberwise initializer
   // will be in terms of that.
@@ -2334,7 +2341,7 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
         // accept a value of the original property type. Otherwise, the
         // memberwise initializer will be in terms of the backing storage
         // type.
-        if (!var->isPropertyWrapperInitializedWithInitialValue()) {
+        if (!var->isPropertyMemberwiseInitializedWithWrappedType()) {
           varInterfaceType = backingPropertyType;
         }
       }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -225,7 +225,7 @@ static ConstructorDecl *findDefaultInit(ASTContext &ctx,
 llvm::Expected<PropertyWrapperTypeInfo>
 PropertyWrapperTypeInfoRequest::evaluate(
     Evaluator &eval, NominalTypeDecl *nominal) const {
-  // We must have the @_propertyWrapper attribute to continue.
+  // We must have the @propertyWrapper attribute to continue.
   if (!nominal->getAttrs().hasAttribute<PropertyWrapperAttr>()) {
     return PropertyWrapperTypeInfo();
   }
@@ -271,7 +271,7 @@ AttachedPropertyWrapperRequest::evaluate(Evaluator &evaluator,
     auto nominal = evaluateOrDefault(
       ctx.evaluator, CustomAttrNominalRequest{mutableAttr, dc}, nullptr);
 
-    // If we didn't find a nominal type with a @_propertyWrapper attribute,
+    // If we didn't find a nominal type with a @propertyWrapper attribute,
     // skip this custom attribute.
     if (!nominal || !nominal->getAttrs().hasAttribute<PropertyWrapperAttr>())
       continue;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -245,6 +245,18 @@ PropertyWrapperTypeInfoRequest::evaluate(
   result.wrapperValueVar =
     findValueProperty(ctx, nominal, ctx.Id_wrapperValue, /*allowMissing=*/true);
 
+  // If there was no wrapperValue property, but there is a delegateValue
+  // property, use that and warn.
+  if (!result.wrapperValueVar) {
+    result.wrapperValueVar =
+      findValueProperty(ctx, nominal, ctx.Id_delegateValue,
+                        /*allowMissing=*/true);
+    if (result.wrapperValueVar) {
+      result.wrapperValueVar->diagnose(diag::property_wrapper_delegateValue)
+        .fixItReplace(result.wrapperValueVar->getNameLoc(), "wrapperValue");
+    }
+  }
+
   return result;
 }
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -75,7 +75,7 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       objcMembers[#Class Attribute#]; name=objcMembers{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       NSApplicationMain[#Class Attribute#]; name=NSApplicationMain{{$}}
 // KEYWORD3-NEXT:             Keyword/None:                       usableFromInline[#Class Attribute#]; name=usableFromInline
-// KEYWORD3-NEXT:             Keyword/None:                       _propertyWrapper[#Class Attribute#]; name=_propertyWrapper
+// KEYWORD3-NEXT:             Keyword/None:                       propertyWrapper[#Class Attribute#]; name=propertyWrapper
 // KEYWORD3-NEXT:             Keyword/None:                       _functionBuilder[#Class Attribute#]; name=_functionBuilder
 // KEYWORD3-NEXT:             End completions
 
@@ -91,7 +91,7 @@ enum E {}
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicCallable[#Enum Attribute#]; name=dynamicCallable
 // KEYWORD4-NEXT:             Keyword/None:                       dynamicMemberLookup[#Enum Attribute#]; name=dynamicMemberLookup
 // KEYWORD4-NEXT:             Keyword/None:                       usableFromInline[#Enum Attribute#]; name=usableFromInline
-// KEYWORD4-NEXT:             Keyword/None:                       _propertyWrapper[#Enum Attribute#]; name=_propertyWrapper
+// KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper
 // KEYWORD4-NEXT:             Keyword/None:                       _functionBuilder[#Enum Attribute#]; name=_functionBuilder
 // KEYWORD4-NEXT:             End completions
 
@@ -103,7 +103,7 @@ struct S{}
 // KEYWORD5-NEXT:             Keyword/None:                       dynamicCallable[#Struct Attribute#]; name=dynamicCallable
 // KEYWORD5-NEXT:             Keyword/None:                       dynamicMemberLookup[#Struct Attribute#]; name=dynamicMemberLookup
 // KEYWORD5-NEXT:             Keyword/None:                       usableFromInline[#Struct Attribute#]; name=usableFromInline
-// KEYWORD5-NEXT:             Keyword/None:                       _propertyWrapper[#Struct Attribute#]; name=_propertyWrapper
+// KEYWORD5-NEXT:             Keyword/None:                       propertyWrapper[#Struct Attribute#]; name=propertyWrapper
 // KEYWORD5-NEXT:             Keyword/None:                       _functionBuilder[#Struct Attribute#]; name=_functionBuilder
 // KEYWORD5-NEXT:             End completions
 
@@ -204,7 +204,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // ON_MEMBER_LAST-DAG: Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable
 // ON_MEMBER_LAST-DAG: Keyword/None:                       IBSegueAction[#Declaration Attribute#]; name=IBSegueAction
-// ON_MEMBER_LAST-DAG: Keyword/None:                       _propertyWrapper[#Declaration Attribute#]; name=_propertyWrapper
+// ON_MEMBER_LAST-DAG: Keyword/None:                       propertyWrapper[#Declaration Attribute#]; name=propertyWrapper
 // ON_MEMBER_LAST-DAG: Keyword/None:                       _functionBuilder[#Declaration Attribute#]; name=_functionBuilder
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
@@ -236,7 +236,7 @@ struct _S {
 // KEYWORD_LAST-NEXT:             Keyword/None:                       usableFromInline[#Declaration Attribute#]; name=usableFromInline{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       discardableResult[#Declaration Attribute#]; name=discardableResult
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
-// KEYWORD_LAST-NEXT:             Keyword/None:                       _propertyWrapper[#Declaration Attribute#]; name=_propertyWrapper
+// KEYWORD_LAST-NEXT:             Keyword/None:                       propertyWrapper[#Declaration Attribute#]; name=propertyWrapper
 // KEYWORD_LAST-NEXT:             Keyword/None:                       _functionBuilder[#Declaration Attribute#]; name=_functionBuilder{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       IBSegueAction[#Declaration Attribute#]; name=IBSegueAction{{$}}
 // KEYWORD_LAST-NOT:              Keyword

--- a/test/IDE/complete_property_delegate.swift
+++ b/test/IDE/complete_property_delegate.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SELF_VARNAME | %FileCheck %s -check-prefix=CONTEXT_VARNAME
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SELF_DOLLAR_VARNAME | %FileCheck %s -check-prefix=CONTEXT_DOLLAR_VARNAME
 
-@_propertyWrapper
+@propertyWrapper
 struct Lazzzy<T> {
   var value: T
 

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -6,7 +6,7 @@ enum MyEnum {
   case east, west
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct MyStruct {
   var value: MyEnum
   init(initialValue: MyEnum) {}

--- a/test/IDE/print_property_wrappers.swift
+++ b/test/IDE/print_property_wrappers.swift
@@ -3,7 +3,7 @@
 // Directly printing the type-checked AST
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename %s | %FileCheck %s
 
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<Value> {
   var _stored: Value?
 

--- a/test/IDE/print_property_wrappers.swift
+++ b/test/IDE/print_property_wrappers.swift
@@ -47,9 +47,9 @@ struct HasWrappers {
   var z: String
 
   // Memberwise initializer.
-  // CHECK: init(x: Wrapper<Int> = Wrapper(closure: foo), y: Bool = true, z: Wrapper<String> = Wrapper())
+  // CHECK: init(x: Wrapper<Int> = Wrapper(closure: foo), y: Bool = true, z: String)
 }
 
 func trigger() {
-  _ = HasWrappers(y: false)
+  _ = HasWrappers(y: false, z: "hello")
 }

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck -check-prefix=CHECK %s
 
-@_propertyWrapper
+@propertyWrapper
 public struct Wrapper<T> {
   public var value: T
 

--- a/test/ParseableInterface/property_wrappers.swift
+++ b/test/ParseableInterface/property_wrappers.swift
@@ -6,12 +6,12 @@
 // RUN: %target-swift-frontend -build-module-from-parseable-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-parseable-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
 
-@_propertyWrapper
+@propertyWrapper
 public struct Wrapper<T> {
   public var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 public struct WrapperWithInitialValue<T> {
   public var value: T
 

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-silgen | %FileCheck %s
 // FIXME: switch to %target-swift-emit-silgen once we have syntax tree support
 
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<T> {
   var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithInitialValue<T> {
   var value: T
 
@@ -107,7 +107,7 @@ func forceHasMemberwiseInit() {
 // CHECK: bb0:
 // CHECK: function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
 struct HasNested<T> {
-  @_propertyWrapper
+  @propertyWrapper
   private struct PrivateWrapper<U> {
     var value: U
     init(initialValue: U) {
@@ -180,7 +180,7 @@ struct WrapperWithDidSetWillSet {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithStorageValue<T> {
   var value: T
 
@@ -201,7 +201,7 @@ struct UseWrapperWithStorageValue {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 enum Lazy<Value> {
   case uninitialized(() -> Value)
   case initialized(Value)
@@ -270,7 +270,7 @@ extension ClassUsingWrapper {
 }
 
 // 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithDefaultInit<T> {
   private var storage: T?
 

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -4,7 +4,7 @@
 
 // REQUIRES: executable_test
 
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<T> {
   var value: T {
     didSet {
@@ -304,7 +304,7 @@ func testGenericClass() {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithDefaultInit<Value> {
   private var _value: Value? = nil
 

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-@_propertyWrapper
+@propertyWrapper
 final class ClassWrapper<T> {
   var value: T {
     didSet {

--- a/test/Serialization/Inputs/def_property_wrappers.swift
+++ b/test/Serialization/Inputs/def_property_wrappers.swift
@@ -1,4 +1,4 @@
-@_propertyWrapper
+@propertyWrapper
 public struct SomeWrapper<T> {
   public var value: T
 
@@ -12,7 +12,7 @@ public struct HasWrappers {
 }
 
 // SR-10844
-@_propertyWrapper
+@propertyWrapper
 class A<T: Equatable> {
 
   private var _value: T
@@ -27,7 +27,7 @@ class A<T: Equatable> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 class B: A<Double> {
   override var value: Double {
     get { super.value }

--- a/test/decl/protocol/special/coding/property_wrappers_codable.swift
+++ b/test/decl/protocol/special/coding/property_wrappers_codable.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<T: Codable> {
   var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithInitialValue<T: Codable> {
   var value: T
 

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -2,7 +2,7 @@
 
 // expect-no-diagnostics
 
-@propertyDelegate
+@propertyDelegate // expected-warning{{'@propertyDelegate' has been renamed to '@propertyWrapper'}}{{2-18=propertyWrapper}}
 struct Delegate<T> {
   var value: T
 
@@ -19,7 +19,7 @@ struct TestDelegateValue {
   }
 }
 
-@propertyWrapper
+@_propertyWrapper // expected-warning{{'@_propertyWrapper' has been renamed to '@propertyWrapper'}}{{2-18=propertyWrapper}}
 struct Wrapper<T> {
   var value: T
 }

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -5,6 +5,18 @@
 @propertyDelegate
 struct Delegate<T> {
   var value: T
+
+  var delegateValue: Wrapper<T> { // expected-warning{{property wrapper's `delegateValue` property should be renamed to 'wrapperValue'; use of 'delegateValue' is deprecated}}{{7-20=wrapperValue}}
+    return Wrapper(value: value)
+  }
+}
+
+struct TestDelegateValue {
+  @Delegate var foo: String
+
+  func test() -> Wrapper<String> {
+    return $foo
+  }
 }
 
 @propertyWrapper

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+// expect-no-diagnostics
+
+@propertyDelegate
+struct Delegate<T> {
+  var value: T
+}
+
+@propertyWrapper
+struct Wrapper<T> {
+  var value: T
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -3,12 +3,12 @@
 // ---------------------------------------------------------------------------
 // Property wrapper type definitions
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<T> {
   var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithInitialValue<T> {
   var value: T
 
@@ -17,7 +17,7 @@ struct WrapperWithInitialValue<T> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperAcceptingAutoclosure<T> {
   private let fn: () -> T
 
@@ -34,30 +34,30 @@ struct WrapperAcceptingAutoclosure<T> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct MissingValue<T> { }
 // expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'value'}}
 
-@_propertyWrapper
+@propertyWrapper
 struct StaticValue {
   static var value: Int = 17
 }
 // expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'value'}}
 
 
-// expected-error@+1{{'@_propertyWrapper' attribute cannot be applied to this declaration}}
-@_propertyWrapper
+// expected-error@+1{{'@propertyWrapper' attribute cannot be applied to this declaration}}
+@propertyWrapper
 protocol CannotBeAWrapper {
   associatedtype Value
   var value: Value { get set }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct NonVisibleValueWrapper<Value> {
   private var value: Value // expected-error{{private property 'value' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleValueWrapper' (which is internal)}}
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct NonVisibleInitWrapper<Value> {
   var value: Value
 
@@ -66,7 +66,7 @@ struct NonVisibleInitWrapper<Value> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct InitialValueTypeMismatch<Value> {
   var value: Value // expected-note{{'value' declared here}}
 
@@ -75,7 +75,7 @@ struct InitialValueTypeMismatch<Value> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct MultipleInitialValues<Value> { // expected-error{{property wrapper type 'MultipleInitialValues' has multiple initial-value initializers}}
   var value: Value? = nil
 
@@ -86,7 +86,7 @@ struct MultipleInitialValues<Value> { // expected-error{{property wrapper type '
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct InitialValueFailable<Value> {
   var value: Value
 
@@ -95,7 +95,7 @@ struct InitialValueFailable<Value> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct InitialValueFailableIUO<Value> {
   var value: Value
 
@@ -107,12 +107,12 @@ struct InitialValueFailableIUO<Value> {
 // ---------------------------------------------------------------------------
 // Property wrapper type definitions
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct _lowercaseWrapper<T> {
   var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct _UppercaseWrapper<T> {
   var value: T
 }
@@ -235,17 +235,17 @@ struct Initialization {
 // ---------------------------------------------------------------------------
 // Wrapper type formation
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct IntWrapper {
   var value: Int
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperForHashable<T: Hashable> { // expected-note{{property wrapper type 'WrapperForHashable' declared here}}
   var value: T
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithTwoParams<T, U> {
   var value: (T, U)
 }
@@ -277,7 +277,7 @@ struct UseWrappersWithDifferentForm {
   var wOkay2: Int
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct Function<T, U> { // expected-note{{property wrapper type 'Function' declared here}}
   var value: (T) -> U?
 }
@@ -296,7 +296,7 @@ struct TestFunction {
 // Nested wrappers
 // ---------------------------------------------------------------------------
 struct HasNestedWrapper<T> {
-  @_propertyWrapper
+  @propertyWrapper
   struct NestedWrapper<U> { // expected-note{{property wrapper type 'NestedWrapper' declared here}}
     var value: U
     init(initialValue: U) {
@@ -304,7 +304,7 @@ struct HasNestedWrapper<T> {
     }
   }
 
-  @_propertyWrapper
+  @propertyWrapper
   struct ConcreteNestedWrapper {
     var value: T
     init(initialValue: T) {
@@ -385,7 +385,7 @@ struct UseWillSetDidSet {
 // ---------------------------------------------------------------------------
 // Mutating/nonmutating
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithNonMutatingSetter<Value> {
   class Box {
     var value: Value
@@ -406,7 +406,7 @@ struct WrapperWithNonMutatingSetter<Value> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithMutatingGetter<Value> {
   var readCount = 0
   var writeCount = 0
@@ -428,7 +428,7 @@ struct WrapperWithMutatingGetter<Value> {
   }
 }
 
-@_propertyWrapper
+@propertyWrapper
 class ClassWrapper<Value> {
   var value: Value
 
@@ -487,7 +487,7 @@ func testMutatingness() {
 // Access control
 // ---------------------------------------------------------------------------
 struct HasPrivateWrapper<T> {
-  @_propertyWrapper
+  @propertyWrapper
   private struct PrivateWrapper<U> { // expected-note{{type declared here}}
     var value: U
     init(initialValue: U) {
@@ -505,7 +505,7 @@ struct HasPrivateWrapper<T> {
 }
 
 public struct HasUsableFromInlineWrapper<T> {
-  @_propertyWrapper
+  @propertyWrapper
   struct InternalWrapper<U> { // expected-note{{type declared here}}
     var value: U
     init(initialValue: U) {
@@ -519,7 +519,7 @@ public struct HasUsableFromInlineWrapper<T> {
   // expected-error@-1{{property wrapper type referenced from a '@usableFromInline' property must be '@usableFromInline' or public}}
 }
 
-@_propertyWrapper
+@propertyWrapper
 class Box<Value> {
   private(set) var value: Value
 
@@ -642,7 +642,7 @@ func testDefaultedPrivateMemberwiseLets() {
 // ---------------------------------------------------------------------------
 // Storage references
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct WrapperWithStorageRef<T> {
   var value: T
 
@@ -681,7 +681,7 @@ func testStorageRef(tsr: TestStorageRef) {
 
 // rdar://problem/50873275 - crash when using wrapper with wrapperValue in
 // generic type.
-@_propertyWrapper
+@propertyWrapper
 struct InitialValueWrapperWithStorageRef<T> {
   var value: T
 
@@ -702,7 +702,7 @@ struct TestGenericStorageRef<T> {
 // ---------------------------------------------------------------------------
 // Misc. semantic issues
 // ---------------------------------------------------------------------------
-@_propertyWrapper
+@propertyWrapper
 struct BrokenLazy { }
 // expected-error@-1{{property wrapper type 'BrokenLazy' does not contain a non-static property named 'value'}}
 // expected-note@-2{{'BrokenLazy' declared here}}
@@ -728,7 +728,7 @@ struct UsesExplicitClosures {
 // ---------------------------------------------------------------------------
 
 // rdar://problem/50822051 - compiler assertion / hang
-@_propertyWrapper
+@propertyWrapper
 struct PD<Value> {
   var value: Value
 
@@ -744,7 +744,7 @@ struct TestPD {
 
 protocol P { }
 
-@_propertyWrapper
+@propertyWrapper
 struct WrapperRequiresP<T: P> {
   var value: T
   var wrapperValue: T { return value }
@@ -760,7 +760,7 @@ struct UsesWrapperRequiringP {
 }
 
 // SR-10899 / rdar://problem/51588022
-@_propertyWrapper
+@propertyWrapper
 struct SR_10899_Wrapper { // expected-note{{property wrapper type 'SR_10899_Wrapper' declared here}}
   var value: String { "hi" }
 }

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -dump-ast %s | %FileCheck %s
 
-@_propertyWrapper
+@propertyWrapper
 struct Wrapper<T> {
   var value: T
 


### PR DESCRIPTION
Improve compatibility of the newer property wrappers implementation with the first property-delegate-based implementation. Specifically:

* Switch over to `@propertyWrapper` as the primary attribute name; add deprecated aliases for `@_propertyWrapper` and `@propertyDelegate`
* Add support for using `delegateValue` when `wrapperValue` is not present