### PR TITLE
[5.1] Two function-builders fixes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2869,7 +2869,13 @@ public:
     assert(!NamingDecl && "already have naming decl");
     NamingDecl = D;
   }
-  
+
+  /// Is this opaque type the opaque return type of the given function?
+  ///
+  /// This is more complex than just checking `getNamingDecl` because the
+  /// function could also be the getter of a storage declaration.
+  bool isOpaqueReturnTypeOfFunction(const AbstractFunctionDecl *func) const;
+
   GenericSignature *getOpaqueInterfaceGenericSignature() const {
     return OpaqueInterfaceGenericSignature;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6445,6 +6445,21 @@ OpaqueTypeDecl::OpaqueTypeDecl(ValueDecl *NamingDecl,
   setImplicit();
 }
 
+bool OpaqueTypeDecl::isOpaqueReturnTypeOfFunction(
+                                       const AbstractFunctionDecl *func) const {
+  // Either the function is declared with its own opaque return type...
+  if (getNamingDecl() == func)
+    return true;
+
+  // ...or the function is a getter for a property or subscript with an
+  // opaque return type.
+  if (auto accessor = dyn_cast<AccessorDecl>(func)) {
+    return accessor->isGetter() && getNamingDecl() == accessor->getStorage();
+  }
+
+  return false;
+}
+
 Identifier OpaqueTypeDecl::getOpaqueReturnTypeIdentifier() const {
   assert(getNamingDecl() && "not an opaque return type");
   if (!OpaqueReturnTypeIdentifier.empty())

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -498,6 +498,11 @@ bool TypeChecker::typeCheckFunctionBuilderFuncBody(FuncDecl *FD,
           FD->getBody()->getSourceRange()))
     options |= TypeCheckExprFlags::SuppressDiagnostics;
 
+  if (auto opaque = returnType->getAs<OpaqueTypeArchetypeType>()) {
+    if (opaque->getDecl()->isOpaqueReturnTypeOfFunction(FD))
+      options |= TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType;
+  }
+
   // Type-check the single result expression.
   Type returnExprType = typeCheckExpression(returnExpr, FD,
                                             TypeLoc::withoutLoc(returnType),

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -136,6 +136,12 @@ public:
       }
 
       if (auto decl = node.dyn_cast<Decl *>()) {
+        // Just ignore #if; the chosen children should appear in the
+        // surrounding context.  This isn't good for source tools but it
+        // at least works.
+        if (isa<IfConfigDecl>(decl))
+          continue;
+
         if (!unhandledNode)
           unhandledNode = decl;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -496,16 +496,8 @@ public:
       auto funcDecl = TheFunc->getAbstractFunctionDecl();
       if (!funcDecl)
         return false;
-      // Either the function is declared with its own opaque return type...
-      if (opaque->getNamingDecl() == funcDecl)
-        return true;
-      // ...or the function is a getter for a property or subscript with an
-      // opaque return type.
-      if (auto accessor = dyn_cast<AccessorDecl>(funcDecl)) {
-        return accessor->isGetter()
-          && opaque->getNamingDecl() == accessor->getStorage();
-      }
-      return false;
+
+      return opaque->isOpaqueReturnTypeOfFunction(funcDecl);
     };
     
     if (auto opaque = ResultTy->getAs<OpaqueTypeArchetypeType>()) {

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -149,6 +149,19 @@ tuplify(true) {
   }
 }
 
+// rdar://50710698
+// CHECK: ("chain5", 8, 9)
+tuplify(true) {
+  "chain5"
+  #if false
+    6
+    $0
+  #else
+    8
+    9
+  #endif
+}
+
 // CHECK: ("getterBuilder", 0, 4, 12)
 @TupleBuilder
 var globalBuilder: (String, Int, Int, Int) {

--- a/test/Constraints/function_builder_opaque_result.swift
+++ b/test/Constraints/function_builder_opaque_result.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
+
+protocol Taggable {}
+extension String: Taggable {}
+
+@_functionBuilder
+struct TaggableBuilder {
+  static func buildBlock(_ params: Taggable...) -> String {
+    return "Your tags weren't worth keeping anyway"
+  }
+}
+
+@TaggableBuilder
+func testFuncWithOpaqueResult() -> some Taggable {
+  "This is an amazing tag"
+}
+
+@TaggableBuilder
+var testGetterWithOpaqueResult: some Taggable {
+  "This is also an amazing tag"
+}


### PR DESCRIPTION
A pair of quick fixes for issues with function builders that have come up in testing.  The first issue is that function-builder attributes like `@ViewBuilder` can't be applied to functions with opaque return types, like `@ViewBuilder var body: some View { ... }` (rdar://51594359).  The second issue is that the function-builder transformation was tripped up by `#if` blocks in the function body (rdar://50710698).  Both of these are straightforward to fix with the existing transformation and pose no risk for non-function-builder code.

The master PRs were #25926 and #25917, respectively.

Scope: stop rejecting a pair of valid code patterns
Risk: low; targeted fixes localized to code for processing function builders
Testing: ordinary regression testing
Reviewer: Joe Groff