### PR TITLE
Revert "[stdlib] AutoreleasingUnsafeMutablePointer: Switch subscripts to _read accessors"

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -374,9 +374,10 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   ///   `Pointee`.
   @inlinable
   public var pointee: Pointee {
-    @_transparent _read {
+    /// Retrieve the value the pointer points to.
+    @_transparent get {
       // We can do a strong load normally.
-      yield UnsafePointer(self).pointee
+      return UnsafePointer(self).pointee
     }
     /// Set the value the pointer points to, copying over the previous value.
     ///
@@ -413,9 +414,9 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   @inlinable // unsafe-performance
   public subscript(i: Int) -> Pointee {
     @_transparent
-    _read {
+    get {
       // We can do a strong load normally.
-      yield ((UnsafePointer<Pointee>(self) + i).pointee)
+      return (UnsafePointer<Pointee>(self) + i).pointee
     }
   }
 


### PR DESCRIPTION
This was an ABI break, since it didn't make it into 5.0. Using _read here is unimportant, so we're just going to revert rather than try being fancy.

This reverts commit 04586e39163c532fa09f1d71d1aa0b35ffa92140.

Fixes rdar://problem/51503385