### PR TITLE
test: fix `ClangImporter.remarks` for Windows

### DIFF
--- a/test/ClangImporter/remarks.swift
+++ b/test/ClangImporter/remarks.swift
@@ -3,4 +3,4 @@
 import Requires.Swift
 // CHECK-NOT: error
 // CHECK: remark: importing module 'SwiftShims'
-// CHECK-NEXT: remark: importing module 'Requires'
+// CHECK: remark: importing module 'Requires'


### PR DESCRIPTION
`SwiftShims` pulls in `visualc` on Windows.  Adjust the test to be a bit
looser about the lines emitted.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
