### PR TITLE
[5.1] [Sema] Bail early in exportability checker if there's no extended type

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1873,7 +1873,12 @@ public:
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
-    if (shouldSkipChecking(ED->getExtendedNominal()))
+    auto extendedType = ED->getExtendedNominal();
+    // TODO: Sometimes we have an extension that is marked valid but has no
+    //       extended type. Assert, just in case we see it while testing, but
+    //       don't crash. rdar://50401284
+    assert(extendedType && "valid extension with no extended type?");
+    if (!extendedType || shouldSkipChecking(extendedType))
       return;
 
     // FIXME: We should allow conforming to implementation-only protocols,


### PR DESCRIPTION
I'm unable to reproduce this or figure out exactly when it happens, but in some
circumstances we might form an extension that is marked valid but that
doesn't have an extended nominal type. Add an assertion here, but don't
crash if we see one of these.

rdar://50401284

Reviewed by @jrose-apple