### PR TITLE
[5.1] Disallow `dynamic` on native Swift declarations under library-evolution mode

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3963,6 +3963,11 @@ ERROR(dynamic_with_transparent,none,
       "a declaration cannot be both '@_tranparent' and 'dynamic'",
       ())
 
+ERROR(dynamic_and_library_evolution_not_supported,none,
+      "marking non-'@objc' Swift declaration 'dynamic' in library evolution mode is not supported",
+      ())
+
+
 //------------------------------------------------------------------------------
 // MARK: @_dynamicReplacement(for:)
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -337,8 +337,11 @@ void AttributeEarlyChecker::visitDynamicAttr(DynamicAttr *attr) {
   // Members cannot be both dynamic and @_transparent.
   if (D->getAttrs().hasAttribute<TransparentAttr>())
     diagnoseAndRemoveAttr(attr, diag::dynamic_with_transparent);
+  if (!D->getAttrs().hasAttribute<ObjCAttr>() &&
+      D->getModuleContext()->isResilient())
+    diagnoseAndRemoveAttr(attr,
+                          diag::dynamic_and_library_evolution_not_supported);
 }
-
 
 void AttributeEarlyChecker::visitIBActionAttr(IBActionAttr *attr) {
   // Only instance methods can be IBActions.

--- a/test/attr/dynamicReplacement_library_evolution.swift
+++ b/test/attr/dynamicReplacement_library_evolution.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-objc-interop -enable-library-evolution  -I %t 
+
+struct Container {
+  dynamic var property: Int { return 1 } // expected-error{{marking non-'@objc' Swift declaration 'dynamic' in library evolution mode is not supported}}
+  dynamic func foo() {} // expected-error{{marking non-'@objc' Swift declaration 'dynamic' in library evolution mode is not supported}}
+}
+
+class AClass {
+  dynamic var property: Int { return 1 } // expected-error{{marking non-'@objc' Swift declaration 'dynamic' in library evolution mode is not supported}}
+  dynamic func foo() {} // expected-error{{marking non-'@objc' Swift declaration 'dynamic' in library evolution mode is not supported}}
+
+  @objc dynamic func allowed() {}
+
+
+  @objc dynamic var allowedProperty : Int { return 1}
+}

--- a/test/attr/dynamicReplacement_library_evolution_implicit_dynamic.swift
+++ b/test/attr/dynamicReplacement_library_evolution_implicit_dynamic.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-objc-interop -enable-library-evolution -enable-implicit-dynamic -I %t
+
+struct Container {
+  var property: Int { return 1 }
+  func foo() {}
+}
+
+class AClass {
+  var property: Int { return 1 }
+  func foo() {}
+
+  @objc dynamic func allowed() {}
+
+
+  @objc dynamic var allowedProperty : Int { return 1}
+}


### PR DESCRIPTION
The current ABI of dynamic is not what we want for certain declarations.

e.g

dynamic var x : Int {
  willset {
  }
}

Is exposed in the .swiftinterface file as

dynamic var x : Int {
  get {}
  set {}
}

However, the actual implementation is marking the willSet only dynamic.

var x : Int {
  dynamic willSet() {}
  get {}
  set {}
}

To be able to rely on `dynamic` in the future we disable dynamic (for
non-@objc) under library-evolution for now until we have made sure that
the ABI is proper.

rdar://51678074
