### PR TITLE
[Name Lookup, ASTScope] simplified and debugged

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -592,17 +592,18 @@ public:
   /// Takes an array in order to batch the consumption before setting
   /// IndexOfFirstOuterResult when necessary.
   virtual bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
-                       Optional<bool> isCascadingUse,
                        NullablePtr<DeclContext> baseDC = nullptr) = 0;
 
   /// Eventually this functionality should move into ASTScopeLookup
-  virtual std::pair<bool, Optional<bool>>
-  lookupInSelfType(NullablePtr<DeclContext> selfDC, DeclContext *const scopeDC,
-                   NominalTypeDecl *const nominal,
-                   Optional<bool> isCascadingUse) = 0;
+  virtual bool
+  lookInMembers(NullablePtr<DeclContext> selfDC, DeclContext *const scopeDC,
+                NominalTypeDecl *const nominal,
+                function_ref<bool(Optional<bool>)> calculateIsCascadingUse) = 0;
 
 #ifndef NDEBUG
-  virtual void stopForDebuggingIfTargetLookup() = 0;
+  virtual void startingNextLookupStep() = 0;
+  virtual void finishingLookup(std::string) const = 0;
+  virtual bool isTargetLookup() const = 0;
 #endif
 };
   
@@ -615,19 +616,19 @@ public:
   virtual ~ASTScopeDeclGatherer() = default;
 
   bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
