### PR TITLE
Make AdditiveArithmetic.zero @_transparent

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -133,6 +133,7 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
   ///
   /// Zero is the identity element for addition. For any value,
   /// `x + .zero == x` and `.zero + x == x`.
+  @_transparent
   static var zero: Self {
     return 0
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Make default implementation of `AdditiveArithmetic.zero` `@_transparent`.
Seems it is simply overlooked.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
