### PR TITLE
Exit early in single element collections.

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -24,7 +24,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///   collection.
   @inlinable // protocol-only
   public mutating func reverse() {
-    if isEmpty { return }
+    if count < 2 { return }
     var f = startIndex
     var l = index(before: endIndex)
     while f < l {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Test if the collection has more than one element before reversing a collection, otherwise exit early. The previous code did an early exit check that tested if the collection was empty. If we are doing an early exit for this case we might as well include the case of a collection that contains only one element.