### PR TITLE
[Foundation]: Add detailed documentation for NSLocalizedString

### DIFF
--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -29,7 +29,140 @@ public let NSNotFound: Int = .max
 // NSLocalizedString
 //===----------------------------------------------------------------------===//
 
-/// Returns a localized string, using the main bundle if one is not specified.
+/// Returns the localized version of a string.
+///
+/// - parameter key: An identifying value used to reference a localized string.
+/// - parameter tableName: The name of the table containing the localized string
+///   identified by `key`. This is the prefix of the strings file—a file with
+///   the `.strings` extension—containing the localized values. If `tableName`
+///   is `nil` or the empty string, the `Localizable` table is used. The default
+///   value is `nil`.
+/// - parameter bundle: The bundle containing the table's strings file. The main
+///   bundle is used by default.
+/// - parameter value: A user-visible string to return when the localized string
+///   for `key` can't be found in the table. The default value is the empty
+///   string, which indicates that `key` should be returned.
+/// - parameter comment: A note to the translator describing the context in
+///   in which this localized string is presented to the user. For example, this
+///   can indicate whether the "Book" is used as a noun or a verb. In French,
+///   the noun is "Livre", whereas the verb is "Réserver".
+///
+/// - returns: A localized version of the string designated by `key` in the
+///   table identified by `tableName`. If the localized string for `key` cannot
+///   be found within the table, the following semantics are used to determine
+///   returned value:
+///     - If `value` is the empty string, `key` is returned.
+///     - If `value` is not the empty string, `value` is returned.
+///
+/// Exporting Localizations
+/// -----------------------
+///
+/// Xcode can read through a project's code to find invocations of
+/// `NSLocalizedString(_:tableName:bundle:value:comment:)` and automatically
+/// generate the appropriate strings files for the project's base localization.
+///
+/// In Xcode, open the project file and, in the `Edit` menu, select
+/// `Export for Localization`. This will generate an XLIFF bundle containing
+/// strings files derived from your code along with other localizable assets.
+/// `xcodebuild` can also be used to generate the localization bundle from the
+/// command line with the `exportLocalizations` option.
+///
+///     xcodebuild -exportLocalizations -project <projectname>.xcodeproj \
+///                                     -localizationPath <path>
+///
+/// These bundles can be sent to translators for localization, and then
+/// reimported into your Xcode project. In Xcode, open the project file. In the
+/// `Edit` menu, select `Import Localizations...`, and select the XLIFF
+/// folder to import. You can also use `xcodebuild` to import localizations with
+/// the `importLocalizations` option.
+///
+///     xcodebuild -importLocalizations -project <projectname>.xcodeproj \
+///                                     -localizationPath <path>
+///
+/// Keys and Values
+/// ---------------
+///
+/// Words can often have multiple different meanings depending on the context
+/// in which they're used. For example, the word "Book" can be used as a noun—a
+/// printed literary work—and it can be used as a verb—the action of making a
+/// reservation. Words with different meanings which share the same spelling are
+/// heteronyms.
+///
+/// Different languages often have different heteronyms. "Book" in English is
+/// one such heteronym, but that's not so in French, where the noun translates
+/// to "Livre", and the verb translates to "Réserver". For this reason, it's
+/// important make sure that each use of the same phrase is translated
+/// appropriately for its context by assigning unique keys to each phrase and
+/// adding a description comment describing how that phrase is used.
+///
+///     NSLocalizedString("book-tag-title", value: "Book", comment: """
+///     noun: A label attached to literary items in the library.
+///     """)
+///
+///     NSLocalizedString("book-button-title", value: "Book", comment: """
+///     verb: Title of the button that makes a reservation.
+///     """)
+///
+/// Limitations
+/// -----------
+///
+/// Variables and interpolated strings cannot be passed into `key`, `tableName`,
+/// `value`, and `comment`.
+///
+///     // Translators will see "1 + 1 = (1 + 1)".
+///     // International users will see a localization "1 + 1 = (1 + 1)".
+///     let localizedString = NSLocalizedString("string-interpolation",
+///                                             value: "1 + 1 = \(1 + 1)"
+///                                             comment: "A math equation.")
+///
+/// These strings must be string literal expressions. When you need
+/// to dynamically insert values within localized strings, set `value` to a
+/// format string, and use `String.localizedStringWithFormat(_:_:)` to insert
+/// those values.
+///
+///     // Translators will see "1 + 1 = %d" (they know what "%d" means).
+///     // International users will see a localization of "1 + 1 = 2".
+///     let format = NSLocalizedString("string-literal",
+///                                    value: "1 + 1 = %d",
+///                                    comment: "A math equation.")
+///     let localizedString = String.localizedStringWithFormat(format, (1 + 1))
+///
+/// Multi-line string literals are technically supported, but will result in
+/// unexpected behavior during internationalization. A newline will be inserted
+/// before and after the body of text within the string, and translators will
+/// likely preserve those in their internaliations.
+///
+/// To preserve some of the aesthetics of having newlines in the string mirrored
+/// in their code representation, string literal concatenation with the `+`
+/// operator can be used.
+///
+///     NSLocalizedString("multi-line-string-literal",
+///                       value: """
+///     This multi-line string literal won't work as expected.
+///     An extra newline added to the beginning and end of the string.
+///     """,
+///                       comment: "The description of a sample of code.")
+///
+///     NSLocalizedString("string-literal-contatenation",
+///                       value: "This string literal concatenated with"
+///                            + "this other string literal works just fine.",
+///                       comment: "The description of a sample of code.")
+///
+/// However, since comments aren't localized, multi-line string literals are
+/// safe to use for `comment`.
+///
+/// Alternatives
+/// ------------
+///
+/// If having Xcode generate strings files from code isn't desired behavior,
+/// you should call `Bundle.localizedString(forKey:value:table:)` instead.
+/// Doing so will require the manual creation and management of the relevant
+/// strings files.
+///
+/// It should be noted that both localization methods can be used at the same
+/// time, but data from manually managed strings file tables will be overwritten
+/// by Xcode if that table is also used with a call to
+/// `NSLocaliedString(_:tableName:bundle:value:comment:)`.
 public
 func NSLocalizedString(_ key: String,
                        tableName: String? = nil,

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -32,6 +32,7 @@ public let NSNotFound: Int = .max
 /// Returns the localized version of a string.
 ///
 /// - parameter key: An identifying value used to reference a localized string.
+///   `key` must not be the empty string.
 /// - parameter tableName: The name of the table containing the localized string
 ///   identified by `key`. This is the prefix of the strings file—a file with
 ///   the `.strings` extension—containing the localized values. If `tableName`

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -32,7 +32,8 @@ public let NSNotFound: Int = .max
 /// Returns the localized version of a string.
 ///
 /// - parameter key: An identifying value used to reference a localized string.
-///   `key` must not be the empty string.
+///   `key` must not be the empty string. Values keyed by the empty string will
+///   not be localized.
 /// - parameter tableName: The name of the table containing the localized string
 ///   identified by `key`. This is the prefix of the strings file—a file with
 ///   the `.strings` extension—containing the localized values. If `tableName`

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -35,8 +35,7 @@ public let NSNotFound: Int = .max
 /// - parameter tableName: The name of the table containing the localized string
 ///   identified by `key`. This is the prefix of the strings file—a file with
 ///   the `.strings` extension—containing the localized values. If `tableName`
-///   is `nil` or the empty string, the `Localizable` table is used. The default
-///   value is `nil`.
+///   is `nil` or the empty string, the `Localizable` table is used.
 /// - parameter bundle: The bundle containing the table's strings file. The main
 ///   bundle is used by default.
 /// - parameter value: A user-visible string to return when the localized string

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -149,14 +149,14 @@ public let NSNotFound: Int = .max
 ///                            + "this other string literal works just fine.",
 ///                       comment: "The description of a sample of code.")
 ///
-/// Luckily, since comments aren't localized, multi-line string literals can be
-/// safely used with `comment`.
+/// Since comments aren't localized, multi-line string literals can be safely
+/// used with `comment`.
 ///
 /// Restrict Autosynthesized Localizations
 /// --------------------------------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,
-/// you should call `Bundle.localizedString(forKey:value:table:)` instead.
+/// call `Bundle.localizedString(forKey:value:table:)` instead.
 ///
 ///     let greeting = Bundle.localizedString(forKey: "program-greeting",
 ///                                           value: "Hello, World!",

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -55,8 +55,8 @@ public let NSNotFound: Int = .max
 ///     - If `value` is the empty string, `key` is returned.
 ///     - If `value` is not the empty string, `value` is returned.
 ///
-/// Exporting Localizations
-/// -----------------------
+/// Export Localizations with Xcode
+/// -------------------------------
 ///
 /// Xcode can read through a project's code to find invocations of
 /// `NSLocalizedString(_:tableName:bundle:value:comment:)` and automatically
@@ -80,8 +80,8 @@ public let NSNotFound: Int = .max
 ///     xcodebuild -importLocalizations -project <projectname>.xcodeproj \
 ///                                     -localizationPath <path>
 ///
-/// Keys and Values
-/// ---------------
+/// Choose Meaningful Keys
+/// ----------------------
 ///
 /// Words can often have multiple different meanings depending on the context
 /// in which they're used. For example, the word "Book" can be used as a noun—a
@@ -104,8 +104,8 @@ public let NSNotFound: Int = .max
 ///     verb: Title of the button that makes a reservation.
 ///     """)
 ///
-/// Limitations
-/// -----------
+/// Use Only String Literals
+/// ------------------------
 ///
 /// Variables and interpolated strings cannot be passed into `key`, `tableName`,
 /// `value`, and `comment`.
@@ -152,8 +152,8 @@ public let NSNotFound: Int = .max
 /// Luckily, since comments aren't localized, multi-line string literals can be
 /// safely used with `comment`.
 ///
-/// Alternatives
-/// ------------
+/// Restrict Autosynthesized Localizations
+/// --------------------------------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,
 /// you should call `Bundle.localizedString(forKey:value:table:)` instead.

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -42,10 +42,11 @@ public let NSNotFound: Int = .max
 /// - parameter value: A user-visible string to return when the localized string
 ///   for `key` can't be found in the table. The default value is the empty
 ///   string, which indicates that `key` should be returned.
-/// - parameter comment: A note to the translator describing the context in
-///   in which this localized string is presented to the user. For example, this
-///   can indicate whether the "Book" is used as a noun or a verb. In French,
-///   the noun is "Livre", whereas the verb is "Réserver".
+/// - parameter comment: A note to the translator describing the context where
+///   the localized string is presented to the user. For example, this can
+///   indicate whether the "Book" is used as a noun or a verb. This distinction
+///   is important when translating to French, where the noun is "Livre" and the
+///   verb is "Réserver".
 ///
 /// - returns: A localized version of the string designated by `key` in the
 ///   table identified by `tableName`. If the localized string for `key` cannot
@@ -148,21 +149,32 @@ public let NSNotFound: Int = .max
 ///                            + "this other string literal works just fine.",
 ///                       comment: "The description of a sample of code.")
 ///
-/// However, since comments aren't localized, multi-line string literals are
-/// safe to use for `comment`.
+/// Luckily, since comments aren't localized, multi-line string literals can be
+/// safely used with `comment`.
 ///
 /// Alternatives
 /// ------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,
 /// you should call `Bundle.localizedString(forKey:value:table:)` instead.
-/// Doing so will require the manual creation and management of the relevant
-/// strings files.
 ///
-/// It should be noted that both localization methods can be used at the same
-/// time, but data from manually managed strings file tables will be overwritten
-/// by Xcode if that table is also used with a call to
-/// `NSLocaliedString(_:tableName:bundle:value:comment:)`.
+///     let greeting = Bundle.localizedString(forKey: "program-greeting",
+///                                           value: "Hello, World!",
+///                                           table: "Localization")
+///
+/// However, this requires the manual creation and management of that table's
+/// strings file.
+///
+///     /* Localization.strings */
+///
+///     /* A friendly greeting to the user when the program starts. */
+///     "program-greeting" = "Hello, World!";
+///
+/// **Note:** Although `NSLocalizedString(_:tableName:bundle:value:comment:)`
+/// and `Bundle.localizedString(forKey:value:table:)` can be used in a project
+/// at the same time, data from a manually managed strings files will be
+/// overwritten by Xcode when their table is also used to look up localized
+/// strings with `NSLocalizedString(_:tableName:bundle:value:comment:)`.
 public
 func NSLocalizedString(_ key: String,
                        tableName: String? = nil,

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -103,8 +103,14 @@ public let NSNotFound: Int = .max
 /// Use Only String Literals
 /// ------------------------
 ///
-/// Variables and interpolated strings cannot be passed into `key`, `tableName`,
-/// `value`, and `comment`.
+/// String literal values must be used with `key`, `tableName`, `value`, and
+/// `comment`.
+///
+/// Xcode does not evaluate interpolated strings and string variables when
+/// generating strings files from code. Using those language features will
+/// result in exported localizations that resemble the code expression instead
+/// of its value. Translators would then translate that exported value—leaving
+/// international users with a localized string containing code.
 ///
 ///     // Translators will see "1 + 1 = (1 + 1)".
 ///     // International users will see a localization "1 + 1 = (1 + 1)".
@@ -112,8 +118,7 @@ public let NSNotFound: Int = .max
 ///                                             value: "1 + 1 = \(1 + 1)"
 ///                                             comment: "A math equation.")
 ///
-/// These strings must be string literal expressions. When you need
-/// to dynamically insert values within localized strings, set `value` to a
+/// To dynamically insert values within localized strings, set `value` to a
 /// format string, and use `String.localizedStringWithFormat(_:_:)` to insert
 /// those values.
 ///

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -51,7 +51,7 @@ public let NSNotFound: Int = .max
 ///   be found within the table, `value` is returned. However, `key` is returned
 ///   instead when `value` is the empty string.
 ///
-/// Export Localizations with Xcode
+/// Export Localizations With Xcode
 /// -------------------------------
 ///
 /// Xcode can read through a project's code to find invocations of
@@ -154,7 +154,7 @@ public let NSNotFound: Int = .max
 /// Since comments aren't localized, multiline string literals can be safely
 /// used with `comment`.
 ///
-/// Work with Manually Managed Strings
+/// Work With Manually Managed Strings
 /// ----------------------------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -107,9 +107,10 @@ public let NSNotFound: Int = .max
 /// `comment`.
 ///
 /// Xcode does not evaluate interpolated strings and string variables when
-/// generating strings files from code. Using those language features will
-/// result in exported localizations that resemble the code expression instead
-/// of its value. Translators would then translate that exported value—leaving
+/// generating strings files from code. Attempting to localize a string using
+/// those language features will cause Xcode to export something that resembles
+/// the original code expression instead of its expected value at runtime.
+/// Translators would then translate that exported value—leaving
 /// international users with a localized string containing code.
 ///
 ///     // Translators will see "1 + 1 = (1 + 1)".

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -51,7 +51,7 @@ public let NSNotFound: Int = .max
 ///   be found within the table, `value` is returned. However, `key` is returned
 ///   instead when `value` is the empty string.
 ///
-/// Export Localizations With Xcode
+/// Export Localizations with Xcode
 /// -------------------------------
 ///
 /// Xcode can read through a project's code to find invocations of
@@ -154,7 +154,7 @@ public let NSNotFound: Int = .max
 /// Since comments aren't localized, multiline string literals can be safely
 /// used with `comment`.
 ///
-/// Work With Manually Managed Strings
+/// Work with Manually Managed Strings
 /// ----------------------------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -130,19 +130,19 @@ public let NSNotFound: Int = .max
 ///                                    comment: "A math equation.")
 ///     let localizedString = String.localizedStringWithFormat(format, (1 + 1))
 ///
-/// Multi-line string literals are technically supported, but will result in
+/// Multiline string literals are technically supported, but will result in
 /// unexpected behavior during internationalization. A newline will be inserted
 /// before and after the body of text within the string, and translators will
-/// likely preserve those in their internaliations.
+/// likely preserve those in their internationalizations.
 ///
 /// To preserve some of the aesthetics of having newlines in the string mirrored
 /// in their code representation, string literal concatenation with the `+`
 /// operator can be used.
 ///
-///     NSLocalizedString("multi-line-string-literal",
+///     NSLocalizedString("multiline-string-literal",
 ///                       value: """
-///     This multi-line string literal won't work as expected.
-///     An extra newline added to the beginning and end of the string.
+///     This multiline string literal won't work as expected.
+///     An extra newline is added to the beginning and end of the string.
 ///     """,
 ///                       comment: "The description of a sample of code.")
 ///
@@ -151,7 +151,7 @@ public let NSNotFound: Int = .max
 ///                            + "this other string literal works just fine.",
 ///                       comment: "The description of a sample of code.")
 ///
-/// Since comments aren't localized, multi-line string literals can be safely
+/// Since comments aren't localized, multiline string literals can be safely
 /// used with `comment`.
 ///
 /// Restrict Autosynthesized Localizations
@@ -174,7 +174,7 @@ public let NSNotFound: Int = .max
 ///
 /// - note: Although `NSLocalizedString(_:tableName:bundle:value:comment:)`
 /// and `Bundle.localizedString(forKey:value:table:)` can be used in a project
-/// at the same time, data from a manually managed strings files will be
+/// at the same time, data from manually managed strings files will be
 /// overwritten by Xcode when their table is also used to look up localized
 /// strings with `NSLocalizedString(_:tableName:bundle:value:comment:)`.
 public

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -32,7 +32,7 @@ public let NSNotFound: Int = .max
 /// Returns the localized version of a string.
 ///
 /// - parameter key: An identifying value used to reference a localized string.
-///   `key` must not be the empty string. Values keyed by the empty string will
+///   Don't use the empty string as a key. Values keyed by the empty string will
 ///   not be localized.
 /// - parameter tableName: The name of the table containing the localized string
 ///   identified by `key`. This is the prefix of the strings file—a file with

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -43,10 +43,7 @@ public let NSNotFound: Int = .max
 ///   for `key` can't be found in the table. The default value is the empty
 ///   string, which indicates that `key` should be returned.
 /// - parameter comment: A note to the translator describing the context where
-///   the localized string is presented to the user. For example, this can
-///   indicate whether the "Book" is used as a noun or a verb. This distinction
-///   is important when translating to French, where the noun is "Livre" and the
-///   verb is "Réserver".
+///   the localized string is presented to the user.
 ///
 /// - returns: A localized version of the string designated by `key` in the
 ///   table identified by `tableName`. If the localized string for `key` cannot

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -170,7 +170,7 @@ public let NSNotFound: Int = .max
 ///     /* A friendly greeting to the user when the program starts. */
 ///     "program-greeting" = "Hello, World!";
 ///
-/// **Note:** Although `NSLocalizedString(_:tableName:bundle:value:comment:)`
+/// - note: Although `NSLocalizedString(_:tableName:bundle:value:comment:)`
 /// and `Bundle.localizedString(forKey:value:table:)` can be used in a project
 /// at the same time, data from a manually managed strings files will be
 /// overwritten by Xcode when their table is also used to look up localized

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -154,8 +154,8 @@ public let NSNotFound: Int = .max
 /// Since comments aren't localized, multiline string literals can be safely
 /// used with `comment`.
 ///
-/// Restrict Autosynthesized Localizations
-/// --------------------------------------
+/// Work with Manually Managed Strings
+/// ----------------------------------
 ///
 /// If having Xcode generate strings files from code isn't desired behavior,
 /// call `Bundle.localizedString(forKey:value:table:)` instead.

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -41,8 +41,8 @@ public let NSNotFound: Int = .max
 /// - parameter bundle: The bundle containing the table's strings file. The main
 ///   bundle is used by default.
 /// - parameter value: A user-visible string to return when the localized string
-///   for `key` can't be found in the table. The default value is the empty
-///   string, which indicates that `key` should be returned.
+///   for `key` cannot be found in the table. If `value` is the empty string,
+///   `key` would be returned instead.
 /// - parameter comment: A note to the translator describing the context where
 ///   the localized string is presented to the user.
 ///

--- a/stdlib/public/Darwin/Foundation/Foundation.swift
+++ b/stdlib/public/Darwin/Foundation/Foundation.swift
@@ -48,10 +48,8 @@ public let NSNotFound: Int = .max
 ///
 /// - returns: A localized version of the string designated by `key` in the
 ///   table identified by `tableName`. If the localized string for `key` cannot
-///   be found within the table, the following semantics are used to determine
-///   returned value:
-///     - If `value` is the empty string, `key` is returned.
-///     - If `value` is not the empty string, `value` is returned.
+///   be found within the table, `value` is returned. However, `key` is returned
+///   instead when `value` is the empty string.
 ///
 /// Export Localizations with Xcode
 /// -------------------------------


### PR DESCRIPTION
The existing documentation for the Swift implementation of `NSLocalizedString` doesn't describe its parameters, return value, semantics, and how it relates to localization as a whole.

This PR coalesces information from the Objective-C documentation, Xcode's Help document about exporting localizations, and WWDC presentations on internalization into a descriptive doc-comment.

**Objective-C Documentation**

- [NSLocallizedString][objc-string]
- [NSLocalizedStringFromTable][objc-table]
- [NSLocalizedStringFromTableInBundle][objc-bundle]
- [NSLocalizedStringWithDefaultValue][objc-default]

[objc-string]: https://developer.apple.com/documentation/foundation/nslocalizedstring
[objc-table]: https://developer.apple.com/documentation/foundation/nslocalizedstringfromtable
[objc-bundle]: https://developer.apple.com/documentation/foundation/nslocalizedstringfromtableinbundle
[objc-default]: https://developer.apple.com/documentation/foundation/nslocalizedstringwithdefaultvalue

**WWDC Sessions**

- [WWDC 2017: Localizing with Xcode 9][wwdc-2017-401]
- [WWDC 2018: New Localization Workflows in Xcode 10][wwdc-2018-404]
- [WWDC 2019: Creating Great Localized Experiences with Xcode 11][wwdc-2019-403]

[wwdc-2017-401]: https://developer.apple.com/videos/play/wwdc2017/401/
[wwdc-2018-404]: https://developer.apple.com/videos/play/wwdc2018/404/
[wwdc-2019-403]: https://developer.apple.com/videos/play/wwdc2019/403/

**Xcode Help**

- [Xcode Help: Export localizations for translation][xcode-help]

[xcode-help]: https://help.apple.com/xcode/mac/11.0/index.html?localePath=en.lproj#/deve7c832cd2