### PR TITLE
[AutoDiff] Fix AST serialization of differentiation structs/enums.

### DIFF
--- a/test/AutoDiff/ast_serialization.swift
+++ b/test/AutoDiff/ast_serialization.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -emit-sib -primary-file %s
+
+// Test AST serialization of differentiation generated structs/enums.
+@differentiable
+func TF_623(_ x: Float) -> Float {
+   if x > 0 {}
+   return x
+}


### PR DESCRIPTION
Fix AST serialization of structs/enums synthesized during differentiation SIL transform.

Resolves [TF-623](https://bugs.swift.org/browse/TF-623). [Asked about robust fix on Swift forums](https://forums.swift.org/t/question-re-adding-derivedfileunit/26427).