### PR TITLE
[Diagnostics] Don't suggest argument destructuring fix-it if closu…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2660,13 +2660,23 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
   auto bodyStmts = closureBody->getElements();
 
   SourceLoc bodyLoc;
+  SourceLoc inLoc = closure->getInLoc();
+  // If location for `in` is unknown we can't proceed
+  // since we'll not be able to figure out source line
+  // to place the fix-it on.
+  if (inLoc.isInvalid())
+    return true;
+
   // If the body is empty let's put the cursor
   // right after "in", otherwise make it start
   // location of the first statement in the body.
   if (bodyStmts.empty())
-    bodyLoc = Lexer::getLocForEndOfToken(sourceMgr, closure->getInLoc());
+    bodyLoc = Lexer::getLocForEndOfToken(sourceMgr, inLoc);
   else
     bodyLoc = bodyStmts.front().getStartLoc();
+
+  if (bodyLoc.isInvalid())
+    return true;
 
   SmallString<64> fixIt;
   llvm::raw_svector_ostream OS(fixIt);
@@ -2674,7 +2684,7 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
   // If this is multi-line closure we'd have to insert new lines
   // in the suggested 'let' to keep the structure of the code intact,
   // otherwise just use ';' to keep everything on the same line.
-  auto inLine = sourceMgr.getLineNumber(closure->getInLoc());
+  auto inLine = sourceMgr.getLineNumber(inLoc);
   auto bodyLine = sourceMgr.getLineNumber(bodyLoc);
   auto isMultiLineClosure = bodyLine > inLine;
   auto indent =

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar51576862.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar51576862.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+func foo() -> [String] {
+  let dict: [String: String] = [:]
+  return dict.filter({ (_


### PR DESCRIPTION
…re is malformed

If closure expression is malformed don't try to suggest a fix-it
about destructuring, because there is no way to figure out where
it would actually go in the source.

Resolves #53350
Resolves: rdar://problem/51576862

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
