### PR TITLE
Use the remaining half bit in the refcount to bypass ObjC deallocation overhead

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -238,13 +238,28 @@ struct RefCountBitOffsets;
 // 32-bit out of line
 template <>
 struct RefCountBitOffsets<8> {
-  static const size_t IsImmortalShift = 0;
-  static const size_t IsImmortalBitCount = 1;
-  static const uint64_t IsImmortalMask = maskForField(IsImmortal);
+  /*
+   The bottom 32 bits (on 64 bit architectures, fewer on 32 bit) of the refcount
+   field are effectively a union of two different configurations:
+   
+   ---Normal case---
+   Bit 0: Does this object need to call out to the ObjC runtime for deallocation
+   Bits 1-31: Unowned refcount
+   
+   ---Immortal case---
+   All bits set, the object does not deallocate or have a refcount
+   */
+  static const size_t PureSwiftDeallocShift = 0;
+  static const size_t PureSwiftDeallocBitCount = 1;
+  static const uint64_t PureSwiftDeallocMask = maskForField(PureSwiftDealloc);
 
-  static const size_t UnownedRefCountShift = shiftAfterField(IsImmortal);
+  static const size_t UnownedRefCountShift = shiftAfterField(PureSwiftDealloc);
   static const size_t UnownedRefCountBitCount = 31;
   static const uint64_t UnownedRefCountMask = maskForField(UnownedRefCount);
+
+  static const size_t IsImmortalShift = 0; // overlaps PureSwiftDealloc and UnownedRefCount
+  static const size_t IsImmortalBitCount = 32;
+  static const uint64_t IsImmortalMask = maskForField(IsImmortal);
 
   static const size_t IsDeinitingShift = shiftAfterField(UnownedRefCount);
   static const size_t IsDeinitingBitCount = 1;
@@ -271,13 +286,17 @@ struct RefCountBitOffsets<8> {
 // 32-bit inline
 template <>
 struct RefCountBitOffsets<4> {
-  static const size_t IsImmortalShift = 0;
-  static const size_t IsImmortalBitCount = 1;
-  static const uint64_t IsImmortalMask = maskForField(IsImmortal);
+  static const size_t PureSwiftDeallocShift = 0;
+  static const size_t PureSwiftDeallocBitCount = 1;
+  static const uint32_t PureSwiftDeallocMask = maskForField(PureSwiftDealloc);
   
-  static const size_t UnownedRefCountShift = shiftAfterField(IsImmortal);
+  static const size_t UnownedRefCountShift = shiftAfterField(PureSwiftDealloc);
   static const size_t UnownedRefCountBitCount = 7;
   static const uint32_t UnownedRefCountMask = maskForField(UnownedRefCount);
+
+  static const size_t IsImmortalShift = 0; // overlaps PureSwiftDealloc and UnownedRefCount
+  static const size_t IsImmortalBitCount = 8;
+  static const uint32_t IsImmortalMask = maskForField(IsImmortal);
 
   static const size_t IsDeinitingShift = shiftAfterField(UnownedRefCount);
   static const size_t IsDeinitingBitCount = 1;
@@ -369,14 +388,37 @@ class RefCountBitsT {
   enum Immortal_t { Immortal };
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
-  bool isImmortal() const {
-    return bool(getField(IsImmortal));
+  bool isImmortal(bool checkSlowRCBit) const {
+    if (checkSlowRCBit) {
+      return (getField(IsImmortal) == Offsets::IsImmortalMask) &&
+           bool(getField(UseSlowRC));
+    } else {
+      return (getField(IsImmortal) == Offsets::IsImmortalMask);
+    }
+  }
+  
+  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  bool isOverflowingUnownedRefCount(uint32_t oldValue, uint32_t inc) const {
+    auto newValue = getUnownedRefCount();
+    return newValue != oldValue + inc ||
+      newValue == Offsets::UnownedRefCountMask;
   }
   
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   void setIsImmortal(bool value) {
-    setField(IsImmortal, value);
+    assert(value);
+    setField(IsImmortal, Offsets::IsImmortalMask);
     setField(UseSlowRC, value);
+  }
+  
+  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  bool pureSwiftDeallocation() const {
+    return bool(getField(PureSwiftDealloc)) && !bool(getField(UseSlowRC));
+  }
+  
+  LLVM_ATTRIBUTE_ALWAYS_INLINE
+  void setPureSwiftDeallocation(bool value) {
+    setField(PureSwiftDealloc, value);
   }
   
   LLVM_ATTRIBUTE_ALWAYS_INLINE
@@ -386,16 +428,16 @@ class RefCountBitsT {
   constexpr
   RefCountBitsT(uint32_t strongExtraCount, uint32_t unownedCount)
     : bits((BitsType(strongExtraCount) << Offsets::StrongExtraRefCountShift) |
+           (BitsType(1)                << Offsets::PureSwiftDeallocShift) |
            (BitsType(unownedCount)     << Offsets::UnownedRefCountShift))
   { }
   
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   constexpr
   RefCountBitsT(Immortal_t immortal)
-    : bits((BitsType(2) << Offsets::StrongExtraRefCountShift) |
-           (BitsType(2) << Offsets::UnownedRefCountShift) |
-           (BitsType(1) << Offsets::IsImmortalShift) |
-           (BitsType(1) << Offsets::UseSlowRCShift))
+  : bits((BitsType(2) << Offsets::StrongExtraRefCountShift) |
+         (BitsType(Offsets::IsImmortalMask)) |
+         (BitsType(1) << Offsets::UseSlowRCShift))
   { }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
@@ -433,7 +475,7 @@ class RefCountBitsT {
   
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   bool hasSideTable() const {
-    bool hasSide = getUseSlowRC() && !isImmortal();
+    bool hasSide = getUseSlowRC() && !isImmortal(false);
 
     // Side table refcount must not point to another side table.
     assert((refcountIsInline || !hasSide)  &&
@@ -523,7 +565,7 @@ class RefCountBitsT {
   LLVM_NODISCARD LLVM_ATTRIBUTE_ALWAYS_INLINE
   bool decrementStrongExtraRefCount(uint32_t dec) {
 #ifndef NDEBUG
-    if (!hasSideTable() && !isImmortal()) {
+    if (!hasSideTable() && !isImmortal(false)) {
       // Can't check these assertions with side table present.
 
       if (getIsDeiniting())
@@ -558,7 +600,7 @@ class RefCountBitsT {
     static_assert(Offsets::UnownedRefCountBitCount +
                   Offsets::IsDeinitingBitCount +
                   Offsets::StrongExtraRefCountBitCount +
-                  Offsets::IsImmortalBitCount +
+                  Offsets::PureSwiftDeallocBitCount +
                   Offsets::UseSlowRCBitCount == sizeof(bits)*8,
                   "inspect isUniquelyReferenced after adding fields");
 
@@ -715,7 +757,7 @@ class RefCounts {
   
   void setIsImmortal(bool immortal) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (oldbits.isImmortal()) {
+    if (oldbits.isImmortal(true)) {
       return;
     }
     RefCountBits newbits;
@@ -725,7 +767,28 @@ class RefCounts {
     } while (!refCounts.compare_exchange_weak(oldbits, newbits,
                                               std::memory_order_relaxed));
   }
-
+  
+  void setPureSwiftDeallocation(bool nonobjc) {
+    auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
+    //Immortal and no objc complications share a bit, so don't let setting
+    //the complications one clear the immmortal one
+    if (oldbits.isImmortal(true) || oldbits.pureSwiftDeallocation() == nonobjc){
+      assert(!oldbits.hasSideTable());
+      return;
+    }
+    RefCountBits newbits;
+    do {
+      newbits = oldbits;
+      newbits.setPureSwiftDeallocation(nonobjc);
+    } while (!refCounts.compare_exchange_weak(oldbits, newbits,
+                                              std::memory_order_relaxed));
+  }
+  
+  bool getPureSwiftDeallocation() {
+    auto bits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
+    return bits.pureSwiftDeallocation();
+  }
+  
   // Initialize from another refcount bits.
   // Only inline -> out-of-line is allowed (used for new side table entries).
   void init(InlineRefCountBits newBits) {
@@ -740,7 +803,7 @@ class RefCounts {
       newbits = oldbits;
       bool fast = newbits.incrementStrongExtraRefCount(inc);
       if (SWIFT_UNLIKELY(!fast)) {
-        if (oldbits.isImmortal())
+        if (oldbits.isImmortal(false))
           return;
         return incrementSlow(oldbits, inc);
       }
@@ -753,7 +816,7 @@ class RefCounts {
     auto newbits = oldbits;
     bool fast = newbits.incrementStrongExtraRefCount(inc);
     if (SWIFT_UNLIKELY(!fast)) {
-      if (oldbits.isImmortal())
+      if (oldbits.isImmortal(false))
         return;
       return incrementNonAtomicSlow(oldbits, inc);
     }
@@ -771,7 +834,7 @@ class RefCounts {
       newbits = oldbits;
       bool fast = newbits.incrementStrongExtraRefCount(1);
       if (SWIFT_UNLIKELY(!fast)) {
-        if (oldbits.isImmortal())
+        if (oldbits.isImmortal(false))
           return true;
         return tryIncrementSlow(oldbits);
       }
@@ -788,7 +851,7 @@ class RefCounts {
     auto newbits = oldbits;
     bool fast = newbits.incrementStrongExtraRefCount(1);
     if (SWIFT_UNLIKELY(!fast)) {
-      if (oldbits.isImmortal())
+      if (oldbits.isImmortal(false))
         return true;
       return tryIncrementNonAtomicSlow(oldbits);
     }
@@ -824,7 +887,7 @@ class RefCounts {
   // Precondition: the reference count must be 1
   void decrementFromOneNonAtomic() {
     auto bits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (bits.isImmortal()) {
+    if (bits.isImmortal(true)) {
       return;
     }
     if (bits.hasSideTable())
@@ -922,7 +985,7 @@ class RefCounts {
         // Decrement completed normally. New refcount is not zero.
         deinitNow = false;
       }
-      else if (oldbits.isImmortal()) {
+      else if (oldbits.isImmortal(false)) {
         return false;
       } else if (oldbits.hasSideTable()) {
         // Decrement failed because we're on some other slow path.
@@ -961,7 +1024,7 @@ class RefCounts {
       // Decrement completed normally. New refcount is not zero.
       deinitNow = false;
     }
-    else if (oldbits.isImmortal()) {
+    else if (oldbits.isImmortal(false)) {
       return false;
     }
     else if (oldbits.hasSideTable()) {
@@ -1001,7 +1064,7 @@ class RefCounts {
       bool fast =
         newbits.decrementStrongExtraRefCount(dec);
       if (SWIFT_UNLIKELY(!fast)) {
-        if (oldbits.isImmortal()) {
+        if (oldbits.isImmortal(false)) {
             return false;
         }
         // Slow paths include side table; deinit; underflow
@@ -1025,7 +1088,7 @@ class RefCounts {
   // Increment the unowned reference count.
   void incrementUnowned(uint32_t inc) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (oldbits.isImmortal())
+    if (oldbits.isImmortal(true))
       return;
     RefCountBits newbits;
     do {
@@ -1037,7 +1100,7 @@ class RefCounts {
       uint32_t oldValue = newbits.incrementUnownedRefCount(inc);
 
       // Check overflow and use the side table on overflow.
-      if (newbits.getUnownedRefCount() != oldValue + inc)
+      if (newbits.isOverflowingUnownedRefCount(oldValue, inc))
         return incrementUnownedSlow(inc);
 
     } while (!refCounts.compare_exchange_weak(oldbits, newbits,
@@ -1046,7 +1109,7 @@ class RefCounts {
 
   void incrementUnownedNonAtomic(uint32_t inc) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (oldbits.isImmortal())
+    if (oldbits.isImmortal(true))
       return;
     if (oldbits.hasSideTable())
       return oldbits.getSideTable()->incrementUnownedNonAtomic(inc);
@@ -1056,7 +1119,7 @@ class RefCounts {
     uint32_t oldValue = newbits.incrementUnownedRefCount(inc);
 
     // Check overflow and use the side table on overflow.
-    if (newbits.getUnownedRefCount() != oldValue + inc)
+    if (newbits.isOverflowingUnownedRefCount(oldValue, inc))
       return incrementUnownedSlow(inc);
 
     refCounts.store(newbits, std::memory_order_relaxed);
@@ -1066,7 +1129,7 @@ class RefCounts {
   // Return true if the caller should free the object.
   bool decrementUnownedShouldFree(uint32_t dec) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (oldbits.isImmortal())
+    if (oldbits.isImmortal(true))
       return false;
     RefCountBits newbits;
     
@@ -1094,7 +1157,7 @@ class RefCounts {
 
   bool decrementUnownedShouldFreeNonAtomic(uint32_t dec) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
-    if (oldbits.isImmortal())
+    if (oldbits.isImmortal(true))
       return false;
     if (oldbits.hasSideTable())
       return oldbits.getSideTable()->decrementUnownedShouldFreeNonAtomic(dec);
@@ -1383,7 +1446,7 @@ inline bool RefCounts<InlineRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
   auto newbits = oldbits;
   bool fast = newbits.decrementStrongExtraRefCount(dec);
   if (!fast) {
-    if (oldbits.isImmortal()) {
+    if (oldbits.isImmortal(false)) {
       return false;
     }
     return doDecrementNonAtomicSlow<performDeinit>(oldbits, dec);

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -17,7 +17,7 @@ namespace swift {
 template <typename RefCountBits>
 void RefCounts<RefCountBits>::incrementSlow(RefCountBits oldbits,
                                             uint32_t n) {
-  if (oldbits.isImmortal()) {
+  if (oldbits.isImmortal(false)) {
     return;
   }
   else if (oldbits.hasSideTable()) {
@@ -36,7 +36,7 @@ template void RefCounts<SideTableRefCountBits>::incrementSlow(SideTableRefCountB
 template <typename RefCountBits>
 void RefCounts<RefCountBits>::incrementNonAtomicSlow(RefCountBits oldbits,
                                                      uint32_t n) {
-  if (oldbits.isImmortal()) {
+  if (oldbits.isImmortal(false)) {
     return;
   }
   else if (oldbits.hasSideTable()) {
@@ -52,7 +52,7 @@ template void RefCounts<SideTableRefCountBits>::incrementNonAtomicSlow(SideTable
 
 template <typename RefCountBits>
 bool RefCounts<RefCountBits>::tryIncrementSlow(RefCountBits oldbits) {
-  if (oldbits.isImmortal()) {
+  if (oldbits.isImmortal(false)) {
     return true;
   }
   else if (oldbits.hasSideTable())
@@ -65,7 +65,7 @@ template bool RefCounts<SideTableRefCountBits>::tryIncrementSlow(SideTableRefCou
 
 template <typename RefCountBits>
 bool RefCounts<RefCountBits>::tryIncrementNonAtomicSlow(RefCountBits oldbits) {
-  if (oldbits.isImmortal()) {
+  if (oldbits.isImmortal(false)) {
     return true;
   }
   else if (oldbits.hasSideTable())

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -239,8 +239,8 @@ static void unownedReleaseALot(TestObject *object, uint64_t count) {
   }
 }
 
-// Maximum legal unowned retain count. 31 bits with no implicit +1.
-const uint64_t maxURC = (1ULL << (32 - 1)) - 1;
+// Maximum legal unowned retain count. 31 bits minus one with no implicit +1.
+const uint64_t maxURC = (1ULL << (32 - 1)) - 2;
 
 TEST(LongRefcountingTest, unowned_retain_max) {
   // Don't generate millions of failures if something goes wrong.
@@ -282,7 +282,7 @@ TEST(LongRefcountingTest, unowned_retain_overflow_DeathTest) {
   auto object = allocTestObject(&deinited, 1);
 
   // URC is 1. Retain to maxURC, then retain again and verify overflow error.
-  unownedRetainALot<true>(object, maxURC - 1);
+  unownedRetainALot<true>(object, maxURC);
   EXPECT_EQ(0u, deinited);
   EXPECT_ALLOCATED(object);
   ASSERT_DEATH(swift_unownedRetain(object),
@@ -329,7 +329,7 @@ TEST(LongRefcountingTest, nonatomic_unowned_retain_overflow_DeathTest) {
   auto object = allocTestObject(&deinited, 1);
 
   // URC is 1. Retain to maxURC, then retain again and verify overflow error.
-  unownedRetainALot<false>(object, maxURC - 1);
+  unownedRetainALot<false>(object, maxURC);
   EXPECT_EQ(0u, deinited);
   EXPECT_ALLOCATED(object);
   ASSERT_DEATH(swift_nonatomic_unownedRetain(object),


### PR DESCRIPTION
We can use the new setAssociatedObject interposition function to make this safe. 1.1-1.5x win on a huge variety of benchmarks.

#ifdef'd out for platforms that don't have the new interposition function, and guarded with __builtin_available so it'll back-deploy

Fixes rdar://36825362