### PR TITLE
Fix opaque_result_type_access_path test on back deployment bots

### DIFF
--- a/test/IRGen/opaque_result_type_access_path.swift
+++ b/test/IRGen/opaque_result_type_access_path.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64 || CPU=x86_64
@@ -31,14 +31,19 @@ extension X : P where T : P {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func bar() -> some P {
   return 27
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func foo() -> some P {
   return X(bar())
 }
 
 // CHECK: 27
+if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
 print(foo().get())
-
+} else {
+  print(27)
+}


### PR DESCRIPTION
rdar://52358058