### PR TITLE
Clean up some old DynamicSelfType debt now that we have an implementation of SE-0068

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -433,7 +433,7 @@ protected:
     HasSingleExpressionBody : 1
   );
 
-  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+2+1+1+1+2,
+  SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+2+1+1+2,
     /// Whether this function is a 'static' method.
     IsStatic : 1,
 
@@ -442,9 +442,6 @@ protected:
 
     /// Whether we are statically dispatched even if overridable
     ForcedStaticDispatch : 1,
-
-    /// Whether this function has a dynamic Self return type.
-    HasDynamicSelf : 1,
 
     /// Whether we've computed the 'self' access kind yet.
     SelfAccessComputed : 1,
@@ -5923,8 +5920,13 @@ public:
   /// True if the declaration is forced to be statically dispatched.
   bool hasForcedStaticDispatch() const;
 
-  /// Get the interface type of this decl and remove the Self context.
+  /// Get the type of this declaration without the Self clause.
+  /// Asserts if not in type context.
   Type getMethodInterfaceType() const;
+
+  /// Tests if this is a function returning a DynamicSelfType, or a
+  /// constructor.
+  bool hasDynamicSelfResult() const;
 
   using DeclContext::operator new;
   using Decl::getASTContext;
@@ -5973,7 +5975,6 @@ protected:
       StaticLoc.isValid() || StaticSpelling != StaticSpellingKind::None;
     Bits.FuncDecl.StaticSpelling = static_cast<unsigned>(StaticSpelling);
 
-    Bits.FuncDecl.HasDynamicSelf = false;
     Bits.FuncDecl.ForcedStaticDispatch = false;
     Bits.FuncDecl.SelfAccess =
       static_cast<unsigned>(SelfAccessKind::NonMutating);
@@ -6086,15 +6087,6 @@ public:
   /// This also allows the binary-operator-ness of a func decl to be determined
   /// prior to type checking.
   bool isBinaryOperator() const;
