### PR TITLE
[5.1] [Diagnostics] Correctly handle subscript misuse without a parent apply expr

### DIFF
--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -326,13 +326,22 @@ class ClassConformingToProtocol: Protocol {}
 class ClassConformingToRefinedProtocol: RefinedProtocol {}
 
 struct GenSubscriptFixitTest {
-  subscript<T>(_ arg: T) -> Bool { return true } // expected-note {{declared here}}
+  subscript<T>(_ arg: T) -> Bool { return true } // expected-note 3 {{declared here}}
 }
 
 func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
   _ = s0.subscript("hello")
   // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+}
+
+func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
+
+  _ = s0.subscript
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-19=[<#index#>]}}
+
+  s0.subscript = true
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{5-15=[<#index#>]}}
 }
 
 struct SubscriptTest1 {


### PR DESCRIPTION
(cherry picked from commit 036906479290b21aceb60927104a41ee38635c12)

Resolves: [SR-10987](http://bugs.swift.org/browse/SR-10987)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
