### PR TITLE
[windows] Use unprefixed library name for immediate mode.

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -78,7 +78,11 @@ static void *loadRuntimeLib(StringRef sharedLibName,
 
 void *swift::immediate::loadSwiftRuntime(ArrayRef<std::string>
                                          runtimeLibPaths) {
+#if defined(_WIN32)
+  return loadRuntimeLib("swiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
+#else
   return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
+#endif
 }
 
 static bool tryLoadLibrary(LinkLibrary linkLib,


### PR DESCRIPTION
The library does not have the lib prefix in Windows, so the immediate
mode was not finding the file. This was making the new tests in
tests/Driver/options.swift fail on Windows. The tests pass after this
change.

Notice that it seems to load the host standard library, so restricting
the change to Windows seems to be OK and should not affect
cross-compilation. Windows was already hardcoding ".dll" as the library
extension, disregarding the target, anyway.
