### PR TITLE
Under -enable-library-evolution, imports need Library Evolution too

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -605,7 +605,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1,
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 
@@ -620,14 +620,18 @@ protected:
     /// Whether all imports have been resolved. Used to detect circular imports.
     HasResolvedImports : 1,
 
-    // If the module was or is being compiled with `-enable-private-imports`.
+    /// If the module was or is being compiled with `-enable-private-imports`.
     PrivateImportsEnabled : 1,
 
-    // If the module is compiled with `-enable-implicit-dynamic`.
+    /// If the module is compiled with `-enable-implicit-dynamic`.
     ImplicitDynamicEnabled : 1,
 
-    // Whether the module is a system module.
-    IsSystemModule : 1
+    /// Whether the module is a system module.
+    IsSystemModule : 1,
+
+    /// Whether the module was imported from Clang (or, someday, maybe another
+    /// language).
+    IsNonSwiftModule : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -792,6 +792,11 @@ ERROR(module_not_compiled_for_private_import,none,
 ERROR(import_implementation_cannot_be_exported,none,
       "module %0 cannot be both exported and implementation-only", (Identifier))
 
+WARNING(module_not_compiled_with_library_evolution,none,
+        "module %0 was not compiled with library evolution support; "
+        "using it means binary compatibility for %1 can't be guaranteed",
+        (Identifier, Identifier))
+
 
 // Operator decls
 ERROR(ambiguous_operator_decls,none,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -337,6 +337,18 @@ public:
     Bits.ModuleDecl.IsSystemModule = flag;
   }
 
+  /// Returns true if this module is a non-Swift module that was imported into
+  /// Swift.
+  ///
+  /// Right now that's just Clang modules.
+  bool isNonSwiftModule() const {
+    return Bits.ModuleDecl.IsNonSwiftModule;
+  }
+  /// \see #isNonSwiftModule
+  void setIsNonSwiftModule(bool flag = true) {
+    Bits.ModuleDecl.IsNonSwiftModule = flag;
+  }
+
   bool isResilient() const {
     return getResilienceStrategy() != ResilienceStrategy::Default;
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1672,8 +1672,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     Identifier name = SwiftContext.getIdentifier((*clangModule).Name);
     result = ModuleDecl::create(name, SwiftContext);
     result->setIsSystemModule(clangModule->IsSystem);
-    // Silence error messages about testably importing a Clang module.
-    result->setTestingEnabled();
+    result->setIsNonSwiftModule();
     result->setHasResolvedImports();
 
     wrapperUnit =
@@ -1842,8 +1841,7 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   Identifier name = SwiftContext.getIdentifier(underlying->Name);
   auto wrapper = ModuleDecl::create(name, SwiftContext);
   wrapper->setIsSystemModule(underlying->IsSystem);
-  // Silence error messages about testably importing a Clang module.
-  wrapper->setTestingEnabled();
+  wrapper->setIsNonSwiftModule();
   wrapper->setHasResolvedImports();
 
   auto file = new (SwiftContext) ClangModuleUnit(*wrapper, *this,

--- a/lib/DWARFImporter/DWARFImporter.cpp
+++ b/lib/DWARFImporter/DWARFImporter.cpp
@@ -120,8 +120,7 @@ public:
       return it->second->getParentModule();
 
     auto *decl = ModuleDecl::create(name, SwiftContext);
-    // Silence error messages about testably importing a Clang module.
-    decl->setTestingEnabled();
+    decl->setIsNonSwiftModule();
     decl->setHasResolvedImports();
     auto wrapperUnit = new (SwiftContext) DWARFModuleUnit(*decl);
     ModuleWrappers.insert({name, wrapperUnit});

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -225,6 +225,7 @@ void NameBinder::addImport(
 
   auto *testableAttr = ID->getAttrs().getAttribute<TestableAttr>();
   if (testableAttr && !topLevelModule->isTestingEnabled() &&
+      !topLevelModule->isNonSwiftModule() &&
       Context.LangOpts.EnableTestableAttrRequiresTestableModule) {
     diagnose(ID->getModulePath().front().second, diag::module_not_testable,
              topLevelModule->getName());
@@ -242,6 +243,15 @@ void NameBinder::addImport(
     } else {
       privateImportFileName = privateImportAttr->getSourceFile();
     }
+  }
+
+  if (SF.getParentModule()->isResilient() &&
+      !topLevelModule->isResilient() &&
+      !topLevelModule->isNonSwiftModule() &&
+      !ID->getAttrs().hasAttribute<ImplementationOnlyAttr>()) {
+    diagnose(ID->getModulePath().front().second,
+             diag::module_not_compiled_with_library_evolution,
+             topLevelModule->getName(), SF.getParentModule()->getName());
   }
 
   ImportOptions options;

--- a/test/ParseableInterface/imports.swift
+++ b/test/ParseableInterface/imports.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s %S/Inputs/imports-other.swift -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution | %FileCheck -implicit-check-not BAD %s
 
 
-@_exported import empty
+@_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'imports' can't be guaranteed}}
+@_exported import emptyButWithLibraryEvolution
 import B.B2
 import func C.c // expected-warning {{scoped imports are not yet supported in module interfaces}}
 import D
@@ -23,4 +25,5 @@ import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported
 // CHECK-NEXT: {{^}}import NotSoSecret2{{$}}
 // CHECK-NEXT: {{^}}import Swift{{$}}
 // CHECK-NEXT: {{^}}@_exported import empty{{$}}
+// CHECK-NEXT: {{^}}@_exported import emptyButWithLibraryEvolution{{$}}
 // CHECK-NOT: import


### PR DESCRIPTION
Otherwise, there's no guarantee of binary compatibility, and whoever turned on library evolution support shouldn't be lulled into a false sense of security.

This is just a warning for now, but will be promoted to an error later once clients have shaken out any places where they're doing this. Note that the still-experimental `@_implementationOnly` opts out of this check, because that enforces that the import doesn't make its way into the current module's public source or binary interface.

rdar://50261171