### PR TITLE
Reduce the malloc traffic for GenericSignatureBuilders and ConstraintSolverArenas

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -878,6 +878,14 @@ Iterator removeAdjacentIf(const Iterator first, const Iterator last,
   return insertionPoint;
 }
 
+/// Like std::default_delete, but only destroys the object in place.
+template <typename T>
+struct default_destroy {
+  static_assert(!std::is_array<T>::value, "not supported for arrays");
+  void operator()(T* ptr) const {
+    ptr->~T();
+  }
+};
 
 } // end namespace swift
 

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -887,6 +887,9 @@ struct default_destroy {
   }
 };
 
+template <typename T>
+using destroying_unique_ptr = std::unique_ptr<T, default_destroy<T>>;
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_INTERLEAVE_H


### PR DESCRIPTION
The former use the PIMPL idiom, and always live as long as their associated arena, so the outer pointer can be allocated in that arena instead of using `new`. The latter cannot outlive their associated allocator.

No intended functionality change. Attempting to counterbalance some of the extra mallocs in #25800.