### PR TITLE
[Diagnostics] Add property wrapper diagnostic for unnecessary $ / _ in member access

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5015,8 +5015,9 @@ public:
     return cast_or_null<VarDecl>(AbstractStorageDecl::getOverriddenDecl());
   }
 
-  /// Determine whether this declaration is an anonymous closure parameter.
-  bool isAnonClosureParam() const;
+  /// Determine whether this declaration is a proprety wrapper, or
+  /// an anonymous closure parameter.
+  bool isWrapperOrAnonClosureParam() const;
 
   /// Return the raw specifier value for this property or parameter.
   Specifier getSpecifier() const {
@@ -5384,6 +5385,9 @@ public:
     assert(isVariadic());
     return getVarargBaseTy(getInterfaceType());
   }
+
+  /// Determine whether this declaration is an anonymous closure parameter.
+  bool isAnonClosureParam() const;
 
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5178,6 +5178,10 @@ public:
   /// bound generic version.
   VarDecl *getPropertyWrapperBackingProperty() const;
 
+  /// Retreive the storage wrapper for a property that has an attached
+  /// property wrapper.
+  VarDecl *getPropertyWrapperStorageWrapper() const;
+
   /// Retrieve the backing storage property for a lazy property.
   VarDecl *getLazyStorageProperty() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5015,9 +5015,8 @@ public:
     return cast_or_null<VarDecl>(AbstractStorageDecl::getOverriddenDecl());
   }
 
-  /// Determine whether this declaration is a proprety wrapper, or
-  /// an anonymous closure parameter.
-  bool isWrapperOrAnonClosureParam() const;
+  /// Determine whether this declaration is an anonymous closure parameter.
+  bool isAnonClosureParam() const;
 
   /// Return the raw specifier value for this property or parameter.
   Specifier getSpecifier() const {
@@ -5389,9 +5388,6 @@ public:
     assert(isVariadic());
     return getVarargBaseTy(getInterfaceType());
   }
-
-  /// Determine whether this declaration is an anonymous closure parameter.
-  bool isAnonClosureParam() const;
 
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -997,13 +997,6 @@ ERROR(missing_address_of,none,
 ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
-<<<<<<< HEAD
-ERROR(extraneous_property_wrapper_unwrap,none,
-      "property %0 will be unwrapped to value of type %1, use '_' to refer to "
-      "wrapper type %2",
-      (DeclName, Type, Type))
-=======
->>>>>>> Sema: Add property wrapper diagnostic for unnecessary $ in member access
 ERROR(extraneous_address_of,none,
       "use of extraneous '&'",
       ())
@@ -1018,20 +1011,12 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
       "'withUnsafeMutablePointer' to explicitly convert argument "
       "to a pointer", ())
 
