### PR TITLE
[5.1] [Driver] Bump the required Apple SDK versions to the 2019 OSs

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1319,14 +1319,14 @@ static bool isSDKTooOld(StringRef sdkPath, llvm::VersionTuple minVersion,
 /// the given target.
 static bool isSDKTooOld(StringRef sdkPath, const llvm::Triple &target) {
   if (target.isMacOSX()) {
-    return isSDKTooOld(sdkPath, llvm::VersionTuple(10, 14), "OSX");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(10, 15), "OSX");
 
   } else if (target.isiOS()) {
     // Includes both iOS and TVOS.
-    return isSDKTooOld(sdkPath, llvm::VersionTuple(12, 0), "Simulator", "OS");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(13, 0), "Simulator", "OS");
 
   } else if (target.isWatchOS()) {
-    return isSDKTooOld(sdkPath, llvm::VersionTuple(5, 0), "Simulator", "OS");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(6, 0), "Simulator", "OS");
 
   } else {
     return false;

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -34,22 +34,11 @@
 // RUN: %empty-directory(%t/MacOSX10.12.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.12.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/MacOSX10.13.sdk) && not %swift_driver -sdk %t/MacOSX10.13.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/MacOSX10.13.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.13.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: %empty-directory(%t/MacOSX10.14.sdk) && %swift_driver -sdk %t/MacOSX10.14.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-// RUN: %empty-directory(%t/MacOSX10.14.Internal.sdk) && %swift_driver -sdk %t/MacOSX10.14.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/MacOSX10.14.sdk) && not %swift_driver -sdk %t/MacOSX10.14.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.14.Internal.sdk) && not %swift_driver -sdk %t/MacOSX10.14.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/MacOSX10.15.sdk) && %swift_driver -sdk %t/MacOSX10.15.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/MacOSX10.15.Internal.sdk) && %swift_driver -sdk %t/MacOSX10.15.Internal.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 // RUN: %empty-directory(%t/OSX50.sdk) && %swift_driver -sdk %t/OSX50.sdk -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-
-// RUN: not %swift_driver -sdk %t/MacOSX10.9.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.9.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.10.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.10.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.11.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.11.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.12.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.12.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.13.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: not %swift_driver -sdk %t/MacOSX10.13.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: %swift_driver -sdk %t/MacOSX10.14.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
-// RUN: %swift_driver -sdk %t/MacOSX10.14.Internal.sdk/ -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // RUN: %empty-directory(%t/iPhoneOS7.0.sdk) && not %swift_driver -sdk %t/iPhoneOS7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/iPhoneOS7.0.Internal.sdk) && not %swift_driver -sdk %t/iPhoneOS7.0.Internal.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
@@ -58,21 +47,24 @@
 // RUN: %empty-directory(%t/iPhoneOS9.0.sdk) && not %swift_driver -sdk %t/iPhoneOS9.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/iPhoneOS10.0.sdk) && not %swift_driver -sdk %t/iPhoneOS10.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/iPhoneOS11.0.sdk) && not %swift_driver -sdk %t/iPhoneOS11.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: %empty-directory(%t/iPhoneOS12.0.sdk) && %swift_driver -sdk %t/iPhoneOS12.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/iPhoneOS12.0.sdk) && not %swift_driver -sdk %t/iPhoneOS12.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/iPhoneOS13.0.sdk) && %swift_driver -sdk %t/iPhoneOS13.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // RUN: %empty-directory(%t/tvOS8.0.sdk) && not %swift_driver -sdk %t/tvOS8.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/tvOS8.0.Internal.sdk) && not %swift_driver -sdk %t/tvOS8.0.Internal.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/tvOS9.0.sdk) && not %swift_driver -sdk %t/tvOS9.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/tvOS10.0.sdk) && not %swift_driver -sdk %t/tvOS10.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/tvOS11.0.sdk) && not %swift_driver -sdk %t/tvOS11.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: %empty-directory(%t/tvOS12.0.sdk) && %swift_driver -sdk %t/tvOS12.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/tvOS12.0.sdk) && not %swift_driver -sdk %t/tvOS12.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/tvOS13.0.sdk) && %swift_driver -sdk %t/tvOS13.0.sdk -target x86_64-apple-tvos9 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // RUN: %empty-directory(%t/watchOS1.0.sdk) && not %swift_driver -sdk %t/watchOS1.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/watchOS1.0.Internal.sdk) && not %swift_driver -sdk %t/watchOS1.0.Internal.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/watchOS2.0.sdk) && not %swift_driver -sdk %t/watchOS2.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/watchOS3.0.sdk) && not %swift_driver -sdk %t/watchOS3.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/watchOS4.0.sdk) && not %swift_driver -sdk %t/watchOS4.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
-// RUN: %empty-directory(%t/watchOS5.0.sdk) && %swift_driver -sdk %t/watchOS5.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
+// RUN: %empty-directory(%t/watchOS5.0.sdk) && not %swift_driver -sdk %t/watchOS5.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
+// RUN: %empty-directory(%t/watchOS6.0.sdk) && %swift_driver -sdk %t/watchOS6.0.sdk -target x86_64-apple-watchos2 -### 2>&1 | %FileCheck -check-prefix=SDK-OKAY %s
 
 // RUN: %empty-directory(%t/iPhoneSimulator7.0.sdk) && not %swift_driver -sdk %t/iPhoneSimulator7.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s
 // RUN: %empty-directory(%t/iPhoneSimulator8.0.sdk) && not %swift_driver -sdk %t/iPhoneSimulator8.0.sdk -target x86_64-apple-ios7 -### 2>&1 | %FileCheck -check-prefix=SDK-TOO-OLD %s


### PR DESCRIPTION
Cherry-pick of #25469 to the 5.1 branch. Reviewed by @bob-wilson and @shahmishal.

rdar://problem/50779459