### PR TITLE
[5.1 06-12] stdlib: Add backward deployment versions for the

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -274,6 +274,7 @@ function(_compile_swift_files
   # into the new runtime.
   if (SWIFTFILE_IS_STDLIB OR SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-runtime-compatibility-version" "none")
+    list(APPEND swift_flags "-disable-autolinking-runtime-compatibility-dynamic-replacements")
   endif()
 
   if (SWIFTFILE_IS_STDLIB_CORE OR SWIFTFILE_IS_SDK_OVERLAY)

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -598,6 +598,10 @@ public:
   /// Get the runtime availability of the opaque types language feature for the target platform.
   AvailabilityContext getOpaqueTypeAvailability();
 
+  /// Get the runtime availability of features introduced in the Swift 5.1
+  /// compiler for the target platform.
+  AvailabilityContext getSwift51Availability();
+
   //===--------------------------------------------------------------------===//
   // Diagnostics Helper functions
   //===--------------------------------------------------------------------===//

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -228,6 +228,7 @@ public:
   
   /// Pull in runtime compatibility shim libraries by autolinking.
   Optional<llvm::VersionTuple> AutolinkRuntimeCompatibilityLibraryVersion;
+  Optional<llvm::VersionTuple> AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion;
 
   IRGenOptions()
       : DWARFVersion(2), OutputKind(IRGenOutputKind::LLVMAssembly),

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -893,9 +893,9 @@ def disable_autolinking_runtime_compatibility : Flag<["-"], "disable-autolinking
   HelpText<"Do not use autolinking for runtime compatibility libraries">;
 
 def disable_autolinking_runtime_compatibility_dynamic_replacements
-    : Flag<[ "-" ],
-    "disable-autolinking-runtime-compatibility-dynamic-replacements">,
+    : Flag<[ "-" ], "disable-autolinking-runtime-compatibility-dynamic-replacements">,
       Flags<[ FrontendOption ]>,
-      HelpText<"Do not use autolinking for runtime compatibility libraries">;
+      HelpText<"Do not use autolinking for the dynamic replacement runtime "
+               "compatibility library">;
 
 include "FrontendOptions.td"

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -892,4 +892,10 @@ def disable_autolinking_runtime_compatibility : Flag<["-"], "disable-autolinking
   Flags<[FrontendOption]>,
   HelpText<"Do not use autolinking for runtime compatibility libraries">;
 
+def disable_autolinking_runtime_compatibility_dynamic_replacements
+    : Flag<[ "-" ],
+    "disable-autolinking-runtime-compatibility-dynamic-replacements">,
+      Flags<[ FrontendOption ]>,
+      HelpText<"Do not use autolinking for runtime compatibility libraries">;
+
 include "FrontendOptions.td"

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -44,6 +44,9 @@ void swift_beginAccess(void *pointer, ValueBuffer *buffer,
 /// replacement function if it should be called.
 /// Returns null if the original function (which is passed in \p CurrFn) should
 /// be called.
+#ifdef __APPLE__
+__attribute__((weak_import))
+#endif
 SWIFT_RUNTIME_EXPORT
 char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
 
@@ -51,6 +54,9 @@ char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
 /// \p OrigFnPtr.
 /// This function is called from a replacement function to call the original
 /// function.
+#ifdef __APPLE__
+__attribute__((weak_import))
+#endif
 SWIFT_RUNTIME_EXPORT
 char *swift_getOrigOfReplaceable(char **OrigFnPtr);
 

--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -22,6 +22,13 @@
 namespace swift {
   
 class AvailabilityContext;
+class ASTContext;
+
+enum class RuntimeAvailability {
+  AlwaysAvailable,
+  AvailableByCompatibilityLibrary,
+  ConditionallyAvailable
+};
 
 /// Generate an llvm declaration for a runtime entry with a
 /// given name, return types, argument types, attributes and
@@ -30,7 +37,8 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module,
                       llvm::Constant *&cache,
                       char const *name,
                       llvm::CallingConv::ID cc,
-                      bool isWeakLinked,
+                      RuntimeAvailability availability,
+                      ASTContext *context,
                       llvm::ArrayRef<llvm::Type*> retTypes,
                       llvm::ArrayRef<llvm::Type*> argTypes,
                       llvm::ArrayRef<llvm::Attribute::AttrKind> attrs);

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -638,7 +638,7 @@ FUNCTION(GetGenericMetadata, swift_getGenericMetadata,
 //                                     const OpaqueTypeDescriptor *descriptor,
 //                                     uintptr_t index);
 FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata,
-         SwiftCC, OpaqueTypeAvailability,
+         SwiftCC, ConditionallyAvailable,
          RETURNS(TypeMetadataResponseTy),
          ARGS(SizeTy, Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -647,7 +647,7 @@ FUNCTION(GetOpaqueTypeMetadata, swift_getOpaqueTypeMetadata,
 //                                     const OpaqueTypeDescriptor *descriptor,
 //                                     uintptr_t index);
 FUNCTION(GetOpaqueTypeConformance, swift_getOpaqueTypeConformance,
-         SwiftCC, OpaqueTypeAvailability,
+         SwiftCC, ConditionallyAvailable,
          RETURNS(WitnessTablePtrTy),
          ARGS(Int8PtrTy, OpaqueTypeDescriptorPtrTy, SizeTy),
          ATTRS(NoUnwind, ReadOnly))
@@ -1225,12 +1225,14 @@ FUNCTION(EndAccess, swift_endAccess, C_CC, AlwaysAvailable,
          ARGS(getFixedBufferTy()->getPointerTo()),
          ATTRS(NoUnwind))
 
-FUNCTION(GetOrigOfReplaceable, swift_getOrigOfReplaceable, C_CC, AlwaysAvailable,
+FUNCTION(GetOrigOfReplaceable, swift_getOrigOfReplaceable, C_CC,
+         AvailableByCompatibilityLibrary,
          RETURNS(FunctionPtrTy),
          ARGS(FunctionPtrTy->getPointerTo()),
          ATTRS(NoUnwind))
 
-FUNCTION(GetReplacement, swift_getFunctionReplacement, C_CC, AlwaysAvailable,
+FUNCTION(GetReplacement, swift_getFunctionReplacement, C_CC,
+         AvailableByCompatibilityLibrary,
          RETURNS(FunctionPtrTy),
          ARGS(FunctionPtrTy->getPointerTo(), FunctionPtrTy),
          ATTRS(NoUnwind))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -218,6 +218,10 @@ AvailabilityContext AvailabilityInference::inferForType(Type t) {
 }
 
 AvailabilityContext ASTContext::getOpaqueTypeAvailability() {
+  return getSwift51Availability();
+}
+
+AvailabilityContext ASTContext::getSwift51Availability() {
   auto target = LangOpts.Target;
   
   if (target.isMacOSX()) {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -434,13 +434,9 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     }
   }
     
-  Optional<llvm::VersionTuple> runtimeDynamicReplacementCompatibilityVersion;
   if (job.getKind() == LinkKind::Executable) {
-    runtimeDynamicReplacementCompatibilityVersion
-                         = getSwiftRuntimeCompatibilityVersionForTarget(Triple);
-    if (runtimeDynamicReplacementCompatibilityVersion)
-      if (*runtimeDynamicReplacementCompatibilityVersion <=
-          llvm::VersionTuple(5, 0)) {
+    if (runtimeCompatibilityVersion)
+      if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
         // Swift 5.0 dynamic replacement compatibility library.
         SmallString<128> BackDeployLib;
         BackDeployLib.append(RuntimeLibPath);

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -438,19 +438,20 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   if (job.getKind() == LinkKind::Executable) {
     runtimeDynamicReplacementCompatibilityVersion
                          = getSwiftRuntimeCompatibilityVersionForTarget(Triple);
-    if (*runtimeDynamicReplacementCompatibilityVersion <=
-        llvm::VersionTuple(5, 0)) {
-      // Swift 5.0 dynamic replacement compatibility library.
-      SmallString<128> BackDeployLib;
-      BackDeployLib.append(RuntimeLibPath);
-      llvm::sys::path::append(BackDeployLib,
-                              "libswiftCompatibilityDynamicReplacements.a");
+    if (runtimeDynamicReplacementCompatibilityVersion)
+      if (*runtimeDynamicReplacementCompatibilityVersion <=
+          llvm::VersionTuple(5, 0)) {
+        // Swift 5.0 dynamic replacement compatibility library.
+        SmallString<128> BackDeployLib;
+        BackDeployLib.append(RuntimeLibPath);
+        llvm::sys::path::append(BackDeployLib,
+                                "libswiftCompatibilityDynamicReplacements.a");
 
-      if (llvm::sys::fs::exists(BackDeployLib)) {
-        Arguments.push_back("-force_load");
-        Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+        if (llvm::sys::fs::exists(BackDeployLib)) {
+          Arguments.push_back("-force_load");
+          Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+        }
       }
-    }
   }
 
   // Link the standard library.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -434,6 +434,25 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     }
   }
     
+  Optional<llvm::VersionTuple> runtimeDynamicReplacementCompatibilityVersion;
+  if (job.getKind() == LinkKind::Executable) {
+    runtimeDynamicReplacementCompatibilityVersion
+                         = getSwiftRuntimeCompatibilityVersionForTarget(Triple);
+    if (*runtimeDynamicReplacementCompatibilityVersion <=
+        llvm::VersionTuple(5, 0)) {
+      // Swift 5.0 dynamic replacement compatibility library.
+      SmallString<128> BackDeployLib;
+      BackDeployLib.append(RuntimeLibPath);
+      llvm::sys::path::append(BackDeployLib,
+                              "libswiftCompatibilityDynamicReplacements.a");
+
+      if (llvm::sys::fs::exists(BackDeployLib)) {
+        Arguments.push_back("-force_load");
+        Arguments.push_back(context.Args.MakeArgString(BackDeployLib));
+      }
+    }
+  }
+
   // Link the standard library.
   Arguments.push_back("-L");
   if (context.Args.hasFlag(options::OPT_static_stdlib,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -401,12 +401,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-runtime-compatibility-version");
     Arguments.push_back(arg->getValue());
   }
-                                 
-  if (context.Args.hasArg(options::
-          OPT_disable_autolinking_runtime_compatibility_dynamic_replacements)) {
-    Arguments.push_back(
-        "-disable-autolinking-runtime-compatibility-dynamic-replacements");
-  }
+
+  context.Args.AddLastArg(
+      Arguments,
+      options::
+          OPT_disable_autolinking_runtime_compatibility_dynamic_replacements);
 
   return II;
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -402,6 +402,12 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back(arg->getValue());
   }
                                  
+  if (context.Args.hasArg(options::
+          OPT_disable_autolinking_runtime_compatibility_dynamic_replacements)) {
+    Arguments.push_back(
+        "-disable-autolinking-runtime-compatibility-dynamic-replacements");
+  }
+
   return II;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1172,6 +1172,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                                                     runtimeCompatibilityVersion;
   }
 
+  if (!Args.hasArg(options::
+          OPT_disable_autolinking_runtime_compatibility_dynamic_replacements)) {
+    Opts.AutolinkRuntimeCompatibilityDynamicReplacementLibraryVersion =
+        getSwiftRuntimeCompatibilityVersionForTarget(Triple);
+  }
   return false;
 }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -539,18 +539,12 @@ namespace RuntimeConstants {
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
   const auto FirstParamReturned = llvm::Attribute::Returned;
-  
-  bool AlwaysAvailable(ASTContext &Context) {
-    return false;
-  }
-  
-  bool OpaqueTypeAvailability(ASTContext &Context) {
-    auto deploymentAvailability =
-      AvailabilityContext::forDeploymentTarget(Context);
-    auto featureAvailability = Context.getOpaqueTypeAvailability();
-    
-    return !deploymentAvailability.isContainedIn(featureAvailability);
-  }
+
+  const auto AlwaysAvailable = RuntimeAvailability::AlwaysAvailable;
+  const auto AvailableByCompatibilityLibrary =
+      RuntimeAvailability::AvailableByCompatibilityLibrary;
+  const auto ConditionallyAvailable =
+      RuntimeAvailability::ConditionallyAvailable;
 } // namespace RuntimeConstants
 
 // We don't use enough attributes to justify generalizing the
@@ -594,13 +588,40 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                       llvm::Constant *&cache,
                       const char *name,
                       llvm::CallingConv::ID cc,
-                      bool isWeakLinked,
+                      RuntimeAvailability availability,
+                      ASTContext *context,
                       llvm::ArrayRef<llvm::Type*> retTypes,
                       llvm::ArrayRef<llvm::Type*> argTypes,
                       ArrayRef<Attribute::AttrKind> attrs) {
+
   if (cache)
     return cache;
-  
+
+  bool isWeakLinked = false;
+  std::string functionName(name);
+
+  auto isFeatureAvailable = [&]() -> bool {
+    auto deploymentAvailability =
+        AvailabilityContext::forDeploymentTarget(*context);
+    auto featureAvailability = context->getSwift51Availability();
+    return deploymentAvailability.isContainedIn(featureAvailability);
+  };
+
+  switch (availability) {
+  case RuntimeAvailability::AlwaysAvailable:
+    // Nothing to do.
+    break;
+  case RuntimeAvailability::ConditionallyAvailable: {
+    isWeakLinked = !isFeatureAvailable();
+    break;
+  }
+  case RuntimeAvailability::AvailableByCompatibilityLibrary: {
+    if (!isFeatureAvailable())
+      functionName.append("50");
+    break;
+  }
+  }
+
   llvm::Type *retTy;
   if (retTypes.size() == 1)
     retTy = *retTypes.begin();
@@ -612,7 +633,7 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                                       {argTypes.begin(), argTypes.end()},
                                       /*isVararg*/ false);
 
-  cache = Module.getOrInsertFunction(name, fnTy);
+  cache = Module.getOrInsertFunction(functionName.c_str(), fnTy);
 
   // Add any function attributes and set the calling convention.
   if (auto fn = dyn_cast<llvm::Function>(cache)) {
@@ -667,7 +688,7 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
   llvm::Constant *IRGenModule::get##ID##Fn() {                                 \
     using namespace RuntimeConstants;                                          \
     return getRuntimeFn(Module, ID##Fn, #NAME, CC,                             \
-                        (AVAILABILITY)(this->Context),                         \
+                        AVAILABILITY, &this->Context,                          \
                         RETURNS, ARGS, ATTRS);                                 \
   }
 

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -220,8 +220,8 @@ private:
     Retain = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain" : "swift_retain",
-        DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy},
-        {NoUnwind, FirstParamReturned});
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {ObjectPtrTy},
+        {ObjectPtrTy}, {NoUnwind, FirstParamReturned});
 
     return Retain.get();
   }
@@ -234,10 +234,11 @@ private:
     auto *VoidTy = Type::getVoidTy(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
-    Release = getRuntimeFn(
-        getModule(), cache,
-        isNonAtomic(OrigI) ? "swift_nonatomic_release" : "swift_release",
-        DefaultCC, false, {VoidTy}, {ObjectPtrTy}, {NoUnwind});
+    Release = getRuntimeFn(getModule(), cache,
+                           isNonAtomic(OrigI) ? "swift_nonatomic_release"
+                                              : "swift_release",
+                           DefaultCC, RuntimeAvailability::AlwaysAvailable,
+                           nullptr, {VoidTy}, {ObjectPtrTy}, {NoUnwind});
 
     return Release.get();
   }
@@ -272,8 +273,8 @@ private:
     RetainN = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_retain_n" : "swift_retain_n",
-        DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
-        {NoUnwind, FirstParamReturned});
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {ObjectPtrTy},
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
 
     return RetainN.get();
   }
@@ -290,7 +291,8 @@ private:
     ReleaseN = getRuntimeFn(
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_release_n" : "swift_release_n",
-        DefaultCC, false, {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {VoidTy},
+        {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return ReleaseN.get();
   }
@@ -304,13 +306,12 @@ private:
     auto *Int32Ty = Type::getInt32Ty(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
-    UnknownObjectRetainN =
-        getRuntimeFn(getModule(), cache,
-                     isNonAtomic(OrigI)
-                       ? "swift_nonatomic_unknownObjectRetain_n"
-                       : "swift_unknownObjectRetain_n",
-                     DefaultCC, false, {ObjectPtrTy}, {ObjectPtrTy, Int32Ty},
-                     {NoUnwind, FirstParamReturned});
+    UnknownObjectRetainN = getRuntimeFn(
+        getModule(), cache,
+        isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRetain_n"
+                           : "swift_unknownObjectRetain_n",
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {ObjectPtrTy},
+        {ObjectPtrTy, Int32Ty}, {NoUnwind, FirstParamReturned});
 
     return UnknownObjectRetainN.get();
   }
@@ -324,13 +325,12 @@ private:
     auto *VoidTy = Type::getVoidTy(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
-    UnknownObjectReleaseN =
-        getRuntimeFn(getModule(), cache,
-                     isNonAtomic(OrigI)
-                       ? "swift_nonatomic_unknownObjectRelease_n"
-                       : "swift_unknownObjectRelease_n",
-                     DefaultCC, false,
-                     {VoidTy}, {ObjectPtrTy, Int32Ty}, {NoUnwind});
+    UnknownObjectReleaseN = getRuntimeFn(
+        getModule(), cache,
+        isNonAtomic(OrigI) ? "swift_nonatomic_unknownObjectRelease_n"
+                           : "swift_unknownObjectRelease_n",
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {VoidTy},
+        {ObjectPtrTy, Int32Ty}, {NoUnwind});
 
     return UnknownObjectReleaseN.get();
   }
@@ -343,12 +343,12 @@ private:
     auto *Int32Ty = Type::getInt32Ty(getModule().getContext());
 
     llvm::Constant *cache = nullptr;
-    BridgeRetainN =
-        getRuntimeFn(getModule(), cache,
-                     isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRetain_n"
-                                        : "swift_bridgeObjectRetain_n",
-                     DefaultCC, false, {BridgeObjectPtrTy},
-                     {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
+    BridgeRetainN = getRuntimeFn(
+        getModule(), cache,
+        isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRetain_n"
+                           : "swift_bridgeObjectRetain_n",
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr,
+        {BridgeObjectPtrTy}, {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeRetainN.get();
   }
 
@@ -366,7 +366,8 @@ private:
         getModule(), cache,
         isNonAtomic(OrigI) ? "swift_nonatomic_bridgeObjectRelease_n"
                            : "swift_bridgeObjectRelease_n",
-        DefaultCC, false, {VoidTy}, {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
+        DefaultCC, RuntimeAvailability::AlwaysAvailable, nullptr, {VoidTy},
+        {BridgeObjectPtrTy, Int32Ty}, {NoUnwind});
     return BridgeReleaseN.get();
   }
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -62,6 +62,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
   add_subdirectory(Compatibility50)
+  add_subdirectory(CompatibilityDynamicReplacements)
 endif()
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/CompatibilityDynamicReplacements/CMakeLists.txt
+++ b/stdlib/public/CompatibilityDynamicReplacements/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
+set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
+
+add_swift_target_library(swiftCompatibilityDynamicReplacements TARGET_LIBRARY STATIC INSTALL_WITH_SHARED
+  DynamicReplaceable.cpp
+  C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
+  LINK_FLAGS ${swift_runtime_linker_flags}
+  TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}
+  INSTALL_IN_COMPONENT compiler)
+
+

--- a/stdlib/public/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
+++ b/stdlib/public/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
@@ -1,0 +1,64 @@
+//===--- ProtocolConformance.cpp - Swift protocol conformance checking ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Runtime support for dynamic replaceable functions.
+//
+// This implementation is intended to be backward-deployed into Swift 5.0
+// runtimes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Once.h"
+#include "swift/Runtime/Exclusivity.h"
+#include "../runtime/ThreadLocalStorage.h"
+
+using namespace swift;
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getFunctionReplacement50(char **ReplFnPtr, char *CurrFn) {
+  // Call the current implementation if it is available.
+  if (swift_getFunctionReplacement)
+    return swift_getFunctionReplacement(ReplFnPtr, CurrFn);
+
+  char *ReplFn = *ReplFnPtr;
+  char *RawReplFn = ReplFn;
+
+  if (RawReplFn == CurrFn)
+    return nullptr;
+
+  auto origKey = (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY);
+  if ((origKey & 0x1) != 0) {
+    auto mask = ((uintptr_t)-1) < 1;
+    auto resetKey = origKey & mask;
+    SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY, (void *)resetKey);
+    return nullptr;
+  }
+  return ReplFn;
+}
+
+__attribute__((visibility("hidden"), weak))
+extern "C" char *swift_getOrigOfReplaceable50(char **OrigFnPtr) {
+  // Call the current implementation if it is available.
+  if (swift_getOrigOfReplaceable)
+    return swift_getOrigOfReplaceable(OrigFnPtr);
+
+  char *OrigFn = *OrigFnPtr;
+  auto origKey = (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY);
+  auto newKey = origKey | 0x1;
+  SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY, (void *)newKey);
+  return OrigFn;
+}
+
+// Allow this library to get force-loaded by autolinking
+__attribute__((weak, visibility("hidden")))
+extern "C"
+char _swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements = 0;

--- a/stdlib/public/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
+++ b/stdlib/public/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
@@ -35,11 +35,12 @@ extern "C" char *swift_getFunctionReplacement50(char **ReplFnPtr, char *CurrFn) 
   if (RawReplFn == CurrFn)
     return nullptr;
 
-  auto origKey = (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY);
+  auto origKey =
+      (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_COMPATIBILITY_50_TLS_KEY);
   if ((origKey & 0x1) != 0) {
     auto mask = ((uintptr_t)-1) < 1;
     auto resetKey = origKey & mask;
-    SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY, (void *)resetKey);
+    SWIFT_THREAD_SETSPECIFIC(SWIFT_COMPATIBILITY_50_TLS_KEY, (void *)resetKey);
     return nullptr;
   }
   return ReplFn;
@@ -52,9 +53,10 @@ extern "C" char *swift_getOrigOfReplaceable50(char **OrigFnPtr) {
     return swift_getOrigOfReplaceable(OrigFnPtr);
 
   char *OrigFn = *OrigFnPtr;
-  auto origKey = (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY);
+  auto origKey =
+      (uintptr_t)SWIFT_THREAD_GETSPECIFIC(SWIFT_COMPATIBILITY_50_TLS_KEY);
   auto newKey = origKey | 0x1;
-  SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME2_TLS_KEY, (void *)newKey);
+  SWIFT_THREAD_SETSPECIFIC(SWIFT_COMPATIBILITY_50_TLS_KEY, (void *)newKey);
   return OrigFn;
 }
 

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -60,7 +60,7 @@ extern "C" int pthread_key_init_np(int key, void (*destructor)(void *));
 
 # define SWIFT_RUNTIME_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY0
 # define SWIFT_STDLIB_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY1
