### PR TITLE
[5.0] Cherry-pick changes to allow testing the OS or just-built Swift dylibs

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -113,6 +113,8 @@ out with ``lit.py -h``. We document some of the more useful ones below:
 * ``--param swift_test_mode=<MODE>`` drives the various suffix variations
   mentioned above. Again, it's best to get the invocation from the existing
   build system targets and modify it rather than constructing it yourself.
+* ``--param use_os_stdlib`` will run all tests with the standard libraries
+  coming from the OS.
 
 ##### Remote testing options
 

--- a/test/Interpreter/protocol_lookup_jit.swift
+++ b/test/Interpreter/protocol_lookup_jit.swift
@@ -1,5 +1,5 @@
 // Test protocol_lookup.swift in JIT mode.
-// RUN: %swift -interpret %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-jit-run %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // REQUIRES: executable_test
 
 // REQUIRES: swift_interpreter

--- a/test/Interpreter/repl_autolinking.swift
+++ b/test/Interpreter/repl_autolinking.swift
@@ -4,7 +4,7 @@
 // RUN: sed -n -e '/REPL_START$/,/REPL_END$/ p' %s > %t/repl.swift
 // RUN: %target-swiftc_driver -emit-library %t/a.swift -I %t -L %t -emit-module-path %t/ModuleA.swiftmodule -autolink-force-load -module-link-name ModuleA -module-name ModuleA -o %t/libModuleA.dylib
 // RUN: %target-swiftc_driver -emit-library %t/b.swift -I %t -L %t -emit-module-path %t/ModuleB.swiftmodule -autolink-force-load -module-link-name ModuleB -module-name ModuleB -o %t/libModuleB.dylib
-// RUN: %swift -repl -I %t -L %t < %t/repl.swift 2>&1 | %FileCheck %s
+// RUN: %target-repl-run-swift -I %t -L %t < %t/repl.swift 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_repl
 // UNSUPPORTED: OS=linux-gnu

--- a/test/SIL/Serialization/deserialize_coregraphics.swift
+++ b/test/SIL/Serialization/deserialize_coregraphics.swift
@@ -2,6 +2,7 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/CoreGraphics.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/CoreGraphics.swiftmodule | %FileCheck %s
 
+// REQUIRES: rdar51868140
 // REQUIRES: objc_interop
 
 // CHECK-NOT: Unknown

--- a/test/SIL/Serialization/deserialize_darwin.sil
+++ b/test/SIL/Serialization/deserialize_darwin.sil
@@ -2,6 +2,7 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/Darwin.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/Darwin.swiftmodule | %FileCheck %s
 
+// REQUIRES: rdar51868140
 // REQUIRES: objc_interop
 
 // CHECK-NOT: Unknown

--- a/test/SIL/Serialization/deserialize_objectivec.sil
+++ b/test/SIL/Serialization/deserialize_objectivec.sil
@@ -2,6 +2,7 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-sdk-overlay-dir/ObjectiveC.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-sdk-overlay-dir/ObjectiveC.swiftmodule | %FileCheck %s
 
+// REQUIRES: rdar51868140
 // REQUIRES: objc_interop
 
 // CHECK-NOT: Unknown

--- a/test/SIL/Serialization/deserialize_stdlib.sil
+++ b/test/SIL/Serialization/deserialize_stdlib.sil
@@ -2,4 +2,6 @@
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %platform-module-dir/Swift.swiftmodule > /dev/null
 // RUN: llvm-bcanalyzer %platform-module-dir/Swift.swiftmodule | %FileCheck %s
 
+// REQUIRES: rdar51868140
+
 // CHECK-NOT: Unknown

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1083,8 +1083,10 @@ if 'swift_interpreter' in config.available_features:
         "%s -interpret %s" %
         (config.target_swift_frontend, sdk_overlay_link_path))
 
+subst_target_repl_run_swift = ""
 subst_target_repl_run_simple_swift = ""
 if 'swift_repl' in config.available_features:
+    subst_target_repl_run_swift = "%s -repl" % (config.target_swift_frontend)
     subst_target_repl_run_simple_swift = (
         "%s -repl %s < %%s 2>&1" %
         (config.target_swift_frontend, sdk_overlay_link_path))
@@ -1145,12 +1147,17 @@ if os.path.exists(static_libswiftCore_path):
 target_stdlib_path = platform_module_dir
 if 'use_os_stdlib' not in lit_config.params:
   lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
-  config.target_run = (
+  library_path_env = (
     "/usr/bin/env "
     "DYLD_LIBRARY_PATH='{0}' " # Apple option
     "LD_LIBRARY_PATH='{0}' " # Linux option
     "SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-    .format(target_stdlib_path)) + config.target_run
+    .format(target_stdlib_path))
+  config.target_run = library_path_env + config.target_run
+  subst_target_jit_run = library_path_env + subst_target_jit_run
+  config.swift_remoteast_test = library_path_env + config.swift_remoteast_test
+  subst_target_repl_run_simple_swift = library_path_env + subst_target_repl_run_simple_swift
+  subst_target_repl_run_swift = library_path_env + subst_target_repl_run_swift
 else:
   os_stdlib_path = ''
   if run_vendor == 'apple':
@@ -1158,12 +1165,17 @@ else:
     os_stdlib_path = "/usr/lib/swift"
   all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
   lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
-  config.target_run = (
+  library_path_env = (
     "/usr/bin/env "
     "DYLD_LIBRARY_PATH='{0}' " # Apple option
     "LD_LIBRARY_PATH='{0}' " # Linux option
     "SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-    .format(all_stdlib_path)) + config.target_run
+    .format(all_stdlib_path))
+  config.target_run = library_path_env + config.target_run
+  subst_target_jit_run = library_path_env + subst_target_jit_run
+  config.swift_remoteast_test = library_path_env + config.swift_remoteast_test
+  subst_target_repl_run_simple_swift = library_path_env + subst_target_repl_run_simple_swift
+  subst_target_repl_run_swift = library_path_env + subst_target_repl_run_swift
 			
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
@@ -1246,6 +1258,7 @@ config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))
 config.substitutions.append(('%target-run-stdlib-swift', config.target_run_stdlib_swift))
+config.substitutions.append(('%target-repl-run-swift', subst_target_repl_run_swift))
 config.substitutions.append(('%target-repl-run-simple-swift', subst_target_repl_run_simple_swift))
 config.substitutions.append(('%target-run', config.target_run))
 config.substitutions.append(('%target-jit-run', subst_target_jit_run))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1143,28 +1143,27 @@ if os.path.exists(static_libswiftCore_path):
 # Set up testing with the standard libraries coming from the OS / just-built libraries
 # default Swift tests to use the just-built libraries
 target_stdlib_path = platform_module_dir
-if not kIsWindows:
-	if 'use_os_stdlib' not in lit_config.params:
-		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
-		config.target_run = (
-			"/usr/bin/env "
-			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}' " # Linux option
-			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(target_stdlib_path)) + config.target_run
-	else:
-		os_stdlib_path = ''
-		if run_vendor == 'apple':
-			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
-			os_stdlib_path = "/usr/lib/swift"
-		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
-		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
-		config.target_run = (
-			"/usr/bin/env "
-			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}' " # Linux option
-			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(all_stdlib_path)) + config.target_run
+if 'use_os_stdlib' not in lit_config.params:
+  lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+  config.target_run = (
+    "/usr/bin/env "
+    "DYLD_LIBRARY_PATH='{0}' " # Apple option
+    "LD_LIBRARY_PATH='{0}' " # Linux option
+    "SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
+    .format(target_stdlib_path)) + config.target_run
+else:
+  os_stdlib_path = ''
+  if run_vendor == 'apple':
+    #If we get swift-in-the-OS for non-Apple platforms, add a condition here
+    os_stdlib_path = "/usr/lib/swift"
+  all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+  lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+  config.target_run = (
+    "/usr/bin/env "
+    "DYLD_LIBRARY_PATH='{0}' " # Apple option
+    "LD_LIBRARY_PATH='{0}' " # Linux option
+    "SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
+    .format(all_stdlib_path)) + config.target_run
 			
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized =                               \
@@ -1177,6 +1176,18 @@ if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_opt_O_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s -O %%s -o %%t/a.out -module-name main && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_opt_Osize_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s -Osize %%s -o %%t/a.out -module-name main && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1166,6 +1166,47 @@ if platform.system() != 'Darwin':
     config.target_resilience_test = ('%s --no-symbol-diff' %
                                      config.target_resilience_test)
 
+platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
+if run_vendor != 'apple':
+    platform_module_dir = make_path(platform_module_dir, run_cpu)
+lit_config.note('Using platform module dir: ' + platform_module_dir)
+if test_sdk_overlay_dir:
+    platform_sdk_overlay_dir = test_sdk_overlay_dir
+else:
+    platform_sdk_overlay_dir = platform_module_dir
+
+# If static stdlib is present, enable static stdlib tests
+static_stdlib_path = make_path(config.swift_lib_dir, "swift_static", config.target_sdk_name)
+static_libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
+if os.path.exists(static_libswiftCore_path):
+    config.available_features.add("static_stdlib")
+    config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
+    lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+
+# Set up testing with the standard libraries coming from the OS / just-built libraries
+# default Swift tests to use the just-built libraries
+target_stdlib_path = platform_module_dir
+if not kIsWindows:
+	if 'use_os_stdlib' not in lit_config.params:
+		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+		config.target_run = (
+			"/usr/bin/env "
+			"DYLD_LIBRARY_PATH='{0}' " # Apple option
+			"LD_LIBRARY_PATH='{0}' " # Linux option
+			.format(target_stdlib_path))
+	else:
+		os_stdlib_path = ''
+		if run_vendor == 'apple':
+			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
+			os_stdlib_path = "/usr/lib/swift"
+		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+		config.target_run = (
+			"/usr/bin/env "
+			"DYLD_LIBRARY_PATH='{0}' " # Apple option
+			"LD_LIBRARY_PATH='{0}' " # Linux option
+			.format(all_stdlib_path))
+
 #
 # When changing substitutions, update docs/Testing.rst.
 #
@@ -1254,13 +1295,6 @@ if hasattr(config, 'target_swift_autolink_extract'):
 config.substitutions.append(('%target-swift-modulewrap',
                              config.target_swift_modulewrap))
 
-platform_module_dir = make_path(test_resource_dir, '%target-sdk-name', run_cpu)
-lit_config.note('Using platform module dir: ' + platform_module_dir)
-if test_sdk_overlay_dir is not None:
-    platform_sdk_overlay_dir = make_path(test_sdk_overlay_dir, run_cpu)
-else:
-    platform_sdk_overlay_dir = platform_module_dir
-
 config.substitutions.insert(0, ('%platform-module-dir', platform_module_dir))
 config.substitutions.insert(0, ('%platform-sdk-overlay-dir', platform_sdk_overlay_dir))
 
@@ -1283,37 +1317,6 @@ config.substitutions.append(
        pipes.quote(config.swift_src_root),
        pipes.quote(config.filecheck))))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
-
-# If static stdlib is present, enable static stdlib tests
-static_stdlib_path = make_path(config.swift_lib_dir, "swift_static", config.target_sdk_name)
-libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
-if os.path.exists(libswiftCore_path):
-    config.available_features.add("static_stdlib")
-    config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
-    lit_config.note('using static stdlib path: %s' % static_stdlib_path)
-
-# Set up testing with the standard libraries coming from the OS / just-built libraries
-# default Swift tests to use the just-built libraries
-target_stdlib_path = platform_module_dir
-if 'use_os_stdlib' not in lit_config.params:
-	lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
-	config.target_run = (
-        "/usr/bin/env "
-        "DYLD_LIBRARY_PATH='{0}' " # Apple option
-        "LD_LIBRARY_PATH='{0}' " # Linux option
-        .format(target_stdlib_path))
-else:
-	os_stdlib_path = ''
-	if run_vendor == 'apple':
-		#If we get swift-in-the-OS for non-Apple platforms, add a condition here
-		os_stdlib_path = "/usr/lib/swift"
-	all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
-	lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
-	config.target_run = (
-        "/usr/bin/env "
-        "DYLD_LIBRARY_PATH='{0}' " # Apple option
-        "LD_LIBRARY_PATH='{0}' " # Linux option
-        .format(all_stdlib_path))
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -605,6 +605,10 @@ def use_interpreter_for_simple_runs():
     config.target_run_simple_swift = make_simple_target_run()
     config.available_features.add('interpret')
 
