### PR TITLE
[Typechecker] Look through all optionals when diagnosing uninhabited types

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1134,6 +1134,7 @@ recur:
     // can silence the warning with an explicit type annotation
     // (and provide a fixit) as a note.
     Type diagTy = type->lookThroughAllOptionalTypes();
+    bool isOptional = !type->getOptionalObjectType().isNull();
     if (!diagTy) diagTy = type;
     
     auto diag = diag::type_inferred_to_undesirable_type;
@@ -1148,10 +1149,12 @@ recur:
         shouldRequireType = true;
     } else if (diagTy->isStructurallyUninhabited()) {
       shouldRequireType = true;
-      diag = diag::type_inferred_to_uninhabited_type;
-      
+      diag = isOptional ? diag::type_inferred_to_undesirable_type
+                        : diag::type_inferred_to_uninhabited_type;
+
       if (diagTy->is<TupleType>()) {
-        diag = diag::type_inferred_to_uninhabited_tuple_type;
+        diag = isOptional ? diag::type_inferred_to_undesirable_type
+                          : diag::type_inferred_to_uninhabited_tuple_type;
       } else {
         assert((diagTy->is<EnumType>() || diagTy->is<BoundGenericEnumType>()) &&
           "unknown structurally uninhabited type");

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1133,7 +1133,7 @@ recur:
     // a variable, or there is some other bug.  We always tell them that they
     // can silence the warning with an explicit type annotation
     // (and provide a fixit) as a note.
-    Type diagTy = type->getOptionalObjectType();
+    Type diagTy = type->lookThroughAllOptionalTypes();
     if (!diagTy) diagTy = type;
     
     auto diag = diag::type_inferred_to_undesirable_type;

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1278,6 +1278,18 @@ let sr8811c = (16, fatalError()) // expected-warning {{constant 'sr8811c' inferr
 
 let sr8811d: (Int, Never) = (16, fatalError()) // Ok
 
+// SR-10995
+
+class SR_10995 {
+  func makeDoubleOptionalNever() -> Never?? {
+    return nil
+  }
+
+  func sr_10995_foo() {
+    let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{Constant 'doubleOptionalNever' inferred to have type 'Never??', which is an enum with no cases}}
+  }
+}
+
 // SR-9267
 
 class SR_9267 {}

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1285,8 +1285,17 @@ class SR_10995 {
     return nil
   }
 
+  func makeSingleOptionalNever() -> Never? {
+    return nil
+  }
+
   func sr_10995_foo() {
-    let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{Constant 'doubleOptionalNever' inferred to have type 'Never??', which is an enum with no cases}}
+    let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{constant 'doubleOptionalNever' inferred to have type 'Never??', which may be unexpected}} 
+    // expected-note@-1 {{add an explicit type annotation to silence this warning}} 
+    // expected-warning@-2 {{initialization of immutable value 'doubleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
+    let singleOptionalNever = makeSingleOptionalNever() // expected-warning {{constant 'singleOptionalNever' inferred to have type 'Never?', which may be unexpected}} 
+    // expected-note@-1 {{add an explicit type annotation to silence this warning}} 
+    // expected-warning@-2 {{initialization of immutable value 'singleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where we wouldn't look through all the optionals in a type when diagnosing the declaration of a property initialised with a function which returns an uninhabited type, for example:

```swift
func foo() -> Never? {
    return nil
}

func bar() -> Never?? {
    return nil
}

let one = foo() // warning: constant 'one' inferred to have type 'Never?', which is an enum with no cases
let two = bar() // no warning
```

Resolves [SR-10995](https://bugs.swift.org/browse/SR-10995).