### PR TITLE
[Sema] Compute superclass of deserialized protocols via generic signature

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 494; // remove linkage from SILVTable
+const uint16_t SWIFTMODULE_VERSION_MINOR = 495; // remove superclass from ProtocolLayout
 
 using DeclIDField = BCFixed<31>;
 
@@ -997,7 +997,6 @@ namespace decls_block {
     BCFixed<1>,             // objc?
     BCFixed<1>,             // existential-type-supported?
     GenericEnvironmentIDField, // generic environment
-    TypeIDField,            // superclass
     AccessLevelField,       // access level
     BCArray<DeclIDField>    // inherited types
     // Trailed by the generic parameters (if any), the members record, and

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3232,15 +3232,13 @@ public:
     DeclContextID contextID;
     bool isImplicit, isClassBounded, isObjC, existentialTypeSupported;
     GenericEnvironmentID genericEnvID;
-    TypeID superclassID;
     uint8_t rawAccessLevel;
     ArrayRef<uint64_t> rawInheritedIDs;
 
     decls_block::ProtocolLayout::readRecord(scratch, nameID, contextID,
                                             isImplicit, isClassBounded, isObjC,
                                             existentialTypeSupported,
-                                            genericEnvID, superclassID,
-                                            rawAccessLevel, rawInheritedIDs);
+                                            genericEnvID, rawAccessLevel, rawInheritedIDs);
 
     auto DC = MF.getDeclContext(contextID);
     if (declOrOffset.isComplete())
@@ -3251,7 +3249,6 @@ public:
                                              /*TrailingWhere=*/nullptr);
     declOrOffset = proto;
 
-    proto->setSuperclass(MF.getType(superclassID));
     proto->setRequiresClass(isClassBounded);
     proto->setExistentialTypeSupported(existentialTypeSupported);
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3290,7 +3290,6 @@ public:
                                  /*resolver=*/nullptr),
                                S.addGenericEnvironmentRef(
                                                 proto->getGenericEnvironment()),
-                               S.addTypeRef(proto->getSuperclass()),
                                rawAccessLevel,
                                inherited);
 

--- a/test/Serialization/Inputs/class-bound-protocol.swift
+++ b/test/Serialization/Inputs/class-bound-protocol.swift
@@ -1,0 +1,15 @@
+public protocol P: C {}
+
+public class C: P {
+  public init() {}
+  public func funcInClass() {}
+}
+
+public protocol GenericP: GenericC<Int> {}
+
+public class GenericC<T> {
+  public init() {}
+  public func funcInClass() {}
+}
+
+extension GenericC: GenericP where T == Int {}

--- a/test/Serialization/use-class-bound-protocol.swift
+++ b/test/Serialization/use-class-bound-protocol.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module-path %t/ClassBoundProtocol.swiftmodule %S/Inputs/class-bound-protocol.swift -module-name ClassBoundProtocol
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+import ClassBoundProtocol
+
+func f() {
+  let p: P = C()
+  p.funcInClass()
+
+  let genericP: GenericP = GenericC<Int>()
+  genericP.funcInClass()
+}


### PR DESCRIPTION
We don't need to serialize the protocol's superclass, we can compute it from the
generic signature. Previously, we would drop the superclass while
serializing because we didn't check the generic signature in
SuperclassTypeRequest, which would cause us to cache `NULL` when we
called `setSuperclass` for a protocol with a superclass constraint.

Fixes rdar://50526401