### PR TITLE
[Diagnostics] Extend property wrapper diagnostics to support subscrip…

### DIFF
--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -944,6 +944,16 @@ struct Foo<T> { // expected-note {{arguments to generic parameter 'T' ('W' and '
     get { return 42 }
     set { }
   }
+
+  subscript(x x: Int) -> Int {
+    get { return 42 }
+    set { }
+  }
+
+  subscript(q q: String, a: Int) -> Bool {
+    get { return false }
+    set { }
+  }
 }
 
 @propertyWrapper
@@ -1021,6 +1031,12 @@ struct MissingPropertyWrapperUnwrap {
 
     self.x["ultimate question"] // expected-error {{referencing subscript 'subscript(_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
     self.x["ultimate question"] = 42 // expected-error {{referencing subscript 'subscript(_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+
+    self.x[x: 42] // expected-error {{referencing subscript 'subscript(x:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+    self.x[x: 42] = 0 // expected-error {{referencing subscript 'subscript(x:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+
+    self.x[q: "ultimate question", 42] // expected-error {{referencing subscript 'subscript(q:_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+    self.x[q: "ultimate question", 42] = true // expected-error {{referencing subscript 'subscript(q:_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
   }
 }
 
@@ -1028,6 +1044,6 @@ struct InvalidPropertyDelegateUse {
   @Foo var x: Int = 42 // expected-error {{extra argument 'initialValue' in call}}
 
   func test() {
-    self.x.foo() // expected-error {{alue of type 'Int' has no member 'foo'}}
+    self.x.foo() // expected-error {{value of type 'Int' has no member 'foo'}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -939,6 +939,11 @@ struct Foo<T> { // expected-note {{arguments to generic parameter 'T' ('W' and '
 
   func foo() {}
   func bar(x: Int) {}
+
+  subscript(q: String) -> Int {
+    get { return 42 }
+    set { }
+  }
 }
 
 @propertyWrapper
@@ -1013,5 +1018,8 @@ struct MissingPropertyWrapperUnwrap {
     c(self.usesProjectedValue) // expected-error {{cannot convert value 'usesProjectedValue' of type 'W' to expected type 'V', use wrapper instead}}{{12-12=$}}
     d(self.$usesProjectedValue) // expected-error {{cannot convert value '$usesProjectedValue' of type 'V' to expected type 'W', use wrapped value instead}}{{12-13=}}
     d(self._usesProjectedValue) // expected-error {{cannot convert value '_usesProjectedValue' of type 'Baz<W>' to expected type 'W', use wrapped value instead}}{{12-13=}}
+
+    self.x["ultimate question"] // expected-error {{referencing subscript 'subscript(_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
+    self.x["ultimate question"] = 42 // expected-error {{referencing subscript 'subscript(_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1023,3 +1023,11 @@ struct MissingPropertyWrapperUnwrap {
     self.x["ultimate question"] = 42 // expected-error {{referencing subscript 'subscript(_:)' requires wrapper 'Foo<Int>'}} {{10-10=_}}
   }
 }
+
+struct InvalidPropertyDelegateUse {
+  @Foo var x: Int = 42 // expected-error {{extra argument 'initialValue' in call}}
+
+  func test() {
+    self.x.foo() // expected-error {{alue of type 'Int' has no member 'foo'}}
+  }
+}


### PR DESCRIPTION
…t refs

Previously unintended property wrapper unwrap diagnostics supported only
dot expressions, let's extend it to cover subscripts as well.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
