### PR TITLE
[CodeCompletion] Don't attach attr to decl if blank line exists

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -189,7 +189,7 @@ public:
   virtual void completeAccessorBeginning(CodeCompletionExpr *E) {};
 
   /// Complete the keyword in attribute, for instance, @available.
-  virtual void completeDeclAttrBeginning(bool Sil) {};
+  virtual void completeDeclAttrBeginning(bool Sil, bool isIndependent) {};
 
   /// Complete the parameters in attribute, for instance, version specifier for
   /// @available.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1351,6 +1351,13 @@ public:
   void setAttrTargetDeclKind(Optional<DeclKind> DK) override {
     if (DK == DeclKind::PatternBinding)
       DK = DeclKind::Var;
+
+    // If the target is already set to 'Module', that means the completion
+    // should be performed as if it's not tied to any specific decl.
+    // see 'completeDeclAttrBeginning()'
+    if (AttTargetDK == DeclKind::Module)
+      DK = None;
+
     AttTargetDK = DK;
   }
 
@@ -1373,7 +1380,7 @@ public:
   void completeCaseStmtKeyword() override;
   void completeCaseStmtBeginning() override;
   void completeCaseStmtDotPrefix() override;
-  void completeDeclAttrBeginning(bool Sil) override;
+  void completeDeclAttrBeginning(bool Sil, bool isIndependent) override;
   void completeDeclAttrParam(DeclAttrKind DK, int Index) override;
   void completeInPrecedenceGroup(SyntaxKind SK) override;
   void completeNominalMemberBeginning(
@@ -4606,10 +4613,15 @@ void CodeCompletionCallbacksImpl::completeDeclAttrParam(DeclAttrKind DK,
   CurDeclContext = P.CurDeclContext;
 }
 
-void CodeCompletionCallbacksImpl::completeDeclAttrBeginning(bool Sil) {
+void CodeCompletionCallbacksImpl::completeDeclAttrBeginning(
+    bool Sil, bool isIndependent) {
   Kind = CompletionKind::AttributeBegin;
   IsInSil = Sil;
   CurDeclContext = P.CurDeclContext;
+
+  // Use 'DeclKind::Module' as the indicator of "This is independent attribute".
+  if (isIndependent)
+    AttTargetDK = DeclKind::Module;
 }
 
 void CodeCompletionCallbacksImpl::completeInPrecedenceGroup(SyntaxKind SK) {
@@ -5373,6 +5385,8 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
 
   case CompletionKind::AttributeBegin: {
+    assert(AttTargetDK != DeclKind::Module &&
+           "'setAttrTargetDeclKind()' hasn't been called");
     Lookup.getAttributeDeclCompletions(IsInSil, AttTargetDK);
 
     // TypeName at attribute position after '@'.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1263,6 +1263,7 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
   bool HasSpace = false;
   bool ShouldCompleteCallPatternAfterParen = true;
   bool PreferFunctionReferencesToCalls = false;
+  bool AttTargetIsIndependent = false;
   Optional<DeclKind> AttTargetDK;
   Optional<StmtKind> ParentStmtKind;
 
@@ -1351,13 +1352,6 @@ public:
   void setAttrTargetDeclKind(Optional<DeclKind> DK) override {
     if (DK == DeclKind::PatternBinding)
       DK = DeclKind::Var;
-
-    // If the target is already set to 'Module', that means the completion
-    // should be performed as if it's not tied to any specific decl.
-    // see 'completeDeclAttrBeginning()'
-    if (AttTargetDK == DeclKind::Module)
-      DK = None;
-
     AttTargetDK = DK;
   }
 
@@ -4618,10 +4612,7 @@ void CodeCompletionCallbacksImpl::completeDeclAttrBeginning(
   Kind = CompletionKind::AttributeBegin;
   IsInSil = Sil;
   CurDeclContext = P.CurDeclContext;
-
-  // Use 'DeclKind::Module' as the indicator of "This is independent attribute".
-  if (isIndependent)
-    AttTargetDK = DeclKind::Module;
+  AttTargetIsIndependent = isIndependent;
 }
 
 void CodeCompletionCallbacksImpl::completeInPrecedenceGroup(SyntaxKind SK) {
@@ -5385,15 +5376,16 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
 
   case CompletionKind::AttributeBegin: {
-    assert(AttTargetDK != DeclKind::Module &&
-           "'setAttrTargetDeclKind()' hasn't been called");
-    Lookup.getAttributeDeclCompletions(IsInSil, AttTargetDK);
+    auto DK = AttTargetDK;
+    if (AttTargetIsIndependent)
+      DK = None;
+    Lookup.getAttributeDeclCompletions(IsInSil, DK);
 
     // TypeName at attribute position after '@'.
     // - VarDecl: Property Wrappers.
     // - ParamDecl/VarDecl/FuncDecl: Function Buildres.
-    if (!AttTargetDK || *AttTargetDK == DeclKind::Var ||
-        *AttTargetDK == DeclKind::Param || *AttTargetDK == DeclKind::Func)
+    if (!DK.hasValue() || *DK == DeclKind::Var || *DK == DeclKind::Param ||
+        *DK == DeclKind::Func)
       Lookup.getTypeCompletionsInDeclContext(
           P.Context.SourceMgr.getCodeCompletionLoc());
     break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1753,8 +1753,12 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
       Tok.isNot(tok::kw_inout)) {
 
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeDeclAttrBeginning(isInSILMode());
+      if (CodeCompletion) {
+        auto ccLine = SourceMgr.getLineNumber(Tok.getLoc());
+        auto nextLine = SourceMgr.getLineNumber(peekToken().getLoc());
+        CodeCompletion->completeDeclAttrBeginning(isInSILMode(),
+                                                  (nextLine - ccLine) > 1);
+      }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1754,10 +1754,11 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
 
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletion) {
-        auto ccLine = SourceMgr.getLineNumber(Tok.getLoc());
-        auto nextLine = SourceMgr.getLineNumber(peekToken().getLoc());
-        CodeCompletion->completeDeclAttrBeginning(isInSILMode(),
-                                                  (nextLine - ccLine) > 1);
+        // If the next token is not on the same line, this attribute might be
+        // starting new declaration instead of adding attribute to existing
+        // decl.
+        auto isIndependent = peekToken().isAtStartOfLine();
+        CodeCompletion->completeDeclAttrBeginning(isInSILMode(), isIndependent);
       }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -10,7 +10,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PROPERTY | %FileCheck %s -check-prefix=ON_PROPERTY
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_METHOD | %FileCheck %s -check-prefix=ON_METHOD
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM | %FileCheck %s -check-prefix=ON_PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT | %FileCheck %s -check-prefix=ON_MEMBER_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_LAST | %FileCheck %s -check-prefix=ON_MEMBER_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT | %FileCheck %s -check-prefix=KEYWORD_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_LAST | %FileCheck %s -check-prefix=KEYWORD_LAST
 
 struct MyStruct {}
@@ -160,6 +162,7 @@ struct _S {
 // ON_PROPERTY: End completions
 
   @#^ON_METHOD^#
+  private
   func foo()
 // ON_METHOD: Begin completions
 // ON_METHOD-DAG: Keyword/None:                       available[#Func Attribute#]; name=available
@@ -183,6 +186,10 @@ struct _S {
 // ON_PARAM: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_PARAM-NOT: Keyword
 // ON_PARAM: End completions
+
+  @#^ON_MEMBER_INDEPENDENT^#
+
+  func dummy() {}
 
   @#^ON_MEMBER_LAST^#
 // ON_MEMBER_LAST: Begin completions
@@ -215,6 +222,10 @@ struct _S {
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
 // ON_MEMBER_LAST: End completions
 }
+
+@#^KEYWORD_INDEPENDENT^#
+
+func dummy() {}
 
 @#^KEYWORD_LAST^#
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -9,10 +9,13 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_INIT | %FileCheck %s -check-prefix=ON_INIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PROPERTY | %FileCheck %s -check-prefix=ON_PROPERTY
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_METHOD | %FileCheck %s -check-prefix=ON_METHOD
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM | %FileCheck %s -check-prefix=ON_PARAM
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT | %FileCheck %s -check-prefix=ON_MEMBER_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM_1 | %FileCheck %s -check-prefix=ON_PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_PARAM_2 | %FileCheck %s -check-prefix=ON_PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_1 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_2 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_LAST | %FileCheck %s -check-prefix=ON_MEMBER_LAST
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT | %FileCheck %s -check-prefix=KEYWORD_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_1 | %FileCheck %s -check-prefix=KEYWORD_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_2 | %FileCheck %s -check-prefix=KEYWORD_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_LAST | %FileCheck %s -check-prefix=KEYWORD_LAST
 
 struct MyStruct {}
@@ -46,8 +49,7 @@ struct MyStruct {}
 // AVAILABILITY2-NEXT:        Keyword/None:                       deprecated: [#Specify version number#]; name=deprecated{{$}}
 // AVAILABILITY2-NEXT:        End completions
 
-@#^KEYWORD2^#
-func method(){}
+@#^KEYWORD2^# func method(){}
 
 // KEYWORD2:                  Begin completions
 // KEYWORD2-NEXT:             Keyword/None:                       available[#Func Attribute#]; name=available{{$}}
@@ -65,8 +67,7 @@ func method(){}
 // KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2:                  End completions
 
-@#^KEYWORD3^#
-class C {}
+@#^KEYWORD3^# class C {}
 
 // KEYWORD3:                  Begin completions
 // KEYWORD3-NEXT:             Keyword/None:                       available[#Class Attribute#]; name=available{{$}}
@@ -83,12 +84,10 @@ class C {}
 // KEYWORD3-NEXT:             Keyword/None:                       _functionBuilder[#Class Attribute#]; name=_functionBuilder
 // KEYWORD3-NEXT:             End completions
 
-@#^KEYWORD3_2^#IB
-class C2 {}
+@#^KEYWORD3_2^#IB class C2 {}
 // Same as KEYWORD3.
 
-@#^KEYWORD4^#
-enum E {}
+@#^KEYWORD4^# enum E {}
 // KEYWORD4:                  Begin completions
 // KEYWORD4-NEXT:             Keyword/None:                       available[#Enum Attribute#]; name=available{{$}}
 // KEYWORD4-NEXT:             Keyword/None:                       objc[#Enum Attribute#]; name=objc{{$}}
@@ -100,8 +99,7 @@ enum E {}
 // KEYWORD4-NEXT:             End completions
 
 
-@#^KEYWORD5^#
-struct S{}
+@#^KEYWORD5^# struct S{}
 // KEYWORD5:                  Begin completions
 // KEYWORD5-NEXT:             Keyword/None:                       available[#Struct Attribute#]; name=available{{$}}
 // KEYWORD5-NEXT:             Keyword/None:                       dynamicCallable[#Struct Attribute#]; name=dynamicCallable
@@ -111,8 +109,7 @@ struct S{}
 // KEYWORD5-NEXT:             Keyword/None:                       _functionBuilder[#Struct Attribute#]; name=_functionBuilder
 // KEYWORD5-NEXT:             End completions
 
-@#^ON_GLOBALVAR^#
-var globalVar
+@#^ON_GLOBALVAR^# var globalVar
 // ON_GLOBALVAR: Begin completions
 // ON_GLOBALVAR-DAG: Keyword/None:                       available[#Var Attribute#]; name=available
 // ON_GLOBALVAR-DAG: Keyword/None:                       objc[#Var Attribute#]; name=objc
@@ -130,8 +127,7 @@ var globalVar
 // ON_GLOBALVAR: End completions
 
 struct _S {
-  @#^ON_INIT^#
-  init()
+  @#^ON_INIT^# init()
 // ON_INIT: Begin completions
 // ON_INIT-DAG: Keyword/None:                       available[#Constructor Attribute#]; name=available
 // ON_INIT-DAG: Keyword/None:                       objc[#Constructor Attribute#]; name=objc
@@ -142,8 +138,7 @@ struct _S {
 // ON_INIT-DAG: Keyword/None:                       discardableResult[#Constructor Attribute#]; name=discardableResult
 // ON_INIT: End completions
 
-  @#^ON_PROPERTY^#
-  var foo
+  @#^ON_PROPERTY^# var foo
 // ON_PROPERTY: Begin completions
 // ON_PROPERTY-DAG: Keyword/None:                       available[#Var Attribute#]; name=available
 // ON_PROPERTY-DAG: Keyword/None:                       objc[#Var Attribute#]; name=objc
@@ -161,8 +156,7 @@ struct _S {
 // ON_PROPERTY-NOT: Decl[PrecedenceGroup]
 // ON_PROPERTY: End completions
 
-  @#^ON_METHOD^#
-  private
+  @#^ON_METHOD^# private
   func foo()
 // ON_METHOD: Begin completions
 // ON_METHOD-DAG: Keyword/None:                       available[#Func Attribute#]; name=available
@@ -180,16 +174,29 @@ struct _S {
 // ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD: End completions
 
-  func bar(@#^ON_PARAM^#)
+  func bar(@#^ON_PARAM_1^#)
 // ON_PARAM: Begin completions
 // ON_PARAM-NOT: Keyword
 // ON_PARAM: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_PARAM-NOT: Keyword
 // ON_PARAM: End completions
 
-  @#^ON_MEMBER_INDEPENDENT^#
+  func bar(
+    @#^ON_PARAM_2^#
 
-  func dummy() {}
+    arg: Int
+  )
+// Same as ON_PARAM.
+
+  @#^ON_MEMBER_INDEPENDENT_1^#
+
+  func dummy1() {}
+// Same as ON_MEMBER_LAST.
+
+  @#^ON_MEMBER_INDEPENDENT_2^#
+  func dummy2() {}
+// Same as ON_MEMBER_LAST.
+
 
   @#^ON_MEMBER_LAST^#
 // ON_MEMBER_LAST: Begin completions
@@ -223,9 +230,14 @@ struct _S {
 // ON_MEMBER_LAST: End completions
 }
 
-@#^KEYWORD_INDEPENDENT^#
+@#^KEYWORD_INDEPENDENT_1^#
 
-func dummy() {}
+func dummy1() {}
+// Same as KEYWORD_LAST.
+
+@#^KEYWORD_INDEPENDENT_2^#
+func dummy2() {}
+// Same as KEYWORD_LAST.
 
 @#^KEYWORD_LAST^#
 

--- a/test/IDE/complete_pound_decl.swift
+++ b/test/IDE/complete_pound_decl.swift
@@ -15,7 +15,7 @@
 // MEMBER: End completions
 
 // ATTR: Begin completions
-// ATTR: available[#Func Attribute#]; name=available
+// ATTR: available[#Declaration Attribute#]; name=available
 // ATTR: End completions
 
 // GLOBAL: Begin completions


### PR DESCRIPTION
```swift
@#^COMPLETE^#

public func something() {}
```
In this case, we can't say the user is adding attribute to the `func` or starting a new declaration. So if there're one or more blank lines after the completion, suggest context free attribute list.

rdar://problem/50441643
