### PR TITLE
 Remove a workaround in the debug info handling of zero-sized types.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2193,11 +2193,6 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     if (Indirection)
       Operands.push_back(llvm::dwarf::DW_OP_deref);
 
-    // There are variables without storage, such as "struct { func foo() {}
-    // }". Emit them as constant 0.
-    if (isa<llvm::UndefValue>(Piece))
-      Piece = llvm::ConstantInt::get(IGM.Int64Ty, 0);
-
     if (IsPiece) {
       // Advance the offset and align it for the next piece.
       OffsetInBits += llvm::alignTo(SizeInBits, AlignInBits);

--- a/test/DebugInfo/nostorage.swift
+++ b/test/DebugInfo/nostorage.swift
@@ -25,8 +25,8 @@ struct AStruct {}
 
 // CHECK2: define{{.*}}app
 public func app() {
-  // No members? No storage! Emitted as a constant 0, because.
-  // CHECK2: call void @llvm.dbg.value(metadata i{{.*}} 0,
+  // No members? No storage!
+  // CHECK2: call void @llvm.dbg.value(metadata {{.*}}* undef,
   // CHECK2-SAME:                      metadata ![[AT:.*]], metadata
   // CHECK2: ![[AT]] = !DILocalVariable(name: "at",{{.*}}line: [[@LINE+1]]
   var at = AStruct()


### PR DESCRIPTION
This fixes potential LLVM verifier errors in exploded variables with undefined
elments, because a few lines below the size of fragments is derived from the
size of the LLVM SSA value and the constant used in the deleted workaround is
always an i64.

rdar://problem/51343998
