### PR TITLE
[SILGen] Consistently call makeUsed() in RValue::getAsSingleValue().

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1965,6 +1965,24 @@ static void validateSelfAccessKind(TypeChecker &TC, FuncDecl *FD) {
     FD->setSelfAccessKind(SelfAccessKind::NonMutating);
   else if (FD->getAttrs().hasAttribute<ConsumingAttr>())
     FD->setSelfAccessKind(SelfAccessKind::__Consuming);
+  else if (auto accessor = dyn_cast<AccessorDecl>(FD)) {
+    if (accessor->getAccessorKind() == AccessorKind::Get ||
+        accessor->getAccessorKind() == AccessorKind::Set ||
+        accessor->getAccessorKind() == AccessorKind::DidSet ||
+        accessor->getAccessorKind() == AccessorKind::WillSet) {
+      auto storage = accessor->getStorage();
+      TC.validateDecl(storage);
+      if (accessor->getAccessorKind() == AccessorKind::Get) {
+        FD->setSelfAccessKind(storage->isGetterMutating()
+                              ? SelfAccessKind::Mutating
+                              : SelfAccessKind::NonMutating);
+      } else {
+        FD->setSelfAccessKind(storage->isSetterMutating()
+                              ? SelfAccessKind::Mutating
+                              : SelfAccessKind::NonMutating);
+      }
+    }
+  }
 
   if (FD->isMutating()) {
     if (!FD->isInstanceMember() ||

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -350,6 +350,55 @@ func testComposition() {
   _ = CompositionMembers(p1: nil)
 }
 
+// Observers with non-default mutatingness.
+@propertyWrapper
+struct NonMutatingSet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    get { fixed }
+    nonmutating set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+@propertyWrapper
+struct MutatingGet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    mutating get { fixed }
+    set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+struct ObservingTest {
+	// ObservingTest.text.setter
+	// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers13ObservingTestV4textSSvs : $@convention(method) (@owned String, @guaranteed ObservingTest) -> ()
+	// CHECK: function_ref @$s17property_wrappers14NonMutatingSetV12wrappedValuexvg
+  @NonMutatingSet var text: String = "" {
+    didSet { }
+  }
+
+  @NonMutatingSet var integer: Int = 17 {
+    willSet { }
+  }
+
+  @MutatingGet var text2: String = "" {
+    didSet { }
+  }
+
+  @MutatingGet var integer2: Int = 17 {
+    willSet { }
+  }
+}
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -400,6 +400,18 @@ struct ObservingTest {
   }
 }
 
+// Tuple initial values.
+struct WithTuples {
+	// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers10WithTuplesVACycfC : $@convention(method) (@thin WithTuples.Type) -> WithTuples {
+	// CHECK: function_ref @$s17property_wrappers10WithTuplesV10$fractions33_F728088E0028E14D18C6A10CF68512E8LLAA07WrapperC12InitialValueVySd_S2dtGvpfi : $@convention(thin) () -> (Double, Double, Double)
+	// CHECK: function_ref @$s17property_wrappers23WrapperWithInitialValueV07initialF0ACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin WrapperWithInitialValue<τ_0_0>.Type) -> @out WrapperWithInitialValue<τ_0_0>
+  @WrapperWithInitialValue var fractions = (1.3, 0.7, 0.3)
+
+	static func getDefault() -> WithTuples {
+		return .init()
+	}
+}
+
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
 // CHECK-NEXT:  #ClassUsingWrapper.x!setter.1: (ClassUsingWrapper) -> (Int) -> () : @$s17property_wrappers17ClassUsingWrapperC1xSivs // ClassUsingWrapper.x.setter


### PR DESCRIPTION
Fixes rdar://problem/50711880.