### PR TITLE
[TSan] Deflake positive TSan+libdispatch test

### DIFF
--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -44,6 +44,7 @@ public func call_foobar() {
 var threads: [pthread_t] = []
 var racey_x: Int;
 
+// TSan %deflake as part of the test.
 for _ in 1...5 {
 #if os(macOS) || os(iOS)
   var t : pthread_t?


### PR DESCRIPTION
TSan does not guarantee the detection of races [1].  This means that any
positive test, i.e., a test that asserts the detection of a race, comes
with inherent flakiness.  In the LLVM TSan test suite this unfortunate
circumstance is mitigated via the deflake utility [2] (plus lit
substitution) which executes a test multiple times.

Since we currently only have 3 positive TSan tests in the Swift test
suite [3] (the remaining ones test the absence of false positives), we
decided against bringing over this utility for now. Instead this change
attempts to "deflake" as part of the test itself.

[1] https://groups.google.com/d/msg/thread-sanitizer/KIok3F_b1oI/RwrMNhyHafwJ
[2] https://github.com/llvm/llvm-project/commit/233f401c2bf247d9764c3ca641513dafb623e00c
[3] Positive TSan tests:
  test/Sanitizers/tsan.swift
  test/Sanitizers/tsan-libdispatch.swift
  validation-test/Sanitizers/tsan-inout.swift

rdar://51730684
