### PR TITLE
Diagnose usages of 'Self' in stored property initializers

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -52,10 +52,18 @@ public:
     }
   }
 
-  CaptureInfo &getCaptureInfo() const {
+  const CaptureInfo &getCaptureInfo() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getCaptureInfo();
     return TheFunction.get<AbstractClosureExpr *>()->getCaptureInfo();
+  }
+
+  void setCaptureInfo(const CaptureInfo &captures) const {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      AFD->setCaptureInfo(captures);
+      return;
+    }
+    TheFunction.get<AbstractClosureExpr *>()->setCaptureInfo(captures);
   }
 
   void getLocalCaptures(SmallVectorImpl<CapturedValue> &Result) const {

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -126,9 +126,9 @@ public:
     : Captures(nullptr), DynamicSelf(nullptr), OpaqueValue(nullptr), Count(0),
       GenericParamCaptures(0), Computed(0) { }
 
-  bool hasBeenComputed() { return Computed; }
+  bool hasBeenComputed() const { return Computed; }
 
-  bool isTrivial() {
+  bool isTrivial() const {
     return Count == 0 && !GenericParamCaptures && !DynamicSelf && !OpaqueValue;
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1931,6 +1931,9 @@ class PatternBindingEntry {
   /// The initializer context used for this pattern binding entry.
   llvm::PointerIntPair<DeclContext *, 1, bool> InitContextAndIsText;
 
+  /// Values captured by this initializer.
+  CaptureInfo Captures;
+
   friend class PatternBindingInitializer;
 
 public:
@@ -2024,6 +2027,9 @@ public:
   /// \param omitAccessors Whether the computation should omit the accessors
   /// from the source range.
   SourceRange getSourceRange(bool omitAccessors = false) const;
+
+  const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
 };
 
 /// This decl contains a pattern and optional initializer for a set
@@ -2120,6 +2126,18 @@ public:
   }
   
   void setPattern(unsigned i, Pattern *Pat, DeclContext *InitContext);
+
+  DeclContext *getInitContext(unsigned i) const {
+    return getPatternList()[i].getInitContext();
+  }
+
+  const CaptureInfo &getCaptureInfo(unsigned i) const {
+    return getPatternList()[i].getCaptureInfo();
+  }
+
+  void setCaptureInfo(unsigned i, const CaptureInfo &captures) {
+    getMutablePatternList()[i].setCaptureInfo(captures);
+  }
 
   /// Given that this PBD is the parent pattern for the specified VarDecl,
   /// return the entry of the VarDecl in our PatternList.  For example, in:

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5846,8 +5846,8 @@ public:
   /// Retrieve the source range of the function declaration name + patterns.
   SourceRange getSignatureSourceRange() const;
 
-  CaptureInfo &getCaptureInfo() { return Captures; }
   const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
 
   /// Retrieve the Objective-C selector that names this method.
   ObjCSelector getObjCSelector(DeclName preferredName = DeclName(),

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2595,6 +2595,8 @@ ERROR(dynamic_self_invalid_subscript,none,
       "covariant 'Self' can only appear at the top level of subscript element type", ())
 ERROR(dynamic_self_invalid_method,none,
       "covariant 'Self' can only appear at the top level of method result type", ())
+ERROR(dynamic_self_stored_property_init,none,
+      "covariant 'Self' type cannot be referenced from a stored property initializer", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3427,8 +3427,8 @@ public:
     Bits.AbstractClosureExpr.Discriminator = Discriminator;
   }
 
-  CaptureInfo &getCaptureInfo() { return Captures; }
   const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
 
   /// Retrieve the parameters of this closure.
   ParameterList *getParameters() { return parameterList; }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1132,6 +1132,7 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   auto *var = pbdEntry.getAnchoringVarDecl();
   auto *init = pbdEntry.getInit();
   auto *initDC = pbdEntry.getInitContext();
+  auto &captureInfo = pbdEntry.getCaptureInfo();
   assert(!pbdEntry.isInitializerSubsumed());
 
   // If this is the backing storage for a property with an attached wrapper
@@ -1148,12 +1149,23 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
 
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
   emitOrDelayFunction(*this, constant,
-                      [this,constant,init,initDC](SILFunction *f) {
+                      [this,var,captureInfo,constant,init,initDC](SILFunction *f) {
     preEmitFunction(constant, init, f, init);
     PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
     f->createProfiler(init, constant, ForDefinition);
-    SILGenFunction(*this, *f, initDC)
-        .emitGeneratorFunction(constant, init, /*EmitProfilerIncrement=*/true);
+    SILGenFunction SGF(*this, *f, initDC);
+
+    // If this is a stored property initializer inside a type at global scope,
+    // it may close over a global variable. If we're emitting top-level code,
+    // then emit a "mark_function_escape" that lists the captured global
+    // variables so that definite initialization can reason about this
+    // escape point.
+    if (!var->getDeclContext()->isLocalContext() &&
+        TopLevelSGF && TopLevelSGF->B.hasValidInsertionPoint()) {
+      emitMarkFunctionEscapeForTopLevelCodeGlobals(var, captureInfo);
+    }
+
+    SGF.emitGeneratorFunction(constant, init, /*EmitProfilerIncrement=*/true);
     postEmitFunction(constant, f);
   });
 }

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -658,14 +658,16 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
     }
   }
 
-  AFR.getCaptureInfo() = finder.getCaptureInfo();
+  auto captures = finder.getCaptureInfo();
 
   // A generic function always captures outer generic parameters.
   auto *AFD = AFR.getAbstractFunctionDecl();
   if (AFD) {
     if (AFD->getGenericParams())
-      AFR.getCaptureInfo().setGenericParamCaptures(true);
+      captures.setGenericParamCaptures(true);
   }
+
+  AFR.setCaptureInfo(captures);
 
   // Extensions of generic ObjC functions can't use generic parameters from
   // their context.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -80,6 +80,10 @@ public:
     return GenericParamCaptureLoc;
   }
 
