### PR TITLE
[5.1][Index/SourceKit] Remove the code related to calculating a module hash from the indexing walker

### DIFF
--- a/include/swift/Index/Index.h
+++ b/include/swift/Index/Index.h
@@ -23,10 +23,8 @@ class DeclContext;
 namespace index {
 
 void indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer);
-void indexSourceFile(SourceFile *SF, StringRef hash,
-                     IndexDataConsumer &consumer);
-void indexModule(ModuleDecl *module, StringRef hash,
-                 IndexDataConsumer &consumer);
+void indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer);
+void indexModule(ModuleDecl *module, IndexDataConsumer &consumer);
 
 } // end namespace index
 } // end namespace swift

--- a/include/swift/Index/IndexDataConsumer.h
+++ b/include/swift/Index/IndexDataConsumer.h
@@ -32,9 +32,8 @@ public:
   virtual void failed(StringRef error) = 0;
   virtual void warning(StringRef warning) {}
 
-  virtual bool recordHash(StringRef hash, bool isKnown) = 0;
   virtual bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                               bool isSystem, StringRef hash) = 0;
+                               bool isSystem) = 0;
   virtual bool finishDependency(bool isClangModule) = 0;
   virtual Action startSourceEntity(const IndexSymbol &symbol) = 0;
   virtual bool finishSourceEntity(SymbolInfo symInfo, SymbolRoleSet roles) = 0;

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -551,9 +551,7 @@ public:
 private:
   bool indexLocals() override { return true; }
   void failed(StringRef error) override {}
-  bool recordHash(StringRef hash, bool isKnown) override { return true; }
-  bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                       bool isSystem, StringRef hash) override {
+  bool startDependency(StringRef name, StringRef path, bool isClangModule, bool isSystem) override {
     return true;
   }
   bool finishDependency(bool isClangModule) override { return true; }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -285,15 +285,14 @@ public:
     assert(Cancelled || ManuallyVisitedAccessorStack.empty());
   }
 
-  void visitModule(ModuleDecl &Mod, StringRef Hash);
+  void visitModule(ModuleDecl &Mod);
   void visitDeclContext(DeclContext *DC);
 
 private:
   bool visitImports(SourceFileOrModule Mod,
                     llvm::SmallPtrSetImpl<ModuleDecl *> &Visited);
 
-  bool handleSourceOrModuleFile(SourceFileOrModule SFOrMod, StringRef KnownHash,
-                                bool &HashIsKnown);
+  bool handleSourceOrModuleFile(SourceFileOrModule SFOrMod);
 
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
     // Do not handle unavailable decls.
@@ -565,10 +564,6 @@ private:
   /// \returns false if AST visitation should stop.
   bool handleWitnesses(Decl *D, SmallVectorImpl<IndexedWitness> &explicitWitnesses);
 
-  void getModuleHash(SourceFileOrModule SFOrMod, llvm::raw_ostream &OS);
-  llvm::hash_code hashModule(llvm::hash_code code, SourceFileOrModule SFOrMod);
-  llvm::hash_code hashFileReference(llvm::hash_code code,
-                                    SourceFileOrModule SFOrMod);
   void getRecursiveModuleImports(ModuleDecl &Mod,
                                  SmallVectorImpl<ModuleDecl *> &Imports);
   void
@@ -601,7 +596,7 @@ void IndexSwiftASTWalker::visitDeclContext(DeclContext *Context) {
     ManuallyVisitedAccessorStack.pop_back();
 }
 
-void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod, StringRef KnownHash) {
+void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod) {
   SourceFile *SrcFile = nullptr;
   for (auto File : Mod.getFiles()) {
     if (auto SF = dyn_cast<SourceFile>(File)) {
@@ -613,41 +608,23 @@ void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod, StringRef KnownHash) {
     }
   }
 
-  bool HashIsKnown;
   if (SrcFile != nullptr) {
     IsModuleFile = false;
-    if (!handleSourceOrModuleFile(*SrcFile, KnownHash, HashIsKnown))
+    if (!handleSourceOrModuleFile(*SrcFile))
       return;
-    if (HashIsKnown)
-      return; // No need to report symbols.
     walk(*SrcFile);
   } else {
     IsModuleFile = true;
     isSystemModule = Mod.isSystemModule();
-    if (!handleSourceOrModuleFile(Mod, KnownHash, HashIsKnown))
+    if (!handleSourceOrModuleFile(Mod))
       return;
-    if (HashIsKnown)
-      return; // No need to report symbols.
     walk(Mod);
   }
 }
 
-bool IndexSwiftASTWalker::handleSourceOrModuleFile(SourceFileOrModule SFOrMod,
-                                                   StringRef KnownHash,
-                                                   bool &HashIsKnown) {
+bool IndexSwiftASTWalker::handleSourceOrModuleFile(SourceFileOrModule SFOrMod) {
   // Common reporting for TU/module file.
 
-  SmallString<32> HashBuf;
-  {
-    llvm::raw_svector_ostream HashOS(HashBuf);
-    getModuleHash(SFOrMod, HashOS);
-    StringRef Hash = HashOS.str();
-    HashIsKnown = Hash == KnownHash;
-    if (!IdxConsumer.recordHash(Hash, HashIsKnown))
-      return false;
-  }
-
-  // We always report the dependencies, even if the hash is known.
   llvm::SmallPtrSet<ModuleDecl *, 16> Visited;
   return visitImports(SFOrMod, Visited);
 }
@@ -703,16 +680,8 @@ bool IndexSwiftASTWalker::visitImports(
       continue;
     bool IsClangModule = *IsClangModuleOpt;
 
-    StringRef Hash;
-    SmallString<32> HashBuf;
-    if (!IsClangModule) {
-      llvm::raw_svector_ostream HashOS(HashBuf);
-      getModuleHash(*Mod, HashOS);
-      Hash = HashOS.str();
-    }
-
     if (!IdxConsumer.startDependency(Mod->getName().str(), Path, IsClangModule,
-                                     Mod->isSystemModule(), Hash))
+                                     Mod->isSystemModule()))
       return false;
     if (!IsClangModule)
       if (!visitImports(*Mod, Visited))
@@ -1441,43 +1410,6 @@ bool IndexSwiftASTWalker::indexComment(const Decl *D) {
   return !Cancelled;
 }
 
