### PR TITLE
Add -enable-cxx-interop flag and support for extern "C" {}

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -147,6 +147,12 @@ namespace swift {
     /// configuration options.
     bool EnableObjCInterop = true;
 
+    /// Enable C++ interop code generation and build configuration
+    /// options. Disabled by default because there is no way to control the
+    /// language mode of clang on a per-header or even per-module basis. Also
+    /// disabled because it is not complete.
+    bool EnableCXXInterop = false;
+
     /// On Darwin platforms, use the pre-stable ABI's mark bit for Swift
     /// classes instead of the stable ABI's bit. This is needed when
     /// targeting OSes prior to macOS 10.14.4 and iOS 12.2, where

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -504,6 +504,11 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
 
+def enable_cxx_interop :
+  Flag<["-"], "enable-cxx-interop">,
+  HelpText<"Enable C++ interop code generation and config directives">,
+  Flags<[FrontendOption, HelpHidden]>;
+
 def use_malloc : Flag<["-"], "use-malloc">,
   HelpText<"Allocate internal data structures using malloc "
            "(for memory debugging)">;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -498,8 +498,11 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
         "-Werror=non-modular-include-in-framework-module");
 
   if (LangOpts.EnableObjCInterop) {
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-x", "objective-c", "-std=gnu11", "-fobjc-arc"});
+    bool EnableCXXInterop = LangOpts.EnableCXXInterop;
+    invocationArgStrs.insert(
+        invocationArgStrs.end(),
+        {"-x", EnableCXXInterop ? "objective-c++" : "objective-c",
+         EnableCXXInterop ? "-std=gnu++17" : "-std=gnu11", "-fobjc-arc"});
     // TODO: Investigate whether 7.0 is a suitable default version.
     if (!triple.isOSDarwin())
       invocationArgStrs.insert(invocationArgStrs.end(),
@@ -518,7 +521,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       });
 
   } else {
-    invocationArgStrs.insert(invocationArgStrs.end(), {"-x", "c", "-std=gnu11"});
+    bool EnableCXXInterop = LangOpts.EnableCXXInterop;
+    invocationArgStrs.insert(invocationArgStrs.end(),
+                             {"-x", EnableCXXInterop ? "c++" : "c",
+                              EnableCXXInterop ? "-std=gnu++17" : "-std=gnu11"});
   }
 
   // Set C language options.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8451,7 +8451,7 @@ bool ClangImporter::Implementation::addMemberAndAlternatesToExtension(
   // Quickly check the context and bail out if it obviously doesn't
   // belong here.
   if (auto *importDC = newName.getEffectiveContext().getAsDeclContext())
-    if (importDC->isTranslationUnit())
+    if (importDC->isFileContext())
       return true;
 
   // Then try to import the decl under the specified name.

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1404,8 +1404,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   case clang::DeclarationName::CXXOperatorName:
   case clang::DeclarationName::CXXUsingDirective:
   case clang::DeclarationName::CXXDeductionGuideName:
-    // Handling these is part of C++ interoperability.
-    llvm_unreachable("unhandled C++ interoperability");
+    // TODO: Handling these is part of C++ interoperability.
+    return ImportedName();
 
   case clang::DeclarationName::Identifier:
     // Map the identifier.

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -196,6 +196,8 @@ public:
       DC = omDecl->getCanonicalDecl();
     } else if (auto fDecl = dyn_cast<clang::FunctionDecl>(dc)) {
       DC = fDecl->getCanonicalDecl();
+    } else if (auto nsDecl = dyn_cast<clang::NamespaceDecl>(dc)) {
+      DC = nsDecl->getCanonicalDecl();
     } else {
       assert(isa<clang::TranslationUnitDecl>(dc) ||
              isa<clang::ObjCContainerDecl>(dc) &&

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -188,6 +188,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_cxx_interop);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);
   inputArgs.AddLastArg(arguments, options::OPT_debug_info_format);
   inputArgs.AddLastArg(arguments, options::OPT_import_underlying_module);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -501,6 +501,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     TargetArg = A->getValue();
   }
 
