### PR TITLE
[String] Switch scalar-aligned bit to a reserved bit.

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -64,10 +64,10 @@ extension String: BidirectionalCollection {
     let stride = _characterStride(startingAt: i)
     let nextOffset = i._encodedOffset &+ stride
     let nextStride = _characterStride(
-      startingAt: Index(_encodedOffset: nextOffset)._aligned)
+      startingAt: Index(_encodedOffset: nextOffset)._scalarAligned)
 
     return Index(
-      encodedOffset: nextOffset, characterStride: nextStride)._aligned
+      encodedOffset: nextOffset, characterStride: nextStride)._scalarAligned
   }
 
   /// Returns the position immediately before the given index.
@@ -82,7 +82,8 @@ extension String: BidirectionalCollection {
     let i = _guts.scalarAlign(i)
     let stride = _characterStride(endingAt: i)
     let priorOffset = i._encodedOffset &- stride
-    return Index(encodedOffset: priorOffset, characterStride: stride)._aligned
+    return Index(
+      encodedOffset: priorOffset, characterStride: stride)._scalarAligned
   }
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -200,7 +201,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(startingAt i: Index) -> Int {
-    _internalInvariant(i._isAligned)
+    _internalInvariant(i._isScalarAligned)
 
     // Fast check if it's already been measured, otherwise check resiliently
     if let d = i.characterStride { return d }
@@ -212,7 +213,7 @@ extension String: BidirectionalCollection {
 
   @inlinable @inline(__always)
   internal func _characterStride(endingAt i: Index) -> Int {
-    _internalInvariant(i._isAligned)
+    _internalInvariant(i._isScalarAligned)
 
     if i == startIndex { return 0 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -268,11 +268,11 @@ extension _StringGuts {
 
   @inlinable @inline(__always)
   internal var startIndex: String.Index {
-   return Index(_encodedOffset: 0)._aligned
+   return Index(_encodedOffset: 0)._scalarAligned
   }
   @inlinable @inline(__always)
   internal var endIndex: String.Index {
-    return Index(_encodedOffset: self.count)._aligned
+    return Index(_encodedOffset: self.count)._scalarAligned
   }
 }
 

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -154,7 +154,7 @@ extension String.UTF16View: BidirectionalCollection {
     if len == 4 && idx.transcodedOffset == 0 {
       return idx.nextTranscoded
     }
-    return idx.strippingTranscoding.encoded(offsetBy: len)._aligned
+    return idx.strippingTranscoding.encoded(offsetBy: len)._scalarAligned
   }
 
   @inlinable @inline(__always)
@@ -178,7 +178,7 @@ extension String.UTF16View: BidirectionalCollection {
 
     // Single UTF-16 code unit
     _internalInvariant((1...3) ~= len)
-    return idx.encoded(offsetBy: -len)._aligned
+    return idx.encoded(offsetBy: -len)._scalarAligned
   }
 
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -587,7 +587,7 @@ extension String.UTF16View {
             _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }
-          return Index(_encodedOffset: readIdx &+ len)._aligned
+          return Index(_encodedOffset: readIdx &+ len)._scalarAligned
         }
 
         readIdx &+= len

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -112,7 +112,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
 
     if _fastPath(_guts.isFastUTF8) {
       let len = _guts.fastUTF8ScalarLength(startingAt: i._encodedOffset)
-      return i.encoded(offsetBy: len)._aligned
+      return i.encoded(offsetBy: len)._scalarAligned
     }
 
     return _foreignIndex(after: i)
@@ -137,7 +137,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
         return _utf8ScalarLength(utf8, endingAt: i._encodedOffset)
       }
       _internalInvariant(len <= 4, "invalid UTF8")
-      return i.encoded(offsetBy: -len)._aligned
+      return i.encoded(offsetBy: -len)._scalarAligned
     }
 
     return _foreignIndex(before: i)
@@ -419,7 +419,7 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: i)
     let len = UTF16.isLeadSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: len)._aligned
+    return i.encoded(offsetBy: len)._scalarAligned
   }
 
   @usableFromInline @inline(never)
