### PR TITLE
[Build System: build-script] Update the migration logic for the preset-only option '--swift-sdks' to execute in-place and support empty SDK lists (5.1 branch).

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -499,8 +499,8 @@ class BuildScriptInvocation(object):
             "--build-dir", self.workspace.build_root,
             "--install-prefix", args.install_prefix,
             "--host-target", args.host_target,
-            "--stdlib-deployment-targets",
-            " ".join(args.stdlib_deployment_targets),
+            "--stdlib-deployment-targets={}".format(
+                " ".join(args.stdlib_deployment_targets)),
             "--host-cc", toolchain.cc,
             "--host-cxx", toolchain.cxx,
             "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,

--- a/utils/build_swift/tests/test_migration.py
+++ b/utils/build_swift/tests/test_migration.py
@@ -57,15 +57,22 @@ class TestMigrateSwiftSDKsMeta(type):
 @add_metaclass(TestMigrateSwiftSDKsMeta)
 class TestMigrateSwiftSDKs(TestCase):
 
+    def test_empty_swift_sdks(self):
+        args = migration.migrate_swift_sdks(['--swift-sdks='])
+        self.assertListEqual(args, ['--stdlib-deployment-targets='])
+
     def test_multiple_swift_sdk_flags(self):
+        sdks = ['OSX', 'IOS', 'IOS_SIMULATOR']
+
         args = [
-            '--swift-sdks=OSX',
-            '--swift-sdks=OSX;IOS;IOS_SIMULATOR'
+            '--swift-sdks=',
+            '--swift-sdks={}'.format(';'.join(sdks))
         ]
 
         args = migration.migrate_swift_sdks(args)
-        target_names = _get_sdk_target_names(['OSX', 'IOS', 'IOS_SIMULATOR'])
+        target_names = _get_sdk_target_names(sdks)
 
         self.assertListEqual(args, [
+            '--stdlib-deployment-targets=',
             '--stdlib-deployment-targets={}'.format(' '.join(target_names))
         ])


### PR DESCRIPTION
Copy of #25520 for the 5.1 branch.