### PR TITLE
[Foundation] Fix two Decimal members with respect to NaN

### DIFF
--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -173,8 +173,8 @@ extension Decimal : Hashable, Comparable {
 
         var d = 0.0
         for idx in stride(from: min(_length, 8), to: 0, by: -1) {
-	        d = d * 65536 + Double(self[idx - 1])
-	    }
+	    d = d * 65536 + Double(self[idx - 1])
+	}
         
         if _exponent < 0 {
             for _ in _exponent..<0 {

--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -166,15 +166,15 @@ extension Decimal : Hashable, Comparable {
         }
     }
     
-    internal var doubleValue : Double {
+    internal var doubleValue: Double {
         if _length == 0 {
             return _isNegative == 1 ? Double.nan : 0
         }
 
         var d = 0.0
-        for idx in stride(from: min(_length, 8), to: 0, by: -1) {
-	    d = d * 65536 + Double(self[idx - 1])
-	}
+        for idx in (0..<min(_length, 8)).reversed() {
+            d = d * 65536 + Double(self[idx])
+        }
         
         if _exponent < 0 {
             for _ in _exponent..<0 {

--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -150,20 +150,31 @@ public func pow(_ x: Decimal, _ y: Int) -> Decimal {
 }
 
 extension Decimal : Hashable, Comparable {
-    internal var doubleValue : Double {
-        var d = 0.0
-        if _length == 0 && _isNegative == 0 {
-            return Double.nan
+    private subscript(index: UInt32) -> UInt16 {
+        get {
+            switch index {
+            case 0: return _mantissa.0
+            case 1: return _mantissa.1
+            case 2: return _mantissa.2
+            case 3: return _mantissa.3
+            case 4: return _mantissa.4
+            case 5: return _mantissa.5
+            case 6: return _mantissa.6
+            case 7: return _mantissa.7
+            default: fatalError("Invalid index \(index) for _mantissa")
+            }
         }
-        
-        d = d * 65536 + Double(_mantissa.7)
-        d = d * 65536 + Double(_mantissa.6)
-        d = d * 65536 + Double(_mantissa.5)
-        d = d * 65536 + Double(_mantissa.4)
-        d = d * 65536 + Double(_mantissa.3)
-        d = d * 65536 + Double(_mantissa.2)
-        d = d * 65536 + Double(_mantissa.1)
-        d = d * 65536 + Double(_mantissa.0)
+    }
+    
+    internal var doubleValue : Double {
+        if _length == 0 {
+            return _isNegative == 1 ? Double.nan : 0
+        }
+
+        var d = 0.0
+        for idx in stride(from: min(_length, 8), to: 0, by: -1) {
+	        d = d * 65536 + Double(self[idx - 1])
+	    }
         
         if _exponent < 0 {
             for _ in _exponent..<0 {
@@ -212,6 +223,7 @@ extension Decimal : ExpressibleByIntegerLiteral {
 
 extension Decimal : SignedNumeric {
   public var magnitude: Decimal {
+      guard _length != 0 else { return self }
       return Decimal(
           _exponent: self._exponent, _length: self._length,
           _isNegative: 0, _isCompact: self._isCompact,

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -303,6 +303,7 @@ class TestDecimal : TestDecimalSuper {
         expectEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         expectEqual(Decimal(1.234), abs(Decimal(1.234)))
         expectEqual(Decimal(1.234), abs(Decimal(-1.234)))
+        expectTrue(Decimal.nan.magnitude.isNaN)
         var a = Decimal(1234)
         var r = a
         expectEqual(.noError, NSDecimalMultiplyByPowerOf10(&r, &a, 1, .plain))


### PR DESCRIPTION
This PR fixes `Decimal.magnitude` so that `Decimal.nan.magnitude` is no longer incorrectly `0`.

It also incorporates changes from apple/swift-corelibs-foundation#1759, which has the salient effect of correcting an error unique to this overlay where `(0 as Decimal).doubleValue` returned `.nan`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10938](https://bugs.swift.org/browse/SR-10938).

