### PR TITLE
Don't offer a fix-it to convert to a 'some' type

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1071,6 +1071,13 @@ public:
              const PrintOptions &PO = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &PO) const;
 
+  /// Can this type be written in source at all?
+  ///
+  /// If not, it shouldn't be shown in fix-its, for instance. The primary
+  /// example is opaque result types, which are written `some P` at the point
+  /// of definition but cannot be uttered anywhere else.
+  bool hasTypeRepr() const;
+
   /// Does this type have grammatically simple syntax?
   bool hasSimpleTypeRepr() const;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1959,6 +1959,9 @@ static bool addTypeCoerceFixit(InFlightDiagnostic &diag, ConstraintSystem &CS,
     fromType = fromType->getOptionalObjectType();
   toType = toType->lookThroughAllOptionalTypes();
 
+  if (!toType->hasTypeRepr())
+    return false;
+
   CheckedCastKind Kind = CS.getTypeChecker().typeCheckCheckedCast(
       fromType, toType, CheckedCastContextKind::None, CS.DC, SourceLoc(),
       nullptr, SourceRange());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -835,6 +835,9 @@ bool MissingExplicitConversionFailure::diagnoseAsError() {
 
   auto fromType = getType(anchor)->getRValueType();
   Type toType = resolveType(ConvertingTo);
+  if (!toType->hasTypeRepr())
+    return false;
+
   bool useAs = TC.isExplicitlyConvertibleTo(fromType, toType, DC);
   bool useAsBang = !useAs && TC.checkedCastMaySucceed(fromType, toType, DC);
   if (!useAs && !useAsBang)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -387,6 +387,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         TC.diagnose(c->getLoc(), diag::collection_literal_empty)
           .highlight(c->getSourceRange());
       else {
+        assert(c->getType()->hasTypeRepr() &&
+               "a defaulted type should always be printable");
         TC.diagnose(c->getLoc(), diag::collection_literal_heterogeneous,
                     c->getType())
           .highlight(c->getSourceRange())
@@ -3377,6 +3379,8 @@ public:
               fnType = fnType->getResult()->getAs<FunctionType>();
 
             // Coerce to this type.
+            assert(fnType->hasTypeRepr() &&
+                   "Objective-C methods should always have printable types");
             out << " as ";
             fnType->print(out);
           }
@@ -3541,6 +3545,9 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     }
 
     void emitSilenceOptionalAnyWarningWithCoercion(Expr *E, Type destType) {
+      assert(destType->hasTypeRepr() &&
+             "coercion to Any should always be printable");
+
       SmallString<16> coercionString;
       coercionString += " as ";
       coercionString += destType->getWithoutParens()->getString();

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -391,3 +391,9 @@ protocol OpaqueProtocolRequirement {
   // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{18-24=<#AssocType#>}}
   subscript() -> some P { get }
 }
+
+func testCoercionDiagnostics() {
+  var opaque = foo()
+  opaque = bar() // expected-error {{cannot assign value of type 'some P' to type 'some P'}} {{none}}
+  opaque = () // expected-error {{cannot assign value of type '()' to type 'some P'}} {{none}}
+}


### PR DESCRIPTION
There's no way to spell an opaque type in a cast, and that means there's no way to force the conversion today (even if you know the types are dynamically the same).

Part of rdar://problem/50346954