### PR TITLE
IRGen: simplify code generation for enum switch statements

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -373,137 +373,10 @@ void EnumPayload::store(IRGenFunction &IGF, Address address) const {
   }
 }
 
-namespace {
-struct ult {
-  bool operator()(const APInt &a, const APInt &b) const {
-    return a.ult(b);
-  }
-};
-} // end anonymous namespace
-
-static void emitSubSwitch(IRGenFunction &IGF,
-                    MutableArrayRef<EnumPayload::LazyValue> values,
-                    APInt mask,
-                    MutableArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
-                    SwitchDefaultDest dflt) {
-recur:
-  assert(!values.empty() && "didn't exit out when exhausting all values?!");
-  
-  assert(!cases.empty() && "switching with no cases?!");
-  
-  auto &DL = IGF.IGM.DataLayout;
-  auto &pv = values.front();
-  values = values.slice(1);
-  auto payloadTy = getPayloadType(pv);
-  unsigned size = DL.getTypeSizeInBits(payloadTy);
-  
-  // Grab a chunk of the mask.
-  auto maskPiece = mask.zextOrTrunc(size);
-  mask = mask.lshr(size);
-  
-  // If the piece is zero, this doesn't affect the switch. We can just move
-  // forward and recur.
-  if (maskPiece == 0) {
-    for (auto &casePair : cases)
-      casePair.first = casePair.first.lshr(size);
-    goto recur;
-  }
-  
-  // Force the value we will test.
-  auto v = forcePayloadValue(pv);
-  auto payloadIntTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), size);
-  
-  // Need to coerce to integer for 'icmp eq' if it's not already an integer
-  // or pointer. (Switching or masking will also require a cast to integer.)
-  if (!isa<llvm::IntegerType>(v->getType())
-      && !isa<llvm::PointerType>(v->getType()))
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-  
-  // Apply the mask if it's interesting.
-  if (!maskPiece.isAllOnesValue()) {
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-    auto maskConstant = llvm::ConstantInt::get(payloadIntTy, maskPiece);
-    v = IGF.Builder.CreateAnd(v, maskConstant);
-  }
-  
-  // Gather the values we will switch over for this payload chunk.
-  // FIXME: std::map is lame. Should hash APInts.
-  std::map<APInt, SmallVector<std::pair<APInt, llvm::BasicBlock*>, 2>, ult>
-    subCases;
-  
-  for (auto casePair : cases) {
-    // Grab a chunk of the value.
-    auto valuePiece = casePair.first.zextOrTrunc(size);
-    // Index the case according to this chunk.
-    subCases[valuePiece].push_back({std::move(casePair.first).lshr(size),
-                                    casePair.second});
-  }
-  
-  bool needsAdditionalCases = !values.empty() && mask != 0;
-  SmallVector<std::pair<llvm::BasicBlock *, decltype(cases)>, 2> recursiveCases;
-  
-  auto blockForCases
-    = [&](MutableArrayRef<std::pair<APInt, llvm::BasicBlock*>> cases)
-        -> llvm::BasicBlock *
-    {
-      // If we need to recur, emit a new block.
-      if (needsAdditionalCases) {
-        auto newBB = IGF.createBasicBlock("");
-        recursiveCases.push_back({newBB, cases});
-        return newBB;
-      }
-      // Otherwise, we can jump directly to the ultimate destination.
-      assert(cases.size() == 1 && "more than one case for final destination?!");
-      return cases.front().second;
-    };
-  
-  // If there's only one case, do a cond_br.
-  if (subCases.size() == 1) {
-    auto &subCase = *subCases.begin();
-    llvm::BasicBlock *block = blockForCases(subCase.second);
-    // If the default case is unreachable, we don't need to conditionally
-    // branch.
-    if (dflt.getInt()) {
-      IGF.Builder.CreateBr(block);
-      goto next;
-    }
-  
-    auto &valuePiece = subCase.first;
-    llvm::Value *valueConstant = llvm::ConstantInt::get(payloadIntTy,
-                                                        valuePiece);
-    valueConstant = IGF.Builder.CreateBitOrPointerCast(valueConstant,
-                                                       v->getType());
-    auto cmp = IGF.Builder.CreateICmpEQ(v, valueConstant);
-    IGF.Builder.CreateCondBr(cmp, block, dflt.getPointer());
-    goto next;
-  }
-  
-  // Otherwise, do a switch.
-  {
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-    auto swi = IGF.Builder.CreateSwitch(v, dflt.getPointer(), subCases.size());
-    
-    for (auto &subCase : subCases) {
-      auto &valuePiece = subCase.first;
-      auto valueConstant = llvm::ConstantInt::get(IGF.IGM.getLLVMContext(),
-                                                  valuePiece);
-
-      swi->addCase(valueConstant, blockForCases(subCase.second));
-    }
-  }
-  
-next:
-  // Emit the recursive cases.
-  for (auto &recursive : recursiveCases) {
-    IGF.Builder.emitBlock(recursive.first);
-    emitSubSwitch(IGF, values, mask, recursive.second, dflt);
-  }
-}
-
 void EnumPayload::emitSwitch(IRGenFunction &IGF,
-                           APInt mask,
-                           ArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
-                           SwitchDefaultDest dflt) const {
+                             const APInt &mask,
+                             ArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
+                             SwitchDefaultDest dflt) const {
   // If there's only one case to test, do a simple compare and branch.
   if (cases.size() == 1) {
     // If the default case is unreachable, don't bother branching at all.
@@ -517,12 +390,16 @@ void EnumPayload::emitSwitch(IRGenFunction &IGF,
     return;
   }
 
-  // Otherwise, break down the decision tree.
-  SmallVector<std::pair<APInt, llvm::BasicBlock*>, 4> mutableCases
-    (cases.begin(), cases.end());
-  
-  emitSubSwitch(IGF, PayloadValues, mask, mutableCases, dflt);
-  
+  // Otherwise emit a switch statement.
+  auto &context = IGF.IGM.getLLVMContext();
+  unsigned numBits = mask.countPopulation();
+  auto target = emitGatherSpareBits(IGF, SpareBitVector::fromAPInt(mask),
+                                    0, numBits);
+  auto swi = IGF.Builder.CreateSwitch(target, dflt.getPointer(), cases.size());
+  for (auto &c : cases) {
+    auto value = llvm::ConstantInt::get(context, gatherBits(mask, c.first));
+    swi->addCase(value, c.second);
+  }
   assert(IGF.Builder.hasPostTerminatorIP());
 }
 

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -141,7 +141,7 @@ public:
   /// Emit a switch over specific bit patterns for the payload.
   /// The value will be tested as if AND-ed against the given mask.
   void emitSwitch(IRGenFunction &IGF,
-                  APInt mask,
+                  const APInt &mask,
                   ArrayRef<std::pair<APInt, llvm::BasicBlock*>> cases,
                   SwitchDefaultDest dflt) const;
   

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6928,6 +6928,24 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
   return result;
 }
 