-ERROR(extraneous_property_wrapper_unwrap,none,
-      "property %0 will be unwrapped to value of type %1, use '$' to refer to "
-      "wrapper type %2",
-      (DeclName, Type, Type))
-ERROR(extraneous_property_wrapper_unwrap_member_access,none,
-      "value of type %1 has no member %0, requires wrapper type %2",
-      (DeclName, Type, Type))
-ERROR(missing_property_wrapper_unwrap,none,
-      "property wrapper %0 has value of type %1, remove '$' to refer to the"
-      "wrapped value of type %2",
-      (DeclName, Type, Type))
-ERROR(missing_property_wrapper_unwrap_member_access,none,
-      "value of type %1 has no member %0, requires wrapped type %2",
-      (DeclName, Type, Type))
+ERROR(incorrect_property_wrapper_reference,none,
+      "cannot convert value %0 of type %1 to expected type %2, use %select{wrapper| wrapped value}3 instead",
+      (Identifier, Type, Type, bool))
+ERROR(incorrect_property_wrapper_reference_member,none,
+      "referencing member %0 requires %select{wrapper|wrapped value of type}1 %2",
+      (DeclName, bool, Type))
 
 ERROR(missing_init_on_metatype_initialization,none,
       "initializing from a metatype value must reference 'init' explicitly",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -997,10 +997,13 @@ ERROR(missing_address_of,none,
 ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
+<<<<<<< HEAD
 ERROR(extraneous_property_wrapper_unwrap,none,
       "property %0 will be unwrapped to value of type %1, use '_' to refer to "
       "wrapper type %2",
       (DeclName, Type, Type))
+=======
+>>>>>>> Sema: Add property wrapper diagnostic for unnecessary $ in member access
 ERROR(extraneous_address_of,none,
       "use of extraneous '&'",
       ())
@@ -1014,6 +1017,21 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
       "cannot pass an inout argument to a subscript; use "
       "'withUnsafeMutablePointer' to explicitly convert argument "
       "to a pointer", ())
+
+ERROR(extraneous_property_wrapper_unwrap,none,
+      "property %0 will be unwrapped to value of type %1, use '$' to refer to "
+      "wrapper type %2",
+      (DeclName, Type, Type))
+ERROR(extraneous_property_wrapper_unwrap_member_access,none,
+      "value of type %1 has no member %0, requires wrapper type %2",
+      (DeclName, Type, Type))
+ERROR(missing_property_wrapper_unwrap,none,
+      "property wrapper %0 has value of type %1, remove '$' to refer to the"
+      "wrapped value of type %2",
+      (DeclName, Type, Type))
+ERROR(missing_property_wrapper_unwrap_member_access,none,
+      "value of type %1 has no member %0, requires wrapped type %2",
+      (DeclName, Type, Type))
 
 ERROR(missing_init_on_metatype_initialization,none,
       "initializing from a metatype value must reference 'init' explicitly",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5542,6 +5542,10 @@ VarDecl *VarDecl::getPropertyWrapperBackingProperty() const {
   return getPropertyWrapperBackingPropertyInfo().backingVar;
 }
 
+VarDecl *VarDecl::getPropertyWrapperStorageWrapper() const {
+  return getPropertyWrapperBackingPropertyInfo().storageWrapperVar;
+}
+
 VarDecl *VarDecl::getLazyStorageProperty() const {
   auto &ctx = getASTContext();
   auto mutableThis = const_cast<VarDecl *>(this);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5429,19 +5429,7 @@ void VarDecl::setSpecifier(Specifier specifier) {
                           StorageIsMutable_t(!isImmutableSpecifier(specifier)));
 }
 
-bool ParamDecl::isAnonClosureParam() const {
-  auto name = getName();
-  if (name.empty())
-    return false;
-
-  auto nameStr = name.str();
-  if (nameStr.empty())
-    return false;
-
-  return nameStr[0] == '$';
-}
-
-bool VarDecl::isWrapperOrAnonClosureParam() const {
+bool VarDecl::isAnonClosureParam() const {
   auto name = getName();
   if (name.empty())
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5429,7 +5429,19 @@ void VarDecl::setSpecifier(Specifier specifier) {
                           StorageIsMutable_t(!isImmutableSpecifier(specifier)));
 }
 
-bool VarDecl::isAnonClosureParam() const {
+bool ParamDecl::isAnonClosureParam() const {
+  auto name = getName();
+  if (name.empty())
+    return false;
+
+  auto nameStr = name.str();
+  if (nameStr.empty())
+    return false;
+
+  return nameStr[0] == '$';
+}
+
+bool VarDecl::isWrapperOrAnonClosureParam() const {
   auto name = getName();
   if (name.empty())
     return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1989,9 +1989,13 @@ bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
   if (isMemberAccess())
     diagnostic = diag::missing_property_wrapper_unwrap_member_access;
 
+  // If we're going from a storage wrapper, remove only one $. Remove two
+  // if we're coming from the backing storage.
+  auto endLoc =
+      getAnchor()->getLoc().getAdvancedLoc(isFromStorageWrapper() ? 0 : 1);
   emitDiagnostic(getAnchor()->getLoc(), diagnostic, getName(), getFromType(),
                  getToType())
-      .fixItRemoveChars(getAnchor()->getLoc(), getAnchor()->getLoc());
+      .fixItRemoveChars(getAnchor()->getLoc(), endLoc);
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1973,11 +1973,25 @@ bool MissingCallFailure::diagnoseAsError() {
   return true;
 }
 
+bool ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError() {
+  auto diagnostic = diag::extraneous_property_wrapper_unwrap;
+  if (isMemberAccess())
+    diagnostic = diag::extraneous_property_wrapper_unwrap_member_access;
+
+  emitDiagnostic(getAnchor()->getLoc(), diagnostic, getName(), getFromType(),
+                 getToType())
+      .fixItInsert(getAnchor()->getLoc(), "$");
+  return true;
+}
+
 bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  emitDiagnostic(getAnchor()->getLoc(),
-                 diag::extraneous_property_wrapper_unwrap, getPropertyName(),
-                 getFromType(), getToType())
-      .fixItInsert(getAnchor()->getLoc(), "_");
+  auto diagnostic = diag::missing_property_wrapper_unwrap;
+  if (isMemberAccess())
+    diagnostic = diag::missing_property_wrapper_unwrap_member_access;
+
+  emitDiagnostic(getAnchor()->getLoc(), diagnostic, getName(), getFromType(),
+                 getToType())
+      .fixItRemoveChars(getAnchor()->getLoc(), getAnchor()->getLoc());
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -807,20 +807,45 @@ public:
   bool diagnoseAsError() override;
 };
 
-class MissingPropertyWrapperUnwrapFailure final : public ContextualFailure {
-  DeclName PropertyName;
+class PropertyWrapperReferenceFailure : public ContextualFailure {
+  DeclName Name;
+  bool IsMemberAccess;
 
 public:
-  MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                      DeclName propertyName, Type base,
-                                      Type wrapper, ConstraintLocator *locator)
-      : ContextualFailure(root, cs, base, wrapper, locator),
-        PropertyName(propertyName) {}
+  PropertyWrapperReferenceFailure(Expr *root, ConstraintSystem &cs,
+                                  DeclName name, Type base, bool isMemberAccess,
+                                  Type wrapper, ConstraintLocator *locator)
+      : ContextualFailure(root, cs, base, wrapper, locator), Name(name),
+        IsMemberAccess(isMemberAccess) {}
+
+  DeclName getName() const { return Name; }
+  bool isMemberAccess() const { return IsMemberAccess; }
+};
+
+class ExtraneousPropertyWrapperUnwrapFailure final
+    : public PropertyWrapperReferenceFailure {
+public:
+  ExtraneousPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                         DeclName name, Type base,
+                                         bool isMemberAccess, Type wrapper,
+                                         ConstraintLocator *locator)
+      : PropertyWrapperReferenceFailure(root, cs, name, base, isMemberAccess,
+                                        wrapper, locator) {}
 
   bool diagnoseAsError() override;
+};
 
-private:
-  DeclName getPropertyName() const { return PropertyName; }
+class MissingPropertyWrapperUnwrapFailure final
+    : public PropertyWrapperReferenceFailure {
+public:
+  MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                      DeclName name, Type base,
+                                      bool isMemberAccess, Type wrapper,
+                                      ConstraintLocator *locator)
+      : PropertyWrapperReferenceFailure(root, cs, name, base, isMemberAccess,
+                                        wrapper, locator) {}
+
+  bool diagnoseAsError() override;
 };
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -813,8 +813,9 @@ class PropertyWrapperReferenceFailure : public ContextualFailure {
 
 public:
   PropertyWrapperReferenceFailure(Expr *root, ConstraintSystem &cs,
-                                  DeclName name, Type base, bool isMemberAccess,
-                                  Type wrapper, ConstraintLocator *locator)
+                                  DeclName name, Type base, Type wrapper,
+                                  bool isMemberAccess,
+                                  ConstraintLocator *locator)
       : ContextualFailure(root, cs, base, wrapper, locator), Name(name),
         IsMemberAccess(isMemberAccess) {}
 
@@ -826,26 +827,32 @@ class ExtraneousPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
 public:
   ExtraneousPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                         DeclName name, Type base,
-                                         bool isMemberAccess, Type wrapper,
+                                         DeclName name, Type base, Type wrapper,
+                                         bool isMemberAccess,
                                          ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(root, cs, name, base, isMemberAccess,
-                                        wrapper, locator) {}
+      : PropertyWrapperReferenceFailure(root, cs, name, base, wrapper,
+                                        isMemberAccess, locator) {}
 
   bool diagnoseAsError() override;
 };
 
 class MissingPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
+  bool FromStorageWrapper;
+
 public:
   MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                      DeclName name, Type base,
-                                      bool isMemberAccess, Type wrapper,
+                                      DeclName name, Type base, Type wrapper,
+                                      bool isMemberAccess,
+                                      bool fromStorageWrapper,
                                       ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(root, cs, name, base, isMemberAccess,
-                                        wrapper, locator) {}
+      : PropertyWrapperReferenceFailure(root, cs, name, base, wrapper,
+                                        isMemberAccess, locator),
+        FromStorageWrapper(fromStorageWrapper) {}
 
   bool diagnoseAsError() override;
+
+  bool isFromStorageWrapper() const { return FromStorageWrapper; }
 };
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -808,51 +808,51 @@ public:
 };
 
 class PropertyWrapperReferenceFailure : public ContextualFailure {
-  DeclName Name;
-  bool IsMemberAccess;
+  VarDecl *Property;
+  DeclName MemberName;
+  bool UsingStorageWrapper;
 
 public:
   PropertyWrapperReferenceFailure(Expr *root, ConstraintSystem &cs,
-                                  DeclName name, Type base, Type wrapper,
-                                  bool isMemberAccess,
-                                  ConstraintLocator *locator)
-      : ContextualFailure(root, cs, base, wrapper, locator), Name(name),
-        IsMemberAccess(isMemberAccess) {}
+                                  VarDecl *property, DeclName memberName,
+                                  bool usingStorageWrapper, Type base,
+                                  Type wrapper, ConstraintLocator *locator)
+      : ContextualFailure(root, cs, base, wrapper, locator), Property(property),
+        MemberName(memberName), UsingStorageWrapper(usingStorageWrapper) {}
 
