### PR TITLE
Look up runtime libraries in SDK

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -194,17 +194,23 @@ protected:
                               file_types::ID InputType,
                               const char *PrefixArgument = nullptr) const;
 
-  /// Get the runtime library link path, which is platform-specific and found
+  /// Get the resource dir link path, which is platform-specific and found
   /// relative to the compiler.
-  void getRuntimeLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
-                             const llvm::opt::ArgList &args, bool shared) const;
+  void getResourceDirPath(SmallVectorImpl<char> &runtimeLibPath,
+                          const llvm::opt::ArgList &args, bool shared) const;
+
+  /// Get the runtime library link paths, which typically include the resource
+  /// dir path and the SDK.
+  void getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibPaths,
+                              const llvm::opt::ArgList &args,
+                              StringRef SDKPath, bool shared) const;
 
   void addPathEnvironmentVariableIfNeeded(Job::EnvironmentVector &env,
                                           const char *name,
                                           const char *separator,
                                           options::ID optionID,
                                           const llvm::opt::ArgList &args,
-                                          StringRef extraEntry = "") const;
+                                          ArrayRef<std::string> extraEntries = {}) const;
 
   /// Specific toolchains should override this to provide additional conditions
   /// under which the compiler invocation should be written into debug info. For

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -72,12 +72,13 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
                                         const JobContext &context) const {
   InvocationInfo II = ToolChain::constructInvocation(job, context);
 
-  SmallString<128> runtimeLibraryPath;
-  getRuntimeLibraryPath(runtimeLibraryPath, context.Args, /*Shared=*/true);
+  SmallVector<std::string, 4> runtimeLibraryPaths;
+  getRuntimeLibraryPaths(runtimeLibraryPaths, context.Args, context.OI.SDKPath,
+                         /*Shared=*/true);
 
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_LIBRARY_PATH",
                                      ":", options::OPT_L, context.Args,
-                                     runtimeLibraryPath);
+                                     runtimeLibraryPaths);
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
                                      ":", options::OPT_F, context.Args);
   // FIXME: Add options::OPT_Fsystem paths to DYLD_FRAMEWORK_PATH as well.
@@ -392,8 +393,8 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
 
   // Add the runtime library link path, which is platform-specific and found
   // relative to the compiler.
-  SmallString<128> RuntimeLibPath;
-  getRuntimeLibraryPath(RuntimeLibPath, context.Args, /*Shared=*/true);
+  SmallString<128> ResourceDirPath;
+  getResourceDirPath(ResourceDirPath, context.Args, /*Shared=*/true);
 
   // Link compatibility libraries, if we're deploying back to OSes that
   // have an older Swift runtime.
@@ -418,7 +419,7 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
     if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
       // Swift 5.0 compatibility library
       SmallString<128> BackDeployLib;
