### PR TITLE
[Diagnostics]: Fix broken diagnostic for unnamed static class property

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1012,6 +1012,7 @@ public:
   ParserResult<VarDecl> parseDeclVarGetSet(Pattern *pattern,
                                            ParseDeclOptions Flags,
                                            SourceLoc StaticLoc,
+                                           StaticSpellingKind StaticSpelling,
                                            SourceLoc VarLoc,
                                            bool hasInitializer,
                                            const DeclAttributes &Attributes,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4675,8 +4675,9 @@ static void fillInAccessorTypeErrors(Parser &P,
 /// Parse the brace-enclosed getter and setter for a variable.
 ParserResult<VarDecl>
 Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
-                           SourceLoc StaticLoc, SourceLoc VarLoc,
-                           bool hasInitializer,
+                           SourceLoc StaticLoc,
+                           StaticSpellingKind StaticSpelling,
+                           SourceLoc VarLoc, bool hasInitializer,
                            const DeclAttributes &Attributes,
                            SmallVectorImpl<Decl *> &Decls) {
   bool Invalid = false;
@@ -4740,7 +4741,7 @@ Parser::parseDeclVarGetSet(Pattern *pattern, ParseDeclOptions Flags,
     PatternBindingEntry entry(pattern, /*EqualLoc*/ SourceLoc(),
                               /*Init*/ nullptr, /*InitContext*/ nullptr);
     auto binding = PatternBindingDecl::create(Context, StaticLoc,
-                                              StaticSpellingKind::None,
+                                              StaticSpelling,
                                               VarLoc, entry, CurDeclContext);
     binding->setInvalid(true);
     storage->setParentPatternBinding(binding);
@@ -5362,9 +5363,9 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     // var-get-set clause, parse the var-get-set clause.
     if (Tok.is(tok::l_brace)) {
       HasAccessors = true;
-      auto boundVar = parseDeclVarGetSet(pattern, Flags, StaticLoc, VarLoc,
-                                         PatternInit != nullptr,Attributes,
-                                         Decls);
+      auto boundVar =
+          parseDeclVarGetSet(pattern, Flags, StaticLoc, StaticSpelling, VarLoc,
+                             PatternInit != nullptr, Attributes, Decls);
       if (boundVar.hasCodeCompletion())
         return makeResult(makeParserCodeCompletionStatus());
       if (PatternInit && boundVar.isNonNull() &&

--- a/test/Parse/pattern_without_variables.swift
+++ b/test/Parse/pattern_without_variables.swift
@@ -37,3 +37,8 @@ func testVarLetPattern(a : SimpleEnum) {
   // expected-warning @+1 {{'if' condition is always true}}
   if case let _ = "str" {}  // expected-warning {{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{11-15=}}
 }
+
+class SR10903 {
+  static var _: Int { 0 } //expected-error {{getter/setter can only be defined for a single variable}}
+  //expected-error@-1 {{property declaration does not bind any variables}}
+}


### PR DESCRIPTION
Previously,
```swift
class C {
  static var _: Int { 0 }
}
```
would erroneously emit `error: ERROR stored properties not supported in classes; did you mean 'static'?`, because the `StaticSpellingKind` was being set to `none` in an error case. This change just propagates the spelling so that the error message no longer appears in this case. (the other, correct errors still appear)

Resolves [SR-10903](https://bugs.swift.org/browse/SR-10903)

cc @hamishknight (original reporter)