### PR TITLE
test: make the static library test actually test something

### DIFF
--- a/test/Driver/static-archive.swift
+++ b/test/Driver/static-archive.swift
@@ -1,28 +1,27 @@
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name ARCHIVER -static 2>&1 > %t.macos.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-MACOS %s
 
-// CHECK: swift
-// CHECK: -o [[OBJECTFILE:.*]]
+// CHECK-MACOS: swift
+// CHECK-MACOS: -o [[OBJECTFILE:.*]]
 
-// CHECK-NEXT: {{(bin/)?}}libtool{{"? }} -static
-// CHECK-DAG: [[OBJECTFILE]]
-// CHECK: -o {{[^ ]+}}
+// CHECK-MACOS-NEXT: {{(bin/)?}}libtool{{"?}} -static
+// CHECK-MACOS-DAG: [[OBJECTFILE]]
+// CHECK-MACOS: -o {{[^ ]+}}
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name ARCHIVER -static 2>&1 > %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-LINUX %s
 
-// CHECK: swift
-// CHECK: -o [[OBJECTFILE:.*]]
+// CHECK-LINUX: swift
+// CHECK-LINUX: -o [[OBJECTFILE:.*]]
 
-// CHECK-NEXT: {{(bin/)?}}{{(llvm-)?}}ar{{"? }} crs
-// CHECK-NEXT: {{[^ ]+}}
+// CHECK-LINUX: {{(bin/)?(llvm-)?}}ar{{"?}} crs
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -emit-library %s -module-name ARCHIVER -static 2>&1 > %t.windows.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-WINDOWS %s
 
-// CHECK: swift
-// CHECK: -o [[OBJECTFILE:.*]]
+// CHECK-WINDOWS: swift
+// CHECK-WINDOWS: -o [[OBJECTFILE:.*]]
 
-// CHECK-NEXT: lib -link
-// CHECK-DAG: [[OBJECTFILE]]
-// CHECK: /OUT:{{[^ ]+}}
+// CHECK-WINDOWS-NEXT: link{{(.exe)?"?}} -lib
+// CHECK-WINDOWS-DAG: [[OBJECTFILE]]
+// CHECK-WINDOWS: /OUT:{{[^ ]+}}
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name ARCHIVER -static | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name ARCHIVER -static | %FileCheck -check-prefix INFERRED_NAME_LINUX %s


### PR DESCRIPTION
It was previously capturing the output but not checking it.  Actually
validate the output.  Fix the windows invocation check.  Ensure that we
disable the logo for the librarian on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
