### PR TITLE
[5.1][cast-optimizer] Fix a leak in the cast optimizer when we perform loa…

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -448,6 +448,13 @@ public:
     return t->getCanonicalType();
   }
 
+  Optional<SILType> getLoweredBridgedTargetObjectType() const {
+    CanType t = getBridgedTargetType();
+    if (!t)
+      return None;
+    return SILType::getPrimitiveObjectType(t);
+  }
+
   bool isConditional() const {
     switch (getKind()) {
     case SILDynamicCastKind::CheckedCastAddrBranchInst: {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3262,10 +3262,6 @@ class BeginBorrowInst
       : UnaryInstructionBase(DebugLoc, LValue,
                              LValue->getType().getObjectType()) {}
 
-private:
-  /// Predicate used to filer EndBorrowRange.
-  struct UseToEndBorrow;
-
 public:
   using EndBorrowRange =
       OptionalTransformRange<use_range, UseToEndBorrow, use_iterator>;

--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -46,9 +46,6 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 //
 // CHECK: [[FAIL_BB]]:
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[NEXT:bb[0-9]+]]
-//
-// CHECK: [[NEXT]]:
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
@@ -121,9 +118,6 @@ bb4:
 //
 // CHECK: [[FAIL_BB]]:
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[FAIL_NEXT:bb[0-9]+]]
-//
-// CHECK: [[FAIL_NEXT]]:
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
@@ -195,9 +189,6 @@ bb4:
 //
 // CHECK: [[FAIL_BB:bb[0-9]+]]:
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[FAIL_NEXT:bb[0-9]+]]
-//
-// CHECK: [[FAIL_NEXT]]:
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
 // CHECK-NEXT:   br [[EXIT_BB]]

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -3,6 +3,14 @@
 
 // REQUIRES: objc_interop
 
+// This test is disabled so we can more easily cherry-pick any cast optimizer
+// fixes without hitting conflicts, while at the same time allowing us to avoid
+// having to cherry-pick all the cast optimizer fixes only needed for ownership
+// to swift-5.1-branch. This makes sense since we are not going to ever run the
+// cast optimizer on ossa on swift-5.1-branch
+//
+// REQUIRES: disabled
+
 sil_stage canonical
 
 import Swift

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -10,67 +10,50 @@ import Foundation
 import Builtin
 
 sil @$ss11AnyHashableVyABxcSHRzlufC : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@in τ_0_0, @thin AnyHashable.Type) -> @out AnyHashable
-
 sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
 
