### PR TITLE
[5.1][ConstraintSystem] Replace special locator for return of single expr …

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2300,7 +2300,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
         CS.TC.isConvertibleTo(srcFT->getResult(), contextualType, CS.DC)) {
 
       auto locator =
-          CS.getConstraintLocator(expr, ConstraintLocator::ContextualType);
+          CS.getConstraintLocator(expr, LocatorPathElt::getContextualType());
       ContextualFailure failure =
           ContextualFailure(nullptr, CS, srcFT, contextualType, locator);
       auto diagnosed = failure.diagnoseAsError();
@@ -2381,7 +2381,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   if (contextualType->isExistentialType()) {
     MissingContextualConformanceFailure failure(
         expr, CS, CTP, exprType, contextualType,
-        CS.getConstraintLocator(expr, ConstraintLocator::ContextualType));
+        CS.getConstraintLocator(expr, LocatorPathElt::getContextualType()));
     return failure.diagnoseAsError();
   }
 
@@ -5723,7 +5723,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
 
       MissingArgumentsFailure failure(
           expr, CS, fnType, inferredArgCount - actualArgCount,
-          CS.getConstraintLocator(CE, ConstraintLocator::ContextualType));
+          CS.getConstraintLocator(CE, LocatorPathElt::getContextualType()));
       return failure.diagnoseAsError();
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2919,8 +2919,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // literals and expressions representing an implicit return type of the single
   // expression functions.
   if (auto elt = locator.last()) {
-    if (elt->getKind() == ConstraintLocator::ClosureResult ||
-        elt->getKind() == ConstraintLocator::SingleExprFuncResultType) {
+    if (elt->isClosureResult() || elt->isResultOfSingleExprFunction()) {
       if (kind >= ConstraintKind::Subtype &&
           (type1->isUninhabited() || type2->isVoid())) {
         increaseScore(SK_FunctionConversion);
@@ -5382,8 +5381,9 @@ done:
                                             {rootTy, valueTy});
   // Let's check whether deduced key path type would match
   // expected contextual one.
-  return matchTypes(resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
-                    locator.withPathElement(ConstraintLocator::ContextualType));
+  return matchTypes(
+      resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
+      locator.withPathElement(LocatorPathElt::getContextualType()));
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1132,10 +1132,10 @@ ConstraintSystem::solveImpl(Expr *&expr,
     if (getContextualTypePurpose() == CTP_YieldByReference)
       constraintKind = ConstraintKind::Bind;
 
+    bool isForSingleExprFunction =
+        getContextualTypePurpose() == CTP_ReturnSingleExpr;
     auto *convertTypeLocator = getConstraintLocator(
-        expr, getContextualTypePurpose() == CTP_ReturnSingleExpr
-                  ? ConstraintLocator::SingleExprFuncResultType
-                  : ConstraintLocator::ContextualType);
+        expr, LocatorPathElt::getContextualType(isForSingleExprFunction));
 
     if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
       convertType = convertType.transform([&](Type type) -> Type {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -81,7 +81,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case KeyPathType:
     case KeyPathRoot:
     case KeyPathValue:
-    case SingleExprFuncResultType:
       if (unsigned numValues = numNumericValuesInPathElement(elt.getKind())) {
         id.AddInteger(elt.getValue());
         if (numValues > 1)
@@ -351,7 +350,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       break;
 
     case ContextualType:
-      out << "contextual type";
+      if (elt.isResultOfSingleExprFunction())
+        out << "expected result type of the function with a single expression";
+      else
+        out << "contextual type";
       break;
 
     case SynthesizedArgument:
@@ -372,10 +374,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case KeyPathValue:
       out << " keypath value";
-      break;
-
-    case SingleExprFuncResultType:
-      out << " expected result type of the function with a single expression";
       break;
     }
   }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -133,8 +133,6 @@ public:
     KeyPathRoot,
     /// The value of a key path
     KeyPathValue,
-    /// The expected type of the function with a single expression body.
-    SingleExprFuncResultType,
   };
 
   /// Determine the number of numeric values used for the given path
@@ -163,13 +161,12 @@ public:
     case Witness:
     case ImplicitlyUnwrappedDisjunctionChoice:
     case DynamicLookupResult:
-    case ContextualType:
     case KeyPathType:
     case KeyPathRoot:
     case KeyPathValue:
-    case SingleExprFuncResultType:
       return 0;
 
+    case ContextualType:
     case OpenedGeneric:
     case GenericArgument:
     case NamedTupleElement:
@@ -236,7 +233,6 @@ public:
     case KeyPathType:
     case KeyPathRoot:
     case KeyPathValue:
-    case SingleExprFuncResultType:
       return 0;
 
     case FunctionArgument:
@@ -394,6 +390,10 @@ public:
       return PathElement(base);
     }
 
+    static PathElement getContextualType(bool isForSingleExprFunction = false) {
+      return PathElement(ContextualType, isForSingleExprFunction);
+    }
+
     /// Retrieve the kind of path element.
     PathElementKind getKind() const {
       switch (static_cast<StoredKind>(storedKind)) {
@@ -501,6 +501,17 @@ public:
 
     bool isKeyPathComponent() const {
       return getKind() == PathElementKind::KeyPathComponent;
+    }
+
+    bool isClosureResult() const {
+      return getKind() == PathElementKind::ClosureResult;
+    }
+
+    /// Determine whether this element points to the contextual type
+    /// associated with result of a single expression function.
+    bool isResultOfSingleExprFunction() const {
+      return getKind() == PathElementKind::ContextualType ? bool(getValue())
+                                                          : false;
     }
   };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2225,8 +2225,8 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   Type convertTo = convertType.getType();
   if (options.contains(TypeCheckExprFlags::ExpressionTypeMustBeOptional)) {
     assert(!convertTo && "convertType and type check options conflict");
-    auto *convertTypeLocator = cs.getConstraintLocator(
-        cs.getConstraintLocator(expr), ConstraintLocator::ContextualType);
+    auto *convertTypeLocator =
+        cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
     Type var = cs.createTypeVariable(convertTypeLocator);
     convertTo = getOptionalType(expr->getLoc(), var);
   }
@@ -2610,7 +2610,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
       // Save the locator we're using for the expression.
       Locator =
-          cs.getConstraintLocator(expr, ConstraintLocator::ContextualType);
+          cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
 
       // Collect constraints from the pattern.
       Type patternType = cs.generateConstraints(pattern, Locator);

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -379,3 +379,18 @@ struct OtherGeneric<X, Y, Z> {
   var y: GenericWithOpaqueAssoc<Y>.Assoc
   var z: GenericWithOpaqueAssoc<Z>.Assoc
 }
+
+
+protocol P_51641323 {
+  associatedtype T
+
+  var foo: Self.T { get }
+}
+
+func rdar_51641323() {
+  struct Foo: P_51641323 {
+    var foo: some P_51641323 { {} }
+    // expected-error@-1 {{return type of property 'foo' requires that '() -> ()' conform to 'P_51641323'}}
+    // expected-note@-2 {{opaque return type declared here}}
+  }
+}


### PR DESCRIPTION
…function with a flag on contextual type locator

It's only needed in one place in the constraint solver to allow
`() -> T` to `() -> ()` and `() -> Never` to `() -> T` for expressions
representing return of a single expression functions, so to simplify
contextual type handling in diagnostic and other places it would be
better to replace dedicated locator kind with a flag on existing `ContextualType`.

Resolves: rdar://problem/51641323
(cherry picked from commit ba6a5e10f840f2afbda53bafb589c54c96cca836)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