-  DeclName getName() const { return Name; }
-  bool isMemberAccess() const { return IsMemberAccess; }
+  VarDecl *getProperty() const { return Property; }
+  StringRef getPropertyName() const { return Property->getName().str(); }
+  DeclName getMemberName() const { return MemberName; }
+  bool usingStorageWrapper() const { return UsingStorageWrapper; }
 };
 
 class ExtraneousPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
 public:
   ExtraneousPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                         DeclName name, Type base, Type wrapper,
-                                         bool isMemberAccess,
+                                         VarDecl *property, DeclName memberName,
+                                         bool usingStorageWrapper, Type base,
+                                         Type wrapper,
                                          ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(root, cs, name, base, wrapper,
-                                        isMemberAccess, locator) {}
+      : PropertyWrapperReferenceFailure(root, cs, property, memberName,
+                                        usingStorageWrapper, base, wrapper,
+                                        locator) {}
 
   bool diagnoseAsError() override;
 };
 
 class MissingPropertyWrapperUnwrapFailure final
     : public PropertyWrapperReferenceFailure {
-  bool FromStorageWrapper;
-
 public:
   MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                      DeclName name, Type base, Type wrapper,
-                                      bool isMemberAccess,
-                                      bool fromStorageWrapper,
-                                      ConstraintLocator *locator)
-      : PropertyWrapperReferenceFailure(root, cs, name, base, wrapper,
-                                        isMemberAccess, locator),
-        FromStorageWrapper(fromStorageWrapper) {}
+                                      VarDecl *property, DeclName memberName,
+                                      bool usingStorageWrapper, Type base,
+                                      Type wrapper, ConstraintLocator *locator)
+      : PropertyWrapperReferenceFailure(root, cs, property, memberName,
+                                        usingStorageWrapper, base, wrapper,
+                                        locator) {}
 
   bool diagnoseAsError() override;
