### PR TITLE
Update checkout for 'tensorflow/swift-apis'.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -401,7 +401,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-06-23-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-06-23-a",
                 "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
-                "tensorflow-swift-apis": "91991b6abdb01acc34139233858d87721ca7312c",
+                "tensorflow-swift-apis": "9a3f393e027ab851cee51324c138e8f05d6fbece",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-06-23-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-06-23-a"
             }


### PR DESCRIPTION
Update to https://github.com/tensorflow/swift-apis/commit/9a3f393e027ab851cee51324c138e8f05d6fbece, getting us function-builder-based `Sequential` layers.