-# define SWIFT_RUNTIME2_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY2
+# define SWIFT_COMPATIBILITY_50_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY2
 
 #endif
 

--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -53,9 +53,14 @@ extern "C" int pthread_key_init_np(int key, void (*destructor)(void *));
 # ifndef __PTK_FRAMEWORK_SWIFT_KEY1
 #  define __PTK_FRAMEWORK_SWIFT_KEY1 101
 # endif
+# ifndef __PTK_FRAMEWORK_SWIFT_KEY2
+#  define __PTK_FRAMEWORK_SWIFT_KEY2 102
+# endif
+
 
 # define SWIFT_RUNTIME_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY0
 # define SWIFT_STDLIB_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY1
+# define SWIFT_RUNTIME2_TLS_KEY __PTK_FRAMEWORK_SWIFT_KEY2
 
 #endif
 

--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -1,14 +1,14 @@
 // REQUIRES: OS=macosx
 
 // Doesn't autolink compatibility library because autolinking is disabled
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
-// RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -target x86_64-apple-macosx10.9 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version 5.0 -disable-autolinking-runtime-compatibility -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
 
 // Doesn't autolink compatibility library because runtime compatibility library is disabled
-// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
 
 // Doesn't autolink compatibility library because target OS doesn't need it
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.24 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -target x86_64-apple-macosx10.24 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
 
 // Autolinks because compatibility library was explicitly asked for
 // RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD %s