@@ -430,6 +430,6 @@ extension String.UnicodeScalarView {
     let cu = _guts.foreignErrorCorrectedUTF16CodeUnit(at: priorIdx)
     let len = UTF16.isTrailSurrogate(cu) ? 2 : 1
 
-    return i.encoded(offsetBy: -len)._aligned
+    return i.encoded(offsetBy: -len)._scalarAligned
   }
 }

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -163,7 +163,7 @@ extension _StringGuts {
   @inline(__always) // fast-path: fold common fastUTF8 check
   internal func scalarAlign(_ idx: Index) -> Index {
     let result: String.Index
-    if _fastPath(idx._isAligned) {
+    if _fastPath(idx._isScalarAligned) {
       result = idx
     } else {
       // TODO(String performance): isASCII check
@@ -172,28 +172,28 @@ extension _StringGuts {
 
     _internalInvariant(isOnUnicodeScalarBoundary(result),
       "Alignment bit is set for non-aligned index")
-    _internalInvariant(result._isAligned)
+    _internalInvariant(result._isScalarAligned)
     return result
   }
 
   @inline(never) // slow-path
   @_alwaysEmitIntoClient // Swift 5.1
   internal func scalarAlignSlow(_ idx: Index) -> Index {
-    _internalInvariant(!idx._isAligned)
+    _internalInvariant(!idx._isScalarAligned)
 
     if _slowPath(idx.transcodedOffset != 0 || idx._encodedOffset == 0) {
       // Transcoded index offsets are already scalar aligned
-      return String.Index(_encodedOffset: idx._encodedOffset)._aligned
+      return String.Index(_encodedOffset: idx._encodedOffset)._scalarAligned
     }
     if _slowPath(self.isForeign) {
       let foreignIdx = foreignScalarAlign(idx)
-      _internalInvariant(foreignIdx._isAligned)
+      _internalInvariant(foreignIdx._isScalarAligned)
       return foreignIdx
     }
 
     return String.Index(_encodedOffset:
       self.withFastUTF8 { _scalarAlign($0, idx._encodedOffset) }
-    )._aligned
+    )._scalarAligned
   }
 
   @inlinable
@@ -359,17 +359,17 @@ extension _StringGuts {
   @usableFromInline @inline(never) // slow-path
   @_effects(releasenone)
   internal func foreignScalarAlign(_ idx: Index) -> Index {
-    guard idx._encodedOffset != self.count else { return idx._aligned }
+    guard idx._encodedOffset != self.count else { return idx._scalarAligned }
 
     _internalInvariant(idx._encodedOffset < self.count)
 
     let ecCU = foreignErrorCorrectedUTF16CodeUnit(at: idx)
     if _fastPath(!UTF16.isTrailSurrogate(ecCU)) {
-      return idx._aligned
+      return idx._scalarAligned
     }
     _internalInvariant(idx._encodedOffset > 0,
       "Error-correction shouldn't give trailing surrogate at position zero")
-    return String.Index(_encodedOffset: idx._encodedOffset &- 1)._aligned
+    return String.Index(_encodedOffset: idx._encodedOffset &- 1)._scalarAligned
   }
 
   @usableFromInline @inline(never)

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -428,7 +428,6 @@ extension Unicode.Scalar.UTF16View : RandomAccessCollection {
   ///   `endIndex` property.
   @inlinable
   public subscript(position: Int) -> UTF16.CodeUnit {
-    _internalInvariant((0..<self.count).contains(position))
     if position == 1 { return UTF16.trailSurrogate(value) }
     if endIndex == 1 { return UTF16.CodeUnit(value.value) }
     return UTF16.leadSurrogate(value)


### PR DESCRIPTION
Since scalar-alignment is set in inlinable code, switch the alignment
bit to one of the previously-reserved bits rather than a grapheme
cache bit. Setting a grapheme cache bit in inlinable would break
backward deployment, as older versions would interpret it as a cached
value.

Also adjust the name to "scalar-aligned", which is clearer, and
removed assertion (which should be a real precondition).

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
