### PR TITLE
[5.1][Test] Fix the dlopen_race test to work with remote-run.

### DIFF
--- a/test/stdlib/dlopen_race.swift
+++ b/test/stdlib/dlopen_race.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library -o %t/dlopen_race.dylib %S/Inputs/dlopen_race_dylib.swift
 // RUN: %target-build-swift -o %t/dlopen_race %s
-// RUN: %target-run %t/dlopen_race
+// RUN: %target-run %t/dlopen_race %t/dlopen_race.dylib
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
@@ -45,7 +45,7 @@ DlopenRaceTests.test("race") {
     add_image_count += 1
   })
   
-  let dylibPath = CommandLine.arguments[0] + ".dylib"
+  let dylibPath = CommandLine.arguments.last!
   
   let beforeCount = add_image_count
   let handle = dlopen(dylibPath, RTLD_LAZY)


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/25608 to 5.1.

The dylib needs to be passed as a command line parameter so that remote-run knows to copy it across.

rdar://problem/51903298