-
-  bool isFromStorageWrapper() const { return FromStorageWrapper; }
 };
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -278,33 +278,37 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
 
-bool UsePropertyWrapperType::diagnose(Expr *root, bool asNote) const {
+bool UsePropertyWrapper::diagnose(Expr *root, bool asNote) const {
   auto failure = ExtraneousPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), Name, Base, Wrapper, IsMemberAccess,
-      getLocator());
+      root, getConstraintSystem(), Wrapped, MemberName, UsingStorageWrapper,
+      Base, Wrapper, getLocator());
   return failure.diagnose(asNote);
 }
 
-UsePropertyWrapperType *
-UsePropertyWrapperType::create(ConstraintSystem &cs, DeclName name, Type base,
-                               Type wrapper, bool isMemberAccess,
-                               ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      UsePropertyWrapperType(cs, name, base, wrapper, isMemberAccess, locator);
+UsePropertyWrapper *UsePropertyWrapper::create(ConstraintSystem &cs,
+                                               VarDecl *wrapped,
+                                               DeclName memberName,
+                                               bool usingStorageWrapper,
+                                               Type base, Type wrapper,
+                                               ConstraintLocator *locator) {
+  return new (cs.getAllocator()) UsePropertyWrapper(
+      cs, wrapped, memberName, usingStorageWrapper, base, wrapper, locator);
 }
 
-bool UseWrappedPropertyType::diagnose(Expr *root, bool asNote) const {
+bool UseWrappedValue::diagnose(Expr *root, bool asNote) const {
   auto failure = MissingPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), Name, Base, Wrapper, IsMemberAccess,
-      FromStorageWrapper, getLocator());
+      root, getConstraintSystem(), PropertyWrapper, MemberName,
+      usingStorageWrapper(), Base, Wrapper, getLocator());
   return failure.diagnose(asNote);
 }
 
-UseWrappedPropertyType *UseWrappedPropertyType::create(
-    ConstraintSystem &cs, DeclName name, Type base, Type wrapper,
-    bool isMemberAccess, bool fromStorageWrapper, ConstraintLocator *locator) {
-  return new (cs.getAllocator()) UseWrappedPropertyType(
-      cs, name, base, wrapper, isMemberAccess, fromStorageWrapper, locator);
+UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
+                                         VarDecl *propertyWrapper,
+                                         DeclName memberName, Type base,
+                                         Type wrapper,
+                                         ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      UseWrappedValue(cs, propertyWrapper, memberName, base, wrapper, locator);
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -278,19 +278,34 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
 
-bool InsertPropertyWrapperUnwrap::diagnose(Expr *root, bool asNote) const {
-  auto failure = MissingPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), getPropertyName(), getBase(), getWrapper(),
+bool UsePropertyWrapperType::diagnose(Expr *root, bool asNote) const {
+  auto failure = ExtraneousPropertyWrapperUnwrapFailure(
+      root, getConstraintSystem(), Name, Base, IsMemberAccess, Wrapper,
       getLocator());
   return failure.diagnose(asNote);
 }
 
-InsertPropertyWrapperUnwrap *
-InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs, DeclName propertyName,
-                                    Type base, Type wrapper,
-                                    ConstraintLocator *locator) {
+UsePropertyWrapperType *
+UsePropertyWrapperType::create(ConstraintSystem &cs, DeclName name, Type base,
+                               Type wrapper, bool isMemberAccess,
+                               ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      InsertPropertyWrapperUnwrap(cs, propertyName, base, wrapper, locator);
+      UsePropertyWrapperType(cs, name, base, wrapper, isMemberAccess, locator);
+}
+
+bool UseWrappedPropertyType::diagnose(Expr *root, bool asNote) const {
+  auto failure = MissingPropertyWrapperUnwrapFailure(
+      root, getConstraintSystem(), Name, Base, IsMemberAccess, Wrapper,
+      getLocator());
+  return failure.diagnose(asNote);
+}
+
+UseWrappedPropertyType *
+UseWrappedPropertyType::create(ConstraintSystem &cs, DeclName name, Type base,
+                               Type wrapper, bool isMemberAccess,
+                               ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      UseWrappedPropertyType(cs, name, base, wrapper, isMemberAccess, locator);
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -280,7 +280,7 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
 
 bool UsePropertyWrapperType::diagnose(Expr *root, bool asNote) const {
   auto failure = ExtraneousPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), Name, Base, IsMemberAccess, Wrapper,
+      root, getConstraintSystem(), Name, Base, Wrapper, IsMemberAccess,
       getLocator());
   return failure.diagnose(asNote);
 }
