### PR TITLE
[5.1 06-12-2019] [SE-0258] Enable default argument for wrapped property going through init().

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1576,6 +1576,11 @@ bool PatternBindingDecl::isDefaultInitializable(unsigned i) const {
     if (auto wrapperInfo = singleVar->getAttachedPropertyWrapperTypeInfo(0)) {
       if (wrapperInfo.defaultInit)
         return true;
+
+      // If one of the attached wrappers is missing an initialValue
+      // initializer, cannot default-initialize.
+      if (!singleVar->allAttachedPropertyWrappersHaveInitialValueInit())
+        return false;
     }
   }
 

--- a/test/IDE/print_property_wrappers.swift
+++ b/test/IDE/print_property_wrappers.swift
@@ -47,7 +47,7 @@ struct HasWrappers {
   var z: String
 
   // Memberwise initializer.
-  // CHECK: init(x: Wrapper<Int> = Wrapper(closure: foo), y: Bool = true, z: String)
+  // CHECK: init(x: Wrapper<Int> = Wrapper(closure: foo), y: Bool = true, z: String = Wrapper())
 }
 
 func trigger() {

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -18,6 +18,20 @@ struct WrapperWithInitialValue<T> {
 }
 
 @propertyWrapper
+struct WrapperWithDefaultInit<T> {
+  private var stored: T?
+
+  var wrappedValue: T {
+    get { stored! }
+    set { stored = newValue }
+  }
+
+  init() {
+    self.stored = nil
+  }
+}
+
+@propertyWrapper
 struct WrapperAcceptingAutoclosure<T> {
   private let fn: () -> T
 
@@ -610,6 +624,21 @@ struct DefaultedMemberwiseInits {
 
   @WrapperWithInitialValue(initialValue: 17)
   var z: Int
+
+  @WrapperWithDefaultInit
+  var w: Int
+
+  @WrapperWithDefaultInit
+  var optViaDefaultInit: Int?
+
+  @WrapperWithInitialValue
+  var optViaInitialValue: Int?
+}
+
+
+struct CannotDefaultMemberwiseOptionalInit { // expected-note{{'init(x:)' declared here}}
+  @Wrapper
+  var x: Int?
 }
 
 func testDefaultedMemberwiseInits() {
@@ -622,6 +651,13 @@ func testDefaultedMemberwiseInits() {
   _ = DefaultedMemberwiseInits(y: 42)
   _ = DefaultedMemberwiseInits(x: Wrapper(wrappedValue: false))
   _ = DefaultedMemberwiseInits(z: WrapperWithInitialValue(initialValue: 42))
+  _ = DefaultedMemberwiseInits(w: WrapperWithDefaultInit())
+  _ = DefaultedMemberwiseInits(optViaDefaultInit: WrapperWithDefaultInit())
+  _ = DefaultedMemberwiseInits(optViaInitialValue: nil)
+  _ = DefaultedMemberwiseInits(optViaInitialValue: 42)
+
+  _ = CannotDefaultMemberwiseOptionalInit() // expected-error{{missing argument for parameter 'x' in call}}
+  _ = CannotDefaultMemberwiseOptionalInit(x: Wrapper(wrappedValue: nil))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
My recent refactoring of default arguments for the memberwise initializer
accidentally dropped support for getting a default argument when the
attached property wrapper has an init(). Reinstate that support,
fixing rdar://problem/52116923.
