### PR TITLE
Demangler: Save state to allow reentrant demangling.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -447,7 +447,21 @@ protected:
     return popNode();
   }
 
-  void init(StringRef MangledName);
+  /// This class handles preparing the initial state for a demangle job in a reentrant way, pushing the
+  /// existing state back when a demangle job is completed.
+  class DemangleInitRAII {
+    Demangler &Dem;
+    Vector<NodePointer> NodeStack;
+    Vector<NodePointer> Substitutions;
+    int NumWords;
+    StringRef Text;
+    size_t Pos;
+    
+  public:
+    DemangleInitRAII(Demangler &Dem, StringRef MangledName);
+    ~DemangleInitRAII();
+  };
+  friend DemangleInitRAII;
   
   void addSubstitution(NodePointer Nd) {
     if (Nd)

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -33,7 +33,7 @@ class AttributeDemangler : public Demangle::Demangler {
 public:
   void demangleAndAddAsChildren(StringRef MangledSpecialization,
                                 NodePointer Parent) {
-    init(MangledSpecialization);
+    DemangleInitRAII state(*this, MangledSpecialization);
     if (!parseAndPushNodes()) {
       llvm::errs() << "Can't demangle: " << MangledSpecialization << '\n';
       abort();

--- a/test/Reflection/Inputs/ConcreteTypes.swift
+++ b/test/Reflection/Inputs/ConcreteTypes.swift
@@ -63,3 +63,11 @@ public struct References {
   public unowned var unownedRef: C
   public unowned(unsafe) var unownedUnsafeRef: C
 }
+
+private struct PrivateStructField {
+  var x: Int16
+}
+
+public struct HasArrayOfPrivateStructField {
+  private var x: [PrivateStructField]
+}

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,6 +1,6 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
 
 // CHECK: FIELDS:
@@ -200,6 +200,13 @@
 // CHECK: unownedUnsafeRef: unowned(unsafe) TypesToReflect.C
 // CHECK: (unmanaged_storage
 // CHECK:   (class TypesToReflect.C))
+
+// CHECK: TypesToReflect.(PrivateStructField
+// CHECK: ----------------------------------
+
+// CHECK: TypesToReflect.HasArrayOfPrivateStructField
+// CHECK: -------------------------------------------
+// CHECK: x: Swift.Array<TypesToReflect.(PrivateStructField{{.*}})>
 
 // CHECK: TypesToReflect.C1
 // CHECK: -----------------
@@ -652,14 +659,14 @@
 // CHECK: TypesToReflect.ClassBoundP
 // CHECK: --------------------------
 
-// CHECK: TypesToReflect.(FileprivateProtocol in _{{[0-9a-fA-F]+}})
+// CHECK: TypesToReflect.(FileprivateProtocol in {{.*}})
 // CHECK: -------------------------------------------------------------------------
 
 // CHECK: TypesToReflect.HasFileprivateProtocol
 // CHECK: -------------------------------------
-// CHECK: x: TypesToReflect.(FileprivateProtocol in ${{[0-9a-fA-F]+}})
+// CHECK: x: TypesToReflect.(FileprivateProtocol in {{.*}})
 // CHECK: (protocol_composition
-// CHECK-NEXT: (protocol TypesToReflect.(FileprivateProtocol in ${{[0-9a-fA-F]+}})))
+// CHECK-NEXT: (protocol TypesToReflect.(FileprivateProtocol in {{.*}})))
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================


### PR DESCRIPTION
If somebody called `demangleType` or `demangleSymbol` using a demangler that was already
in the middle of demangling a string, then the state for the new demangler would clobber the old
demangler. This manifested in rdar://problem/50380275 and rdar://problem/52349591 because, as part of demangling a
string with a symbolic reference to a private type's context, we would demangle the debug string
for the referenced context using the same demangler. If there were additional operators in the
original string after the symbolic reference, these never got demangled because the demangler
was now in the state of having completed demangling the other string, so we would drop nesting,
and incorrectly report field types of, for instance, `Array<PrivateStruct>` or
`(PrivateStruct, OtherStruct)` as just being `PrivateStruct`.

This is a likely situation to be in, especially now that `Demangler` objects also serve as
arena allocators for their demangled nodes, so change the top-level demangler entry points
to use an RAII object to push and pop the existing state instead of unilaterally clobbering
the existing state.