### PR TITLE
[5.1]Disable typo-correction by default until we can make it work within acceptable performance bounds

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -89,7 +89,8 @@ namespace swift {
     bool DisableAvailabilityChecking = false;
 
     /// Maximum number of typo corrections we are allowed to perform.
-    unsigned TypoCorrectionLimit = 10;
+    /// This is disabled by default until we can get typo-correction working within acceptable performance bounds.
+    unsigned TypoCorrectionLimit = 0;
     
     /// Should access control be respected?
     bool EnableAccessControl = true;

--- a/test/SourceKit/Sema/sema_symlink.swift.response
+++ b/test/SourceKit/Sema/sema_symlink.swift.response
@@ -12,28 +12,12 @@
     key.column: 16,
     key.filepath: real.swift,
     key.severity: source.diagnostic.severity.error,
-    key.description: "use of unresolved identifier 'goo'; did you mean 'Bool'?",
+    key.description: "use of unresolved identifier 'goo'",
     key.diagnostic_stage: source.diagnostic.stage.swift.sema,
     key.ranges: [
       {
         key.offset: 15,
         key.length: 3
-      }
-    ],
-    key.fixits: [
-      {
-        key.offset: 15,
-        key.length: 3,
-        key.sourcetext: "Bool"
-      }
-    ],
-    key.diagnostics: [
-      {
-        key.line: 1,
-        key.column: 16,
-        key.filepath: real.swift,
-        key.severity: source.diagnostic.severity.note,
-        key.description: "'Bool' declared here (Swift.Bool)"
       }
     ]
   }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1070,6 +1070,10 @@ else:
     lit_config.fatal("Don't know how to define target_run and "
                      "target_build_swift for platform " + config.variant_triple)
 
+# Enable typo-correction for testing purposes.
+config.target_swift_frontend += " -typo-correction-limit 10 "
+subst_target_swift_frontend_mock_sdk += " -typo-correction-limit 10 "
+
 config.substitutions.append(('%module-target-triple',
                              target_specific_module_triple))
 


### PR DESCRIPTION
Typo-correction can be so expensive that it can slow down typechecking over 10x.
It can be a significant productivity drain for developing on large projects.

Unfortunately it is best that we disable it until we can dedicate the time to address its performance issues
and we are certain it works within acceptable performance bounds.

rdar://51966070

master: https://github.com/apple/swift/pull/25674