### PR TITLE
build-script: Make lit -v the default.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -26,7 +26,6 @@ tvos
 watchos
 test
 validation-test
-lit-args=-v
 compiler-vendor=apple
 
 dash-dash
@@ -296,7 +295,7 @@ lldb-assertions
 [preset: buildbot_incremental_base]
 test
 validation-test
-lit-args=-v --time-tests
+lit-args=--time-tests
 
 compiler-vendor=apple
 
@@ -588,7 +587,6 @@ build-subdir=buildbot_incremental_llvmonly
 release-debug
 assertions
 test=0
-lit-args=-v
 
 compiler-vendor=apple
 
@@ -771,7 +769,7 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-lit-args=-v --time-tests
+lit-args=--time-tests
 
 dash-dash
 
@@ -916,7 +914,6 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-lit-args=-v
 
 dash-dash
 
@@ -935,7 +932,6 @@ validation-test
 long-test
 stress-test
 foundation
-lit-args=-v
 indexstore-db=0
 sourcekit-lsp=0
 
@@ -985,7 +981,6 @@ assertions
 release
 test
 validation-test
-lit-args=-v
 
 dash-dash
 
@@ -1702,7 +1697,6 @@ skip-build-benchmarks
 
 test
 validation-test
-lit-args=-v
 
 dash-dash
 
@@ -1715,7 +1709,6 @@ skip-reconfigure
 
 test
 validation-test
-lit-args=-v
 
 dash-dash
 
@@ -1727,7 +1720,6 @@ skip-reconfigure
 [preset: mixin_buildbot_incremental,test=tvOS,type=simulator]
 test
 validation-test
-lit-args=-v
 
 dash-dash
 
@@ -1740,7 +1732,6 @@ skip-reconfigure
 
 test
 validation-test
-lit-args=-v
 
 dash-dash
 
@@ -1972,7 +1963,6 @@ skip-test-tvos
 skip-test-watchos
 skip-build-benchmark
 verbose-build
-lit-args=-v
 reconfigure
 build-ninja
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -4001,7 +4001,7 @@ function build_and_test_installable_package() {
                 call tar xzf "${package_for_host}"
 
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \
-                call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}"
+                call python "${LIT_EXECUTABLE_PATH}" . -v --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}"
         fi
     fi
 }

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -488,7 +488,7 @@ def create_argument_parser():
                 'optimization')
 
     option('--lit-args', store,
-           default='-sv',
+           default='-v',
            metavar='LITARGS',
            help='lit args to use when testing')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -149,7 +149,7 @@ EXPECTED_DEFAULTS = {
     'legacy_impl': False,
     'libdispatch_build_variant': 'Debug',
     'libicu_build_variant': 'Debug',
-    'lit_args': '-sv',
+    'lit_args': '-v',
     'llbuild_assertions': True,
     'lldb_assertions': True,
     'lldb_build_variant': 'Debug',

--- a/utils/run-test
+++ b/utils/run-test
@@ -231,7 +231,7 @@ def main():
     if args.verbose:
         test_args = ["-a"]
     else:
-        test_args = ["-sv"]
+        test_args = ["-v"]
 
     # Test parameters.
     test_args += ['--param', 'swift_test_mode=%s' % args.mode,


### PR DESCRIPTION
On all bots this is what you want to get meaningful progress reports.
Changing the default simplifies most build presets and should have no
effect for users on interactive terminals.
