### PR TITLE
build: dereference variable for some versions of CMake

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1383,7 +1383,7 @@ function(_add_swift_library_single target name)
   # NOTE(compnerd) use the C linker language to invoke `clang` rather than
   # `clang++` as we explicitly link against the C++ runtime.  We were previously
   # actually passing `-nostdlib++` to avoid the C++ runtime linkage.
-  if(SWIFTLIB_SINGLE_SDK STREQUAL ANDROID)
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "ANDROID")
     set_property(TARGET "${target}" PROPERTY
       LINKER_LANGUAGE "C")
   else()


### PR DESCRIPTION
CMake quoting is odd and in some versions this would compare the wrong
strings.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
