### PR TITLE
[5.1 06/12][ConstraintSystem] Detect and diagnose missing generic arguments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -928,6 +928,8 @@ NOTE(note_call_to_operator,none,
      "in call to operator %0", (DeclName))
 NOTE(note_call_to_func,none,
      "in call to function %0", (DeclName))
+NOTE(note_call_to_subscript,none,
+     "in call to %0", (DeclName))
 NOTE(note_call_to_initializer,none,
      "in call to initializer", ())
 NOTE(note_init_parameter,none,

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -363,6 +363,10 @@ public:
                                       ArrayRef<TypeRepr*> GenericArgs,
                                       SourceRange AngleBrackets);
 
+  unsigned getNumGenericArgs() const {
+    return Bits.GenericIdentTypeRepr.NumGenericArgs;
+  }
+
   ArrayRef<TypeRepr*> getGenericArgs() const {
     return {getTrailingObjects<TypeRepr*>(),
             Bits.GenericIdentTypeRepr.NumGenericArgs};

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -76,6 +76,10 @@ Type FailureDiagnostic::getType(Expr *expr) const {
   return resolveType(CS.getType(expr));
 }
 
+Type FailureDiagnostic::getType(const TypeLoc &loc) const {
+  return resolveType(CS.getType(loc));
+}
+
 template <typename... ArgTypes>
 InFlightDiagnostic
 FailureDiagnostic::emitDiagnostic(ArgTypes &&... Args) const {
@@ -2937,4 +2941,238 @@ bool SkipUnhandledConstructInFunctionBuilderFailure::diagnoseAsError() {
 bool SkipUnhandledConstructInFunctionBuilderFailure::diagnoseAsNote() {
   diagnosePrimary(/*asNote=*/true);
   return true;
+}
+
+bool MissingGenericArgumentsFailure::hasLoc(GenericTypeParamType *GP) const {
+  return GP->getDecl()->getStartLoc().isValid();
+}
+
+bool MissingGenericArgumentsFailure::diagnoseAsError() {
+  llvm::SmallDenseMap<TypeRepr *, SmallVector<GenericTypeParamType *, 4>>
+      scopedParameters;
+
+  auto isScoped =
+      findArgumentLocations([&](TypeRepr *base, GenericTypeParamType *GP) {
+        scopedParameters[base].push_back(GP);
+      });
+
+  if (!isScoped)
+    return diagnoseForAnchor(getAnchor(), Parameters);
+
+  bool diagnosed = false;
+  for (const auto &scope : scopedParameters)
+    diagnosed |= diagnoseForAnchor(scope.first, scope.second);
+  return diagnosed;
+}
+
+bool MissingGenericArgumentsFailure::diagnoseForAnchor(
+    Anchor anchor, ArrayRef<GenericTypeParamType *> params) const {
+  bool diagnosed = false;
+  for (auto *GP : params)
+    diagnosed |= diagnoseParameter(anchor, GP);
+
+  if (!diagnosed)
+    return false;
+
+  auto *DC = getDeclContext();
+  if (auto *SD = dyn_cast<SubscriptDecl>(DC)) {
+    emitDiagnostic(SD, diag::note_call_to_subscript, SD->getFullName());
+    return true;
+  }
+
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
+    if (isa<ConstructorDecl>(AFD)) {
+      emitDiagnostic(AFD, diag::note_call_to_initializer);
+    } else {
+      emitDiagnostic(AFD,
+                     AFD->isOperator() ? diag::note_call_to_operator
+                                       : diag::note_call_to_func,
+                     AFD->getFullName());
+    }
+    return true;
+  }
+
+  emitGenericSignatureNote(anchor);
+  return true;
+}
+
+bool MissingGenericArgumentsFailure::diagnoseParameter(
+    Anchor anchor, GenericTypeParamType *GP) const {
+  auto &cs = getConstraintSystem();
+
+  auto loc = anchor.is<Expr *>() ? anchor.get<Expr *>()->getLoc()
+                                 : anchor.get<TypeRepr *>()->getLoc();
+
+  auto *locator = getLocator();
+  // Type variables associated with missing generic parameters are
+  // going to be completely cut off from the rest of constraint system,
+  // that's why we'd get two fixes in this case which is not ideal.
+  if (locator->isForContextualType() &&
+      llvm::count_if(cs.DefaultedConstraints,
+                     [&GP](const ConstraintLocator *locator) {
+                       return locator->getGenericParameter() == GP;
+                     }) > 1) {
+    return false;
+  }
+
+  if (auto *CE = dyn_cast<ExplicitCastExpr>(getRawAnchor())) {
+    auto castTo = getType(CE->getCastTypeLoc());
+    auto *NTD = castTo->getAnyNominal();
+    emitDiagnostic(loc, diag::unbound_generic_parameter_cast, GP,
+                   NTD ? NTD->getDeclaredType() : castTo);
+  } else {
+    emitDiagnostic(loc, diag::unbound_generic_parameter, GP);
+  }
+
+  if (!hasLoc(GP))
+    return true;
+
+  Type baseTyForNote;
+  auto *DC = getDeclContext();
+
+  if (auto *NTD =
+          dyn_cast_or_null<NominalTypeDecl>(DC->getSelfNominalTypeDecl())) {
+    baseTyForNote = NTD->getDeclaredType();
+  } else if (auto *TAD = dyn_cast<TypeAliasDecl>(DC)) {
+    baseTyForNote = TAD->getUnboundGenericType();
+  } else {
+    return true;
+  }
+
+  emitDiagnostic(GP->getDecl(), diag::archetype_declared_in_type, GP,
+                 baseTyForNote);
+  return true;
+}
+
+void MissingGenericArgumentsFailure::emitGenericSignatureNote(
+    Anchor anchor) const {
+  auto &cs = getConstraintSystem();
+  auto &TC = getTypeChecker();
+  auto *paramDC = getDeclContext();
+
+  auto *GTD = dyn_cast<GenericTypeDecl>(paramDC);
+  if (!GTD || anchor.is<Expr *>())
+    return;
+
+  auto getParamDecl =
+      [](const ConstraintLocator *locator) -> GenericTypeParamDecl * {
+    return locator->isForGenericParameter()
+               ? locator->getGenericParameter()->getDecl()
+               : nullptr;
+  };
+
+  llvm::SmallDenseMap<GenericTypeParamDecl *, Type> params;
+  for (auto *typeVar : cs.getTypeVariables()) {
+    auto *GP = typeVar->getImpl().getGenericParameter();
+    if (!GP)
+      continue;
+
+    auto type = resolveType(typeVar);
+    // This could happen if the diagnostic is used by CSDiag.
+    if (type->is<TypeVariableType>())
+      continue;
+
+    // If this is one of the defaulted parameter types, attempt
+    // to emit placeholder for it instead of `Any`.
+    if (llvm::any_of(cs.DefaultedConstraints,
+                     [&](const ConstraintLocator *locator) {
+                       return GP->getDecl() == getParamDecl(locator);
+                     }))
+      continue;
+
+    params[GP->getDecl()] = type;
+  }
+
+  auto getPreferredType = [&](const GenericTypeParamDecl *GP) -> Type {
+    auto type = params.find(GP);
+    return (type == params.end()) ? Type() : type->second;
+  };
+
+  SmallString<64> paramsAsString;
+  auto baseType = anchor.get<TypeRepr *>();
+  if (TC.getDefaultGenericArgumentsString(paramsAsString, GTD,
+                                          getPreferredType)) {
+    auto diagnostic = emitDiagnostic(
+        baseType->getLoc(), diag::unbound_generic_parameter_explicit_fix);
+
+    if (auto *genericTy = dyn_cast<GenericIdentTypeRepr>(baseType)) {
+      // If some of the eneric arguments have been specified, we need to
+      // replace existing signature with a new one.
+      diagnostic.fixItReplace(genericTy->getAngleBrackets(), paramsAsString);
+    } else {
+      // Otherwise we can simply insert new generic signature.
+      diagnostic.fixItInsertAfter(baseType->getEndLoc(), paramsAsString);
+    }
+  }
+}
+
+bool MissingGenericArgumentsFailure::findArgumentLocations(
+    llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)> callback) {
+  using Callback = llvm::function_ref<void(TypeRepr *, GenericTypeParamType *)>;
+
+  auto *anchor = getRawAnchor();
+
+  TypeLoc typeLoc;
+  if (auto *TE = dyn_cast<TypeExpr>(anchor))
+    typeLoc = TE->getTypeLoc();
+  else if (auto *ECE = dyn_cast<ExplicitCastExpr>(anchor))
+    typeLoc = ECE->getCastTypeLoc();
+
+  if (!typeLoc.hasLocation())
+    return false;
+
+  struct AssociateMissingParams : public ASTWalker {
+    llvm::SmallVector<GenericTypeParamType *, 4> Params;
+    Callback Fn;
+
+    AssociateMissingParams(ArrayRef<GenericTypeParamType *> params,
+                           Callback callback)
+        : Params(params.begin(), params.end()), Fn(callback) {}
+
+    bool walkToTypeReprPre(TypeRepr *T) override {
+      if (Params.empty())
+        return false;
+
+      auto *ident = dyn_cast<ComponentIdentTypeRepr>(T);
+      if (!ident)
+        return true;
+
+      auto *decl = dyn_cast_or_null<GenericTypeDecl>(ident->getBoundDecl());
+      if (!decl)
+        return true;
+
+      auto *paramList = decl->getGenericParams();
+      if (!paramList)
+        return true;
+
+      // There could a situation like `S<S>()`, so we need to be
+      // careful not to point at first `S` because it has all of
+      // its generic parameters specified.
+      if (auto *generic = dyn_cast<GenericIdentTypeRepr>(ident)) {
+        if (paramList->size() == generic->getNumGenericArgs())
+          return true;
+      }
+
+      for (auto *candidate : paramList->getParams()) {
+        auto result =
+            llvm::find_if(Params, [&](const GenericTypeParamType *param) {
+              return candidate == param->getDecl();
+            });
+
+        if (result != Params.end()) {
+          Fn(ident, *result);
+          Params.erase(result);
+        }
+      }
+
+      // Keep walking.
+      return true;
+    }
+
+    bool allParamsAssigned() const { return Params.empty(); }
+
+  } associator(Parameters, callback);
+
+  typeLoc.getTypeRepr()->walk(associator);
+  return associator.allParamsAssigned();
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -556,3 +556,20 @@ bool SkipUnhandledConstructInFunctionBuilder::diagnose(Expr *root,
       root, getConstraintSystem(), unhandled, builder, getLocator());
   return failure.diagnose(asNote);
 }
+
+bool ExplicitlySpecifyGenericArguments::diagnose(Expr *root,
+                                                 bool asNote) const {
+  auto &cs = getConstraintSystem();
+  MissingGenericArgumentsFailure failure(root, cs, getParameters(),
+                                         getLocator());
+  return failure.diagnose(asNote);
+}
+
+ExplicitlySpecifyGenericArguments *ExplicitlySpecifyGenericArguments::create(
+    ConstraintSystem &cs, ArrayRef<GenericTypeParamType *> params,
+    ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<GenericTypeParamType *>(params.size());
+  void *mem = cs.getAllocator().Allocate(
+      size, alignof(ExplicitlySpecifyGenericArguments));
+  return new (mem) ExplicitlySpecifyGenericArguments(cs, params, locator);
+}

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -167,16 +167,28 @@ bool ConstraintLocator::isForKeyPathComponent() const {
   });
 }
 
