### PR TITLE
[5.1] Make sure all failures to load module interfaces are diagnosed

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -615,7 +615,7 @@ ERROR(sema_opening_import,Fatal,
       "opening import file for module %0: %1", (Identifier, StringRef))
 
 ERROR(serialization_load_failed,Fatal,
-      "failed to load module %0", (Identifier))
+      "failed to load module '%0'", (StringRef))
 ERROR(serialization_malformed_module,Fatal,
       "malformed compiled module: %0", (StringRef))
 ERROR(serialization_module_too_new,Fatal,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -718,7 +718,8 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
   case serialization::Status::FailedToLoadBridgingHeader:
     // We already emitted a diagnostic about the bridging header. Just emit
     // a generic message here.
-    Ctx.Diags.diagnose(diagLoc, diag::serialization_load_failed, ModuleName);
+    Ctx.Diags.diagnose(diagLoc, diag::serialization_load_failed,
+                       ModuleName.str());
     break;
 
   case serialization::Status::NameMismatch: {

--- a/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ParseableInterface/ModuleCache/module-cache-diagnostics.swift
@@ -57,7 +57,9 @@
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR <%t/err.txt
 // CHECK-ERROR: LeafModule.swiftinterface:7:8: error: no such module 'NotAModule'
-// CHECK-ERROR: OtherModule.swiftinterface:4:8: error: no such module 'LeafModule'
+// CHECK-ERROR: OtherModule.swiftinterface:4:8: error: failed to load module 'LeafModule'
+// CHECK-ERROR: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to load module 'OtherModule'
+// CHECK-ERROR-NOT: error:
 //
 //
 // Next test: same as above, but with a .dia file
@@ -80,7 +82,9 @@
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR-INLINE <%t/err-inline.txt
 // CHECK-ERROR-INLINE: LeafModule.swiftinterface:6:33: error: use of unresolved identifier 'unresolved'
-// CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: no such module 'LeafModule'
+// CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: failed to load module 'LeafModule'
+// CHECK-ERROR-INLINE: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to load module 'OtherModule'
+// CHECK-ERROR-INLINE-NOT: error:
 //
 //
 // Next test: same as above, but with a .dia file

--- a/validation-test/ParseableInterface/Inputs/failing-overlay/HasOverlay.swiftinterface
+++ b/validation-test/ParseableInterface/Inputs/failing-overlay/HasOverlay.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags:
+
+garbage

--- a/validation-test/ParseableInterface/Inputs/failing-overlay/ImportsOverlay.h
+++ b/validation-test/ParseableInterface/Inputs/failing-overlay/ImportsOverlay.h
@@ -1,0 +1,1 @@
+#include <HasOverlay.h>

--- a/validation-test/ParseableInterface/Inputs/failing-overlay/module.modulemap
+++ b/validation-test/ParseableInterface/Inputs/failing-overlay/module.modulemap
@@ -1,0 +1,8 @@
+module HasOverlay {
+  header "HasOverlay.h"
+}
+
+module ImportsOverlay {
+  header "ImportsOverlay.h"
+  export *
+}

--- a/validation-test/ParseableInterface/failing-overlay.swift
+++ b/validation-test/ParseableInterface/failing-overlay.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -I %S/Inputs/failing-overlay/ -typecheck %s 2>&1 | %FileCheck %s
+
+import ImportsOverlay
+
+// FIXME: It would be better if this had a useful location, like inside the
+// C header that caused the importing of the overlay.
+// CHECK: <unknown>:0: error: failed to load module 'HasOverlay'


### PR DESCRIPTION
Cherry-pick of #25636 to the 5.1 branch. Reviewed by @harlanhaskins and @nathawes.

rdar://problem/50789839