### PR TITLE
Allow #if in function builders.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -136,6 +136,12 @@ public:
       }
 
       if (auto decl = node.dyn_cast<Decl *>()) {
+        // Just ignore #if; the chosen children should appear in the
+        // surrounding context.  This isn't good for source tools but it
+        // at least works.
+        if (isa<IfConfigDecl>(decl))
+          continue;
+
         if (!unhandledNode)
           unhandledNode = decl;
 

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -149,6 +149,19 @@ tuplify(true) {
   }
 }
 
+// rdar://50710698
+// CHECK: ("chain5", 8, 9)
+tuplify(true) {
+  "chain5"
+  #if false
+    6
+    $0
+  #else
+    8
+    9
+  #endif
+}
+
 // CHECK: ("getterBuilder", 0, 4, 12)
 @TupleBuilder
 var globalBuilder: (String, Int, Int, Int) {


### PR DESCRIPTION
Dropping the IfConfigDecl is not a great implementation, but it'll work well enough to unblock this code while we work to allow multi-statement bodies in general.

rdar://50710698