### PR TITLE
[ClangImporter] Pass -skip-unused-modulemap-deps to clang

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -478,6 +478,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       "-fretain-comments-from-system-headers",
 
       "-isystem", searchPathOpts.RuntimeResourcePath,
+
+      // Only record modulemaps in the dependency collector if they were
+      // actually loaded.
+      "-Xclang", "-skip-unused-modulemap-deps",
   });
 
   // Enable Position Independence.  `-fPIC` is not supported on Windows, which

--- a/test/ClangImporter/Inputs/unused-modulemap/UnusedModule/module.modulemap
+++ b/test/ClangImporter/Inputs/unused-modulemap/UnusedModule/module.modulemap
@@ -1,0 +1,3 @@
+module UnusedModule {
+  header "dummy.h"
+}

--- a/test/ClangImporter/Inputs/unused-modulemap/module.swiftinterface
+++ b/test/ClangImporter/Inputs/unused-modulemap/module.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.1-dev (LLVM e56fafcd29, Swift e46d71ffe6)
+// swift-module-flags: -enable-library-evolution -module-name module
+import Swift

--- a/test/ClangImporter/unused-modulemap-in-search-paths.swift
+++ b/test/ClangImporter/unused-modulemap-in-search-paths.swift
@@ -1,0 +1,5 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/unused-modulemap -module-cache-path %t/MCP
+// RUN: llvm-bcanalyzer -dump %t/MCP/module*.swiftmodule | not grep UnusedModule
+
+import module

--- a/test/Index/Store/unit-with-bridging-header.swift
+++ b/test/Index/Store/unit-with-bridging-header.swift
@@ -20,7 +20,6 @@
 // PCH-UNIT: DEPEND START
 // PCH-UNIT: Record | user | {{.*}}bridge-include.h | bridge-include.h-
 // PCH-UNIT: File | user | {{.*}}bridge-head.h
-// PCH-UNIT: File | user | {{.*}}module.modulemap
 // PCH-UNIT: DEPEND END (3)
 // PCH-UNIT: INCLUDE START
 // PCH-UNIT: {{.*}}bridge-head.h:1 | {{.*}}bridge-include.h


### PR DESCRIPTION
If there was a clang module in any of the search paths the swift module
loader was searching in, the clang dependency collector would include it
in our dependency tracker. This caused unfortunate build errors when
using .swiftinterface files from the SDK, because they would suddenly
depend on modulemaps in the benchmark suite.

rdar://51713745