### PR TITLE
 [ModuleInterfaces] Rebuild if a dependency is missing

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -281,9 +281,6 @@ ERROR(unsupported_version_of_module_interface,none,
       (StringRef, llvm::VersionTuple))
 ERROR(error_extracting_flags_from_module_interface,none,
       "error extracting flags from module interface", ())
-ERROR(missing_dependency_of_module_interface,none,
-      "missing dependency '%0' of module interface '%1': %2",
-      (StringRef, StringRef, StringRef))
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
 NOTE(out_of_date_module_here,none,
@@ -291,6 +288,9 @@ NOTE(out_of_date_module_here,none,
      (unsigned, StringRef))
 NOTE(module_interface_dependency_out_of_date,none,
      "dependency is out of date: '%0'",
+     (StringRef))
+NOTE(module_interface_dependency_missing,none,
+     "dependency is missing: '%0'",
      (StringRef))
 NOTE(compiled_module_invalid,none,
      "unable to load compiled module '%0'",

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -284,6 +284,7 @@ class swift::ParseableInterfaceBuilder {
   const SourceLoc diagnosticLoc;
   DependencyTracker *const dependencyTracker;
   CompilerInvocation subInvocation;
+  SmallVector<StringRef, 3> extraDependencies;
 
   void configureSubInvocationInputsAndOutputs(StringRef OutPath) {
     auto &SubFEOpts = subInvocation.getFrontendOptions();
@@ -397,6 +398,8 @@ class swift::ParseableInterfaceBuilder {
     auto DTDeps = SubInstance.getDependencyTracker()->getDependencies();
     SmallVector<StringRef, 16> InitialDepNames(DTDeps.begin(), DTDeps.end());
     InitialDepNames.push_back(interfacePath);
+    InitialDepNames.insert(InitialDepNames.end(),
+                           extraDependencies.begin(), extraDependencies.end());
     llvm::StringSet<> AllDepNames;
     SmallString<128> Scratch;
 
@@ -485,6 +488,12 @@ public:
 
   const CompilerInvocation &getSubInvocation() const {
     return subInvocation;
+  }
+
+  /// Ensures the requested file name is added as a dependency of the resulting
+  /// module.
+  void addExtraDependency(StringRef path) {
+    extraDependencies.push_back(path);
   }
 
   bool buildSwiftModule(StringRef OutPath, bool ShouldSerializeDeps,
@@ -670,6 +679,15 @@ struct ModuleRebuildInfo {
   void addMissingDependency(StringRef modulePath, StringRef depPath) {
     getOrInsertOutOfDateModule(modulePath)
       .missingDependencies.push_back(depPath);
+  }
+
+  /// Determines if we saw the given module path and registered is as out of
+  /// date.
+  bool sawOutOfDateModule(StringRef modulePath) {
+    for (auto &mod : outOfDateModules)
+      if (mod.path == modulePath)
+        return true;
+    return false;
   }
 
   const char *invalidModuleReason(serialization::Status status) {
@@ -1318,6 +1336,14 @@ class ParseableInterfaceModuleLoaderImpl {
       rebuildInfo.diagnose(ctx, diagnosticLoc, moduleName,
                            interfacePath);
     }
+
+    // If we found an out-of-date .swiftmodule, we still want to add it as
+    // a dependency of the .swiftinterface. That way if it's updated, but
+    // the .swiftinterface remains the same, we invalidate the cache and
+    // check the new .swiftmodule, because it likely has more information
+    // about the state of the world.
+    if (rebuildInfo.sawOutOfDateModule(modulePath))
+      builder.addExtraDependency(modulePath);
 
     if (builder.buildSwiftModule(cachedOutputPath, /*shouldSerializeDeps*/true,
                                  &moduleBuffer))

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -913,7 +913,12 @@ class ParseableInterfaceModuleLoaderImpl {
   bool serializedASTBufferIsUpToDate(
       StringRef path, const llvm::MemoryBuffer &buf,
       SmallVectorImpl<FileDependency> &allDeps) {
-    LLVM_DEBUG(llvm::dbgs() << "Validating deps of " << modulePath << "\n");
+
+    // Clear the existing dependencies, because we're going to re-fill them
+    // in validateSerializedAST.
+    allDeps.clear();
+
+    LLVM_DEBUG(llvm::dbgs() << "Validating deps of " << path << "\n");
     auto validationInfo = serialization::validateSerializedAST(
         buf.getBuffer(), /*ExtendedValidationInfo=*/nullptr, &allDeps);
 
@@ -944,6 +949,13 @@ class ParseableInterfaceModuleLoaderImpl {
       StringRef path, const ForwardingModule &fwd,
       SmallVectorImpl<FileDependency> &deps,
       std::unique_ptr<llvm::MemoryBuffer> &moduleBuffer) {
+
+    // Clear the existing dependencies, because we're going to re-fill them
+    // from the forwarding module.
+    deps.clear();
+
+    LLVM_DEBUG(llvm::dbgs() << "Validating deps of " << path << "\n");
+
     // First, make sure the underlying module path exists and is valid.
     auto modBuf = fs.getBufferForFile(fwd.underlyingModulePath);
     if (!modBuf || !serializedASTLooksValid(*modBuf.get()))

--- a/test/ParseableInterface/ModuleCache/RebuildRemarks/missing-dependency.swift
+++ b/test/ParseableInterface/ModuleCache/RebuildRemarks/missing-dependency.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/Build)
+
+// 1. Create a dummy module
+// RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
+
+// 2. Create both an interface and a compiled module for it
+// RUN: %target-swift-frontend -emit-module -o %t/Build/TestModule.swiftmodule %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -module-name TestModule
+
+// 3. Make the compiled module unreadable so it gets added as a dependency but is not used
+// RUN: mv %t/Build/TestModule.swiftmodule %t/Build/TestModule.swiftmodule.moved-aside
+// RUN: echo 'this is unreadable' > %t/Build/TestModule.swiftmodule
+
+// 4. Try to import the module, which will create a cached module that depends on both the .swiftmodule and .swiftinterface
+// RUN: %target-swift-frontend -typecheck %s -I %t/Build -module-cache-path %t/ModuleCache
+
+// 5. Remove the .swiftmodule, which will result in a missing dependency note
+// RUN: rm %t/Build/TestModule.swiftmodule
+
+// 6. Rebuild with remarks enabled, make sure the missing dependency note is emitted
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t/Build -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+// 7. Put the module back, make the interface unreadable, and make sure the compiler succeeds
+// RUN: mv %t/Build/TestModule.swiftmodule.moved-aside %t/Build/TestModule.swiftmodule
+// RUN: mv %t/Build/TestModule.swiftinterface %t/Build/TestModule.swiftinterface.moved-aside
+// RUN: echo 'this is unreadable' > %t/Build/TestModule.swiftinterface
+// RUN: %target-swift-frontend -typecheck %s -I %t/Build -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+import TestModule // expected-remark {{rebuilding module 'TestModule' from interface}}
+// expected-note @-1 {{cached module is out of date}}
+// expected-note @-2 {{dependency is missing}}

--- a/test/ParseableInterface/ModuleCache/prebuilt-module-cache-forwarding.swift
+++ b/test/ParseableInterface/ModuleCache/prebuilt-module-cache-forwarding.swift
@@ -12,16 +12,18 @@
 
 // Make sure we installed a forwarding module.
 // RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/Lib-*.swiftmodule
+// RUN: cat %t/MCP/Lib-*.swiftmodule
 
-// Make sure it passes:
-// RUN: sleep 1
+// Now invalidate a dependency of the prebuilt module, by changing the hash of the .swiftinterface.
+// RUN: cp %t/Lib.swiftinterface %t/Lib.swiftinterface.moved-aside
+// RUN: echo ' ' >> %t/Lib.swiftinterface
 
-// Now invalidate a dependency of the prebuilt module, and make sure the forwarding file is replaced with a real module.
-// RUN: %{python} %S/Inputs/make-old.py %t/Lib.swiftinterface
+// Make sure the forwarding file is replaced with a real module.
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-INTERFACE %s
 
-// Delete the cached module we just created, and create the forwarding module again
+// Delete the cached module we just created, put the old .swiftinterface back, and create the forwarding module again
 // RUN: %empty-directory(%t/MCP)
+// RUN: mv %t/Lib.swiftinterface.moved-aside %t/Lib.swiftinterface
 // RUN: not %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/MCP -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache/ -prebuilt-module-cache-path %t/prebuilt-cache %s 2>&1 | %FileCheck -check-prefix=FROM-PREBUILT %s
 
 // Move the prebuilt module out of the way, so the forwarding module points to nothing.


### PR DESCRIPTION
A dependency being removed is not a hard error, because the recovery step is to recompile the interface. That might fail because of the change in dependencies, but that is a more actionable error.

Fixes rdar://51959698

Also, if there’s a `.swiftmodule` corresponding to the `.swiftinterface` we’re loading, but it’s out of date or otherwise unusable, still make it a dependency of the cached module.

The general assumption with cached modules is that, by virtue of them being in the cache, they have a more up-to-date view of the world than the adjacent compiled module. However, if a new `.swiftmodule` comes along that’s totally valid, we should consider it as having a newer view of the world than the cached one, so we should use it instead.

Fixes rdar://51959788