### PR TITLE
 [SE-0258] Rename 'value' to 'wrappedValue'. 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4387,7 +4387,8 @@ ERROR(property_wrapper_ambiguous_value_property, none,
   "named %1", (Type, Identifier))
 ERROR(property_wrapper_wrong_initial_value_init, none,
       "'init(initialValue:)' parameter type (%0) must be the same as its "
-      "'value' property type (%1) or an @autoclosure thereof", (Type, Type))
+      "'wrappedValue' property type (%1) or an @autoclosure thereof",
+      (Type, Type))
 ERROR(property_wrapper_failable_init, none,
       "%0 cannot be failable", (DeclName))
 ERROR(property_wrapper_ambiguous_initial_value_init, none,
@@ -4440,7 +4441,7 @@ NOTE(property_wrapper_direct_init,none,
      "'(...') on the attribute", ())
 
 ERROR(property_wrapper_incompatible_property, none,
-      "property type %0 does not match that of the 'value' property of "
+      "property type %0 does not match that of the 'wrappedValue' property of "
       "its wrapper type %1", (Type, Type))
 
 ERROR(property_wrapper_type_access,none,
@@ -4460,6 +4461,9 @@ ERROR(property_wrapper_type_not_usable_from_inline,none,
 WARNING(property_wrapper_delegateValue,none,
         "property wrapper's `delegateValue` property should be renamed to "
         "'wrapperValue'; use of 'delegateValue' is deprecated", ())
+WARNING(property_wrapper_value,none,
+        "property wrapper's `value` property should be renamed to "
+        "'wrappedValue'; use of 'value' is deprecated", ())
 
 //------------------------------------------------------------------------------
 // MARK: function builder diagnostics

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -121,6 +121,7 @@ IDENTIFIER(WinSDK)
 IDENTIFIER(with)
 IDENTIFIER(withArguments)
 IDENTIFIER(withKeywordArguments)
+IDENTIFIER(wrappedValue)
 IDENTIFIER(wrapperValue)
 
 // Kinds of layout constraints

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5794,25 +5794,71 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
 
 Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
                                                      Expr *init) {
-  auto attr = var->getAttachedPropertyWrappers().front();
-
-  // Direct initialization implies no original initial value.
-  if (attr->getArg())
+  auto *PBD = var->getParentPatternBinding();
+  if (!PBD)
     return nullptr;
 
-  // Look through any expressions wrapping the initializer.
-  init = init->getSemanticsProvidingExpr();
-  auto initCall = dyn_cast<CallExpr>(init);
-  if (!initCall)
+  // If there is no '=' on the pattern, there was no initial value.
+  if (PBD->getPatternList()[0].getEqualLoc().isInvalid())
     return nullptr;
 
-  auto initArg = cast<TupleExpr>(initCall->getArg())->getElement(0);
-  initArg = initArg->getSemanticsProvidingExpr();
-  if (auto autoclosure = dyn_cast<AutoClosureExpr>(initArg)) {
-    initArg =
-        autoclosure->getSingleExpressionBody()->getSemanticsProvidingExpr();
+  ASTContext &ctx = var->getASTContext();
+  auto dc = var->getInnermostDeclContext();
+  auto innermostAttr = var->getAttachedPropertyWrappers().back();
+  auto innermostNominal = evaluateOrDefault(
+      ctx.evaluator, CustomAttrNominalRequest{innermostAttr, dc}, nullptr);
+  if (!innermostNominal)
+    return nullptr;
+
+      // Walker
+  class Walker : public ASTWalker {
+  public:
+    NominalTypeDecl *innermostNominal;
+    Expr *initArg = nullptr;
+
+    Walker(NominalTypeDecl *innermostNominal)
+      : innermostNominal(innermostNominal) { }
+
+    virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      if (initArg)
+        return { false, E };
+
+      if (auto call = dyn_cast<CallExpr>(E)) {
+        // We're looking for an implicit call.
+        if (!call->isImplicit())
+          return { true, E };
+
+        // ... producing a value of the same nominal type as the innermost
+        // property wrapper.
+        if (call->getType()->getAnyNominal() != innermostNominal)
+          return { true, E };
+
+        // Find the implicit initialValue argument.
+        if (auto tuple = dyn_cast<TupleExpr>(call->getArg())) {
+          ASTContext &ctx = innermostNominal->getASTContext();
+          for (unsigned i : range(tuple->getNumElements())) {
+            if (tuple->getElementName(i) == ctx.Id_initialValue &&
+                tuple->getElementNameLoc(i).isInvalid()) {
+              initArg = tuple->getElement(i);
+              return { false, E };
+            }
+          }
+        }
+      }
+
+      return { true, E };
+    }
+  } walker(innermostNominal);
+  init->walk(walker);
+
+  Expr *initArg = walker.initArg;
+  if (initArg) {
+    initArg = initArg->getSemanticsProvidingExpr();
+    if (auto autoclosure = dyn_cast<AutoClosureExpr>(initArg)) {
+      initArg =
+          autoclosure->getSingleExpressionBody()->getSemanticsProvidingExpr();
+    }
   }
-
   return initArg;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5489,12 +5489,13 @@ VarDecl *VarDecl::getPropertyWrapperBackingProperty() const {
   return getPropertyWrapperBackingPropertyInfo().backingVar;
 }
 
-bool VarDecl::isPropertyWrapperInitializedWithInitialValue() const {
-  auto customAttrs = getAttachedPropertyWrappers();
+static bool propertyWrapperInitializedViaInitialValue(
+   const VarDecl *var, bool checkDefaultInit) {
+  auto customAttrs = var->getAttachedPropertyWrappers();
   if (customAttrs.empty())
     return false;
 
-  auto *PBD = getParentPatternBinding();
+  auto *PBD = var->getParentPatternBinding();
   if (!PBD)
     return false;
 
@@ -5509,36 +5510,23 @@ bool VarDecl::isPropertyWrapperInitializedWithInitialValue() const {
     return false;
 
   // Default initialization does not use a value.
-  if (getAttachedPropertyWrapperTypeInfo(0).defaultInit)
+  if (checkDefaultInit &&
+      var->getAttachedPropertyWrapperTypeInfo(0).defaultInit)
     return false;
 
   // If all property wrappers have an initialValue initializer, the property
   // wrapper will be initialized that way.
-  return allAttachedPropertyWrappersHaveInitialValueInit();
+  return var->allAttachedPropertyWrappersHaveInitialValueInit();
+}
+
+bool VarDecl::isPropertyWrapperInitializedWithInitialValue() const {
+  return propertyWrapperInitializedViaInitialValue(
+      this, /*checkDefaultInit=*/true);
 }
 
 bool VarDecl::isPropertyMemberwiseInitializedWithWrappedType() const {
-  auto customAttrs = getAttachedPropertyWrappers();
-  if (customAttrs.empty())
-    return false;
-
-  auto *PBD = getParentPatternBinding();
-  if (!PBD)
-    return false;
-
-  // If there was an initializer on the original property, initialize
-  // via the initial value.
-  if (PBD->getPatternList()[0].getEqualLoc().isValid())
-    return true;
-
-  // If there was an initializer on the outermost wrapper, initialize
-  // via the full wrapper.
-  if (customAttrs[0]->getArg() != nullptr)
-    return false;
-
-  // If all property wrappers have an initialValue initializer, the property
-  // wrapper will be initialized that way.
-  return allAttachedPropertyWrappersHaveInitialValueInit();
+  return propertyWrapperInitializedViaInitialValue(
+      this, /*checkDefaultInit=*/false);
 }
 
 Identifier VarDecl::getObjCPropertyName() const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4662,7 +4662,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       // If the base type is optional because we haven't chosen to force an
       // implicit optional, don't try to fix it. The IUO will be forced instead.
-      if (auto dotExpr = dyn_cast<UnresolvedDotExpr>(locator->getAnchor())) {
+      if (auto dotExpr =
+              dyn_cast_or_null<UnresolvedDotExpr>(locator->getAnchor())) {
         auto baseExpr = dotExpr->getBase();
         auto resolvedOverload = getResolvedOverloadSets();
         while (resolvedOverload) {
@@ -4682,8 +4683,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       auto innerTV = createTypeVariable(locator,
                                         TVO_CanBindToLValue |
                                         TVO_CanBindToNoEscape);
-      Type optTy = getTypeChecker().getOptionalType(
-          locator->getAnchor()->getSourceRange().Start, innerTV);
+      Type optTy = getTypeChecker().getOptionalType(SourceLoc(), innerTV);
       SmallVector<Constraint *, 2> optionalities;
       auto nonoptionalResult = Constraint::createFixed(
           *this, ConstraintKind::Bind,

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -296,6 +296,60 @@ class UseWrapperWithDefaultInit {
 // CHECK: function_ref @$s17property_wrappers22WrapperWithDefaultInitVACyxGycfC
 // CHECK: return {{%.*}} : $WrapperWithDefaultInit<String>
 
+// Property wrapper composition.
+@propertyWrapper
+struct WrapperA<Value> {
+  var value: Value
+
+  init(initialValue: Value) {
+    value = initialValue
+  }
+}
+
+@propertyWrapper
+struct WrapperB<Value> {
+  var value: Value
+
+  init(initialValue: Value) {
+    value = initialValue
+  }
+}
+
+@propertyWrapper
+struct WrapperC<Value> {
+  var value: Value?
+
+  init(initialValue: Value?) {
+    value = initialValue
+  }
+}
+
+struct CompositionMembers {
+  // CompositionMembers.p1.getter
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p1SiSgvg : $@convention(method) (@guaranteed CompositionMembers) -> Optional<Int>
+  // CHECK: bb0([[SELF:%.*]] : @guaranteed $CompositionMembers):
+  // CHECK: [[P1:%.*]] = struct_extract [[SELF]] : $CompositionMembers, #CompositionMembers.$p1
+  // CHECK: [[P1_VALUE:%.*]] = struct_extract [[P1]] : $WrapperA<WrapperB<WrapperC<Int>>>, #WrapperA.value
+  // CHECK: [[P1_VALUE2:%.*]] = struct_extract [[P1_VALUE]] : $WrapperB<WrapperC<Int>>, #WrapperB.value
+  // CHECK: [[P1_VALUE3:%.*]] = struct_extract [[P1_VALUE2]] : $WrapperC<Int>, #WrapperC.value
+  // CHECK: return [[P1_VALUE3]] : $Optional<Int>
+  @WrapperA @WrapperB @WrapperC var p1: Int?
+  @WrapperA @WrapperB @WrapperC var p2 = "Hello"
+
+  // variable initialization expression of CompositionMembers.$p2
+  // CHECK-LABEL: sil hidden [transparent] [ossa] @$s17property_wrappers18CompositionMembersV3$p233_{{.*}}8WrapperAVyAA0N1BVyAA0N1CVySSGGGvpfi : $@convention(thin) () -> @owned Optional<String> {
+  // CHECK: %0 = string_literal utf8 "Hello"
+
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p12p2ACSiSg_SSSgtcfC : $@convention(method) (Optional<Int>, @owned Optional<String>, @thin CompositionMembers.Type) -> @owned CompositionMembers
+  // CHECK: function_ref @$s17property_wrappers8WrapperCV12initialValueACyxGxSg_tcfC
+  // CHECK: function_ref @$s17property_wrappers8WrapperBV12initialValueACyxGx_tcfC
+  // CHECK: function_ref @$s17property_wrappers8WrapperAV12initialValueACyxGx_tcfC
+}
+
+func testComposition() {
+  _ = CompositionMembers(p1: nil)
+}
+
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -1,19 +1,19 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 @propertyWrapper
 final class ClassWrapper<T> {
-  var value: T {
+  var wrappedValue: T {
     didSet {
-      print("  .. set \(value)")
+      print("  .. set \(wrappedValue)")
     }
   }
 
   init(initialValue: T) {
     print("  .. init \(initialValue)")
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 
   deinit {
-    print("  .. deinit \(value)")
+    print("  .. deinit \(wrappedValue)")
   }
 }
 

--- a/test/decl/protocol/special/coding/property_wrappers_codable.swift
+++ b/test/decl/protocol/special/coding/property_wrappers_codable.swift
@@ -2,15 +2,15 @@
 
 @propertyWrapper
 struct Wrapper<T: Codable> {
-  var value: T
+  var wrappedValue: T
 }
 
 @propertyWrapper
 struct WrapperWithInitialValue<T: Codable> {
-  var value: T
+  var wrappedValue: T
 
   init(initialValue: T) {
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -4,10 +4,10 @@
 
 @propertyDelegate // expected-warning{{'@propertyDelegate' has been renamed to '@propertyWrapper'}}{{2-18=propertyWrapper}}
 struct Delegate<T> {
-  var value: T
+  var wrappedValue: T
 
   var delegateValue: Wrapper<T> { // expected-warning{{property wrapper's `delegateValue` property should be renamed to 'wrapperValue'; use of 'delegateValue' is deprecated}}{{7-20=wrapperValue}}
-    return Wrapper(value: value)
+    return Wrapper(wrappedValue: wrappedValue)
   }
 }
 
@@ -21,5 +21,18 @@ struct TestDelegateValue {
 
 @_propertyWrapper // expected-warning{{'@_propertyWrapper' has been renamed to '@propertyWrapper'}}{{2-18=propertyWrapper}}
 struct Wrapper<T> {
-  var value: T
+  var wrappedValue: T
+}
+
+@propertyWrapper
+struct OldValue<T> {
+  var value: T // expected-warning{{property wrapper's `value` property should be renamed to 'wrappedValue'; use of 'value' is deprecated}}
+}
+
+struct TestOldValue {
+  @OldValue var x: String
+
+  func f() -> String {
+    return x
+  }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -5,15 +5,15 @@
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct Wrapper<T> {
-  var value: T
+  var wrappedValue: T
 }
 
 @propertyWrapper
 struct WrapperWithInitialValue<T> {
-  var value: T
+  var wrappedValue: T
 
   init(initialValue: T) {
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 
@@ -21,7 +21,7 @@ struct WrapperWithInitialValue<T> {
 struct WrapperAcceptingAutoclosure<T> {
   private let fn: () -> T
 
-  var value: T {
+  var wrappedValue: T {
     return fn()
   }
 
@@ -36,48 +36,48 @@ struct WrapperAcceptingAutoclosure<T> {
 
 @propertyWrapper
 struct MissingValue<T> { }
-// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'value'}}
+// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'wrappedValue'}}
 
 @propertyWrapper
 struct StaticValue {
-  static var value: Int = 17
+  static var wrappedValue: Int = 17
 }
-// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'value'}}
+// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}
 
 
 // expected-error@+1{{'@propertyWrapper' attribute cannot be applied to this declaration}}
 @propertyWrapper
 protocol CannotBeAWrapper {
   associatedtype Value
-  var value: Value { get set }
+  var wrappedValue: Value { get set }
 }
 
 @propertyWrapper
 struct NonVisibleValueWrapper<Value> {
-  private var value: Value // expected-error{{private property 'value' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleValueWrapper' (which is internal)}}
+  private var wrappedValue: Value // expected-error{{private property 'wrappedValue' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleValueWrapper' (which is internal)}}
 }
 
 @propertyWrapper
 struct NonVisibleInitWrapper<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   private init(initialValue: Value) { // expected-error{{private initializer 'init(initialValue:)' cannot have more restrictive access than its enclosing property wrapper type 'NonVisibleInitWrapper' (which is internal)}}
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 
 @propertyWrapper
 struct InitialValueTypeMismatch<Value> {
-  var value: Value // expected-note{{'value' declared here}}
+  var wrappedValue: Value // expected-note{{'wrappedValue' declared here}}
 
-  init(initialValue: Value?) { // expected-error{{'init(initialValue:)' parameter type ('Value?') must be the same as its 'value' property type ('Value') or an @autoclosure thereof}}
-    self.value = initialValue!
+  init(initialValue: Value?) { // expected-error{{'init(initialValue:)' parameter type ('Value?') must be the same as its 'wrappedValue' property type ('Value') or an @autoclosure thereof}}
+    self.wrappedValue = initialValue!
   }
 }
 
 @propertyWrapper
 struct MultipleInitialValues<Value> { // expected-error{{property wrapper type 'MultipleInitialValues' has multiple initial-value initializers}}
-  var value: Value? = nil
+  var wrappedValue: Value? = nil
 
   init(initialValue: Int) { // expected-note{{initializer 'init(initialValue:)' declared here}}
   }
@@ -88,7 +88,7 @@ struct MultipleInitialValues<Value> { // expected-error{{property wrapper type '
 
 @propertyWrapper
 struct InitialValueFailable<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init?(initialValue: Value) { // expected-error{{'init(initialValue:)' cannot be failable}}
     return nil
@@ -97,7 +97,7 @@ struct InitialValueFailable<Value> {
 
 @propertyWrapper
 struct InitialValueFailableIUO<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init!(initialValue: Value) {  // expected-error{{'init(initialValue:)' cannot be failable}}
     return nil
@@ -109,12 +109,12 @@ struct InitialValueFailableIUO<Value> {
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct _lowercaseWrapper<T> {
-  var value: T
+  var wrappedValue: T
 }
 
 @propertyWrapper
 struct _UppercaseWrapper<T> {
-  var value: T
+  var wrappedValue: T
 }
 
 // ---------------------------------------------------------------------------
@@ -131,20 +131,20 @@ func testLocalContext() {
 enum SomeEnum {
   case foo
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var bar: Int // expected-error{{property 'bar' declared inside an enum cannot have a wrapper}}
   // expected-error@-1{{enums must not contain stored properties}}
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   static var x: Int
 }
 
 protocol SomeProtocol {
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var bar: Int // expected-error{{property 'bar' declared inside a protocol cannot have a wrapper}}
   // expected-error@-1{{property in protocol must have explicit { get } or { get set } specifier}}
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   static var x: Int // expected-error{{property 'x' declared inside a protocol cannot have a wrapper}}
   // expected-error@-1{{property in protocol must have explicit { get } or { get set } specifier}}
 }
@@ -152,16 +152,16 @@ protocol SomeProtocol {
 struct HasWrapper { }
 
 extension HasWrapper {
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var inExt: Int // expected-error{{property 'inExt' declared inside an extension cannot have a wrapper}}
   // expected-error@-1{{extensions must not contain stored properties}}
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   static var x: Int
 }
 
 class ClassWithWrappers {
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var x: Int
 }
 
@@ -177,7 +177,7 @@ class SubclassOfClassWithWrappers: ClassWithWrappers {
 }
 
 class SubclassWithWrapper: Superclass {
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   override var x: Int { get { return 0 } set { } } // expected-error{{property 'x' with attached wrapper cannot override another property}}
 }
 
@@ -193,7 +193,7 @@ struct BadCombinations {
 }
 
 struct MultipleWrappers {
-  @Wrapper(value: 17) // expected-error{{cannot convert value of type 'Wrapper<Int>' to specified type 'Int'}}
+  @Wrapper(wrappedValue: 17) // expected-error{{cannot convert value of type 'Wrapper<Int>' to specified type 'Int'}}
   @WrapperWithInitialValue
   var x: Int = 17 // expected-error{{property 'x' with attached wrapper cannot initialize both the wrapper type and the property}}
 
@@ -206,16 +206,16 @@ struct MultipleWrappers {
 // ---------------------------------------------------------------------------
 
 struct Initialization {
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var x: Int
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var x2: Double
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var x3 = 42 // expected-error{{property 'x3' with attached wrapper cannot initialize both the wrapper type and the property}}
 
-  @Wrapper(value: 17)
+  @Wrapper(wrappedValue: 17)
   var x4
 
   @WrapperWithInitialValue
@@ -237,17 +237,17 @@ struct Initialization {
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct IntWrapper {
-  var value: Int
+  var wrappedValue: Int
 }
 
 @propertyWrapper
 struct WrapperForHashable<T: Hashable> { // expected-note{{property wrapper type 'WrapperForHashable' declared here}}
-  var value: T
+  var wrappedValue: T
 }
 
 @propertyWrapper
 struct WrapperWithTwoParams<T, U> {
-  var value: (T, U)
+  var wrappedValue: (T, U)
 }
 
 struct NotHashable { }
@@ -258,7 +258,7 @@ struct UseWrappersWithDifferentForm {
 
   // FIXME: Diagnostic should be better here
   @WrapperForHashable
-  var y: NotHashable // expected-error{{property type 'NotHashable' does not match that of the 'value' property of its wrapper type 'WrapperForHashable'}}
+  var y: NotHashable // expected-error{{property type 'NotHashable' does not match that of the 'wrappedValue' property of its wrapper type 'WrapperForHashable'}}
 
   @WrapperForHashable
   var yOkay: Int
@@ -268,7 +268,7 @@ struct UseWrappersWithDifferentForm {
 
   // FIXME: Need a better diagnostic here
   @HasNestedWrapper.NestedWrapper
-  var w: Int // expected-error{{property type 'Int' does not match that of the 'value' property of its wrapper type 'HasNestedWrapper.NestedWrapper'}}
+  var w: Int // expected-error{{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'HasNestedWrapper.NestedWrapper'}}
 
   @HasNestedWrapper<Double>.NestedWrapper
   var wOkay: Int
@@ -279,13 +279,13 @@ struct UseWrappersWithDifferentForm {
 
 @propertyWrapper
 struct Function<T, U> { // expected-note{{property wrapper type 'Function' declared here}}
-  var value: (T) -> U?
+  var wrappedValue: (T) -> U?
 }
 
 struct TestFunction {
   @Function var f: (Int) -> Float?
   
-  @Function var f2: (Int) -> Float // expected-error{{property type '(Int) -> Float' does not match that of the 'value' property of its wrapper type 'Function'}}
+  @Function var f2: (Int) -> Float // expected-error{{property type '(Int) -> Float' does not match that of the 'wrappedValue' property of its wrapper type 'Function'}}
 
   func test() {
     let _: Int = $f // expected-error{{cannot convert value of type 'Function<Int, Float>' to specified type 'Int'}}
@@ -298,17 +298,17 @@ struct TestFunction {
 struct HasNestedWrapper<T> {
   @propertyWrapper
   struct NestedWrapper<U> { // expected-note{{property wrapper type 'NestedWrapper' declared here}}
-    var value: U
+    var wrappedValue: U
     init(initialValue: U) {
-      self.value = initialValue
+      self.wrappedValue = initialValue
     }
   }
 
   @propertyWrapper
   struct ConcreteNestedWrapper {
-    var value: T
+    var wrappedValue: T
     init(initialValue: T) {
-      self.value = initialValue
+      self.wrappedValue = initialValue
     }
   }
 
@@ -388,21 +388,21 @@ struct UseWillSetDidSet {
 @propertyWrapper
 struct WrapperWithNonMutatingSetter<Value> {
   class Box {
-    var value: Value
-    init(value: Value) {
-      self.value = value
+    var wrappedValue: Value
+    init(wrappedValue: Value) {
+      self.wrappedValue = wrappedValue
     }
   }
 
   var box: Box
 
   init(initialValue: Value) {
-    self.box = Box(value: initialValue)
+    self.box = Box(wrappedValue: initialValue)
   }
 
-  var value: Value {
-    get { return box.value }
-    nonmutating set { box.value = newValue }
+  var wrappedValue: Value {
+    get { return box.wrappedValue }
+    nonmutating set { box.wrappedValue = newValue }
   }
 }
 
@@ -416,7 +416,7 @@ struct WrapperWithMutatingGetter<Value> {
     self.stored = initialValue
   }
 
-  var value: Value {
+  var wrappedValue: Value {
     mutating get {
       readCount += 1
       return stored
@@ -430,10 +430,10 @@ struct WrapperWithMutatingGetter<Value> {
 
 @propertyWrapper
 class ClassWrapper<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init(initialValue: Value) {
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 
@@ -489,9 +489,9 @@ func testMutatingness() {
 struct HasPrivateWrapper<T> {
   @propertyWrapper
   private struct PrivateWrapper<U> { // expected-note{{type declared here}}
-    var value: U
+    var wrappedValue: U
     init(initialValue: U) {
-      self.value = initialValue
+      self.wrappedValue = initialValue
     }
   }
 
@@ -507,9 +507,9 @@ struct HasPrivateWrapper<T> {
 public struct HasUsableFromInlineWrapper<T> {
   @propertyWrapper
   struct InternalWrapper<U> { // expected-note{{type declared here}}
-    var value: U
+    var wrappedValue: U
     init(initialValue: U) {
-      self.value = initialValue
+      self.wrappedValue = initialValue
     }
   }
 
@@ -521,10 +521,10 @@ public struct HasUsableFromInlineWrapper<T> {
 
 @propertyWrapper
 class Box<Value> {
-  private(set) var value: Value
+  private(set) var wrappedValue: Value
 
   init(initialValue: Value) {
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 
@@ -560,11 +560,11 @@ func testMemberwiseInits() {
   // expected-error@+1{{type '(Wrapper<Bool>, Double) -> MemberwiseInits<Double>'}}
   let _: Int = MemberwiseInits<Double>.init
 
-  _ = MemberwiseInits(x: Wrapper(value: true), y: 17)
+  _ = MemberwiseInits(x: Wrapper(wrappedValue: true), y: 17)
 }
 
 struct DefaultedMemberwiseInits {
-  @Wrapper(value: true)
+  @Wrapper(wrappedValue: true)
   var x: Bool
 
   @WrapperWithInitialValue
@@ -577,12 +577,12 @@ struct DefaultedMemberwiseInits {
 func testDefaultedMemberwiseInits() {
   _ = DefaultedMemberwiseInits()
   _ = DefaultedMemberwiseInits(
-    x: Wrapper(value: false),
+    x: Wrapper(wrappedValue: false),
     y: 42,
     z: WrapperWithInitialValue(initialValue: 42))
 
   _ = DefaultedMemberwiseInits(y: 42)
-  _ = DefaultedMemberwiseInits(x: Wrapper(value: false))
+  _ = DefaultedMemberwiseInits(x: Wrapper(wrappedValue: false))
   _ = DefaultedMemberwiseInits(z: WrapperWithInitialValue(initialValue: 42))
 }
 
@@ -590,7 +590,7 @@ func testDefaultedMemberwiseInits() {
 // Default initializers
 // ---------------------------------------------------------------------------
 struct DefaultInitializerStruct {
-  @Wrapper(value: true)
+  @Wrapper(wrappedValue: true)
   var x
 
   @WrapperWithInitialValue
@@ -603,7 +603,7 @@ struct NoDefaultInitializerStruct { // expected-note{{'init(x:)' declared here}}
 }
 
 class DefaultInitializerClass {
-  @Wrapper(value: true)
+  @Wrapper(wrappedValue: true)
   var x
 
   @WrapperWithInitialValue
@@ -622,7 +622,7 @@ func testDefaultInitializers() {
 }
 
 struct DefaultedPrivateMemberwiseLets {
-  @Wrapper(value: true)
+  @Wrapper(wrappedValue: true)
   private var x: Bool
 
   @WrapperWithInitialValue
@@ -635,7 +635,7 @@ struct DefaultedPrivateMemberwiseLets {
 func testDefaultedPrivateMemberwiseLets() {
   _ = DefaultedPrivateMemberwiseLets()
   _ = DefaultedPrivateMemberwiseLets(y: 42)
-  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(value: false)) // expected-error{{incorrect argument label in call (have 'x:', expected 'y:')}}
+  _ = DefaultedPrivateMemberwiseLets(x: Wrapper(wrappedValue: false)) // expected-error{{incorrect argument label in call (have 'x:', expected 'y:')}}
 }
 
 
@@ -644,10 +644,10 @@ func testDefaultedPrivateMemberwiseLets() {
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct WrapperWithStorageRef<T> {
-  var value: T
+  var wrappedValue: T
 
   var wrapperValue: Wrapper<T> {
-    return Wrapper(value: value)
+    return Wrapper(wrappedValue: wrappedValue)
   }
 }
 
@@ -660,7 +660,7 @@ struct TestStorageRef {
   // expected-note@-1{{'$x' declared here}}
 
   init(x: Int) {
-    self.$$x = WrapperWithStorageRef(value: x)
+    self.$$x = WrapperWithStorageRef(wrappedValue: x)
   }
 
   mutating func test() {
@@ -670,7 +670,7 @@ struct TestStorageRef {
 
     // x is mutable, $x is not
     x = 17
-    $x = Wrapper(value: 42) // expected-error{{cannot assign to property: '$x' is immutable}}
+    $x = Wrapper(wrappedValue: 42) // expected-error{{cannot assign to property: '$x' is immutable}}
   }
 }
 
@@ -683,14 +683,14 @@ func testStorageRef(tsr: TestStorageRef) {
 // generic type.
 @propertyWrapper
 struct InitialValueWrapperWithStorageRef<T> {
-  var value: T
+  var wrappedValue: T
 
   init(initialValue: T) {
-    value = initialValue
+    wrappedValue = initialValue
   }
 
   var wrapperValue: Wrapper<T> {
-    return Wrapper(value: value)
+    return Wrapper(wrappedValue: wrappedValue)
   }
 }
 
@@ -704,12 +704,12 @@ struct TestGenericStorageRef<T> {
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct BrokenLazy { }
-// expected-error@-1{{property wrapper type 'BrokenLazy' does not contain a non-static property named 'value'}}
+// expected-error@-1{{property wrapper type 'BrokenLazy' does not contain a non-static property named 'wrappedValue'}}
 // expected-note@-2{{'BrokenLazy' declared here}}
 
 struct S {
   @BrokenLazy // expected-error{{struct 'BrokenLazy' cannot be used as an attribute}}
-  var value: Int
+  var wrappedValue: Int
 }
 
 // ---------------------------------------------------------------------------
@@ -730,10 +730,10 @@ struct UsesExplicitClosures {
 // rdar://problem/50822051 - compiler assertion / hang
 @propertyWrapper
 struct PD<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init<A>(initialValue: Value, a: A) { // expected-note{{'init(initialValue:a:)' declared here}}
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 }
 
@@ -746,8 +746,8 @@ protocol P { }
 
 @propertyWrapper
 struct WrapperRequiresP<T: P> {
-  var value: T
-  var wrapperValue: T { return value }
+  var wrappedValue: T
+  var wrapperValue: T { return wrappedValue }
 }
 
 struct UsesWrapperRequiringP {
@@ -762,11 +762,11 @@ struct UsesWrapperRequiringP {
 // SR-10899 / rdar://problem/51588022
 @propertyWrapper
 struct SR_10899_Wrapper { // expected-note{{property wrapper type 'SR_10899_Wrapper' declared here}}
-  var value: String { "hi" }
+  var wrappedValue: String { "hi" }
 }
 
 struct SR_10899_Usage {
-  @SR_10899_Wrapper var thing: Bool // expected-error{{property type 'Bool' does not match that of the 'value' property of its wrapper type 'SR_10899_Wrapper'}}
+  @SR_10899_Wrapper var thing: Bool // expected-error{{property type 'Bool' does not match that of the 'wrappedValue' property of its wrapper type 'SR_10899_Wrapper'}}
 }
 
 // ---------------------------------------------------------------------------
@@ -774,39 +774,39 @@ struct SR_10899_Usage {
 // ---------------------------------------------------------------------------
 @propertyWrapper
 struct WrapperA<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init(initialValue: Value) {
-    value = initialValue
+    wrappedValue = initialValue
   }
 }
 
 @propertyWrapper
 struct WrapperB<Value> {
-  var value: Value
+  var wrappedValue: Value
 
   init(initialValue: Value) {
-    value = initialValue
+    wrappedValue = initialValue
   }
 }
 
 @propertyWrapper
 struct WrapperC<Value> {
-  var value: Value?
+  var wrappedValue: Value?
 
   init(initialValue: Value?) {
-    value = initialValue
+    wrappedValue = initialValue
   }
 }
 
 @propertyWrapper
 struct WrapperD<Value, X, Y> { // expected-note{{property wrapper type 'WrapperD' declared here}}
-  var value: Value
+  var wrappedValue: Value
 }
 
 @propertyWrapper
 struct WrapperE<Value> {
-  var value: Value
+  var wrappedValue: Value
 }
 
 struct TestComposition {
@@ -814,7 +814,7 @@ struct TestComposition {
   @WrapperA @WrapperB @WrapperC var p2 = "Hello"
   @WrapperD<WrapperE, Int, String> @WrapperE var p3: Int?
   @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int?
-  @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{property type 'Int' does not match that of the 'value' property of its wrapper type 'WrapperD<WrapperC, Int, String>'}}
+  @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'WrapperD<WrapperC, Int, String>'}}
 
 	func triggerErrors(d: Double) {
 		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -799,15 +799,30 @@ struct WrapperC<Value> {
   }
 }
 
+@propertyWrapper
+struct WrapperD<Value, X, Y> { // expected-note{{property wrapper type 'WrapperD' declared here}}
+  var value: Value
+}
+
+@propertyWrapper
+struct WrapperE<Value> {
+  var value: Value
+}
+
 struct TestComposition {
   @WrapperA @WrapperB @WrapperC var p1: Int?
   @WrapperA @WrapperB @WrapperC var p2 = "Hello"
+  @WrapperD<WrapperE, Int, String> @WrapperE var p3: Int?
+  @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int?
+  @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{property type 'Int' does not match that of the 'value' property of its wrapper type 'WrapperD<WrapperC, Int, String>'}}
 
 	func triggerErrors(d: Double) {
 		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}}
 		p2 = d // expected-error{{cannot assign value of type 'Double' to type 'String?'}}
+    p3 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}}
 
 		$p1 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperA<WrapperB<WrapperC<Int>>>'}}
 		$p2 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperA<WrapperB<WrapperC<String>>>'}}
+    $p3 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperD<WrapperE<Int?>, Int, String>'}}
 	}
 }


### PR DESCRIPTION
The latter name is far less likely to conflict. Maintain backward compatibility
by also accepting 'value' (with a warning).