+  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_cxx_interop);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin());

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -24,7 +24,10 @@
 #include "Visibility.h"
 
 #ifdef __cplusplus
-namespace swift { extern "C" {
+#ifndef __swift__
+namespace swift {
+#endif
+extern "C" {
 #endif
 
 struct _SwiftArrayBodyStorage {
@@ -102,7 +105,10 @@ static_assert(
     4 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
   "_SwiftSetBodyStorage has unexpected size");
 
-}} // extern "C", namespace swift
+} // extern "C"
+#ifndef __swift__
+} // namespace swift
+#endif
 #endif
 
 #endif

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -20,7 +20,7 @@
 #define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_64 16
 #define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_32 8
 
-#ifdef __cplusplus
+#ifndef __swift__
 #include <type_traits>
 #include "swift/Basic/type_traits.h"
 
@@ -48,7 +48,7 @@ struct HeapObject {
 
   SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS;
 
-#ifdef __cplusplus
+#ifndef __swift__
   HeapObject() = default;
 
   // Initialize a HeapObject header as appropriate for a newly-allocated object.
@@ -68,7 +68,7 @@ struct HeapObject {
   void dump() const LLVM_ATTRIBUTE_USED;
 #endif
 
-#endif // __cplusplus
+#endif // __swift__
 };
 
 #ifdef __cplusplus
@@ -92,7 +92,7 @@ __swift_size_t swift_weakRetainCount(HeapObject *obj);
 } // extern "C"
 #endif
 
-#ifdef __cplusplus
+#ifndef __swift__
 static_assert(std::is_trivially_destructible<HeapObject>::value,
               "HeapObject must be trivially destructible");
 

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -21,7 +21,7 @@ typedef struct {
   __swift_uintptr_t refCounts SWIFT_ATTRIBUTE_UNAVAILABLE;
 } InlineRefCountsPlaceholder;
 
-#if !defined(__cplusplus)
+#if defined(__swift__)
 
 typedef InlineRefCountsPlaceholder InlineRefCounts;
 

--- a/stdlib/public/SwiftShims/SwiftStddef.h
+++ b/stdlib/public/SwiftShims/SwiftStddef.h
@@ -29,7 +29,7 @@ typedef __SIZE_TYPE__ __swift_size_t;
 #endif
 
 // This selects the signed equivalent of the unsigned type chosen for size_t.
-#if __STDC_VERSION__-0 >= 201112l
+#if __STDC_VERSION__-0 >= 201112l || defined(__swift__)
 typedef __typeof__(_Generic((__swift_size_t)0,                                 \
                             unsigned long long int : (long long int)0,         \
                             unsigned long int : (long int)0,                   \

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Ensure c++ features are used.
+namespace ns {
+class T {};
+} // namespace ns
+
+struct Basic {
+  int a;
+  ns::T *b;
+};
+
+Basic makeA();

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -36,6 +36,10 @@ module CoreCooling {
   export *
 }
 
+module CXXInterop {
+  header "cxx_interop.h"
+}
+
 module ctypes_bits_exported {
   header "ctypes_bits_exported.h"
   export *

--- a/test/ClangImporter/cxx_interop.swift
+++ b/test/ClangImporter/cxx_interop.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop
+
+import CXXInterop
+
+// Basic structs
+do {
+  var tmp: Basic = makeA()
+  tmp.a = 3
+  tmp.b = nil
+}


### PR DESCRIPTION
This is an attempt to get the basic c++ interop working in a flag protected fashion.

Here a forum post for more context: https://forums.swift.org/t/c-interop/25567.

Some context on the changes:
The existing swift header files assume that c means that it is the swift compiler and c++ means that it is just clang. This changes them to also use the __swift__ to properly support inclusion from swift in c++ mode. There will probably be other libraries which need support to compile in c++ mode, but this is enough to make the basic tests pass.
Also, support for extern "C" {} is needed to get anywhere with the current headers, so add that as well.