### PR TITLE
Syntax: introduce a token kind for single quote to preserve round-trip printing of syntax tree

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1963,8 +1963,9 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
   unsigned QuoteLength;
   tok QuoteKind;
   std::tie(QuoteLength, QuoteKind) =
-      Tok.isMultilineString() ? std::make_tuple(3, tok::multiline_string_quote)
-                              : std::make_tuple(1, tok::string_quote);
+    Tok.isMultilineString() ? std::make_tuple(3, tok::multiline_string_quote)
+                            : std::make_tuple(1, Tok.getText().startswith("\'") ?
+                                          tok::single_quote: tok::string_quote);
   unsigned CloseQuoteBegin = Tok.getLength() - DelimiterLength - QuoteLength;
 
   OpenDelimiterStr = Tok.getRawText().take_front(DelimiterLength);

--- a/test/Syntax/round_trip_fix_quote.swift
+++ b/test/Syntax/round_trip_fix_quote.swift
@@ -1,0 +1,7 @@
+// RUN: rm -rf %t
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
+// RUN: diff -u %s %t
+
+"abc"
+
+RoundedRectangle(cornerRadius: 6.0)lengthlength'Integer' field' [binding value: \(int.value)]int'Double' field [binding value: \(double.value)]double

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -249,6 +249,8 @@ SYNTAX_TOKENS = [
 
     Punctuator('StringQuote', 'string_quote', text='\\\"',
                classification='StringLiteral', serialization_code=102),
+    Punctuator('SingleQuote', 'single_quote', text='\\\'',
+               classification='StringLiteral', serialization_code=120),
     Punctuator('MultilineStringQuote', 'multiline_string_quote',
                text='\\\"\\\"\\\"', classification='StringLiteral',
                serialization_code=103),


### PR DESCRIPTION
For invalid code, lexer is forgiving enough to allow single quote ''' as the starting point of string literals. Later, parser assumes the string literals are always using double quote "\"", and passes such knowledge to SwiftSyntax side, leading to the round-trip failure we observed in the radar. This commit fixes the issue by introducing another token kind for single quote.

rdar://51071021