### PR TITLE
[CodeCompletion] Eliminate super related completion

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -485,8 +485,6 @@ enum class CompletionKind {
   PostfixExprBeginning,
   PostfixExpr,
   PostfixExprParen,
-  SuperExpr,
-  SuperExprDot,
   KeyPathExprObjC,
   KeyPathExprSwift,
   TypeDeclResultBeginning,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -143,13 +143,6 @@ public:
   /// left parenthesis.
   virtual void completePostfixExprParen(Expr *E, Expr *CodeCompletionE) {};
 
-  /// Complete expr-super after we have consumed the 'super' keyword.
-  virtual void completeExprSuper(SuperRefExpr *SRE) {};
-
-  /// Complete expr-super after we have consumed the 'super' keyword and
-  /// a dot.
-  virtual void completeExprSuperDot(SuperRefExpr *SRE) {};
-
   /// Complete the argument to an Objective-C #keyPath
   /// expression.
   ///

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1323,7 +1323,7 @@ public:
   ParserResult<Expr> parseExprKeyPathObjC();
   ParserResult<Expr> parseExprKeyPath();
   ParserResult<Expr> parseExprSelector();
-  ParserResult<Expr> parseExprSuper(bool isExprBasic);
+  ParserResult<Expr> parseExprSuper();
   ParserResult<Expr> parseExprConfiguration();
   ParserResult<Expr> parseExprStringLiteral();
   ParserResult<Expr> parseExprTypeOf();

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -116,7 +116,7 @@
 // RUN: %FileCheck %s -check-prefix=NO_CONSTRUCTORS < %t.super.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLOSURE_2 > %t.super.txt
-// RUN: %FileCheck %s -check-prefix=COMMON_BASE_A_DOT < %t.super.txt
+// RUN: %FileCheck %s -check-prefix=COMMON_BASE_A_DOT_CONTEXT < %t.super.txt
 // RUN: %FileCheck %s -check-prefix=CLOSURE_2 < %t.super.txt
 // RUN: %FileCheck %s -check-prefix=NO_CONSTRUCTORS < %t.super.txt
 
@@ -226,6 +226,15 @@ extension SuperBaseA {
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceVar]/CurrNominal:    baseExtProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_A_DOT-DAG: Decl[InstanceMethod]/CurrNominal: baseExtFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_A_DOT: End completions
+
+// COMMON_BASE_A_DOT_CONTEXT: Begin completions
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseInstanceVar[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseProp[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc0()[#Void#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseExtProp[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseExtFunc0()[#Void#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT: End completions
 
 class SuperDerivedA : SuperBaseA {
   var derivedInstanceVar: Int
@@ -514,7 +523,7 @@ class Closures : SuperBaseA {
   }
 
   func bar() {
-    let inner = { () -> Void in
+    let inner = { () -> Int in
       // CLOSURE_2: Begin completions, 6 items
       // CLOSURE_2: End completions
       super.#^CLOSURE_2^#


### PR DESCRIPTION
Code simplification.

In parser, `parseExprPostfixSuffix()` can parse postfix expression for `super` as well. `parseExprSuper()` doesn't need to parse them.

In code-completion, `completeExprSuper()` and `completeExprSuperDot()` can be consolidated to `completePostfixExpr()` and `completeDotExpr()`.
