### PR TITLE
[AutoDiff] Support differentiation of `switch_enum`.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -424,6 +424,8 @@ WARNING(autodiff_nonvaried_result_fixit,none,
         "result does not depend on differentiation arguments and will always "
         "have a zero derivative; do you want to add '.withoutDerivative()'?",
         ())
+NOTE(autodiff_enums_unsupported,none,
+     "differentiating enum values is not yet supported", ())
 NOTE(autodiff_global_let_closure_not_differentiable,none,
      "global constant closure is not differentiable", ())
 NOTE(autodiff_cannot_differentiate_global_var_closures,none,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1533,6 +1533,15 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
               setVaried(cbi->getFalseBB()->getArgument(opIdx), i);
           }
         }
+        // Handle `switch_enum`.
+        else if (auto *sei = dyn_cast<SwitchEnumInst>(&inst)) {
+          if (isVaried(sei->getOperand(), i)) {
+            for (auto *succBB : sei->getSuccessorBlocks())
+              for (auto *arg : succBB->getArguments())
+                setVaried(arg, i);
+            // Default block cannot have arguments.
+          }
+        }
         // Handle everything else.
         else {
           for (auto &op : inst.getAllOperands())
@@ -1767,8 +1776,9 @@ static bool diagnoseUnsupportedControlFlow(ADContext &context,
   // Diagnose unsupported branching terminators.
   for (auto &bb : *original) {
     auto *term = bb.getTerminator();
-    // Supported terminators are: `br`, `cond_br`.
-    if (isa<BranchInst>(term) || isa<CondBranchInst>(term))
+    // Supported terminators are: `br`, `cond_br`, `switch_enum`.
+    if (isa<BranchInst>(term) || isa<CondBranchInst>(term) ||
+        isa<SwitchEnumInst>(term))
       continue;
     // If terminator is an unsupported branching terminator, emit an error.
     if (term->isBranch()) {
@@ -3134,6 +3144,56 @@ public:
         getOpBasicBlock(cbi->getFalseBB()), falseArgs);
   }
 
+  void visitSwitchEnumInst(SwitchEnumInst *sei) {
+    // Build pullback struct value for original block.
+    auto *origBB = sei->getParent();
+    auto *pbStructVal = buildPullbackValueStructValue(sei);
+
+    // Creates a trampoline block for given original successor block. The
+    // trampoline block has the same arguments as the VJP successor block but
+    // drops the last predecessor enum argument. The generated `switch_enum`
+    // instruction branches to the trampoline block, and the trampoline block
+    // constructs a predecessor enum value and branches to the VJP successor
+    // block.
+    auto createTrampolineBasicBlock =
+      [&](SILBasicBlock *origSuccBB) -> SILBasicBlock * {
+        auto *vjpSuccBB = getOpBasicBlock(origSuccBB);
+        // Create the trampoline block.
+        auto *trampolineBB = vjp->createBasicBlockBefore(vjpSuccBB);
+        for (auto *arg : vjpSuccBB->getArguments().drop_back())
+          trampolineBB->createPhiArgument(arg->getType(),
+                                          arg->getOwnershipKind());
+        // Build predecessor enum value for successor block and branch to it.
+        SILBuilder trampolineBuilder(trampolineBB);
+        auto *succEnumVal = buildPredecessorEnumValue(
+            trampolineBuilder, origBB, origSuccBB, pbStructVal);
+        SmallVector<SILValue, 4> forwardedArguments(
+            trampolineBB->getArguments().begin(),
+            trampolineBB->getArguments().end());
+        forwardedArguments.push_back(succEnumVal);
+        trampolineBuilder.createBranch(
+            sei->getLoc(), vjpSuccBB, forwardedArguments);
+        return trampolineBB;
+      };
+
+    // Create trampoline successor basic blocks.
+    SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 4> caseBBs;
+    for (unsigned i : range(sei->getNumCases())) {
+      auto caseBB = sei->getCase(i);
+      auto *trampolineBB = createTrampolineBasicBlock(caseBB.second);
+      caseBBs.push_back({caseBB.first, trampolineBB});
+    }
+    // Create trampoline default basic block.
+    SILBasicBlock *newDefaultBB = nullptr;
+    if (auto *defaultBB = sei->getDefaultBBOrNull().getPtrOrNull())
+      newDefaultBB = createTrampolineBasicBlock(defaultBB);
+
+    // Create a new `switch_enum` instruction.
+    getBuilder().createSwitchEnum(
+        sei->getLoc(), getOpValue(sei->getOperand()),
+        newDefaultBB, caseBBs);
+  }
+
   // If an `apply` has active results or active inout parameters, replace it
   // with an `apply` of its VJP.
   void visitApplyInst(ApplyInst *ai) {
@@ -4155,6 +4215,13 @@ public:
       auto addActiveValue = [&](SILValue v) {
         if (visited.count(v))
           return;
+        // Diagnose active enum values. Differentiation of enum values is not
+        // yet supported; requires special adjoint handling.
+        if (v->getType().getEnumOrBoundGenericEnum()) {
+          getContext().emitNondifferentiabilityError(
+              v, getInvoker(), diag::autodiff_enums_unsupported);
+          errorOccurred = true;
+        }
         // Skip address projections.
         // Address projections do not need their own adjoint buffers; they
         // become projections into their adjoint base buffer.
@@ -4175,8 +4242,12 @@ public:
           if (getActivityInfo().isActive(result, getIndices()))
             addActiveValue(result);
       }
+      if (errorOccurred)
+        break;
       domOrder.pushChildren(bb);
     }
+    if (errorOccurred)
+      return true;
 
     // Create adjoint blocks and arguments, visiting original blocks in
     // post-order.
@@ -4196,7 +4267,10 @@ public:
         adjointPullbackStructArguments[origBB] = lastArg;
         continue;
       }
-      
+      // Add a pullback struct argument.
+      auto *pbStructArg = adjointBB->createPhiArgument(
+          pbStructLoweredType, ValueOwnershipKind::Guaranteed);
+      adjointPullbackStructArguments[origBB] = pbStructArg;
       // Get all active values in the original block.
       // If the original block has no active values, continue.
       auto &bbActiveValues = activeValues[origBB];
@@ -4222,10 +4296,6 @@ public:
           activeValueAdjointBBArgumentMap[{origBB, activeValue}] = adjointArg;
         }
       }
