### PR TITLE
[5.1] [ConstraintSystem] Fix crash on function conversion reliant on conditional conformance

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -175,8 +175,7 @@ ProtocolConformance *RequirementFailure::getConformanceForConditionalReq(
     return nullptr;
   }
 
-  auto *typeReqLoc = cs.getConstraintLocator(getRawAnchor(), path.drop_back(),
-                                             /*summaryFlags=*/0);
+  auto *typeReqLoc = getConstraintLocator(getRawAnchor(), path.drop_back());
 
   auto result = llvm::find_if(
       cs.CheckedConformances,
@@ -1758,8 +1757,7 @@ bool MissingCallFailure::diagnoseAsError() {
 
     case ConstraintLocator::AutoclosureResult: {
       auto &cs = getConstraintSystem();
-      auto loc = cs.getConstraintLocator(getRawAnchor(), path.drop_back(),
-                                         /*summaryFlags=*/0);
+      auto loc = getConstraintLocator(getRawAnchor(), path.drop_back());
       AutoClosureForwardingFailure failure(cs, loc);
       return failure.diagnoseAsError();
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -112,10 +112,9 @@ Optional<SelectedOverload> FailureDiagnostic::getChoiceFor(Expr *expr) {
 
   if (auto *AE = dyn_cast<ApplyExpr>(expr)) {
     if (auto *TE = dyn_cast<TypeExpr>(AE->getFn())) {
-      locator = cs.getConstraintLocator(AE,
-                                        {ConstraintLocator::ApplyFunction,
-                                         ConstraintLocator::ConstructorMember},
-                                        /*summaryFlags=*/0);
+      locator =
+          getConstraintLocator(AE, {ConstraintLocator::ApplyFunction,
+                                    ConstraintLocator::ConstructorMember});
     }
     return getChoiceFor(AE->getFn());
   } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
@@ -586,10 +585,9 @@ Type NoEscapeFuncToTypeConversionFailure::getParameterTypeFor(
       locator =
           cs.getConstraintLocator(fnExpr, ConstraintLocator::UnresolvedMember);
     } else if (auto *TE = dyn_cast<TypeExpr>(fnExpr)) {
-      locator = cs.getConstraintLocator(call,
-                                        {ConstraintLocator::ApplyFunction,
-                                         ConstraintLocator::ConstructorMember},
-                                        /*summaryFlags=*/0);
+      locator =
+          getConstraintLocator(call, {ConstraintLocator::ApplyFunction,
+                                      ConstraintLocator::ConstructorMember});
     } else {
       locator = cs.getConstraintLocator(fnExpr);
     }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -149,7 +149,7 @@ protected:
   /// path, uniqued and automatically calculate the summary flags
   ConstraintLocator *
   getConstraintLocator(Expr *anchor,
-                       ArrayRef<ConstraintLocator::PathElement> path) {
+                       ArrayRef<ConstraintLocator::PathElement> path) const {
     return CS.getConstraintLocator(anchor, path);
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -145,6 +145,14 @@ protected:
     return nullptr;
   }
 
+  /// Retrive the constraint locator for the given anchor and
+  /// path, uniqued and automatically calculate the summary flags
+  ConstraintLocator *
+  getConstraintLocator(Expr *anchor,
+                       ArrayRef<ConstraintLocator::PathElement> path) {
+    return CS.getConstraintLocator(anchor, path);
+  }
+
   /// \returns true is locator hasn't been simplified down to expression.
   bool hasComplexLocator() const { return HasComplexLocator; }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3437,8 +3437,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         auto reqPath = ArrayRef<LocatorPathElt>(path).drop_back();
         // Underlying conformance requirement is itself fixed,
         // this wouldn't lead to a right solution.
-        if (hasFixFor(getConstraintLocator(anchor, reqPath,
-                                           /*summaryFlags=*/0)))
+        if (hasFixFor(getConstraintLocator(anchor, reqPath)))
           return SolutionKind::Error;
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2001,13 +2001,11 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
     auto reqPath = path.drop_back();
     // If underlying conformance requirement has been fixed,
     // then there is no reason to fix up conditional requirements.
-    if (cs.hasFixFor(cs.getConstraintLocator(anchor, reqPath,
-                                             /*summaryFlags=*/0)))
+    if (cs.hasFixFor(cs.getConstraintLocator(anchor, reqPath)))
       return nullptr;
   }
 
-  auto *reqLoc = cs.getConstraintLocator(anchor, path,
-                                         /*summaryFlags=*/0);
+  auto *reqLoc = cs.getConstraintLocator(anchor, path);
 
   auto reqKind = static_cast<RequirementKind>(req.getValue2());
   switch (reqKind) {
@@ -2169,8 +2167,7 @@ bool ConstraintSystem::repairFailures(
                                       getASTContext().TheEmptyTupleType);
       conversionsOrFixes.push_back(AddMissingArguments::create(
           *this, fnType, {FunctionType::Param(*arg)},
-          getConstraintLocator(anchor, path,
-                               /*summaryFlags=*/0)));
+          getConstraintLocator(anchor, path)));
     }
     break;
   }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -313,8 +313,8 @@ StepResult ComponentStep::take(bool prevFailed) {
       // Let's drop `generic parameter '...'` part of the locator to
       // group all of the missing generic parameters related to the
       // same path together.
-      defaultableGenericParams[CS.getConstraintLocator(anchor, path.drop_back(),
-                                                       /*summaryFlags=*/0)]
+      defaultableGenericParams[CS.getConstraintLocator(anchor,
+                                                       path.drop_back())]
           .push_back(locator->getGenericParameter());
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -375,6 +375,12 @@ getAlternativeLiteralTypes(KnownProtocolKind kind) {
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
+    Expr *anchor, ArrayRef<ConstraintLocator::PathElement> path) {
+  auto summaryFlags = ConstraintLocator::getSummaryFlagsForPath(path);
+  return getConstraintLocator(anchor, path, summaryFlags);
+}
+
+ConstraintLocator *ConstraintSystem::getConstraintLocator(
                      Expr *anchor,
                      ArrayRef<ConstraintLocator::PathElement> path,
                      unsigned summaryFlags) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1888,6 +1888,12 @@ public:
                        ArrayRef<ConstraintLocator::PathElement> path,
                        unsigned summaryFlags);
 
