### PR TITLE
AST: Fix type reconstruction for @convention(c) function types [5.1]

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -378,10 +378,14 @@ Type ASTBuilder::createFunctionType(
 
   auto einfo = AnyFunctionType::ExtInfo(representation,
                                         /*throws*/ flags.throws());
-  if (flags.isEscaping())
-    einfo = einfo.withNoEscape(false);
-  else
-    einfo = einfo.withNoEscape(true);
+
+  if (representation == FunctionTypeRepresentation::Swift ||
+      representation == FunctionTypeRepresentation::Block) {
+    if (flags.isEscaping())
+      einfo = einfo.withNoEscape(false);
+    else
+      einfo = einfo.withNoEscape(true);
+  }
 
   // The result type must be materializable.
   if (!output->isMaterializable()) return Type();

--- a/test/TypeDecoder/structural_types.swift
+++ b/test/TypeDecoder/structural_types.swift
@@ -120,6 +120,12 @@ do {
   let escaping: (@escaping () -> ()) -> () = { _ in }
   blackHole(escaping)
 }
+
+do {
+  let c: [@convention(c) () -> ()] = []
+  blackHole(c)
+}
+
 // DEMANGLE: $syycD
 // DEMANGLE: $sySSzcD
 // DEMANGLE: $sySSncD
@@ -136,6 +142,7 @@ do {
 // DEMANGLE: $sSim_Sf1xSitD
 // DEMANGLE: $sSi1x_SfSim1ytD
 // DEMANGLE: $syyyccD
+// DEMANGLE: $sSayyyXCGD
 
 // CHECK: () -> ()
 // CHECK: (inout String) -> ()
@@ -153,6 +160,7 @@ do {
 // CHECK: (Int.Type, x: Float, Int)
 // CHECK: (x: Int, Float, y: Int.Type)
 // CHECK: (@escaping () -> ()) -> ()
+// CHECK: Array<@convention(c) () -> ()>
 
 // DEMANGLE: $sSimD
 // DEMANGLE: $syycmD
@@ -171,6 +179,7 @@ do {
 // DEMANGLE: $sSim_Sf1xSitmD
 // DEMANGLE: $sSi1x_SfSim1ytmD
 // DEMANGLE: $syyyccmD
+// DEMANGLE: $sSayyyXCGmD
 
 // CHECK: Int.Type
 // CHECK: ((inout String) -> ()).Type
@@ -188,3 +197,4 @@ do {
 // CHECK: (Int.Type, x: Float, Int).Type
 // CHECK: (x: Int, Float, y: Int.Type).Type
 // CHECK: ((@escaping () -> ()) -> ()).Type
+// CHECK: Array<@convention(c) () -> ()>.Type


### PR DESCRIPTION
They're never 'escaping'.

Fixes <https://bugs.swift.org/browse/SR-10335>, <rdar://problem/51646233>.