-llvm::hash_code
-IndexSwiftASTWalker::hashFileReference(llvm::hash_code code,
-                                       SourceFileOrModule SFOrMod) {
-  StringRef Filename = SFOrMod.getFilename();
-  if (Filename.empty())
-    return code;
-
-  // FIXME: FileManager for swift ?
-
-  llvm::sys::fs::file_status Status;
-  if (std::error_code Ret = llvm::sys::fs::status(Filename, Status)) {
-    // Failure to read the file, just use filename to recover.
-    warn([&](llvm::raw_ostream &OS) {
-      OS << "failed to stat file: " << Filename << " (" << Ret.message() << ')';
-    });
-    return hash_combine(code, Filename);
-  }
-
-  // Don't use inode because it can easily change when you update the repository
-  // even though the file is supposed to be the same (same size/time).
-  code = hash_combine(code, Filename);
-  auto mtime = Status.getLastModificationTime().time_since_epoch().count();
-  return hash_combine(code, Status.getSize(), mtime);
-}
-
-llvm::hash_code IndexSwiftASTWalker::hashModule(llvm::hash_code code,
-                                                SourceFileOrModule SFOrMod) {
-  code = hashFileReference(code, SFOrMod);
-
-  SmallVector<ModuleDecl *, 16> Imports;
-  getRecursiveModuleImports(SFOrMod.getModule(), Imports);
-  for (auto Import : Imports)
-    code = hashFileReference(code, *Import);
-
-  return code;
-}
-
 void IndexSwiftASTWalker::getRecursiveModuleImports(
     ModuleDecl &Mod, SmallVectorImpl<ModuleDecl *> &Imports) {
   auto It = ImportsMap.find(&Mod);
@@ -1575,13 +1507,6 @@ void IndexSwiftASTWalker::collectRecursiveModuleImports(
   }
 }
 
-void IndexSwiftASTWalker::getModuleHash(SourceFileOrModule Mod,
-                                        llvm::raw_ostream &OS) {
-  // FIXME: Use a longer hash string to minimize possibility for conflicts.
-  llvm::hash_code code = hashModule(0, Mod);
-  OS << llvm::APInt(64, code).toString(36, /*Signed=*/false);
-}
-
 static Type getContextFreeInterfaceType(ValueDecl *VD) {
   if (auto AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
     return AFD->getMethodInterfaceType();
@@ -1661,19 +1586,17 @@ void index::indexDeclContext(DeclContext *DC, IndexDataConsumer &consumer) {
   consumer.finish();
 }
 
-void index::indexSourceFile(SourceFile *SF, StringRef hash,
-                            IndexDataConsumer &consumer) {
+void index::indexSourceFile(SourceFile *SF, IndexDataConsumer &consumer) {
   assert(SF);
   unsigned bufferID = SF->getBufferID().getValue();
   IndexSwiftASTWalker walker(consumer, SF->getASTContext(), bufferID);
-  walker.visitModule(*SF->getParentModule(), hash);
+  walker.visitModule(*SF->getParentModule());
   consumer.finish();
 }
 
-void index::indexModule(ModuleDecl *module, StringRef hash,
-                        IndexDataConsumer &consumer) {
+void index::indexModule(ModuleDecl *module, IndexDataConsumer &consumer) {
   assert(module);
   IndexSwiftASTWalker walker(consumer, module->getASTContext());
-  walker.visitModule(*module, hash);
+  walker.visitModule(*module);
   consumer.finish();
 }

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -164,9 +164,7 @@ public:
     // FIXME: expose errors?
   }
 
-  bool recordHash(StringRef hash, bool isKnown) override { return true; }
-  bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                       bool isSystem, StringRef hash) override {
+  bool startDependency(StringRef name, StringRef path, bool isClangModule, bool isSystem) override {
     return true;
   }
   bool finishDependency(bool isClangModule) override { return true; }
@@ -203,9 +201,7 @@ public:
     // FIXME: expose errors?
   }
 
-  bool recordHash(StringRef hash, bool isKnown) override { return true; }
-  bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                       bool isSystem, StringRef hash) override {
+  bool startDependency(StringRef name, StringRef path, bool isClangModule, bool isSystem) override {
     return true;
   }
   bool finishDependency(bool isClangModule) override { return true; }
@@ -342,7 +338,7 @@ recordSourceFile(SourceFile *SF, StringRef indexStorePath,
   bool failed = false;
   auto consumer = makeRecordingConsumer(SF->getFilename(), indexStorePath,
                                         &diags, &recordFile, &failed);
-  indexSourceFile(SF, /*Hash=*/"", *consumer);
+  indexSourceFile(SF, *consumer);
 
   if (!failed && !recordFile.empty())
     callback(recordFile, SF->getFilename());
@@ -482,7 +478,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     bool failed = false;
     auto consumer = makeRecordingConsumer(filename, indexStorePath,
                                           &diags, &recordFile, &failed);
-    indexModule(module, /*Hash=*/"", *consumer);
+    indexModule(module, *consumer);
 
     if (failed)
       return true;
@@ -531,7 +527,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
       records.emplace_back(outRecordFile, moduleName.str());
       return true;
     });
-    indexModule(module, /*Hash=*/"", groupIndexConsumer);
+    indexModule(module, groupIndexConsumer);
     if (failed)
       return true;
   }

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/a.index.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
+++ b/test/SourceKit/Indexing/Inputs/implicit-vis/b.index.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -1,25 +1,21 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     },
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "SwiftOnoneSupport",
       key.filepath: SwiftOnoneSupport.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1,
       key.dependencies: [
         {
           key.kind: source.lang.swift.import.module.swift,
           key.name: "Swift",
           key.filepath: Swift.swiftmodule,
-          key.hash: <hash>,
           key.is_system: 1
         }
       ]

--- a/test/SourceKit/Indexing/index.swift
+++ b/test/SourceKit/Indexing/index.swift
@@ -1,8 +1,4 @@
-// FIXME(integers): %t.response content is non-deterministic with the new
-// integer protocols
-// XFAIL: *
-
-// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean | sed -e 's/key.usr: \".*\"/key.usr: <usr>/g' > %t.response
 // RUN: diff -u %s.response %t.response
 
 var globV: Int

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],
@@ -13,105 +11,113 @@
     {
       key.kind: source.lang.swift.decl.var.global,
       key.name: "globV",
-      key.usr: "s:5index5globVSiv",
+      key.usr: <usr>,
       key.line: 4,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
-          key.usr: "s:5index5globVSifg",
+          key.usr: <usr>,
           key.line: 4,
-          key.column: 5
+          key.column: 5,
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
-          key.usr: "s:5index5globVSifs",
+          key.usr: <usr>,
           key.line: 4,
-          key.column: 5
+          key.column: 5,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.ref.struct,
       key.name: "Int",
-      key.usr: "s:Si",
+      key.usr: <usr>,
       key.line: 4,
       key.column: 12
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "CC",
-      key.usr: "s:5index2CCC",
+      key.usr: <usr>,
       key.line: 6,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init()",
-          key.usr: "s:5index2CCCACycfc",
+          key.usr: <usr>,
           key.line: 7,
           key.column: 3
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "instV",
-          key.usr: "s:5index2CCC5instVACv",
+          key.usr: <usr>,
           key.line: 8,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:5index2CCC5instVACfg",
+              key.usr: <usr>,
               key.line: 8,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:5index2CCC5instVACfs",
+              key.usr: <usr>,
               key.line: 8,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 8,
           key.column: 14
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "meth()",
-          key.usr: "s:5index2CCC4methyyF",
+          key.usr: <usr>,
           key.line: 9,
-          key.column: 8
+          key.column: 8,
+          key.is_dynamic: 1
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "instanceFunc0(_:b:)",
-          key.usr: "s:5index2CCC13instanceFunc0S2i_Sf1btF",
+          key.usr: <usr>,
           key.line: 10,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 10,
               key.column: 27
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Float",
-              key.usr: "s:Sf",
+              key.usr: <usr>,
               key.line: 10,
               key.column: 35
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 10,
               key.column: 45
             }