+  SourceLoc getDynamicSelfCaptureLoc() const {
+    return DynamicSelfCaptureLoc;
+  }
+
   /// Check if the type of an expression references any generic
   /// type parameters, or the dynamic Self type.
   ///
@@ -697,6 +701,11 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
                               /*NoEscape=*/false,
                               /*ObjC=*/false);
       init->walk(finder);
+
+      if (finder.getDynamicSelfCaptureLoc().isValid()) {
+        diagnose(finder.getDynamicSelfCaptureLoc(),
+                 diag::dynamic_self_stored_property_init);
+      }
 
       auto captures = finder.getCaptureInfo();
       PBD->setCaptureInfo(i, captures);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -627,35 +627,10 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
                           AFR.getAsDeclContext(),
                           AFR.isKnownNoEscape(),
                           AFR.isObjC());
-  if (AFR.getBody())
-    AFR.getBody()->walk(finder);
+  AFR.getBody()->walk(finder);
 
   if (AFR.hasType() && !AFR.isObjC()) {
     finder.checkType(AFR.getType(), AFR.getLoc());
-  }
-
-  // If this is an init(), explicitly walk the initializer values for members of
-  // the type.  They will be implicitly emitted by SILGen into the generated
-  // initializer.
-  if (auto CD =
-        dyn_cast_or_null<ConstructorDecl>(AFR.getAbstractFunctionDecl())) {
-    auto *typeDecl = dyn_cast<NominalTypeDecl>(CD->getDeclContext());
-    if (typeDecl && CD->isDesignatedInit()) {
-      for (auto member : typeDecl->getMembers()) {
-        // Ignore everything other than PBDs.
-        auto *PBD = dyn_cast<PatternBindingDecl>(member);
-        if (!PBD) continue;
-        // Walk the initializers for all properties declared in the type with
-        // an initializer.
-        for (auto &elt : PBD->getPatternList()) {
-          if (elt.isInitializerSubsumed())
-            continue;
-
-          if (auto *init = elt.getInit())
-            init->walk(finder);
-        }
-      }
-    }
   }
 
   auto captures = finder.getCaptureInfo();
@@ -699,4 +674,32 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   if (cFunctionPointers != LocalCFunctionPointers.end())
     for (auto *expr : cFunctionPointers->second)
       maybeDiagnoseCaptures(expr, AFR);
