### PR TITLE
[IDE][Index] Property wrapper rename support

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -299,6 +299,9 @@ struct PrintOptions {
   /// Empty means allow all.
   std::vector<AnyAttrKind> ExclusiveAttrList;
 
+  /// List of decls that should be printed even if they are implicit and \c SkipImplicit is set to true.
+  std::vector<const Decl*> TreatAsExplicitDeclList;
+
   /// Whether to print function @convention attribute on function types.
   bool PrintFunctionRepresentationAttrs = true;
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -264,13 +264,14 @@ struct ResolvedLoc {
 /// Resolved locations also indicate the nature of the matched occurrence (e.g.
 /// whether it is within active/inactive code, or a selector or string literal).
 class NameMatcher: public ASTWalker {
-  using LocAndAttrArg = std::pair<SourceLoc, Expr *>;
-
   SourceFile &SrcFile;
   std::vector<UnresolvedLoc> LocsToResolve;
   std::vector<ResolvedLoc> ResolvedLocs;
   ArrayRef<Token> TokensToCheck;
-  llvm::Optional<LocAndAttrArg> CustomAttrDelayedArg;
+
+  /// The \c Expr argument of a parent \c CustomAttr (if one exists) and
+  /// the \c SourceLoc of the type name it applies to.
+  llvm::Optional<std::pair<SourceLoc, Expr *>> CustomAttrArg;
   unsigned InactiveConfigRegionNestings = 0;
   unsigned SelectorNestings = 0;
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -264,10 +264,13 @@ struct ResolvedLoc {
 /// Resolved locations also indicate the nature of the matched occurrence (e.g.
 /// whether it is within active/inactive code, or a selector or string literal).
 class NameMatcher: public ASTWalker {
+  using LocAndAttrArg = std::pair<SourceLoc, Expr *>;
+
   SourceFile &SrcFile;
   std::vector<UnresolvedLoc> LocsToResolve;
   std::vector<ResolvedLoc> ResolvedLocs;
   ArrayRef<Token> TokensToCheck;
+  llvm::Optional<LocAndAttrArg> CustomAttrDelayedArg;
   unsigned InactiveConfigRegionNestings = 0;
   unsigned SelectorNestings = 0;
 
@@ -287,6 +290,7 @@ class NameMatcher: public ASTWalker {
                   bool checkParentForLabels = false);
   bool tryResolve(ASTWalker::ParentTy Node, SourceLoc NameLoc, LabelRangeType RangeType,
                   ArrayRef<CharSourceRange> LabelLocs);
+  bool handleCustomAttrs(Decl *D);
 
   std::pair<bool, Expr*> walkToExprPre(Expr *E) override;
   Expr* walkToExprPost(Expr *E) override;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1572,8 +1572,11 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     return false;
   }
 
-  if (Options.SkipImplicit && D->isImplicit())
-    return false;
+  if (Options.SkipImplicit && D->isImplicit()) {
+    const auto &IgnoreList = Options.TreatAsExplicitDeclList;
+    if (std::find(IgnoreList.begin(), IgnoreList.end(), D) == IgnoreList.end())
+        return false;
+  }
 
   if (Options.SkipUnavailable &&
       D->getAttrs().isUnavailable(D->getASTContext()))

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -123,31 +123,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   //===--------------------------------------------------------------------===//
-  //                               Attributes
-  //===--------------------------------------------------------------------===//
-  bool visitCustomAttributes(Decl *D) {
-    for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-      CustomAttr *mutableCustomAttr = const_cast<CustomAttr *>(customAttr);
-      if (doIt(mutableCustomAttr->getTypeLoc()))
-        return true;
-
-      if (auto semanticInit = customAttr->getSemanticInit()) {
-        if (auto newSemanticInit = doIt(semanticInit))
-          mutableCustomAttr->setSemanticInit(newSemanticInit);
-        else
-          return true;
-      } else if (auto arg = customAttr->getArg()) {
-        if (auto newArg = doIt(arg))
-          mutableCustomAttr->setArg(newArg);
-        else
-          return true;
-      }
-    }
-
-    return false;
-  }
-
-  //===--------------------------------------------------------------------===//
   //                                 Decls
   //===--------------------------------------------------------------------===//
 
@@ -179,9 +154,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     // If there is a single variable, walk it's attributes.
     bool isPropertyWrapperBackingProperty = false;
     if (auto singleVar = PBD->getSingleVar()) {
-      if (visitCustomAttributes(singleVar))
-        return true;
-
       isPropertyWrapperBackingProperty =
         singleVar->getOriginalWrappedProperty() != nullptr;
     }
@@ -1148,13 +1120,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (!Walker.walkToParameterListPre(PL))
       return false;
     
+    // Walk each parameter decl, typeloc and default value.
     for (auto P : *PL) {
-      // Walk each parameter's decl and typeloc and default value.
       if (doIt(P))
         return true;
-
-      // Visit any custom attributes on the parameter.
-      visitCustomAttributes(P);
 
       // Don't walk into the type if the decl is implicit, or if the type is
       // implicit.
@@ -1257,7 +1226,7 @@ public:
 
     return P;
   }
-  
+
   bool doIt(const StmtCondition &C) {
     for (auto &elt : C) {
       switch (elt.getKind()) {
@@ -1286,6 +1255,7 @@ public:
     return false;
   }
 
+  /// Returns true on failure
   bool doIt(TypeLoc &TL) {
     if (!Walker.walkToTypeLocPre(TL))
       return false;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1120,8 +1120,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     if (!Walker.walkToParameterListPre(PL))
       return false;
     
-    // Walk each parameter decl, typeloc and default value.
     for (auto P : *PL) {
+      // Walk each parameter's decl and typeloc and default value.
       if (doIt(P))
         return true;
 
@@ -1137,7 +1137,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         P->setDefaultValue(res);
       }
     }
-    
+
     return Walker.walkToParameterListPost(PL);
   }
   
@@ -1255,7 +1255,6 @@ public:
     return false;
   }
 
-  /// Returns true on failure
   bool doIt(TypeLoc &TL) {
     if (!Walker.walkToTypeLocPre(TL))
       return false;

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -552,8 +552,11 @@ std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
 }
 
 bool SemaAnnotator::handleCustomAttributes(Decl *D) {
+  // CustomAttrs of non-param VarDecls are handled when this method is called
+  // on their containing PatternBindingDecls (see below).
   if (isa<VarDecl>(D) && !isa<ParamDecl>(D))
     return true;
+
   if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
     if (auto *SingleVar = PBD->getSingleVar()) {
       D = SingleVar;

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -571,6 +571,8 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
         assert(customAttr->getArg());
         if (!SemaInit->walk(*this))
           return false;
+        // Don't walk this again via the associated PatternBindingDecl's
+        // initializer
         ExprsToSkip.insert(SemaInit);
       }
     } else if (auto *Arg = customAttr->getArg()) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -86,8 +86,15 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
     // Handle references to the implicitly generated vars in case statements
     // matching multiple patterns
     if (VD->isImplicit()) {
-      if (auto * Parent = VD->getParentVarDecl())
+      if (auto * Parent = VD->getParentVarDecl()) {
         D = Parent;
+        VD = Parent;
+      }
+    }
+    // If this is the backing property of a property wrapper, treat it as
+    // the wrapped value instead.
+    if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
+      D = Wrapped;
     }
   }
   CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -91,11 +91,6 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
         VD = Parent;
       }
     }
-    // If this is the backing property of a property wrapper, treat it as
-    // the wrapped value instead.
-    if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
-      D = Wrapped;
-    }
   }
   CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);
   return true;
@@ -791,9 +786,10 @@ bool NameMatcher::tryResolve(ASTWalker::ParentTy Node, SourceLoc NameLoc,
       WasResolved = true;
     }
 
-    if (Range.getByteLength() > 1 && Range.str().front() == '$') {
-      // Also try after any leading dollar for name references of wrapped
-      // properties, e.g. 'foo' in '$foo' occurrences.
+    if (Range.getByteLength() > 1 &&
+        (Range.str().front() == '_' || Range.str().front() == '$')) {
+      // Also try after any leading _ or $ for name references of wrapped
+      // properties, e.g. 'foo' in '_foo' and '$foo' occurrences.
       auto NewRange = CharSourceRange(Range.getStart().getAdvancedLoc(1),
                                       Range.getByteLength() - 1);
       if (NewRange.getStart() == Next.Loc) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -451,12 +451,13 @@ private:
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;
 
-    // If this is a reference to a property wrapper backing property, report a
-    // reference to the wrapped property too (i.e. report an occurrence of `foo`
-    // in `$foo`.
+    // If this is a reference to a property wrapper backing property or
+    // projected value, report a reference to the wrapped property too (i.e.
+    // report an occurrence of `foo` in `_foo` and '$foo').
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
-        assert(Range.getByteLength() > 1 && Range.str().front() == '$');
+        assert(Range.getByteLength() > 1 &&
+               (Range.str().front() == '_' || Range.str().front() == '$'));
         auto AfterDollar = Loc.getAdvancedLoc(1);
         reportRef(Wrapped, AfterDollar, Info, None);
       }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -495,9 +495,9 @@ private:
   }
 
   Decl *getContainingDecl() const {
-    auto Containers = (SymbolRoleSet)SymbolRole::Definition | (SymbolRoleSet)SymbolRole::Declaration;
     for (const auto &Entity: EntitiesStack) {
-      if (isa<AbstractFunctionDecl>(Entity.D) && (Entity.Roles & Containers)) {
+      if (isa<AbstractFunctionDecl>(Entity.D) &&
+          (Entity.Roles & (SymbolRoleSet)SymbolRole::Definition)) {
         return Entity.D;
       }
     }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -445,6 +445,17 @@ private:
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;
 
+    // Report a reference to the underlying property if this is an explicit
+    // property wrapper reference, e.g. report 'foo' for a '$foo' reference.
+    if (auto *VD = dyn_cast<VarDecl>(D)) {
+      if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
+        if (Range.getByteLength() > 1 && Range.str().front() == '$') {
+          auto AfterDollar = Loc.getAdvancedLoc(1);
+          reportRef(Wrapped, AfterDollar, Info, None);
+        }
+      }
+    }
+
     return true;
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -326,6 +326,12 @@ private:
     return true;
   }
 