@@ -120,28 +126,29 @@
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "instanceFunc1(a:b:)",
-          key.usr: "s:5index2CCC13instanceFunc1S2i1a_Sf1btF",
+          key.usr: <usr>,
           key.line: 13,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 13,
               key.column: 27
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Float",
-              key.usr: "s:Sf",
+              key.usr: <usr>,
               key.line: 13,
               key.column: 37
             },
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 13,
               key.column: 47
             }
@@ -150,37 +157,38 @@
         {
           key.kind: source.lang.swift.decl.function.method.class,
           key.name: "smeth()",
-          key.usr: "s:5index2CCC5smethyyFZ",
+          key.usr: <usr>,
           key.line: 16,
-          key.column: 14
+          key.column: 14,
+          key.is_dynamic: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "+(_:_:)",
-      key.usr: "s:5index1poiAA2CCCAD_ADtF",
+      key.usr: <usr>,
       key.line: 19,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 19,
           key.column: 12
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 19,
           key.column: 19
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 19,
           key.column: 26
         }
@@ -189,37 +197,44 @@
     {
       key.kind: source.lang.swift.decl.struct,
       key.name: "S",
-      key.usr: "s:5index1SV",
+      key.usr: <usr>,
       key.line: 23,
       key.column: 8,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "meth()",
-          key.usr: "s:5index1SV4methyyF",
+          key.usr: <usr>,
           key.line: 24,
           key.column: 8
         },
         {
           key.kind: source.lang.swift.decl.function.method.static,
           key.name: "smeth()",
-          key.usr: "s:5index1SV5smethyyFZ",
+          key.usr: <usr>,
           key.line: 25,
           key.column: 15
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 23,
+          key.column: 8,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.enum,
       key.name: "E",
-      key.usr: "s:5index1EO",
+      key.usr: <usr>,
       key.line: 28,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.enumelement,
           key.name: "EElem",
-          key.usr: "s:5index1EO5EElemA2CmF",
+          key.usr: <usr>,
           key.line: 29,
           key.column: 8
         }
@@ -228,21 +243,22 @@
     {
       key.kind: source.lang.swift.decl.protocol,
       key.name: "Prot",
-      key.usr: "s:5index4ProtP",
+      key.usr: <usr>,
       key.line: 32,
       key.column: 10,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "protMeth(_:)",
-          key.usr: "s:5index4ProtP8protMethyAaB_pF",
+          key.usr: <usr>,
           key.line: 33,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.protocol,
               key.name: "Prot",
-              key.usr: "s:5index4ProtP",
+              key.usr: <usr>,
               key.line: 33,
               key.column: 22
             }
@@ -253,67 +269,69 @@
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "foo(_:b:)",
-      key.usr: "s:5index3fooyAA2CCC_AA1EOz1btF",
+      key.usr: <usr>,
       key.line: 36,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 36,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.ref.enum,
           key.name: "E",
-          key.usr: "s:5index1EO",
+          key.usr: <usr>,
           key.line: 36,
           key.column: 28
         },
         {
           key.kind: source.lang.swift.ref.var.global,
           key.name: "globV",
-          key.usr: "s:5index5globVSiv",
+          key.usr: <usr>,
           key.line: 37,
           key.column: 3,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.setter,
-              key.usr: "s:5index5globVSifs",
+              key.usr: <usr>,
               key.line: 37,
-              key.column: 3
+              key.column: 3,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.function.operator.infix,
           key.name: "+(_:_:)",
-          key.usr: "s:5index1poiAA2CCCAD_ADtF",
+          key.usr: <usr>,
           key.line: 38,
           key.column: 5
         },
         {
           key.kind: source.lang.swift.ref.var.instance,
           key.name: "instV",
-          key.usr: "s:5index2CCC5instVACv",
+          key.usr: <usr>,
           key.line: 38,
           key.column: 9,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index2CCC5instVACfg",
+              key.usr: <usr>,
               key.line: 38,
               key.column: 9,
               key.receiver_usr: "s:5index2CCC",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.function.method.instance,
           key.name: "meth()",
-          key.usr: "s:5index2CCC4methyyF",
+          key.usr: <usr>,
           key.line: 39,
           key.column: 5,
           key.receiver_usr: "s:5index2CCC",
@@ -322,14 +340,14 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 40,
           key.column: 3
         },
         {
           key.kind: source.lang.swift.ref.function.method.class,
           key.name: "smeth()",
-          key.usr: "s:5index2CCC5smethyyFZ",
+          key.usr: <usr>,
           key.line: 40,
           key.column: 6,
           key.receiver_usr: "s:5index2CCC"
@@ -337,21 +355,21 @@
         {
           key.kind: source.lang.swift.ref.enum,
           key.name: "E",
-          key.usr: "s:5index1EO",
+          key.usr: <usr>,
           key.line: 41,
           key.column: 7
         },
         {
           key.kind: source.lang.swift.ref.enumelement,
           key.name: "EElem",
-          key.usr: "s:5index1EO5EElemA2CmF",
+          key.usr: <usr>,
           key.line: 41,
           key.column: 9
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 42,
           key.column: 14
         }
@@ -360,14 +378,14 @@
     {
       key.kind: source.lang.swift.decl.typealias,
       key.name: "CCAlias",
-      key.usr: "s:5index7CCAliasa",
+      key.usr: <usr>,
       key.line: 47,
       key.column: 11,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 47,
           key.column: 21
         }
@@ -376,14 +394,14 @@
     {
       key.kind: source.lang.swift.decl.extension.class,
       key.name: "CC",
-      key.usr: "s:e:s:5index2CCC5meth2yACF",
+      key.usr: <usr>,
       key.line: 49,
       key.column: 11,
       key.related: [
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 49,
           key.column: 16
         }
@@ -392,28 +410,29 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 49,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 49,
           key.column: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "meth2(_:)",
-          key.usr: "s:5index2CCC5meth2yACF",
+          key.usr: <usr>,
           key.line: 50,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.typealias,
               key.name: "CCAlias",
-              key.usr: "s:5index7CCAliasa",
+              key.usr: <usr>,
               key.line: 50,
               key.column: 19
             }
@@ -422,21 +441,22 @@
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "protMeth(_:)",
-          key.usr: "s:5index2CCC8protMethyAA4Prot_pF",
+          key.usr: <usr>,
           key.line: 51,
           key.column: 8,
+          key.is_dynamic: 1,
           key.related: [
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "protMeth(_:)",
-              key.usr: "s:5index4ProtP8protMethyAaB_pF"
+              key.usr: <usr>
             }
           ],
           key.entities: [
             {
               key.kind: source.lang.swift.ref.protocol,
               key.name: "Prot",
-              key.usr: "s:5index4ProtP",
+              key.usr: <usr>,
               key.line: 51,
               key.column: 22
             }
@@ -445,23 +465,24 @@
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "extV",
-          key.usr: "s:5index2CCC4extVSiv",
+          key.usr: <usr>,
           key.line: 52,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:extV",
-              key.usr: "s:5index2CCC4extVSifg",
+              key.usr: <usr>,
               key.line: 52,
-              key.column: 18
+              key.column: 18,
+              key.is_dynamic: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 52,
           key.column: 14
         }
