### PR TITLE
[windows] Use both directory separators in test patterns.

### DIFF
--- a/test/ParseableInterface/swift_build_sdk_interfaces/find-modules.test-sh
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/find-modules.test-sh
@@ -2,11 +2,11 @@ RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -v -n -o %t/output > %
 RUN: %FileCheck %s < %t.txt
 RUN: %FileCheck -check-prefix NEGATIVE %s < %t.txt
 
-CHECK-DAG: System/Library/Frameworks/Simple.framework/Modules/Simple.swiftmodule/xyz.swiftinterface -o {{.+}}output/Simple.swiftmodule/xyz.swiftmodule
-CHECK-DAG: usr/lib/swift/Flat.swiftinterface -o {{.+}}output/Flat.swiftmodule
-CHECK-DAG: usr/lib/swift/Normal.swiftmodule/xyz.swiftinterface -o {{.+}}output/Normal.swiftmodule/xyz.swiftmodule
-CHECK-DAG: System/iOSSupport/System/Library/Frameworks/Simple.framework/Modules/Simple.swiftmodule/xyzzy.swiftinterface -o {{.+}}output/Simple.swiftmodule/xyzzy.swiftmodule
-CHECK-DAG: System/iOSSupport/usr/lib/swift/Caramel.swiftmodule/xyz.swiftinterface -o {{.+}}output/Caramel.swiftmodule/xyz.swiftmodule
+CHECK-DAG: System/Library/Frameworks{{\\|/}}Simple.framework{{\\|/}}Modules{{\\|/}}Simple.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Simple.swiftmodule{{\\|/}}xyz.swiftmodule
+CHECK-DAG: usr/lib/swift{{\\|/}}Flat.swiftinterface -o {{.+}}output{{\\|/}}Flat.swiftmodule
+CHECK-DAG: usr/lib/swift{{\\|/}}Normal.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Normal.swiftmodule{{\\|/}}xyz.swiftmodule
+CHECK-DAG: System/iOSSupport/System/Library/Frameworks{{\\|/}}Simple.framework{{\\|/}}Modules{{\\|/}}Simple.swiftmodule{{\\|/}}xyzzy.swiftinterface -o {{.+}}output{{\\|/}}Simple.swiftmodule{{\\|/}}xyzzy.swiftmodule
+CHECK-DAG: System/iOSSupport/usr/lib/swift{{\\|/}}Caramel.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Caramel.swiftmodule{{\\|/}}xyz.swiftmodule
 
 NEGATIVE-NOT: BAD
 
@@ -23,9 +23,9 @@ RUN: touch %t/sdk/usr/lib/swift/Swift.swiftmodule/def.swiftinterface
 RUN: %swift_build_sdk_interfaces -sdk %t/sdk -v -n -o %t/output | %FileCheck -check-prefix CHECK-WITH-STDLIB %s
 
 CHECK-WITH-STDLIB-NOT: .swiftinterface -o
-CHECK-WITH-STDLIB: Swift.swiftmodule/{{abc|def}}.swiftinterface -o
+CHECK-WITH-STDLIB: Swift.swiftmodule{{\\|/}}{{abc|def}}.swiftinterface -o
 CHECK-WITH-STDLIB-NOT: .swiftinterface -o
-CHECK-WITH-STDLIB: Swift.swiftmodule/{{abc|def}}.swiftinterface -o
+CHECK-WITH-STDLIB: Swift.swiftmodule{{\\|/}}{{abc|def}}.swiftinterface -o
 CHECK-WITH-STDLIB: .swiftinterface -o
 
 # ...unless we pass -skip-stdlib.
@@ -41,14 +41,14 @@ RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -v -n -o %t/output Sys
 RUN: %FileCheck -check-prefix CHECK-CUSTOM-PATHS %s < %t.txt
 RUN: %FileCheck -check-prefix NEGATIVE-CUSTOM-PATHS %s < %t.txt
 
