### PR TITLE
[5.1][String] Scalar-alignment bug fixes.

### DIFF
--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -60,3 +60,11 @@ extension Substring {
     return try copy.withUTF8(body)
   }
 }
+
+extension String {
+  @usableFromInline // Never actually used in inlinable code...
+  internal func _nativeCopyUTF16CodeUnits(
+    into buffer: UnsafeMutableBufferPointer<UInt16>,
+    range: Range<String.Index>
+  ) { fatalError() }
+}

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -420,6 +420,6 @@ extension String {
   ) {
     _internalInvariant(buffer.count >= range.count)
     let indexRange = self._toUTF16Indices(range)
-    self._nativeCopyUTF16CodeUnits(into: buffer, range: indexRange)
+    self.utf16._nativeCopy(into: buffer, alignedRange: indexRange)
   }
 }

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -173,17 +173,17 @@ internal enum _KnownCocoaString {
 #if !(arch(i386) || arch(arm))
   case tagged
 #endif
-  
+
   @inline(__always)
   init(_ str: _CocoaString) {
-    
+
 #if !(arch(i386) || arch(arm))
     if _isObjCTaggedPointer(str) {
       self = .tagged
       return
     }
 #endif
-    
+
     switch unsafeBitCast(_swift_classOfObjCHeapObject(str), to: UInt.self) {
     case unsafeBitCast(__StringStorage.self, to: UInt.self):
       self = .storage
@@ -272,13 +272,13 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
     //   3) If it's mutable with associated information, must make the call
     let immutableCopy
       = _stdlib_binary_CFStringCreateCopy(cocoaString) as AnyObject
-    
+
 #if !(arch(i386) || arch(arm))
     if _isObjCTaggedPointer(immutableCopy) {
       return _StringGuts(_SmallString(taggedCocoa: immutableCopy))
     }
 #endif
-    
+
     let (fastUTF8, isASCII): (Bool, Bool)
     switch _getCocoaStringPointer(immutableCopy) {
     case .ascii(_): (fastUTF8, isASCII) = (true, true)
@@ -286,7 +286,7 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
     default:  (fastUTF8, isASCII) = (false, false)
     }
     let length = _stdlib_binary_CFStringGetLength(immutableCopy)
-    
+
     return _StringGuts(
       cocoa: immutableCopy,
       providesFastUTF8: fastUTF8,

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -64,10 +64,10 @@ extension String: BidirectionalCollection {
     let stride = _characterStride(startingAt: i)
     let nextOffset = i._encodedOffset &+ stride
     let nextStride = _characterStride(
-      startingAt: Index(_encodedOffset: nextOffset).aligned)
+      startingAt: Index(_encodedOffset: nextOffset)._aligned)
 
     return Index(
-      encodedOffset: nextOffset, characterStride: nextStride).aligned
+      encodedOffset: nextOffset, characterStride: nextStride)._aligned
   }
 
   /// Returns the position immediately before the given index.
@@ -82,7 +82,7 @@ extension String: BidirectionalCollection {
     let i = _guts.scalarAlign(i)
     let stride = _characterStride(endingAt: i)
     let priorOffset = i._encodedOffset &- stride
-    return Index(encodedOffset: priorOffset, characterStride: stride).aligned
+    return Index(encodedOffset: priorOffset, characterStride: stride)._aligned
   }
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -200,7 +200,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(startingAt i: Index) -> Int {
-    _internalInvariant(i.isAligned)
+    _internalInvariant(i._isAligned)
 
     // Fast check if it's already been measured, otherwise check resiliently
     if let d = i.characterStride { return d }
@@ -212,7 +212,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(endingAt i: Index) -> Int {
-    _internalInvariant(i.isAligned)
+    _internalInvariant(i._isAligned)
 
     if i == startIndex { return 0 }
 

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -64,10 +64,10 @@ extension String: BidirectionalCollection {
     let stride = _characterStride(startingAt: i)
     let nextOffset = i._encodedOffset &+ stride
     let nextStride = _characterStride(
-      startingAt: Index(_encodedOffset: nextOffset)._aligned)
+      startingAt: Index(_encodedOffset: nextOffset)._scalarAligned)
 
     return Index(
-      encodedOffset: nextOffset, characterStride: nextStride)._aligned
+      encodedOffset: nextOffset, characterStride: nextStride)._scalarAligned
   }
 
   /// Returns the position immediately before the given index.
@@ -82,7 +82,8 @@ extension String: BidirectionalCollection {
     let i = _guts.scalarAlign(i)
     let stride = _characterStride(endingAt: i)
     let priorOffset = i._encodedOffset &- stride
-    return Index(encodedOffset: priorOffset, characterStride: stride)._aligned
+    return Index(
+      encodedOffset: priorOffset, characterStride: stride)._scalarAligned
   }
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -200,7 +201,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(startingAt i: Index) -> Int {
-    _internalInvariant(i._isAligned)
+    _internalInvariant(i._isScalarAligned)
 
     // Fast check if it's already been measured, otherwise check resiliently
     if let d = i.characterStride { return d }
@@ -212,7 +213,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(endingAt i: Index) -> Int {
-    _internalInvariant(i._isAligned)
+    _internalInvariant(i._isScalarAligned)
 
     if i == startIndex { return 0 }
 

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -86,17 +86,18 @@ private func _hasGraphemeBreakBetween(
 private func _measureCharacterStrideICU(
   of utf8: UnsafeBufferPointer<UInt8>, startingAt i: Int
 ) -> Int {
-  let iterator = _ThreadLocalStorage.getUBreakIterator(utf8)
-  let offset = __swift_stdlib_ubrk_following(
-    iterator, Int32(truncatingIfNeeded: i))
+  // ICU will gives us a different result if we feed in the whole buffer, so
+  // slice it appropriately.
+  let utf8Slice = UnsafeBufferPointer(rebasing: utf8[i...])
+  let iterator = _ThreadLocalStorage.getUBreakIterator(utf8Slice)
+  let offset = __swift_stdlib_ubrk_following(iterator, 0)
+
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
-  if _fastPath(offset != -1) {
-    // The offset into our buffer is the distance.
-    _internalInvariant(offset > i, "zero-sized grapheme?")
-    return Int(truncatingIfNeeded: offset) &- i
-  }
-  _internalInvariant(utf8.count > i)
-  return utf8.count &- i
+  guard _fastPath(offset != -1) else { return utf8Slice.count }
+
+  // The offset into our buffer is the distance.
+  _internalInvariant(offset > 0, "zero-sized grapheme?")
+  return Int(truncatingIfNeeded: offset)
 }
 
 @inline(never) // slow-path
@@ -104,16 +105,18 @@ private func _measureCharacterStrideICU(
 private func _measureCharacterStrideICU(
   of utf16: UnsafeBufferPointer<UInt16>, startingAt i: Int
 ) -> Int {
-  let iterator = _ThreadLocalStorage.getUBreakIterator(utf16)
-  let offset = __swift_stdlib_ubrk_following(
-    iterator, Int32(truncatingIfNeeded: i))
+  // ICU will gives us a different result if we feed in the whole buffer, so
+  // slice it appropriately.
+  let utf16Slice = UnsafeBufferPointer(rebasing: utf16[i...])
+  let iterator = _ThreadLocalStorage.getUBreakIterator(utf16Slice)
+  let offset = __swift_stdlib_ubrk_following(iterator, 0)
+
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
-  if _fastPath(offset != -1) {
-    // The offset into our buffer is the distance.
-    _internalInvariant(offset > i, "zero-sized grapheme?")
-    return Int(truncatingIfNeeded: offset) &- i
-  }
-  return utf16.count &- i
+  guard _fastPath(offset != -1) else { return utf16Slice.count }
+
+  // The offset into our buffer is the distance.
+  _internalInvariant(offset > 0, "zero-sized grapheme?")
+  return Int(truncatingIfNeeded: offset)
 }
 
 @inline(never) // slow-path
@@ -121,9 +124,12 @@ private func _measureCharacterStrideICU(
 private func _measureCharacterStrideICU(
   of utf8: UnsafeBufferPointer<UInt8>, endingAt i: Int
 ) -> Int {
-  let iterator = _ThreadLocalStorage.getUBreakIterator(utf8)
-  let offset = __swift_stdlib_ubrk_preceding(
-    iterator, Int32(truncatingIfNeeded: i))
+  // Slice backwards as well, even though ICU currently seems to give the same
+  // answer as unsliced.
+  let utf8Slice = UnsafeBufferPointer(rebasing: utf8[..<i])
+  let iterator = _ThreadLocalStorage.getUBreakIterator(utf8Slice)
+  let offset = __swift_stdlib_ubrk_preceding(iterator, Int32(utf8Slice.count))
+
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.
@@ -138,9 +144,12 @@ private func _measureCharacterStrideICU(
 private func _measureCharacterStrideICU(
   of utf16: UnsafeBufferPointer<UInt16>, endingAt i: Int
 ) -> Int {
-  let iterator = _ThreadLocalStorage.getUBreakIterator(utf16)
-  let offset = __swift_stdlib_ubrk_preceding(
-    iterator, Int32(truncatingIfNeeded: i))
+  // Slice backwards as well, even though ICU currently seems to give the same
+  // answer as unsliced.
+  let utf16Slice = UnsafeBufferPointer(rebasing: utf16[..<i])
+  let iterator = _ThreadLocalStorage.getUBreakIterator(utf16Slice)
+  let offset = __swift_stdlib_ubrk_preceding(iterator, Int32(utf16Slice.count))
+
   // ubrk_following returns -1 (UBRK_DONE) when it hits the end of the buffer.
   if _fastPath(offset != -1) {
     // The offset into our buffer is the distance.

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -268,11 +268,11 @@ extension _StringGuts {
 
   @inlinable @inline(__always)
   internal var startIndex: String.Index {
-   return Index(_encodedOffset: 0)._aligned
+   return Index(_encodedOffset: 0)._scalarAligned
   }
   @inlinable @inline(__always)
   internal var endIndex: String.Index {
-    return Index(_encodedOffset: self.count)._aligned
+    return Index(_encodedOffset: self.count)._scalarAligned
   }
 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -268,11 +268,11 @@ extension _StringGuts {
 
   @inlinable @inline(__always)
   internal var startIndex: String.Index {
-   return Index(_encodedOffset: 0).aligned
+   return Index(_encodedOffset: 0)._aligned
   }
   @inlinable @inline(__always)
   internal var endIndex: String.Index {
-    return Index(_encodedOffset: self.count).aligned
+    return Index(_encodedOffset: self.count)._aligned
   }
 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -268,11 +268,11 @@ extension _StringGuts {
 
   @inlinable @inline(__always)
   internal var startIndex: String.Index {
-   return Index(_encodedOffset: 0)
+   return Index(_encodedOffset: 0).aligned
   }
   @inlinable @inline(__always)
   internal var endIndex: String.Index {
-    return Index(_encodedOffset: self.count)
+    return Index(_encodedOffset: self.count).aligned
   }
 }
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -152,7 +152,7 @@ extension String.Index {
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
     _internalInvariant(_encodedOffset >= 0)
-    if self.isAligned {
+    if self._isAligned {
       _internalInvariant(transcodedOffset == 0)
     }
   }
@@ -249,11 +249,11 @@ extension String.Index {
 extension String.Index {
   @_alwaysEmitIntoClient // Swift 5.1
   @inline(__always)
-  internal var isAligned: Bool { return 0 != _rawBits & 0x2000 }
+  internal var _isAligned: Bool { return 0 != _rawBits & 0x2000 }
 
   @_alwaysEmitIntoClient // Swift 5.1
   @inline(__always)
-  internal var aligned: String.Index {
+  internal var _aligned: String.Index {
     var idx = self
     idx._rawBits |= 0x2000
     idx._invariantCheck()

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -16,21 +16,25 @@ import SwiftShims
 
 String's Index has the following layout:
 
- ┌──────────┬───────────────────┬────────────────┬──────────┐
- │ b63:b16  │      b15:b14      │     b13:b8     │ b7:b0    │
- ├──────────┼───────────────────┼────────────────┼──────────┤
- │ position │ transcoded offset │ grapheme cache │ reserved │
- └──────────┴───────────────────┴────────────────┴──────────┘
+ ┌──────────┬───────────────────┬─────────╥────────────────┬──────────┐
+ │ b63:b16  │      b15:b14      │   b13   ║     b12:b8     │  b6:b0   │
+ ├──────────┼───────────────────┼─────────╫────────────────┼──────────┤
+ │ position │ transcoded offset │ aligned ║ grapheme cache │ reserved │
+ └──────────┴───────────────────┴─────────╨────────────────┴──────────┘
 
-- grapheme cache: A 6-bit value remembering the distance to the next grapheme
+Position, transcoded offset, and aligned are fully exposed in the ABI. Grapheme
+cache and reserved are partially resilient: the fact that there are 13 bits with
+a default value of `0` is ABI, but not the layout, construction, or
+interpretation of those bits. All use of grapheme cache should be behind
+non-inlinable function calls.
+
+- position aka `encodedOffset`: A 48-bit offset into the string's code units
+- transcoded offset: a 2-bit sub-scalar offset, derived from transcoding
+- aligned, whether this index is known to be scalar-aligned (see below)
+<resilience barrier>
+- grapheme cache: A 5-bit value remembering the distance to the next grapheme
 boundary
-- position aka `encodedOffset`: An offset into the string's code units
-- transcoded offset: a sub-scalar offset, derived from transcoding
-
-The use and interpretation of both `reserved` and `grapheme cache` is not part
-of Index's ABI; it should be hidden behind non-inlinable calls. However, the
-position of the sequence of 14 bits allocated is part of Index's ABI, as well as
-the default value being `0`.
+- reserved: 8-bit for future use.
 
 */
 extension String {
@@ -82,7 +86,7 @@ extension String.Index {
 
   @usableFromInline
   internal var characterStride: Int? {
-    let value = (_rawBits & 0x3F00) &>> 8
+    let value = (_rawBits & 0x1F00) &>> 8
     return value > 0 ? Int(truncatingIfNeeded: value) : nil
   }
 
@@ -132,9 +136,7 @@ extension String.Index {
     encodedOffset: Int, transcodedOffset: Int, characterStride: Int
   ) {
     self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
-    if _slowPath(characterStride > 63) { return }
-
-    _internalInvariant(characterStride == characterStride & 0x3F)
+    if _slowPath(characterStride > 0x1F) { return }
     self._rawBits |= UInt64(truncatingIfNeeded: characterStride &<< 8)
     self._invariantCheck()
   }
@@ -150,6 +152,9 @@ extension String.Index {
   @usableFromInline @inline(never) @_effects(releasenone)
   internal func _invariantCheck() {
     _internalInvariant(_encodedOffset >= 0)
+    if self.isAligned {
+      _internalInvariant(transcodedOffset == 0)
+    }
   }
   #endif // INTERNAL_CHECKS_ENABLED
 }
@@ -188,6 +193,7 @@ extension String.Index {
       transcodedOffset: self.transcodedOffset &- 1)
   }
 
+
   // Get an index with an encoded offset relative to this one.
   // Note: strips any transcoded offset.
   @inlinable @inline(__always)
@@ -200,7 +206,59 @@ extension String.Index {
     _internalInvariant(self.transcodedOffset == 0)
     return String.Index(encodedOffset: self._encodedOffset, transcodedOffset: n)
   }
+}
 
+/*
+  Index Alignment
+
+  SE-0180 unifies the Index type of String and all its views and allows
+  non-scalar-aligned indices to be used across views. In order to guarantee
+  behavior, we often have to check and perform scalar alignment. To speed up
+  these checks, we allocate a bit denoting known-to-be-aligned, so that the
+  alignment check can skip the load. The below shows what views need to check
+  for alignment before they can operate, and whether the indices they produce
+  are aligned.
+
+  ┌───────────────╥────────────────────┬──────────────────────────┐
+  │ View          ║ Requires Alignment │ Produces Aligned Indices │
+  ╞═══════════════╬════════════════════╪══════════════════════════╡
+  │ Native UTF8   ║ no                 │ no                       │
+  ├───────────────╫────────────────────┼──────────────────────────┤
+  │ Native UTF16  ║ yes                │ no                       │
+  ╞═══════════════╬════════════════════╪══════════════════════════╡
+  │ Foreign UTF8  ║ yes                │ no                       │
+  ├───────────────╫────────────────────┼──────────────────────────┤
+  │ Foreign UTF16 ║ no                 │ no                       │
+  ╞═══════════════╬════════════════════╪══════════════════════════╡
+  │ UnicodeScalar ║ yes                │ yes                      │
+  ├───────────────╫────────────────────┼──────────────────────────┤
+  │ Character     ║ yes                │ yes                      │
+  └───────────────╨────────────────────┴──────────────────────────┘
+
+  The "requires alignment" applies to any operation taking a String.Index that's
+  not defined entirely in terms of other operations taking a String.Index. These
+  include:
+
+  * index(after:)
+  * index(before:)
+  * subscript
+  * distance(from:to:) (since `to` is compared against directly)
+  * UTF16View._nativeGetOffset(for:)
+
+*/
+extension String.Index {
+  @_alwaysEmitIntoClient // Swift 5.1
+  @inline(__always)
+  internal var isAligned: Bool { return 0 != _rawBits & 0x2000 }
+
+  @_alwaysEmitIntoClient // Swift 5.1
+  @inline(__always)
+  internal var aligned: String.Index {
+    var idx = self
+    idx._rawBits |= 0x2000
+    idx._invariantCheck()
+    return idx
+  }
 }
 
 extension String.Index: Equatable {

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -143,9 +143,9 @@ extension _AbstractStringStorage {
       // one of ours.
 
       defer { _fixLifetime(other) }
-      
+
       let otherUTF16Length = _stdlib_binary_CFStringGetLength(other)
-      
+
       // CFString will only give us ASCII bytes here, but that's fine.
       // We already handled non-ASCII UTF8 strings earlier since they're Swift.
       if let otherStart = _cocoaUTF8Pointer(other) {
@@ -156,11 +156,11 @@ extension _AbstractStringStorage {
         return (start == otherStart ||
           (memcmp(start, otherStart, count) == 0)) ? 1 : 0
       }
-      
+
       if UTF16Length != otherUTF16Length {
         return 0
       }
-      
+
       /*
        The abstract implementation of -isEqualToString: falls back to -compare:
        immediately, so when we run out of fast options to try, do the same.

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -154,7 +154,7 @@ extension String.UTF16View: BidirectionalCollection {
     if len == 4 && idx.transcodedOffset == 0 {
       return idx.nextTranscoded
     }
-    return idx.strippingTranscoding.encoded(offsetBy: len)._aligned
+    return idx.strippingTranscoding.encoded(offsetBy: len)._scalarAligned
   }
 
   @inlinable @inline(__always)
@@ -178,7 +178,7 @@ extension String.UTF16View: BidirectionalCollection {
 
     // Single UTF-16 code unit
     _internalInvariant((1...3) ~= len)
-    return idx.encoded(offsetBy: -len)._aligned
+    return idx.encoded(offsetBy: -len)._scalarAligned
   }
 
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -587,7 +587,7 @@ extension String.UTF16View {
             _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }
-          return Index(_encodedOffset: readIdx &+ len)._aligned
+          return Index(_encodedOffset: readIdx &+ len)._scalarAligned
         }
 
         readIdx &+= len

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -154,7 +154,7 @@ extension String.UTF16View: BidirectionalCollection {
     if len == 4 && idx.transcodedOffset == 0 {
       return idx.nextTranscoded
     }
-    return idx.strippingTranscoding.encoded(offsetBy: len).aligned
+    return idx.strippingTranscoding.encoded(offsetBy: len)._aligned
   }
 
   @inlinable @inline(__always)
@@ -178,7 +178,7 @@ extension String.UTF16View: BidirectionalCollection {
 
     // Single UTF-16 code unit
     _internalInvariant((1...3) ~= len)
-    return idx.encoded(offsetBy: -len).aligned
+    return idx.encoded(offsetBy: -len)._aligned
   }
 
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -587,7 +587,7 @@ extension String.UTF16View {
             _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }
-          return Index(_encodedOffset: readIdx &+ len).aligned
+          return Index(_encodedOffset: readIdx &+ len)._aligned
         }
 
         readIdx &+= len

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -139,40 +139,46 @@ extension String.UTF16View: BidirectionalCollection {
   public var endIndex: Index { return _guts.endIndex }
 
   @inlinable @inline(__always)
-  public func index(after i: Index) -> Index {
-    if _slowPath(_guts.isForeign) { return _foreignIndex(after: i) }
-    if _guts.isASCII { return i.nextEncoded }
+  public func index(after idx: Index) -> Index {
+    if _slowPath(_guts.isForeign) { return _foreignIndex(after: idx) }
+    if _guts.isASCII { return idx.nextEncoded }
 
     // For a BMP scalar (1-3 UTF-8 code units), advance past it. For a non-BMP
     // scalar, use a transcoded offset first.
-    let len = _guts.fastUTF8ScalarLength(startingAt: i._encodedOffset)
-    if len == 4 && i.transcodedOffset == 0 {
-      return i.nextTranscoded
+
+    // TODO: do the ugly if non-transcoded make sure to scalar align thing...
+    // Also, can we just jump ahead 4 is transcoded is 1?
+
+    let idx = _utf16AlignNativeIndex(idx)
+    let len = _guts.fastUTF8ScalarLength(startingAt: idx._encodedOffset)
+    if len == 4 && idx.transcodedOffset == 0 {
+      return idx.nextTranscoded
     }
-    return i.strippingTranscoding.encoded(offsetBy: len)
+    return idx.strippingTranscoding.encoded(offsetBy: len).aligned
   }
 
   @inlinable @inline(__always)
-  public func index(before i: Index) -> Index {
-    precondition(!i.isZeroPosition)
-    if _slowPath(_guts.isForeign) { return _foreignIndex(before: i) }
-    if _guts.isASCII { return i.priorEncoded }
+  public func index(before idx: Index) -> Index {
+    precondition(!idx.isZeroPosition)
+    if _slowPath(_guts.isForeign) { return _foreignIndex(before: idx) }
+    if _guts.isASCII { return idx.priorEncoded }
 
-    if i.transcodedOffset != 0 {
-      _internalInvariant(i.transcodedOffset == 1)
-      return i.strippingTranscoding
+    if idx.transcodedOffset != 0 {
+      _internalInvariant(idx.transcodedOffset == 1)
+      return idx.strippingTranscoding
     }
 
-    let len = _guts.fastUTF8ScalarLength(endingAt: i._encodedOffset)
+    let idx = _utf16AlignNativeIndex(idx)
+    let len = _guts.fastUTF8ScalarLength(endingAt: idx._encodedOffset)
     if len == 4 {
       // 2 UTF-16 code units comprise this scalar; advance to the beginning and
       // start mid-scalar transcoding
-      return i.encoded(offsetBy: -len).nextTranscoded
+      return idx.encoded(offsetBy: -len).nextTranscoded
     }
 
     // Single UTF-16 code unit
     _internalInvariant((1...3) ~= len)
-    return i.encoded(offsetBy: -len)
+    return idx.encoded(offsetBy: -len).aligned
   }
 
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -239,19 +245,16 @@ extension String.UTF16View: BidirectionalCollection {
   /// - Parameter position: A valid index of the view. `position` must be
   ///   less than the view's end index.
   @inlinable @inline(__always)
-  public subscript(i: Index) -> UTF16.CodeUnit {
-    String(_guts)._boundsCheck(i)
+  public subscript(idx: Index) -> UTF16.CodeUnit {
+    String(_guts)._boundsCheck(idx)
 
     if _fastPath(_guts.isFastUTF8) {
       let scalar = _guts.fastUTF8Scalar(
-        startingAt: _guts.scalarAlign(i)._encodedOffset)
-      if scalar.value <= 0xFFFF {
-        return UInt16(truncatingIfNeeded: scalar.value)
-      }
-      return scalar.utf16[i.transcodedOffset]
+        startingAt: _guts.scalarAlign(idx)._encodedOffset)
+      return scalar.utf16[idx.transcodedOffset]
     }
 
-    return _foreignSubscript(position: i)
+    return _foreignSubscript(position: idx)
   }
 }
 
@@ -426,27 +429,30 @@ extension String.UTF16View {
   @_effects(releasenone)
   internal func _foreignIndex(after i: Index) -> Index {
     _internalInvariant(_guts.isForeign)
-    return i.nextEncoded
+    return i.strippingTranscoding.nextEncoded
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(before i: Index) -> Index {
     _internalInvariant(_guts.isForeign)
-    return i.priorEncoded
+    return i.strippingTranscoding.priorEncoded
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignSubscript(position i: Index) -> UTF16.CodeUnit {
     _internalInvariant(_guts.isForeign)
-    return _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
+    return _guts.foreignErrorCorrectedUTF16CodeUnit(at: i.strippingTranscoding)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignDistance(from start: Index, to end: Index) -> Int {
     _internalInvariant(_guts.isForeign)
+
+    // Ignore transcoded offsets, i.e. scalar align if-and-only-if from a
+    // transcoded view
     return end._encodedOffset - start._encodedOffset
   }
 
@@ -460,14 +466,14 @@ extension String.UTF16View {
     if n > 0 ? l >= 0 && l < n : l <= 0 && n < l {
       return nil
     }
-    return i.encoded(offsetBy: n)
+    return i.strippingTranscoding.encoded(offsetBy: n)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
   internal func _foreignIndex(_ i: Index, offsetBy n: Int) -> Index {
     _internalInvariant(_guts.isForeign)
-    return i.encoded(offsetBy: n)
+    return i.strippingTranscoding.encoded(offsetBy: n)
   }
 
   @usableFromInline @inline(never)
@@ -475,6 +481,19 @@ extension String.UTF16View {
   internal func _foreignCount() -> Int {
     _internalInvariant(_guts.isForeign)
     return endIndex._encodedOffset - startIndex._encodedOffset
+  }
+
+  // Align a native UTF-8 index to a valid UTF-16 position. If there is a
+  // transcoded offset already, this is already a valid UTF-16 position
+  // (referring to the second surrogate) and returns `idx`. Otherwise, this will
+  // scalar-align the index. This is needed because we may be passed a
+  // non-scalar-aligned index from the UTF8View.
+  @_alwaysEmitIntoClient // Swift 5.1
+  @inline(__always)
+  internal func _utf16AlignNativeIndex(_ idx: String.Index) -> String.Index {
+    _internalInvariant(!_guts.isForeign)
+    guard idx.transcodedOffset == 0 else { return idx }
+    return _guts.scalarAlign(idx)
   }
 }
 
@@ -506,6 +525,7 @@ extension String.UTF16View {
       return idx._encodedOffset
     }
 
+    let idx = _utf16AlignNativeIndex(idx)
     if idx._encodedOffset < _shortHeuristic || !_guts.hasBreadcrumbs {
       return _distance(from: startIndex, to: idx)
     }
@@ -567,22 +587,27 @@ extension String.UTF16View {
             _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }
-          return Index(_encodedOffset: readIdx &+ len)
+          return Index(_encodedOffset: readIdx &+ len).aligned
         }
 
         readIdx &+= len
       }
     }
   }
-}
 
-extension String {
-  @usableFromInline // @testable
-  internal func _nativeCopyUTF16CodeUnits(
+  // Copy (i.e. transcode to UTF-16) our contents into a buffer. `alignedRange`
+  // means that the indices are part of the UTF16View.indices -- they are either
+  // scalar-aligned or transcoded (e.g. derived from the UTF-16 view). They do
+  // not need to go through an alignment check.
+  internal func _nativeCopy(
     into buffer: UnsafeMutableBufferPointer<UInt16>,
-    range: Range<String.Index>
+    alignedRange range: Range<String.Index>
   ) {
     _internalInvariant(_guts.isFastUTF8)
+    _internalInvariant(
+      range.lowerBound == _utf16AlignNativeIndex(range.lowerBound))
+    _internalInvariant(
+      range.upperBound == _utf16AlignNativeIndex(range.upperBound))
 
     if _slowPath(range.isEmpty) { return }
 
@@ -637,8 +662,6 @@ extension String {
         writeIdx &+= 1
       }
       _internalInvariant(writeIdx <= writeEnd)
-
     }
   }
 }
-

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -137,7 +137,7 @@ extension String.UTF8View: BidirectionalCollection {
   @inlinable @inline(__always)
   public func index(after i: Index) -> Index {
     if _fastPath(_guts.isFastUTF8) {
-      return i.nextEncoded
+      return i.strippingTranscoding.nextEncoded
     }
 
     return _foreignIndex(after: i)
@@ -147,7 +147,7 @@ extension String.UTF8View: BidirectionalCollection {
   public func index(before i: Index) -> Index {
     precondition(!i.isZeroPosition)
     if _fastPath(_guts.isFastUTF8) {
-      return i.priorEncoded
+      return i.strippingTranscoding.priorEncoded
     }
 
     return _foreignIndex(before: i)
@@ -157,7 +157,7 @@ extension String.UTF8View: BidirectionalCollection {
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     if _fastPath(_guts.isFastUTF8) {
       _precondition(n + i._encodedOffset <= _guts.count)
-      return i.encoded(offsetBy: n)
+      return i.strippingTranscoding.encoded(offsetBy: n)
     }
 
     return _foreignIndex(i, offsetBy: n)
@@ -398,56 +398,77 @@ extension String.UTF8View {
 
 // Foreign string support
 extension String.UTF8View {
+  // Align a foreign UTF-16 index to a valid UTF-8 position. If there is a
+  // transcoded offset already, this is already a valid UTF-8 position
+  // (referring to a continuation byte) and returns `idx`. Otherwise, this will
+  // scalar-align the index. This is needed because we may be passed a
+  // non-scalar-aligned foreign index from the UTF16View.
+  @inline(__always)
+  internal func _utf8AlignForeignIndex(_ idx: String.Index) -> String.Index {
+    _internalInvariant(_guts.isForeign)
+    guard idx.transcodedOffset == 0 else { return idx }
+    return _guts.scalarAlign(idx)
+  }
+
   @usableFromInline @inline(never)
   @_effects(releasenone)
-  internal func _foreignIndex(after i: Index) -> Index {
+  internal func _foreignIndex(after idx: Index) -> Index {
     _internalInvariant(_guts.isForeign)
 
+    let idx = _utf8AlignForeignIndex(idx)
+
     let (scalar, scalarLen) = _guts.foreignErrorCorrectedScalar(
-      startingAt: i.strippingTranscoding)
+      startingAt: idx.strippingTranscoding)
     let utf8Len = UTF8.width(scalar)
 
     if utf8Len == 1 {
-      _internalInvariant(i.transcodedOffset == 0)
-      return i.nextEncoded
+      _internalInvariant(idx.transcodedOffset == 0)
+      return idx.nextEncoded
     }
 
     // Check if we're still transcoding sub-scalar
-    if i.transcodedOffset < utf8Len - 1 {
-      return i.nextTranscoded
+    if idx.transcodedOffset < utf8Len - 1 {
+      return idx.nextTranscoded
     }
 
     // Skip to the next scalar
-    return i.encoded(offsetBy: scalarLen)
+    return idx.encoded(offsetBy: scalarLen)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
-  internal func _foreignIndex(before i: Index) -> Index {
+  internal func _foreignIndex(before idx: Index) -> Index {
     _internalInvariant(_guts.isForeign)
-    if i.transcodedOffset != 0 {
-      _internalInvariant((1...3) ~= i.transcodedOffset)
-      return i.priorTranscoded
+
+    let idx = _utf8AlignForeignIndex(idx)
+
+    if idx.transcodedOffset != 0 {
+      _internalInvariant((1...3) ~= idx.transcodedOffset)
+      return idx.priorTranscoded
     }
 
     let (scalar, scalarLen) = _guts.foreignErrorCorrectedScalar(
-      endingAt: i)
+      endingAt: idx.strippingTranscoding)
     let utf8Len = UTF8.width(scalar)
-    return i.encoded(offsetBy: -scalarLen).transcoded(withOffset: utf8Len &- 1)
+    return idx.encoded(
+      offsetBy: -scalarLen
+    ).transcoded(withOffset: utf8Len &- 1)
   }
 
   @usableFromInline @inline(never)
   @_effects(releasenone)
-  internal func _foreignSubscript(position i: Index) -> UTF8.CodeUnit {
+  internal func _foreignSubscript(position idx: Index) -> UTF8.CodeUnit {
     _internalInvariant(_guts.isForeign)
 
+    let idx = _utf8AlignForeignIndex(idx)
+
     let scalar = _guts.foreignErrorCorrectedScalar(
-      startingAt: _guts.scalarAlign(i)).0
+      startingAt: idx.strippingTranscoding).0
     let encoded = Unicode.UTF8.encode(scalar)._unsafelyUnwrappedUnchecked
-    _internalInvariant(i.transcodedOffset < 1+encoded.count)
+    _internalInvariant(idx.transcodedOffset < 1+encoded.count)
 
     return encoded[
-      encoded.index(encoded.startIndex, offsetBy: i.transcodedOffset)]
+      encoded.index(encoded.startIndex, offsetBy: idx.transcodedOffset)]
   }
 
   @usableFromInline @inline(never)
@@ -470,16 +491,20 @@ extension String.UTF8View {
   @_effects(releasenone)
   internal func _foreignDistance(from i: Index, to j: Index) -> Int {
     _internalInvariant(_guts.isForeign)
-    
+
+    let i = _utf8AlignForeignIndex(i)
+    let j = _utf8AlignForeignIndex(j)
+
+
     #if _runtime(_ObjC)
-    // Currently, foreign  means NSString
+    // Currently, foreign means NSString
     if let count = _cocoaStringUTF8Count(
       _guts._object.cocoaObject,
       range: i._encodedOffset ..< j._encodedOffset
     ) {
-      //_cocoaStringUTF8Count gave us the scalar aligned count, but we still
-      //need to compensate for sub-scalar indexing, e.g. if `i` is in the middle
-      //of a two-byte UTF8 scalar.
+      // _cocoaStringUTF8Count gave us the scalar aligned count, but we still
+      // need to compensate for sub-scalar indexing, e.g. if `i` is in the
+      // middle of a two-byte UTF8 scalar.
       let refinedCount = count - (i.transcodedOffset + j.transcodedOffset)
       _internalInvariant(refinedCount == _distance(from: i, to: j))
       return refinedCount
@@ -487,7 +512,6 @@ extension String.UTF8View {
     #endif
 
     return _distance(from: i, to: j)
-   
   }
 
   @usableFromInline @inline(never)
@@ -503,14 +527,7 @@ extension String.Index {
   @_effects(releasenone)
   internal func _foreignIsWithin(_ target: String.UTF8View) -> Bool {
     _internalInvariant(target._guts.isForeign)
-    // Currently, foreign means UTF-16.
-
-    // If we're transcoding, we're already a UTF8 view index.
-    if self.transcodedOffset != 0 { return true }
-
-    // Otherwise, we must be scalar-aligned, i.e. not pointing at a trailing
-    // surrogate.
-    return target._guts.isOnUnicodeScalarBoundary(self)
+    return self == target._utf8AlignForeignIndex(self)
   }
 }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -112,7 +112,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
 
     if _fastPath(_guts.isFastUTF8) {
       let len = _guts.fastUTF8ScalarLength(startingAt: i._encodedOffset)
-      return i.encoded(offsetBy: len)._aligned
+      return i.encoded(offsetBy: len)._scalarAligned
     }
 
     return _foreignIndex(after: i)
@@ -137,7 +137,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
         return _utf8ScalarLength(utf8, endingAt: i._encodedOffset)
       }
       _internalInvariant(len <= 4, "invalid UTF8")
-      return i.encoded(offsetBy: -len)._aligned
+      return i.encoded(offsetBy: -len)._scalarAligned
     }
 
     return _foreignIndex(before: i)
@@ -419,7 +419,7 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
     let len = UTF16.isLeadSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: len)._aligned
+    return i.encoded(offsetBy: len)._scalarAligned
   }
 
   @usableFromInline @inline(never)
@@ -430,6 +430,6 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: priorIdx)
     let len = UTF16.isTrailSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: -len)._aligned
+    return i.encoded(offsetBy: -len)._scalarAligned
   }
 }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -112,7 +112,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
 
     if _fastPath(_guts.isFastUTF8) {
       let len = _guts.fastUTF8ScalarLength(startingAt: i._encodedOffset)
-      return i.encoded(offsetBy: len).aligned
+      return i.encoded(offsetBy: len)._aligned
     }
 
     return _foreignIndex(after: i)
@@ -137,7 +137,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
         return _utf8ScalarLength(utf8, endingAt: i._encodedOffset)
       }
       _internalInvariant(len <= 4, "invalid UTF8")
-      return i.encoded(offsetBy: -len).aligned
+      return i.encoded(offsetBy: -len)._aligned
     }
 
     return _foreignIndex(before: i)
@@ -419,7 +419,7 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
     let len = UTF16.isLeadSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: len).aligned
+    return i.encoded(offsetBy: len)._aligned
   }
 
   @usableFromInline @inline(never)
@@ -430,6 +430,6 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: priorIdx)
     let len = UTF16.isTrailSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: -len).aligned
+    return i.encoded(offsetBy: -len)._aligned
   }
 }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -106,15 +106,21 @@ extension String.UnicodeScalarView: BidirectionalCollection {
   /// - Precondition: The next location exists.
   @inlinable @inline(__always)
   public func index(after i: Index) -> Index {
+    let i = _guts.scalarAlign(i)
     _internalInvariant(i < endIndex)
     // TODO(String performance): isASCII fast-path
 
     if _fastPath(_guts.isFastUTF8) {
       let len = _guts.fastUTF8ScalarLength(startingAt: i._encodedOffset)
-      return i.encoded(offsetBy: len)
+      return i.encoded(offsetBy: len).aligned
     }
 
     return _foreignIndex(after: i)
+  }
+
+  @_alwaysEmitIntoClient // Swift 5.1 bug fix
+  public func distance(from start: Index, to end: Index) -> Int {
+    return _distance(from: _guts.scalarAlign(start), to: _guts.scalarAlign(end))
   }
 
   /// Returns the previous consecutive location before `i`.
@@ -122,6 +128,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
   /// - Precondition: The previous location exists.
   @inlinable @inline(__always)
   public func index(before i: Index) -> Index {
+    let i = _guts.scalarAlign(i)
     precondition(i._encodedOffset > 0)
     // TODO(String performance): isASCII fast-path
 
@@ -130,7 +137,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
         return _utf8ScalarLength(utf8, endingAt: i._encodedOffset)
       }
       _internalInvariant(len <= 4, "invalid UTF8")
-      return i.encoded(offsetBy: -len)
+      return i.encoded(offsetBy: -len).aligned
     }
 
     return _foreignIndex(before: i)
@@ -412,7 +419,7 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
     let len = UTF16.isLeadSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: len)
+    return i.encoded(offsetBy: len).aligned
   }
 
   @usableFromInline @inline(never)
@@ -423,6 +430,6 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: priorIdx)
     let len = UTF16.isTrailSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: -len)
+    return i.encoded(offsetBy: -len).aligned
   }
 }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -99,7 +99,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
       return Unicode.Scalar(_unchecked: value)
     }
   }
-  
+
   @inline(__always)
   @inlinable
   public static func encode(
@@ -136,7 +136,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF16.self) {
       let c = _identityCast(content, to: UTF16.EncodedScalar.self)
-      var u0 = UInt16(truncatingIfNeeded: c._storage) 
+      var u0 = UInt16(truncatingIfNeeded: c._storage)
       if _fastPath(u0 < 0x80) {
         return EncodedScalar(_containing: UInt8(truncatingIfNeeded: u0))
       }
@@ -169,7 +169,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
     public init() { _buffer = _Buffer() }
     public var _buffer: _Buffer
   }
-  
+
   @frozen
   public struct ReverseParser {
     public typealias _Buffer = _UIntBuffer<UInt8>
@@ -246,7 +246,7 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
     }
     return 1
   }
-  
+
   @inline(__always)
   @inlinable
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
@@ -263,7 +263,7 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
   @inlinable
   public func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8) {
     _internalInvariant(_buffer._storage & 0x80 != 0) // this case handled elsewhere
-    
+
     if _buffer._storage & 0b0__1100_0000__1110_0000
                        == 0b0__1000_0000__1100_0000 {
       // 2-byte sequence. At least one of the top 4 bits of the decoded result
@@ -317,7 +317,7 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
     }
     return 1
   }
-  
+
   @inlinable
   public func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar {
     let x = UInt32(_buffer._storage) &+ 0x01010101

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -163,7 +163,7 @@ extension _StringGuts {
   @inline(__always) // fast-path: fold common fastUTF8 check
   internal func scalarAlign(_ idx: Index) -> Index {
     let result: String.Index
-    if _fastPath(idx.isAligned) {
+    if _fastPath(idx._isAligned) {
       result = idx
     } else {
       // TODO(String performance): isASCII check
@@ -172,28 +172,28 @@ extension _StringGuts {
 
     _internalInvariant(isOnUnicodeScalarBoundary(result),
       "Alignment bit is set for non-aligned index")
-    _internalInvariant(result.isAligned)
+    _internalInvariant(result._isAligned)
     return result
   }
 
   @inline(never) // slow-path
   @_alwaysEmitIntoClient // Swift 5.1
   internal func scalarAlignSlow(_ idx: Index) -> Index {
-    _internalInvariant(!idx.isAligned)
+    _internalInvariant(!idx._isAligned)
 
     if _slowPath(idx.transcodedOffset != 0 || idx._encodedOffset == 0) {
       // Transcoded index offsets are already scalar aligned
-      return String.Index(_encodedOffset: idx._encodedOffset).aligned
+      return String.Index(_encodedOffset: idx._encodedOffset)._aligned
     }
     if _slowPath(self.isForeign) {
       let foreignIdx = foreignScalarAlign(idx)
-      _internalInvariant(foreignIdx.isAligned)
+      _internalInvariant(foreignIdx._isAligned)
       return foreignIdx
     }
 
     return String.Index(_encodedOffset:
       self.withFastUTF8 { _scalarAlign($0, idx._encodedOffset) }
-    ).aligned
+    )._aligned
   }
 
   @inlinable
@@ -359,17 +359,17 @@ extension _StringGuts {
   @usableFromInline @inline(never) // slow-path
   @_effects(releasenone)
   internal func foreignScalarAlign(_ idx: Index) -> Index {
-    guard idx._encodedOffset != self.count else { return idx.aligned }
+    guard idx._encodedOffset != self.count else { return idx._aligned }
 
     _internalInvariant(idx._encodedOffset < self.count)
 
     let ecCU = foreignErrorCorrectedUTF16CodeUnit(at: idx)
     if _fastPath(!UTF16.isTrailSurrogate(ecCU)) {
-      return idx.aligned
+      return idx._aligned
     }
     _internalInvariant(idx._encodedOffset > 0,
       "Error-correction shouldn't give trailing surrogate at position zero")
-    return String.Index(_encodedOffset: idx._encodedOffset &- 1).aligned
+    return String.Index(_encodedOffset: idx._encodedOffset &- 1)._aligned
   }
 
   @usableFromInline @inline(never)

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -163,7 +163,7 @@ extension _StringGuts {
   @inline(__always) // fast-path: fold common fastUTF8 check
   internal func scalarAlign(_ idx: Index) -> Index {
     let result: String.Index
-    if _fastPath(idx._isAligned) {
+    if _fastPath(idx._isScalarAligned) {
       result = idx
     } else {
       // TODO(String performance): isASCII check
@@ -172,28 +172,28 @@ extension _StringGuts {
 
     _internalInvariant(isOnUnicodeScalarBoundary(result),
       "Alignment bit is set for non-aligned index")
-    _internalInvariant(result._isAligned)
+    _internalInvariant(result._isScalarAligned)
     return result
   }
 
   @inline(never) // slow-path
   @_alwaysEmitIntoClient // Swift 5.1
   internal func scalarAlignSlow(_ idx: Index) -> Index {
-    _internalInvariant(!idx._isAligned)
+    _internalInvariant(!idx._isScalarAligned)
 
     if _slowPath(idx.transcodedOffset != 0 || idx._encodedOffset == 0) {
       // Transcoded index offsets are already scalar aligned
-      return String.Index(_encodedOffset: idx._encodedOffset)._aligned
+      return String.Index(_encodedOffset: idx._encodedOffset)._scalarAligned
     }
     if _slowPath(self.isForeign) {
       let foreignIdx = foreignScalarAlign(idx)
-      _internalInvariant(foreignIdx._isAligned)
+      _internalInvariant(foreignIdx._isScalarAligned)
       return foreignIdx
     }
 
     return String.Index(_encodedOffset:
       self.withFastUTF8 { _scalarAlign($0, idx._encodedOffset) }
-    )._aligned
+    )._scalarAligned
   }
 
   @inlinable
@@ -359,17 +359,17 @@ extension _StringGuts {
   @usableFromInline @inline(never) // slow-path
   @_effects(releasenone)
   internal func foreignScalarAlign(_ idx: Index) -> Index {
-    guard idx._encodedOffset != self.count else { return idx._aligned }
+    guard idx._encodedOffset != self.count else { return idx._scalarAligned }
 
     _internalInvariant(idx._encodedOffset < self.count)
 
     let ecCU = foreignErrorCorrectedUTF16CodeUnit(at: idx)
     if _fastPath(!UTF16.isTrailSurrogate(ecCU)) {
-      return idx._aligned
+      return idx._scalarAligned
     }
     _internalInvariant(idx._encodedOffset > 0,
       "Error-correction shouldn't give trailing surrogate at position zero")
-    return String.Index(_encodedOffset: idx._encodedOffset &- 1)._aligned
+    return String.Index(_encodedOffset: idx._encodedOffset &- 1)._scalarAligned
   }
 
   @usableFromInline @inline(never)

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -428,7 +428,6 @@ extension Unicode.Scalar.UTF16View : RandomAccessCollection {
   ///   `endIndex` property.
   @inlinable
   public subscript(position: Int) -> UTF16.CodeUnit {
-    _internalInvariant((0..<self.count).contains(position))
     if position == 1 { return UTF16.trailSurrogate(value) }
     if endIndex == 1 { return UTF16.CodeUnit(value.value) }
     return UTF16.leadSurrogate(value)

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -428,9 +428,10 @@ extension Unicode.Scalar.UTF16View : RandomAccessCollection {
   ///   `endIndex` property.
   @inlinable
   public subscript(position: Int) -> UTF16.CodeUnit {
-    return position == 0 ? (
-      endIndex == 1 ? UTF16.CodeUnit(value.value) : UTF16.leadSurrogate(value)
-    ) : UTF16.trailSurrogate(value)
+    _internalInvariant((0..<self.count).contains(position))
+    if position == 1 { return UTF16.trailSurrogate(value) }
+    if endIndex == 1 { return UTF16.CodeUnit(value.value) }
+    return UTF16.leadSurrogate(value)
   }
 }
 

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -99,12 +99,7 @@ StringIndexTests.test("interchange") {
   // Basic index alignment
 
   func validateIndices(_ s: String) {
-    let utf8Indices = s.utf8.indices
-    let utf16Indices = s.utf16.indices
-    let unicodeScalarIndices = s.unicodeScalars.indices
-    let characterIndices = s.indices
-
-    for idx in utf8Indices {
+    for idx in s.utf8.indices {
       let char = s.utf8[idx]
 
       // ASCII or leading code unit in the scalar
@@ -193,7 +188,7 @@ StringIndexTests.test("Scalar Align UTF-8 indices") {
   expectEqual(1, roundedIdx.utf16Offset(in: str))
 
   let roundedIdx2 = str.utf8[...subScalarIdx].lastIndex { $0 & 0xC0 != 0x80 }
-  expectEqual(roundedIdx, roundedIdx)
+  expectEqual(roundedIdx, roundedIdx2)
 
   var roundedIdx3 = subScalarIdx
   while roundedIdx3.samePosition(in: str.unicodeScalars) == nil {
@@ -232,21 +227,238 @@ StringIndexTests.test("String.Index(_:within) / Range<String.Index>(_:in:)") {
       expectEqual(strLB, substrLB)
       expectEqual(strUB, substrUB)
 
-      if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
-        let nsRange = NSRange(location: location, length: length)
-        let strRange = Range<String.Index>(nsRange, in: str)
-        let substrRange = Range<String.Index>(nsRange, in: substr)
+      let nsRange = NSRange(location: location, length: length)
+      let strRange = Range<String.Index>(nsRange, in: str)
+      let substrRange = Range<String.Index>(nsRange, in: substr)
 
-        expectEqual(strRange, substrRange)
-        guard strLB != nil && strUB != nil else {
-          expectNil(strRange)
-          continue
-        }
-        expectEqual(strRange, Range(uncheckedBounds: (strLB!, strUB!)))
+      expectEqual(strRange, substrRange)
+      guard strLB != nil && strUB != nil else {
+        expectNil(strRange)
+        continue
       }
+      expectEqual(strRange, Range(uncheckedBounds: (strLB!, strUB!)))
     }
   }
 }
+
+StringIndexTests.test("Misaligned") {
+  func doIt(_ str: String) {
+    let characterIndices = Array(str.indices)
+    let scalarIndices = Array(str.unicodeScalars.indices) + [str.endIndex]
+    let utf8Indices = Array(str.utf8.indices)
+
+    var lastScalarI = 0
+    for i in 1..<utf8Indices.count {
+      let idx = utf8Indices[i]
+
+      // Skip aligned indices
+      guard idx < scalarIndices[lastScalarI + 1] else {
+        assert(idx == scalarIndices[lastScalarI + 1])
+        lastScalarI += 1
+        continue
+      }
+      expectTrue(UTF8.isContinuation(str.utf8[idx]))
+
+      let lastScalarIdx = scalarIndices[lastScalarI]
+
+      // Check aligning-down
+      expectEqual(str[lastScalarIdx], str[idx])
+      expectEqual(str.utf16[lastScalarIdx], str.utf16[idx])
+      expectEqual(str.unicodeScalars[lastScalarIdx], str.unicodeScalars[idx])
+
+      // Check distance
+      let (start, end) = (str.startIndex, str.endIndex)
+      if characterIndices.contains(lastScalarIdx) {
+        expectEqual(0, str.distance(from: lastScalarIdx, to: idx))
+        expectEqual(str[..<idx].count, str.distance(from: start, to: idx))
+        expectEqual(str[idx...].count, str.distance(from: idx, to: end))
+      }
+      expectEqual(
+        0, str.unicodeScalars.distance(from: lastScalarIdx, to: idx))
+      expectEqual(
+        str.unicodeScalars[..<idx].count,
+        str.unicodeScalars.distance(from: start, to: idx))
+      expectEqual(
+        str.unicodeScalars[idx...].count,
+        str.unicodeScalars.distance(from: idx, to: end))
+
+      expectEqual(0, str.utf16.distance(from: lastScalarIdx, to: idx))
+      expectEqual(
+        str.utf16[..<idx].count, str.utf16.distance(from: start, to: idx))
+      expectEqual(
+        str.utf16[idx...].count, str.utf16.distance(from: idx, to: end))
+    }
+  }
+
+  let nsstring: NSString = "aодиde\u{301}日🧟‍♀️"
+  doIt(nsstring as String)
+
+  let string = "aодиde\u{301}日🧟‍♀️"
+  doIt(string)
+}
+
 #endif // _runtime(_ObjC)
+
+StringIndexTests.test("Exhaustive Index Interchange") {
+  // Exhaustively test aspects of string index interchange
+  func testInterchange(
+    _ str: String,
+    stackTrace: SourceLocStack = SourceLocStack(),
+    showFrame: Bool = true,
+    file: String = #file,
+    line: UInt = #line
+  ) {
+    guard #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) else {
+      return
+    }
+
+    let stackTrace = stackTrace.pushIf(showFrame, file: file, line: line)
+    func expect(
+      _ condition: @autoclosure () -> Bool,
+      _ message: String = "",
+      file: String = #file,
+      line: UInt = #line
+    ) {
+      expectTrue(condition(), message,
+        stackTrace: stackTrace, showFrame: showFrame,
+        file: file, line: line)
+    }
+
+    var curCharIdx = str.startIndex
+    var curScalarIdx = str.startIndex
+    var curUTF8Idx = str.startIndex
+    var curUTF16Idx = str.startIndex
+
+    while curCharIdx < str.endIndex {
+      let curChar = str[curCharIdx]
+      expect(curChar == str[curScalarIdx])
+      expect(curChar == str[curUTF8Idx])
+      expect(curChar == str[curUTF16Idx])
+
+      // Advance the character index once and have the scalar index catch up
+      str.formIndex(after: &curCharIdx)
+
+      let scalarStartIdx = curScalarIdx
+      defer {
+        let sub = str[scalarStartIdx..<curScalarIdx]
+        expect(sub.count == 1)
+        expect(sub.first! == curChar)
+        expect(str.distance(from: scalarStartIdx, to: curScalarIdx) == 1)
+      }
+
+      while curScalarIdx < curCharIdx {
+        let scalarStartIdx = curScalarIdx
+        let curScalar = str.unicodeScalars[curScalarIdx]
+        let curSubChar = str[curScalarIdx]
+
+        // If there is a Character prior to this scalar, remember it and check
+        // that misalignd code unit indices also produce it.
+        let scalarPriorCharacter: Character?
+        if scalarStartIdx == str.startIndex {
+          scalarPriorCharacter = nil
+        } else {
+          scalarPriorCharacter = str[str.index(before: scalarStartIdx)]
+        }
+
+        // Advance the scalar index once and have the code unit indices catch up
+        str.unicodeScalars.formIndex(after: &curScalarIdx)
+
+
+        let utf8StartIdx = curUTF8Idx
+        defer {
+          let sub = str.unicodeScalars[utf8StartIdx..<curUTF8Idx]
+          expect(sub.count == 1)
+          expect(sub.first! == curScalar)
+          expect(str.unicodeScalars.distance(
+            from: utf8StartIdx, to: curUTF8Idx) == 1)
+          expect(str.utf8.distance(
+            from: utf8StartIdx, to: curUTF8Idx) == curScalar.utf8.count)
+        }
+
+        while curUTF8Idx < curScalarIdx {
+          expect(curScalar == str.unicodeScalars[curUTF8Idx])
+          expect(curSubChar == str[curUTF8Idx])
+          expect(!UTF16.isTrailSurrogate(str.utf16[curUTF8Idx]))
+          expect(utf8StartIdx == str[curUTF8Idx...].startIndex)
+          expect(str[utf8StartIdx..<curUTF8Idx].isEmpty)
+          expect(0 == str.utf16.distance(from: utf8StartIdx, to: curUTF8Idx))
+
+          if let scalarPrior = scalarPriorCharacter {
+            expect(scalarPrior == str[str.index(before: curUTF8Idx)])
+          }
+
+          str.utf8.formIndex(after: &curUTF8Idx)
+        }
+        expect(curUTF8Idx == curScalarIdx)
+
+        var utf8RevIdx = curUTF8Idx
+        while utf8RevIdx > utf8StartIdx {
+          str.utf8.formIndex(before: &utf8RevIdx)
+
+          expect(curScalar == str.unicodeScalars[utf8RevIdx])
+          expect(curSubChar == str[utf8RevIdx])
+          expect(!UTF16.isTrailSurrogate(str.utf16[utf8RevIdx]))
+          expect(utf8StartIdx == str[utf8RevIdx...].startIndex)
+          expect(str[utf8StartIdx..<utf8RevIdx].isEmpty)
+          expect(0 == str.utf16.distance(from: utf8StartIdx, to: utf8RevIdx))
+        }
+        expect(utf8RevIdx == utf8StartIdx)
+
+        let utf16StartIdx = curUTF16Idx
+        defer {
+          let sub = str.unicodeScalars[utf16StartIdx..<curUTF16Idx]
+          expect(sub.count == 1)
+          expect(sub.first! == curScalar)
+          expect(str.unicodeScalars.distance(
+            from: utf16StartIdx, to: curUTF16Idx) == 1)
+          expect(str.utf16.distance(
+            from: utf16StartIdx, to: curUTF16Idx) == curScalar.utf16.count)
+        }
+
+        while curUTF16Idx < curScalarIdx {
+          expect(curScalar == str.unicodeScalars[curUTF16Idx])
+          expect(curSubChar == str[curUTF16Idx])
+          expect(!UTF8.isContinuation(str.utf8[curUTF16Idx]))
+          expect(utf16StartIdx == str[curUTF16Idx...].startIndex)
+          expect(str[utf16StartIdx..<curUTF16Idx].isEmpty)
+          expect(0 == str.utf8.distance(from: utf16StartIdx, to: curUTF16Idx))
+
+          if let scalarPrior = scalarPriorCharacter {
+            expect(scalarPrior == str[str.index(before: curUTF16Idx)])
+          }
+
+          str.utf16.formIndex(after: &curUTF16Idx)
+        }
+        expect(curUTF16Idx == curScalarIdx)
+
+        var utf16RevIdx = curUTF16Idx
+        while utf16RevIdx > utf16StartIdx {
+          str.utf16.formIndex(before: &utf16RevIdx)
+
+          expect(curScalar == str.unicodeScalars[utf16RevIdx])
+          expect(curSubChar == str[utf16RevIdx])
+          expect(!UTF8.isContinuation(str.utf8[utf16RevIdx]))
+          expect(utf16StartIdx == str[utf16RevIdx...].startIndex)
+          expect(str[utf16StartIdx..<utf16RevIdx].isEmpty)
+          expect(0 == str.utf8.distance(from: utf16StartIdx, to: utf16RevIdx))
+        }
+        expect(utf16RevIdx == utf16StartIdx)
+
+      }
+    }
+  }
+
+  testInterchange("abc\r\ndefg")
+
+#if _runtime(_ObjC)
+  testInterchange(("abc\r\ndefg" as NSString) as String)
+#endif // _runtime(_ObjC)
+
+  testInterchange("ab\r\ncдe\u{301}日🧟‍♀️x🧟x🏳️‍🌈🇺🇸🇨🇦")
+
+#if _runtime(_ObjC)
+  testInterchange(("ab\r\ncдe\u{301}日🧟‍♀️x🧟x🏳️‍🌈🇺🇸🇨🇦" as NSString) as String)
+#endif // _runtime(_ObjC)
+}
 
 runAllTests()

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -168,17 +168,5 @@ StringTraps.test("UTF8ViewIndex/offsetCrash")
   _ = s8.utf8[i]
 }
 
-StringTraps.test("String.Index.utf16Offset(in:)/subscalarUTF8")
-  .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  let s = "😇"
-  let u8 = s.utf8
-  let i = u8.index(after: u8.startIndex)
-  expectCrashLater()
-  _ = i.utf16Offset(in: s)
-}
-
 runAllTests()
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -602,11 +602,11 @@ StringTests.test("appendToSubstringBug")
     if s0.unusedCapacity == 0 { s0 += "y" }
     let cap = s0.unusedCapacity
     expectNotEqual(0, cap)
-    
+
     // This sorta checks for the original bug
     expectEqual(
       cap, String(s0[s0.index(_nth: 1)..<s0.endIndex]).unusedCapacity)
-    
+
     return (s0, cap)
   }
 
@@ -616,7 +616,7 @@ StringTests.test("appendToSubstringBug")
       return (String(s0[s0.index(_nth: 5)..<s0.endIndex]), unused)
     }()
     let originalID = s.bufferID
-    // Appending to a String always results in storage that 
+    // Appending to a String always results in storage that
     // starts at the beginning of its native buffer
     s += "z"
     expectNotEqual(originalID, s.bufferID)
@@ -880,7 +880,7 @@ StringTests.test("stringGutsExtensibility")
   for k in 0..<3 {
     for count in 1..<16 {
       for boundary in 0..<count {
-        
+
         var x = (
             k == 0 ? asciiString("b")
           : k == 1 ? ("b" as NSString as String)
@@ -888,7 +888,7 @@ StringTests.test("stringGutsExtensibility")
         )
 
         if k == 0 { expectTrue(x._guts.isFastUTF8) }
-        
+
         for i in 0..<count {
           x.append(String(
             decoding: repeatElement(i < boundary ? ascii : nonAscii, count: 3),
@@ -897,7 +897,7 @@ StringTests.test("stringGutsExtensibility")
         // Make sure we can append pure ASCII to wide storage
         x.append(String(
           decoding: repeatElement(ascii, count: 2), as: UTF16.self))
-        
+
         expectEqualSequence(
           [UTF16.CodeUnit(UnicodeScalar("b").value)]
           + Array(repeatElement(ascii, count: 3*boundary))
@@ -951,17 +951,17 @@ StringTests.test("stringGutsReserve")
       fatalError("case unhandled!")
     }
     expectEqual(isSwiftNative(base), startedNative)
-    
+
     let originalBuffer = base.bufferID
     let isUnique = base._guts.isUniqueNative
     let startedUnique =
       startedNative &&
       base._classify()._objectIdentifier != nil &&
       isUnique
-    
+
     base.reserveCapacity(16)
     // Now it's unique
-    
+
     // If it was already native and unique, no reallocation
     if startedUnique && startedNative {
       expectEqual(originalBuffer, base.bufferID)
@@ -1302,14 +1302,14 @@ StringTests.test("unicodeViews") {
   // FIXME: note changed String(describing:) results
   expectEqual(
     "\u{FFFD}",
-    String(describing: 
+    String(describing:
       winter.utf8[
         winter.utf8.startIndex
         ..<
         winter.utf8.index(after: winter.utf8.index(after: winter.utf8.startIndex))
       ]))
   */
-  
+
   expectEqual(
     "\u{1F3C2}", String(
       winter.utf8[winter.utf8.startIndex..<winter.utf8.index(_nth: 4)]))
@@ -1317,7 +1317,7 @@ StringTests.test("unicodeViews") {
   expectEqual(
     "\u{1F3C2}", String(
       winter.utf16[winter.utf16.startIndex..<winter.utf16.index(_nth: 2)]))
-  
+
   expectEqual(
     "\u{1F3C2}", String(
       winter.unicodeScalars[
@@ -1358,7 +1358,7 @@ StringTests.test("indexConversion")
   let s = "go further into the larder to barter."
 
   var matches: [String] = []
-  
+
   re.enumerateMatches(
     in: s, options: NSRegularExpression.MatchingOptions(), range: NSRange(0..<s.utf16.count)
   ) {
@@ -1812,18 +1812,18 @@ public let testSuffix = "z"
 StringTests.test("COW.Smoke") {
   var s1 = "COW Smoke Cypseloides" + testSuffix
   let identity1 = s1._rawIdentifier()
-  
+
   var s2 = s1
   expectEqual(identity1, s2._rawIdentifier())
-  
+
   s2.append(" cryptus")
   expectTrue(identity1 != s2._rawIdentifier())
-  
+
   s1.remove(at: s1.startIndex)
   expectEqual(identity1, s1._rawIdentifier())
-  
+
   _fixLifetime(s1)
-  _fixLifetime(s2)  
+  _fixLifetime(s2)
 }
 
 struct COWStringTest {
@@ -1841,7 +1841,7 @@ for test in testCases {
   StringTests.test("COW.\(test.name).IndexesDontAffectUniquenessCheck") {
     let s = test.test + testSuffix
     let identity1 = s._rawIdentifier()
-  
+
     let startIndex = s.startIndex
     let endIndex = s.endIndex
     expectNotEqual(startIndex, endIndex)
@@ -1849,9 +1849,9 @@ for test in testCases {
     expectLE(startIndex, endIndex)
     expectGT(endIndex, startIndex)
     expectGE(endIndex, startIndex)
-  
+
     expectEqual(identity1, s._rawIdentifier())
-  
+
     // Keep indexes alive during the calls above
     _fixLifetime(startIndex)
     _fixLifetime(endIndex)
@@ -1973,7 +1973,7 @@ for test in testCases {
 
     expectGT(s.count, 0)
     expectEqual(identity1, s._rawIdentifier())
-  } 
+  }
 }
 
 for test in testCases {
@@ -2028,16 +2028,16 @@ enum _Ordering: Int, Equatable {
   }
 }
 
-struct ComparisonTestCase {  
+struct ComparisonTestCase {
   var strings: [String]
   // var test: (String, String) -> Void
   var comparison: _Ordering
-  
+
   init(_ strings: [String], _ comparison: _Ordering) {
     self.strings = strings
     self.comparison = comparison
   }
-  
+
   func test() {
     for pair in zip(strings, strings[1...]) {
       switch comparison {
@@ -2064,7 +2064,7 @@ struct ComparisonTestCase {
       }
     }
   }
-  
+
   func testOpaqueStrings() {
 #if _runtime(_ObjC)
     let opaqueStrings = strings.map { NSSlowString(string: $0) as String }
@@ -2081,16 +2081,16 @@ struct ComparisonTestCase {
     expectEqualSequence(strings, opaqueStrings)
 #endif
   }
-  
+
   func testOpaqueSubstrings() {
 #if _runtime(_ObjC)
     for pair in zip(strings, strings[1...]) {
       let string1 = pair.0.dropLast()
       let string2 = pair.1
       let opaqueString = (NSSlowString(string: pair.0) as String).dropLast()
-      
+
       guard string1.count > 0 else { return }
-      
+
       expectEqual(string1, opaqueString)
       expectEqual(string1 < string2, opaqueString < string2)
       expectEqual(string1 > string2, opaqueString > string2)
@@ -2110,7 +2110,7 @@ let comparisonTestCases = [
 
   ComparisonTestCase(["á", "\u{0061}\u{0301}"], .equal),
   ComparisonTestCase(["à", "\u{0061}\u{0301}", "â", "\u{e3}", "a\u{0308}"], .less),
-  
+
   // Exploding scalars AND exploding segments
   ComparisonTestCase(["\u{fa2}", "\u{fa1}\u{fb7}"], .equal),
   ComparisonTestCase([
@@ -2143,15 +2143,15 @@ let comparisonTestCases = [
     "🧀" // D83E DDC0 -- aka a really big scalar
   ], .less),
 
-  
+
   ComparisonTestCase(["f̛̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͣͤͥͦ͘͜͟͢͝͞͠͡", "ơ̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͥͦͧͨͩͪͫͬͭͮ͘"], .less),
   ComparisonTestCase(["\u{f90b}", "\u{5587}"], .equal),
-  
+
   ComparisonTestCase(["a\u{1D160}a", "a\u{1D158}\u{1D1C7}"], .less),
 
   ComparisonTestCase(["a\u{305}\u{315}", "a\u{315}\u{305}"], .equal),
   ComparisonTestCase(["a\u{315}bz", "a\u{315}\u{305}az"], .greater),
-  
+
   ComparisonTestCase(["\u{212b}", "\u{00c5}"], .equal),
   ComparisonTestCase([
     "A",
@@ -2181,7 +2181,7 @@ let comparisonTestCases = [
     "\u{FFEE}", // half width CJK dot
     "🧀", // D83E DDC0 -- aka a really big scalar
   ], .less),
-  
+
   ComparisonTestCase(["ư̴̵̶̷̸̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͣͤͥͦͧͨͩͪͫͬͭͮ͘͜͟͢͝͞͠͡", "ì̡̢̧̨̝̞̟̠̣̤̥̦̩̪̫̬̭̮̯̰̹̺̻̼͇͈͉͍͎́̂̃̄̉̊̋̌̍̎̏̐̑̒̓̽̾̿̀́͂̓̈́͆͊͋͌ͅ͏͓͔͕͖͙͐͑͒͗ͬͭͮ͘"], .greater),
   ComparisonTestCase(["ư̴̵̶̷̸̗̘̙̜̹̺̻̼͇͈͉͍͎̽̾̿̀́͂̓̈́͆͊͋͌̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͣͤͥͦͧͨͩͪͫͬͭͮ͘͜͟͢͝͞͠͡", "aì̡̢̧̨̝̞̟̠̣̤̥̦̩̪̫̬̭̮̯̰̹̺̻̼͇͈͉͍͎́̂̃̄̉̊̋̌̍̎̏̐̑̒̓̽̾̿̀́͂̓̈́͆͊͋͌ͅ͏͓͔͕͖͙͐͑͒͗ͬͭͮ͘"], .greater),
   ComparisonTestCase(["ì̡̢̧̨̝̞̟̠̣̤̥̦̩̪̫̬̭̮̯̰̹̺̻̼͇͈͉͍͎́̂̃̄̉̊̋̌̍̎̏̐̑̒̓̽̾̿̀́͂̓̈́͆͊͋͌ͅ͏͓͔͕͖͙͐͑͒͗ͬͭͮ͘", "ì̡̢̧̨̝̞̟̠̣̤̥̦̩̪̫̬̭̮̯̰̹̺̻̼͇͈͉͍͎́̂̃̄̉̊̋̌̍̎̏̐̑̒̓̽̾̿̀́͂̓̈́͆͊͋͌ͅ͏͓͔͕͖͙͐͑͒͗ͬͭͮ͘"], .equal)
@@ -2209,7 +2209,7 @@ StringTests.test("Comparison.Substrings") {
   let str = "abcdefg"
   let expectedStr = "bcdef"
   let substring = str.dropFirst().dropLast()
-  
+
   expectEqual(expectedStr, substring)
 }
 
@@ -2220,7 +2220,7 @@ StringTests.test("Comparison.Substrings/Opaque")
   let str = NSSlowString(string: "abcdefg") as String
   let expectedStr = NSSlowString(string: "bcdef") as String
   let substring = str.dropFirst().dropLast()
-  
+
   expectEqual(expectedStr, substring)
 #endif
 }
@@ -2228,7 +2228,7 @@ StringTests.test("Comparison.Substrings/Opaque")
 StringTests.test("NormalizationBufferCrashRegressionTest") {
   let str = "\u{0336}\u{0344}\u{0357}\u{0343}\u{0314}\u{0351}\u{0340}\u{0300}\u{0340}\u{0360}\u{0314}\u{0357}\u{0315}\u{0301}\u{0344}a"
   let set = Set([str])
-  
+
   expectTrue(set.contains(str))
 }
 

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -778,14 +778,14 @@ tests.test("String.UTF8View/Collection")
   .forEach(in: utfTests) {
   test in
 
-  checkBidirectionalCollection(test.utf8, test.string.utf8) { $0 == $1 }
+  checkBidirectionalCollection(test.utf8, test.string.utf8)
 }
 
 tests.test("String.UTF16View/BidirectionalCollection")
   .forEach(in: utfTests) {
   test in
 
-  checkBidirectionalCollection(test.utf16, test.string.utf16) { $0 == $1 }
+  checkBidirectionalCollection(test.utf16, test.string.utf16)
 }
 
 tests.test("String.UTF32View/BidirectionalCollection")
@@ -793,7 +793,7 @@ tests.test("String.UTF32View/BidirectionalCollection")
   test in
 
   checkBidirectionalCollection(
-    test.unicodeScalars, test.string.unicodeScalars) { $0 == $1 }
+    test.unicodeScalars, test.string.unicodeScalars)
 }
 
 tests.test("String View Setters") {
@@ -818,6 +818,28 @@ tests.test("String View Setters") {
   expectEqual(winter, string)
   string = summer
   expectEqual(summer, string)
+}
+
+tests.test("Scalar alignment") {
+  let str = "😀"
+  let idx = str.utf8.index(after: str.startIndex)
+  let substr = str[idx...]
+  expectEqual(str, substr)
+
+  checkBidirectionalCollection(str, substr)
+  checkBidirectionalCollection(str.utf16, substr.utf16)
+  checkBidirectionalCollection(str.utf8, substr.utf8)
+  checkBidirectionalCollection(str.unicodeScalars, substr.unicodeScalars)
+
+  let idxBeforeLast = str.utf8.index(before: str.endIndex)
+  let substr2 = str[idx...]
+  expectEqual(str, substr2)
+  expectEqual(substr, substr2)
+
+  checkBidirectionalCollection(str, substr2)
+  checkBidirectionalCollection(str.utf16, substr2.utf16)
+  checkBidirectionalCollection(str.utf8, substr2.utf8)
+  checkBidirectionalCollection(str.unicodeScalars, substr2.unicodeScalars)
 }
 
 runAllTests()


### PR DESCRIPTION
5.1 cherry-pick of https://github.com/apple/swift/pull/23834

Explanation: All String views use the same index type, with the semantics being that we interpret them as representing the nearest prior scalar-aligned position. However, we were not checking or aligning indices previously, leading to crashes in the (somewhat uncommon) situation that a non-scalar-aligned index was interchanged between sub-scalar views. This change checks and performs alignment, and allocates a known-to-be-scalar-aligned bit in String.Index’s ABI to recoup the performance back.

Scope: Swift Standard Library

Issue: <rdar://problem/51199363> and https://bugs.swift.org/browse/SR-10124

Risk: Low. There is a chance that code that was improperly exchanging indices between different Strings (not just different views) will not get the correct behavior provided by this fix, if the known-to-be-aligned bit were set from one String.

Testing: Full integration testing, benchmarking

Reviewer: @stephentyrone, @lorentey, @Catfish-Man
