### PR TITLE
[Diagnostics] Add a variant of the extraneous property wrapper unwrap diagnostic for function arguments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -992,6 +992,9 @@ ERROR(missing_address_of,none,
 ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
+ERROR(missing_property_wrapper_unwrap,none,
+      "wrapped value of type %0 must be unwraped to value of type %1",
+      (Type, Type))
 ERROR(extraneous_address_of,none,
       "use of extraneous '&'",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -992,9 +992,10 @@ ERROR(missing_address_of,none,
 ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
-ERROR(missing_property_wrapper_unwrap,none,
-      "wrapped value of type %0 must be unwraped to value of type %1",
-      (Type, Type))
+ERROR(extraneous_property_wrapper_unwrap,none,
+      "property %0 will be unwrapped to value of type %1, use '$' to refer to "
+      "the %2 property wrapper",
+      (DeclName, Type, Type))
 ERROR(extraneous_address_of,none,
       "use of extraneous '&'",
       ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1888,8 +1888,9 @@ bool MissingCallFailure::diagnoseAsError() {
 }
 
 bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  emitDiagnostic(getAnchor()->getLoc(), diag::extraneous_property_wrapper_unwrap,
-                 getPropertyName(), getFromType(), getToType())
+  emitDiagnostic(getAnchor()->getLoc(),
+                 diag::extraneous_property_wrapper_unwrap, getPropertyName(),
+                 getFromType(), getToType())
       .fixItInsert(getAnchor()->getLoc(), "$");
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1887,6 +1887,13 @@ bool MissingCallFailure::diagnoseAsError() {
   return true;
 }
 
+bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
+  emitDiagnostic(getAnchor()->getLoc(), diag::missing_property_wrapper_unwrap,
+                 getFromType(), getToType())
+      .fixItInsert(getAnchor()->getLoc(), "$");
+  return true;
+}
+
 bool SubscriptMisuseFailure::diagnoseAsError() {
   auto &sourceMgr = getASTContext().SourceMgr;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1888,8 +1888,8 @@ bool MissingCallFailure::diagnoseAsError() {
 }
 
 bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  emitDiagnostic(getAnchor()->getLoc(), diag::missing_property_wrapper_unwrap,
-                 getFromType(), getToType())
+  emitDiagnostic(getAnchor()->getLoc(), diag::extraneous_property_wrapper_unwrap,
+                 getPropertyName(), getFromType(), getToType())
       .fixItInsert(getAnchor()->getLoc(), "$");
   return true;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -795,14 +795,20 @@ public:
 };
 
 class MissingPropertyWrapperUnwrapFailure final : public ContextualFailure {
+  DeclName PropertyName;
 
 public:
   MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                      DeclName propertyName,
                                       Type base, Type wrapper,
                                       ConstraintLocator *locator)
-      : ContextualFailure(root, cs, base, wrapper, locator) {}
+      : ContextualFailure(root, cs, base, wrapper, locator),
+        PropertyName(propertyName) {}
 
   bool diagnoseAsError() override;
+
+private:
+  DeclName getPropertyName() const { return PropertyName; }
 };
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -794,6 +794,17 @@ public:
   bool diagnoseAsError() override;
 };
 
+class MissingPropertyWrapperUnwrapFailure final : public ContextualFailure {
+
+public:
+  MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                      Type base, Type wrapper,
+                                      ConstraintLocator *locator)
+      : ContextualFailure(root, cs, base, wrapper, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 class SubscriptMisuseFailure final : public FailureDiagnostic {
 public:
   SubscriptMisuseFailure(Expr *root, ConstraintSystem &cs,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -799,9 +799,8 @@ class MissingPropertyWrapperUnwrapFailure final : public ContextualFailure {
 
 public:
   MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                      DeclName propertyName,
-                                      Type base, Type wrapper,
-                                      ConstraintLocator *locator)
+                                      DeclName propertyName, Type base,
+                                      Type wrapper, ConstraintLocator *locator)
       : ContextualFailure(root, cs, base, wrapper, locator),
         PropertyName(propertyName) {}
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -277,6 +277,21 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
 
+bool InsertPropertyWrapperUnwrap::diagnose(Expr *root, bool asNote) const {
+  auto failure = MissingPropertyWrapperUnwrapFailure(
+      root, getConstraintSystem(), getBase(), getWrapper(),
+      getLocator());
+  return failure.diagnose(asNote);
+}
+
+InsertPropertyWrapperUnwrap *
+InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs,
+                                    Type base, Type wrapper,
+                                    ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      InsertPropertyWrapperUnwrap(cs, base, wrapper, locator);
+}
+
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {
   auto failure = SubscriptMisuseFailure(root, getConstraintSystem(), getLocator());
   return failure.diagnose(asNote);

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -285,8 +285,7 @@ bool InsertPropertyWrapperUnwrap::diagnose(Expr *root, bool asNote) const {
 }
 
 InsertPropertyWrapperUnwrap *
-InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs,
-                                    DeclName propertyName,
+InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs, DeclName propertyName,
                                     Type base, Type wrapper,
                                     ConstraintLocator *locator) {
   return new (cs.getAllocator())

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -279,17 +279,18 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
 
 bool InsertPropertyWrapperUnwrap::diagnose(Expr *root, bool asNote) const {
   auto failure = MissingPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), getBase(), getWrapper(),
+      root, getConstraintSystem(), getPropertyName(), getBase(), getWrapper(),
       getLocator());
   return failure.diagnose(asNote);
 }
 
 InsertPropertyWrapperUnwrap *
 InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs,
+                                    DeclName propertyName,
                                     Type base, Type wrapper,
                                     ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      InsertPropertyWrapperUnwrap(cs, base, wrapper, locator);
+      InsertPropertyWrapperUnwrap(cs, propertyName, base, wrapper, locator);
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -652,8 +652,8 @@ public:
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static InsertPropertyWrapperUnwrap *create(ConstraintSystem &cs,
-                                             DeclName propertyName,
-                                             Type base, Type wrapper,
+                                             DeclName propertyName, Type base,
+                                             Type wrapper,
                                              ConstraintLocator *locator);
 };
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -630,25 +630,29 @@ public:
 };
 
 class InsertPropertyWrapperUnwrap final : public ConstraintFix {
+  DeclName PropertyName;
   Type Base;
   Type Wrapper;
 
-  InsertPropertyWrapperUnwrap(ConstraintSystem &cs, Type base, Type wrapper,
+  InsertPropertyWrapperUnwrap(ConstraintSystem &cs, DeclName propertyName,
+                              Type base, Type wrapper,
                               ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::InsertPropertyWrapperUnwrap, locator),
-        Base(base), Wrapper(wrapper) {}
+        PropertyName(propertyName), Base(base), Wrapper(wrapper) {}
 
 public:
   std::string getName() const override {
     return "insert a $ to unwrap the property wrapper";
   }
 
+  DeclName getPropertyName() const { return PropertyName; }
   Type getBase() const { return Base; }
   Type getWrapper() const { return Wrapper; }
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
   static InsertPropertyWrapperUnwrap *create(ConstraintSystem &cs,
+                                             DeclName propertyName,
                                              Type base, Type wrapper,
                                              ConstraintLocator *locator);
 };

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -103,6 +103,9 @@ enum class FixKind : uint8_t {
   /// Add explicit `()` at the end of function or member to call it.
   InsertCall,
 
+  /// Add one or more property unwrap operators ('$')
+  InsertPropertyWrapperUnwrap,
+
   /// Instead of spelling out `subscript` directly, use subscript operator.
   UseSubscriptOperator,
 
@@ -624,6 +627,30 @@ public:
 
   static InsertExplicitCall *create(ConstraintSystem &cs,
                                     ConstraintLocator *locator);
+};
+
+class InsertPropertyWrapperUnwrap final : public ConstraintFix {
+  Type Base;
+  Type Wrapper;
+
+  InsertPropertyWrapperUnwrap(ConstraintSystem &cs, Type base, Type wrapper,
+                              ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::InsertPropertyWrapperUnwrap, locator),
+        Base(base), Wrapper(wrapper) {}
+
+public:
+  std::string getName() const override {
+    return "insert a $ to unwrap the property wrapper";
+  }
+
+  Type getBase() const { return Base; }
+  Type getWrapper() const { return Wrapper; }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static InsertPropertyWrapperUnwrap *create(ConstraintSystem &cs,
+                                             Type base, Type wrapper,
+                                             ConstraintLocator *locator);
 };
 
 class UseSubscriptOperator final : public ConstraintFix {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4784,21 +4784,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
 
       auto wrappedProperty = getPropertyWrapperInformation(resolvedOverload);
       if (wrappedProperty) {
-        auto wrapperTy = wrappedProperty->second->castTo<UnboundGenericType>();
-
-        llvm::SmallVector<Type, 4> genericArgs;
-        genericArgs.push_back(baseTy);
-        auto newBase = BoundGenericType::get(
-            dyn_cast<NominalTypeDecl>(wrapperTy->getDecl()),
-            Type(), genericArgs);
-
-        auto result = solveWithNewBaseOrName(newBase, member);
+        auto wrapperTy = wrappedProperty->second;
+        auto result = solveWithNewBaseOrName(wrapperTy, member);
         if (result == SolutionKind::Solved) {
           auto *fix = InsertPropertyWrapperUnwrap::create(
-              *this, resolvedOverload->Choice.getDecl()->getFullName(),
-              baseTy, newBase, locator);
-          return recordFix(fix) ? SolutionKind::Error
-                                  : SolutionKind::Solved;
+              *this, resolvedOverload->Choice.getDecl()->getFullName(), baseTy,
+              wrapperTy, locator);
+          return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
         }
       }
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4788,8 +4788,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         auto result = solveWithNewBaseOrName(wrapperTy, member);
         if (result == SolutionKind::Solved) {
           auto *fix = InsertPropertyWrapperUnwrap::create(
-              *this, resolvedOverload->Choice.getDecl()->getFullName(), baseTy,
-              wrapperTy, locator);
+              *this, wrappedProperty->first->getFullName(), baseTy, wrapperTy,
+              locator);
           return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
         }
       }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -25,20 +25,20 @@
 #include "ConstraintLocator.h"
 #include "OverloadChoice.h"
 #include "TypeChecker.h"
