### PR TITLE
[TF] Change macOS tensorflow preset from release debug info to release.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2123,7 +2123,10 @@ swiftpm
 swiftsyntax
 skstresstester
 playgroundsupport
-release-debuginfo
+# SWIFT_ENABLE_TENSORFLOW
+# FIXME(TF-597): IRGenDebugInfo crash for `pullback(at:in:)`.
+# release-debuginfo
+release
 lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release


### PR DESCRIPTION
Workaround for [TF-597](https://bugs.swift.org/browse/TF-597): IRGenDebugInfo crash.