### PR TITLE
[Sema] Compute superclass of deserialized protocols via generic signature

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 493; // backing variables
+const uint16_t SWIFTMODULE_VERSION_MINOR = 495; // remove superclass from ProtocolLayout
 
 using DeclIDField = BCFixed<31>;
 
@@ -997,7 +997,6 @@ namespace decls_block {
     BCFixed<1>,             // objc?
     BCFixed<1>,             // existential-type-supported?
     GenericEnvironmentIDField, // generic environment
-    TypeIDField,            // superclass
     AccessLevelField,       // access level
     BCArray<DeclIDField>    // inherited types
     // Trailed by the generic parameters (if any), the members record, and

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -2039,6 +2040,25 @@ SuperclassDeclRequest::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *subject) const {
   auto &Ctx = subject->getASTContext();
 
+  // Protocols may get their superclass bound from a `where Self : Superclass`
+  // clause.
+  if (auto *proto = dyn_cast<ProtocolDecl>(subject)) {
+    // If the protocol came from a serialized module, compute the superclass via
+    // its generic signature.
+    if (proto->wasDeserialized()) {
+      auto superTy = proto->getGenericSignature()
+          ->getSuperclassBound(proto->getSelfInterfaceType());
+      if (superTy)
+        return superTy->getClassOrBoundGenericClass();
+    }
+
+    // Otherwise check the where clause.
+    auto selfBounds = getSelfBoundsFromWhereClause(proto);
+    for (auto inheritedNominal : selfBounds.decls)
+      if (auto classDecl = dyn_cast<ClassDecl>(inheritedNominal))
+        return classDecl;
+  }
+
   for (unsigned i : indices(subject->getInherited())) {
     // Find the inherited declarations referenced at this position.
     auto inheritedTypes = evaluateOrDefault(evaluator,
@@ -2058,15 +2078,6 @@ SuperclassDeclRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  // Protocols also support '... where Self : Superclass'.
-  auto *proto = dyn_cast<ProtocolDecl>(subject);
-  if (proto == nullptr)
-    return nullptr;
-
-  auto selfBounds = getSelfBoundsFromWhereClause(proto);
-  for (auto inheritedNominal : selfBounds.decls)
-    if (auto classDecl = dyn_cast<ClassDecl>(inheritedNominal))
-      return classDecl;
 
   return nullptr;
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3288,15 +3288,13 @@ public:
     DeclContextID contextID;
     bool isImplicit, isClassBounded, isObjC, existentialTypeSupported;
     GenericEnvironmentID genericEnvID;
-    TypeID superclassID;
     uint8_t rawAccessLevel;
     ArrayRef<uint64_t> rawInheritedIDs;
 
     decls_block::ProtocolLayout::readRecord(scratch, nameID, contextID,
                                             isImplicit, isClassBounded, isObjC,
                                             existentialTypeSupported,
-                                            genericEnvID, superclassID,
-                                            rawAccessLevel, rawInheritedIDs);
+                                            genericEnvID, rawAccessLevel, rawInheritedIDs);
 
     auto DC = MF.getDeclContext(contextID);
     if (declOrOffset.isComplete())
@@ -3307,7 +3305,6 @@ public:
                                              /*TrailingWhere=*/nullptr);
     declOrOffset = proto;
 
-    proto->setSuperclass(MF.getType(superclassID));
     proto->setRequiresClass(isClassBounded);
     proto->setExistentialTypeSupported(existentialTypeSupported);
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3334,7 +3334,6 @@ void Serializer::writeDecl(const Decl *D) {
                                  /*resolver=*/nullptr),
                                addGenericEnvironmentRef(
                                                 proto->getGenericEnvironment()),
-                               addTypeRef(proto->getSuperclass()),
                                rawAccessLevel,
                                inherited);
 

--- a/test/Serialization/Inputs/class-bound-protocol.swift
+++ b/test/Serialization/Inputs/class-bound-protocol.swift
@@ -1,0 +1,15 @@
+public protocol P: C {}
+
+public class C: P {
+  public init() {}
+  public func funcInClass() {}
+}
+
+public protocol GenericP: GenericC<Int> {}
+
+public class GenericC<T> {
+  public init() {}
+  public func funcInClass() {}
+}
+
+extension GenericC: GenericP where T == Int {}

--- a/test/Serialization/use-class-bound-protocol.swift
+++ b/test/Serialization/use-class-bound-protocol.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module-path %t/ClassBoundProtocol.swiftmodule %S/Inputs/class-bound-protocol.swift -module-name ClassBoundProtocol
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+import ClassBoundProtocol
+
+func f() {
+  let p: P = C()
+  p.funcInClass()
+
+  let genericP: GenericP = GenericC<Int>()
+  genericP.funcInClass()
+}


### PR DESCRIPTION
We don't need to serialize the protocol's superclass, we can compute it from the
generic signature. Previously, we would drop the superclass while
serializing because we didn't check the generic signature in
SuperclassTypeRequest, which would cause us to cache `NULL` when we
called `setSuperclass` for a protocol with a superclass constraint.

Fixes rdar://50526401

(Cherry-picked from #25551, reviewed by @slavapestov)