### PR TITLE
[5.1][SR-10972] swift-api-digester: avoid diagnosing the removal of __derived_enum_equals and __derived_struct_equals

### DIFF
--- a/test/api-digester/Inputs/cake_baseline/color.swift
+++ b/test/api-digester/Inputs/cake_baseline/color.swift
@@ -1,0 +1,1 @@
+public enum Color { case Red }

--- a/test/api-digester/Inputs/cake_current/color.swift
+++ b/test/api-digester/Inputs/cake_current/color.swift
@@ -1,0 +1,6 @@
+public enum Color { case Red }
+
+extension Color: RawRepresentable {
+    public var rawValue: String { return "" }
+    public init(rawValue: String) { self = .Red }
+}

--- a/test/api-digester/Outputs/color.txt
+++ b/test/api-digester/Outputs/color.txt
@@ -1,0 +1,2 @@
+color: Func Color.hash(into:) has been removed
+color: Var Color.hashValue has been removed

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -11,3 +11,14 @@
 // RUN: %clang -E -P -x c %S/Outputs/Cake.txt -o - | sed '/^\s*$/d' > %t.expected
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
+
+// Run another module API checking without -enable-library-evolution
+// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
+// RUN: %swift -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name color
+// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
+// RUN: %api-digester -dump-sdk -module color -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
+
+// RUN: %clang -E -P -x c %S/Outputs/color.txt -o - | sed '/^\s*$/d' > %t.expected
+// RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
+// RUN: diff -u %t.expected %t.result.tmp

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -164,6 +164,10 @@ class SDKContext {
   std::vector<BreakingAttributeInfo> BreakingAttrs;
 
 public:
+  // Define the set of known identifiers.
+#define IDENTIFIER_WITH_NAME(Name, IdStr) StringRef Id_##Name = IdStr;
+#include "swift/AST/KnownIdentifiers.def"
+
   SDKContext(CheckerOptions Options);
   llvm::BumpPtrAllocator &allocator() {
     return Allocator;

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1959,6 +1959,18 @@ void DiagnosisEmitter::handle(const SDKNodeDecl *Node, NodeAnnotation Anno) {
     }
     if (FoundInSuperclass)
       return;
+
+    // When diagnosing API changes, avoid complaining the removal of these
+    // synthesized functions since they are compiler implementation details.
+    // If an enum is no longer equatable, another diagnostic about removing
+    // conforming protocol will be emitted.
+    if (!Ctx.checkingABI()) {
+      if (Node->getName() == Ctx.Id_derived_struct_equals ||
+          Node->getName() == Ctx.Id_derived_enum_equals) {
+        return;
+      }
+    }
+
     Node->emitDiag(diag::removed_decl, Node->isDeprecated());
     return;
   }


### PR DESCRIPTION
These functions are compiler implementation details and diagnosing
them is redundant and may be confusing to framework authors.