### PR TITLE
[Diagnostics] Guard against missing parent initializer in missing unw…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -819,9 +819,10 @@ MissingOptionalUnwrapFailure::getOperatorParameterFor(Expr *expr) const {
 
 void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
     DeclContext *DC, Expr *expr) const {
-  auto *anchor = getAnchor();
+  assert(expr);
 
-  // If anchor is an explicit address-of, or expression which produces
+  auto *anchor = getAnchor();
+  // If anchor is n explicit address-of, or expression which produces
   // an l-value (e.g. first argument of `+=` operator), let's not
   // suggest default value here because that would produce r-value type.
   if (isa<InOutExpr>(anchor))
@@ -966,7 +967,10 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
       if (singleUse && binding && binding->getNumPatternEntries() == 1 &&
           varDecl->getTypeSourceRangeForDiagnostics().isInvalid()) {
 
-        Expr *initializer = varDecl->getParentInitializer();
+        auto *initializer = varDecl->getParentInitializer();
+        if (!initializer)
+          return true;
+
         if (auto declRefExpr = dyn_cast<DeclRefExpr>(initializer)) {
           if (declRefExpr->getDecl()
                   ->getAttrs()


### PR DESCRIPTION
…rap diagnostic

While trying to diagnose missing optional unwrap for single use
vars guard against it not having a parent initializer.

Unfortunately there is no test-case for this but we have
received multiple reports about `offerDefaultValueUnwrapFixIt`
crashing trying to access locator on passed in `expr`.

Resolves: rdar://problem/51784793

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
