### PR TITLE
[SE-0249] [TypeChecker] Improve simplifyKeyPathConstraint() and friends

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1079,8 +1079,7 @@ namespace {
       }
 
       // Add the member constraint for a subscript declaration.
-      // FIXME: weak name!
-      auto memberTy = CS.createTypeVariable(resultLocator, TVO_CanBindToNoEscape);
+      auto memberTy = CS.createTypeVariable(memberLocator, TVO_CanBindToNoEscape);
 
       // FIXME: synthesizeMaterializeForSet() wants to statically dispatch to
       // a known subscript here. This might be cleaner if we split off a new

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -279,8 +279,8 @@ public func memoryLayoutDotAlignmentWithResilientStruct() -> Int {
 public func memoryLayoutDotOffsetOfWithResilientStruct() -> Int? {
   // CHECK-NEXT: entry:
   // CHECK: [[RAW_KEY_PATH:%.*]] = call %swift.refcounted* @swift_getKeyPath
-  // CHECK: [[WRITABLE_KEY_PATH:%.*]] = bitcast %swift.refcounted* [[RAW_KEY_PATH]] to %Ts15WritableKeyPathCy16resilient_struct4SizeVSiG*
-  // CHECK: [[PARTIAL_KEY_PATH:%.*]] = bitcast %Ts15WritableKeyPathCy16resilient_struct4SizeVSiG* [[WRITABLE_KEY_PATH]] to %Ts14PartialKeyPathCy16resilient_struct4SizeVG*
+  // CHECK: [[WRITABLE_KEY_PATH:%.*]] = bitcast %swift.refcounted* [[RAW_KEY_PATH]] to %Ts7KeyPathCy16resilient_struct4SizeVSiG*
+  // CHECK: [[PARTIAL_KEY_PATH:%.*]] = bitcast %Ts7KeyPathCy16resilient_struct4SizeVSiG* [[WRITABLE_KEY_PATH]] to %Ts14PartialKeyPathCy16resilient_struct4SizeVG*
   // CHECK: [[ANY_KEY_PATH:%.*]] = bitcast %Ts14PartialKeyPathCy16resilient_struct4SizeVG* [[PARTIAL_KEY_PATH]] to %Ts10AnyKeyPathC*
 
   // CHECK: [[STORED_INLINE_OFFSET:%.*]] = call swiftcc { [[INT]], i8 } @"$ss10AnyKeyPathC19_storedInlineOffsetSiSgvgTj"(%Ts10AnyKeyPathC* swiftself [[ANY_KEY_PATH]])


### PR DESCRIPTION
This PR modifies how key path constraints are generated and simplified so that a hard constraint on optional-chaining key paths to `KeyPath<Root, Value?>` can be removed, which is a prerequisite to making the implementation of SE-0249 work properly. In the process, it also fixes some other bugs in key path typechecking; you'll see several test changes in the first commit reflecting this.

**This is still a work in progress.** While I think this is at least closer to the right strategy for key path typechecking, I need to clean up how it is implemented. It also causes regressions in the diagnostics on three tests:

```
/Volumes/DocumentsHD/Code/open-swift/swift/test/expr/unary/keypath/keypath.swift:680:26: error: incorrect message found
  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to specified type 'ReferenceWritableKeyPath<PP, Int>'}}
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                         cannot convert value of type 'KeyPath<Base, Int>' to specified type 'ReferenceWritableKeyPath<PP, Int>'
/Volumes/DocumentsHD/Code/open-swift/swift/test/expr/unary/keypath/keypath.swift:778:54: error: incorrect message found
  let _: KeyPath<S, Int> = \.foo // expected-error {{key path cannot refer to instance method 'foo()'}}
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                     type of expression is ambiguous without more context
/Volumes/DocumentsHD/Code/open-swift/swift/test/expr/unary/keypath/keypath.swift:779:54: error: incorrect message found
  let _: KeyPath<S, Int> = \.bar // expected-error {{key path cannot refer to static member 'bar()'}}
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                     type of expression is ambiguous without more context
```

It also doesn't actually, you know, *implement* SE-0249, and will probably create merge conflicts with that implementation. Oh well, it's still progress.