### PR TITLE
Fix crash when refining protocol from a testable import

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7177,8 +7177,7 @@ inline bool Decl::isPotentiallyOverridable() const {
       isa<SubscriptDecl>(this) ||
       isa<FuncDecl>(this) ||
       isa<DestructorDecl>(this)) {
-    return getDeclContext()->getSelfClassDecl() ||
-           isa<ProtocolDecl>(getDeclContext());
+    return getDeclContext()->getSelfClassDecl();
   } else {
     return false;
   }

--- a/test/multifile/Inputs/protocol-override-other.swift
+++ b/test/multifile/Inputs/protocol-override-other.swift
@@ -1,0 +1,3 @@
+protocol Base {
+  var foo: String { get }
+}

--- a/test/multifile/protocol-override.swift
+++ b/test/multifile/protocol-override.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/other.swiftmodule %S/Inputs/protocol-override-other.swift -module-name other -enable-testing
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+@testable import other
+
+protocol Sub : Base {
+  var foo: String { get set }
+}


### PR DESCRIPTION
We were giving protocol requirements 'open' access, which trips up other code that assumes 'open' implies its inside a class. Tighten the screws a little so that this no longer happens.

Fixes <rdar://problem/51108930>, <https://bugs.swift.org/browse/SR-10761>.