### PR TITLE
[5.1] Diagnose missing expr in non-void single-expr func. [52025782]

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -68,6 +68,18 @@ public:
     return !TheFunction.get<AbstractClosureExpr *>()->getType().isNull();
   }
 
+  bool hasSingleExpressionBody() const {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
+      return AFD->hasSingleExpressionBody();
+    return TheFunction.get<AbstractClosureExpr *>()->hasSingleExpressionBody();
+  }
+
+  Expr *getSingleExpressionBody() const {
+    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
+      return AFD->getSingleExpressionBody();
+    return TheFunction.get<AbstractClosureExpr *>()->getSingleExpressionBody();
+  }
+
   Type getType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->getInterfaceType();

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3684,6 +3684,12 @@ public:
   /// Whether this closure consists of a single expression.
   bool hasSingleExpressionBody() const;
 
+  /// Retrieve the body for closure that has a single expression for
+  /// its body.
+  ///
+  /// Only valid when \c hasSingleExpressionBody() is true.
+  Expr *getSingleExpressionBody() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_AbstractClosureExpr &&
            E->getKind() <= ExprKind::Last_AbstractClosureExpr;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1911,6 +1911,15 @@ bool AbstractClosureExpr::hasSingleExpressionBody() const {
   return true;
 }
 
+Expr *AbstractClosureExpr::getSingleExpressionBody() const {
+  if (auto closure = dyn_cast<ClosureExpr>(this))
+    return closure->getSingleExpressionBody();
+  else if (auto autoclosure = dyn_cast<AutoClosureExpr>(this))
+    return autoclosure->getSingleExpressionBody();
+
+  return nullptr;
+}
+
 #define FORWARD_SOURCE_LOCS_TO(CLASS, NODE) \
   SourceRange CLASS::getSourceRange() const {     \
     return (NODE)->getSourceRange();              \

--- a/test/Parse/omit_return_fail.swift
+++ b/test/Parse/omit_return_fail.swift
@@ -3,3 +3,7 @@
 func badIs<T>(_ value: Any, anInstanceOf type: T.Type) -> Bool {
     value is type // expected-error {{use of undeclared type 'type'}}
 }
+
+func foo() -> Int {
+    return // expected-error {{non-void function should return a value}}
+}


### PR DESCRIPTION
After SE-0255, compiling

```
func foo() -> Int {
    return
}
```

would result in a diagnostic without source location:

```
<unknown>:0: error: cannot convert return expression of type '()' to
```

Now, it results in

```
filename.swift:8:5: error: non-void function should return a value
    return
    ^
```

as it did prior to SE-0255.

To achieve that, during type checking for statements, when the StmtChecker visits return statements, check whether we are within a non-void-returning, single-expression function and that that single expression is an implicit empty tuple.  (An empty implicit tuple is added as the result of a resultless return statement that appears as the only element in a single-expression function.)

To facilitate that, `hasSingleExpressionBody` and `getSingleExpressionBody` was added to `AnyFunctionRef` and added `getSingleExpressionBody` to `AbstractClosureExpr` (which already had `hasSingleExpressionBody`).

rdar://problem/52025782

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
