### PR TITLE
Stop synthesizing accessors inside the parser

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1907,6 +1907,16 @@ bool AbstractStorageDecl::requiresOpaqueModifyCoroutine() const {
   if (!supportsMutation())
     return false;
 
+  auto *dc = getDeclContext();
+
+  // Local properties don't have modify accessors.
+  if (dc->isLocalContext())
+    return false;
+
+  // Fixed-layout global properties don't have modify accessors.
+  if (dc->isModuleScopeContext() && !isResilient())
+    return false;
+
   // Imported storage declarations don't have eagerly-generated modify
   // accessors.
   if (hasClangNode())
@@ -1919,7 +1929,6 @@ bool AbstractStorageDecl::requiresOpaqueModifyCoroutine() const {
     return false;
 
   // Requirements of ObjC protocols don't support the modify coroutine.
-  auto *dc = getDeclContext();
   if (auto protoDecl = dyn_cast<ProtocolDecl>(dc))
     if (protoDecl->isObjC())
       return false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4968,32 +4968,6 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
   if (auto *subscript = dyn_cast<SubscriptDecl>(storage))
     genericParams = subscript->getGenericParams();
 
-  // Create an implicit accessor declaration.
-  auto createImplicitAccessor = [&](AccessorKind kind,
-                                    AccessorDecl *funcForParams = nullptr) {
-    // We never use this to create addressors.
-    assert(kind != AccessorKind::Address &&
-           kind != AccessorKind::MutableAddress);
-
-    // Create the paramter list for a setter.
-    ParameterList *argList = nullptr;
-    if (kind == AccessorKind::Set) {
-      assert(funcForParams);
-      auto argLoc = funcForParams->getStartLoc();
-
-      auto argument = createSetterAccessorArgument(
-          argLoc, Identifier(), AccessorKind::Set, P, elementTy);
-      argList = ParameterList::create(P.Context, argument);
-    }
-
-    auto accessor = createAccessorFunc(SourceLoc(), argList,
-                                       genericParams, indices, elementTy,
-                                       staticLoc, flags, kind,
-                                       storage, &P, SourceLoc());
-    accessor->setImplicit();
-    add(accessor);
-  };
-
   // If there was a problem parsing accessors, mark all parsed accessors
   // as invalid to avoid tripping up later invariants.
   // We also want to avoid diagnose missing accessors if something
@@ -5020,12 +4994,6 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
 
     // Otherwise, we have either a stored or inherited observing property.
     } else {
-      // Observing properties will have getters and setters synthesized
-      // by Sema.  Create their prototypes now.
-      auto argFunc = (WillSet ? WillSet : DidSet);
-      createImplicitAccessor(AccessorKind::Get);
-      createImplicitAccessor(AccessorKind::Set, argFunc);
-
       if (attrs.hasAttribute<OverrideAttr>()) {
         return StorageImplInfo(ReadImplKind::Inherited,
                                WriteImplKind::InheritedWithObservers,
@@ -5066,7 +5034,7 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
                  isa<SubscriptDecl>(storage),
                  getAccessorNameForDiagnostic(mutator, /*article*/ true));
     }
-    createImplicitAccessor(AccessorKind::Get);
+
     readImpl = ReadImplKind::Get;
 
   // Subscripts always have to have some sort of accessor; they can't be
@@ -5076,7 +5044,6 @@ Parser::ParsedAccessors::classify(Parser &P, AbstractStorageDecl *storage,
       P.diagnose(LBLoc, diag::subscript_without_get);
     }
 
-    createImplicitAccessor(AccessorKind::Get);
     readImpl = ReadImplKind::Get;
 
   // Otherwise, it's stored.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -188,11 +188,13 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *d) {}
   void visitOpaqueTypeDecl(OpaqueTypeDecl *d) {}
   void visitAbstractTypeParamDecl(AbstractTypeParamDecl *d) {}
-  void visitSubscriptDecl(SubscriptDecl *d) {}
   void visitConstructorDecl(ConstructorDecl *d) {}
   void visitDestructorDecl(DestructorDecl *d) {}
   void visitModuleDecl(ModuleDecl *d) { }
   void visitMissingMemberDecl(MissingMemberDecl *d) {}
+
+  // Emitted as part of its storage.
+  void visitAccessorDecl(AccessorDecl *ad) {}
 
   void visitFuncDecl(FuncDecl *fd);
   void visitPatternBindingDecl(PatternBindingDecl *vd);
@@ -202,6 +204,7 @@ public:
   void visitNominalTypeDecl(NominalTypeDecl *ntd);
   void visitExtensionDecl(ExtensionDecl *ed);
   void visitVarDecl(VarDecl *vd);
+  void visitSubscriptDecl(SubscriptDecl *sd);
 
   void emitAbstractFuncDecl(AbstractFunctionDecl *AFD);
   

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1192,6 +1192,10 @@ void SILGenFunction::visitPatternBindingDecl(PatternBindingDecl *PBD) {
 
 void SILGenFunction::visitVarDecl(VarDecl *D) {
   // We handle emitting the variable storage when we see the pattern binding.
+
+  // Emit the variable's accessors.
+  for (auto *accessor : D->getAllAccessors())
+    SGM.emitFunction(accessor);
 }
 
 /// Emit literals for the major, minor, and subminor components of the version

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1787,6 +1787,9 @@ public:
     llvm_unreachable("Not yet implemented");
   }
 
+  // Emitted as part of its storage.
+  void visitAccessorDecl(AccessorDecl *D) {}
+
   void visitFuncDecl(FuncDecl *D);
   void visitPatternBindingDecl(PatternBindingDecl *D);
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -72,7 +72,7 @@ static void addMemberToContextIfNeeded(Decl *D, DeclContext *DC,
   } else if (auto *ed = dyn_cast<ExtensionDecl>(DC)) {
     ed->addMember(D, Hint);
   } else {
-    assert((isa<AbstractFunctionDecl>(DC) || isa<FileUnit>(DC)) &&
+    assert((DC->isLocalContext() || isa<FileUnit>(DC)) &&
            "Unknown declcontext");
   }
 }
@@ -2036,8 +2036,8 @@ void swift::maybeAddAccessorsToStorage(AbstractStorageDecl *storage) {
 
   auto *dc = storage->getDeclContext();
 
-  // Local variables don't otherwise get accessors.
-  if (dc->isLocalContext())
+  // Local stored variables don't otherwise get accessors.
+  if (dc->isLocalContext() && storage->getImplInfo().isSimpleStored())
     return;
 
   // Implicit properties don't get accessors.
@@ -2053,7 +2053,7 @@ void swift::maybeAddAccessorsToStorage(AbstractStorageDecl *storage) {
       return;
     }
     // Fixed-layout global variables don't get accessors.
-    if (!storage->isResilient())
+    if (!storage->isResilient() && storage->getImplInfo().isSimpleStored())
       return;
 
   // In a protocol context, variables written as just "var x : Int" or

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2335,6 +2335,16 @@ public:
 
     triggerAccessorSynthesis(TC, VD);
 
+    // FIXME: Temporary hack until capture computation has been request-ified.
+    if (VD->getDeclContext()->isLocalContext()) {
+      VD->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
+        auto accessor = VD->getAccessor(kind);
+        if (!accessor) return;
+
+        TC.definedFunctions.push_back(accessor);
+      });
+    }
+
     // Under the Swift 3 inference rules, if we have @IBInspectable or
     // @GKInspectable but did not infer @objc, warn that the attribute is
     if (!VD->isObjC() && TC.Context.LangOpts.EnableSwift3ObjCInference) {

--- a/test/ParseableInterface/inlinable-function.swift
+++ b/test/ParseableInterface/inlinable-function.swift
@@ -31,7 +31,7 @@ public struct Foo: Hashable {
   // CHECK: public var hasDidSet: Swift.Int {
   public var hasDidSet: Int {
     // CHECK-NEXT: @_transparent get{{$}}
-    // CHECK-NEXT: set[[NEWVALUE]]{{$}}
+    // CHECK-NEXT: set{{(\(value\))?}}{{$}}
     // CHECK-NOT: didSet
     didSet {
       print("b set to \(hasDidSet)")

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -26,6 +26,40 @@ public struct DidSetWillSetTests {
   }
 
   public var a: Int {
+    // This is the synthesized getter and setter for the willset/didset variable.
+
+    // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s9observers010DidSetWillC5TestsV1aSivg
+    // CHECK: bb0(%0 : $DidSetWillSetTests):
+    // CHECK-NEXT:   debug_value %0
+    // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
+
+
+    // CHECK-LABEL: sil [ossa] @$s9observers010DidSetWillC5TestsV1aSivs
+    // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+    // CHECK-NEXT: debug_value %0
+    // CHECK-NEXT: debug_value_addr %1
+
+    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[READ]]
+    // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
+
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
+    // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
+    // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+
     // CHECK-LABEL: sil private [ossa] @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
@@ -91,40 +125,6 @@ public struct DidSetWillSetTests {
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
     }
   }
-
-  // This is the synthesized getter and setter for the willset/didset variable.
-
-  // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s9observers010DidSetWillC5TestsV1aSivg
-  // CHECK: bb0(%0 : $DidSetWillSetTests):
-  // CHECK-NEXT:   debug_value %0
-  // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
-
-
-  // CHECK-LABEL: sil [ossa] @$s9observers010DidSetWillC5TestsV1aSivs
-  // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
-  // CHECK-NEXT: debug_value %0
-  // CHECK-NEXT: debug_value_addr %1
-
-  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
-  // CHECK-NEXT: end_access [[READ]]
-  // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
-
-  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
-  // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
-  // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: end_access [[WRITE]]
-  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
-  // CHECK-NEXT: end_access [[WRITE]]
-  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
-  // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
 
   // CHECK-LABEL: sil hidden [ossa] @$s9observers010DidSetWillC5TestsV8testReadSiyF
   // CHECK:         [[SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
@@ -313,7 +313,7 @@ func propertyWithDidSetTakingOldValue() {
 
 // CHECK-LABEL: sil private [ossa] @$s9observers32propertyWithDidSetTakingOldValueyyF1pL_Sivs
 // CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : @guaranteed ${ var Int }):
-// CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
+// CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "value", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
 // CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] [[ARG2_PB]]


### PR DESCRIPTION
Sema can already synthesize accessors as needed, but a few cases weren't handled, such as the getter and setter for observed properties in local and global context.