-#include "swift/Basic/LLVM.h"
-#include "swift/Basic/OptionSet.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/NameLookup.h"
-#include "swift/AST/Types.h"
-#include "swift/AST/TypeCheckerDebugConsumer.h"
-#include "llvm/ADT/ilist.h"
-#include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/AST/TypeCheckerDebugConsumer.h"
+#include "swift/AST/Types.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/OptionSet.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ilist.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -2263,11 +2263,10 @@ public:
   Optional<std::pair<VarDecl *, Type>>
   getPropertyWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
     if (resolvedOverload && resolvedOverload->Choice.isDecl()) {
-      if (auto *decl =
-              dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
+      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (decl->hasAttachedPropertyWrapper()) {
-          auto rawWrapperTy = decl->getAttachedPropertyWrapperType(0);
-          return std::make_pair(decl, rawWrapperTy);
+          auto wrapperTy = decl->getPropertyWrapperBackingPropertyType();
+          return std::make_pair(decl, wrapperTy);
         }
       }
     }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -888,10 +888,27 @@ struct Foo<T> {
   func foo() {}
 }
 
+@propertyWrapper
+struct Bar<T, V> {
+  var wrappedValue: T
+
+  func bar() {}
+}
+
+extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
+  func barWhereVIsString() {}
+}
+
 struct MissingPropertyWrapperUnwrap {
   @Foo var x: Int
+  @Bar<Int, Bool> var y: Int
+  @Bar<Int, String> var z: Int
 
   func baz() {
     self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '$' to refer to the 'Foo<Int>' property wrapper}}{{10-10=$}}
