### PR TITLE
Diagnose usages of 'Self' in stored property initializers [5.1]

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -52,10 +52,18 @@ public:
     }
   }
 
-  CaptureInfo &getCaptureInfo() const {
+  const CaptureInfo &getCaptureInfo() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getCaptureInfo();
     return TheFunction.get<AbstractClosureExpr *>()->getCaptureInfo();
+  }
+
+  void setCaptureInfo(const CaptureInfo &captures) const {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      AFD->setCaptureInfo(captures);
+      return;
+    }
+    TheFunction.get<AbstractClosureExpr *>()->setCaptureInfo(captures);
   }
 
   void getLocalCaptures(SmallVectorImpl<CapturedValue> &Result) const {

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -156,9 +156,9 @@ public:
     : Captures(nullptr), DynamicSelf(nullptr), OpaqueValue(nullptr), Count(0),
       GenericParamCaptures(0), Computed(0) { }
 
-  bool hasBeenComputed() { return Computed; }
+  bool hasBeenComputed() const { return Computed; }
 
-  bool isTrivial() {
+  bool isTrivial() const {
     return Count == 0 && !GenericParamCaptures && !DynamicSelf && !OpaqueValue;
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1940,6 +1940,9 @@ class PatternBindingEntry {
   /// The initializer context used for this pattern binding entry.
   llvm::PointerIntPair<DeclContext *, 1, bool> InitContextAndIsText;
 
+  /// Values captured by this initializer.
+  CaptureInfo Captures;
+
   friend class PatternBindingInitializer;
 
 public:
@@ -2033,6 +2036,9 @@ public:
   /// \param omitAccessors Whether the computation should omit the accessors
   /// from the source range.
   SourceRange getSourceRange(bool omitAccessors = false) const;
+
+  const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
 };
 
 /// This decl contains a pattern and optional initializer for a set
@@ -2129,6 +2135,18 @@ public:
   }
   
   void setPattern(unsigned i, Pattern *Pat, DeclContext *InitContext);
+
+  DeclContext *getInitContext(unsigned i) const {
+    return getPatternList()[i].getInitContext();
+  }
+
+  const CaptureInfo &getCaptureInfo(unsigned i) const {
+    return getPatternList()[i].getCaptureInfo();
+  }
+
+  void setCaptureInfo(unsigned i, const CaptureInfo &captures) {
+    getMutablePatternList()[i].setCaptureInfo(captures);
+  }
 
   /// Given that this PBD is the parent pattern for the specified VarDecl,
   /// return the entry of the VarDecl in our PatternList.  For example, in:

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5800,8 +5800,8 @@ public:
   /// Retrieve the source range of the function declaration name + patterns.
   SourceRange getSignatureSourceRange() const;
 
-  CaptureInfo &getCaptureInfo() { return Captures; }
   const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
 
   /// Retrieve the Objective-C selector that names this method.
   ObjCSelector getObjCSelector(DeclName preferredName = DeclName(),

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2557,6 +2557,9 @@ ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean '%0'?", (StringRef))
 
+ERROR(dynamic_self_stored_property_init,none,
+      "covariant 'Self' type cannot be referenced from a stored property initializer", ())
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Attributes
 //------------------------------------------------------------------------------

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3558,8 +3558,8 @@ public:
     Bits.AbstractClosureExpr.Discriminator = Discriminator;
   }
 
-  CaptureInfo &getCaptureInfo() { return Captures; }
   const CaptureInfo &getCaptureInfo() const { return Captures; }
+  void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
 
   /// Retrieve the parameters of this closure.
   ParameterList *getParameters() { return parameterList; }

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -747,14 +747,16 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
     }
   }
 
-  AFR.getCaptureInfo() = finder.getCaptureInfo();
+  auto captures = finder.getCaptureInfo();
 
   // A generic function always captures outer generic parameters.
   auto *AFD = AFR.getAbstractFunctionDecl();
   if (AFD) {
     if (AFD->getGenericParams())
-      AFR.getCaptureInfo().setGenericParamCaptures(true);
+      captures.setGenericParamCaptures(true);
   }
