### PR TITLE
[reflection-dump] Teach reflection dump how to dump protocols from the __swift5_protos section of a .o

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -124,9 +124,9 @@ struct External {
 
   template <typename T, bool Nullable = false>
   using RelativeIndirectablePointer = int32_t;
-  
+
   template <typename T, bool Nullable = true>
-  using RelativeDirectPointer = int32_t;
+  using RelativeDirectPointer = RelativeDirectPointer<T, Nullable>;
 };
 
 /// Template for branching on native pointer types versus external ones

--- a/include/swift/Reflection/MetadataSourceBuilder.h
+++ b/include/swift/Reflection/MetadataSourceBuilder.h
@@ -18,6 +18,8 @@
 #define SWIFT_REFLECTION_METADATASOURCEBUILDER_H
 
 #include "swift/Reflection/MetadataSource.h"
+#include <memory>
+#include <vector>
 
 namespace swift {
 namespace reflection {

--- a/include/swift/Reflection/ProtocolConformance.h
+++ b/include/swift/Reflection/ProtocolConformance.h
@@ -1,0 +1,76 @@
+//===--- ProtocolConformance.h --------------------------------*- C++ -*---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REFLECTION_PROTOCOLCONFORMANCE_H
+#define SWIFT_REFLECTION_PROTOCOLCONFORMANCE_H
+
+#if !defined(__APPLE__) || !defined(__MACH__)
+// TODO: Implement this.
+#error "Only supported on Darwin now. Do not include this otherwise!"
+#endif
+
+#include "swift/ABI/Metadata.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Reflection/ReflectionInfo.h"
+
+namespace swift {
+namespace reflection {
+
+template <typename Runtime>
+class ProtocolDescriptorIterator
+    : public std::iterator<std::forward_iterator_tag,
+                           TargetProtocolDescriptor<Runtime>> {
+  // The protocol descriptor section is filled with relative direct
+  // pointers to protocol descriptors.
+  using PointerType = RelativeDirectPointer<TargetProtocolDescriptor<Runtime>>;
+
+public:
+  using ProtocolDescriptor = TargetProtocolDescriptor<Runtime>;
+
+  const void *Cur;
+  const void *const End;
+
+  ProtocolDescriptorIterator(const ReflectionInfo &reflectionInfo)
+      : Cur(reflectionInfo.Protocol.Metadata.getStartAddress()),
+        End(reflectionInfo.Protocol.Metadata.getEndAddress()) {}
+
+  const ProtocolDescriptor &operator*() const { return *curAsPointer(); }
+
+  const ProtocolDescriptor *operator->() const { return curAsPointer(); }
+
+  bool hasNext() const { return Cur < End; }
+
+  ProtocolDescriptorIterator &operator++() {
+    assert(hasNext());
+    const void *Next =
+        reinterpret_cast<const char *>(Cur) + sizeof(PointerType);
+    Cur = Next;
+    return *this;
+  }
+
+  bool operator==(ProtocolDescriptorIterator const &other) const {
+    return Cur == other.Cur && End == other.End;
+  }
+
+  bool operator!=(ProtocolDescriptorIterator const &other) const {
+    return !(*this == other);
+  }
+
+  const ProtocolDescriptor *curAsPointer() const {
+    return static_cast<const PointerType *>(Cur)->get();
+  }
+};
+
+} // namespace reflection
+} // namespace swift
+
+#endif

--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -17,9 +17,11 @@
 #ifndef SWIFT_REFLECTION_RECORDS_H
 #define SWIFT_REFLECTION_RECORDS_H
 
+#include "swift/Basic/LLVM.h"
 #include "swift/Basic/RelativePointer.h"
 #include "swift/Demangling/Demangle.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -224,27 +224,26 @@ public:
     auto CaptureSec = findMachOSectionByName("__swift5_capture");
     auto TypeRefMdSec = findMachOSectionByName("__swift5_typeref");
     auto ReflStrMdSec = findMachOSectionByName("__swift5_reflstr");
+    auto ProtocolSec = findMachOSectionByName("__swift5_protos");
 
-    if (FieldMdSec.first == nullptr &&
-        AssocTySec.first == nullptr &&
-        BuiltinTySec.first == nullptr &&
-        CaptureSec.first == nullptr &&
-        TypeRefMdSec.first == nullptr &&
-        ReflStrMdSec.first == nullptr)
+    if (FieldMdSec.first == nullptr && AssocTySec.first == nullptr &&
+        BuiltinTySec.first == nullptr && CaptureSec.first == nullptr &&
+        TypeRefMdSec.first == nullptr && ReflStrMdSec.first == nullptr &&
+        ProtocolSec.first == nullptr)
       return false;
 
     auto LocalStartAddress = reinterpret_cast<uint64_t>(SectBuf.get());
     auto RemoteStartAddress = static_cast<uint64_t>(RangeStart);
 
-    ReflectionInfo info = {
-        {{FieldMdSec.first, FieldMdSec.second}, 0},
-        {{AssocTySec.first, AssocTySec.second}, 0},
-        {{BuiltinTySec.first, BuiltinTySec.second}, 0},
-        {{CaptureSec.first, CaptureSec.second}, 0},
-        {{TypeRefMdSec.first, TypeRefMdSec.second}, 0},
-        {{ReflStrMdSec.first, ReflStrMdSec.second}, 0},
-        LocalStartAddress,
-        RemoteStartAddress};
+    ReflectionInfo info = {{{FieldMdSec.first, FieldMdSec.second}, 0},
+                           {{AssocTySec.first, AssocTySec.second}, 0},
+                           {{BuiltinTySec.first, BuiltinTySec.second}, 0},
+                           {{CaptureSec.first, CaptureSec.second}, 0},
+                           {{TypeRefMdSec.first, TypeRefMdSec.second}, 0},
+                           {{ReflStrMdSec.first, ReflStrMdSec.second}, 0},
+                           {{ProtocolSec.first, ProtocolSec.second}, 0},
+                           LocalStartAddress,
+                           RemoteStartAddress};
 
     this->addReflectionInfo(info);
 

--- a/include/swift/Reflection/ReflectionInfo.h
+++ b/include/swift/Reflection/ReflectionInfo.h
@@ -1,0 +1,138 @@
+//===--- ReflectionInfo.h --------------------------------*- C++ -*--------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REFLECTION_REFLECTIONINFO_H
+#define SWIFT_REFLECTION_REFLECTIONINFO_H
+
+#include "swift/Reflection/MetadataSource.h"
+#include "swift/Reflection/Records.h"
+#include "swift/Reflection/TypeRef.h"
+#include "swift/Remote/MetadataReader.h"
+
+namespace swift {
+namespace reflection {
+
+template <typename IteratorTy> class ReflectionSection {
+  using const_iterator = IteratorTy;
+  uintptr_t startAddress;
+  uintptr_t endAddress;
+
+public:
+  ReflectionSection(const void *startAddress, const void *endAddress)
+      : startAddress(uintptr_t(startAddress)),
+        endAddress(uintptr_t(endAddress)) {}
+
+  ReflectionSection(uintptr_t startAddress, uintptr_t endAddress)
+      : startAddress(startAddress), endAddress(endAddress) {}
+
+  void *getStartAddress() { return reinterpret_cast<void *>(startAddress); }
+
+  const void *getStartAddress() const {
+    return reinterpret_cast<const void *>(startAddress);
+  }
+
+  const void *getEndAddress() const {
+    return reinterpret_cast<const void *>(endAddress);
+  }
+
+  const_iterator begin() const {
+    return const_iterator(getStartAddress(), getEndAddress());
+  }
+
+  const_iterator end() const {
+    return const_iterator(getEndAddress(), getEndAddress());
+  }
+
+  size_t size() const { return endAddress - startAddress; }
+};
+
+/// A section of packed void * pointers.
+using GenericSection = ReflectionSection<const void *>;
+
+template <typename Runtime> class ReflectionContext;
+
+using FieldSection = ReflectionSection<FieldDescriptorIterator>;
+using AssociatedTypeSection = ReflectionSection<AssociatedTypeIterator>;
+using BuiltinTypeSection = ReflectionSection<BuiltinTypeDescriptorIterator>;
+using CaptureSection = ReflectionSection<CaptureDescriptorIterator>;
+
+struct ReflectionInfo {
+  struct {
+    FieldSection Metadata;
+    uint64_t SectionOffset;
+  } Field;
+
+  struct {
+    AssociatedTypeSection Metadata;
+    uint64_t SectionOffset;
+  } AssociatedType;
+
+  struct {
+    BuiltinTypeSection Metadata;
+    uint64_t SectionOffset;
+  } Builtin;
+
+  struct {
+    CaptureSection Metadata;
+    uint64_t SectionOffset;
+  } Capture;
+
+  struct {
+    GenericSection Metadata;
+    uint64_t SectionOffset;
+  } TypeReference;
+
+  struct {
+    GenericSection Metadata;
+    uint64_t SectionOffset;
+  } ReflectionString;
+
+  uint64_t LocalStartAddress;
+  uint64_t RemoteStartAddress;
+};
+
+struct ClosureContextInfo {
+  std::vector<const TypeRef *> CaptureTypes;
+  std::vector<std::pair<const TypeRef *, const MetadataSource *>>
+      MetadataSources;
+  unsigned NumBindings = 0;
+
+  void dump() const;
+  void dump(std::ostream &OS) const;
+};
+
+struct FieldTypeInfo {
+  std::string Name;
+  const TypeRef *TR;
+  bool Indirect;
+
+  FieldTypeInfo() : Name(""), TR(nullptr), Indirect(false) {}
+  FieldTypeInfo(const std::string &Name, const TypeRef *TR, bool Indirect)
+      : Name(Name), TR(TR), Indirect(Indirect) {}
+
+  static FieldTypeInfo forEmptyCase(std::string Name) {
+    return FieldTypeInfo(Name, nullptr, false);
+  }
+
+  static FieldTypeInfo forIndirectCase(std::string Name, const TypeRef *TR) {
+    return FieldTypeInfo(Name, TR, true);
+  }
+
+  static FieldTypeInfo forField(std::string Name, const TypeRef *TR) {
+    return FieldTypeInfo(Name, TR, false);
+  }
+};
+
+} // namespace reflection
+} // namespace swift
+
+#endif

--- a/include/swift/Reflection/ReflectionInfo.h
+++ b/include/swift/Reflection/ReflectionInfo.h
@@ -96,6 +96,13 @@ struct ReflectionInfo {
     uint64_t SectionOffset;
   } ReflectionString;
 
+#if defined(__APPLE__) && defined(__MACH__)
+  struct {
+    GenericSection Metadata;
+    uint64_t SectionOffset;
+  } Protocol;
+#endif
+
   uint64_t LocalStartAddress;
   uint64_t RemoteStartAddress;
 };

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -18,11 +18,12 @@
 #ifndef SWIFT_REFLECTION_TYPEREFBUILDER_H
 #define SWIFT_REFLECTION_TYPEREFBUILDER_H
 
-#include "swift/Remote/MetadataReader.h"
 #include "swift/Reflection/MetadataSourceBuilder.h"
 #include "swift/Reflection/Records.h"
+#include "swift/Reflection/ReflectionInfo.h"
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
+#include "swift/Remote/MetadataReader.h"
 #include "llvm/ADT/Optional.h"
 
 #include <iostream>
@@ -31,119 +32,6 @@
 
 namespace swift {
 namespace reflection {
-
-template <typename Runtime> class ReflectionContext;
-
-template <typename Iterator>
-class ReflectionSection {
-  using const_iterator = Iterator;
-  const void * Begin;
-  const void * End;
-
-public:
-  ReflectionSection(const void * Begin,
-                    const void * End)
-  : Begin(Begin), End(End) {}
-
-  ReflectionSection(uint64_t Begin, uint64_t End)
-  : Begin(reinterpret_cast<const void *>(Begin)),
-    End(reinterpret_cast<const void *>(End)) {}
-
-  void *startAddress() {
-    return const_cast<void *>(Begin);
-  }
-  const void *startAddress() const {
-    return Begin;
-  }
-  
-  const void *endAddress() const {
-    return End;
-  }
-
-  const_iterator begin() const {
-    return const_iterator(Begin, End);
-  }
-
-  const_iterator end() const {
-    return const_iterator(End, End);
-  }
-
-  size_t size() const {
-    return (const char *)End - (const char *)Begin;
-  }
-};
-
-using FieldSection = ReflectionSection<FieldDescriptorIterator>;
-using AssociatedTypeSection = ReflectionSection<AssociatedTypeIterator>;
-using BuiltinTypeSection = ReflectionSection<BuiltinTypeDescriptorIterator>;
-using CaptureSection = ReflectionSection<CaptureDescriptorIterator>;
-using GenericSection = ReflectionSection<const void *>;
-
-struct ReflectionInfo {
-  struct {
-    FieldSection Metadata;
-    uint64_t SectionOffset;
-  } Field;
-
-  struct {
-    AssociatedTypeSection Metadata;
-    uint64_t SectionOffset;
-  } AssociatedType;
-
-  struct {
-    BuiltinTypeSection Metadata;
-    uint64_t SectionOffset;
-  } Builtin;
-
-  struct {
-    CaptureSection Metadata;
-    uint64_t SectionOffset;
-  } Capture;
-
-  struct {
-    GenericSection Metadata;
-    uint64_t SectionOffset;
-  } TypeReference;
-
-  struct {
-    GenericSection Metadata;
-    uint64_t SectionOffset;
-  } ReflectionString;
-
-  uint64_t LocalStartAddress;
-  uint64_t RemoteStartAddress;
-};
-
-struct ClosureContextInfo {
-  std::vector<const TypeRef *> CaptureTypes;
-  std::vector<std::pair<const TypeRef *, const MetadataSource *>> MetadataSources;
-  unsigned NumBindings = 0;
-
-  void dump() const;
-  void dump(std::ostream &OS) const;
-};
-
-struct FieldTypeInfo {
-  std::string Name;
-  const TypeRef *TR;
-  bool Indirect;
-
-  FieldTypeInfo() : Name(""), TR(nullptr), Indirect(false) {}
-  FieldTypeInfo(const std::string &Name, const TypeRef *TR, bool Indirect)
-      : Name(Name), TR(TR), Indirect(Indirect) {}
-
-  static FieldTypeInfo forEmptyCase(std::string Name) {
-    return FieldTypeInfo(Name, nullptr, false);
-  }
-
-  static FieldTypeInfo forIndirectCase(std::string Name, const TypeRef *TR) {
-    return FieldTypeInfo(Name, TR, true);
-  }
-
-  static FieldTypeInfo forField(std::string Name, const TypeRef *TR) {
-    return FieldTypeInfo(Name, TR, false);
-  }
-};
 
 /// An implementation of MetadataReader's BuilderType concept for
 /// building TypeRefs, and parsing field metadata from any images

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -31,7 +31,7 @@ TypeRefBuilder::getRemoteAddrOfTypeRefPointer(const void *pointer) {
   // Find what type ref section the pointer resides in, if any.
   const ReflectionInfo *containingInfo = nullptr;
   for (auto &info : ReflectionInfos) {
-    auto start = (uint64_t)info.TypeReference.Metadata.startAddress();
+    auto start = (uint64_t)info.TypeReference.Metadata.getStartAddress();
     auto size = (uint64_t)info.TypeReference.Metadata.size();
     if (start <= (uint64_t)pointer && (uint64_t)pointer < start + size) {
        containingInfo = &info;
@@ -194,8 +194,10 @@ bool TypeRefBuilder::getFieldTypeRefs(
                        - FD.second->TypeReference.SectionOffset;
     auto FieldOffset = FD.second->Field.SectionOffset
                      - FD.second->ReflectionString.SectionOffset;
-    auto Low = (uintptr_t)(FD.second->ReflectionString.Metadata.startAddress());
-    auto High = (uintptr_t)(FD.second->ReflectionString.Metadata.endAddress());
+    auto Low =
+        (uintptr_t)(FD.second->ReflectionString.Metadata.getStartAddress());
+    auto High =
+        (uintptr_t)(FD.second->ReflectionString.Metadata.getEndAddress());
     auto FieldName = Field.getFieldName(FieldOffset, Low, High);
 
     // Empty cases of enums do not have a type
@@ -341,8 +343,10 @@ void TypeRefBuilder::dumpFieldSection(std::ostream &OS) {
         OS << '-';
       OS << '\n';
       for (auto &field : descriptor) {
-        auto Low = (uintptr_t)sections.ReflectionString.Metadata.startAddress();
-        auto High = (uintptr_t)sections.ReflectionString.Metadata.endAddress();
+        auto Low =
+            (uintptr_t)sections.ReflectionString.Metadata.getStartAddress();
+        auto High =
+            (uintptr_t)sections.ReflectionString.Metadata.getEndAddress();
         OS << std::string(field.getFieldName(NameOffset, Low, High).begin(),
                           field.getFieldName(NameOffset, Low, High).end());
         if (field.hasMangledTypeName()) {

--- a/test/Reflection/protocol_descriptors.swift
+++ b/test/Reflection/protocol_descriptors.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name protocol_descriptors -o %t/protocol_descriptors%{target-shared-library-suffix}
+// RUN: %target-swift-reflection-dump -binary-filename %t/protocol_descriptors%{target-shared-library-suffix} | %FileCheck %s
+
+// TODO: Linux support.
+// UNSUPPORTED: linux
+
+// CHECK: PROTOCOL DESCRIPTORS:
+// CHECK: ---
+// CHECK: name:{{ +}}FirstProtocol
+// CHECK: numRequirementsInSignature: 0
+// CHECK: numRequirements: 1
+// CHECK: associatedTypeNames: ''
+// CHECK: ...
+protocol FirstProtocol {
+  var i: Int { get }
+}
+
+// CHECK: ---
+// CHECK: name:{{ +}}SecondProtocol
+// CHECK: numRequirementsInSignature: 0
+// CHECK: numRequirements: 2
+// CHECK: associatedTypeNames: ''
+// CHECK: ...
+protocol SecondProtocol {
+  var j: Int { get }
+  var k: Int { get }
+}
+
+// CHECK: ---
+// CHECK: name:{{ +}}KrakenProtocol
+// CHECK: numRequirementsInSignature: 0
+// CHECK: numRequirements: 4
+// CHECK: associatedTypeNames: Toy1 Toy2
+// CHECK: ...
+protocol KrakenProtocol {
+  associatedtype Toy1
+  associatedtype Toy2
+
+  var k: String { get }
+  var k2: String { get }
+}
+
+// CHECK: ---
+// CHECK: name:{{ +}}ChildOfTheKrakenProtocol
+// CHECK: numRequirementsInSignature: 0
+// CHECK: numRequirements: 3
+// CHECK: associatedTypeNames: ToyM
+// CHECK: ...
+protocol ChildOfTheKrakenProtocol {
+  associatedtype ToyM
+
+  var k: Int { get }
+  var k2: String { get }
+}
+
+// CHECK: ---
+// CHECK: name:{{ +}}EmptyProtocol
+// CHECK: numRequirementsInSignature: 0
+// CHECK: numRequirements: 0
+// CHECK: associatedTypeNames: ''
+// CHECK: ...
+protocol EmptyProtocol {
+
+}

--- a/tools/swift-reflection-dump/ProtocolRecord.h
+++ b/tools/swift-reflection-dump/ProtocolRecord.h
@@ -1,0 +1,66 @@
+//===--- ProtocolRecord.h -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SWIFTREFLECTIONDUMP_PROTOCOLRECORD_H
+#define SWIFT_SWIFTREFLECTIONDUMP_PROTOCOLRECORD_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Reflection/ProtocolConformance.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/YAMLTraits.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace swift {
+namespace reflection {
+namespace yaml {
+
+struct ProtocolRecord {
+  StringRef name;
+  unsigned numRequirementsInSignature;
+  unsigned numRequirements;
+  StringRef associatedTypeNames;
+
+  ProtocolRecord() = default;
+
+  template <typename Runtime>
+  ProtocolRecord(const TargetProtocolDescriptor<Runtime> &descriptor) {
+    name = descriptor.Name.get();
+    numRequirementsInSignature = descriptor.NumRequirementsInSignature;
+    numRequirements = descriptor.NumRequirements;
+    // TODO: Split these up.
+    if (const char *ptr = descriptor.AssociatedTypeNames.get()) {
+      associatedTypeNames = StringRef(ptr);
+    }
+  }
+};
+
+} // namespace yaml
+} // namespace reflection
+} // namespace swift
+
+namespace llvm {
+namespace yaml {
+
+template <> struct MappingTraits<swift::reflection::yaml::ProtocolRecord> {
+  static void mapping(IO &io, swift::reflection::yaml::ProtocolRecord &info) {
+    io.mapRequired("name", info.name);
+    io.mapRequired("numRequirementsInSignature",
+                   info.numRequirementsInSignature);
+    io.mapRequired("numRequirements", info.numRequirements);
+    io.mapRequired("associatedTypeNames", info.associatedTypeNames);
+  }
+};
+
+} // namespace yaml
+} // namespace llvm
+
+#endif

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -86,8 +86,9 @@ static void reportError(std::error_code EC) {
   exit(EXIT_FAILURE);
 }
 
+using NativeRuntime = External<RuntimeTarget<sizeof(uintptr_t)>>;
 using NativeReflectionContext =
-    swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
+    swift::reflection::ReflectionContext<NativeRuntime>;
 
 using ReadBytesResult = swift::remote::MemoryReader::ReadBytesResult;
 


### PR DESCRIPTION
I am spending a little bit of time learning more how the metadata/runtime system fit all together. This PR teaches swift-reflection-dump how to dump the protocols from __swift5_protos. My small project here is to get enough done that I can create a runtime function (based off this work) that gets all conformances for a specific protocol.