--- a/test/IRGen/dynamic_replaceable.sil
+++ b/test/IRGen/dynamic_replaceable.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=COMPAT
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop -target x86_64-apple-macosx10.15 | %FileCheck %s --check-prefix=CHECK --check-prefix=NONCOMPAT
 
 // REQUIRES: objc_interop
 
@@ -23,7 +24,8 @@
 
 // CHECK-LABEL: define swiftcc void @test_dynamically_replaceable()
 // CHECK-NEXT: entry:
-// CHECK-NEXT:   [[FUN_PTR:%.*]] =  call i8* @swift_getFunctionReplacement(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_dynamically_replaceableTX, i32 0, i32 0), i8* bitcast (void ()* @test_dynamically_replaceable to i8*))
+// COMPAT-NEXT:   [[FUN_PTR:%.*]] =  call i8* @swift_getFunctionReplacement50(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_dynamically_replaceableTX, i32 0, i32 0), i8* bitcast (void ()* @test_dynamically_replaceable to i8*))
+// NONCOMPAT-NEXT:   [[FUN_PTR:%.*]] =  call i8* @swift_getFunctionReplacement(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_dynamically_replaceableTX, i32 0, i32 0), i8* bitcast (void ()* @test_dynamically_replaceable to i8*))
 // CHECK-NEXT:   [[CMP:%.*]] = icmp eq i8* [[FUN_PTR]], null
 // CHECK-NEXT:   br i1 [[CMP]], label %[[ORIGBB:[a-z_]*]], label %[[FWBB:[a-z_]*]]
 // CHECK:      [[FWBB]]:
