### PR TITLE
[Diagnostics] Desugar syntax sugared types if they have unresolved types

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -457,6 +457,10 @@ public:
   /// types, optionals, etc.
   TypeBase *reconstituteSugar(bool Recursive);
 
+  // If this type is a syntax sugar type, desugar it. Also desugar any nested
+  // syntax sugar types.
+  TypeBase *getWithoutSyntaxSugar();
+
   /// getASTContext - Return the ASTContext that this type belongs to.
   ASTContext &getASTContext() {
     // If this type is canonical, it has the ASTContext in it.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -468,6 +468,13 @@ static void formatDiagnosticArgument(StringRef Modifier,
     
     // Strip extraneous parentheses; they add no value.
     auto type = Arg.getAsType()->getWithoutParens();
+
+    // If a type has an unresolved type, print it with syntax sugar removed for
+    // clarity. For example, print `Array<_>` instead of `[_]`.
+    if (type->hasUnresolvedType()) {
+      type = type->getWithoutSyntaxSugar();
+    }
+
     bool isAmbiguous = typeSpellingIsAmbiguous(type, Args);
 
     if (isAmbiguous && isa<OpaqueTypeArchetypeType>(type.getPointer())) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1252,6 +1252,15 @@ TypeBase *TypeBase::reconstituteSugar(bool Recursive) {
     return Func(this).getPointer();
 }
 
+TypeBase *TypeBase::getWithoutSyntaxSugar() {
+  auto Func = [](Type Ty) -> Type {
+    if (auto *syntaxSugarType = dyn_cast<SyntaxSugarType>(Ty.getPointer()))
+      return syntaxSugarType->getSinglyDesugaredType()->getWithoutSyntaxSugar();
+    return Ty;
+  };
+  return Type(this).transform(Func).getPointer();
+}
+
 #define TYPE(Id, Parent)
 #define SUGARED_TYPE(Id, Parent) \
   static_assert(std::is_base_of<SugarType, Id##Type>::value, "Sugar mismatch");

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -424,7 +424,7 @@ enum Color {
 }
 
 // FIXME: This used to be better: "'map' produces '[T]', not the expected contextual result type '(Int, Color)'"
-let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{expression type '((Int) throws -> _) throws -> [_]' is ambiguous without more context}}
+let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{expression type '((Int) throws -> _) throws -> Array<_>' is ambiguous without more context}}
 
 let _: [(Int, Color)] = [1,2].map({ ($0, .Unknown("")) })// expected-error {{missing argument label 'description:' in call}}
 
@@ -1233,3 +1233,24 @@ let baz: (Swift.Error) = Error() //expected-error {{value of type 'diagnostics.E
 let baz2: Swift.Error = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
 let baz3: (Swift.Error) = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
 let baz4: ((Swift.Error)) = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
+
+// SyntaxSugarTypes with unresolved types
+func takesGenericArray<T>(_ x: [T]) {}
+takesGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<_>'}}
+func takesNestedGenericArray<T>(_ x: [[T]]) {}
+takesNestedGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Array<_>>'}}
+func takesSetOfGenericArrays<T>(_ x: Set<[T]>) {}
+takesSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Set<Array<_>>'}}
+func takesArrayOfSetOfGenericArrays<T>(_ x: [Set<[T]>]) {}
+takesArrayOfSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Set<Array<_>>>'}}
+func takesArrayOfGenericOptionals<T>(_ x: [T?]) {}
+takesArrayOfGenericOptionals(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Optional<_>>'}}
+func takesGenericDictionary<T, U>(_ x: [T : U]) {}
+takesGenericDictionary(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<_, _>'}}
+typealias Z = Int
+func takesGenericDictionaryWithTypealias<T>(_ x: [T : Z]) {}
+takesGenericDictionaryWithTypealias(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<_, Z>'}}
+func takesGenericFunction<T>(_ x: ([T]) -> Void) {}
+takesGenericFunction(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type '(Array<_>) -> Void'}}
+func takesTuple<T>(_ x: ([T], [T])) {}
+takesTuple(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type '(Array<_>, Array<_>)'}}

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -35,7 +35,7 @@ func variadic() {
   // expected-error@-1 {{cannot convert value of type '([Int]) -> ()' to specified type '(Int...) -> ()'}}
 
   takesVariadicGeneric({takesIntArray($0)})
-  // expected-error@-1 {{cannot convert value of type '[_]' to expected argument type '[Int]'}}
+  // expected-error@-1 {{cannot convert value of type 'Array<_>' to expected argument type '[Int]'}}
 
   takesVariadicGeneric({let _: [Int] = $0})
   // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(_...) -> ()'}}


### PR DESCRIPTION
If a syntax sugared type like Array had an unresolved type, it used to print as `[_]` in diagnostics, which could be confusing.
Instead, desugar these unresolved types before printing, so Array, for example, prints as `Array<_>`.
Currently this only applies to Array, Dictionary, and Optional.

This change was inspired by [SR-11021](https://bugs.swift.org/browse/SR-11021), which I think is a good example of how the current printing can be confusing if it's not immediately obvious an Array type is involved, and the programmer doesn't immediately associate a `_` outside angle brackets with an unresolved generic parameter.

In the end this is a kind of subjective change, but I do think the new behavior is at least a little more beginner-friendly.

cc @xedin , @jrose-apple 