### PR TITLE
[ownership] Verify functions before we strip ownership.

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -382,6 +382,9 @@ struct OwnershipModelEliminator : SILModuleTransform {
       if (SkipTransparent && F.isTransparent())
         continue;
 
+      // Verify here to make sure ownership is correct before we strip.
+      F.verify();
+
       if (stripOwnership(F)) {
         auto InvalidKind =
             SILAnalysis::InvalidationKind::BranchesAndInstructions;


### PR DESCRIPTION
Today before/after running optimizations, the driver always verifies the entire
SILModule. Sadly since we are stripping ownership in the /middle/ of the
pipeline, we do not get the same benefit for ownership SIL.

With this change, we verify before we strip ownership to ensure that the code is
[ossa] correct /before/ we strip.

This will only run in asserts builds unless -sil-verify-all is passed in.
