### PR TITLE
[5.1] [Runtime] Fix private generic type witness demangling failure

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1677,12 +1677,13 @@ buildDescriptorPath(const ContextDescriptor *context) const {
       hasNonKeyGenericParams = true;
   }
 
-  // Form the path element.
-  descriptorPath.push_back(PathElement{localGenericParams,
-                                       context->getNumGenericParams(),
-                                       numKeyGenericParamsInParent,
-                                       numKeyGenericParamsHere,
-                                       hasNonKeyGenericParams});
+  // Form the path element if there are any generic parameters to be found.
+  if (numKeyGenericParamsHere != 0)
+    descriptorPath.push_back(PathElement{localGenericParams,
+                                         context->getNumGenericParams(),
+                                         numKeyGenericParamsInParent,
+                                         numKeyGenericParamsHere,
+                                         hasNonKeyGenericParams});
   return numKeyGenericParamsInParent + numKeyGenericParamsHere;
 }
 

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -73,5 +73,44 @@ AssociatedTypeDemangleTests.test("generic anonymous contexts") {
   expectEqual("Inner<Int>", String(describing: getP2_A(C3<Int>.self)))
 }
 
+// rdar://problem/47773183
+struct Pair<First, Second> {
+  var first: First
+  var second: Second
+}
+
+protocol PairConvertible {
+  associatedtype First
+  associatedtype Second
+  associatedtype PairType = Pair<First, Second>
+
+  var first: First { get }
+  var second: Second { get }
+}
+
+extension PairConvertible where PairType == Pair<First, Second> {
+  var pair: PairType { Pair(first: first, second: second) }
+}
+
+private struct Parent<Unused> {
+  struct Nested<First, Second>: PairConvertible {
+    var first: First
+    var second: Second
+  }
+}
+
+AssociatedTypeDemangleTests.test("nested private generic types in associated type witnesses") {
+  // Fixed in custom runtimes.
+  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, * ) {}
+  // Fixed in Swift 5.1+ runtimes.
+  else if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {}
+  // Bug is still present in Swift 5.0 runtime.
+  else {
+    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+  }
+
+  _ = Parent<Never>.Nested(first: "String", second: 0).pair
+}
+
 
 runAllTests()

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -106,7 +106,9 @@ AssociatedTypeDemangleTests.test("nested private generic types in associated typ
   else if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
-    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    // FIXME: rdar://problem/51959305
+    // expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    return
   }
 
   _ = Parent<Never>.Nested(first: "String", second: 0).pair


### PR DESCRIPTION
Cherry-pick of #25611 to 5.1; original reviewed by @jckarter.

> This one’s screwily specific—if you have:
> 
> * a private generic type,
> * with a nested generic type in it,
> * and the nested type conforms to a protocol with an associated type,
> * and that associated type’s witness is a generic type,
> * and some of the witness type’s generic parameters are generic parameters of the nested type,
> 
> demangling would fail. The problem is that the substitution machinery in the runtime would consider there to be three, not two, generic context depths involved. Depth 1, which should correspond to the nested type, would instead have no generic parameters. The fix is to skip over depths with zero generic parameters.
> 
> Fixes <rdar://problem/47773183>.