### PR TITLE
[windows] Fix ParseableInterface tests.

### DIFF
--- a/test/ParseableInterface/swift_build_sdk_interfaces/check-only-mode.swift
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/check-only-mode.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface -emit-module -o /dev/null -module-name Normal
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Normal
 // RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name FMWK
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt -check-only
 // RUN: ls %t/prebuilt | %FileCheck %s
@@ -18,7 +18,7 @@
 // Touch a file in the SDK (to make it look like it changed) and try again.
 // In -check-only mode, this should force a rebuild.
 // RUN: rm -rf %t/MCP
-// RUN: %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface
+// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: not %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Normal-*.swiftmodule
 

--- a/test/ParseableInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface -emit-module -o /dev/null -module-name Normal
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Normal
 // RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name FMWK
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s
@@ -19,7 +19,7 @@
 // This should still be able to use the prebuilt modules because they track
 // content hashes, not just size+mtime.
 // RUN: rm -rf %t/MCP
-// RUN: %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface
+// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: ls %t/MCP/*.swiftmodule | %FileCheck -check-prefix CHECK-CACHE %s
 // RUN: %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/*.swiftmodule
@@ -31,7 +31,7 @@
 // Actually change a file in the SDK, to check that we're tracking dependencies
 // at all.
 // RUN: rm -rf %t/MCP
-// RUN: echo "public func another()" >> %t/sdk/usr/lib/swift/Normal.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface
+// RUN: echo "public func another()" >> %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-cpu.swiftinterface
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: ls %t/MCP/*.swiftmodule | %FileCheck -check-prefix CHECK-CACHE %s
 // RUN: not %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Normal-*.swiftmodule

--- a/test/ParseableInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/system-dependencies-sdk %t/sdk
-// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/$(basename %target-swiftmodule-name .swiftmodule).swiftinterface -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk
+// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-parseable-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/%target-cpu.swiftinterface -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s
@@ -13,7 +13,7 @@
 // This should still be able to use the prebuilt modules because they track
 // content hashes, not just size+mtime.
 // RUN: rm -rf %t/MCP
-// RUN: %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/include/Platform.h
+// RUN: %{python} %S/../ModuleCache/Inputs/make-old.py %t/sdk/usr/include/Platform.h
 // RUN: %target-typecheck-verify-swift -sdk %t/sdk -I %t/sdk/usr/lib/swift/ -module-cache-path %t/MCP -prebuilt-module-cache-path %t/prebuilt
 // RUN: %{python} %S/../ModuleCache/Inputs/check-is-forwarding-module.py %t/MCP/Swifty-*.swiftmodule
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1087,10 +1087,6 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_object_format = "elf"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".so"
-    config.target_swiftmodule_name = get_architecture_value(armv7="arm.swiftmodule",
-                                                            aarch64="arm64.swiftmodule")
-    config.target_swiftdoc_name = get_architecture_value(armv7="arm.swiftdoc",
-                                                         aarch64="arm64.swiftdoc")
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -67,6 +67,28 @@ constants.""")
         slashes_re = r'/'
 
     stdin = sys.stdin.read()
+
+    if args.enable_windows_compatibility:
+        # Let's look for paths in the output, and try to transform them to use
+        # Unix directory separators to be automatically picked up by the tests.
+        # This only picks up absolute paths, but those should be the more
+        # common in the tools output and the easier to detect without false
+        # positives.
+
+        def replace_slashes(matchobj):
+            return re.sub(r'\\\\|\\', r'/', matchobj.group(0))
+
+        # The regex is composed of three parts:
+        #              Matches a drive letter followed by a slash (backward
+        #              escaped, simple backward, or forward)
+        stdin = re.sub(r'\b[a-zA-Z]:(?:\\\\|\\|\/)' +
+                       # Matches the path part, it always ends up in a slash.
+                       r'(?:[-a-zA-Z0-9_.]+(?:\\\\|\\|\/))*' +
+                       # Matches the last path component, which do not has a
+                       # trailing slash, but it is optional.
+                       r'(?:[-a-zA-Z0-9_.]+)?\b',
+                       replace_slashes, stdin)
+
     for s in args.sanitize_strings:
         replacement, pattern = s.split('=', 1)
         # We are replacing the Unix path separators in the paths passed as


### PR DESCRIPTION
There were several Unix specific things in the ParseableInterface tests:
the Bash subcommand was used, a Python tool was invoked without an
explicit interpreter, and Unix path separators are used in CHECK lines.

The Bash subcommand is replaced by a Lit substitution. Both swiftmodule
and swiftdoc had substitutions, however swiftinterface uses the target CPU
instead.

The Python tool is invoked with an explicit interpreter.

The Unix paths, instead of adding the ugly {{\\|/}} pattern everywhere
are fixed in the PathSanitizing tool instead, that gets a new capability
in Windows compatibility mode where all the Windows path found in the
input are transformed into Windows path with only forward slashes (Unix
slashes) in the output, which can be checked textually against the CHECK
lines.