### PR TITLE
Remove the remaining swift_test_mode_optimize_none_with_implicit_dynamic

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1394,7 +1394,7 @@ config.target_resilience_test = (
 
 # FIXME: Get symbol diffing working with binutils nm as well. The flags are slightly
 # different.
-if platform.system() != 'Darwin':
+if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_implicit_dynamic':
     config.target_resilience_test = ('%s --no-symbol-diff' %
                                      config.target_resilience_test)
 

--- a/validation-test/Evolution/test_bitwise_takable.swift
+++ b/validation-test/Evolution/test_bitwise_takable.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import bitwise_takable
 

--- a/validation-test/Evolution/test_class_change_size.swift
+++ b/validation-test/Evolution/test_class_change_size.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import class_change_size
 

--- a/validation-test/Evolution/test_class_insert_superclass.swift
+++ b/validation-test/Evolution/test_class_insert_superclass.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import class_insert_superclass
 

--- a/validation-test/Evolution/test_class_remove_property.swift
+++ b/validation-test/Evolution/test_class_remove_property.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import class_remove_property
 

--- a/validation-test/Evolution/test_enum_change_size.swift
+++ b/validation-test/Evolution/test_enum_change_size.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import enum_change_size
 

--- a/validation-test/Evolution/test_global_change_size.swift
+++ b/validation-test/Evolution/test_global_change_size.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import global_change_size
 

--- a/validation-test/Evolution/test_struct_add_property.swift
+++ b/validation-test/Evolution/test_struct_add_property.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_add_property
 

--- a/validation-test/Evolution/test_struct_change_size.swift
+++ b/validation-test/Evolution/test_struct_change_size.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_change_size
 

--- a/validation-test/Evolution/test_struct_change_stored_to_computed.swift
+++ b/validation-test/Evolution/test_struct_change_stored_to_computed.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_change_stored_to_computed
 

--- a/validation-test/Evolution/test_struct_change_stored_to_computed_static.swift
+++ b/validation-test/Evolution/test_struct_change_stored_to_computed_static.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_change_stored_to_computed_static
 

--- a/validation-test/Evolution/test_struct_fixed_layout_remove_conformance.swift
+++ b/validation-test/Evolution/test_struct_fixed_layout_remove_conformance.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_fixed_layout_remove_conformance
 

--- a/validation-test/Evolution/test_struct_remove_property.swift
+++ b/validation-test/Evolution/test_struct_remove_property.swift
@@ -1,7 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
 import StdlibUnittest
 import struct_remove_property

--- a/validation-test/Evolution/test_struct_resilient_remove_conformance.swift
+++ b/validation-test/Evolution/test_struct_resilient_remove_conformance.swift
@@ -1,8 +1,6 @@
 // RUN: %target-resilience-test
 // REQUIRES: executable_test
 
-// UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
-
 import StdlibUnittest
 import struct_resilient_remove_conformance
 


### PR DESCRIPTION
It is expected that under enable-private-import internal/private symbols
become public. So that symbol-diffing would fail. Disable symbol diffing
under that test mode.

rdar://51304243