### PR TITLE
SILGen: Fix generated vtable thunk when a final override is more visible than the base [5.1]

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -99,8 +99,9 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
   // If the base method is less visible than the derived method, we need
   // a thunk.
   bool baseLessVisibleThanDerived =
-    (derivedDecl->isEffectiveLinkageMoreVisibleThan(baseDecl) &&
-     !usesObjCDynamicDispatch);
+    (!usesObjCDynamicDispatch &&
+     !derivedDecl->isFinal() &&
+     derivedDecl->isEffectiveLinkageMoreVisibleThan(baseDecl));
 
   // Determine the derived thunk type by lowering the derived type against the
   // abstraction pattern of the base.

--- a/test/Interpreter/Inputs/vtables_multifile_2.swift
+++ b/test/Interpreter/Inputs/vtables_multifile_2.swift
@@ -13,6 +13,12 @@ open class Derived : Base {
   }
 }
 
+public final class FinalDerived : Base {
+  public override func privateMethod() -> Int {
+    return super.privateMethod() + 1
+  }
+}
+
 public func callBaseMethod(_ b: Base) -> Int {
   return b.privateMethod()
 }

--- a/test/Interpreter/vtables_multifile.swift
+++ b/test/Interpreter/vtables_multifile.swift
@@ -21,6 +21,12 @@ open class OtherDerived : Derived {
   }
 }
 
+public final class OtherFinalDerived : Derived {
+  public override func privateMethod() -> Int {
+    return super.privateMethod() + 1
+  }
+}
+
 VTableTestSuite.test("Base") {
   expectEqual(1, callBaseMethod(Base()))
 }
@@ -33,6 +39,11 @@ VTableTestSuite.test("Derived") {
 VTableTestSuite.test("OtherDerived") {
   expectEqual(3, callBaseMethod(OtherDerived()))
   expectEqual(3, callDerivedMethod(OtherDerived()))
+}
+
+VTableTestSuite.test("OtherFinalDerived") {
+  expectEqual(3, callBaseMethod(OtherFinalDerived()))
+  expectEqual(3, callDerivedMethod(OtherFinalDerived()))
 }
 
 runAllTests()


### PR DESCRIPTION
Don't re-dispatch to the override's vtable slot if the override
is final; there's no vtable slot and this will result in an
infinite loop.

Fixes <rdar://problem/52006394>.