### PR TITLE
[5.1][Diagnostics] Don't suggest argument destructuring fix-it if closure …

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar51576862.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar51576862.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+func foo() -> [String] {
+  let dict: [String: String] = [:]
+  return dict.filter({ (_


### PR DESCRIPTION
…is malformed

If closure expression is malformed don't try to suggest a fix-it
about destructuring, because there is no way to figure out where
it would actually go in the source.

Resolves: rdar://problem/51576862
(cherry picked from commit ebe0e42461659f73e942431cbc76a5483933709d)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
