### PR TITLE
[Diagnostics]: Add diagnostics for incorrect property wrapper references in function arguments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1013,7 +1013,7 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
 
 ERROR(incorrect_property_wrapper_reference,none,
       "cannot convert value %0 of type %1 to expected type %2, "
-      "use %select{wrapper| wrapped value}3 instead",
+      "use %select{wrapper|wrapped value}3 instead",
       (Identifier, Type, Type, bool))
 ERROR(incorrect_property_wrapper_reference_member,none,
       "referencing %0 %1 requires %select{wrapper|wrapped value of type}2 %3",

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2077,6 +2077,44 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   llvm_unreachable("covered switch");
 }
 
+static ConstraintFix *fixPropertyWrapperFailure(
+    ConstraintSystem &cs, Type baseTy, Expr *anchor, ConstraintLocator *locator,
+    llvm::function_ref<bool(ResolvedOverloadSetListItem *, VarDecl *, Type)>
+        attemptFix,
+    Optional<Type> toType = None) {
+  auto resolvedOverload = cs.findSelectedOverloadFor(anchor);
+  if (!resolvedOverload)
+    return nullptr;
+
+  if (auto storageWrapper =
+          cs.getStorageWrapperInformation(resolvedOverload)) {
+    if (attemptFix(resolvedOverload, storageWrapper->first,
+                    storageWrapper->second))
+      return UsePropertyWrapper::create(
+          cs, storageWrapper->first,
+          /*usingStorageWrapper=*/true, baseTy,
+          toType.getValueOr(storageWrapper->second), locator);
+  }
+
+  if (auto wrapper = cs.getPropertyWrapperInformation(resolvedOverload)) {
+    if (attemptFix(resolvedOverload, wrapper->first, wrapper->second))
+      return UsePropertyWrapper::create(
+          cs, wrapper->first,
+          /*usingStorageWrappeer=*/false, baseTy,
+          toType.getValueOr(wrapper->second), locator);
+  }
+
+  if (auto wrappedProperty =
+          cs.getWrappedPropertyInformation(resolvedOverload)) {
+    if (attemptFix(resolvedOverload, wrappedProperty->first,
+                    wrappedProperty->second))
+      return UseWrappedValue::create(
+          cs, wrappedProperty->first, baseTy,
+          toType.getValueOr(wrappedProperty->second), locator);
+  }
+  return nullptr;
+}
+
 /// Attempt to repair typing failures and record fixes if needed.
 /// \return true if at least some of the failures has been repaired
 /// successfully, which allows type matcher to continue.
