### PR TITLE
[AutoDiff] Eliminate flow-sensitivity in '@differentiable' closure conversions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1100,10 +1100,6 @@ NOTE(string_index_not_integer_note,none,
      "consider using an existing high level algorithm, "
      "str.startIndex.advanced(by: n), or a projection like str.utf8", ())
 
-// SWIFT_ENABLE_TENSORFLOW
-ERROR(invalid_tensorflow_fn_conversion,none,
-      "TensorFlow functions cannot be converted to other function types", ())
-
 
 ERROR(invalid_c_function_pointer_conversion_expr,none,
       "a C function pointer can only be formed from a reference to a 'func' or "
@@ -1118,6 +1114,12 @@ ERROR(c_function_pointer_from_function_with_context,none,
       "%select{local function|closure}0 that captures "
       "%select{context|generic parameters|dynamic Self type|<<error>}1",
       (bool, unsigned))
+// SWIFT_ENABLE_TENSORFLOW
+ERROR(invalid_differentiable_function_conversion_expr,none,
+      "a '@differentiable' function can only be formed from a reference to a "
+      "'func' or a literal closure", ())
+NOTE(invalid_differentiable_function_conversion_parameter,none,
+     "did you mean to take a '%0' closure?", (StringRef))
 ERROR(invalid_autoclosure_forwarding,none,
       "add () to forward @autoclosure parameter", ())
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5849,6 +5849,58 @@ maybeDiagnoseUnsupportedFunctionConversion(ConstraintSystem &cs, Expr *expr,
     tc.diagnose(expr->getLoc(),
                 diag::invalid_c_function_pointer_conversion_expr);
   }
+
+  // Conversion from a non-`@differentiable` function to a `@differentiable` is
+  // only allowed from a closure expression or a declaration/member reference.
+  if (toType->isDifferentiable() && !fromFnType->isDifferentiable()) {
+    auto maybeDiagnoseFunctionRef = [&](Expr *semanticExpr) {
+      if (auto *capture = dyn_cast<CaptureListExpr>(semanticExpr))
+        semanticExpr = capture->getClosureBody();
+      if (isa<ClosureExpr>(semanticExpr)) return;
+      if (auto *declRef = dyn_cast<DeclRefExpr>(semanticExpr)) {
+        if (isa<FuncDecl>(declRef->getDecl())) return;
+        // If the referenced decl is a function parameter, the user may want
+        // to change the declaration to be a '@differentiable' closure. Emit a
+        // note with a fix-it.
+        if (auto *paramDecl = dyn_cast<ParamDecl>(declRef->getDecl())) {
+          tc.diagnose(expr->getLoc(),
+                      diag::invalid_differentiable_function_conversion_expr);
+          if (paramDecl->getType()->is<AnyFunctionType>()) {
+            auto *typeRepr = paramDecl->getTypeLoc().getTypeRepr();
+            while (auto *attributed = dyn_cast<AttributedTypeRepr>(typeRepr))
+              typeRepr = attributed->getTypeRepr();
+            std::string attributeString = "@differentiable";
+            switch (toType->getDifferentiabilityKind()) {
+            case DifferentiabilityKind::Linear:
+              attributeString += "(linear)";
+              break;
+            case DifferentiabilityKind::Normal:
+            case DifferentiabilityKind::NonDifferentiable:
+              break;
+            }
+            auto *funcTypeRepr = cast<FunctionTypeRepr>(typeRepr);
+            auto paramListLoc = funcTypeRepr->getArgsTypeRepr()->getStartLoc();
+            tc.diagnose(paramDecl->getLoc(),
+                diag::invalid_differentiable_function_conversion_parameter,
+                attributeString)
+               .highlight(paramDecl->getTypeLoc().getSourceRange())
+               .fixItInsert(paramListLoc, attributeString + " ");
+          }
+          return;
+        }
+      } else if (auto *memberRef = dyn_cast<MemberRefExpr>(semanticExpr)) {
+        if (isa<FuncDecl>(memberRef->getMember().getDecl())) return;
+      } else if (auto *dotSyntaxCall =
+                     dyn_cast<DotSyntaxCallExpr>(semanticExpr)) {
+        if (isa<FuncDecl>(dotSyntaxCall->getFn()
+                ->getSemanticsProvidingExpr()->getReferencedDecl().getDecl()))
+          return;
+      }
+      tc.diagnose(expr->getLoc(),
+                  diag::invalid_differentiable_function_conversion_expr);
+    };
+    maybeDiagnoseFunctionRef(getSemanticExprForDeclOrMemberRef(expr));
+  }
 }
 
 /// Build the conversion of an element in a collection upcast.

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -1,16 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
 //===----------------------------------------------------------------------===//
