### PR TITLE
[AutoDiff] Release associated functions after 'autodiff_function' folding.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6406,8 +6406,12 @@ void ADContext::foldAutoDiffFunctionExtraction(AutoDiffFunctionInst *source) {
     adfei->eraseFromParent();
   }
   // If the `autodiff_function` instruction has no remaining uses, erase it.
-  if (isInstructionTriviallyDead(source))
+  if (isInstructionTriviallyDead(source)) {
+    SILBuilder builder(source);
+    for (auto &assocFn : source->getAssociatedFunctions())
+      emitCleanup(builder, source->getLoc(), assocFn.get());
     source->eraseFromParent();
+  }
   // Mark `source` as processed so that it won't be reprocessed after deletion.
   processedAutoDiffFunctionInsts.insert(source);
 }


### PR DESCRIPTION
Associated functions should be released when an `autodiff_function` instruction has been folded away.

This is to quickly reduce some ongoing memory leaks. I'll add tests in a separate PR.