### PR TITLE
Remove a retain release pair in foreign string hashing

### DIFF
--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -44,7 +44,7 @@ extension StringProtocol {
 }
 
 extension _StringGutsSlice {
-  @inline(never) // slow-path
+  @_effects(releasenone) @inline(never) // slow-path
   internal func _normalizedHash(into hasher: inout Hasher) {
     if self.isNFCFastUTF8 {
       self.withFastUTF8 {


### PR DESCRIPTION
(cherry picked from commit 75185aa5567d59ea2a7aaee41cefe2582c094296 from https://github.com/apple/swift/pull/25771)

Fixes rdar://problem/52157564