### PR TITLE
[CSApply] Don't try to transform editor placeholder if it's type is invalid

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7398,7 +7398,11 @@ namespace {
           ClosuresToTypeCheck.push_back(closure);
         }
 
-        tc.ClosuresWithUncomputedCaptures.push_back(closure);
+        // Don't try to register captures if constraint system is used to
+        // produce diagnostics for one of the sub-expressions.
+        if (!cs.Options.contains(
+                ConstraintSystemFlags::SubExpressionDiagnostics))
+          tc.ClosuresWithUncomputedCaptures.push_back(closure);
 
         return { false, closure };
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3897,6 +3897,19 @@ namespace {
       simplifyExprType(E);
       auto valueType = cs.getType(E);
 
+      // TODO(diagnostics): Once all of the diagnostics are moved to
+      // new diagnostics framework this check could be eliminated.
+      //
+      // Only way for this to happen is CSDiag try to re-typecheck
+      // sub-expression which contains this placeholder with
+      // `AllowUnresolvedTypeVariables` flag set.
+      //
+      // A better solution could be to replace placeholders with this
+      // implicit call early on and type-check that call together with
+      // the rest of the constraint system.
+      if (valueType->hasUnresolvedType())
+        return nullptr;
+
       auto &tc = cs.getTypeChecker();
       auto &ctx = tc.Context;
       // Synthesize a call to _undefined() of appropriate type.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -840,6 +840,14 @@ enum class ConstraintSystemFlags {
   /// If set, the top-level expression may be able to provide an underlying
   /// type for the contextual opaque archetype.
   UnderlyingTypeForOpaqueReturnType = 0x40,
+
+  /// FIXME(diagnostics): Once diagnostics are completely switched to new
+  /// framework, this flag could be removed as obsolete.
+  ///
+  /// If set, this identifies constraint system as being used to re-typecheck
+  /// one of the sub-expressions as part of the expression diagnostics, which
+  /// is attempting to narrow down failure location.
+  SubExpressionDiagnostics = 0x80,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2184,6 +2184,9 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   if (options.contains(TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType))
     csOptions |= ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType;
 
+  if (options.contains(TypeCheckExprFlags::SubExpressionDiagnostics))
+    csOptions |= ConstraintSystemFlags::SubExpressionDiagnostics;
+
   ConstraintSystem cs(*this, dc, csOptions, expr);
   cs.baseCS = baseCS;
 

--- a/validation-test/compiler_crashers_2_fixed/0196-rdar48937223.swift
+++ b/validation-test/compiler_crashers_2_fixed/0196-rdar48937223.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+func fn<T, U: P>(_ arg1: T, arg2: (T) -> U) {}
+
+func test(str: String) {
+  fn(str) { arg in
+    <#FOO#> // expected-error {{editor placeholder in source file}}
+  }
+}


### PR DESCRIPTION
CSDiag could re-typecheck closure or other expression which has
editor placeholder inside allowing type variables be bound to unresolved
type, which doesn't really form a valid solution to be applied to AST.
So we need to guard against trying to transform placeholder into a call 
to `_undefined` in such case, otherwise in asserts build it's going to crash
with an assert but in release build it would crash in some other place e.g.
SILGen or trying to type-check captures.

Resolves: rdar://problem/48937223
Resolves: rdar://problem/51599529

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
