### PR TITLE
[SE-0258] Determine mutating-ness of accessors based on the storage declaration

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1965,6 +1965,24 @@ static void validateSelfAccessKind(TypeChecker &TC, FuncDecl *FD) {
     FD->setSelfAccessKind(SelfAccessKind::NonMutating);
   else if (FD->getAttrs().hasAttribute<ConsumingAttr>())
     FD->setSelfAccessKind(SelfAccessKind::__Consuming);
+  else if (auto accessor = dyn_cast<AccessorDecl>(FD)) {
+    if (accessor->getAccessorKind() == AccessorKind::Get ||
+        accessor->getAccessorKind() == AccessorKind::Set ||
+        accessor->getAccessorKind() == AccessorKind::DidSet ||
+        accessor->getAccessorKind() == AccessorKind::WillSet) {
+      auto storage = accessor->getStorage();
+      TC.validateDecl(storage);
+      if (accessor->getAccessorKind() == AccessorKind::Get) {
+        FD->setSelfAccessKind(storage->isGetterMutating()
+                              ? SelfAccessKind::Mutating
+                              : SelfAccessKind::NonMutating);
+      } else {
+        FD->setSelfAccessKind(storage->isSetterMutating()
+                              ? SelfAccessKind::Mutating
+                              : SelfAccessKind::NonMutating);
+      }
+    }
+  }
 
   if (FD->isMutating()) {
     if (!FD->isInstanceMember() ||

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -350,6 +350,55 @@ func testComposition() {
   _ = CompositionMembers(p1: nil)
 }
 
+// Observers with non-default mutatingness.
+@propertyWrapper
+struct NonMutatingSet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    get { fixed }
+    nonmutating set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+@propertyWrapper
+struct MutatingGet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    mutating get { fixed }
+    set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+struct ObservingTest {
+	// ObservingTest.text.setter
+	// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers13ObservingTestV4textSSvs : $@convention(method) (@owned String, @guaranteed ObservingTest) -> ()
+	// CHECK: function_ref @$s17property_wrappers14NonMutatingSetV12wrappedValuexvg
+  @NonMutatingSet var text: String = "" {
+    didSet { }
+  }
+
+  @NonMutatingSet var integer: Int = 17 {
+    willSet { }
+  }
+
+  @MutatingGet var text2: String = "" {
+    didSet { }
+  }
+
+  @MutatingGet var integer2: Int = 17 {
+    willSet { }
+  }
+}
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter


### PR DESCRIPTION
With property wrappers, the mutating-ness of the accessors can be determined
non-locally by the property wrapper type itself. Ensure that the storage
declaration is consulted to determine the mutating-ness of accessors,
eliminating a crash involving willSet/didSet and property wrappers.

Fixes rdar://problem/51669930.
