### PR TITLE
[AutoDiff] Rename `AdjointEmitter` and corresponding uses of adjoint to `PullbackEmitter`.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -5203,7 +5203,7 @@ void PullbackEmitter::materializeAdjointIndirect(
 }
 
 ValueWithCleanup PullbackEmitter::materializeAdjoint(AdjointValue val,
-                                                    SILLocation loc) {
+                                                     SILLocation loc) {
   if (val.isConcrete()) {
     LLVM_DEBUG(getADDebugStream()
         << "Materializing adjoint: Value is concrete.\n");
@@ -5275,7 +5275,7 @@ void PullbackEmitter::materializeAdjointIndirectHelper(
 }
 
 void PullbackEmitter::emitZeroIndirect(CanType type, SILValue bufferAccess,
-                                      SILLocation loc) {
+                                       SILLocation loc) {
   auto tangentSpace = getTangentSpace(type);
   assert(tangentSpace && "No tangent space for this type");
   switch (tangentSpace->getKind()) {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -5341,7 +5341,7 @@ void PullbackEmitter::emitCleanupForAdjointValue(AdjointValue value) {
 
 AdjointValue
 PullbackEmitter::accumulateAdjointsDirect(AdjointValue lhs,
-                                         AdjointValue rhs) {
+                                          AdjointValue rhs) {
   LLVM_DEBUG(getADDebugStream()
              << "Materializing adjoint directly.\nLHS: " << lhs
              << "\nRHS: " << rhs << '\n');

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -383,7 +383,7 @@ public:
 /// A pullback struct is an aggregate value containing pullbacks checkpointed
 /// during the VJP computation. Pullback structs are generated for every
 /// original function during VJP generation. Pullback struct values are
-/// constructed by VJP functions and consumed by adjoint functions.
+/// constructed by VJP functions and consumed by pullback functions.
 class PullbackInfo {
 private:
   /// The original function.
@@ -823,7 +823,7 @@ private:
   /// `NestedApplyInfo`s.
   DenseMap<ApplyInst *, NestedApplyInfo> nestedApplyInfo;
 
-  /// List of generated functions (JVPs, VJPs, adjoints, and thunks).
+  /// List of generated functions (JVPs, VJPs, pullbacks, and thunks).
   /// Saved for deletion during cleanup.
   SmallVector<SILFunction *, 32> generatedFunctions;
 
@@ -2689,7 +2689,7 @@ static void collectMinimalIndicesForFunctionCall(
 namespace {
 class VJPEmitter final
     : public TypeSubstCloner<VJPEmitter, SILOptFunctionBuilder> {
-  friend class AdjointEmitter;
+  friend class PullbackEmitter;
 
 private:
   /// The global context.
@@ -2704,8 +2704,8 @@ private:
   /// The VJP function.
   SILFunction *const vjp;
 
-  /// The adjoint function.
-  SILFunction *adjoint;
+  /// The pullback function.
+  SILFunction *pullback;
 
   /// The pullback info.
   PullbackInfo pullbackInfo;
@@ -2762,12 +2762,12 @@ public:
         pullbackInfo(context, original, vjp, attr->getIndices()),
         invoker(invoker), activityInfo(getActivityInfo(
                               context, original, attr->getIndices(), vjp)) {
-    // Create empty adjoint function.
-    adjoint = createEmptyAdjoint();
-    context.getGeneratedFunctions().push_back(adjoint);
+    // Create empty pullback function.
+    pullback = createEmptyPullback();
+    context.getGeneratedFunctions().push_back(pullback);
   }
 
-  SILFunction *createEmptyAdjoint() {
+  SILFunction *createEmptyPullback() {
     auto &module = context.getModule();
     auto origTy = original->getLoweredFunctionType();
     auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
@@ -2827,34 +2827,34 @@ public:
       return {tanType, conv};
     };
 
-    // Parameters of the adjoint are:
+    // Parameters of the pullback are:
     // - a seed,
     // - a pullback struct,
     // - original results, and
     // - the original parameters.
-    // Results of the adjoint are in the tangent space of the original
+    // Results of the pullback are in the tangent space of the original
     // parameters.
-    SmallVector<SILParameterInfo, 8> adjParams;
+    SmallVector<SILParameterInfo, 8> pbParams;
     SmallVector<SILResultInfo, 8> adjResults;
     auto origParams = origTy->getParameters();
     auto indices = attr->getIndices();
 
-    // Add adjoint parameter for the seed.
+    // Add pullback parameter for the seed.
     auto origResInfo = origTy->getResults()[indices.source];
-    adjParams.push_back(getTangentParameterInfoForOriginalResult(
+    pbParams.push_back(getTangentParameterInfoForOriginalResult(
         origResInfo.getType()
             ->getAutoDiffAssociatedTangentSpace(lookupConformance)
             ->getCanonicalType(), origResInfo.getConvention()));
 
-    // Accept a pullback struct in the adjoint parameter list. This is the
+    // Accept a pullback struct in the pullback parameter list. This is the
     // returned pullback's closure context.
     auto *origExit = &*original->findReturnBB();
     auto *pbStruct = pullbackInfo.getPullbackStruct(origExit);
     auto pbStructType = pbStruct->getDeclaredInterfaceType()
         ->getCanonicalType();
-    adjParams.push_back({pbStructType, ParameterConvention::Direct_Guaranteed});
+    pbParams.push_back({pbStructType, ParameterConvention::Direct_Guaranteed});
 
-    // Add adjoint results for the requested wrt parameters.
+    // Add pullback results for the requested wrt parameters.
     for (auto i : indices.parameters->getIndices()) {
       auto origParam = origParams[i];
       adjResults.push_back(getTangentResultInfoForOriginalParameter(
@@ -2863,31 +2863,31 @@ public:
               ->getCanonicalType(), origParam.getConvention()));
     }
 
-    auto adjName = original->getASTContext()
+    auto pbName = original->getASTContext()
                        .getIdentifier("AD__" + original->getName().str() +
-                                      "__adjoint_" + indices.mangle())
+                                      "__pullback_" + indices.mangle())
                        .str();
-    auto adjGenericSig = getAssociatedFunctionGenericSignature(attr, original);
-    auto *adjGenericEnv = adjGenericSig
-        ? adjGenericSig->createGenericEnvironment()
+    auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+    auto *adjGenericEnv = pbGenericSig
+        ? pbGenericSig->createGenericEnvironment()
         : nullptr;
-    auto adjType = SILFunctionType::get(
-        adjGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
-        origTy->getCalleeConvention(), adjParams, {}, adjResults, None,
+    auto pbType = SILFunctionType::get(
+        pbGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+        origTy->getCalleeConvention(), pbParams, {}, adjResults, None,
         original->getASTContext());
 
     SILOptFunctionBuilder fb(context.getTransform());
-    // The generated adjoint linkage is set to Hidden because generated adjoints
-    // are never called cross-module.
+    // The generated pullback linkage is set to Hidden because generated
+    // pullbacks are never called cross-module.
     auto linkage = SILLinkage::Hidden;
-    auto *adjoint = fb.createFunction(
-        linkage, adjName, adjType, adjGenericEnv, original->getLocation(),
+    auto *pullback = fb.createFunction(
+        linkage, pbName, pbType, adjGenericEnv, original->getLocation(),
         original->isBare(), IsNotTransparent, original->isSerialized(),
         original->isDynamicallyReplaceable());
-    adjoint->setOwnershipEliminated();
-    adjoint->setDebugScope(new (module)
-                               SILDebugScope(original->getLocation(), adjoint));
-    return adjoint;
+    pullback->setOwnershipEliminated();
+    pullback->setDebugScope(new (module)
+                               SILDebugScope(original->getLocation(), pullback));
+    return pullback;
   }
 
   /// Run VJP generation. Returns true on error.
@@ -3000,20 +3000,20 @@ public:
     SmallVector<SILValue, 8> origResults;
     extractAllElements(origResult, builder, origResults);
 
-    // Get and partially apply the adjoint to get a pullback.
+    // Get and partially apply the pullback to get the uncurried pullback.
     auto vjpGenericEnv = vjp->getGenericEnvironment();
     auto vjpSubstMap = vjpGenericEnv
         ? vjpGenericEnv->getForwardingSubstitutionMap()
         : vjp->getForwardingSubstitutionMap();
-    auto *adjointRef = builder.createFunctionRef(loc, adjoint);
-    auto *adjointPartialApply = builder.createPartialApply(
-        loc, adjointRef, vjpSubstMap, {pbStructVal},
+    auto *pullbackRef = builder.createFunctionRef(loc, pullback);
+    auto *pullbackPartialApply = builder.createPartialApply(
+        loc, pullbackRef, vjpSubstMap, {pbStructVal},
         ParameterConvention::Direct_Guaranteed);
 
     // Return a tuple of the original result and pullback.
     SmallVector<SILValue, 8> directResults;
     directResults.append(origResults.begin(), origResults.end());
-    directResults.push_back(adjointPartialApply);
+    directResults.push_back(pullbackPartialApply);
     builder.createReturn(
         ri->getLoc(), joinElements(directResults, builder, loc));
   }
@@ -3368,7 +3368,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 namespace {
-class AdjointEmitter;
+class PullbackEmitter;
 class AdjointValue;
 
 class Cleanup {
@@ -3513,7 +3513,7 @@ class AdjointValueBase {
 /// 1, in addition to a materialized SILValue. This is expected to be passed
 /// around by value in most cases, as it's two words long.
 class AdjointValue final {
-  friend class AdjointEmitter;
+  friend class PullbackEmitter;
 
 private:
   /// The kind of this adjoint value.
@@ -3620,12 +3620,12 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 } // end anonymous namespace
 
 //===----------------------------------------------------------------------===//
-// AdjointEmitter - visitors on the original function for adjoint code
+// PullbackEmitter - visitors on the original function for pullback code
 // generation
 //===----------------------------------------------------------------------===//
 
 namespace {
-class AdjointEmitter final : public SILInstructionVisitor<AdjointEmitter> {
+class PullbackEmitter final : public SILInstructionVisitor<PullbackEmitter> {
 private:
   /// The parent VJP emitter.
   VJPEmitter &vjpEmitter;
@@ -3647,18 +3647,18 @@ private:
   /// adjoint buffers.
   DenseMap<std::pair<SILBasicBlock *, SILValue>, ValueWithCleanup> bufferMap;
 
-  /// Mapping from original basic blocks to corresponding adjoint basic blocks.
-  /// Adjoint basic blocks always have the predecessor as the single argument.
+  /// Mapping from original basic blocks to corresponding pullback basic blocks.
+  /// Pullback basic blocks always have the predecessor as the single argument.
   DenseMap<SILBasicBlock *, SILBasicBlock *> adjointBBMap;
 
-  /// Mapping from adjoint basic blocks to pullback struct arguments.
-  DenseMap<SILBasicBlock *, SILArgument *> adjointPullbackStructArguments;
+  /// Mapping from pullback basic blocks to pullback struct arguments.
+  DenseMap<SILBasicBlock *, SILArgument *> pullbackStructArguments;
 
   /// Mapping from original basic blocks and successor basic blocks to
-  /// corresponding adjoint trampoline basic blocks. Trampoline basic blocks
+  /// corresponding pullback trampoline basic blocks. Trampoline basic blocks
   /// take additional arguments in addition to the predecessor enum argument.
   DenseMap<std::pair<SILBasicBlock *, SILBasicBlock *>, SILBasicBlock *>
-      adjointTrampolineBBMap;
+      pullbackTrampolineBBMap;
 
   /// Mapping from original basic blocks to dominated active values.
   DenseMap<SILBasicBlock *, SmallVector<SILValue, 8>> activeValues;
@@ -3674,10 +3674,10 @@ private:
   DenseMap<SILBasicBlock *, SmallVector<AdjointValue, 8>>
       blockLocalAdjointValues;
 
-  /// Stack buffers allocated for storing local adjoint adjoint values.
+  /// Stack buffers allocated for storing local adjoint values.
   SmallVector<ValueWithCleanup, 8> functionLocalAllocations;
 
-  /// The seed argument in the adjoint function.
+  /// The seed argument in the pullback function.
   SILArgument *seed = nullptr;
 
   /// The main builder.
@@ -3692,9 +3692,9 @@ private:
 
   ADContext &getContext() const { return vjpEmitter.context; }
   SILModule &getModule() const { return getContext().getModule(); }
-  ASTContext &getASTContext() const { return getAdjoint().getASTContext(); }
+  ASTContext &getASTContext() const { return getPullback().getASTContext(); }
   SILFunction &getOriginal() const { return *vjpEmitter.original; }
-  SILFunction &getAdjoint() const { return *vjpEmitter.adjoint; }
+  SILFunction &getPullback() const { return *vjpEmitter.pullback; }
   SILDifferentiableAttr *getAttr() const { return vjpEmitter.attr; }
   DifferentiationInvoker getInvoker() const { return vjpEmitter.invoker; }
   PullbackInfo &getPullbackInfo() { return vjpEmitter.pullbackInfo; }
@@ -3704,19 +3704,19 @@ private:
   const DifferentiableActivityInfo &getActivityInfo() const {
     return vjpEmitter.activityInfo;
   }
-  SILArgument *getAdjointBlockPullbackStructArgument(SILBasicBlock *origBB) {
+  SILArgument *getPullbackBlockPullbackStructArgument(SILBasicBlock *origBB) {
 #ifndef NDEBUG
-    auto *pbStruct = adjointPullbackStructArguments[origBB]->getType()
+    auto *pbStruct = pullbackStructArguments[origBB]->getType()
         .getStructOrBoundGenericStruct();
     assert(pbStruct == getPullbackInfo().getPullbackStruct(origBB));
 #endif
-    return adjointPullbackStructArguments[origBB];
+    return pullbackStructArguments[origBB];
   }
 
 public:
-  explicit AdjointEmitter(VJPEmitter &vjpEmitter)
-      : vjpEmitter(vjpEmitter), builder(getAdjoint()),
-        localAllocBuilder(getAdjoint()) {
+  explicit PullbackEmitter(VJPEmitter &vjpEmitter)
+      : vjpEmitter(vjpEmitter), builder(getPullback()),
+        localAllocBuilder(getPullback()) {
     // Get dominance and post-order info for the original function.
     auto &passManager = getContext().getPassManager();
     auto *domAnalysis = passManager.getAnalysis<DominanceAnalysis>();
@@ -3811,8 +3811,8 @@ private:
   /// Remap any archetypes into the current function's context.
   SILType remapType(SILType ty) {
     if (ty.hasArchetype())
-      return getAdjoint().mapTypeIntoContext(ty.mapTypeOutOfContext());
-    return getAdjoint().mapTypeIntoContext(ty);
+      return getPullback().mapTypeIntoContext(ty.mapTypeOutOfContext());
+    return getPullback().mapTypeIntoContext(ty);
   }
 
   Optional<VectorSpace> getTangentSpace(CanType type) {
@@ -3831,7 +3831,7 @@ private:
   /// Substitutes all replacement types of the given substitution map using the
   /// adjoint function's substitution map.
   SubstitutionMap remapSubstitutionMap(SubstitutionMap substMap) {
-    return substMap.subst(getAdjoint().getForwardingSubstitutionMap());
+    return substMap.subst(getPullback().getForwardingSubstitutionMap());
   }
 
   //--------------------------------------------------------------------------//
@@ -3971,7 +3971,7 @@ private:
   SILBasicBlock::iterator getNextFunctionLocalAllocationInsertionPoint() {
     // If there are no local allocations, insert at the adjont entry beginning.
     if (functionLocalAllocations.empty())
-      return getAdjoint().getEntryBlock()->begin();
+      return getPullback().getEntryBlock()->begin();
     // Otherwise, insert before the last local allocation. Inserting before
     // rather than after ensures that allocation and zero initialization
     // instructions are grouped together.
@@ -4012,7 +4012,7 @@ private:
     // allocation, or at the start of the adjoint function's entry if no local
     // allocations exist yet.
     localAllocBuilder.setInsertionPoint(
-        getAdjoint().getEntryBlock(),
+        getPullback().getEntryBlock(),
         getNextFunctionLocalAllocationInsertionPoint());
     // Allocate local buffer and initialize to zero.
     auto *newBuf = localAllocBuilder.createAllocStack(
@@ -4045,7 +4045,7 @@ private:
     assert(originalBuffer->getType().isAddress() &&
            rhsBufferAccess->getType().isAddress());
     assert(originalBuffer->getFunction() == &getOriginal());
-    assert(rhsBufferAccess->getFunction() == &getAdjoint());
+    assert(rhsBufferAccess->getFunction() == &getPullback());
     auto adjointBuffer = getAdjointBuffer(origBB, originalBuffer);
     if (errorOccurred)
       return;
@@ -4068,7 +4068,7 @@ private:
 
   SILBasicBlock *getAdjointTrampolineBlock(
       SILBasicBlock *originalBlock, SILBasicBlock *successorBlock) {
-    return adjointTrampolineBBMap.lookup({originalBlock, successorBlock});
+    return pullbackTrampolineBBMap.lookup({originalBlock, successorBlock});
   }
 
   //--------------------------------------------------------------------------//
@@ -4114,11 +4114,11 @@ public:
   /// any error occurs.
   bool run() {
     auto &original = getOriginal();
-    auto &adjoint = getAdjoint();
-    auto adjLoc = getAdjoint().getLocation();
-    LLVM_DEBUG(getADDebugStream() << "Running AdjointEmitter on\n" << original);
+    auto &adjoint = getPullback();
+    auto adjLoc = getPullback().getLocation();
+    LLVM_DEBUG(getADDebugStream() << "Running PullbackEmitter on\n" << original);
 
-    auto *adjGenEnv = getAdjoint().getGenericEnvironment();
+    auto *adjGenEnv = getPullback().getGenericEnvironment();
     auto adjGenSig = adjGenEnv
         ? adjGenEnv->getGenericSignature()->getCanonicalSignature()
         : nullptr;
@@ -4207,10 +4207,10 @@ public:
       // create entry arguments and continue to the next block.
       if (origBB == origExit) {
         assert(adjointBB->isEntry());
-        createEntryArguments(&getAdjoint());
+        createEntryArguments(&getPullback());
         auto *lastArg = adjointBB->getArguments().back();
         assert(lastArg->getType() == pbStructLoweredType);
-        adjointPullbackStructArguments[origBB] = lastArg;
+        pullbackStructArguments[origBB] = lastArg;
         continue;
       }
       // Get all active values in the original block.
@@ -4241,14 +4241,14 @@ public:
       // Add a pullback struct argument.
       auto *pbStructArg = adjointBB->createPhiArgument(
           pbStructLoweredType, ValueOwnershipKind::Guaranteed);
-      adjointPullbackStructArguments[origBB] = pbStructArg;
+      pullbackStructArguments[origBB] = pbStructArg;
       // - Create adjoint trampoline blocks for each successor block of the
       //   original block. Adjoint trampoline blocks only have a pullback
       //   struct argument, and branch from the adjoint successor block to the
       //   adjoint original block, trampoline adjoint values of active values.
       for (auto *succBB : origBB->getSuccessorBlocks()) {
         auto *adjointTrampolineBB = adjoint.createBasicBlockBefore(adjointBB);
-        adjointTrampolineBBMap.insert({{origBB, succBB}, adjointTrampolineBB});
+        pullbackTrampolineBBMap.insert({{origBB, succBB}, adjointTrampolineBB});
         // Get the enum element type (i.e. the pullback struct type). The enum
         // element type may be boxed if the enum is indirect.
         auto enumLoweredTy =
@@ -4346,7 +4346,7 @@ public:
       // Otherwise, add a `switch_enum` terminator for non-exit adjoint blocks.
       // 1. Get the pullback struct adjoint bb argument.
       // 2. Extract the predecessor enum value from the pullback struct value.
-      auto *pbStructVal = getAdjointBlockPullbackStructArgument(bb);
+      auto *pbStructVal = getPullbackBlockPullbackStructArgument(bb);
       auto *predEnum = getPullbackInfo().getPredecessorEnum(bb);
       auto *predEnumField =
           getPullbackInfo().lookUpPullbackStructPredecessorField(bb);
@@ -4562,7 +4562,7 @@ public:
     if (errorOccurred)
       return;
 
-    LLVM_DEBUG(getADDebugStream() << "AdjointEmitter visited:\n[ORIG]"
+    LLVM_DEBUG(getADDebugStream() << "PullbackEmitter visited:\n[ORIG]"
                << *inst);
 #ifndef NDEBUG
     auto beforeInsertion = std::prev(builder.getInsertionPoint());
@@ -4602,7 +4602,7 @@ public:
     assert(field);
     auto loc = ai->getLoc();
     SILValue pullback = builder.createStructExtract(
-        loc, getAdjointBlockPullbackStructArgument(ai->getParent()), field);
+        loc, getPullbackBlockPullbackStructArgument(ai->getParent()), field);
 
     // Get the original result of the `apply` instruction.
     SmallVector<SILValue, 8> args;
@@ -4656,7 +4656,7 @@ public:
     if (applyInfo.originalPullbackType) {
       SILOptFunctionBuilder fb(getContext().getTransform());
       auto *thunk = getOrCreateReabstractionThunk(
-          fb, getContext().getModule(), loc, &getAdjoint(),
+          fb, getContext().getModule(), loc, &getPullback(),
           pullbackType, *applyInfo.originalPullbackType);
       auto *thunkRef = builder.createFunctionRef(loc, thunk);
       pullback = builder.createPartialApply(
@@ -4704,7 +4704,7 @@ public:
             return;
           auto *tmpBuf = builder.createAllocStack(loc, tan->getType());
           builder.createStore(loc, tan, tmpBuf,
-              getBufferSOQ(tmpBuf->getType().getASTType(), getAdjoint()));
+              getBufferSOQ(tmpBuf->getType().getASTType(), getPullback()));
           auto *readAccess = builder.createBeginAccess(
               loc, tmpBuf, SILAccessKind::Read, SILAccessEnforcement::Static,
               /*noNestedConflict*/ true, /*fromBuiltin*/ false);
@@ -4972,7 +4972,7 @@ public:
         SILAccessEnforcement::Static, /*noNestedConflict*/ true,
         /*fromBuiltin*/ false);
     builder.createStore(li->getLoc(), adjVal, initAccess,
-        getBufferSOQ(localBuf->getType().getASTType(), getAdjoint()));
+        getBufferSOQ(localBuf->getType().getASTType(), getPullback()));
     builder.createEndAccess(li->getLoc(), initAccess, /*aborted*/ false);
     // Get the adjoint buffer.
     auto &adjBuf = getAdjointBuffer(bb, li->getOperand());
@@ -5002,7 +5002,7 @@ public:
       return;
     auto bufType = remapType(adjBuf.getType());
     auto adjVal = builder.createLoad(si->getLoc(), adjBuf,
-        getBufferLOQ(bufType.getASTType(), getAdjoint()));
+        getBufferLOQ(bufType.getASTType(), getPullback()));
     // Disable the buffer's top-level cleanup (which is supposed to operate on
     // the buffer), create a cleanup for the value that carrys all child
     // cleanups.
@@ -5120,7 +5120,7 @@ public:
 };
 } // end anonymous namespace
 
-Cleanup *AdjointEmitter::makeCleanup(SILValue value, Cleanup::Func func,
+Cleanup *PullbackEmitter::makeCleanup(SILValue value, Cleanup::Func func,
                                      ArrayRef<Cleanup *> children) {
   SmallVector<Cleanup *, 2> nonnullChildren;
   for (auto *c : children)
@@ -5128,7 +5128,8 @@ Cleanup *AdjointEmitter::makeCleanup(SILValue value, Cleanup::Func func,
   return Cleanup::create(allocator, value, func, nonnullChildren);
 }
 
-Cleanup *AdjointEmitter::makeCleanupFromChildren(ArrayRef<Cleanup *> children) {
+Cleanup *
+PullbackEmitter::makeCleanupFromChildren(ArrayRef<Cleanup *> children) {
   if (children.empty())
     return nullptr;
   if (children.size() == 1)
@@ -5137,22 +5138,22 @@ Cleanup *AdjointEmitter::makeCleanupFromChildren(ArrayRef<Cleanup *> children) {
   return makeCleanup(SILValue(), /*func*/ nullptr, uniqued.getArrayRef());
 }
 
-AdjointValue AdjointEmitter::makeZeroAdjointValue(SILType type) {
+AdjointValue PullbackEmitter::makeZeroAdjointValue(SILType type) {
   return AdjointValue::createZero(allocator, remapType(type));
 }
 
 AdjointValue
-AdjointEmitter::makeConcreteAdjointValue(ValueWithCleanup value) {
+PullbackEmitter::makeConcreteAdjointValue(ValueWithCleanup value) {
   return AdjointValue::createConcrete(allocator, value);
 }
 
 template<typename EltRange>
-AdjointValue AdjointEmitter::makeAggregateAdjointValue(
+AdjointValue PullbackEmitter::makeAggregateAdjointValue(
     SILType type, EltRange elements) {
   return AdjointValue::createAggregate(allocator, remapType(type), elements);
 }
 
-ValueWithCleanup AdjointEmitter::materializeAdjointDirect(
+ValueWithCleanup PullbackEmitter::materializeAdjointDirect(
     AdjointValue val, SILLocation loc) {
   assert(val.getType().isObject());
   LLVM_DEBUG(getADDebugStream() <<
@@ -5188,7 +5189,7 @@ ValueWithCleanup AdjointEmitter::materializeAdjointDirect(
   }
 }
 
-void AdjointEmitter::materializeAdjointIndirect(
+void PullbackEmitter::materializeAdjointIndirect(
     AdjointValue val, ValueWithCleanup &destBuffer) {
   ValueWithCleanup access(
       builder.createBeginAccess(
@@ -5201,7 +5202,7 @@ void AdjointEmitter::materializeAdjointIndirect(
   builder.createEndAccess(access.getLoc(), access, /*aborted*/ false);
 }
 
-ValueWithCleanup AdjointEmitter::materializeAdjoint(AdjointValue val,
+ValueWithCleanup PullbackEmitter::materializeAdjoint(AdjointValue val,
                                                     SILLocation loc) {
   if (val.isConcrete()) {
     LLVM_DEBUG(getADDebugStream()
@@ -5213,7 +5214,7 @@ ValueWithCleanup AdjointEmitter::materializeAdjoint(AdjointValue val,
   return materializeAdjointDirect(val, loc);
 }
 
-void AdjointEmitter::materializeAdjointIndirectHelper(
+void PullbackEmitter::materializeAdjointIndirectHelper(
     AdjointValue val, ValueWithCleanup &destBufferAccess) {
   auto loc = destBufferAccess.getLoc();
   auto soq = getBufferSOQ(val.getType().getASTType(), builder.getFunction());
@@ -5273,7 +5274,7 @@ void AdjointEmitter::materializeAdjointIndirectHelper(
   }
 }
 
-void AdjointEmitter::emitZeroIndirect(CanType type, SILValue bufferAccess,
+void PullbackEmitter::emitZeroIndirect(CanType type, SILValue bufferAccess,
                                       SILLocation loc) {
   auto tangentSpace = getTangentSpace(type);
   assert(tangentSpace && "No tangent space for this type");
@@ -5298,7 +5299,7 @@ void AdjointEmitter::emitZeroIndirect(CanType type, SILValue bufferAccess,
   }
 }
 
-SILValue AdjointEmitter::emitZeroDirect(CanType type, SILLocation loc) {
+SILValue PullbackEmitter::emitZeroDirect(CanType type, SILLocation loc) {
   auto silType = getModule().Types.getLoweredLoadableType(
       type, ResilienceExpansion::Minimal);
   auto *buffer = builder.createAllocStack(loc, silType);
@@ -5313,13 +5314,13 @@ SILValue AdjointEmitter::emitZeroDirect(CanType type, SILLocation loc) {
                                               /*noNestedConflict*/ true,
                                               /*fromBuiltin*/ false);
   auto *loaded = builder.createLoad(loc, readAccess,
-                                    getBufferLOQ(type, getAdjoint()));
+                                    getBufferLOQ(type, getPullback()));
   builder.createEndAccess(loc, readAccess, /*aborted*/ false);
   builder.createDeallocStack(loc, buffer);
   return loaded;
 }
 
-void AdjointEmitter::emitCleanupForAdjointValue(AdjointValue value) {
+void PullbackEmitter::emitCleanupForAdjointValue(AdjointValue value) {
   switch (value.getKind()) {
   case AdjointValueKind::Zero: return;
   case AdjointValueKind::Aggregate:
@@ -5339,7 +5340,7 @@ void AdjointEmitter::emitCleanupForAdjointValue(AdjointValue value) {
 }
 
 AdjointValue
-AdjointEmitter::accumulateAdjointsDirect(AdjointValue lhs,
+PullbackEmitter::accumulateAdjointsDirect(AdjointValue lhs,
                                          AdjointValue rhs) {
   LLVM_DEBUG(getADDebugStream()
              << "Materializing adjoint directly.\nLHS: " << lhs
@@ -5418,7 +5419,7 @@ AdjointEmitter::accumulateAdjointsDirect(AdjointValue lhs,
   }
 }
 
-SILValue AdjointEmitter::accumulateDirect(SILValue lhs, SILValue rhs) {
+SILValue PullbackEmitter::accumulateDirect(SILValue lhs, SILValue rhs) {
   // TODO: Optimize for the case when lhs == rhs.
   LLVM_DEBUG(getADDebugStream() <<
              "Emitting adjoint accumulation for lhs: " << lhs <<
@@ -5445,9 +5446,9 @@ SILValue AdjointEmitter::accumulateDirect(SILValue lhs, SILValue rhs) {
         loc, rhsBuf, SILAccessKind::Init, SILAccessEnforcement::Static,
         /*noNestedConflict*/ true, /*fromBuiltin*/ false);
     builder.createStore(loc, lhs, lhsBufInitAccess,
-                        getBufferSOQ(adjointASTTy, getAdjoint()));
+                        getBufferSOQ(adjointASTTy, getPullback()));
     builder.createStore(loc, rhs, rhsBufInitAccess,
-                        getBufferSOQ(adjointASTTy, getAdjoint()));
+                        getBufferSOQ(adjointASTTy, getPullback()));
     builder.createEndAccess(loc, lhsBufInitAccess, /*aborted*/ false);
     builder.createEndAccess(loc, rhsBufInitAccess, /*aborted*/ false);
     // Accumulate the adjoints.
@@ -5472,7 +5473,7 @@ SILValue AdjointEmitter::accumulateDirect(SILValue lhs, SILValue rhs) {
         SILAccessKind::Read, SILAccessEnforcement::Static,
         /*noNestedConflict*/ true, /*fromBuiltin*/ false);
     auto val = builder.createLoad(loc, resultBufAccess,
-        getBufferLOQ(lhs->getType().getASTType(), getAdjoint()));
+        getBufferLOQ(lhs->getType().getASTType(), getPullback()));
     builder.createEndAccess(loc, resultBufAccess, /*aborted*/ false);
     // Deallocate result buffer.
     builder.createDeallocStack(loc, resultBuf);
@@ -5495,19 +5496,19 @@ SILValue AdjointEmitter::accumulateDirect(SILValue lhs, SILValue rhs) {
   }
 }
 
-void AdjointEmitter::accumulateIndirect(
+void PullbackEmitter::accumulateIndirect(
     SILValue resultBufAccess, SILValue lhsBufAccess, SILValue rhsBufAccess) {
   // TODO: Optimize for the case when lhs == rhs.
   assert(lhsBufAccess->getType() == rhsBufAccess->getType()
-         && "Adjoints must have equal types!");
+         && "Pullbacks must have equal types!");
   assert(lhsBufAccess->getType().isAddress() &&
          rhsBufAccess->getType().isAddress()
-         && "Adjoint types must be both address types!");
+         && "Pullback types must be both address types!");
   auto loc = resultBufAccess.getLoc();
-  auto adjointTy = lhsBufAccess->getType();
-  auto adjointASTTy = adjointTy.getASTType();
+  auto pullbackTy = lhsBufAccess->getType();
+  auto pullbackASTTy = pullbackTy.getASTType();
   auto *swiftMod = getModule().getSwiftModule();
-  auto tangentSpace = adjointASTTy->getAutoDiffAssociatedTangentSpace(
+  auto tangentSpace = pullbackASTTy->getAutoDiffAssociatedTangentSpace(
       LookUpConformanceInModule(swiftMod));
   assert(tangentSpace && "No tangent space for this type");
   switch (tangentSpace->getKind()) {
@@ -5515,22 +5516,23 @@ void AdjointEmitter::accumulateIndirect(
     auto *proto = getContext().getAdditiveArithmeticProtocol();
     auto *combinerFuncDecl = getContext().getPlusDecl();
     // Call the combiner function and return.
-    auto adjointParentModule = tangentSpace->getNominal()
+    auto pullbackParentModule = tangentSpace->getNominal()
         ? tangentSpace->getNominal()->getModuleContext()
         : getModule().getSwiftModule();
-    auto confRef = adjointParentModule->lookupConformance(adjointASTTy, proto);
+    auto confRef = pullbackParentModule->lookupConformance(pullbackASTTy,
+                                                           proto);
     assert(confRef.hasValue() && "Missing conformance to `AdditiveArithmetic`");
     SILDeclRef declRef(combinerFuncDecl, SILDeclRef::Kind::Func);
     auto silFnTy = getContext().getTypeConverter().getConstantType(declRef);
     // %0 = witness_method @+
-    auto witnessMethod = builder.createWitnessMethod(loc, adjointASTTy,
+    auto witnessMethod = builder.createWitnessMethod(loc, pullbackASTTy,
                                                      *confRef, declRef,
                                                      silFnTy);
     auto subMap = SubstitutionMap::getProtocolSubstitutions(
-        proto, adjointASTTy, *confRef);
+        proto, pullbackASTTy, *confRef);
     // %1 = metatype $T.Type
     auto metatypeType =
-        CanMetatypeType::get(adjointASTTy, MetatypeRepresentation::Thick);
+        CanMetatypeType::get(pullbackASTTy, MetatypeRepresentation::Thick);
     auto metatypeSILType = SILType::getPrimitiveObjectType(metatypeType);
     auto metatype = builder.createMetatype(loc, metatypeSILType);
     // %2 = apply $0(%result, %new, %old, %1)
@@ -5551,17 +5553,17 @@ void AdjointEmitter::accumulateIndirect(
   }
   case VectorSpace::Kind::Function: {
     llvm_unreachable(
-        "Unimplemented: Emit thunks for abstracting adjoint accumulation");
+        "Unimplemented: Emit thunks for abstracting pullback accumulation");
   }
   }
 }
 
-void AdjointEmitter::accumulateIndirect(SILValue lhsDestAccess,
+void PullbackEmitter::accumulateIndirect(SILValue lhsDestAccess,
                                         SILValue rhsAccess) {
   assert(lhsDestAccess->getType().isAddress() &&
          rhsAccess->getType().isAddress());
-  assert(lhsDestAccess->getFunction() == &getAdjoint());
-  assert(rhsAccess->getFunction() == &getAdjoint());
+  assert(lhsDestAccess->getFunction() == &getPullback());
+  assert(rhsAccess->getFunction() == &getPullback());
   auto loc = lhsDestAccess.getLoc();
   auto type = lhsDestAccess->getType();
   auto astType = type.getASTType();
@@ -5605,7 +5607,7 @@ void AdjointEmitter::accumulateIndirect(SILValue lhsDestAccess,
   }
   case VectorSpace::Kind::Function: {
     llvm_unreachable(
-        "Unimplemented: Emit thunks for abstracting adjoint accumulation");
+        "Unimplemented: Emit thunks for abstracting pullback accumulation");
   }
   }
 }
@@ -5626,9 +5628,9 @@ bool VJPEmitter::run() {
   if (errorOccurred)
     return true;
 
-  // Generate adjoint code.
-  AdjointEmitter adjointEmitter(*this);
-  if (adjointEmitter.run()) {
+  // Generate pullback code.
+  PullbackEmitter PullbackEmitter(*this);
+  if (PullbackEmitter.run()) {
     errorOccurred = true;
     return true;
   }

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -24,7 +24,7 @@ public func closureCaptureMutable() {
 
 // CHECK-LABEL: @AD__{{.*}}closureCaptureMutable{{.*}}___vjp_src_0_wrt_0
 // CHECK: bb0({{%.*}} : $Float, [[INOUT_ARG:%.*]] : $*Float):
-// CHECK:   [[ADJOINT:%.*]] = function_ref @AD__{{.*}}closureCaptureMutabley{{.*}}___adjoint_src_0_wrt_0
+// CHECK:   [[ADJOINT:%.*]] = function_ref @AD__{{.*}}closureCaptureMutabley{{.*}}___pullback_src_0_wrt_0
 // CHECK:   {{.*}} = partial_apply [callee_guaranteed] [[ADJOINT]]({{.*}})
 
 // TF-30: VJP return value should match the return type.

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -61,12 +61,12 @@ func cond(_ x: Float) -> Float {
 
 // CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
 // CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__cond_bb3__PB__src_0_wrt_0
-// CHECK-SIL:   [[ADJOINT_REF:%.*]] = function_ref @AD__cond__adjoint_src_0_wrt_0
-// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[ADJOINT_REF]]([[BB3_PB_STRUCT]])
+// CHECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @AD__cond__pullback_src_0_wrt_0
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]]
 
-// CHECK-SIL-LABEL: sil hidden @AD__cond__adjoint_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL-LABEL: sil hidden @AD__cond__pullback_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_bb3__PB__src_0_wrt_0) -> Float {
 // CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_bb3__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB3_PRED:%.*]] = struct_extract %1 : $_AD__cond_bb3__PB__src_0_wrt_0, #_AD__cond_bb3__PB__src_0_wrt_0.predecessor
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt.1: bb3, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt.1: bb1
@@ -152,7 +152,7 @@ func loop_generic<T : Differentiable & FloatingPoint>(_ x: T) -> T {
 }
 
 // Test control flow + tuple buffer.
-// Verify that adjoint buffers are not allocated for address projections.
+// Verify that pullback buffers are not allocated for address projections.
 
 @differentiable
 @_silgen_name("cond_tuple_var")
@@ -164,7 +164,7 @@ func cond_tuple_var(_ x: Float) -> Float {
   }
   return y.1
 }
-// CHECK-SIL-LABEL: sil hidden @AD__cond_tuple_var__adjoint_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_tuple_var_bb3__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL-LABEL: sil hidden @AD__cond_tuple_var__pullback_src_0_wrt_0 : $@convention(thin) (Float, @guaranteed _AD__cond_tuple_var_bb3__PB__src_0_wrt_0) -> Float {
 // CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0):
 // CHECK-SIL:   [[BB3_PRED:%.*]] = struct_extract %1 : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0, #_AD__cond_tuple_var_bb3__PB__src_0_wrt_0.predecessor
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -9,7 +9,7 @@ _ = gradient(at: Float(1), in: { x in identity(x) })
 // Test AdjointEmitter local buffer allocation.
 // Verify that local buffers are immediately set to zero.
 
-// CHECK-SIL-LABEL: sil hidden @AD__identity__adjoint_src_0_wrt_0
+// CHECK-SIL-LABEL: sil hidden @AD__identity__pullback_src_0_wrt_0
 // CHECK-SIL:      [[ORIG_COTAN:%.*]] = alloc_stack $τ_0_0.TangentVector
 // CHECK-SIL-NEXT: [[ORIG_COTAN_BEGIN:%.*]] = begin_access [init] [static] [no_nested_conflict] [[ORIG_COTAN]]
 // CHECK-SIL-NEXT: [[ZERO_WITNESS:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter.1

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -44,24 +44,24 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK-LABEL: enum {{.*}}testOwnedVector{{.*}}__Pred__src_0_wrt_0 {
 // CHECK-NEXT: }
 
-// CHECK-LABEL: sil hidden @{{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__adjoint_src_0_wrt_0_1
+// CHECK-LABEL: sil hidden @{{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__pullback_src_0_wrt_0_1
 // CHECK: bb0([[SEED:%.*]] : $Vector, [[PB_STRUCT:%.*]] : ${{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__PB__src_0_wrt_0_1):
 // CHECK:   [[PB:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__PB__src_0_wrt_0_1
 // CHECK:   [[NEEDED_COTAN:%.*]] = apply [[PB]]([[SEED]]) : $@callee_guaranteed (@guaranteed Vector) -> @owned Vector
 // CHECK:   release_value [[SEED:%.*]] : $Vector
 
-// CHECK-LABEL sil hidden @{{.*}}subset_adjoint_releases_unused_ones{{.*}}__adjoint_src_0_wrt_0
-// CHECK: bb0([[SEED:%.*]] : $Vector, [[PB_STRUCT:%.*]] : ${{.*}}subset_adjoint_releases_unused_ones{{.*}}__PB__src_0_wrt_0):
-// CHECK:   [[PB0:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}subset_adjoint_releases_unused_ones{{.*}}, #{{.*}}subset_adjoint_releases_unused_ones{{.*}}__PB__src_0_wrt_0.pullback_1
+// CHECK-LABEL sil hidden @{{.*}}subset_pullback_releases_unused_ones{{.*}}__pullback_src_0_wrt_0
+// CHECK: bb0([[SEED:%.*]] : $Vector, [[PB_STRUCT:%.*]] : ${{.*}}subset_pullback_releases_unused_ones{{.*}}__PB__src_0_wrt_0):
+// CHECK:   [[PB0:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}subset_pullback_releases_unused_ones{{.*}}, #{{.*}}subset_pullback_releases_unused_ones{{.*}}__PB__src_0_wrt_0.pullback_1
 // CHECK:   [[NEEDED_COTAN0:%.*]] = apply [[PB0]]([[SEED]]) : $@callee_guaranteed (@guaranteed Vector) -> @owned Vector
 // CHECK-NOT:  release_value [[NEEDED_COTAN0]] : $Vector
-// CHECK:   [[PB1:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}subset_adjoint_releases_unused_ones{{.*}}__PB__src_0_wrt_0, #{{.*}}subset_adjoint_releases_unused_ones{{.*}}__PB__src_0_wrt_0.pullback_0
+// CHECK:   [[PB1:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}subset_pullback_releases_unused_ones{{.*}}__PB__src_0_wrt_0, #{{.*}}subset_pullback_releases_unused_ones{{.*}}__PB__src_0_wrt_0.pullback_0
 // CHECK:   [[NEEDED_COTAN1:%.*]] = apply [[PB1]]([[NEEDED_COTAN0]]) : $@callee_guaranteed (@guaranteed Vector) -> @owned Vector
 // CHECK:   release_value [[NEEDED_COTAN0]] : $Vector
 // CHECK:   release_value [[SEED]] : $Vector
 // CHECK:   return [[NEEDED_COTAN1]] : $Vector
 
-// CHECK-LABEL: sil hidden @{{.*}}side_effect_release_zero{{.*}}__adjoint_src_0_wrt_0
+// CHECK-LABEL: sil hidden @{{.*}}side_effect_release_zero{{.*}}__pullback_src_0_wrt_0
 // CHECK: bb0([[SEED:%.*]] : $Vector, %1 : ${{.*}}side_effect_release_zero{{.*}}_bb0__PB__src_0_wrt_0):
 // CHECK:   [[BUF:%.*]] = alloc_stack $Vector
 // CHECK:   [[BUF_ACCESS:%.*]] = begin_access [init] [static] [no_nested_conflict] [[BUF]] : $*Vector
@@ -87,9 +87,9 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK-NOT:   release_value [[ADD_VJP_RESULT]]
 // CHECK-NOT:   release_value [[ADD_PULLBACK]]
 
-// The adjoint should not release pullback struct argument because it has @guaranteed convention.
+// The pullback should not release pullback struct argument because it has @guaranteed convention.
 //
-// CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__adjoint_src_0_wrt_0
+// CHECK-LABEL: @{{.*}}testOwnedVector{{.*}}__pullback_src_0_wrt_0
 // CHECK: bb0({{%.*}} : $Vector, [[PB_STRUCT:%.*]] : ${{.*}}testOwnedVector{{.*}}__PB__src_0_wrt_0):
 // CHECK:   [[PULLBACK0:%.*]] = struct_extract [[PB_STRUCT]] : ${{.*}}testOwnedVector{{.*}}__PB__src_0_wrt_0, #{{.*}}testOwnedVector{{.*}}__PB__src_0_wrt_0.pullback_0
 // CHECK-NOT:   release_value [[PULLBACK0]]
@@ -105,11 +105,11 @@ func side_effect_release_zero(_ x: Vector) -> Vector {
 }
 _ = pullback(at: Vector.zero, in: side_effect_release_zero)
 
-func subset_adjoint_releases_unused_ones(_ x: Vector) -> Vector {
+func subset_pullback_releases_unused_ones(_ x: Vector) -> Vector {
   let y = x + .zero
   return .zero + y
 }
-_ = pullback(at: .zero, in: subset_adjoint_releases_unused_ones)
+_ = pullback(at: .zero, in: subset_pullback_releases_unused_ones)
 
 struct FakeMaxPool : Differentiable {
   @differentiable(wrt: (self, input))


### PR DESCRIPTION
As a first step for clarity, we are renaming the `AdjointEmitter` class to `PullbackEmitter`. As the function that differentiation uses is the pullback, not the adjoint. However, we still have `AdjointValues`.