+  /// Retrive the constraint locator for the given anchor and
+  /// path, uniqued and automatically infer the summary flags
+  ConstraintLocator *
+  getConstraintLocator(Expr *anchor,
+                       ArrayRef<ConstraintLocator::PathElement> path);
+
   /// Retrieve the constraint locator for the given anchor and
   /// an empty path, uniqued.
   ConstraintLocator *getConstraintLocator(Expr *anchor) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1892,7 +1892,7 @@ public:
   /// path, uniqued and automatically infer the summary flags
   ConstraintLocator *
   getConstraintLocator(Expr *anchor,
-                       ArrayRef<ConstraintLocator::PathElement> path) const;
+                       ArrayRef<ConstraintLocator::PathElement> path);
 
   /// Retrieve the constraint locator for the given anchor and
   /// an empty path, uniqued.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1892,7 +1892,7 @@ public:
   /// path, uniqued and automatically infer the summary flags
   ConstraintLocator *
   getConstraintLocator(Expr *anchor,
-                       ArrayRef<ConstraintLocator::PathElement> path);
+                       ArrayRef<ConstraintLocator::PathElement> path) const;
 
   /// Retrieve the constraint locator for the given anchor and
   /// an empty path, uniqued.

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -402,3 +402,14 @@ extension BinaryInteger {
             // expected-error@-1 {{referencing instance method 'reduce' on 'ClosedRange' requires that 'Self.Stride' conform to 'SignedInteger'}}
   }
 }
+
+// SR-10992
+
+protocol SR_10992_P {}
+struct SR_10992_S<T> {}
+extension SR_10992_S: SR_10992_P where T: SR_10992_P {} // expected-note {{requirement from conditional conformance of 'SR_10992_S<String>' to 'SR_10992_P'}}
+	
+func sr_10992_foo(_ fn: (SR_10992_S<String>) -> Void) {}
+func sr_10992_bar(_ fn: (SR_10992_P) -> Void) {
+  sr_10992_foo(fn) // expected-error {{global function 'sr_10992_foo' requires that 'String' conform to 'SR_10992_P'}}
+}

--- a/validation-test/compiler_crashers_2_fixed/sr10992.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10992.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol P {}
+struct S<T> {}
+extension S : P where T : P {}
+
+func foo(_ fn: (S<String>) -> Void) {}
+func bar(_ fn: (P) -> Void) {
+  foo(fn)
+}


### PR DESCRIPTION
This PR fixes a compiler crasher related to a function conversion reliant on conditional conformance. Example:

```swift
protocol P {}
struct S<T> {}
extension S : P where T : P {}

func foo(_ fn: (S<String>) -> Void) {}
func bar(_ fn: (P) -> Void) {
  foo(fn)
}
```

Resolves [SR-10992](https://bugs.swift.org/browse/SR-10992).

---

Cherry pick of #25721.