### PR TITLE
[utils/gyb_syntax_support] Add the classification kind for identifiers

### DIFF
--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -314,7 +314,7 @@ SYNTAX_TOKENS = [
             classification='StringLiteral', serialization_code=113),
 
     Misc('Unknown', 'unknown', serialization_code=115),
-    Misc('Identifier', 'identifier', classification=None,
+    Misc('Identifier', 'identifier', classification='Identifier',
          serialization_code=105),
     Misc('UnspacedBinaryOperator', 'oper_binary_unspaced',
          serialization_code=107),


### PR DESCRIPTION
**Explanation**: SwiftSyntax’s classification mechanism should tag normal identifier tokens as `Identifier`. This is useful for community tools using this mechanism from SwiftSyntax. For more context see this post: https://forums.swift.org/t/classification-of-identifier/20860
**Scope**: Affects the syntax classifier mechanism of SwiftSyntax
**Issue**: rdar://problem/52543169
**Risk**: Very Low, doesn't affect anything in the compiler side
**Testing**: Updated tests in SwiftSyntax repo
**Reviewer**: Xi Ge (@nkcsgexi)