### PR TITLE
[5.1 06/12][CSDiag] Always find and set correct declaration context for sub-expr type-check

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar50869732.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar50869732.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype T : P
+}
+
+struct Generic<T> {
+  init(_ value: T) {}
+}
+
+@_functionBuilder
+struct Builder {
+  static func buildBlock<C0, C1>(_ c0: C0, _ c1: C1)
+           -> Generic<(C0, C1)> where C0 : P, C1 : P {
+    return Generic((c0, c1))
+  }
+}
+
+struct G<C> {
+  init(@Builder _: () -> C) {}
+}
+
+struct Empty {
+  init() {}
+}
+
+struct Test<T> where T : P {
+  init(@Builder _: () -> T) {}
+}
+
+let x = G {
+  Empty()
+  Test { <#code#> } // expected-error {{editor placeholder in source file}}
+}


### PR DESCRIPTION
- **Explanation**: 

Replace dedicated method with `typeCheckChildIndependently` always
setting the closest possible declaration context for type-check call.
This fixes a problem where sub-expression comes from multiple levels
or nested closures but CSDiag didn't re-typecheck parent closure.

- **Issue**: rdar://problem/50869732

- **Scope**: Diagnostics, in subset of cases where there multiple nested single-statement closures involved.

- **Risk**: Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @DougGregor

Resolves: rdar://problem/50869732
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
