### PR TITLE
[IRGen] Use Singleton metadata strategy in JIT mode.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2317,6 +2317,11 @@ IRGenModule::getClassMetadataStrategy(const ClassDecl *theClass) {
   // If we have resiliently-sized fields, we might be able to use the
   // update pattern.
   if (resilientLayout.doesMetadataRequireUpdate()) {
+      
+    // FixedOrUpdate strategy does not work in JIT mode
+    if (IRGen.Opts.UseJIT)
+      return ClassMetadataStrategy::Singleton;
+      
     // The update pattern only benefits us on platforms with an Objective-C
     // runtime, otherwise just use the singleton pattern.
     if (!Context.LangOpts.EnableObjCInterop)

--- a/test/IRGen/Inputs/legacy_type_info/b.yaml
+++ b/test/IRGen/Inputs/legacy_type_info/b.yaml
@@ -1,0 +1,6 @@
+Name:            resilient_struct
+Decls:
+  - Name:            16resilient_struct15ResilientDoubleV
+    Size:            8
+    Alignment:       8
+    ExtraInhabitants: 0

--- a/test/IRGen/jit_metadata_strategy.swift
+++ b/test/IRGen/jit_metadata_strategy.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_struct)) -enable-library-evolution %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+
+// RUN: %target-swift-frontend -use-jit %s -emit-ir -lresilient_struct -L %t -I %t -enable-objc-interop -read-legacy-type-info-path=%S/Inputs/legacy_type_info/b.yaml | %FileCheck %s
+// RUN: %target-swift-frontend -interpret %s -lresilient_struct -L %t -I %t -enable-objc-interop -read-legacy-type-info-path=%S/Inputs/legacy_type_info/b.yaml
+
+// REQUIRES: objc_interop
+// UNSUPPORTED: OS=ios || OS=watchos || OS=tvos
+
+import resilient_struct
+
+@_optimize(none) func blackHole<T>(_: T) {}
+
+// ClassMetadataStrategy::Fixed
+class FixedSizeClass {
+    var v4: String?
+    var v5: Int?
+    var v6: String?
+}
+
+// ClassMetadataStrategy::Singleton
+class GenericSuperclass<T> { }
+class ClassWithGenericSuperclass: GenericSuperclass<Int> {
+    var v1: ResilientDouble?
+    var v2: ResilientDouble?
+    var v3: ResilientDouble?
+    var v4: String?
+    var v5: Int?
+    var v6: String?
+}
+
+// ClassMetadataStrategy::FixedOrUpdate when compiling
+// ClassMetadataStrategy::Singleton when interpreting
+class ClassNeedingUpdate {
+    var v1: ResilientDouble?
+    var v2: ResilientDouble?
+    var v3: ResilientDouble?
+    var v4: String?
+    var v5: Int?
+    var v6: String?
+}
+
+blackHole(FixedSizeClass())
+blackHole(ClassWithGenericSuperclass())
+blackHole(ClassNeedingUpdate())
+
+// CHECK-LABEL: define{{( protected)?}} private void @runtime_registration
+// CHECK:             call void @swift_instantiateObjCClass({{.*}} @"$s21jit_metadata_strategy14FixedSizeClassCN")
+// CHECK-NOT:         call void @swift_instantiateObjCClass({{.*}} @"$s21jit_metadata_strategy18ClassNeedingUpdateCN")


### PR DESCRIPTION
<!-- What's in this pull request? -->
In Xcode 10.2.1, the Swift compiler crashes when interpreting https://github.com/JiriTrecak/Laurine/blob/master/LaurineGenerator.swift. I have reduced the problem and am adding it as a test case. The swift compiler built from the master branch at the time of writing fails this test. My change makes this test pass and does not brake any other tests (on my machine).

The fix approach is based on work I have done on try! Swift San Jose and would like to thank Slava Pestov for providing explanation and ideas how to fix this.

This commit: https://github.com/jirid/swift/commit/d2f1d36615a7ec55b9db944ebe897a62bab82072
shows the original fix recommended by Slava, unfortunately that did break the following tests:
IRGen/playground.swift
Interpreter/imported_objc_generics.swift
IRGen/objc_generic_class_metadata.sil

Please review thoroughly as my understanding of the Swift compiler is very limited and this is my first contribution to Swift.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://49639321

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->