+target_specific_module_triple = config.variant_triple
+
+config.target_run = ""
+
 if run_vendor == 'apple':
     config.available_features.add('objc_interop')
     config.target_object_format = "macho"
@@ -1193,7 +1197,8 @@ if not kIsWindows:
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
 			"LD_LIBRARY_PATH='{0}' " # Linux option
-			.format(target_stdlib_path))
+			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
+			.format(target_stdlib_path)) + config.target_run
 	else:
 		os_stdlib_path = ''
 		if run_vendor == 'apple':
@@ -1205,7 +1210,8 @@ if not kIsWindows:
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
 			"LD_LIBRARY_PATH='{0}' " # Linux option
-			.format(all_stdlib_path))
+			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
+			.format(all_stdlib_path)) + config.target_run
 
 #
 # When changing substitutions, update docs/Testing.rst.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1077,53 +1077,6 @@ if sftp_server_path:
 config.substitutions.append(('%sftp-server',
                              sftp_server_path or 'no-sftp-server'))
 
-
-if not getattr(config, 'target_run_simple_swift', None):
-    config.target_run_simple_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_opt_O_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s -O %%s -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_opt_Osize_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s -Osize %%s -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_stdlib_swift = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_simple_swiftgyb = (
-        '%%empty-directory(%%t) && '
-        '%%gyb %%s -o %%t/main.swift && '
-        '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main && '
-        '%s %%t/a.out &&'
-        '%%line-directive %%t/main.swift -- '
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-    config.target_run_stdlib_swiftgyb = (
-        '%%empty-directory(%%t) && '
-        '%%gyb %%s -o %%t/main.swift && '
-        '%%line-directive %%t/main.swift -- '
-        '%s %s %%t/main.swift -o %%t/a.out -module-name main '
-        '-Xfrontend -disable-access-control && '
-        '%s %%t/a.out &&'
-        '%%line-directive %%t/main.swift -- '
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
-
 subst_target_jit_run = ""
 if 'swift_interpreter' in config.available_features:
     subst_target_jit_run = (
@@ -1212,6 +1165,47 @@ if not kIsWindows:
 			"LD_LIBRARY_PATH='{0}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
 			.format(all_stdlib_path)) + config.target_run
+			
+if not getattr(config, 'target_run_simple_swift', None):
+    config.target_run_simple_swift_parameterized =                               \
+        (SubstituteCaptures('%%empty-directory(%%t) && '
+                            '%s %s %%s \\1 -o %%t/a.out -module-name main  && '
+                            '%s %%t/a.out &&'
+                            '%s %%t/a.out' % (config.target_build_swift,
+                                              mcp_opt, config.target_codesign,
+                                              config.target_run)))
+    config.target_run_simple_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_stdlib_swift = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -o %%t/a.out -module-name main '
+        '-Xfrontend -disable-access-control  && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_simple_swiftgyb = (
+        '%%empty-directory(%%t) && '
+        '%%gyb %%s -o %%t/main.swift && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main  && '
+        '%s %%t/a.out &&'
+        '%%line-directive %%t/main.swift -- '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
+    config.target_run_stdlib_swiftgyb = (
+        '%%empty-directory(%%t) && '
+        '%%gyb %%s -o %%t/main.swift && '
+        '%%line-directive %%t/main.swift -- '
+        '%s %s %%t/main.swift -o %%t/a.out -module-name main '
+        '-Xfrontend -disable-access-control  && '
+        '%s %%t/a.out &&'
+        '%%line-directive %%t/main.swift -- '
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, config.target_codesign, config.target_run))
 
 #
 # When changing substitutions, update docs/Testing.rst.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -12,9 +12,9 @@
 #
 # This is a configuration file for the 'lit' test runner.
 #
-# Refer to docs/Testing.rst for documentation.
+# Refer to docs/Testing.md for documentation.
 #
-# Update docs/Testing.rst when changing this file.
+# Update docs/Testing.md when changing this file.
 #
 # -----------------------------------------------------------------------------
 
@@ -925,6 +925,15 @@ if (not getattr(config, 'target_run', None) and
     remote_run_host = lit_config.params['remote_run_host']
     remote_tmp_dir = lit_config.params['remote_run_tmpdir']
     remote_lib_dir = os.path.join(remote_tmp_dir, 'stdlib')
+    remote_run_lib_path = ''
+    if 'use_os_stdlib' not in lit_config.params:
+        remote_run_lib_path = remote_lib_dir
+    else:
+        os_stdlib_path = ''
+        if run_vendor == 'apple':
+            #If we get swift-in-the-OS for non-Apple platforms, add a condition here
+            os_stdlib_path = "/usr/lib/swift"
+        remote_run_lib_path = os.path.pathsep.join((os_stdlib_path, remote_lib_dir))
 
     remote_run_extra_args_param = lit_config.params.get('remote_run_extra_args')
     remote_run_extra_args = shlex.split(remote_run_extra_args_param or '')
@@ -973,7 +982,7 @@ if (not getattr(config, 'target_run', None) and
         "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
         "REMOTE_RUN_CHILD_LD_LIBRARY_PATH='{0}' " # Linux option
         "'{1}'/remote-run --input-prefix '{2}' --output-prefix %t "
-        "--remote-dir '{3}'%t {4} {5}".format(remote_lib_dir,
+        "--remote-dir '{3}'%t {4} {5}".format(remote_run_lib_path,
                                               config.swift_utils,
                                               config.swift_src_root,
                                               remote_tmp_dir,
@@ -1282,6 +1291,29 @@ if os.path.exists(libswiftCore_path):
     config.available_features.add("static_stdlib")
     config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
     lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+
+# Set up testing with the standard libraries coming from the OS / just-built libraries
+# default Swift tests to use the just-built libraries
+target_stdlib_path = platform_module_dir
+if 'use_os_stdlib' not in lit_config.params:
+	lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+	config.target_run = (
+        "/usr/bin/env "
+        "DYLD_LIBRARY_PATH='{0}' " # Apple option
+        "LD_LIBRARY_PATH='{0}' " # Linux option
+        .format(target_stdlib_path))
+else:
+	os_stdlib_path = ''
+	if run_vendor == 'apple':
+		#If we get swift-in-the-OS for non-Apple platforms, add a condition here
+		os_stdlib_path = "/usr/lib/swift"
+	all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+	lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+	config.target_run = (
+        "/usr/bin/env "
+        "DYLD_LIBRARY_PATH='{0}' " # Apple option
+        "LD_LIBRARY_PATH='{0}' " # Linux option
+        .format(all_stdlib_path))
 
 if config.lldb_build_root != "":
     config.available_features.add('lldb')

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3342,6 +3342,9 @@ for host in "${ALL_HOSTS[@]}"; do
                     echo "Skipping PlaygroundLogger tests on non-macOS platform"
                     continue
                 fi
+
+                echo "Skipping PlaygroundLogger tests due to rdar://47528005"
+                continue
                 
                 PLAYGROUNDSUPPORT_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFTC_BIN="$(build_directory_bin ${host} swift)/swiftc"

--- a/validation-test/execution/interpret-with-dependencies.swift
+++ b/validation-test/execution/interpret-with-dependencies.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar51868140
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
All of #25451 plus disable playgroundsupport tests