### PR TITLE
SIL: Fix incorrect lowering of tuples containing trivial types which are resilient

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -436,7 +436,7 @@ namespace {
       }
       assert(props.isFixedABI() && "unsupported combination for now");
       if (props.isTrivial()) {
-        return asImpl().handleTrivial(type);
+        return asImpl().handleTrivial(type, props);
       }
       return asImpl().handleNonTrivialAggregate(type, props);
     }
@@ -1532,8 +1532,10 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
 
   if (prev == nullptr)
     insert(key, lowering);
-  else
+  else {
     prev->NextExpansion = lowering;
+    assert(prev->isResilient() == lowering->isResilient());
+  }
 
   return *lowering;
 }
@@ -1680,9 +1682,10 @@ TypeConverter::getTypeLoweringForLoweredType(TypeKey key,
                        forExpansion,
                        key.isDependent()).visit(key.SubstType);
 
-  if (prev)
+  if (prev) {
     prev->NextExpansion = lowering;
-  else
+    assert(prev->isResilient() == lowering->isResilient());
+  } else
     insert(key, lowering);
   return *lowering;
 }

--- a/test/SILOptimizer/Inputs/type_lowering_resilience_other.swift
+++ b/test/SILOptimizer/Inputs/type_lowering_resilience_other.swift
@@ -1,0 +1,12 @@
+@frozen public struct Holder<T> {
+  var ref: AnyObject?
+  var inner: (T, T)
+
+  public init(_ t: T) { ref = nil; inner = (t, t) }
+}
+
+public struct Inner {
+  var x: Int
+
+  public init() { x = 0 }
+}

--- a/test/SILOptimizer/type_lowering_resilience.swift
+++ b/test/SILOptimizer/type_lowering_resilience.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil -O %S/Inputs/type_lowering_resilience_other.swift -primary-file %s -enable-library-evolution
+
+@inline(__always) public func generic<T>(_ t: T) {
+  _ = Holder<T>(t)
+}
+
+public func concrete() {
+  generic(Inner())
+}


### PR DESCRIPTION
If a type is trivial in its own module but resilient outside, then we
fail to propagate the 'is resilient' bit to the outer type's lowering.

As a result, if the first time the type is lowered with the Maximal
expansion, we don't re-compute the lowering when it is again lowered
with the Minimal expansion.

This can produce invalid SIL and trigger assertions.

Fixes <rdar://problem/52270675>.