### PR TITLE
[ModuleInterface] Explicitly print implied Hashable et al on enums

### DIFF
--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -225,6 +225,19 @@ class InheritedProtocolCollector {
       // FIXME: This ignores layout constraints, but currently we don't support
       // any of those besides 'AnyObject'.
     }
+
+    // Check for synthesized protocols, like Hashable on enums.
+    if (auto *nominal = dyn_cast<NominalTypeDecl>(D)) {
+      SmallVector<ProtocolConformance *, 4> localConformances =
+          nominal->getLocalConformances(ConformanceLookupKind::NonInherited);
+
+      for (auto *conf : localConformances) {
+        if (conf->getSourceKind() != ConformanceEntryKind::Synthesized)
+          continue;
+        ExtraProtocols.push_back({conf->getProtocol(),
+                                  getAvailabilityAttrs(D, availableAttrs)});
+      }
+    }
   }
 
   /// For each type directly inherited by \p extension, record any protocols

--- a/test/ParseableInterface/enums-layout.swift
+++ b/test/ParseableInterface/enums-layout.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift
+// RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t | %FileCheck %s
 

--- a/test/ParseableInterface/synthesized.swift
+++ b/test/ParseableInterface/synthesized.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path - %s -disable-objc-attr-requires-foundation-module -enable-objc-interop > %t.swiftinterface
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
 // CHECK-LABEL: public enum HasRawValue : Swift.Int {
 public enum HasRawValue: Int {
@@ -23,3 +25,35 @@ public enum HasRawValue: Int {
 // CHECK-DAG:   @inlinable get{{$}}
 // CHECK-DAG: }
 // CHECK: {{^}$}}
+
+// CHECK-LABEL: public enum NoRawValueWithExplicitEquatable : Swift.Equatable {
+public enum NoRawValueWithExplicitEquatable : Equatable {
+  // CHECK-NEXT: case a, b, c
+  case a, b, c
+} // CHECK: {{^}$}}
+
+// CHECK-LABEL: public enum NoRawValueWithExplicitHashable {
+public enum NoRawValueWithExplicitHashable {
+  // CHECK-NEXT: case a, b, c
+case a, b, c
+} // CHECK: {{^}$}}
+
+// CHECK-LABEL: extension NoRawValueWithExplicitHashable : Swift.Hashable {
+extension NoRawValueWithExplicitHashable : Hashable {
+  // CHECK-NEXT: public func foo()
+  public func foo() {}
+} // CHECK: {{^}$}}
+
+// CHECK: extension synthesized.HasRawValue : Swift.Equatable {}
+// CHECK: extension synthesized.HasRawValue : Swift.Hashable {}
+// CHECK: extension synthesized.HasRawValue : Swift.RawRepresentable {}
+
+// CHECK: extension synthesized.ObjCEnum : Swift.Equatable {}
+// CHECK: extension synthesized.ObjCEnum : Swift.Hashable {}
+// CHECK: extension synthesized.ObjCEnum : Swift.RawRepresentable {}
+
+// CHECK: extension synthesized.NoRawValueWithExplicitEquatable : Swift.Hashable {}
+// NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable : Swift.Equatable
+
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Equatable
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Hashable {}


### PR DESCRIPTION
Enums have a handful of conformances that are implied by their structure: Equatable and Hashable if they have no payloads, and RawRepresentable if they have a raw value. In the spirit of making implicit things explicit, these should be printed in the module interface.

rdar://problem/50100142