### PR TITLE
Convert DictionaryExpr to not use tc.callWitness() or generate a SemanticExpr.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -2128,8 +2128,6 @@ class CollectionExpr : public Expr {
   SourceLoc RBracketLoc;
   ConcreteDeclRef Initializer;
 
-  Expr *SemanticExpr = nullptr;
-
   /// Retrieve the intrusive pointer storage from the subtype
   Expr *const *getTrailingObjectsPointer() const;
   Expr **getTrailingObjectsPointer() {
@@ -2194,9 +2192,6 @@ public:
   SourceRange getSourceRange() const {
     return SourceRange(LBracketLoc, RBracketLoc);
   }
-  
-  Expr *getSemanticExpr() const { return SemanticExpr; }
-  void setSemanticExpr(Expr *e) { SemanticExpr = e; }
 
   static bool classof(const Expr *e) {
     return e->getKind() >= ExprKind::First_CollectionExpr &&
@@ -2274,6 +2269,8 @@ public:
   static bool classof(const Expr *e) {
     return e->getKind() == ExprKind::Dictionary;
   }
+
+  Type getElementType();
 };
 
 /// Subscripting expressions like a[i] that refer to an element within a

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2127,16 +2127,16 @@ public:
       OS << '\n';
       printRec(elt);
     }
-    printSemanticExpr(E->getSemanticExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitDictionaryExpr(DictionaryExpr *E) {
     printCommon(E, "dictionary_expr");
+    PrintWithColorRAII(OS, LiteralValueColor) << " initializer=";
+    E->getInitializer().dump(PrintWithColorRAII(OS, LiteralValueColor).getOS());
     for (auto elt : E->getElements()) {
       OS << '\n';
       printRec(elt);
     }
-    printSemanticExpr(E->getSemanticExpr());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitSubscriptExpr(SubscriptExpr *E) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -525,8 +525,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitCollectionExpr(CollectionExpr *E) {
-    HANDLE_SEMANTIC_EXPR(E);
-
     for (auto &elt : E->getElements())
       if (Expr *Sub = doIt(elt))
         elt = Sub;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1485,6 +1485,19 @@ Type ArrayExpr::getElementType() {
       .subst(init.getSubstitutions());
 }
 
+Type DictionaryExpr::getElementType() {
+  auto init = getInitializer();
+  if (!init)
+    return Type();
+
+  auto *decl = cast<ConstructorDecl>(init.getDecl());
+  return decl->getMethodInterfaceType()
+      ->getAs<AnyFunctionType>()
+      ->getParams()[0]
+      .getPlainType()
+      .subst(init.getSubstitutions());
+}
+
 DictionaryExpr *DictionaryExpr::create(ASTContext &C, SourceLoc LBracketLoc,
                              ArrayRef<Expr*> Elements,
                              ArrayRef<SourceLoc> CommaLocs,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3317,9 +3317,7 @@ namespace {
         }
 
         // Remove any semantic expression injected by typechecking.
-        if (auto CE = dyn_cast<CollectionExpr>(expr)) {
-          CE->setSemanticExpr(nullptr);
-        } else if (auto ISLE = dyn_cast<InterpolatedStringLiteralExpr>(expr)) {
+        if (auto ISLE = dyn_cast<InterpolatedStringLiteralExpr>(expr)) {
           ISLE->setSemanticExpr(nullptr);
         } else if (auto OLE = dyn_cast<ObjectLiteralExpr>(expr)) {
           OLE->setSemanticExpr(nullptr);

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -256,6 +256,39 @@ func throwingElement<T : FooProtocol>() throws -> [T] {
   return try [makeBasic(), makeThrowing()]
 }
 
+class TakesDictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
+  required init(dictionaryLiteral elements: (Key, Value)...) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8literals23returnsCustomDictionaryAA05TakesD7LiteralCyS2iGyF : $@convention(thin) () -> @owned TakesDictionaryLiteral<Int, Int> {
+// CHECK: [[TMP:%.*]] = apply %2(%0, %1) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+// CHECK: [[ARRAY_LENGTH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK: // function_ref _allocateUninitializedArray<A>(_:)
+// CHECK: [[ALLOCATE_VARARGS:%.*]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+// CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<(Int, Int)>([[ARRAY_LENGTH]])
+// CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
+// CHECK: [[TUPLE_ADDR:%.*]] = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*(Int, Int)
+// CHECK: [[KEY_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR]] : $*(Int, Int), 0
+// CHECK: [[VALUE_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR]] : $*(Int, Int), 1
+// CHECK: store [[TMP]] to [trivial] [[KEY_ADDR]] : $*Int
+// CHECK: store [[TMP]] to [trivial] [[VALUE_ADDR]] : $*Int
+// CHECK: [[IDX1:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[TUPLE_ADDR1:%.*]] = index_addr [[TUPLE_ADDR]] : $*(Int, Int), [[IDX1]] : $Builtin.Word
+// CHECK: [[KEY_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR1]] : $*(Int, Int), 0
+// CHECK: [[VALUE_ADDR:%.*]] = tuple_element_addr [[TUPLE_ADDR1]] : $*(Int, Int), 1
+// CHECK: store [[TMP]] to [trivial] [[KEY_ADDR]] : $*Int
+// CHECK: store [[TMP]] to [trivial] [[VALUE_ADDR]] : $*Int
+// CHECK: [[METATYPE:%.*]] = metatype $@thick TakesDictionaryLiteral<Int, Int>.Type
+// CHECK: [[CTOR:%.*]] = class_method [[METATYPE]] : $@thick TakesDictionaryLiteral<Int, Int>.Type, #TakesDictionaryLiteral.init!allocator.1 : <Key, Value> (TakesDictionaryLiteral<Key, Value>.Type) -> ((Key, Value)...) -> TakesDictionaryLiteral<Key, Value>, $@convention(method) <τ_0_0, τ_0_1> (@owned Array<(τ_0_0, τ_0_1)>, @thick TakesDictionaryLiteral<τ_0_0, τ_0_1>.Type) -> @owned TakesDictionaryLiteral<τ_0_0, τ_0_1>
+// CHECK: [[RESULT:%.*]] = apply [[CTOR]]<Int, Int>(%8, %21)
+// CHECK: return [[RESULT]]
+
+func returnsCustomDictionary() -> TakesDictionaryLiteral<Int, Int> {
+  // Use temporary to simplify generated_sil
+  let tmp = 77
+  return [tmp: tmp, tmp : tmp]
+}
+
 struct Color: _ExpressibleByColorLiteral {
   init(_colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float) {}
 }

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -259,17 +259,15 @@ func tuple_element(_ x: (Int, Float)) {
 }
 
 func containers() -> ([Int], Dictionary<String, Int>) {
-  return ([1, 2, 3], ["Ankeny": 1, "Burnside": 2, "Couch": 3])
+  return ([1, 2, 3], ["Ankeny": 101, "Burnside": 102, "Couch": 103])
   // CHECK-LABEL: sil hidden [ossa] @$s13sil_locations10containers{{[_0-9a-zA-Z]*}}F
-  // CHECK: apply {{%.*}}<(String, Int)>({{%.*}}), loc "{{.*}}":[[@LINE-2]]:23
   
-  // CHECK: string_literal utf8 "Ankeny", loc "{{.*}}":[[@LINE-4]]:23
+  // CHECK: string_literal utf8 "Ankeny", loc "{{.*}}":[[@LINE-3]]:23
 
-  // CHECK: integer_literal $Builtin.IntLiteral, 1, loc "{{.*}}":[[@LINE-6]]:33
-  // CHECK: integer_literal $Builtin.IntLiteral, 2, loc "{{.*}}":[[@LINE-7]]:48
+  // CHECK: integer_literal $Builtin.IntLiteral, 101, loc "{{.*}}":[[@LINE-5]]:33
+  // CHECK: integer_literal $Builtin.IntLiteral, 102, loc "{{.*}}":[[@LINE-6]]:50
 
-  
-  
+  // CHECK: apply {{%.*}}<String, Int>({{%.*}}, {{%.*}}) : {{.*}}, loc "{{.*}}":[[@LINE-8]]:22
 }
 
 


### PR DESCRIPTION
For reference, everything else except string interpolation has been
migrated to this new form.