### PR TITLE
[ConstraintSystem] Add keypath subscript choice only if argument has …

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -264,6 +264,8 @@ public:
 
   bool isSpecial() const { return getKind() != Kind::Normal; }
 
+  bool isSubscript() const { return getKind() == Kind::Subscript; }
+
   /// Return the identifier backing the name. Assumes that the name is not
   /// special.
   Identifier getIdentifier() const {

--- a/lib/Sema/OverloadChoice.h
+++ b/lib/Sema/OverloadChoice.h
@@ -256,6 +256,10 @@ public:
   /// unwrapped.
   bool isImplicitlyUnwrappedValueOrReturnValue() const;
 
+  bool isKeyPathDynamicMemberLookup() const {
+    return getKind() == OverloadChoiceKind::KeyPathDynamicMemberLookup;
+  }
+
   /// Get the name of the overload choice.
   DeclName getName() const;
 

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -26,8 +26,7 @@ struct X {
 }
 
 func testSubscript(x: X, i: Int) {
-  // CHECK: disabled disjunction term {{.*}} bound to key path application
-  // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:)
+  // CHECK: disabled disjunction term {{.*}}X.subscript(_:)
   // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:_:_:)
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.subscript(_:_:)
   _ = x[i, i]

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -128,8 +128,6 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
   //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, Prop>' to specified type 'ReferenceWritableKeyPath<A, Prop>'}}
 
-  // FIXME: shouldn't be ambiguous
-  // expected-error@+1{{ambiguous}}
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]


### PR DESCRIPTION
…an expected label

Currently only valid way to form keypath subscript is to use `keyPath:`
label in subscript invocation, so let's avoid adding keypath overload
choice to every subscript lookup and instead only add it when it could
potentially match.

This among other things greatly helps diagnostics because sometimes
`keypath application` becomes the only choice even although it's
not really viable, which impedes member reference diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