-  
-  /// Determine whether this function has a dynamic \c Self return
-  /// type.
-  bool hasDynamicSelf() const { return Bits.FuncDecl.HasDynamicSelf; }
-
-  /// Set whether this function has a dynamic \c Self return or not.
-  void setDynamicSelf(bool hasDynamicSelf) { 
-    Bits.FuncDecl.HasDynamicSelf = hasDynamicSelf;
-  }
 
   void getLocalCaptures(SmallVectorImpl<CapturedValue> &Result) const {
     return getCaptureInfo().getLocalCaptures(Result);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2581,6 +2581,8 @@ ERROR(dynamic_self_invalid,none,
       "did you mean '%0'?", (StringRef))
 ERROR(dynamic_self_in_mutable_property,none,
       "mutable property cannot have covariant 'Self' type", ())
+ERROR(dynamic_self_in_stored_property,none,
+      "stored property cannot have covariant 'Self' type", ())
 ERROR(dynamic_self_in_mutable_subscript,none,
       "mutable subscript cannot have covariant 'Self' type", ())
 ERROR(dynamic_self_invalid_property,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2579,6 +2579,14 @@ ERROR(dynamic_self_non_method,none,
 ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean '%0'?", (StringRef))
+ERROR(self_in_alias,none,
+      "'Self' is not available in a typealias", ())
+ERROR(self_in_mutable_property,none,
+      "'Self' is not available as the type of a mutable property", ())
+ERROR(self_in_mutable_subscript,none,
+      "'Self' is not available as the type of a mutable subscript", ())
+ERROR(self_in_parameter,none,
+      "'Self' cannot be the type of a (contravariant) function argument", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2587,6 +2587,8 @@ ERROR(self_in_mutable_subscript,none,
       "'Self' is not available as the type of a mutable subscript", ())
 ERROR(self_in_parameter,none,
       "'Self' cannot be the type of a (contravariant) function argument", ())
+ERROR(self_in_nested_return,none,
+      "'Self' cannot be the type of a nested return value", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2588,7 +2588,7 @@ ERROR(self_in_mutable_subscript,none,
 ERROR(self_in_parameter,none,
       "'Self' cannot be the type of a function argument in a class", ())
 ERROR(self_in_nested_return,none,
-      "'Self' cannot be the type of a nested return value", ())
+      "'Self' can only appear at the top level of a method result type", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2576,19 +2576,19 @@ NOTE(missing_member_type_conformance_prevents_synthesis, none,
 ERROR(dynamic_self_non_method,none,
       "%select{global|local}0 function cannot return 'Self'", (bool))
 
-ERROR(self_in_nominal,none,
-      "'Self' is only available in a protocol or as the result of a "
-      "method in a class; did you mean '%0'?", (StringRef))
-ERROR(self_in_alias,none,
-      "'Self' is not available in a typealias", ())
-ERROR(self_in_mutable_property,none,
-      "'Self' is not available as the type of a mutable property", ())
-ERROR(self_in_mutable_subscript,none,
-      "'Self' is not available as the type of a mutable subscript", ())
-ERROR(self_in_parameter,none,
-      "'Self' cannot be the type of a function argument in a class", ())
-ERROR(self_in_nested_return,none,
-      "'Self' can only appear at the top level of a method result type", ())
+ERROR(dynamic_self_invalid,none,
+      "covariant 'Self' can only appear as the type of a property, subscript or method result; "
+      "did you mean '%0'?", (StringRef))
+ERROR(dynamic_self_in_mutable_property,none,
+      "mutable property cannot have covariant 'Self' type", ())
+ERROR(dynamic_self_in_mutable_subscript,none,
+      "mutable subscript cannot have covariant 'Self' type", ())
+ERROR(dynamic_self_invalid_property,none,
+      "covariant 'Self' can only appear at the top level of property type", ())
+ERROR(dynamic_self_invalid_subscript,none,
+      "covariant 'Self' can only appear at the top level of subscript element type", ())
+ERROR(dynamic_self_invalid_method,none,
+      "covariant 'Self' can only appear at the top level of method result type", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2586,7 +2586,7 @@ ERROR(self_in_mutable_property,none,
 ERROR(self_in_mutable_subscript,none,
       "'Self' is not available as the type of a mutable subscript", ())
 ERROR(self_in_parameter,none,
-      "'Self' cannot be the type of a (contravariant) function argument", ())
+      "'Self' cannot be the type of a function argument in a class", ())
 ERROR(self_in_nested_return,none,
       "'Self' cannot be the type of a nested return value", ())
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 496; // changes for lazy storage request
+const uint16_t SWIFTMODULE_VERSION_MINOR = 497; // remove FuncDecl::hasDynamicSelf()
 
 using DeclIDField = BCFixed<31>;
 
@@ -1082,7 +1082,6 @@ namespace decls_block {
     StaticSpellingKindField, // spelling of 'static' or 'class'
     BCFixed<1>,   // isObjC?
     SelfAccessKindField,   // self access kind
-    BCFixed<1>,   // has dynamic self?
     BCFixed<1>,   // has forced static dispatch?
     BCFixed<1>,   // throws?
     GenericEnvironmentIDField, // generic environment
@@ -1124,7 +1123,6 @@ namespace decls_block {
     StaticSpellingKindField, // spelling of 'static' or 'class'
     BCFixed<1>,   // isObjC?
     SelfAccessKindField,   // self access kind
-    BCFixed<1>,   // has dynamic self?
     BCFixed<1>,   // has forced static dispatch?
     BCFixed<1>,   // throws?
     GenericEnvironmentIDField, // generic environment

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2412,10 +2412,15 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     isStatic = FD->isStatic();
     selfAccess = FD->getSelfAccessKind();
 
+    if (auto *AD = dyn_cast<AccessorDecl>(AFD)) {
+      if (wantDynamicSelf && AD->getStorage()
+          ->getValueInterfaceType()->hasDynamicSelfType())
+        isDynamicSelf = true;
+    }
     // Methods returning 'Self' have a dynamic 'self'.
     //
     // FIXME: All methods of non-final classes should have this.
-    if (wantDynamicSelf && FD->hasDynamicSelf())
+    else if (wantDynamicSelf && FD->hasDynamicSelf())
       isDynamicSelf = true;
   } else if (auto *CD = dyn_cast<ConstructorDecl>(AFD)) {
     if (isInitializingCtor) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2412,6 +2412,7 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     isStatic = FD->isStatic();
     selfAccess = FD->getSelfAccessKind();
 
+    // `self`s type for subscripts and properties
     if (auto *AD = dyn_cast<AccessorDecl>(AFD)) {
       if (wantDynamicSelf && AD->getStorage()
           ->getValueInterfaceType()->hasDynamicSelfType())

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2421,7 +2421,7 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     // Methods returning 'Self' have a dynamic 'self'.
     //
     // FIXME: All methods of non-final classes should have this.
-    else if (wantDynamicSelf && FD->hasDynamicSelf())
+    else if (wantDynamicSelf && FD->hasDynamicSelfResult())
       isDynamicSelf = true;
   } else if (auto *CD = dyn_cast<ConstructorDecl>(AFD)) {
     if (isInitializingCtor) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6174,6 +6174,12 @@ Type AbstractFunctionDecl::getMethodInterfaceType() const {
   return Ty->castTo<AnyFunctionType>()->getResult();
 }
 
+bool AbstractFunctionDecl::hasDynamicSelfResult() const {
+  if (auto *funcDecl = dyn_cast<FuncDecl>(this))
+    return funcDecl->getResultInterfaceType()->hasDynamicSelfType();
+  return isa<ConstructorDecl>(this);
+}
+
 bool AbstractFunctionDecl::argumentNameIsAPIByDefault() const {
   // Initializers have argument labels.
   if (isa<ConstructorDecl>(this))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1817,9 +1817,11 @@ getObjCObjectRepresentable(Type type, const DeclContext *dc) {
     return ForeignRepresentableKind::Bridged;
   }
 
-  // Look through DynamicSelfType.
+  // DynamicSelfType is always representable in Objective-C, even if
+  // the class is not @objc, allowing Self-returning methods to witness
+  // @objc protocol requirements.
   if (auto dynSelf = type->getAs<DynamicSelfType>())
-    type = dynSelf->getSelfType();
+    return ForeignRepresentableKind::Object;
 
   // @objc classes.
   if (auto classDecl = type->getClassOrBoundGenericClass()) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2340,8 +2340,6 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
     if (auto dyn = dyn_cast<DynamicSelfType>(t2
                                              ->getCanonicalType())) {
-//      dyn->dump();
-//      t1->dump();
       if (dyn->getSelfType()->isExactSuperclassOf(t1))
         return true;
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2337,9 +2337,17 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   }
 
   // Class-to-class.
-  if (matchMode.contains(TypeMatchFlags::AllowOverride))
-    if (t2->isExactSuperclassOf(t1))
+  if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
+    if (auto dyn = dyn_cast<DynamicSelfType>(t2
+                                             ->getCanonicalType())) {
+//      dyn->dump();
+//      t1->dump();
+      if (dyn->getSelfType()->isExactSuperclassOf(t1))
+        return true;
+    }
+    else if (t2->isExactSuperclassOf(t1))
       return true;
+  }
 
   if (matchMode.contains(TypeMatchFlags::AllowABICompatible))
     if (isABICompatibleEvenAddingOptional(t1, t2))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2983,6 +2983,9 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
   // If we don't have a substituted base type, fail.
   if (!substBase) return failed();
 
+  if (auto *selfType = substBase->getAs<DynamicSelfType>())
+    substBase = selfType->getSelfType();
+
   // Error recovery path.
   // FIXME: Generalized existentials will look here.
   if (substBase->isOpenedExistential())

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3587,9 +3587,14 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
     type = type->replaceSelfParameterType(this);
     if (afd->hasDynamicSelfResult())
       type = type->replaceCovariantResultType(this, /*uncurryLevel=*/2);
+  } else if (auto *sd = dyn_cast<SubscriptDecl>(baseDecl)) {
+    if (sd->getElementInterfaceType()->hasDynamicSelfType())
+      type = type->replaceCovariantResultType(this, /*uncurryLevel=*/1);
+  } else if (auto *vd = dyn_cast<VarDecl>(baseDecl)) {
+    if (vd->getValueInterfaceType()->hasDynamicSelfType())
+      type = type->replaceCovariantResultType(this, /*uncurryLevel=*/0);
   }
 
-  // FIXME: Properties and subscripts can also have dynamic self returns...
   return type;
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2337,15 +2337,9 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   }
 
   // Class-to-class.
-  if (matchMode.contains(TypeMatchFlags::AllowOverride)) {
-    if (auto dyn = dyn_cast<DynamicSelfType>(t2
-                                             ->getCanonicalType())) {
-      if (dyn->getSelfType()->isExactSuperclassOf(t1))
-        return true;
-    }
-    else if (t2->isExactSuperclassOf(t1))
+  if (matchMode.contains(TypeMatchFlags::AllowOverride))
+    if (t2->eraseDynamicSelfType()->isExactSuperclassOf(t1))
       return true;
-  }
 
   if (matchMode.contains(TypeMatchFlags::AllowABICompatible))
     if (isABICompatibleEvenAddingOptional(t1, t2))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4109,10 +4109,8 @@ namespace {
       // If the method has a related result type that is representable
       // in Swift as DynamicSelf, do so.
       if (!prop && decl->hasRelatedResultType()) {
-        result->setDynamicSelf(true);
         resultTy = DynamicSelfType::get(dc->getSelfInterfaceType(),
                                         Impl.SwiftContext);
-        assert(!dc->getSelfInterfaceType()->getOptionalObjectType());
         isIUO = false;
 
         OptionalTypeKind nullability = OTK_ImplicitlyUnwrappedOptional;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4109,8 +4109,9 @@ namespace {
       // If the method has a related result type that is representable
       // in Swift as DynamicSelf, do so.
       if (!prop && decl->hasRelatedResultType()) {
-        resultTy = DynamicSelfType::get(dc->getSelfInterfaceType(),
-                                        Impl.SwiftContext);
+        resultTy = dc->getSelfInterfaceType();
+        if (dc->getSelfClassDecl())
+          resultTy = DynamicSelfType::get(resultTy, Impl.SwiftContext);
         isIUO = false;
 
         OptionalTypeKind nullability = OTK_ImplicitlyUnwrappedOptional;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -571,7 +571,7 @@ private:
     // Constructors and methods returning DynamicSelf return
     // instancetype.
     if (isa<ConstructorDecl>(AFD) ||
-        (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelf())) {
+        (isa<FuncDecl>(AFD) && cast<FuncDecl>(AFD)->hasDynamicSelfResult())) {
       if (errorConvention && errorConvention->stripsResultOptionality()) {
         printNullability(OTK_Optional, NullabilityPrintKind::ContextSensitive);
       } else if (auto ctor = dyn_cast<ConstructorDecl>(AFD)) {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1930,6 +1930,14 @@ private:
       decl = type->getDecl();
     }
 
+    if (auto *proto = dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
+      if (type->isEqual(proto->getSelfInterfaceType())) {
+        printNullability(optionalKind, NullabilityPrintKind::ContextSensitive);
+        os << "instancetype";
+        return;
+      }
+    }
+
     assert(decl->getClangDecl() && "can only handle imported ObjC generics");
     os << cast<clang::ObjCTypeParamDecl>(decl->getClangDecl())->getName();
     printNullability(optionalKind);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2843,7 +2843,7 @@ public:
 
     // If the method returns Self, substitute AnyObject for the result type.
     if (auto fnDecl = dyn_cast<FuncDecl>(method.getDecl())) {
-      if (fnDecl->hasDynamicSelf()) {
+      if (fnDecl->hasDynamicSelfResult()) {
         auto anyObjectTy = C.getAnyObjectType();
         for (auto &dynResult : dynResults) {
           auto newResultTy

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -110,7 +110,7 @@ getPartialApplyOfDynamicMethodFormalType(SILGenModule &SGM, SILDeclRef member,
   // Adjust the result type to replace dynamic-self with AnyObject.
   CanType resultType = completeMethodTy.getResult();
   if (auto fnDecl = dyn_cast<FuncDecl>(member.getDecl())) {
-    if (fnDecl->hasDynamicSelf()) {
+    if (fnDecl->hasDynamicSelfResult()) {
       auto anyObjectTy = SGM.getASTContext().getAnyObjectType();
       resultType = resultType->replaceCovariantResultType(anyObjectTy, 0)
                              ->getCanonicalType();

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -452,11 +452,8 @@ ManagedValue Transform::transform(ManagedValue v,
 
   // A base class method returning Self can be used in place of a derived
   // class method returning Self.
-  if (auto outputSelfType = dyn_cast<DynamicSelfType>(outputSubstType)) {
-    if (auto inputSelfType = dyn_cast<DynamicSelfType>(inputSubstType)) {
-      inputSubstType = inputSelfType.getSelfType();
-      outputSubstType = outputSelfType.getSelfType();
-    }
+  if (auto inputSelfType = dyn_cast<DynamicSelfType>(inputSubstType)) {
+    inputSubstType = inputSelfType.getSelfType();
   }
 
   //  - upcasts for classes

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -822,13 +822,11 @@ namespace {
             }
           }
         }
-        else if (auto decl = dyn_cast<VarDecl>(member)) {
-          if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
-                                                   ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(containerTy, 1);
-            if (!baseTy->isEqual(containerTy)) {
-              dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
-            }
+        else if (isa<DynamicSelfType>(member->getInterfaceType()
+                                      ->getCanonicalType())) {
+          refTy = refTy->replaceCovariantResultType(containerTy, 1);
+          if (!baseTy->isEqual(containerTy)) {
+            dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
           }
         }
       }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -822,6 +822,14 @@ namespace {
             }
           }
         }
+//        member->dump();
+        if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
+          printf("HEREE2!!!!!!!!!!!!!!!!\n");
+          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+                                                   ->getCanonicalType())) {
+            refTy = refTy->replaceCovariantResultType(baseTy, 2);
+          }
+        }
       }
 
       // References to properties with accessors and storage usually go

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -812,17 +812,14 @@ namespace {
       Type dynamicSelfFnType;
       if (!member->getDeclContext()->getSelfProtocolDecl()) {
         if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
-          if ((isa<FuncDecl>(func) &&
-               cast<FuncDecl>(func)->hasDynamicSelf()) ||
-              (isa<ConstructorDecl>(func) &&
-               containerTy->getClassOrBoundGenericClass())) {
+          if (func->hasDynamicSelfResult() &&
+              !baseTy->getOptionalObjectType()) {
             refTy = refTy->replaceCovariantResultType(containerTy, 2);
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(baseTy, 2);
             }
           }
-        }
-        else if (auto *decl = dyn_cast<VarDecl>(member)) {
+        } else if (auto *decl = dyn_cast<VarDecl>(member)) {
           if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
             refTy = refTy->replaceCovariantResultType(containerTy, 1);
             if (!baseTy->isEqual(containerTy)) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -834,8 +834,8 @@ namespace {
           if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
                                                    ->getCanonicalType())) {
             refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
-            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
-            dyn.dump();
+//            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
+//            dyn.dump();
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
             }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -822,20 +822,10 @@ namespace {
             }
           }
         }
-//        member->dump();
-//        else if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
-//          fprintf(stderr, "HEREE2!!!!!!!!!!!!!!!!\n");
-//          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
-//                                                   ->getCanonicalType())) {
-//            refTy = refTy->replaceCovariantResultType(dyn, 2);
-//          }
-//        }
-        else if (auto *sub = dyn_cast<VarDecl>(member)) {
-          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
+        else if (auto decl = dyn_cast<VarDecl>(member)) {
+          if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
                                                    ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
-//            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
-//            dyn.dump();
+            refTy = refTy->replaceCovariantResultType(containerTy, 1);
             if (!baseTy->isEqual(containerTy)) {
               dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
             }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -823,11 +823,22 @@ namespace {
           }
         }
 //        member->dump();
-        if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
-          printf("HEREE2!!!!!!!!!!!!!!!!\n");
-          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//        else if (auto *sub = dyn_cast<SubscriptDecl>(member)) {
+//          fprintf(stderr, "HEREE2!!!!!!!!!!!!!!!!\n");
+//          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//                                                   ->getCanonicalType())) {
+//            refTy = refTy->replaceCovariantResultType(dyn, 2);
+//          }
+//        }
+        else if (auto *sub = dyn_cast<VarDecl>(member)) {
+          if (auto dyn = dyn_cast<DynamicSelfType>(sub->getValueInterfaceType()
                                                    ->getCanonicalType())) {
-            refTy = refTy->replaceCovariantResultType(baseTy, 2);
+            refTy = refTy->replaceCovariantResultType(containerTy/*or dyn or baseTy or containerTy*/, 1);
+            fprintf(stderr, "HEREE22!!!!!!!!!!!!!!!!\n");
+            dyn.dump();
+            if (!baseTy->isEqual(containerTy)) {
+              dynamicSelfFnType = refTy->replaceCovariantResultType(containerTy, 1);
+            }
           }
         }
       }
@@ -938,7 +949,6 @@ namespace {
 
       // For properties, build member references.
       if (isa<VarDecl>(member)) {
-        assert(!dynamicSelfFnType && "Converted type doesn't make sense here");
         if (!baseIsInstance && member->isInstanceMember()) {
           assert(memberLocator.getBaseLocator() && 
                  cs.UnevaluatedRootExprs.count(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -908,7 +908,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
     // If this is a method whose result type is dynamic Self, replace
     // DynamicSelf with the actual object type.
     if (!func->getDeclContext()->getSelfProtocolDecl()) {
-      if (func->hasDynamicSelf()) {
+      if (func->getResultInterfaceType()->hasDynamicSelfType()) {
         auto params = openedType->getParams();
         assert(params.size() == 1);
         Type selfTy = params.front().getPlainType()->getMetatypeInstanceType();
@@ -1299,17 +1299,15 @@ ConstraintSystem::getTypeOfMemberReference(
     // Class methods returning Self as well as constructors get the
     // result replaced with the base object type.
     if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
-      if ((isa<FuncDecl>(func) && cast<FuncDecl>(func)->hasDynamicSelf()) ||
-          (isa<ConstructorDecl>(func) && !baseObjTy->getOptionalObjectType())) {
+      if (func->hasDynamicSelfResult() &&
+          !baseObjTy->getOptionalObjectType()) {
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
-    }
-    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
+    } else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
       if (decl->getElementInterfaceType()->hasDynamicSelfType()) {
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
-    }
-    else if (auto *decl = dyn_cast<VarDecl>(value)) {
+    } else if (auto *decl = dyn_cast<VarDecl>(value)) {
       if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
         openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
       }
@@ -1487,16 +1485,17 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
       // Cope with 'Self' returns.
       if (!decl->getDeclContext()->getSelfProtocolDecl()) {
-        if ((isa<FuncDecl>(decl) && cast<FuncDecl>(decl)->hasDynamicSelf()) ||
-            (isa<ConstructorDecl>(decl) &&
-             !overload.getBaseType()->getOptionalObjectType())) {
+        if (isa<AbstractFunctionDecl>(decl) &&
+            cast<AbstractFunctionDecl>(decl)->hasDynamicSelfResult()) {
           if (!overload.getBaseType())
             return Type();
 
-          Type selfType = overload.getBaseType()->getRValueType()
-              ->getMetatypeInstanceType()
-              ->lookThroughAllOptionalTypes();
-          type = type->replaceCovariantResultType(selfType, 2);
+          if (!overload.getBaseType()->getOptionalObjectType()) {
+            Type selfType = overload.getBaseType()->getRValueType()
+                ->getMetatypeInstanceType()
+                ->lookThroughAllOptionalTypes();
+            type = type->replaceCovariantResultType(selfType, 2);
+          }
         }
       }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2236,8 +2236,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
       if (auto selfType = lookupBaseType->getAs<DynamicSelfType>())
         lookupBaseType = selfType->getSelfType();
 
-      if (lookupBaseType->mayHaveMembers() ||
-          lookupBaseType->is<DynamicSelfType>()) {
+      if (lookupBaseType->mayHaveMembers()) {
         auto *proto = assocType->getProtocol();
         auto conformance = cs.DC->getParentModule()->lookupConformance(
           lookupBaseType, proto);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1304,11 +1304,9 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (auto decl = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
-                                               ->getCanonicalType())) {
-        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
-      }
+    else if (isa<DynamicSelfType>(value->getInterfaceType()
+                                  ->getCanonicalType())) {
+      openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
     }
   } else {
     // Protocol requirements returning Self have a dynamic Self return

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1304,23 +1304,20 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (auto *sub = dyn_cast<SubscriptDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+//    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
+//      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getElementInterfaceType()
+//                                               ->getCanonicalType())) {
+//        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
+//        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
+//        baseObjTy->dump();
+////        outerDC->dumpContext();
+//      }
+//    }
+    else if (auto *decl = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getInterfaceType()
                                                ->getCanonicalType())) {
-        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
-//        openedType->dump();
-//        outerDC->dumpContext();
-      }
-    }
-    else if (auto *sub = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getInterfaceType()
-                                               ->getCanonicalType())) {
-        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
-        dyn.dump();
+//        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
-//        openedType->dump();
-//        outerDC->dumpContext();
       }
     }
   } else {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1460,12 +1460,10 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
       if (doesStorageProduceLValue(subscript, overload.getBaseType(), useDC))
         elementTy = LValueType::get(elementTy);
-      else {
+      else if (elementTy->hasDynamicSelfType()) {
         Type selfType = overload.getBaseType()->getRValueType()
-            ->getMetatypeInstanceType()
-            ->lookThroughAllOptionalTypes();
-        if (elementTy->hasDynamicSelfType())
-          elementTy = elementTy->replaceCovariantResultType(selfType, 0);
+            ->getMetatypeInstanceType()->lookThroughAllOptionalTypes();
+        elementTy = elementTy->replaceCovariantResultType(selfType, 0);
       }
 
       // See ConstraintSystem::resolveOverload() -- optional and dynamic

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1308,7 +1308,17 @@ ConstraintSystem::getTypeOfMemberReference(
       if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
                                                ->getCanonicalType())) {
         fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
+//        openedType->dump();
+//        outerDC->dumpContext();
+      }
+    }
+    else if (auto *sub = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getInterfaceType()
+                                               ->getCanonicalType())) {
+        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
+        dyn.dump();
+        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
 //        openedType->dump();
 //        outerDC->dumpContext();
       }
@@ -1365,6 +1375,7 @@ ConstraintSystem::getTypeOfMemberReference(
     // For a static member referenced through a metatype or an instance
     // member referenced through an instance, strip off the 'self'.
     type = openedFnType->getResult();
+//    type->dump();
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1301,12 +1301,21 @@ ConstraintSystem::getTypeOfMemberReference(
     if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
       if ((isa<FuncDecl>(func) && cast<FuncDecl>(func)->hasDynamicSelf()) ||
           (isa<ConstructorDecl>(func) && !baseObjTy->getOptionalObjectType())) {
+        fprintf(stderr, "getTypeOfMemberReference AbstractFunctionDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-    else if (isa<DynamicSelfType>(value->getInterfaceType()
-                                  ->getCanonicalType())) {
-      openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
+    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
+      if (decl->getElementInterfaceType()->hasDynamicSelfType()) {
+        fprintf(stderr, "getTypeOfMemberReference SubscriptDecl !!!!!!!\n");
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+      }
+    }
+    else if (auto *decl = dyn_cast<VarDecl>(value)) {
+      if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
+        fprintf(stderr, "getTypeOfMemberReference VarDecl !!!!!!!\n");
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
+      }
     }
   } else {
     // Protocol requirements returning Self have a dynamic Self return

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1304,20 +1304,10 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
-//    else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
-//      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getElementInterfaceType()
-//                                               ->getCanonicalType())) {
-//        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
-//        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 2);
-//        baseObjTy->dump();
-////        outerDC->dumpContext();
-//      }
-//    }
-    else if (auto *decl = dyn_cast<VarDecl>(value)) {
-      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getInterfaceType()
+    else if (auto decl = dyn_cast<VarDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(decl->getValueInterfaceType()
                                                ->getCanonicalType())) {
-//        fprintf(stderr, "HEREEE!!!!!!!!!!!!!!!!\n");
-        openedType = openedType->replaceCovariantResultType(baseObjTy/*not dyn*/, 1);
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
       }
     }
   } else {
@@ -1372,7 +1362,6 @@ ConstraintSystem::getTypeOfMemberReference(
     // For a static member referenced through a metatype or an instance
     // member referenced through an instance, strip off the 'self'.
     type = openedFnType->getResult();
-//    type->dump();
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1301,19 +1301,16 @@ ConstraintSystem::getTypeOfMemberReference(
     if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
       if ((isa<FuncDecl>(func) && cast<FuncDecl>(func)->hasDynamicSelf()) ||
           (isa<ConstructorDecl>(func) && !baseObjTy->getOptionalObjectType())) {
-        fprintf(stderr, "getTypeOfMemberReference AbstractFunctionDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
     else if (auto *decl = dyn_cast<SubscriptDecl>(value)) {
       if (decl->getElementInterfaceType()->hasDynamicSelfType()) {
-        fprintf(stderr, "getTypeOfMemberReference SubscriptDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
     else if (auto *decl = dyn_cast<VarDecl>(value)) {
       if (decl->getValueInterfaceType()->hasDynamicSelfType()) {
-        fprintf(stderr, "getTypeOfMemberReference VarDecl !!!!!!!\n");
         openedType = openedType->replaceCovariantResultType(baseObjTy, 1);
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1304,6 +1304,15 @@ ConstraintSystem::getTypeOfMemberReference(
         openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
       }
     }
+    else if (auto *sub = dyn_cast<SubscriptDecl>(value)) {
+      if (auto dyn = dyn_cast<DynamicSelfType>(sub->getElementInterfaceType()
+                                               ->getCanonicalType())) {
+        fprintf(stderr, "HEREE!!!!!!!!!!!!!!!! %d\n", isDynamicResult);
+        openedType = openedType->replaceCovariantResultType(baseObjTy, 2);
+//        openedType->dump();
+//        outerDC->dumpContext();
+      }
+    }
   } else {
     // Protocol requirements returning Self have a dynamic Self return
     // type. Erase the dynamic Self since it only comes into play during

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1460,6 +1460,13 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
 
       if (doesStorageProduceLValue(subscript, overload.getBaseType(), useDC))
         elementTy = LValueType::get(elementTy);
+      else {
+        Type selfType = overload.getBaseType()->getRValueType()
+            ->getMetatypeInstanceType()
+            ->lookThroughAllOptionalTypes();
+        if (elementTy->hasDynamicSelfType())
+          elementTy = elementTy->replaceCovariantResultType(selfType, 0);
+      }
 
       // See ConstraintSystem::resolveOverload() -- optional and dynamic
       // subscripts are a special case, because the optionality is

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4177,15 +4177,13 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   // Handle contextual type, result type, and returnsSelf.
   Type contextType = afd->getDeclContext()->getDeclaredInterfaceType();
   Type resultType;
-  bool returnsSelf = false;
+  bool returnsSelf = afd->hasDynamicSelfResult();
 
   if (auto func = dyn_cast<FuncDecl>(afd)) {
     resultType = func->getResultInterfaceType();
     resultType = func->mapTypeIntoContext(resultType);
-    returnsSelf = func->hasDynamicSelf();
   } else if (isa<ConstructorDecl>(afd)) {
     resultType = contextType;
-    returnsSelf = true;
   }
 
   // Figure out the first parameter name.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3716,8 +3716,7 @@ bool checkDynamicSelfReturn(FuncDecl *func) {
     return false;
 
   // 'Self' on a free function is not dynamic 'Self'.
-  if (!func->getDeclContext()->getSelfClassDecl() &&
-      !isa<ProtocolDecl>(func->getDeclContext()))
+  if (!func->getDeclContext()->getSelfClassDecl())
     return false;
 
   // 'Self' on a property accessor is not dynamic 'Self'...even on a read-only

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2376,9 +2376,11 @@ public:
     if (VD->getDeclContext()->getSelfClassDecl()) {
       checkDynamicSelfType(VD, VD->getValueInterfaceType());
 
-      if (VD->getValueInterfaceType()->hasDynamicSelfType() &&
-          VD->isSettable(nullptr)) {
-        VD->diagnose(diag::dynamic_self_in_mutable_property);
+      if (VD->getValueInterfaceType()->hasDynamicSelfType()) {
+        if (VD->hasStorage())
+          VD->diagnose(diag::dynamic_self_in_stored_property);
+        else if (VD->isSettable(nullptr))
+          VD->diagnose(diag::dynamic_self_in_mutable_property);
       }
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3180,6 +3180,15 @@ public:
     TC.checkParameterAttributes(FD->getParameters());
 
     checkExplicitAvailability(FD);
+=
+    for (auto *Param : *FD->getParameters()) {
+      auto TL = Param->getTypeLoc();
+      auto Loc = TL.hasLocation() ? TL.getLoc() : Param->getLoc();
+      if (Param->getInterfaceType()->hasDynamicSelfType())
+        TC.diagnose(Loc, diag::self_in_parameter);
+      else
+        diagnoseSelfTypedParameters(Param->getInterfaceType(), Loc);
+    }
   }
 
   void visitModuleDecl(ModuleDecl *) { }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3194,7 +3194,7 @@ public:
     TC.checkParameterAttributes(FD->getParameters());
 
     checkExplicitAvailability(FD);
-=
+
     if (isDeclaredInClass(FD)) {
       for (auto *Param : *FD->getParameters()) {
         TypeLoc TyLoc = Param->getTypeLoc();

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -590,7 +590,6 @@ bool swift::isRepresentableInObjC(
     if (!ResultType->hasError() &&
         !ResultType->isVoid() &&
         !ResultType->isUninhabited() &&
-        !ResultType->hasDynamicSelfType() &&
         !ResultType->isRepresentableIn(ForeignLanguage::ObjectiveC,
                                        const_cast<FuncDecl *>(FD))) {
       if (Diagnose) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -567,15 +567,12 @@ void TypeChecker::validateGenericFuncOrSubscriptSignature(
       decl->getDeclContext()->getGenericSignatureOfContext();
 
   auto params = func ? func->getParameters() : subscr->getIndices();
-  bool hasDynamicSelf = false;
   TypeLoc emptyLoc;
   TypeLoc &resultTyLoc = [&]() -> TypeLoc& {
     if (subscr)
       return subscr->getElementTypeLoc();
-    if (auto fn = dyn_cast<FuncDecl>(func)) {
-      hasDynamicSelf = fn->hasDynamicSelf();
+    if (auto fn = dyn_cast<FuncDecl>(func))
       return fn->getBodyResultTypeLoc();
-    }
     return emptyLoc;
   }();
 
@@ -605,9 +602,8 @@ void TypeChecker::validateGenericFuncOrSubscriptSignature(
     if (!resultTyLoc.isNull() &&
         !(resultTyLoc.getTypeRepr() &&
           isa<OpaqueReturnTypeRepr>(resultTyLoc.getTypeRepr())))
-      validateType(resultTyLoc, resolution, hasDynamicSelf
-                     ? TypeResolverContext::DynamicSelfResult
-                     : TypeResolverContext::FunctionResult);
+      validateType(resultTyLoc, resolution,
+                   TypeResolverContext::FunctionResult);
 
     // Infer requirements from it.
     if (resultTyLoc.getTypeRepr()) {
@@ -658,9 +654,8 @@ void TypeChecker::validateGenericFuncOrSubscriptSignature(
       resultTyLoc.setType(
           getOrCreateOpaqueResultType(resolution, decl, opaqueTy));
     } else {
-      validateType(resultTyLoc, resolution, hasDynamicSelf
-                   ? TypeResolverContext::DynamicSelfResult
-                   : TypeResolverContext::FunctionResult);
+      validateType(resultTyLoc, resolution,
+                   TypeResolverContext::FunctionResult);
     }
   }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -555,7 +555,9 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       auto typeDecl =
         concrete->getTypeWitnessAndDecl(assocType, lazyResolver).second;
 
-      assert(typeDecl && "Missing type witness?");
+      // Circularity.
+      if (!typeDecl)
+        continue;
 
       auto memberType =
           substMemberTypeWithBase(dc->getParentModule(), typeDecl, type);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2847,7 +2847,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
     // If the function has a dynamic Self, it's okay.
     if (auto func = dyn_cast<FuncDecl>(witness)) {
       if (func->getDeclContext()->getSelfClassDecl() &&
-          !func->hasDynamicSelf()) {
+          !func->hasDynamicSelfResult()) {
         diagnoseOrDefer(requirement, false,
           [witness, requirement](NormalProtocolConformance *conformance) {
             auto proto = conformance->getProtocol();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4113,18 +4113,17 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     recordDependency();
   }
 
+  if (options.contains(ConformanceCheckFlags::SkipConditionalRequirements))
+    return lookupResult;
+
   auto condReqs = lookupResult->getConditionalRequirementsIfAvailable();
+  assert(condReqs &&
+         "unhandled recursion: missing conditional requirements when they're "
+         "required");
+
   // If we have a conditional requirements that
   // we need to check, do so now.
-  if (!condReqs) {
-    assert(
-        options.contains(
-            ConformanceCheckFlags::AllowUnavailableConditionalRequirements) &&
-        "unhandled recursion: missing conditional requirements when they're "
-        "required");
-  } else if (!condReqs->empty() &&
-             !options.contains(
-                 ConformanceCheckFlags::SkipConditionalRequirements)) {
+  if (!condReqs->empty()) {
     // Figure out the location of the conditional conformance.
     auto conformanceDC = lookupResult->getConcrete()->getDeclContext();
     SourceLoc noteLoc;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -937,7 +937,7 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
           parentTy, protocol, dc,
           (ConformanceCheckFlags::InExpression |
            ConformanceCheckFlags::SuppressDependencyTracking |
-           ConformanceCheckFlags::AllowUnavailableConditionalRequirements))) {
+           ConformanceCheckFlags::SkipConditionalRequirements))) {
     if (conformanceRef->isConcrete())
       conformance = conformanceRef->getConcrete();
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1051,6 +1051,8 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 //
 // SE-0068 is "Expanding Swift Self to class members and value types"
 // Returns a Type if 'Self' is available in the current implementation.
+// Errs on the side of returning `Self` in most circumstances which is
+// subsequently validated in the various vistors in TypeCheckDecl.cpp.
 //
 // https://github.com/apple/swift-evolution/blob/master/proposals/0068-universal-self.md
 //

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1132,12 +1132,11 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     }
 
     // Try ignoring access control.
-    DeclContext *lookupDC = dc;
     NameLookupOptions relookupOptions = lookupOptions;
     relookupOptions |= NameLookupFlags::KnownPrivate;
     relookupOptions |= NameLookupFlags::IgnoreAccessControl;
     auto inaccessibleResults =
-    TypeChecker::lookupUnqualifiedType(lookupDC, comp->getIdentifier(),
+    TypeChecker::lookupUnqualifiedType(dc, comp->getIdentifier(),
                                        comp->getIdLoc(), relookupOptions);
     if (!inaccessibleResults.empty()) {
       // FIXME: What if the unviable candidates have different levels of access?
@@ -1283,7 +1282,6 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   // Resolve the first component, which is the only one that requires
   // unqualified name lookup.
   auto DC = resolution.getDeclContext();
-  DeclContext *lookupDC = DC;
 
   // Dynamic 'Self' in the result type of a function body.
   if (options.getBaseContext() == TypeResolverContext::DynamicSelfResult &&
@@ -1305,7 +1303,7 @@ resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
   if (options.contains(TypeResolutionFlags::KnownNonCascadingDependency))
     lookupOptions |= NameLookupFlags::KnownPrivate;
-  auto globals = TypeChecker::lookupUnqualifiedType(lookupDC,
+  auto globals = TypeChecker::lookupUnqualifiedType(DC,
                                                     id,
                                                     comp->getIdLoc(),
                                                     lookupOptions);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1072,6 +1072,13 @@ static Type SelfAllowedBySE0068(TypeResolution resolution,
     bool isTypeAliasInClass = insideClass &&
       options.is(TypeResolverContext::TypeAliasDecl);
 
+    if (isMutablePropertyOrSubscriptOfClass) {
+      if (auto prop = dyn_cast_or_null<ValueDecl>
+          (dc->getInnermostDeclarationDeclContext()))
+        if (!prop->isSettable(dc))
+          isMutablePropertyOrSubscriptOfClass = false;
+    }
+
     if (((!insideClass || !declaringMethod) &&
          !isMutablePropertyOrSubscriptOfClass && !isTypeAliasInClass &&
          !options.is(TypeResolverContext::GenericRequirement)) ||

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1050,6 +1050,8 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 
 //
 // SE-0068 is "Expanding Swift Self to class members and value types"
+// Returns a Type if 'Self' is available in the current implementation.
+//
 // https://github.com/apple/swift-evolution/blob/master/proposals/0068-universal-self.md
 //
 static Type SelfAllowedBySE0068(TypeResolution resolution,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1064,29 +1064,9 @@ static Type SelfAllowedBySE0068(TypeResolution resolution,
       (nominal = nominalDC->getSelfNominalTypeDecl())) {
     assert(!isa<ProtocolDecl>(nominal) && "Cannot be a protocol");
 
-    bool insideClass = nominalDC->getSelfClassDecl() != nullptr;
-    AbstractFunctionDecl *methodDecl = dc->getInnermostMethodContext();
-    bool declaringMethod = methodDecl &&
-      methodDecl->getDeclContext() == dc->getParentForLookup();
-    bool isMutablePropertyOrSubscriptOfClass = insideClass &&
-      (options.is(TypeResolverContext::PatternBindingDecl) ||
-       options.is(TypeResolverContext::FunctionResult));
-    bool isTypeAliasInClass = insideClass &&
-      options.is(TypeResolverContext::TypeAliasDecl);
-
-    if (isMutablePropertyOrSubscriptOfClass) {
-      if (auto prop = dyn_cast_or_null<ValueDecl>
-          (dc->getInnermostDeclarationDeclContext()))
-        if (!prop->isSettable(dc))
-          isMutablePropertyOrSubscriptOfClass = false;
-    }
-
-    if (((!insideClass || !declaringMethod) &&
-         !isMutablePropertyOrSubscriptOfClass && !isTypeAliasInClass &&
-         !options.is(TypeResolverContext::GenericRequirement)) ||
-        options.is(TypeResolverContext::ExplicitCastExpr)) {
+    if (!options.is(TypeResolverContext::GenericRequirement)) {
       Type SelfType = nominal->getSelfInterfaceType();
-      if (insideClass)
+      if (nominalDC->getSelfClassDecl() != nullptr)
         SelfType = DynamicSelfType::get(SelfType, ctx);
       return resolution.mapTypeIntoContext(SelfType);
     }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -94,10 +94,6 @@ enum class TypeResolverContext : uint8_t {
   /// tuple return values. See also: TypeResolutionFlags::Direct
   FunctionResult,
 
-  /// Whether we are in the result type of a function body that is
-  /// known to produce dynamic Self.
-  DynamicSelfResult,
-
   /// Whether we are in a protocol's where clause
   ProtocolWhereClause,
 
@@ -211,7 +207,6 @@ public:
     case Context::FunctionInput:
     case Context::VariadicFunctionInput:
     case Context::FunctionResult:
-    case Context::DynamicSelfResult:
     case Context::ProtocolWhereClause:
     case Context::ExtensionBinding:
     case Context::SubscriptDecl:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -502,13 +502,6 @@ enum class ConformanceCheckFlags {
   /// correctly used. Otherwise (the default), all of the conditional
   /// requirements will be checked.
   SkipConditionalRequirements = 0x04,
-
-  /// Whether to require that the conditional requirements have been computed.
-  ///
-  /// When set, if the conditional requirements aren't available, they are just
-  /// skipped, and the caller is responsible for detecting and handling this
-  /// case (likely via another call to getConditionalRequirementsIfAvailable).
-  AllowUnavailableConditionalRequirements = 0x08,
 };
 
 /// Options that control protocol conformance checking.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2921,7 +2921,7 @@ public:
     bool isStatic;
     uint8_t rawStaticSpelling, rawAccessLevel, rawMutModifier;
     uint8_t rawAccessorKind;
-    bool isObjC, hasDynamicSelf, hasForcedStaticDispatch, throws;
+    bool isObjC, hasForcedStaticDispatch, throws;
     unsigned numNameComponentsBiased;
     GenericEnvironmentID genericEnvID;
     TypeID resultInterfaceTypeID;
@@ -2935,7 +2935,7 @@ public:
     if (!isAccessor) {
       decls_block::FuncLayout::readRecord(scratch, contextID, isImplicit,
                                           isStatic, rawStaticSpelling, isObjC,
-                                          rawMutModifier, hasDynamicSelf,
+                                          rawMutModifier,
                                           hasForcedStaticDispatch, throws,
                                           genericEnvID,
                                           resultInterfaceTypeID,
@@ -2948,7 +2948,7 @@ public:
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
                                           isStatic, rawStaticSpelling, isObjC,
-                                          rawMutModifier, hasDynamicSelf,
+                                          rawMutModifier,
                                           hasForcedStaticDispatch, throws,
                                           genericEnvID,
                                           resultInterfaceTypeID,
@@ -3131,7 +3131,6 @@ public:
     if (isImplicit)
       fn->setImplicit();
     fn->setIsObjC(isObjC);
-    fn->setDynamicSelf(hasDynamicSelf);
     fn->setForcedStaticDispatch(hasForcedStaticDispatch);
     fn->setNeedsNewVTableEntry(needsNewVTableEntry);
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3426,7 +3426,6 @@ public:
                            fn->isObjC(),
                            uint8_t(
                              getStableSelfAccessKind(fn->getSelfAccessKind())),
-                           fn->hasDynamicSelf(),
                            fn->hasForcedStaticDispatch(),
                            fn->hasThrows(),
                            S.addGenericEnvironmentRef(
@@ -3503,7 +3502,6 @@ public:
                                fn->isObjC(),
                                uint8_t(getStableSelfAccessKind(
                                                   fn->getSelfAccessKind())),
-                               fn->hasDynamicSelf(),
                                fn->hasForcedStaticDispatch(),
                                fn->hasThrows(),
                                S.addGenericEnvironmentRef(

--- a/test/Interpreter/dynamic_self.swift
+++ b/test/Interpreter/dynamic_self.swift
@@ -237,7 +237,6 @@ print(B1(i: 100).copied.i)
 class A0<T, S> {
   var i = "Base"
   required init() {}
-  var foo: (Self) -> () { return { (a: Self) in } }
 
   func copy() -> Self {
     let copy = Self.init()

--- a/test/Interpreter/dynamic_self.swift
+++ b/test/Interpreter/dynamic_self.swift
@@ -186,5 +186,104 @@ print((Derived() as Base).returnsNewInstance())
 print((Derived() as Base).returnsNewInstanceTransparent())
 print((Derived() as Base).returnsNewInstanceTransparentProtocol())
 
+
+// Read-only properties and subscripts returning Self
+
+open class A1<T> {
+  let i: Int
+  public required init(i: Int) {
+    self.i = i
+  }
+  func copy() -> Self {
+    let copy = Self.init(i: 81)
+    return copy
+  }
+
+  open var copied: Self {
+    let copy = Self.init(i: 82)
+    return copy
+  }
+  open subscript (i: Int) -> Self {
+    return Self.init(i: 80+i)
+  }
+}
+
+class B1: A1<Int> {
+  let j = 88
+  override func copy() -> Self {
+    let copy = super.copy() as! Self // supported
+    return copy
+  }
+  override var copied: Self {
+    let copy = Self.init(i: 99)
+    return copy
+  }
+  //  override subscript (i: Int) -> Self {
+  //    return Self.init(i: i+1000)
+  //  }
+}
+
+// CHECK: 181
+// CHECK: 88
+// CHECK: 88
+// CHECK: 82
+// CHECK: 99
+print(A1<Int>(i: 100)[101].i)
+print(B1(i: 100)[101].j)
+print(B1(i: 100).copy().j)
+print(A1<Int>(i: 100).copied.i)
+print(B1(i: 100).copied.i)
+
+class A0<T, S> {
+  var i = "Base"
+  required init() {}
+  var foo: (Self) -> () { return { (a: Self) in } }
+
+  func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+
+  var copied: Self {
+    get {
+      let copy = Self.init()
+      return copy
+    }
+  }
+  open subscript (i: Int) -> Self {
+    get {
+      return Self.init()
+    }
+  }
+}
+
+protocol Prot3 {
+  static func +(x: Self, y: Self) -> String
+}
+
+class B: A0<Int, Double>, Prot3 {
+  var j = "Derived"
+  static func + (x: B, y: B) -> String {
+    return x.j + x.j
+  }
+  override func copy() -> Self {
+    let copy = Self.init()
+    return copy
+  }
+  override var copied: Self {
+    get {
+      return copy() as! Self
+    }
+  }
+  //  override subscript (i: Int) -> Self {
+  //    return Self.init()
+  //  }
+}
+
+// CHECK: DerivedDerived
+// CHECK: DerivedDerived
+print(B()[0][0].j + B().copied.copied.j)
+print(B()[0][0] + B().copied.copied)
+
 // CHECK-NEXT: Done
 print("Done")

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -130,7 +130,7 @@ func methodCalls(
   // CHECK: [[PAYLOAD:%.*]] = open_existential_ref [[ARG0]] : $Base<Int> & P to $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[SELF_BOX:%.*]] = alloc_stack $@opened("{{.*}}") Base<Int> & P
   // CHECK: store_borrow [[PAYLOAD]] to [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
-  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn!1 : <Self where Self : P> (Self) -> () -> @dynamic_self Self, [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn!1 : <Self where Self : P> (Self) -> () -> Self, [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_box
   // CHECK: [[RESULT_BUF:%.*]] = project_box [[RESULT_BOX]]
   // CHECK: apply [[METHOD]]<@opened("{{.*}}") Base<Int> & P>([[RESULT_BUF]], [[SELF_BOX]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
@@ -151,7 +151,7 @@ func methodCalls(
   let _: Base<Int> & P = baseAndPType.classSelfReturn()
 
   // CHECK: [[METATYPE:%.*]] = open_existential_metatype %1 : $@thick (Base<Int> & P).Type to $@thick (@opened("{{.*}}") (Base<Int> & P)).Type
-  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") (Base<Int> & P), #P.protocolSelfReturn!1 : <Self where Self : P> (Self.Type) -> () -> @dynamic_self Self, [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
+  // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") (Base<Int> & P), #P.protocolSelfReturn!1 : <Self where Self : P> (Self.Type) -> () -> Self, [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_box
   // CHECK: [[RESULT_BUF:%.*]] = project_box
   // CHECK: apply [[METHOD]]<@opened("{{.*}}") (Base<Int> & P)>([[RESULT_BUF]], [[METATYPE]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -78,7 +78,7 @@ bb0(%0 : $P):
   // function_ref P.combine<A> (first : A1) -> (A1) -> Bool
   %3 = function_ref @P_combine : $@convention(method) <τ_0_0 where τ_0_0 : P><τ_1_0> (@in τ_1_0, @guaranteed τ_0_0) -> @owned @callee_owned (@in τ_1_0) -> Bool
   %4 = open_existential_ref %0 : $P to $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P
-  %5 = witness_method $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P, #P.getSelf!1 : <Self where Self : P> (Self) -> () -> @dynamic_self Self, %4 : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> @owned τ_0_0
+  %5 = witness_method $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P, #P.getSelf!1 : <Self where Self : P> (Self) -> () -> Self, %4 : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> @owned τ_0_0
   %6 = apply %5<@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> @owned τ_0_0
   %7 = init_existential_ref %6 : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P : $@opened("41B14A4E-F49C-11E6-BE69-A45E60E99281") P, $P
   %8 = alloc_stack $P

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -116,11 +116,11 @@ sil @$s28witness_return_optional_self2CCCACycfC : $@convention(method) (@thick C
 // CHECK-LABEL: sil @$s28witness_return_optional_self29testWitnessReturnOptionalSelfAA2PP_pSgyF : $@convention(thin) () -> @owned Optional<PP> {
 // CHECK: [[E1:%.*]] = init_existential_ref %{{.*}} : $CC : $CC, $PP
 // CHECK: [[O1:%.*]] = open_existential_ref [[E1]] : $PP to $@opened("{{.*}}") PP
-// CHECK: [[W1:%.*]] = witness_method $CC, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> @dynamic_self Self? : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
+// CHECK: [[W1:%.*]] = witness_method $CC, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> Self? : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK: apply [[W1]]<@opened("{{.*}}") PP>([[O1]]) : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK: [[E2:%.*]] = init_existential_ref %{{.*}} : $@opened("{{.*}}") PP : $@opened("{{.*}}") PP, $PP
 // CHECK: [[O2:%.*]] = open_existential_ref [[E2]] : $PP to $@opened("{{.*}}") PP
-// CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> @dynamic_self Self?, [[O1]] : $@opened("{{.*}}") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
+// CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> Self?, [[O1]] : $@opened("{{.*}}") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK: apply [[W2]]<@opened("{{.*}}") PP>([[O2]]) : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK-LABEL: } // end sil function '$s28witness_return_optional_self29testWitnessReturnOptionalSelfAA2PP_pSgyF'
 sil @$s28witness_return_optional_self29testWitnessReturnOptionalSelfAA2PP_pSgyF : $@convention(thin) () -> @owned Optional<PP> {
@@ -131,14 +131,14 @@ bb0:
   %2 = apply %1(%0) : $@convention(method) (@thick CC.Type) -> @owned CC
   %3 = init_existential_ref %2 : $CC : $CC, $PP
   %5 = open_existential_ref %3 : $PP to $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP
-  %6 = witness_method $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> @dynamic_self Self?, %5 : $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
+  %6 = witness_method $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> Self?, %5 : $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
   %7 = apply %6<@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP>(%5) : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
   %8 = unchecked_enum_data %7 : $Optional<@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP>, #Optional.some!enumelt.1
   %11 = init_existential_ref %8 : $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP : $@opened("00000000-72AD-11E8-88DF-ACDE48001122") PP, $PP
   %12 = enum $Optional<PP>, #Optional.some!enumelt.1, %11 : $PP
   %13 = unchecked_enum_data %12 : $Optional<PP>, #Optional.some!enumelt.1
   %18 = open_existential_ref %13 : $PP to $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP
-  %19 = witness_method $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> @dynamic_self Self?, %18 : $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
+  %19 = witness_method $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> Self?, %18 : $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
   %20 = apply %19<@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP>(%18) : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
   %21 = unchecked_enum_data %20 : $Optional<@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP>, #Optional.some!enumelt.1
   %22 = init_existential_ref %21 : $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP : $@opened("FFFFFFFF-72AD-11E8-88DF-ACDE48001122") PP, $PP
@@ -180,13 +180,13 @@ sil @$s37witness_return_optional_indirect_self1SVACycfC : $@convention(method) (
 // CHECK-LABEL: sil @$s37witness_return_optional_indirect_self37testWitnessReturnOptionalIndirectSelfyyF : $@convention(thin) () -> () {
 // CHECK: [[O1:%.*]] = open_existential_addr immutable_access %0 : $*PPP to $*@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP
 // CHECK: [[R1:%.*]] = alloc_stack $Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>
-// CHECK: [[W1:%.*]] = witness_method $S, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> @dynamic_self Self? : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+// CHECK: [[W1:%.*]] = witness_method $S, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> Self? : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: apply [[W1]]<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>([[R1]], [[O1]]) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: inject_enum_addr [[OE1:%.*]] : $*Optional<PPP>, #Optional.some!enumelt.1
 // CHECK: [[E1:%.*]] = unchecked_take_enum_data_addr [[OE1]] : $*Optional<PPP>, #Optional.some!enumelt.1
 // CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[E1]] : $*PPP to $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP
 // CHECK: [[R2:%.*]] = alloc_stack $Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>
-// CHECK: [[W2:%.*]] = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> @dynamic_self Self?, %19 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+// CHECK: [[W2:%.*]] = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> Self?, %19 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: apply [[W2]]<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>([[R2]], [[O2]]) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK-LABEL: } // end sil function '$s37witness_return_optional_indirect_self37testWitnessReturnOptionalIndirectSelfyyF'
 sil @$s37witness_return_optional_indirect_self37testWitnessReturnOptionalIndirectSelfyyF : $@convention(thin) () -> () {
@@ -204,7 +204,7 @@ bb0:
   %9 = init_enum_data_addr %7 : $*Optional<PPP>, #Optional.some!enumelt.1
   %10 = init_existential_addr %9 : $*PPP, $@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP
   %11 = alloc_stack $Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>
-  %12 = witness_method $@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> @dynamic_self Self?, %8 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+  %12 = witness_method $@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> Self?, %8 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %13 = apply %12<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>(%11, %8) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %14 = unchecked_take_enum_data_addr %11 : $*Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP>, #Optional.some!enumelt.1
   copy_addr [take] %14 to [initialization] %10 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122") PPP
@@ -215,7 +215,7 @@ bb0:
   %30 = init_enum_data_addr %6 : $*Optional<PPP>, #Optional.some!enumelt.1
   %31 = init_existential_addr %30 : $*PPP, $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP
   %32 = alloc_stack $Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>
-  %33 = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> @dynamic_self Self?, %29 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+  %33 = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> Self?, %29 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %34 = apply %33<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>(%32, %29) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %41 = unchecked_take_enum_data_addr %32 : $*Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP>, #Optional.some!enumelt.1
   copy_addr [take] %41 to [initialization] %31 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122") PPP
@@ -390,7 +390,7 @@ struct StructOfAnyP : AnyP {
 // CHECK-LABEL: sil @testWitnessCopiedSelfWithIndirectResult : $@convention(thin) () -> () {
 // CHECK: [[IN:%[0-9]+]] = alloc_stack $StructOfAnyP
 // CHECK: [[OUT:%[0-9]+]] = alloc_stack $StructOfAnyP
-// CHECK: witness_method $StructOfAnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+// CHECK: witness_method $StructOfAnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
 // CHECK: apply %{{.*}}<StructOfAnyP>([[OUT]], [[IN]]) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
 // CHECK-LABEL: } // end sil function 'testWitnessCopiedSelfWithIndirectResult'
 sil @testWitnessCopiedSelfWithIndirectResult : $() -> () {
@@ -401,7 +401,7 @@ bb0:
   copy_addr %a0 to [initialization] %a1 : $*AnyP
   %o0 = open_existential_addr immutable_access %a1 : $*AnyP to $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP
   %a2 = alloc_stack $StructOfAnyP
-  %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+  %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
   %c0 = apply %w0<@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP>(%a2, %o0) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
   dealloc_stack %a2 : $*StructOfAnyP
   dealloc_stack %a1 : $*AnyP
@@ -416,7 +416,7 @@ sil @takeany :  $@convention(thin) (@in_guaranteed AnyP) -> ()
 // CHECK: [[IN:%[0-9]+]] = alloc_stack $AnyP
 // CHECK: [[EA:%[0-9]+]] = init_existential_addr [[IN]]
 // CHECK: [[OUT:%[0-9]+]] = alloc_stack $StructOfAnyP
-// CHECK: witness_method $StructOfAnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+// CHECK: witness_method $StructOfAnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
 // CHECK: apply %{{.*}}<StructOfAnyP>([[OUT]], [[EA]]) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
 // CHECK-LABEL: } // end sil function 'testWitnessCopiedSelfWithIndirectResult2'
 sil @testWitnessCopiedSelfWithIndirectResult2 : $() -> () {
@@ -429,7 +429,7 @@ bb0:
   copy_addr %a0 to [initialization] %a1 : $*AnyP
   %o0 = open_existential_addr immutable_access %a1 : $*AnyP to $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP
   %a2 = alloc_stack $StructOfAnyP
-  %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> @dynamic_self Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
+  %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP, #AnyP.returnsSelf!1 : <Self where Self : AnyP> (Self) -> () -> Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
   %c0 = apply %w0<@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD") AnyP>(%a2, %o0) : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
   dealloc_stack %a2 : $*StructOfAnyP
   dealloc_stack %a1 : $*AnyP

--- a/test/SILOptimizer/sil_combine_concrete_existential.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential.swift
@@ -59,7 +59,7 @@ final class CC: PP {
 // CHECK: [[O1:%.*]] = open_existential_ref [[E1]] : $PP to $@opened("{{.*}}") PP
 // CHECK: [[E2:%.*]] = init_existential_ref %{{.*}} : $@opened("{{.*}}") PP : $@opened("{{.*}}") PP, $PP
 // CHECK: [[O2:%.*]] = open_existential_ref [[E2]] : $PP to $@opened("{{.*}}") PP
-// CHECK: [[W:%.*]] = witness_method $@opened("{{.*}}") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> @dynamic_self Self?, [[O1]] : $@opened("{{.*}}") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
+// CHECK: [[W:%.*]] = witness_method $@opened("{{.*}}") PP, #PP.returnOptionalSelf!1 : <Self where Self : PP> (Self) -> () -> Self?, [[O1]] : $@opened("{{.*}}") PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK: apply [[W]]<@opened("{{.*}}") PP>([[O2]]) : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> @owned Optional<τ_0_0>
 // CHECK-LABEL: } // end sil function '$s32sil_combine_concrete_existential29testWitnessReturnOptionalSelfAA2PP_pSgyF'
 public func testWitnessReturnOptionalSelf() -> PP? {
@@ -96,7 +96,7 @@ struct SS: PPP {
 // CHECK-LABEL: sil @$s32sil_combine_concrete_existential37testWitnessReturnOptionalIndirectSelfyyF : $@convention(thin) () -> () {
 // CHECK: switch_enum_addr %{{.*}} : $*Optional<@opened("{{.*}}") PPP>, case #Optional.some!enumelt.1: bb{{.*}}, case #Optional.none!enumelt: bb{{.*}}
 // CHECK: [[O:%.*]] = open_existential_addr immutable_access %{{.*}} : $*PPP to $*@opened("{{.*}}") PPP
-// CHECK: [[W:%.*]] = witness_method $@opened("{{.*}}") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> @dynamic_self Self?, [[O]] : $*@opened("{{.*}}") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
+// CHECK: [[W:%.*]] = witness_method $@opened("{{.*}}") PPP, #PPP.returnsOptionalIndirect!1 : <Self where Self : PPP> (Self) -> () -> Self?, [[O]] : $*@opened("{{.*}}") PPP : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: apply [[W]]<@opened("{{.*}}") PPP>(%{{.*}}, [[O]]) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK-LABEL: } // end sil function '$s32sil_combine_concrete_existential37testWitnessReturnOptionalIndirectSelfyyF'
 public func testWitnessReturnOptionalIndirectSelf() {

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -149,7 +149,7 @@ extension Array where Element == String { }
 extension GenericClass : P3 where T : P3 { }
 
 extension GenericClass where Self : P3 { }
-// expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
+// expected-error@-1{{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
 // expected-error@-2{{'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol P4 {

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -150,6 +150,7 @@ extension GenericClass : P3 where T : P3 { }
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
+// expected-error@-2{{'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol P4 {
   associatedtype T

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -24,9 +24,9 @@ enum E0 {
 class C0 {
   func f() -> Self { } // okay
 
-  func g(_ ds: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func g(_ ds: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 
-  func h(_ ds: Self) -> Self { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{16-20=C0}}
+  func h(_ ds: Self) -> Self { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 }
 
 protocol P0 {
@@ -72,8 +72,8 @@ class C1 {
     // One can use `type(of:)` to attempt to construct an object of type Self.
     if !b { return type(of: self).init(int: 5) }
 
-    // Can't utter Self within the body of a method.
-    var _: Self = self // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C1'?}} {{12-16=C1}}
+    // Can utter Self within the body of a method.
+    var _: Self = self
 
     // Okay to return 'self', because it has the appropriate type.
     return self // okay

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -24,9 +24,9 @@ enum E0 {
 class C0 {
   func f() -> Self { } // okay
 
-  func g(_ ds: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
+  func g(_ ds: Self) { } // expected-error{{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'C0'?}}
 
-  func h(_ ds: Self) -> Self { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
+  func h(_ ds: Self) -> Self { } // expected-error{{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'C0'?}}
 }
 
 protocol P0 {

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -84,14 +84,14 @@ class IntNode: Node {}
 
 // SR-8902
 protocol P8902 {
-    associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+    associatedtype A
     func f(_ x: A) -> Self
 }
 struct S : P8902 {
     func f(_ x: Bool) -> S { fatalError() }
 }
-class C8902 : P8902 { // expected-error {{type 'C8902' does not conform to protocol 'P8902'}}
-    func f(_ x: Bool) -> C8902 { fatalError() }
+class C8902 : P8902 {
+    func f(_ x: Bool) -> C8902 { fatalError() } // expected-error {{method 'f' in non-final class 'C8902' must return 'Self' to conform to protocol 'P8902'}}
 }
 final class C8902b : P8902 {
     func f(_ x: Bool) -> C8902b { fatalError() }

--- a/test/decl/protocol/req/subscript.swift
+++ b/test/decl/protocol/req/subscript.swift
@@ -78,7 +78,7 @@ protocol Initable {
 
 protocol GenericSubscriptProtocol {
   subscript<T : Initable>(t: T.Type) -> T { get set }
-  // expected-note@-1 {{protocol requires subscript with type '<T where T : Initable> (T.Type) -> T'; do you want to add a stub?}}
+  // expected-note@-1 {{protocol requires subscript with type '<T> (T.Type) -> T'; do you want to add a stub?}}
 }
 
 struct GenericSubscriptWitness : GenericSubscriptProtocol {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -119,12 +119,60 @@ class B: A<Int> {
 class C {
   required init() {
   }
+
   func f() {
     func g(_: Self) {}
   }
   func g() {
     _ = Self.init() as? Self
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
+  }
+  func h(j: () -> Self) -> () -> Self {
+    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+    // expected-error@-2 {{'Self' cannot be the type of a nested return value}}
+    return { return self }
+    // expected-error@-1 {{cannot convert value of type 'C' to closure result type 'Self'}}
+  }
+
+  let p0: Self?
+  var p1: Self? // expected-error {{'Self' is not available as the type of a mutable property}}
+  // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+  // expected-error@-2 {{'Self' cannot be the type of a function argument in a class}}
+
+  var prop: Self { // expected-error {{'Self' is not available as the type of a mutable property}}
+    get {
+      return self
+    }
+    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    }
+  }
+  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
+    get {
+      return self
+    }
+    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    }
+  }
+}
+
+struct S1 {
+  typealias _SELF = Self
+  let j = 99.1
+  subscript (i: Int) -> Self {
+    get {
+      return self
+    }
+    set(newValue) {
+    }
+  }
+  var foo: Self {
+    get {
+      return self// as! Self
+    }
+    set (newValue) {
+    }
+  }
+  func x(y: () -> Self, z: Self) {
   }
 }
 
@@ -143,7 +191,7 @@ struct S2 {
     }
     func foo(a: [Self]) -> Self? {
       Self.x()
-      return Self.init() as? Self
+      return self as? Self
       // expected-warning@-1 {{conditional cast from 'S2.S3<T>' to 'S2.S3<T>' always succeeds}}
     }
   }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -5,7 +5,7 @@ struct S0<T> {
 }
 
 class C0<T> {
-  func foo(_ other: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
+  func foo(_ other: Self) { } // expected-error{{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'C0'?}}
 }
 
 enum E0<T> {
@@ -47,7 +47,7 @@ final class FinalMario : Mario {
 
 class A<T> {
   typealias _Self = Self
-  // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  // expected-error@-1 {{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'A'?}}
   let b: Int
   required init(a: Int) {
     print("\(Self.self).\(#function)")
@@ -55,7 +55,7 @@ class A<T> {
     b = a
   }
   static func z(n: Self? = nil) {
-    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+    // expected-error@-1 {{covariant 'Self' can only appear as the type of a property, subscript or method result; did you mean 'A'?}}
     print("\(Self.self).\(#function)")
   }
   class func y() {
@@ -80,12 +80,11 @@ class A<T> {
     let copy = Self.init(a: 11)
     return copy
   }
-  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
+  subscript (i: Int) -> Self { // expected-error {{mutable subscript cannot have covariant 'Self' type}}
     get {
       return Self.init(a: i)
     }
     set(newValue) {
-      // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     }
   }
 }
@@ -122,38 +121,39 @@ class C {
 
   func f() {
     func g(_: Self) {}
+    let x: Self = self as! Self
+    g(x)
+    typealias _Self = Self
   }
   func g() {
     _ = Self.init() as? Self
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
   }
   func h(j: () -> Self) -> () -> Self {
-    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
-    // expected-error@-2 {{'Self' can only appear at the top level of a method result type}}
+    // expected-error@-1 {{covariant 'Self' can only appear at the top level of method result type}}
     return { return self }
   }
   func i() -> (Self, Self) {}
-  // expected-error@-1 {{'Self' can only appear at the top level of a method result type}}
+  // expected-error@-1 {{covariant 'Self' can only appear at the top level of method result type}}
 
   func j() -> Self.Type {}
-  // expected-error@-1 {{'Self' can only appear at the top level of a method result type}}
+  // expected-error@-1 {{covariant 'Self' can only appear at the top level of method result type}}
 
   let p0: Self?
-  var p1: Self? // expected-error {{'Self' is not available as the type of a mutable property}}
-  // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
+  var p1: Self? // expected-error {{mutable property cannot have covariant 'Self' type}}
 
-  var prop: Self { // expected-error {{'Self' is not available as the type of a mutable property}}
+  var prop: Self { // expected-error {{mutable property cannot have covariant 'Self' type}}
     get {
       return self
     }
-    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    set (newValue) {
     }
   }
-  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
+  subscript (i: Int) -> Self { // expected-error {{mutable subscript cannot have covariant 'Self' type}}
     get {
       return self
     }
-    set (newValue) { // expected-error {{'Self' cannot be the type of a function argument in a class}}
+    set (newValue) {
     }
   }
 }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -139,8 +139,11 @@ class C {
   func j() -> Self.Type {}
   // expected-error@-1 {{covariant 'Self' can only appear at the top level of method result type}}
 
-  let p0: Self?
-  var p1: Self? // expected-error {{mutable property cannot have covariant 'Self' type}}
+  let p0: Self? // expected-error {{stored property cannot have covariant 'Self' type}}
+  var p1: Self? // expected-error {{stored property cannot have covariant 'Self' type}}
+
+  static func staticFunc() -> Self {}
+  let stored: Self = Self.staticFunc() // expected-error {{stored property cannot have covariant 'Self' type}}
 
   var prop: Self { // expected-error {{mutable property cannot have covariant 'Self' type}}
     get {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -77,7 +77,7 @@ class A<T> {
     return copy
   }
 
-  var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  var copied: Self {
     let copy = Self.init(a: 11)
     return copy
   }
@@ -110,7 +110,7 @@ class B: A<Int> {
     let copy = super.copy() as! Self // supported
     return copy
   }
-  override var copied: Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'B'?}}
+  override var copied: Self {
     let copy = super.copied as! Self // unsupported
     return copy
   }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -137,7 +137,6 @@ class C {
   let p0: Self?
   var p1: Self? // expected-error {{'Self' is not available as the type of a mutable property}}
   // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
-  // expected-error@-2 {{'Self' cannot be the type of a function argument in a class}}
 
   var prop: Self { // expected-error {{'Self' is not available as the type of a mutable property}}
     get {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -129,10 +129,15 @@ class C {
   }
   func h(j: () -> Self) -> () -> Self {
     // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
-    // expected-error@-2 {{'Self' cannot be the type of a nested return value}}
+    // expected-error@-2 {{'Self' can only appear at the top level of a method result type}}
     return { return self }
     // expected-error@-1 {{cannot convert value of type 'C' to closure result type 'Self'}}
   }
+  func i() -> (Self, Self) {}
+  // expected-error@-1 {{'Self' can only appear at the top level of a method result type}}
+
+  func j() -> Self.Type {}
+  // expected-error@-1 {{'Self' can only appear at the top level of a method result type}}
 
   let p0: Self?
   var p1: Self? // expected-error {{'Self' is not available as the type of a mutable property}}

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -47,7 +47,7 @@ final class FinalMario : Mario {
 
 class A<T> {
   typealias _Self = Self
-  // expected-error@-1 {{'Self' is not available in a typealias}}
+  // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
   let b: Int
   required init(a: Int) {
     print("\(Self.self).\(#function)")

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -5,7 +5,7 @@ struct S0<T> {
 }
 
 class C0<T> {
-  func foo(_ other: Self) { } // expected-error{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'C0'?}}{{21-25=C0}}
+  func foo(_ other: Self) { } // expected-error{{'Self' cannot be the type of a function argument in a class}}
 }
 
 enum E0<T> {
@@ -47,7 +47,7 @@ final class FinalMario : Mario {
 
 class A<T> {
   typealias _Self = Self
-  // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  // expected-error@-1 {{'Self' is not available in a typealias}}
   let b: Int
   required init(a: Int) {
     print("\(Self.self).\(#function)")
@@ -55,7 +55,7 @@ class A<T> {
     b = a
   }
   static func z(n: Self? = nil) {
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+    // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     print("\(Self.self).\(#function)")
   }
   class func y() {
@@ -67,7 +67,6 @@ class A<T> {
     Self.y()
     Self.z()
     let _: Self = Self.init(a: 66)
-    // expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
     return Self.init(a: 77) as? Self as? A
     // expected-warning@-1 {{conditional cast from 'Self' to 'Self' always succeeds}}
     // expected-warning@-2 {{conditional downcast from 'Self?' to 'A<T>' is equivalent to an implicit conversion to an optional 'A<T>'}}
@@ -81,11 +80,12 @@ class A<T> {
     let copy = Self.init(a: 11)
     return copy
   }
-  subscript (i: Int) -> Self { // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'A'?}}
+  subscript (i: Int) -> Self { // expected-error {{'Self' is not available as the type of a mutable subscript}}
     get {
       return Self.init(a: i)
     }
     set(newValue) {
+      // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     }
   }
 }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -131,7 +131,6 @@ class C {
     // expected-error@-1 {{'Self' cannot be the type of a function argument in a class}}
     // expected-error@-2 {{'Self' can only appear at the top level of a method result type}}
     return { return self }
-    // expected-error@-1 {{cannot convert value of type 'C' to closure result type 'Self'}}
   }
   func i() -> (Self, Self) {}
   // expected-error@-1 {{'Self' can only appear at the top level of a method result type}}

--- a/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
+++ b/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
@@ -8,4 +8,4 @@ struct Var<N> {}
 extension Var : P2 where N : P1 { }
 
 protocol P3 {}
-extension Var : P3 where Self : P2 {} // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'Var'?}}
+extension Var : P3 where Self : P2 {} // expected-error {{type 'Var<N>' in conformance requirement does not refer to a generic parameter or associated type}}


### PR DESCRIPTION
Builds on https://github.com/apple/swift/pull/23991, cleaning up some older code that was making the full implementation of SE-0068 difficult.

- Support immutable (computed) properties and subscripts with `Self` type (this was @johnno1962's PR).
- Stop wrapping Self-returning protocol methods with DynamicSelfType.
- Remove `FuncDecl::hasDynamicSelf()` and the weird TypeRepr inspection that was used to compute it.

Fixes #52726.