### PR TITLE
[sil] Add an overload to SILDebugScope::dump that just takes a SILMod…

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -65,8 +65,10 @@ public:
   SILFunction *getParentFunction() const;
 
 #ifndef NDEBUG
-  void dump(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
-            unsigned Indent = 0) const;
+  LLVM_ATTRIBUTE_DEPRECATED(void dump(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
+                            unsigned Indent = 0) const,
+                  "only for use in the debugger");
+  LLVM_ATTRIBUTE_DEPRECATED(void dump(SILModule &Mod) const, "only for use in the debugger");
 #endif
 };
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3005,6 +3005,12 @@ void SILDebugScope::dump(SourceManager &SM, llvm::raw_ostream &OS,
   }
   OS << "}\n";
 }
+
+void SILDebugScope::dump(SILModule &Mod) const {
+  // We just use the default indent and llvm::errs().
+  dump(Mod.getASTContext().SourceMgr);
+}
+
 #endif
 
 void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {


### PR DESCRIPTION
…ule as an argument.

We do not in general want SIL code to root around in the ASTContext. Better to
just have a helper that knows how to fish it out.
