### PR TITLE
[CodeCompletion] Enable 'openArchetypes' when checking if convertible

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -46,7 +46,7 @@ namespace swift {
   /// Check if T1 is convertible to T2.
   ///
   /// \returns true on convertible, false on not.
-  bool isConvertibleTo(Type T1, Type T2, DeclContext &DC);
+  bool isConvertibleTo(Type T1, Type T2, bool openArchetypes, DeclContext &DC);
 
   bool isEqual(Type T1, Type T2, DeclContext &DC);
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -845,7 +845,12 @@ static CodeCompletionResult::ExpectedTypeRelation calculateTypeRelation(
   if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
     if (Ty->isEqual(ExpectedTy))
       return CodeCompletionResult::ExpectedTypeRelation::Identical;
-    if (!ExpectedTy->isAny() && isConvertibleTo(Ty, ExpectedTy, *DC))
+    bool isAny = false;
+    isAny |= ExpectedTy->isAny();
+    isAny |= ExpectedTy->is<ArchetypeType>() &&
+             !ExpectedTy->castTo<ArchetypeType>()->hasRequirements();
+
+    if (!isAny && isConvertibleTo(Ty, ExpectedTy, /*openArchetypes=*/true, *DC))
       return CodeCompletionResult::ExpectedTypeRelation::Convertible;
   }
   if (auto FT = Ty->getAs<AnyFunctionType>()) {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -353,14 +353,19 @@ static bool collectPossibleCalleesForApply(
   auto *fnExpr = callExpr->getFn();
 
   if (auto type = fnExpr->getType()) {
-    if (auto *funcType = type->getAs<AnyFunctionType>()) {
-      auto refDecl = fnExpr->getReferencedDecl();
-      if (!refDecl)
-        if (auto apply = dyn_cast<ApplyExpr>(fnExpr))
-          refDecl = apply->getFn()->getReferencedDecl();
-      candidates.emplace_back(funcType, refDecl.getDecl());
+    if (!type->hasUnresolvedType() && !type->hasError()) {
+      if (auto *funcType = type->getAs<AnyFunctionType>()) {
+        auto refDecl = fnExpr->getReferencedDecl();
+        if (!refDecl)
+          if (auto apply = dyn_cast<ApplyExpr>(fnExpr))
+            refDecl = apply->getFn()->getReferencedDecl();
+        candidates.emplace_back(funcType, refDecl.getDecl());
+        return true;
+      }
     }
-  } else if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
+  }
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
     if (auto *decl = DRE->getDecl()) {
       auto declType = decl->getInterfaceType();
       if (auto *funcType = declType->getAs<AnyFunctionType>())
@@ -918,7 +923,13 @@ bool swift::ide::isReferenceableByImplicitMemberExpr(
     // because we are emitting all `.init()`s.
     if (declTy->isEqual(T))
       return false;
-    return swift::isConvertibleTo(declTy, T, *DC);
+
+    // Only non-protocol nominal type can be instantiated.
+    auto nominal = declTy->getAnyNominal();
+    if (!nominal || isa<ProtocolDecl>(nominal))
+      return false;
+
+    return swift::isConvertibleTo(declTy, T, /*openArchetypes=*/true, *DC);
   }
 
   // Only static member can be referenced.
@@ -935,5 +946,6 @@ bool swift::ide::isReferenceableByImplicitMemberExpr(
     // FIXME: This emits just 'factory'. We should emit 'factory()' instead.
     declTy = FT->getResult();
   }
-  return declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC);
+  return declTy->isEqual(T) ||
+         swift::isConvertibleTo(declTy, T, /*openArchetypes=*/true, *DC);
 }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -327,7 +327,8 @@ struct SynthesizedExtensionAnalyzer::Implementation {
           // conformance instead of subtyping
           if (!canPossiblyConvertTo(First, Second, *DC))
             return true;
-          else if (!isConvertibleTo(First, Second, *DC))
+          else if (!isConvertibleTo(First, Second, /*openArchetypes=*/false,
+                                    *DC))
             MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           break;
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -153,7 +153,8 @@ void ContextInfoCallbacks::getImplicitMembers(
       // Static properties which is convertible to 'Self'.
       if (isa<VarDecl>(VD) && VD->isStatic()) {
         auto declTy = T->getTypeOfMember(CurModule, VD);
-        if (declTy->isEqual(T) || swift::isConvertibleTo(declTy, T, *DC))
+        if (declTy->isEqual(T) ||
+            swift::isConvertibleTo(declTy, T, /*openArchetypes=*/true, *DC))
           return true;
       }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3829,8 +3829,9 @@ bool swift::isEqual(Type T1, Type T2, DeclContext &DC) {
   return T1->isEqual(T2);
 }
 
-bool swift::isConvertibleTo(Type T1, Type T2, DeclContext &DC) {
-  return canSatisfy(T1, T2, false, ConstraintKind::Conversion, &DC);
+bool swift::isConvertibleTo(Type T1, Type T2, bool openArchetypes,
+                            DeclContext &DC) {
+  return canSatisfy(T1, T2, openArchetypes, ConstraintKind::Conversion, &DC);
 }
 
 void swift::eraseOpenedExistentials(ConstraintSystem &CS, Expr *&expr) {

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -464,9 +464,8 @@ struct TestBoundGeneric1 {
   func test2() {
     takeArray(#^BOUND_GENERIC_1_2^#)
   }
-// FIXME: These should be convertible to [T]. rdar://problem/24570603
-// BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal:      x[#[Int]#];
-// BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal:      y[#[Int]#];
+// BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: x[#[Int]#];
+// BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: y[#[Int]#];
 }
 
 func whereConvertible<T>(lhs: T, rhs: T) where T: Collection {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -107,6 +107,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_2 | %FileCheck %s -check-prefix=UNRESOLVED_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPEPARAM_IN_CONTEXTTYPE_1 | %FileCheck %s -check-prefix=TYPEPARAM_IN_CONTEXTTYPE_1
+
 enum SomeEnum1 {
   case South
   case North
@@ -691,4 +693,27 @@ func testDefaultArgument(arg: SomeEnum1 = .#^DEFAULT_ARG_1^#) {}
 class TestDefalutArg {
   func method(arg: SomeEnum1 = .#^DEFAULT_ARG_2^#) {}
   init(arg: SomeEnum1 = .#^DEFAULT_ARG_3^#) {}
+}
+
+
+struct ConcreteMyProtocol: MyProtocol {}
+struct OtherProtocol {}
+struct ConcreteOtherProtocol: OtherProtocol {}
+
+struct MyStruct<T> {}
+extension MyStruct where T: MyProtocol {
+  static var myProtocolOption: MyStruct<ConcreteMyProtocol> { fatalError() }
+}
+extension MyStruct where T: OtherProtocol {
+  static var otherProtocolOption: MyStruct<ConcreteOtherProtocol> { fatalError() }
+}
+
+func receiveMyStructOfMyProtocol<T: MyProtocol>(value: MyStruct<T>) {}
+func testTypeParamInContextType() {
+  receiveMyStructOfMyProtocol(value: .#^TYPEPARAM_IN_CONTEXTTYPE_1^#)
+// TYPEPARAM_IN_CONTEXTTYPE_1: Begin completions, 2 items
+// TYPEPARAM_IN_CONTEXTTYPE_1-NOT: otherProtocolOption
+// TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[Constructor]/CurrNominal:      init()[#MyStruct<MyProtocol>#];
+// TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: myProtocolOption[#MyStruct<ConcreteMyProtocol>#];
+// TYPEPARAM_IN_CONTEXTTYPE_1: End completions
 }


### PR DESCRIPTION
```swift
protocol Proto {}
struct ConcreteProto: Proto {}

struct MyStruct<T> {}
extension MyStruct where T: Proto {
  static var option: MyStruct<ConcreteProto> { get }
}

func foo<T: Proto>(arg: MyStruct<T>) {}
func test() {
  foo(arg: .#^HERE^#)
}
```
In this case, the type of `MyStruct.option` is `MyStruct<ConcreteProto>` whereas the context type is `MyStruct<T> where T: Proto`.
When checking the convertibility of them , we need to "open archetype types".

rdar://problem/24570603
rdar://problem/51723460