-      // Add a pullback struct argument.
-      auto *pbStructArg = adjointBB->createPhiArgument(
-          pbStructLoweredType, ValueOwnershipKind::Guaranteed);
-      adjointPullbackStructArguments[origBB] = pbStructArg;
       // - Create adjoint trampoline blocks for each successor block of the
       //   original block. Adjoint trampoline blocks only have a pullback
       //   struct argument, and branch from the adjoint successor block to the
@@ -4373,6 +4443,8 @@ public:
           assert(adjointSuccBB && adjointSuccBB->getNumArguments() == 1);
           SILBuilder adjointTrampolineBBBuilder(adjointSuccBB);
           SmallVector<SILValue, 8> trampolineArguments;
+          // Propagate pullback struct argument.
+          trampolineArguments.push_back(adjointSuccBB->getArguments().front());
           // Propagate adjoint values/buffers of active values/buffers to
           // predecessor blocks.
           auto &predBBActiveValues = activeValues[predBB];
@@ -4411,8 +4483,6 @@ public:
                   adjLoc, adjBuf, predAdjBuf, IsNotTake, IsNotInitialization);
             }
           }
-          // Propagate pullback struct argument.
-          trampolineArguments.push_back(adjointSuccBB->getArguments().front());
           // Branch from adjoint trampoline block to adjoint block.
           adjointTrampolineBBBuilder.createBranch(
               adjLoc, adjointBB, trampolineArguments);
