### PR TITLE
[5.1] ReplaceOpaqueTypesWithUnderlyingTypes: In primary-file mode the…

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2563,10 +2563,10 @@ operator()(SubstitutableType *maybeOpaqueType) const {
   }
 
   auto subs = opaqueRoot->getDecl()->getUnderlyingTypeSubstitutions();
-  // TODO: Check the resilience expansion, and handle opaque types with
-  // unknown underlying types. For now, all opaque types are always
-  // fragile.
-  assert(subs.hasValue() && "resilient opaque types not yet supported");
+  // If the body of the opaque decl providing decl has not been type checked we
+  // don't have a underlying subsitution.
+  if (!subs.hasValue())
+    return maybeOpaqueType;
 
   // Apply the underlying type substitutions to the interface type of the
   // archetype in question. This will map the inner generic signature of the
@@ -2614,7 +2614,10 @@ operator()(CanType maybeOpaqueType, Type replacementType,
   }
 
   auto subs = opaqueRoot->getDecl()->getUnderlyingTypeSubstitutions();
-  assert(subs.hasValue());
+  // If the body of the opaque decl providing decl has not been type checked we
+  // don't have a underlying subsitution.
+  if (!subs.hasValue())
+    return abstractRef;
 
   // Apply the underlying type substitutions to the interface type of the
   // archetype in question. This will map the inner generic signature of the

--- a/test/SILOptimizer/Inputs/specialize_opaque_type_archetypes_multifile_A.swift
+++ b/test/SILOptimizer/Inputs/specialize_opaque_type_archetypes_multifile_A.swift
@@ -1,0 +1,4 @@
+@inline(never)
+func bar2(_ x: Int) -> some P {
+  return x
+}

--- a/test/SILOptimizer/specialize_opaque_type_archetypes_multifile.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes_multifile.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -O -Xllvm -enable-opaque-archetype-specializer -disable-availability-checking -primary-file %s %S/Inputs/specialize_opaque_type_archetypes_multifile_A.swift -emit-sil | %FileCheck %s
+
+protocol P {}
+
+extension Int : P {}
+
+struct Pair {
+  var x: Int64 = 0
+  var y: Int64 = 0
+}
+
+extension Pair : P {}
+
+@inline(never)
+func bar(_ x: Int) -> some P {
+  return x
+}
+
+// CHECK-LABEL: sil @$s43specialize_opaque_type_archetypes_multifile4testyyF : $@convention(thin) () -> () {
+// CHECK: function_ref @$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF : $@convention(thin) (Int) -> @out @_opaqueReturnTypeOf("$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF", 0)
+public func test() {
+  print(bar(5))
+  print(bar2(5))
+}


### PR DESCRIPTION
…re might not be an underlying type because the body of the opaque type providing decl has not been type checked yet.

rdar://51949476