### PR TITLE
build-script: Throttle the number of parallel tests run acording to -j.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -754,14 +754,12 @@ function set_build_options_for_host() {
         -DSWIFT_HOST_VARIANT_ARCH="${SWIFT_HOST_VARIANT_ARCH}"
     )
 
-    if [[ "${LLVM_LIT_ARGS}" ]]; then
-        llvm_cmake_options+=(
-            -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"
-        )
-        swift_cmake_options+=(
-            -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS}"
-        )
-    fi
+    llvm_cmake_options+=(
+        -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS} -j ${BUILD_JOBS}"
+    )
+    swift_cmake_options+=(
+        -DLLVM_LIT_ARGS="${LLVM_LIT_ARGS} -j ${BUILD_JOBS}"
+    )
 
     if [[ "${CLANG_PROFILE_INSTR_USE}" ]]; then
         llvm_cmake_options+=(
@@ -3140,7 +3138,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 if [[ "${ENABLE_ASAN}" ]] ; then
                     # Limit the number of parallel tests
-                    LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --threads=$(sysctl hw.physicalcpu | awk '{ print $2 }')"
+                    LLVM_LIT_ARGS="${LLVM_LIT_ARGS} -j $(sysctl hw.physicalcpu | awk -v N=${BUILD_JOBS} '{ print (N < $2) ? N : $2 }')"
                 fi
 
 		if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "TRUE" ]]; then
@@ -3151,9 +3149,9 @@ for host in "${ALL_HOSTS[@]}"; do
                 LLVM_LIT_ARGS="${LLVM_LIT_ARGS} -v --time-tests"
                 if [[ "$using_xcodebuild" == "FALSE" ]] ; then
                     with_pushd ${lldb_build_dir} \
-                        call ${NINJA_BIN} unittests/LLDBUnitTests
+                        call ${NINJA_BIN} -j ${BUILD_JOBS} unittests/LLDBUnitTests
                     with_pushd ${lldb_build_dir} \
-                        call ${NINJA_BIN} lldb-test-deps
+                        call ${NINJA_BIN} -j ${BUILD_JOBS} lldb-test-deps
                     with_pushd ${results_dir} \
                         call "${llvm_build_dir}/bin/llvm-lit" \
                              "${lldb_build_dir}/lit" \


### PR DESCRIPTION
This patch propagates the number of parallel jobs from build-script to
llvm-lit. Due to the way how build-script-impl is implemented, changing this
number needs a reconfigure for the Swift tests and can be done on the fly for
LLDB tests, since build-script-impl directly invokes llvm-lit in the latter
case.

rdar://problem/52062631
