### PR TITLE
[5.1][IDE/SyntaxModel] Make sure to properly annotate comment markers in single-line comment blocks

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1272,6 +1272,10 @@ bool ModelASTWalker::processComment(CharSourceRange Range) {
   if (NewLinePos != StringRef::npos) {
     Text = Text.substr(0, NewLinePos);
   }
+  if (Text.endswith("*/")) {
+    Text = Text.drop_back(2);
+  }
+  Text = Text.rtrim();
 
   CharSourceRange BeforeMarker{ SM, Range.getStart(), Loc };
   CharSourceRange Marker(Loc, Text.size());

--- a/test/IDE/coloring_comments.swift
+++ b/test/IDE/coloring_comments.swift
@@ -36,9 +36,9 @@ func f(x: Int) -> Int {
 
 
 
-/* FIXME: blah*/
+/* FIXME: blah */
 
-// CHECK: <comment-block>/* <comment-marker>FIXME: blah*/</comment-marker></comment-block>
+// CHECK: <comment-block>/* <comment-marker>FIXME: blah</comment-marker> */</comment-block>
 
 /*
  * FIXME: blah


### PR DESCRIPTION
rdar://51893731

master: https://github.com/apple/swift/pull/25718