### PR TITLE
[typelowering] Workaround for rdar://52270675

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -740,8 +740,18 @@ public:
   /// Get the method dispatch strategy for a protocol.
   static ProtocolDispatchStrategy getProtocolDispatchStrategy(ProtocolDecl *P);
 
-  /// Count the total number of fields inside the given SIL Type
-  unsigned countNumberOfFields(SILType Ty, ResilienceExpansion expansion);
+  /// Count the total number of fields inside the given SIL Type. Returns
+  /// .some(count) if given the current resilience expansion it is safe to
+  /// expand this value. Returns .none otherwise.
+  ///
+  /// WORKAROUND WARNING: This returns an optional as a workaround for
+  /// rdar52270675. The problem is that in certain cases we are producing
+  /// TypeLowerings for value types in minimal resilience expansions where the
+  /// parent type is fragile/loadable but one of the substypes is reslient (and
+  /// thus the /whole/ type should be address only). Once that is resolved, this
+  /// should unconditionally return an unsigned.
+  Optional<unsigned> countNumberOfFields(SILType Ty,
+                                         ResilienceExpansion expansion);
 
   /// True if a protocol uses witness tables for dynamic dispatch.
   static bool protocolRequiresWitnessTable(ProtocolDecl *P) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1502,12 +1502,17 @@ bool swift::shouldExpand(SILModule &Module, SILType Ty) {
   if (Module.Types.getTypeLowering(Ty, Expansion).isAddressOnly()) {
     return false;
   }
+
+  Optional<unsigned> NumFields =
+      Module.Types.countNumberOfFields(Ty, Expansion);
+  if (!NumFields.hasValue())
+    return false;
+
   if (EnableExpandAll) {
     return true;
   }
 
-  unsigned NumFields = Module.Types.countNumberOfFields(Ty, Expansion);
-  return (NumFields <= 6);
+  return NumFields.getValue() <= 6;
 }
 
 /// Some support functions for the global-opt and let-properties-opts


### PR DESCRIPTION
The problem here is that in certain cases that I am investigating, given a
minimal resilience expansion, we are producing loadable, fragile types that have
subelements that are resilient =><=. The correct behavior is for this to be
address only.

So far, it seems we have only hit this problem around expanding types, so I am
putting in a small workaround while I investigate in order to unblock
Jordan/Doug.

rdar://52270675
