### PR TITLE
[Index] Don't index non-public imported declarations

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2961,7 +2961,7 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
     if (resultDC->isLocalContext() || access == AccessLevel::Private)
       return AccessScope(resultDC, /*private*/true);
 
-    if (auto enclosingNominal = dyn_cast<NominalTypeDecl>(resultDC)) {
+    if (auto enclosingNominal = dyn_cast<GenericTypeDecl>(resultDC)) {
       auto enclosingAccess =
           getAdjustedFormalAccess(enclosingNominal, useDC,
                                   treatUsableFromInlineAsPublic);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -546,6 +546,10 @@ private:
     if (D->isImplicit() && !isa<ConstructorDecl>(D))
       return false;
 
+    // Do not handle non-public imported decls.
+    if (IsModuleFile && !D->isAccessibleFrom(nullptr))
+      return false;
+
     if (!IdxConsumer.indexLocals() && isLocalSymbol(D))
       return isa<ParamDecl>(D) && !IsRef &&
         D->getDeclContext()->getContextKind() != DeclContextKind::AbstractClosureExpr;

--- a/test/Index/Inputs/implementation-only-imports-helper.swift
+++ b/test/Index/Inputs/implementation-only-imports-helper.swift
@@ -1,0 +1,2 @@
+public protocol SECRETProtocol {}
+open class SECRETClass {}

--- a/test/Index/Inputs/my_system_overlay/my_system_overlay.swift
+++ b/test/Index/Inputs/my_system_overlay/my_system_overlay.swift
@@ -3,9 +3,10 @@
 public func some_func() {}
 
 public class BaseCls {
-  func theMeth() {}
+  public func theMeth() {}
+  internal func SECRET() {}
 }
 
 public class SubCls : BaseCls {
-  override func theMeth() {}
+  public override func theMeth() {}
 }

--- a/test/Index/implementation-only-imports.swift
+++ b/test/Index/implementation-only-imports.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -o %t -module-name CoreFoo %S/Inputs/implementation-only-imports-helper.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t -module-name FooKit %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-name FooKit -source-filename %s -I %t > %t.out
+
+// RUN: mv %t/CoreFoo.swiftmodule %t/SecretCoreFoo.swiftmodule
+// RUN: echo '---FROM MODULE---' >> %t.out
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print FooKit -source-filename %s -I %t >> %t.out
+// RUN: %FileCheck %s -input-file=%t.out
+// RUN: %FileCheck -check-prefix NEGATIVE %s -input-file=%t.out
+
+// CHECK: module | user | CoreFoo | {{.+}}CoreFoo.swiftmodule
+@_implementationOnly import CoreFoo
+// CHECK: [[@LINE-1]]:{{[0-9]+}} | module/Swift | CoreFoo | c:@M@CoreFoo | Ref | rel: 0
+
+internal class SECRETSubclass : SECRETClass {}
+// CHECK: [[@LINE-1]]:{{[0-9]+}} | class/Swift | SECRETSubclass | [[SECRET_SUBCLASS_USR:s:[^|]+]] | Def | rel: 0
+// CHECK: [[@LINE-2]]:{{[0-9]+}} | class/Swift | SECRETClass | [[SECRET_CLASS_USR:s:[^|]+]] | Ref,RelBase | rel: 1
+// CHECK-NEXT:  RelBase | class/Swift | SECRETSubclass | [[SECRET_SUBCLASS_USR]]{{$}}
+
+public class PublicClass {
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | class/Swift | PublicClass | [[PUBLIC_CLASS_USR:s:[^|]+]] | Def | rel: 0
+  internal var propSECRET: SECRETClass? { nil }
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property/Swift | propSECRET |
+  internal var propSECRET2: SECRETSubclass? { nil }
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-property/Swift | propSECRET2 |
+}
+
+extension SECRETClass {
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-class/Swift | SECRETClass |
+  internal func testSECRET() {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+}
+
+extension PublicClass {
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR:s:[^|]+]] |
+  public func extensionNamingMethod() {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | extensionNamingMethod() |
+
+  internal func testSECRET() {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+
+  internal struct SECRETStruct: SECRETProtocol {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | struct/Swift | SECRETStruct | [[SECRET_NESTED_STRUCT_USR:s:[^|]+]] |
+  // CHECK: [[@LINE-2]]:{{[0-9]+}} | protocol/Swift | SECRETProtocol | [[SECRET_PROTOCOL_USR:s:[^|]+]] | Ref,RelBase | rel: 1
+  // CHECK-NEXT: RelBase | struct/Swift | SECRETStruct | [[SECRET_NESTED_STRUCT_USR]]
+}
+
+extension Optional where Wrapped: SECRETProtocol {
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | extension/ext-enum/Swift | Optional |
+  internal func extensionNamingMethod() {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | extensionNamingMethod() |
+
+  internal func testSECRET() {}
+  // CHECK: [[@LINE-1]]:{{[0-9]+}} | instance-method/Swift | testSECRET() |
+}
+
+// CHECK-LABEL: ---FROM MODULE---
+// NEGATIVE-LABEL: ---FROM MODULE---
+
+// CHECK: 0:0 | class/Swift | PublicClass | [[PUBLIC_CLASS_USR]] | Def | rel: 0
+// CHECK: 0:0 | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR]] | Def | rel: 0
+// CHECK: 0:0 | class/Swift | PublicClass | [[PUBLIC_CLASS_USR]] | Ref,RelExt | rel: 1
+// CHECK-NEXT: RelExt | extension/ext-class/Swift | PublicClass | [[PUBLIC_CLASS_EXTENSION_USR]]
+
+
+// NEGATIVE-NOT: CoreFoo
+// NEGATIVE-NOT: SECRET

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -20,6 +20,11 @@ public class CCC {}
 // CHECK: [[@LINE-2]]:14 | constructor/Swift | init() | [[CCC_init_USR:.*]] | Def,Impl,RelChild | rel: 1
 // CHECK-NEXT:   RelChild | class/Swift | CCC | [[CCC_USR]]
 
+public typealias GenericTypealias<T> = Optional<T>
+// CHECK: [[@LINE-1]]:18 | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR:.*]] | Def | rel: 0
+// CHECK: [[@LINE-2]]:35 | type-alias/generic-type-param/Swift | T | s:12index_module16GenericTypealiasa1Txmfp | Def,RelChild | rel: 1
+// CHECK-NEXT:   RelChild | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR]]
+
 // --- Check the module ---
 
 // CHECK: 0:0 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
@@ -31,5 +36,6 @@ public class CCC {}
 // CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0
 
 // CHECK: 0:0 | class/Swift | CCC | [[CCC_USR]] | Def | rel: 0
-// CHECK: 0:0 | constructor/Swift | init() | [[CCC_init_USR]] | Def,Impl,RelChild | rel: 1
-// CHECK-NEXT:  RelChild | class/Swift | CCC | [[CCC_USR]]
+// CHECK-NOT: constructor/Swift
+
+// CHECK: 0:0 | type-alias/Swift | GenericTypealias | [[TYPEALIAS_USR]] | Def | rel: 0

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/my_system_overlay/my_system_overlay.swift -Xcc -I -Xcc %S/Inputs/my_system_overlay
 // RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print my_system_overlay -source-filename %s -I %t -Xcc -I -Xcc %S/Inputs/my_system_overlay > %t.out
 // RUN: %FileCheck %s -input-file=%t.out
+// RUN: %FileCheck -check-prefix NEGATIVE %s -input-file=%t.out
 
 // CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
 // CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Def | rel: 0
@@ -14,3 +15,5 @@
 // CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
 // CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR]]
 // CHECK-NEXT: RelChild | class/Swift | SubCls | [[SUBCLS_USR]]
+
+// NEGATIVE-NOT: SECRET

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -25,14 +25,7 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "Empty",
-      key.usr: "s:11test_module5EmptyC",
-      key.entities: [
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:11test_module5EmptyCACycfc",
-          key.is_implicit: 1
-        }
-      ]
+      key.usr: "s:11test_module5EmptyC"
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -107,11 +100,6 @@
               key.is_dynamic: 1
             }
           ]
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:11test_module16ComputedPropertyCACycfc",
-          key.is_implicit: 1
         }
       ]
     },
