### PR TITLE
[Sema] `Differentiable` conformance derivation for class types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2869,9 +2869,9 @@ ERROR(compiler_evaluable_ref_non_compiler_evaluable,none,
       "@compilerEvaluable functions may not reference non-@compilerEvaluable functions", ())
 
 // @noDerivative attribute
-ERROR(noderivative_only_on_stored_properties_in_differentiable_structs,none,
-      "'@noDerivative' is only allowed on stored properties in structure types "
-      "that declare a conformance to 'Differentiable'", ())
+ERROR(noderivative_only_on_stored_properties_in_differentiable_types,none,
+      "'@noDerivative' is only allowed on stored properties in structure or "
+      "class types that declare a conformance to 'Differentiable'", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2869,7 +2869,7 @@ ERROR(compiler_evaluable_ref_non_compiler_evaluable,none,
       "@compilerEvaluable functions may not reference non-@compilerEvaluable functions", ())
 
 // @noDerivative attribute
-ERROR(noderivative_only_on_stored_properties_in_differentiable_types,none,
+ERROR(noderivative_only_on_differentiable_struct_or_class_fields,none,
       "'@noDerivative' is only allowed on stored properties in structure or "
       "class types that declare a conformance to 'Differentiable'", ())
 

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -950,6 +950,7 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
   bool hasNoDerivativeStoredProp = diffProperties.size() != numStoredProperties;
 
   // Check conditions for returning `Self`.
+  // - `Self` is not a class type.
   // - No `@noDerivative` stored properties exist.
   // - All stored properties must have specified associated type equal to
   //   `Self`.
@@ -967,7 +968,7 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
                             parentDC, None);
 
   // Return `Self` if conditions are met.
-  if (!hasNoDerivativeStoredProp &&
+  if (!hasNoDerivativeStoredProp && !nominal->getSelfClassDecl() &&
       (id == C.Id_AllDifferentiableVariables ||
        (allMembersAssocTypeEqualsSelf && nominalConformsToAddArith))) {
     auto selfType = parentDC->getSelfTypeInContext();

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -13,7 +13,7 @@
 // SWIFT_ENABLE_TENSORFLOW
 //
 // This file implements explicit derivation of the Differentiable protocol for
-// struct types.
+// struct and class types.
 //
 //===----------------------------------------------------------------------===//
 
@@ -108,8 +108,7 @@ static StructDecl *getAssociatedStructDecl(DeclContext *DC, Identifier id) {
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   assert(diffableProto && "`Differentiable` protocol not found");
   auto conf = TypeChecker::conformsToProtocol(DC->getSelfTypeInContext(),
-                                              diffableProto,
-                                              DC, None);
+                                              diffableProto, DC, None);
   assert(conf && "Nominal must conform to `Differentiable`");
   Type assocType = conf->getTypeWitnessByName(DC->getSelfTypeInContext(), id);
   assert(assocType && "`Differentiable` protocol associated type not found");
@@ -120,9 +119,8 @@ static StructDecl *getAssociatedStructDecl(DeclContext *DC, Identifier id) {
 
 bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
                                                  DeclContext *DC) {
-  // Nominal type must be a struct. (Zero stored properties is okay.)
-  auto *structDecl = dyn_cast<StructDecl>(nominal);
-  if (!structDecl)
+  // Nominal type must be a struct or class. (No stored properties is okay.)
+  if (!isa<StructDecl>(nominal) && !isa<ClassDecl>(nominal))
     return false;
   auto &C = nominal->getASTContext();
   auto *lazyResolver = C.getLazyResolver();
@@ -153,8 +151,7 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
     //   `X == X.TangentVector`.
     if (nominal->isImplicit() && structDecl == nominal->getDeclContext() &&
         TypeChecker::conformsToProtocol(structDecl->getDeclaredInterfaceType(),
-                                        diffableProto, DC,
-                                        None))
+                                        diffableProto, DC, None))
       return structDecl;
     // 3. Equal nominal (and conform to `AdditiveArithmetic` if flag is true).
     if (structDecl == nominal) {
@@ -199,7 +196,7 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
   //     initializers that initialize all stored properties, including initial
   //     value information.
   SmallVector<VarDecl *, 16> diffProperties;
-  getStoredPropertiesForDifferentiation(structDecl, DC, diffProperties);
+  getStoredPropertiesForDifferentiation(nominal, DC, diffProperties);
   return llvm::all_of(diffProperties, [&](VarDecl *v) {
     if (!v->hasInterfaceType())
       lazyResolver->resolveDeclSignature(v);
@@ -325,7 +322,8 @@ static ValueDecl *deriveDifferentiable_method(
                                     /*Throws*/ false, SourceLoc(),
                                     /*GenericParams=*/nullptr, params,
                                     TypeLoc::withoutLoc(returnType), parentDC);
-  funcDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+  if (!nominal->getSelfClassDecl())
+    funcDecl->setSelfAccessKind(SelfAccessKind::Mutating);
   funcDecl->setImplicit();
   funcDecl->setBodySynthesizer(bodySynthesizer.Fn, bodySynthesizer.Context);
 
@@ -804,6 +802,8 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
                                                  DeclContext* DC) {
   auto *diffableProto =
       TC.Context.getProtocol(KnownProtocolKind::Differentiable);
+  bool nominalCanDeriveAdditiveArithmetic =
+      DerivedConformance::canDeriveAdditiveArithmetic(nominal, DC);
   for (auto *vd : nominal->getStoredProperties()) {
     if (!vd->hasInterfaceType())
       TC.resolveDeclSignature(vd);
@@ -814,8 +814,7 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
       continue;
     // Check whether to diagnose stored property.
     bool conformsToDifferentiable =
-        TC.conformsToProtocol(varType, diffableProto, nominal,
-                              None).hasValue();
+        TC.conformsToProtocol(varType, diffableProto, nominal, None).hasValue();
     // If stored property should not be diagnosed, continue.
     if (conformsToDifferentiable && !vd->isLet())
       continue;
@@ -829,8 +828,6 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
     // `Differentiable` protocol requirements all have default implementations
     // when `Self` conforms to `AdditiveArithmetic`, so `Differentiable`
     // derived conformances will no longer be necessary.
-    bool nominalCanDeriveAdditiveArithmetic =
-        DerivedConformance::canDeriveAdditiveArithmetic(nominal, DC);
     if (!conformsToDifferentiable) {
       TC.diagnose(loc,
                   diag::differentiable_nondiff_type_implicit_noderivative_fixit,
@@ -844,7 +841,6 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
                 vd->getName(), nominal->getName(),
                 nominalCanDeriveAdditiveArithmetic)
         .fixItInsert(loc, "@noDerivative ");
-
   }
 }
 

--- a/lib/Sema/DerivedConformanceRingMathProtocols.cpp
+++ b/lib/Sema/DerivedConformanceRingMathProtocols.cpp
@@ -178,8 +178,10 @@ static void deriveBodyMathOperator(AbstractFunctionDecl *funcDecl,
     // If conformance reference is concrete, then use concrete witness
     // declaration for the operator.
     if (confRef->isConcrete())
-      memberOpDecl = confRef->getConcrete()->getWitnessDecl(
-          operatorReq, C.getLazyResolver());
+      if (auto *concreteMemberMethodDecl =
+              confRef->getConcrete()->getWitnessDecl(operatorReq,
+                                                     C.getLazyResolver()))
+        memberOpDecl = concreteMemberMethodDecl;
     assert(memberOpDecl && "Member operator declaration must exist");
     auto memberOpDRE =
         new (C) DeclRefExpr(memberOpDecl, DeclNameLoc(), /*Implicit*/ true);

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -588,7 +588,7 @@ DerivedConformance::declareDerivedProperty(Identifier name,
                                       parentDC);
   // SWIFT_ENABLE_TENSORFLOW
   // TODO: Upstream this change to master.
-  if (isFinal)
+  if (isFinal && parentDC->getSelfClassDecl())
     propDecl->getAttrs().add(new (C) FinalAttr(/*Implicit*/ true));
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -554,7 +554,9 @@ DerivedConformance::declareDerivedPropertySetter(TypeChecker &tc,
     /*GenericParams*/ nullptr, params, TypeLoc(), parentDC);
   setterDecl->setImplicit();
   setterDecl->setStatic(isStatic);
-  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+  // Set mutating if parent is not a class.
+  if (!parentDC->getSelfClassDecl())
+    setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
 
   // If this is supposed to be a final method, mark it as such.
   assert(isFinal || !parentDC->getSelfClassDecl());
@@ -584,6 +586,10 @@ DerivedConformance::declareDerivedProperty(Identifier name,
   VarDecl *propDecl = new (C) VarDecl(/*IsStatic*/isStatic, VarDecl::Specifier::Var,
                                       /*IsCaptureList*/false, SourceLoc(), name,
                                       parentDC);
+  // SWIFT_ENABLE_TENSORFLOW
+  // TODO: Upstream this change to master.
+  if (isFinal)
+    propDecl->getAttrs().add(new (C) FinalAttr(/*Implicit*/ true));
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3759,20 +3759,20 @@ void AttributeChecker::visitNoDerivativeAttr(NoDerivativeAttr *attr) {
     return;
   if (!vd || vd->isStatic()) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_structs);
+        diag::noderivative_only_on_stored_properties_in_differentiable_types);
     return;
   }
-  auto *structDecl = dyn_cast<StructDecl>(vd->getDeclContext());
-  if (!structDecl) {
+  auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
+  if (!nominal || (!isa<StructDecl>(nominal) && !isa<ClassDecl>(nominal))) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_structs);
+        diag::noderivative_only_on_stored_properties_in_differentiable_types);
     return;
   }
   if (!conformsToDifferentiable(
-          structDecl->getDeclaredInterfaceType(),
-          structDecl->getDeclContext())) {
+          nominal->getDeclaredInterfaceType(),
+          nominal->getDeclContext())) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_structs);
+        diag::noderivative_only_on_stored_properties_in_differentiable_types);
     return;
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3759,20 +3759,20 @@ void AttributeChecker::visitNoDerivativeAttr(NoDerivativeAttr *attr) {
     return;
   if (!vd || vd->isStatic()) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_types);
