### PR TITLE
[sil] Add support to SILType for looking up its mangled name.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -538,7 +538,11 @@ public:
   bool operator!=(SILType rhs) const {
     return value.getOpaqueValue() != rhs.value.getOpaqueValue();
   }
-  
+
+  /// Return the mangled name of this type, ignoring its prefix. Meant for
+  /// diagnostic purposes.
+  std::string getMangledName() const;
+
   std::string getAsString() const;
   void dump() const;
   void print(raw_ostream &OS) const;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -14,6 +14,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Type.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include "swift/SIL/SILFunctionConventions.h"
@@ -96,6 +97,11 @@ bool SILType::isNoReturnFunction() const {
     return funcTy->isNoReturnFunction();
 
   return false;
+}
+
+std::string SILType::getMangledName() const {
+  Mangle::ASTMangler mangler(false/*use dwarf mangling*/);
+  return mangler.mangleTypeWithoutPrefix(getASTType());
 }
 
 std::string SILType::getAsString() const {


### PR DESCRIPTION
This can be really useful when using conditional break points in
TypeLowering.

NOTE: Certain SILTypes do not have manglings and this will assert! We should
change the mangling infrastructure to just return Optional<None> or false
instead.