-CHECK-CUSTOM-PATHS-DAG: System/Library/PrivateFrameworks/PrivateSimple.framework/Modules/PrivateSimple.swiftmodule/xyz.swiftinterface -o {{.+}}output/PrivateSimple.swiftmodule/xyz.swiftmodule
-CHECK-CUSTOM-PATHS-DAG: usr/lib/swift/Flat.swiftinterface -o {{.+}}output/Flat.swiftmodule
-CHECK-CUSTOM-PATHS-DAG: usr/lib/swift/Normal.swiftmodule/xyz.swiftinterface -o {{.+}}output/Normal.swiftmodule/xyz.swiftmodule
-CHECK-CUSTOM-PATHS-DAG: System/iOSSupport/usr/lib/swift/Caramel.swiftmodule/xyz.swiftinterface -o {{.+}}output/Caramel.swiftmodule/xyz.swiftmodule
+CHECK-CUSTOM-PATHS-DAG: System/Library/PrivateFrameworks{{\\|/}}PrivateSimple.framework{{\\|/}}Modules{{\\|/}}PrivateSimple.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}PrivateSimple.swiftmodule{{\\|/}}xyz.swiftmodule
+CHECK-CUSTOM-PATHS-DAG: usr/lib/swift{{\\|/}}Flat.swiftinterface -o {{.+}}output{{\\|/}}Flat.swiftmodule
+CHECK-CUSTOM-PATHS-DAG: usr/lib/swift{{\\|/}}Normal.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Normal.swiftmodule{{\\|/}}xyz.swiftmodule
+CHECK-CUSTOM-PATHS-DAG: System/iOSSupport/usr/lib/swift{{\\|/}}Caramel.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Caramel.swiftmodule{{\\|/}}xyz.swiftmodule
 NEGATIVE-CUSTOM-PATHS-NOT: System/Library/Frameworks/
 
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -v -n -o %t/output System/Library/Frameworks System/Library/PrivateFrameworks > %t.txt
 RUN: %FileCheck -check-prefix CHECK-CUSTOM-PATHS -check-prefix CHECK-NORMAL-PATHS %s < %t.txt
 RUN: %FileCheck -check-prefix NEGATIVE %s < %t.txt
 
-CHECK-NORMAL-PATHS-DAG: System/Library/Frameworks/Simple.framework/Modules/Simple.swiftmodule/xyz.swiftinterface -o {{.+}}output/Simple.swiftmodule/xyz.swiftmodule
+CHECK-NORMAL-PATHS-DAG: System/Library/Frameworks{{\\|/}}Simple.framework{{\\|/}}Modules{{\\|/}}Simple.swiftmodule{{\\|/}}xyz.swiftinterface -o {{.+}}output{{\\|/}}Simple.swiftmodule{{\\|/}}xyz.swiftmodule

--- a/test/ParseableInterface/swift_build_sdk_interfaces/ignore-non-stdlib-failures.test-sh
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/ignore-non-stdlib-failures.test-sh
@@ -1,17 +1,17 @@
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output | %FileCheck %s
 
-CHECK-DAG: # (FAIL) {{.+}}/Bad.swiftinterface
-CHECK-DAG: # (PASS) {{.+}}/Good.swiftinterface
+CHECK-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-DAG: # (PASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -ignore-non-stdlib-failures | %FileCheck -check-prefix=CHECK-IGNORING-FAILURES %s
 
-CHECK-IGNORING-FAILURES-DAG: # (XFAIL) {{.+}}/Bad.swiftinterface
-CHECK-IGNORING-FAILURES-DAG: # (UPASS) {{.+}}/Good.swiftinterface
+CHECK-IGNORING-FAILURES-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-IGNORING-FAILURES-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -ignore-non-stdlib-failures | %FileCheck -check-prefix CHECK-BROKEN-STDLIB %s
 
-CHECK-BROKEN-STDLIB: # (FAIL) {{.+}}/Swift.swiftinterface
+CHECK-BROKEN-STDLIB: # (FAIL) {{.+}}{{\\|/}}Swift.swiftinterface
 CHECK-BROKEN-STDLIB-NOT: {{^}}#
 
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/broken-stdlib-sdk/ -v -o %t/output -skip-stdlib | %FileCheck %s

