### PR TITLE
Frontend: correct `-sdk` search paths for !Darwin

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -89,6 +89,10 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   if (!SearchPathOpts.SDKPath.empty()) {
     LibPath = SearchPathOpts.SDKPath;
     llvm::sys::path::append(LibPath, "usr", "lib", "swift");
+    if (!Triple.isOSDarwin()) {
+      llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
+      llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
+    }
     SearchPathOpts.RuntimeLibraryImportPaths.push_back(LibPath.str());
   }
 }

--- a/test/Driver/Inputs/android.sdk/usr/lib/swift/android/x86_64/Swift.swiftinterface
+++ b/test/Driver/Inputs/android.sdk/usr/lib/swift/android/x86_64/Swift.swiftinterface
@@ -1,0 +1,3 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-unknown-linux-android -disable-objc-interop -swift-version 5 -O -module-name Swift -parse-stdlib
+

--- a/test/Driver/android-sdk.swift
+++ b/test/Driver/android-sdk.swift
@@ -1,0 +1,1 @@
+// RUN: %swift -target x86_64-unknown-linux-android -sdk %S/Inputs/android.sdk %s -typecheck


### PR DESCRIPTION
This adjusts the runtime library import paths to add the OS/architecture
subdirectory to the path.  This allows the use of `-sdk` with the
compiler to target Android and Windows as well (and Linux).  The SDK
image is identical to that generated by the current CMake setup without
the host tools.  Ideally, we would change the layout for the modules on
other targets to be identical to the Darwin layout which converts to
OS/<module>/architecture.<extension> rather than
OS/architecture/<module>.<extension>.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
