### PR TITLE
Treat 'some' types as having non-simple representations by default

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5599,6 +5599,7 @@ inline bool TypeBase::hasSimpleTypeRepr() const {
   case TypeKind::NestedArchetype:
     return cast<NestedArchetypeType>(this)->getParent()->hasSimpleTypeRepr();
       
+  case TypeKind::OpaqueTypeArchetype:
   case TypeKind::OpenedArchetype:
     return false;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3456,7 +3456,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     }
 
     bool isSimple = T->hasSimpleTypeRepr();
-    if (isSimple && T->is<OpaqueTypeArchetypeType>()) {
+    if (!isSimple && T->is<OpaqueTypeArchetypeType>()) {
       auto opaqueTy = T->castTo<OpaqueTypeArchetypeType>();
       switch (Options.OpaqueReturnTypePrinting) {
       case PrintOptions::OpaqueReturnTypePrintingMode::StableReference:


### PR DESCRIPTION
That is, if they appear inside a larger type, they may need to be parenthesized. ASTPrinter is careful about this already, so this doesn't actually change any existing behavior, but it makes the default more conservative when no PrintOptions are in play.