### PR TITLE
[Definite Initialization] Fix a bug that made DI wrongly think that an unused access to 'self' in a delegating initializer is a use of the form: 'type(of:self)'

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1568,11 +1568,15 @@ collectDelegatingInitUses(const DIMemoryObjectInfo &TheMemory,
     // be an end_borrow use in addition to the value_metatype.
     if (isa<LoadBorrowInst>(User)) {
       auto UserVal = cast<SingleValueInstruction>(User);
-      bool onlyUseIsValueMetatype = true;
+      bool onlyUseIsValueMetatype = false;
       for (auto use : UserVal->getUses()) {
-        if (isa<EndBorrowInst>(use->getUser())
-            || isa<ValueMetatypeInst>(use->getUser()))
+        auto *user = use->getUser();
+        if (isa<EndBorrowInst>(user))
           continue;
+        if (isa<ValueMetatypeInst>(user)) {
+          onlyUseIsValueMetatype = true;
+          continue;
+        }
         onlyUseIsValueMetatype = false;
         break;
       }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1579,3 +1579,12 @@ class WeakCycle {
     self.d = 10
   }
 }
+
+// <rdar://51198592> DI was crashing as it wrongly detected a `type(of: self)`
+// use in a delegating initializer, when there was none.
+class DelegatingInitTest {
+  convenience init(x: Int) {
+    self // expected-warning {{expression of type 'DelegatingInitTest' is unused}}
+      // expected-error@-1 {{'self' used before 'self.init' call or assignment to 'self'}}
+  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+}

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -275,3 +275,20 @@ bb2:
   %7 = tuple ()
   return %7 : $()
 }
+
+// <rdar://51198592> DI was crashing as it wrongly detected a `type(of: self)`
+// use in a delegating initializer, when there was none.
+class MyClass4 {
+}
+
+sil hidden [ossa] @test_self_uninit_use_in_delegating_init : $@convention(method) (@thick MyClass4.Type) -> @owned MyClass4 {
+bb0(%1 : $@thick MyClass4.Type):
+  %2 = alloc_stack $MyClass4, let, name "self"
+  %3 = mark_uninitialized [delegatingself] %2 : $*MyClass4
+  %5 = load_borrow %3 : $*MyClass4 // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  end_borrow %5 : $MyClass4
+  %7 = load [copy] %3 : $*MyClass4 // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+  destroy_addr %3 : $*MyClass4
+  dealloc_stack %2 : $*MyClass4
+  return %7 : $MyClass4
+}


### PR DESCRIPTION
<rdar://51198592>

(cherry-pick from master PR: https://github.com/apple/swift/pull/25403)