### PR TITLE
[Serialization] Drop protocols whose requirements can't be loaded

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 499; // remove protocol's generic env
+const uint16_t SWIFTMODULE_VERSION_MINOR = 500; // dependency types for protocols
 
 using DeclIDField = BCFixed<31>;
 
@@ -997,7 +997,8 @@ namespace decls_block {
     BCFixed<1>,             // objc?
     BCFixed<1>,             // existential-type-supported?
     AccessLevelField,       // access level
-    BCArray<DeclIDField>    // inherited types
+    BCVBR<4>,               // number of inherited types
+    BCArray<TypeIDField>    // inherited types, followed by dependency types
     // Trailed by the generic parameters (if any), the members record, and
     // the default witness table record
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3280,11 +3280,27 @@ public:
 
     auto contextID = S.addDeclContextRef(proto->getDeclContext());
 
-    SmallVector<DeclID, 8> inherited;
+    SmallVector<TypeID, 4> inheritedAndDependencyTypes;
+    llvm::SmallSetVector<Type, 4> dependencyTypes;
+
     for (auto element : proto->getInherited()) {
       assert(!element.getType()->hasArchetype());
-      inherited.push_back(S.addTypeRef(element.getType()));
+      inheritedAndDependencyTypes.push_back(S.addTypeRef(element.getType()));
+      if (element.getType()->is<ProtocolType>())
+        dependencyTypes.insert(element.getType());
     }
+
+    for (Requirement req : proto->getRequirementSignature()) {
+      // Requirements can be cyclic, so for now filter out any requirements
+      // from elsewhere in the module. This isn't perfect---something else in
+      // the module could very well fail to compile for its own reasons---but
+      // it's better than nothing.
+      collectDependenciesFromRequirement(dependencyTypes, req,
+                                         /*excluding*/S.M);
+    }
+
+    for (Type ty : dependencyTypes)
+      inheritedAndDependencyTypes.push_back(S.addTypeRef(ty));
 
     uint8_t rawAccessLevel = getRawStableAccessLevel(proto->getFormalAccess());
 
@@ -3298,8 +3314,8 @@ public:
                                proto->isObjC(),
                                proto->existentialTypeSupported(
                                  /*resolver=*/nullptr),
-                               rawAccessLevel,
-                               inherited);
+                               rawAccessLevel, proto->getInherited().size(),
+                               inheritedAndDependencyTypes);
 
     const_cast<ProtocolDecl*>(proto)->createGenericParamsIfMissing();
     writeGenericParams(proto->getGenericParams());

--- a/test/Serialization/Recovery/private-conformances.swift
+++ b/test/Serialization/Recovery/private-conformances.swift
@@ -4,15 +4,23 @@
 // RUN: %target-swift-frontend -emit-module -DPROTOCOL_LIB -DBEFORE %s -module-name protocol_lib -emit-module-path %t/protocol_lib.swiftmodule
 // RUN: %target-swift-frontend -emit-module -DCONFORMS_LIB %s -module-name conforms_lib -emit-module-path %t/conforms_lib.swiftmodule -I %t
 // RUN: %target-swift-frontend -emit-module -DINHERITS_LIB %s -module-name inherits_lib -emit-module-path %t/inherits_lib.swiftmodule -I %t
+// RUN: %target-swift-frontend -emit-module -DCYCLIC_DEPENDENCY_LIB %s -module-name cyclic_dependency_lib -emit-module-path %t/cyclic_dependency_lib.swiftmodule -I %t
 
 // Rebuild the protocol library to omit PrivateProtocol.
 // RUN: %target-swift-frontend -emit-module -DPROTOCOL_LIB -DAFTER %s -module-name protocol_lib -emit-module-path %t/protocol_lib.swiftmodule
 
 // The conforming library's types should still deserialize.
-// RUN: %target-swift-ide-test -print-module -source-filename %s -D CONFORMS_LIB -module-to-print conforms_lib -I %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print conforms_lib -I %t | %FileCheck %s
 
-// Make sure we *cannot* recover from a missing inherited protocol.
-// RUN: not --crash %target-swift-ide-test -print-module -source-filename %s -D INHERITS_LIB -module-to-print inherits_lib -I %t
+// Protocols that use a missing protocol have to disappear (see the FileCheck
+// lines).
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print inherits_lib -I %t > %t/inherits_lib.txt
+// RUN: %FileCheck -check-prefix=CHECK-INHERITS %s < %t/inherits_lib.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE-INHERITS %s < %t/inherits_lib.txt
+
+// We can't yet handle protocols with dependencies within the same module that
+// can't be deserialized
+// RUN: not --crash %target-swift-ide-test -print-module -source-filename %s -module-to-print cyclic_dependency_lib -I %t
 
 #if PROTOCOL_LIB
 
@@ -55,6 +63,34 @@ extension S2 : PrivateProtocol, PublicProtocol {}
 #elseif INHERITS_LIB
 import protocol_lib
 
+// NEGATIVE-INHERITS-NOT: protocol InheritsPrivateProtocol
 public protocol InheritsPrivateProtocol : PrivateProtocol {}
+
+// NEGATIVE-INHERITS-NOT: protocol TransitivelyInheritsPrivateProtocol
+public protocol TransitivelyInheritsPrivateProtocol : InheritsPrivateProtocol {}
+
+// NEGATIVE-INHERITS-NOT: protocol RequiresPrivateProtocol
+public protocol RequiresPrivateProtocol {
+  associatedtype Assoc: PrivateProtocol
+}
+
+// CHECK-INHERITS: protocol HasAssoc
+public protocol HasAssoc {
+  associatedtype Assoc
+}
+
+// NEGATIVE-INHERITS-NOT: protocol RequiresPrivateProtocolRefinement
+public protocol RequiresPrivateProtocolRefinement : HasAssoc where Assoc: PrivateProtocol {}
+
+#elseif CYCLIC_DEPENDENCY_LIB
+import protocol_lib
+
+public protocol CycleA : PrivateProtocol {
+  associatedtype Assoc: CycleB
+}
+
+public protocol CycleB {
+  associatedtype Assoc: CycleA
+}
 
 #endif


### PR DESCRIPTION
(builds on #25800)

If a protocol inherits from a protocol that can't be loaded, drop it entirely. Similarly, if it has requirements that reference types in other modules that can't be loaded, drop the protocol entirely—at least for now, we don't want to deal with a protocol that exists but has the wrong requirement signature. That "in other modules" isn't perfect, but it avoids cases where two protocols depend on each other. Unfortunately, it means the compiler may still get into exactly the situation above if a protocol depends on another protocol in the same module, and *that* protocol can't be loaded for some other reason. But it's progress.

This comes up when referencing implementation-only-imported protocols from non-public protocols, but is also just general deserialization recovery goodness.

rdar://problem/52141347