### PR TITLE
[update-checkout]: Add --fetch option.

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -96,7 +96,8 @@ def update_single_repository(args):
             checkout_target = None
 
             if should_fetch:
-                shell.run(['git', 'fetch'], echo=True)
+                shell.run(['git', 'fetch', '--recurse-submodules=yes',
+                           '--targs'], echo=True)
 
             if tag:
                 checkout_target = confirm_tag_in_repo(tag, repo_name)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -84,7 +84,7 @@ def get_branch_for_repo(config, repo_name, scheme_name, scheme_map,
 
 def update_single_repository(args):
     config, repo_name, scheme_name, scheme_map, tag, timestamp, \
-        reset_to_remote, should_clean, cross_repos_pr = args
+        reset_to_remote, should_clean, cross_repos_pr, should_fetch = args
     repo_path = os.path.join(SWIFT_SOURCE_ROOT, repo_name)
     if not os.path.isdir(repo_path):
         return
@@ -94,6 +94,10 @@ def update_single_repository(args):
         with shell.pushd(repo_path, dry_run=False, echo=False):
             cross_repo = False
             checkout_target = None
+
+            if should_fetch:
+                shell.run(['git', 'fetch'], echo=True)
+
             if tag:
                 checkout_target = confirm_tag_in_repo(tag, repo_name)
             elif scheme_name:
@@ -207,7 +211,8 @@ def update_all_repositories(args, config, scheme_name, cross_repos_pr):
                    timestamp,
                    args.reset_to_remote,
                    args.clean,
-                   cross_repos_pr]
+                   cross_repos_pr,
+                   args.fetch]
         pool_args.append(my_args)
 
     return shell.run_parallel(update_single_repository, pool_args,
@@ -430,6 +435,10 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     parser.add_argument(
         "--clone-with-ssh",
         help="Obtain Sources for Swift and Related Projects via SSH",
+        action="store_true")
+    parser.add_argument(
+        "--fetch",
+        help="Fetch the latest branches and tags before checking out code.",
         action="store_true")
     parser.add_argument(
         "--skip-history",


### PR DESCRIPTION
When checking out repositories, it's sometimes necessary to run `git fetch`
first to pull the latest commits, branches, and tags down from GitHub. This
commit adds a `--fetch` option so that the update-checkout script will
perform a `git fetch` first.

Note: this change preserves the default behavior, such that update-checkout can
be run without an internet connection.