@@ -470,175 +491,228 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "SubCC",
-      key.usr: "s:5index5SubCCC",
+      key.usr: <usr>,
       key.line: 55,
       key.column: 7,
       key.related: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 55,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 55,
           key.column: 19
         }
       ],
       key.entities: [
         {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.usr: <usr>,
+          key.line: 55,
+          key.column: 7,
+          key.is_implicit: 1,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.method.instance,
+              key.name: "protMeth(_:)",
+              key.usr: <usr>
+            }
+          ]
+        },
+        {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC",
-          key.usr: "s:5index2CCC",
+          key.usr: <usr>,
           key.line: 55,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 55,
           key.column: 19
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 55,
+          key.column: 24,
+          key.is_implicit: 1,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: <usr>
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.override
+            }
+          ]
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
       key.name: "globV2",
-      key.usr: "s:5index6globV2AA5SubCCCv",
+      key.usr: <usr>,
       key.line: 57,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
-          key.usr: "s:5index6globV2AA5SubCCCfg",
+          key.usr: <usr>,
           key.line: 57,
-          key.column: 5
+          key.column: 5,
+          key.is_implicit: 1
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
-          key.usr: "s:5index6globV2AA5SubCCCfs",
+          key.usr: <usr>,
           key.line: 57,
-          key.column: 5
+          key.column: 5,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.ref.class,
       key.name: "SubCC",
-      key.usr: "s:5index5SubCCC",
+      key.usr: <usr>,
       key.line: 57,
       key.column: 13
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "ComputedProperty",
-      key.usr: "s:5index16ComputedPropertyC",
+      key.usr: <usr>,
       key.line: 59,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "value",
-          key.usr: "s:5index16ComputedPropertyC5valueSiv",
+          key.usr: <usr>,
           key.line: 60,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:value",
-              key.usr: "s:5index16ComputedPropertyC5valueSifg",
+              key.usr: <usr>,
               key.line: 61,
-              key.column: 5
+              key.column: 5,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:value",
-              key.usr: "s:5index16ComputedPropertyC5valueSifs",
+              key.usr: <usr>,
               key.line: 65,
-              key.column: 5
+              key.column: 5,
+              key.is_dynamic: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 60,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "readOnly",
-          key.usr: "s:5index16ComputedPropertyC8readOnlySiv",
+          key.usr: <usr>,
           key.line: 70,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:readOnly",
-              key.usr: "s:5index16ComputedPropertyC8readOnlySifg",
+              key.usr: <usr>,
               key.line: 70,
-              key.column: 22
+              key.column: 22,
+              key.is_dynamic: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 70,
           key.column: 18
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 59,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "BC2",
-      key.usr: "s:5index3BC2C",
+      key.usr: <usr>,
       key.line: 73,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "protMeth(_:)",
-          key.usr: "s:5index3BC2C8protMethyAA4Prot_pF",
+          key.usr: <usr>,
           key.line: 74,
           key.column: 8,
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.protocol,
               key.name: "Prot",
-              key.usr: "s:5index4ProtP",
+              key.usr: <usr>,
               key.line: 74,
               key.column: 22
             }
           ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 73,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "SubC2",
-      key.usr: "s:5index5SubC2C",
+      key.usr: <usr>,
       key.line: 76,
       key.column: 7,
       key.related: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "BC2",
-          key.usr: "s:5index3BC2C",
+          key.usr: <usr>,
           key.line: 76,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 76,
           key.column: 20
         }
@@ -647,42 +721,62 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "BC2",
-          key.usr: "s:5index3BC2C",
+          key.usr: <usr>,
           key.line: 76,
           key.column: 15
         },
         {
           key.kind: source.lang.swift.ref.protocol,
           key.name: "Prot",
-          key.usr: "s:5index4ProtP",
+          key.usr: <usr>,
           key.line: 76,
           key.column: 20
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "protMeth(_:)",
-          key.usr: "s:5index5SubC2C8protMethyAA4Prot_pF",
+          key.usr: <usr>,
           key.line: 77,
           key.column: 17,
+          key.is_dynamic: 1,
           key.related: [
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "protMeth(_:)",
-              key.usr: "s:5index3BC2C8protMethyAA4Prot_pF"
+              key.usr: <usr>
             },
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "protMeth(_:)",
-              key.usr: "s:5index4ProtP8protMethyAaB_pF"
+              key.usr: <usr>
             }
           ],
           key.entities: [
             {
               key.kind: source.lang.swift.ref.protocol,
               key.name: "Prot",
-              key.usr: "s:5index4ProtP",
+              key.usr: <usr>,
               key.line: 77,
               key.column: 31
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.override
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 76,
+          key.column: 25,
+          key.is_implicit: 1,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: <usr>
             }
           ],
           key.attributes: [
@@ -696,211 +790,175 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "CC2",
-      key.usr: "s:5index3CC2C",
+      key.usr: <usr>,
       key.line: 80,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:5index3CC2C9subscriptS2ici",
+          key.usr: <usr>,
           key.line: 81,
           key.column: 3,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:subscript(_:)",
-              key.usr: "s:5index3CC2C9subscriptS2icfg",
+              key.usr: <usr>,
               key.line: 82,
-              key.column: 5
+              key.column: 5,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:subscript(_:)",
-              key.usr: "s:5index3CC2C9subscriptS2icfs",
+              key.usr: <usr>,
               key.line: 85,
               key.column: 5,
+              key.is_dynamic: 1,
               key.entities: [
                 {
                   key.kind: source.lang.swift.ref.function.operator.infix,
                   key.name: "+(_:_:)",
-                  key.usr: "s:s1poiS2i_SitF",
+                  key.usr: <usr>,
                   key.line: 86,
                   key.column: 8
                 }
               ]
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: <usr>,
+              key.line: 81,
+              key.column: 18
+            },
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: <usr>,
+              key.line: 81,
+              key.column: 26
             }
           ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 80,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "test1(_:sub:)",
-      key.usr: "s:5index5test1yAA16ComputedPropertyC_AA3CC2C3subtF",
+      key.usr: <usr>,
       key.line: 91,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "ComputedProperty",
