### PR TITLE
[5.1][driver] For `-index-file` mode add `-disable-typo-correction`

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -380,6 +380,12 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (context.Args.hasArg(options::OPT_embed_bitcode_marker))
     Arguments.push_back("-embed-bitcode-marker");
 
+  // For `-index-file` mode add `-disable-typo-correction`, since the errors
+  // will be ignored and it can be expensive to do typo-correction.
+  if (job.getType() == file_types::TY_IndexData) {
+    Arguments.push_back("-disable-typo-correction");
+  }
+
   if (context.Args.hasArg(options::OPT_index_store_path)) {
     context.Args.AddLastArg(Arguments, options::OPT_index_store_path);
     if (!context.Args.hasArg(options::OPT_index_ignore_system_modules))

--- a/test/Index/Store/driver-index.swift
+++ b/test/Index/Store/driver-index.swift
@@ -1,2 +1,2 @@
 // RUN: %swiftc_driver -driver-print-jobs -index-file -index-file-path %s %S/Inputs/SwiftModuleA.swift %s -o %t.output_for_index -index-store-path %t.index_store -module-name driver_index 2>&1 | %FileCheck %s
-// CHECK: {{.*}}swift{{(c.EXE")?}} -frontend -typecheck {{.*}}SwiftModuleA.swift{{"?}} -primary-file {{.*}}driver-index.swift{{"?}} {{.*}}-o {{.*}}.output_for_index{{"?}} {{.*}}-index-store-path {{.*}}.index_store{{"?}} -index-system-modules
+// CHECK: {{.*}}swift{{(c.EXE")?}} -frontend -typecheck {{.*}}SwiftModuleA.swift{{"?}} -primary-file {{.*}}driver-index.swift{{"?}} {{.*}}-o {{.*}}.output_for_index{{"?}} {{.*}}-disable-typo-correction {{.*}}-index-store-path {{.*}}.index_store{{"?}} -index-system-modules


### PR DESCRIPTION
We don't need typo-correction for that since the errors will be ignored and it can be expensive to do typo-correction.

master: https://github.com/apple/swift/pull/25628