### PR TITLE
Don’t lookupOverrides of special names.

### DIFF
--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -504,7 +504,7 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
 void UnqualifiedLookupFactory::lookUpTopLevelNamesInModuleScopeContext(
     DeclContext *DC) {
   // TODO: Does the debugger client care about compound names?
-  if (Name.isSimpleName() && DebugClient &&
+  if (Name.isSimpleName() && !Name.isSpecial() && DebugClient &&
       DebugClient->lookupOverrides(Name.getBaseName(), DC, Loc,
                                    isOriginallyTypeLookup, Results))
     return;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Per [SR-10949](https://bugs.swift.org/browse/SR-10949) , fixes a compiler crash. When the base name is computed for the debug client and the name is special, the getBaseName function fails. So, don't try to compute an override for a special name.

Resolves #53340