### PR TITLE
[Diagnostics] Insert access level fixits in front of 'override', if it's there

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4019,6 +4019,11 @@ void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
       attr->setInvalid();
     }
 
+  } else if (auto *override = VD->getAttrs().getAttribute<OverrideAttr>()) {
+    // Insert the access in front of 'override', if it exists, in order to
+    // match the same keyword order as produced by method autocompletion.
+    diag.fixItInsert(override->getLocation(), fixItString);
+
   } else if (auto var = dyn_cast<VarDecl>(VD)) {
     if (auto PBD = var->getParentPatternBinding())
       diag.fixItInsert(PBD->getStartLoc(), fixItString);

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -195,12 +195,12 @@ internal extension Base {
 
 public class PublicSub: Base {
   private required init() {} // expected-error {{'required' initializer must be accessible wherever class 'PublicSub' can be subclassed}} {{3-10=internal}}
-  override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{12-12=public }}
-  override var bar: Int { // expected-error {{overriding property must be as accessible as the declaration it overrides}} {{12-12=public }}
+  override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{3-3=public }}
+  override var bar: Int { // expected-error {{overriding property must be as accessible as the declaration it overrides}} {{3-3=public }}
     get { return 0 }
     set {}
   }
-  override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{12-12=public }}
+  override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{3-3=public }}
 }
 
 public class PublicSubGood: Base {

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -194,12 +194,12 @@ internal extension Base {
 
 public class PublicSub: Base {
   private required init() {} // expected-error {{'required' initializer must be accessible wherever class 'PublicSub' can be subclassed}} {{3-10=internal}}
-  override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{12-12=public }}
-  override var bar: Int { // expected-error {{overriding property must be as accessible as the declaration it overrides}} {{12-12=public }}
+  override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{3-3=public }}
+  override var bar: Int { // expected-error {{overriding property must be as accessible as the declaration it overrides}} {{3-3=public }}
     get { return 0 }
     set {}
   }
-  override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{12-12=public }}
+  override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{3-3=public }}
 }
 
 public class PublicSubGood: Base {


### PR DESCRIPTION
... instead of after. This is so that code produced by this fixit matches the same keyword
order as code produced by autocompleting a method decl in a new subclass.

We've noticed that making a class public and then subclassing results in `public override func` declarations (when using Xcode's autocompletion), whereas subclassing and then making the superclass public results in `override public func` (via an access level fixit on the subclass). It's a lot nicer if the tooling helps the coders be consistent.