### PR TITLE
Sema: Bail out early from checkOverrideAccessControl() if we have protocol requirements [5.1]

### DIFF
--- a/test/multifile/Inputs/protocol-override-other.swift
+++ b/test/multifile/Inputs/protocol-override-other.swift
@@ -1,0 +1,3 @@
+protocol Base {
+  var foo: String { get }
+}

--- a/test/multifile/protocol-override.swift
+++ b/test/multifile/protocol-override.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/other.swiftmodule %S/Inputs/protocol-override-other.swift -module-name other -enable-testing
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+@testable import other
+
+protocol Sub : Base {
+  var foo: String { get set }
+}


### PR DESCRIPTION
Fixes <rdar://problem/51108930>, <https://bugs.swift.org/browse/SR-10761>.