### PR TITLE
test: loosen the static-archive test

### DIFF
--- a/test/Driver/static-archive.swift
+++ b/test/Driver/static-archive.swift
@@ -12,7 +12,7 @@
 // CHECK-LINUX: swift
 // CHECK-LINUX: -o [[OBJECTFILE:.*]]
 
-// CHECK-LINUX: {{(bin/)?(llvm-)?}}ar{{"?}} crs
+// CHECK-LINUX: {{(bin/)?(llvm-)?}}ar{{(.exe)?"?}} crs
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -emit-library %s -module-name ARCHIVER -static 2>&1 | %FileCheck -check-prefix CHECK-WINDOWS %s
 


### PR DESCRIPTION
The test was overfitted to execution on Unix platforms.  Loosen it to
work on Windows as well.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
