### PR TITLE
Capture checking cleanup

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -113,6 +113,12 @@ ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",
       (Type, Type))
 
+ERROR(c_function_pointer_from_function_with_context,none,
+      "a C function pointer cannot be formed from a "
+      "%select{local function|closure}0 that captures "
+      "%select{context|generic parameters|dynamic Self type|<<error>}1",
+      (bool, unsigned))
+
 ERROR(objc_selector_malformed,none,"the type ObjectiveC.Selector is malformed",
       ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1121,11 +1121,6 @@ ERROR(c_function_pointer_from_method,none,
 ERROR(c_function_pointer_from_generic_function,none,
       "a C function pointer cannot be formed from a reference to a generic "
       "function", ())
-ERROR(c_function_pointer_from_function_with_context,none,
-      "a C function pointer cannot be formed from a "
-      "%select{local function|closure}0 that captures "
-      "%select{context|generic parameters|dynamic Self type|<<error>}1",
-      (bool, unsigned))
 ERROR(invalid_autoclosure_forwarding,none,
       "add () to forward @autoclosure parameter", ())
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5795,8 +5795,6 @@ maybeDiagnoseUnsupportedFunctionConversion(ConstraintSystem &cs, Expr *expr,
       } else if (fn->getGenericParams()) {
         tc.diagnose(expr->getLoc(),
                     diag::c_function_pointer_from_generic_function);
-      } else {
-        tc.maybeDiagnoseCaptures(expr, fn);
       }
     };
     
@@ -5817,10 +5815,8 @@ maybeDiagnoseUnsupportedFunctionConversion(ConstraintSystem &cs, Expr *expr,
       semanticExpr = capture->getClosureBody();
     
     // Can convert a literal closure that doesn't capture context.
-    if (auto closure = dyn_cast<ClosureExpr>(semanticExpr)) {
-      tc.maybeDiagnoseCaptures(expr, closure);
+    if (auto closure = dyn_cast<ClosureExpr>(semanticExpr))
       return;
-    }
     
     tc.diagnose(expr->getLoc(),
                 diag::invalid_c_function_pointer_conversion_expr);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -569,13 +569,6 @@ public:
   /// will need to compute captures for.
   std::vector<AbstractClosureExpr *> ClosuresWithUncomputedCaptures;
 
-  /// A set of local functions from which C function pointers are derived.
-  ///
-  /// This is used to diagnose the use of local functions with captured context
-  /// as C function pointers when the function's captures have not yet been
-  /// computed.
-  llvm::DenseMap<AnyFunctionRef, std::vector<Expr*>> LocalCFunctionPointers;
-
 private:
   /// The # of times we have performed typo correction.
   unsigned NumTypoCorrections = 0;
@@ -1433,10 +1426,6 @@ public:
 
   /// Type-check a for-each loop's pattern binding and sequence together.
   bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt);
-
-  /// Lazily diagnose conversions to C function pointers of closures
-  /// with captures.
-  void maybeDiagnoseCaptures(Expr *E, AnyFunctionRef AFR);
 
   /// Compute the set of captures for the given function or closure.
   void computeCaptures(AnyFunctionRef AFR);

--- a/test/Parse/c_function_pointers.swift
+++ b/test/Parse/c_function_pointers.swift
@@ -11,19 +11,12 @@ class C {
 }
 
 if true {
-  var x = 0
   func local() -> Int { return 0 }
-  func localWithContext() -> Int { return x }
 
   let a: @convention(c) () -> Int = global
   let _: @convention(c) () -> Int = main.global
   let _: @convention(c) () -> Int = { 0 }
   let _: @convention(c) () -> Int = local
-
-  // Can't convert a closure with context to a C function pointer
-  let _: @convention(c) () -> Int = { x } // expected-error{{cannot be formed from a closure that captures context}}
-  let _: @convention(c) () -> Int = { [x] in x } // expected-error{{cannot be formed from a closure that captures context}}
-  let _: @convention(c) () -> Int = localWithContext // expected-error{{cannot be formed from a local function that captures context}}
 
   // Can't convert a closure value to a C function pointer
   let global2 = global
@@ -49,14 +42,6 @@ if true {
 
   func handler(_ callback: (@convention(c) () -> Int)!) {}
   handler(iuo_global) // expected-error{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}
-}
-
-class Generic<X : C> {
-  func f<Y : C>(_ y: Y) {
-    let _: @convention(c) () -> Int = { return 0 }
-    let _: @convention(c) () -> Int = { return X.staticMethod() } // expected-error{{cannot be formed from a closure that captures generic parameters}}
-    let _: @convention(c) () -> Int = { return Y.staticMethod() } // expected-error{{cannot be formed from a closure that captures generic parameters}}
-  }
 }
 
 func genericFunc<T>(_ t: T) -> T { return t }

--- a/test/SILGen/c_function_pointers.swift
+++ b/test/SILGen/c_function_pointers.swift
@@ -73,3 +73,7 @@ func pointers_to_nested_local_functions_in_generics<T>(x: T) -> Int{
 
   return calls(foo, 0)
 }
+
+func capture_list_no_captures(x: Int) {
+  calls({ [x] in $0 }, 0) // expected-warning {{capture 'x' was never used}}
+}


### PR DESCRIPTION
Continue chipping away at TypeChecker's global state by eliminating LocalCFunctionPointers.