### PR TITLE
Show 'some' type origins in diagnostics, like 'aka' for sugared types

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -164,7 +164,8 @@ enum class DescriptiveDeclKind : uint8_t {
   Module,
   MissingMember,
   Requirement,
-  OpaqueType,
+  OpaqueResultType,
+  OpaqueVarType
 };
 
 /// Keeps track of stage of circularity checking for the given protocol.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -292,17 +292,21 @@ namespace swift {
     const std::string OpeningQuotationMark;
     const std::string ClosingQuotationMark;
     const std::string AKAFormatString;
+    const std::string OpaqueResultFormatString;
 
     DiagnosticFormatOptions(std::string OpeningQuotationMark,
                             std::string ClosingQuotationMark,
-                            std::string AKAFormatString)
+                            std::string AKAFormatString,
+                            std::string OpaqueResultFormatString)
         : OpeningQuotationMark(OpeningQuotationMark),
           ClosingQuotationMark(ClosingQuotationMark),
-          AKAFormatString(AKAFormatString) {}
+          AKAFormatString(AKAFormatString),
+          OpaqueResultFormatString(OpaqueResultFormatString) {}
 
     DiagnosticFormatOptions()
         : OpeningQuotationMark("'"), ClosingQuotationMark("'"),
-          AKAFormatString("'%s' (aka '%s')") {}
+          AKAFormatString("'%s' (aka '%s')"),
+          OpaqueResultFormatString("'%s' (%s of '%s')") {}
   };
   
   /// Diagnostic - This is a specific instance of a diagnostic along with all of

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -163,7 +163,6 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
   TRIVIAL_KIND(Param);
   TRIVIAL_KIND(Module);
   TRIVIAL_KIND(MissingMember);
-  TRIVIAL_KIND(OpaqueType);
 
    case DeclKind::Enum:
      return cast<EnumDecl>(this)->getGenericParams()
@@ -260,6 +259,13 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
        return DescriptiveDeclKind::ClassMethod;
      }
    }
+
+   case DeclKind::OpaqueType: {
+     auto *opaqueTypeDecl = cast<OpaqueTypeDecl>(this);
+     if (dyn_cast_or_null<VarDecl>(opaqueTypeDecl->getNamingDecl()))
+       return DescriptiveDeclKind::OpaqueVarType;
+     return DescriptiveDeclKind::OpaqueResultType;
+   }
   }
 #undef TRIVIAL_KIND
   llvm_unreachable("bad DescriptiveDeclKind");
@@ -320,7 +326,8 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(Module, "module");
   ENTRY(MissingMember, "missing member placeholder");
   ENTRY(Requirement, "requirement");
-  ENTRY(OpaqueType, "opaque type");
+  ENTRY(OpaqueResultType, "result");
+  ENTRY(OpaqueVarType, "type");
   }
 #undef ENTRY
   llvm_unreachable("bad DescriptiveDeclKind");

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -394,6 +394,13 @@ protocol OpaqueProtocolRequirement {
 
 func testCoercionDiagnostics() {
   var opaque = foo()
-  opaque = bar() // expected-error {{cannot assign value of type 'some opaque.P' to type 'some opaque.P'}} {{none}}
+  opaque = bar() // expected-error {{cannot assign value of type 'some P' (result of 'bar()') to type 'some P' (result of 'foo()')}} {{none}}
   opaque = () // expected-error {{cannot assign value of type '()' to type 'some P'}} {{none}}
+  opaque = computedProperty // expected-error {{cannot assign value of type 'some P' (type of 'computedProperty') to type 'some P' (result of 'foo()')}} {{none}}
+  opaque = SubscriptTest()[0] // expected-error {{cannot assign value of type 'some P' (result of 'SubscriptTest.subscript(_:)') to type 'some P' (result of 'foo()')}} {{none}}
+
+  var opaqueOpt: Optional = opaque
+  // FIXME: It would be nice to show the "from" info here as well.
+  opaqueOpt = bar() // expected-error {{cannot assign value of type 'some P' to type '(some P)?'}} {{none}}
+  opaqueOpt = () // expected-error {{cannot assign value of type '()' to type '(some P)?'}} {{none}}
 }


### PR DESCRIPTION
Currently only works for types that are *just* a 'some' type, not in a nested position. Also won't show them for opaque types with different requirements, to avoid noise when it's not strictly necessary. This does mean that `some P` vs. `some P & Q` won't get the origin part.

Part of rdar://problem/50346954. Builds on @owenv's #25510 (which isn't quite passing all tests yet) as well as the tests in my own #25619, so only the third commit is relevant. I'll rebase once those both make it in.
