### PR TITLE
[Testing] Do not assume unqualified path to `clang++`

### DIFF
--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -1,2 +1,2 @@
 // RUN: env PATH= %swiftc_driver_plain -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
-// CHECK: {{^}}clang++
+// CHECK: clang++


### PR DESCRIPTION
Without this change, unified builds are broken on my Linux workstation (Fedora 30, x86-64).