--- a/test/ParseableInterface/swift_build_sdk_interfaces/iosmac.test-sh
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/iosmac.test-sh
@@ -2,13 +2,13 @@ RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/iosmac-sdk/MacOSX.sdk/ -Fsystem-
 RUN: %FileCheck %s < %t.txt
 RUN: %FileCheck -check-prefix NEGATIVE %s < %t.txt
 
-CHECK-DAG: MacOSX.sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/x86_64.swiftinterface -o {{.+}}/output/FMWK.swiftmodule/x86_64-apple-macos.swiftmodule
-CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System/iOSSupport/System/Library/Frameworks {{.+}}MacOSX.sdk/System/iOSSupport/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/x86_64.swiftinterface -o {{.+}}/output/FMWK.swiftmodule/x86_64-apple-ios-macabi.swiftmodule
-CHECK-DAG: MacOSX.sdk/usr/lib/swift/Foo.swiftmodule/x86_64.swiftinterface -o {{.+}}output/Foo.swiftmodule/x86_64-apple-macos.swiftmodule
-CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System/iOSSupport/System/Library/Frameworks {{.+}}MacOSX.sdk/System/iOSSupport/usr/lib/swift/Foo.swiftmodule/x86_64.swiftinterface -o {{.+}}output/Foo.swiftmodule/x86_64-apple-ios-macabi.swiftmodule
-CHECK-DAG: MacOSX.sdk/System/Library/Frameworks/Zippered.framework/Modules/Zippered.swiftmodule/x86_64.swiftinterface -o {{.+}}/output/Zippered.swiftmodule/x86_64-apple-macos.swiftmodule
-CHECK-DAG: MacOSX.sdk/System/Library/Frameworks/Zippered.framework/Modules/Zippered.swiftmodule/x86_64-apple-macos.swiftinterface -o {{.+}}/output/Zippered.swiftmodule/x86_64-apple-macos.swiftmodule
-CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System/iOSSupport/System/Library/Frameworks {{.+}}MacOSX.sdk/System/Library/Frameworks/Zippered.framework/Modules/Zippered.swiftmodule/x86_64-apple-ios-macabi.swiftinterface -o {{.+}}/output/Zippered.swiftmodule/x86_64-apple-ios-macabi.swiftmodule
+CHECK-DAG: MacOSX.sdk/System/Library/Frameworks{{\\|/}}FMWK.framework{{\\|/}}Modules{{\\|/}}FMWK.swiftmodule{{\\|/}}x86_64.swiftinterface -o {{.+}}/output{{\\|/}}FMWK.swiftmodule{{\\|/}}x86_64-apple-macos.swiftmodule
+CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System{{\\|/}}iOSSupport{{\\|/}}System{{\\|/}}Library{{\\|/}}Frameworks {{.+}}MacOSX.sdk/System/iOSSupport/System/Library/Frameworks{{\\|/}}FMWK.framework{{\\|/}}Modules{{\\|/}}FMWK.swiftmodule{{\\|/}}x86_64.swiftinterface -o {{.+}}/output{{\\|/}}FMWK.swiftmodule{{\\|/}}x86_64-apple-ios-macabi.swiftmodule
+CHECK-DAG: MacOSX.sdk/usr/lib/swift{{\\|/}}Foo.swiftmodule{{\\|/}}x86_64.swiftinterface -o {{.+}}output{{\\|/}}Foo.swiftmodule{{\\|/}}x86_64-apple-macos.swiftmodule
+CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System{{\\|/}}iOSSupport{{\\|/}}System{{\\|/}}Library{{\\|/}}Frameworks {{.+}}MacOSX.sdk/System/iOSSupport/usr/lib/swift{{\\|/}}Foo.swiftmodule{{\\|/}}x86_64.swiftinterface -o {{.+}}output{{\\|/}}Foo.swiftmodule{{\\|/}}x86_64-apple-ios-macabi.swiftmodule
+CHECK-DAG: MacOSX.sdk/System/Library/Frameworks{{\\|/}}Zippered.framework{{\\|/}}Modules{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64.swiftinterface -o {{.+}}/output{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64-apple-macos.swiftmodule
+CHECK-DAG: MacOSX.sdk/System/Library/Frameworks{{\\|/}}Zippered.framework{{\\|/}}Modules{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64-apple-macos.swiftinterface -o {{.+}}/output{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64-apple-macos.swiftmodule
+CHECK-DAG: -Fsystem SECRET_SEARCH_PATH -Fsystem {{.+}}MacOSX.sdk/System{{\\|/}}iOSSupport{{\\|/}}System{{\\|/}}Library{{\\|/}}Frameworks {{.+}}MacOSX.sdk/System/Library/Frameworks{{\\|/}}Zippered.framework{{\\|/}}Modules{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64-apple-ios-macabi.swiftinterface -o {{.+}}/output{{\\|/}}Zippered.swiftmodule{{\\|/}}x86_64-apple-ios-macabi.swiftmodule
 
 NEGATIVE-NOT: iOSSupport{{.+}}{{macos|x86_64}}.swiftmodule
 NEGATIVE-NOT: SECRET_SEARCH_PATH{{.+}}{{macos|x86_64}}.swiftmodule

--- a/test/ParseableInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
@@ -2,7 +2,7 @@ RUN: %empty-directory(%t)
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs | %FileCheck %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
-CHECK: # (FAIL) {{.+}}/Bad.swiftinterface
+CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 
 PRINTS-ERROR: unresolved identifier 'garbage'
 
@@ -11,26 +11,26 @@ RUN: echo '["Good"]' > %t/xfails-good.json
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs -xfails %t/xfails-good.json | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
-CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-GOOD-DAG: # (UPASS) {{.+}}/Good.swiftinterface
+CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-GOOD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good", "Bad"]' > %t/xfails-good-and-bad.json
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs -xfails %t/xfails-good-and-bad.json| %FileCheck -check-prefix=CHECK-XFAIL-GOOD-AND-BAD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
-CHECK-XFAIL-GOOD-AND-BAD-DAG: # (XFAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-GOOD-AND-BAD-DAG: # (UPASS) {{.+}}/Good.swiftinterface
+CHECK-XFAIL-GOOD-AND-BAD-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-GOOD-AND-BAD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: %empty-directory(%t)
 RUN: echo '["Bad"]' > %t/xfails-bad.json
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs -xfails %t/xfails-bad.json | %FileCheck -check-prefix=CHECK-XFAIL-BAD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt
 
-CHECK-XFAIL-BAD: # (XFAIL) {{.+}}/Bad.swiftinterface
+CHECK-XFAIL-BAD: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
 
 RUN: %empty-directory(%t)
 RUN: not %swift_build_sdk_interfaces -sdk %t -o %t/output -log-path %t/logs %S/Inputs/xfail-logs-framework/ | %FileCheck -check-prefix=CHECK-FRAMEWORK %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/BadFMWK-x86_64-apple-macos-err.txt
 
-CHECK-FRAMEWORK: # (FAIL) {{.+}}/BadFMWK.swiftmodule/x86_64-apple-macos.swiftinterface
+CHECK-FRAMEWORK: # (FAIL) {{.+}}{{\\|/}}BadFMWK.swiftmodule{{\\|/}}x86_64-apple-macos.swiftinterface

--- a/test/ParseableInterface/swift_build_sdk_interfaces/xfails.test-sh
+++ b/test/ParseableInterface/swift_build_sdk_interfaces/xfails.test-sh
@@ -4,9 +4,9 @@ RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output 2> %t/stderr.txt | %FileCheck -check-prefix CHECK-VERBOSE %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
-CHECK: # (FAIL) {{.+}}/Bad.swiftinterface
-CHECK-VERBOSE-DAG: # (FAIL) {{.+}}/Bad.swiftinterface
-CHECK-VERBOSE-DAG: # (PASS) {{.+}}/Good.swiftinterface
+CHECK: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-VERBOSE-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-VERBOSE-DAG: # (PASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 PRINTS-ERROR: unresolved identifier 'garbage'
 HIDES-ERROR-NOT: unresolved identifier 'garbage'
@@ -18,8 +18,8 @@ RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
-CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-GOOD-DAG: # (UPASS) {{.+}}/Good.swiftinterface
+CHECK-XFAIL-GOOD-DAG: # (FAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-GOOD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: %empty-directory(%t)
 RUN: echo '["Good", "Bad"]' > %t/xfails-good-and-bad.json
@@ -28,8 +28,8 @@ RUN: %FileCheck -check-prefix HIDES-ERROR -allow-empty %s < %t/stderr.txt
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-good-and-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-GOOD-AND-BAD %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
-CHECK-XFAIL-GOOD-AND-BAD-DAG: # (XFAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-GOOD-AND-BAD-DAG: # (UPASS) {{.+}}/Good.swiftinterface
+CHECK-XFAIL-GOOD-AND-BAD-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-GOOD-AND-BAD-DAG: # (UPASS) {{.+}}{{\\|/}}Good.swiftinterface
 
 RUN: %empty-directory(%t)
 RUN: echo '["Bad"]' > %t/xfails-bad.json
@@ -38,6 +38,6 @@ RUN: %FileCheck -check-prefix HIDES-ERROR -allow-empty %s < %t/stderr.txt
 RUN: %swift_build_sdk_interfaces -sdk %S/Inputs/xfails-sdk/ -v -o %t/output -xfails %t/xfails-bad.json 2> %t/stderr.txt | %FileCheck -check-prefix=CHECK-XFAIL-BAD-VERBOSE %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/stderr.txt
 
-CHECK-XFAIL-BAD: # (XFAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-BAD-VERBOSE-DAG: # (XFAIL) {{.+}}/Bad.swiftinterface
-CHECK-XFAIL-BAD-VERBOSE-DAG: # (PASS) {{.+}}/Good.swiftinterface
+CHECK-XFAIL-BAD: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-BAD-VERBOSE-DAG: # (XFAIL) {{.+}}{{\\|/}}Bad.swiftinterface
+CHECK-XFAIL-BAD-VERBOSE-DAG: # (PASS) {{.+}}{{\\|/}}Good.swiftinterface

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -68,27 +68,6 @@ constants.""")
 
     stdin = sys.stdin.read()
 
-    if args.enable_windows_compatibility:
-        # Let's look for paths in the output, and try to transform them to use
-        # Unix directory separators to be automatically picked up by the tests.
-        # This only picks up absolute paths, but those should be the more
-        # common in the tools output and the easier to detect without false
-        # positives.
-
-        def replace_slashes(matchobj):
-            return re.sub(r'\\\\|\\', r'/', matchobj.group(0))
-
-        # The regex is composed of three parts:
-        #              Matches a drive letter followed by a slash (backward
-        #              escaped, simple backward, or forward)
-        stdin = re.sub(r'\b[a-zA-Z]:(?:\\\\|\\|\/)' +
-                       # Matches the path part, it always ends up in a slash.
-                       r'(?:[-a-zA-Z0-9_.]+(?:\\\\|\\|\/))*' +
-                       # Matches the last path component, which do not has a
-                       # trailing slash, but it is optional.
-                       r'(?:[-a-zA-Z0-9_.]+)?\b',
-                       replace_slashes, stdin)
-
     for s in args.sanitize_strings:
         replacement, pattern = s.split('=', 1)
         # We are replacing the Unix path separators in the paths passed as


### PR DESCRIPTION
Admit defeat and realize that one simply cannot win against Windows. Use
the pattern with both separators in the tests and remove the hack in
PathSanitizingFileCheck because it created false positives, some of them
could not have been easily fixed.

Sadly lit substitutions or other tricks in lit.cfg will not work,
because CHECK lines are not processed by lit, but by FileCheck.
