### PR TITLE
[5.1][Diagnostics] Add property wrapper diagnostic for unnecessary $/'_' i…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5148,6 +5148,10 @@ public:
   /// bound generic version.
   VarDecl *getPropertyWrapperBackingProperty() const;
 
+  /// Retreive the storage wrapper for a property that has an attached
+  /// property wrapper.
+  VarDecl *getPropertyWrapperStorageWrapper() const;
+
   /// Whether this is a property with a property wrapper that was initialized
   /// via a value of the original type, e.g.,
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -981,10 +981,6 @@ ERROR(missing_address_of,none,
 ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
-ERROR(extraneous_property_wrapper_unwrap,none,
-      "property %0 will be unwrapped to value of type %1, use '_' to refer to "
-      "wrapper type %2",
-      (DeclName, Type, Type))
 ERROR(extraneous_address_of,none,
       "use of extraneous '&'",
       ())
@@ -998,6 +994,14 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
       "cannot pass an inout argument to a subscript; use "
       "'withUnsafeMutablePointer' to explicitly convert argument "
       "to a pointer", ())
+
+ERROR(incorrect_property_wrapper_reference,none,
+      "cannot convert value %0 of type %1 to expected type %2, "
+      "use %select{wrapper| wrapped value}3 instead",
+      (Identifier, Type, Type, bool))
+ERROR(incorrect_property_wrapper_reference_member,none,
+      "referencing %0 %1 requires %select{wrapper|wrapped value of type}2 %3",
+      (DescriptiveDeclKind, DeclName, bool, Type))
 
 ERROR(missing_init_on_metatype_initialization,none,
       "initializing from a metatype value must reference 'init' explicitly",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5454,6 +5454,10 @@ VarDecl *VarDecl::getPropertyWrapperBackingProperty() const {
   return getPropertyWrapperBackingPropertyInfo().backingVar;
 }
 
+VarDecl *VarDecl::getPropertyWrapperStorageWrapper() const {
+  return getPropertyWrapperBackingPropertyInfo().storageWrapperVar;
+}
+
 static bool propertyWrapperInitializedViaInitialValue(
    const VarDecl *var, bool checkDefaultInit) {
   auto customAttrs = var->getAttachedPropertyWrappers();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1721,11 +1721,39 @@ bool MissingCallFailure::diagnoseAsError() {
   return true;
 }
 
+bool ExtraneousPropertyWrapperUnwrapFailure::diagnoseAsError() {
+  auto loc = getAnchor()->getLoc();
+  auto newPrefix = usingStorageWrapper() ? "$" : "_";
+
+  if (auto *member = getReferencedMember()) {
+    emitDiagnostic(loc, diag::incorrect_property_wrapper_reference_member,
+                   member->getDescriptiveKind(), member->getFullName(), false,
+                   getToType())
+        .fixItInsert(loc, newPrefix);
+    return true;
+  }
+
+  emitDiagnostic(loc, diag::incorrect_property_wrapper_reference,
+                 getPropertyName(), getFromType(), getToType(), false)
+      .fixItInsert(loc, newPrefix);
+  return true;
+}
+
 bool MissingPropertyWrapperUnwrapFailure::diagnoseAsError() {
-  emitDiagnostic(getAnchor()->getLoc(),
-                 diag::extraneous_property_wrapper_unwrap, getPropertyName(),
-                 getFromType(), getToType())
-      .fixItInsert(getAnchor()->getLoc(), "_");
+  auto loc = getAnchor()->getLoc();
+  auto endLoc = getAnchor()->getLoc().getAdvancedLoc(1);
+
+  if (auto *member = getReferencedMember()) {
+    emitDiagnostic(loc, diag::incorrect_property_wrapper_reference_member,
+                   member->getDescriptiveKind(), member->getFullName(), true,
+                   getToType())
+        .fixItRemoveChars(loc, endLoc);
+    return true;
+  }
+
+  emitDiagnostic(loc, diag::incorrect_property_wrapper_reference,
+                 getPropertyName(), getFromType(), getToType(), true)
+      .fixItRemoveChars(loc, endLoc);
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -119,7 +119,7 @@ protected:
     return None;
   }
 
-  ValueDecl *getResolvedMemberRef(UnresolvedDotExpr *member) {
+  ValueDecl *getResolvedMemberRef(UnresolvedDotExpr *member) const {
     auto locator = CS.getConstraintLocator(member, ConstraintLocator::Member);
     return CS.findResolvedMemberRef(locator);
   }
@@ -759,20 +759,57 @@ public:
   bool diagnoseAsError() override;
 };
 
-class MissingPropertyWrapperUnwrapFailure final : public ContextualFailure {
-  DeclName PropertyName;
+class PropertyWrapperReferenceFailure : public ContextualFailure {
+  VarDecl *Property;
+  bool UsingStorageWrapper;
 
 public:
-  MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
-                                      DeclName propertyName, Type base,
-                                      Type wrapper, ConstraintLocator *locator)
-      : ContextualFailure(root, cs, base, wrapper, locator),
-        PropertyName(propertyName) {}
+  PropertyWrapperReferenceFailure(Expr *root, ConstraintSystem &cs,
+                                  VarDecl *property, bool usingStorageWrapper,
+                                  Type base, Type wrapper,
+                                  ConstraintLocator *locator)
+      : ContextualFailure(root, cs, base, wrapper, locator), Property(property),
+        UsingStorageWrapper(usingStorageWrapper) {}
+
+  VarDecl *getProperty() const { return Property; }
+
+  Identifier getPropertyName() const { return Property->getName(); }
+
+  bool usingStorageWrapper() const { return UsingStorageWrapper; }
+
+  ValueDecl *getReferencedMember() const {
+    auto *locator = getLocator();
+    if (auto overload = getOverloadChoiceIfAvailable(locator))
+      return overload->choice.getDeclOrNull();
+    return nullptr;
+  }
+};
+
+class ExtraneousPropertyWrapperUnwrapFailure final
+    : public PropertyWrapperReferenceFailure {
+public:
+  ExtraneousPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                         VarDecl *property,
+                                         bool usingStorageWrapper, Type base,
+                                         Type wrapper,
+                                         ConstraintLocator *locator)
+      : PropertyWrapperReferenceFailure(root, cs, property, usingStorageWrapper,
+                                        base, wrapper, locator) {}
 
   bool diagnoseAsError() override;
+};
 
-private:
-  DeclName getPropertyName() const { return PropertyName; }
+class MissingPropertyWrapperUnwrapFailure final
+    : public PropertyWrapperReferenceFailure {
+public:
+  MissingPropertyWrapperUnwrapFailure(Expr *root, ConstraintSystem &cs,
+                                      VarDecl *property,
+                                      bool usingStorageWrapper, Type base,
+                                      Type wrapper, ConstraintLocator *locator)
+      : PropertyWrapperReferenceFailure(root, cs, property, usingStorageWrapper,
+                                        base, wrapper, locator) {}
+
+  bool diagnoseAsError() override;
 };
 
 class SubscriptMisuseFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -260,19 +260,36 @@ InsertExplicitCall *InsertExplicitCall::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) InsertExplicitCall(cs, locator);
 }
 
