### PR TITLE
[Type checker] Compute correct contextual substitutions for local generics

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -826,6 +826,13 @@ Type TypeChecker::applyUnboundGenericArguments(
 
     subs = parentType->getContextSubstitutions(decl->getDeclContext());
     skipRequirementsCheck |= parentType->hasTypeVariable();
+  } else if (auto genericEnv =
+                 decl->getDeclContext()->getGenericEnvironmentOfContext()) {
+    auto subMap = genericEnv->getForwardingSubstitutionMap();
+    for (auto gp : subMap.getGenericSignature()->getGenericParams()) {
+      subs[gp->getCanonicalType()->castTo<GenericTypeParamType>()] =
+        Type(gp).subst(subMap);
+    }
   }
 
   SourceLoc noteLoc = decl->getLoc();

--- a/validation-test/compiler_crashers_2_fixed/0196-sr9954.swift
+++ b/validation-test/compiler_crashers_2_fixed/0196-sr9954.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+// SR-9954 / rdar://problem/48223824
+// Rejects well-formed that triggered a fallback diagnostic due to a bad
+// substitution.
+struct GenericThing <Param1, Param2> {
+    init (closure: (String)->()) {
+        
+    }
+}
+
+struct ThingHolder <Param1> {
+    func acceptThing <Param2> (thingGenerator: ()->GenericThing<Param1, Param2>) {
+
+    }
+}
+
+struct A { }
+
+func demo <Param1> (thingHolder: ThingHolder<Param1>) {
+    typealias Thing <Param2> = GenericThing<Param1, Param2>
+    thingHolder.acceptThing {
+        Thing<A> { string in
+
+        }
+    }
+}
+


### PR DESCRIPTION
When applying generic arguments to a local generic type within a generic
function, ensure that we correctly produce the contextual substitutions from
the generic function. Fixed with Pavel, who painstakingly tracked down
the bogus substitution.

Fixes SR-9954 / rdar://problem/48223824.
