### PR TITLE
[5.1] [Demangle] Fix OldDemangler DependentMemberTypeName infinite loop

### DIFF
--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -1426,6 +1426,7 @@ private:
       // we could try to fish it out of the generic signature constraints on the
       // base.
       NodePointer ID = demangleIdentifier();
+      if (!ID) return nullptr;
       assocTy = Factory.createNode(Node::Kind::DependentAssociatedTypeRef);
       if (!assocTy) return nullptr;
       assocTy->addChild(ID, Factory);

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -318,6 +318,8 @@ _TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function 
 _TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
 _TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
 _TTSf ---> _TTSf
+_TtW0_j ---> _TtW0_j
+_TtW_4m3a3v ---> _TtW_4m3a3v
 _TVGVGSS_2v0 ---> _TVGVGSS_2v0
 $SSD1BySSSBsg_G ---> $SSD1BySSSBsg_G
 _Ttu4222222222222222222222222_rW_2T_2TJ_ ---> <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AB, BB, CB, DB, EB, FB, GB, HB, IB, JB, KB, LB, MB, NB, OB, PB, QB, RB, SB, TB, UB, VB, WB, XB, YB, ZB, AC, BC, CC, DC, EC, FC, GC, HC, IC, JC, KC, LC, MC, NC, OC, PC, QC, RC, SC, TC, UC, VC, WC, XC, YC, ZC, AD, BD, CD, DD, ED, FD, GD, HD, ID, JD, KD, LD, MD, ND, OD, PD, QD, RD, SD, TD, UD, VD, WD, XD, YD, ZD, AE, BE, CE, DE, EE, FE, GE, HE, IE, JE, KE, LE, ME, NE, OE, PE, QE, RE, SE, TE, UE, VE, WE, XE, ...> B.T_.TJ


### PR DESCRIPTION
Cherry-pick of #25791 to the 5.1 branch (reviewed by me).

[SR-10961](https://bugs.swift.org/browse/SR-10961)