### PR TITLE
TF-587: Default arguments not working in Swift-Jupyter

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1654,16 +1654,13 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
     return {llvm::GlobalValue::ExternalLinkage, PublicDefinitionVisibility,
             ExportedStorage};
 
-  case SILLinkage::PublicNonABI:
-    return isDefinition ? RESULT(WeakODR, Hidden, Default)
-                        : RESULT(External, Hidden, Default);
-
   case SILLinkage::Shared:
   case SILLinkage::SharedExternal:
     return isDefinition ? RESULT(LinkOnceODR, Hidden, Default)
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
+  case SILLinkage::PublicNonABI:
     return RESULT(External, Hidden, Default);
 
   case SILLinkage::Private: {

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -5,7 +5,7 @@ sil_stage canonical
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
-// CHECK: define weak_odr hidden swiftcc void @public_non_abi_function_test() {{.*}} {
+// CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {


### PR DESCRIPTION
I found the commit that is at fault and reverted it. I assume that this breaks something in Windows, but I think that swift-jupyter is a higher priority than Windows for S4TF v0.4. I filed https://bugs.swift.org/browse/SR-10994 for a proper fix, so the proper fix should eventually percolate from upstream to our branch.

Resolves https://bugs.swift.org/browse/TF-587.

Revert "IRGen: give non_abi WeakODR linkage"

This reverts commit 846a64b538145ba70bd76185a080876a34c93991.