-          key.usr: "s:5index16ComputedPropertyC",
+          key.usr: <usr>,
           key.line: 91,
           key.column: 18
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC2",
-          key.usr: "s:5index3CC2C",
+          key.usr: <usr>,
           key.line: 91,
           key.column: 41
         },
         {
           key.kind: source.lang.swift.ref.var.instance,
           key.name: "value",
-          key.usr: "s:5index16ComputedPropertyC5valueSiv",
+          key.usr: <usr>,
           key.line: 92,
           key.column: 14,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index16ComputedPropertyC5valueSifg",
+              key.usr: <usr>,
               key.line: 92,
               key.column: 14,
               key.receiver_usr: "s:5index16ComputedPropertyC",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.var.instance,
           key.name: "readOnly",
-          key.usr: "s:5index16ComputedPropertyC8readOnlySiv",
+          key.usr: <usr>,
           key.line: 93,
           key.column: 10,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index16ComputedPropertyC8readOnlySifg",
+              key.usr: <usr>,
               key.line: 93,
               key.column: 10,
               key.receiver_usr: "s:5index16ComputedPropertyC",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.var.instance,
           key.name: "value",
-          key.usr: "s:5index16ComputedPropertyC5valueSiv",
+          key.usr: <usr>,
           key.line: 94,
           key.column: 6,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.setter,
-              key.usr: "s:5index16ComputedPropertyC5valueSifs",
+              key.usr: <usr>,
               key.line: 94,
               key.column: 6,
               key.receiver_usr: "s:5index16ComputedPropertyC",
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
-          key.kind: source.lang.swift.ref.function.operator.prefix,
-          key.name: "++(_:)",
-          key.usr: "s:s2ppopS2izF",
-          key.line: 95,
-          key.column: 3
-        },
-        {
-          key.kind: source.lang.swift.ref.var.instance,
-          key.name: "value",
-          key.usr: "s:5index16ComputedPropertyC5valueSiv",
-          key.line: 95,
-          key.column: 8,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index16ComputedPropertyC5valueSifg",
-              key.line: 95,
-              key.column: 8,
-              key.receiver_usr: "s:5index16ComputedPropertyC",
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.ref.function.accessor.setter,
-              key.usr: "s:5index16ComputedPropertyC5valueSifs",
-              key.line: 95,
-              key.column: 8,
-              key.receiver_usr: "s:5index16ComputedPropertyC",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:5index3CC2C9subscriptS2ici",
+          key.usr: <usr>,
           key.line: 96,
           key.column: 10,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index3CC2C9subscriptS2icfg",
+              key.usr: <usr>,
               key.line: 96,
               key.column: 10,
               key.receiver_usr: "s:5index3CC2C",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.function.subscript,
           key.name: "subscript(_:)",
-          key.usr: "s:5index3CC2C9subscriptS2ici",
+          key.usr: <usr>,
           key.line: 97,
           key.column: 6,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.setter,
-              key.usr: "s:5index3CC2C9subscriptS2icfs",
+              key.usr: <usr>,
               key.line: 97,
               key.column: 6,
               key.receiver_usr: "s:5index3CC2C",
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
-          key.kind: source.lang.swift.ref.function.operator.prefix,
-          key.name: "++(_:)",
-          key.usr: "s:s2ppopS2izF",
-          key.line: 98,
-          key.column: 3
-        },
-        {
-          key.kind: source.lang.swift.ref.function.subscript,
-          key.name: "subscript(_:)",
-          key.usr: "s:5index3CC2C9subscriptS2ici",
-          key.line: 98,
-          key.column: 8,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index3CC2C9subscriptS2icfg",
-              key.line: 98,
-              key.column: 8,
-              key.receiver_usr: "s:5index3CC2C",
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.ref.function.accessor.setter,
-              key.usr: "s:5index3CC2C9subscriptS2icfs",
-              key.line: 98,
-              key.column: 8,
-              key.receiver_usr: "s:5index3CC2C",
-              key.is_dynamic: 1
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             }
           ]
         }
@@ -909,37 +967,51 @@
     {
       key.kind: source.lang.swift.decl.struct,
       key.name: "S2",
-      key.usr: "s:5index2S2V",
+      key.usr: <usr>,
       key.line: 101,
       key.column: 8,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "sfoo()",
-          key.usr: "s:5index2S2V4sfooyyF",
+          key.usr: <usr>,
           key.line: 102,
           key.column: 8
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 101,
+          key.column: 8,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
       key.name: "globReadOnly",
-      key.usr: "s:5index12globReadOnlyAA2S2Vv",
+      key.usr: <usr>,
       key.line: 105,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
           key.name: "getter:globReadOnly",
-          key.usr: "s:5index12globReadOnlyAA2S2Vfg",
+          key.usr: <usr>,
           key.line: 106,
           key.column: 3,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "S2",
-              key.usr: "s:5index2S2V",
+              key.usr: <usr>,
+              key.line: 107,
+              key.column: 12
+            },
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: <usr>,
               key.line: 107,
               key.column: 12
             }
@@ -950,36 +1022,37 @@
     {
       key.kind: source.lang.swift.ref.struct,
       key.name: "S2",
-      key.usr: "s:5index2S2V",
+      key.usr: <usr>,
       key.line: 105,
       key.column: 20
     },
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "test2()",
-      key.usr: "s:5index5test2yyF",
+      key.usr: <usr>,
       key.line: 111,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.var.global,
           key.name: "globReadOnly",
-          key.usr: "s:5index12globReadOnlyAA2S2Vv",
+          key.usr: <usr>,
           key.line: 112,
           key.column: 3,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:5index12globReadOnlyAA2S2Vfg",
+              key.usr: <usr>,
               key.line: 112,
-              key.column: 3
+              key.column: 3,
+              key.is_implicit: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.function.method.instance,
           key.name: "sfoo()",
-          key.usr: "s:5index2S2V4sfooyyF",
+          key.usr: <usr>,
           key.line: 112,
           key.column: 16,
           key.receiver_usr: "s:5index2S2V"
@@ -989,30 +1062,38 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "B1",
-      key.usr: "s:5index2B1C",
+      key.usr: <usr>,
       key.line: 115,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "foo()",
-          key.usr: "s:5index2B1C3fooyyF",
+          key.usr: <usr>,
           key.line: 116,
-          key.column: 8
+          key.column: 8,
+          key.is_dynamic: 1
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 115,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "SB1",
-      key.usr: "s:5index3SB1C",
+      key.usr: <usr>,
       key.line: 119,
       key.column: 7,
       key.related: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "B1",
-          key.usr: "s:5index2B1C",
+          key.usr: <usr>,
           key.line: 119,
           key.column: 13
         }
@@ -1021,28 +1102,29 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "B1",
-          key.usr: "s:5index2B1C",
+          key.usr: <usr>,
           key.line: 119,
           key.column: 13
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "foo()",
-          key.usr: "s:5index3SB1C3fooyyF",
+          key.usr: <usr>,
           key.line: 120,
           key.column: 17,
