### PR TITLE
[sil] Add dumpers for ResilienceExpansion/TypeLowering.

### DIFF
--- a/include/swift/AST/ResilienceExpansion.h
+++ b/include/swift/AST/ResilienceExpansion.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_AST_RESILIENCE_EXPANSION_H
 #define SWIFT_AST_RESILIENCE_EXPANSION_H
 
+#include "llvm/Support/raw_ostream.h"
+
 namespace swift {
 
 /// A specification for how much to expand resilient types.
@@ -43,6 +45,16 @@ enum class ResilienceExpansion : unsigned {
 
   Last_ResilienceExpansion = Maximal
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     ResilienceExpansion expansion) {
+  switch (expansion) {
+  case ResilienceExpansion::Minimal:
+    return os << "Minimal";
+  case ResilienceExpansion::Maximal:
+    return os << "Maximal";
+  }
+}
 
 } // namespace swift
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -250,6 +250,12 @@ public:
 
   virtual ~TypeLowering() {}
 
+  /// Print out the internal state of this type lowering into \p os.
+  void print(llvm::raw_ostream &os) const;
+
+  /// Dump out the internal state of this type lowering to llvm::dbgs().
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "Only for use in the debugger");
+
   /// Are r-values of this type passed as arguments indirectly by formal
   /// convention?
   ///

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2687,3 +2687,22 @@ unsigned TypeConverter::countNumberOfFields(SILType Ty,
   TypeFields[key] = fieldsCount;
   return std::max(fieldsCount, 1U);
 }
+
+void TypeLowering::print(llvm::raw_ostream &os) const {
+  auto BOOL = [&](bool b) -> StringRef {
+    if (b)
+      return "true";
+    return "false";
+  };
+  os << "Type Lowering for lowered type: " << LoweredType << ".\n"
+     << "Expansion: " << ResilienceExpansion(ForExpansion) << "\n"
+     << "isTrivial: " << BOOL(Properties.isTrivial()) << ".\n"
+     << "isFixedABI: " << BOOL(Properties.isFixedABI()) << ".\n"
+     << "isAddressOnly: " << BOOL(Properties.isAddressOnly()) << ".\n"
+     << "isResilient: " << BOOL(Properties.isResilient()) << ".\n"
+     << "\n";
+}
+
+void TypeLowering::dump() const {
+  print(llvm::dbgs());
+}


### PR DESCRIPTION
This makes it much easier to debug TypeLowering since one can find when
recursive properties do not match up/etc.
