### PR TITLE
[5.1][ConstraintSystem] Consolidate logic forming locators to callees

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4591,8 +4591,7 @@ namespace {
     buildKeyPathPropertyComponent(const SelectedOverload &overload,
                                   SourceLoc componentLoc,
                                   ConstraintLocator *locator) {
-      if (overload.choice.isDecl()) {
-        auto property = overload.choice.getDecl();
+      if (auto *property = overload.choice.getDeclOrNull()) {
         // Key paths can only refer to properties currently.
         auto varDecl = cast<VarDecl>(property);
         // Key paths don't work with mutating-get properties.
@@ -4909,10 +4908,8 @@ static ConcreteDeclRef resolveLocatorToDecl(
     // Overloaded and unresolved cases: find the resolved overload.
     auto anchorLocator = cs.getConstraintLocator(anchor);
     if (auto selected = findOvlChoice(anchorLocator)) {
-      if (selected->choice.isDecl())
-        return getConcreteDeclRef(selected->choice.getDecl(),
-                                  selected->openedType,
-                                  anchorLocator);
+      if (auto *decl = selected->choice.getDeclOrNull())
+        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
     }
   }
   
@@ -4921,10 +4918,8 @@ static ConcreteDeclRef resolveLocatorToDecl(
     auto anchorLocator = cs.getConstraintLocator(anchor,
                            ConstraintLocator::UnresolvedMember);
     if (auto selected = findOvlChoice(anchorLocator)) {
-      if (selected->choice.isDecl())
-        return getConcreteDeclRef(selected->choice.getDecl(),
-                                  selected->openedType,
-                                  anchorLocator);
+      if (auto *decl = selected->choice.getDeclOrNull())
+        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
     }
   }
 
@@ -4933,10 +4928,8 @@ static ConcreteDeclRef resolveLocatorToDecl(
     auto anchorLocator = cs.getConstraintLocator(anchor,
                                                  ConstraintLocator::Member);
     if (auto selected = findOvlChoice(anchorLocator)) {
-      if (selected->choice.isDecl())
-        return getConcreteDeclRef(selected->choice.getDecl(),
-                                  selected->openedType,
-                                  anchorLocator);
+      if (auto *decl = selected->choice.getDeclOrNull())
+        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
     }
   }
 
@@ -4949,10 +4942,8 @@ static ConcreteDeclRef resolveLocatorToDecl(
     auto anchorLocator =
       cs.getConstraintLocator(anchor, ConstraintLocator::SubscriptMember);
     if (auto selected = findOvlChoice(anchorLocator)) {
-      if (selected->choice.isDecl())
-        return getConcreteDeclRef(selected->choice.getDecl(),
-                                  selected->openedType,
-                                  anchorLocator);
+      if (auto *decl = selected->choice.getDeclOrNull())
+        return getConcreteDeclRef(decl, selected->openedType, anchorLocator);
     }
   }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -940,9 +940,8 @@ bool FailureDiagnosis::diagnoseGeneralOverloadFailure(Constraint *constraint) {
   if (constraint->getKind() == ConstraintKind::Disjunction) {
     for (auto elt : constraint->getNestedConstraints()) {
       if (elt->getKind() != ConstraintKind::BindOverload) continue;
-      if (!elt->getOverloadChoice().isDecl()) continue;
-      auto candidate = elt->getOverloadChoice().getDecl();
-      diagnose(candidate, diag::found_candidate);
+      if (auto *candidate = elt->getOverloadChoice().getDeclOrNull())
+        diagnose(candidate, diag::found_candidate);
     }
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -156,7 +156,7 @@ protected:
   /// reference or subscript, nullptr otherwise.
   Expr *getArgumentExprFor(Expr *anchor) const;
 
-  Optional<SelectedOverload> getChoiceFor(Expr *);
+  Optional<SelectedOverload> getChoiceFor(Expr *) const;
 
 private:
   /// Compute anchor expression associated with current diagnostic.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -602,9 +602,9 @@ namespace {
     unsigned numFavoredConstraints = 0;
     Constraint *firstFavored = nullptr;
     for (auto constraint : disjunction->getNestedConstraints()) {
-      if (!constraint->getOverloadChoice().isDecl())
+      auto *decl = constraint->getOverloadChoice().getDeclOrNull();
+      if (!decl)
         continue;
-      auto decl = constraint->getOverloadChoice().getDecl();
 
       if (mustConsider && mustConsider(decl)) {
         // Roll back any constraints we favored.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -828,8 +828,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
                            hasTrailingClosure, nullptr);
 
   // If there's a declaration, return it.
-  if (choice->isDecl()) {
-    auto decl = choice->getDecl();
+  if (auto *decl = choice->getDeclOrNull()) {
     bool hasCurriedSelf = false;
     if (decl->getDeclContext()->isTypeContext()) {
       if (auto function = dyn_cast<AbstractFunctionDecl>(decl)) {
@@ -4570,9 +4569,7 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
              Optional<MemberLookupResult::UnviableReason> reason = None) {
   // Not all of the choices handled here are going
   // to refer to a declaration.
-  if (choice.isDecl()) {
-    auto *decl = choice.getDecl();
-
+  if (auto *decl = choice.getDeclOrNull()) {
     if (auto *CD = dyn_cast<ConstructorDecl>(decl)) {
       if (auto *fix = validateInitializerRef(cs, CD, locator))
         return fix;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2104,11 +2104,9 @@ void ConstraintSystem::partitionDisjunction(
     forEachChoice(Choices, [&](unsigned index, Constraint *constraint) -> bool {
       if (constraint->getKind() != ConstraintKind::BindOverload)
         return false;
-      if (!constraint->getOverloadChoice().isDecl())
-        return false;
 
-      auto *decl = constraint->getOverloadChoice().getDecl();
-      auto *funcDecl = dyn_cast<FuncDecl>(decl);
+      auto *decl = constraint->getOverloadChoice().getDeclOrNull();
+      auto *funcDecl = dyn_cast_or_null<FuncDecl>(decl);
       if (!funcDecl)
         return false;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2134,8 +2134,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   }
   assert(!refType->hasTypeParameter() && "Cannot have a dependent type here");
   
-  if (choice.isDecl()) {
-    auto decl = choice.getDecl();
+  if (auto *decl = choice.getDeclOrNull()) {
     // If we're binding to an init member, the 'throws' need to line up between
     // the bound and reference types.
     if (auto CD = dyn_cast<ConstructorDecl>(decl)) {
@@ -2457,11 +2456,6 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   if (solutions.empty())
     return false;
 
-  auto getOverloadDecl = [&](SelectedOverload &overload) -> ValueDecl * {
-    auto &choice = overload.choice;
-    return choice.isDecl() ? choice.getDecl() : nullptr;
-  };
-
   // Problems related to fixes forming ambiguous solution set
   // could only be diagnosed (at the moment), if all of the fixes
   // have the same callee locator, which means they fix different
@@ -2490,7 +2484,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     if (!overload)
       return false;
 
-    auto *decl = getOverloadDecl(*overload);
+    auto *decl = overload->choice.getDeclOrNull();
     if (!decl)
       return false;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -716,16 +716,6 @@ public:
     return None;
   }
 
-  /// Retrieve overload choices associated with given expression.
-  void getOverloadChoices(Expr *anchor,
-                          SmallVectorImpl<SelectedOverload> &overloads) const {
-    for (auto &e : overloadChoices) {
-      auto *locator = e.first;
-      if (locator->getAnchor() == anchor)
-        overloads.push_back(e.second);
-    }
-  }
-
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1927,6 +1927,11 @@ public:
     return e != ExprWeights.end() ? e->second.second : nullptr;
   }
 
+  /// Returns a locator describing the callee for a given expression. For
+  /// a function application, this is a locator describing the function expr.
+  /// For an unresolved dot/member, this is a locator to the member.
+  ConstraintLocator *getCalleeLocator(Expr *expr);
+
 public:
 
   /// Whether we should attempt to fix problems.

--- a/lib/Sema/OverloadChoice.h
+++ b/lib/Sema/OverloadChoice.h
@@ -244,6 +244,12 @@ public:
     return DeclOrKind.get<ValueDecl*>();
   }
 
+  /// Retrieves the declaration that corresponds to this overload choice, or
+  /// \c nullptr if this choice is not for a declaration.
+  ValueDecl *getDeclOrNull() const {
+    return isDecl() ? getDecl() : nullptr;
+  }
+
   /// Returns true if this is either a decl for an optional that was
   /// declared as one that can be implicitly unwrapped, or is a
   /// function-typed decl that has a return value that is implicitly

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -107,6 +107,13 @@ func foo(block: () -> (), other: () -> Int) {
   takesAny(other) // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}
 }
 
+struct S {
+  init<T>(_ x: T, _ y: T) {} // expected-note {{generic parameters are always considered '@escaping'}}
+  init(fn: () -> Int) {
+    self.init({ 0 }, fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T' may allow it to escape}}
+  }
+}
+
 protocol P {
   associatedtype U
 }

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -109,8 +109,11 @@ func foo(block: () -> (), other: () -> Int) {
 
 struct S {
   init<T>(_ x: T, _ y: T) {} // expected-note {{generic parameters are always considered '@escaping'}}
-  init(fn: () -> Int) {
+  subscript<T>() -> (T, T) -> Void { { _, _ in } }
+
+  init(fn: () -> Int) { // expected-note {{parameter 'fn' is implicitly non-escaping}}
     self.init({ 0 }, fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T' may allow it to escape}}
+    _ = self[]({ 0 }, fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
   }
 }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -704,6 +704,26 @@ func member_ref_with_explicit_init() {
   // expected-error@-1 {{generic struct 'S' requires that 'Int' conform to 'P'}}
 }
 
+protocol Q {
+  init<T : P>(_ x: T) // expected-note 2{{where 'T' = 'T'}}
+}
+
+struct SR10694 {
+  init<T : P>(_ x: T) {} // expected-note 2{{where 'T' = 'T'}}
+  func bar<T>(_ x: T, _ s: SR10694, _ q: Q) {
+    SR10694.self(x) // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
+
+    type(of: s)(x)  // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
+    // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}
+
+    Q.self(x) // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
+    // expected-error@-1 {{protocol type 'Q' cannot be instantiated}}
+
+    type(of: q)(x)  // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
+    // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}
+  }
+}
+
 func rdar_50007727() {
   struct A<T> { // expected-note {{'T' declared as parameter to type 'A'}}
     struct B<U> : ExpressibleByStringLiteral {


### PR DESCRIPTION
This PR adds `ConstraintSystem::getCalleeLocator`, which forms a locator that describes the callee of a given expression. This function is then used to replace various places where this logic is duplicated, and in doing so improves a couple of diagnostics due to catching cases that were previously missed. Most notably, it's now more lenient when forming a `ConstructorMember` locator for an apply. Previously such a locator was only formed for an apply of a `TypeExpr`, however now it's formed for an apply of an expr of `AnyMetatypeType`. This better matches the logic in `simplifyApplicableFnConstraint` and allows us to better diagnose things like `type(of: x)(...)`.

`getCalleeLocator` is then used when checking if we can diagnose an ambiguity with fixes, which allows us to have fixes anchored to both the apply and to its function expr (where the former could be looking at an argument of the apply, and the latter could be looking at a requirement of the callee).

Finally, this PR adds a convenience `getDeclOrNull` function to `OverloadChoice`, and fixes a simple compiler crasher. Given how straightforward these changes were, I didn't feel it was worth splitting them into a separate PR.

Resolves [SR-10694] and [SR-10696].

 [SR-10694]: https://bugs.swift.org/browse/SR-10694
 [SR-10696]: https://bugs.swift.org/browse/SR-10696

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
