### PR TITLE
[Sema] Always create memberwise init when deriving `AdditiveArithmetic`.

### DIFF
--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -64,7 +64,7 @@ static ValueDecl *getProtocolRequirement(ProtocolDecl *proto, Identifier name) {
 // Get the effective memberwise initializer of the given nominal type, or create
 // it if it does not exist.
 static ConstructorDecl *getOrCreateEffectiveMemberwiseInitializer(
-      TypeChecker &TC, NominalTypeDecl *nominal) {
+    TypeChecker &TC, NominalTypeDecl *nominal) {
   auto &C = nominal->getASTContext();
   if (auto *initDecl = nominal->getEffectiveMemberwiseInitializer())
     return initDecl;

--- a/test/Sema/struct_additive_arithmetic.swift
+++ b/test/Sema/struct_additive_arithmetic.swift
@@ -91,6 +91,13 @@ struct NoMemberwiseInitializer<T : AdditiveArithmetic> : AdditiveArithmetic {
   var value: T
   init(randomLabel value: T) { self.value = value }
 }
+struct NoMemberwiseInitializerCustomZero: AdditiveArithmetic {
+  var x: Float
+  static var zero: Self { return NoMemberwiseInitializerCustomZero(0) }
+  init(_ x: Float) {
+    self.x = x
+  }
+}
 struct NoMemberwiseInitializerExtended<T> {
   var value: T
   init(_ value: T) {


### PR DESCRIPTION
Previously, during `AdditiveArithmetic` derived conformances, memberwise
initializers were synthesized only when synthesizing `static var zero`.
This led to a crash for types that specified `static var zero` but not
other requirements.

Resolves [TF-579](https://bugs.swift.org/browse/TF-579).