+static bool isLastElement(const ConstraintLocator *locator,
+                          ConstraintLocator::PathElementKind expectedKind) {
+  auto path = locator->getPath();
+  return !path.empty() && path.back().getKind() == expectedKind;
+}
+
 bool ConstraintLocator::isForGenericParameter() const {
-  auto path = getPath();
-  return !path.empty() &&
-         path.back().getKind() == ConstraintLocator::GenericParameter;
+  return isLastElement(this, ConstraintLocator::GenericParameter);
 }
 
 bool ConstraintLocator::isForSequenceElementType() const {
+  return isLastElement(this, ConstraintLocator::SequenceElementType);
+}
+
+bool ConstraintLocator::isForContextualType() const {
+  return isLastElement(this, ConstraintLocator::ContextualType);
+}
+
+GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
+  assert(isForGenericParameter());
   auto path = getPath();
-  return !path.empty() &&
-         path.back().getKind() == ConstraintLocator::SequenceElementType;
+  return path.back().getGenericParameter();
 }
 
 void ConstraintLocator::dump(SourceManager *sm) {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -578,6 +578,12 @@ public:
   /// sequence in a for ... in ... loop.
   bool isForSequenceElementType() const;
 
+  /// Determine whether this locator points to the contextual type.
+  bool isForContextualType() const;
+
+  /// If this locator points to generic parameter return its type.
+  GenericTypeParamType *getGenericParameter() const;
+
   /// Produce a profile of this locator, for use in a folding set.
   static void Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
                       ArrayRef<PathElement> path);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -101,13 +101,9 @@ void ConstraintSystem::incrementLeafScopes() {
 
 bool ConstraintSystem::hasFreeTypeVariables() {
   // Look for any free type variables.
-  for (auto tv : TypeVariables) {
-    if (!tv->getImpl().hasRepresentativeOrFixed()) {
-      return true;
-    }
-  }
-  
-  return false;
+  return llvm::any_of(TypeVariables, [](const TypeVariableType *typeVar) {
+    return !typeVar->getImpl().hasRepresentativeOrFixed();
+  });
 }
 
 void ConstraintSystem::addTypeVariable(TypeVariableType *typeVar) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -80,12 +80,9 @@ GenericTypeParamType *
 TypeVariableType::Implementation::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter
   // locator.
-  if (!locator || locator->getPath().empty() ||
-      locator->getPath().back().getKind() != ConstraintLocator::GenericParameter)
-    return nullptr;
-
-  // Retrieve the archetype.
-  return locator->getPath().back().getGenericParameter();
+  return locator && locator->isForGenericParameter()
+             ? locator->getGenericParameter()
+             : nullptr;
 }
 
 // Only allow allocation of resolved overload set list items using the

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -102,7 +102,7 @@ func longArray() {
   var _=["1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1", "1"]
 }
 