-// Top-level (before VJP/adjoint synthesis)
-//===----------------------------------------------------------------------===//
-
-// expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
-func foo(_ f: (Float) -> Float) -> Float {
-  // expected-error @+1 {{function is not differentiable}}
-  return gradient(at: 0, in: f)
-}
-
-//===----------------------------------------------------------------------===//
 // Basic function
 //===----------------------------------------------------------------------===//
 

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -16,15 +16,14 @@ func diffableClosureInStruct(s: Foo) {
 
 public func closureCaptureMutable() {
   var val: Float = 10
-  let clo: (Float) -> Float = { x in
+  _ = gradient(at: 0) { (x: Float) -> Float in
     val += 2
     return val * x
   }
-  _ = gradient(at: 0, in: clo)
 }
 
 // CHECK-LABEL: @AD__{{.*}}closureCaptureMutable{{.*}}___vjp_src_0_wrt_0
-// CHECK: bb0({{%.*}} : $Float, [[BOXED_ARG:%.*]] : ${ var Float }):
+// CHECK: bb0({{%.*}} : $Float, [[INOUT_ARG:%.*]] : $*Float):
 // CHECK:   [[ADJOINT:%.*]] = function_ref @AD__{{.*}}closureCaptureMutabley{{.*}}___adjoint_src_0_wrt_0
 // CHECK:   {{.*}} = partial_apply [callee_guaranteed] [[ADJOINT]]({{.*}})
 

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -75,7 +75,7 @@ MethodTests.test("instance method with generated adjoint, called from differenta
 MethodTests.test("instance method with generated adjoint, differentiated directly") {
   // This is our current syntax for taking gradients of instance methods
   // directly. If/when we develop nicer syntax for this, change this test.
-  let g = { (p: Parameter) in p.squared() }
+  func g(p: Parameter) -> Float { p.squared() }
   expectEqual(Parameter(x: 4), gradient(at: Parameter(x: 2), in: g))
   expectEqual(Parameter(x: 40), gradient(at: Parameter(x: 20), in: g))
 }
@@ -136,7 +136,7 @@ MethodTests.test("static method with generated adjoint, wrt only second param") 
 }
 
 MethodTests.test("static method with generated adjoint, wrt all params") {
-  let g = { (a: Parameter, b: Parameter) in a * b }
+  func g(a: Parameter, b: Parameter) -> Float { a * b }
   expectEqual((Parameter(x: 100), Parameter(x: 200)),
               gradient(at: Parameter(x: 200), Parameter(x: 100), in: g))
   expectEqual((Parameter(x: 200), Parameter(x: 100)),
@@ -291,7 +291,7 @@ MethodTests.test("instance method with custom adjoint, called from differentated
 MethodTests.test("instance method with generated adjoint, differentated directly") {
   // This is our current syntax for taking gradients of instance methods
   // directly. If/when we develop nicer syntax for this, change this test.
-  let g = { (p: CustomParameter) in p.squared() }
+  func g(p: CustomParameter) -> Float { p.squared() }
   expectEqual(CustomParameter(x: 4), gradient(at: CustomParameter(x: 2), in: g))
   expectEqual(CustomParameter(x: 10), gradient(at: CustomParameter(x: 20), in: g))
 }
@@ -328,7 +328,7 @@ MethodTests.test("instance method with custom adjoint, wrt only non-self") {
 }
 
 MethodTests.test("instance method with custom adjoint, wrt self and non-self") {
-  let g = { (p: CustomParameter, o: Float) in p.multiplied(with: o) }
+  func g(p: CustomParameter, o: Float) -> Float { p.multiplied(with: o) }
   expectEqual((CustomParameter(x: 5), 10), gradient(at: CustomParameter(x: 100), 5, in: g))
   expectEqual((CustomParameter(x: 10), 5), gradient(at: CustomParameter(x: 5), 100, in: g))
 }

--- a/test/AutoDiff/simd.swift
+++ b/test/AutoDiff/simd.swift
@@ -13,7 +13,7 @@ var SIMDTests = TestSuite("SIMD")
 SIMDTests.test("init(repeating:)") {
   let g = SIMD4<Float>(1, 1, 1, 1)
   
-  let foo1 = { (x: Float) -> SIMD4<Float> in
+  func foo1(x: Float) -> SIMD4<Float> {
     return SIMD4<Float>(repeating: 2 * x)
   }
   let (val1, bp1) = valueWithPullback(at: 5, in: foo1)
@@ -24,7 +24,7 @@ SIMDTests.test("init(repeating:)") {
 SIMDTests.test("Sum") {
   let a = SIMD4<Float>(1, 2, 3, 4)
   
-  let foo1 = { (x: SIMD4<Float>) -> Float in
+  func foo1(x: SIMD4<Float>) -> Float {
     return x.sum()
   }
   let (val1, bp1) = valueWithPullback(at: a, in: foo1)
@@ -36,7 +36,7 @@ SIMDTests.test("Identity") {
   let a = SIMD4<Float>(1, 2, 3, 4)
   let g = SIMD4<Float>(1, 1, 1, 1)
   
-  let foo1 = { (x: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return x
   }
   let (val1, bp1) = valueWithPullback(at: a, in: foo1)
@@ -48,7 +48,7 @@ SIMDTests.test("Negate") {
   let a = SIMD4<Float>(1, 2, 3, 4)
   let g = SIMD4<Float>(1, 1, 1, 1)
   
-  let foo1 = { (x: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return -x
   }
   let (val1, bp1) = valueWithPullback(at: a, in: foo1)
@@ -59,7 +59,7 @@ SIMDTests.test("Negate") {
 SIMDTests.test("subscript") {
   let a = SIMD4<Float>(1, 2, 3, 4)
   
-  let foo1 = { (x: SIMD4<Float>) -> Float in
+  func foo1(x: SIMD4<Float>) -> Float {
     return x[3]
   }
   
@@ -73,7 +73,7 @@ SIMDTests.test("Addition") {
   let g = SIMD4<Float>(1, 1, 1, 1)
   
   // SIMD + SIMD
-  let foo1 = { (x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x + y
   }
   let (val1, bp1) = valueWithPullback(at: a, a, in: foo1)
@@ -81,7 +81,7 @@ SIMDTests.test("Addition") {
   expectEqual((g, g), bp1(g))
   
   // SIMD + Scalar
-  let foo2 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x + y
   }
   let (val2, bp2) = valueWithPullback(at: a, 5, in: foo2)
@@ -89,7 +89,7 @@ SIMDTests.test("Addition") {
   expectEqual((g, 4), bp2(g))
   
   // Scalar + SIMD
-  let foo3 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y + x
   }
   let (val3, bp3) = valueWithPullback(at: a, 5, in: foo3)
@@ -102,7 +102,7 @@ SIMDTests.test("Subtraction") {
   let g = SIMD4<Float>(1, 1, 1, 1)
   
   // SIMD - SIMD
-  let foo1 = { (x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x - y
   }
   let (val1, bp1) = valueWithPullback(at: a, a, in: foo1)
@@ -110,7 +110,7 @@ SIMDTests.test("Subtraction") {
   expectEqual((g, -g), bp1(g))
   
   // SIMD - Scalar
-  let foo2 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x - y
   }
   let (val2, bp2) = valueWithPullback(at: a, 5, in: foo2)
@@ -118,7 +118,7 @@ SIMDTests.test("Subtraction") {
   expectEqual((g, -4), bp2(g))
   
   // Scalar - SIMD
-  let foo3 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y - x
   }
   let (val3, bp3) = valueWithPullback(at: a, 5, in: foo3)
@@ -131,7 +131,7 @@ SIMDTests.test("Multiplication") {
   let g = SIMD4<Float>(1, 1, 1, 1)
 
   // SIMD * SIMD
-  let foo1 = { (x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x * y
   }
   let (val1, bp1) = valueWithPullback(at: a, a, in: foo1)
@@ -139,7 +139,7 @@ SIMDTests.test("Multiplication") {
   expectEqual((a, a), bp1(g))
 
   // SIMD * Scalar
-  let foo2 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x * y
   }
   let (val2, bp2) = valueWithPullback(at: a, 5, in: foo2)
@@ -147,7 +147,7 @@ SIMDTests.test("Multiplication") {
   expectEqual((SIMD4<Float>(5, 5, 5, 5), 10), bp2(g))
 
   // Scalar * SIMD
-  let foo3 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y * x
   }
   let (val3, bp3) = valueWithPullback(at: a, 5, in: foo3)
@@ -160,7 +160,7 @@ SIMDTests.test("Division") {
   let g = SIMD4<Float>(1, 1, 1, 1)
   
   // SIMD / SIMD
-  let foo1 = { (x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> in
+  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x / y
   }
   let dlhs1 = g / a
@@ -170,7 +170,7 @@ SIMDTests.test("Division") {
   expectEqual((dlhs1, drhs1), bp1(g))
   
   // SIMD / Scalar
-  let foo2 = { (x: SIMD4<Float>, y: Float) -> SIMD4<Float> in
+  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x / y
   }
   let dlhs2 = g / 5
@@ -180,7 +180,7 @@ SIMDTests.test("Division") {
   expectEqual((dlhs2, drhs2), bp2(g))
   
   // Scalar / SIMD
-  let foo3 = { (x: Float, y: SIMD4<Float>) -> SIMD4<Float> in
+  func foo3(x: Float, y: SIMD4<Float>) -> SIMD4<Float> {
     return x / y
   }
   let dlhs3 = (g / a).sum()

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -11,30 +11,30 @@ import Glibc
 var SimpleMathTests = TestSuite("SimpleMath")
 
 SimpleMathTests.test("Arithmetics") {
-  let foo1 = { (x: Float, y: Float) -> Float in
+  func foo1(x: Float, y: Float) -> Float {
     return x * y
   }
   expectEqual((4, 3), gradient(at: 3, 4, in: foo1))
-  let foo2 = { (x: Float, y: Float) -> Float in
+  func foo2(x: Float, y: Float) -> Float {
     return -x * y
   }
   expectEqual((-4, -3), gradient(at: 3, 4, in: foo2))
-  let foo3 = { (x: Float, y: Float) -> Float in
+  func foo3(x: Float, y: Float) -> Float {
     return -x + y
   }
   expectEqual((-1, 1), gradient(at: 3, 4, in: foo3))
 }
 
 SimpleMathTests.test("Fanout") {
-  let foo1 = { (x: Float) -> Float in
+  func foo1(x: Float) -> Float {
      x - x
   }
   expectEqual(0, gradient(at: 100, in: foo1))
-  let foo2 = { (x: Float) -> Float in
+  func foo2(x: Float) -> Float {
      x + x
   }
   expectEqual(2, gradient(at: 100, in: foo2))
-  let foo3 = { (x: Float, y: Float) -> Float in
+  func foo3(x: Float, y: Float) -> Float {
     x + x + x * y
   }
   expectEqual((4, 3), gradient(at: 3, 2, in: foo3))
@@ -66,7 +66,7 @@ SimpleMathTests.test("CaptureLocal") {
 
 var globalVar: Float = 10
 SimpleMathTests.test("CaptureGlobal") {
-  let foo: (Float) -> Float = { x in
+  func foo(x: Float) -> Float {
     globalVar += 20
     return globalVar * x
   }


### PR DESCRIPTION
`@differentiable` function conversion from a non-`@differentiable` function is handled by inserting an `AutoDiffFunctionExpr` in CSApply when the contextual type is `@differentiable`. This is similar to C function poster conversion. One thing that we have not checked during these conversions is whether the original function expression is a literal closure expression or a reference to a `func` declaration. Lacking this check made `@differentiable` closure conversion flow-sensitive, which caused many semantic inconsistencies as described in [TF-577](https://bugs.swift.org/browse/TF-577).

This patch makes `@differentiable` closure conversion only valid when the from-expression is a literal closure expression or a reference to a `func` declaration. This eliminates all flow-sensitivity in `@differentiable` closure conversions.

In common cases where a user writes a higher-order function that differentiates the argument closure but forgets to make the parameter have a `@differentiable` or `@differentiable(linear)` function type, we produce a note and a fix-it to insert a `@differentiable` or `@differentiable(linear)` attribute to the parameter's type signature.