+          key.is_dynamic: 1,
           key.related: [
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "foo()",
-              key.usr: "s:5index2B1C3fooyyF"
+              key.usr: <usr>
             }
           ],
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "foo()",
-              key.usr: "s:5index3SB1C3fooyyF",
+              key.usr: <usr>,
               key.line: 121,
               key.column: 5,
               key.receiver_usr: "s:5index3SB1C",
@@ -1051,7 +1133,7 @@
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "foo()",
-              key.usr: "s:5index3SB1C3fooyyF",
+              key.usr: <usr>,
               key.line: 122,
               key.column: 10,
               key.receiver_usr: "s:5index3SB1C",
@@ -1060,10 +1142,29 @@
             {
               key.kind: source.lang.swift.ref.function.method.instance,
               key.name: "foo()",
-              key.usr: "s:5index2B1C3fooyyF",
+              key.usr: <usr>,
               key.line: 123,
               key.column: 11,
               key.receiver_usr: "s:5index2B1C"
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.override
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 119,
+          key.column: 16,
+          key.is_implicit: 1,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: <usr>
             }
           ],
           key.attributes: [
@@ -1077,35 +1178,35 @@
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "test3(_:s:)",
-      key.usr: "s:5index5test3yAA3SB1C_AA2S2V1stF",
+      key.usr: <usr>,
       key.line: 127,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "SB1",
-          key.usr: "s:5index3SB1C",
+          key.usr: <usr>,
           key.line: 127,
           key.column: 17
         },
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "S2",
-          key.usr: "s:5index2S2V",
+          key.usr: <usr>,
           key.line: 127,
           key.column: 25
         },
         {
           key.kind: source.lang.swift.ref.function.free,
           key.name: "test2()",
-          key.usr: "s:5index5test2yyF",
+          key.usr: <usr>,
           key.line: 128,
           key.column: 3
         },
         {
           key.kind: source.lang.swift.ref.function.method.instance,
           key.name: "foo()",
-          key.usr: "s:5index3SB1C3fooyyF",
+          key.usr: <usr>,
           key.line: 129,
           key.column: 5,
           key.receiver_usr: "s:5index3SB1C",
@@ -1114,7 +1215,7 @@
         {
           key.kind: source.lang.swift.ref.function.method.instance,
           key.name: "sfoo()",
-          key.usr: "s:5index2S2V4sfooyyF",
+          key.usr: <usr>,
           key.line: 130,
           key.column: 5,
           key.receiver_usr: "s:5index2S2V"
@@ -1124,35 +1225,35 @@
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "meth()",
-      key.usr: "s:5index4methXeXeF",
+      key.usr: <usr>,
       key.line: 134,
       key.column: 8
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "CC4",
-      key.usr: "s:5index3CC4C",
+      key.usr: <usr>,
       key.line: 137,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(x:)",
-          key.usr: "s:5index3CC4CACSi1x_tcfc",
+          key.usr: <usr>,
           key.line: 138,
           key.column: 15,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 138,
               key.column: 23
             },
             {
               key.kind: source.lang.swift.ref.function.constructor,
               key.name: "init(x:)",
-              key.usr: "s:5index3CC4CACSi1x_tcfc",
+              key.usr: <usr>,
               key.line: 139,
               key.column: 10,
               key.receiver_usr: "s:5index3CC4C",
@@ -1164,20 +1265,27 @@
               key.attribute: source.decl.attribute.convenience
             }
           ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 137,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "SubCC4",
-      key.usr: "s:5index6SubCC4C",
+      key.usr: <usr>,
       key.line: 143,
       key.column: 7,
       key.related: [
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC4",
-          key.usr: "s:5index3CC4C",
+          key.usr: <usr>,
           key.line: 143,
           key.column: 16
         }
@@ -1186,38 +1294,57 @@
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "CC4",
-          key.usr: "s:5index3CC4C",
+          key.usr: <usr>,
           key.line: 143,
           key.column: 16
         },
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init(x:)",
-          key.usr: "s:5index6SubCC4CACSi1x_tcfc",
+          key.usr: <usr>,
           key.line: 144,
           key.column: 3,
           key.related: [
             {
               key.kind: source.lang.swift.ref.function.constructor,
               key.name: "init(x:)",
-              key.usr: "s:5index3CC4CACSi1x_tcfc"
+              key.usr: <usr>
             }
           ],
           key.entities: [
             {
               key.kind: source.lang.swift.ref.struct,
               key.name: "Int",
-              key.usr: "s:Si",
+              key.usr: <usr>,
               key.line: 144,
               key.column: 11
             },
             {
               key.kind: source.lang.swift.ref.function.constructor,
               key.name: "init(x:)",
-              key.usr: "s:5index3CC4CACSi1x_tcfc",
+              key.usr: <usr>,
               key.line: 145,
               key.column: 11,
               key.receiver_usr: "s:5index3CC4C"
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 143,
+          key.column: 20,
+          key.is_implicit: 1,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.function.constructor,
+              key.name: "init()",
+              key.usr: <usr>
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute.override
             }
           ]
         }
@@ -1226,47 +1353,51 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "Observing",
-      key.usr: "s:5index9ObservingC",
+      key.usr: <usr>,
       key.line: 149,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
           key.name: "init()",
-          key.usr: "s:5index9ObservingCACycfc",
+          key.usr: <usr>,
           key.line: 150,
           key.column: 3
         },
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "globObserving",
-          key.usr: "s:5index9ObservingC04globB0Siv",
+          key.usr: <usr>,
           key.line: 151,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:5index9ObservingC04globB0Sifg",
+              key.usr: <usr>,
               key.line: 151,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:5index9ObservingC04globB0Sifs",
+              key.usr: <usr>,
               key.line: 151,
-              key.column: 7
+              key.column: 7,
+              key.is_dynamic: 1,
+              key.is_implicit: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.willset,
               key.name: "willSet:globObserving",
