### PR TITLE
[Parser] Handle TopLevelCode case

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3144,6 +3144,8 @@ void Parser::parseDeclDelayed() {
         NTD->addMember(D);
       } else if (auto *ED = dyn_cast<ExtensionDecl>(parent)) {
         ED->addMember(D);
+      } else if (auto *SF = dyn_cast<SourceFile>(parent)) {
+        SF->Decls.push_back(D);
       }
     }
   });


### PR DESCRIPTION
In order for ASTScope lookup to work, add `SourceFile` parent case to `parseDeclDelayed`.