### PR TITLE
Judge the need for an external key path reference by the overridden base.

### DIFF
--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -102,3 +102,14 @@ func sharedCProperty() {
   // CHECK-NOT: external #c_union.some_field
   let dataKeyPath: WritableKeyPath<c_union, some_struct>? = \c_union.some_field
 }
+
+class OverrideFrameworkObjCProperty: A {
+  override var counter: Int32 {
+    get { return 0 }
+    set { }
+  }
+}
+
+func overrideFrameworkObjCProperty() {
+  let _ = \OverrideFrameworkObjCProperty.counter
+}


### PR DESCRIPTION
We identify overrides using the same key path descriptor as the base, but an overridden base
may not have a property descriptor if it's @objc or fragile. Fixes rdar://problem/51479334.