### PR TITLE
[5.1] [Property wrappers] Validate wrappedValue before using it.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1601,6 +1601,7 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   if (!var->hasInterfaceType()) {
     auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
     tc.validateDecl(var);
+    assert(var->hasInterfaceType());
   }
 
   // Make sure that the property type matches the value of the

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -265,6 +265,9 @@ PropertyWrapperTypeInfoRequest::evaluate(
       .fixItReplace(valueVar->getNameLoc(), "wrappedValue");
   }
 
+  if (!valueVar->hasInterfaceType())
+    static_cast<TypeChecker &>(*ctx.getLazyResolver()).validateDecl(valueVar);
+
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;
   result.initialValueInit = findInitialValueInit(ctx, nominal, valueVar);


### PR DESCRIPTION
Fixes SR-10984 / rdar://problem/52095853. This change was needed on master for the test reduced from SR-10933. It *might* be needed in more complex cases than I could find (and does not hurt in any case), so pull it in here to be safe.