### PR TITLE
[Gardening] Remove extra Foundation imports

### DIFF
--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -13,7 +13,6 @@
 // This test is based on single-source/Phonebook, with
 // to test uppercase and lowercase ASCII string fast paths.
 import TestsUtils
-import Foundation
 
 public let AngryPhonebook = BenchmarkInfo(
   name: "AngryPhonebook",

--- a/benchmark/single-source/BinaryFloatingPointConversionFromBinaryInteger.swift
+++ b/benchmark/single-source/BinaryFloatingPointConversionFromBinaryInteger.swift
@@ -13,7 +13,6 @@
 // This test checks performance of generic binary floating-point conversion from
 // a binary integer.
 
-import Foundation
 import TestsUtils
 
 #if swift(>=4.2)
@@ -110,7 +109,7 @@ extension MockBinaryInteger : BinaryInteger {
   var trailingZeroBitCount: Int {
     return _value.trailingZeroBitCount
   }
-  
+
   func isMultiple(of other: MockBinaryInteger<T>) -> Bool {
     return _value.isMultiple(of: other._value)
   }
@@ -211,4 +210,3 @@ public func run_BinaryFloatingPointConversionFromBinaryInteger(_ N: Int) {
 }
 
 #endif
-

--- a/benchmark/single-source/BinaryFloatingPointProperties.swift
+++ b/benchmark/single-source/BinaryFloatingPointProperties.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import TestsUtils
 
 public let BinaryFloatingPointPropertiesBinade = BenchmarkInfo(

--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -13,7 +13,6 @@
 // This test checks performance of Swift bit count.
 // and mask operator.
 // rdar://problem/22151678
-import Foundation
 import TestsUtils
 
 public let BitCount = BenchmarkInfo(

--- a/benchmark/single-source/BucketSort.swift
+++ b/benchmark/single-source/BucketSort.swift
@@ -16,17 +16,16 @@
 // https://github.com/raywenderlich/swift-algorithm-club/tree/master/Bucket%20Sort
 //
 // It sorts an array of generic `SortableItem`s. If the type of `sortingAlgo`
-// is not known to the call site at line 90, the `sort` method can not be
+// is not known to the call site at line 89, the `sort` method can not be
 // specialized to integer array sorting, which will lead to a huge performance
 // loss. Since `SortingAlgorithm` and `InsertionSort` are declared to be
-// `public` and the lines 89-91 can not be inlined in `bucketSort` (due to
+// `public` and the lines 88-90 can not be inlined in `bucketSort` (due to
 // inlining heuristic limitations), compiler without ExistentialSpecializer
 // optimization can not achieve this feat. With ExistentialSpecializer which
 // enables generic specialization recursively in a call chain, we're able to
-// specialize line 90 for `InsertionSort` on integers.
+// specialize line 89 for `InsertionSort` on integers.
 
 import TestsUtils
-import Foundation
 
 public let BucketSort = BenchmarkInfo(
   name: "BucketSort",
@@ -117,7 +116,8 @@ let items: [Int] = {
 let buckets: [Bucket<Int>] = {
   let bucketCount = 10
   let maxValue = items.max()!.convertToInt()
-  let maxCapacity = Int(ceil(Double(maxValue + 1) / Double(bucketCount)))
+  let maxCapacity = Int(
+    (Double(maxValue + 1) / Double(bucketCount)).rounded(.up))
   return (0..<bucketCount).map { _ in Bucket<Int>(capacity: maxCapacity) }
 }()
 

--- a/benchmark/single-source/ByteSwap.swift
+++ b/benchmark/single-source/ByteSwap.swift
@@ -13,7 +13,6 @@
 // This test checks performance of Swift byte swap.
 // rdar://problem/22151907
 
-import Foundation
 import TestsUtils
 
 public let ByteSwap = BenchmarkInfo(

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -13,6 +13,8 @@
 import TestsUtils
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif

--- a/benchmark/single-source/Calculator.swift
+++ b/benchmark/single-source/Calculator.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-import Foundation
 
 public let Calculator = BenchmarkInfo(
   name: "Calculator",
@@ -53,4 +52,3 @@ public func run_Calculator(_ N: Int) {
   }
   CheckResults(c == 0)
 }
-

--- a/benchmark/single-source/Hanoi.swift
+++ b/benchmark/single-source/Hanoi.swift
@@ -12,7 +12,6 @@
 
 // This test checks performance of Swift hanoi tower.
 // <rdar://problem/22151932>
-import Foundation
 import TestsUtils
 
 public let Hanoi = BenchmarkInfo(

--- a/benchmark/single-source/OpenClose.swift
+++ b/benchmark/single-source/OpenClose.swift
@@ -11,8 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-import Foundation
-
 
 // A micro benchmark for checking the speed of string-based enums.
 public let OpenClose = BenchmarkInfo(
@@ -38,4 +36,3 @@ public func run_OpenClose(_ N: Int) {
   }
   CheckResults(c == 0)
 }
-

--- a/benchmark/single-source/ProtocolDispatch2.swift
+++ b/benchmark/single-source/ProtocolDispatch2.swift
@@ -15,7 +15,6 @@
 
 
 import TestsUtils
-import Foundation
 
 public let ProtocolDispatch2 = BenchmarkInfo(
   name: "ProtocolDispatch2",

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -15,7 +15,6 @@
 //
 // Description:
 //     Create a sorted sparse RGB histogram from an array of 300 RGB values.
-import Foundation
 import TestsUtils
 
 public let RGBHistogram = [

--- a/benchmark/single-source/Radix2CooleyTukey.swift
+++ b/benchmark/single-source/Radix2CooleyTukey.swift
@@ -2,7 +2,11 @@
 //
 // Originally written by @owensd. Used with his permission.
 
-import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 import TestsUtils
 
 public var Radix2CooleyTukey = [

--- a/benchmark/single-source/Radix2CooleyTukey.swift
+++ b/benchmark/single-source/Radix2CooleyTukey.swift
@@ -4,6 +4,8 @@
 
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif

--- a/benchmark/single-source/ReduceInto.swift
+++ b/benchmark/single-source/ReduceInto.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TestsUtils
-import Foundation
 
 public let ReduceInto = [
   BenchmarkInfo(name: "FilterEvenUsingReduce", runFunction: run_FilterEvenUsingReduce, tags: [.validation, .api], legacyFactor: 10),

--- a/benchmark/single-source/SortLettersInPlace.swift
+++ b/benchmark/single-source/SortLettersInPlace.swift
@@ -12,7 +12,6 @@
 
 // This test checks performance and correctness of Swift sortInPlace on an
 // array of letters.
-import Foundation
 import TestsUtils
 
 public let SortLettersInPlace = BenchmarkInfo(

--- a/benchmark/single-source/StringEdits.swift
+++ b/benchmark/single-source/StringEdits.swift
@@ -13,6 +13,8 @@
 import TestsUtils
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -13,6 +13,8 @@
 import TestsUtils
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif

--- a/benchmark/single-source/Walsh.swift
+++ b/benchmark/single-source/Walsh.swift
@@ -13,6 +13,8 @@
 import TestsUtils
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif
@@ -89,4 +91,3 @@ public func run_Walsh(_ N: Int) {
     InverseWalshTransform(&data2)
   }
 }
-

--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -12,6 +12,8 @@
 
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif

--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 enum ArgumentError: Error {
   case missingValue(String)

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -12,6 +12,8 @@
 
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 import LibProc

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -12,6 +12,8 @@
 
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import MSVCRT
 #else
 import Darwin
 #endif


### PR DESCRIPTION
Remove the import of Foundation where it is not necessary for testing the ObjC interoperability.

Edit: Also import **MSVCRT** in Windows where the `#if os(Linux) import Glibc` pattern occurs.