@@ -2185,13 +2223,31 @@ bool ConstraintSystem::repairFailures(
   switch (elt.getKind()) {
   case ConstraintLocator::LValueConversion:
   case ConstraintLocator::ApplyArgToParam: {
+    auto loc = getConstraintLocator(locator);
     if (repairByInsertingExplicitCall(lhs, rhs))
       return true;
 
     if (lhs->getOptionalObjectType() && !rhs->getOptionalObjectType()) {
       conversionsOrFixes.push_back(
-          ForceOptional::create(*this, lhs, lhs->getOptionalObjectType(),
-                                getConstraintLocator(locator)));
+          ForceOptional::create(*this, lhs, lhs->getOptionalObjectType(), loc));
+    }
+
+    if (elt.getKind() != ConstraintLocator::ApplyArgToParam)
+      break;
+
+    auto anchor = simplifyLocatorToAnchor(*this, loc);
+
+    if (auto *fix = fixPropertyWrapperFailure(
+            *this, lhs, anchor, loc,
+            [&](ResolvedOverloadSetListItem *overload, VarDecl *decl,
+                Type newBase) {
+              return matchTypes(newBase, rhs, ConstraintKind::Subtype,
+                                TypeMatchFlags::TMF_ApplyingFix,
+                                overload->Locator)
+                  .isSuccess();
+            },
+            rhs)) {
+      conversionsOrFixes.push_back(fix);
     }
     break;
   }
@@ -4815,45 +4871,15 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     if (auto dotExpr =
             dyn_cast_or_null<UnresolvedDotExpr>(locator->getAnchor())) {
       auto baseExpr = dotExpr->getBase();
-
-      if (auto resolvedOverload = findSelectedOverloadFor(baseExpr)) {
-        if (auto storageWrapper =
-                getStorageWrapperInformation(resolvedOverload)) {
-          auto wrapperTy = storageWrapper->second;
-          auto result =
-              solveWithNewBaseOrName(wrapperTy, member, /*allowFixes=*/false);
-          if (result == SolutionKind::Solved) {
-            auto *fix = UsePropertyWrapper::create(*this, storageWrapper->first,
-                                                   /*usingStorageWrapper=*/true,
-                                                   baseTy, wrapperTy, locator);
-            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
-          }
-        }
-
-        if (auto wrapper = getPropertyWrapperInformation(resolvedOverload)) {
-          auto wrapperTy = wrapper->second;
-          auto result =
-              solveWithNewBaseOrName(wrapperTy, member, /*allowFixes=*/false);
-          if (result == SolutionKind::Solved) {
-            auto *fix = UsePropertyWrapper::create(
-                *this, wrapper->first,
-                /*usingStorageWrappeer=*/false, baseTy, wrapperTy, locator);
-            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
-          }
-        }
-
-        if (auto wrappedProperty =
-                getWrappedPropertyInformation(resolvedOverload)) {
-          auto wrappedTy = wrappedProperty->second;
-          auto result =
-              solveWithNewBaseOrName(wrappedTy, member, /*allowFixes=*/false);
-
-          if (result == SolutionKind::Solved) {
-            auto *fix = UseWrappedValue::create(*this, wrappedProperty->first,
-                                                baseTy, wrappedTy, locator);
-            return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
-          }
-        }
+      if (auto *fix = fixPropertyWrapperFailure(
+              *this, baseTy, baseExpr, locator,
+              [&](ResolvedOverloadSetListItem *overload, VarDecl *decl,
+                  Type newBase) {
+                return solveWithNewBaseOrName(newBase, member,
+                                              /*allowFixes=*/false) ==
+                       SolutionKind::Solved;
+              })) {
+        return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
       }
     }
 
@@ -6806,7 +6832,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SkipSuperclassRequirement:
   case FixKind::ContextualMismatch:
   case FixKind::AddMissingArguments:
-  case FixKind::SkipUnhandledConstructInFunctionBuilder: {
+  case FixKind::SkipUnhandledConstructInFunctionBuilder:
+  case FixKind::UsePropertyWrapper:
+  case FixKind::UseWrappedValue: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
@@ -6827,8 +6855,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::TreatKeyPathSubscriptIndexAsHashable:
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::ExplicitlySpecifyGenericArguments:
-  case FixKind::UsePropertyWrapper:
-  case FixKind::UseWrappedValue:
   case FixKind::GenericArgumentsMismatch:
     llvm_unreachable("handled elsewhere");
   }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -968,7 +968,7 @@ extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
 }
 
 struct V {
-  func onWrapperValue() {}
+  func onProjectedValue() {}
 }
 
 struct W {
@@ -980,7 +980,13 @@ struct MissingPropertyWrapperUnwrap {
   @Foo var x: Int
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
-  @Baz var usesWrapperValue: W
+  @Baz var usesProjectedValue: W
+  
+  func a<T>(_: Foo<T>) {}
+  func a<T>(named: Foo<T>) {}
+  func b(_: Foo<Int>) {}
+  func c(_: V) {}
+  func d(_: W) {}
 
   func baz() {
     self.x.foo() // expected-error {{referencing instance method 'foo()' requires wrapper 'Foo<Int>'}}{{10-10=_}}
@@ -990,11 +996,18 @@ struct MissingPropertyWrapperUnwrap {
     self.y.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
     self.z.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, String>'}}{{10-10=_}}
-    self.usesWrapperValue.onPropertyWrapper() // expected-error {{referencing instance method 'onPropertyWrapper()' requires wrapper 'Baz<W>'}}{{10-10=_}}
+    self.usesProjectedValue.onPropertyWrapper() // expected-error {{referencing instance method 'onPropertyWrapper()' requires wrapper 'Baz<W>'}}{{10-10=_}}
 
     self._w.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
-    self.usesWrapperValue.onWrapperValue() // expected-error {{referencing instance method 'onWrapperValue()' requires wrapper 'V'}}{{10-10=$}}
-    self.$usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
-    self._usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self.usesProjectedValue.onProjectedValue() // expected-error {{referencing instance method 'onProjectedValue()' requires wrapper 'V'}}{{10-10=$}}
+    self.$usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self._usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    
+    a(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<W>', use wrapper instead}}{{12-12=_}}
+    b(self.x) // expected-error {{cannot convert value 'x' of type 'Int' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
+    b(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
+    c(self.usesProjectedValue) // expected-error {{cannot convert value 'usesProjectedValue' of type 'W' to expected type 'V', use wrapper instead}}{{12-12=$}}
+    d(self.$usesProjectedValue) // expected-error {{cannot convert value '$usesProjectedValue' of type 'V' to expected type 'W', use wrapped value instead}}{{12-13=}}
+    d(self._usesProjectedValue) // expected-error {{cannot convert value '_usesProjectedValue' of type 'Baz<W>' to expected type 'W', use wrapped value instead}}{{12-13=}}
   }
 }


### PR DESCRIPTION
Adds recording of `UsePropertyWrapper` and `UseWrappedValue` fixes in function arguments. Additionally refactors a lot of the logic for determining the correct diagnostic away from the diagnostic site and into `fixPropertyWrapperFailure` which gets used both here, and in the same diagnostic for member references.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10928](https://bugs.swift.org/browse/SR-10928).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
