### PR TITLE
[5.1 06-12-2019] Serialization: Deserialize opaque type xrefs from the right extension module.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2833,6 +2833,11 @@ public:
   
   ValueDecl *getNamingDecl() const { return NamingDecl; }
   
+  void setNamingDecl(ValueDecl *D) {
+    assert(!NamingDecl && "already have naming decl");
+    NamingDecl = D;
+  }
+  
   GenericSignature *getOpaqueInterfaceGenericSignature() const {
     return OpaqueInterfaceGenericSignature;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1724,9 +1724,10 @@ giveUpFastPath:
       
       auto name = getIdentifier(DefiningDeclNameID);
       pathTrace.addOpaqueReturnType(name);
-      
-      if (auto opaqueTy = baseModule->lookupOpaqueResultType(name.str(),
-                                                             nullptr)) {
+    
+      auto lookupModule = M ? M : baseModule;
+      if (auto opaqueTy = lookupModule->lookupOpaqueResultType(name.str(),
+                                                               nullptr)) {
         values.push_back(opaqueTy);
       }
       break;
@@ -3168,7 +3169,6 @@ public:
                                               interfaceTypeID, genericEnvID,
                                               underlyingTypeID);
     
-    auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));
     auto declContext = MF.getDeclContext(contextID);
     auto sig = MF.getGenericSignature(interfaceSigID);
     auto interfaceType = MF.getType(interfaceTypeID)
@@ -3180,9 +3180,12 @@ public:
       
     // Create the decl.
     auto opaqueDecl =
-      new (ctx) OpaqueTypeDecl(namingDecl, nullptr, declContext,
+      new (ctx) OpaqueTypeDecl(nullptr, nullptr, declContext,
                                sig, interfaceType);
     declOrOffset = opaqueDecl;
+
+    auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));
+    opaqueDecl->setNamingDecl(namingDecl);
 
     if (auto genericParams = MF.maybeReadGenericParams(opaqueDecl))
       opaqueDecl->setGenericParams(genericParams);

--- a/test/SIL/Serialization/Inputs/OpaqueReturnTypeExporter.swift
+++ b/test/SIL/Serialization/Inputs/OpaqueReturnTypeExporter.swift
@@ -2,3 +2,9 @@ public protocol Butt {}
 extension Int: Butt {}
 
 public func exportsOpaqueReturn() -> some Butt { return 0 }
+
+extension Int {
+  public func someButt() -> some Butt {
+    return self
+  }
+}

--- a/test/SIL/Serialization/opaque_return_type_serialize.sil
+++ b/test/SIL/Serialization/opaque_return_type_serialize.sil
@@ -3,18 +3,27 @@
 // RUN: %target-sil-opt -I %t %s -emit-sib -module-name test -o %t/test.sib
 // RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir %t/test.sib
 
+import Swift
 import OpaqueReturnTypeExporter
 
 typealias SomeButt = @_opaqueReturnTypeOf("$s24OpaqueReturnTypeExporter07exportsaB0QryF", 0) opaque
+typealias SomeButt2 = @_opaqueReturnTypeOf("$sSi24OpaqueReturnTypeExporterE8someButtQryF", 0) opaque
 
 sil @$s24OpaqueReturnTypeExporter07exportsaB0QryF : $@convention(thin) () -> @out SomeButt
+sil @$sSi24OpaqueReturnTypeExporterE8someButtQryF : $@convention(thin) (Int) -> @out SomeButt2
 
-sil @use_opaque_type : $@convention(thin) () -> () {
-entry:
+sil @use_opaque_type : $@convention(thin) (Int) -> () {
+entry(%a : $Int):
   %f = function_ref @$s24OpaqueReturnTypeExporter07exportsaB0QryF : $@convention(thin) () -> @out SomeButt
   %x = alloc_stack $SomeButt
   apply %f(%x) : $@convention(thin) () -> @out SomeButt
   destroy_addr %x : $*SomeButt
   dealloc_stack %x : $*SomeButt
+
+  %g = function_ref @$sSi24OpaqueReturnTypeExporterE8someButtQryF : $@convention(thin) (Int) -> @out SomeButt2
+  %y = alloc_stack $SomeButt2
+  apply %g(%y, %a) : $@convention(thin) (Int) -> @out SomeButt2
+  destroy_addr %y : $*SomeButt2
+  dealloc_stack %y : $*SomeButt2
   return undef : $()
 }


### PR DESCRIPTION
When deserializing an opaque type xref inside an extension context, we were looking
incorrectly in the base module of the type being extended, rather than in the module
of the extension, where the opaque type would really be. Fixes rdar://problem/51775500.

This includes a small refactoring of OpaqueTypeDecl deserialization to break the inevitable
cycle between deserializing the namingDecl, and the namingDecl turning around and re-
deserializing its opaque return type. This is NFC but avoids some unnecessary work.

Reviewed by: @jrose-apple 
Risk: Low, small bug fix