### PR TITLE
[5.1 06-12-2019][CodeCompletion] Enable custom attribute completion for func decl

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5381,9 +5381,11 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::AttributeBegin: {
     Lookup.getAttributeDeclCompletions(IsInSil, AttTargetDK);
 
-    // Provide any type name for property delegate.
+    // TypeName at attribute position after '@'.
+    // - VarDecl: Property Wrappers.
+    // - ParamDecl/VarDecl/FuncDecl: Function Buildres.
     if (!AttTargetDK || *AttTargetDK == DeclKind::Var ||
-        *AttTargetDK == DeclKind::Param)
+        *AttTargetDK == DeclKind::Param || *AttTargetDK == DeclKind::Func)
       Lookup.getTypeCompletionsInDeclContext(
           P.Context.SourceMgr.getCodeCompletionLoc());
     break;

--- a/test/IDE/complete_attributes.swift
+++ b/test/IDE/complete_attributes.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER_DECL_ATTR_1 -code-completion-keywords=false | %FileCheck %s -check-prefix=ERROR_COMMON
 
 // ERROR_COMMON: found code completion token
-// ERROR_COMMON-NOT: Begin completions
+// ERROR_COMMON-NOT: Keyword/
 
 @#^TOP_LEVEL_ATTR_1^# class TopLevelDeclAttr1 {}
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -59,7 +59,9 @@ func method(){}
 // KEYWORD2-NEXT:             Keyword/None:                       usableFromInline[#Func Attribute#]; name=usableFromInline
 // KEYWORD2-NEXT:             Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // KEYWORD2-NEXT:             Keyword/None:                       IBSegueAction[#Func Attribute#]; name=IBSegueAction{{$}}
-// KEYWORD2-NEXT:             End completions
+// KEYWORD2-NOT:              Keyword
+// KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// KEYWORD2:                  End completions
 
 @#^KEYWORD3^#
 class C {}
@@ -171,6 +173,8 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       usableFromInline[#Func Attribute#]; name=usableFromInline
 // ON_METHOD-DAG: Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // ON_METHOD-DAG: Keyword/None:                       IBSegueAction[#Func Attribute#]; name=IBSegueAction
+// ON_METHOD-NOT: Keyword
+// ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD: End completions
 
   func bar(@#^ON_PARAM^#)


### PR DESCRIPTION
Cherry-pick #25583 into swift-5.1-branch

* **Explanation**: Since https://github.com/apple/swift/commit/952eb9d8, function builders are implemented for function and accessor decls as well. Code completion support for that by suggesting type names for attributes for func decls.
* **Scope**: Attribute name completion for function declaration
* **Risk**: Very Low. Scope is limited. The change is simple enough.
* **Issue**: rdar://problem/50352482
* **Reviewer**: Ben Langmuir (@benlangmuir)