### PR TITLE
[CodeCompletion] Map the result type for keypath member lookup

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -232,13 +232,14 @@ namespace swift {
   /// @dynamicMemberLookup attribute on it.
   bool hasDynamicMemberLookupAttribute(Type type);
 
-  /// Returns the root type of the keypath type in a keypath dynamic member
-  /// lookup subscript, or \c None if it cannot be determined.
+  /// Returns the root type and result type of the keypath type in a keypath
+  /// dynamic member lookup subscript, or \c None if it cannot be determined.
   ///
   /// \param subscript The potential keypath dynamic member lookup subscript.
   /// \param DC The DeclContext from which the subscript is being referenced.
-  Optional<Type> getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
-                                                   const DeclContext *DC);
+  Optional<std::pair<Type, Type>>
+  getRootAndResultTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
+                                             const DeclContext *DC);
 }
 
 #endif

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1988,12 +1988,80 @@ public:
 
   Type getTypeOfMember(const ValueDecl *VD,
                        DynamicLookupInfo dynamicLookupInfo) {
-    if (dynamicLookupInfo.getKind() == DynamicLookupInfo::None) {
+    switch (dynamicLookupInfo.getKind()) {
+    case DynamicLookupInfo::None:
       return getTypeOfMember(VD, this->ExprType);
-    } else {
-      // FIXME: for keypath dynamic members we should substitute the subscript
-      // return type; for now just avoid substituting at all by passing null.
+    case DynamicLookupInfo::AnyObject:
       return getTypeOfMember(VD, Type());
+    case DynamicLookupInfo::KeyPathDynamicMember: {
+      auto &keyPathInfo = dynamicLookupInfo.getKeyPathDynamicMember();
+
+      // Map the result of VD to keypath member lookup results.
+      // Given:
+      //   struct Wrapper<T> {
+      //     subscript<U>(dynamicMember: KeyPath<T, U>) -> Wrapped<U> { get }
+      //   }
+      //   struct Circle {
+      //     var center: Point { get }
+      //     var radius: Length { get }
+      //   }
+      //
+      // Consider 'Wrapper<Circle>.center'.
+      //   'VD' is 'Circle.center' decl.
+      //   'keyPathInfo.subscript' is 'Wrapper<T>.subscript' decl.
+      //   'keyPathInfo.baseType' is 'Wrapper<Circle>' type.
+
+      // FIXME: Handle nested keypath member lookup.
+      // i.e. cases where 'ExprType' != 'keyPathInfo.baseType'.
+
+      auto *SD = keyPathInfo.subscript;
+      auto elementTy = SD->getElementTypeLoc().getType();
+      if (!elementTy->hasTypeParameter())
+        return elementTy;
+
+      // Map is:
+      //   { τ_0_0(T) => Circle
+      //     τ_1_0(U) => U }
+      auto subs = keyPathInfo.baseType->getMemberSubstitutions(SD);
+
+      // Extract the root and result type of the KeyPath type in the parameter.
+      // i.e. 'T' and 'U'
+      auto rootAndResult =
+          getRootAndResultTypeOfKeypathDynamicMember(SD, CurrDeclContext);
+
+      // If the keyPath result type has type parameters, that might affect the
+      // subscript result type.
+      auto keyPathResultTy = rootAndResult->second->mapTypeOutOfContext();
+      if (keyPathResultTy->hasTypeParameter()) {
+        auto keyPathRootTy =
+            rootAndResult->first.subst(QueryTypeSubstitutionMap{subs},
+                                       LookUpConformanceInModule(CurrModule));
+
+        // The result type of the VD.
+        // i.e. 'Circle.center' => 'Point'.
+        auto innerResultTy = getTypeOfMember(VD, keyPathRootTy);
+
+        if (auto paramTy = keyPathResultTy->getAs<GenericTypeParamType>()) {
+          // Replace keyPath result type in the map with the inner result type.
+          // i.e. Make the map as:
+          //   { τ_0_0(T) => Circle
+          //     τ_1_0(U) => Point }
+          auto key =
+              paramTy->getCanonicalType()->castTo<GenericTypeParamType>();
+          subs[key] = innerResultTy;
+        } else {
+          // FIXME: Handle the case where the KeyPath result is generic.
+          // e.g. 'subscript<U>(dynamicMember: KeyPath<T, Box<U>>) -> Bag<U>'
+          // For now, just return the inner type.
+          return innerResultTy;
+        }
+      }
+
+      // Substitute the element type of the subscript using modified map.
+      // i.e. 'Wrapped<U>' => 'Wrapped<Point>'.
+      return elementTy.subst(QueryTypeSubstitutionMap{subs},
+                             LookUpConformanceInModule(CurrModule));
+    }
     }
   }
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -973,18 +973,20 @@ static void lookupVisibleDynamicMemberLookupDecls(
     if (!subscript)
       continue;
 
-    auto rootType = getRootTypeOfKeypathDynamicMember(subscript, dc);
-    if (!rootType)
+    auto rootAndResult =
+        getRootAndResultTypeOfKeypathDynamicMember(subscript, dc);
+    if (!rootAndResult)
       continue;
+    auto rootType = rootAndResult->first;
 
     auto subs =
         baseType->getMemberSubstitutionMap(dc->getParentModule(), subscript);
-    auto memberType = rootType->subst(subs);
+    auto memberType = rootType.subst(subs);
     if (!memberType || !memberType->mayHaveMembers())
       continue;
 
-    KeyPathDynamicMemberConsumer::SubscriptChange(consumer, subscript,
-                                                  baseType);
+    KeyPathDynamicMemberConsumer::SubscriptChange sub(consumer, subscript,
+                                                      baseType);
 
     lookupVisibleMemberAndDynamicMemberDecls(memberType, consumer, consumer, dc,
                                              LS, reason, typeResolver, GSB,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1028,9 +1028,9 @@ bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
   return false;
 }
 
-Optional<Type>
-swift::getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
-                                         const DeclContext *DC) {
+Optional<std::pair<Type, Type>>
+swift::getRootAndResultTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
+                                                  const DeclContext *DC) {
   auto &TC = TypeChecker::createForContext(DC->getASTContext());
 
   if (!isValidKeyPathDynamicMemberLookup(subscript, TC))
@@ -1040,11 +1040,10 @@ swift::getRootTypeOfKeypathDynamicMember(SubscriptDecl *subscript,
   auto keyPathType = param->getType()->getAs<BoundGenericType>();
   if (!keyPathType)
     return None;
-
-  assert(!keyPathType->getGenericArgs().empty() &&
+  auto genericArgs = keyPathType->getGenericArgs();
+  assert(!genericArgs.empty() && genericArgs.size() == 2 &&
          "invalid keypath dynamic member");
-  auto rootType = keyPathType->getGenericArgs()[0];
-  return rootType;
+  return std::pair<Type, Type>{genericArgs[0], genericArgs[1]};
 }
 
 /// The @dynamicMemberLookup attribute is only allowed on types that have at


### PR DESCRIPTION
```swift
struct Circle {
  var center: Point { get }
  var radius: Length { get }
}

@dynamicMemberLookup
struct Wrapper<T> {
  subscript<U>(dynamicMember: KeyPath<T, U>) -> Wrapped<U> { get }
}

func test(value: Wrapper<Circle>) {
  value.#HERE#
}
```
The type of `center` and `radius` should be `Wrapped<Point>` and `Wrapped<Length>` respectively.

rdar://problem/50073837

NOTE: This implementation doesn't properly handle:
- Nested wrapper
  (e.g. `Wrapper<Wrapper<Point>>`)
- Generic result type in `KeyPath`
  (e.g. `subscript<U>(dynamicMember: KeyPath<T, Box<U>>) -> Wrapper<U>`)
