### PR TITLE
[Parse] 'super' requires following l-square

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -874,8 +874,8 @@ ParserResult<Expr> Parser::parseExprSuper() {
 
   // 'super.' must be followed by a member ref, explicit initializer ref, or
   // subscript call.
-  if (Tok.isNot(tok::period, tok::period_prefix, tok::l_square,
-                tok::code_complete)) {
+  if (!Tok.isAny(tok::period, tok::period_prefix, tok::code_complete) &&
+      !Tok.isFollowingLSquare()) {
     if (!consumeIf(tok::unknown))
       diagnose(Tok, diag::expected_dot_or_subscript_after_super);
     return nullptr;

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -53,6 +53,11 @@ class D : B {
   func bad_super_2() {
     super(0) // expected-error{{expected '.' or '[' after 'super'}}
   }
+
+  func bad_super_3() {
+    super // expected-error{{expected '.' or '[' after 'super'}}
+      [1]
+  }
 }
 
 class Closures : B {


### PR DESCRIPTION
Follow-up to #25787 .
`super` must be followed by `period`, `period_prefix`, or *`l_square` on the same line*. i.e.
```
super
[0]
```
is invalid.