### PR TITLE
[CMake] Install SwiftShims when not building stdlib and building tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,7 @@ else()
   # ensure we build that when building tools.
   if(SWIFT_INCLUDE_TOOLS)
     add_subdirectory(stdlib/public/Reflection)
+    add_subdirectory(stdlib/public/SwiftShims)
   endif()
 endif()
 


### PR DESCRIPTION
Some swift tools will rely on the shims to work properly, but currently they are
only installed if we build the swift stdlib. Like Reflection, we build it if we
are building the tools even if we aren't building the stdlib.

cc @compnerd @drodriguez @gottesmm @Rostepher 
