### PR TITLE
Driver: silence linker logo

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -204,17 +204,16 @@ toolchains::Windows::constructInvocation(const StaticLinkJobAction &job,
 
   ArgStringList Arguments;
 
-  // Configure the toolchain.
   const char *Link = "link";
   Arguments.push_back("-lib");
+  Arguments.push_back("-nologo");
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
                          file_types::TY_Object);
   addInputsOfType(Arguments, context.InputActions, file_types::TY_Object);
 
-  Arguments.push_back(
-      context.Args.MakeArgString(Twine("/OUT:") + 
-      context.Output.getPrimaryOutputFilename()));
+  StringRef OutputFile = context.Output.getPrimaryOutputFilename();
+  Arguments.push_back(context.Args.MakeArgString(Twine("/OUT:") + OutputFile));
 
   InvocationInfo II{Link, Arguments};
   II.allowsResponseFiles = true;


### PR DESCRIPTION
Adjust the librarian invocation to avoid the unnecessary logo printing.
This is needed to generate static libraries with Swift.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