-      BackDeployLib.append(RuntimeLibPath);
+      BackDeployLib.append(ResourceDirPath);
       llvm::sys::path::append(BackDeployLib, "libswiftCompatibility50.a");
       
       if (llvm::sys::fs::exists(BackDeployLib)) {
@@ -433,7 +434,7 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
       if (*runtimeCompatibilityVersion <= llvm::VersionTuple(5, 0)) {
         // Swift 5.0 dynamic replacement compatibility library.
         SmallString<128> BackDeployLib;
-        BackDeployLib.append(RuntimeLibPath);
+        BackDeployLib.append(ResourceDirPath);
         llvm::sys::path::append(BackDeployLib,
                                 "libswiftCompatibilityDynamicReplacements.a");
 
@@ -445,22 +446,34 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   // Link the standard library.
-  Arguments.push_back("-L");
   if (context.Args.hasFlag(options::OPT_static_stdlib,
                            options::OPT_no_static_stdlib, false)) {
-    SmallString<128> StaticRuntimeLibPath;
-    getRuntimeLibraryPath(StaticRuntimeLibPath, context.Args, /*Shared=*/false);
-    Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath));
+    SmallVector<std::string, 4> StaticRuntimeLibPaths;
+    getRuntimeLibraryPaths(StaticRuntimeLibPaths, context.Args,
+                           context.OI.SDKPath, /*Shared=*/false);
+
+    for (auto path : StaticRuntimeLibPaths) {
+      Arguments.push_back("-L");
+      Arguments.push_back(context.Args.MakeArgString(path));
+    }
+
     Arguments.push_back("-lc++");
     Arguments.push_back("-framework");
     Arguments.push_back("Foundation");
     Arguments.push_back("-force_load_swift_libs");
   } else {
-    Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
-    // FIXME: We probably shouldn't be adding an rpath here unless we know ahead
-    // of time the standard library won't be copied. SR-1967
-    Arguments.push_back("-rpath");
-    Arguments.push_back(context.Args.MakeArgString(RuntimeLibPath));
+    SmallVector<std::string, 4> SharedRuntimeLibPaths;
+    getRuntimeLibraryPaths(SharedRuntimeLibPaths, context.Args,
+                           context.OI.SDKPath, /*Shared=*/true);
+
+    for (auto path : SharedRuntimeLibPaths) {
+      Arguments.push_back("-L");
+      Arguments.push_back(context.Args.MakeArgString(path));
+      // FIXME: We probably shouldn't be adding an rpath here unless we know ahead
+      // of time the standard library won't be copied. SR-1967
+      Arguments.push_back("-rpath");
+      Arguments.push_back(context.Args.MakeArgString(path));
+    }
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1110,16 +1110,17 @@ ToolChain::constructInvocation(const StaticLinkJobAction &job,
 
 void ToolChain::addPathEnvironmentVariableIfNeeded(
     Job::EnvironmentVector &env, const char *name, const char *separator,
-    options::ID optionID, const ArgList &args, StringRef extraEntry) const {
+    options::ID optionID, const ArgList &args,
+    ArrayRef<std::string> extraEntries) const {
   auto linkPathOptions = args.filtered(optionID);
-  if (linkPathOptions.begin() == linkPathOptions.end() && extraEntry.empty())
+  if (linkPathOptions.begin() == linkPathOptions.end() && extraEntries.empty())
     return;
 
   std::string newPaths;
   interleave(linkPathOptions,
              [&](const Arg *arg) { newPaths.append(arg->getValue()); },
              [&] { newPaths.append(separator); });
-  if (!extraEntry.empty()) {
+  for (auto extraEntry : extraEntries) {
     if (!newPaths.empty())
       newPaths.append(separator);
     newPaths.append(extraEntry.data(), extraEntry.size());
@@ -1143,7 +1144,7 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
                                     SmallString<128> &LibPath) const {
   const llvm::Triple &T = getTriple();
 
-  getRuntimeLibraryPath(LibPath, Args, /*Shared=*/true);
+  getResourceDirPath(LibPath, Args, /*Shared=*/true);
   // Remove platform name.
   llvm::sys::path::remove_filename(LibPath);
   llvm::sys::path::append(LibPath, "clang", "lib",
@@ -1153,25 +1154,39 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
 
 /// Get the runtime library link path, which is platform-specific and found
 /// relative to the compiler.
-void ToolChain::getRuntimeLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
-                                      const llvm::opt::ArgList &args,
-                                      bool shared) const {
+void ToolChain::getResourceDirPath(SmallVectorImpl<char> &resourceDirPath,
+                                   const llvm::opt::ArgList &args,
+                                   bool shared) const {
   // FIXME: Duplicated from CompilerInvocation, but in theory the runtime
   // library link path and the standard library module import path don't
   // need to be the same.
   if (const Arg *A = args.getLastArg(options::OPT_resource_dir)) {
     StringRef value = A->getValue();
-    runtimeLibPath.append(value.begin(), value.end());
+    resourceDirPath.append(value.begin(), value.end());
   } else {
     auto programPath = getDriver().getSwiftProgramPath();
-    runtimeLibPath.append(programPath.begin(), programPath.end());
-    llvm::sys::path::remove_filename(runtimeLibPath); // remove /swift
-    llvm::sys::path::remove_filename(runtimeLibPath); // remove /bin
-    llvm::sys::path::append(runtimeLibPath, "lib",
+    resourceDirPath.append(programPath.begin(), programPath.end());
+    llvm::sys::path::remove_filename(resourceDirPath); // remove /swift
+    llvm::sys::path::remove_filename(resourceDirPath); // remove /bin
+    llvm::sys::path::append(resourceDirPath, "lib",
                             shared ? "swift" : "swift_static");
   }
-  llvm::sys::path::append(runtimeLibPath,
+  llvm::sys::path::append(resourceDirPath,
                           getPlatformNameForTriple(getTriple()));
+}
+
+void ToolChain::getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibPaths,
+                                       const llvm::opt::ArgList &args,
+                                       StringRef SDKPath, bool shared) const {
+  SmallString<128> scratchPath;
+  getResourceDirPath(scratchPath, args, shared);
+  runtimeLibPaths.push_back(scratchPath.str());
+
+  if (!SDKPath.empty()) {
+    scratchPath = SDKPath;
+    llvm::sys::path::append(scratchPath, "usr", "lib", "swift");
+    runtimeLibPaths.push_back(scratchPath.str());
+  }
 }
 
 bool ToolChain::sanitizerRuntimeLibExists(const ArgList &args,

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -194,12 +194,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   getRuntimeLibraryPaths(RuntimeLibPaths, context.Args, context.OI.SDKPath,
                          /*Shared=*/!(staticExecutable || staticStdlib));
 
-  // Add the runtime library link paths.
-  for (auto path : RuntimeLibPaths) {
-    Arguments.push_back("-L");
-    Arguments.push_back(context.Args.MakeArgString(path));
-  }
-
   if (!(staticExecutable || staticStdlib) && shouldProvideRPathToLinker()) {
     // FIXME: We probably shouldn't be adding an rpath here unless we know
     //        ahead of time the standard library won't be copied.
@@ -246,9 +240,15 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
           Twine("@") + OutputInfo.getPrimaryOutputFilename()));
   }
 
-  // Link the standard library.
+  // Add the runtime library link paths.
+  for (auto path : RuntimeLibPaths) {
+    Arguments.push_back("-L");
+    Arguments.push_back(context.Args.MakeArgString(path));
+  }
 
-  // If we need to use an .lnk file, linkFilePath will contain it.
+  // Link the standard library. In two paths, we do this using a .lnk file;
+  // if we're going that route, we'll set `linkFilePath` to the path to that
+  // file.
   SmallString<128> linkFilePath;
   getResourceDirPath(linkFilePath, context.Args, /*Shared=*/false);
 

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -108,28 +108,36 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   // driver rather than the `clang-cl` driver.
   Arguments.push_back("-nostartfiles");
 
-  SmallString<128> SharedRuntimeLibPath;
-  getRuntimeLibraryPath(SharedRuntimeLibPath, context.Args,
-                        /*Shared=*/true);
-
   // Link the standard library.
-  Arguments.push_back("-L");
   if (context.Args.hasFlag(options::OPT_static_stdlib,
                            options::OPT_no_static_stdlib, false)) {
-    SmallString<128> StaticRuntimeLibPath;
-    getRuntimeLibraryPath(StaticRuntimeLibPath, context.Args,
-                          /*Shared=*/false);
+    SmallVector<std::string, 4> StaticRuntimeLibPaths;
+    getRuntimeLibraryPaths(StaticRuntimeLibPaths, context.Args,
+                           context.OI.SDKPath, /*Shared=*/false);
 
-    // Since Windows has separate libraries per architecture, link against the
-    // architecture specific version of the static library.
-    Arguments.push_back(context.Args.MakeArgString(StaticRuntimeLibPath + "/" +
-                                                   getTriple().getArchName()));
+    for (auto path : StaticRuntimeLibPaths) {
+      Arguments.push_back("-L");
+      // Since Windows has separate libraries per architecture, link against the
+      // architecture specific version of the static library.
+      Arguments.push_back(context.Args.MakeArgString(path + "/" +
+                                                     getTriple().getArchName()));
+    }
   } else {
-    Arguments.push_back(context.Args.MakeArgString(SharedRuntimeLibPath + "/" +
-                                                   getTriple().getArchName()));
+    SmallVector<std::string, 4> SharedRuntimeLibPaths;
+    getRuntimeLibraryPaths(SharedRuntimeLibPaths, context.Args,
+                           context.OI.SDKPath, /*Shared=*/true);
+
+    for (auto path : SharedRuntimeLibPaths) {
+      Arguments.push_back("-L");
+      Arguments.push_back(context.Args.MakeArgString(path + "/" +
+                                                     getTriple().getArchName()));
+    }
   }
 
-  SmallString<128> swiftrtPath = SharedRuntimeLibPath;
+  SmallString<128> SharedResourceDirPath;
+  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
+
+  SmallString<128> swiftrtPath = SharedResourceDirPath;
   llvm::sys::path::append(swiftrtPath,
                           swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(swiftrtPath, "swiftrt.obj");
@@ -164,7 +172,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
-    SmallString<128> LibProfile(SharedRuntimeLibPath);
+    SmallString<128> LibProfile(SharedResourceDirPath);
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -291,11 +291,11 @@
 // LINUX_DYNLIB-x86_64-DAG: -shared
 // LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
 // LINUX_DYNLIB-x86_64-NOT: -pie
-// LINUX_DYNLIB-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)linux]]
-// LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)linux]]
 // LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]{{/|\\\\}}x86_64{{/|\\\\}}swiftrt.o
 // LINUX_DYNLIB-x86_64-DAG: [[OBJECTFILE]]
 // LINUX_DYNLIB-x86_64-DAG: @[[AUTOLINKFILE]]
+// LINUX_DYNLIB-x86_64-DAG: [[STDLIB_PATH]]
 // LINUX_DYNLIB-x86_64-DAG: -lswiftCore
 // LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64: -o dynlib.out

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -291,11 +291,11 @@
 // LINUX_DYNLIB-x86_64-DAG: -shared
 // LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
 // LINUX_DYNLIB-x86_64-NOT: -pie
-// LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)linux]]
+// LINUX_DYNLIB-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)linux]]
+// LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
 // LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]{{/|\\\\}}x86_64{{/|\\\\}}swiftrt.o
 // LINUX_DYNLIB-x86_64-DAG: [[OBJECTFILE]]
 // LINUX_DYNLIB-x86_64-DAG: @[[AUTOLINKFILE]]
-// LINUX_DYNLIB-x86_64-DAG: [[STDLIB_PATH]]
 // LINUX_DYNLIB-x86_64-DAG: -lswiftCore
 // LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64: -o dynlib.out

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -51,12 +51,12 @@
 // CHECK-F2-ENV: #
 // CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
 
-// RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s | %FileCheck -check-prefix=CHECK-COMPLEX %s
+// RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s | %FileCheck -check-prefix=CHECK-COMPLEX %s
 // CHECK-COMPLEX: -F /foo/
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #
 // CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
-// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:[^:]+\.sdk/usr/lib/swift($| )}}
+// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -28,7 +28,7 @@
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
 // RUN: env DYLD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2-ENV %s
-// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/abc/$}}
+// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:[^:]+\.sdk/usr/lib/swift:/abc/$}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
@@ -56,7 +56,7 @@
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #
 // CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
-// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx($| )}}
+// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:[^:]+\.sdk/usr/lib/swift($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -27,8 +27,8 @@
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2 %s
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
-// RUN: env DYLD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2-ENV %s
-// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:[^:]+\.sdk/usr/lib/swift:/abc/$}}
+// RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2-ENV %s
+// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -14,7 +14,9 @@
 // OSX-NEXT: bin{{/|\\\\}}swift
 // OSX: -sdk {{.*}}/Inputs/clang-importer-sdk
 // OSX: {{.*}}.o{{[ "]}}
-// OSX: {{-syslibroot|--sysroot}} {{.*}}/Inputs/clang-importer-sdk
+// OSX: {{-syslibroot|--sysroot}} {{[^ ]*}}/Inputs/clang-importer-sdk
+// OSX: -L {{[^ ]*}}/Inputs/clang-importer-sdk/usr/lib/swift
+// OSX: -rpath {{[^ ]*}}/Inputs/clang-importer-sdk/usr/lib/swift
 
 // LINUX-NOT: warning: no such SDK:
 // LINUX: bin{{/|\\\\}}swift


### PR DESCRIPTION
In #23175, we started looking in the SDK for swiftmodules, but we want to look for the libraries there too while linking. Fixes <rdar://problem/52059706>.

~~(This PR is not quite fully baked, but I want to kick off Linux tests while I read over the code and check a few details about how this should behave.)~~

This PR ought to be ready to go, but I could use confirmation that it's actually implementing the desired behavior.