### PR TITLE
[5.1]  [ClangImporter] Fix macOS app extension deprecated-as-unavailable check

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1747,7 +1747,7 @@ PlatformAvailability::PlatformAvailability(LangOptions &langOpts)
         "APIs deprecated as of macOS 10.9 and earlier are unavailable in Swift";
     break;
 
-  default:
+  case PlatformKind::none:
     break;
   }
 }
@@ -1788,7 +1788,11 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   Optional<unsigned> minor = version.getMinor();
 
   switch (platformKind) {
+  case PlatformKind::none:
+    llvm_unreachable("version but no platform?");
+
   case PlatformKind::OSX:
+  case PlatformKind::OSXApplicationExtension:
     // Anything deprecated in OSX 10.9.x and earlier is unavailable in Swift.
     return major < 10 ||
            (major == 10 && (!minor.hasValue() || minor.getValue() <= 9));
@@ -1804,10 +1808,9 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
   case PlatformKind::watchOSApplicationExtension:
     // No deprecation filter on watchOS
     return false;
-
-  default:
-    return false;
   }
+
+  llvm_unreachable("Unexpected platform");
 }
 
 ClangImporter::Implementation::Implementation(ASTContext &ctx,

--- a/test/ClangImporter/availability_ios.swift
+++ b/test/ClangImporter/availability_ios.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
 
 // REQUIRES: OS=ios
 

--- a/test/ClangImporter/availability_macosx.swift
+++ b/test/ClangImporter/availability_macosx.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules -application-extension %s
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
Cherry-pick of #25399. Reviewed by @devincoughlin.

rdar://51417764