### PR TITLE
[ClangImporter] Always use the VFS when debugger support is requested

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1012,7 +1012,10 @@ ClangImporter::create(ASTContext &ctx,
 
   // Set up the file manager.
   {
-    if (!ctx.SearchPathOpts.VFSOverlayFiles.empty()) {
+    if (importerOpts.DebuggerSupport) {
+      // The debugger uses the virtual file system for reproducers.
+      instance.setVirtualFileSystem(ctx.SourceMgr.getFileSystem());
+    } else if (!ctx.SearchPathOpts.VFSOverlayFiles.empty()) {
       // If the clang instance has overlays it means the user has provided
       // -ivfsoverlay options and swift -vfsoverlay options.  We're going to
       // clobber their file system with our own, so warn about it.


### PR DESCRIPTION
Reproducers in LLDB use the VFS to abstract file locations. The The
clang importer should use the VFS when debugger support is requested.