### PR TITLE
 [ModuleInterface] Qualify all types in module interfaces

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -494,7 +494,7 @@ struct PrintOptions {
   /// consistent and well-formed.
   ///
   /// \see swift::emitParseableInterface
-  static PrintOptions printParseableInterfaceFile();
+  static PrintOptions printParseableInterfaceFile(bool preferTypeRepr);
 
   static PrintOptions printModuleInterface();
   static PrintOptions printTypeInterface(Type T);

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -27,6 +27,10 @@ class ModuleDecl;
 
 /// Options for controlling the generation of the .swiftinterface output.
 struct ParseableInterfaceOptions {
+  /// Should we prefer printing TypeReprs when writing out types in a module
+  /// interface, or should we fully-qualify them?
+  bool PreserveTypesAsWrittenInModuleInterface = false;
+
   /// Copy of all the command-line flags passed at .swiftinterface
   /// generation time, re-applied to CompilerInvocation when reading
   /// back .swiftinterface and reconstructing .swiftmodule.

--- a/include/swift/Frontend/ParseableInterfaceSupport.h
+++ b/include/swift/Frontend/ParseableInterfaceSupport.h
@@ -29,7 +29,7 @@ class ModuleDecl;
 struct ParseableInterfaceOptions {
   /// Should we prefer printing TypeReprs when writing out types in a module
   /// interface, or should we fully-qualify them?
-  bool PreserveTypesAsWrittenInModuleInterface = false;
+  bool PreserveTypesAsWritten = false;
 
   /// Copy of all the command-line flags passed at .swiftinterface
   /// generation time, re-applied to CompilerInvocation when reading

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -535,10 +535,10 @@ def build_module_from_parseable_interface :
   Alias<compile_module_from_interface>,
   ModeOpt;
 
-def preserve_types_as_written_in_module_interface :
-  Flag<["-"], "preserve-types-as-written-in-module-interface">,
-  HelpText<"When emitting a module interface, preserve the types as they were "
-           "written in the source, rather than fully-qualifying them.">;
+def module_interface_preserve_types_as_written :
+  Flag<["-"], "module-interface-preserve-types-as-written">,
+  HelpText<"When emitting a module interface, preserve types as they were "
+           "written in the source">;
 
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -535,6 +535,11 @@ def build_module_from_parseable_interface :
   Alias<compile_module_from_interface>,
   ModeOpt;
 
+def preserve_types_as_written_in_module_interface :
+  Flag<["-"], "preserve-types-as-written-in-module-interface">,
+  HelpText<"When emitting a module interface, preserve the types as they were "
+           "written in the source, rather than fully-qualifying them.">;
+
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
   HelpText<"Directory of prebuilt modules for loading module interfaces">;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -94,7 +94,7 @@ static bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
   return !ND->isResilient() && ASD->hasStorage() && !ASD->isStatic();
 }
 
-PrintOptions PrintOptions::printParseableInterfaceFile() {
+PrintOptions PrintOptions::printParseableInterfaceFile(bool preferTypeRepr) {
   PrintOptions result;
   result.PrintLongAttrsOnSeparateLines = true;
   result.TypeDefinitions = true;
@@ -110,7 +110,7 @@ PrintOptions PrintOptions::printParseableInterfaceFile() {
   result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
   result.OpaqueReturnTypePrinting =
       OpaqueReturnTypePrintingMode::StableReference;
-  result.PreferTypeRepr = false;
+  result.PreferTypeRepr = preferTypeRepr;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -110,6 +110,7 @@ PrintOptions PrintOptions::printParseableInterfaceFile() {
   result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
   result.OpaqueReturnTypePrinting =
       OpaqueReturnTypePrintingMode::StableReference;
+  result.PreferTypeRepr = false;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;
@@ -1004,7 +1005,18 @@ void PrintAST::printAttributes(const Decl *D) {
 void PrintAST::printTypedPattern(const TypedPattern *TP) {
   printPattern(TP->getSubPattern());
   Printer << ": ";
-  printTypeLoc(TP->getTypeLoc());
+
+  // Make sure to check if the underlying var decl is an implicitly unwrapped
+  // optional.
+  bool isIUO = false;
+  if (auto *named = dyn_cast<NamedPattern>(TP->getSubPattern()))
+    if (auto decl = named->getDecl())
+      isIUO = decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
+
+  if (isIUO)
+    printTypeLocForImplicitlyUnwrappedOptional(TP->getTypeLoc());
+  else
+    printTypeLoc(TP->getTypeLoc());
 }
 
 /// Determines if we are required to print the name of a property declaration,
@@ -2530,6 +2542,14 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
       tyLoc = TypeLoc::withoutLoc(decl->getInterfaceType());
 
     Printer.printDeclResultTypePre(decl, tyLoc);
+
+    // HACK: When printing result types for vars with opaque result types,
+    //       always print them using the `some` keyword instead of printing
+    //       the full stable reference.
+    llvm::SaveAndRestore<PrintOptions::OpaqueReturnTypePrintingMode>
+    x(Options.OpaqueReturnTypePrinting,
+      PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword);
+
     if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
       printTypeLocForImplicitlyUnwrappedOptional(tyLoc);
     else
@@ -2805,6 +2825,14 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 
       Printer.printDeclResultTypePre(decl, ResultTyLoc);
       Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
+
+      // HACK: When printing result types for funcs with opaque result types,
+      //       always print them using the `some` keyword instead of printing
+      //       the full stable reference.
+      llvm::SaveAndRestore<PrintOptions::OpaqueReturnTypePrintingMode>
+      x(Options.OpaqueReturnTypePrinting,
+        PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword);
+
       if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
         printTypeLocForImplicitlyUnwrappedOptional(ResultTyLoc);
       else
@@ -2947,6 +2975,14 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
   if (!elementTy.getTypeRepr())
     elementTy = TypeLoc::withoutLoc(decl->getElementInterfaceType());
+
+  // HACK: When printing result types for subscripts with opaque result types,
+  //       always print them using the `some` keyword instead of printing
+  //       the full stable reference.
+  llvm::SaveAndRestore<PrintOptions::OpaqueReturnTypePrintingMode>
+  x(Options.OpaqueReturnTypePrinting,
+    PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword);
+
   if (decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
     printTypeLocForImplicitlyUnwrappedOptional(elementTy);
   else

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2046,17 +2046,8 @@ TypeDecl *EquivalenceClass::lookupNestedType(
         continue;
       }
 
-      // If this is another type declaration, determine whether we should
-      // record it.
+      // If this is another type declaration, record it.
       if (auto type = dyn_cast<TypeDecl>(member)) {
-        // FIXME: Filter out type declarations that aren't in the same
-        // module as the protocol itself. This is an unprincipled hack, but
-        // provides consistent lookup semantics for the generic signature
-        // builder in all contents.
-        if (type->getDeclContext()->getParentModule()
-              != proto->getParentModule())
-          continue;
-
         concreteDecls.push_back(type);
         continue;
       }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -201,8 +201,8 @@ static void ParseParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
                                         ArgList &Args) {
   using namespace options;
 
-  Opts.PreserveTypesAsWrittenInModuleInterface |=
-    Args.hasArg(OPT_preserve_types_as_written_in_module_interface);
+  Opts.PreserveTypesAsWritten |=
+    Args.hasArg(OPT_module_interface_preserve_types_as_written);
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -197,6 +197,14 @@ static void PrintArg(raw_ostream &OS, const char *Arg, StringRef TempDir) {
   OS << '"';
 }
 
+static void ParseParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
+                                        ArgList &Args) {
+  using namespace options;
+
+  Opts.PreserveTypesAsWrittenInModuleInterface |=
+    Args.hasArg(OPT_preserve_types_as_written_in_module_interface);
+}
+
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running
 /// in a mode that is going to emit a .swiftinterface file.
 static void SaveParseableInterfaceArgs(ParseableInterfaceOptions &Opts,
@@ -1305,6 +1313,7 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
+  ParseParseableInterfaceArgs(ParseableInterfaceOpts, ParsedArgs);
   SaveParseableInterfaceArgs(ParseableInterfaceOpts, FrontendOpts,
                              ParsedArgs, Diags);
 

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -412,7 +412,7 @@ bool swift::emitParseableInterface(raw_ostream &out,
   printImports(out, M);
 
   const PrintOptions printOptions = PrintOptions::printParseableInterfaceFile(
-      Opts.PreserveTypesAsWrittenInModuleInterface);
+      Opts.PreserveTypesAsWritten);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -411,7 +411,8 @@ bool swift::emitParseableInterface(raw_ostream &out,
   printToolVersionAndFlagsComment(out, Opts, M);
   printImports(out, M);
 
-  const PrintOptions printOptions = PrintOptions::printParseableInterfaceFile();
+  const PrintOptions printOptions = PrintOptions::printParseableInterfaceFile(
+      Opts.PreserveTypesAsWrittenInModuleInterface);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;

--- a/stdlib/public/Darwin/XCTest/CMakeLists.txt
+++ b/stdlib/public/Darwin/XCTest/CMakeLists.txt
@@ -7,7 +7,14 @@ add_swift_target_library(swiftXCTest ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS
   XCTestCaseAdditions.mm
   XCTest.swift
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
+  SWIFT_COMPILE_FLAGS
+    "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
+
+    # XCTest has a type called XCTest, which exposes an issue in module
+    # interfaces -- because types are fully-qualified, the compiler currently
+    # doesn't disambiguate between XCTest-the-module and XCTest-the-class.
+    # rdar://48445154
+    -Xfrontend -module-interface-preserve-types-as-written
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
   SWIFT_MODULE_DEPENDS ObjectiveC Foundation

--- a/test/Generics/Inputs/external-protocol.swift
+++ b/test/Generics/Inputs/external-protocol.swift
@@ -1,0 +1,1 @@
+public protocol AnExternalProtocol {}

--- a/test/Generics/typealias-in-extension-of-external-protocol.swift
+++ b/test/Generics/typealias-in-extension-of-external-protocol.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module-path %t/ExternalProtocol.swiftmodule %S/Inputs/external-protocol.swift -module-name ExternalProtocol
+// RUN: %target-swift-frontend -typecheck -I %t %s
+
+import ExternalProtocol
+
+extension AnExternalProtocol {
+  typealias TypeAlias = Int
+
+  func methodUsingAlias(_ alias: Self.TypeAlias) {}
+}

--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -1,4 +1,4 @@
-// CHECK-LABEL: public enum FutureproofEnum : Int
+// CHECK-LABEL: public enum FutureproofEnum : Swift.Int
 public enum FutureproofEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -8,7 +8,7 @@ public enum FutureproofEnum: Int {
   case c = 100
 }
 
-// CHECK-LABEL: public enum FrozenEnum : Int
+// CHECK-LABEL: public enum FrozenEnum : Swift.Int
 @_frozen public enum FrozenEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -18,7 +18,7 @@ public enum FutureproofEnum: Int {
   case c = 100
 }
 
-// CHECK-LABEL: public enum FutureproofObjCEnum : Int32
+// CHECK-LABEL: public enum FutureproofObjCEnum : Swift.Int32
 @objc public enum FutureproofObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -28,7 +28,7 @@ public enum FutureproofEnum: Int {
   case c = 100
 }
 
-// CHECK-LABEL: public enum FrozenObjCEnum : Int32
+// CHECK-LABEL: public enum FrozenObjCEnum : Swift.Int32
 @_frozen @objc public enum FrozenObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -37,4 +37,3 @@ public enum FutureproofEnum: Int {
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
 }
-

--- a/test/ParseableInterface/ModuleCache/swiftdoc-next-to-swiftinterface.swift
+++ b/test/ParseableInterface/ModuleCache/swiftdoc-next-to-swiftinterface.swift
@@ -1,21 +1,21 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-parseable-module-interface-path %t/Lib.swiftinterface -emit-module-doc -parse-stdlib -o %t/Lib.swiftmodule %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x > %t/from-module.txt
+// RUN: %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x -prefer-type-repr=false -fully-qualified-types=true > %t/from-module.txt
 // RUN: %FileCheck %s < %t/from-module.txt
 
 // RUN: rm %t/Lib.swiftmodule
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x > %t/from-interface.txt
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x -prefer-type-repr=false -fully-qualified-types=true > %t/from-interface.txt
 // RUN: diff %t/from-module.txt %t/from-interface.txt
 
 // Try again with architecture-specific subdirectories.
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Lib.swiftmodule)
 // RUN: %target-swift-frontend -emit-module -emit-parseable-module-interface-path %t/Lib.swiftmodule/%target-cpu.swiftinterface -emit-module-doc -parse-stdlib -o %t/Lib.swiftmodule/%target-swiftmodule-name -module-name Lib %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x > %t/from-module.txt
+// RUN: %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x -prefer-type-repr=false -fully-qualified-types=true > %t/from-module.txt
 // RUN: %FileCheck %s < %t/from-module.txt
 
 // RUN: rm %t/Lib.swiftmodule/%target-swiftmodule-name
-// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x > %t/from-interface.txt
+// RUN: env SWIFT_FORCE_MODULE_LOADING=prefer-serialized %target-swift-ide-test -print-module -module-to-print=Lib -access-filter-public -I %t -source-filename=x -prefer-type-repr=false -fully-qualified-types=true > %t/from-interface.txt
 // RUN: diff %t/from-module.txt %t/from-interface.txt
 
 /// Very important documentation!

--- a/test/ParseableInterface/access-filter.swift
+++ b/test/ParseableInterface/access-filter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s -module-name AccessFilter
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
@@ -109,7 +109,7 @@ extension UFIProto {
 
 // CHECK: extension PublicStruct {{[{]$}}
 extension PublicStruct {
-  // CHECK: @_hasInitialValue public static var secretlySettable: Int {
+  // CHECK: @_hasInitialValue public static var secretlySettable: Swift.Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: }
   public private(set) static var secretlySettable: Int = 0
@@ -120,7 +120,7 @@ extension InternalStruct_BAD: PublicProto {
   internal static var dummy: Int { return 0 }
 }
 
-// CHECK: extension UFIStruct : PublicProto {{[{]$}}
+// CHECK: extension UFIStruct : AccessFilter.PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
   // CHECK-NEXT: @usableFromInline
   // CHECK-NEXT: internal typealias Assoc = Swift.Int
@@ -135,7 +135,7 @@ extension UFIStruct: PublicProto {
 public enum PublicEnum {
   // CHECK-NEXT: case x
   case x
-  // CHECK-NEXT: case y(Int)
+  // CHECK-NEXT: case y(Swift.Int)
   case y(Int)
 } // CHECK-NEXT: {{^[}]$}}
 
@@ -148,7 +148,7 @@ enum InternalEnum_BAD {
 @usableFromInline enum UFIEnum {
   // CHECK-NEXT: case x
   case x
-  // CHECK-NEXT: case y(Int)
+  // CHECK-NEXT: case y(Swift.Int)
   case y(Int)
 } // CHECK-NEXT: {{^[}]$}}
 
@@ -167,13 +167,13 @@ class InternalClass_BAD {
 // CHECK: public struct GenericStruct<T>
 public struct GenericStruct<T> {}
 
-// CHECK: extension GenericStruct where T == main.PublicStruct {{[{]$}}
-extension GenericStruct where T == PublicStruct {
+// CHECK: extension GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
+extension GenericStruct where T == AccessFilter.PublicStruct {
   // CHECK-NEXT: public func constrainedToPublicStruct(){{$}}
   public func constrainedToPublicStruct() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == main.UFIStruct {{[{]$}}
-extension GenericStruct where T == UFIStruct {
+// CHECK: extension GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
+extension GenericStruct where T == AccessFilter.UFIStruct {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct(){{$}}
   @usableFromInline internal func constrainedToUFIStruct() {}
@@ -182,12 +182,12 @@ extension GenericStruct where T == InternalStruct_BAD {
   @usableFromInline internal func constrainedToInternalStruct_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T == main.PublicStruct {{[{]$}}
+// CHECK: extension GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
 extension GenericStruct where PublicStruct == T {
   // CHECK-NEXT: public func constrainedToPublicStruct2(){{$}}
   public func constrainedToPublicStruct2() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == main.UFIStruct {{[{]$}}
+// CHECK: extension GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
 extension GenericStruct where UFIStruct == T {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct2(){{$}}
@@ -197,12 +197,12 @@ extension GenericStruct where InternalStruct_BAD == T {
   @usableFromInline internal func constrainedToInternalStruct2_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T : main.PublicProto {{[{]$}}
+// CHECK: extension GenericStruct where T : AccessFilter.PublicProto {{[{]$}}
 extension GenericStruct where T: PublicProto {
   // CHECK-NEXT: public func constrainedToPublicProto(){{$}}
   public func constrainedToPublicProto() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T : main.UFIProto {{[{]$}}
+// CHECK: extension GenericStruct where T : AccessFilter.UFIProto {{[{]$}}
 extension GenericStruct where T: UFIProto {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIProto(){{$}}
@@ -212,12 +212,12 @@ extension GenericStruct where T: InternalProto_BAD {
   @usableFromInline internal func constrainedToInternalProto_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T : main.PublicClass {{[{]$}}
+// CHECK: extension GenericStruct where T : AccessFilter.PublicClass {{[{]$}}
 extension GenericStruct where T: PublicClass {
   // CHECK-NEXT: public func constrainedToPublicClass(){{$}}
   public func constrainedToPublicClass() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T : main.UFIClass {{[{]$}}
+// CHECK: extension GenericStruct where T : AccessFilter.UFIClass {{[{]$}}
 extension GenericStruct where T: UFIClass {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIClass(){{$}}
@@ -236,21 +236,21 @@ extension GenericStruct where T: AnyObject {
 public struct PublicAliasBase {}
 internal struct ReallyInternalAliasBase_BAD {}
 
-// CHECK: public typealias PublicAlias = PublicAliasBase
+// CHECK: public typealias PublicAlias = AccessFilter.PublicAliasBase
 public typealias PublicAlias = PublicAliasBase
 internal typealias InternalAlias_BAD = PublicAliasBase
 // CHECK: @usableFromInline
-// CHECK-NEXT: internal typealias UFIAlias = PublicAliasBase
+// CHECK-NEXT: internal typealias UFIAlias = AccessFilter.PublicAliasBase
 @usableFromInline internal typealias UFIAlias = PublicAliasBase
 
 internal typealias ReallyInternalAlias_BAD = ReallyInternalAliasBase_BAD
 
-// CHECK: extension GenericStruct where T == main.PublicAlias {{[{]$}}
+// CHECK: extension GenericStruct where T == AccessFilter.PublicAlias {{[{]$}}
 extension GenericStruct where T == PublicAlias {
   // CHECK-NEXT: public func constrainedToPublicAlias(){{$}}
   public func constrainedToPublicAlias() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == main.UFIAlias {{[{]$}}
+// CHECK: extension GenericStruct where T == AccessFilter.UFIAlias {{[{]$}}
 extension GenericStruct where T == UFIAlias {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIAlias(){{$}}
@@ -275,7 +275,7 @@ extension GenericStruct: PublicProto where T: InternalProto_BAD {
 
 public struct MultiGenericStruct<First, Second> {}
 
-// CHECK: extension MultiGenericStruct where First == main.PublicStruct, Second == main.PublicStruct {{[{]$}}
+// CHECK: extension MultiGenericStruct where First == AccessFilter.PublicStruct, Second == AccessFilter.PublicStruct {{[{]$}}
 extension MultiGenericStruct where First == PublicStruct, Second == PublicStruct {
   // CHECK-NEXT: public func publicPublic(){{$}}
   public func publicPublic() {}

--- a/test/ParseableInterface/attrs.swift
+++ b/test/ParseableInterface/attrs.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface -enable-library-evolution %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: @_transparent public func glass() -> Int { return 0 }{{$}}
+// CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }
 
 // CHECK: @_effects(readnone) public func illiterate(){{$}}
@@ -9,8 +9,8 @@
 
 // CHECK-LABEL: @frozen public struct Point {
 @frozen public struct Point {
-  // CHECK-NEXT: public var x: Int
+  // CHECK-NEXT: public var x: Swift.Int
   public var x: Int
-  // CHECK-NEXT: public var y: Int
+  // CHECK-NEXT: public var y: Swift.Int
   public var y: Int
 } // CHECK-NEXT: {{^}$}}

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -14,10 +14,10 @@ public protocol SimpleProto {
   func inference(_: Inferred)
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: public struct SimpleImpl<Element> : SimpleProto {
+// CHECK-LABEL: public struct SimpleImpl<Element> : conformances.SimpleProto {
 public struct SimpleImpl<Element>: SimpleProto {
   // NEGATIVE-NOT: typealias Element =
-  // CHECK: public func inference(_: Int){{$}}
+  // CHECK: public func inference(_: Swift.Int){{$}}
   public func inference(_: Int) {}
   // CHECK: public typealias Inferred = Swift.Int
 } // CHECK: {{^}$}}
@@ -26,10 +26,10 @@ public struct SimpleImpl<Element>: SimpleProto {
 public protocol PublicProto {}
 private protocol PrivateProto {}
 
-// CHECK: public struct A1 : PublicProto {
+// CHECK: public struct A1 : conformances.PublicProto {
 // NEGATIVE-NOT: extension conformances.A1
 public struct A1: PublicProto, PrivateProto {}
-// CHECK: public struct A2 : PublicProto {
+// CHECK: public struct A2 : conformances.PublicProto {
 // NEGATIVE-NOT: extension conformances.A2
 public struct A2: PrivateProto, PublicProto {}
 // CHECK: public struct A3 {
@@ -45,31 +45,31 @@ private protocol PrivateSubProto: PublicBaseProto {}
 // CHECK: public struct B1 {
 // CHECK-END: extension conformances.B1 : conformances.PublicBaseProto {}
 public struct B1: PrivateSubProto {}
-// CHECK: public struct B2 : PublicBaseProto {
+// CHECK: public struct B2 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B2
 public struct B2: PublicBaseProto, PrivateSubProto {}
 // CHECK: public struct B3 {
 // CHECK-END: extension conformances.B3 : conformances.PublicBaseProto {}
 public struct B3: PublicBaseProto & PrivateSubProto {}
-// CHECK: public struct B4 : PublicBaseProto {
+// CHECK: public struct B4 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension B4 {
 // NEGATIVE-NOT: extension conformances.B4
 public struct B4: PublicBaseProto {}
 extension B4: PrivateSubProto {}
 // CHECK: public struct B5 {
-// CHECK: extension B5 : PublicBaseProto {
+// CHECK: extension B5 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B5
 public struct B5: PrivateSubProto {}
 extension B5: PublicBaseProto {}
 // CHECK: public struct B6 {
 // NEGATIVE-NOT: extension B6 {
-// CHECK: extension B6 : PublicBaseProto {
+// CHECK: extension B6 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B6
 public struct B6 {}
 extension B6: PrivateSubProto {}
 extension B6: PublicBaseProto {}
 // CHECK: public struct B7 {
-// CHECK: extension B7 : PublicBaseProto {
+// CHECK: extension B7 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension B7 {
 // NEGATIVE-NOT: extension conformances.B7
 public struct B7 {}
@@ -115,10 +115,10 @@ extension C3: AnotherPrivateSubProto {}
 public protocol PublicSubProto: PublicBaseProto {}
 public protocol APublicSubProto: PublicBaseProto {}
 
-// CHECK: public struct D1 : PublicSubProto {
+// CHECK: public struct D1 : conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D1
 public struct D1: PublicSubProto, PrivateSubProto {}
-// CHECK: public struct D2 : PublicSubProto {
+// CHECK: public struct D2 : conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D2
 public struct D2: PrivateSubProto, PublicSubProto {}
 // CHECK: public struct D3 {
@@ -130,11 +130,11 @@ public struct D3: PrivateSubProto & PublicSubProto {}
 // CHECK-END: extension conformances.D4 : conformances.PublicBaseProto {}
 public struct D4: APublicSubProto & PrivateSubProto {}
 // CHECK: public struct D5 {
-// CHECK: extension D5 : PublicSubProto {
+// CHECK: extension D5 : conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D5
 public struct D5: PrivateSubProto {}
 extension D5: PublicSubProto {}
-// CHECK: public struct D6 : PublicSubProto {
+// CHECK: public struct D6 : conformances.PublicSubProto {
 // NEGATIVE-NOT: extension D6 {
 // NEGATIVE-NOT: extension conformances.D6
 public struct D6: PublicSubProto {}
@@ -162,7 +162,7 @@ public class Base {}
 private protocol BaseConstrainedProto: Base, PublicProto {}
 
 public class H1: Base, ClassConstrainedProto {}
-// CHECK: public class H1 : Base {
+// CHECK: public class H1 : conformances.Base {
 // CHECK-END: extension conformances.H1 : conformances.PublicProto {}
 
 public struct MultiGeneric<T, U, V> {}
@@ -218,7 +218,7 @@ extension PrivateProtoConformer : PrivateProto {
 }
 // CHECK: public struct PrivateProtoConformer {
 // CHECK: extension PrivateProtoConformer {
-// CHECK-NEXT: public var member: Int {
+// CHECK-NEXT: public var member: Swift.Int {
 // CHECK-NEXT:   get
 // CHECK-NEXT: }
 // CHECK-NEXT: {{^}$}}

--- a/test/ParseableInterface/convenience-init.swift
+++ b/test/ParseableInterface/convenience-init.swift
@@ -25,8 +25,7 @@ public class Base {
 }
 
 public class Derived: Base {
-  // MERGE: {{^}}  public init(z: Swift.Int)
-  // SINGLE: {{^}}  public init(z: Int)
+  // CHECK: {{^}}  public init(z: Swift.Int)
   public init(z: Int) {
     super.init(x: z)
   }
@@ -44,7 +43,7 @@ public class Derived2: Base {
   }
 
   // MERGE: {{^}}  override public convenience init(x: Swift.Int)
-  // SINGLE: {{^}}  override convenience public init(x: Int)
+  // SINGLE: {{^}}  override convenience public init(x: Swift.Int)
   override convenience public init(x: Int) {
     self.init()
   }

--- a/test/ParseableInterface/default-args.swift
+++ b/test/ParseableInterface/default-args.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
 // RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
-// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t -prefer-type-repr=false -fully-qualified-types=true | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/Test.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t/Test.swiftinterface -module-name Test -enable-library-evolution %s
 // RUN: rm %t/Test.swiftmodule
 // RUN: echo "import Test" > %t/test-client.swift
 // RUN: %target-swift-frontend -typecheck -I%t %t/test-client.swift
@@ -11,46 +11,46 @@
 
 // CHECK: class Base {
 public class Base {
-  // CHECK: init(x: Int = 3)
+  // CHECK: init(x: Swift.Int = 3)
   public init(x: Int = 3) {}
   public convenience init(convInit: Int) {
     self.init(x: convInit)
   }
-  // CHECK: foo(y: Int = 42)
+  // CHECK: foo(y: Swift.Int = 42)
   public func foo(y: Int = 42) {}
 }
 
-// CHECK: class Derived : Base {
+// CHECK: class Derived : Test.Base {
 public class Derived: Base {
-  // CHECK: init(y: Int)
+  // CHECK: init(y: Swift.Int)
   public convenience init(y: Int) {
     self.init()
   }
 
-  // CHECK-NOT: init(convInit: Int = super)
-  // CHECK: override {{(public )?}}init(x: {{(Swift.)?}}Int = super)
-  // CHECK-NOT: init(convInit: Int = super)
+  // CHECK-NOT: init(convInit: Swift.Int = super)
+  // CHECK: override {{(public )?}}init(x: Swift.Int = super)
+  // CHECK-NOT: init(convInit: Swift.Int = super)
 }
 
 public enum Enum {
-  // CHECK: case pie(filling: String = "apple")
+  // CHECK: case pie(filling: Swift.String = "apple")
   case pie(filling: String = "apple")
 }
 
 public struct HasSubscript {
-  // CHECK: subscript(x: Int = 0) -> Int {
+  // CHECK: subscript(x: Swift.Int = 0) -> Swift.Int {
   public subscript(x: Int = 0) -> Int { return 0 }
 }
 
-// CHECK: func hasClosureDefaultArg(_ x: () -> Void = {
+// CHECK: func hasClosureDefaultArg(_ x: () -> Swift.Void = {
 // CHECK-NEXT: })
 public func hasClosureDefaultArg(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasMagicDefaultArgs(_ f: String = #file, _ fu: String = #function, _ l: Int = #line)
+// CHECK: func hasMagicDefaultArgs(_ f: Swift.String = #file, _ fu: Swift.String = #function, _ l: Swift.Int = #line)
 public func hasMagicDefaultArgs(_ f: String = #file, _ fu: String = #function, _ l: Int = #line) {}
 
-// CHECK: func hasSimpleDefaultArgs(_ x: Int = 0, b: Int = 1)
+// CHECK: func hasSimpleDefaultArgs(_ x: Swift.Int = 0, b: Swift.Int = 1)
 public func hasSimpleDefaultArgs(_ x: Int = 0, b: Int = 1) {
 }

--- a/test/ParseableInterface/escape-Type-and-Protocol.swift
+++ b/test/ParseableInterface/escape-Type-and-Protocol.swift
@@ -33,7 +33,7 @@ public struct C {
 
 // CHECK: public struct D {
 public struct D {
-  // CHECK: public typealias `Type` = Int
+  // CHECK: public typealias `Type` = Swift.Int
   public typealias `Type` = Int
 // CHECK-NEXT: }
 }

--- a/test/ParseableInterface/exported-module-name.swift
+++ b/test/ParseableInterface/exported-module-name.swift
@@ -8,7 +8,7 @@
 // CHECK: import CoreKit
 import CoreKit
 
-// CHECK-LABEL: public struct CKThingWrapper : RawRepresentable {
+// CHECK-LABEL: public struct CKThingWrapper : Swift.RawRepresentable {
 public struct CKThingWrapper: RawRepresentable {
   public var rawValue: CKThing
   public init(rawValue: CKThing) {

--- a/test/ParseableInterface/fixed-layout-property-initializers.swift
+++ b/test/ParseableInterface/fixed-layout-property-initializers.swift
@@ -15,24 +15,24 @@
 // COMMON: @frozen public struct MyStruct {
 @frozen
 public struct MyStruct {
-  // COMMON: public var publicVar: [[BOOL:(Swift\.)?Bool]] = false
+  // COMMON: public var publicVar: Swift.Bool = false
   public var publicVar: Bool = false
 
-  // COMMON: internal var internalVar: ([[BOOL]], [[BOOL]]) = (false, true)
+  // COMMON: internal var internalVar: (Swift.Bool, Swift.Bool) = (false, true)
   internal var internalVar: (Bool, Bool) = (false, true)
 
-  // COMMON: private var privateVar: [[BOOL]] = Bool(4 < 10)
+  // COMMON: private var privateVar: Swift.Bool = Bool(4 < 10)
   private var privateVar: Bool = Bool(4 < 10)
 
   // COMMON: @usableFromInline
-  // COMMON-NEXT: internal var ufiVar: [[BOOL]] = true
+  // COMMON-NEXT: internal var ufiVar: Swift.Bool = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // COMMON: public var multiVar1: [[BOOL]] = Bool(false), (multiVar2, multiVar3): ([[BOOL]], [[BOOL]]) = (true, 3 == 0)
+  // COMMON: public var multiVar1: Swift.Bool = Bool(false), (multiVar2, multiVar3): (Swift.Bool, Swift.Bool) = (true, 3 == 0)
   public var multiVar1: Bool = Bool(false), (multiVar2, multiVar3): (Bool, Bool) = (true, 3 == 0)
 
-  // NONRESILIENT: @_hasInitialValue public static var staticVar: [[BOOL]]
-  // RESILIENT: {{^}}  public static var staticVar: [[BOOL]]
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift.Bool
+  // RESILIENT: {{^}}  public static var staticVar: Swift.Bool
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -43,21 +43,21 @@ public struct MyStruct {
 // COMMON: @_fixed_layout public class MyClass {
 @_fixed_layout
 public class MyClass {
-  // COMMON: public var publicVar: [[BOOL]] = false
+  // COMMON: public var publicVar: Swift.Bool = false
   public var publicVar: Bool = false
 
-  // COMMON: internal var internalVar: [[BOOL]] = false
+  // COMMON: internal var internalVar: Swift.Bool = false
   internal var internalVar: Bool = false
 
-  // COMMON: private var privateVar: {{(Swift\.)?}}UInt8 = UInt8(2)
+  // COMMON: private var privateVar: Swift.UInt8 = UInt8(2)
   private var privateVar: UInt8 = UInt8(2)
 
   // COMMON: @usableFromInline
-  // COMMON-NEXT: internal var ufiVar: [[BOOL]] = true
+  // COMMON-NEXT: internal var ufiVar: Swift.Bool = true
   @usableFromInline internal var ufiVar: Bool = true
 
-  // NONRESILIENT: @_hasInitialValue public static var staticVar: [[BOOL]]
-  // RESILIENT: {{^}}  public static var staticVar: [[BOOL]]
+  // NONRESILIENT: @_hasInitialValue public static var staticVar: Swift.Bool
+  // RESILIENT: {{^}}  public static var staticVar: Swift.Bool
   public static var staticVar: Bool = Bool(true && false)
 
   // FROMSOURCE: @inlinable internal init() {}
@@ -65,6 +65,6 @@ public class MyClass {
   @inlinable init() {}
 }
 
-// NONRESILIENT: @_hasInitialValue public var topLevelVar: [[BOOL]]
-// RESILIENT: {{^}}public var topLevelVar: [[BOOL]]
+// NONRESILIENT: @_hasInitialValue public var topLevelVar: Swift.Bool
+// RESILIENT: {{^}}public var topLevelVar: Swift.Bool
 public var topLevelVar: Bool = Bool(false && !true)

--- a/test/ParseableInterface/function_builders.swift
+++ b/test/ParseableInterface/function_builders.swift
@@ -8,7 +8,7 @@ public struct TupleBuilder {
   public static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
     return (t1, t2)
   }
-  
+
   public static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
       -> (T1, T2, T3) {
     return (t1, t2, t3)
@@ -29,7 +29,7 @@ public struct TupleBuilder {
   public static func buildIf<T>(_ value: T?) -> T? { return value }
 }
 
-// CHECK-LABEL: public func tuplify<T>(_ cond: Bool, @FunctionBuilders.TupleBuilder body: (Bool) -> T)
+// CHECK-LABEL: public func tuplify<T>(_ cond: Swift.Bool, @FunctionBuilders.TupleBuilder body: (Swift.Bool) -> T)
 public func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
   print(body(cond))
 }

--- a/test/ParseableInterface/iboutlet-private-set.swift
+++ b/test/ParseableInterface/iboutlet-private-set.swift
@@ -1,9 +1,9 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -disable-objc-attr-requires-foundation-module -emit-parseable-module-interface-path %t/Foo.swiftinterface %s
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-name Foo -emit-parseable-module-interface-path %t/Foo.swiftinterface %s
 // RUN: %FileCheck %s -input-file %t/Foo.swiftinterface
-// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+// RUN: %target-swift-frontend -build-module-from-parseable-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule -module-name Foo
 
 // Test the interface we generate for @IBOutlet private(set) properties is
 // consumable.
@@ -11,7 +11,7 @@
 @objc public class MyType {}
 
 open class Bar {
-	// CHECK: @objc @IBOutlet weak public var foo: MyType! {
+	// CHECK: @objc @IBOutlet weak public var foo: Foo.MyType! {
 	// CHECK-NEXT: get
 	// CHECK-NEXT: }
 	@IBOutlet public private(set) weak var foo: MyType!

--- a/test/ParseableInterface/if-configs.swift
+++ b/test/ParseableInterface/if-configs.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
 // RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
-// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t -prefer-type-repr=false -fully-qualified-types=true | %FileCheck %s
 
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface -enable-library-evolution %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Void = {
+// CHECK: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #elseif !NOT_PROVIDED
@@ -34,7 +34,7 @@ public func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Void = {
+// CHECK: func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if NOT_PROVIDED
 // CHECK-NOT: print("should not exist")
 // CHECK-NOT: #else
@@ -63,7 +63,7 @@ public func hasClosureDefaultArgWithComplexPoundIf(_ x: () -> Void = {
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Void = {
+// CHECK: func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if (
 // CHECK-NOT:   !false && true
 // CHECK-NOT: )
@@ -94,7 +94,7 @@ public func hasClosureDefaultArgWithMultilinePoundIfCondition(_ x: () -> Void = 
 }) {
 }
 
-// CHECK: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Void = {
+// CHECK: func hasClosureDefaultArgWithSinglePoundIf(_ x: () -> Swift.Void = {
 // CHECK-NOT: #if true
 // CHECK: print("true")
 // CHECK-NOT: #else

--- a/test/ParseableInterface/inlinable-function.swift
+++ b/test/ParseableInterface/inlinable-function.swift
@@ -6,10 +6,9 @@
 
 // FIXME: These shouldn't be different, or we'll get different output from
 // WMO and non-WMO builds.
-// FROMSOURCE-LABEL: public struct Foo : Hashable {
-// FROMMODULE-LABEL: public struct Foo : Swift.Hashable {
+// CHECK-LABEL: public struct Foo : Swift.Hashable {
 public struct Foo: Hashable {
-  // CHECK: public var inlinableGetPublicSet: [[INT:(Swift.)?Int]] {
+  // CHECK: public var inlinableGetPublicSet: Swift.Int {
   public var inlinableGetPublicSet: Int {
   // FROMSOURCE: @inlinable get {
   // FROMMODULE: @inlinable get{{$}}
@@ -26,10 +25,10 @@ public struct Foo: Hashable {
     // CHECK-NEXT: {{^}}  }
   }
 
-  // CHECK: public var noAccessors: [[INT]]{{$}}
+  // CHECK: public var noAccessors: Swift.Int{{$}}
   public var noAccessors: Int
 
-  // CHECK: public var hasDidSet: [[INT]] {
+  // CHECK: public var hasDidSet: Swift.Int {
   public var hasDidSet: Int {
     // CHECK-NEXT: @_transparent get{{$}}
     // CHECK-NEXT: set[[NEWVALUE]]{{$}}
@@ -40,7 +39,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: {{^}}  }
   }
 
-  // CHECK: @_transparent public var transparent: [[INT]] {
+  // CHECK: @_transparent public var transparent: Swift.Int {
   // FROMMODULE-NEXT: get{{$}}
   // FROMSOURCE-NEXT: get {
   // FROMSOURCE-NEXT:   return 34
@@ -51,7 +50,7 @@ public struct Foo: Hashable {
     return 34
   }
 
-  // CHECK: public var transparentSet: [[INT]] {
+  // CHECK: public var transparentSet: Swift.Int {
   public var transparentSet: Int {
     // CHECK-NEXT: get{{$}}
     get {
@@ -83,7 +82,7 @@ public struct Foo: Hashable {
     }
   }
 
-  // CHECK: @inlinable public var inlinableProperty: [[INT]] {
+  // CHECK: @inlinable public var inlinableProperty: Swift.Int {
   @inlinable
   public var inlinableProperty: Int {
     // FROMMODULE:      get{{$}}
@@ -112,7 +111,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: @inlinable public var inlinableReadAndModify: [[INT]] {
+  // CHECK: @inlinable public var inlinableReadAndModify: Swift.Int {
   @inlinable
   public var inlinableReadAndModify: Int {
     // FROMMODULE:      _read{{$}}
@@ -134,7 +133,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var inlinableReadNormalModify: [[INT]] {
+  // CHECK: public var inlinableReadNormalModify: Swift.Int {
   public var inlinableReadNormalModify: Int {
     // FROMMODULE: @inlinable _read{{$}}
     // FROMSOURCE: @inlinable _read {
@@ -155,7 +154,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var normalReadInlinableModify: [[INT]] {
+  // CHECK: public var normalReadInlinableModify: Swift.Int {
   public var normalReadInlinableModify: Int {
     // CHECK: _read{{$}}
     // CHECK-NOT: yield 0
@@ -176,7 +175,7 @@ public struct Foo: Hashable {
     // CHECK-NEXT: }
   }
 
-  // CHECK: public var normalReadAndModify: [[INT]] {
+  // CHECK: public var normalReadAndModify: Swift.Int {
   public var normalReadAndModify: Int {
     // CHECK-NEXT: _read{{$}}
     _read { yield 0 }
@@ -219,7 +218,7 @@ public struct Foo: Hashable {
     print("Not inlinable")
   }
 
-  // CHECK: public subscript(i: [[INT]]) -> [[INT]] {
+  // CHECK: public subscript(i: Swift.Int) -> Swift.Int {
   // CHECK-NEXT:   get{{$}}
   // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] { print("set") }
   // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
@@ -229,7 +228,7 @@ public struct Foo: Hashable {
     @inlinable set { print("set") }
   }
 
-  // CHECK: public subscript(j: [[INT]], k: [[INT]]) -> [[INT]] {
+  // CHECK: public subscript(j: Swift.Int, k: Swift.Int) -> Swift.Int {
   // FROMMODULE-NEXT:   @inlinable get{{$}}
   // FROMSOURCE-NEXT:   @inlinable get { return 0 }
   // CHECK-NEXT:   set[[NEWVALUE]]{{$}}
@@ -239,7 +238,7 @@ public struct Foo: Hashable {
     set { print("set") }
   }
 
-  // CHECK: @inlinable public subscript(l: [[INT]], m: [[INT]], n: [[INT]]) -> [[INT]] {
+  // CHECK: @inlinable public subscript(l: Swift.Int, m: Swift.Int, n: Swift.Int) -> Swift.Int {
   // FROMMODULE-NEXT:   get{{$}}
   // FROMSOURCE-NEXT:   get { return 0 }
   // FROMMODULE-NEXT:   set[[NEWVALUE]]{{$}}
@@ -251,8 +250,8 @@ public struct Foo: Hashable {
     set { print("set") }
   }
 
-  // FROMMODULE: @inlinable public init(value: [[INT]]){{$}}
-  // FROMSOURCE: @inlinable public init(value: [[INT]]) {
+  // FROMMODULE: @inlinable public init(value: Swift.Int){{$}}
+  // FROMSOURCE: @inlinable public init(value: Swift.Int) {
   // FROMSOURCE-NEXT: topLevelUsableFromInline()
   // FROMSOURCE-NEXT: noAccessors = value
   // FROMSOURCE-NEXT: hasDidSet = value

--- a/test/ParseableInterface/lazy-vars.swift
+++ b/test/ParseableInterface/lazy-vars.swift
@@ -12,13 +12,13 @@
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-parseable-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
 
 // CHECK: @frozen public struct HasLazyVarsFixedLayout {
-// CHECK-NEXT: public var foo: [[INT:(Swift\.)?Int]] {
+// CHECK-NEXT: public var foo: Swift.Int {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// CHECK: private var $__lazy_storage_$_foo: [[INT]]?
+// CHECK: private var $__lazy_storage_$_foo: Swift.Int?
 // CHECK-NOT: private var bar
-// CHECK: private var $__lazy_storage_$_bar: [[INT]]?
+// CHECK: private var $__lazy_storage_$_bar: Swift.Int?
 // CHECK-NEXT: }
 @frozen
 public struct HasLazyVarsFixedLayout {
@@ -27,13 +27,13 @@ public struct HasLazyVarsFixedLayout {
 }
 
 // CHECK: public struct HasLazyVars {
-// CHECK-NEXT: public var foo: [[INT:(Swift\.)?Int]] {
+// CHECK-NEXT: public var foo: Swift.Int {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// NONRESILIENT: private var $__lazy_storage_$_foo: [[INT]]?
+// NONRESILIENT: private var $__lazy_storage_$_foo: Swift.Int?
 // CHECK-NOT: private var bar
-// NONRESILIENT: private var $__lazy_storage_$_bar: [[INT]]?
+// NONRESILIENT: private var $__lazy_storage_$_bar: Swift.Int?
 // CHECK-NEXT: }
 public struct HasLazyVars {
   public lazy var foo: Int = 0

--- a/test/ParseableInterface/modifiers.swift
+++ b/test/ParseableInterface/modifiers.swift
@@ -5,7 +5,7 @@
 
 // CHECK-LABEL: final public class FinalClass {
 public final class FinalClass {
-  // CHECK: @inlinable final public class var a: [[INT:(Swift.)?Int]] {
+  // CHECK: @inlinable final public class var a: Swift.Int {
   // FROMSOURCE-NEXT: {{^}} get {
   // FROMSOURCE-NEXT: return 3
   // FROMSOURCE-NEXT: }
@@ -16,7 +16,7 @@ public final class FinalClass {
     return 3
   }
 
-  // CHECK: final public class var b: [[INT]] {
+  // CHECK: final public class var b: Swift.Int {
   // FROMSOURCE-NEXT: {{^}} @inlinable get {
   // FROMSOURCE-NEXT:   return 3
   // FROMSOURCE-NEXT: }
@@ -32,7 +32,7 @@ public final class FinalClass {
     }
   }
 
-  // CHECK: public static var c: [[INT]] {
+  // CHECK: public static var c: Swift.Int {
   // CHECK-NEXT: {{^}} get
   // FROMSOURCE-NEXT:   @inlinable set[[NEWVALUE]] {}
   // FROMMODULE-NEXT:   @inlinable set[[NEWVALUE]]{{$}}
@@ -44,7 +44,7 @@ public final class FinalClass {
     @inlinable set {}
   }
 
-  // CHECK: @objc dynamic final public var d: [[INT]] {
+  // CHECK: @objc dynamic final public var d: Swift.Int {
   // CHECK-NEXT: {{^}} @objc get{{$}}
   // CHECK-NEXT: {{^}} @objc set[[NEWVALUE]]{{$}}
   // CHECK-NEXT: }
@@ -60,7 +60,7 @@ public final class FinalClass {
 public class Base {
   // CHECK-NEXT: @objc public init(){{$}}
   @objc public init() {}
-  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
   @objc public required init(x: Int) {}
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
@@ -79,14 +79,14 @@ public class SubExplicit: Base {
   // Make sure adding "required" preserves both "required" and "override".
   // CHECK-NEXT: @objc override required public init(){{$}}
   public override required init() { super.init() }
-  // CHECK-NEXT: @objc required public init(x: [[INT]]){{$}}
+  // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
   public required init(x: Int) { super.init() }
   // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 // CHECK-LABEL: public struct MyStruct {
 public struct MyStruct {
-  // CHECK: public var e: [[INT]] {
+  // CHECK: public var e: Swift.Int {
   // CHECK-NEXT: {{^}} mutating get{{$}}
   // FROMSOURCE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]] {}
   // FROMMODULE-NEXT: {{^}} @inlinable nonmutating set[[NEWVALUE]]{{$}}

--- a/test/ParseableInterface/opaque-result-types.swift
+++ b/test/ParseableInterface/opaque-result-types.swift
@@ -6,19 +6,19 @@
 public protocol Foo {}
 extension Int: Foo {}
 
-// CHECK-LABEL: public func foo(_: Int) -> some Foo
+// CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
-// CHECK-LABEL: @inlinable public func foo(_: String) -> some Foo {
+// CHECK-LABEL: @inlinable public func foo(_: Swift.String) -> some OpaqueResultTypes.Foo {
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
-// CHECK-LABEL: public func foo<T>(_ x: T) -> some Foo where T : OpaqueResultTypes.Foo
+// CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T : OpaqueResultTypes.Foo
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
@@ -39,7 +39,7 @@ public protocol AssocTypeInference {
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
-  // CHECK-LABEL: public func foo(_: Int) -> some Foo
+  // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
   @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo(_: Int) -> some Foo {
     return 20721
@@ -50,7 +50,7 @@ public struct Bar<T>: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
   @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -60,7 +60,7 @@ public struct Bar<T>: AssocTypeInference {
   public struct Bas: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -71,7 +71,7 @@ public struct Bar<T>: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -95,7 +95,7 @@ public struct Bar<T>: AssocTypeInference {
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -106,13 +106,13 @@ public struct Bar<T>: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo(_ x: U) -> some Foo
+    // CHECK-LABEL: public func foo(_ x: U) -> some OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
@@ -159,7 +159,7 @@ public struct Zim: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
   @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -179,7 +179,7 @@ public struct Zim: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -199,7 +199,7 @@ public struct Zim: AssocTypeInference {
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
-    // CHECK-LABEL: public func foo(_: Int) -> some Foo
+    // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo(_: Int) -> some Foo {
       return 20721
@@ -215,7 +215,7 @@ public struct Zim: AssocTypeInference {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
     @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x

--- a/test/ParseableInterface/preserve-type-repr.swift
+++ b/test/ParseableInterface/preserve-type-repr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name PreferTypeRepr -preserve-types-as-written-in-module-interface | %FileCheck %s --check-prefix PREFER
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name PreferTypeRepr -module-interface-preserve-types-as-written | %FileCheck %s --check-prefix PREFER
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name PreferTypeRepr | %FileCheck %s --check-prefix DONTPREFER
 
 public protocol Pet {}

--- a/test/ParseableInterface/preserve-type-repr.swift
+++ b/test/ParseableInterface/preserve-type-repr.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name PreferTypeRepr -preserve-types-as-written-in-module-interface | %FileCheck %s --check-prefix PREFER
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name PreferTypeRepr | %FileCheck %s --check-prefix DONTPREFER
+
+public protocol Pet {}
+
+// PREFER: public struct Parrot : Pet {
+// DONTPREFER: public struct Parrot : PreferTypeRepr.Pet {
+// CHECK-NEXT: }
+public struct Parrot: Pet {}
+
+// CHECK: public struct Ex<T> where T : PreferTypeRepr.Pet {
+public struct Ex<T: Pet> {
+  // PREFER: public var hasCeasedToBe: Bool {
+  // DONTPREFER: public var hasCeasedToBe: Swift.Bool {
+  // CHECK: get
+  // CHECK-NEXT: }
+  public var hasCeasedToBe: Bool { false }
+
+// CHECK-NEXT: }
+}
+
+// CHECK: public struct My<T> {
+// CHECK-NEXT: }
+public struct My<T> {}
+
+// CHECK: extension My where T : PreserveTypeRepr.Pet
+extension My where T: Pet {
+  // CHECK: public func isPushingUpDaisies() -> Swift.String
+  public func isPushingUpDaisies() -> String { "" }
+}
+
+// PREFER: public func isNoMore(_ pet: Ex<Parrot>) -> Bool
+// DONTPREFER: public func isNoMore(_ pet: PreferTypeRepr.Ex<PreferTypeRepr.Parrot>) -> Swift.Bool
+public func isNoMore(_ pet: Ex<Parrot>) -> Bool {}

--- a/test/ParseableInterface/private-stored-members.swift
+++ b/test/ParseableInterface/private-stored-members.swift
@@ -15,34 +15,34 @@
 
 // COMMON: struct MyStruct {{{$}}
 public struct MyStruct {
-// COMMON-NEXT: var publicVar: [[INT64:(Swift\.)?Int64]]{{$}}
+// COMMON-NEXT: var publicVar: Swift.Int64{{$}}
   public var publicVar: Int64
 
-// COMMON-NEXT: let publicLet: [[BOOL:(Swift\.)?Bool]]{{$}}
+// COMMON-NEXT: let publicLet: Swift.Bool{{$}}
   public let publicLet: Bool
 
-// CHECK-NEXT: internal var internalVar: [[INT64]]{{$}}
-// RESILIENT-NOT: internal var internalVar: [[INT64]]{{$}}
+// CHECK-NEXT: internal var internalVar: Swift.Int64{{$}}
+// RESILIENT-NOT: internal var internalVar: Swift.Int64{{$}}
   var internalVar: Int64
 
-// CHECK-NEXT: internal let internalLet: [[BOOL]]{{$}}
-// RESILIENT-NOT: internal let internalLet: [[BOOL]]{{$}}
+// CHECK-NEXT: internal let internalLet: Swift.Bool{{$}}
+// RESILIENT-NOT: internal let internalLet: Swift.Bool{{$}}
   let internalLet: Bool
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal var ufiVar: [[INT64]]{{$}}
+// COMMON-NEXT: internal var ufiVar: Swift.Int64{{$}}
   @usableFromInline var ufiVar: Int64
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal let ufiLet: [[BOOL]]{{$}}
+// COMMON-NEXT: internal let ufiLet: Swift.Bool{{$}}
   @usableFromInline let ufiLet: Bool
 
-// CHECK-NEXT: private var privateVar: [[INT64]]{{$}}
-// RESILIENT-NOT: private var privateVar: [[INT64]]{{$}}
+// CHECK-NEXT: private var privateVar: Swift.Int64{{$}}
+// RESILIENT-NOT: private var privateVar: Swift.Int64{{$}}
   private var privateVar: Int64
 
-// CHECK-NEXT: private let privateLet: [[BOOL]]{{$}}
-// RESILIENT-NOT: private let privateLet: [[BOOL]]{{$}}
+// CHECK-NEXT: private let privateLet: Swift.Bool{{$}}
+// RESILIENT-NOT: private let privateLet: Swift.Bool{{$}}
   private let privateLet: Bool
 
 // CHECK-NOT: private var
@@ -55,7 +55,7 @@ public struct MyStruct {
 // RESILIENT-NOT: private static var
   private static var staticPrivateVar: Int64 = 0
 
-// COMMON: var publicEndVar: [[INT64]]{{$}}
+// COMMON: var publicEndVar: Swift.Int64{{$}}
   public var publicEndVar: Int64 = 0
 
 // COMMON: }{{$}}
@@ -63,34 +63,34 @@ public struct MyStruct {
 
 // COMMON: class MyClass {{{$}}
 public class MyClass {
-// COMMON-NEXT: var publicVar: [[INT64]]{{$}}
+// COMMON-NEXT: var publicVar: Swift.Int64{{$}}
   public var publicVar: Int64 = 0
 
-// COMMON-NEXT: let publicLet: [[BOOL]]{{$}}
+// COMMON-NEXT: let publicLet: Swift.Bool{{$}}
   public let publicLet: Bool = true
 
-// CHECK-NEXT: internal var internalVar: [[INT64]]{{$}}
-// RESILIENT-NOT: internal var internalVar: [[INT64]]{{$}}
+// CHECK-NEXT: internal var internalVar: Swift.Int64{{$}}
+// RESILIENT-NOT: internal var internalVar: Swift.Int64{{$}}
   var internalVar: Int64 = 0
 
-// CHECK-NEXT: internal let internalLet: [[BOOL]]{{$}}
-// RESILIENT-NOT: internal let internalLet: [[BOOL]]{{$}}
+// CHECK-NEXT: internal let internalLet: Swift.Bool{{$}}
+// RESILIENT-NOT: internal let internalLet: Swift.Bool{{$}}
   let internalLet: Bool = true
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal var ufiVar: [[INT64]]{{$}}
+// COMMON-NEXT: internal var ufiVar: Swift.Int64{{$}}
   @usableFromInline var ufiVar: Int64 = 0
 
 // COMMON-NEXT: @usableFromInline
-// COMMON-NEXT: internal let ufiLet: [[BOOL]]{{$}}
+// COMMON-NEXT: internal let ufiLet: Swift.Bool{{$}}
   @usableFromInline let ufiLet: Bool = true
 
-// CHECK-NEXT: private var privateVar: [[INT64]]{{$}}
-// RESILIENT-NOT: private var privateVar: [[INT64]]{{$}}
+// CHECK-NEXT: private var privateVar: Swift.Int64{{$}}
+// RESILIENT-NOT: private var privateVar: Swift.Int64{{$}}
   private var privateVar: Int64 = 0
 
-// CHECK-NEXT: private let privateLet: [[BOOL]]{{$}}
-// RESILIENT-NOT: private let privateLet: [[BOOL]]{{$}}
+// CHECK-NEXT: private let privateLet: Swift.Bool{{$}}
+// RESILIENT-NOT: private let privateLet: Swift.Bool{{$}}
   private let privateLet: Bool = true
 
 // CHECK-NOT: private var
@@ -103,7 +103,7 @@ public class MyClass {
 // RESILIENT-NOT: private static var
   private static var staticPrivateVar: Int64 = 0
 
-// COMMON: var publicEndVar: [[INT64]]{{$}}
+// COMMON: var publicEndVar: Swift.Int64{{$}}
   public var publicEndVar: Int64 = 0
 
   public init() {}

--- a/test/ParseableInterface/smoke-test.swift
+++ b/test/ParseableInterface/smoke-test.swift
@@ -4,7 +4,7 @@
 // CHECK: public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}
 
-// CHECK: public func ownership(_ x: __shared AnyObject){{$}}
+// CHECK: public func ownership(_ x: __shared Swift.AnyObject){{$}}
 public func ownership(_ x: __shared AnyObject) {}
 
 // CHECK-MULTI-FILE: public func otherFileFunction(){{$}}

--- a/test/ParseableInterface/stored-properties.swift
+++ b/test/ParseableInterface/stored-properties.swift
@@ -1,25 +1,25 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.swiftinterface -module-name StoredProperties %s
 // RUN: %FileCheck %s < %t.swiftinterface --check-prefix CHECK --check-prefix COMMON
 
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t-resilient.swiftinterface -module-name StoredProperties -enable-library-evolution %s
 // RUN: %FileCheck %s < %t-resilient.swiftinterface --check-prefix RESILIENT --check-prefix COMMON
 
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix CHECK --check-prefix COMMON
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -module-name StoredProperties %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name StoredProperties -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix CHECK --check-prefix COMMON
 
-// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-library-evolution %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-library-evolution -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -module-name StoredProperties -enable-library-evolution %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name StoredProperties -enable-library-evolution -emit-parseable-module-interface-path - | %FileCheck %s --check-prefix RESILIENT --check-prefix COMMON
 
 // COMMON: public struct HasStoredProperties {
 public struct HasStoredProperties {
-  // COMMON: public var computedGetter: [[INT:.*Int]] {
+  // COMMON: public var computedGetter: Swift.Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: }
   public var computedGetter: Int { return 3 }
 
-  // COMMON: public var computedGetSet: [[INT]] {
+  // COMMON: public var computedGetSet: Swift.Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }
@@ -28,14 +28,14 @@ public struct HasStoredProperties {
     set {}
   }
 
-  // COMMON: public let simpleStoredImmutable: [[INT]]{{$}}
+  // COMMON: public let simpleStoredImmutable: Swift.Int{{$}}
   public let simpleStoredImmutable: Int
 
-  // COMMON: public var simpleStoredMutable: [[INT]]{{$}}
+  // COMMON: public var simpleStoredMutable: Swift.Int{{$}}
   public var simpleStoredMutable: Int
 
-  // CHECK: @_hasStorage public var storedWithObservers: [[BOOL:.*Bool]] {
-  // RESILIENT: {{^}}  public var storedWithObservers: [[BOOL:.*Bool]] {
+  // CHECK: @_hasStorage public var storedWithObservers: Swift.Bool {
+  // RESILIENT: {{^}}  public var storedWithObservers: Swift.Bool {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }
@@ -43,18 +43,18 @@ public struct HasStoredProperties {
     willSet {}
   }
 
-  // CHECK: @_hasStorage public var storedPrivateSet: [[INT]] {
-  // RESILIENT: {{^}}  public var storedPrivateSet: [[INT]] {
+  // CHECK: @_hasStorage public var storedPrivateSet: Swift.Int {
+  // RESILIENT: {{^}}  public var storedPrivateSet: Swift.Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: }
   public private(set) var storedPrivateSet: Int
 
-  // CHECK: private var privateVar: [[BOOL]]
-  // RESILIENT-NOT: private var privateVar: [[BOOL]]
+  // CHECK: private var privateVar: Swift.Bool
+  // RESILIENT-NOT: private var privateVar: Swift.Bool
   private var privateVar: Bool
 
-  // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: [[INT]] {
-  // RESILIENT: {{^}}  public var storedWithObserversInitialValue: [[INT]] {
+  // CHECK: @_hasStorage @_hasInitialValue public var storedWithObserversInitialValue: Swift.Int {
+  // RESILIENT: {{^}}  public var storedWithObserversInitialValue: Swift.Int {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }
@@ -77,16 +77,16 @@ public struct HasStoredProperties {
 // COMMON: @frozen public struct BagOfVariables {
 @frozen
 public struct BagOfVariables {
-  // COMMON: private let hidden: [[INT]] = 0
+  // COMMON: private let hidden: Swift.Int = 0
   private let hidden: Int = 0
 
-  // COMMON: public let a: [[INT]] = 0
+  // COMMON: public let a: Swift.Int = 0
   public let a: Int = 0
 
-  // COMMON: public var b: [[BOOL]] = false
+  // COMMON: public var b: Swift.Bool = false
   public var b: Bool = false
 
-  // COMMON: public var c: [[INT]] = 0
+  // COMMON: public var c: Swift.Int = 0
   public var c: Int = 0
 
   // COMMON: public init()
@@ -98,10 +98,10 @@ public struct BagOfVariables {
 // COMMON: @frozen public struct HasStoredPropertiesFixedLayout {
 @frozen
 public struct HasStoredPropertiesFixedLayout {
-  // COMMON: public var simpleStoredMutable: [[BAGOFVARIABLES:.*BagOfVariables]]
+  // COMMON: public var simpleStoredMutable: StoredProperties.BagOfVariables
   public var simpleStoredMutable: BagOfVariables
 
-  // COMMON: @_hasStorage public var storedWithObservers: [[BAGOFVARIABLES]] {
+  // COMMON: @_hasStorage public var storedWithObservers: StoredProperties.BagOfVariables {
   // COMMON-NEXT: get
   // COMMON-NEXT: set
   // COMMON-NEXT: }

--- a/test/ParseableInterface/synthesized.swift
+++ b/test/ParseableInterface/synthesized.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
 
-// CHECK-LABEL: public enum HasRawValue : Int {
+// CHECK-LABEL: public enum HasRawValue : Swift.Int {
 public enum HasRawValue: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
@@ -15,7 +15,7 @@ public enum HasRawValue: Int {
   case a, b = 5, c
 }
 
-// CHECK-LABEL: @objc public enum ObjCEnum : Int32 {
+// CHECK-LABEL: @objc public enum ObjCEnum : Swift.Int32 {
 // CHECK-NEXT: case a, b = 5, c
 // CHECK-DAG: public typealias RawValue = Swift.Int32
 // CHECK-DAG: @inlinable public init?(rawValue: Swift.Int32)


### PR DESCRIPTION
We should not be making assumptions about module lookup when we're
compiling a module interface, so instead print the types fully
qualified.

rdar://48445154