### PR TITLE
Android cross-compile on macOS: Fix for compile error addressed Float80 data type.

### DIFF
--- a/include/swift/Runtime/SwiftDtoa.h
+++ b/include/swift/Runtime/SwiftDtoa.h
@@ -37,6 +37,10 @@
  #endif
 #endif
 
+#if defined(__ANDROID__) && (defined(__i386) || defined(__x86_64__))
+ #undef SWIFT_DTOA_FLOAT80_SUPPORT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/swift/Runtime/SwiftDtoa.h
+++ b/include/swift/Runtime/SwiftDtoa.h
@@ -30,15 +30,13 @@
 #if defined(_WIN32)
  // Windows has `long double` == `double` on all platforms, so disable this.
  #undef SWIFT_DTOA_FLOAT80_SUPPORT
+#elif defined(__ANDROID__)
+ // At least for now Float80 is disabled. See: https://github.com/apple/swift/pull/25502
 #elif defined(__APPLE__) || defined(__linux__)
  // macOS and Linux support Float80 on X86 hardware but not on ARM
  #if defined(__x86_64__) || defined(__i386)
   #define SWIFT_DTOA_FLOAT80_SUPPORT 1
  #endif
-#endif
-
-#if defined(__ANDROID__) && (defined(__i386) || defined(__x86_64__))
- #undef SWIFT_DTOA_FLOAT80_SUPPORT
 #endif
 
 #ifdef __cplusplus

--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -46,7 +46,7 @@ public struct CGFloat {
     self.native = NativeType(value)
   }
 
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
   @_transparent public init(_ value: Float80) {
     self.native = NativeType(value)
   }

--- a/stdlib/public/Platform/Glibc.swift.gyb
+++ b/stdlib/public/Platform/Glibc.swift.gyb
@@ -36,7 +36,7 @@ public let FLT_RADIX = Double.radix
 
 %for type, prefix in [('Float', 'FLT'), ('Double', 'DBL'), ('Float80', 'LDBL')]:
 % if type == "Float80":
