### PR TITLE
[mandatory-inlining] When running with sil-verify-all, verify at the …

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -945,6 +945,7 @@ class MandatoryInlining : public SILModuleTransform {
     ClassHierarchyAnalysis *CHA = getAnalysis<ClassHierarchyAnalysis>();
     SILModule *M = getModule();
     bool ShouldCleanup = !getOptions().DebugSerialization;
+    bool SILVerifyAll = getOptions().VerifyAll;
     DenseFunctionSet FullyInlinedSet;
     ImmutableFunctionSet::Factory SetFactory;
 
@@ -965,6 +966,13 @@ class MandatoryInlining : public SILModuleTransform {
       // The inliner splits blocks at call sites. Re-merge trivial branches
       // to reestablish a canonical CFG.
       mergeBasicBlocks(&F);
+
+      // If we are asked to perform SIL verify all, perform that now so that we
+      // can discover the immediate inlining trigger of the problematic
+      // function.
+      if (SILVerifyAll) {
+        F.verify();
+      }
     }
 
     if (!ShouldCleanup)


### PR DESCRIPTION
…root of each function we visit.

This at least ensures that we error immediately after processing the bad
root function. NOTE: we will inline recursively into it still, but at least we
stop before processing the entire module.
