### PR TITLE
Move MarkUninitializedFixup to ./lib/SILOptimizer/Mandatory since it …

### DIFF
--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -13,6 +13,7 @@ silopt_register_sources(
   DiagnoseUnreachable.cpp
   GuaranteedARCOpts.cpp
   IRGenPrepare.cpp
+  MarkUninitializedFixup.cpp
   MandatoryInlining.cpp
   PredictableMemOpt.cpp
   PMOMemoryUseCollector.cpp

--- a/lib/SILOptimizer/Mandatory/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/MarkUninitializedFixup.cpp
@@ -107,9 +107,8 @@ struct MarkUninitializedFixup : SILFunctionTransform {
             Projections.push_back(PBI);
           }
         }
-        assert(!Projections.empty()
-               && "SILGen should never emit a "
-                  "mark_uninitialized by itself");
+        assert(!Projections.empty() && "SILGen should never emit a "
+                                       "mark_uninitialized by itself");
 
         // First replace all uses of the mark_uninitialized with the box.
         MUI->replaceAllUsesWith(Box);
@@ -137,7 +136,6 @@ struct MarkUninitializedFixup : SILFunctionTransform {
           SILAnalysis::InvalidationKind::BranchesAndInstructions);
   }
 };
-
 } // end anonymous namespace
 
 SILTransform *swift::createMarkUninitializedFixup() {

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -18,7 +18,6 @@ silopt_register_sources(
   Devirtualizer.cpp
   GenericSpecializer.cpp
   MergeCondFail.cpp
-  MarkUninitializedFixup.cpp
   Outliner.cpp
   ObjectOutliner.cpp
   OwnershipModelEliminator.cpp


### PR DESCRIPTION
…is only used in the mandatory pipeline.
