### PR TITLE
Convert ForEachStmt to not use tc.callWitness().

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/AvailabilitySpec.h"
+#include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/NullablePtr.h"
@@ -802,12 +803,15 @@ class ForEachStmt : public LabeledStmt {
   Expr *Sequence;
   Expr *WhereExpr = nullptr;
   BraceStmt *Body;
-  
-  /// The iterator variable along with its initializer.
-  PatternBindingDecl *Iterator = nullptr;
-  /// The expression that advances the iterator and returns an Optional with
-  /// the next value or None to signal end-of-stream.
-  Expr *IteratorNext = nullptr;
+
+  // Set by Sema:
+  Optional<ProtocolConformanceRef> sequenceConformance;
+  ConcreteDeclRef makeIterator;
+  ConcreteDeclRef iteratorNext;
+  VarDecl *iteratorVar = nullptr;
+  Expr *iteratorVarRef = nullptr;
+  OpaqueValueExpr *elementExpr = nullptr;
+  Expr *convertElementExpr = nullptr;
 
 public:
   ForEachStmt(LabeledStmtInfo LabelInfo, SourceLoc ForLoc, Pattern *Pat,
@@ -819,7 +823,32 @@ public:
       WhereExpr(WhereExpr), Body(Body) {
     setPattern(Pat);
   }
-  
+
+  void setIteratorVar(VarDecl *var) { iteratorVar = var; }
+  VarDecl *getIteratorVar() const { return iteratorVar; }
+
+  void setIteratorVarRef(Expr *var) { iteratorVarRef = var; }
+  Expr *getIteratorVarRef() const { return iteratorVarRef; }
+
+  void setElementExpr(OpaqueValueExpr *expr) { elementExpr = expr; }
+  OpaqueValueExpr *getElementExpr() const { return elementExpr; }
+
+  void setConvertElementExpr(Expr *expr) { convertElementExpr = expr; }
+  Expr *getConvertElementExpr() const { return convertElementExpr; }
+
+  void setMakeIterator(ConcreteDeclRef declRef) { makeIterator = declRef; }
+  ConcreteDeclRef getMakeIterator() const { return makeIterator; }
+
+  void setIteratorNext(ConcreteDeclRef declRef) { iteratorNext = declRef; }
+  ConcreteDeclRef getIteratorNext() const { return iteratorNext; }
+
+  void setSequenceConformance(Optional<ProtocolConformanceRef> conformance) {
+    sequenceConformance = conformance;
+  }
+  Optional<ProtocolConformanceRef> getSequenceConformance() const {
+    return sequenceConformance;
+  }
+
   /// getForLoc - Retrieve the location of the 'for' keyword.
   SourceLoc getForLoc() const { return ForLoc; }
 
@@ -840,15 +869,6 @@ public:
   /// expression to extract a range, use \c getRangeInit().
   Expr *getSequence() const { return Sequence; }
   void setSequence(Expr *S) { Sequence = S; }
-  
-  /// Retrieve the pattern binding that contains the (implicit) iterator
-  /// variable and its initialization from the container.
-  PatternBindingDecl *getIterator() const { return Iterator; }
-  void setIterator(PatternBindingDecl *It) { Iterator = It; }
-  
-  /// Retrieve the expression that advances the iterator.
-  Expr *getIteratorNext() const { return IteratorNext; }
-  void setIteratorNext(Expr *E) { IteratorNext = E; }
 
   /// getBody - Retrieve the body of the loop.
   BraceStmt *getBody() const { return Body; }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1603,7 +1603,14 @@ public:
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitForEachStmt(ForEachStmt *S) {
-    printCommon(S, "for_each_stmt") << '\n';
+    printCommon(S, "for_each_stmt");
+    PrintWithColorRAII(OS, LiteralValueColor) << " make_generator=";
+    S->getMakeIterator().dump(
+        PrintWithColorRAII(OS, LiteralValueColor).getOS());
+    PrintWithColorRAII(OS, LiteralValueColor) << " next=";
+    S->getIteratorNext().dump(
+        PrintWithColorRAII(OS, LiteralValueColor).getOS());
+    OS << '\n';
     printRec(S->getPattern());
     OS << '\n';
     if (S->getWhere()) {
@@ -1617,12 +1624,20 @@ public:
     OS << '\n';
     printRec(S->getSequence());
     OS << '\n';
-    if (S->getIterator()) {
-      printRec(S->getIterator());
+    if (S->getIteratorVar()) {
+      printRec(S->getIteratorVar());
       OS << '\n';
     }
-    if (S->getIteratorNext()) {
-      printRec(S->getIteratorNext());
+    if (S->getIteratorVarRef()) {
+      printRec(S->getIteratorVarRef());
+      OS << '\n';
+    }
+    if (S->getConvertElementExpr()) {
+      printRec(S->getConvertElementExpr());
+      OS << '\n';
+    }
+    if (S->getElementExpr()) {
+      printRec(S->getElementExpr());
       OS << '\n';
     }
     printRec(S->getBody());

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -784,6 +784,26 @@ public:
       popScope(BS);
     }
 
+    bool shouldVerify(ForEachStmt *S) {
+      if (!shouldVerify(cast<Stmt>(S)))
+        return false;
+
+      if (!S->getElementExpr())
+        return true;
+
+      assert(!OpaqueValues.count(S->getElementExpr()));
+      OpaqueValues[S->getElementExpr()] = 0;
+      return true;
+    }
+
+    void cleanup(ForEachStmt *S) {
+      if (!S->getElementExpr())
+        return;
+
+      assert(OpaqueValues.count(S->getElementExpr()));
+      OpaqueValues.erase(S->getElementExpr());
+    }
+
     bool shouldVerify(OpenExistentialExpr *expr) {
       if (!shouldVerify(cast<Expr>(expr)))
         return false;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1555,20 +1555,28 @@ Stmt *Traversal::visitForEachStmt(ForEachStmt *S) {
 
   // The iterator decl is built directly on top of the sequence
   // expression, so don't visit both.
-  if (PatternBindingDecl *Iterator = S->getIterator()) {
-    if (doIt(Iterator))
-      return nullptr;
-
-  } else if (Expr *Sequence = S->getSequence()) {
+  if (Expr *Sequence = S->getSequence()) {
     if ((Sequence = doIt(Sequence)))
       S->setSequence(Sequence);
     else
       return nullptr;
   }
 
-  if (auto IteratorNext = S->getIteratorNext()) {
+  if (auto IteratorNext = S->getConvertElementExpr()) {
     if ((IteratorNext = doIt(IteratorNext)))
-      S->setIteratorNext(IteratorNext);
+      S->setConvertElementExpr(IteratorNext);
+    else
+      return nullptr;
+  }
+
+  if (auto IteratorVar = S->getIteratorVar()) {
+    if (doIt(IteratorVar))
+      return nullptr;
+  }
+
+  if (auto IteratorVarRef = S->getIteratorVarRef()) {
+    if ((IteratorVarRef = doIt(IteratorVarRef)))
+      S->setIteratorVarRef(IteratorVarRef);
     else
       return nullptr;
   }

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -162,15 +162,6 @@ SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
 
 namespace {
 
-/// Walk the non-static initializers in \p PBD.
-static void walkPatternForProfiling(PatternBindingDecl *PBD,
-                                    ASTWalker &Walker) {
-  if (PBD && !PBD->isStatic())
-    for (auto E : PBD->getPatternList())
-      if (auto init = E.getExecutableInit())
-        init->walk(Walker);
-}
-
 /// Special logic for handling function visitation.
 ///
 /// To avoid creating duplicate mappings, a function decl is only profiled if
@@ -235,7 +226,6 @@ struct MapRegionCounters : public ASTWalker {
       mapRegion(RWS->getBody());
     } else if (auto *FES = dyn_cast<ForEachStmt>(S)) {
       mapRegion(FES->getBody());
-      walkPatternForProfiling(FES->getIterator(), *this);
     } else if (auto *SS = dyn_cast<SwitchStmt>(S)) {
       mapRegion(SS);
     } else if (auto *CS = dyn_cast<CaseStmt>(S)) {
@@ -564,7 +554,6 @@ struct PGOMapping : public ASTWalker {
       CounterMap[FES] = parent;
       auto count = loadExecutionCount(FES);
       LoadedCounterMap[FES] = count;
-      walkPatternForProfiling(FES->getIterator(), *this);
     } else if (auto *SS = dyn_cast<SwitchStmt>(S)) {
       CounterMap[SS] = NextCounter++;
       auto ssCount = loadExecutionCount(SS);
@@ -896,7 +885,6 @@ public:
     } else if (auto *FES = dyn_cast<ForEachStmt>(S)) {
       assignCounter(FES, CounterExpr::Zero());
       assignCounter(FES->getBody());
-      walkPatternForProfiling(FES->getIterator(), *this);
 
     } else if (auto *SS = dyn_cast<SwitchStmt>(S)) {
       assignCounter(SS);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1480,6 +1480,10 @@ public:
                                         PreparedArguments &&args, Type overriddenSelfType,
                                         SGFContext ctx);
 
+  RValue emitApplyMethod(SILLocation loc, ConcreteDeclRef declRef,
+                         ArgumentSource &&self, PreparedArguments &&args,
+                         SGFContext C);
+
   RValue emitApplyPropertyWrapperAllocator(SILLocation loc,
                                             SubstitutionMap subs,
                                             SILDeclRef ctorRef,

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -190,7 +190,7 @@ public:
 
       // point at the for stmt, to look nice
       SourceLoc StartLoc = FES->getStartLoc();
-      SourceLoc EndLoc = FES->getIterator()->getEndLoc();
+      SourceLoc EndLoc = FES->getSequence()->getEndLoc();
       // FIXME: get the 'end' of the for stmt
       // if (FD->getBodyResultTypeLoc().hasLocation()) {
       //   EndLoc = FD->getBodyResultTypeLoc().getSourceRange().End;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -725,17 +725,17 @@ public:
     }
 
     // Retrieve the 'Iterator' protocol.
-    ProtocolDecl *generatorProto
-      = TC.getProtocol(S->getForLoc(), KnownProtocolKind::IteratorProtocol);
-    if (!generatorProto) {
+    ProtocolDecl *iteratorProto =
+        TC.getProtocol(S->getForLoc(), KnownProtocolKind::IteratorProtocol);
+    if (!iteratorProto) {
       return nullptr;
     }
-    
+
     Expr *sequence = S->getSequence();
 
     // Invoke iterator() to get an iterator from the sequence.
-    Type generatorTy;
-    VarDecl *generator;
+    Type iteratorTy;
+    VarDecl *iterator;
     {
       Type sequenceType = sequence->getType();
       auto conformance =
@@ -744,43 +744,61 @@ public:
                                         sequence->getLoc());
       if (!conformance)
         return nullptr;
+      S->setSequenceConformance(conformance);
 
-      generatorTy = TC.getWitnessType(sequenceType, sequenceProto,
-                                      *conformance,
-                                      TC.Context.Id_Iterator,
-                                      diag::sequence_protocol_broken);
-
-      if (!generatorTy)
+      iteratorTy = TC.getWitnessType(sequenceType, sequenceProto, *conformance,
+                                     TC.Context.Id_Iterator,
+                                     diag::sequence_protocol_broken);
+      if (!iteratorTy)
         return nullptr;
-      
-      Expr *getIterator
-        = TC.callWitness(sequence, DC, sequenceProto, *conformance,
-                         TC.Context.Id_makeIterator,
-                         {}, diag::sequence_protocol_broken);
-      if (!getIterator) return nullptr;
 
-      // Create a local variable to capture the generator.
+      auto witness = conformance->getWitnessByName(
+          sequenceType->getRValueType(), TC.Context.Id_makeIterator);
+      if (!witness)
+        return nullptr;
+      S->setMakeIterator(witness);
+
+      // Create a local variable to capture the iterator.
       std::string name;
       if (auto np = dyn_cast_or_null<NamedPattern>(S->getPattern()))
         name = "$"+np->getBoundName().str().str();
       name += "$generator";
-      generator = new (TC.Context)
-        VarDecl(/*IsStatic*/false, VarDecl::Specifier::Var, /*IsCaptureList*/false,
-                S->getInLoc(), TC.Context.getIdentifier(name), DC);
-      generator->setType(generatorTy);
-      generator->setInterfaceType(generatorTy->mapTypeOutOfContext());
-      generator->setImplicit();
 
-      // Create a pattern binding to initialize the generator.
-      auto genPat = new (TC.Context) NamedPattern(generator);
+      iterator = new (TC.Context) VarDecl(
+          /*IsStatic*/ false, VarDecl::Specifier::Var, /*IsCaptureList*/ false,
+          S->getInLoc(), TC.Context.getIdentifier(name), DC);
+      iterator->setType(iteratorTy);
+      iterator->setInterfaceType(iteratorTy->mapTypeOutOfContext());
+      iterator->setImplicit();
+      S->setIteratorVar(iterator);
+
+      auto genPat = new (TC.Context) NamedPattern(iterator);
       genPat->setImplicit();
+
+      // TODO: test/DebugInfo/iteration.swift requires this extra info to
+      // be around.
+      auto nextResultType =
+          OptionalType::get(conformance->getTypeWitnessByName(
+                                sequenceType, DC->getASTContext().Id_Element))
+              ->getCanonicalType();
       auto *genBinding = PatternBindingDecl::createImplicit(
-          TC.Context, StaticSpellingKind::None, genPat, getIterator, DC,
+          TC.Context, StaticSpellingKind::None, genPat,
+          new (TC.Context) OpaqueValueExpr(S->getInLoc(), nextResultType), DC,
           /*VarLoc*/ S->getForLoc());
-      S->setIterator(genBinding);
+
+      Type newSequenceType = cast<AbstractFunctionDecl>(witness.getDecl())
+            ->getInterfaceType()
+            ->getAs<AnyFunctionType>()
+            ->getParams()[0].getPlainType().subst(witness.getSubstitutions());
+
+      // Necessary type coersion for method application.
+      if (TC.convertToType(sequence, newSequenceType, DC, None)) {
+        return nullptr;
+      }
+      S->setSequence(sequence);
     }
 
-    // Working with generators requires Optional.
+    // Working with iterators requires Optional.
     if (TC.requireOptionalIntrinsics(S->getForLoc()))
       return nullptr;
 
@@ -788,43 +806,49 @@ public:
     // we'll use to drive the loop.
     // FIXME: Would like to customize the diagnostic emitted in
     // conformsToProtocol().
-    auto genConformance =
-      TypeChecker::conformsToProtocol(generatorTy, generatorProto, DC,
-                                      ConformanceCheckFlags::InExpression,
-                                      sequence->getLoc());
+    auto genConformance = TypeChecker::conformsToProtocol(
+        iteratorTy, iteratorProto, DC, ConformanceCheckFlags::InExpression,
+        sequence->getLoc());
     if (!genConformance)
       return nullptr;
 
-    Type elementTy = TC.getWitnessType(generatorTy, generatorProto,
+    Type elementTy = TC.getWitnessType(iteratorTy, iteratorProto,
                                        *genConformance, TC.Context.Id_Element,
                                        diag::iterator_protocol_broken);
     if (!elementTy)
       return nullptr;
-    
-    // Compute the expression that advances the generator.
-    Expr *iteratorNext
-      = TC.callWitness(TC.buildCheckedRefExpr(generator, DC,
-                                              DeclNameLoc(S->getInLoc()),
-                                              /*implicit*/true),
-                       DC, generatorProto, *genConformance,
-                       TC.Context.Id_next, {}, diag::iterator_protocol_broken);
-    if (!iteratorNext) return nullptr;
-    // Check that next() produces an Optional<T> value.
-    if (iteratorNext->getType()->getAnyNominal()
-          != TC.Context.getOptionalDecl()) {
-      TC.diagnose(S->getForLoc(), diag::iterator_protocol_broken);
+
+    auto *varRef =
+        TC.buildCheckedRefExpr(iterator, DC, DeclNameLoc(S->getInLoc()),
+                               /*implicit*/ true);
+    if (!varRef)
       return nullptr;
-    }
+
+    S->setIteratorVarRef(varRef);
+
+    auto witness =
+        genConformance->getWitnessByName(iteratorTy, TC.Context.Id_next);
+    S->setIteratorNext(witness);
+
+    auto nextResultType = cast<FuncDecl>(S->getIteratorNext().getDecl())
+                              ->getResultInterfaceType()
+                              .subst(S->getIteratorNext().getSubstitutions())
+                              ->getCanonicalType();
 
     // Convert that Optional<T> value to Optional<Element>.
     auto optPatternType = OptionalType::get(S->getPattern()->getType());
-    if (!optPatternType->isEqual(iteratorNext->getType()) &&
-        TC.convertToType(iteratorNext, optPatternType, DC, S->getPattern())) {
-      return nullptr;
+    if (!optPatternType->isEqual(nextResultType)) {
+      OpaqueValueExpr *elementExpr =
+          new (TC.Context) OpaqueValueExpr(S->getInLoc(), nextResultType);
+      Expr *convertElementExpr = elementExpr;
+      if (TC.convertToType(convertElementExpr, optPatternType, DC,
+                           S->getPattern())) {
+        return nullptr;
+      }
+      S->setElementExpr(elementExpr);
+      S->setConvertElementExpr(convertElementExpr);
     }
 
-    S->setIteratorNext(iteratorNext);
-    
     // Type-check the body of the loop.
     AddLabeledStmt loopNest(*this, S);
     BraceStmt *Body = S->getBody();

--- a/test/Profiler/pgo_foreach.swift
+++ b/test/Profiler/pgo_foreach.swift
@@ -42,7 +42,7 @@ public func guessForEach1(x: Int32) -> Int32 {
 // IR-OPT-LABEL: define swiftcc i32 @$s9pgo_foreach10guessWhiles5Int32VAD1x_tF
 
 public func guessForEach2(x: Int32) -> Int32 {
-  // SIL: switch_enum {{.*}} : $Optional<(String, Int32)>, case #Optional.some!enumelt.1: {{.*}} !case_count(168), case #Optional.none!enumelt: {{.*}} !case_count(42)
+  // SIL: switch_enum {{.*}} : $Optional<(key: String, value: Int32)>, case #Optional.some!enumelt.1: {{.*}} !case_count(168), case #Optional.none!enumelt: {{.*}} !case_count(42)
 
   var ret : Int32 = 0
   let names = ["John" : Int32(1), "Paul" : Int32(2), "George" : Int32(3), "Ringo" : Int32(x)]

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -109,14 +109,14 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<Int>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<Int>>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -209,14 +209,14 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<P>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<P>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<[P]>([[ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<P>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<P>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:
@@ -369,14 +369,14 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF
-// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
+// CHECK:   apply [[MAKE_ITERATOR_FUNC]]<Array<GenericStruct<T>>>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<GenericStruct<T>>>
 // CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method)
-// CHECK:   apply [[FUNC_REF]]<[GenericStruct<T>]>([[ELT_STACK]], [[WRITE]])
+// CHECK:   apply [[FUNC_REF]]<Array<GenericStruct<T>>>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -168,7 +168,7 @@ func for_loops2() {
   // CHECK: alloc_stack $Optional<MyClass>
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
   // CHECK: [[NEXT:%[0-9]+]] = function_ref @$ss16IndexingIteratorV4next{{[_0-9a-zA-Z]*}}F
-  // CHECK-NEXT: apply [[NEXT]]<[MyClass]>
+  // CHECK-NEXT: apply [[NEXT]]<Array<MyClass>>
   // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo!1
   let objects = [MyClass(), MyClass() ]
   for obj in objects {


### PR DESCRIPTION
For reference, everything else except string interpolation has been converted
not to call this method.