### PR TITLE
[AutoDiff] Rename `withGradient` to `withDerivative`.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -248,33 +248,18 @@ public func differentiableFunction<T, U, R>(
 }
 
 public extension Differentiable {
-  @differentiable(wrt: self, vjp: _vjpWithGrad)
-  func withGradient(_ body: @escaping (inout TangentVector) -> Void) -> Self {
+  @differentiable(wrt: self, vjp: _vjpWithDerivative)
+  func withDerivative(_ body: @escaping (inout TangentVector) -> Void) -> Self {
     return self
   }
 
   @inlinable
-  internal func _vjpWithGrad(
+  internal func _vjpWithDerivative(
     _ body: @escaping (inout TangentVector) -> Void
   ) -> (Self, (TangentVector) -> TangentVector) {
     return (self, { grad in
       var grad = grad
       body(&grad)
-      return grad
-    })
-  }
-
-  @differentiable(wrt: self, vjp: _vjpWithGrad)
-  func withGradient(_ body: @escaping (TangentVector) -> Void) -> Self {
-    return self
-  }
-
-  @inlinable
-  internal func _vjpWithGrad(
-    _ body: @escaping (TangentVector) -> Void
-  ) -> (Self, (TangentVector) -> TangentVector) {
-    return (self, { grad in
-      body(grad)
       return grad
     })
   }

--- a/test/AutoDiff/custom_derivatives.swift
+++ b/test/AutoDiff/custom_derivatives.swift
@@ -72,18 +72,18 @@ CustomDerivativesTests.test("Checkpointing") {
 
 CustomDerivativesTests.test("SumOfGradPieces") {
   var grad: Float = 0
-  let addToGrad = { grad += $0 }
+  func addToGrad(_ x: inout Float) { grad += x }
   _ = gradient(at: 4) { (x: Float) in
-    x.withGradient(addToGrad)
-      * x.withGradient(addToGrad)
-        * x.withGradient(addToGrad)
+    x.withDerivative(addToGrad)
+      * x.withDerivative(addToGrad)
+        * x.withDerivative(addToGrad)
   }
   expectEqual(48, grad)
 }
 
 CustomDerivativesTests.test("ModifyGradientOfSum") {
   expectEqual(30, gradient(at: 4) { (x: Float) in
-    x.withGradient { $0 *= 10 } + x.withGradient { $0 *= 20 }
+    x.withDerivative { $0 *= 10 } + x.withDerivative { $0 *= 20 }
   })
 }
 


### PR DESCRIPTION
`withDerivative` is a more accurate name.
Remove non-`inout` overload to avoid ambiguity.