+}
+
+void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
+  for (auto member : typeDecl->getMembers()) {
+    // Ignore everything other than PBDs.
+    auto *PBD = dyn_cast<PatternBindingDecl>(member);
+    if (!PBD) continue;
+    // Walk the initializers for all properties declared in the type with
+    // an initializer.
+    for (unsigned i = 0, e = PBD->getNumPatternEntries(); i < e; ++i) {
+      if (PBD->isInitializerSubsumed(i))
+        continue;
+
+      auto *init = PBD->getInit(i);
+      if (init == nullptr)
+        continue;
+
+      FindCapturedVars finder(*this,
+                              init->getLoc(),
+                              PBD->getInitContext(i),
+                              /*NoEscape=*/false,
+                              /*ObjC=*/false);
+      init->walk(finder);
+
+      auto captures = finder.getCaptureInfo();
+      PBD->setCaptureInfo(i, captures);
+    }
+  }
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2829,6 +2829,8 @@ public:
     for (Decl *Member : SD->getMembers())
       visit(Member);
 
+    TC.checkPatternBindingCaptures(SD);
+
     TC.checkDeclAttributes(SD);
 
     checkInheritanceClause(SD);
@@ -2954,6 +2956,8 @@ public:
     for (Decl *Member : CD->getMembers()) {
       visit(Member);
     }
+
+    TC.checkPatternBindingCaptures(CD);
 
     // If this class requires all of its stored properties to have
     // in-class initializers, diagnose this now.
@@ -5644,10 +5648,6 @@ void TypeChecker::defineDefaultConstructor(NominalTypeDecl *decl) {
   stmts.push_back(new (Context) ReturnStmt(decl->getLoc(), nullptr));
   ctor->setBody(BraceStmt::create(Context, SourceLoc(), stmts, SourceLoc()));
   ctor->setBodyTypeCheckedIfPresent();
-
-  // FIXME: This is still needed so that DI can check captures for
-  // initializer expressions. Rethink that completely.
-  Context.addSynthesizedDecl(ctor);
 }
 
 static void validateAttributes(TypeChecker &TC, Decl *D) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1441,6 +1441,9 @@ public:
   /// Compute the set of captures for the given function or closure.
   void computeCaptures(AnyFunctionRef AFR);
 
+  /// Check for invalid captures from stored property initializers.
+  void checkPatternBindingCaptures(NominalTypeDecl *typeDecl);
+
   /// Change the context of closures in the given initializer
   /// expression to the given context.
   ///

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -60,9 +60,8 @@ var w: String  // expected-note {{variable defined here}}
                // expected-note@-1 {{variable defined here}}
                // expected-note@-2 {{variable defined here}}
 
-// FIXME: the error should blame the class definition: <rdar://41490541>.
-class TestClass1 { // expected-error {{variable 'w' used by function definition before being initialized}}
-  let fld = w
+class TestClass1 {
+  let fld = w // expected-error {{variable 'w' used by function definition before being initialized}}
 }
 
 class TestClass2 {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -144,6 +144,7 @@ class C {
 
   static func staticFunc() -> Self {}
   let stored: Self = Self.staticFunc() // expected-error {{stored property cannot have covariant 'Self' type}}
+  // expected-error@-1 {{covariant 'Self' type cannot be referenced from a stored property initializer}}
 
   var prop: Self { // expected-error {{mutable property cannot have covariant 'Self' type}}
     get {
@@ -246,4 +247,10 @@ enum E {
     Self.f()
     return .e
   }
+}
+
+class SelfStoredPropertyInit {
+  static func myValue() -> Int { return 123 }
+
+  var value = Self.myValue() // expected-error {{covariant 'Self' type cannot be referenced from a stored property initializer}}
 }


### PR DESCRIPTION
Instead of walking stored property initializer expressions as part of computing the captures for a designated initializer, walk and store them separately. This makes more sense since SILGen emits them as separate functions.

Also, diagnose DynamicSelfType references inside stored property initializers, which are currently not supported.

Fixes <rdar://problem/41490541>, <rdar://problem/51561208>, <https://bugs.swift.org/browse/SR-10969>.