### PR TITLE
build: dereference a variable when checking (NFC)

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1905,7 +1905,7 @@ function(add_swift_target_library name)
     if(SWIFTLIB_SHARED)
       if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
         list(APPEND swiftlib_link_flags_all "-dynamiclib -Wl,-headerpad_max_install_names")
-      elseif(sdk STREQUAL ANDROID)
+      elseif(${sdk} STREQUAL ANDROID)
         list(APPEND swiftlib_link_flags_all "-shared")
         # TODO: Instead of `lib${name}.so` find variable or target property which already have this value.
         list(APPEND swiftlib_link_flags_all "-Wl,-soname,lib${name}.so")


### PR DESCRIPTION
Some versions of CMake dereference the variable here and others do not.
Explicitly dereference to ensure that the library name is properly set.
Failure to do so will fail to load the library as the output path
becomes the name.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
