### PR TITLE
[5.1] ABI Checker: diagnose underlying type changes of opaque result types from inlinable decls.

### DIFF
--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -175,3 +175,21 @@ public protocol HasMutatingMethodClone: HasMutatingMethod {
 public extension Int {
   public func IntEnhancer() {}
 }
+
+public protocol Animal {}
+public class Cat: Animal { public init() {} }
+public class Dog: Animal { public init() {} }
+
+public class Zoo {
+  public init() {}
+  @inlinable
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public var current: some Animal {
+    return Cat()
+  }
+  @inlinable
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public func getCurrentAnimalInlinable() -> some Animal {
+    return Cat()
+  }
+}

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -182,3 +182,21 @@ public protocol HasMutatingMethodClone: HasMutatingMethod {
   func foo()
   var bar: Int { get }
 }
+
+public protocol Animal {}
+public class Cat: Animal { public init() {} }
+public class Dog: Animal { public init() {} }
+
+public class Zoo {
+  public init() {}
+  @inlinable
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public var current: some Animal {
+    return Dog()
+  }
+  @inlinable
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public func getCurrentAnimalInlinable() -> some Animal {
+    return Dog()
+  }
+}

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -31,6 +31,7 @@ cake: Func S1.foo5(x:y:) has been renamed to Func foo5(x:y:z:)
 cake: Struct Somestruct2 has been renamed to Struct NSSomestruct2
 
 /* Type Changes */
+cake: Accessor Zoo.current.Get() has return type change from Cat to Dog
 cake: AssociatedType AssociatedTypePro.T3 has default type change from C1 to C6
 cake: Class TChangesFromIntToString has type witness type for AssociatedTypesProtocol.T changing from Int to String
 cake: Constructor S1.init(_:) has parameter 0 type change from Int to Double
@@ -40,8 +41,10 @@ cake: Func C7.foo(_:_:) has removed default argument from parameter 1
 cake: Func EscapingFunctionType.addedEscaping(_:) has added @escaping in parameter 0
 cake: Func EscapingFunctionType.removedEscaping(_:) has removed @escaping in parameter 0
 cake: Func Somestruct2.foo1(_:) has parameter 0 type change from C3 to C1
+cake: Func Zoo.getCurrentAnimalInlinable() has return type change from Cat to Dog
 cake: Func ownershipChange(_:_:) has parameter 0 changing from InOut to Default
 cake: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
+cake: Var Zoo.current has declared type change from Cat to Dog
 
 /* Decl Attribute changes */
 cake: Accessor GlobalLetChangedToVar.Modify() is a new API without @available attribute


### PR DESCRIPTION
Explanation: The changes of underlying types pf opaque result types returned from inlinable functions can break the existing ABI. This change teaches the ABI checker to diagnose such changes.
Scope: Swift ABI checker
Issue: rdar://52273137
Risk: Very Low, doesn't affect anything in the compiler side
Testing: Regression tests added
Reviewer: Argyrios Kyrtzidis (@akyrtzi)