### PR TITLE
[Parser][QoI] Offer fixit for changing the platform condition kind

### DIFF
--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -1,0 +1,44 @@
+//===--- PlatformConditionKinds.def - Kinds of Platform Conditions - C++ ---*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with the kinds of
+// platform conditions that can be used for conditional compilation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PLATFORM_CONDITION
+#define PLATFORM_CONDITION(LABEL, IDENTIFIER)
+#endif
+#ifndef PLATFORM_CONDITION_
+#define PLATFORM_CONDITION_(LABEL, IDENTIFIER) PLATFORM_CONDITION(LABEL, "_" IDENTIFIER)
+#endif
+
+/// The active os target (OSX, iOS, Linux, etc.)
+PLATFORM_CONDITION(OS, "os")
+
+/// The active arch target (x86_64, i386, arm, arm64, etc.)
+PLATFORM_CONDITION(Arch, "arch")
+
+/// The active endianness target (big or little)
+PLATFORM_CONDITION_(Endianness, "endian")
+
+/// Runtime support (_ObjC or _Native)
+PLATFORM_CONDITION_(Runtime, "runtime")
+
+/// Conditional import of module
+PLATFORM_CONDITION(CanImport, "canImport")
+
+/// Target Environment (currently just 'simulator' or absent)
+PLATFORM_CONDITION(TargetEnvironment, "targetEnvironment")
+
+#undef PLATFORM_CONDITION
+#undef PLATFORM_CONDITION_

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -437,11 +437,13 @@ namespace swift {
     /// Returns true if the given platform condition argument represents
     /// a supported target operating system.
     ///
-    /// \param suggestions Populated with suggested replacements
+    /// \param suggestedKind Populated with suggested replacement platform condition
+    /// \param suggestedValues Populated with suggested replacement values
     /// if a match is not found.
     static bool checkPlatformConditionSupported(
       PlatformConditionKind Kind, StringRef Value,
-      std::vector<StringRef> &suggestions);
+      PlatformConditionKind &suggestedKind,
+      std::vector<StringRef> &suggestedValues);
 
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -37,18 +37,8 @@ namespace swift {
 
   /// Kind of implicit platform conditions.
   enum class PlatformConditionKind {
-    /// The active os target (OSX, iOS, Linux, etc.)
-    OS,
-    /// The active arch target (x86_64, i386, arm, arm64, etc.)
-    Arch,
-    /// The active endianness target (big or little)
-    Endianness,
-    /// Runtime support (_ObjC or _Native)
-    Runtime,
-    /// Conditional import of module
-    CanImport,
-    /// Target Environment (currently just 'simulator' or absent)
-    TargetEnvironment,
+#define PLATFORM_CONDITION(LABEL, IDENTIFIER) LABEL,
+#include "swift/AST/PlatformConditionKinds.def"
   };
 
   /// Describes which Swift 3 Objective-C inference warnings should be

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -65,8 +65,9 @@ static const StringRef SupportedConditionalCompilationTargetEnvironments[] = {
   "simulator",
 };
 
-static const PlatformConditionKind AllPlatformConditionKinds[] = {
+static const PlatformConditionKind AllPublicPlatformConditionKinds[] = {
 #define PLATFORM_CONDITION(LABEL, IDENTIFIER) PlatformConditionKind::LABEL,
+#define PLATFORM_CONDITION_(LABEL, IDENTIFIER)
 #include "swift/AST/PlatformConditionKinds.def"
 };
 
@@ -95,7 +96,7 @@ std::pair<const StringRef*, size_t> getSupportedConditionalCompilationValues(con
 PlatformConditionKind suggestedPlatformConditionKind(PlatformConditionKind Kind, const StringRef &V,
                                                      std::vector<StringRef> &suggestedValues) {
   std::string lower = V.lower();
-  for (const PlatformConditionKind& candidateKind : AllPlatformConditionKinds) {
+  for (const PlatformConditionKind& candidateKind : AllPublicPlatformConditionKinds) {
     if (candidateKind != Kind) {
       auto supportedValues = getSupportedConditionalCompilationValues(candidateKind);
       auto supportedValuesArray = supportedValues.first;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -71,25 +71,20 @@ static const PlatformConditionKind AllPublicPlatformConditionKinds[] = {
 #include "swift/AST/PlatformConditionKinds.def"
 };
 
-template <size_t N>
-constexpr int count(const StringRef (&)[N]) {
-  return N;
-}
-
-std::pair<const StringRef*, size_t> getSupportedConditionalCompilationValues(const PlatformConditionKind &Kind) {
+ArrayRef<StringRef> getSupportedConditionalCompilationValues(const PlatformConditionKind &Kind) {
   switch (Kind) {
   case PlatformConditionKind::OS:
-    return { SupportedConditionalCompilationOSs, count(SupportedConditionalCompilationOSs) };
+    return SupportedConditionalCompilationOSs;
   case PlatformConditionKind::Arch:
-    return { SupportedConditionalCompilationArches, count(SupportedConditionalCompilationArches) };
+    return SupportedConditionalCompilationArches;
   case PlatformConditionKind::Endianness:
-    return { SupportedConditionalCompilationEndianness, count(SupportedConditionalCompilationEndianness) };
+    return SupportedConditionalCompilationEndianness;
   case PlatformConditionKind::Runtime:
-    return { SupportedConditionalCompilationRuntimes, count(SupportedConditionalCompilationRuntimes) };
+    return SupportedConditionalCompilationRuntimes;
   case PlatformConditionKind::CanImport:
-    return { {}, 0 };
+    return { };
   case PlatformConditionKind::TargetEnvironment:
-    return { SupportedConditionalCompilationTargetEnvironments, count(SupportedConditionalCompilationTargetEnvironments) };
+    return SupportedConditionalCompilationTargetEnvironments;
   }
 }
 
@@ -99,10 +94,7 @@ PlatformConditionKind suggestedPlatformConditionKind(PlatformConditionKind Kind,
   for (const PlatformConditionKind& candidateKind : AllPublicPlatformConditionKinds) {
     if (candidateKind != Kind) {
       auto supportedValues = getSupportedConditionalCompilationValues(candidateKind);
-      auto supportedValuesArray = supportedValues.first;
-      auto supportedValuesCount = supportedValues.second;
-      for (unsigned i = 0; i < supportedValuesCount; i++) {
-        auto candidateValue = supportedValuesArray[i];
+      for (const StringRef& candidateValue : supportedValues) {
         if (candidateValue.lower() == lower) {
           suggestedValues.clear();
           if (candidateValue != V) {
@@ -123,10 +115,7 @@ bool isMatching(PlatformConditionKind Kind, const StringRef &V,
   unsigned minDistance = std::numeric_limits<unsigned>::max();
   std::string lower = V.lower();
   auto supportedValues = getSupportedConditionalCompilationValues(Kind);
-  auto supportedValuesArray = supportedValues.first;
-  auto supportedValuesCount = supportedValues.second;
-  for (unsigned i = 0; i < supportedValuesCount; i++) {
-    auto candidate = supportedValuesArray[i];
+  for (const StringRef& candidate : supportedValues) {
     if (candidate == V) {
       suggestedKind = Kind;
       suggestions.clear();

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -66,12 +66,8 @@ static const StringRef SupportedConditionalCompilationTargetEnvironments[] = {
 };
 
 static const PlatformConditionKind AllPlatformConditionKinds[] = {
-  PlatformConditionKind::OS,
-  PlatformConditionKind::Arch,
-  PlatformConditionKind::Endianness,
-  PlatformConditionKind::Runtime,
-  PlatformConditionKind::CanImport,
-  PlatformConditionKind::TargetEnvironment
+#define PLATFORM_CONDITION(LABEL, IDENTIFIER) PlatformConditionKind::LABEL,
+#include "swift/AST/PlatformConditionKinds.def"
 };
 
 template <size_t N>

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -38,30 +38,18 @@ namespace {
 static
 Optional<PlatformConditionKind> getPlatformConditionKind(StringRef Name) {
   return llvm::StringSwitch<Optional<PlatformConditionKind>>(Name)
-    .Case("os", PlatformConditionKind::OS)
-    .Case("arch", PlatformConditionKind::Arch)
-    .Case("_endian", PlatformConditionKind::Endianness)
-    .Case("_runtime", PlatformConditionKind::Runtime)
-    .Case("canImport", PlatformConditionKind::CanImport)
-    .Case("targetEnvironment", PlatformConditionKind::TargetEnvironment)
+#define PLATFORM_CONDITION(LABEL, IDENTIFIER) \
+    .Case(IDENTIFIER, PlatformConditionKind::LABEL)
+#include "swift/AST/PlatformConditionKinds.def"
     .Default(None);
 }
 
 /// Get platform condition name from PlatformConditionKind.
 static StringRef getPlatformConditionName(PlatformConditionKind Kind) {
   switch (Kind) {
-  case PlatformConditionKind::OS:
-    return "os";
-  case PlatformConditionKind::Arch:
-    return "arch";
-  case PlatformConditionKind::Endianness:
-    return "_endian";
-  case PlatformConditionKind::Runtime:
-    return "_runtime";
-  case PlatformConditionKind::CanImport:
-    return "canImport";
-  case PlatformConditionKind::TargetEnvironment:
-    return "targetEnvironment";
+#define PLATFORM_CONDITION(LABEL, IDENTIFIER) \
+  case PlatformConditionKind::LABEL: return IDENTIFIER;
+#include "swift/AST/PlatformConditionKinds.def"
   }
 }
 

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -148,7 +148,7 @@ undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'
 #if _endian(arm64) // expected-warning {{unknown endianness for build configuration '_endian'}} expected-note {{did you mean 'arch'}} {{5-12=arch}}
 #endif
 
-#if targetEnvironment(_ObjC) // expected-warning {{unknown target environment for build configuration 'targetEnvironment'}} expected-note {{did you mean '_runtime'}} {{5-22=_runtime}}
+#if targetEnvironment(_ObjC) // expected-warning {{unknown target environment for build configuration 'targetEnvironment'}} expected-note {{did you mean 'simulator'}} {{23-28=simulator}}
 #endif
 
 #if os(iOS) || os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{16-18=targetEnvironment}}

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -139,6 +139,24 @@ func undefinedFunc() // ignored.
 #endif
 undefinedFunc() // expected-error {{use of unresolved identifier 'undefinedFunc'}}
 
+#if os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{5-7=targetEnvironment}}
+#endif
+
+#if arch(iOS) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note {{did you mean 'os'}} {{5-9=os}}
+#endif
+
+#if _endian(arm64) // expected-warning {{unknown endianness for build configuration '_endian'}} expected-note {{did you mean 'arch'}} {{5-12=arch}}
+#endif
+
+#if targetEnvironment(_ObjC) // expected-warning {{unknown target environment for build configuration 'targetEnvironment'}} expected-note {{did you mean '_runtime'}} {{5-22=_runtime}}
+#endif
+
+#if os(iOS) || os(simulator) // expected-warning {{unknown operating system for build configuration 'os'}} expected-note {{did you mean 'targetEnvironment'}} {{16-18=targetEnvironment}}
+#endif
+
+#if arch(ios) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note {{did you mean 'os'}} {{5-9=os}} expected-note {{did you mean 'iOS'}} {{10-13=iOS}}
+#endif
+
 #if FOO
 #else if BAR
 // expected-error@-1 {{unexpected 'if' keyword following '#else' conditional compilation directive; did you mean '#elseif'?}} {{1-9=#elseif}}


### PR DESCRIPTION
Resolves [SR-11037](https://bugs.swift.org/browse/SR-11037).

In case there’s an exact match with a value of an alternate kind, this solution offers a single fixit to change the platform conditional kind. For example:

```
#if os(simulator)
// Fixit: os -> targetEnvironment
#endif
```

In case there’s only a case-insensitive match with a value of an alternate kind, this solution offers two fixits: one for the kind and one for the value. For example:

```
#if os(Simulator)
// Fixit: os -> targetEnvironment
// Fixit: Simulator -> simulator
#endif
```
Implementation details:

To search for a match in an alternate platform conditional kind, we need a way to loop through the different platform conditional value arrays (SupportedConditionalCompilationOSs, SupportedConditionalCompilationArches, …), for which I’m using a std::pair<const StringRef*, size_t> to represent each array. I’m open to suggestions on an alternate representation.
