### PR TITLE
[Sema] Add memberwise initializers to nominal type declarations.

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmeticVectorProtocol.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmeticVectorProtocol.cpp
@@ -427,7 +427,7 @@ static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
   if (!nominal->getEffectiveMemberwiseInitializer()) {
     auto *initDecl = createImplicitConstructor(
         TC, nominal, ImplicitConstructorKind::Memberwise);
-    derived.addMembersToConformanceContext(initDecl);
+    nominal->addMember(initDecl);
     C.addSynthesizedDecl(initDecl);
   }
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -386,11 +386,7 @@ static ValueDecl *deriveDifferentiable_method(
     // constructor is synthesized during SILGen, which is too late.
     auto *initDecl = createImplicitConstructor(
         TC, returnNominal, ImplicitConstructorKind::Memberwise);
-    initDecl->setDeclContext(parentDC);
-    if (nominal == returnNominal)
-      derived.addMembersToConformanceContext(initDecl);
-    else
-      returnNominal->addMember(initDecl);
+    returnNominal->addMember(initDecl);
     C.addSynthesizedDecl(initDecl);
   }
 

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -86,11 +86,19 @@ struct GenericExtended<T> {
 }
 extension GenericExtended : Equatable, AdditiveArithmetic where T : AdditiveArithmetic {}
 
-// Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
-struct HasCustomNonMemberwiseInitializer<T : AdditiveArithmetic>: AdditiveArithmetic {
+// Test memberwise initializer synthesis.
+struct NoMemberwiseInitializer<T : AdditiveArithmetic> : AdditiveArithmetic {
   var value: T
   init(randomLabel value: T) { self.value = value }
 }
+struct NoMemberwiseInitializerExtended<T> {
+  var value: T
+  init(_ value: T) {
+    self.value = value
+  }
+}
+extension NoMemberwiseInitializerExtended: Equatable, AdditiveArithmetic
+  where T : AdditiveArithmetic {}
 
 // Test derived conformances in disallowed contexts.
 

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -331,6 +331,18 @@ struct InvalidInitializer : Differentiable {
   init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}
 }
 
+// Test memberwise initializer synthesis.
+struct NoMemberwiseInitializerExtended<T> {
+  var value: T
+  init(_ value: T) {
+    self.value = value
+  }
+}
+extension NoMemberwiseInitializerExtended: Equatable, AdditiveArithmetic
+  where T : AdditiveArithmetic {}
+extension NoMemberwiseInitializerExtended: Differentiable
+  where T : Differentiable & AdditiveArithmetic {}
+
 // Test derived conformances in disallowed contexts.
 
 // expected-error @+2 {{type 'OtherFileNonconforming' does not conform to protocol 'Differentiable'}}

--- a/test/Sema/struct_vector_protocol.swift
+++ b/test/Sema/struct_vector_protocol.swift
@@ -96,11 +96,21 @@ struct InvalidMixedScalar: VectorProtocol { // expected-error {{type 'InvalidMix
   var double: Double
 }
 
-// Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
-struct HasCustomNonMemberwiseInitializer<T : VectorProtocol>: VectorProtocol {
+// Test memberwise initializer synthesis.
+struct NoMemberwiseInitializer<T : VectorProtocol> : VectorProtocol {
   var value: T
   init(randomLabel value: T) { self.value = value }
 }
+struct NoMemberwiseInitializerExtended<T> {
+  var value: T
+  init(_ value: T) {
+    self.value = value
+  }
+}
+extension NoMemberwiseInitializerExtended : Equatable, AdditiveArithmetic
+  where T : AdditiveArithmetic {}
+extension NoMemberwiseInitializerExtended : VectorProtocol
+  where T : VectorProtocol {}
 
 // Test derived conformances in disallowed contexts.
 


### PR DESCRIPTION
Always add synthesized memberwise initializers to nominal type declarations
instead of conformance contexts, which may be extensions. This is safe
because derived conformances cannot be requested from cross-file extensions
(see https://github.com/apple/swift/pull/24538).

Resolves [TF-574](https://bugs.swift.org/browse/TF-574).