### PR TITLE
IRGen: Public non-resilient types that reference resilient types from the same module must view those types as non-fixed

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5794,7 +5794,9 @@ std::unique_ptr<EnumImplStrategy>
 EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
   unsigned numElements = 0;
   TypeInfoKind tik = Loadable;
-  IsFixedSize_t alwaysFixedSize = IsFixedSize;
+  IsFixedSize_t alwaysFixedSize =
+      TC.IGM.isResilient(theEnum, ResilienceExpansion::Minimal) ? IsNotFixedSize
+                                                                : IsFixedSize;
   bool allowFixedLayoutOptimizations = true;
   std::vector<Element> elementsWithPayload;
   std::vector<Element> elementsWithNoPayload;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5794,12 +5794,13 @@ std::unique_ptr<EnumImplStrategy>
 EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
   unsigned numElements = 0;
   TypeInfoKind tik = Loadable;
-  IsFixedSize_t alwaysFixedSize =
-      TC.IGM.isResilient(theEnum, ResilienceExpansion::Minimal) ? IsNotFixedSize
-                                                                : IsFixedSize;
+  IsFixedSize_t alwaysFixedSize = IsFixedSize;
   bool allowFixedLayoutOptimizations = true;
   std::vector<Element> elementsWithPayload;
   std::vector<Element> elementsWithNoPayload;
+
+  if (TC.IGM.isResilient(theEnum, ResilienceExpansion::Minimal))
+    alwaysFixedSize = IsNotFixedSize;
 
   // Resilient enums are manipulated as opaque values, except we still
   // make the following assumptions:

--- a/test/multifile/Inputs/resilient-module-2.swift
+++ b/test/multifile/Inputs/resilient-module-2.swift
@@ -1,0 +1,10 @@
+public enum ResilientType {
+  case a(Int64)
+  case b(Int64)
+}
+
+@frozen
+public enum SomeEnum {
+  case first(ResilientType)
+  case second(ResilientType)
+}

--- a/test/multifile/resilient-module.swift
+++ b/test/multifile/resilient-module.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(A) | %FileCheck %s
 
 
-// METADATA: @"$s1A8SomeEnumOMn" = constant <{ i32, i32, i32, i32, i32, i32, i32 }> <{{{.*}} i32 33554434, i32 0 }>
+// METADATA: @"$s1A8SomeEnumOMn" = {{.*}}constant <{ i32, i32, i32, i32, i32, i32, i32 }> <{{{.*}} i32 33554434, i32 0 }>
 
 import A
 

--- a/test/multifile/resilient-module.swift
+++ b/test/multifile/resilient-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(A)) -enable-library-evolution -module-name A -emit-module -emit-module-path %t/A.swiftmodule %S/Inputs/resilient-module-2.swift
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.14 -enable-library-evolution -module-name A %S/Inputs/resilient-module-2.swift -emit-ir | %FileCheck --check-prefix=METADATA %s
+// RUN: %target-swift-frontend -enable-library-evolution -module-name A %S/Inputs/resilient-module-2.swift -emit-ir | %FileCheck --check-prefix=METADATA %s
 // RUN: %target-build-swift -I%t -L%t -lA -o %t/main %target-rpath(%t) %s
 // RUN: %target-build-swift -I%t -L%t -lA -o %t/main %target-rpath(%t) %s
 // RUN: %target-codesign %t/main %t/%target-library-name(A)

--- a/test/multifile/resilient-module.swift
+++ b/test/multifile/resilient-module.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(A)) -enable-library-evolution -module-name A -emit-module -emit-module-path %t/A.swiftmodule %S/Inputs/resilient-module-2.swift
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.14 -enable-library-evolution -module-name A %S/Inputs/resilient-module-2.swift -emit-ir | %FileCheck --check-prefix=METADATA %s
+// RUN: %target-build-swift -I%t -L%t -lA -o %t/main %target-rpath(%t) %s
+// RUN: %target-build-swift -I%t -L%t -lA -o %t/main %target-rpath(%t) %s
+// RUN: %target-codesign %t/main %t/%target-library-name(A)
+// RUN: %target-run %t/main %t/%target-library-name(A) | %FileCheck %s
+
+
+// METADATA: @"$s1A8SomeEnumOMn" = constant <{ i32, i32, i32, i32, i32, i32, i32 }> <{{{.*}} i32 33554434, i32 0 }>
+
+import A
+
+func runTest() {
+  let e = SomeEnum.first(ResilientType.a(Int64(10)))
+  // CHECK: first(A.ResilientType.a(10))
+  print(e)
+}
+
+runTest()


### PR DESCRIPTION
Otherwise, we don't emit certain parts of the metadata that is expected
when these types are used outside the module (payload size).

rdar://51422528