### PR TITLE
 [SE-0258] Support initial values & explicit initialization arguments.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4430,12 +4430,6 @@ ERROR(property_with_wrapper_overrides,none,
       "property %0 with attached wrapper cannot override another property",
       (DeclName))
 
-ERROR(property_wrapper_and_normal_init,none,
-      "property %0 with attached wrapper cannot initialize both the "
-      "wrapper type and the property", (DeclName))
-ERROR(property_wrapper_init_without_initial_value, none,
-      "initializing property %0 with wrapper %1 that lacks "
-      "an 'init(initialValue:)' initializer", (DeclName, Type))
 NOTE(property_wrapper_direct_init,none,
      "initialize the property wrapper type directly with "
      "'(...') on the attribute", ())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1847,8 +1847,8 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   }
 
   // Get the property wrapper information.
-  if (!var->allAttachedPropertyWrappersHaveInitialValueInit()) {
-    assert(!originalInitialValue);
+  if (!var->allAttachedPropertyWrappersHaveInitialValueInit() &&
+      !originalInitialValue) {
     return PropertyWrapperBackingPropertyInfo(
         backingVar, storageVar, nullptr, nullptr, nullptr);
   }
@@ -1859,9 +1859,10 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
       new (ctx) OpaqueValueExpr(var->getLoc(), var->getType(),
                                 /*isPlaceholder=*/true);
   Expr *initializer = buildPropertyWrapperInitialValueCall(
-      var, storageType, origValue);
-  typeCheckSynthesizedWrapperInitializer(pbd, backingVar, parentPBD,
-                                         initializer);
+      var, storageType, origValue,
+      /*ignoreAttributeArgs=*/!originalInitialValue);
+  typeCheckSynthesizedWrapperInitializer(
+      pbd, backingVar, parentPBD, initializer);
 
   return PropertyWrapperBackingPropertyInfo(
       backingVar, storageVar, originalInitialValue, initializer, origValue);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2709,7 +2709,16 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       // call.
       auto &ctx = singleVar->getASTContext();
       auto outermostWrapperAttr = wrapperAttrs.front();
