### PR TITLE
Remove residual gyb bits from LazyPrefixWhileCollection.

### DIFF
--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -98,15 +98,15 @@ extension LazySequenceProtocol {
   }
 }
 
-/// A lazy `${Collection}` wrapper that includes the initial consecutive
+/// A lazy collection wrapper that includes the initial consecutive
 /// elements of an underlying collection that satisfy a predicate.
 ///
-/// - Note: The performance of accessing `endIndex`, `last`, any methods that
-///   depend on `endIndex`, or moving an index depends on how many elements
+/// - Note: The performance of accessing `endIndex`, `last`, or any methods that
+///   depend on `endIndex`, or of moving an index, depends on how many elements
 ///   satisfy the predicate at the start of the collection, and may not offer
 ///   the usual performance given by the `Collection` protocol. Be aware,
-///   therefore, that general operations on `${Self}` instances may not have
-///   the documented complexity.
+///   therefore, that general operations on instances of this collection may
+///   not have the documented complexity.
 public typealias LazyPrefixWhileCollection<T: Collection> = LazyPrefixWhileSequence<T>
 
 extension LazyPrefixWhileCollection {

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -13,6 +13,13 @@
 
 /// A sequence whose elements consist of the initial consecutive elements of
 /// some base sequence that satisfy a given predicate.
+///
+/// - Note: When `LazyPrefixWhileSequence` wraps a collection type, the 
+///   performance of accessing `endIndex` depends on how many 
+///   elements satisfy the predicate at the start of the collection, and may 
+///   not offer the usual performance given by the `Collection` protocol.
+///   Accessing `endIndex`, the `last` property, or calling methods that
+///   depend on moving indices may not have the documented complexity.
 @frozen // lazy-performance
 public struct LazyPrefixWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
@@ -101,12 +108,11 @@ extension LazySequenceProtocol {
 /// A lazy collection wrapper that includes the initial consecutive
 /// elements of an underlying collection that satisfy a predicate.
 ///
-/// - Note: The performance of accessing `endIndex`, `last`, or any methods that
-///   depend on `endIndex`, or of moving an index, depends on how many elements
-///   satisfy the predicate at the start of the collection, and may not offer
-///   the usual performance given by the `Collection` protocol. Be aware,
-///   therefore, that general operations on instances of this collection may
-///   not have the documented complexity.
+/// - Note: The performance of accessing `endIndex` depends on how many 
+///   elements satisfy the predicate at the start of the collection, and may 
+///   not offer the usual performance given by the `Collection` protocol.
+///   Accessing `endIndex`, the `last` property, or calling methods that
+///   depend on moving indices may not have the documented complexity.
 public typealias LazyPrefixWhileCollection<T: Collection> = LazyPrefixWhileSequence<T>
 
 extension LazyPrefixWhileCollection {

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -16,10 +16,10 @@
 ///
 /// - Note: When `LazyPrefixWhileSequence` wraps a collection type, the 
 ///   performance of accessing `endIndex` depends on how many 
-///   elements satisfy the predicate at the start of the collection, and may 
+///   elements satisfy the predicate at the start of the collection, and might 
 ///   not offer the usual performance given by the `Collection` protocol.
 ///   Accessing `endIndex`, the `last` property, or calling methods that
-///   depend on moving indices may not have the documented complexity.
+///   depend on moving indices might not have the documented complexity.
 @frozen // lazy-performance
 public struct LazyPrefixWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
@@ -109,10 +109,10 @@ extension LazySequenceProtocol {
 /// elements of an underlying collection that satisfy a predicate.
 ///
 /// - Note: The performance of accessing `endIndex` depends on how many 
-///   elements satisfy the predicate at the start of the collection, and may 
+///   elements satisfy the predicate at the start of the collection, and might 
 ///   not offer the usual performance given by the `Collection` protocol.
 ///   Accessing `endIndex`, the `last` property, or calling methods that
-///   depend on moving indices may not have the documented complexity.
+///   depend on moving indices might not have the documented complexity.
 public typealias LazyPrefixWhileCollection<T: Collection> = LazyPrefixWhileSequence<T>
 
 extension LazyPrefixWhileCollection {


### PR DESCRIPTION
Fix up the `${Collection}` and `${Self}` that were left behind when de-gybbing this file.