### PR TITLE
[test] Mark resilient-module as executable.

### DIFF
--- a/test/multifile/resilient-module.swift
+++ b/test/multifile/resilient-module.swift
@@ -6,6 +6,7 @@
 // RUN: %target-codesign %t/main %t/%target-library-name(A)
 // RUN: %target-run %t/main %t/%target-library-name(A) | %FileCheck %s
 
+// REQUIRES: executable_test
 
 // METADATA: @"$s1A8SomeEnumOMn" = {{.*}}constant <{ i32, i32, i32, i32, i32, i32, i32 }> <{{{.*}} i32 33554434, i32 0 }>
 


### PR DESCRIPTION
Android CI do not run the executable tests because there's no device
attached, but this test was not marked to be skipped, and it broke the
Android CI.

See
https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/1235/
and
https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/3005/.
