### PR TITLE
Driver: emit a diagnostic if `clang++` is not found

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -80,7 +80,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   // Configure the toolchain.
   // By default, use the system clang++ to link.
-  const char *Clang = nullptr;
+  const char *Clang = "clang++";
   if (const Arg *A = context.Args.getLastArg(options::OPT_tools_directory)) {
     StringRef toolchainPath(A->getValue());
 
@@ -89,12 +89,6 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
             llvm::sys::findProgramByName("clang++", {toolchainPath}))
       Clang = context.Args.MakeArgString(toolchainClang.get());
   }
-  if (Clang == nullptr) {
-    if (auto pathClang = llvm::sys::findProgramByName("clang++", None))
-      Clang = context.Args.MakeArgString(pathClang.get());
-  }
-  assert(Clang &&
-         "clang++ was not found in the toolchain directory or system path.");
 
   std::string Target = getTriple().str();
   if (!Target.empty()) {

--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -1,0 +1,2 @@
+// RUN: env PATH= %swiftc_driver_plain -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
+// CHECK: {{^}}clang++


### PR DESCRIPTION
Rather than aborting due to an assertion failure, emit a diagnostic.
This is much safer and generally easier to understand why the command
failed.  It solves the problem of running swiftc from the build without
the path being set such that the clang++ driver is found by the swift
driver.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
