### PR TITLE
Sema: Handle protocol compositions containing type variables in matchTypes() [5.1]

### DIFF
--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -63,6 +63,7 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case RValueAdjustment:
     case ClosureResult:
     case ParentType:
+    case ExistentialSuperclassType:
     case InstanceType:
     case SequenceElementType:
     case AutoclosureResult:
@@ -306,6 +307,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
         
     case ParentType:
       out << "parent type";
+      break;
+
+    case ExistentialSuperclassType:
+      out << "existential superclass type";
       break;
 
     case LValueConversion:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -96,6 +96,8 @@ public:
     ClosureResult,
     /// The parent of a nested type.
     ParentType,
+    /// The superclass of a protocol existential type.
+    ExistentialSuperclassType,
     /// The instance of a metatype type.
     InstanceType,
     /// The element type of a sequence in a for ... in ... loop.
@@ -155,6 +157,7 @@ public:
     case ClosureResult:
     case ParentType:
     case InstanceType:
+    case ExistentialSuperclassType:
     case SequenceElementType:
     case AutoclosureResult:
     case Requirement:
@@ -212,6 +215,7 @@ public:
     case MemberRefBase:
     case UnresolvedMember:
     case ParentType:
+    case ExistentialSuperclassType:
     case LValueConversion:
     case RValueAdjustment:
     case SubscriptMember:

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -530,3 +530,21 @@ struct DerivedBox<T : Derived> {}
 
 func takesBoxWithP3(_: DerivedBox<Derived & P3>) {}
 // expected-error@-1 {{'DerivedBox' requires that 'Derived & P3' inherit from 'Derived'}}
+
+// A bit of a tricky setup -- the real problem is that matchTypes() did the
+// wrong thing when solving a Bind constraint where both sides were protocol
+// compositions, but one of them had a superclass constraint containing type
+// variables. We were checking type equality in this case, which is not
+// correct; we have to do a 'deep equality' check, recursively matching the
+// superclass types.
+struct Generic<T> {
+  var _x: (Base<T> & P2)!
+
+  var x: (Base<T> & P2)? {
+    get { return _x }
+    set { _x = newValue }
+    _modify {
+      yield &_x
+    }
+  }
+}


### PR DESCRIPTION
We would previously fail to match something like `(C<$T1> & P)` against
`(C<Int> & P)` when the constraint kind was <= Subtype, because we would
fall back to a type equality test in that case.

However, this was only valid for protocol compositions without superclass
constraints since the superclass could contain a type variable on one
side of the constraint.

Fix this by adding support for protocol composition types to
matchDeepEqualityTypes().