### PR TITLE
[AutoDiff] Fix `@differentiable(wrt: self)` type-checking.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2874,6 +2874,8 @@ static AutoDiffParameterIndices *computeDifferentiationParameters(
       auto selfType = function->getImplicitSelfDecl()->getInterfaceType();
       if (derivativeGenEnv)
         selfType = derivativeGenEnv->mapTypeIntoContext(selfType);
+      else
+        selfType = function->mapTypeIntoContext(selfType);
       // FIXME(TF-568): `Differentiable`-conforming protocols cannot define
       // `@differentiable` computed properties because the check below returns
       // false.

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -60,6 +60,15 @@ struct ComputedPropertyDupeAttributes<T : Differentiable> : Differentiable {
   }
 }
 
+// Test TF-568.
+protocol WrtOnlySelfProtocol : Differentiable {
+  @differentiable
+  var computedProperty: Float { get }
+
+  @differentiable
+  func method() -> Float
+}
+
 class Class {}
 // expected-error @+1 {{class objects and protocol existentials ('Class') cannot be differentiated with respect to}}
 @differentiable(wrt: x)


### PR DESCRIPTION
Fix `@differentiable(wrt: self)` type-checking for protocol members.
Resolves [TF-568](https://bugs.swift.org/projects/TF/issues/TF-568).