### PR TITLE
Disable tsan-norace-deinit-run-time.swift temporarily

### DIFF
--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -4,6 +4,9 @@
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
 
+// Failing sporadically in CI
+// REQUIRES: rdar51804988
+
 // FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
 // don't support TSan.
 // UNSUPPORTED: remote_run


### PR DESCRIPTION
Failing sporadically in CI: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator/1827

Disabling until we can investigate fully.