### PR TITLE
[5.1] SILGen: Don't explode inout tuples in init allocating entry points.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -311,8 +311,8 @@ static void makeArgument(Type ty, ParamDecl *decl,
                          SmallVectorImpl<SILValue> &args, SILGenFunction &SGF) {
   assert(ty && "no type?!");
   
-  // Destructure tuple arguments.
-  if (TupleType *tupleTy = ty->getAs<TupleType>()) {
+  // Destructure tuple value arguments.
+  if (TupleType *tupleTy = decl->isInOut() ? nullptr : ty->getAs<TupleType>()) {
     for (auto fieldType : tupleTy->getElementTypes())
       makeArgument(fieldType, decl, args, SGF);
   } else {

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1147,3 +1147,10 @@ extension MemberInits {
     // CHECK-NEXT:  = apply [[INIT_FN]]<Array<T>>() : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> () -> @owned String
   }
 }
+
+// rdar://problem/51302498
+
+class Butt {
+  init(foo: inout (Int, Int)) { }
+}
+


### PR DESCRIPTION
Explanation: Miscompile in SILGen, where we would enter an inconsistent state when class initializers take inout tuples

Scope: Regression from Swift 4.2

Issue: rdar://problem/51302498

Risk: Low

Testing: Swift CI, compat suite

Reviewed by: @slavapestov 