### PR TITLE
[Diagnostics] Adjust diagnostic for subscript references on type

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2134,9 +2134,15 @@ bool MissingMemberFailure::diagnoseAsError() {
   };
 
   if (getName().getBaseName().getKind() == DeclBaseName::Kind::Subscript) {
-    emitDiagnostic(anchor->getLoc(), diag::could_not_find_value_subscript,
-                   baseType)
+    auto loc = anchor->getLoc();
+    if (auto *metatype = baseType->getAs<MetatypeType>()) {
+      emitDiagnostic(loc, diag::could_not_find_type_member,
+                     metatype->getInstanceType(), getName())
         .highlight(baseExpr->getSourceRange());
+    } else {
+      emitDiagnostic(loc, diag::could_not_find_value_subscript, baseType)
+        .highlight(baseExpr->getSourceRange());
+    }
   } else if (getName().getBaseName() == "deinit") {
     // Specialised diagnostic if trying to access deinitialisers
     emitDiagnostic(anchor->getLoc(), diag::destructor_not_accessible)

--- a/test/ClangImporter/objc_class_subscript.swift
+++ b/test/ClangImporter/objc_class_subscript.swift
@@ -8,11 +8,11 @@
 import ObjCSubscripts
 
 func testClass() {
-  _ = NoClassSubscript[0] // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
-  NoClassSubscript[0] = "" // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+  _ = NoClassSubscript[0] // expected-error{{type 'NoClassSubscript' has no member 'subscript'}}
+  NoClassSubscript[0] = "" // expected-error{{type 'NoClassSubscript' has no member 'subscript'}}
   
-  _ = NoClassSubscript["foo"] // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
-  NoClassSubscript["foo"] = "" // expected-error{{value of type 'NoClassSubscript.Type' has no subscripts}}
+  _ = NoClassSubscript["foo"] // expected-error{{type 'NoClassSubscript' has no member 'subscript'}}
+  NoClassSubscript["foo"] = "" // expected-error{{type 'NoClassSubscript' has no member 'subscript'}}
 }
 
 func testInstance(x: NoClassSubscript) {


### PR DESCRIPTION
Instead of `value of X.Type` let's say `type of X` for subscript
references on metatype.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