-      if (auto outermostArg = outermostWrapperAttr->getArg()) {
+      if (initializer) {
+        // Form init(initialValue:) call(s).
+        Expr *wrappedInitializer =
+            buildPropertyWrapperInitialValueCall(
+                singleVar, Type(), initializer, /*ignoreAttributeArgs=*/false);
+        if (!wrappedInitializer)
+          return;
+
+        initializer = wrappedInitializer;
+      } else if (auto outermostArg = outermostWrapperAttr->getArg()) {
         Type outermostWrapperType =
             singleVar->getAttachedPropertyWrapperType(0);
         if (!outermostWrapperType)
@@ -2718,63 +2727,14 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         auto typeExpr = TypeExpr::createImplicitHack(
             outermostWrapperAttr->getTypeLoc().getLoc(),
             outermostWrapperType, ctx);
-        if (initializer) {
-          singleVar->diagnose(diag::property_wrapper_and_normal_init,
-                              singleVar->getFullName())
-            .highlight(outermostWrapperAttr->getRange())
-            .highlight(initializer->getSourceRange());
-        }
-
         initializer = CallExpr::create(
             ctx, typeExpr, outermostArg,
             outermostWrapperAttr->getArgumentLabels(),
             outermostWrapperAttr->getArgumentLabelLocs(),
             /*hasTrailingClosure=*/false,
             /*implicit=*/false);
-      } else if (singleVar->allAttachedPropertyWrappersHaveInitialValueInit()) {
-        // FIXME: we want to use the initialValueInits we found.
-        assert(initializer);
-        
-        // Form init(initialValue:) call(s).
-        Expr *wrappedInitializer =
-            buildPropertyWrapperInitialValueCall(singleVar, Type(),
-                                                 initializer);
-        if (!wrappedInitializer)
-          return;
-        
-        initializer = wrappedInitializer;
       } else {
-        // Find the property wrapper that does not have an initialValue
-        // initializer and diagnose it.
-        for (unsigned i : indices(wrapperAttrs)) {
-          auto wrapperTypeInfo =
-              singleVar->getAttachedPropertyWrapperTypeInfo(i);
-          if (wrapperTypeInfo.initialValueInit)
-            continue;
-          
-          Type wrapperType = singleVar->getAttachedPropertyWrapperType(i);
-          if (!wrapperType)
-            return;
-          
-          auto wrapperNominal = wrapperType->getAnyNominal();
-          if (!wrapperNominal)
-            return;
-          
-          CustomAttr *wrapperAttr = wrapperAttrs[i];
-          singleVar->diagnose(diag::property_wrapper_init_without_initial_value,
-                              singleVar->getFullName(), wrapperType)
-            .highlight(initializer->getSourceRange());
-          ctx.Diags.diagnose(wrapperAttr->getLocation(),
-                             diag::property_wrapper_direct_init)
-            .fixItInsertAfter(initializer->getSourceRange().End,
-                              "(<# initializer args #>)");
-          wrapperNominal->diagnose(diag::kind_declname_declared_here,
-                                    wrapperNominal->getDescriptiveKind(),
-                                    wrapperNominal->getFullName());
-          return;
-        }
-        
-        llvm_unreachable("All wrappers had init(initialValue:)?");
+        llvm_unreachable("No initializer anywhere?");
       }
       wrapperAttrs[0]->setSemanticInit(initializer);
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -560,7 +560,8 @@ Type swift::computeWrappedValueType(VarDecl *var, Type backingStorageType,
 }
 
 Expr *swift::buildPropertyWrapperInitialValueCall(
-    VarDecl *var, Type backingStorageType, Expr *value) {
+    VarDecl *var, Type backingStorageType, Expr *value,
+    bool ignoreAttributeArgs) {
   // From the innermost wrapper type out, form init(initialValue:) calls.
   ASTContext &ctx = var->getASTContext();
   auto wrapperAttrs = var->getAttachedPropertyWrappers();
@@ -575,8 +576,39 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
     auto typeExpr = TypeExpr::createImplicitHack(
         wrapperAttrs[i]->getTypeLoc().getLoc(),
         wrapperType, ctx);
+
+    // If there were no arguments provided for the attribute at this level,
+    // call `init(initialValue:)` directly.
+    auto attr = wrapperAttrs[i];
+    if (!attr->getArg() || ignoreAttributeArgs) {
+      initializer = CallExpr::createImplicit(
+          ctx, typeExpr, {initializer}, {ctx.Id_initialValue});
+      continue;
+    }
+
+    // Splice `initialValue:` into the argument list.
+    SmallVector<Expr *, 4> elements;
+    SmallVector<Identifier, 4> elementNames;
+    SmallVector<SourceLoc, 4> elementLocs;
+    elements.push_back(initializer);
+    elementNames.push_back(ctx.Id_initialValue);
+    elementLocs.push_back(SourceLoc());
+
+    if (auto tuple = dyn_cast<TupleExpr>(attr->getArg())) {
+      for (unsigned i : range(tuple->getNumElements())) {
+        elements.push_back(tuple->getElement(i));
+        elementNames.push_back(tuple->getElementName(i));
+        elementLocs.push_back(tuple->getElementNameLoc(i));
+      }
+    } else {
+      auto paren = cast<ParenExpr>(attr->getArg());
+      elements.push_back(paren->getSubExpr());
+      elementNames.push_back(Identifier());
+      elementLocs.push_back(SourceLoc());
+    }
+
     initializer = CallExpr::createImplicit(
-        ctx, typeExpr, {initializer}, {ctx.Id_initialValue});
+        ctx, typeExpr, elements, elementNames);
   }
   
   return initializer;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -261,7 +261,8 @@ PropertyWrapperTypeInfoRequest::evaluate(
       return PropertyWrapperTypeInfo();
     }
 
-    valueVar->diagnose(diag::property_wrapper_value);
+    valueVar->diagnose(diag::property_wrapper_value)
+      .fixItReplace(valueVar->getNameLoc(), "wrappedValue");
   }
 
   PropertyWrapperTypeInfo result;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2163,7 +2163,8 @@ Type computeWrappedValueType(VarDecl *var, Type backingStorageType,
 /// \c value as the original value.
 Expr *buildPropertyWrapperInitialValueCall(VarDecl *var,
                                            Type backingStorageType,
-                                           Expr *value);
+                                           Expr *value,
+                                           bool ignoreAttributeArgs);
   
 /// Whether an overriding declaration requires the 'override' keyword.
 enum class OverrideRequiresKeyword {

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -26,7 +26,7 @@ struct Wrapper<T> {
 
 @propertyWrapper
 struct OldValue<T> {
-  var value: T // expected-warning{{property wrapper's `value` property should be renamed to 'wrappedValue'; use of 'value' is deprecated}}
+  var value: T // expected-warning{{property wrapper's `value` property should be renamed to 'wrappedValue'; use of 'value' is deprecated}}{{7-12=wrappedValue}}
 }
 
 struct TestOldValue {


### PR DESCRIPTION
Allow both explicit initialization and initial values to work together, e.g.,

```swift
@Clamping(min: 0, max: 255) var red: Int = 127
```

gets initialized as

```swift
Clamping(initialValue: 127, min: 0, max: 255)
```