-bool InsertPropertyWrapperUnwrap::diagnose(Expr *root, bool asNote) const {
+bool UsePropertyWrapper::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
+  auto failure = ExtraneousPropertyWrapperUnwrapFailure(
+      root, cs, Wrapped, UsingStorageWrapper, Base, Wrapper, getLocator());
+  return failure.diagnose(asNote);
+}
+
+UsePropertyWrapper *UsePropertyWrapper::create(ConstraintSystem &cs,
+                                               VarDecl *wrapped,
+                                               bool usingStorageWrapper,
+                                               Type base, Type wrapper,
+                                               ConstraintLocator *locator) {
+  return new (cs.getAllocator()) UsePropertyWrapper(
+      cs, wrapped, usingStorageWrapper, base, wrapper, locator);
+}
+
+bool UseWrappedValue::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
   auto failure = MissingPropertyWrapperUnwrapFailure(
-      root, getConstraintSystem(), getPropertyName(), getBase(), getWrapper(),
+      root, cs, PropertyWrapper, usingStorageWrapper(), Base, Wrapper,
       getLocator());
   return failure.diagnose(asNote);
 }
 
-InsertPropertyWrapperUnwrap *
-InsertPropertyWrapperUnwrap::create(ConstraintSystem &cs, DeclName propertyName,
-                                    Type base, Type wrapper,
-                                    ConstraintLocator *locator) {
+UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
+                                         VarDecl *propertyWrapper, Type base,
+                                         Type wrapper,
+                                         ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      InsertPropertyWrapperUnwrap(cs, propertyName, base, wrapper, locator);
+      UseWrappedValue(cs, propertyWrapper, base, wrapper, locator);
 }
 
 bool UseSubscriptOperator::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4741,31 +4741,61 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       return SolutionKind::Solved;
     }
 
