### PR TITLE
[AutoDiff] Fix a subset-parameters thunk parameter indexing crasher.

### DIFF
--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -33,6 +33,14 @@ SupersetVJPTests.test("CrossModuleClosure") {
   expectEqual(1, gradient(at: Float(1)) { x in x + 2 })
 }
 
+SupersetVJPTests.test("SubsetOfSubset") {
+  @differentiable(wrt: (x, z))
+  func foo(_ x: Float, _ y: Float, _ z: Float) -> Float {
+    Float(0).withoutDerivative()
+  }
+  expectEqual(0, gradient(at: 0, in: { x in foo(x, 0, 0) }))
+}
+
 // FIXME: The expression `(+) as @differentiable (Float, @nondiff Float) -> Float)`
 // forms a curry thunk of `Float.+` before conversion to @differentiable, and AD
 // doesn't know how to differentiate the curry thunk, so it produces a

--- a/test/AutoDiff/superset_adjoint.swift
+++ b/test/AutoDiff/superset_adjoint.swift
@@ -36,7 +36,7 @@ SupersetVJPTests.test("CrossModuleClosure") {
 SupersetVJPTests.test("SubsetOfSubset") {
   @differentiable(wrt: (x, z))
   func foo(_ x: Float, _ y: Float, _ z: Float) -> Float {
-    Float(0).withoutDerivative()
+    withoutDerivative(at: 0)
   }
   expectEqual(0, gradient(at: 0, in: { x in foo(x, 0, 0) }))
 }


### PR DESCRIPTION
The subset parameters thunk generation logic is not handling cases where the original JVP/JVP is already producing a subset-parameters linear map. This patch fixes it by computing indices w.r.t. the linear map from indices w.r.t. the original function. 

Resolves [TF-594](https://bugs.swift.org/browse/TF-594) and unblocks tensorflow/swift-apis#147.