### PR TITLE
Bridge non-ASCII SmallStrings as native Swift Strings rather than by creating CFStrings. This gets consistent behavior with non-smol Strings when the String contains a BOM

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -321,14 +321,24 @@ extension String {
   @_effects(releasenone)
   public // SPI(Foundation)
   func _bridgeToObjectiveCImpl() -> AnyObject {
-    if _guts.isSmall {
+    // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
+    if _guts.isSmallASCII {
       return _guts.asSmall.withUTF8 { bufPtr in
         return _createCFString(
-            bufPtr.baseAddress._unsafelyUnwrappedUnchecked,
-            bufPtr.count,
-            kCFStringEncodingUTF8
+          bufPtr.baseAddress._unsafelyUnwrappedUnchecked,
+          bufPtr.count,
+          kCFStringEncodingUTF8
         )
       }
+    }
+    if _guts.isSmall {
+        // We can't form a tagged pointer String, so grow to a non-small String,
+        // and bridge that instead. Also avoids CF deleting any BOM that may be
+        // present
+        var copy = self
+        copy._guts.grow(_SmallString.capacity + 1)
+        _internalInvariant(!copy._guts.isSmall)
+        return copy._bridgeToObjectiveCImpl()
     }
     if _guts._object.isImmortal {
       // TODO: We'd rather emit a valid ObjC object statically than create a

--- a/test/stdlib/TestNSString.swift
+++ b/test/stdlib/TestNSString.swift
@@ -30,16 +30,40 @@ import FoundationBridgeObjC
 
 class TestNSString : TestNSStringSuper {
     
-    func test_equalOverflow() {
-      let cyrillic = "чебурашка@ящик-с-апельсинами.рф"
-      let other = getNSStringEqualTestString()
-      print(NSStringBridgeTestEqual(cyrillic, other))
-    }
+  func test_equalOverflow() {
+    let cyrillic = "чебурашка@ящик-с-апельсинами.рф"
+    let other = getNSStringEqualTestString()
+    print(NSStringBridgeTestEqual(cyrillic, other))
+  }
+  
+  func test_smallString_BOM() {
+    let bom = "\u{FEFF}" // U+FEFF (ZERO WIDTH NO-BREAK SPACE)
+//    expectEqual(1, NSString(string: bom).length)
+//    expectEqual(4, NSString(string: "\(bom)abc").length)
+//    expectEqual(5, NSString(string: "\(bom)\(bom)abc").length)
+//    expectEqual(4, NSString(string: "a\(bom)bc").length)
+//    expectEqual(13, NSString(string: "\(bom)234567890123").length)
+//    expectEqual(14, NSString(string: "\(bom)2345678901234").length)
+    
+    expectEqual(1, (bom as NSString).length)
+    expectEqual(4, ("\(bom)abc" as NSString).length)
+    expectEqual(5, ("\(bom)\(bom)abc" as NSString).length)
+    expectEqual(4, ("a\(bom)bc" as NSString).length)
+    expectEqual(13, ("\(bom)234567890123" as NSString).length)
+    expectEqual(14, ("\(bom)2345678901234" as NSString).length)
+    
+    let string = "\(bom)abc"
+    let middleIndex = string.index(string.startIndex, offsetBy: 2)
+    string.enumerateSubstrings(in: middleIndex..<string.endIndex, options: .byLines) { (_, _, _, _) in }  //shouldn't crash
+  }
   
 }
 
 #if !FOUNDATION_XCTEST
 var NSStringTests = TestSuite("TestNSString")
 NSStringTests.test("test_equalOverflow") { TestNSString().test_equalOverflow() }
+NSStringTests.test("test_smallString_BOM") {
+  TestNSString().test_smallString_BOM()
+}
 runAllTests()
 #endif


### PR DESCRIPTION
5.1 version of https://github.com/apple/swift/pull/25866

(cherry picked from commit 27359bdec601950d7136c5c39c3a83c1af38e54c)

Fixes rdar://problem/52565005

Explanation: CFString removes UTF8 byte order marks on creation, which we do when bridging SmallStrings. This means that bridging SmallStrings will unexpectedly reduce the length of the resulting NSString, resulting in out of index crashes and so on.

Scope: Swift Standard Library

Issue: rdar://problem/52565005

Risk: Low. This is a change of behavior, but it's restoring 4.2 behavior; additionally it only comes into effect in edge cases, since byte order marks are discouraged in UTF8 content.

Testing: Regular tests + new automated tests specifically for this issue

Reviewer: @milseman 