-[1,2].map // expected-error {{expression type '((Int) throws -> _) throws -> [_]' is ambiguous without more context}}
+[1,2].map // expected-error {{generic parameter 'T' could not be inferred}}
 
 
 // <rdar://problem/25563498> Type checker crash assigning array literal to type conforming to ArrayProtocol

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -223,7 +223,9 @@ func takesDictionary<K, V>(_ p: Dictionary<K, V>) {} // expected-note {{in call 
 func takesArray<T>(_ t: Array<T>) {} // expected-note {{in call to function 'takesArray'}}
 func rdar19695671() {
   takesSet(NSSet() as! Set) // expected-error{{generic parameter 'T' could not be inferred}}
-  takesDictionary(NSDictionary() as! Dictionary) // expected-error{{generic parameter 'K' could not be inferred}}
+  takesDictionary(NSDictionary() as! Dictionary)
+  // expected-error@-1 {{generic parameter 'K' could not be inferred}}
+  // expected-error@-2 {{generic parameter 'V' could not be inferred}}
   takesArray(NSArray() as! Array) // expected-error{{generic parameter 'T' could not be inferred}}
 }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -716,7 +716,7 @@ func rdar37790062() {
 }
 
 // <rdar://problem/39489003>
-typealias KeyedItem<K, T> = (key: K, value: T)
+typealias KeyedItem<K, T> = (key: K, value: T) // expected-note {{'T' declared as parameter to type 'KeyedItem'}}
 
 protocol Node {
   associatedtype T
@@ -730,8 +730,7 @@ extension Node {
   func getChild(for key:K)->(key: K, value: T) {
     return children.first(where: { (item:KeyedItem) -> Bool in
         return item.key == key
-        // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '_' and 'Self.K'}}
-        // expected-note@-2 {{overloads for '==' exist with these partially matching parameter lists:}}
+        // expected-error@-1 {{generic parameter 'T' could not be inferred}}
       })!
   }
 }
@@ -814,13 +813,15 @@ func rdar_40537960() {
     init(_: P_40537960) {}
   }
 
-  struct A<T: Collection, P: P_40537960> {
+  struct A<T: Collection, P: P_40537960> { // expected-note {{'P' declared as parameter to type 'A'}}
     typealias Data = T.Element
     init(_: T, fn: (Data) -> R<P>) {}
   }
 
   var arr: [S] = []
-  _ = A(arr, fn: { L($0.v) }) // expected-error {{cannot convert value of type 'L' to closure result type 'R<T>'}}
+  _ = A(arr, fn: { L($0.v) }) // expected-error {{cannot convert value of type 'L' to closure result type 'R<Any>'}}
+  // expected-error@-1 {{generic parameter 'P' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{8-8=<[S], <#P: P_40537960#>>}}
 }
 
 // rdar://problem/45659733

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -903,7 +903,7 @@ func test2208() {
 
 // SR-2164: Erroneous diagnostic when unable to infer generic type
 
-struct SR_2164<A, B> { // expected-note 3 {{'B' declared as parameter to type 'SR_2164'}} expected-note 2 {{'A' declared as parameter to type 'SR_2164'}} expected-note * {{generic type 'SR_2164' declared here}}
+struct SR_2164<A, B> { // expected-note 4 {{'B' declared as parameter to type 'SR_2164'}} expected-note 2 {{'A' declared as parameter to type 'SR_2164'}} expected-note * {{generic type 'SR_2164' declared here}}
   init(a: A) {}
   init(b: B) {}
   init(c: Int) {}
@@ -921,7 +921,10 @@ struct SR_2164_Dict<A: Hashable, B> { // expected-note {{'B' declared as paramet
 
 SR_2164(a: 0) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
 SR_2164(b: 1) // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
-SR_2164(c: 2) // expected-error {{generic parameter 'A' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+SR_2164(c: 2)
+// expected-error@-1 {{generic parameter 'A' could not be inferred}}
+// expected-error@-2 {{generic parameter 'B' could not be inferred}}
+// expected-note@-3 {{explicitly specify the generic arguments to fix this issue}} {{8-8=<Any, Any>}}
 SR_2164(3) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
 SR_2164_Array([4]) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
 SR_2164(e: 5) // expected-error {{generic parameter 'B' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}

--- a/test/Constraints/incomplete_function_ref.swift
+++ b/test/Constraints/incomplete_function_ref.swift
@@ -1,12 +1,13 @@
 // RUN: %target-typecheck-verify-swift
 
 struct MyCollection<Element> {  // expected-note {{'Element' declared as parameter to type 'MyCollection'}}
-  func map<T>(_ transform: (Element) -> T) -> MyCollection<T> {
+  func map<T>(_ transform: (Element) -> T) -> MyCollection<T> { // expected-note 2 {{in call to function 'map'}}
     fatalError("implement")
   }
 }
 
 MyCollection.map // expected-error{{generic parameter 'Element' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{13-13=<Any>}}
+// expected-error@-1 {{generic parameter 'T' could not be inferred}}
 
 let a = MyCollection<Int>()
 a.map // expected-error{{generic parameter 'T' could not be inferred}}

--- a/test/Constraints/keyword_arguments.swift
+++ b/test/Constraints/keyword_arguments.swift
@@ -347,7 +347,9 @@ func trailingClosure5<T>(_ file: String = #file, line: UInt = #line, expression:
 func trailingClosure6<T>(value: Int, expression: () -> T?) { }
 
 trailingClosure5(file: "hello", line: 17) { return Optional.Some(5) } // expected-error{{extraneous argument label 'file:' in call}}{{18-24=}}
+// expected-error@-1 {{enum type 'Optional<Any>' has no case 'Some'; did you mean 'some'}} {{61-65=some}}
 trailingClosure6(5) { return Optional.Some(5) } // expected-error{{missing argument label 'value:' in call}}{{18-18=value: }}
+// expected-error@-1 {{enum type 'Optional<Any>' has no case 'Some'; did you mean 'some'}} {{39-43=some}}
 
 class MismatchOverloaded1 {
   func method1(_ x: Int!, arg: ((Int) -> Int)!) { }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -219,13 +219,13 @@ extension r25271859 {
   func map<U>(f: (T) -> U) -> r25271859<U> {
   }
 
-  func andThen<U>(f: (T) -> r25271859<U>) {
+  func andThen<U>(f: (T) -> r25271859<U>) { // expected-note {{in call to function 'andThen(f:)'}}
   }
 }
 
 func f(a : r25271859<(Float, Int)>) {
-  a.map { $0.0 }
-    .andThen { _ in   // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{18-18=-> r25271859<String> }}
+  a.map { $0.0 } // expected-error {{generic parameter 'U' could not be inferred}} (This is related to how solver is setup with multiple statements)
+    .andThen { _ in
       print("hello") // comment this out and it runs, leave any form of print in and it doesn't
       return r25271859<String>()
   }

--- a/test/Generics/invalid.swift
+++ b/test/Generics/invalid.swift
@@ -23,7 +23,7 @@ struct Lunch<T> {
   }
 }
 
-class Deli<Spices> {
+class Deli<Spices> { // expected-note {{'Spices' declared as parameter to type 'Deli'}}
 
   class Pepperoni {}
   struct Sausage {}
@@ -79,7 +79,8 @@ func badDiagnostic2() {
 func takesAny(_ a: Any) {}
 
 func badDiagnostic3() {
-  takesAny(Deli.self) // expected-error {{argument type 'Deli<_>.Type' does not conform to expected type 'Any'}}
+  takesAny(Deli.self) // expected-error {{generic parameter 'Spices' could not be inferred}}
+  // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{16-16=<Any>}}
 }
 
 // Crash with missing nested type inside concrete type

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -20,7 +20,7 @@ fg({x in x}) // expected-error {{generic parameter 'T' could not be inferred}}
 
 
 struct S {
-  func f<T>(_ i: (T) -> T, _ j: Int) -> Void {}
+  func f<T>(_ i: (T) -> T, _ j: Int) -> Void {} // expected-note {{in call to function 'f'}}
   func f(_ d: (Double) -> Double) -> Void {}
   func test() -> Void {
     f({x in x}, 2) // expected-error {{generic parameter 'T' could not be inferred}}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -390,7 +390,8 @@ func testPostfixOperatorOnTuple<A, B>(a: A, b: B) {
   _ = (§)foo
   // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
-  // expected-warning@-3 {{expression of type '(A, (B, B), A)' is unused}}
+  // expected-error@-3 {{generic parameter 'U' could not be inferred}}
+  // expected-warning@-4 {{expression of type '(A, (B, B), A)' is unused}}
   _ = (§)(foo)
   _ = (a, (b, b), a)§
   _ = (§)(a, (b, b), a) // expected-error {{operator function '§' expects a single parameter of type '(T, (U, U), T)'}}

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -377,7 +377,7 @@ protocol ExpressibleByDogLiteral {}
 struct Kitten : ExpressibleByCatLiteral {}
 struct Puppy : ExpressibleByDogLiteral {}
 
-struct Claws<A: ExpressibleByCatLiteral> {
+struct Claws<A: ExpressibleByCatLiteral> { // expected-note 3 {{'A' declared as parameter to type 'Claws'}}
   struct Fangs<B: ExpressibleByDogLiteral> { } // expected-note {{where 'B' = 'NotADog'}}
 }
 
@@ -387,7 +387,7 @@ func pets<T>(fur: T) -> Claws<Kitten>.Fangs<T> {
   return Claws<Kitten>.Fangs<T>()
 }
 
-func something<T>() -> T { // expected-note {{in call to function 'something()'}}
+func something<T>() -> T {
   while true {}
 }
 
@@ -398,11 +398,14 @@ func test() {
   let _: Claws.Fangs<Puppy> = pets(fur: Puppy())
   let _: Claws.Fangs<Puppy> = Claws<Kitten>.Fangs()
   let _: Claws.Fangs<Puppy> = Claws.Fangs()
-  // expected-error@-1 {{cannot convert value of type 'Claws<_>.Fangs<_>' to specified type 'Claws.Fangs<Puppy>'}}
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{36-36=<<#A: ExpressibleByCatLiteral#>>}}
   let _: Claws.Fangs<NotADog> = something()
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
-  _ = Claws.Fangs<NotADog>() // TODO(diagnostics): There should be two errors here - "cannot infer A" and "NotADog conformance to ExpressibleByDogLiteral"
-  // expected-error@-1 {{referencing initializer 'init()' on 'Claws.Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  _ = Claws.Fangs<NotADog>()
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-error@-2 {{referencing initializer 'init()' on 'Claws.Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
+  // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}} {{12-12=<<#A: ExpressibleByCatLiteral#>>}}
 }
 
 // https://bugs.swift.org/browse/SR-4379

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -60,7 +60,7 @@ typealias B<T1> = MyType<T1, T1>  // expected-note {{'T1' declared as parameter 
 typealias C<T> = MyType<String, T>
 
 // Type aliases with unused generic params.
-typealias D<T1, T2, T3> = MyType<T2, T1>  // expected-note {{'T3' declared as parameter to type 'D'}}
+typealias D<T1, T2, T3> = MyType<T2, T1>  // expected-note 3 {{'T3' declared as parameter to type 'D'}}
 
 typealias E<T1, T2> = Int  // expected-note {{generic type 'E' declared here}}
 
@@ -72,17 +72,18 @@ typealias G<S1, S2> = A<S1, S2>
 let _ : E<Int, Float> = 42
 let _ : E<Float> = 42   // expected-error {{generic type 'E' specialized with too few type parameters (got 1, but expected 2)}}
 let _ : E = 42   // expected-error {{cannot convert value of type 'Int' to specified type 'E'}}
-let _ : D = D(a: 1, b: 2)  // expected-error {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
+let _ : D = D(a: 1, b: 2)
+// expected-error@-1 {{generic parameter 'T3' could not be inferred}}
+// expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{14-14=<Int, Int, Any>}}
 
 let _ : D<Int, Int, Float> = D<Int, Int, Float>(a: 1, b: 2)
 
-// FIXME: This is not a great error.
-// expected-error @+1 {{cannot convert value of type 'D<Int, Int, Float>' (aka 'MyType<Int, Int>') to specified type 'D'}}
 let _ : D = D<Int, Int, Float>(a: 1, b: 2)
+// expected-error@-1 {{generic parameter 'T3' could not be inferred}}
 
 
 // expected-error @+2 {{generic parameter 'T3' could not be inferred}}
-// expected-note @+1 {{explicitly specify the generic arguments to fix this issue}} {{31-31=<Any, Any, Any>}}
+// expected-note @+1 {{explicitly specify the generic arguments to fix this issue}} {{31-31=<Int, Int, Any>}}
 let _ : D<Int, Int, Float> = D(a: 1, b: 2)
 
 let _ : F = { (a : Int) -> Int in a }  // Infer the types of F

--- a/test/expr/delayed-ident/enum.swift
+++ b/test/expr/delayed-ident/enum.swift
@@ -15,7 +15,7 @@ e1 = .Third(5, 3.14159)
 e1 = .default  // SE-0071
 
 // Generic enumeration type
-enum E2<T> {
+enum E2<T> { // expected-note {{'T' declared as parameter to type 'E2'}}
   case First
   case Second(T)
 }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -36,7 +36,7 @@ struct A: Hashable {
   func hash(into hasher: inout Hasher) { fatalError() }
 }
 struct B {}
-struct C<T> {
+struct C<T> { // expected-note 2 {{'T' declared as parameter to type 'C'}}
   var value: T
   subscript() -> T { get { return value } }
   subscript(sub: Sub) -> T { get { return value } set { } }
@@ -190,7 +190,7 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: AnyKeyPath = \A.property
   let _: AnyKeyPath = \C<A>.value
   let _: AnyKeyPath = \.property // expected-error{{ambiguous}}
-  let _: AnyKeyPath = \C.value // expected-error{{cannot convert}} (need to improve diagnostic)
+  let _: AnyKeyPath = \C.value // expected-error{{generic parameter 'T' could not be inferred}}
   let _: AnyKeyPath = \.value // expected-error{{ambiguous}}
 
   let _ = \Prop.[nonHashableSub] // expected-error{{subscript index of type 'NonHashableSub' in a key path must be Hashable}}
@@ -282,9 +282,8 @@ func tupleGeneric<T, U>(_ v: (T, U)) {
 
   _ = ("tuple", "too", "big")[keyPath: tuple_el_1()]
   // expected-note@-12 {{}}
-  // expected-error@-2 {{cannot be applied}}
-  // expected-error@-3 {{cannot be applied}}
-  // expected-error@-4 {{could not be inferred}}
+  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-3 {{generic parameter 'U' could not be inferred}}
 }
 
 struct Z { }

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -34,7 +34,7 @@ extension A: K {
 
 struct B {
     let v: String
-    func f1<T, E>(block: (T) -> E) -> B {
+    func f1<T, E>(block: (T) -> E) -> B { // expected-note {{in call to function 'f1(block:)'}}
         return self
     }
 

--- a/test/stdlib/KeyPathAppending.swift
+++ b/test/stdlib/KeyPathAppending.swift
@@ -49,32 +49,32 @@ func mismatchedAppends<T, U, V>(readOnlyLeft: KeyPath<T, U>,
                                 readOnlyRight: KeyPath<U, V>,
                                 writableRight: WritableKeyPath<U, V>,
                                 referenceRight: ReferenceWritableKeyPath<U, V>){
-  // expected-error@+1{{}}
   _ = readOnlyRight.appending(path: readOnlyLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'KeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = readOnlyRight.appending(path: writableLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'KeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = readOnlyRight.appending(path: referenceLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'KeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = writableRight.appending(path: readOnlyLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'WritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = writableRight.appending(path: writableLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'WritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = writableRight.appending(path: referenceLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'WritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = referenceRight.appending(path: readOnlyLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'ReferenceWritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = referenceRight.appending(path: writableLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'ReferenceWritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 
-  // expected-error@+1{{}}
   _ = referenceRight.appending(path: referenceLeft)
+  // expected-error@-1 {{referencing instance method 'appending(path:)' on '_AppendKeyPath' requires the types 'ReferenceWritableKeyPath<U, V>' and 'AnyKeyPath' be equivalent}}
 }
 
 func partialAppends<T, U, V>(partial: PartialKeyPath<T>,


### PR DESCRIPTION
- **Explanation**: Introduce a fix to detect and diagnose situations when omitted
generic arguments couldn't be deduced by the solver based on
the enclosing context.

Example:

```swift
struct S<T> {
}

_ = S() // There is not enough context to deduce `T`
```

- **Issue**: rdar://problem/51203824, rdar://problem/50512161

- **Scope**: Diagnostics, in subset of cases where solver couldn't resolve some of the arguments for generic parameters

- **Risk**: Low. 

- **Testing**: Added compiler regression tests and adjusted existing ones.

- **Reviewed by**: @DougGregor, @slavapestov 

Resolves: rdar://problem/51203824
Resolves: rdar://problem/50512161
(cherry picked from commit bfe19872b79e9d487054ec5e0c092665dacb5ef5)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
