### PR TITLE
[5.1] Yet more minor fixes for property wrappers

### DIFF
--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -396,6 +396,18 @@ struct ObservingTest {
   }
 }
 
+// Tuple initial values.
+struct WithTuples {
+	// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers10WithTuplesVACycfC : $@convention(method) (@thin WithTuples.Type) -> WithTuples {
+	// CHECK: function_ref @$s17property_wrappers10WithTuplesV10$fractions33_F728088E0028E14D18C6A10CF68512E8LLAA07WrapperC12InitialValueVySd_S2dtGvpfi : $@convention(thin) () -> (Double, Double, Double)
+	// CHECK: function_ref @$s17property_wrappers23WrapperWithInitialValueV07initialF0ACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin WrapperWithInitialValue<τ_0_0>.Type) -> @out WrapperWithInitialValue<τ_0_0>
+  @WrapperWithInitialValue var fractions = (1.3, 0.7, 0.3)
+
+	static func getDefault() -> WithTuples {
+		return .init()
+	}
+}
+
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
 // CHECK:  #ClassUsingWrapper.x!setter.1: (ClassUsingWrapper) -> (Int) -> () : @$s17property_wrappers17ClassUsingWrapperC1xSivs // ClassUsingWrapper.x.setter

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -346,6 +346,55 @@ func testComposition() {
   _ = CompositionMembers(p1: nil)
 }
 
+// Observers with non-default mutatingness.
+@propertyWrapper
+struct NonMutatingSet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    get { fixed }
+    nonmutating set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+@propertyWrapper
+struct MutatingGet<T> {
+  private var fixed: T
+
+  var wrappedValue: T {
+    mutating get { fixed }
+    set { }
+  }
+
+  init(initialValue: T) {
+    fixed = initialValue
+  }
+}
+
+struct ObservingTest {
+	// ObservingTest.text.setter
+	// CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers13ObservingTestV4textSSvs : $@convention(method) (@owned String, @guaranteed ObservingTest) -> ()
+	// CHECK: function_ref @$s17property_wrappers14NonMutatingSetV12wrappedValuexvg
+  @NonMutatingSet var text: String = "" {
+    didSet { }
+  }
+
+  @NonMutatingSet var integer: Int = 17 {
+    willSet { }
+  }
+
+  @MutatingGet var text2: String = "" {
+    didSet { }
+  }
+
+  @MutatingGet var integer2: Int = 17 {
+    willSet { }
+  }
+}
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter


### PR DESCRIPTION
Fix two more small issues with property wrappers:

* A crash involving the mutating-ness of accessors in the presence of `willSet`/`didSet`: rdar://problem/51669930
* A SILGen assertion when property wrappers are initialized with tuple values: rdar://problem/50711880
