### PR TITLE
[AutoDiff] Fix cross-module JVP/VJP method thunking logic.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -781,6 +781,7 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
   LLVM_DEBUG(llvm::dbgs() << "lowered sil:\n";
              F->print(llvm::dbgs()));
 
+  // SWIFT_ENABLE_TENSORFLOW
   // Create self-reordering thunks for JVPs/VJPs of `@differentiable` methods.
   if (constant.hasDecl()) {
     auto *AFD = constant.getAbstractFunctionDecl();

--- a/test/AutoDiff/Inputs/method_self_reordering_thunk_other_module.swift
+++ b/test/AutoDiff/Inputs/method_self_reordering_thunk_other_module.swift
@@ -1,0 +1,12 @@
+struct TF_619: Differentiable {
+  var p: Float = 1
+
+  @differentiable(vjp: vjpFoo)
+  func foo(_ x: Float) -> Float {
+    return p * x
+  }
+
+  func vjpFoo(_ x: Float) -> (Float, (Float) -> (TangentVector, Float)) {
+    return (x, { v in (TangentVector(p: v * x), v * self.p) })
+  }
+}

--- a/test/AutoDiff/method_self_reordering_thunk/main.swift
+++ b/test/AutoDiff/method_self_reordering_thunk/main.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/method_self_reordering_thunk_other_module.swift %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var MethodSelfReorderingThunkTests = TestSuite("MethodSelfReorderingThunks")
+
+// Test TF-619: cross-module import of `@differentiable` methods with
+// self-ordering thunks.
+MethodSelfReorderingThunkTests.test("CrossModuleMethodSelfReorderingThunk") {
+  expectEqual(1, gradient(at: 0) { x in TF_619().foo(x) })
+}
+
+runAllTests()

--- a/test/AutoDiff/tbdgen.swift
+++ b/test/AutoDiff/tbdgen.swift
@@ -42,6 +42,14 @@ public extension Float {
   }
 
   // This should generate public symbols for both JVP and VJP.
+  // Tests self-reordering-method thunking.
+  @differentiable
+  func method(x: Float, y: Float) -> Float {
+    return x
+  }
+
+  // This should generate public symbols for both JVP and VJP.
+  // Tests self-reordering-method thunking.
   @differentiable
   subscript(x: Float) -> Float {
     return x


### PR DESCRIPTION
Fix hole in cross-module method self-ordering thunk logic.
Use mangled symbol for JVP/VJP methods in `SILFunctionBuilder` and during TBDGen.

Add cross-module test.

Resolves [TF-619](https://bugs.swift.org/browse/TF-619).