### PR TITLE
SourceKit/Indentation: avoid indenting closing paren of function-like decls if it appears in a new line

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -355,6 +355,20 @@ public:
       }
     }
 
+    // func foo(a: Int,
+    //          b: Int
+    // ) {} <- Avoid adding indentation here
+    SourceLoc SignatureEnd;
+    if (auto *AFD = dyn_cast_or_null<AbstractFunctionDecl>(Cursor->getAsDecl())) {
+      SignatureEnd = AFD->getSignatureSourceRange().End;
+    } else if (auto *SD = dyn_cast_or_null<SubscriptDecl>(Cursor->getAsDecl())) {
+      SignatureEnd = SD->getSignatureSourceRange().End;
+    }
+    if (SignatureEnd.isValid() && TInfo &&
+        TInfo.StartOfLineTarget->getLoc() == SignatureEnd) {
+      return false;
+    }
+
     // If we're at the beginning of a brace on a separate line in the context
     // of anything other than BraceStmt, don't add an indent.
     // For example:

--- a/test/SourceKit/CodeFormat/indent-param.swift
+++ b/test/SourceKit/CodeFormat/indent-param.swift
@@ -1,0 +1,23 @@
+public static func buildBlock(
+    _ shapes: PathShape...
+) -> PathShape {
+    return nil
+}
+
+class C {
+    init(a: Int,
+        b: Int
+) {}
+    subscript(index1: Int,
+              index2: Int
+) -> Int { get {} }
+}
+
+// RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=10 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=13 -length=1 %s >>%t.response
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+
+// CHECK: key.sourcetext: ") -> PathShape {"
+// CHECK: key.sourcetext: "    ) {}"
+// CHECK: key.sourcetext: "    ) -> Int { get {} }"


### PR DESCRIPTION
rdar://51719094