-              key.usr: "s:5index9ObservingC04globB0Sifw",
+              key.usr: <usr>,
               key.line: 152,
               key.column: 5,
               key.entities: [
                 {
                   key.kind: source.lang.swift.ref.function.free,
                   key.name: "test2()",
-                  key.usr: "s:5index5test2yyF",
+                  key.usr: <usr>,
                   key.line: 153,
                   key.column: 7
                 }
@@ -1280,14 +1411,14 @@
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
               key.name: "didSet:globObserving",
-              key.usr: "s:5index9ObservingC04globB0SifW",
+              key.usr: <usr>,
               key.line: 155,
               key.column: 5,
               key.entities: [
                 {
                   key.kind: source.lang.swift.ref.function.free,
                   key.name: "test2()",
-                  key.usr: "s:5index5test2yyF",
+                  key.usr: <usr>,
                   key.line: 156,
                   key.column: 7
                 }
@@ -1303,7 +1434,7 @@
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 151,
           key.column: 23
         }
@@ -1312,33 +1443,37 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "rdar18640140",
-      key.usr: "s:5index12rdar18640140C",
+      key.usr: <usr>,
       key.line: 162,
       key.column: 7,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "S1",
-          key.usr: "s:5index12rdar18640140C2S1Siv",
+          key.usr: <usr>,
           key.line: 164,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:5index12rdar18640140C2S1Sifg",
-              key.line: 164,
-              key.column: 7
+              key.name: "getter:S1",
+              key.usr: <usr>,
+              key.line: 165,
+              key.column: 5,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:5index12rdar18640140C2S1Sifs",
-              key.line: 164,
-              key.column: 7
+              key.name: "setter:S1",
+              key.usr: <usr>,
+              key.line: 168,
+              key.column: 5,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.didset,
               key.name: "didSet:S1",
-              key.usr: "s:5index12rdar18640140C2S1SifW",
+              key.usr: <usr>,
               key.line: 170,
               key.column: 5,
               key.attributes: [
@@ -1352,46 +1487,63 @@
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 164,
           key.column: 11
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 162,
+          key.column: 7,
+          key.is_implicit: 1
         }
       ]
     },
     {
       key.kind: source.lang.swift.decl.protocol,
       key.name: "rdar18640140Protocol",
-      key.usr: "s:5index20rdar18640140ProtocolP",
+      key.usr: <usr>,
       key.line: 175,
       key.column: 10,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.var.instance,
           key.name: "S1",
-          key.usr: "s:5index20rdar18640140ProtocolP2S1Siv",
+          key.usr: <usr>,
           key.line: 176,
           key.column: 7,
           key.entities: [
             {
               key.kind: source.lang.swift.decl.function.accessor.getter,
               key.name: "getter:S1",
-              key.usr: "s:5index20rdar18640140ProtocolP2S1Sifg",
-              key.line: 179,
-              key.column: 5
+              key.usr: <usr>,
+              key.line: 177,
+              key.column: 5,
+              key.is_dynamic: 1
             },
             {
               key.kind: source.lang.swift.decl.function.accessor.setter,
               key.name: "setter:S1",
-              key.usr: "s:5index20rdar18640140ProtocolP2S1Sifs",
+              key.usr: <usr>,
               key.line: 178,
-              key.column: 5
+              key.column: 5,
+              key.is_dynamic: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.name: "getter:S1",
+              key.usr: <usr>,
+              key.line: 179,
+              key.column: 5,
+              key.is_dynamic: 1
             }
           ]
         },
         {
           key.kind: source.lang.swift.ref.struct,
           key.name: "Int",
-          key.usr: "s:Si",
+          key.usr: <usr>,
           key.line: 176,
           key.column: 11
         }
@@ -1400,9 +1552,18 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "ConditionalUnavailableClass1",
-      key.usr: "s:5index28ConditionalUnavailableClass1C",
+      key.usr: <usr>,
       key.line: 188,
       key.column: 7,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 188,
+          key.column: 7,
+          key.is_implicit: 1
+        }
+      ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.available
@@ -1412,9 +1573,18 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "ConditionalUnavailableClass2",
-      key.usr: "s:5index28ConditionalUnavailableClass2C",
+      key.usr: <usr>,
       key.line: 192,
       key.column: 7,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.usr: <usr>,