-               Optional<bool> isCascadingUse,
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   /// Eventually this functionality should move into ASTScopeLookup
-  std::pair<bool, Optional<bool>>
-  lookupInSelfType(NullablePtr<DeclContext>, DeclContext *const,
-                   NominalTypeDecl *const,
-                   Optional<bool> isCascadingUse) override {
-    return std::make_pair(false, isCascadingUse);
+  bool lookInMembers(NullablePtr<DeclContext>, DeclContext *const,
+                     NominalTypeDecl *const,
+                     function_ref<bool(Optional<bool>)>) override {
+    return false;
   }
 
 #ifndef NDEBUG
-  void stopForDebuggingIfTargetLookup() override {}
+  void startingNextLookupStep() override {}
+  void finishingLookup(std::string) const override {}
+  bool isTargetLookup() const override { return false; }
 #endif
 
   ArrayRef<ValueDecl *> getDecls() { return values; }
@@ -641,11 +642,16 @@ class ASTScope {
 
 public:
   ASTScope(SourceFile *);
-  static Optional<bool>
+
+  /// \return the scopes traversed
+  static llvm::SmallVector<const ast_scope::ASTScopeImpl *, 0>
   unqualifiedLookup(SourceFile *, DeclName, SourceLoc,
                     const DeclContext *startingContext,
-                    Optional<bool> isCascadingUse,
                     namelookup::AbstractASTScopeDeclConsumer &);
+
+  static Optional<bool>
+  computeIsCascadingUse(ArrayRef<const ast_scope::ASTScopeImpl *> history,
+                        Optional<bool> initialIsCascadingUse);
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -249,7 +249,7 @@ namespace swift {
     /// Default is in \c ParseLangArgs
     ///
     /// This is a staging flag; eventually it will be removed.
-    bool EnableASTScopeLookup = false;
+    bool EnableASTScopeLookup = true;
 
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -249,7 +249,7 @@ namespace swift {
     /// Default is in \c ParseLangArgs
     ///
     /// This is a staging flag; eventually it will be removed.
-    bool EnableASTScopeLookup;
+    bool EnableASTScopeLookup = false;
 
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -246,8 +246,11 @@ namespace swift {
     bool EnableDeserializationRecovery = true;
 
     /// Should we use \c ASTScope-based resolution for unqualified name lookup?
-    bool EnableASTScopeLookup = false;
-    
+    /// Default is in \c ParseLangArgs
+    ///
+    /// This is a staging flag; eventually it will be removed.
+    bool EnableASTScopeLookup;
+
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -249,7 +249,7 @@ namespace swift {
     /// Default is in \c ParseLangArgs
     ///
     /// This is a staging flag; eventually it will be removed.
-    bool EnableASTScopeLookup = true;
+    bool EnableASTScopeLookup = false;
 
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -869,7 +869,12 @@ def enable_astscope_lookup : Flag<["-"], "enable-astscope-lookup">,
   Flags<[FrontendOption]>,
   HelpText<"Enable ASTScope-based unqualified name lookup">;
 
-def disable_parser_lookup : Flag<["-"], "disable_parser_lookup">,
+def disable_astscope_lookup : Flag<["-"], "disable-astscope-lookup">,
+  Flags<[FrontendOption]>,
+  HelpText<"Disable ASTScope-based unqualified name lookup">;
+
+def disable_parser_lookup : Flag<["-"], "disable-parser-lookup">,
+  Flags<[FrontendOption]>,
   HelpText<"Disable parser lookup & use ast scope lookup only (experimental)">;
 
 def index_file : Flag<["-"], "index-file">,

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -132,6 +132,28 @@ public:
     // So, only check source ranges for PatternBindingDecls
     if (isa<PatternBindingDecl>(d) && (d->getStartLoc() == d->getEndLoc()))
       return false;
+    /// In
+    /// \code
+    /// @propertyWrapper
+    /// public struct Wrapper<T> {
+    ///   public var value: T
+    ///
+    ///   public init(body: () -> T) {
+    ///     self.value = body()
+    ///   }
+    /// }
+    ///
+    /// let globalInt = 17
+    ///
+    /// @Wrapper(body: { globalInt })
+    /// public var y: Int
+    /// \endcode
+    /// I'm seeing a dumped AST include:
+    /// (pattern_binding_decl range=[test.swift:13:8 - line:12:29]
+    const auto &SM = d->getASTContext().SourceMgr;
+    assert((d->getStartLoc().isInvalid() ||
+            !SM.isBeforeInBuffer(d->getEndLoc(), d->getStartLoc())) &&
+           "end-before-start will break tree search via location");
     return true;
   }
 
@@ -179,9 +201,10 @@ private:
       function_ref<void(NullablePtr<CaptureListExpr>, ClosureExpr *)>
           foundClosure);
 
+  // A safe way to discover this, without creating a circular request.
+  // Cannot call getAttachedPropertyWrappers.
   static bool hasCustomAttribute(VarDecl *vd) {
-    return AttachedPropertyWrapperScope::getCustomAttributesSourceRange(vd)
-        .isValid();
+    return vd->getAttrs().getAttribute<CustomAttr>();
   }
 
 public:
@@ -190,8 +213,9 @@ public:
 
   void createAttachedPropertyWrapperScope(PatternBindingDecl *patternBinding,
                                           ASTScopeImpl *parent) {
+ 
     patternBinding->getPattern(0)->forEachVariable([&](VarDecl *vd) {
-      // assume all same as first
+        // assume all same as first
       if (hasCustomAttribute(vd))
         createSubtree<AttachedPropertyWrapperScope>(parent, vd);
     });
@@ -221,7 +245,7 @@ public:
   void
   forEachSpecializeAttrInSourceOrder(Decl *declBeingSpecialized,
                                      function_ref<void(SpecializeAttr *)> fn) {
-    llvm::SmallVector<SpecializeAttr *, 8> sortedSpecializeAttrs;
+    SmallVector<SpecializeAttr *, 8> sortedSpecializeAttrs;
     for (auto *attr : declBeingSpecialized->getAttrs()) {
       if (auto *specializeAttr = dyn_cast<SpecializeAttr>(attr)) {
         if (!isDuplicate(specializeAttr))
@@ -584,6 +608,8 @@ CREATES_NEW_INSERTION_POINT(TopLevelCodeScope)
 
 NO_NEW_INSERTION_POINT(AbstractFunctionBodyScope)
 NO_NEW_INSERTION_POINT(AbstractFunctionDeclScope)
+NO_NEW_INSERTION_POINT(AttachedPropertyWrapperScope)
+
 NO_NEW_INSERTION_POINT(CaptureListScope)
 NO_NEW_INSERTION_POINT(CaseStmtScope)
 NO_NEW_INSERTION_POINT(CatchStmtScope)
@@ -606,7 +632,6 @@ NO_EXPANSION(ClosureParametersScope)
 NO_EXPANSION(SpecializeAttributeScope)
 // no accessors, unlike PatternEntryUseScope
 NO_EXPANSION(ConditionalClausePatternUseScope)
-NO_EXPANSION(AttachedPropertyWrapperScope)
 NO_EXPANSION(GuardStmtUseScope)
 
 #undef CREATES_NEW_INSERTION_POINT
@@ -744,8 +769,10 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
     }
   }
   // Create scope for the body.
-  if (decl->getBody()) {
-    if (decl->getDeclContext()->isTypeContext())
+  // We create body scopes when there is no body for source kit to complete
+  // erroneous code in bodies.
+  if (decl->getBodySourceRange().isValid()) {
+    if (AbstractFunctionBodyScope::isAMethod(decl))
       scopeCreator.createSubtree<MethodBodyScope>(leaf, decl);
     else
       scopeCreator.createSubtree<PureFunctionBodyScope>(leaf, decl);
@@ -754,8 +781,10 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
 
 void AbstractFunctionBodyScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
     ScopeCreator &scopeCreator) {
-  BraceStmt *braceStmt = decl->getBody();
-  ASTVisitorForScopeCreation().visitBraceStmt(braceStmt, this, scopeCreator);
+  // We create body scopes when there is no body for source kit to complete
+  // erroneous code in bodies.
+  if (BraceStmt *braceStmt = decl->getBody())
+    ASTVisitorForScopeCreation().visitBraceStmt(braceStmt, this, scopeCreator);
 }
 
 void IfStmtScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
@@ -898,6 +927,15 @@ void DefaultArgumentInitializerScope::
   ASTVisitorForScopeCreation().visitExpr(initExpr, this, scopeCreator);
 }
 
+void AttachedPropertyWrapperScope::
+    expandAScopeThatDoesNotCreateANewInsertionPoint(
+        ScopeCreator &scopeCreator) {
+  for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
+    if (auto *expr = attr->getArg())
+      ASTVisitorForScopeCreation().visitExpr(expr, this, scopeCreator);
+  }
+}
+
 #pragma mark expandScope
 
 ASTScopeImpl *GenericTypeOrExtensionWholePortion::expandScope(
@@ -911,8 +949,7 @@ ASTScopeImpl *GenericTypeOrExtensionWholePortion::expandScope(
       scope->getDecl().get(), scope->getGenericContext()->getGenericParams(),
       scope);
   if (scope->getGenericContext()->getTrailingWhereClause())
-    deepestScope =
-        scope->createTrailingWhereClauseScope(deepestScope, scopeCreator);
+    scope->createTrailingWhereClauseScope(deepestScope, scopeCreator);
   scope->createBodyScope(deepestScope, scopeCreator);
   return scope->getParent().get();
 }

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -35,17 +35,16 @@ using namespace swift;
 using namespace namelookup;
 using namespace ast_scope;
 
-Optional<bool> ASTScopeImpl::unqualifiedLookup(
+llvm::SmallVector<const ASTScopeImpl *, 0> ASTScopeImpl::unqualifiedLookup(
     SourceFile *sourceFile, const DeclName name, const SourceLoc loc,
-    const DeclContext *const startingContext,
-    const Optional<bool> isCascadingUseArg, DeclConsumer consumer) {
+    const DeclContext *const startingContext, DeclConsumer consumer) {
+  SmallVector<const ASTScopeImpl *, 0> history;
+
   const auto *start =
       findStartingScopeForLookup(sourceFile, name, loc, startingContext);
-  if (!start)
-    return isCascadingUseArg;
-
-  return start->lookup(NullablePtr<DeclContext>(), nullptr, nullptr,
-                       isCascadingUseArg, consumer);
+  if (start)
+    start->lookup(history, nullptr, nullptr, consumer);
+  return history;
 }
 
 const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
@@ -171,242 +170,209 @@ bool GenericParamScope::doesContextMatchStartingContext(
 
 #pragma mark lookup methods that run once per scope
 
-Optional<bool> ASTScopeImpl::lookup(
-    const NullablePtr<DeclContext> selfDC,
-    const NullablePtr<const ASTScopeImpl> limit,
-    const NullablePtr<const Decl> scopeWhoseTypeWasAlreadySearched,
-    const Optional<bool> isCascadingUseArg, DeclConsumer consumer) const {
+void ASTScopeImpl::lookup(SmallVectorImpl<const ASTScopeImpl *> &history,
+                          const NullablePtr<const ASTScopeImpl> limit,
+                          NullablePtr<const GenericParamList> lastListSearched,
+                          DeclConsumer consumer) const {
+
+  history.push_back(this);
+
 #ifndef NDEBUG
-  consumer.stopForDebuggingIfTargetLookup();
+  consumer.startingNextLookupStep();
 #endif
 
   // Certain illegal nestings, e.g. protocol nestled inside a struct,
   // require that lookup stop at the outer scope.
-  if (this == limit.getPtrOrNull())
-    return isCascadingUseArg;
-
-  const Optional<bool> isCascadingUseForThisScope =
-      resolveIsCascadingUseForThisScope(isCascadingUseArg);
-  // Check local variables, etc. first.
-  if (lookupLocalBindings(isCascadingUseForThisScope, consumer))
-    return isCascadingUseForThisScope;
-
-  /// Because a body scope nests in a generic param scope, etc, we might look in
-  /// the self type twice. That's why we pass scopeWhoseTypeWasAlreadySearched.
-  /// Look in the generics and self type only iff haven't already looked there.
-  const bool skipSearchForGenericsAndMembers =
-      scopeWhoseTypeWasAlreadySearched &&
-      scopeWhoseTypeWasAlreadySearched == getDecl().getPtrOrNull();
+  if (this == limit.getPtrOrNull()) {
+#ifndef NDEBUG
+    consumer.finishingLookup("limit return");
+#endif
+    return;
+  }
 
   // Look for generics before members in violation of lexical ordering because
   // you can say "self.name" to get a name shadowed by a generic but you
   // can't do the opposite to get a generic shadowed by a name.
-  if (!skipSearchForGenericsAndMembers) {
-    if (lookInMyGenericParameters(isCascadingUseForThisScope, consumer))
-      return isCascadingUseForThisScope;
-  }
-  // Dig out the type we're looking into.
-  // Perform lookup into the type
-  Optional<bool> isCascadingUseResult = isCascadingUseForThisScope;
-  if (!skipSearchForGenericsAndMembers) {
-    bool isDone;
-    std::tie(isDone, isCascadingUseResult) =
-        lookupInSelfType(selfDC, isCascadingUseResult, consumer);
-    if (isDone)
-      return isCascadingUseResult;
-  }
+  const auto doneAndListSearched =
+      lookInMyGenericParameters(lastListSearched, consumer);
+  if (doneAndListSearched.first)
+    return;
 
-  return lookupInParent(selfDC, limit, scopeWhoseTypeWasAlreadySearched,
-                        isCascadingUseResult, consumer);
-}
-
-Optional<bool> ASTScopeImpl::lookupInParent(
-    const NullablePtr<DeclContext> selfDC,
-    const NullablePtr<const ASTScopeImpl> limit,
-    const NullablePtr<const Decl> scopeWhoseTypeWasAlreadySearched,
-    const Optional<bool> isCascadingUse, DeclConsumer consumer) const {
+  if (lookupLocalsOrMembers(history, consumer))
+    return;
 
   const auto *const lookupParent = getLookupParent().getPtrOrNull();
-  if (!lookupParent)
-    return isCascadingUse;
-
-  // If this scope has an associated Decl, we have already searched its generics
-  // and selfType, so no need to look again.
-  NullablePtr<const Decl> scopeWhoseTypeWasAlreadySearchedForParent =
-      getDecl() ? getDecl().getPtrOrNull() : scopeWhoseTypeWasAlreadySearched;
+  if (!lookupParent) {
+#ifndef NDEBUG
+    consumer.finishingLookup("Finished lookup; no parent");
+#endif
+    return;
+  }
 
   // If there is no limit and this scope induces one, pass that on.
   const NullablePtr<const ASTScopeImpl> limitForParent =
       limit ? limit : getLookupLimit();
 
-  return lookupParent->lookup(computeSelfDCForParent(selfDC), limitForParent,
-                              scopeWhoseTypeWasAlreadySearchedForParent,
-                              isCascadingUse, consumer);
+  return lookupParent->lookup(history, limitForParent, lastListSearched,
+                              consumer);
 }
 
-#pragma mark lookInMyGenericParameters
+#pragma mark genericParams()
 
-bool ASTScopeImpl::lookInMyGenericParameters(Optional<bool> isCascadingUse,
-                                             ASTScopeImpl::DeclConsumer) const {
-  return false;
+NullablePtr<const GenericParamList> ASTScopeImpl::genericParams() const {
+  return nullptr;
 }
-
-bool AbstractFunctionDeclScope::lookInMyGenericParameters(
-    Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer consumer) const {
-  return lookInGenericParametersOf(decl->getGenericParams(), isCascadingUse,
-                                   consumer);
+NullablePtr<const GenericParamList>
+AbstractFunctionDeclScope::genericParams() const {
+  return decl->getGenericParams();
 }
-
-bool SubscriptDeclScope::lookInMyGenericParameters(
-    Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer consumer) const {
-  return lookInGenericParametersOf(decl->getGenericParams(), isCascadingUse,
-                                   consumer);
+NullablePtr<const GenericParamList> SubscriptDeclScope::genericParams() const {
+  return decl->getGenericParams();
 }
-
-bool GenericTypeScope::lookInMyGenericParameters(
-    Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer consumer) const {
+NullablePtr<const GenericParamList> GenericTypeScope::genericParams() const {
   // For Decls:
   // WAIT, WHAT?! Isn't this covered by the GenericParamScope
-  // lookupLocalBindings? No, that's for use of generics in the body. This is
+  // lookupLocalsOrMembers? No, that's for use of generics in the body. This is
   // for generic restrictions.
 
   // For Bodies:
   // Sigh... These must be here so that from body, we search generics before
   // members. But they also must be on the Decl scope for lookups starting from
   // generic parameters, where clauses, etc.
-  return lookInGenericParametersOf(getGenericContext()->getGenericParams(),
-                                   isCascadingUse, consumer);
+  return getGenericContext()->getGenericParams();
+}
+NullablePtr<const GenericParamList> ExtensionScope::genericParams() const {
+  return decl->getGenericParams();
 }
 
-bool ExtensionScope::lookInMyGenericParameters(
-    Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer consumer) const {
+#pragma mark lookInMyGenericParameters
+
+std::pair<bool, NullablePtr<const GenericParamList>>
+ASTScopeImpl::lookInMyGenericParameters(
+    NullablePtr<const GenericParamList> formerListSearched,
+    ASTScopeImpl::DeclConsumer consumer) const {
+  auto listToSearch = genericParams();
+  if (listToSearch == formerListSearched)
+    return std::make_pair(false, formerListSearched);
+
   // For extensions of nested types, must check outer parameters
-  for (auto *params = decl->getGenericParams(); params;
+  for (auto *params = listToSearch.getPtrOrNull(); params;
        params = params->getOuterParameters()) {
-    if (lookInGenericParametersOf(params, isCascadingUse, consumer))
-      return true;
+    if (lookInGenericParametersOf(params, consumer))
+      return std::make_pair(true, listToSearch);
   }
-  return false;
+  return std::make_pair(false, listToSearch);
 }
 
 bool ASTScopeImpl::lookInGenericParametersOf(
     const NullablePtr<const GenericParamList> paramList,
-    Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer consumer) {
+    ASTScopeImpl::DeclConsumer consumer) {
   if (!paramList)
     return false;
   SmallVector<ValueDecl *, 32> bindings;
   for (auto *param : paramList.get()->getParams())
     bindings.push_back(param);
-  if (consumer.consume(bindings, DeclVisibilityKind::GenericParameter,
-                       isCascadingUse))
+  if (consumer.consume(bindings, DeclVisibilityKind::GenericParameter))
     return true;
   return false;
 }
 
-#pragma mark lookupInSelfType
+#pragma mark looking in locals or members - members
 
-std::pair<bool, Optional<bool>>
-ASTScopeImpl::lookupInSelfType(NullablePtr<DeclContext>,
-                               const Optional<bool> isCascadingUse,
-                               DeclConsumer) const {
-  return doNotLookupInSelfType(isCascadingUse);
+bool ASTScopeImpl::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                         DeclConsumer) const {
+  return false; // many kinds of scopes have none
 }
 
-std::pair<bool, Optional<bool>> GenericTypeOrExtensionScope::lookupInSelfType(
-    NullablePtr<DeclContext> selfDC, const Optional<bool> isCascadingUse,
+bool GenericTypeOrExtensionScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *> history,
     ASTScopeImpl::DeclConsumer consumer) const {
-  return portion->lookupInSelfTypeOf(this, selfDC, isCascadingUse, consumer);
+  // isCascadingUseArg must have already been resolved, for a real lookup
+  // but may be \c None for dumping.
+  return portion->lookupMembersOf(this, history, consumer);
 }
 
-std::pair<bool, Optional<bool>> Portion::lookupInSelfTypeOf(
-    const GenericTypeOrExtensionScope *scope, NullablePtr<DeclContext> selfDC,
-    const Optional<bool> isCascadingUse, ASTScopeImpl::DeclConsumer) const {
-  return scope->doNotLookupInSelfType(isCascadingUse);
+bool Portion::lookupMembersOf(const GenericTypeOrExtensionScope *,
+                              ArrayRef<const ASTScopeImpl *>,
+                              ASTScopeImpl::DeclConsumer) const {
+  return false;
 }
 
-std::pair<bool, Optional<bool>>
-GenericTypeOrExtensionWhereOrBodyPortion::lookupInSelfTypeOf(
-    const GenericTypeOrExtensionScope *scope, NullablePtr<DeclContext> selfDC,
-    const Optional<bool> isCascadingUse,
+bool GenericTypeOrExtensionWhereOrBodyPortion::lookupMembersOf(
+    const GenericTypeOrExtensionScope *scope,
+    ArrayRef<const ASTScopeImpl *> history,
     ASTScopeImpl::DeclConsumer consumer) const {
   auto nt = scope->getCorrespondingNominalTypeDecl().getPtrOrNull();
   if (!nt)
-    return Portion::lookupInSelfTypeOf(scope, selfDC, isCascadingUse, consumer);
-  return consumer.lookupInSelfType(selfDC, scope->getDeclContext().get(), nt,
-                                   isCascadingUse);
+    return false;
+  auto selfDC = computeSelfDC(history);
+  return consumer.lookInMembers(selfDC, scope->getDeclContext().get(), nt,
+                                [&](Optional<bool> initialIsCascadingUse) {
+                                  return ASTScopeImpl::computeIsCascadingUse(
+                                             history, initialIsCascadingUse)
+                                      .getValueOr(true);
+                                });
 }
 
-#pragma mark lookupLocalBindings
+#pragma mark looking in locals or members - locals
 
-bool ASTScopeImpl::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                       DeclConsumer consumer) const {
-  return false; // most kinds of scopes have none
-}
-
-bool GenericParamScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                            DeclConsumer consumer) const {
+bool GenericParamScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                              DeclConsumer consumer) const {
   auto *param = paramList->getParams()[index];
-  return consumer.consume({param}, DeclVisibilityKind::GenericParameter,
-                          isCascadingUse);
+  return consumer.consume({param}, DeclVisibilityKind::GenericParameter);
 }
 
-bool PatternEntryUseScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                               DeclConsumer consumer) const {
+bool PatternEntryUseScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                                 DeclConsumer consumer) const {
   if (vis != DeclVisibilityKind::LocalVariable)
     return false; // look in self type will find this later
-  return lookupLocalBindingsInPattern(getPattern(), isCascadingUse, vis,
-                                      consumer);
+  return lookupLocalBindingsInPattern(getPattern(), vis, consumer);
 }
 
-bool ForEachPatternScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                              DeclConsumer consumer) const {
-  return lookupLocalBindingsInPattern(stmt->getPattern(), isCascadingUse,
-                                      DeclVisibilityKind::LocalVariable,
-                                      consumer);
+bool ForEachPatternScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                                DeclConsumer consumer) const {
+  return lookupLocalBindingsInPattern(
+      stmt->getPattern(), DeclVisibilityKind::LocalVariable, consumer);
 }
 
-bool CatchStmtScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                         DeclConsumer consumer) const {
-  return lookupLocalBindingsInPattern(stmt->getErrorPattern(), isCascadingUse,
-                                      DeclVisibilityKind::LocalVariable,
-                                      consumer);
+bool CatchStmtScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                           DeclConsumer consumer) const {
+  return lookupLocalBindingsInPattern(
+      stmt->getErrorPattern(), DeclVisibilityKind::LocalVariable, consumer);
 }
 
-bool CaseStmtScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                        DeclConsumer consumer) const {
+bool CaseStmtScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                          DeclConsumer consumer) const {
   for (auto &item : stmt->getMutableCaseLabelItems())
-    if (lookupLocalBindingsInPattern(item.getPattern(), isCascadingUse,
-                                     DeclVisibilityKind::LocalVariable,
-                                     consumer))
+    if (lookupLocalBindingsInPattern(
+            item.getPattern(), DeclVisibilityKind::LocalVariable, consumer))
       return true;
   return false;
 }
 
-bool AbstractFunctionBodyScope::lookupLocalBindings(
-    Optional<bool> isCascadingUse, DeclConsumer consumer) const {
+bool AbstractFunctionBodyScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   if (auto *paramList = decl->getParameters()) {
     for (auto *paramDecl : *paramList)
-      if (consumer.consume({paramDecl}, DeclVisibilityKind::FunctionParameter,
-                           isCascadingUse))
+      if (consumer.consume({paramDecl}, DeclVisibilityKind::FunctionParameter))
         return true;
   }
   return false;
 }
 
-bool MethodBodyScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                          DeclConsumer consumer) const {
-  assert(decl->getImplicitSelfDecl());
-  if (AbstractFunctionBodyScope::lookupLocalBindings(isCascadingUse, consumer))
+bool MethodBodyScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *> history, DeclConsumer consumer) const {
+  assert(isAMethod(decl));
+  if (AbstractFunctionBodyScope::lookupLocalsOrMembers(history, consumer))
     return true;
   return consumer.consume({decl->getImplicitSelfDecl()},
-                          DeclVisibilityKind::FunctionParameter,
-                          isCascadingUse);
+                          DeclVisibilityKind::FunctionParameter);
 }
 
-bool PureFunctionBodyScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                                DeclConsumer consumer) const {
-  assert(!decl->getImplicitSelfDecl());
-  if (AbstractFunctionBodyScope::lookupLocalBindings(isCascadingUse, consumer))
+bool PureFunctionBodyScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *> history, DeclConsumer consumer) const {
+  assert(!isAMethod(decl));
+  if (AbstractFunctionBodyScope::lookupLocalsOrMembers(history, consumer))
     return true;
 
   // Consider \c var t: T { (did/will/)get/set { ... t }}
@@ -415,25 +381,23 @@ bool PureFunctionBodyScope::lookupLocalBindings(Optional<bool> isCascadingUse,
   // then t needs to be found as a local binding:
   if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
     if (auto *storage = accessor->getStorage())
-      if (consumer.consume({storage}, DeclVisibilityKind::LocalVariable,
-                           isCascadingUse))
+      if (consumer.consume({storage}, DeclVisibilityKind::LocalVariable))
         return true;
   }
   return false;
 }
 
-bool SpecializeAttributeScope::lookupLocalBindings(
-    Optional<bool> isCascadingUse, DeclConsumer consumer) const {
+bool SpecializeAttributeScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   if (auto *params = whatWasSpecialized->getGenericParams())
     for (auto *param : params->getParams())
-      if (consumer.consume({param}, DeclVisibilityKind::GenericParameter,
-                           isCascadingUse))
+      if (consumer.consume({param}, DeclVisibilityKind::GenericParameter))
         return true;
   return false;
 }
 
-bool BraceStmtScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                         DeclConsumer consumer) const {
+bool BraceStmtScope::lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
+                                           DeclConsumer consumer) const {
   // All types and functions are visible anywhere within a brace statement
   // scope. When ordering matters (i.e. var decl) we will have split the brace
   // statement into nested scopes.
@@ -448,50 +412,48 @@ bool BraceStmtScope::lookupLocalBindings(Optional<bool> isCascadingUse,
         localBindings.push_back(cast<ValueDecl>(localBinding));
     }
   }
-  return consumer.consume(localBindings, DeclVisibilityKind::LocalVariable,
-                          isCascadingUse);
+  return consumer.consume(localBindings, DeclVisibilityKind::LocalVariable);
 }
 
-bool PatternEntryInitializerScope::lookupLocalBindings(
-    Optional<bool> isCascadingUse, DeclConsumer consumer) const {
+bool PatternEntryInitializerScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   // 'self' is available within the pattern initializer of a 'lazy' variable.
   auto *initContext = cast_or_null<PatternBindingInitializer>(
       decl->getPatternList()[0].getInitContext());
   if (initContext) {
     if (auto *selfParam = initContext->getImplicitSelfDecl()) {
-      return consumer.consume(
-          {selfParam}, DeclVisibilityKind::FunctionParameter, isCascadingUse);
+      return consumer.consume({selfParam},
+                              DeclVisibilityKind::FunctionParameter);
     }
   }
   return false;
 }
 
-bool ClosureParametersScope::lookupLocalBindings(Optional<bool> isCascadingUse,
-                                                 DeclConsumer consumer) const {
+bool ClosureParametersScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   if (auto *cl = captureList.getPtrOrNull()) {
     CaptureListExpr *mutableCL =
         const_cast<CaptureListExpr *>(captureList.get());
     for (auto &e : mutableCL->getCaptureList()) {
-      if (consumer.consume({e.Var}, DeclVisibilityKind::LocalVariable,
-                           isCascadingUse)) // or FunctionParameter??
+      if (consumer.consume(
+              {e.Var},
+              DeclVisibilityKind::LocalVariable)) // or FunctionParameter??
         return true;
     }
   }
   for (auto param : *closureExpr->getParameters())
-    if (consumer.consume({param}, DeclVisibilityKind::FunctionParameter,
-                         isCascadingUse))
+    if (consumer.consume({param}, DeclVisibilityKind::FunctionParameter))
       return true;
   return false;
 }
 
-bool ConditionalClausePatternUseScope::lookupLocalBindings(
-    Optional<bool> isCascadingUse, DeclConsumer consumer) const {
+bool ConditionalClausePatternUseScope::lookupLocalsOrMembers(
+    ArrayRef<const ASTScopeImpl *>, DeclConsumer consumer) const {
   return lookupLocalBindingsInPattern(
-      pattern, isCascadingUse, DeclVisibilityKind::LocalVariable, consumer);
+      pattern, DeclVisibilityKind::LocalVariable, consumer);
 }
 
 bool ASTScopeImpl::lookupLocalBindingsInPattern(Pattern *p,
-                                                Optional<bool> isCascadingUse,
                                                 DeclVisibilityKind vis,
                                                 DeclConsumer consumer) {
   if (!p)
@@ -499,9 +461,36 @@ bool ASTScopeImpl::lookupLocalBindingsInPattern(Pattern *p,
   bool isDone = false;
   p->forEachVariable([&](VarDecl *var) {
     if (!isDone)
-      isDone = consumer.consume({var}, vis, isCascadingUse);
+      isDone = consumer.consume({var}, vis);
   });
   return isDone;
+}
+
+#pragma mark computeSelfDC
+
+NullablePtr<DeclContext>
+GenericTypeOrExtensionWhereOrBodyPortion::computeSelfDC(
+    ArrayRef<const ASTScopeImpl *> history) {
+  assert(history.size() != 0 && "includes current scope");
+  size_t i = history.size() - 1; // skip last entry (this scope)
+  while (i != 0) {
+    Optional<NullablePtr<DeclContext>> maybeSelfDC =
+        history[--i]->computeSelfDCForParent();
+    if (maybeSelfDC)
+      return *maybeSelfDC;
+  }
+  return nullptr;
+}
+
+#pragma mark compute isCascadingUse
+
+Optional<bool> ASTScopeImpl::computeIsCascadingUse(
+    ArrayRef<const ASTScopeImpl *> history,
+    const Optional<bool> initialIsCascadingUse) {
+  Optional<bool> isCascadingUse = initialIsCascadingUse;
+  for (const auto *scope : history)
+    isCascadingUse = scope->resolveIsCascadingUseForThisScope(isCascadingUse);
+  return isCascadingUse;
 }
 
 #pragma mark getLookupLimit
@@ -543,6 +532,12 @@ NominalTypeScope::getLookupLimitForDecl() const {
       [&](const Decl *const d) { return isa<ProtocolDecl>(d); });
 }
 
+NullablePtr<const ASTScopeImpl> ExtensionScope::getLookupLimitForDecl() const {
+  // Extensions can only be legally nested in a SourceFile,
+  // so any other kind of Decl is illegal
+  return parentIfNotChildOfTopScope();
+}
+
 NullablePtr<const ASTScopeImpl> ASTScopeImpl::ancestorWithDeclSatisfying(
     function_ref<bool(const Decl *)> predicate) const {
   for (NullablePtr<const ASTScopeImpl> s = getParent(); s;
@@ -563,19 +558,19 @@ NullablePtr<const ASTScopeImpl> ASTScopeImpl::ancestorWithDeclSatisfying(
 
 // By default, propagate the selfDC up to a NomExt decl, body,
 // or where clause
-NullablePtr<DeclContext>
-ASTScopeImpl::computeSelfDCForParent(NullablePtr<DeclContext> selfDC) const {
-  return selfDC;
+Optional<NullablePtr<DeclContext>>
+ASTScopeImpl::computeSelfDCForParent() const {
+  return None;
 }
 
 // Forget the "self" declaration:
-NullablePtr<DeclContext> GenericTypeOrExtensionScope::computeSelfDCForParent(
-    NullablePtr<DeclContext>) const {
-  return nullptr;
+Optional<NullablePtr<DeclContext>>
+GenericTypeOrExtensionScope::computeSelfDCForParent() const {
+  return NullablePtr<DeclContext>();
 }
 
-NullablePtr<DeclContext> PatternEntryInitializerScope::computeSelfDCForParent(
-    NullablePtr<DeclContext> selfDC) const {
+Optional<NullablePtr<DeclContext>>
+PatternEntryInitializerScope::computeSelfDCForParent() const {
   // Pattern binding initializers are only interesting insofar as they
   // affect lookup in an enclosing nominal type or extension thereof.
   if (auto *ic = getPatternEntry().getInitContext()) {
@@ -583,19 +578,16 @@ NullablePtr<DeclContext> PatternEntryInitializerScope::computeSelfDCForParent(
       // Lazy variable initializer contexts have a 'self' parameter for
       // instance member lookup.
       if (bindingInit->getImplicitSelfDecl()) {
-        assert((selfDC.isNull() || selfDC == bindingInit) &&
-               "Would lose information");
-        return bindingInit;
+        return NullablePtr<DeclContext>(bindingInit);
       }
     }
   }
-  return selfDC;
+  return None;
 }
 
-NullablePtr<DeclContext>
-MethodBodyScope::computeSelfDCForParent(NullablePtr<DeclContext> selfDC) const {
-  assert(!selfDC && "Losing selfDC");
-  return decl;
+Optional<NullablePtr<DeclContext>>
+MethodBodyScope::computeSelfDCForParent() const {
+  return NullablePtr<DeclContext>(decl);
 }
 
 #pragma mark ifUnknownIsCascadingUseAccordingTo
@@ -636,6 +628,7 @@ Optional<bool> AbstractFunctionBodyScope::resolveIsCascadingUseForThisScope(
 
 Optional<bool> GenericTypeOrExtensionScope::resolveIsCascadingUseForThisScope(
     Optional<bool> isCascadingUse) const {
+  // Could override for ExtensionScope and just return true
   return ifUnknownIsCascadingUseAccordingTo(isCascadingUse,
                                             getDeclContext().get());
 }

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -61,7 +61,7 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
   namelookup::ASTScopeDeclGatherer gatherer;
   // Print the local bindings introduced by this scope.
-  locScope->lookupLocalBindings(None, gatherer);
+  locScope->lookupLocalsOrMembers({this}, gatherer);
   if (!gatherer.getDecls().empty()) {
     llvm::errs() << "Local bindings: ";
     interleave(gatherer.getDecls().begin(), gatherer.getDecls().end(),

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -149,6 +149,11 @@ bool ASTScopeImpl::verifyThatThisNodeComeAfterItsPriorSibling() const {
   print(out);
   out << "\n***Parent node***\n";
   getParent().get()->print(out);
+  llvm::errs() << "\n\nsource:\n"
+               << getSourceManager()
+                      .getRangeForBuffer(
+                          getSourceFile()->getBufferID().getValue())
+                      .str();
   abort();
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -234,9 +234,9 @@ namespace {
     bool useASTScopesForExperimentalLookupIfEnabled() const;
     
     void lookUpTopLevelNamesInModuleScopeContext(DeclContext *);
-    
-    void experimentallyLookInASTScopes(ContextAndUnresolvedIsCascadingUse);
-    
+
+    void experimentallyLookInASTScopes();
+
     /// Can lookup stop searching for results, assuming hasn't looked for outer
     /// results yet?
     bool isFirstResultEnough() const;
@@ -343,7 +343,12 @@ namespace {
     static NLOptions
     computeBaseNLOptions(const UnqualifiedLookup::Options options,
                          const bool isOriginallyTypeLookup);
-    
+
+    Optional<bool> getInitialIsCascadingUse() const {
+      return options.contains(Flags::KnownPrivate) ? Optional<bool>(false)
+                                                   : None;
+    }
+
     static bool resolveIsCascadingUse(const DeclContext *const dc,
                                       Optional<bool> isCascadingUse,
                                       bool onlyCareAboutFunctionBody) {
@@ -377,6 +382,7 @@ namespace {
     StringRef getSourceFileName() const;
 
 #ifndef NDEBUG
+    bool isTargetLookup() const;
     void stopForDebuggingIfStartingTargetLookup(bool isASTScopeLookup) const;
     void stopForDebuggingIfDuringTargetLookup(bool isASTScopeLookup) const;
     void
@@ -400,18 +406,22 @@ public:
   virtual ~ASTScopeDeclConsumerForUnqualifiedLookup() = default;
 
   bool consume(ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
-               Optional<bool> isCascadingUse,
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   /// returns true if finished and new value for isCascadingUse
-  std::pair<bool, Optional<bool>>
-  lookupInSelfType(NullablePtr<DeclContext> selfDC, DeclContext *const scopeDC,
-                   NominalTypeDecl *const nominal,
-                   Optional<bool> isCascadingUse) override;
+  bool lookInMembers(NullablePtr<DeclContext> selfDC,
+                     DeclContext *const scopeDC, NominalTypeDecl *const nominal,
+                     function_ref<bool(Optional<bool>)>) override;
 
 #ifndef NDEBUG
-  void stopForDebuggingIfTargetLookup() override {
+  void startingNextLookupStep() override {
     factory.stopForDebuggingIfDuringTargetLookup(true);
+  }
+  bool isTargetLookup() const override { return factory.isTargetLookup(); }
+
+  void finishingLookup(std::string msg) const override {
+    if (isTargetLookup())
+      llvm::errs() << "Finishing lookup: " << msg << "\n";
   }
 #endif
   };
@@ -469,18 +479,18 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
   stopForDebuggingIfStartingTargetLookup(false);
 #endif
 
-  const Optional<bool> isCascadingUseInitial =
-  options.contains(Flags::KnownPrivate) ? Optional<bool>(false) : None;
+  const Optional<bool> initialIsCascadingUse = getInitialIsCascadingUse();
 
   ContextAndUnresolvedIsCascadingUse contextAndIsCascadingUse{
-      DC, isCascadingUseInitial};
-  if (useASTScopesForExperimentalLookup()) {
+      DC, initialIsCascadingUse};
+  const bool compareToASTScopes = Ctx.LangOpts.CompareToASTScopeLookup;
+  if (useASTScopesForExperimentalLookup() && !compareToASTScopes) {
     static bool haveWarned = false;
     if (!haveWarned) {
       haveWarned = true;
       llvm::errs() << "WARNING: TRYING Scope exclusively\n";
     }
-    experimentallyLookInASTScopes(contextAndIsCascadingUse);
+    experimentallyLookInASTScopes();
     return;
   }
 
@@ -489,13 +499,12 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
   else
     lookupNamesIntroducedBy(contextAndIsCascadingUse);
 
-  const bool compareToASTScopes = Ctx.LangOpts.CompareToASTScopeLookup;
   if (compareToASTScopes && useASTScopesForExperimentalLookupIfEnabled()) {
     ResultsVector results;
     size_t indexOfFirstOuterResult = 0;
     UnqualifiedLookupFactory scopeLookup(Name, DC, TypeResolver, Loc, options,
                                          results, indexOfFirstOuterResult);
-    scopeLookup.experimentallyLookInASTScopes(contextAndIsCascadingUse);
+    scopeLookup.experimentallyLookInASTScopes();
     assert(verifyEqualTo(std::move(scopeLookup), "UnqualifedLookup",
                          "Scope lookup"));
   }
@@ -1100,14 +1109,7 @@ UnqualifiedLookupFactory::ResultFinderForTypeContext::findSelfBounds(
 
 #pragma mark ASTScopeImpl support
 
-void UnqualifiedLookupFactory::experimentallyLookInASTScopes(
-    const ContextAndUnresolvedIsCascadingUse contextAndIsCascadingUseArg) {
-  
-  // NOT const--may be changed by the lookup
-  Optional<bool> isCascadingUse = !Name.isOperator()
-    ? contextAndIsCascadingUseArg.isCascadingUse
-    : resolveIsCascadingUse(contextAndIsCascadingUseArg,
-                            /*onlyCareAboutFunctionBody*/ true);
+void UnqualifiedLookupFactory::experimentallyLookInASTScopes() {
 
   ASTScopeDeclConsumerForUnqualifiedLookup consumer(*this);
 
@@ -1115,24 +1117,33 @@ void UnqualifiedLookupFactory::experimentallyLookInASTScopes(
   stopForDebuggingIfStartingTargetLookup(true);
 #endif
 
-  Optional<bool> isCascadingUseResult = ASTScope::unqualifiedLookup(
-      DC->getParentSourceFile(), Name, Loc,
-      contextAndIsCascadingUseArg.whereToLook, isCascadingUse, consumer);
+  const auto history = ASTScope::unqualifiedLookup(DC->getParentSourceFile(),
+                                                   Name, Loc, DC, consumer);
 
   ifNotDoneYet([&] {
     // Copied from lookupInModuleScopeContext
     // If no result has been found yet, the dependency must be on a top-level
     // name, since up to now, the search has been for non-top-level names.
     auto *const moduleScopeContext = DC->getParentSourceFile();
+
+    const Optional<bool> isCascadingUseAtStartOfLookup =
+        !Name.isOperator()
+            ? getInitialIsCascadingUse()
+            : resolveIsCascadingUse(DC, getInitialIsCascadingUse(),
+                                    /*onlyCareAboutFunctionBody*/ true);
+
+    const Optional<bool> isCascadingUseAfterLookup =
+        ASTScope::computeIsCascadingUse(history, isCascadingUseAtStartOfLookup);
+
     recordDependencyOnTopLevelName(moduleScopeContext, Name,
-                                   isCascadingUseResult.getValueOr(true));
+                                   isCascadingUseAfterLookup.getValueOr(true));
     lookUpTopLevelNamesInModuleScopeContext(moduleScopeContext);
   });
 }
 
 bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
     ArrayRef<ValueDecl *> values, DeclVisibilityKind vis,
-    Optional<bool> isCascadingUse, NullablePtr<DeclContext> baseDC) {
+    NullablePtr<DeclContext> baseDC) {
   for (auto *value: values) {
     if (factory.isOriginallyTypeLookup && !isa<TypeDecl>(value))
       continue;
@@ -1160,7 +1171,7 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::consume(
 }
 
 bool ASTScopeDeclGatherer::consume(ArrayRef<ValueDecl *> valuesArg,
-                                   DeclVisibilityKind, Optional<bool>,
+                                   DeclVisibilityKind,
                                    NullablePtr<DeclContext>) {
   for (auto *v: valuesArg)
     values.push_back(v);
@@ -1168,28 +1179,24 @@ bool ASTScopeDeclGatherer::consume(ArrayRef<ValueDecl *> valuesArg,
 }
 
 // TODO: in future, migrate this functionality into ASTScopes
-std::pair<bool, Optional<bool>>
-ASTScopeDeclConsumerForUnqualifiedLookup::lookupInSelfType(
+bool ASTScopeDeclConsumerForUnqualifiedLookup::lookInMembers(
     NullablePtr<DeclContext> selfDC, DeclContext *const scopeDC,
-    NominalTypeDecl *const nominal, const Optional<bool> isCascadingUseArg) {
+    NominalTypeDecl *const nominal,
+    function_ref<bool(Optional<bool>)> calculateIsCascadingUse) {
   if (selfDC) {
     if (auto *d = selfDC.get()->getAsDecl()) {
-      if (auto *afd = dyn_cast<AbstractFunctionDecl>(d)) {
+      if (auto *afd = dyn_cast<AbstractFunctionDecl>(d))
         assert(!factory.isOutsideBodyOfFunction(afd) && "Should be inside");
-      }
     }
   }
   auto resultFinder = UnqualifiedLookupFactory::ResultFinderForTypeContext(
       &factory, selfDC ? selfDC.get() : scopeDC, scopeDC);
-  // If we haven't determined whether we have a cascading use, do so now.
-  const bool isCascadingUseResult = factory.resolveIsCascadingUse(
-      scopeDC, isCascadingUseArg, /*onlyCareAboutFunctionBody=*/false);
-
+  const bool isCascadingUse =
+      calculateIsCascadingUse(factory.getInitialIsCascadingUse());
   factory.findResultsAndSaveUnavailables(scopeDC, std::move(resultFinder),
-                                         isCascadingUseResult,
-                                         factory.baseNLOptions);
+                                         isCascadingUse, factory.baseNLOptions);
   factory.recordCompletionOfAScope();
-  return std::make_pair(factory.isFirstResultEnough(), isCascadingUseResult);
+  return factory.isFirstResultEnough();
 }
 
 
@@ -1391,9 +1398,13 @@ bool UnqualifiedLookupFactory::shouldDiffer() const {
 #pragma mark breakpointing
 #ifndef NDEBUG
 
+bool UnqualifiedLookupFactory::isTargetLookup() const {
+  return lookupCounter == targetLookup;
+}
+
 void UnqualifiedLookupFactory::stopForDebuggingIfStartingTargetLookup(
     const bool isASTScopeLookup) const {
-  if (lookupCounter != targetLookup)
+  if (!isTargetLookup())
     return;
   if (isASTScopeLookup)
     llvm::errs() << "starting target ASTScopeImpl lookup\n";
@@ -1403,7 +1414,7 @@ void UnqualifiedLookupFactory::stopForDebuggingIfStartingTargetLookup(
 
 void UnqualifiedLookupFactory::stopForDebuggingIfDuringTargetLookup(
     const bool isASTScopeLookup) const {
-  if (lookupCounter != targetLookup)
+  if (!isTargetLookup())
     return;
   if (isASTScopeLookup)
     llvm::errs() << "during target ASTScopeImpl lookup\n";
@@ -1413,7 +1424,7 @@ void UnqualifiedLookupFactory::stopForDebuggingIfDuringTargetLookup(
 
 void UnqualifiedLookupFactory::stopForDebuggingIfAddingTargetLookupResult(
     const LookupResultEntry &e) const {
-  if (lookupCounter != targetLookup)
+  if (!isTargetLookup())
     return;
   auto &out = llvm::errs();
   out << "\nresult for Target lookup:\n";

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -227,6 +227,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
   inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
   inputArgs.AddLastArg(arguments, options::OPT_enable_astscope_lookup);
+  inputArgs.AddLastArg(arguments, options::OPT_disable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);
 
   // Pass on any build config options

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -327,7 +327,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
   Opts.EnableASTScopeLookup =
       Args.hasFlag(options::OPT_enable_astscope_lookup,
-                   options::OPT_disable_astscope_lookup, EnableASTScopeLookup) ||
+                   options::OPT_disable_astscope_lookup, Opts.EnableASTScopeLookup) ||
       Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -324,8 +324,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_target_os_checking);
   }
   
-  Opts.EnableASTScopeLookup |= Args.hasArg(OPT_enable_astscope_lookup) || Args.hasArg(OPT_disable_parser_lookup);
+  Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
+  Opts.EnableASTScopeLookup =
+      Args.hasFlag(options::OPT_enable_astscope_lookup,
+                   options::OPT_disable_astscope_lookup, true) ||
+      Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
+
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.NamedLazyMemberLoading &= !Args.hasArg(OPT_disable_named_lazy_member_loading);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -327,7 +327,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
   Opts.EnableASTScopeLookup =
       Args.hasFlag(options::OPT_enable_astscope_lookup,
-                   options::OPT_disable_astscope_lookup, true) ||
+                   options::OPT_disable_astscope_lookup, false) ||
       Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -327,7 +327,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableParserLookup |= Args.hasArg(OPT_disable_parser_lookup);
   Opts.EnableASTScopeLookup =
       Args.hasFlag(options::OPT_enable_astscope_lookup,
-                   options::OPT_disable_astscope_lookup, false) ||
+                   options::OPT_disable_astscope_lookup, EnableASTScopeLookup) ||
       Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3144,6 +3144,8 @@ void Parser::parseDeclDelayed() {
         NTD->addMember(D);
       } else if (auto *ED = dyn_cast<ExtensionDecl>(parent)) {
         ED->addMember(D);
+      } else if (auto *SF = dyn_cast<SourceFile>(parent)) {
+        SF->Decls.push_back(D);
       }
     }
   });

--- a/test/NameBinding/scope_map-astscopelookup.swift
+++ b/test/NameBinding/scope_map-astscopelookup.swift
@@ -1,4 +1,4 @@
-// XFAIL: enable-astscope-lookup
+// REQUIRES: enable-astscope-lookup
 // Note: test of the scope map. All of these tests are line- and
 // column-sensitive, so any additions should go at the end.
 
@@ -199,7 +199,7 @@ class LazyProperties {
 
 
 // CHECK-EXPANDED:      ***Complete scope map***
-// CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, [1:1 - 52{{[0-9]}}:1] 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}NameBinding{{[/\\]}}scope_map.swift'
+// CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, [1:1 - 52{{[0-9]}}:1] 'SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift'
 // CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [5:1 - 7:1] 'S0'
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [5:11 - 7:1] 'S0'
 // CHECK-EXPANDED-NEXT:     `-NominalTypeDeclScope {{.*}}, [6:3 - 6:19] 'InnerC0'
@@ -283,9 +283,9 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:                         |-TypeAliasDeclScope {{.*}}, [61:3 - 61:23] <no extended nominal?!>
 // CHECK-EXPANDED-NEXT:                         |-IfStmtScope {{.*}}, [63:3 - 67:3]
 // CHECK-EXPANDED-NEXT:                           |-ConditionalClauseScope, [63:6 - 65:3] index 0
-// CHECK-EXPANDED-NEXT:                             `-ConditionalClausePatternUseScope, [63:18 - 65:3] let b1?
+// CHECK-EXPANDED-NEXT:                             `-ConditionalClausePatternUseScope, [63:18 - 65:3] let b1
 // CHECK-EXPANDED-NEXT:                               `-ConditionalClauseScope, [63:18 - 65:3] index 1
-// CHECK-EXPANDED-NEXT:                                 `-ConditionalClausePatternUseScope, [63:29 - 65:3] let b2?
+// CHECK-EXPANDED-NEXT:                                 `-ConditionalClausePatternUseScope, [63:29 - 65:3] let b2
 // CHECK-EXPANDED-NEXT:                                   `-BraceStmtScope {{.*}}, [63:29 - 65:3]
 // CHECK-EXPANDED-NEXT:                                     `-PatternEntryDeclScope {{.*}}, [64:9 - 64:14] entry 0 'c1'
 // CHECK-EXPANDED-NEXT:                                       |-PatternEntryInitializerScope {{.*}}, [64:14 - 64:14] entry 0 'c1'
@@ -296,13 +296,13 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:                               `-PatternEntryUseScope {{.*}}, [66:14 - 66:14] entry 0 'c2'
 // CHECK-EXPANDED-NEXT:                         `-GuardStmtScope {{.*}}, [69:3 - 100:38]
 // CHECK-EXPANDED-NEXT:                           |-ConditionalClauseScope, [69:9 - 69:53] index 0
-// CHECK-EXPANDED-NEXT:                             `-ConditionalClausePatternUseScope, [69:21 - 69:53] let b1?
+// CHECK-EXPANDED-NEXT:                             `-ConditionalClausePatternUseScope, [69:21 - 69:53] let b1
 // CHECK-EXPANDED-NEXT:                               `-ConditionalClauseScope, [69:21 - 69:53] index 1
 // CHECK-EXPANDED-NEXT:                                 |-WholeClosureScope {{.*}}, [69:21 - 69:30]
 // CHECK-EXPANDED-NEXT:                                   `-ClosureBodyScope {{.*}}, [69:21 - 69:30]
 // CHECK-EXPANDED-NEXT:                                     `-BraceStmtScope {{.*}}, [69:21 - 69:30]
 // CHECK-EXPANDED-NEXT:                                 `-ConditionalClauseScope, [69:37 - 69:53] index 2
-// CHECK-EXPANDED-NEXT:                                   `-ConditionalClausePatternUseScope, [69:53 - 69:53] let b2?
+// CHECK-EXPANDED-NEXT:                                   `-ConditionalClausePatternUseScope, [69:53 - 69:53] let b2
 // CHECK-EXPANDED-NEXT:                           |-BraceStmtScope {{.*}}, [69:53 - 72:3]
 // CHECK-EXPANDED-NEXT:                             `-PatternEntryDeclScope {{.*}}, [70:9 - 70:13] entry 0 'c'
 // CHECK-EXPANDED-NEXT:                               |-PatternEntryInitializerScope {{.*}}, [70:13 - 70:13] entry 0 'c'
@@ -310,9 +310,9 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:                           `-GuardStmtUseScope, [72:3 - 100:38]
 // CHECK-EXPANDED-NEXT:                             |-WhileStmtScope {{.*}}, [74:3 - 76:3]
 // CHECK-EXPANDED-NEXT:                               `-ConditionalClauseScope, [74:9 - 76:3] index 0
-// CHECK-EXPANDED-NEXT:                                 `-ConditionalClausePatternUseScope, [74:21 - 76:3] let b3?
+// CHECK-EXPANDED-NEXT:                                 `-ConditionalClausePatternUseScope, [74:21 - 76:3] let b3
 // CHECK-EXPANDED-NEXT:                                   `-ConditionalClauseScope, [74:21 - 76:3] index 1
-// CHECK-EXPANDED-NEXT:                                     `-ConditionalClausePatternUseScope, [74:32 - 76:3] let b4?
+// CHECK-EXPANDED-NEXT:                                     `-ConditionalClausePatternUseScope, [74:32 - 76:3] let b4
 // CHECK-EXPANDED-NEXT:                                       `-BraceStmtScope {{.*}}, [74:32 - 76:3]
 // CHECK-EXPANDED-NEXT:                                         `-PatternEntryDeclScope {{.*}}, [75:9 - 75:13] entry 0 'c'
 // CHECK-EXPANDED-NEXT:                                           |-PatternEntryInitializerScope {{.*}}, [75:13 - 75:13] entry 0 'c'
@@ -350,7 +350,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [109:13 - 113:1] 'MyEnum'
 // CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [115:1 - 131:1] 'StructContainsAbstractStorageDecls'
 // CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [115:43 - 131:1] 'StructContainsAbstractStorageDecls'
-// CHECK-EXPANDED-NEXT:     |-SubscriptDeclScope {{.*}}, [116:3 - 122:3] scope_map.(file).StructContainsAbstractStorageDecls.subscript(_:_:)@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:116:3
+// CHECK-EXPANDED-NEXT:     |-SubscriptDeclScope {{.*}}, [116:3 - 122:3] main.(file).StructContainsAbstractStorageDecls.subscript(_:_:)@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:116:3
 // CHECK-EXPANDED-NEXT:       `-AbstractFunctionParamsScope {{.*}}, [116:13 - 122:3]
 // CHECK-EXPANDED-NEXT:         |-AbstractFunctionDeclScope {{.*}}, [117:5 - 118:5] '_'
 // CHECK-EXPANDED-NEXT:           `-MethodBodyScope {{.*}}, [117:9 - 118:5]
@@ -360,7 +360,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:             `-BraceStmtScope {{.*}}, [119:9 - 121:5]
 // CHECK-EXPANDED-NEXT:     `-PatternEntryDeclScope {{.*}}, [124:7 - 130:3] entry 0 'computed'
 // CHECK-EXPANDED-NEXT:       `-PatternEntryUseScope {{.*}}, [124:17 - 130:3] entry 0 'computed'
-// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [124:21 - 130:3] scope_map.(file).StructContainsAbstractStorageDecls.computed@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:124:7
+// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [124:21 - 130:3] main.(file).StructContainsAbstractStorageDecls.computed@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:124:7
 // CHECK-EXPANDED-NEXT:           |-AbstractFunctionDeclScope {{.*}}, [125:5 - 127:5] '_'
 // CHECK-EXPANDED-NEXT:             `-MethodBodyScope {{.*}}, [125:9 - 127:5]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [125:9 - 127:5]
@@ -372,14 +372,14 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:     |-PatternEntryDeclScope {{.*}}, [134:7 - 136:3] entry 0 'willSetProperty'
 // CHECK-EXPANDED-NEXT:       |-PatternEntryInitializerScope {{.*}}, [134:30 - 134:30] entry 0 'willSetProperty'
 // CHECK-EXPANDED-NEXT:       `-PatternEntryUseScope {{.*}}, [134:30 - 136:3] entry 0 'willSetProperty'
-// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [134:32 - 136:3] scope_map.(file).ClassWithComputedProperties.willSetProperty@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:134:7
+// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [134:32 - 136:3] main.(file).ClassWithComputedProperties.willSetProperty@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:134:7
 // CHECK-EXPANDED-NEXT:           `-AbstractFunctionDeclScope {{.*}}, [135:5 - 135:15] '_'
 // CHECK-EXPANDED-NEXT:             `-MethodBodyScope {{.*}}, [135:13 - 135:15]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [135:13 - 135:15]
 // CHECK-EXPANDED-NEXT:     `-PatternEntryDeclScope {{.*}}, [138:7 - 140:3] entry 0 'didSetProperty'
 // CHECK-EXPANDED-NEXT:       |-PatternEntryInitializerScope {{.*}}, [138:29 - 138:29] entry 0 'didSetProperty'
 // CHECK-EXPANDED-NEXT:       `-PatternEntryUseScope {{.*}}, [138:29 - 140:3] entry 0 'didSetProperty'
-// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [138:31 - 140:3] scope_map.(file).ClassWithComputedProperties.didSetProperty@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:138:7
+// CHECK-EXPANDED-NEXT:         `-VarDeclScope {{.*}}, [138:31 - 140:3] main.(file).ClassWithComputedProperties.didSetProperty@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:138:7
 // CHECK-EXPANDED-NEXT:           `-AbstractFunctionDeclScope {{.*}}, [139:5 - 139:14] '_'
 // CHECK-EXPANDED-NEXT:             `-MethodBodyScope {{.*}}, [139:12 - 139:14]
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [139:12 - 139:14]
@@ -389,7 +389,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [143:41 - 156:1]
 // CHECK-EXPANDED-NEXT:         `-PatternEntryDeclScope {{.*}}, [144:7 - 155:8] entry 0 'computed'
 // CHECK-EXPANDED-NEXT:           `-PatternEntryUseScope {{.*}}, [144:17 - 155:8] entry 0 'computed'
-// CHECK-EXPANDED-NEXT:             |-VarDeclScope {{.*}}, [144:21 - 150:3] scope_map.(file).funcWithComputedProperties(i:).computed@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:144:7
+// CHECK-EXPANDED-NEXT:             |-VarDeclScope {{.*}}, [144:21 - 150:3] main.(file).funcWithComputedProperties(i:).computed@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:144:7
 // CHECK-EXPANDED-NEXT:               |-AbstractFunctionDeclScope {{.*}}, [145:5 - 146:5] '_'
 // CHECK-EXPANDED-NEXT:                 `-PureFunctionBodyScope {{.*}}, [145:9 - 146:5]
 // CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [145:9 - 146:5]
@@ -401,7 +401,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:               `-PatternEntryUseScope {{.*}}, [150:36 - 155:8] entry 1 'stored1' 'stored2'
 // CHECK-EXPANDED-NEXT:                 `-PatternEntryDeclScope {{.*}}, [151:3 - 155:8] entry 2 'alsoComputed'
 // CHECK-EXPANDED-NEXT:                   `-PatternEntryUseScope {{.*}}, [151:21 - 155:8] entry 2 'alsoComputed'
-// CHECK-EXPANDED-NEXT:                     |-VarDeclScope {{.*}}, [151:25 - 153:3] scope_map.(file).funcWithComputedProperties(i:).alsoComputed@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:151:7
+// CHECK-EXPANDED-NEXT:                     |-VarDeclScope {{.*}}, [151:25 - 153:3] main.(file).funcWithComputedProperties(i:).alsoComputed@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:151:7
 // CHECK-EXPANDED-NEXT:                       `-AbstractFunctionDeclScope {{.*}}, [151:25 - 153:3] '_'
 // CHECK-EXPANDED-NEXT:                         `-PureFunctionBodyScope {{.*}}, [151:25 - 153:3]
 // CHECK-EXPANDED-NEXT:                           `-BraceStmtScope {{.*}}, [151:25 - 153:3]
@@ -435,7 +435,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [168:32 - 168:42]
 // CHECK-EXPANDED-NEXT:         `-PureFunctionBodyScope {{.*}}, [168:51 - 176:1]
 // CHECK-EXPANDED-NEXT:           `-BraceStmtScope {{.*}}, [168:51 - 176:1]
-// CHECK-EXPANDED-NEXT:             `-AbstractFunctionDeclScope {{.*}}, [170:3 - 172:3] 'localWithDefaults(i:j:)'
+// CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [170:3 - 172:3] 'localWithDefaults(i:j:)'
 // CHECK-EXPANDED-NEXT:               `-AbstractFunctionParamsScope {{.*}}, [170:25 - 172:3]
 // CHECK-EXPANDED-NEXT:                 |-DefaultArgumentInitializerScope {{.*}}, [170:35 - 170:35]
 // CHECK-EXPANDED-NEXT:                 |-DefaultArgumentInitializerScope {{.*}}, [171:35 - 171:51]
@@ -444,6 +444,12 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:                       `-BraceStmtScope {{.*}}, [171:35 - 171:45]
 // CHECK-EXPANDED-NEXT:                 `-PureFunctionBodyScope {{.*}}, [171:54 - 172:3]
 // CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [171:54 - 172:3]
+// CHECK-EXPANDED-NEXT:             `-PatternEntryDeclScope {{.*}}, [174:7 - 175:11] entry 0 'a'
+// CHECK-EXPANDED-NEXT:               |-PatternEntryInitializerScope {{.*}}, [174:11 - 175:11] entry 0 'a'
+// CHECK-EXPANDED-NEXT:                 `-WholeClosureScope {{.*}}, [175:3 - 175:8]
+// CHECK-EXPANDED-NEXT:                   `-ClosureBodyScope {{.*}}, [175:3 - 175:8]
+// CHECK-EXPANDED-NEXT:                     `-BraceStmtScope {{.*}}, [175:3 - 175:8]
+// CHECK-EXPANDED-NEXT:               `-PatternEntryUseScope {{.*}}, [175:11 - 175:11] entry 0 'a'
 // CHECK-EXPANDED-NEXT:     |-NominalTypeDeclScope {{.*}}, [178:1 - 181:1] 'PatternInitializers'
 // CHECK-EXPANDED-NEXT:       `-NominalTypeBodyScope {{.*}}, [178:28 - 181:1] 'PatternInitializers'
 // CHECK-EXPANDED-NEXT:         `-PatternEntryDeclScope {{.*}}, [179:7 - 180:25] entry 0 'a' 'b'
@@ -455,7 +461,7 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:     |-NominalTypeDeclScope {{.*}}, [183:1 - 185:1] 'ProtoWithSubscript'
 // CHECK-EXPANDED-NEXT:       `-GenericParamScope {{.*}}, [183:29 - 185:1] param 0 'Self : ProtoWithSubscript'
 // CHECK-EXPANDED-NEXT:         `-NominalTypeBodyScope {{.*}}, [183:29 - 185:1] 'ProtoWithSubscript'
-// CHECK-EXPANDED-NEXT:           `-SubscriptDeclScope {{.*}}, [184:3 - 184:43] scope_map.(file).ProtoWithSubscript.subscript(_:)@SOURCE_DIR{{[/\]}}test{{[/\]}}NameBinding{{[/\]}}scope_map.swift:184:3
+// CHECK-EXPANDED-NEXT:           `-SubscriptDeclScope {{.*}}, [184:3 - 184:43] main.(file).ProtoWithSubscript.subscript(_:)@SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift:184:3
 // CHECK-EXPANDED-NEXT:             `-AbstractFunctionParamsScope {{.*}}, [184:12 - 184:43]
 // CHECK-EXPANDED-NEXT:               |-AbstractFunctionDeclScope {{.*}}, [184:35 - 184:35] '_'
 // CHECK-EXPANDED-NEXT:               `-AbstractFunctionDeclScope {{.*}}, [184:39 - 184:39] '_'
@@ -479,12 +485,8 @@ class LazyProperties {
 // CHECK-EXPANDED-NEXT:           `-PatternEntryUseScope {{.*}}, [194:29 - 194:29] entry 0 'prop'
 
 
-
-
-
 // RUN: not %target-swift-frontend -dump-scope-maps 71:8,27:20,6:18,167:32,180:18,194:26 %s 2> %t.searches
 // RUN: %FileCheck -check-prefix CHECK-SEARCHES %s < %t.searches
-
 
 // CHECK-SEARCHES:      ***Scope at 71:8***
 // CHECK-SEARCHES-NEXT: BraceStmtScope {{.*}}, [69:53 - 72:3]
@@ -492,29 +494,28 @@ class LazyProperties {
 // CHECK-SEARCHES-NEXT: AbstractFunctionParamsScope {{.*}}, [27:13 - 28:3]
 // CHECK-SEARCHES-NEXT: ***Scope at 6:18***
 // CHECK-SEARCHES-NEXT: NominalTypeBodyScope {{.*}}, [6:17 - 6:19] 'InnerC0'
-// CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
-// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
+// CHECK-SEARCHES-NEXT: {{.*}} Module name=main
+// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} StructDecl name=S0
 // CHECK-SEARCHES-NEXT:       {{.*}} ClassDecl name=InnerC0
 // CHECK-SEARCHES-NEXT: ***Scope at 167:32***
 // CHECK-SEARCHES-NEXT: DefaultArgumentInitializerScope {{.*}}, [167:32 - 167:32]
-// CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
-// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
+// CHECK-SEARCHES-NEXT: {{.*}} Module name=main
+// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} AbstractFunctionDecl name=defaultArguments(i:j:) : (Int, Int) -> ()
 // CHECK-SEARCHES-NEXT:       {{.*}} Initializer DefaultArgument index=0
 // CHECK-SEARCHES-NEXT: ***Scope at 180:18***
 // CHECK-SEARCHES-NEXT: PatternEntryInitializerScope {{.*}}, [180:16 - 180:25] entry 1 'c' 'd'
-// CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
-// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
+// CHECK-SEARCHES-NEXT: {{.*}} Module name=main
+// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} StructDecl name=PatternInitializers
-// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}}80 #1
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #1
 // CHECK-SEARCHES-NEXT: ***Scope at 194:26***
 // CHECK-SEARCHES-NEXT: PatternEntryInitializerScope {{.*}}, [194:24 - 194:29] entry 0 'prop'
-// CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
-// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
+// CHECK-SEARCHES-NEXT: {{.*}} Module name=main
+// CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map-astscopelookup.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} ClassDecl name=LazyProperties
-// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}}78 #0
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #0
 // CHECK-SEARCHES-NEXT: Local bindings: self
-
 
 // CHECK-SEARCHES-NOT:  ***Complete scope map***

--- a/test/NameBinding/scope_map.swift
+++ b/test/NameBinding/scope_map.swift
@@ -507,13 +507,13 @@ class LazyProperties {
 // CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
 // CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} StructDecl name=PatternInitializers
-// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}}80 #1
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #1
 // CHECK-SEARCHES-NEXT: ***Scope at 194:26***
 // CHECK-SEARCHES-NEXT: PatternEntryInitializerScope {{.*}}, [194:24 - 194:29] entry 0 'prop'
 // CHECK-SEARCHES-NEXT: {{.*}} Module name=scope_map
 // CHECK-SEARCHES-NEXT:   {{.*}} FileUnit file="SOURCE_DIR{{[/]}}test{{[/]}}NameBinding{{[/]}}scope_map.swift"
 // CHECK-SEARCHES-NEXT:     {{.*}} ClassDecl name=LazyProperties
-// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}}78 #0
+// CHECK-SEARCHES-NEXT:       {{.*}} Initializer PatternBinding {{.*}} #0
 // CHECK-SEARCHES-NEXT: Local bindings: self
 
 


### PR DESCRIPTION
Improved draft of ASTScope lookup, disabled by default. Includes options to enable or disable, and parser lookup disable option. Passes tests per `ninja check-swift`  with  `export SWIFT_TEST_OPTIONS=-enable-astscope-lookup` set for XFAIL purposes.
