### PR TITLE
[5.1 06-12-2019] Temporarily disable validation-test/stdlib/ModelIO.swift

### DIFF
--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -11,7 +11,8 @@ import ModelIO
 var ModelIOTests = TestSuite("ModelIO")
 
 if #available(OSX 10.13, iOS 11.0, tvOS 11.0, *) {
-    ModelIOTests.test("MDLAnimatedScalar/accessors") {
+    ModelIOTests.test("MDLAnimatedScalar/accessors")
+    .skip(.always("rdar://problem/50449570")) {
         let animatedVal = MDLAnimatedScalar()
         let testCount = 10
         let testTimeVal = 5.0

--- a/validation-test/stdlib/ModelIO.swift
+++ b/validation-test/stdlib/ModelIO.swift
@@ -12,7 +12,7 @@ var ModelIOTests = TestSuite("ModelIO")
 
 if #available(OSX 10.13, iOS 11.0, tvOS 11.0, *) {
     ModelIOTests.test("MDLAnimatedScalar/accessors")
-    .skip(.always("rdar://problem/50449570")) {
+    .skip(.always("rdar://problem/50449570")).code {
         let animatedVal = MDLAnimatedScalar()
         let testCount = 10
         let testTimeVal = 5.0


### PR DESCRIPTION
Cherry-pick #25474 to swift-5.1-branch-06-12-2019

This has been crashing sometimes in CI. Disable it until we get a real fix.