### PR TITLE
[5.1 06-12-2019][CodeCompleiton] Don't hide members for unresolved base types

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3680,7 +3680,8 @@ bool swift::isExtensionApplied(const DeclContext *DC, Type BaseTy,
                                const ExtensionDecl *ED) {
   // We can't do anything if the base type has unbound generic parameters.
   // We can't leak type variables into another constraint system.
-  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType())
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType() ||
+      BaseTy->hasUnresolvedType() || BaseTy->hasError())
     return true;
 
   if (!ED->isConstrainedExtension())
@@ -3700,7 +3701,8 @@ bool swift::isMemberDeclApplied(const DeclContext *DC, Type BaseTy,
                                 const ValueDecl *VD) {
   // We can't leak type variables into another constraint system.
   // We can't do anything if the base type has unbound generic parameters.
-  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType())
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType()||
+      BaseTy->hasUnresolvedType() || BaseTy->hasError())
     return true;
 
   const GenericContext *genericDecl = VD->getAsGenericContext();

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -52,6 +52,7 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPENDENT_IN_CLOSURE_1 | %FileCheck %s -check-prefix=DEPENDENT_IN_CLOSURE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPENDENT_IN_CLOSURE_2 | %FileCheck %s -check-prefix=DEPENDENT_IN_CLOSURE_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_WITH_UNRESOLVEDTYPE_1 | %FileCheck %s -check-prefix=INIT_WITH_UNRESOLVEDTYPE_1
 
 func freeFunc() {}
 
@@ -395,4 +396,17 @@ func testDependentTypeInClosure() {
 // DEPENDENT_IN_CLOSURE_2-DAG: Decl[Constructor]/CurrNominal:      init({#(arg): _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#})[#DependentTypeInClosure<_>#]; name=init(arg: _, fn: (_.Content) -> Void)
 // DEPENDENT_IN_CLOSURE_2-DAG: Decl[Constructor]/CurrNominal:      init({#arg: _#}, {#fn: () -> _.Content##() -> _.Content#})[#DependentTypeInClosure<_>#]; name=init(arg: _, fn: () -> _.Content)
 // DEPENDENT_IN_CLOSURE_2: End completions
+}
+struct InitWithUnresolved<Data: DataType> where Data.Content: Comparable {
+  init(arg: Data, fn: (Data.Content) -> Void) {}
+}
+extension InitWithUnresolved where Self.Data: Comparable {
+  init(arg2: Data) {}
+}
+func testInitWithUnresolved() {
+  let _ = InitWithUnresolved(#^INIT_WITH_UNRESOLVEDTYPE_1^#
+// INIT_WITH_UNRESOLVEDTYPE_1: Begin completions, 2 items
+// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg: _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#InitWithUnresolved<_>#];
+// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg2: _#}[')'][#InitWithUnresolved<_>#];
+// INIT_WITH_UNRESOLVEDTYPE_1: End completions
 }


### PR DESCRIPTION
Cherry-pick of #25574 into `swift-5.1-branch-06-12-2019`

* **Explanation**: Previously, if the type has constrained generic parameters, initializer call pattern completion (e.g. `TypeName(#HERE#`) used to not work without explicit generic arguments `TypeName<Int>(#HERE#` because the generic parameters are unresolved. This patch fixes the issue by not hiding members for type with unresolved types.
* **Scope**: Code completion for initializer call pattern.  And qualified member list
* **Issue**: rdar://problem/49480808
* **Risk**: Low
* **Testing**: Added regression tests
* **Reviewer**: Ben Langmuir (@benlangmuir)