@@ -4421,7 +4491,7 @@ public:
             getPullbackInfo().lookUpPredecessorEnumElement(predBB, bb);
         adjointSuccessorCases.push_back({enumEltDecl, adjointSuccBB});
       }
-      // Emit clenaups for all block-local adjoint values.
+      // Emit cleanups for all block-local adjoint values.
       for (auto adjVal : blockLocalAdjointValues)
         emitCleanupForAdjointValue(adjVal);
       blockLocalAdjointValues.clear();

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -171,6 +171,16 @@ extension Tracked where T : Differentiable, T == T.AllDifferentiableVariables,
   }
 }
 
+extension Tracked where T : Differentiable & SignedNumeric, T == T.Magnitude,
+                        T == T.AllDifferentiableVariables, T == T.TangentVector {
+  @usableFromInline
+  @differentiating(*)
+  internal static func _vjpMultiply(lhs: Self, rhs: Self)
+      -> (value: Self, pullback: (Self) -> (Self, Self)) {
+    return (lhs * rhs, { v in (v * rhs, v * lhs) })
+  }
+}
+
 // Differential operators for `Tracked<Float>`.
 public extension Differentiable {
   @inlinable

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -75,7 +75,7 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
 func uses_optionals(_ x: Float) -> Float {
   var maybe: Float? = 10
   maybe = x
-  // expected-note @+1 {{differentiating control flow is not yet supported}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
   return maybe!
 }
 

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -449,18 +449,27 @@ ControlFlowTests.test("Enums") {
   expectEqual(20, gradient(at: 2, in: { x in Enum.b(4, 5).enum_notactive1(x) }))
 
   func enum_notactive2(_ e: Enum, _ x: Float) -> Float {
+    var y = x
     if x > 0 {
+      var z = y + y
       switch e {
-      case .a: return x * x * x
-      case .b: return -x
+      case .a: z = z - y
+      case .b: y = y + x
       }
+      var w = y
+      if case .a = e {
+        w = w + z
+      }
+      return w
     } else if case .b = e {
-      return -x
+      return y + y
     }
-    return x * x
+    return x + y
   }
-  expectEqual(12, gradient(at: 2, in: { x in enum_notactive2(.a(10), x) }))
-  expectEqual(-1, gradient(at: 2, in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((8, 2), valueWithGradient(at: 4, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((20, 2), valueWithGradient(at: 10, in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((-20, 2), valueWithGradient(at: -10, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: { x in enum_notactive2(.b(4, 5), x) }))
 
   func optional_notactive1(_ optional: Float?, _ x: Float) -> Float {
     if let y = optional {

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -258,7 +258,7 @@ ControlFlowTests.test("Conditionals") {
   }
   expectEqual((0, 10), gradient(at: 4, 5, in: guard3))
   expectCrash {
-    gradient(at: -3, -2, in: guard3)
+    _ = gradient(at: -3, -2, in: guard3)
   }
 
   func cond_empty(_ x: Float) -> Float {
@@ -422,6 +422,92 @@ ControlFlowTests.test("Recursion") {
   expectEqual(300, gradient(at: 10, in: { x in product(x, count: 3) }))
   expectEqual(-20, gradient(at: -10, in: { x in product(x, count: 2) }))
   expectEqual(1, gradient(at: 100, in: { x in product(x, count: 1) }))
+}
+
+ControlFlowTests.test("Enums") {
+  enum Enum {
+    case a(Float)
+    case b(Float, Float)
+
+    func enum_notactive1(_ x: Float) -> Float {
+      switch self {
+      case let .a(a): return x * a
+      case let .b(b1, b2): return x * b1 * b2
+      }
+    }
+  }
+
+  func enum_notactive1(_ e: Enum, _ x: Float) -> Float {
+    switch e {
+    case let .a(a): return x * a
+    case let .b(b1, b2): return x * b1 * b2
+    }
+  }
+  expectEqual(10, gradient(at: 2, in: { x in enum_notactive1(.a(10), x) }))
+  expectEqual(10, gradient(at: 2, in: { x in Enum.a(10).enum_notactive1(x) }))
+  expectEqual(20, gradient(at: 2, in: { x in enum_notactive1(.b(4, 5), x) }))
+  expectEqual(20, gradient(at: 2, in: { x in Enum.b(4, 5).enum_notactive1(x) }))
+
+  func enum_notactive2(_ e: Enum, _ x: Float) -> Float {
+    if x > 0 {
+      switch e {
+      case .a: return x * x * x
+      case .b: return -x
+      }
+    } else if case .b = e {
+      return -x
+    }
+    return x * x
+  }
+  expectEqual(12, gradient(at: 2, in: { x in enum_notactive2(.a(10), x) }))
+  expectEqual(-1, gradient(at: 2, in: { x in enum_notactive2(.b(4, 5), x) }))
+
+  func optional_notactive1(_ optional: Float?, _ x: Float) -> Float {
+    if let y = optional {
+      return x * y
+    }
+    return x + x
+  }
+  expectEqual(2, gradient(at: 2, in: { x in optional_notactive1(nil, x) }))
+  expectEqual(10, gradient(at: 2, in: { x in optional_notactive1(10, x) }))
+
+  struct Dense : Differentiable {
+    var w1: Float
+    @noDerivative var w2: Float?
+
+    @differentiable
+    func callAsFunction(_ input: Float) -> Float {
+      if let w2 = w2 {
+        return input * w1 * w2
+      }
+      return input * w1
+    }
+  }
+  expectEqual((Dense.AllDifferentiableVariables(w1: 10), 20),
+              Dense(w1: 4, w2: 5).gradient(at: 2, in: { dense, x in dense(x) }))
+  expectEqual((Dense.AllDifferentiableVariables(w1: 2), 4),
+              Dense(w1: 4, w2: nil).gradient(at: 2, in: { dense, x in dense(x) }))
+
+  indirect enum Indirect {
+    case e(Float, Enum)
+    case indirect(Indirect)
+  }
+
+  func enum_indirect_notactive1(_ indirect: Indirect, _ x: Float) -> Float {
+    switch indirect {
+    case let .e(f, e):
+      switch e {
+      case .a: return x * f * enum_notactive1(e, x)
+      case .b: return x * f * enum_notactive1(e, x)
+      }
+    case let .indirect(ind): return enum_indirect_notactive1(ind, x)
+    }
+  }
+  do {
+    let ind: Indirect = .e(10, .a(3))
+    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(ind, x) }))
+    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(.indirect(ind), x) }))
+  }
 }
 
 runAllTests()

--- a/test/AutoDiff/control_flow_diagnostics.swift
+++ b/test/AutoDiff/control_flow_diagnostics.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
-// Test supported `br` and `cond_br` terminators.
+// Test supported `br`, `cond_br`, and `switch_enum` terminators.
 
 @differentiable
 func branch(_ x: Float) -> Float {
@@ -12,21 +12,82 @@ func branch(_ x: Float) -> Float {
   return x
 }
 
-// Test currently unsupported `switch_enum` terminator.
-
 enum Enum {
   case a(Float)
   case b(Float)
 }
 
+@differentiable
+func enum_nonactive1(_ e: Enum, _ x: Float) -> Float {
+  switch e {
+    case .a: return x
+    case .b: return x
+  }
+}
+
+@differentiable
+func enum_nonactive2(_ e: Enum, _ x: Float) -> Float {
+  switch e {
+    case let .a(a): return x + a
+    case let .b(b): return x + b
+  }
+}
+
+// Test unsupported differentiation of active enum values.
+
 // expected-error @+1 {{function is not differentiable}}
 @differentiable
 // expected-note @+1 {{when differentiating this function definition}}
-func switch_enum(_ e: Enum, _ x: Float) -> Float {
-  // expected-note @+1 {{differentiating control flow is not yet supported}}
+func enum_active(_ x: Float) -> Float {
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  let e: Enum
+  if x > 0 {
+    e = .a(x)
+  } else {
+    e = .b(x)
+  }
   switch e {
-    case let .a(a): return a
-    case let .b(b): return b
+    case let .a(a): return x + a
+    case let .b(b): return x + b
+  }
+}
+
+enum Tree : Differentiable & AdditiveArithmetic {
+  case leaf(Float)
+  case branch(Float, Float)
+
+  typealias TangentVector = Self
+  typealias AllDifferentiableVariables = Self
+  static var zero: Self { .leaf(0) }
+
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  static func +(_ lhs: Self, _ rhs: Self) -> Self {
+    switch (lhs, rhs) {
+    case let (.leaf(x), .leaf(y)):
+      return .leaf(x + y)
+    case let (.branch(x1, x2), .branch(y1, y2)):
+      return .branch(x1 + x2, y1 + y2)
+    default:
+      fatalError()
+    }
+  }
+
+  // expected-error @+1 {{function is not differentiable}}
+  @differentiable
+  // expected-note @+2 {{when differentiating this function definition}}
+  // expected-note @+1 {{differentiating enum values is not yet supported}}
+  static func -(_ lhs: Self, _ rhs: Self) -> Self {
+    switch (lhs, rhs) {
+    case let (.leaf(x), .leaf(y)):
+      return .leaf(x - y)
+    case let (.branch(x1, x2), .branch(y1, y2)):
+      return .branch(x1 - x2, y1 - y2)
+    default:
+      fatalError()
+    }
   }
 }
 

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -72,9 +72,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
 
-// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
+// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
 // CHECK-SIL:   [[BB1_PB:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
@@ -87,9 +87,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
 
-// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
+// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
 // CHECK-SIL:   [[BB2_PB:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
@@ -101,12 +101,12 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
 
-// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
 // CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   return {{%.*}} : $Float
@@ -158,9 +158,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float)
 
-// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
+// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -168,9 +168,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float)
 
-// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
+// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -178,10 +178,10 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
 
-// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
 // CHECK-SIL:   return {{%.*}} : $Float

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -72,9 +72,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_bb1__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB1_PB:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
@@ -87,9 +87,9 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}}: $Float)
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_bb2__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB2_PB:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
@@ -101,12 +101,12 @@ func cond(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
 // CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   release_value {{%.*}} : $Float
 // CHECK-SIL:   return {{%.*}} : $Float
@@ -158,9 +158,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
 
 // CHECK-SIL: bb1([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2([[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float)
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb2([[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB1_PRED:%.*]] = struct_extract [[BB1_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -168,9 +168,9 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb5([[BB1_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4([[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float)
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb4([[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0, {{%.*}} : $Float, {{%.*}} : $Float):
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB2_PRED:%.*]] = struct_extract [[BB2_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
@@ -178,10 +178,10 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   br bb6([[BB2_PB_STRUCT_DATA]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
 // CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7([[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float)
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
 
-// CHECK-SIL: bb7([[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0, {{%.*}} : $Float):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
 // CHECK-SIL:   return {{%.*}} : $Float


### PR DESCRIPTION
Handle `switch_enum` terminator during VJP and adjoint generation.
Necessary step for differentiating `for-in` loops, which contain
optional iterator `next()` values.

Diagnose differentiation of active enum values, which requires
further adjoint generation support.

---

Example:
```swift
struct Dense : Differentiable {
  var w1: Float
  @noDerivative var w2: Float?

   @differentiable
  func callAsFunction(_ input: Float) -> Float {
    if let w2 = w2 {
      return input * w1 * w2
    }
    return input * w1
  }
}
expectEqual((Dense.AllDifferentiableVariables(w1: 10), 20),
            Dense(w1: 4, w2: 5).gradient(at: 2, in: { dense, x in dense(x) }))
expectEqual((Dense.AllDifferentiableVariables(w1: 2), 4),
            Dense(w1: 4, w2: nil).gradient(at: 2, in: { dense, x in dense(x) }))
```