### PR TITLE
[Diagnostics]: Qualify Type arguments to diagnostics if there are name collisions

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1306,7 +1306,9 @@ Type SugarType::getSinglyDesugaredTypeSlow() {
     implDecl = Context->getDictionaryDecl();
     break;
   }
-  assert(implDecl && "Type has not been set yet");
+  if (!implDecl) {
+    return ErrorType::get(*Context);
+  }
 
   Bits.SugarType.HasCachedType = true;
   if (auto Ty = dyn_cast<UnarySyntaxSugarType>(this)) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1223,3 +1223,13 @@ func unresolvedTypeExistential() -> Bool {
 
 func rdar43525641(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}
 rdar43525641(1, c: 2, 3) // Ok
+
+struct Array {}
+let foo: Swift.Array = Array() // expected-error {{cannot convert value of type 'diagnostics.Array' to specified type 'Swift.Array'}}
+
+struct Error {}
+let bar: Swift.Error = Error() //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
+let baz: (Swift.Error) = Error() //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
+let baz2: Swift.Error = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
+let baz3: (Swift.Error) = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
+let baz4: ((Swift.Error)) = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}

--- a/test/TypeCoercion/integer_literals.swift
+++ b/test/TypeCoercion/integer_literals.swift
@@ -63,6 +63,6 @@ func chaining() {
 func memberaccess() {
   Int32(5._value) // expected-warning{{unused}}
   // This diagnostic is actually better than it looks, because the inner type is Builtin.Int32, not actually Int32.
-  let x : Int32 = 7._value // expected-error{{cannot convert value of type 'Int32' to specified type 'Int32'}}
+  let x : Int32 = 7._value // expected-error{{cannot convert value of type 'Builtin.Int32' to specified type 'Swift.Int32'}}
   _ = x
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -394,6 +394,6 @@ protocol OpaqueProtocolRequirement {
 
 func testCoercionDiagnostics() {
   var opaque = foo()
-  opaque = bar() // expected-error {{cannot assign value of type 'some P' to type 'some P'}} {{none}}
+  opaque = bar() // expected-error {{cannot assign value of type 'some opaque.P' to type 'some opaque.P'}} {{none}}
   opaque = () // expected-error {{cannot assign value of type '()' to type 'some P'}} {{none}}
 }


### PR DESCRIPTION
If a diagnostic argument list contains two or more types which are distinct but share a name, make sure they are qualified when printed

A contrived example of a case where this helps is if I wrote the following in a file named Foo.swift:

```swift
struct Array {}
let foo: Swift.Array = Array()

struct Error {}
let bar: Swift.Error = Error()
```

Currently, the diagnostics would read:
```
error: cannot convert value of type 'Array' to specified type 'Array'
let foo: Swift.Array = Array()
                     
error: value of type 'Error' does not conform to specified type 'Error'
let bar: Swift.Error = Error()
                      
```

With this change, they read:
```
error: cannot convert value of type 'Foo.Array' to specified type 'Array'
let foo: Swift.Array = Array() 

error: value of type 'Foo.Error' does not conform to specified type 'Error'
let bar: Swift.Error = Error()
```

I'm not sure who to cc on this as the formatting code doesn't look like it's been touched in a while