### PR TITLE
build: do not implicitly track build dependencies for host

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -7,6 +7,17 @@ include(AddSwiftStdlib)
 
 # Create convenience targets for the Swift standard library.
 
+# NOTE(compnerd) this will pass the *build* configuration to the *host*
+# libraries.  Explicitly indicate to CMake that it should **NOT** track the
+# implicit language runtimes.  This can go away once we migrate to an external
+# project with its own configure with the CMAKE_SYSTEM_NAME set rather than
+# using the custom cross-compilation solution
+set(CMAKE_C_IMPLICIT_LINK_LIBRARIES "")
+set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+
+set(CMAKE_C_IMPLICIT_LINK_DIRECTORIES "")
+set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
+
 # NOTE(compnerd) save the original compiler for the host swiftReflection that
 # we build
 set(HOST_CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER})


### PR DESCRIPTION
Because we do a custom cross-compilation, we are tracking the *build*
dependencies when building libraries for the *host*.  That is to say, if
you are building for Linux on Darwin, we track Darwin's libc++ as a
dependency for the Linux swiftCore.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
