### PR TITLE
swift-api-checker: teach the script to collect Swift only frameworks from the SDK.

### DIFF
--- a/utils/api_checker/sdk-module-lists/infer-imports.py
+++ b/utils/api_checker/sdk-module-lists/infer-imports.py
@@ -15,7 +15,7 @@ def get_immediate_subdirectories(a_dir):
             if os.path.isdir(os.path.join(a_dir, name))]
 
 
-def get_frameworks(sdk_path):
+def get_frameworks(sdk_path, swift_frameworks_only):
     frameworks_path = sdk_path + "/System/Library/Frameworks"
     names = []
     for frame in os.listdir(frameworks_path):
@@ -31,6 +31,9 @@ def get_frameworks(sdk_path):
             if os.path.exists(swiftmodule_path):
                 if name not in blacklist:
                     names.append(name)
+                continue
+            # We only care about Swift frameworks then we are done.
+            if swift_frameworks_only:
                 continue
 
             if not os.path.exists(header_dir_path):
@@ -95,7 +98,8 @@ def main():
     parser.add_option("-o", "--output", help="output mode",
                       type=str, dest="out_mode", default="list")
     parser.add_option("--hash", action="store_true", dest="use_hash")
-
+    parser.add_option("--swift-frameworks-only", action="store_true")
+    parser.add_option("--v", action="store_true")
     (opts, cmd) = parser.parse_args()
 
     if not opts.sdk:
@@ -105,7 +109,10 @@ def main():
         parser.error(
             "output mode not specified: 'clang-import'/'swift-import'/'list'")
 
-    frames = get_frameworks(opts.sdk)
+    frames = get_frameworks(opts.sdk, opts.swift_frameworks_only)
+    if opts.v:
+        for name in frames:
+            print >>sys.stderr, 'Including: ', name
     if opts.out_mode == "clang-import":
         print_clang_imports(frames, opts.use_hash)
     elif opts.out_mode == "swift-import":

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -47,8 +47,16 @@ def get_sdk_path(platform):
     return check_output(['xcrun', '-sdk', platform, '-show-sdk-path'])
 
 
-def prepare_module_list(platform, file):
-    check_call([INFER_IMPORT_PATH, '-s', get_sdk_path(platform)], output=file)
+def prepare_module_list(platform, file, verbose, swift_frameworks_only):
+    cmd = [INFER_IMPORT_PATH, '-s', get_sdk_path(platform)]
+    if swift_frameworks_only:
+        cmd.extend(['--swift-frameworks-only'])
+    if verbose:
+        cmd.extend(['--v'])
+    check_call(cmd, output=file)
+    # The fixed modules are all objc frameworks.
+    if swift_frameworks_only:
+        return
     with open(INFER_IMPORT_DIR + '/fixed-modules-common.txt', 'r') as extra:
         file.write(extra.read())
     with open(INFER_IMPORT_DIR + '/fixed-modules-' + platform + '.txt',
@@ -78,7 +86,8 @@ class DumpConfig:
             self.sdk + '/System/Library/Frameworks/',
             os.path.realpath(self.sdk + '/../../Library/Frameworks/')]
 
-    def run(self, output, module, swift_ver, opts, verbose):
+    def run(self, output, module, swift_ver, opts, verbose,
+            swift_frameworks_only):
         cmd = [self.tool_path, '-o', output, '-sdk', self.sdk, '-target',
                self.target, '-dump-sdk', '-module-cache-path',
                '/tmp/ModuleCache', '-swift-version',
@@ -93,7 +102,8 @@ class DumpConfig:
             check_call(cmd, verbose=verbose)
         else:
             with tempfile.NamedTemporaryFile() as tmp:
-                prepare_module_list(self.platform, tmp)
+                prepare_module_list(self.platform, tmp, verbose,
+                                    swift_frameworks_only)
                 cmd.extend(['-module-list-file', tmp.name])
                 check_call(cmd, verbose=verbose)
 
@@ -147,6 +157,10 @@ A convenient wrapper for swift-api-digester.
         name of the module/framework to generate baseline, e.g. Foundation
         ''')
 
+    basic_group.add_argument('--swift-frameworks-only',
+                             action='store_true',
+                             help='Only include Swift frameworks in the dump')
+
     basic_group.add_argument('--opts', nargs='+', default=[], help='''
         additional flags to pass to swift-api-digester
         ''')
@@ -176,7 +190,8 @@ A convenient wrapper for swift-api-digester.
         runner = DumpConfig(tool_path=args.tool_path, platform=args.target)
         runner.run(output=args.output, module=args.module,
                    swift_ver=args.swift_version, opts=args.opts,
-                   verbose=args.v)
+                   verbose=args.v,
+                   swift_frameworks_only=args.swift_frameworks_only)
     elif args.action == 'diagnose':
         if not args.dump_before:
             fatal_error("Need to specify --dump-before")


### PR DESCRIPTION
This will only include frameworks like SwiftUI, Combine, etc.

Related: rdar://48456712