### PR TITLE
[Build System: CMake] Move the legacy_layouts CMake target generation into stdlib/public/legacy_layouts/CMakeLists.txt (5.1 branch).

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -113,48 +113,6 @@ if(SWIFT_STDLIB_ENABLE_SIB_TARGETS)
 endif()
 swift_create_stdlib_targets("swift-test-stdlib" "" FALSE)
 
-foreach(sdk ${SWIFT_SDKS})
-  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-    set(platform "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
-    set(input "${SWIFT_SOURCE_DIR}/stdlib/public/legacy_layouts/${platform}/layouts-${arch}.yaml")
-    set(output "${SWIFTLIB_DIR}/${platform}/layouts-${arch}.yaml")
-
-    if(EXISTS "${input}")
-      # Copy the input file to the build directory.
-      add_custom_command(
-        OUTPUT "${output}"
-        DEPENDS "${input}"
-        COMMAND
-          "${CMAKE_COMMAND}" -E copy
-          "${input}"
-          "${output}")
-
-      # Define a target for this so that we can depend on it when
-      # building Swift sources.
-      add_custom_target(
-        "copy-legacy-layouts-${platform}-${arch}"
-        DEPENDS "${output}"
-        SOURCES "${input}")
-
-      # Make sure we ultimately always do this as part of building the
-      # standard library. In practice we'll do this earlier if at least
-      # one Swift source file has changed.
-      add_dependencies(
-        "swift-stdlib-${platform}-${arch}"
-        "copy-legacy-layouts-${platform}-${arch}")
-
-      swift_install_in_component(compiler
-          FILES ${input}
-          DESTINATION "lib/swift/${platform}/")
-    else()
-      # Add a dummy target that does nothing so we can still depend on it
-      # later without checking if the input files exist.
-      add_custom_target(
-        "copy-legacy-layouts-${platform}-${arch}")
-    endif()
-  endforeach()
-endforeach()
-
 add_subdirectory(public)
 add_subdirectory(private)
 add_subdirectory(tools)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -52,6 +52,7 @@ if(CXX_SUPPORTS_DEFAULT_HIDDEN_VISIBILITY)
   list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-fvisibility=hidden")
 endif()
 
+add_subdirectory(legacy_layouts)
 add_subdirectory(SwiftShims)
 
 if(SWIFT_BUILD_STDLIB)

--- a/stdlib/public/legacy_layouts/CMakeLists.txt
+++ b/stdlib/public/legacy_layouts/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_custom_target("copy-legacy-layouts" ALL)
+
+foreach(sdk ${SWIFT_SDKS})
+  foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+    set(platform "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+
+    set(input "${SWIFT_SOURCE_DIR}/stdlib/public/legacy_layouts/${platform}/layouts-${arch}.yaml")
+    set(output "${SWIFTLIB_DIR}/${platform}/layouts-${arch}.yaml")
+
+    set(copy_target "copy-legacy-layouts-${platform}-${arch}")
+    set(stdlib_target "swift-stdlib-${platform}-${arch}")
+
+    if(EXISTS "${input}")
+      # Copy the input file to the build directory.
+      add_custom_command(
+        OUTPUT "${output}"
+        DEPENDS "${input}"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${input}" "${output}")
+
+      # Define a target for this so that we can depend on it when
+      # building Swift sources.
+      add_custom_target(
+        "${copy_target}"
+        DEPENDS "${output}"
+        SOURCES "${input}")
+
+      # Make sure we ultimately always do this as part of building the
+      # standard library. In practice we'll do this earlier if at least
+      # one Swift source file has changed.
+      if(TARGET "${stdlib_target}")
+        add_dependencies("${stdlib_target}" "${copy_target}")
+      endif()
+
+      swift_install_in_component(compiler
+        FILES "${input}"
+        DESTINATION "lib/swift/${platform}/")
+    else()
+      # Add a dummy target that does nothing so we can still depend on it
+      # later without checking if the input files exist.
+      add_custom_target("${copy_target}")
+    endif()
+
+    add_dependencies("copy-legacy-layouts" "${copy_target}")
+  endforeach()
+endforeach()


### PR DESCRIPTION
Copy of #25756 for the 5.1 branch.

rdar://52060909