### PR TITLE
[ModuleInterface] Propagate availability for nested types too

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1528,6 +1528,9 @@ public:
   void dump(const Decl *D = nullptr) const;
   void print(ASTPrinter &Printer, const PrintOptions &Options,
              const Decl *D = nullptr) const;
+  static void print(ASTPrinter &Printer, const PrintOptions &Options,
+                    ArrayRef<const DeclAttribute *> FlattenedAttrs,
+                    const Decl *D = nullptr);
 
   template <typename T, typename DERIVED>
   class iterator_base : public std::iterator<std::forward_iterator_tag, T *> {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -332,9 +332,14 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   if (!DeclAttrs)
     return;
 
+  SmallVector<const DeclAttribute *, 8> orderedAttributes(begin(), end());
+  print(Printer, Options, orderedAttributes, D);
+}
+
+void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
+                           ArrayRef<const DeclAttribute *> FlattenedAttrs,
+                           const Decl *D) {
   using AttributeVector = SmallVector<const DeclAttribute *, 8>;
-  AttributeVector orderedAttributes(begin(), end());
-  std::reverse(orderedAttributes.begin(), orderedAttributes.end());
 
   // Process attributes in passes.
   AttributeVector shortAvailableAttributes;
@@ -344,7 +349,7 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   AttributeVector attributes;
   AttributeVector modifiers;
 
-  for (auto DA : orderedAttributes) {
+  for (auto DA : llvm::reverse(FlattenedAttrs)) {
     if (!Options.PrintImplicitAttrs && DA->isImplicit())
       continue;
     if (!Options.PrintUserInaccessibleAttrs &&

--- a/lib/Frontend/ParseableInterfaceSupport.cpp
+++ b/lib/Frontend/ParseableInterfaceSupport.cpp
@@ -178,11 +178,28 @@ class InheritedProtocolCollector {
   SmallVector<const ProtocolType *, 8> ConditionalConformanceProtocols;
 
   /// Helper to extract the `@available` attributes on a decl.
-  AvailableAttrList getAvailabilityAttrs(const Decl *D) {
-    AvailableAttrList result;
-    auto attrRange = D->getAttrs().getAttributes<AvailableAttr>();
-    result.insert(result.begin(), attrRange.begin(), attrRange.end());
-    return result;
+  static AvailableAttrList
+  getAvailabilityAttrs(const Decl *D, Optional<AvailableAttrList> &cache) {
+    if (cache.hasValue())
+      return cache.getValue();
+
+    cache.emplace();
+    while (D) {
+      for (auto *nextAttr : D->getAttrs().getAttributes<AvailableAttr>()) {
+        // FIXME: This is just approximating the effects of nested availability
+        // attributes for the same platform; formally they'd need to be merged.
+        bool alreadyHasMoreSpecificAttrForThisPlatform =
+            llvm::any_of(*cache, [nextAttr](const AvailableAttr *existingAttr) {
+          return existingAttr->Platform == nextAttr->Platform;
+        });
+        if (alreadyHasMoreSpecificAttrForThisPlatform)
+          continue;
+        cache->push_back(nextAttr);
+      }
+      D = D->getDeclContext()->getAsDecl();
+    }
+
+    return cache.getValue();
   }
 
   /// For each type in \p directlyInherited, classify the protocols it refers to
@@ -197,16 +214,13 @@ class InheritedProtocolCollector {
         continue;
 
       bool canPrintNormally = isPublicOrUsableFromInline(inheritedTy);
-      if (!canPrintNormally && !availableAttrs.hasValue())
-        availableAttrs = getAvailabilityAttrs(D);
-
       ExistentialLayout layout = inheritedTy->getExistentialLayout();
       for (ProtocolType *protoTy : layout.getProtocols()) {
         if (canPrintNormally)
           IncludedProtocols.push_back(protoTy->getDecl());
         else
           ExtraProtocols.push_back({protoTy->getDecl(),
-                                    availableAttrs.getValue()});
+                                    getAvailabilityAttrs(D, availableAttrs)});
       }
       // FIXME: This ignores layout constraints, but currently we don't support
       // any of those besides 'AnyObject'.
@@ -332,8 +346,7 @@ public:
     // a bit more memory.
     // FIXME: This will pick the availability attributes from the first sight
     // of a protocol rather than the maximally available case.
-    SmallVector<std::pair<ProtocolDecl *, AvailableAttrList>, 16>
-        protocolsToPrint;
+    SmallVector<ProtocolAndAvailability, 16> protocolsToPrint;
     for (const auto &protoAndAvailability : ExtraProtocols) {
       protoAndAvailability.first->walkInheritedProtocols(
           [&](ProtocolDecl *inherited) -> TypeWalker::Action {
@@ -354,8 +367,11 @@ public:
 
     for (const auto &protoAndAvailability : protocolsToPrint) {
       StreamPrinter printer(out);
-      for (const AvailableAttr *attr : protoAndAvailability.second)
-        attr->print(printer, printOptions);
+      // FIXME: Shouldn't this be an implicit conversion?
+      TinyPtrVector<const DeclAttribute *> attrs;
+      attrs.insert(attrs.end(), protoAndAvailability.second.begin(),
+                   protoAndAvailability.second.end());
+      DeclAttributes::print(printer, printOptions, attrs);
 
       printer << "extension ";
       nominal->getDeclaredType().print(printer, printOptions);

--- a/test/ParseableInterface/conformances.swift
+++ b/test/ParseableInterface/conformances.swift
@@ -195,21 +195,21 @@ extension Bool: ExtraHashable {}
 @available(macOS, unavailable)
 public struct CoolTVType: PrivateSubProto {}
 // CHECK: public struct CoolTVType {
-// CHECK-END: @available(OSX, unavailable)
-// CHECK-END-NEXT: @available(iOS, unavailable)
+// CHECK-END: @available(iOS, unavailable)
+// CHECK-END-NEXT: @available(OSX, unavailable)
 // CHECK-END-NEXT: extension conformances.CoolTVType : conformances.PublicBaseProto {}
 
 @available(macOS 10.99, *)
 public struct VeryNewMacType: PrivateSubProto {}
 // CHECK: public struct VeryNewMacType {
-// CHECK-END: @available(OSX, introduced: 10.99)
+// CHECK-END: @available(OSX 10.99, *)
 // CHECK-END-NEXT: extension conformances.VeryNewMacType : conformances.PublicBaseProto {}
 
 public struct VeryNewMacProto {}
 @available(macOS 10.98, *)
 extension VeryNewMacProto: PrivateSubProto {}
 // CHECK: public struct VeryNewMacProto {
-// CHECK-END: @available(OSX, introduced: 10.98)
+// CHECK-END: @available(OSX 10.98, *)
 // CHECK-END-NEXT: extension conformances.VeryNewMacProto : conformances.PublicBaseProto {}
 
 public struct PrivateProtoConformer {}
@@ -226,6 +226,20 @@ extension PrivateProtoConformer : PrivateProto {
 
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable
+
+
+@available(macOS 10.97, iOS 22, *)
+@available(tvOS, unavailable)
+@available(swift 4.2.123)
+public struct NestedAvailabilityOuter {
+  @available(iOS 23, *)
+  public struct Inner: PrivateSubProto {}
+}
+
+// CHECK-END: @available(swift 4.2.123)
+// CHECK-END-NEXT: @available(OSX 10.97, iOS 23, *)
+// CHECK-END-NEXT: @available(tvOS, unavailable)
+// CHECK-END-NEXT: extension conformances.NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}
 
 
 // CHECK-END: @usableFromInline


### PR DESCRIPTION
Previously the module interface printing would scrape the AvailableAttrs from the containing decl in order to print synthesized extensions for conformances that wouldn't otherwise be printed...but that missed the case where a containing lexical scope had the availability attributes instead. Now it walks up the chain of parent DeclContexts and collects the most specific AvailableAttr for each platform.

This *still* isn't formally correct because it doesn't merge availability for one platform (if something inside is deprecated unconditionally but outside has an "introduced" version), but it's going to match the vast majority of code out there.

Pre-requisite for rdar://problem/50100142 and #25650.