### PR TITLE
test: disable Runtime/associated_type_demangle_private.swift

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -3,6 +3,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// REQUIRES: rdar51959305
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
Related: rdar://51959305