### PR TITLE
Driver: honour `-use-ld` on Windows static links

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -204,8 +204,11 @@ toolchains::Windows::constructInvocation(const StaticLinkJobAction &job,
 
   ArgStringList Arguments;
 
-  const char *Link = "link";
-  Arguments.push_back("-lib");
+  const char *Linker = "link";
+  if (const Arg *A = context.Args.getLastArg(options::OPT_use_ld))
+    Linker = context.Args.MakeArgString(A->getValue());
+
+  Arguments.push_back("/lib");
   Arguments.push_back("-nologo");
 
   addPrimaryInputsOfType(Arguments, context.Inputs, context.Args,
@@ -215,7 +218,7 @@ toolchains::Windows::constructInvocation(const StaticLinkJobAction &job,
   StringRef OutputFile = context.Output.getPrimaryOutputFilename();
   Arguments.push_back(context.Args.MakeArgString(Twine("/OUT:") + OutputFile));
 
-  InvocationInfo II{Link, Arguments};
+  InvocationInfo II{Linker, Arguments};
   II.allowsResponseFiles = true;
 
   return II;

--- a/test/Driver/static-archive.swift
+++ b/test/Driver/static-archive.swift
@@ -19,9 +19,18 @@
 // CHECK-WINDOWS: swift
 // CHECK-WINDOWS: -o [[OBJECTFILE:.*]]
 
-// CHECK-WINDOWS-NEXT: link{{(.exe)?"?}} -lib
+// CHECK-WINDOWS-NEXT: link{{(.exe)?"?}} /lib
 // CHECK-WINDOWS-DAG: [[OBJECTFILE]]
 // CHECK-WINDOWS: /OUT:{{[^ ]+}}
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -use-ld=lld-link -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-WINDOWS-LLD %s
+
+// CHECK-WINDOWS-LLD: swift
+// CHECK-WINDOWS-LLD: -o [[OBJECTFILE:.*]]
+
+// CHECK-WINDOWS-LLD-NEXT: lld-link{{(.exe)?"?}} /lib
+// CHECK-WINDOWS-LLD-DAG: [[OBJECTFILE]]
+// CHECK-WINDOWS-LLD: /OUT:{{[^ ]+}}
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name ARCHIVER -static | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name ARCHIVER -static | %FileCheck -check-prefix INFERRED_NAME_LINUX %s


### PR DESCRIPTION
The librarian on Windows is a part of the linker.  Enabling `-use-ld=`
for driver for static linking on Windows enables the user to override
the linker.  This is particularly important for cross-linking Windows
from Linux where link.exe is not present as it is a part of the MSVC
toolset.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
