### PR TITLE
Attempt to fix attr/require_explicit_availability test on non-mac

### DIFF
--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
+// RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
+// RUN: %swift -typecheck -parse-stdlib -target x86_64-apple-macosx10.10 -warnings-as-errors %s
 
 public struct S { // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}}
   public func method() { }


### PR DESCRIPTION
There was an unepxected warning because of mixing iOS and mac flags.
