### PR TITLE
[cast-optimizer] Fix a leak in the cast optimizer when we perform loa…

### DIFF
--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -22,7 +22,20 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 // CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
 // CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
 //
-// CHECK: [[SUCCESS_BB:bb[0-9]+]]:
+// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
+// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
+// CHECK:   strong_retain [[INPUT_VALUE]]
+// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
+// CHECK:   strong_release [[INPUT_VALUE]]
+// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
+// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_TMP]]
+// CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCCESS_BB]]:
 // CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
 // CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
 // CHECK-NEXT:   release_value [[SUCCESS_VAL]]
@@ -31,7 +44,7 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
-// CHECK: [[FAIL_BB:bb[0-9]+]]:
+// CHECK: [[FAIL_BB]]:
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -41,18 +54,6 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 // CHECK: [[EXIT_BB]]:
 // CHECK:   return
 //
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.none!enumelt: [[FAIL_BB]], default [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB]]
 // CHECK: } // end sil function 'array_downcast_copyonsuccess'
 sil @array_downcast_copyonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
 bb0(%0 : $NSArray):
@@ -92,7 +93,21 @@ bb4:
 // CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
 // CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
 //
-// CHECK: [[SUCCESS_BB:bb[0-9]+]]:
+// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
+// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
+// CHECK:   strong_retain [[INPUT_VALUE]]
+// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
+// CHECK:   strong_release [[INPUT_VALUE]]
+// NOTE: In contrast to with take_always, the release_value is above in SUCCESS_BLOCK
+// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
+// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_TMP]]
+// CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCCESS_BB]]:
 // CHECK:   strong_release [[INPUT_VALUE:%.*]] :
 // CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
 // CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
@@ -101,7 +116,7 @@ bb4:
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
-// CHECK: [[FAIL_BB:bb[0-9]+]]:
+// CHECK: [[FAIL_BB]]:
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -110,20 +125,6 @@ bb4:
 //
 // CHECK: [[EXIT_BB]]:
 // CHECK:   return
-//
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// NOTE: In contrast to with take_always, the release_value is above in SUCCESS_BLOCK
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.none!enumelt: [[FAIL_BB]], default [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB]]
 // CHECK: } // end sil function 'array_downcast_takeonsuccess'
 sil @array_downcast_takeonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
 bb0(%0 : $NSArray):
@@ -162,6 +163,22 @@ bb4:
 // CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
 // CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
 //
+// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
+// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
+// CHECK:   strong_retain [[INPUT_VALUE]]
+// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
+// CHECK:   strong_release [[INPUT_VALUE]]
+// NOTE: When we perform take_always, this is the take of the cast.
+// CHECK:   strong_release [[INPUT_VALUE]]
+// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB]]
+//
+// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
+// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_TMP]]
+// CHECK:   br [[SUCCESS_BB]]
+//
+//
 // CHECK: [[SUCCESS_BB:bb[0-9]+]]:
 // CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
 // CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
@@ -179,20 +196,6 @@ bb4:
 // CHECK: [[EXIT_BB]]:
 // CHECK:   return
 //
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// NOTE: When we perform take_always, this is the take of the cast.
-// CHECK:   strong_release [[INPUT_VALUE]]
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.none!enumelt: [[FAIL_BB]], default [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB]]
 // CHECK: } // end sil function 'array_downcast_takealways'
 sil @array_downcast_takealways : $@convention(thin) (@guaranteed NSArray) -> () {
 bb0(%0 : $NSArray):
@@ -217,6 +220,833 @@ bb3:
   br bb4
 
 bb4:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure we handle correctly various sorts of NSObject casts without
+// breaking ownership invariants when compiling in ossa.
+
+// CHECK-LABEL: sil @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_string'
+sil @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_string'
+sil @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_string'
+sil @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_array_of_any'
+sil @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_array_of_any'
+sil @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_array_of_any'
+sil @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_dictionary_anyhashable_to_any'
+sil @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_dictionary_anyhashable_to_any'
+sil @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_dictionary_anyhashable_to_any'
+sil @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_set_anyhashable'
+sil @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_set_anyhashable'
+sil @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]:
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   strong_retain [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
+// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_set_anyhashable'
+sil @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -131,3 +131,845 @@ bb4:
   return %9999 : $()
 }
 
+// Make sure we handle correctly various sorts of NSObject casts without
+// breaking ownership invariants when compiling in ossa.
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_string'
+sil [ossa] @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCAST_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCAST_INPUT:%.*]] to [init] [[INPUT]]
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_string'
+sil [ossa] @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_string'
+sil [ossa] @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $String
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to String in %stringDest : $*String, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*String
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*String
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_array_of_any'
+sil [ossa] @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_array_of_any'
+sil [ossa] @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_array_of_any'
+sil [ossa] @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Array<Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Array<Any> in %stringDest : $*Array<Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Array<Any>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Array<Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_dictionary_anyhashable_to_any'
+sil [ossa] @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_dictionary_anyhashable_to_any'
+sil [ossa] @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_dictionary_anyhashable_to_any'
+sil [ossa] @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Dictionary<AnyHashable, Any> in %stringDest : $*Dictionary<AnyHashable, Any>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Dictionary<AnyHashable, Any>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Dictionary<AnyHashable, Any>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_always_set_anyhashable'
+sil [ossa] @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_always NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_take_on_success_set_anyhashable'
+sil [ossa] @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br take_on_success NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
+// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
+// CHECK:   br bb1
+//
+// CHECK: bb1:
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
+// CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
+//
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
+// CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
+//
+// CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
+// CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
+// CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_SUCC]]:
+// CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   dealloc_stack [[CAST_RESULT]]
+// CHECK:   destroy_addr [[OUTPUT]]
+// CHECK:   destroy_addr [[INPUT]]
+// CHECK:   br [[EXIT_BB:bb[0-9]+]]
+//
+// CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
+//
+// CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
+// CHECK-NEXT:   destroy_addr [[INPUT]]
+// CHECK-NEXT:   br [[EXIT_BB]]
+//
+// CHECK: [[EXIT_BB]]:
+// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
+// CHECK-NEXT:   dealloc_stack [[INPUT]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'nsobject_test_copy_on_success_set_anyhashable'
+sil [ossa] @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
+  %nsSource = alloc_stack $NSObject
+  store %0 to [init] %nsSource : $*NSObject
+  %stringDest = alloc_stack $Set<AnyHashable>
+  br bb1
+
+bb1:
+  checked_cast_addr_br copy_on_success NSObject in %nsSource : $*NSObject to Set<AnyHashable> in %stringDest : $*Set<AnyHashable>, bb2, bb3
+
+bb2:
+  destroy_addr %stringDest : $*Set<AnyHashable>
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb3:
+  destroy_addr %nsSource : $*NSObject
+  br bb4
+
+bb4:
+  dealloc_stack %stringDest : $*Set<AnyHashable>
+  dealloc_stack %nsSource : $*NSObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…d promotion and fail.

Specifically, in this part of the cast optimizer we are trying to optimize casts
that can be done in two parts. As an example consider: NSObject ->
Array<Any>. In this case, we first cast from NSObject -> NSArray and then try to
conditionally bridge to Array<Any> from NSArray.

The problem is we did not destroy the NSObject correctly if the first cast
failed. I couldn't figure out how to create an actual swift test case that
produces this problem since we are pretty conservative about triggering this
code path. But in SIL it is pretty easy and in ossa, we trigger the ownership
verifier.

This is another victory for the ownership verifier!

rdar://51753580
