### PR TITLE
[Diagnostics] Undefining REMARK macro.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -102,4 +102,5 @@ WARNING(clang_vfs_overlay_is_ignored,none,
 # undef NOTE
 # undef WARNING
 # undef ERROR
+# undef REMARK
 #endif


### PR DESCRIPTION
Follow up on fix for SR-10915 where I forgot to undefine the REMARK
macro.

ref: https://github.com/apple/swift/pull/25585