+    self.y.bar() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, Bool>' property wrapper}}{{10-10=$}}
+    self.y.barWhereVIsString() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, Bool>' property wrapper}}{{10-10=$}}
+    // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
+    self.z.barWhereVIsString() // expected-error {{property 'z' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, String>' property wrapper}}{{10-10=$}} 
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -877,3 +877,21 @@ struct TestComposition {
     $p3 = d // expected-error{{cannot assign value of type 'Double' to type 'WrapperD<WrapperE<Int?>, Int, String>'}}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Missing Property Wrapper Unwrap Diagnostics
+// ---------------------------------------------------------------------------
+@propertyWrapper
+struct Foo<T> {
+  var wrappedValue: T
+
+  func foo() {}
+}
+
+struct MissingPropertyWrapperUnwrap {
+  @Foo var x: Int
+
+  func baz() {
+    self.x.foo() // expected-error {{wrapped value of type 'Int' must be unwraped to value of type 'Foo<Int>'}}{{10-10=$}}
+  }
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -892,6 +892,6 @@ struct MissingPropertyWrapperUnwrap {
   @Foo var x: Int
 
   func baz() {
-    self.x.foo() // expected-error {{wrapped value of type 'Int' must be unwraped to value of type 'Foo<Int>'}}{{10-10=$}}
+    self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '$' to refer to the 'Foo<Int>' property wrapper}}{{10-10=$}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -915,6 +915,6 @@ struct MissingPropertyWrapperUnwrap {
   }
 
   func bar() {
-    foo(self.x) //expected-error {{wrapped value of type 'Int' must be unwraped to value of type 'Foo<Int>'}}{{14-14=$}}
+    foo(self.x) //expected-error {{property 'x' will be unwrapped to value of type 'Int', use '$' to refer to the 'Foo<Int>' property wrapper}}{{14-14=$}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -904,11 +904,17 @@ struct MissingPropertyWrapperUnwrap {
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
 
+  func foo<T>(_: Foo<T>) {}
+
   func baz() {
     self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '$' to refer to the 'Foo<Int>' property wrapper}}{{10-10=$}}
     self.y.bar() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, Bool>' property wrapper}}{{10-10=$}}
     self.y.barWhereVIsString() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, Bool>' property wrapper}}{{10-10=$}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
     self.z.barWhereVIsString() // expected-error {{property 'z' will be unwrapped to value of type 'Int', use '$' to refer to the 'Bar<Int, String>' property wrapper}}{{10-10=$}} 
+  }
+
+  func bar() {
+    foo(self.x) //expected-error {{wrapped value of type 'Int' must be unwraped to value of type 'Foo<Int>'}}{{14-14=$}}
   }
 }


### PR DESCRIPTION
Adds an instance of the missing property wrapper unwrap diagnostic for function arguments. This pull request depends on https://github.com/apple/swift/pull/25507. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to [SR-10928](https://bugs.swift.org/browse/SR-10928).
