### PR TITLE
IRGen: fix multithreaded COMDAT handling for PE/COFF

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3629,6 +3629,8 @@ ConstantReference IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
 
   auto addr = getAddrOfLLVMVariable(*entity, ConstantInit(), DbgTy, refKind,
                                     defaultVarTy);
+  if (auto *GV = dyn_cast<llvm::GlobalVariable>(addr.getValue()))
+    GV->setComdat(nullptr);
 
   // FIXME: MC breaks when emitting alias references on some platforms
   // (rdar://problem/22450593 ). Work around this by referring to the aliasee


### PR DESCRIPTION
Correct the COMDAT handling for the type metadata emission.  In
particular, declarations should not be emitted with COMDATs.  The
pattern used in the compiler for the metadata emission is different than
the other structures.  In particular, `getAddrOfTypeMetadata` emits the
declaration for the type metadata symbol.  The definition for the type
metadata will be emitted via `defineTypeMetadata`.  This change adjusts
the IRGen to remove the COMDAT on the declaration permitting the
definition from `defineTypeMetadata` being emitted strongly.

This exposes a bug in the LLVM MC layer which is a separate change that
will enable this to function properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