@@ -49,7 +51,8 @@ bb0:
 // The thunk that implement the prev_dynamic_function_ref lookup.
 // CHECK-LABEL: define swiftcc void @test_replacementTI()
 // CHECK: entry:
-// CHECK:   [[FUN_PTR:%.*]] = call i8* @swift_getOrigOfReplaceable(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_replacementTX, i32 0, i32 0))
+// COMPAT:   [[FUN_PTR:%.*]] = call i8* @swift_getOrigOfReplaceable50(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_replacementTX, i32 0, i32 0))
+// NONCOMPAT:   [[FUN_PTR:%.*]] = call i8* @swift_getOrigOfReplaceable(i8** getelementptr inbounds (%swift.dyn_repl_link_entry, %swift.dyn_repl_link_entry* @test_replacementTX, i32 0, i32 0))
 // CHECK:   [[TYPED_PTR:%.*]] = bitcast i8* [[FUN_PTR]] to void ()*
 // CHECK:   call swiftcc void [[TYPED_PTR]]()
 // CHECK:   ret void

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -runtime-compatibility-version none -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -parse-stdlib -o %t -module-name someModule -module-link-name module %S/../Inputs/empty.swift
-// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -lmagic %s -I %t > %t/out.txt
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -lmagic %s -I %t > %t/out.txt
 // RUN: %FileCheck %s < %t/out.txt
 // RUN: %FileCheck -check-prefix=NO-FORCE-LOAD %s < %t/out.txt
 
 // RUN: %empty-directory(%t/someModule.framework/Modules/someModule.swiftmodule)
 // RUN: mv %t/someModule.swiftmodule %t/someModule.framework/Modules/someModule.swiftmodule/%target-swiftmodule-name
-// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -lmagic %s -F %t > %t/framework.txt
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -lmagic %s -F %t > %t/framework.txt
 // RUN: %FileCheck -check-prefix=FRAMEWORK %s < %t/framework.txt
 // RUN: %FileCheck -check-prefix=NO-FORCE-LOAD %s < %t/framework.txt
 
@@ -15,7 +15,7 @@
 // RUN: %FileCheck %s < %t/force-load.txt
 // RUN: %FileCheck -check-prefix FORCE-LOAD-CLIENT -check-prefix FORCE-LOAD-CLIENT-%target-object-format %s < %t/force-load.txt
 
-// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
+// RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name 0module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD-HEX %s
 

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -18,3 +18,6 @@ void swift_retain(){}
 void swift_allocBox(){}
 void swift_getWitnessTable(void) {}
 void swift_getObjCClassMetadata(void) {}
+void swift_once() {}
+void swift_getFunctionReplacement() {}
+void swift_getOrigOfReplaceable() {}


### PR DESCRIPTION
 dynamic-replacement runtime functions.

The recent change of how we do dynamic replacements added 2 new runtime
functions. This patch adds those functions to the Compatibility50 static
archive.

This will allow backward deployment to a swift 5.0 runtime.

Patch by Erik Eckstein with a modification to call the standard
libraries implementation (marked as weak) when it is available.

This ensures we can change the implementation in the future and are not
ABI locked.

rdar://problem/51601233