### PR TITLE
Fixing SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}  -parse-stdlib.

### DIFF
--- a/stdlib/public/Darwin/simd/CMakeLists.txt
+++ b/stdlib/public/Darwin/simd/CMakeLists.txt
@@ -9,9 +9,8 @@ add_swift_target_library(swiftsimd ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_S
     simd.swift.gyb
     Quaternion.swift.gyb
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" -parse-stdlib
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-  SWIFT_COMPILE_FLAGS -parse-stdlib
   SWIFT_MODULE_DEPENDS_OSX Darwin # auto-updated
   SWIFT_MODULE_DEPENDS_IOS Darwin # auto-updated
   SWIFT_MODULE_DEPENDS_TVOS Darwin # auto-updated


### PR DESCRIPTION
This stdlib/public/Darwin/simd/CMakeLists.txt file has SWIFT_COMPILE_FLAGS specified on two separate lines which looks and probably is wrong. 