+        diag::noderivative_only_on_differentiable_struct_or_class_fields);
     return;
   }
   auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
   if (!nominal || (!isa<StructDecl>(nominal) && !isa<ClassDecl>(nominal))) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_types);
+        diag::noderivative_only_on_differentiable_struct_or_class_fields);
     return;
   }
   if (!conformsToDifferentiable(
           nominal->getDeclaredInterfaceType(),
           nominal->getDeclContext())) {
     diagnoseAndRemoveAttr(attr,
-        diag::noderivative_only_on_stored_properties_in_differentiable_types);
+        diag::noderivative_only_on_differentiable_struct_or_class_fields);
     return;
   }
 }

--- a/test/AutoDiff/noderivative-attr.swift
+++ b/test/AutoDiff/noderivative-attr.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-// expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
+// expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure or class types that declare a conformance to 'Differentiable'}}
 @noDerivative var flag: Bool
 
 struct Foo {
-  // expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure types that declare a conformance to 'Differentiable'}}
+  // expected-error @+1 {{'@noDerivative' is only allowed on stored properties in structure or class types that declare a conformance to 'Differentiable'}}
   @noDerivative var flag: Bool
 }
 

--- a/test/Sema/Inputs/class_differentiable_other_module.swift
+++ b/test/Sema/Inputs/class_differentiable_other_module.swift
@@ -1,0 +1,9 @@
+// SWIFT_ENABLE_TENSORFLOW
+
+// expected-note @+1 {{type declared here}}
+class OtherFileNonconforming {}
+
+// expected-note @+1 {{type declared here}}
+class GenericOtherFileNonconforming<T : Differentiable> {
+  var x: T
+}

