### PR TITLE
[TSan] Remove usage of obsolete flag in tests

### DIFF
--- a/test/Sanitizers/tsan-norace-block-release.swift
+++ b/test/Sanitizers/tsan-norace-block-release.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
-// RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
+// RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
-// RUN: env %env-TSAN_OPTIONS=abort_on_error=0:ignore_interceptors_accesses=1 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
+// RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 

--- a/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
+++ b/validation-test/Sanitizers/tsan-ignores-arc-locks.swift
@@ -1,5 +1,5 @@
 // RUN: %target-build-swift -target %sanitizers-target-triple -sanitize=thread %s -o %t_binary
-// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
+// RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: tsan_runtime

--- a/validation-test/Sanitizers/tsan-type-metadata.swift
+++ b/validation-test/Sanitizers/tsan-type-metadata.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swiftc_driver -target %sanitizers-target-triple -sanitize=thread %import-libdispatch %s -o %t_binary
-// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
+// RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: tsan_runtime

--- a/validation-test/Sanitizers/witness_table_lookup.swift
+++ b/validation-test/Sanitizers/witness_table_lookup.swift
@@ -1,5 +1,5 @@
 // RUN: %target-build-swift -sanitize=thread %import-libdispatch -target %sanitizers-target-triple %s -o %t_binary
-// RUN: %env-TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %target-run %t_binary
+// RUN: %env-TSAN_OPTIONS=halt_on_error=1 %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test
 // REQUIRES: tsan_runtime


### PR DESCRIPTION
Cleanup usages of the flag `ignore_interceptors_accesses` which is superseded
by `ignore_noninstrumented_modules` (which is now on by default on all
platforms for Swift).
