### PR TITLE
[Driver] Add warning when using -F and path ends in ".framework"

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -254,6 +254,10 @@ WARNING(cannot_assign_value_to_conditional_compilation_flag,none,
         "conditional compilation flags do not have values in Swift; they are "
         "either present or absent (rather than '%0')", (StringRef))
 
+WARNING(framework_search_path_includes_framework_extension,none,
+        "framework search path ends in \".framework\"; add directory containing "
+        "framework instead: %0", (StringRef))
+
 ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
       (StringRef, StringRef))
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -230,6 +230,17 @@ static void validateCompilationConditionArgs(DiagnosticEngine &diags,
   }
 }
 
+static void validateSearchPathArgs(DiagnosticEngine &diags,
+                                   const ArgList &args) {
+  for (const Arg *A : args.filtered(options::OPT_F, options::OPT_Fsystem)) {
+    StringRef name = A->getValue();
+    if (name.endswith(".framework") || name.endswith(".framework/"))
+      diags.diagnose(SourceLoc(),
+                     diag::framework_search_path_includes_framework_extension,
+                     name);
+  }
+}
+
 static void validateAutolinkingArgs(DiagnosticEngine &diags,
                                     const ArgList &args) {
   auto *forceLoadArg = args.getLastArg(options::OPT_autolink_force_load);
@@ -255,6 +266,7 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args) {
   validateProfilingArgs(diags, args);
   validateDebugInfoArgs(diags, args);
   validateCompilationConditionArgs(diags, args);
+  validateSearchPathArgs(diags, args);
   validateAutolinkingArgs(diags, args);
 }
 

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -123,3 +123,13 @@
 // RUN: not %swiftc_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swiftc_driver -gdwarf-types -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // BAD_DEBUG_LEVEL_ERROR: error: argument '-debug-info-format=codeview' is not allowed with '{{.*}}'
+
+// RUN: %swift_driver -F %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swiftc_driver -F %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swift_driver -Fsystem %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swiftc_driver -Fsystem %t/test.framework %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swift_driver -F %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swiftc_driver -F %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swift_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// RUN: %swiftc_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
+// SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION: warning: framework search path ends in ".framework"


### PR DESCRIPTION
This pull request adds a warning when a user uses -F/-Fsystem and the path ends in ".framework" or ".frameworkl/"

Resolves [SR-10966](https://bugs.swift.org/browse/SR-10966).