### PR TITLE
[AutoDiff] Declare differential-producing differential operators.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -338,8 +338,9 @@ public extension Differentiable {
 
 // Transpose
 
+@available(*, unavailable)
 @inlinable
-func transpose<T, R>(
+public func transpose<T, R>(
   of body: @escaping @differentiable/*(linear)*/ (T) -> R
 ) -> @differentiable/*(linear)*/ (R) -> T {
   fatalError()
@@ -347,16 +348,18 @@ func transpose<T, R>(
 
 // Value with differential
 
+@available(*, unavailable)
 @inlinable
-func valueWithDifferential<T, R>(
+public func valueWithDifferential<T, R>(
   at x: T, in body: @differentiable (T) -> R
 ) -> (value: R, differential: @differentiable/*(linear)*/
         (T.TangentVector) -> R.TangentVector) {
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable
-func valueWithDifferential<T, U, R>(
+public func valueWithDifferential<T, U, R>(
   at x: T, _ y: U, in body: @differentiable (T, U) -> R
 ) -> (value: R,
       differential: @differentiable/*(linear)*/
@@ -392,6 +395,7 @@ public func valueWithPullback<T, U, V, R>(
 
 // Differential
 
+@available(*, unavailable)
 @inlinable
 public func differential<T, R>(
   at x: T, in body: @differentiable(T) -> R
@@ -399,6 +403,7 @@ public func differential<T, R>(
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable
 public func differential<T, U, R>(
   at x: T, _ y: U, in body: @differentiable(T, U) -> R
@@ -433,15 +438,17 @@ public func pullback<T, U, V, R>(
 
 // Derivative
 
+@available(*, unavailable)
 @inlinable
-func derivative<T: FloatingPoint, R>(
+public func derivative<T: FloatingPoint, R>(
   at x: T, in body: @escaping @differentiable (T) -> R
 ) ->  R.TangentVector where T.TangentVector : FloatingPoint {
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable
-func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
   at x: T, _ y: U, in body: @escaping @differentiable (T) -> R
 ) -> R.TangentVector where T.TangentVector : FloatingPoint {
   fatalError()
@@ -475,16 +482,18 @@ public func gradient<T, U, V, R>(
 
 // Value with derivative
 
+@available(*, unavailable)
 @inlinable
-func valueWithDerivative<T: FloatingPoint, R>(
+public func valueWithDerivative<T: FloatingPoint, R>(
   at x: T, in body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector : FloatingPoint {
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable
-func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
   at x: T, _ y: U, in body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector : FloatingPoint {
@@ -523,21 +532,23 @@ public func valueWithGradient<T, U, V, R>(
 
 // Derivative (curried)
 
+@available(*, unavailable)
 @inlinable 
-func derivative<T: FloatingPoint, R>(
+public func derivative<T: FloatingPoint, R>(
   of body: @escaping @differentiable (T) -> R
 ) -> (T) -> R.TangentVector where T.TangentVector : FloatingPoint {
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable 
-func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
   of body: @escaping @differentiable (T, U) -> R
 ) -> (T, U) -> R.TangentVector where T.TangentVector : FloatingPoint {
   fatalError()
 }
 
-// Gradient of (curried)
+// Gradient (curried)
 
 @inlinable
 public func gradient<T, R>(
@@ -563,18 +574,20 @@ public func gradient<T, U, V, R>(
   return { x, y, z in gradient(at: x, y, z, in: f) }
 }
 
-// Value with derivative of (curried)
+// Value with derivative (curried)
 
+@available(*, unavailable)
 @inlinable
-func valueWithDerivative<T: FloatingPoint, R>(
+public func valueWithDerivative<T: FloatingPoint, R>(
   of body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector: FloatingPoint {
   fatalError()
 }
 
+@available(*, unavailable)
 @inlinable
-func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
   of body: @escaping @differentiable (T, U) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector: FloatingPoint, U.TangentVector: FloatingPoint {

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -350,8 +350,7 @@ func transpose<T, R>(
 @inlinable
 func valueWithDifferential<T, R>(
   at x: T, in body: @differentiable (T) -> R
-) -> (value: R,
-      differential: @differentiable/*(linear)*/
+) -> (value: R, differential: @differentiable/*(linear)*/
         (T.TangentVector) -> R.TangentVector) {
   fatalError()
 }
@@ -455,7 +454,7 @@ public func gradient<T, R>(
   at x: T, in f: @differentiable (T) -> R
 ) -> T.TangentVector
   where R : FloatingPoint, R.TangentVector == R {
-    return pullback(at: x, in: f)(R(1))
+  return pullback(at: x, in: f)(R(1))
 }
 
 @inlinable
@@ -463,7 +462,7 @@ public func gradient<T, U, R>(
   at x: T, _ y: U, in f: @differentiable (T, U) -> R
 ) -> (T.TangentVector, U.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-    return pullback(at: x, y, in: f)(R(1))
+  return pullback(at: x, y, in: f)(R(1))
 }
 
 @inlinable
@@ -471,7 +470,7 @@ public func gradient<T, U, V, R>(
   at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
 ) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-    return pullback(at: x, y, z, in: f)(R(1))
+  return pullback(at: x, y, z, in: f)(R(1))
 }
 
 // Value with derivative
@@ -481,7 +480,7 @@ func valueWithDerivative<T: FloatingPoint, R>(
   at x: T, in body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector : FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 @inlinable
@@ -489,7 +488,7 @@ func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
   at x: T, _ y: U, in body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector : FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 // Value with gradient
@@ -528,14 +527,14 @@ public func valueWithGradient<T, U, V, R>(
 func derivative<T: FloatingPoint, R>(
   of body: @escaping @differentiable (T) -> R
 ) -> (T) -> R.TangentVector where T.TangentVector : FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 @inlinable 
 func derivative<T: FloatingPoint, U: FloatingPoint, R>(
   of body: @escaping @differentiable (T, U) -> R
 ) -> (T, U) -> R.TangentVector where T.TangentVector : FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 // Gradient of (curried)
@@ -571,7 +570,7 @@ func valueWithDerivative<T: FloatingPoint, R>(
   of body: @escaping @differentiable (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector: FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 @inlinable
@@ -579,7 +578,7 @@ func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
   of body: @escaping @differentiable (T, U) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector: FloatingPoint, U.TangentVector: FloatingPoint {
-    fatalError()
+  fatalError()
 }
 
 // Value with gradient (curried)
@@ -589,7 +588,7 @@ public func valueWithGradient<T, R>(
   of f: @escaping @differentiable (T) -> R
 ) -> (T) -> (value: R, gradient: T.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-    return { x in valueWithGradient(at: x, in: f) }
+  return { x in valueWithGradient(at: x, in: f) }
 }
 
 @inlinable
@@ -597,7 +596,7 @@ public func valueWithGradient<T, U, R>(
   of f: @escaping @differentiable (T, U) -> R
 ) -> (T, U) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
   where R : FloatingPoint, R.TangentVector == R {
-    return { x, y in valueWithGradient(at: x, y, in: f) }
+  return { x, y in valueWithGradient(at: x, y, in: f) }
 }
 
 @inlinable
@@ -607,7 +606,7 @@ public func valueWithGradient<T, U, V, R>(
   -> (value: R,
       gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
   where R : FloatingPoint, R.TangentVector == R {
-    return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
+  return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -336,6 +336,35 @@ public extension Differentiable {
 // Free-function-style differential operators
 //===----------------------------------------------------------------------===//
 
+// Transpose
+
+@inlinable
+func transpose<T, R>(
+  of body: @escaping @differentiable/*(linear)*/ (T) -> R
+) -> @differentiable/*(linear)*/ (R) -> T {
+  fatalError()
+}
+
+// Value with differential
+
+@inlinable
+func valueWithDifferential<T, R>(
+  at x: T, in body: @differentiable (T) -> R
+) -> (value: R,
+      differential: @differentiable/*(linear)*/
+        (T.TangentVector) -> R.TangentVector) {
+  fatalError()
+}
+
+@inlinable
+func valueWithDifferential<T, U, R>(
+  at x: T, _ y: U, in body: @differentiable (T, U) -> R
+) -> (value: R,
+      differential: @differentiable/*(linear)*/
+        (T.TangentVector, U.TangentVector) -> R.TangentVector) {
+  fatalError()
+}
+
 // Value with pullback
 
 @inlinable
@@ -362,6 +391,23 @@ public func valueWithPullback<T, U, V, R>(
   return Builtin.autodiffApply_vjp_arity3(f, x, y, z)
 }
 
+// Differential
+
+@inlinable
+public func differential<T, R>(
+  at x: T, in body: @differentiable(T) -> R
+) -> @differentiable/*(linear)*/ (T.TangentVector) -> R.TangentVector {
+  fatalError()
+}
+
+@inlinable
+public func differential<T, U, R>(
+  at x: T, _ y: U, in body: @differentiable(T, U) -> R
+) -> @differentiable/*(linear)*/ (T.TangentVector, U.TangentVector)
+    -> R.TangentVector {
+  fatalError()
+}
+
 // Pullback
 
 @inlinable
@@ -384,6 +430,66 @@ public func pullback<T, U, V, R>(
 ) -> (R.TangentVector)
     -> (T.TangentVector, U.TangentVector, V.TangentVector) {
   return Builtin.autodiffApply_vjp_arity3(f, x, y, z).1
+}
+
+// Derivative
+
+@inlinable
+func derivative<T: FloatingPoint, R>(
+  at x: T, in body: @escaping @differentiable (T) -> R
+) ->  R.TangentVector where T.TangentVector : FloatingPoint {
+  fatalError()
+}
+
+@inlinable
+func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+  at x: T, _ y: U, in body: @escaping @differentiable (T) -> R
+) -> R.TangentVector where T.TangentVector : FloatingPoint {
+  fatalError()
+}
+
+// Gradient
+
+@inlinable
+public func gradient<T, R>(
+  at x: T, in f: @differentiable (T) -> R
+) -> T.TangentVector
+  where R : FloatingPoint, R.TangentVector == R {
+    return pullback(at: x, in: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, R>(
+  at x: T, _ y: U, in f: @differentiable (T, U) -> R
+) -> (T.TangentVector, U.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+    return pullback(at: x, y, in: f)(R(1))
+}
+
+@inlinable
+public func gradient<T, U, V, R>(
+  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
+) -> (T.TangentVector, U.TangentVector, V.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+    return pullback(at: x, y, z, in: f)(R(1))
+}
+
+// Value with derivative
+
+@inlinable
+func valueWithDerivative<T: FloatingPoint, R>(
+  at x: T, in body: @escaping @differentiable (T) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector : FloatingPoint {
+    fatalError()
+}
+
+@inlinable
+func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+  at x: T, _ y: U, in body: @escaping @differentiable (T) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector : FloatingPoint {
+    fatalError()
 }
 
 // Value with gradient
@@ -416,61 +522,23 @@ public func valueWithGradient<T, U, V, R>(
   return (y, pullback(R(1)))
 }
 
-// Value with gradient (curried)
+// Derivative (curried)
 
-@inlinable
-public func valueWithGradient<T, R>(
-  of f: @escaping @differentiable (T) -> R
-) -> (T) -> (value: R, gradient: T.TangentVector)
-  where R : FloatingPoint, R.TangentVector == R {
-  return { x in valueWithGradient(at: x, in: f) }
+@inlinable 
+func derivative<T: FloatingPoint, R>(
+  of body: @escaping @differentiable (T) -> R
+) -> (T) -> R.TangentVector where T.TangentVector : FloatingPoint {
+    fatalError()
 }
 
-@inlinable
-public func valueWithGradient<T, U, R>(
-  of f: @escaping @differentiable (T, U) -> R
-) -> (T, U) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
-  where R : FloatingPoint, R.TangentVector == R {
-  return { x, y in valueWithGradient(at: x, y, in: f) }
+@inlinable 
+func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+  of body: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> R.TangentVector where T.TangentVector : FloatingPoint {
+    fatalError()
 }
 
-@inlinable
-public func valueWithGradient<T, U, V, R>(
-  of f: @escaping @differentiable (T, U, V) -> R
-) -> (T, U, V)
-    -> (value: R,
-        gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
-  where R : FloatingPoint, R.TangentVector == R {
-  return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
-}
-
-// Gradient
-
-@inlinable
-public func gradient<T, R>(
-  at x: T, in f: @differentiable (T) -> R
-) -> T.TangentVector
-  where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, in: f)(R(1))
-}
-
-@inlinable
-public func gradient<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable (T, U) -> R
-) -> (T.TangentVector, U.TangentVector)
-  where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, y, in: f)(R(1))
-}
-
-@inlinable
-public func gradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable (T, U, V) -> R
-) -> (T.TangentVector, U.TangentVector, V.TangentVector)
-  where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, y, z, in: f)(R(1))
-}
-
-// Gradient (curried)
+// Gradient of (curried)
 
 @inlinable
 public func gradient<T, R>(
@@ -494,6 +562,52 @@ public func gradient<T, U, V, R>(
 ) -> (T, U, V) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
   return { x, y, z in gradient(at: x, y, z, in: f) }
+}
+
+// Value with derivative of (curried)
+
+@inlinable
+func valueWithDerivative<T: FloatingPoint, R>(
+  of body: @escaping @differentiable (T) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector: FloatingPoint {
+    fatalError()
+}
+
+@inlinable
+func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+  of body: @escaping @differentiable (T, U) -> R
+) -> (value: R, derivative: R.TangentVector)
+  where T.TangentVector: FloatingPoint, U.TangentVector: FloatingPoint {
+    fatalError()
+}
+
+// Value with gradient (curried)
+
+@inlinable
+public func valueWithGradient<T, R>(
+  of f: @escaping @differentiable (T) -> R
+) -> (T) -> (value: R, gradient: T.TangentVector)
+  where R : FloatingPoint, R.TangentVector == R {
+    return { x in valueWithGradient(at: x, in: f) }
+}
+
+@inlinable
+public func valueWithGradient<T, U, R>(
+  of f: @escaping @differentiable (T, U) -> R
+) -> (T, U) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+    return { x, y in valueWithGradient(at: x, y, in: f) }
+}
+
+@inlinable
+public func valueWithGradient<T, U, V, R>(
+  of f: @escaping @differentiable (T, U, V) -> R
+) -> (T, U, V)
+  -> (value: R,
+      gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
+  where R : FloatingPoint, R.TangentVector == R {
+    return { x, y, z in valueWithGradient(at: x, y, z, in: f) }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Add differential operators in the [design overview](https://docs.google.com/document/d/1bPepWLfRQa6CtXqKA8CDQ87uZHixNav-TFjLSisuKag/edit#bookmark=id.5e1uqt7lvl62) that haven't been declared and reorder the declarations to match the design overview.