### PR TITLE
[AutoDiff] [stdlib] Add a top-level 'withoutDerivative(at:in:)' API.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -94,10 +94,22 @@ public extension Differentiable where TangentVector == Self {
 }
 
 public extension Differentiable {
-  /// Identity function that stops gradients from propagating.
+  /// Identity function that stops derivatives from propagating.
+  @inlinable
   @inline(__always)
   @_semantics("autodiff.nonvarying")
   func withoutDerivative() -> Self { return self }
+}
+
+/// Applies the given closure `body` to `x`. When used in a context where `x` is
+/// being differentiated with respect to, this function will not produce any
+/// derivative at `x`.
+// FIXME: Support throws-rethrows.
+@inlinable
+@inline(__always)
+@_semantics("autodiff.nonvarying")
+public func withoutDerivative<T, R>(at x: T, in body: (T) -> R) -> R {
+  body(x)
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -87,4 +87,12 @@ CustomDerivativesTests.test("ModifyGradientOfSum") {
   })
 }
 
+CustomDerivativesTests.test("WithoutDerivative") {
+  expectEqual(0, gradient(at: Float(4)) { x in
+    withoutDerivative(at: x) { x in
+      sinf(x) + cosf(x)
+    }
+  })
+}
+
 runAllTests()


### PR DESCRIPTION
The existing `withoutDerivative()` method on `Differentiable` is not general enough to support generic algorithms that are conditionally differentiable, for example:

```swift
@differentiable(where T: Differentiable)
func foo<T: Numeric>(x: T) -> T {
    2 * x.withoutDerivative()
}
// Error: 'x' does not conform to 'Differentiable'.
```

We add a top-level function that makes this possible.

```swift
@differentiable(where T: Differentiable)
func foo<T: Numeric>(x: T) -> T {
    withoutDerivative(at: x) { x in
        2 * x
    } // Okay!
}
```