### PR TITLE
[5.1] [code-completion] Disable diagnostics in @functionBuilder bodies

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -103,6 +103,13 @@ public:
            rangeContainsTokenLoc(Enclosing, Inner.End);
   }
 
+  /// Returns true if range \p R contains the code-completion location, if any.
+  bool rangeContainsCodeCompletionLoc(SourceRange R) const {
+    return CodeCompletionBufferID
+               ? rangeContainsTokenLoc(R, getCodeCompletionLoc())
+               : false;
+  }
+
   /// Returns the buffer ID for the specified *valid* location.
   ///
   /// Because a valid source location always corresponds to a source buffer,


### PR DESCRIPTION
Cherry-pick #25922 to swift-5.1-branch. Reviewed by @xedin and @rintaro

---

When performing code-completion inside the body of a @functionBuilder
closure/function, set the flag to suppress diagnostics. This works
around a big performance problem in some complex bodies that do not
typecheck, which is typical during code-completion. A real-world example
with SwitfUI went from ~50 seconds to 0.5. We do not disable diagnostics
in general because the diagnostic paths provide falback types that are
useful to code-completion.

rdar://52356229