@@ -140,14 +128,7 @@
     {
       key.kind: source.lang.swift.decl.class,
       key.name: "C2",
-      key.usr: "s:11test_module2C2C",
-      key.entities: [
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:11test_module2C2CACycfc",
-          key.is_implicit: 1
-        }
-      ]
+      key.usr: "s:11test_module2C2C"
     },
     {
       key.kind: source.lang.swift.decl.extension.class,
@@ -175,6 +156,11 @@
       key.kind: source.lang.swift.decl.function.free,
       key.name: "globalFunc()",
       key.usr: "s:11test_module10globalFuncyyF"
+    },
+    {
+      key.kind: source.lang.swift.decl.extension.class,
+      key.name: "C2",
+      key.usr: "s:e:s:11test_module2C2C6SECRETyyF"
     }
   ]
 }

--- a/test/SourceKit/Indexing/Inputs/test_module.swift
+++ b/test/SourceKit/Indexing/Inputs/test_module.swift
@@ -1,7 +1,7 @@
 public class Empty {}
 
 public class TwoInts {
-  var x, y : Int
+  public var x, y : Int
   
   public init(a : Int, b : Int) {
     x = a
@@ -30,3 +30,9 @@ public class C2 { }
 extension C2 : Prot3, Prot1, Prot2 { }
 
 public func globalFunc() {}
+
+private func SECRET() {}
+
+extension C2 {
+  internal func SECRET() {}
+}


### PR DESCRIPTION
Apart from mildly speeding up indexing, this also keeps the compiler from running into issues with implementation-only imports that may not be present while we're trying to index.

rdar://problem/52083709