### PR TITLE
add `CollectionDifference.inverse()` and test coverage

### DIFF
--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -154,8 +154,8 @@ public struct CollectionDifference<ChangeElement> {
   }
 
   /// Internal initializer for use by algorithms that cannot produce invalid
-  /// collections of changes. These include the Myers' diff algorithm and
-  /// the move inferencer.
+  /// collections of changes. These include the Myers' diff algorithm,
+  /// self.inverse(), and the move inferencer.
   ///
   /// If parameter validity cannot be guaranteed by the caller then
   /// `CollectionDifference.init?(_:)` should be used instead.
@@ -199,6 +199,17 @@ public struct CollectionDifference<ChangeElement> {
 
     removals = Array(sortedChanges[0..<firstInsertIndex])
     insertions = Array(sortedChanges[firstInsertIndex..<sortedChanges.count])
+  }
+
+  public func inverse() -> Self {
+    return CollectionDifference(_validatedChanges: self.map { c in
+      switch c {
+        case .remove(let o, let e, let a):
+          return .insert(offset: o, element: e, associatedWith: a)
+        case .insert(let o, let e, let a):
+          return .remove(offset: o, element: e, associatedWith: a)
+      }
+    })
   }
 }
 

--- a/test/stdlib/Diffing.swift
+++ b/test/stdlib/Diffing.swift
@@ -626,6 +626,7 @@ if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, * ) {
 
                 // Validate application
                 expectEqual(b, a.applying(diff)!)
+                expectEqual(a, b.applying(diff.inverse())!)
               }}}}}}
   }
 
@@ -645,6 +646,7 @@ if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, * ) {
       expectNotNil(applied)
       if let applied = applied {
         expectEqual(b, applied)
+        expectEqual(a, applied.applying(d.inverse()))
         if (b != applied) {
           print("""
             // repro:
@@ -652,6 +654,7 @@ if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, * ) {
             let b = \(b)
             let d = b.difference(from: a)
             expectEqual(b, a.applying(d))
+            expectEqual(a, applied.applying(d.inverse()))
             """)
           break
         }


### PR DESCRIPTION
Per the amendment proposed [on the forums](https://forums.swift.org/t/amendment-se-0240-ordered-collection-diffing/26084), this method allows convenient production of diffs for reverting their original's application. IoW:

``` swift
let diff = b.difference(from: a)
assert( a == a.applying(diff).applying(diff.inverse()) )
```