-// CHECK-LABEL: sil @array_downcast_copyonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
-// CHECK: bb0([[ARG:%.*]] : $NSArray):
-// CHECK:   [[INPUT:%.*]] = alloc_stack $NSArray
-// CHECK:   retain_value [[ARG]]
-// CHECK:   store [[ARG]] to [[INPUT]]
-// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<String>
-// CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
-// CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
-//
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_BB]]:
-// CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
-// CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
-// CHECK-NEXT:   release_value [[SUCCESS_VAL]]
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   destroy_addr [[INPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
-//
-// CHECK: [[FAIL_BB]]:
-// CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[NEXT:bb[0-9]+]]
-//
-// CHECK: [[NEXT]]:
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   destroy_addr [[INPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB]]
-//
-// CHECK: [[EXIT_BB]]:
-// CHECK:   return
-//
+// CHECK-LABEL: sil [ossa] @bridged_cast_anyhashable : $@convention(method) (@guaranteed NSArray) -> @out Optional<AnyHashable> {
+// CHECK: [[FUNC:%.*]] = function_ref @$ss37_forceBridgeFromObjectiveC_bridgeableyx01_D5CTypeQz_xmts01_D11CBridgeableRzlF :
+// CHECK: apply [[FUNC]]<Array<AnyHashable>>(
+// CHECK: } // end sil function 'bridged_cast_anyhashable'
+sil [ossa] @bridged_cast_anyhashable : $@convention(method) (@guaranteed NSArray) -> @out Optional<AnyHashable> {
+bb0(%0 : $*Optional<AnyHashable>, %1 : @guaranteed $NSArray):
+  %3 = init_enum_data_addr %0 : $*Optional<AnyHashable>, #Optional.some!enumelt.1
+  %4 = metatype $@thin AnyHashable.Type
+  %5 = alloc_stack $NSArray
+  %6 = copy_value %1 : $NSArray
+  store %6 to [init] %5 : $*NSArray
+  %8 = alloc_stack $Array<AnyHashable>
+  unconditional_checked_cast_addr NSArray in %5 : $*NSArray to Array<AnyHashable> in %8 : $*Array<AnyHashable>
+  %10 = load [take] %8 : $*Array<AnyHashable>
+  %11 = alloc_stack $Array<AnyHashable>
+  store %10 to [init] %11 : $*Array<AnyHashable>
+  %13 = function_ref @$ss11AnyHashableVyABxcSHRzlufC : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@in τ_0_0, @thin AnyHashable.Type) -> @out AnyHashable
+  %14 = apply %13<[AnyHashable]>(%3, %11, %4) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@in τ_0_0, @thin AnyHashable.Type) -> @out AnyHashable
+  dealloc_stack %11 : $*Array<AnyHashable>
+  dealloc_stack %8 : $*Array<AnyHashable>
+  dealloc_stack %5 : $*NSArray
+  inject_enum_addr %0 : $*Optional<AnyHashable>, #Optional.some!enumelt.1
+  %19 = tuple ()
+  return %19 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @array_downcast_copyonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
+// CHECK-NOT: checked_cast_addr_br
 // CHECK: } // end sil function 'array_downcast_copyonsuccess'
-sil @array_downcast_copyonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
-bb0(%0 : $NSArray):
+sil [ossa] @array_downcast_copyonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
+bb0(%0 : @guaranteed $NSArray):
   %4 = alloc_stack $NSArray
-  retain_value %0 : $NSArray
-  store %0 to %4 : $*NSArray
+  %5 = copy_value %0 : $NSArray
+  store %5 to [init] %4 : $*NSArray
   %7 = alloc_stack $Array<String>
   checked_cast_addr_br copy_on_success NSArray in %4 : $*NSArray to Array<String> in %7 : $*Array<String>, bb2, bb3
 
 bb2:
-  %9 = load %7 : $*Array<String>
+  %9 = load [take] %7 : $*Array<String>
   %10 = function_ref @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
   apply %10<String>(%9) : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
-  release_value %9 : $Array<String>
+  destroy_value %9 : $Array<String>
   dealloc_stack %7 : $*Array<String>
   destroy_addr %4 : $*NSArray
   dealloc_stack %4 : $*NSArray
@@ -87,64 +70,22 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @array_downcast_takeonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
-// CHECK: bb0([[ARG:%.*]] : $NSArray):
-// CHECK:   [[INPUT:%.*]] = alloc_stack $NSArray
-// CHECK:   retain_value [[ARG]]
-// CHECK:   store [[ARG]] to [[INPUT]]
-// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<String>
-// CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
-// CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
-//
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// NOTE: In contrast to with take_always, the release_value is above in SUCCESS_BLOCK
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
-//
-// CHECK: [[SUCCESS_BB]]:
-// CHECK:   strong_release [[INPUT_VALUE:%.*]] :
-// CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
-// CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
-// CHECK-NEXT:   release_value [[SUCCESS_VAL]]
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
-//
-// CHECK: [[FAIL_BB]]:
-// CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[FAIL_NEXT:bb[0-9]+]]
-//
-// CHECK: [[FAIL_NEXT]]:
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   destroy_addr [[INPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB]]
-//
-// CHECK: [[EXIT_BB]]:
-// CHECK:   return
+// CHECK-LABEL: sil [ossa] @array_downcast_takeonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
+// CHECK-NOT: checked_cast_addr_br
 // CHECK: } // end sil function 'array_downcast_takeonsuccess'
-sil @array_downcast_takeonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
-bb0(%0 : $NSArray):
+sil [ossa] @array_downcast_takeonsuccess : $@convention(thin) (@guaranteed NSArray) -> () {
+bb0(%0 : @guaranteed $NSArray):
   %4 = alloc_stack $NSArray
-  retain_value %0 : $NSArray
-  store %0 to %4 : $*NSArray
+  %5 = copy_value %0 : $NSArray
+  store %5 to [init] %4 : $*NSArray
   %7 = alloc_stack $Array<String>
   checked_cast_addr_br take_on_success NSArray in %4 : $*NSArray to Array<String> in %7 : $*Array<String>, bb2, bb3
 
 bb2:
-  %9 = load %7 : $*Array<String>
+  %9 = load [take] %7 : $*Array<String>
   %10 = function_ref @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
   apply %10<String>(%9) : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
-  release_value %9 : $Array<String>
+  destroy_value %9 : $Array<String>
   dealloc_stack %7 : $*Array<String>
   dealloc_stack %4 : $*NSArray
   br bb4
@@ -160,65 +101,22 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @array_downcast_takealways : $@convention(thin) (@guaranteed NSArray) -> () {
-// CHECK: bb0([[ARG:%.*]] : $NSArray):
-// CHECK:   [[INPUT:%.*]] = alloc_stack $NSArray
-// CHECK:   retain_value [[ARG]]
-// CHECK:   store [[ARG]] to [[INPUT]]
-// CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<String>
-// CHECK:   [[INPUT_VALUE:%.*]] = load [[INPUT]]
-// CHECK:   br [[BRIDGE_BB:bb[0-9]+]]([[INPUT_VALUE]] :
-//
-// CHECK: [[BRIDGE_BB]]([[INPUT_VALUE:%.*]] : $NSArray):
-// CHECK:   [[CAST_TMP:%.*]] = alloc_stack $Optional<Array<String>>
-// CHECK:   strong_retain [[INPUT_VALUE]]
-// CHECK:   apply {{%.*}}<Array<String>>([[CAST_TMP]], [[INPUT_VALUE]],
-// CHECK:   strong_release [[INPUT_VALUE]]
-// NOTE: When we perform take_always, this is the take of the cast.
-// CHECK:   strong_release [[INPUT_VALUE]]
-// CHECK:   switch_enum_addr [[CAST_TMP]] : $*Optional<Array<String>>, case #Optional.some!enumelt.1: [[SUCCESS_TRAMPOLINE_BB:bb[0-9]+]], case #Optional.none!enumelt: [[FAIL_BB]]
-//
-// CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
-// CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
-// CHECK:   dealloc_stack [[CAST_TMP]]
-// CHECK:   br [[SUCCESS_BB]]
-//
-//
-// CHECK: [[SUCCESS_BB:bb[0-9]+]]:
-// CHECK:   [[SUCCESS_VAL:%.*]] = load [[OUTPUT]]
-// CHECK:   [[CAST_RESULT:%.*]] = apply {{%.*}}<String>([[SUCCESS_VAL]])
-// CHECK-NEXT:   release_value [[SUCCESS_VAL]]
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
-//
-// CHECK: [[FAIL_BB:bb[0-9]+]]:
-// CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
-// CHECK-NEXT:   br [[FAIL_NEXT:bb[0-9]+]]
-//
-// CHECK: [[FAIL_NEXT]]:
-// CHECK-NEXT:   dealloc_stack [[OUTPUT]]
-// CHECK-NEXT:   dealloc_stack [[INPUT]]
-// CHECK-NEXT:   br [[EXIT_BB]]
-//
-// CHECK: [[EXIT_BB]]:
-// CHECK:   return
-//
+// CHECK-LABEL: sil [ossa] @array_downcast_takealways : $@convention(thin) (@guaranteed NSArray) -> () {
+// CHECK-NOT: checked_cast_addr_br
 // CHECK: } // end sil function 'array_downcast_takealways'
-sil @array_downcast_takealways : $@convention(thin) (@guaranteed NSArray) -> () {
-bb0(%0 : $NSArray):
+sil [ossa] @array_downcast_takealways : $@convention(thin) (@guaranteed NSArray) -> () {
+bb0(%0 : @guaranteed $NSArray):
   %4 = alloc_stack $NSArray
-  retain_value %0 : $NSArray
-  store %0 to %4 : $*NSArray
+  %5 = copy_value %0 : $NSArray
+  store %5 to [init] %4 : $*NSArray
   %7 = alloc_stack $Array<String>
   checked_cast_addr_br take_always NSArray in %4 : $*NSArray to Array<String> in %7 : $*Array<String>, bb2, bb3
 
 bb2:
-  %9 = load %7 : $*Array<String>
+  %9 = load [take] %7 : $*Array<String>
   %10 = function_ref @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
   apply %10<String>(%9) : $@convention(thin) <τ_0_0> (@guaranteed Array<τ_0_0>) -> ()
-  release_value %9 : $Array<String>
+  destroy_value %9 : $Array<String>
   dealloc_stack %7 : $*Array<String>
   dealloc_stack %4 : $*NSArray
   br bb4
@@ -236,27 +134,27 @@ bb4:
 // Make sure we handle correctly various sorts of NSObject casts without
 // breaking ownership invariants when compiling in ossa.
 
-// CHECK-LABEL: sil @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
-// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -279,10 +177,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_always_string'
-sil @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_always_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $String
   br bb1
 
@@ -303,38 +201,41 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
 // CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
 // CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCAST_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCAST_INPUT:%.*]] to [init] [[INPUT]]
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
 // CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
@@ -347,10 +248,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_on_success_string'
-sil @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $String
   br bb1
 
@@ -372,26 +273,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $String
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSString, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<String>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<String>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<String>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -416,10 +318,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_copy_on_success_string'
-sil @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_copy_on_success_string : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $String
   br bb1
 
@@ -442,27 +344,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
-// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -485,10 +387,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_always_array_of_any'
-sil @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_always_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Array<Any>
   br bb1
 
@@ -509,38 +411,41 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
 // CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
 // CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
 // CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
@@ -553,10 +458,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_on_success_array_of_any'
-sil @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Array<Any>
   br bb1
 
@@ -578,26 +483,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Array<Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSArray, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Array<Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Array<Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Array<Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -622,10 +528,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_copy_on_success_array_of_any'
-sil @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_copy_on_success_array_of_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Array<Any>
   br bb1
 
@@ -648,27 +554,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
-// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -691,10 +597,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_always_dictionary_anyhashable_to_any'
-sil @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_always_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
   br bb1
 
@@ -715,38 +621,41 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
 // CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
 // CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
 // CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
@@ -759,10 +668,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_on_success_dictionary_anyhashable_to_any'
-sil @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
   br bb1
 
@@ -784,26 +693,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Dictionary<AnyHashable, Any>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSDictionary, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Dictionary<AnyHashable, Any>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Dictionary<AnyHashable, Any>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Dictionary<AnyHashable, Any>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -828,10 +738,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_copy_on_success_dictionary_anyhashable_to_any'
-sil @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_copy_on_success_dictionary_anyhashable_to_any : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Dictionary<AnyHashable, Any>
   br bb1
 
@@ -854,27 +764,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
-// CHECK-NEXT:   strong_release [[LOADED_INPUT]]
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   destroy_value [[DEFAULT_ARG]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -897,10 +807,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_always_set_anyhashable'
-sil @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_always_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Set<AnyHashable>
   br bb1
 
@@ -921,38 +831,41 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
 // CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
-// CHECK:   strong_release [[CASTED_INPUT]]
+// CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
 // CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
+// CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
 // CHECK: [[FAIL_EXIT_TRAMPOLINE]]:
@@ -965,10 +878,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_take_on_success_set_anyhashable'
-sil @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_take_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Set<AnyHashable>
   br bb1
 
@@ -990,26 +903,27 @@ bb4:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+// CHECK-LABEL: sil [ossa] @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[INPUT:%.*]] = alloc_stack $NSObject
-// CHECK:   store [[ARG]] to [[INPUT]] :
+// CHECK:   store [[ARG]] to [init] [[INPUT]] :
 // CHECK:   [[OUTPUT:%.*]] = alloc_stack $Set<AnyHashable>
 // CHECK:   br bb1
 //
 // CHECK: bb1:
-// CHECK:   [[LOADED_INPUT:%.*]] = load [[INPUT]]
+// CHECK:   [[LOADED_INPUT:%.*]] = load [take] [[INPUT]]
 // CHECK:   checked_cast_br [[LOADED_INPUT]] : $NSObject to $NSSet, [[YES_BB:bb[0-9]+]], [[NO_BB:bb[0-9]+]]
 //
-// CHECK: [[NO_BB]]:
+// CHECK: [[NO_BB]]([[DEFAULT_ARG:%.*]] :
+// CHECK-NEXT:   store [[DEFAULT_ARG]] to [init] [[INPUT]]
 // CHECK-NEXT:   br [[FAIL_EXIT_TRAMPOLINE:bb[0-9]+]]
 //
 // CHECK: [[YES_BB]]([[CASTED_INPUT:%.*]] :
 // CHECK:   [[CAST_RESULT:%.*]] = alloc_stack $Optional<Set<AnyHashable>>
-// CHECK:   strong_retain [[CASTED_INPUT]]
-// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT]], {{%.*}}) :
-// CHECK:   strong_release [[CASTED_INPUT]]
-// CHECK-NOT:   strong_release [[CASTED_INPUT]]
+// CHECK:   [[CASTED_INPUT_COPY:%.*]] = copy_value [[CASTED_INPUT]]
+// CHECK:   apply {{%.*}}<Set<AnyHashable>>([[CAST_RESULT]], [[CASTED_INPUT_COPY]], {{%.*}}) :
+// CHECK:   destroy_value [[CASTED_INPUT_COPY]]
+// CHECK-NOT:   destroy_value [[CASTED_INPUT]]
 // CHECK:   switch_enum_addr [[CAST_RESULT]] : $*Optional<Set<AnyHashable>>, case #Optional.some!enumelt.1: [[COND_CAST_SUCC:bb[0-9]+]], case #Optional.none!enumelt: [[COND_CAST_FAIL:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_SUCC]]:
@@ -1034,10 +948,10 @@ bb4:
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK: } // end sil function 'nsobject_test_copy_on_success_set_anyhashable'
-sil @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
-bb0(%0 : $NSObject):
+sil [ossa] @nsobject_test_copy_on_success_set_anyhashable : $@convention(thin) (@owned NSObject) -> () {
+bb0(%0 : @owned $NSObject):
   %nsSource = alloc_stack $NSObject
-  store %0 to %nsSource : $*NSObject
+  store %0 to [init] %nsSource : $*NSObject
   %stringDest = alloc_stack $Set<AnyHashable>
   br bb1
 


### PR DESCRIPTION
…d promotion and fail.

Specifically, in this part of the cast optimizer we are trying to optimize casts
that can be done in two parts. As an example consider: NSObject ->
Array<Any>. In this case, we first cast from NSObject -> NSArray and then try to
conditionally bridge to Array<Any> from NSArray.

The problem is we did not destroy the NSObject correctly if the first cast
failed. I couldn't figure out how to create an actual swift test case that
produces this problem since we are pretty conservative about triggering this
code path. But in SIL it is pretty easy and in ossa, we trigger the ownership
verifier.

This is another victory for the ownership verifier!

rdar://51753580
(cherry picked from commit c5e9fc286a9f6d5774ad7d8f7831a0f84a80fd71)

Conflicts:
	lib/SILOptimizer/Utils/CastOptimizer.cpp
	test/SILOptimizer/constant_propagation_objc.sil
	test/SILOptimizer/constant_propagation_ownership_objc.sil

The conflicts came from my having on master extracted out the piece of code
where this is done into a helper function.
