### PR TITLE
Unskip most of associated_type_demangle_private

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -3,7 +3,6 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: rdar51959305
 
 import Swift
 import StdlibUnittest
@@ -107,7 +106,9 @@ AssociatedTypeDemangleTests.test("nested private generic types in associated typ
   else if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
-    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    // FIXME: rdar://problem/51959305
+    // expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    return
   }
 
   _ = Parent<Never>.Nested(first: "String", second: 0).pair


### PR DESCRIPTION
There’s only one specific case that isn’t working correctly right now; re-enable the rest of the test.

Related to rdar://problem/51959305.