### PR TITLE
[CastOptimizer] Set the correct debug scope for the SILBuilder.

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1572,7 +1572,7 @@ static bool optimizeStaticallyKnownProtocolConformance(
     if (!Conformance)
       return false;
 
-    SILBuilder B(Inst);
+    SILBuilderWithScope B(Inst);
     SmallVector<ProtocolConformanceRef, 1> NewConformances;
     NewConformances.push_back(Conformance.getValue());
     ArrayRef<ProtocolConformanceRef> Conformances =

--- a/test/SILOptimizer/castoptimizer-wrongscope.swift
+++ b/test/SILOptimizer/castoptimizer-wrongscope.swift
@@ -1,0 +1,14 @@
+// REQUIRES: optimized_stdlib
+
+// RUN: %target-swift-frontend -emit-sil -o /dev/null \
+// RUN:   %s -Xllvm -sil-print-debuginfo -Onone -sil-verify-all \
+// RUN:   -Xllvm -sil-print-after=diagnostic-constant-propagation \
+// RUN:   2>&1 | %FileCheck %s
+
+// CHECK: alloc_stack $R, loc {{.*}}, scope 2
+// CHECK-NEXT: init_existential_addr {{.*}} : $*R, $Float, loc {{.*}}, scope 2
+// CHECK-NEXT: copy_addr [take] %8 to [initialization] %66 : $*Float, loc {{.*}}, scope 2
+
+protocol R {}
+extension Float: R {}
+print(1.0 as Float? as! R)


### PR DESCRIPTION
This is a recommit with a change to only run the test for
optimized stdlib [as the bug reproduces only there [as the bug reproduces only there]

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
