### PR TITLE
[AutoDiff] Fix substitution map remapping bug.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -3828,6 +3828,12 @@ private:
         type.getCategory());
   }
 
+  /// Substitutes all replacement types of the given substitution map using the
+  /// adjoint function's substitution map.
+  SubstitutionMap remapSubstitutionMap(SubstitutionMap substMap) {
+    return substMap.subst(getAdjoint().getForwardingSubstitutionMap());
+  }
+
   //--------------------------------------------------------------------------//
   // Managed value mapping
   //--------------------------------------------------------------------------//
@@ -4654,7 +4660,8 @@ public:
           pullbackType, *applyInfo.originalPullbackType);
       auto *thunkRef = builder.createFunctionRef(loc, thunk);
       pullback = builder.createPartialApply(
-          loc, thunkRef, thunk->getForwardingSubstitutionMap(),
+          loc, thunkRef,
+          remapSubstitutionMap(thunk->getForwardingSubstitutionMap()),
           {pullback}, pullbackType->getCalleeConvention());
     }
     args.push_back(seed);

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -170,23 +170,6 @@ struct TF_305 : Differentiable {
   }
 }
 
-protocol TF_534_Layer : Differentiable {
-  associatedtype Input : Differentiable
-  associatedtype Output : Differentiable
-
-  @differentiable
-  func callAsFunction(_ input: Input) -> Output
-}
-struct TF_534_Tensor<Scalar> : Differentiable {}
-
-func TF_534<Model: TF_534_Layer>(
-  _ model: inout Model, inputs: Model.Input
-) -> TF_534_Tensor<Float> where Model.Output == TF_534_Tensor<Float> {
-  return valueWithPullback(at: model) { model -> Model.Output in
-    return model(inputs)
-  }.0
-}
-
 //===----------------------------------------------------------------------===//
 // Classes and existentials (not yet supported)
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -151,4 +151,22 @@ func TF_523_f(_ x: TF_523_Struct) -> Float {
   return x.a * 2
 }
 
+// TF_534: Thunk substitution map remapping.
+protocol TF_534_Layer : Differentiable {
+  associatedtype Input : Differentiable
+  associatedtype Output : Differentiable
+
+  @differentiable
+  func callAsFunction(_ input: Input) -> Output
+}
+struct TF_534_Tensor<Scalar> : Differentiable {}
+
+func TF_534<Model: TF_534_Layer>(
+  _ model: inout Model, inputs: Model.Input
+) -> TF_534_Tensor<Float> where Model.Output == TF_534_Tensor<Float> {
+  return valueWithPullback(at: model) { model -> Model.Output in
+    return model(inputs)
+  }.0
+}
+
 // TODO: add more tests.


### PR DESCRIPTION
Remap thunk substitution maps during VJP and adjoint generation.
Move test location so that test is actually effective.

Resolves [TF-534](https://bugs.swift.org/browse/TF-534).