### PR TITLE
remove FileSystem from SourceKit AST cache key

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -168,7 +168,6 @@ void InvocationOptions::profile(llvm::FoldingSetNodeID &ID) const {
   for (auto &Arg : Args)
     ID.AddString(Arg);
   ID.AddString(PrimaryFile);
-  ID.AddPointer(FileSystem.get());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
There is already [other logic for triggering recompilations when files have changed](https://github.com/apple/swift/blob/899693953ee72e2a66ebcf1cefaf3ca8f2edfe7e/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp#L817), so putting the FileSystem pointer in the cache key just triggers unnecessary recompilations when we change the FileSystem pointer without changing any relevant files.