### PR TITLE
build: add a workaround for android NDK[<21]

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -288,6 +288,21 @@ function(_add_variant_c_compile_flags)
     endif()
   endif()
 
+  if(CFLAGS_SDK STREQUAL ANDROID)
+    if(CFLAGS_ARCH STREQUAL x86_64)
+      # NOTE(compnerd) Android NDK 21 or lower will generate library calls to
+      # `__sync_val_compare_and_swap_16` rather than lowering to the CPU's
+      # `cmpxchg16b` instruction as the `cx16` feature is disabled due to a bug
+      # in Clang.  This is being fixed in the current master Clang and will
+      # hopefully make it into Clang 9.0.  In the mean time, workaround this in
+      # the build.
+      if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION
+          VERSION_LESS 9.0.0)
+        list(APPEND result -mcx16)
+      endif()
+    endif()
+  endif()
+
   if(CFLAGS_ENABLE_ASSERTIONS)
     list(APPEND result "-UNDEBUG")
   else()


### PR DESCRIPTION
The clang in the android NDK (as well as the current stable Clang in
Swift) have a bug with Android x86_64 targets where the CPU's 16-byte
(double-word) CAS instruction feature is disabled resulting in the
double word CAS being lowered to a libcall
(`__sync_val_compare_and_swap_16`) rather than the CPU instruction
(`cmpxchg16b`).  This results in the inability to link the content.
Work around this by enabling the feature manually in the build for now.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
