### PR TITLE
[5.1][SDK] Add overlay shims for ClockKit framework

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -49,6 +49,8 @@ set(sources
   NSTimeZoneShims.h
   NSUndoManagerShims.h
 
+  ClockKitOverlayShims.h
+
   module.modulemap
   )
 set(output_dir "${SWIFTLIB_DIR}/shims")

--- a/stdlib/public/SwiftShims/ClockKitOverlayShims.h
+++ b/stdlib/public/SwiftShims/ClockKitOverlayShims.h
@@ -1,0 +1,23 @@
+//===--- ClockKitOverlayShims.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_CLOCKKITOVERLAY_H
+#define SWIFT_STDLIB_SHIMS_CLOCKKITOVERLAY_H
+
+@import ClockKit;
+
+@interface CLKTextProvider (OverlaySupport)
++ (CLKTextProvider *)textProviderWithFormat:(NSString *)format arguments:(va_list)arguments API_AVAILABLE(watchos(2.0)) API_UNAVAILABLE(macos, tvos, ios);
+@end
+
+// SWIFT_STDLIB_SHIMS_CLOCKKITOVERLAY_H
+#endif

--- a/stdlib/public/SwiftShims/module.modulemap
+++ b/stdlib/public/SwiftShims/module.modulemap
@@ -71,3 +71,7 @@ module _SwiftFoundationOverlayShims {
 module _SwiftNetworkOverlayShims {
   header "NetworkOverlayShims.h"
 }
+
+module _SwiftClockKitOverlayShims {
+    header "ClockKitOverlayShims.h"
+}


### PR DESCRIPTION
(Cherry-picked from #25444)

This resolves a mismatch between the SDKs in Xcode 11 and this repository, fixing a spurious build issue.

rdar://problem/51583518