+
+  AFR.setCaptureInfo(captures);
 
   // Extensions of generic ObjC functions can't use generic parameters from
   // their context.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -104,6 +104,10 @@ public:
     return GenericParamCaptureLoc;
   }
 
+  SourceLoc getDynamicSelfCaptureLoc() const {
+    return DynamicSelfCaptureLoc;
+  }
+
   /// Check if the type of an expression references any generic
   /// type parameters, or the dynamic Self type.
   ///
@@ -786,6 +790,11 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
                               /*NoEscape=*/false,
                               /*ObjC=*/false);
       init->walk(finder);
+
+      if (finder.getDynamicSelfCaptureLoc().isValid()) {
+        diagnose(finder.getDynamicSelfCaptureLoc(),
+                 diag::dynamic_self_stored_property_init);
+      }
 
       auto captures = finder.getCaptureInfo();
       PBD->setCaptureInfo(i, captures);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -56,31 +56,52 @@ namespace {
 
 class FindCapturedVars : public ASTWalker {
   TypeChecker &TC;
-  SmallVectorImpl<CapturedValue> &Captures;
+  SmallVector<CapturedValue, 4> Captures;
   llvm::SmallDenseMap<ValueDecl*, unsigned, 4> captureEntryNumber;
+  SourceLoc GenericParamCaptureLoc;
+  SourceLoc DynamicSelfCaptureLoc;
+  DynamicSelfType *DynamicSelf = nullptr;
+  OpaqueValueExpr *OpaqueValue = nullptr;
   SourceLoc CaptureLoc;
-  SourceLoc &GenericParamCaptureLoc;
-  SourceLoc &DynamicSelfCaptureLoc;
-  DynamicSelfType *&DynamicSelf;
-  OpaqueValueExpr *&OpaqueValue;
+  DeclContext *CurDC;
+  bool NoEscape, ObjC;
   llvm::SmallPtrSet<ValueDecl *, 2> Diagnosed;
-  /// The AbstractClosureExpr or AbstractFunctionDecl being analyzed.
-  AnyFunctionRef AFR;
+
 public:
   FindCapturedVars(TypeChecker &tc,
-                   SmallVectorImpl<CapturedValue> &Captures,
-                   SourceLoc &GenericParamCaptureLoc,
-                   SourceLoc &DynamicSelfCaptureLoc,
-                   DynamicSelfType *&DynamicSelf,
-                   OpaqueValueExpr *&OpaqueValue,
-                   AnyFunctionRef AFR)
-      : TC(tc), Captures(Captures),
-        GenericParamCaptureLoc(GenericParamCaptureLoc),
-        DynamicSelfCaptureLoc(DynamicSelfCaptureLoc),
-        DynamicSelf(DynamicSelf),
-        OpaqueValue(OpaqueValue),
-        AFR(AFR) {
-    CaptureLoc = getCaptureLoc(AFR);
+                   SourceLoc CaptureLoc,
+                   DeclContext *CurDC,
+                   bool NoEscape,
+                   bool ObjC)
+      : TC(tc), CaptureLoc(CaptureLoc), CurDC(CurDC),
+        NoEscape(NoEscape), ObjC(ObjC) {}
+
+  CaptureInfo getCaptureInfo() const {
+    CaptureInfo result;
+
+    // Anything can capture an opaque value placeholder.
+    if (OpaqueValue)
+      result.setOpaqueValue(OpaqueValue);
+
+    // Only local functions capture dynamic 'Self'.
+    if (CurDC->getParent()->isLocalContext()) {
+      if (GenericParamCaptureLoc.isValid())
+        result.setGenericParamCaptures(true);
+
+      if (DynamicSelfCaptureLoc.isValid())
+        result.setDynamicSelfType(DynamicSelf);
+    }
+
+    if (Captures.empty())
+      result.setCaptures(None);
+    else
+      result.setCaptures(TC.Context.AllocateCopy(Captures));
+
+    return result;
+  }
+
+  SourceLoc getGenericParamCaptureLoc() const {
+    return GenericParamCaptureLoc;
   }
 
   /// Check if the type of an expression references any generic
@@ -91,7 +112,6 @@ public:
   /// list, it also implicitly captures outer parameters, even if they're
   /// not used anywhere inside the body.
   void checkType(Type type, SourceLoc loc) {
-
     if (!type)
       return;
 
@@ -99,18 +119,18 @@ public:
     type = type->getCanonicalType();
     
     class TypeCaptureWalker : public TypeWalker {
-      AnyFunctionRef AFR;
+      bool ObjC;
       std::function<void(Type)> Callback;
     public:
-      explicit TypeCaptureWalker(AnyFunctionRef AFR,
+      explicit TypeCaptureWalker(bool ObjC,
                                  std::function<void(Type)> callback)
-        : AFR(AFR), Callback(std::move(callback)) {}
+        : ObjC(ObjC), Callback(std::move(callback)) {}
     
       Action walkToTypePre(Type ty) override {
         Callback(ty);
         // Pseudogeneric classes don't use their generic parameters so we
         // don't need to visit them.
-        if (AFR.isObjC()) {
+        if (ObjC) {
           if (auto clas = dyn_cast_or_null<ClassDecl>(ty->getAnyNominal())) {
             if (clas->usesObjCGenericsModel()) {
               return Action::SkipChildren;
@@ -132,7 +152,7 @@ public:
     // retainable pointer. Similarly stored property access does not
     // need it, etc.
     if (type->hasDynamicSelfType()) {
-      type.walk(TypeCaptureWalker(AFR, [&](Type t) {
+      type.walk(TypeCaptureWalker(ObjC, [&](Type t) {
         if (auto *dynamicSelf = t->getAs<DynamicSelfType>()) {
           if (DynamicSelfCaptureLoc.isInvalid()) {
             DynamicSelfCaptureLoc = loc;
@@ -150,7 +170,7 @@ public:
     // instead, but even there we don't really have enough information to
     // perform it accurately.
     if (type->hasArchetype() || type->hasTypeParameter()) {
-      type.walk(TypeCaptureWalker(AFR, [&](Type t) {
+      type.walk(TypeCaptureWalker(ObjC, [&](Type t) {
         if ((t->is<ArchetypeType>() ||
              t->is<GenericTypeParamType>()) &&
             !t->isOpenedExistential() &&
@@ -161,7 +181,7 @@ public:
     }
 
     if (auto *gft = type->getAs<GenericFunctionType>()) {
-      TypeCaptureWalker walker(AFR, [&](Type t) {
+      TypeCaptureWalker walker(ObjC, [&](Type t) {
         if (t->is<GenericTypeParamType>() &&
             GenericParamCaptureLoc.isInvalid()) {
           GenericParamCaptureLoc = loc;
@@ -198,7 +218,7 @@ public:
     // Visit the type of the capture, if it isn't a class reference, since
     // we'd need the metadata to do so.
     if (VD->hasInterfaceType()
-        && (!AFR.isObjC()
+        && (!ObjC
             || !isa<VarDecl>(VD)
             || !cast<VarDecl>(VD)->getType()->hasRetainablePointerRepresentation()))
       checkType(VD->getInterfaceType(), VD->getLoc());
@@ -226,7 +246,7 @@ public:
     // local declaration in which case we will pick up generic
     // parameter references transitively.
     if (!D->getDeclContext()->isLocalContext()) {
-      if (!AFR.isObjC() || !D->isObjC() || isa<ConstructorDecl>(D)) {
+      if (!ObjC || !D->isObjC() || isa<ConstructorDecl>(D)) {
         if (auto subMap = DRE->getDeclRef().getSubstitutions()) {
           auto genericSig = subMap.getGenericSignature();
           for (auto gp : genericSig->getGenericParams()) {
@@ -241,7 +261,6 @@ public:
     // DC is the DeclContext where D was defined
     // CurDC is the DeclContext where D was referenced
     auto DC = D->getDeclContext();
-    auto CurDC = AFR.getAsDeclContext();
 
     // A local reference is not a capture.
     if (CurDC == DC)
@@ -328,7 +347,8 @@ public:
       if (auto func = dyn_cast<FuncDecl>(capturedDecl)) {
         if (!func->getCaptureInfo().hasBeenComputed()) {
           // Check later.
-          TC.ForwardCapturedFuncs[func].push_back(AFR);
+          // FIXME: Nothing actually looks at ForwardCapturedFuncs.
+          // TC.ForwardCapturedFuncs[func].push_back(AFR);
           return true;
         }
         // Recursively check the transitive captures.
@@ -374,19 +394,18 @@ public:
     // If this is a direct reference to underlying storage, then this is a
     // capture of the storage address - not a capture of the getter/setter.
     if (auto var = dyn_cast<VarDecl>(D)) {
-      auto *DC = AFR.getAsDeclContext();
       if (var->getAccessStrategy(DRE->getAccessSemantics(),
                                  var->supportsMutation()
                                    ? AccessKind::ReadWrite
                                    : AccessKind::Read,
-                                 DC->getParentModule(),
-                                 DC->getResilienceExpansion())
+                                 CurDC->getParentModule(),
+                                 CurDC->getResilienceExpansion())
           .getKind() == AccessStrategy::Storage)
         Flags |= CapturedValue::IsDirect;
     }
 
     // If the closure is noescape, then we can capture the decl as noescape.
-    if (AFR.isKnownNoEscape())
+    if (NoEscape)
       Flags |= CapturedValue::IsNoEscape;
 
     addCapture(CapturedValue(D, Flags), DRE->getStartLoc());
@@ -395,9 +414,6 @@ public:
 
   void propagateCaptures(AnyFunctionRef innerClosure, SourceLoc captureLoc) {
     TC.computeCaptures(innerClosure);
-
-    auto CurDC = AFR.getAsDeclContext();
-    bool isNoEscapeClosure = AFR.isKnownNoEscape();
 
     auto &captureInfo = innerClosure.getCaptureInfo();
 
@@ -415,7 +431,7 @@ public:
 
       // If this is an escaping closure, then any captured decls are also
       // escaping, even if they are coming from an inner noescape closure.
-      if (!isNoEscapeClosure)
+      if (!NoEscape)
         Flags &= ~CapturedValue::IsNoEscape;
 
       addCapture(CapturedValue(capture.getDecl(), Flags), captureLoc);
@@ -455,7 +471,7 @@ public:
 
   bool usesTypeMetadataOfFormalType(Expr *E) {
     // For non-ObjC closures, assume the type metadata is always used.
-    if (!AFR.isObjC())
+    if (!ObjC)
       return true;
 
     if (!E->getType() || E->getType()->hasError())
@@ -517,7 +533,7 @@ public:
     if (auto tuple = dyn_cast<TupleExpr>(E)) {
       for (auto elt : tuple->getType()->castTo<TupleType>()->getElements()) {
         if (!elt.getType()->isRepresentableIn(ForeignLanguage::ObjectiveC,
-                                              AFR.getAsDeclContext()))
+                                              CurDC))
           return true;
       }
       return false;
@@ -631,7 +647,6 @@ public:
 
     // When we see a reference to the 'super' expression, capture 'self' decl.
     if (auto *superE = dyn_cast<SuperRefExpr>(E)) {
-      auto CurDC = AFR.getAsDeclContext();
       if (CurDC->isChildContextOf(superE->getSelf()->getDeclContext()))
         addCapture(CapturedValue(superE->getSelf(), 0), superE->getLoc());
       return { false, superE };
@@ -696,17 +711,11 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   if (!AFR.getBody())
     return;
 
-  SmallVector<CapturedValue, 4> Captures;
-  SourceLoc GenericParamCaptureLoc;
-  SourceLoc DynamicSelfCaptureLoc;
-  DynamicSelfType *DynamicSelf = nullptr;
-  OpaqueValueExpr *OpaqueValuePlaceholder = nullptr;
-  FindCapturedVars finder(*this, Captures,
-                          GenericParamCaptureLoc,
-                          DynamicSelfCaptureLoc,
-                          DynamicSelf,
-                          OpaqueValuePlaceholder,
-                          AFR);
+  FindCapturedVars finder(*this,
+                          getCaptureLoc(AFR),
+                          AFR.getAsDeclContext(),
+                          AFR.isKnownNoEscape(),
+                          AFR.isObjC());
   if (AFR.getBody())
     AFR.getBody()->walk(finder);
 
@@ -738,6 +747,8 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
     }
   }
 
+  AFR.getCaptureInfo() = finder.getCaptureInfo();
+
   // A generic function always captures outer generic parameters.
   auto *AFD = AFR.getAbstractFunctionDecl();
   if (AFD) {
@@ -745,27 +756,9 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
       AFR.getCaptureInfo().setGenericParamCaptures(true);
   }
 
-  // Anything can capture an opaque value placeholder.
-  if (OpaqueValuePlaceholder)
-    AFR.getCaptureInfo().setOpaqueValue(OpaqueValuePlaceholder);
-
-  // Only local functions capture dynamic 'Self'.
-  if (AFR.getAsDeclContext()->getParent()->isLocalContext()) {
-    if (GenericParamCaptureLoc.isValid())
-      AFR.getCaptureInfo().setGenericParamCaptures(true);
-
-    if (DynamicSelfCaptureLoc.isValid())
-      AFR.getCaptureInfo().setDynamicSelfType(DynamicSelf);
-  }
-
-  if (Captures.empty())
-    AFR.getCaptureInfo().setCaptures(None);
-  else
-    AFR.getCaptureInfo().setCaptures(Context.AllocateCopy(Captures));
-
   // Extensions of generic ObjC functions can't use generic parameters from
   // their context.
-  if (AFD && GenericParamCaptureLoc.isValid()) {
+  if (AFD && finder.getGenericParamCaptureLoc().isValid()) {
     if (auto Clas = AFD->getParent()->getSelfClassDecl()) {
       if (Clas->usesObjCGenericsModel()) {
         diagnose(AFD->getLoc(),
@@ -781,7 +774,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
             .fixItInsert(AFD->getAttributeInsertionLoc(false), "@objc ");
         }
 
-        diagnose(GenericParamCaptureLoc,
+        diagnose(finder.getGenericParamCaptureLoc(),
                  diag::objc_generic_extension_using_type_parameter_here);
       }
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2607,6 +2607,8 @@ public:
     for (Decl *Member : SD->getMembers())
       visit(Member);
 
+    TC.checkPatternBindingCaptures(SD);
+
     TC.checkDeclAttributes(SD);
 
     checkInheritanceClause(SD);
@@ -2734,6 +2736,8 @@ public:
     for (Decl *Member : CD->getMembers()) {
       visit(Member);
     }
+
+    TC.checkPatternBindingCaptures(CD);
 
     // If this class requires all of its stored properties to have
     // in-class initializers, diagnose this now.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1482,6 +1482,9 @@ public:
   /// Compute the set of captures for the given function or closure.
   void computeCaptures(AnyFunctionRef AFR);
 
+  /// Check for invalid captures from stored property initializers.
+  void checkPatternBindingCaptures(NominalTypeDecl *typeDecl);
+
   /// Change the context of closures in the given initializer
   /// expression to the given context.
   ///

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -60,9 +60,8 @@ var w: String  // expected-note {{variable defined here}}
                // expected-note@-1 {{variable defined here}}
                // expected-note@-2 {{variable defined here}}
 
-// FIXME: the error should blame the class definition: <rdar://41490541>.
-class TestClass1 { // expected-error {{variable 'w' used by function definition before being initialized}}
-  let fld = w
+class TestClass1 {
+  let fld = w // expected-error {{variable 'w' used by function definition before being initialized}}
 }
 
 class TestClass2 {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -177,3 +177,9 @@ enum E {
     return .e
   }
 }
+
+class SelfStoredPropertyInit {
+  static func myValue() -> Int { return 123 }
+
+  var value = Self.myValue() // expected-error {{covariant 'Self' type cannot be referenced from a stored property initializer}}
+}


### PR DESCRIPTION
Instead of walking stored property initializer expressions as part of computing the captures for a designated initializer, walk and store them separately. This makes more sense since SILGen emits them as separate functions.

Also, diagnose DynamicSelfType references inside stored property initializers, which are currently not supported.

Fixes rdar://problem/41490541, rdar://problem/51561208, https://bugs.swift.org/browse/SR-10969.