### PR TITLE
[lldb] Do not print qualified lldb module names.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3472,6 +3472,22 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
   }
 
   bool shouldPrintFullyQualified(TypeBase *T) {
+    // SWIFT_ENABLE_TENSORFLOW
+    // NOTE(TF-590): Workaround for REPL qualified module name bug.
+    // Do not print qualified LLDB module names.
+    {
+      Decl *D;
+      if (auto *TAT = dyn_cast<TypeAliasType>(T))
+        D = TAT->getDecl();
+      else
+        D = T->getAnyGeneric();
+
+      ModuleDecl *M = D->getDeclContext()->getParentModule();
+      if (isLLDBExpressionModule(M))
+        return false;
+    }
+    // SWIFT_ENABLE_TENSORFLOW END
+
     if (Options.FullyQualifiedTypes)
       return true;
 


### PR DESCRIPTION
Non-robust fix for `use of undeclared type '__lldb_expr_'` errors in the REPL.
Patch for [TF-590](https://bugs.swift.org/browse/TF-590).