### PR TITLE
[Build System: build-script] Update the --stdlib-deployment-targets flag to no longer append from multiple uses, instead use the standard last-wins strategy (5.1 branch).

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -501,7 +501,7 @@ def create_argument_parser():
            help='A space separated list of targets to cross-compile host '
                 'Swift tools for. Can be used multiple times.')
 
-    option('--stdlib-deployment-targets', append,
+    option('--stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=None,
            help='list of targets to compile or cross-compile the Swift '

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -523,6 +523,7 @@ EXPECTED_OPTIONS = [
     StrOption('--host-target'),
     StrOption('--lit-args'),
     StrOption('--llvm-targets-to-build'),
+    StrOption('--stdlib-deployment-targets'),
     StrOption('--swift-darwin-module-archs'),
     StrOption('--swift-darwin-supported-archs'),
 
@@ -558,7 +559,6 @@ EXPECTED_OPTIONS = [
     AppendOption('--cross-compile-hosts'),
     AppendOption('--extra-cmake-options'),
     AppendOption('--extra-swift-args'),
-    AppendOption('--stdlib-deployment-targets'),
     AppendOption('--test-paths'),
 
     UnsupportedOption('--build-jobs'),


### PR DESCRIPTION
Copy of #25534 for the 5.1 branch.