+  /// Report calls to the initializers of property wrapper types on wrapped properties.
+  ///
+  /// These may be either explicit:
+  ///     `\@Wrapper(initialialValue: 42) var x: Int`
+  /// or implicit:
+  ///     `\@Wrapper var x = 10`
   bool handleCustomAttrInitRefs(Decl * D) {
     for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
       if (customAttr->isImplicit())
@@ -445,8 +451,9 @@ private:
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;
 
-    // Report a reference to the underlying property if this is an explicit
-    // property wrapper reference, e.g. report 'foo' for a '$foo' reference.
+    // If this is a reference to a property wrapper backing property, report a
+    // reference to the wrapped property too (i.e. report an occurrence of `foo`
+    // in `$foo`.
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
         assert(Range.getByteLength() > 1 && Range.str().front() == '$');

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -449,10 +449,9 @@ private:
     // property wrapper reference, e.g. report 'foo' for a '$foo' reference.
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (auto *Wrapped = VD->getOriginalWrappedProperty()) {
-        if (Range.getByteLength() > 1 && Range.str().front() == '$') {
-          auto AfterDollar = Loc.getAdvancedLoc(1);
-          reportRef(Wrapped, AfterDollar, Info, None);
-        }
+        assert(Range.getByteLength() > 1 && Range.str().front() == '$');
+        auto AfterDollar = Loc.getAdvancedLoc(1);
+        reportRef(Wrapped, AfterDollar, Info, None);
       }
     }
 

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -442,6 +442,6 @@ class PropertyDelgate {
 
 // CHECK: <kw>func</kw> acceptBuilder<T>(
 func acceptBuilder<T>(
-  // CHECK: @SomeBuilder<Element> label param: () -> <type>T</type>
+  // CHECK: @<type>SomeBuilder</type><<type>Element</type>> label param: () -> <type>T</type>
   @SomeBuilder<Element> label param: () -> T
 ) {}

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -337,6 +337,13 @@ func foo() {
   if #available (OSX 10.10, iOS 8.01, *) {let _ = "iOS"}
 }
 
+class AvailableWithOverride {
+  // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.01</float>, <kw>OSX</kw> <float>10.10</float>, *)
+  @available(iOS 8.01, OSX 10.10, *)
+  // CHECK: <attr-builtin>public</attr-builtin> <attr-builtin>override</attr-builtin> <kw>var</kw> multiple: <type>Int</type> { <kw>return</kw> <int>24</int> }
+  public override var multiple: Int { return 24 }
+}
+
 // CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
   // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}

--- a/test/Index/function_builders.swift
+++ b/test/Index/function_builders.swift
@@ -5,9 +5,7 @@ struct Tagged<Tag, Entity> {
   let entity: Entity
 }
 
-protocol Taggable {
-}
-
+protocol Taggable {}
 extension Taggable {
   func tag<Tag>(_ tag: Tag) -> Tagged<Tag, Self> {
     return Tagged(tag: tag, entity: self)
@@ -38,8 +36,16 @@ enum Color {
 }
 
 func acceptColorTagged<Result>(@TaggedBuilder<Color> body: () -> Result) {
+// CHECK: [[@LINE-1]]:6 | function/Swift | acceptColorTagged(body:) | s:14swift_ide_test17acceptColorTagged4bodyyxyXE_tlF | Def | rel: 0
+// CHECK: [[@LINE-2]]:33 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref,RelCont | rel: 1
+// CHECK: [[@LINE-3]]:47 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref,RelCont | rel: 1
   print(body())
 }
 
-// CHECK: 40:33 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref,RelCont | rel: 1
-// CHECK: 40:47 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref,RelCont | rel: 1
+struct Context {
+    @TaggedBuilder<Color>
+    // CHECK: [[@LINE-1]]:6 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref | rel: 0
+    // CHECK: [[@LINE-2]]:20 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref | rel: 0
+    func foo() -> () {}
+    // CHECK: [[@LINE-1]]:10 | instance-method/Swift | foo() | s:14swift_ide_test7ContextV3fooyyF | Def,RelChild | rel: 1
+}

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -29,7 +29,7 @@ func foo(a: Int, b: Int, c: Int) {
         case foo(x: LocalStruct)
         // LOCAL: [[@LINE-1]]:14 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
         // CHECK-NOT: [[@LINE-2]]:14 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR:.*]] | Def,RelChild | rel: 1
-        // LOCAL: [[@LINE-3]]:21 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref | rel: 0
+        // LOCAL: [[@LINE-3]]:21 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
     }
 
     let _ = LocalEnum.foo(x: LocalStruct())

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -24,7 +24,7 @@ public struct HasWrappers {
   @Wrapper
   // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
   public var x: Int = globalInt
-  // CHECK-NOT: [[@LINE-1]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+  // CHECK-NOT: [[@LINE-1]]:23 | variable/Swift | globalInt
   // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl | rel: 0
   // CHECK: [[@LINE-3]]:14 | instance-property/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
   // CHECK: [[@LINE-4]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
@@ -35,7 +35,7 @@ public struct HasWrappers {
   // CHECK: [[@LINE-3]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call | rel: 0
   public var y: Int
   // CHECK: [[@LINE-1]]:14 | instance-property/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt
 
   @Wrapper(body: {
   // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -3,17 +3,17 @@
 @propertyWrapper
 public struct Wrapper<T> {
   // CHECK: [[@LINE-1]]:15 | struct/Swift | Wrapper | [[Wrapper_USR:.*]] | Def | rel: 0
-  public var value: T
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | value | [[value_USR:.*]] | Def,RelChild | rel: 1
+  public var wrappedValue: T
+  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | wrappedValue | [[wrappedValue_USR:.*]] | Def,RelChild | rel: 1
 
   public init(initialValue: T) {
   // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR:.*]] | Def,RelChild | rel: 1
-    self.value = initialValue
+    self.wrappedValue = initialValue
   }
 
   public init(body: () -> T) {
   // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR:.*]] | Def,RelChild | rel: 1
-    self.value = body()
+    self.wrappedValue = body()
   }
 }
 
@@ -54,12 +54,12 @@ public struct HasWrappers {
   // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
 
   func backingUse() {
-    _ = $y.value + $z.value + x + $x.value
+    _ = $y.wrappedValue + $z.wrappedValue + x + $x.wrappedValue
     // CHECK: [[@LINE-1]]:10 | instance-property/Swift | y | [[y_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-2]]:12 | instance-property/Swift | value | [[value_USR:.*]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-3]]:21 | instance-property/Swift | z | [[z_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-4]]:31 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-5]]:36 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-2]]:12 | instance-property/Swift | wrappedValue | [[wrappedValue_USR:.*]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-3]]:28 | instance-property/Swift | z | [[z_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-4]]:45 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-5]]:50 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
   }
 }
 

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -15,6 +15,14 @@ public struct Wrapper<T> {
   // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR:.*]] | Def,RelChild | rel: 1
     self.wrappedValue = body()
   }
+
+  public var projectedValue: Projection<T> {
+    get { Projection(item: wrappedValue) }
+  }
+}
+
+public struct Projection<T> {
+    var item: T
 }
 
 var globalInt: Int { return 17 }
@@ -54,12 +62,13 @@ public struct HasWrappers {
   // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
 
   func backingUse() {
-    _ = $y.wrappedValue + $z.wrappedValue + x + $x.wrappedValue
+    _ = _y.wrappedValue + _z.wrappedValue + x + _x.wrappedValue + $y.item
     // CHECK: [[@LINE-1]]:10 | instance-property/Swift | y | [[y_USR]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-2]]:12 | instance-property/Swift | wrappedValue | [[wrappedValue_USR:.*]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-3]]:28 | instance-property/Swift | z | [[z_USR]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-4]]:45 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
     // CHECK: [[@LINE-5]]:50 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-6]]:68 | instance-property/Swift | y | [[y_USR]] | Ref,Read,RelCont | rel: 1
   }
 }
 

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -2,51 +2,65 @@
 
 @propertyWrapper
 public struct Wrapper<T> {
+  // CHECK: [[@LINE-1]]:15 | struct/Swift | Wrapper | [[Wrapper_USR:.*]] | Def | rel: 0
   public var value: T
+  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | value | [[value_USR:.*]] | Def,RelChild | rel: 1
 
   public init(initialValue: T) {
+  // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR:.*]] | Def,RelChild | rel: 1
     self.value = initialValue
   }
 
   public init(body: () -> T) {
+  // CHECK: [[@LINE-1]]:10 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR:.*]] | Def,RelChild | rel: 1
     self.value = body()
   }
 }
 
 var globalInt: Int { return 17 }
+// CHECK: [[@LINE-1]]:5 | variable/Swift | globalInt | [[globalInt_USR:.*]] | Def | rel: 0
 
 public struct HasWrappers {
   @Wrapper
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
   public var x: Int = globalInt
-  // CHECK: [[@LINE-2]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-  // CHECK-NOT: [[@LINE-2]]:23 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
-  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | s:14swift_ide_test7WrapperV12initialValueACyxGx_tcfc | Ref,Call,Impl | rel: 0
-  // CHECK: [[@LINE-4]]:14 | instance-property/Swift | x | s:14swift_ide_test11HasWrappersV1xSivp | Def,RelChild | rel: 1
-  // CHECK: [[@LINE-5]]:23 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+  // CHECK-NOT: [[@LINE-1]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl | rel: 0
+  // CHECK: [[@LINE-3]]:14 | instance-property/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-4]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
 
   @Wrapper(body: { globalInt })
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-2]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+  // CHECK: [[@LINE-3]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call | rel: 0
   public var y: Int
-  // CHECK: [[@LINE-2]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-  // CHECK: [[@LINE-3]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
-  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(body:) | s:14swift_ide_test7WrapperV4bodyACyxGxyXE_tcfc | Ref,Call | rel: 0
-  // CHECK: [[@LINE-4]]:14 | instance-property/Swift | y | s:14swift_ide_test11HasWrappersV1ySivp | Def,RelChild | rel: 1
-  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
 
   @Wrapper(body: {
-  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
     struct Inner {
       @Wrapper
-      // CHECK: [[@LINE-1]]:8 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-      // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(initialValue:) | s:14swift_ide_test7WrapperV12initialValueACyxGx_tcfc | Ref,Call,Impl | rel: 0
+      // CHECK: [[@LINE-1]]:8 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
+      // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl | rel: 0
       var x: Int = globalInt
-      // CHECK: [[@LINE-1]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+      // CHECK: [[@LINE-1]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
     }
     return Inner().x + globalInt
-    // CHECK: [[@LINE-1]]:24 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+    // CHECK: [[@LINE-1]]:24 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
   })
-  // CHECK: [[@LINE-12]]:4 | constructor/Swift | init(body:) | s:14swift_ide_test7WrapperV4bodyACyxGxyXE_tcfc | Ref,Call | rel: 0
+  // CHECK: [[@LINE-12]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call | rel: 0
   public var z: Int
-  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | s:14swift_ide_test11HasWrappersV1zSivp | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
+
+  func backingUse() {
+    _ = $y.value + $z.value + x + $x.value
+    // CHECK: [[@LINE-1]]:10 | instance-property/Swift | y | [[y_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-2]]:12 | instance-property/Swift | value | [[value_USR:.*]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-3]]:21 | instance-property/Swift | z | [[z_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-4]]:31 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-5]]:36 | instance-property/Swift | x | [[x_USR]] | Ref,Read,RelCont | rel: 1
+  }
 }
 
 func useMemberwiseInits(i: Int) {

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -18,25 +18,38 @@ var globalInt: Int { return 17 }
 public struct HasWrappers {
   @Wrapper
   public var x: Int = globalInt
+  // CHECK: [[@LINE-2]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
+  // CHECK-NOT: [[@LINE-2]]:23 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | s:14swift_ide_test7WrapperV12initialValueACyxGx_tcfc | Ref,Call,Impl | rel: 0
+  // CHECK: [[@LINE-4]]:14 | instance-property/Swift | x | s:14swift_ide_test11HasWrappersV1xSivp | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-5]]:23 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
 
   @Wrapper(body: { globalInt })
   public var y: Int
+  // CHECK: [[@LINE-2]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
+  // CHECK: [[@LINE-3]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(body:) | s:14swift_ide_test7WrapperV4bodyACyxGxyXE_tcfc | Ref,Call | rel: 0
+  // CHECK: [[@LINE-4]]:14 | instance-property/Swift | y | s:14swift_ide_test11HasWrappersV1ySivp | Def,RelChild | rel: 1
+  // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
 
-  @Wrapper(body: { return globalInt })
+  @Wrapper(body: {
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
+    struct Inner {
+      @Wrapper
+      // CHECK: [[@LINE-1]]:8 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
+      // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(initialValue:) | s:14swift_ide_test7WrapperV12initialValueACyxGx_tcfc | Ref,Call,Impl | rel: 0
+      var x: Int = globalInt
+      // CHECK: [[@LINE-1]]:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+    }
+    return Inner().x + globalInt
+    // CHECK: [[@LINE-1]]:24 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
+  })
+  // CHECK: [[@LINE-12]]:4 | constructor/Swift | init(body:) | s:14swift_ide_test7WrapperV4bodyACyxGxyXE_tcfc | Ref,Call | rel: 0
   public var z: Int
+  // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | s:14swift_ide_test11HasWrappersV1zSivp | Def,RelChild | rel: 1
 }
 
 func useMemberwiseInits(i: Int) {
   _ = HasWrappers(x: i)
   _ = HasWrappers(y: Wrapper(initialValue: i))
 }
-
-// CHECK: 19:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-// CHECK: 20:14 | instance-property/Swift | x | s:14swift_ide_test11HasWrappersV1xSivp | Def,RelChild | rel: 1
-// CHECK: 20:23 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
-
-// CHECK: 22:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-// CHECK: 22:20 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0
-
-// CHECK: 25:4 | struct/Swift | Wrapper | s:14swift_ide_test7WrapperV | Ref | rel: 0
-// CHECK: 25:27 | variable/Swift | globalInt | s:14swift_ide_test9globalIntSivp | Ref,Read | rel: 0

--- a/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
@@ -15,6 +15,19 @@ struct MyStruct {
   }
 }
 
+// Split between custom attr and initializer
+extension Wrapper {
+    init(initialValue: T, fieldNumber: Int, special: Bool = false) {
+        wrappedValue = initialValue
+    }
+}
+
+let someValue = 10
+struct OtherStruct {
+    @Wrapper(fieldNumber: someValue, special: true)
+    var complex: Int = someValue
+}
+
 // Tests that CursorInfo falls through to the wrapped property on
 // property wrapper backing properties occurreces, and that global
 // rename is reported as available on both (i.e. from foo and $foo).
@@ -28,3 +41,14 @@ struct MyStruct {
 // CHECK: ACTIONS BEGIN
 // CHECK: source.refactoring.kind.rename.global
 // CHECK: ACTIONS END
+//
+// Tests that CursofInfo finds occurrences within a property wrapper
+// constructor call where the arguments are split across the custom
+// attribute argument and the var initializer.
+//
+// RUN: %sourcekitd-test -req=cursor -pos=25:5 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=27:27 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
+// RUN: %sourcekitd-test -req=cursor -pos=28:24 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
+// CHECK2_DECL: source.lang.swift.decl.var.global (25:5-25:14)
+// CHECK2_REF: source.lang.swift.ref.var.global (25:5-25:14)
+// CHECK2-NEXT: someValue

--- a/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
@@ -1,0 +1,30 @@
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+  init(initialValue: T) {
+    wrappedValue = initialValue
+  }
+}
+
+struct MyStruct {
+  @Wrapper
+  var foo: Int = 10
+  func doStuff() {
+    _ = foo
+    _ = $foo
+  }
+}
+
+// Tests that CursorInfo falls through to the wrapped property on
+// property wrapper backing properties occurreces, and that global
+// rename is reported as available on both (i.e. from foo and $foo).
+//
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=11:7 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_DECL %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=13:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_REF %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=14:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_REF %s
+// CHECK_DECL: source.lang.swift.decl.var.instance (11:7-11:10)
+// CHECK_REF: source.lang.swift.ref.var.instance (11:7-11:10)
+// CHECK-NEXT: foo
+// CHECK: ACTIONS BEGIN
+// CHECK: source.refactoring.kind.rename.global
+// CHECK: ACTIONS END

--- a/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift
@@ -4,15 +4,24 @@ struct Wrapper<T> {
   init(initialValue: T) {
     wrappedValue = initialValue
   }
+  var projectedValue: Projection<T> {
+    get { Projection(item: wrappedValue) }
+  }
 }
 
 struct MyStruct {
+  /// Here is some documentation.
   @Wrapper
   var foo: Int = 10
   func doStuff() {
     _ = foo
+    _ = _foo
     _ = $foo
   }
+}
+
+struct Projection<T> {
+  var item: T
 }
 
 // Split between custom attr and initializer
@@ -28,27 +37,33 @@ struct OtherStruct {
     var complex: Int = someValue
 }
 
-// Tests that CursorInfo falls through to the wrapped property on
-// property wrapper backing properties occurreces, and that global
-// rename is reported as available on both (i.e. from foo and $foo).
+// Tests we get the same USR and documentation for the foo, _foo and $foo, so
+// that rename renames them all at the same time.
 //
-// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=11:7 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_DECL %s
-// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=13:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_REF %s
-// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=14:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_REF %s
-// CHECK_DECL: source.lang.swift.decl.var.instance (11:7-11:10)
-// CHECK_REF: source.lang.swift.ref.var.instance (11:7-11:10)
-// CHECK-NEXT: foo
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=17:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_WRAPPED %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=18:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_BACKING %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=19:9 %s -- %s | %FileCheck -check-prefixes=CHECK,CHECK_PROJECTED %s
+//
+// CHECK: source.lang.swift.ref.var.instance (15:7-15:10)
+// CHECK_PROJECTED: $foo
+// CHECK_BACKING: _foo
+// CHECK_WRAPPED: foo
+// CHECK: s:29cursor_info_property_wrappers8MyStructV3fooSivp
+// CHECK_PROJECTED: Projection<Int>
+// CHECK_BACKING: Wrapper<Int>
+// CHECK_WRAPPED: Int
+// CHECK: <CommentParts><Abstract><Para>Here is some documentation.</Para></Abstract></CommentParts>
 // CHECK: ACTIONS BEGIN
 // CHECK: source.refactoring.kind.rename.global
-// CHECK: ACTIONS END
 //
-// Tests that CursofInfo finds occurrences within a property wrapper
-// constructor call where the arguments are split across the custom
-// attribute argument and the var initializer.
 //
-// RUN: %sourcekitd-test -req=cursor -pos=25:5 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_DECL %s
-// RUN: %sourcekitd-test -req=cursor -pos=27:27 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
-// RUN: %sourcekitd-test -req=cursor -pos=28:24 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
-// CHECK2_DECL: source.lang.swift.decl.var.global (25:5-25:14)
-// CHECK2_REF: source.lang.swift.ref.var.global (25:5-25:14)
+// Tests that CursorInfo resolves occurrences within a property wrapper
+// constructor call where the arguments are split across the custom attribute
+// argument and the var initializer.
+//
+// RUN: %sourcekitd-test -req=cursor -pos=34:5 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_DECL %s
+// RUN: %sourcekitd-test -req=cursor -pos=36:27 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
+// RUN: %sourcekitd-test -req=cursor -pos=37:24 %s -- %s | %FileCheck -check-prefixes=CHECK2,CHECK2_REF %s
+// CHECK2_DECL: source.lang.swift.decl.var.global (34:5-34:14)
+// CHECK2_REF: source.lang.swift.ref.var.global (34:5-34:14)
 // CHECK2-NEXT: someValue

--- a/test/SourceKit/RelatedIdents/related_idents.swift
+++ b/test/SourceKit/RelatedIdents/related_idents.swift
@@ -50,6 +50,9 @@ struct Wrapper<T> {
   init(initialValue: T) {
     wrappedValue = initialValue
   }
+  var projectedValue: Projection<T> {
+    get { Projection(item: wrappedValue) }
+  }
 }
 
 struct MyStruct {
@@ -57,8 +60,13 @@ struct MyStruct {
   var foo: Int = 10
   func doStuff() {
     _ = foo
+    _ = _foo
     _ = $foo
   }
+}
+
+struct Projection<T> {
+  var item: T
 }
 
 // RUN: %sourcekitd-test -req=related-idents -pos=6:17 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK1 %s
@@ -128,11 +136,13 @@ struct MyStruct {
 
 // Test find-related-idents considers wrapped properties and their associated property wrapper backing properties as 'related'
 // but only returns the name portion of the property wrapper backing property occurrences (i.e. just the 'foo' in '$foo'),
-// RUN: %sourcekitd-test -req=related-idents -pos=57:7 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
-// RUN: %sourcekitd-test -req=related-idents -pos=59:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
-// RUN: %sourcekitd-test -req=related-idents -pos=60:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=60:7 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=62:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=63:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=64:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
 // CHECK10:      START RANGES
-// CHECK10-NEXT: 57:7 - 3
-// CHECK10-NEXT: 59:9 - 3
-// CHECK10-NEXT: 60:10 - 3
+// CHECK10-NEXT: 60:7 - 3
+// CHECK10-NEXT: 62:9 - 3
+// CHECK10-NEXT: 63:10 - 3
+// CHECK10-NEXT: 64:10 - 3
 // CHECK10-NEXT: END RANGES

--- a/test/SourceKit/RelatedIdents/related_idents.swift
+++ b/test/SourceKit/RelatedIdents/related_idents.swift
@@ -44,6 +44,23 @@ switch X.first(2, "") {
     break
 }
 
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+  init(initialValue: T) {
+    wrappedValue = initialValue
+  }
+}
+
+struct MyStruct {
+  @Wrapper
+  var foo: Int = 10
+  func doStuff() {
+    _ = foo
+    _ = $foo
+  }
+}
+
 // RUN: %sourcekitd-test -req=related-idents -pos=6:17 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: START RANGES
 // CHECK1-NEXT: 1:7 - 2
@@ -108,3 +125,14 @@ switch X.first(2, "") {
 // CHECK9-NEXT: 41:20 - 1
 // CHECK9-NEXT: 43:11 - 1
 // CHECK9-NEXT: END RANGES
+
+// Test find-related-idents considers wrapped properties and their associated property wrapper backing properties as 'related'
+// but only returns the name portion of the property wrapper backing property occurrences (i.e. just the 'foo' in '$foo'),
+// RUN: %sourcekitd-test -req=related-idents -pos=57:7 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=59:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=related-idents -pos=60:9 %s -- -module-name related_idents %s | %FileCheck -check-prefix=CHECK10 %s
+// CHECK10:      START RANGES
+// CHECK10-NEXT: 57:7 - 3
+// CHECK10-NEXT: 59:9 - 3
+// CHECK10-NEXT: 60:10 - 3
+// CHECK10-NEXT: END RANGES

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/<base>Foo</base><T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/<base>Foo</base><Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped+1*/$foo.wrappedValue
         let _: Int = /*wrapped*/foo
         let _: /*wrapper*/<base>Foo</base><String> = $bar
     }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/<base>Foo</base><T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/<base>Foo</base><Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.wrappedValue
+        let _: /*wrapper*/<base>Foo</base><Int> = /*wrapped+1*/_foo
+        let _: Int = /*wrapped+1*/_foo.wrappedValue
         let _: Int = /*wrapped*/foo
-        let _: /*wrapper*/<base>Foo</base><String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$foo
+        let _: /*wrapper*/<base>Foo</base><String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
@@ -18,7 +18,7 @@ struct /*builder:def*/Other {
 
 struct Bar {
     @/*wrapper*/<base>Foo</base>
-    var foo: Int = 10
+    var /*wrapped:def*/foo: Int = 10
     @/*wrapper*/<base>Foo</base>(initialValue: "hello")
     var bar: String
     @/*wrapper*/<base>Foo</base>
@@ -41,11 +41,10 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/<base>Foo</base><Int> = $foo
-        let _: Int = $foo.value
-        let _: Int = foo
+        let _: /*wrapper*/<base>Foo</base><Int> = /*wrapped+1*/$foo
+        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped*/foo
         let _: /*wrapper*/<base>Foo</base><String> = $bar
-        let _: String = $bar.value
     }
 }
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Foo.swift.expected
@@ -1,0 +1,52 @@
+@propertyWrapper
+struct /*wrapper:def*/<base>Foo</base><T> {
+    public var value: T
+    init(initialValue: T) {
+        value = initialValue
+    }
+    init(initialValue: T, otherThing: Bool) {
+        self.init(initialValue: initialValue)
+    }
+}
+
+@_functionBuilder
+struct /*builder:def*/Other {
+    public static func buildBlock(_ components: String...) -> String {
+        return components.joined()
+    }
+}
+
+struct Bar {
+    @/*wrapper*/<base>Foo</base>
+    var foo: Int = 10
+    @/*wrapper*/<base>Foo</base>(initialValue: "hello")
+    var bar: String
+    @/*wrapper*/<base>Foo</base>
+    var jim: String = {
+        struct Bar {
+            @/*wrapper*/<base>Foo</base>
+            var inner: String = "It's 42"
+        }
+        return Bar().inner
+    }()
+
+    func combined(@/*builder*/Other _ a: () -> String) -> String {
+        return a()
+    }
+
+     @/*builder*/Other
+    func hello() -> String {
+        "hello"
+        "there"
+    }
+
+    func baz() {
+        let _: /*wrapper*/<base>Foo</base><Int> = $foo
+        let _: Int = $foo.value
+        let _: Int = foo
+        let _: /*wrapper*/<base>Foo</base><String> = $bar
+        let _: String = $bar.value
+    }
+}
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped+1*/$foo.wrappedValue
         let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
@@ -18,7 +18,7 @@ struct /*builder:def*/<base>Other</base> {
 
 struct Bar {
     @/*wrapper*/Foo
-    var foo: Int = 10
+    var /*wrapped:def*/foo: Int = 10
     @/*wrapper*/Foo(initialValue: "hello")
     var bar: String
     @/*wrapper*/Foo
@@ -41,11 +41,10 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = $foo
-        let _: Int = $foo.value
-        let _: Int = foo
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
+        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo<String> = $bar
-        let _: String = $bar.value
     }
 }
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
@@ -1,0 +1,52 @@
+@propertyWrapper
+struct /*wrapper:def*/Foo<T> {
+    public var value: T
+    init(initialValue: T) {
+        value = initialValue
+    }
+    init(initialValue: T, otherThing: Bool) {
+        self.init(initialValue: initialValue)
+    }
+}
+
+@_functionBuilder
+struct /*builder:def*/<base>Other</base> {
+    public static func buildBlock(_ components: String...) -> String {
+        return components.joined()
+    }
+}
+
+struct Bar {
+    @/*wrapper*/Foo
+    var foo: Int = 10
+    @/*wrapper*/Foo(initialValue: "hello")
+    var bar: String
+    @/*wrapper*/Foo
+    var jim: String = {
+        struct Bar {
+            @/*wrapper*/Foo
+            var inner: String = "It's 42"
+        }
+        return Bar().inner
+    }()
+
+    func combined(@/*builder*/<base>Other</base> _ a: () -> String) -> String {
+        return a()
+    }
+
+     @/*builder*/<base>Other</base>
+    func hello() -> String {
+        "hello"
+        "there"
+    }
+
+    func baz() {
+        let _: /*wrapper*/Foo<Int> = $foo
+        let _: Int = $foo.value
+        let _: Int = foo
+        let _: /*wrapper*/Foo<String> = $bar
+        let _: String = $bar.value
+    }
+}
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/Other.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.wrappedValue
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/_foo
+        let _: Int = /*wrapped+1*/_foo.wrappedValue
         let _: Int = /*wrapped*/foo
-        let _: /*wrapper*/Foo<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$foo
+        let _: /*wrapper*/Foo<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$<base>foo</base>
-        let _: Int = /*wrapped+1*/$<base>foo</base>.wrappedValue
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/_<base>foo</base>
+        let _: Int = /*wrapped+1*/_<base>foo</base>.wrappedValue
         let _: Int = /*wrapped*/<base>foo</base>
-        let _: /*wrapper*/Foo<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$<base>foo</base>
+        let _: /*wrapper*/Foo<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$<base>foo</base>
-        let _: Int = /*wrapped+1*/$<base>foo</base>.value
+        let _: Int = /*wrapped+1*/$<base>foo</base>.wrappedValue
         let _: Int = /*wrapped*/<base>foo</base>
         let _: /*wrapper*/Foo<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/custom-attrs/wrapped.swift.expected
@@ -10,7 +10,7 @@ struct /*wrapper:def*/Foo<T> {
 }
 
 @_functionBuilder
-struct /*builder:def*/OtherBuilder {
+struct /*builder:def*/Other {
     public static func buildBlock(_ components: String...) -> String {
         return components.joined()
     }
@@ -18,7 +18,7 @@ struct /*builder:def*/OtherBuilder {
 
 struct Bar {
     @/*wrapper*/Foo
-    var /*wrapped:def*/foo: Int = 10
+    var /*wrapped:def*/<base>foo</base>: Int = 10
     @/*wrapper*/Foo(initialValue: "hello")
     var bar: String
     @/*wrapper*/Foo
@@ -30,20 +30,20 @@ struct Bar {
         return Bar().inner
     }()
 
-    func combined(@/*builder*/OtherBuilder _ a: () -> String) -> String {
+    func combined(@/*builder*/Other _ a: () -> String) -> String {
         return a()
     }
 
-     @/*builder*/OtherBuilder
+     @/*builder*/Other
     func hello() -> String {
         "hello"
         "there"
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
-        let _: Int = /*wrapped*/foo
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$<base>foo</base>
+        let _: Int = /*wrapped+1*/$<base>foo</base>.value
+        let _: Int = /*wrapped*/<base>foo</base>
         let _: /*wrapper*/Foo<String> = $bar
     }
 }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/body.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/body.swift.expected
@@ -1,12 +1,12 @@
 public struct Outer {
     @propertyWrapper
     public struct InnerWrapper<T> {
-        public var value: T
+        public var wrappedValue: T
         public /*init:def*/init(initialValue: T) {
-            self.value = initialValue
+            self.wrappedValue = initialValue
         }
         public /*body:def*/<keywordBase>init</keywordBase>(<arglabel index=0>first</arglabel><param index=0></param>: Int, <arglabel index=1>body</arglabel><param index=1></param>: () -> T) {
-            self.value = body()
+            self.wrappedValue = body()
         }
     }
 }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/body.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/body.swift.expected
@@ -1,0 +1,37 @@
+public struct Outer {
+    @propertyWrapper
+    public struct InnerWrapper<T> {
+        public var value: T
+        public /*init:def*/init(initialValue: T) {
+            self.value = initialValue
+        }
+        public /*body:def*/<keywordBase>init</keywordBase>(<arglabel index=0>first</arglabel><param index=0></param>: Int, <arglabel index=1>body</arglabel><param index=1></param>: () -> T) {
+            self.value = body()
+        }
+    }
+}
+
+var globalInt: Int { return 17 }
+public struct HasWrappers {
+    @Outer.InnerWrapper
+    public var x: Int = globalInt
+    
+    @Outer . /*body:call*/InnerWrapper(<callarg index=0>first</callarg><callcolon index=0>: </callcolon>20, <callarg index=1>body</callarg><callcolon index=1>: </callcolon>{ globalInt })
+    public var y: Int
+    
+    @Outer . /*body:call*/InnerWrapper(<callarg index=0>first</callarg><callcolon index=0>: </callcolon>10, <callarg index=1>body</callarg><callcolon index=1>: </callcolon>{
+        struct Inner {
+            @Outer . /*init:call*/InnerWrapper(initialValue: globalInt)
+            var x: Int
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+}
+
+func uses() {
+    _ = Outer . /*body:call*/InnerWrapper(<callarg index=0>first</callarg><callcolon index=0>: </callcolon>42, <callarg index=1>body</callarg><callcolon index=1>: </callcolon>{ 45 })
+    _ = Outer . /*init:call*/InnerWrapper(initialValue: 0)
+}
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/init.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/init.swift.expected
@@ -1,12 +1,12 @@
 public struct Outer {
     @propertyWrapper
     public struct InnerWrapper<T> {
-        public var value: T
+        public var wrappedValue: T
         public /*init:def*/<keywordBase>init</keywordBase>(<arglabel index=0>initialValue</arglabel><param index=0></param>: T) {
-            self.value = initialValue
+            self.wrappedValue = initialValue
         }
         public /*body:def*/init(first: Int, body: () -> T) {
-            self.value = body()
+            self.wrappedValue = body()
         }
     }
 }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/init.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-init/init.swift.expected
@@ -1,0 +1,37 @@
+public struct Outer {
+    @propertyWrapper
+    public struct InnerWrapper<T> {
+        public var value: T
+        public /*init:def*/<keywordBase>init</keywordBase>(<arglabel index=0>initialValue</arglabel><param index=0></param>: T) {
+            self.value = initialValue
+        }
+        public /*body:def*/init(first: Int, body: () -> T) {
+            self.value = body()
+        }
+    }
+}
+
+var globalInt: Int { return 17 }
+public struct HasWrappers {
+    @Outer.InnerWrapper
+    public var x: Int = globalInt
+    
+    @Outer . /*body:call*/InnerWrapper(first: 20, body: { globalInt })
+    public var y: Int
+    
+    @Outer . /*body:call*/InnerWrapper(first: 10, body: {
+        struct Inner {
+            @Outer . /*init:call*/InnerWrapper(<callarg index=0>initialValue</callarg><callcolon index=0>: </callcolon>globalInt)
+            var x: Int
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+}
+
+func uses() {
+    _ = Outer . /*body:call*/InnerWrapper(first: 42, body: { 45 })
+    _ = Outer . /*init:call*/InnerWrapper(<callarg index=0>initialValue</callarg><callcolon index=0>: </callcolon>0)
+}
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-split/someValue.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-split/someValue.swift.expected
@@ -1,0 +1,21 @@
+@propertyWrapper
+struct Wrapper<T> {
+    var wrappedValue: T
+    /*split:def*/init(initialValue: T, fieldName: String, special: Bool = false) {
+        wrappedValue = initialValue
+    }
+}
+let /*someValue:def*/<base>someValue</base> = "some"
+struct User {
+    @/*split:call*/Wrapper(fieldName: "bar")
+    var bar = 10
+
+    @/*split:call*/Wrapper(fieldName: {
+        return /*someValue*/<base>someValue</base>
+    }(), special: true)
+    var complex: Int = {
+        return /*someValue*/<base>someValue</base>.starts(with: "b") ? 43 : 0
+    }()
+}
+
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-split/split.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/property-wrapper-split/split.swift.expected
@@ -1,0 +1,21 @@
+@propertyWrapper
+struct Wrapper<T> {
+    var wrappedValue: T
+    /*split:def*/<keywordBase>init</keywordBase>(<arglabel index=0>initialValue</arglabel><param index=0></param>: T, <arglabel index=1>fieldName</arglabel><param index=1></param>: String, <arglabel index=2>special</arglabel><param index=2></param>: Bool = false) {
+        wrappedValue = initialValue
+    }
+}
+let /*someValue:def*/someValue = "some"
+struct User {
+    @/*split:call*/Wrapper(<callarg index=1>fieldName</callarg><callcolon index=1>: </callcolon>"bar")
+    var bar = 10
+
+    @/*split:call*/Wrapper(<callarg index=1>fieldName</callarg><callcolon index=1>: </callcolon>{
+        return /*someValue*/someValue
+    }(), <callarg index=2>special</callarg><callcolon index=2>: </callcolon>true)
+    var complex: Int = {
+        return /*someValue*/someValue.starts(with: "b") ? 43 : 0
+    }()
+}
+
+

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
@@ -18,7 +18,7 @@ struct /*builder:def*/Other {
 
 struct Bar {
     @/*wrapper*/Foo2
-    var foo: Int = 10
+    var /*wrapped:def*/foo: Int = 10
     @/*wrapper*/Foo2(initialValue: "hello")
     var bar: String
     @/*wrapper*/Foo2
@@ -41,11 +41,10 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo2<Int> = $foo
-        let _: Int = $foo.value
-        let _: Int = foo
+        let _: /*wrapper*/Foo2<Int> = /*wrapped+1*/$foo
+        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo2<String> = $bar
-        let _: String = $bar.value
     }
 }
 

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo2<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo2<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped+1*/$foo.wrappedValue
         let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo2<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo2<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo2<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.wrappedValue
+        let _: /*wrapper*/Foo2<Int> = /*wrapped+1*/_foo
+        let _: Int = /*wrapped+1*/_foo.wrappedValue
         let _: Int = /*wrapped*/foo
-        let _: /*wrapper*/Foo2<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$foo
+        let _: /*wrapper*/Foo2<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Foo.swift.expected
@@ -1,0 +1,52 @@
+@propertyWrapper
+struct /*wrapper:def*/Foo2<T> {
+    public var value: T
+    init(initialValue: T) {
+        value = initialValue
+    }
+    init(initialValue: T, otherThing: Bool) {
+        self.init(initialValue: initialValue)
+    }
+}
+
+@_functionBuilder
+struct /*builder:def*/Other {
+    public static func buildBlock(_ components: String...) -> String {
+        return components.joined()
+    }
+}
+
+struct Bar {
+    @/*wrapper*/Foo2
+    var foo: Int = 10
+    @/*wrapper*/Foo2(initialValue: "hello")
+    var bar: String
+    @/*wrapper*/Foo2
+    var jim: String = {
+        struct Bar {
+            @/*wrapper*/Foo2
+            var inner: String = "It's 42"
+        }
+        return Bar().inner
+    }()
+
+    func combined(@/*builder*/Other _ a: () -> String) -> String {
+        return a()
+    }
+
+     @/*builder*/Other
+    func hello() -> String {
+        "hello"
+        "there"
+    }
+
+    func baz() {
+        let _: /*wrapper*/Foo2<Int> = $foo
+        let _: Int = $foo.value
+        let _: Int = foo
+        let _: /*wrapper*/Foo2<String> = $bar
+        let _: String = $bar.value
+    }
+}
+
+

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped+1*/$foo.wrappedValue
         let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.wrappedValue
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/_foo
+        let _: Int = /*wrapped+1*/_foo.wrappedValue
         let _: Int = /*wrapped*/foo
-        let _: /*wrapper*/Foo<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$foo
+        let _: /*wrapper*/Foo<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/Other.swift.expected
@@ -1,0 +1,52 @@
+@propertyWrapper
+struct /*wrapper:def*/Foo<T> {
+    public var value: T
+    init(initialValue: T) {
+        value = initialValue
+    }
+    init(initialValue: T, otherThing: Bool) {
+        self.init(initialValue: initialValue)
+    }
+}
+
+@_functionBuilder
+struct /*builder:def*/OtherBuilder {
+    public static func buildBlock(_ components: String...) -> String {
+        return components.joined()
+    }
+}
+
+struct Bar {
+    @/*wrapper*/Foo
+    var foo: Int = 10
+    @/*wrapper*/Foo(initialValue: "hello")
+    var bar: String
+    @/*wrapper*/Foo
+    var jim: String = {
+        struct Bar {
+            @/*wrapper*/Foo
+            var inner: String = "It's 42"
+        }
+        return Bar().inner
+    }()
+
+    func combined(@/*builder*/OtherBuilder _ a: () -> String) -> String {
+        return a()
+    }
+
+     @/*builder*/OtherBuilder
+    func hello() -> String {
+        "hello"
+        "there"
+    }
+
+    func baz() {
+        let _: /*wrapper*/Foo<Int> = $foo
+        let _: Int = $foo.value
+        let _: Int = foo
+        let _: /*wrapper*/Foo<String> = $bar
+        let _: String = $bar.value
+    }
+}
+
+

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$descriptive
-        let _: Int = /*wrapped+1*/$descriptive.value
+        let _: Int = /*wrapped+1*/$descriptive.wrappedValue
         let _: Int = /*wrapped*/descriptive
         let _: /*wrapper*/Foo<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
@@ -10,7 +10,7 @@ struct /*wrapper:def*/Foo<T> {
 }
 
 @_functionBuilder
-struct /*builder:def*/OtherBuilder {
+struct /*builder:def*/Other {
     public static func buildBlock(_ components: String...) -> String {
         return components.joined()
     }
@@ -18,7 +18,7 @@ struct /*builder:def*/OtherBuilder {
 
 struct Bar {
     @/*wrapper*/Foo
-    var /*wrapped:def*/foo: Int = 10
+    var /*wrapped:def*/descriptive: Int = 10
     @/*wrapper*/Foo(initialValue: "hello")
     var bar: String
     @/*wrapper*/Foo
@@ -30,20 +30,20 @@ struct Bar {
         return Bar().inner
     }()
 
-    func combined(@/*builder*/OtherBuilder _ a: () -> String) -> String {
+    func combined(@/*builder*/Other _ a: () -> String) -> String {
         return a()
     }
 
-     @/*builder*/OtherBuilder
+     @/*builder*/Other
     func hello() -> String {
         "hello"
         "there"
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
-        let _: Int = /*wrapped*/foo
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$descriptive
+        let _: Int = /*wrapped+1*/$descriptive.value
+        let _: Int = /*wrapped*/descriptive
         let _: /*wrapper*/Foo<String> = $bar
     }
 }

--- a/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/custom-attrs/wrapped.swift.expected
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$descriptive
-        let _: Int = /*wrapped+1*/$descriptive.wrappedValue
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/_descriptive
+        let _: Int = /*wrapped+1*/_descriptive.wrappedValue
         let _: Int = /*wrapped*/descriptive
-        let _: /*wrapper*/Foo<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$descriptive
+        let _: /*wrapper*/Foo<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/body.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/body.swift.expected
@@ -1,0 +1,37 @@
+public struct Outer {
+    @propertyWrapper
+    public struct InnerWrapper<T> {
+        public var value: T
+        public /*init:def*/init(initialValue: T) {
+            self.value = initialValue
+        }
+        public /*body:def*/init(second: Int, head: () -> T) {
+            self.value = body()
+        }
+    }
+}
+
+var globalInt: Int { return 17 }
+public struct HasWrappers {
+    @Outer.InnerWrapper
+    public var x: Int = globalInt
+    
+    @Outer . /*body:call*/InnerWrapper(second: 20, head: { globalInt })
+    public var y: Int
+    
+    @Outer . /*body:call*/InnerWrapper(second: 10, head: {
+        struct Inner {
+            @Outer . /*init:call*/InnerWrapper(initialValue: globalInt)
+            var x: Int
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+}
+
+func uses() {
+    _ = Outer . /*body:call*/InnerWrapper(second: 42, head: { 45 })
+    _ = Outer . /*init:call*/InnerWrapper(initialValue: 0)
+}
+
+

--- a/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/body.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/body.swift.expected
@@ -1,12 +1,12 @@
 public struct Outer {
     @propertyWrapper
     public struct InnerWrapper<T> {
-        public var value: T
+        public var wrappedValue: T
         public /*init:def*/init(initialValue: T) {
-            self.value = initialValue
+            self.wrappedValue = initialValue
         }
         public /*body:def*/init(second: Int, head: () -> T) {
-            self.value = body()
+            self.wrappedValue = body()
         }
     }
 }

--- a/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/init.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/init.swift.expected
@@ -1,12 +1,12 @@
 public struct Outer {
     @propertyWrapper
     public struct InnerWrapper<T> {
-        public var value: T
+        public var wrappedValue: T
         public /*init:def*/init(somethingElse: T) {
-            self.value = initialValue
+            self.wrappedValue = initialValue
         }
         public /*body:def*/init(first: Int, body: () -> T) {
-            self.value = body()
+            self.wrappedValue = body()
         }
     }
 }

--- a/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/init.swift.expected
+++ b/test/refactoring/SyntacticRename/Outputs/property-wrapper-init/init.swift.expected
@@ -1,0 +1,37 @@
+public struct Outer {
+    @propertyWrapper
+    public struct InnerWrapper<T> {
+        public var value: T
+        public /*init:def*/init(somethingElse: T) {
+            self.value = initialValue
+        }
+        public /*body:def*/init(first: Int, body: () -> T) {
+            self.value = body()
+        }
+    }
+}
+
+var globalInt: Int { return 17 }
+public struct HasWrappers {
+    @Outer.InnerWrapper
+    public var x: Int = globalInt
+    
+    @Outer . /*body:call*/InnerWrapper(first: 20, body: { globalInt })
+    public var y: Int
+    
+    @Outer . /*body:call*/InnerWrapper(first: 10, body: {
+        struct Inner {
+            @Outer . /*init:call*/InnerWrapper(somethingElse: globalInt)
+            var x: Int
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+}
+
+func uses() {
+    _ = Outer . /*body:call*/InnerWrapper(first: 42, body: { 45 })
+    _ = Outer . /*init:call*/InnerWrapper(somethingElse: 0)
+}
+
+

--- a/test/refactoring/SyntacticRename/custom-attrs.swift
+++ b/test/refactoring/SyntacticRename/custom-attrs.swift
@@ -1,0 +1,62 @@
+@propertyWrapper
+struct /*wrapper:def*/Foo<T> {
+    public var value: T
+    init(initialValue: T) {
+        value = initialValue
+    }
+    init(initialValue: T, otherThing: Bool) {
+        self.init(initialValue: initialValue)
+    }
+}
+
+@_functionBuilder
+struct /*builder:def*/Other {
+    public static func buildBlock(_ components: String...) -> String {
+        return components.joined()
+    }
+}
+
+struct Bar {
+    @/*wrapper*/Foo
+    var foo: Int = 10
+    @/*wrapper*/Foo(initialValue: "hello")
+    var bar: String
+    @/*wrapper*/Foo
+    var jim: String = {
+        struct Bar {
+            @/*wrapper*/Foo
+            var inner: String = "It's 42"
+        }
+        return Bar().inner
+    }()
+
+    func combined(@/*builder*/Other _ a: () -> String) -> String {
+        return a()
+    }
+
+     @/*builder*/Other
+    func hello() -> String {
+        "hello"
+        "there"
+    }
+
+    func baz() {
+        let _: /*wrapper*/Foo<Int> = $foo
+        let _: Int = $foo.value
+        let _: Int = foo
+        let _: /*wrapper*/Foo<String> = $bar
+        let _: String = $bar.value
+    }
+}
+
+
+// RUN: %empty-directory(%t.result)
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="wrapper" -is-non-protocol-type -old-name "Foo" -new-name "Foo2" >> %t.result/custom-attrs-Foo.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="wrapper" -is-non-protocol-type -old-name "Foo" >> %t.ranges/custom-attrs-Foo.swift
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="builder" -is-non-protocol-type -old-name "Other" -new-name "OtherBuilder" >> %t.result/custom-attrs-Other.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="builder" -is-non-protocol-type -old-name "Other" >> %t.ranges/custom-attrs-Other.swift
+// RUN: diff -u %S/Outputs/custom-attrs/Foo.swift.expected %t.result/custom-attrs-Foo.swift
+// RUN: diff -u %S/FindRangeOutputs/custom-attrs/Foo.swift.expected %t.ranges/custom-attrs-Foo.swift
+// RUN: diff -u %S/Outputs/custom-attrs/Other.swift.expected %t.result/custom-attrs-Other.swift
+// RUN: diff -u %S/FindRangeOutputs/custom-attrs/Other.swift.expected %t.ranges/custom-attrs-Other.swift

--- a/test/refactoring/SyntacticRename/custom-attrs.swift
+++ b/test/refactoring/SyntacticRename/custom-attrs.swift
@@ -1,8 +1,8 @@
 @propertyWrapper
 struct /*wrapper:def*/Foo<T> {
-    public var value: T
+    public var wrappedValue: T
     init(initialValue: T) {
-        value = initialValue
+        wrappedValue = initialValue
     }
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
@@ -42,7 +42,7 @@ struct Bar {
 
     func baz() {
         let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped+1*/$foo.wrappedValue
         let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo<String> = $bar
     }

--- a/test/refactoring/SyntacticRename/custom-attrs.swift
+++ b/test/refactoring/SyntacticRename/custom-attrs.swift
@@ -7,6 +7,13 @@ struct /*wrapper:def*/Foo<T> {
     init(initialValue: T, otherThing: Bool) {
         self.init(initialValue: initialValue)
     }
+    var projectedValue: Projection<T> {
+      get { Projection(item: wrappedValue) }
+    }
+}
+
+struct Projection<T> {
+    var item: T
 }
 
 @_functionBuilder
@@ -41,10 +48,11 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
-        let _: Int = /*wrapped+1*/$foo.wrappedValue
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/_foo
+        let _: Int = /*wrapped+1*/_foo.wrappedValue
         let _: Int = /*wrapped*/foo
-        let _: /*wrapper*/Foo<String> = $bar
+        let _: Projection<Int> = /*wrapped+1*/$foo
+        let _: /*wrapper*/Foo<String> = _bar
     }
 }
 

--- a/test/refactoring/SyntacticRename/custom-attrs.swift
+++ b/test/refactoring/SyntacticRename/custom-attrs.swift
@@ -18,7 +18,7 @@ struct /*builder:def*/Other {
 
 struct Bar {
     @/*wrapper*/Foo
-    var foo: Int = 10
+    var /*wrapped:def*/foo: Int = 10
     @/*wrapper*/Foo(initialValue: "hello")
     var bar: String
     @/*wrapper*/Foo
@@ -41,11 +41,10 @@ struct Bar {
     }
 
     func baz() {
-        let _: /*wrapper*/Foo<Int> = $foo
-        let _: Int = $foo.value
-        let _: Int = foo
+        let _: /*wrapper*/Foo<Int> = /*wrapped+1*/$foo
+        let _: Int = /*wrapped+1*/$foo.value
+        let _: Int = /*wrapped*/foo
         let _: /*wrapper*/Foo<String> = $bar
-        let _: String = $bar.value
     }
 }
 
@@ -54,9 +53,13 @@ struct Bar {
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="wrapper" -is-non-protocol-type -old-name "Foo" -new-name "Foo2" >> %t.result/custom-attrs-Foo.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="wrapper" -is-non-protocol-type -old-name "Foo" >> %t.ranges/custom-attrs-Foo.swift
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="wrapped" -old-name "foo" -new-name "descriptive" >> %t.result/custom-attrs-wrapped.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="wrapped" -old-name "foo" >> %t.ranges/custom-attrs-wrapped.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="builder" -is-non-protocol-type -old-name "Other" -new-name "OtherBuilder" >> %t.result/custom-attrs-Other.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="builder" -is-non-protocol-type -old-name "Other" >> %t.ranges/custom-attrs-Other.swift
 // RUN: diff -u %S/Outputs/custom-attrs/Foo.swift.expected %t.result/custom-attrs-Foo.swift
 // RUN: diff -u %S/FindRangeOutputs/custom-attrs/Foo.swift.expected %t.ranges/custom-attrs-Foo.swift
+// RUN: diff -u %S/Outputs/custom-attrs/wrapped.swift.expected %t.result/custom-attrs-wrapped.swift
+// RUN: diff -u %S/FindRangeOutputs/custom-attrs/wrapped.swift.expected %t.ranges/custom-attrs-wrapped.swift
 // RUN: diff -u %S/Outputs/custom-attrs/Other.swift.expected %t.result/custom-attrs-Other.swift
 // RUN: diff -u %S/FindRangeOutputs/custom-attrs/Other.swift.expected %t.ranges/custom-attrs-Other.swift

--- a/test/refactoring/SyntacticRename/property-wrapper-init.swift
+++ b/test/refactoring/SyntacticRename/property-wrapper-init.swift
@@ -1,0 +1,47 @@
+public struct Outer {
+    @propertyWrapper
+    public struct InnerWrapper<T> {
+        public var value: T
+        public /*init:def*/init(initialValue: T) {
+            self.value = initialValue
+        }
+        public /*body:def*/init(first: Int, body: () -> T) {
+            self.value = body()
+        }
+    }
+}
+
+var globalInt: Int { return 17 }
+public struct HasWrappers {
+    @Outer.InnerWrapper
+    public var x: Int = globalInt
+    
+    @Outer . /*body:call*/InnerWrapper(first: 20, body: { globalInt })
+    public var y: Int
+    
+    @Outer . /*body:call*/InnerWrapper(first: 10, body: {
+        struct Inner {
+            @Outer . /*init:call*/InnerWrapper(initialValue: globalInt)
+            var x: Int
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+}
+
+func uses() {
+    _ = Outer . /*body:call*/InnerWrapper(first: 42, body: { 45 })
+    _ = Outer . /*init:call*/InnerWrapper(initialValue: 0)
+}
+
+
+// RUN: %empty-directory(%t.result)
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="init" -is-function-like -old-name "init(initialValue:)" -new-name "init(somethingElse:)" >> %t.result/property-wrapper-init.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="init" -is-function-like -old-name "init(initialValue:)" >> %t.ranges/property-wrapper-init.swift
+// RUN: %refactor -syntactic-rename -source-filename %s -pos="body" -is-function-like -old-name "init(first:body:)" -new-name "init(second:head:)" >> %t.result/property-wrapper-body.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="body" -is-function-like -old-name "init(first:body:)" >> %t.ranges/property-wrapper-body.swift
+// RUN: diff -u %S/Outputs/property-wrapper-init/init.swift.expected %t.result/property-wrapper-init.swift
+// RUN: diff -u %S/FindRangeOutputs/property-wrapper-init/init.swift.expected %t.ranges/property-wrapper-init.swift
+// RUN: diff -u %S/Outputs/property-wrapper-init/body.swift.expected %t.result/property-wrapper-body.swift
+// RUN: diff -u %S/FindRangeOutputs/property-wrapper-init/body.swift.expected %t.ranges/property-wrapper-body.swift

--- a/test/refactoring/SyntacticRename/property-wrapper-init.swift
+++ b/test/refactoring/SyntacticRename/property-wrapper-init.swift
@@ -1,12 +1,12 @@
 public struct Outer {
     @propertyWrapper
     public struct InnerWrapper<T> {
-        public var value: T
+        public var wrappedValue: T
         public /*init:def*/init(initialValue: T) {
-            self.value = initialValue
+            self.wrappedValue = initialValue
         }
         public /*body:def*/init(first: Int, body: () -> T) {
-            self.value = body()
+            self.wrappedValue = body()
         }
     }
 }

--- a/test/refactoring/SyntacticRename/property-wrapper-split.swift
+++ b/test/refactoring/SyntacticRename/property-wrapper-split.swift
@@ -1,0 +1,26 @@
+@propertyWrapper
+struct Wrapper<T> {
+    var wrappedValue: T
+    /*split:def*/init(initialValue: T, fieldName: String, special: Bool = false) {
+        wrappedValue = initialValue
+    }
+}
+let /*someValue:def*/someValue = "some"
+struct User {
+    @/*split:call*/Wrapper(fieldName: "bar")
+    var bar = 10
+
+    @/*split:call*/Wrapper(fieldName: {
+        return /*someValue*/someValue
+    }(), special: true)
+    var complex: Int = {
+        return /*someValue*/someValue.starts(with: "b") ? 43 : 0
+    }()
+}
+
+
+// RUN: %empty-directory(%t.ranges)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="someValue" -old-name "someValue" >> %t.ranges/property-wrapper-split-someValue.swift
+// RUN: diff -u %S/FindRangeOutputs/property-wrapper-split/someValue.swift.expected %t.ranges/property-wrapper-split-someValue.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="split" -is-function-like -old-name "init(initialValue:fieldName:special:)" >> %t.ranges/property-wrapper-split-split.swift
+// RUN: diff -u %S/FindRangeOutputs/property-wrapper-split/split.swift.expected %t.ranges/property-wrapper-split-split.swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -408,6 +408,15 @@ static void printAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
+  // If this is a property wrapper backing property (_foo) or projected value
+  // ($foo) and the wrapped property is not implicit, still print it.
+  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
+    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
+      if (!Wrapped->isImplicit())
+        PO.TreatAsExplicitDeclList.push_back(VD);
+    }
+  }
+
   // Wrap this up in XML, as that's what we'll use for documentation comments.
   OS<<"<Declaration>";
   VD->print(Printer, PO);
@@ -430,6 +439,14 @@ void SwiftLangSupport::printFullyAnnotatedDeclaration(const ValueDecl *VD,
   while (VD->isImplicit() && VD->getOverriddenDecl())
     VD = VD->getOverriddenDecl();
 
+  // If this is a property wrapper backing property (_foo) or projected value
+  // ($foo) and the wrapped property is not implicit, still print it.
+  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
+    if (auto *Wrapped = VarD->getOriginalWrappedProperty()) {
+      if (!Wrapped->isImplicit())
+        PO.TreatAsExplicitDeclList.push_back(VD);
+    }
+  }
   VD->print(Printer, PO);
 }
 
@@ -736,10 +753,19 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   }
   unsigned NameEnd = SS.size();
 
+  // If VD is the syntehsized property wrapper backing storage (_foo) or
+  // projected value ($foo) of a property (foo), use that property's USR instead
+  // so that a rename refactoring renames all three (foo, $foo, and _foo).
+  const ValueDecl* OriginalProperty = VD;
+  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
+    if (auto *Wrapped = VarD->getOriginalWrappedProperty())
+        OriginalProperty = Wrapped;
+  }
+
   unsigned USRBegin = SS.size();
   {
     llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printUSR(VD, OS);
+    SwiftLangSupport::printUSR(OriginalProperty, OS);
     if (InSynthesizedExtension) {
         OS << LangSupport::SynthesizedUSRSeparator;
         SwiftLangSupport::printUSR(BaseType->getAnyNominal(), OS);
@@ -770,10 +796,13 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   }
   unsigned MangledContainerTypeEnd = SS.size();
 
+  // If VD is the syntehsized property wrapper backing storage (_foo) or
+  // projected value ($foo) of a property (foo), use that property's
+  // documentation instead.
   unsigned DocCommentBegin = SS.size();
   {
     llvm::raw_svector_ostream OS(SS);
-    ide::getDocumentationCommentAsXML(VD, OS);
+    ide::getDocumentationCommentAsXML(OriginalProperty, OS);
   }
   unsigned DocCommentEnd = SS.size();
 
@@ -905,9 +934,12 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   StringRef LocalizationKey = StringRef(SS.begin() + LocalizationBegin,
                                         LocalizationEnd - LocalizationBegin);
 
+  // If VD is the syntehsized property wrapper backing storage (_foo) or
+  // projected value ($foo) of a property (foo), base the location on that
+  // property instead.
   llvm::Optional<std::pair<unsigned, unsigned>> DeclarationLoc;
   StringRef Filename;
-  getLocationInfo(VD, DeclarationLoc, Filename);
+  getLocationInfo(OriginalProperty, DeclarationLoc, Filename);
   if (DeclarationLoc.hasValue()) {
     DeclarationLoc = tryRemappingLocToLatestSnapshot(Lang,
                                                      *DeclarationLoc,
@@ -1875,6 +1907,13 @@ public:
       //   case .third(let x)
       //     print(x)
       Dcl = V->getCanonicalVarDecl();
+
+      // If we have a prioperty wrapper backing property or projected value, use
+      // the wrapped property instead (i.e. if this is _foo or $foo, pretend
+      // it's foo).
+      if (auto *Wrapped = V->getOriginalWrappedProperty()) {
+        Dcl = Wrapped;
+      }
     } else {
       Dcl = D;
     }
@@ -1893,6 +1932,7 @@ private:
       return passId(Range);
     return true;
   }
+
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
@@ -1902,10 +1942,12 @@ private:
     if (auto *V = dyn_cast<VarDecl>(D)) {
       D = V->getCanonicalVarDecl();
 
-      // If we have a backing property of a property wrapper, use the wrapped
-      // property instead (i.e. if this is $foo, pretend it's foo).
+      // If we have a prioperty wrapper backing property or projected value, use
+      // the wrapped property for comparison instead (i.e. if this is _foo or
+      // $foo, pretend it's foo).
       if (auto *Wrapped = V->getOriginalWrappedProperty()) {
-        assert(Range.getByteLength() > 1 && Range.str().front() == '$');
+        assert(Range.getByteLength() > 1 &&
+               (Range.str().front() == '_' || Range.str().front() == '$'));
         D = Wrapped;
         Range = CharSourceRange(Range.getStart().getAdvancedLoc(1), Range.getByteLength() - 1);
       }


### PR DESCRIPTION
This PR fixes up rename support for property wrappers. There were three main issues this addresses:

1. Renaming an `@propertyWrapper` struct was failing due to rename's `NameMatcher` using the range of a `Decl` itself, not including its attributes, to decide if it contained a location that needed to be resolved.
2. Renaming a constructor of a `@propertyWrapper` struct would not pick up occurrences of that constructor's argument labels used in custom attributes, e.g. renaming `MyWrapper`'s `init(initialValue:minValue:maxValue)` constructor would miss the argument labels in custom attributes like `@MyWrapper(initialValue: 50, minValue: 0, maxValue: 100)`. This is because the indexer didn't report an occurrence of the constructor call in custom attributes. Rename's `NameMatcher` also needed to be updated to handle resolving these newly-added occurrences, since the call expression in the AST doesn't have an explicit base (`MyWrapper` is not part of the call expression, but is where the index reports the call taking place).
3. Renaming a wrapped property (e.g. `foo`) wasn't updating the corresponding synthesized `$`-prefixed backing property (`$foo`). The synthesized backing property declarations were implicit, so the index wasn't recording them, and even if it did, it's a different property so wouldn't be picked up automatically.
\
To resolve this, the index now records an occurrence of the wrapped property within the synthesized backing property occurrences (i.e. on the `foo` within each `$foo`) so that rename on the wrapped property updates the synthesized backing property occurrences too.  To support rename being invoked via an occurrence of a synthesized property, the `CusorInfo` request that determines which symbol is renamed for a given location now treats occurrences of synthesized properties as if they were the corresponding wrapped properties. The `FindRelatedIdents` request was also similarly updated so that rename-like features that are based on it (like Xcode's edit-all-in-scope) can get both the underlying and synthesized property ranges, regardless of which is was invoked on.

This PR also includes some small and/or incidental IDE issue fixes around custom attributes:
- syntax coloring wasn't working for the custom attribute type occurrences (only semantic highlighting)
- interleaving of availability attributes, custom attributes and built-in attributes would sometimes result in incorrect syntax highlighting.

Resolves rdar://problem/49036613
Resolves rdar://problem/50073641
Resolves rdar://problem/51695783
Resolves rdar://problem/52053678