### PR TITLE
[Diagnostics] Hooking up remarks emitted from Clang.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE)))
-#  error Must define either DIAG or the set {ERROR,WARNING,NOTE}
+#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE) && defined(REMARK)))
+#  error Must define either DIAG or the set {ERROR,WARNING,NOTE,REMARK}
 #endif
 
 #ifndef ERROR
@@ -36,11 +36,18 @@
   DIAG(NOTE,ID,Options,Text,Signature)
 #endif
 
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature) \
+  DIAG(REMARK,ID,Options,Text,Signature)
+#endif
+
 WARNING(warning_from_clang,none,
   "%0", (StringRef))
 ERROR(error_from_clang,none,
   "%0", (StringRef))
 NOTE(note_from_clang,none,
+  "%0", (StringRef))
+REMARK(remark_from_clang,none,
   "%0", (StringRef))
 
 ERROR(clang_cannot_build_module,Fatal,

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -227,8 +227,8 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
       diagKind = diag::note_from_clang;
       break;
     case clang::DiagnosticsEngine::Remark:
-      // FIXME: We don't handle remarks yet.
-      return;
+      diagKind = diag::remark_from_clang;
+      break;
     case clang::DiagnosticsEngine::Warning:
       diagKind = diag::warning_from_clang;
       break;

--- a/test/ClangImporter/remarks.swift
+++ b/test/ClangImporter/remarks.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -typecheck %s -Xcc -Rmodule-import -I %S/Inputs/custom-modules 2>&1 | %FileCheck %s
+
+import Requires.Swift
+// CHECK-NOT: error
+// CHECK: remark: importing module 'SwiftShims'
+// CHECK-NEXT: remark: importing module 'Requires'


### PR DESCRIPTION
Now that Swift support remarks ClangImporter we pass them
to the Clang diagnostic producer instead of ignoring them.

Fixes [SR-10915](https://bugs.swift.org/browse/SR-10915)