### PR TITLE
Support opaque stored property types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3337,6 +3337,9 @@ ERROR(trailing_closure_requires_parens,none,
       "trailing closure requires parentheses for disambiguation in this"
       " context", ())
 
+ERROR(opaque_type_var_no_init,none,
+      "property declares an opaque return type, but has no initializer "
+      "expression from which to infer an underlying type", ())
 ERROR(opaque_type_no_underlying_type_candidates,none,
       "function declares an opaque return type, but has no return statements "
       "in its body from which to infer an underlying type", ())
@@ -3348,6 +3351,9 @@ NOTE(opaque_type_underlying_type_candidate_here,none,
 ERROR(opaque_type_self_referential_underlying_type,none,
       "function opaque return type was inferred as %0, which defines the "
       "opaque type in terms of itself", (Type))
+ERROR(opaque_type_var_no_underlying_type,none,
+      "property declares an opaque return type, but cannot infer the "
+      "underlying type from its initializer expression", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Patterns

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1208,7 +1208,8 @@ ConstraintSystem::solveImpl(Expr *&expr,
     auto constraintKind = ConstraintKind::Conversion;
     
     if ((getContextualTypePurpose() == CTP_ReturnStmt ||
-         getContextualTypePurpose() == CTP_ReturnSingleExpr)
+         getContextualTypePurpose() == CTP_ReturnSingleExpr ||
+         getContextualTypePurpose() == CTP_Initialization)
         && Options.contains(ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
       constraintKind = ConstraintKind::OpaqueUnderlyingType;
     

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2535,6 +2535,12 @@ public:
           if (!var->hasType())
             var->markInvalid();
         };
+        
+        // Properties with an opaque return type need an initializer to
+        // determine their underlying type.
+        if (var->getOpaqueResultTypeDecl()) {
+          TC.diagnose(var->getLoc(), diag::opaque_type_var_no_init);
+        }
 
         // Non-member observing properties need an initializer.
         if (var->getWriteImpl() == WriteImplKind::StoredWithObservers &&
@@ -2593,8 +2599,9 @@ public:
       if (!PBD->isInitialized(i))
         continue;
 
-      if (!PBD->isInitializerChecked(i))
+      if (!PBD->isInitializerChecked(i)) {
         TC.typeCheckPatternBinding(PBD, i);
+      }
 
       if (!PBD->isInvalid()) {
         auto &entry = PBD->getPatternList()[i];

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -192,3 +192,9 @@ struct X<T: R, U: R>: R {
   }
 }
 
+var globalOProp: some O = 0
+
+struct OpaqueProps {
+  static var staticOProp: some O = 0
+  var instanceOProp: some O = 0
+}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -12,10 +12,9 @@ extension Array: P, Q { func paul() {}; mutating func priscilla() {}; func quinn
 class C {}
 class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {} }
 
-// TODO: Should be valid
-
-let property: some P = 1 // TODO expected-error{{cannot convert}}
-let deflessProperty: some P // TODO e/xpected-error{{butz}}
+let property: some P = 1
+let deflessLet: some P // expected-error{{has no initializer}}
+var deflessVar: some P // expected-error{{has no initializer}}
 
 struct GenericProperty<T: P> {
   var x: T
@@ -159,7 +158,6 @@ func typeIdentity() {
 
   // The opaque type should expose the members implied by its protocol
   // constraints
-  // TODO: associated types
   do {
     var a = alice()
     a.paul()
@@ -403,4 +401,15 @@ func testCoercionDiagnostics() {
   // FIXME: It would be nice to show the "from" info here as well.
   opaqueOpt = bar() // expected-error {{cannot assign value of type 'some P' to type '(some P)?'}} {{none}}
   opaqueOpt = () // expected-error {{cannot assign value of type '()' to type '(some P)?'}} {{none}}
+}
+
+var globalVar: some P = 17
+let globalLet: some P = 38
+
+struct Foo {
+  static var staticVar: some P = 17
+  static let staticLet: some P = 38
+
+  var instanceVar: some P = 17
+  let instanceLet: some P = 38
 }


### PR DESCRIPTION
Type-check the initializer expression to get the underlying type (or raise an error if there
is none). rdar://problem/51127135