+/// Pack masked bits into the low bits of an integer value.
+llvm::APInt irgen::gatherBits(const llvm::APInt &mask,
+                              const llvm::APInt &value) {
+  assert(mask.getBitWidth() == value.getBitWidth());
+  llvm::APInt result = llvm::APInt(mask.countPopulation(), 0);
+  unsigned j = 0;
+  for (unsigned i = 0; i < mask.getBitWidth(); ++i) {
+    if (!mask[i]) {
+      continue;
+    }
+    if (value[i]) {
+      result.setBit(j);
+    }
+    ++j;
+  }
+  return result;
+}
+
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 llvm::APInt irgen::scatterBits(const llvm::APInt &mask, unsigned value) {

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -106,6 +106,10 @@ llvm::Value *emitGatherBits(IRGenFunction &IGF,
                             unsigned resultLowBit,
                             unsigned resultBitWidth);
 
+/// Pack masked bits into the low bits of an integer value.
+llvm::APInt gatherBits(const llvm::APInt &mask,
+                       const llvm::APInt &value);
+
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 /// Equivalent to a parallel bit deposit instruction (PDEP),
@@ -118,7 +122,7 @@ llvm::Value *emitScatterBits(IRGenFunction &IGF,
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 llvm::APInt scatterBits(const llvm::APInt &mask, unsigned value);
-  
+
 /// An implementation strategy for an enum, which handles how the enum is
 /// laid out and how to perform TypeInfo operations on values of the enum.
 class EnumImplStrategy {

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -882,23 +882,12 @@ enum SinglePayloadSpareBit {
 sil @single_payload_spare_bit_switch : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
-// CHECK-64:  switch i64 %0, label %[[X_DEST:[0-9]+]] [
+// CHECK:  switch i64 %{{[0-9]+}}, label %[[X_DEST:[0-9]+]] [
 // --              0x8000_0000_0000_0000
-// CHECK-64:    i64 -9223372036854775808, label %[[Y_DEST:[0-9]+]]
+// CHECK:    i64 -9223372036854775808, label %[[Y_DEST:[0-9]+]]
 // --              0x8000_0000_0000_0001
-// CHECK-64:    i64 -9223372036854775807, label %[[Z_DEST:[0-9]+]]
-// CHECK-64:  ]
-
-// CHECK-32:  switch i32 %0, label %[[X_DEST:[0-9]+]] [
-// CHECK-32:    i32 0, label %[[Y_HIGH:[0-9]+]]
-// CHECK-32:    i32 1, label %[[Z_HIGH:[0-9]+]]
-// CHECK-32:  ]
-// CHECK-32: ; <label>:[[Y_HIGH]]
-// CHECK-32:  [[IS_Y:%.*]] = icmp eq i32 %1, -2147483648
-// CHECK-32:  br i1 [[IS_Y]], label %[[Y_DEST:[0-9]+]], label %[[X_DEST]]
-// CHECK-32: ; <label>:[[Z_HIGH]]
-// CHECK-32:  [[IS_Z:%.*]] = icmp eq i32 %1, -2147483648
-// CHECK-32:  br i1 [[IS_Z]], label %[[Z_DEST:[0-9]+]], label %[[X_DEST]]
+// CHECK:    i64 -9223372036854775807, label %[[Z_DEST:[0-9]+]]
+// CHECK:  ]
   switch_enum %u : $SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
 // CHECK: ; <label>:[[X_DEST]]


### PR DESCRIPTION
This change uses the 'gather bits' functionality of enum payloads
to create a contiguous value to switch over. This allows us to
remove the code that currently attempts to build a switch statement
by comparing each element in the payload in turn.

The downside of this technique is that we may do more work up front
gathering bits and we may also need to compare larger values in some
situations. The upside is that we can remove a lot of complicated
code from IRGen. Also, we pass the responsibility for multi-way
branch generation to LLVM which can make use of a wider range of
switch lowering strategies than IRGen can sensibly support.