@@ -295,17 +295,16 @@ UsePropertyWrapperType::create(ConstraintSystem &cs, DeclName name, Type base,
 
 bool UseWrappedPropertyType::diagnose(Expr *root, bool asNote) const {
   auto failure = MissingPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), Name, Base, IsMemberAccess, Wrapper,
-      getLocator());
+      root, getConstraintSystem(), Name, Base, Wrapper, IsMemberAccess,
+      FromStorageWrapper, getLocator());
   return failure.diagnose(asNote);
 }
 
-UseWrappedPropertyType *
-UseWrappedPropertyType::create(ConstraintSystem &cs, DeclName name, Type base,
-                               Type wrapper, bool isMemberAccess,
-                               ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      UseWrappedPropertyType(cs, name, base, wrapper, isMemberAccess, locator);
+UseWrappedPropertyType *UseWrappedPropertyType::create(
+    ConstraintSystem &cs, DeclName name, Type base, Type wrapper,
+    bool isMemberAccess, bool fromStorageWrapper, ConstraintLocator *locator) {
+  return new (cs.getAllocator()) UseWrappedPropertyType(
+      cs, name, base, wrapper, isMemberAccess, fromStorageWrapper, locator);
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -671,12 +671,14 @@ class UseWrappedPropertyType final : public ConstraintFix {
   bool IsMemberAccess;
   Type Base;
   Type Wrapper;
+  bool FromStorageWrapper;
 
   UseWrappedPropertyType(ConstraintSystem &cs, DeclName name, Type base,
                          Type wrapper, bool isMemberAccess,
-                         ConstraintLocator *locator)
+                         bool fromStorageWrapper, ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::UseWrappedPropertyType, locator), Name(name),
-        IsMemberAccess(isMemberAccess), Base(base), Wrapper(wrapper) {}
+        IsMemberAccess(isMemberAccess), Base(base), Wrapper(wrapper),
+        FromStorageWrapper(fromStorageWrapper) {}
 
 public:
   std::string getName() const override {
@@ -688,6 +690,7 @@ public:
   static UseWrappedPropertyType *create(ConstraintSystem &cs, DeclName name,
                                         Type base, Type wrapper,
                                         bool isMemberAccess,
+                                        bool fromStorageWrapper,
                                         ConstraintLocator *locator);
 };
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -267,8 +267,7 @@ namespace {
 
       if (auto DRE = dyn_cast<DeclRefExpr>(expr)) {
         if (auto varDecl = dyn_cast<VarDecl>(DRE->getDecl())) {
-          auto paramDecl = dyn_cast<ParamDecl>(varDecl);
-          if (paramDecl && paramDecl->isAnonClosureParam()) {
+          if (varDecl->isAnonClosureParam()) {
             LTI.anonClosureParams.push_back(DRE);
           } else if (CS.hasType(DRE)) {
             LTI.collectedTypes.insert(CS.getType(DRE).getPointer());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -267,7 +267,8 @@ namespace {
 
       if (auto DRE = dyn_cast<DeclRefExpr>(expr)) {
         if (auto varDecl = dyn_cast<VarDecl>(DRE->getDecl())) {
-          if (varDecl->isAnonClosureParam()) {
+          auto paramDecl = dyn_cast<ParamDecl>(varDecl);
+          if (paramDecl && paramDecl->isAnonClosureParam()) {
             LTI.anonClosureParams.push_back(DRE);
           } else if (CS.hasType(DRE)) {
             LTI.collectedTypes.insert(CS.getType(DRE).getPointer());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4837,9 +4837,18 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
           auto result = solveWithNewBaseOrName(wrappedTy, member);
 
           if (result == SolutionKind::Solved) {
+            auto name = wrappedProperty->first->getName();
+
+            bool fromStorageWrapper = true;
+            if (!name.empty()) {
+              auto nameStr = name.str();
+              assert(!nameStr.empty() && nameStr[0] == '$');
+              fromStorageWrapper = nameStr.size() >= 2 && nameStr[1] != '$';
+            }
+
             auto *fix = UseWrappedPropertyType::create(
-                *this, member, baseTy, wrappedTy,
-                /*isMemberAccess=*/true, locator);
+                *this, member, baseTy, wrappedTy, /*isMemberAccess=*/true,
+                fromStorageWrapper, locator);
             return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
           }
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4817,9 +4817,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       auto resolvedOverload = findSelectedOverloadFor(baseExpr);
 
       if (resolvedOverload) {
-        if (auto propertyWrapper =
-                getPropertyWrapperInformation(resolvedOverload)) {
-          auto wrapperTy = propertyWrapper->second;
+        auto wrapper = getStorageWrapperInformation(resolvedOverload);
+        if (!wrapper)
+          wrapper = getPropertyWrapperInformation(resolvedOverload);
+        if (wrapper) {
+          auto wrapperTy = wrapper->second;
           auto result = solveWithNewBaseOrName(wrapperTy, member);
           if (result == SolutionKind::Solved) {
             auto *fix = UsePropertyWrapperType::create(

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2265,6 +2265,7 @@ public:
   /// storage wrapper if the decl has an associated storage wrapper.
   Optional<std::pair<VarDecl *, Type>>
   getStorageWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    assert(resolvedOverload);
     if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (decl->hasAttachedPropertyWrapper()) {
@@ -2281,6 +2282,7 @@ public:
   /// backing storage if the decl has an associated property wrapper.
   Optional<std::pair<VarDecl *, Type>>
   getPropertyWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    assert(resolvedOverload);
     if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (decl->hasAttachedPropertyWrapper()) {
@@ -2296,8 +2298,8 @@ public:
   /// resolved overload has a decl which is the backing storage for a
   /// property wrapper.
   Optional<std::pair<VarDecl *, Type>>
-  getWrappedPropertyInformation(ResolvedOverloadSetListItem *resolvedOverload,
-                                Type baseTy, DeclContext *useDC) {
+  getWrappedPropertyInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    assert(resolvedOverload);
     if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (auto wrapped = decl->getOriginalWrappedProperty()) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2261,8 +2261,24 @@ public:
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
-  /// Gets the VarDecl, and the type of its attached property wrapper if the
-  /// resolved overload has a decl with an attached property wrapper.
+  /// Gets the VarDecl associateed with resolvedOverload, and the type of the
+  /// storage wrapper if the decl has an associated storage wrapper.
+  Optional<std::pair<VarDecl *, Type>>
+  getStorageWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    if (resolvedOverload->Choice.isDecl()) {
+      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
+        if (decl->hasAttachedPropertyWrapper()) {
+          if (auto storageWrapper = decl->getPropertyWrapperStorageWrapper()) {
+            return std::make_pair(decl, storageWrapper->getType());
+          }
+        }
+      }
+    }
+    return None;
+  }
+
+  /// Gets the VarDecl associateed with resolvedOverload, and the type of the
+  /// backing storage if the decl has an associated property wrapper.
   Optional<std::pair<VarDecl *, Type>>
   getPropertyWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
     if (resolvedOverload->Choice.isDecl()) {
@@ -2284,15 +2300,8 @@ public:
                                 Type baseTy, DeclContext *useDC) {
     if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
-        auto *baseTyDecl = baseTy->getAnyNominal();
-        if (decl->isWrapperOrAnonClosureParam() && baseTyDecl) {
-          auto wrapperTyInfo = baseTyDecl->getPropertyWrapperTypeInfo();
-          if (wrapperTyInfo.isValid()) {
-            auto valueTy = baseTy->getTypeOfMember(
-                useDC->getParentModule(), wrapperTyInfo.valueVar,
-                wrapperTyInfo.valueVar->getValueInterfaceType());
-            return std::make_pair(decl, valueTy);
-          }
+        if (auto wrapped = decl->getOriginalWrappedProperty()) {
+          return std::make_pair(decl, wrapped->getType());
         }
       }
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2261,18 +2261,38 @@ public:
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
-  /// Gets the a VarDecl, and the type of its attached property wrapper if the
-  /// resolved overload has an attached property wrapper.
-  ///
-  /// \return A pair of the VarDecl and the attached property wrapper type if
-  ///         the given resolved overload has an attached property wrapper.
+  /// Gets the VarDecl, and the type of its attached property wrapper if the
+  /// resolved overload has a decl with an attached property wrapper.
   Optional<std::pair<VarDecl *, Type>>
   getPropertyWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
-    if (resolvedOverload && resolvedOverload->Choice.isDecl()) {
+    if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (decl->hasAttachedPropertyWrapper()) {
           auto wrapperTy = decl->getPropertyWrapperBackingPropertyType();
           return std::make_pair(decl, wrapperTy);
+        }
+      }
+    }
+    return None;
+  }
+
+  /// Gets the VarDecl, and the type of the type property that it wraps if
+  /// resolved overload has a decl which is the backing storage for a
+  /// property wrapper.
+  Optional<std::pair<VarDecl *, Type>>
+  getWrappedPropertyInformation(ResolvedOverloadSetListItem *resolvedOverload,
+                                Type baseTy, DeclContext *useDC) {
+    if (resolvedOverload->Choice.isDecl()) {
+      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
+        if (decl->getName().str().startswith("$")) {
+          auto wrapperTyInfo =
+              baseTy->getAnyNominal()->getPropertyWrapperTypeInfo();
+          if (wrapperTyInfo.isValid()) {
+            auto valueTy = baseTy->getTypeOfMember(
+                useDC->getParentModule(), wrapperTyInfo.valueVar,
+                wrapperTyInfo.valueVar->getValueInterfaceType());
+            return std::make_pair(decl, valueTy);
+          }
         }
       }
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2284,9 +2284,9 @@ public:
                                 Type baseTy, DeclContext *useDC) {
     if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
-        if (decl->getName().str().startswith("$")) {
-          auto wrapperTyInfo =
-              baseTy->getAnyNominal()->getPropertyWrapperTypeInfo();
+        auto *baseTyDecl = baseTy->getAnyNominal();
+        if (decl->isWrapperOrAnonClosureParam() && baseTyDecl) {
+          auto wrapperTyInfo = baseTyDecl->getPropertyWrapperTypeInfo();
           if (wrapperTyInfo.isValid()) {
             auto valueTy = baseTy->getTypeOfMember(
                 useDC->getParentModule(), wrapperTyInfo.valueVar,

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -945,8 +945,21 @@ struct Bar<T, V> {
   func bar() {}
 }
 
+@propertyWrapper
+struct Baz<T> {
+  var wrappedValue: T
+
+  var wrapperValue: V {
+    return V()
+  }
+}
+
 extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
   func barWhereVIsString() {}
+}
+
+struct V {
+  func onWrapperValue() {}
 }
 
 struct W {
@@ -958,21 +971,16 @@ struct MissingPropertyWrapperUnwrap {
   @Foo var x: Int
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
+  @Baz var usesWrapperValue: W
 
   func baz() {
-<<<<<<< HEAD
-    self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Foo<Int>'}}{{10-10=_}}
-    self.y.bar() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
-    self.y.barWhereVIsString() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
-    // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
-    self.z.barWhereVIsString() // expected-error {{property 'z' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, String>'}}{{10-10=_}} 
-=======
     self.x.foo() // expected-error {{value of type 'Int' has no member 'foo', requires wrapper type 'Foo<Int>'}}{{10-10=$}}
     self.y.bar() // expected-error {{value of type 'Int' has no member 'bar', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
     self.y.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
     self.z.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, String>'}}{{10-10=$}}
     self.$w.onWrapped() // expected-error {{value of type 'Foo<W>' has no member 'onWrapped', requires wrapped type 'W'}} {{10-10=}}
->>>>>>> Sema: Add property wrapper diagnostic for unnecessary $ in member access
+    self.usesWrapperValue.onWrapperValue() // expected-error {{value of type 'W' has no member 'onWrapperValue', requires wrapper type 'V'}}{{10-10=$}}
+    self.$usesWrapperValue.onWrapped() // expected-error {{value of type 'V' has no member 'onWrapped', requires wrapped type 'W'}}{{10-10=}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -948,8 +948,10 @@ struct Bar<T, V> {
 @propertyWrapper
 struct Baz<T> {
   var wrappedValue: T
+  
+  func onPropertyWrapper() {}
 
-  var wrapperValue: V {
+  var projectedValue: V {
     return V()
   }
 }
@@ -972,16 +974,18 @@ struct MissingPropertyWrapperUnwrap {
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
   @Baz var usesWrapperValue: W
-
+  
   func baz() {
-    self.x.foo() // expected-error {{value of type 'Int' has no member 'foo', requires wrapper type 'Foo<Int>'}}{{10-10=$}}
-    self.y.bar() // expected-error {{value of type 'Int' has no member 'bar', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
-    self.y.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
+    self.x.foo() // expected-error {{referencing to member 'foo' requires wrapper 'Foo<Int>'}}{{10-10=_}}
+    self.y.bar() // expected-error {{referencing to member 'bar' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
+    self.y.barWhereVIsString() // expected-error {{referencing to member 'barWhereVIsString' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
-    self.z.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, String>'}}{{10-10=$}}
-    self.$w.onWrapped() // expected-error {{value of type 'Foo<W>' has no member 'onWrapped', requires wrapped type 'W'}} {{10-10=}}
-    self.usesWrapperValue.onWrapperValue() // expected-error {{value of type 'W' has no member 'onWrapperValue', requires wrapper type 'V'}}{{10-10=$}}
-    self.$usesWrapperValue.onWrapped() // expected-error {{value of type 'V' has no member 'onWrapped', requires wrapped type 'W'}}{{10-10=}}
-    self.$$usesWrapperValue.onWrapped() // expected-error {{value of type 'Baz<W>' has no member 'onWrapped', requires wrapped type 'W'}}{{10-11=}}
+    self.z.barWhereVIsString() // expected-error {{referencing to member 'barWhereVIsString' requires wrapper 'Bar<Int, String>'}}{{10-10=_}}
+    self.usesWrapperValue.onPropertyWrapper() // expected-error {{referencing to member 'onPropertyWrapper' requires wrapper 'Baz<W>'}}{{10-10=_}}
+    
+    self._w.onWrapped() // expected-error {{referencing to member 'onWrapped' requires wrapped value of type 'W'}}{{10-11=}}
+    self.usesWrapperValue.onWrapperValue() // expected-error {{referencing to member 'onWrapperValue' requires wrapper 'V'}}{{10-10=$}}
+    self.$usesWrapperValue.onWrapped() // expected-error {{referencing to member 'onWrapped' requires wrapped value of type 'W'}}{{10-11=}}
+    self._usesWrapperValue.onWrapped() // expected-error {{referencing to member 'onWrapped' requires wrapped value of type 'W'}}{{10-11=}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -982,5 +982,6 @@ struct MissingPropertyWrapperUnwrap {
     self.$w.onWrapped() // expected-error {{value of type 'Foo<W>' has no member 'onWrapped', requires wrapped type 'W'}} {{10-10=}}
     self.usesWrapperValue.onWrapperValue() // expected-error {{value of type 'W' has no member 'onWrapperValue', requires wrapper type 'V'}}{{10-10=$}}
     self.$usesWrapperValue.onWrapped() // expected-error {{value of type 'V' has no member 'onWrapped', requires wrapped type 'W'}}{{10-10=}}
+    self.$$usesWrapperValue.onWrapped() // expected-error {{value of type 'Baz<W>' has no member 'onWrapped', requires wrapped type 'W'}}{{10-11=}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -949,16 +949,30 @@ extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
   func barWhereVIsString() {}
 }
 
+struct W {
+  func onWrapped() {}
+}
+
 struct MissingPropertyWrapperUnwrap {
+  @Foo var w: W
   @Foo var x: Int
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
 
   func baz() {
+<<<<<<< HEAD
     self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Foo<Int>'}}{{10-10=_}}
     self.y.bar() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
     self.y.barWhereVIsString() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
     self.z.barWhereVIsString() // expected-error {{property 'z' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, String>'}}{{10-10=_}} 
+=======
+    self.x.foo() // expected-error {{value of type 'Int' has no member 'foo', requires wrapper type 'Foo<Int>'}}{{10-10=$}}
+    self.y.bar() // expected-error {{value of type 'Int' has no member 'bar', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
+    self.y.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, Bool>'}}{{10-10=$}}
+    // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
+    self.z.barWhereVIsString() // expected-error {{value of type 'Int' has no member 'barWhereVIsString', requires wrapper type 'Bar<Int, String>'}}{{10-10=$}}
+    self.$w.onWrapped() // expected-error {{value of type 'Foo<W>' has no member 'onWrapped', requires wrapped type 'W'}} {{10-10=}}
+>>>>>>> Sema: Add property wrapper diagnostic for unnecessary $ in member access
   }
 }


### PR DESCRIPTION
Additionally, refactor some of the logic for the original add $ diagnostic so that a lot of logic can be shared between the two. Also rename the original fix and diagnostic to better reflect their purpose.

## Diagnostic Message Changes

Tagging people who had thoughts about this before so you all can take a look: @jckarter @harlanhaskins @xedin.

One of the most important changes to discuss in this pull request is the change to the diagnostic messages, all of which I would like to solidify before merging this pull request, so if you have any ideas for better messages, please leave a review! Currently, there are four different messages which can be displayed:

Given:

```swift

func a<X>(_: Foo<X>) {}
func b(_: Bar) {}

struct Bar {
  func bar() {}
}

@propertyWrapper
struct Foo {
  func foo() {}
}

struct MyStruct {
  @Foo var x: Int
  @Foo var y: Bar

  func doThings() {
    // ...
  }
}
```

#### General type mismatches, for example for function calls:
```swift
a(self.x)
```
Produces: `property 'x' will be unwrapped to value of type 'Int', use '$' to refer to wrapper type 'Foo<Int>'`

```swift
b(self.$y)
```
Produces: `property wrapper '$y' has value of type 'Foo<Bar>', remove '$' to refer to the wrapped value of type 'Bar'`

#### Member accesses

```swift
self.x.foo()
```
Produces: `value of type 'Int' has no member 'foo', requires wrapper type 'Foo<Int>'`

```swift
self.$y.bar()
```
Produces: `value of type 'Foo<Bar>' has no member 'bar', requires wrapped type 'Bar'`

*Note:* In all cases, a fixit to add or remove a `$` is produced.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to [SR-10928](https://bugs.swift.org/browse/SR-10928).