--- a/test/Sema/class_differentiable.swift
+++ b/test/Sema/class_differentiable.swift
@@ -1,5 +1,5 @@
 // SWIFT_ENABLE_TENSORFLOW
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_differentiable_other_module.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/class_differentiable_other_module.swift
 
 // Verify that a `Differentiable` type upholds `AllDifferentiableVariables == TangentVector`.
 func assertAllDifferentiableVariablesEqualsTangentVector<T>(_: T.Type)
@@ -14,7 +14,25 @@ func assertConformsToElementaryFunctions<T>(_: T.Type) where T : ElementaryFunct
 // Verify that a type `T` conforms to `VectorProtocol`.
 func assertConformsToVectorProtocol<T>(_: T.Type) where T : VectorProtocol {}
 
-struct Empty : Differentiable {}
+// Dummy protocol with default implementations for `AdditiveArithmetic` requirements.
+// Used to test `Self : AdditiveArithmetic` requirements.
+protocol DummyAdditiveArithmetic : AdditiveArithmetic {}
+extension DummyAdditiveArithmetic {
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    fatalError()
+  }
+  static var zero: Self {
+    fatalError()
+  }
+  static func + (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+  static func - (lhs: Self, rhs: Self) -> Self {
+    fatalError()
+  }
+}
+
+class Empty : Differentiable {}
 func testEmpty() {
   assertConformsToAdditiveArithmetic(Empty.AllDifferentiableVariables.self)
   assertConformsToAdditiveArithmetic(Empty.TangentVector.self)
@@ -22,104 +40,145 @@ func testEmpty() {
   assertConformsToElementaryFunctions(Empty.TangentVector.self)
 }
 
-// Test interaction with `AdditiveArithmetic` derived conformances.
-// Previously, this crashed due to duplicate memberwise initializer synthesis.
-struct EmptyAdditiveArithmetic : AdditiveArithmetic, Differentiable {}
-
 // Test structs with `let` stored properties.
 // Derived conformances fail because `mutating func move` requires all stored
 // properties to be mutable.
-struct ImmutableStoredProperties : Differentiable {
+class ImmutableStoredProperties : Differentiable {
   var okay: Float
 
-  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute, or conform 'ImmutableStoredProperties' to 'AdditiveArithmetic'}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{stored property 'nondiff' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties to be mutable; use 'var' instead, or add an explicit '@noDerivative' attribute, or conform 'ImmutableStoredProperties' to 'AdditiveArithmetic'}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties to be mutable; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
+
+  init() {
+    okay = 0
+    nondiff = 0
+    diff = 0
+  }
 }
 func testImmutableStoredProperties() {
   _ = ImmutableStoredProperties.TangentVector(okay: 1)
 }
-struct MutableStoredPropertiesWithInitialValue : Differentiable {
+class MutableStoredPropertiesWithInitialValue : Differentiable {
   var x = Float(1)
   var y = Double(1)
 }
-// Test struct with both an empty constructor and memberwise initializer.
-struct AllMixedStoredPropertiesHaveInitialValue : Differentiable {
+// Test class with both an empty constructor and memberwise initializer.
+class AllMixedStoredPropertiesHaveInitialValue : Differentiable {
   let x = Float(1) // expected-warning {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties to be mutable; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
   static func testMemberwiseInitializer() {
-    _ = AllMixedStoredPropertiesHaveInitialValue(y: 1)
+    _ = AllMixedStoredPropertiesHaveInitialValue()
   }
 }
-struct HasCustomConstructor: Differentiable {
+/*
+class HasCustomConstructor: Differentiable {
   var x = Float(1)
   var y = Float(1)
   // Custom constructor should not affect synthesis.
   init(x: Float, y: Float, z: Bool) {}
 }
+*/
 
-struct Simple : AdditiveArithmetic, Differentiable {
+class Simple : Differentiable {
   var w: Float
   var b: Float
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
 func testSimple() {
-  var simple = Simple(w: 1, b: 1)
-  simple.allDifferentiableVariables = simple + simple
-  simple.move(along: simple)
+  let simple = Simple(w: 1, b: 1)
+  let tangent = Simple.TangentVector(w: 1, b: 1)
+  simple.move(along: tangent)
 }
 
 // Test type with mixed members.
-struct Mixed : AdditiveArithmetic, Differentiable {
+class Mixed : Differentiable {
   var simple: Simple
   var float: Float
+
+  init(simple: Simple, float: Float) {
+    self.simple = simple
+    self.float = float
+  }
 }
-func testMixed(_ simple: Simple) {
-  var mixed = Mixed(simple: simple, float: 1)
-  mixed.allDifferentiableVariables = Mixed(simple: simple, float: 2)
-  mixed.move(along: mixed)
+func testMixed(_ simple: Simple, _ simpleTangent: Simple.TangentVector) {
+  let mixed = Mixed(simple: simple, float: 1)
+  let tangent = Mixed.TangentVector(simple: simpleTangent, float: 1)
+  mixed.move(along: tangent)
 }
 
 // Test type with manual definition of vector space types to `Self`.
-struct VectorSpacesEqualSelf : AdditiveArithmetic, Differentiable {
+final class VectorSpacesEqualSelf : Differentiable & DummyAdditiveArithmetic {
   var w: Float
   var b: Float
   typealias TangentVector = VectorSpacesEqualSelf
   typealias AllDifferentiableVariables = VectorSpacesEqualSelf
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
+/*
+extension VectorSpacesEqualSelf : Equatable, AdditiveArithmetic {
+  static func == (lhs: VectorSpacesEqualSelf, rhs: VectorSpacesEqualSelf) -> Bool {
+    fatalError()
+  }
+  static var zero: VectorSpacesEqualSelf {
+    fatalError()
+  }
+  static func + (lhs: VectorSpacesEqualSelf, rhs: VectorSpacesEqualSelf) -> VectorSpacesEqualSelf {
+    fatalError()
+  }
+  static func - (lhs: VectorSpacesEqualSelf, rhs: VectorSpacesEqualSelf) -> VectorSpacesEqualSelf {
+    fatalError()
+  }
+}
+*/
 
 // Test generic type with vector space types to `Self`.
-struct GenericVectorSpacesEqualSelf<T> : AdditiveArithmetic, Differentiable
+class GenericVectorSpacesEqualSelf<T> : Differentiable
   where T : Differentiable, T == T.TangentVector,
         T == T.AllDifferentiableVariables
 {
   var w: T
   var b: T
+
+  init(w: T, b: T) {
+    self.w = w
+    self.b = b
+  }
 }
 func testGenericVectorSpacesEqualSelf() {
-  var genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
-  genericSame.allDifferentiableVariables = genericSame + genericSame
-  genericSame.move(along: genericSame)
+  let genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
+  let tangent = GenericVectorSpacesEqualSelf.TangentVector(w: 1, b: 1)
+  genericSame.move(along: tangent)
 }
 
 // Test nested type.
-struct Nested : AdditiveArithmetic, Differentiable {
+class Nested : Differentiable {
   var simple: Simple
   var mixed: Mixed
   var generic: GenericVectorSpacesEqualSelf<Double>
+
+  init(simple: Simple, mixed: Mixed, generic: GenericVectorSpacesEqualSelf<Double>) {
+    self.simple = simple
+    self.mixed = mixed
+    self.generic = generic
+  }
 }
 func testNested(
   _ simple: Simple, _ mixed: Mixed,
   _ genericSame: GenericVectorSpacesEqualSelf<Double>
 ) {
-  var nested = Nested(simple: simple, mixed: mixed, generic: genericSame)
-  nested.move(along: nested)
-
-  _ = pullback(at: nested) { model in
-    model.simple + model.simple
-  }
+  _ = Nested(simple: simple, mixed: mixed, generic: genericSame)
 }
 
 // Test type that does not conform to `AdditiveArithmetic` but whose members do.
@@ -127,9 +186,14 @@ func testNested(
 // Vector space structs types must be synthesized.
 // Note: it would be nice to emit a warning if conforming `Self` to
 // `AdditiveArithmetic` is possible.
-struct AllMembersAdditiveArithmetic : Differentiable {
+class AllMembersAdditiveArithmetic : Differentiable {
   var w: Float
   var b: Float
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
 func testAllMembersAdditiveArithmetic() {
   assertAllDifferentiableVariablesEqualsTangentVector(AllMembersAdditiveArithmetic.self)
@@ -141,10 +205,20 @@ func testAllMembersAdditiveArithmetic() {
 struct MyVector : VectorProtocol, Differentiable {
   var w: Float
   var b: Float
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
-struct AllMembersVectorProtocol : Differentiable {
+class AllMembersVectorProtocol : Differentiable {
   var v1: MyVector
   var v2: MyVector
+
+  init(v: MyVector) {
+    v1 = v
+    v2 = v
+  }
 }
 func testAllMembersVectorProtocol() {
   assertConformsToVectorProtocol(AllMembersVectorProtocol.AllDifferentiableVariables.self)
@@ -157,10 +231,20 @@ func testAllMembersVectorProtocol() {
 struct MyVector2 : ElementaryFunctions, Differentiable {
   var w: Float
   var b: Float
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
-struct AllMembersElementaryFunctions : Differentiable {
+class AllMembersElementaryFunctions : Differentiable {
   var v1: MyVector2
   var v2: MyVector2
+
+  init(v: MyVector2) {
+    v1 = v
+    v2 = v
+  }
 }
 func testAllMembersElementaryFunctions() {
   assertConformsToElementaryFunctions(AllMembersElementaryFunctions.AllDifferentiableVariables.self)
@@ -168,11 +252,17 @@ func testAllMembersElementaryFunctions() {
 }
 
 // Test type whose properties are not all differentiable.
-struct DifferentiableSubset : Differentiable {
+class DifferentiableSubset : Differentiable {
   var w: Float
   var b: Float
   @noDerivative var flag: Bool
   @noDerivative let technicallyDifferentiable: Float = .pi
+
+  init(w: Float, b: Float, flag: Bool) {
+    self.w = w
+    self.b = b
+    self.flag = flag
+  }
 }
 func testDifferentiableSubset() {
   assertConformsToAdditiveArithmetic(DifferentiableSubset.AllDifferentiableVariables.self)
@@ -189,10 +279,16 @@ func testDifferentiableSubset() {
 }
 
 // Test nested type whose properties are not all differentiable.
-struct NestedDifferentiableSubset : Differentiable {
+class NestedDifferentiableSubset : Differentiable {
   var x: DifferentiableSubset
   var mixed: Mixed
   @noDerivative var technicallyDifferentiable: Float
+
+  init(x: DifferentiableSubset, mixed: Mixed) {
+    self.x = x
+    self.mixed = mixed
+    technicallyDifferentiable = 0
+  }
 }
 func testNestedDifferentiableSubset() {
   assertAllDifferentiableVariablesEqualsTangentVector(NestedDifferentiableSubset.self)
@@ -200,37 +296,55 @@ func testNestedDifferentiableSubset() {
 
 // Test type that uses synthesized vector space types but provides custom
 // method.
-struct HasCustomMethod : Differentiable {
+class HasCustomMethod : Differentiable {
   var simple: Simple
   var mixed: Mixed
   var generic: GenericVectorSpacesEqualSelf<Double>
-  mutating func move(along direction: TangentVector) {
-     print("Hello world")
-     simple.move(along: direction.simple)
-     mixed.move(along: direction.mixed)
-     generic.move(along: direction.generic)
+
+  init(simple: Simple, mixed: Mixed, generic: GenericVectorSpacesEqualSelf<Double>) {
+    self.simple = simple
+    self.mixed = mixed
+    self.generic = generic
+  }
+
+  func move(along direction: TangentVector) {
+    print("Hello world")
+    simple.move(along: direction.simple)
+    mixed.move(along: direction.mixed)
+    generic.move(along: direction.generic)
   }
 }
 
 // Test type that conforms to `KeyPathIterable`.
-// The `AllDifferentiableVariables` struct should also conform to `KeyPathIterable`.
-struct TestKeyPathIterable : Differentiable, KeyPathIterable {
+// The `AllDifferentiableVariables` class should also conform to `KeyPathIterable`.
+class TestKeyPathIterable : Differentiable, KeyPathIterable {
   var w: Float
   @noDerivative let technicallyDifferentiable: Float = .pi
+
+  // NOTE: `KeyPathIterable` derived conformances do not yet support class
+  // types.
+  var allKeyPaths: [PartialKeyPath<TestKeyPathIterable>] {
+    [\TestKeyPathIterable.w, \TestKeyPathIterable.technicallyDifferentiable]
+  }
+
+  init(w: Float) {
+    self.w = w
+    technicallyDifferentiable = 0
+  }
 }
 func testKeyPathIterable(x: TestKeyPathIterable) {
   _ = x.allDifferentiableVariables.allKeyPaths
 }
 
 // Test type with user-defined memberwise initializer.
-struct TF_25: Differentiable {
+class TF_25: Differentiable {
   public var bar: Float
   public init(bar: Float) {
     self.bar = bar
   }
 }
 // Test user-defined memberwise initializer.
-struct TF_25_Generic<T : Differentiable>: Differentiable {
+class TF_25_Generic<T : Differentiable>: Differentiable {
   public var bar: T
   public init(bar: T) {
     self.bar = bar
@@ -238,59 +352,94 @@ struct TF_25_Generic<T : Differentiable>: Differentiable {
 }
 
 // Test initializer that is not a memberwise initializer because of stored property name vs parameter label mismatch.
-struct HasCustomNonMemberwiseInitializer<T : Differentiable>: Differentiable {
+class HasCustomNonMemberwiseInitializer<T : Differentiable>: Differentiable {
   var value: T
   init(randomLabel value: T) { self.value = value }
 }
 
 // Test type with generic environment.
-struct HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differentiable {
-  var x: Float
+class HasGenericEnvironment<Scalar : FloatingPoint & Differentiable> : Differentiable {
+  var x: Float = 0
 }
 
 // Test type with generic members that conform to `Differentiable`.
-struct GenericSynthesizeAllStructs<T : Differentiable> : Differentiable {
+class GenericSynthesizeAllStructs<T : Differentiable> : Differentiable {
   var w: T
   var b: T
+
+  init(w: T, b: T) {
+    self.w = w
+    self.b = b
+  }
 }
 
 // Test type in generic context.
-struct A<T : Differentiable> {
-  struct B<U : Differentiable, V> : Differentiable {
-    struct InGenericContext : Differentiable {
+class A<T : Differentiable> {
+  class B<U : Differentiable, V> : Differentiable {
+    class InGenericContext : Differentiable {
       @noDerivative var a: A
       var b: B
       var t: T
       var u: U
+
+      init(a: A, b: B, t: T, u: U) {
+        self.a = a
+        self.b = b
+        self.t = t
+        self.u = u
+      }
     }
   }
 }
 
 // Test extension.
-struct Extended {
+class Extended {
   var x: Float
+
+  init(x: Float) {
+    self.x = x
+  }
 }
 extension Extended : Differentiable {}
 
 // Test extension of generic type.
-struct GenericExtended<T> {
+class GenericExtended<T> {
   var x: T
+
+  init(x: T) {
+    self.x = x
+  }
 }
 extension GenericExtended : Differentiable where T : Differentiable {}
 
 // Test constrained extension of generic type.
-struct GenericConstrained<T> {
+class GenericConstrained<T> {
   var x: T
+
+  init(x: T) {
+    self.x = x
+  }
 }
 extension GenericConstrained : Differentiable
   where T : Differentiable {}
 
-struct TF_260<T : Differentiable> : Differentiable & AdditiveArithmetic {
+final class TF_260<T : Differentiable> : Differentiable & DummyAdditiveArithmetic {
   var x: T.TangentVector
+
+  init(x: T.TangentVector) {
+    self.x = x
+  }
 }
 
 // TF-269: Test crash when differentiation properties have no getter.
 // Related to access levels and associated type inference.
+
+// TODO(TF-631): Blocked by class type differentiation support.
+// [AD] Unhandled instruction in adjoint emitter:   %2 = ref_element_addr %0 : $TF_269, #TF_269.filter // user: %3
+// [AD] Diagnosing non-differentiability.
+// [AD] For instruction:
+//   %2 = ref_element_addr %0 : $TF_269, #TF_269.filter // user: %3
+/*
 public protocol TF_269_Layer: Differentiable & KeyPathIterable
   where AllDifferentiableVariables: KeyPathIterable {
 
@@ -299,29 +448,63 @@ public protocol TF_269_Layer: Differentiable & KeyPathIterable
   func applied(to input: Input) -> Output
 }
 
-public struct TF_269 : TF_269_Layer {
+public class TF_269 : TF_269_Layer {
   public var filter: Float
   public typealias Activation = @differentiable (Output) -> Output
-  @noDerivative public let activation: Activation
+  @noDerivative public let activation: @differentiable (Output) -> Output
+
+  init(filter: Float, activation: @escaping Activation) {
+    self.filter = filter
+    self.activation = activation
+  }
+
+  // NOTE: `KeyPathIterable` derived conformances do not yet support class
+  // types.
+  public var allKeyPaths: [PartialKeyPath<TF_269>] {
+    []
+  }
 
   public func applied(to input: Float) -> Float {
     return input
   }
 }
+*/
 
 // Test errors.
+
+// expected-error @+1 {{class 'MissingInitializer' has no initializers}}
+class MissingInitializer : Differentiable {
+  // expected-note @+1 {{stored property 'w' without initial value prevents synthesized initializers}}
+  var w: Float
+  // expected-note @+1 {{stored property 'b' without initial value prevents synthesized initializers}}
+  var b: Float
+}
 
 // Test manually customizing vector space types.
 // Thees should fail. Synthesis is semantically unsupported if vector space
 // types are customized.
-// expected-error @+1 {{type 'VectorSpaceTypeAlias' does not conform to protocol 'Differentiable'}}
-struct VectorSpaceTypeAlias : AdditiveArithmetic, Differentiable {
+final class TangentVectorWB : DummyAdditiveArithmetic, Differentiable {
   var w: Float
   var b: Float
-  typealias TangentVector = Simple
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
+}
+// expected-error @+1 {{type 'VectorSpaceTypeAlias' does not conform to protocol 'Differentiable'}}
+final class VectorSpaceTypeAlias : DummyAdditiveArithmetic, Differentiable {
+  var w: Float
+  var b: Float
+  typealias TangentVector = TangentVectorWB
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
 // expected-error @+1 {{type 'VectorSpaceCustomStruct' does not conform to protocol 'Differentiable'}}
-struct VectorSpaceCustomStruct : AdditiveArithmetic, Differentiable {
+final class VectorSpaceCustomStruct : DummyAdditiveArithmetic, Differentiable {
   var w: Float
   var b: Float
   struct TangentVector : AdditiveArithmetic, Differentiable {
@@ -329,40 +512,49 @@ struct VectorSpaceCustomStruct : AdditiveArithmetic, Differentiable {
     var b: Float.TangentVector
     typealias TangentVector = VectorSpaceCustomStruct.TangentVector
   }
+
+  init(w: Float, b: Float) {
+    self.w = w
+    self.b = b
+  }
 }
 
-struct StaticNoDerivative : Differentiable {
+class StaticNoDerivative : Differentiable {
   @noDerivative static var s: Bool = true // expected-error {{'@noDerivative' is only allowed on stored properties in structure or class types that declare a conformance to 'Differentiable'}}
 }
 
-struct StaticMembersShouldNotAffectAnything : AdditiveArithmetic, Differentiable {
+final class StaticMembersShouldNotAffectAnything : DummyAdditiveArithmetic, Differentiable {
   static var x: Bool = true
   static var y: Bool = false
 }
 
-struct ImplicitNoDerivative : Differentiable {
-  var a: Float
-  var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
+class ImplicitNoDerivative : Differentiable {
+  var a: Float = 0
+  var b: Bool = true // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
 }
 
-struct ImplicitNoDerivativeWithSeparateTangent : Differentiable {
+class ImplicitNoDerivativeWithSeparateTangent : Differentiable {
   var x: DifferentiableSubset
-  var b: Bool // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  var b: Bool = true // expected-warning {{stored property 'b' has no derivative because it does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+
+  init(x: DifferentiableSubset) {
+    self.x = x
+  }
 }
 
 // TF-265: Test invalid initializer (that uses a non-existent type).
-struct InvalidInitializer : Differentiable {
+class InvalidInitializer : Differentiable {
   init(filterShape: (Int, Int, Int, Int), blah: NonExistentType) {} // expected-error {{use of undeclared type 'NonExistentType'}}
 }
 
 // Test memberwise initializer synthesis.
-struct NoMemberwiseInitializerExtended<T> {
+final class NoMemberwiseInitializerExtended<T> {
   var value: T
   init(_ value: T) {
     self.value = value
   }
 }
-extension NoMemberwiseInitializerExtended: Equatable, AdditiveArithmetic
+extension NoMemberwiseInitializerExtended: Equatable, AdditiveArithmetic, DummyAdditiveArithmetic
   where T : AdditiveArithmetic {}
 extension NoMemberwiseInitializerExtended: Differentiable
   where T : Differentiable & AdditiveArithmetic {}


### PR DESCRIPTION
`Differentiable` derived conformances now supports class types.
Synthesis works just like for struct types.

Class differentiation support requires further differentiation transform changes.

Resolves [TF-630](https://bugs.swift.org/browse/TF-630).

Next steps:
* [TF-631](https://bugs.swift.org/browse/TF-631): Enable differentiation of class methods (handle `ref_element_addr` in differentiation transform).
* [TF-633](https://bugs.swift.org/browse/TF-633): Update `tensorflow-swift-apis` using `Differentiable`-conforming class types.

---

```swift
class Example<T : Differentiable> : Differentiable {
  var x, y: T
  @noDerivative var flag: Bool = true

  // Unlike structs, classes do not get synthesized memberwise initializers.
  // User must define initializer or provide default values for stored properties.
  init(x: T, y: T) {
    self.x = x
    self.y = y
  }

  // Compiler synthesizes (omitting `AllDifferentiableVariables` code):
  //
  // struct TangentVector : Differentiable, AdditiveArithmetic {
  //   var x: T.TangentVector
  //   var y: T.TangentVector
  //   init(x: T.TangentVector, y: T.TangentVector)
  //   typealias TangentVector = Example<T>.TangentVector
  //   final static var zero: Example<T>.TangentVector { get }
  //   static func + (lhs: Example<T>.TangentVector, rhs: Example<T>.TangentVector) -> Example<T>.TangentVector
  //   static func - (lhs: Example<T>.TangentVector, rhs: Example<T>.TangentVector) -> Example<T>.TangentVector
  //   @_implements(Equatable, ==(_:_:)) static func __derived_struct_equals(_ a: Example<T>.TangentVector, _ b: Example<T>.TangentVector) -> Bool
  // }
  //
  // func move(along direction: Example<T>.TangentVector) {
  //   x.move(along: direction.x)
  //   y.move(along: direction.y)
  // }
}
```