### PR TITLE
[5.1] Add diagnostics for incorrect property wrapper references in function arguments 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -997,7 +997,7 @@ ERROR(cannot_pass_inout_arg_to_subscript,none,
 
 ERROR(incorrect_property_wrapper_reference,none,
       "cannot convert value %0 of type %1 to expected type %2, "
-      "use %select{wrapper| wrapped value}3 instead",
+      "use %select{wrapper|wrapped value}3 instead",
       (Identifier, Type, Type, bool))
 ERROR(incorrect_property_wrapper_reference_member,none,
       "referencing %0 %1 requires %select{wrapper|wrapped value of type}2 %3",

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -968,7 +968,7 @@ extension Bar where V == String { // expected-note {{where 'V' = 'Bool'}}
 }
 
 struct V {
-  func onWrapperValue() {}
+  func onProjectedValue() {}
 }
 
 struct W {
@@ -980,7 +980,13 @@ struct MissingPropertyWrapperUnwrap {
   @Foo var x: Int
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
-  @Baz var usesWrapperValue: W
+  @Baz var usesProjectedValue: W
+  
+  func a<T>(_: Foo<T>) {}
+  func a<T>(named: Foo<T>) {}
+  func b(_: Foo<Int>) {}
+  func c(_: V) {}
+  func d(_: W) {}
 
   func baz() {
     self.x.foo() // expected-error {{referencing instance method 'foo()' requires wrapper 'Foo<Int>'}}{{10-10=_}}
@@ -990,11 +996,18 @@ struct MissingPropertyWrapperUnwrap {
     self.y.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, Bool>'}}{{10-10=_}}
     // expected-error@-1 {{referencing instance method 'barWhereVIsString()' on 'Bar' requires the types 'Bool' and 'String' be equivalent}}
     self.z.barWhereVIsString() // expected-error {{referencing instance method 'barWhereVIsString()' requires wrapper 'Bar<Int, String>'}}{{10-10=_}}
-    self.usesWrapperValue.onPropertyWrapper() // expected-error {{referencing instance method 'onPropertyWrapper()' requires wrapper 'Baz<W>'}}{{10-10=_}}
+    self.usesProjectedValue.onPropertyWrapper() // expected-error {{referencing instance method 'onPropertyWrapper()' requires wrapper 'Baz<W>'}}{{10-10=_}}
 
     self._w.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
-    self.usesWrapperValue.onWrapperValue() // expected-error {{referencing instance method 'onWrapperValue()' requires wrapper 'V'}}{{10-10=$}}
-    self.$usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
-    self._usesWrapperValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self.usesProjectedValue.onProjectedValue() // expected-error {{referencing instance method 'onProjectedValue()' requires wrapper 'V'}}{{10-10=$}}
+    self.$usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    self._usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
+    
+    a(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<W>', use wrapper instead}}{{12-12=_}}
+    b(self.x) // expected-error {{cannot convert value 'x' of type 'Int' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
+    b(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
+    c(self.usesProjectedValue) // expected-error {{cannot convert value 'usesProjectedValue' of type 'W' to expected type 'V', use wrapper instead}}{{12-12=$}}
+    d(self.$usesProjectedValue) // expected-error {{cannot convert value '$usesProjectedValue' of type 'V' to expected type 'W', use wrapped value instead}}{{12-13=}}
+    d(self._usesProjectedValue) // expected-error {{cannot convert value '_usesProjectedValue' of type 'Baz<W>' to expected type 'W', use wrapped value instead}}{{12-13=}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -981,12 +981,13 @@ struct MissingPropertyWrapperUnwrap {
   @Bar<Int, Bool> var y: Int
   @Bar<Int, String> var z: Int
   @Baz var usesProjectedValue: W
-  
+
   func a<T>(_: Foo<T>) {}
   func a<T>(named: Foo<T>) {}
   func b(_: Foo<Int>) {}
   func c(_: V) {}
   func d(_: W) {}
+  func e(_: Foo<W>) {}
 
   func baz() {
     self.x.foo() // expected-error {{referencing instance method 'foo()' requires wrapper 'Foo<Int>'}}{{10-10=_}}
@@ -1002,10 +1003,11 @@ struct MissingPropertyWrapperUnwrap {
     self.usesProjectedValue.onProjectedValue() // expected-error {{referencing instance method 'onProjectedValue()' requires wrapper 'V'}}{{10-10=$}}
     self.$usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
     self._usesProjectedValue.onWrapped() // expected-error {{referencing instance method 'onWrapped()' requires wrapped value of type 'W'}}{{10-11=}}
-    
+
     a(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<W>', use wrapper instead}}{{12-12=_}}
     b(self.x) // expected-error {{cannot convert value 'x' of type 'Int' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
-    b(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<Int>', use wrapper instead}}{{12-12=_}}
+    b(self.w) // expected-error {{cannot convert value of type 'W' to expected argument type 'Foo<Int>'}}
+    e(self.w) // expected-error {{cannot convert value 'w' of type 'W' to expected type 'Foo<W>', use wrapper instead}}{{12-12=_}}
     c(self.usesProjectedValue) // expected-error {{cannot convert value 'usesProjectedValue' of type 'W' to expected type 'V', use wrapper instead}}{{12-12=$}}
     d(self.$usesProjectedValue) // expected-error {{cannot convert value '$usesProjectedValue' of type 'V' to expected type 'W', use wrapped value instead}}{{12-13=}}
     d(self._usesProjectedValue) // expected-error {{cannot convert value '_usesProjectedValue' of type 'Baz<W>' to expected type 'W', use wrapped value instead}}{{12-13=}}


### PR DESCRIPTION
Cherry pick commit from #25889
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10928](https://bugs.swift.org/browse/SR-10928).


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
