### PR TITLE
[irgen] Add a small test that provides an example of how to write vec…

### DIFF
--- a/test/IRGen/builtin_vector.sil
+++ b/test/IRGen/builtin_vector.sil
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -emit-ir -parse-sil %s -module-name Swift -parse-stdlib | %FileCheck %s
+
+// This file provides examples on how vector computations are written at the SIL
+// level and how they are translated by IRGen to LLVM IR intrinsics.
+
+import Builtin
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc <4 x i32> @vector_int_add(<4 x i32>, <4 x i32>) {{.*}} {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %2 = add <4 x i32> %0, %1
+// CHECK-NEXT: ret <4 x i32> %2
+// CHECK-NEXT: }
+sil @vector_int_add : $@convention(thin) (Builtin.Vec4xInt32, Builtin.Vec4xInt32) -> Builtin.Vec4xInt32 {
+bb0(%0 : $Builtin.Vec4xInt32, %1 : $Builtin.Vec4xInt32):
+  %2 = builtin "add_Vec4xInt32" (%0 : $Builtin.Vec4xInt32, %1 : $Builtin.Vec4xInt32) : $Builtin.Vec4xInt32
+  return %2 : $Builtin.Vec4xInt32
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc <4 x float> @vector_float_add(<4 x float>, <4 x float>) {{.*}} {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %2 = fadd <4 x float> %0, %1
+// CHECK-NEXT: ret <4 x float> %2
+// CHECK-NEXT: }
+sil @vector_float_add : $@convention(thin) (Builtin.Vec4xFPIEEE32, Builtin.Vec4xFPIEEE32) -> Builtin.Vec4xFPIEEE32 {
+bb0(%0 : $Builtin.Vec4xFPIEEE32, %1 : $Builtin.Vec4xFPIEEE32):
+  %2 = builtin "fadd_Vec4xFPIEEE32"(%0 : $Builtin.Vec4xFPIEEE32, %1 : $Builtin.Vec4xFPIEEE32) : $Builtin.Vec4xFPIEEE32
+  return %2 : $Builtin.Vec4xFPIEEE32
+}


### PR DESCRIPTION
…tor code in SIL and the type of LLVM-IR it lowers to.

This is intended to be an always correct reference for new implementors.
