### PR TITLE
Don't emit the FORCE_LOAD symbols when the compiler is running

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1033,7 +1033,12 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
   }
   }
 
-  if (linkLib.shouldForceLoad()) {
+  // Don't emit the FORCE_LOAD symbols when the compiler is running
+  // on behalf of the debugger.  The debugger will read the LinkLibrary's
+  // from all the modules it sees, and hand load all the required dependencies,
+  // and since the symbol is weak it doesn't even tell us whether a
+  // required dependency is missing. So it serves no purpose in this case.
+  if (linkLib.shouldForceLoad() && !Context.LangOpts.DebuggerSupport) {
     llvm::SmallString<64> buf;
     encodeForceLoadSymbolName(buf, linkLib.getName());
     auto ForceImportThunk =

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1012,7 +1012,7 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
   // The debugger gets the autolink information directly from
   // the LinkLibraries of the module, so there's no reason to
   // emit it into the IR of debugger expressions.
-  if (!Context.LangOpts.DebuggerSupport)
+  if (Context.LangOpts.DebuggerSupport)
     return;
   
   switch (linkLib.getKind()) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1009,12 +1009,9 @@ llvm::SmallString<32> getTargetDependentLibraryOption(const llvm::Triple &T,
 void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
   llvm::LLVMContext &ctx = Module.getContext();
 
-  // Don't emit the FORCE_LOAD symbols and metadata when the compiler is 
-  // running on behalf of the debugger.  The debugger will read the LinkLibrary's
-  // from all the modules it sees, and hand load all the required dependencies.
-  // so it doesn't need this information.  And since the FORCE_LOAD symbol is
-  // weak it doesn't even tell us whether a required dependency is missing.
-  // So it serves no purpose in this case.
+  // The debugger gets the autolink information directly from
+  // the LinkLibraries of the module, so there's no reason to
+  // emit it into the IR of debugger expressions.
   if (!Context.LangOpts.DebuggerSupport)
     return;
   

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -15,6 +15,10 @@
 // RUN: %FileCheck %s < %t/force-load.txt
 // RUN: %FileCheck -check-prefix FORCE-LOAD-CLIENT -check-prefix FORCE-LOAD-CLIENT-%target-object-format %s < %t/force-load.txt
 
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -debugger-support -lmagic %s -I %t > %t/force-load.txt
+// RUN: %FileCheck %s < %t/force-load.txt
+// RUN: %FileCheck -check-prefix NO-FORCE-LOAD-CLIENT %s < %t/force-load.txt
+
 // RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name 0module %S/../Inputs/empty.swift -autolink-force-load | %FileCheck --check-prefix=FORCE-LOAD-HEX %s
@@ -42,6 +46,7 @@ import someModule
 // FORCE-LOAD-HEX:   ret void
 // FORCE-LOAD-HEX: }
 
+// NO-FORCE-LOAD-CLIENT-NOT: FORCE_LOAD
 // FORCE-LOAD-CLIENT: @"_swift_FORCE_LOAD_$_module_$_autolinking" = weak_odr hidden constant void ()* @"_swift_FORCE_LOAD_$_module"
 // FORCE-LOAD-CLIENT: @llvm.used = appending global [{{[0-9]+}} x i8*] [
 // FORCE-LOAD-CLIENT: i8* bitcast (void ()** @"_swift_FORCE_LOAD_$_module_$_autolinking" to i8*)

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -15,8 +15,7 @@
 // RUN: %FileCheck %s < %t/force-load.txt
 // RUN: %FileCheck -check-prefix FORCE-LOAD-CLIENT -check-prefix FORCE-LOAD-CLIENT-%target-object-format %s < %t/force-load.txt
 
-// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -debugger-support -lmagic %s -I %t > %t/force-load.txt
-// RUN: %FileCheck %s < %t/force-load.txt
+// RUN: %target-swift-frontend -runtime-compatibility-version none -emit-ir -debugger-support %s -I %t > %t/force-load.txt
 // RUN: %FileCheck -check-prefix NO-FORCE-LOAD-CLIENT %s < %t/force-load.txt
 
 // RUN: %target-swift-frontend -disable-autolinking-runtime-compatibility-dynamic-replacements -runtime-compatibility-version none -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift | %FileCheck --check-prefix=NO-FORCE-LOAD %s
@@ -39,6 +38,8 @@ import someModule
 // FRAMEWORK-DAG: !{{[0-9]+}} = !{!"-framework", !"someModule"}
 
 // NO-FORCE-LOAD-NOT: FORCE_LOAD
+// NO-FORCE-LOAD-NOT -lmodule
+// NO-FORCE-LOAD-NOT -lmagic
 // FORCE-LOAD: define{{( dllexport)?}} void @"_swift_FORCE_LOAD_$_module"() {
 // FORCE-LOAD:   ret void
 // FORCE-LOAD: }


### PR DESCRIPTION
on behalf of the debugger.  The debugger will read the LinkLibrary's
from all the modules it sees, and hand load all the required dependencies,
and since the symbol is weak it doesn't even tell us whether a
required dependency is missing. So it serves no purpose in this case.

<rdar://problem/51463642>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
