### PR TITLE
[5.1][SourceKit] Add completion kind field to completion response

### DIFF
--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift
@@ -1,0 +1,16 @@
+enum Foo {
+  case east, west
+  case other(String)
+  init(i: Int) {}
+  init(s: String) {}
+  static var instance: Foo { .east }
+  static func create() -> Foo { .west }
+}
+
+func test() -> Foo {
+  return .
+}
+
+// RUN: %sourcekitd-test -req=complete -pos=11:11 %s -- %s > %t.response
+// RUN: diff -u %s.response %t.response
+

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
@@ -1,0 +1,82 @@
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.function.method.class,
+      key.name: "create()",
+      key.sourcetext: "create()",
+      key.description: "create()",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO6createACyFZ",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "east",
+      key.sourcetext: "east",
+      key.description: "east",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.exprspecific,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO4eastyA2CmF",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.constructor,
+      key.name: "init(i:)",
+      key.sourcetext: "init(i: <#T##Int#>)",
+      key.description: "init(i: Int)",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO1iACSi_tcfc",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.function.constructor,
+      key.name: "init(s:)",
+      key.sourcetext: "init(s: <#T##String#>)",
+      key.description: "init(s: String)",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO1sACSS_tcfc",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.var.class,
+      key.name: "instance",
+      key.sourcetext: "instance",
+      key.description: "instance",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO8instanceACvpZ",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "other()",
+      key.sourcetext: "other(<#T##String#>)",
+      key.description: "other(String)",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.exprspecific,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO5otheryACSScACmF",
+      key.modulename: "complete_unresolvedmember"
+    },
+    {
+      key.kind: source.lang.swift.decl.enumelement,
+      key.name: "west",
+      key.sourcetext: "west",
+      key.description: "west",
+      key.typename: "Foo",
+      key.context: source.codecompletion.context.exprspecific,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "s:25complete_unresolvedmember3FooO4westyA2CmF",
+      key.modulename: "complete_unresolvedmember"
+    }
+  ],
+  key.kind: source.lang.swift.completion.unresolvedmember
+}

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -141,6 +141,7 @@ public:
 
   virtual void failed(StringRef ErrDescription) = 0;
 
+  virtual void setCompletionKind(UIdent kind) {};
   virtual bool handleResult(const CodeCompletionInfo &Info) = 0;
 };
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1835,6 +1835,7 @@ public:
 
   void failed(StringRef ErrDescription) override;
 
+  void setCompletionKind(UIdent kind) override;
   bool handleResult(const CodeCompletionInfo &Info) override;
 };
 } // end anonymous namespace
@@ -1851,6 +1852,11 @@ static sourcekitd_response_t codeComplete(llvm::MemoryBuffer *InputBuf,
 
 void SKCodeCompletionConsumer::failed(StringRef ErrDescription) {
   ErrorDescription = ErrDescription;
+}
+
+void SKCodeCompletionConsumer::setCompletionKind(UIdent kind) {
+  assert(kind.isValid());
+  RespBuilder.getDictionary().set(KeyKind, kind);
 }
 
 bool SKCodeCompletionConsumer::handleResult(const CodeCompletionInfo &R) {


### PR DESCRIPTION
* **Explanation**: Add optional "completion kind" field to code completion response. For now it only exposes `unresolvedmember` kind. So that editors can implement custom post-process (e.g. sorting) logic based on the completion kind
* **Scope**: SourceKit code-completion response
* **Risk**: Low. This change only affect response for "unresolved member" completion
* **Issue**: rdar://problem/52352045
* **Testing**: Added regression test
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi)