-#if arch(i386) || arch(x86_64)
+#if !os(Android) && (arch(i386) || arch(x86_64))
 % end
 //  Where does the 1 come from? C counts the usually-implicit leading
 //  significand bit, but Swift does not. Neither is really right or wrong.

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -193,7 +193,7 @@ def TypedBinaryFunctions():
 // Note these do not have a corresponding LLVM intrinsic
 % for T, CT, f, ufunc in TypedUnaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -220,7 +220,7 @@ public func tgamma(_ x: Float) -> Float {
   return Float.gamma(x)
 }
 
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 @_transparent
 public func cbrt(_ x: Float80) -> Float80 {
   return Float80.root(x, 3)
@@ -242,7 +242,7 @@ public func tgamma(_ x: Float80) -> Float80 {
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  end
 %  if ufunc[-3:] != 'int':
 @_transparent
@@ -265,7 +265,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // Binary functions
 % for T, CT, f in OverlayFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  end
 @_transparent
 public func atan2(_ y: ${T}, _ x: ${T}) -> ${T} {
@@ -318,7 +318,7 @@ public func fmax(_ x: ${T}, _ y: ${T}) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  else:
 //  lgamma not available on Windows, apparently?
 #if !os(Windows)
@@ -334,7 +334,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  end
 @_transparent
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
@@ -350,7 +350,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 
 % for T, CT, f in OverlayFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 %  end
 @available(swift, deprecated: 4.2/*, obsoleted: 5.1*/, message:
            "use ${T}(nan: ${T}.RawSignificand).")

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -34,7 +34,7 @@ namespace swift { extern "C" {
 // This declaration might not be universally correct.
 // We verify its correctness for the current platform in the runtime code.
 #if defined(__linux__)
-# if defined(__ANDROID__) && !defined(__aarch64__)
+# if defined(__ANDROID__) && !(defined(__aarch64__) || defined(__x86_64__))
 typedef __swift_uint16_t __swift_mode_t;
 # else
 typedef __swift_uint32_t __swift_mode_t;

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1497,7 +1497,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -39,7 +39,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 %   Self = floatName(bits)
 
 % if bits == 80:
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % end
 
 //===--- Parsing ----------------------------------------------------------===//

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -54,7 +54,7 @@ else:
 }%
 
 % if bits == 80:
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % end
 
 ${SelfDocComment}
@@ -1664,7 +1664,7 @@ extension ${Self} {
 %   That = src_type.stdlib_name
 
 %   if (srcBits == 80) and (bits != 80):
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %   end
 
 %   if srcBits == bits:

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1128,7 +1128,7 @@ public struct ${Self}
 %     (lower, upper) = getFtoIBounds(floatBits=FloatBits, intBits=int(bits), signed=signed)
 
 %     if FloatType == 'Float80':
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %     end
 
   /// Creates an integer from the given floating-point value, rounding toward

--- a/stdlib/public/core/MathFunctions.swift.gyb
+++ b/stdlib/public/core/MathFunctions.swift.gyb
@@ -62,7 +62,7 @@ public protocol ElementaryFunctions {
 
 %for type in all_floating_point_types():
 % if type.bits == 80:
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
 % end
 % Self = type.stdlib_name
 extension ${Self}: ElementaryFunctions {

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -53,7 +53,7 @@ extension ${Type[0]} : _CustomPlaygroundQuickLookable {
 }
 % end
 
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 extension Float80 : CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -153,7 +153,7 @@ internal struct _Buffer72 {
 % for bits in [ 32, 64, 80 ]:
 
 % if bits == 80:
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % end
 
 @_silgen_name("swift_float${bits}ToString")

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -400,7 +400,7 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 extension Float80 : CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.


### PR DESCRIPTION
Swift forum discussion: https://forums.swift.org/t/android-crosscompilation-on-macos-is-swift-float80-support-really-needed-for-android-intel-x86-and-x86-64-targets/25835

This PR disables **Float80** support for Android. This PR fixes compile error shown below:

```
cd /swift-everywhere-toolchain/ToolChain/Build/darwin/swift && ninja -j3 swiftGlibc-android-i686 swiftCore-android-i686 swiftSwiftOnoneSupport-android-i686
[33/75] Building CXX object stdlib/public/runtime/CMakeFiles/swiftRuntime-android-i686.dir/SwiftDtoa.cpp.o
FAILED: stdlib/public/runtime/CMakeFiles/swiftRuntime-android-i686.dir/SwiftDtoa.cpp.o
/swift-everywhere-toolchain/ToolChain/Build/darwin/llvm/./bin/clang++  \
-DCMARK_STATIC_DEFINE -DGTEST_HAS_RTTI=0 -D_DEBUG -D__STDC_CONSTANT_MACROS \
-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Istdlib/public/runtime \
-I/swift-everywhere-toolchain/ToolChain/Sources/swift/stdlib/public/runtime \
-Iinclude -I/swift-everywhere-toolchain/ToolChain/Sources/swift/include \
-I/swift-everywhere-toolchain/ToolChain/Sources/llvm/include \
-I/swift-everywhere-toolchain/ToolChain/Build/darwin/llvm/include \
-I/swift-everywhere-toolchain/ToolChain/Sources/llvm/tools/clang/include \
-I/swift-everywhere-toolchain/ToolChain/Build/darwin/llvm/tools/clang/include \
-I/swift-everywhere-toolchain/ToolChain/Sources/cmark/src \
-I/swift-everywhere-toolchain/ToolChain/Build/darwin/cmark/src \
-Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector \
-fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -Wextra -Wno-unused-parameter \
-Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-class-memaccess \
-Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fdiagnostics-color -Werror=switch -Wdocumentation \
-Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -DOBJC_OLD_DISPATCH_PROTOTYPES=0 \
-fno-sanitize=all -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 -O3  \
-isysroot /Volumes/Data/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk   \
-UNDEBUG  -fno-exceptions -fno-rtti -Wall -Wglobal-constructors -Wexit-time-destructors -fvisibility=hidden -DswiftCore_EXPORTS \
-I/swift-everywhere-toolchain/ToolChain/Sources/swift/include -DSWIFT_TARGET_LIBRARY_NAME=swiftRuntime \
-target i686-unknown-linux-android \
--sysroot=/Users/vova/Library/Android/sdk/ndk-bundle/platforms/android-24/arch-x86 \
-B /Users/vova/Library/Android/sdk/ndk-bundle/toolchains/x86-4.9/prebuilt/darwin-x86_64/i686-linux-android/bin \
-O2 -momit-leaf-frame-pointer -g0 -DNDEBUG "-I/ndk-bundle/sources/cxx-stl/llvm-libc++/include" \
/ndk-bundle/sysroot/usr/include/i686-linux-android" -D__ANDROID_API__=24 \
-isystem /swift-everywhere-toolchain/ToolChain/Sources/icu/icu4c/source/common \
-isystem /swift-everywhere-toolchain/ToolChain/Sources/icu/icu4c/source/i18n \
-MD -MT stdlib/public/runtime/CMakeFiles/swiftRuntime-android-i686.dir/SwiftDtoa.cpp.o \
-MF stdlib/public/runtime/CMakeFiles/swiftRuntime-android-i686.dir/SwiftDtoa.cpp.o.d \
-o stdlib/public/runtime/CMakeFiles/swiftRuntime-android-i686.dir/SwiftDtoa.cpp.o \
-c /swift-everywhere-toolchain/ToolChain/Sources/swift/stdlib/public/runtime/SwiftDtoa.cpp
/swift-everywhere-toolchain/ToolChain/Sources/swift/stdlib/public/runtime/SwiftDtoa.cpp:148:2: error: "Are you certain `long double` on this platform is really Intel 80-bit extended precision?"

#error "Are you certain `long double` on this platform is really Intel 80-bit extended precision?"
 ^
1 error generated.
```
