### PR TITLE
[Sema] NFC: Expand TypeVar ID/GraphIndex to 32 bits

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -336,16 +336,14 @@ protected:
     NumProtocols : 16
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 20+4+20,
-    /// The unique number assigned to this type variable.
-    ID : 20,
+  SWIFT_INLINE_BITFIELD_FULL(TypeVariableType, TypeBase, 4+32,
+    : NumPadBits,
 
     /// Type variable options.
     Options : 4,
 
-    ///  Index into the list of type variables, as used by the
-    ///  constraint graph.
-    GraphIndex : 20
+    /// The unique number assigned to this type variable.
+    ID : 32
   );
 
   SWIFT_INLINE_BITFIELD(SILFunctionType, TypeBase, NumSILExtInfoBits+3+1+2,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -192,6 +192,10 @@ class TypeVariableType::Implementation {
   /// The corresponding node in the constraint graph.
   constraints::ConstraintGraphNode *GraphNode = nullptr;
 
+  ///  Index into the list of type variables, as used by the
+  ///  constraint graph.
+  unsigned GraphIndex;
+
   friend class constraints::SavedTypeVariableBinding;
 
 public:
@@ -250,12 +254,12 @@ public:
   /// Retrieve the index into the constraint graph's list of type variables.
   unsigned getGraphIndex() const { 
     assert(GraphNode && "Graph node isn't set");
-    return getTypeVariable()->Bits.TypeVariableType.GraphIndex; 
+    return GraphIndex;
   }
 
   /// Set the index into the constraint graph's list of type variables.
   void setGraphIndex(unsigned newIndex) {
-    getTypeVariable()->Bits.TypeVariableType.GraphIndex = newIndex;
+    GraphIndex = newIndex;
   }
   
   /// Check whether this type variable either has a representative that


### PR DESCRIPTION
As an aside, I really wish these user visible limits were formalized and not side effects of internal compiler data structures.