### PR TITLE
[5.1 06-12-2019] Sema: Protocol requirements cannot use opaque return types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3611,6 +3611,10 @@ ERROR(unsupported_opaque_type,none,
 ERROR(opaque_type_unsupported_pattern,none,
       "'some' type can only be declared on a single property declaration", ())
 
+ERROR(opaque_type_in_protocol_requirement,none,
+      "'some' type cannot be the return type of a protocol requirement; did you mean to add an associated type?",
+      ())
+
 // SIL
 ERROR(opened_non_protocol,none,
       "@opened cannot be applied to non-protocol type %0", (Type))

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -176,6 +176,26 @@ static void revertDependentTypeLoc(TypeLoc &tl) {
 Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
                                               ValueDecl *originatingDecl,
                                               OpaqueReturnTypeRepr *repr) {
+  // Protocol requirements can't have opaque return types.
+  //
+  // TODO: Maybe one day we could treat this as sugar for an associated type.
+  if (isa<ProtocolDecl>(originatingDecl->getDeclContext())
+      && originatingDecl->isProtocolRequirement()) {
+    
+    SourceLoc fixitLoc;
+    if (auto vd = dyn_cast<VarDecl>(originatingDecl)) {
+      fixitLoc = vd->getParentPatternBinding()->getStartLoc();
+    } else {
+      fixitLoc = originatingDecl->getStartLoc();
+    }
+    
+    diagnose(repr->getLoc(), diag::opaque_type_in_protocol_requirement)
+      .fixItInsert(fixitLoc, "associatedtype <#AssocType#>\n")
+      .fixItReplace(repr->getSourceRange(), "<#AssocType#>");
+    
+    return ErrorType::get(Context);
+  }
+  
   // If the decl already has an opaque type decl for its return type, use it.
   if (auto existingDecl = originatingDecl->getOpaqueResultTypeDecl()) {
     return existingDecl->getDeclaredInterfaceType();

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -380,7 +380,6 @@ struct OtherGeneric<X, Y, Z> {
   var z: GenericWithOpaqueAssoc<Z>.Assoc
 }
 
-
 protocol P_51641323 {
   associatedtype T
 
@@ -393,4 +392,16 @@ func rdar_51641323() {
     // expected-error@-1 {{return type of property 'foo' requires that '() -> ()' conform to 'P_51641323'}}
     // expected-note@-2 {{opaque return type declared here}}
   }
+}
+
+// Protocol requirements cannot have opaque return types
+protocol OpaqueProtocolRequirement {
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{20-26=<#AssocType#>}}
+  func method() -> some P
+
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{13-19=<#AssocType#>}}
+  var prop: some P { get }
+
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{18-24=<#AssocType#>}}
+  subscript() -> some P { get }
 }


### PR DESCRIPTION
We could invent a meaning for this in the future (such as having it be sugar for an unnamed
associated type), but for now raise an error with a fixit. rdar://problem/50678247

Reviewed by: @jrose-apple 

Risk: Low, introduces a diagnostic for invalid code that formerly caused a compiler crash.

