### PR TITLE
[5.1] Parser: avoid emitting disabled var diagnostics when building syntax tree

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2283,14 +2283,16 @@ Expr *Parser::parseExprIdentifier() {
     if (D) {
       for (auto activeVar : DisabledVars) {
         if (activeVar == D) {
-          diagnose(loc.getBaseNameLoc(), DisabledVarReason);
+          if (!Context.LangOpts.BuildSyntaxTree)
+            diagnose(loc.getBaseNameLoc(), DisabledVarReason);
           return new (Context) ErrorExpr(loc.getSourceRange());
         }
       }
     } else {
       for (auto activeVar : DisabledVars) {
         if (activeVar->getFullName() == name) {
-          diagnose(loc.getBaseNameLoc(), DisabledVarReason);
+          if (!Context.LangOpts.BuildSyntaxTree)
+            diagnose(loc.getBaseNameLoc(), DisabledVarReason);
           return new (Context) ErrorExpr(loc.getSourceRange());
         }
       }

--- a/test/Syntax/Parser/diags.swift
+++ b/test/Syntax/Parser/diags.swift
@@ -25,4 +25,10 @@ if (5 ‒ 5) == 0 {}
 // CHECK-NEXT: ([[@LINE-4]]:7,[[@LINE-4]]:10) Fixit: "-"
 // CHECK-NEXT: [[@LINE-5]]:11 Error: expected ',' separator
 // CHECK-NEXT: ([[@LINE-6]]:6,[[@LINE-6]]:6) Fixit: ","
+
+let dateFormatter: DateFormatter = {
+    let dateFormatter = DateFormatter()
+    return dateFormatter
+}()
+
 // CHECK-NEXT: 7 error(s) 0 warnings(s) 2 note(s)


### PR DESCRIPTION
This is swift-5.1-branch only fix. The fix on master has been superseded by this pull request: https://github.com/apple/swift/pull/24594

rdar://52128292