+          key.line: 192,
+          key.column: 7,
+          key.is_implicit: 1
+        }
+      ],
       key.attributes: [
         {
           key.attribute: source.decl.attribute.available

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -1,18 +1,15 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     },
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "ObjectiveC",
       key.filepath: ObjectiveC.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1,
       key.dependencies: [
         {
@@ -25,21 +22,18 @@
           key.kind: source.lang.swift.import.module.swift,
           key.name: "Swift",
           key.filepath: Swift.swiftmodule,
-          key.hash: <hash>,
           key.is_system: 1
         },
         {
           key.kind: source.lang.swift.import.module.swift,
           key.name: "SwiftOnoneSupport",
           key.filepath: SwiftOnoneSupport.swiftmodule,
-          key.hash: <hash>,
           key.is_system: 1,
           key.dependencies: [
             {
               key.kind: source.lang.swift.import.module.swift,
               key.name: "Swift",
               key.filepath: Swift.swiftmodule,
-              key.hash: <hash>,
               key.is_system: 1
             }
           ]

--- a/test/SourceKit/Indexing/index_big_array.swift.response
+++ b/test/SourceKit/Indexing/index_big_array.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_func_import.swift.response
+++ b/test/SourceKit/Indexing/index_func_import.swift.response
@@ -1,38 +1,32 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     },
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "test_module",
       key.filepath: test_module.swiftmodule,
-      key.hash: <hash>,
       key.dependencies: [
         {
           key.kind: source.lang.swift.import.module.swift,
           key.name: "Swift",
           key.filepath: Swift.swiftmodule,
-          key.hash: <hash>,
           key.is_system: 1
         },
         {
           key.kind: source.lang.swift.import.module.swift,
           key.name: "SwiftOnoneSupport",
           key.filepath: SwiftOnoneSupport.swiftmodule,
-          key.hash: <hash>,
           key.is_system: 1,
           key.dependencies: [
             {
               key.kind: source.lang.swift.import.module.swift,
               key.name: "Swift",
               key.filepath: Swift.swiftmodule,
-              key.hash: <hash>,
               key.is_system: 1
             }
           ]

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_objcMembers.swift.response
+++ b/test/SourceKit/Indexing/index_objcMembers.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_operators.swift.response
+++ b/test/SourceKit/Indexing/index_operators.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/index_with_clang_module.swift
+++ b/test/SourceKit/Indexing/index_with_clang_module.swift
@@ -16,7 +16,6 @@ func foo(a: FooClassDerived) {
 // CHECK:      key.kind: source.lang.swift.import.module.clang
 // CHECK-NEXT: key.name: "Foo"
 // CHECK-NEXT: key.filepath: "{{.*[/\\]}}Foo{{.*}}.pcm"
-// CHECK-NOT: key.hash:
 
 // CHECK:      key.kind: source.lang.swift.ref.module
 // CHECK-NEXT: key.name: "Foo"

--- a/test/SourceKit/Indexing/index_with_swift_module.swift
+++ b/test/SourceKit/Indexing/index_with_swift_module.swift
@@ -14,12 +14,10 @@ func foo(a: TwoInts) {
 // CHECK:      key.kind: source.lang.swift.import.module.swift
 // CHECK-NEXT: key.name: "Swift"
 // CHECK-NEXT: key.filepath: "{{.*[/\\]Swift[.]swiftmodule([/\\].+[.]swiftmodule)?}}"
-// CHECK-NEXT: key.hash:
 
 // CHECK:      key.kind: source.lang.swift.import.module.swift
 // CHECK-NEXT: key.name: "test_module"
 // CHECK-NEXT: key.filepath: "{{.*[/\\]}}test_module.swiftmodule"
-// CHECK-NEXT: key.hash:
 
 // CHECK:      key.kind: source.lang.swift.ref.module
 // CHECK-NEXT: key.name: "test_module"

--- a/test/SourceKit/Indexing/rdar_21602898.swift.response
+++ b/test/SourceKit/Indexing/rdar_21602898.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/Indexing/sr_3815.swift.response
+++ b/test/SourceKit/Indexing/sr_3815.swift.response
@@ -1,11 +1,9 @@
 {
-  key.hash: <hash>,
   key.dependencies: [
     {
       key.kind: source.lang.swift.import.module.swift,
       key.name: "Swift",
       key.filepath: Swift.swiftmodule,
-      key.hash: <hash>,
       key.is_system: 1
     }
   ],

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -9,13 +9,11 @@ elif 'swift_evolve' in config.available_features:
     config.unsupported = True
 
 else:
-    sed_clean = r"grep -v 'key.hash: \"0\"'"
-    sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule[/\\\\].*\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
+    sed_clean = r"sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule[/\\\\].*\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swiftmodule\"/key.filepath: \\1.swiftmodule/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)\\.swift\"/key.filepath: \\1.swift/g'"
     sed_clean += r" | sed -e 's/key.filepath: \".*[/\\\\]\\(.*\\)-[0-9A-Z]*\\.pcm\"/key.filepath: \\1.pcm/g'"
     sed_clean += r" | sed -e 's/ file=\\\\\".*[/\\\\]\\(.*\\)\\.h\\\\\"/ file=\\1.h/g'"
-    sed_clean += r" | sed -e 's/key.hash: \".*\"/key.hash: <hash>/g'"
 
     config.substitutions.append( ('%sourcekitd-test', config.sourcekitd_test) )
     config.substitutions.append( ('%complete-test', config.complete_test) )

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -60,13 +60,10 @@ public:
 
   virtual void failed(StringRef ErrDescription) = 0;
 
-  virtual bool recordHash(StringRef Hash, bool isKnown) = 0;
-
   virtual bool startDependency(UIdent Kind,
                                StringRef Name,
                                StringRef Path,
-                               bool IsSystem,
-                               StringRef Hash) = 0;
+                               bool IsSystem) = 0;
 
   virtual bool finishDependency(UIdent Kind) = 0;
 
@@ -638,8 +635,7 @@ public:
 
   virtual void indexSource(StringRef Filename,
                            IndexingConsumer &Consumer,
-                           ArrayRef<const char *> Args,
-                           StringRef Hash) = 0;
+                           ArrayRef<const char *> Args) = 0;
 
   virtual void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
                             CodeCompletionConsumer &Consumer,

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -50,14 +50,9 @@ private:
     return Logger::isLoggingEnabledForLevel(Logger::Level::Warning);
   }
 
-  bool recordHash(StringRef hash, bool isKnown) override {
-    return impl.recordHash(hash, isKnown);
-  }
-
-  bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                       bool isSystem, StringRef hash) override {
+  bool startDependency(StringRef name, StringRef path, bool isClangModule, bool isSystem) override {
     auto kindUID = getUIDForDependencyKind(isClangModule);
-    return impl.startDependency(kindUID, name, path, isSystem, hash);
+    return impl.startDependency(kindUID, name, path, isSystem);
   }
 
   bool finishDependency(bool isClangModule) override {
@@ -168,7 +163,6 @@ private:
 
 static void indexModule(llvm::MemoryBuffer *Input,
                         StringRef ModuleName,
-                        StringRef Hash,
                         IndexingConsumer &IdxConsumer,
                         CompilerInstance &CI,
                         ArrayRef<const char *> Args) {
@@ -208,7 +202,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
   (void)createTypeChecker(Ctx);
 
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
-  index::indexModule(Mod, Hash, IdxDataConsumer);
+  index::indexModule(Mod, IdxDataConsumer);
 }
 
 
@@ -239,8 +233,7 @@ void trace::initTraceInfo(trace::SwiftInvocation &SwiftArgs,
 
 void SwiftLangSupport::indexSource(StringRef InputFile,
                                    IndexingConsumer &IdxConsumer,
-                                   ArrayRef<const char *> OrigArgs,
-                                   StringRef Hash) {
+                                   ArrayRef<const char *> OrigArgs) {
   std::string Error;
   auto InputBuf = ASTMgr->getMemoryBuffer(InputFile, Error);
   if (!InputBuf) {
@@ -288,7 +281,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     }
 
     indexModule(InputBuf.get(), llvm::sys::path::stem(Filename),
-                Hash, IdxConsumer, CI, Args);
+                IdxConsumer, CI, Args);
     return;
   }
 
@@ -320,5 +313,5 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   (void)createTypeChecker(CI.getASTContext());
 
   SKIndexDataConsumer IdxDataConsumer(IdxConsumer);
-  index::indexSourceFile(CI.getPrimarySourceFile(), Hash, IdxDataConsumer);
+  index::indexSourceFile(CI.getPrimarySourceFile(), IdxDataConsumer);
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -409,7 +409,7 @@ public:
   //==========================================================================//
 
   void indexSource(StringRef Filename, IndexingConsumer &Consumer,
-                   ArrayRef<const char *> Args, StringRef Hash) override;
+                   ArrayRef<const char *> Args) override;
 
   void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
                     SourceKit::CodeCompletionConsumer &Consumer,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2971,12 +2971,11 @@ namespace {
     bool indexLocals() override { return shouldIndexLocals; }
     void failed(StringRef error) override {}
 
-    bool recordHash(StringRef hash, bool isKnown) override { return true; }
     bool startDependency(StringRef name, StringRef path, bool isClangModule,
-                         bool isSystem, StringRef hash) override {
+                         bool isSystem) override {
       OS << (isClangModule ? "clang-module" : "module") << " | ";
       OS << (isSystem ? "system" : "user") << " | ";
-      OS << name << " | " << path << "-" << hash << "\n";
+      OS << name << " | " << path << "\n";
       return true;
     }
     bool finishDependency(bool isClangModule) override {
@@ -3041,7 +3040,7 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
   llvm::outs() << llvm::sys::path::filename(SF->getFilename()) << '\n';
   llvm::outs() << "------------\n";
   PrintIndexDataConsumer consumer(llvm::outs(), indexLocals);
-  indexSourceFile(SF, StringRef(), consumer);
+  indexSourceFile(SF, consumer);
 
   return 0;
 }
@@ -3073,7 +3072,7 @@ static int doPrintIndexedSymbolsFromModule(const CompilerInvocation &InitInvok,
   }
 
   PrintIndexDataConsumer consumer(llvm::outs());
-  indexModule(M, StringRef(), consumer);
+  indexModule(M, consumer);
 
   return 0;
 }


### PR DESCRIPTION
This has been an unnecessary code path for a long time now and should be removed particularly because it triggers wasteful `stat` calls.

rdar://51523161

master: https://github.com/apple/swift/pull/25672