### PR TITLE
[5.1] SourceKit/ExpressionType: allow users to canonicalize collected expression types

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -196,7 +196,9 @@ namespace swift {
   /// be printed to \c OS.
   ArrayRef<ExpressionTypeInfo> collectExpressionType(SourceFile &SF,
     ArrayRef<const char *> ExpectedProtocols,
-    std::vector<ExpressionTypeInfo> &scratch, llvm::raw_ostream &OS);
+    std::vector<ExpressionTypeInfo> &scratch,
+    bool CanonicalType,
+    llvm::raw_ostream &OS);
 
   /// Resolve a list of mangled names to accessible protocol decls from
   /// the decl context.

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -603,6 +603,9 @@ class ExpressionTypeCollector: public SourceEntityWalker {
   // these protocols.
   llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols;
 
+  // Specified by the client whether we should canonicalize types before printing
+  const bool CanonicalType;
+
   bool shouldReport(unsigned Offset, unsigned Length, Expr *E,
                     std::vector<StringRef> &Conformances) {
     assert(Conformances.empty());
@@ -649,11 +652,13 @@ public:
   ExpressionTypeCollector(SourceFile &SF,
               llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols,
                           std::vector<ExpressionTypeInfo> &Results,
+                          bool CanonicalType,
                           llvm::raw_ostream &OS): Module(*SF.getParentModule()),
                             SM(SF.getASTContext().SourceMgr),
                             BufferId(*SF.getBufferID()),
                             Results(Results), OS(OS),
-                            InterestedProtocols(InterestedProtocols) {}
+                            InterestedProtocols(InterestedProtocols),
+                            CanonicalType(CanonicalType) {}
   bool walkToExprPre(Expr *E) override {
     if (E->getSourceRange().isInvalid())
       return true;
@@ -668,7 +673,12 @@ public:
     SmallString<64> Buffer;
     {
       llvm::raw_svector_ostream OS(Buffer);
-      E->getType()->getRValueType()->reconstituteSugar(true)->print(OS);
+      auto Ty = E->getType()->getRValueType();
+      if (CanonicalType) {
+        Ty->getCanonicalType()->print(OS);
+      } else {
+        Ty->reconstituteSugar(true)->print(OS);
+      }
     }
     auto Ty = getTypeOffsets(Buffer.str());
     // Add the type information to the result list.
@@ -719,11 +729,13 @@ ArrayRef<ExpressionTypeInfo>
 swift::collectExpressionType(SourceFile &SF,
                              ArrayRef<const char *> ExpectedProtocols,
                              std::vector<ExpressionTypeInfo> &Scratch,
+                             bool CanonicalType,
                              llvm::raw_ostream &OS) {
   llvm::MapVector<ProtocolDecl*, StringRef> InterestedProtocols;
   if (resolveProtocolNames(&SF, ExpectedProtocols, InterestedProtocols))
     return {};
-  ExpressionTypeCollector Walker(SF, InterestedProtocols, Scratch, OS);
+  ExpressionTypeCollector Walker(SF, InterestedProtocols, Scratch,
+    CanonicalType, OS);
   Walker.walk(SF);
   return Scratch;
 }

--- a/test/IDE/Inputs/ExprType.swift
+++ b/test/IDE/Inputs/ExprType.swift
@@ -20,3 +20,9 @@ struct S {
 func DictS(_ a: [Int: S]) {
   _ = a[2]?.val.advanced(by: 1).byteSwapped
 }
+
+typealias MyInt = Int
+
+func calculateAdd(a: MyInt, b: MyInt) -> MyInt {
+	return a + b
+}

--- a/test/IDE/expr_type.swift
+++ b/test/IDE/expr_type.swift
@@ -1,8 +1,13 @@
-// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprType.swift -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprType.swift -swift-version 5 | %FileCheck %s -check-prefix=CHECK-SUGAR
+// RUN: %target-swift-ide-test -print-expr-type -source-filename %S/Inputs/ExprType.swift -swift-version 5 -canonicalize-type | %FileCheck %s -check-prefix=CHECK-CANON
 
-// CHECK: func foo() -> Int { return <expr type:"Int">1</expr> }
-// CHECK: func bar(f: Float) -> Float { return <expr type:"Float"><expr type:"(Float) -> Float">bar</expr><expr type:"(f: Float)">(f: <expr type:"Float">1</expr>)</expr></expr> }
-// CHECK: func fooP(_ p: P) { <expr type:"()"><expr type:"(P) -> ()">fooP</expr><expr type:"(P)">(<expr type:"P">p</expr>)</expr></expr> }
-// CHECK: <expr type:"()"><expr type:"Int">_</expr> = <expr type:"Int"><expr type:"[C]">a</expr>.count</expr></expr>
-// CHECK: <expr type:"()"><expr type:"String">_</expr> = <expr type:"String"><expr type:"Int"><expr type:"(Int) -> Int"><expr type:"Int"><expr type:"String"><expr type:"[C]">a</expr>.description</expr>.count</expr>.<expr type:"(Int) -> (Int) -> Int">advanced</expr></expr><expr type:"(by: Int)">(by: <expr type:"Int">1</expr>)</expr></expr>.description</expr></expr>
-// CHECK: <expr type:"()"><expr type:"Int?">_</expr> = <expr type:"Int?"><expr type:"Int"><expr type:"(Int) -> Int"><expr type:"Int"><expr type:"S"><expr type:"S?"><expr type:"[Int : S]">a</expr><expr type:"(Int)">[<expr type:"Int">2</expr>]</expr></expr>?</expr>.val</expr>.<expr type:"(Int) -> (Int) -> Int">advanced</expr></expr><expr type:"(by: Int)">(by: <expr type:"Int">1</expr>)</expr></expr>.byteSwapped</expr></expr>
+// CHECK-SUGAR: func foo() -> Int { return <expr type:"Int">1</expr> }
+// CHECK-SUGAR: func bar(f: Float) -> Float { return <expr type:"Float"><expr type:"(Float) -> Float">bar</expr><expr type:"(f: Float)">(f: <expr type:"Float">1</expr>)</expr></expr> }
+// CHECK-SUGAR: func fooP(_ p: P) { <expr type:"()"><expr type:"(P) -> ()">fooP</expr><expr type:"(P)">(<expr type:"P">p</expr>)</expr></expr> }
+// CHECK-SUGAR: <expr type:"()"><expr type:"Int">_</expr> = <expr type:"Int"><expr type:"[C]">a</expr>.count</expr></expr>
+// CHECK-SUGAR: <expr type:"()"><expr type:"String">_</expr> = <expr type:"String"><expr type:"Int"><expr type:"(Int) -> Int"><expr type:"Int"><expr type:"String"><expr type:"[C]">a</expr>.description</expr>.count</expr>.<expr type:"(Int) -> (Int) -> Int">advanced</expr></expr><expr type:"(by: Int)">(by: <expr type:"Int">1</expr>)</expr></expr>.description</expr></expr>
+// CHECK-SUGAR: <expr type:"()"><expr type:"Int?">_</expr> = <expr type:"Int?"><expr type:"Int"><expr type:"(Int) -> Int"><expr type:"Int"><expr type:"S"><expr type:"S?"><expr type:"[Int : S]">a</expr><expr type:"(Int)">[<expr type:"Int">2</expr>]</expr></expr>?</expr>.val</expr>.<expr type:"(Int) -> (Int) -> Int">advanced</expr></expr><expr type:"(by: Int)">(by: <expr type:"Int">1</expr>)</expr></expr>.byteSwapped</expr></expr>
+
+
+// CHECK-SUGAR: return <expr type:"MyInt"><expr type:"MyInt">a</expr> <expr type:"(Int, Int) -> Int">+</expr> <expr type:"MyInt">b</expr></expr>
+// CHECK-CANON: return <expr type:"Int"><expr type:"Int">a</expr> <expr type:"(Int, Int) -> Int">+</expr> <expr type:"Int">b</expr></expr>

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -775,6 +775,7 @@ public:
   virtual void collectExpressionTypes(StringRef FileName,
                                       ArrayRef<const char *> Args,
                                       ArrayRef<const char *> ExpectedProtocols,
+                                      bool CanonicalType,
                                       std::function<void(const
                                           RequestResult<ExpressionTypesInFile> &)> Receiver) = 0;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -527,6 +527,7 @@ public:
 
   void collectExpressionTypes(StringRef FileName, ArrayRef<const char *> Args,
                               ArrayRef<const char *> ExpectedProtocols,
+                              bool CanonicalType,
                               std::function<void(const RequestResult<ExpressionTypesInFile> &)> Receiver) override;
 
   void semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1012,7 +1012,10 @@ handleSemanticRequest(RequestDict Req,
     SmallVector<const char *, 8> ExpectedProtocols;
     if (Req.getStringArray(KeyExpectedTypes, ExpectedProtocols, true))
       return Rec(createErrorRequestInvalid("invalid 'key.interested_protocols'"));
+    int64_t CanonicalTy = false;
+    Req.getInt64(KeyCanonicalizeType, CanonicalTy, /*isOptional=*/true);
     return Lang.collectExpressionTypes(*SourceFile, Args, ExpectedProtocols,
+                                       CanonicalTy,
       [Rec](const RequestResult<ExpressionTypesInFile> &Result) {
         reportExpressionTypeInfo(Result, Rec);
       });

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -689,6 +689,10 @@ static llvm::cl::opt<std::string>
 GraphVisPath("output-request-graphviz",
              llvm::cl::desc("Emit GraphViz output visualizing the request graph."),
              llvm::cl::cat(Category));
+
+static llvm::cl::opt<bool>
+CanonicalizeType("canonicalize-type", llvm::cl::Hidden,
+                   llvm::cl::cat(Category), llvm::cl::init(false));
 } // namespace options
 
 static std::unique_ptr<llvm::MemoryBuffer>
@@ -1737,7 +1741,8 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   for (auto &u: options::UsrFilter)
     Usrs.push_back(u.c_str());
   // Collect all tags of expressions.
-  for (auto R: collectExpressionType(*CI.getPrimarySourceFile(), Usrs, Scratch, OS)) {
+  for (auto R: collectExpressionType(*CI.getPrimarySourceFile(), Usrs, Scratch,
+                                     options::CanonicalizeType, OS)) {
     SortedTags.push_back({R.offset,
       (llvm::Twine("<expr type:\"") + TypeBuffer.str().substr(R.typeOffset,
                                                   R.typeLength) + "\">").str()});

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -169,6 +169,7 @@ UID_KEYS = [
     KEY('ExpressionOffset', 'key.expression_offset'),
     KEY('ExpressionLength', 'key.expression_length'),
     KEY('ExpressionType', 'key.expression_type'),
+    KEY('CanonicalizeType', 'key.canonicalize_type'),
     KEY('InternalDiagnostic', "key.internal_diagnostic"),
 ]
 


### PR DESCRIPTION
The default response of the expression type request doesn't canonicalize expression
types. This patch adds a flag to allow users to canonicalize them.
