### PR TITLE
[Build System: build-script] Update the --stdlib-deployment-targets flag to no longer append from multiple uses, instead use the standard last-wins strategy.

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -510,7 +510,7 @@ def create_argument_parser():
            help='A space separated list of targets to cross-compile host '
                 'Swift tools for. Can be used multiple times.')
 
-    option('--stdlib-deployment-targets', append,
+    option('--stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=None,
            help='list of targets to compile or cross-compile the Swift '

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -535,6 +535,7 @@ EXPECTED_OPTIONS = [
     StrOption('--host-target'),
     StrOption('--lit-args'),
     StrOption('--llvm-targets-to-build'),
+    StrOption('--stdlib-deployment-targets'),
     StrOption('--swift-darwin-module-archs'),
     StrOption('--swift-darwin-supported-archs'),
 
@@ -570,7 +571,6 @@ EXPECTED_OPTIONS = [
     AppendOption('--cross-compile-hosts'),
     AppendOption('--extra-cmake-options'),
     AppendOption('--extra-swift-args'),
-    AppendOption('--stdlib-deployment-targets'),
     AppendOption('--test-paths'),
 
     UnsupportedOption('--build-jobs'),


### PR DESCRIPTION
This aligns better with the existing documentation for the argument and the similar `--build-stdlib-deployment-targets` flag. I've programmatically verified that all presets existing in the repo do not utilize the previously undocumented behavior. Which is to say that there are no presets that ever have two occurrences of `--stdlib-deployment-targets` once expanded and the `--swift-sdks` argument has been migrated.