### PR TITLE
[5.1] [Property wrappers] Make sure to canonicalize a type properly in DI.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1409,7 +1409,8 @@ namespace {
                         SGF.getModule().getSwiftModule(), ctor);
 
         Type ity = ctor->getInterfaceType();
-        AnyFunctionType *substIty = ity.subst(subs)->castTo<AnyFunctionType>();
+        AnyFunctionType *substIty =
+          ity.subst(subs)->getCanonicalType()->castTo<AnyFunctionType>();
 
         auto initRef = SILDeclRef(ctor, SILDeclRef::Kind::Allocator)
           .asForeign(requiresForeignEntryPoint(ctor));

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -346,8 +346,26 @@ func testDefaultInit() {
   // CHECK: set value hello
 }
 
+// rdar://problem/51581937: DI crash with a property wrapper of an optional
+struct OptIntStruct {
+  @Wrapper var wrapped: Int?
+
+  init() {
+     wrapped = 42
+  }
+}
+
+func testOptIntStruct() {
+  // CHECK: ## OptIntStruct
+  print("\n## OptIntStruct")
+
+  let use = OptIntStruct()
+  // CHECK-NEXT:   .. init Optional(42)
+}
+
 testIntStruct()
 testIntClass()
 testRefStruct()
 testGenericClass()
 testDefaultInit()
+testOptIntStruct()


### PR DESCRIPTION
Fixes a crash/assertion involving sugared types rdar://problem/51581937.