-    auto solveWithNewBaseOrName = [&](Type baseType,
-                                      DeclName memberName) -> SolutionKind {
+    auto solveWithNewBaseOrName = [&](Type baseType, DeclName memberName,
+                                      bool allowFixes = true) -> SolutionKind {
       // Let's re-enable fixes for this member, because
       // the base or member name has been changed.
-      MissingMembers.remove(locator);
+      if (allowFixes)
+        MissingMembers.remove(locator);
       return simplifyMemberConstraint(kind, baseType, memberName, memberTy,
                                       useDC, functionRefKind, outerAlternatives,
                                       flags, locatorB);
     };
 
     // Check if any property wrappers on the base of the member lookup have
-    // mactching members that we can fall back to.
+    // matching members that we can fall back to, or if the type wraps any
+    // properties that have matching members.
     if (auto dotExpr =
             dyn_cast_or_null<UnresolvedDotExpr>(locator->getAnchor())) {
       auto baseExpr = dotExpr->getBase();
-      auto resolvedOverload = findSelectedOverloadFor(baseExpr);
-      if (auto wrappedProperty =
-              getPropertyWrapperInformation(resolvedOverload)) {
-        auto wrapperTy = wrappedProperty->second;
-        auto result = solveWithNewBaseOrName(wrapperTy, member);
-        if (result == SolutionKind::Solved) {
-          auto *fix = InsertPropertyWrapperUnwrap::create(
-              *this, wrappedProperty->first->getFullName(), baseTy, wrapperTy,
-              locator);
-          return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+
+      if (auto resolvedOverload = findSelectedOverloadFor(baseExpr)) {
+        if (auto storageWrapper =
+                getStorageWrapperInformation(resolvedOverload)) {
+          auto wrapperTy = storageWrapper->second;
+          auto result =
+              solveWithNewBaseOrName(wrapperTy, member, /*allowFixes=*/false);
+          if (result == SolutionKind::Solved) {
+            auto *fix = UsePropertyWrapper::create(*this, storageWrapper->first,
+                                                   /*usingStorageWrapper=*/true,
+                                                   baseTy, wrapperTy, locator);
+            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          }
+        }
+
+        if (auto wrapper = getPropertyWrapperInformation(resolvedOverload)) {
+          auto wrapperTy = wrapper->second;
+          auto result =
+              solveWithNewBaseOrName(wrapperTy, member, /*allowFixes=*/false);
+          if (result == SolutionKind::Solved) {
+            auto *fix = UsePropertyWrapper::create(
+                *this, wrapper->first,
+                /*usingStorageWrappeer=*/false, baseTy, wrapperTy, locator);
+            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          }
+        }
+
+        if (auto wrappedProperty =
+                getWrappedPropertyInformation(resolvedOverload)) {
+          auto wrappedTy = wrappedProperty->second;
+          auto result =
+              solveWithNewBaseOrName(wrappedTy, member, /*allowFixes=*/false);
+
+          if (result == SolutionKind::Solved) {
+            auto *fix = UseWrappedValue::create(*this, wrappedProperty->first,
+                                                baseTy, wrappedTy, locator);
+            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          }
         }
       }
     }
@@ -6716,7 +6746,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::TreatKeyPathSubscriptIndexAsHashable:
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::ExplicitlySpecifyGenericArguments:
-  case FixKind::InsertPropertyWrapperUnwrap:
+  case FixKind::UsePropertyWrapper:
+  case FixKind::UseWrappedValue:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2207,18 +2207,49 @@ public:
     return typeVar->getImpl().getRepresentative(getSavedBindings());
   }
 
-  /// Gets the a VarDecl, and the type of its attached property wrapper if the
-  /// resolved overload has an attached property wrapper.
-  ///
-  /// \return A pair of the VarDecl and the attached property wrapper type if
-  ///         the given resolved overload has an attached property wrapper.
+  /// Gets the VarDecl associateed with resolvedOverload, and the type of the
+  /// storage wrapper if the decl has an associated storage wrapper.
+  Optional<std::pair<VarDecl *, Type>>
+  getStorageWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    assert(resolvedOverload);
+    if (resolvedOverload->Choice.isDecl()) {
+      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
+        if (decl->hasAttachedPropertyWrapper()) {
+          if (auto storageWrapper = decl->getPropertyWrapperStorageWrapper()) {
+            return std::make_pair(decl, storageWrapper->getType());
+          }
+        }
+      }
+    }
+    return None;
+  }
+
+  /// Gets the VarDecl associateed with resolvedOverload, and the type of the
+  /// backing storage if the decl has an associated property wrapper.
   Optional<std::pair<VarDecl *, Type>>
   getPropertyWrapperInformation(ResolvedOverloadSetListItem *resolvedOverload) {
-    if (resolvedOverload && resolvedOverload->Choice.isDecl()) {
+    assert(resolvedOverload);
+    if (resolvedOverload->Choice.isDecl()) {
       if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
         if (decl->hasAttachedPropertyWrapper()) {
           auto wrapperTy = decl->getPropertyWrapperBackingPropertyType();
           return std::make_pair(decl, wrapperTy);
+        }
+      }
+    }
+    return None;
+  }
+
+  /// Gets the VarDecl, and the type of the type property that it wraps if
+  /// resolved overload has a decl which is the backing storage for a
+  /// property wrapper.
+  Optional<std::pair<VarDecl *, Type>>
+  getWrappedPropertyInformation(ResolvedOverloadSetListItem *resolvedOverload) {
+    assert(resolvedOverload);
+    if (resolvedOverload->Choice.isDecl()) {
+      if (auto *decl = dyn_cast<VarDecl>(resolvedOverload->Choice.getDecl())) {
+        if (auto wrapped = decl->getOriginalWrappedProperty()) {
+          return std::make_pair(decl, wrapped->getType());
         }
       }
     }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -935,7 +935,10 @@ struct TestComposition {
 struct Foo<T> {
   var wrappedValue: T
 
+  var prop: Int = 42
+
   func foo() {}
+  func bar(x: Int) {}
 }
 
 @propertyWrapper
@@ -943,22 +946,55 @@ struct Bar<T, V> {
   var wrappedValue: T
 
   func bar() {}
+
+  // TODO(diagnostics): We need to figure out what to do about subscripts.
+  // The problem standing in our way - keypath application choice
+  // is always added to results even if it's not applicable.
+}
+
+@propertyWrapper
+struct Baz<T> {
+  var wrappedValue: T
+  
+  func onPropertyWrapper() {}
+
+  var projectedValue: V {
+    return V()
+  }
 }
 
 extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
   func barWhereVIsString() {}
 }
 
+struct V {
+  func onWrapperValue() {}
+}
+
+struct W {
+  func onWrapped() {}
+}
+
 struct MissingPropertyWrapperUnwrap {
+  @Foo var w: W
   @Foo var x: Int
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
+  @Baz var usesWrapperValue: W
 
   func baz() {
-    self.x.foo() // expected-error {{property 'x' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Foo<Int>'}}{{10-10=_}}
-    self.y.bar() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
-    self.y.barWhereVIsString() // expected-error {{property 'y' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, Bool>'}}{{10-10=_}}
+    self.x.foo() // expected-error {{referencing instance method 'foo()' requires wrapper 'Foo<Int>'}}{{10-10=_}}
+    self.x.prop  // expected-error {{referencing property 'prop' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+    self.x.bar(x: 42) // expected-error {{referencing instance method 'bar(x:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+    self.y.bar() // expected-error {{referencing instance method 'bar()' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
+    self.y.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
-    self.z.barWhereVIsString() // expected-error {{property 'z' will be unwrapped to value of type 'Int', use '_' to refer to wrapper type 'Bar<Int, String>'}}{{10-10=_}} 
+    self.z.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, String>'}}{{10-10=_}}
+    self.usesWrapperValue.onPropertyWrapper() // expected-error {{referencing instance method 'onPropertyWrapper()' requires wrapper 'Baz<W>'}}{{10-10=_}}
+
+    self._w.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self.usesWrapperValue.onWrapperValue() // expected-error {{referencing instance method 'onWrapperValue()' requires wrapper 'V'}}{{10-10=$}}
+    self.$usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self._usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
   }
 }


### PR DESCRIPTION
…n member access

Detect and diagnose incorrect use of `$` or `_` while referencing members.

Also:

 - Refactor some of the logic for the original missing `$` diagnostic,
   so that a lot of logic can be shared between the two.

 - Rename the original fix and diagnostic to better reflect their purpose.

Resolves: [SR-10928](https://bugs.swift.org/browse/SR-10928)
Resolves: rdar://problem/51580712

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
