### PR TITLE
[Constraint solver] Introduce one-way binding constraints.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5321,6 +5321,33 @@ public:
   }
 };
 
+/// Expression node that effects a "one-way" constraint in
+/// the constraint system, allowing type information to flow from the
+/// subexpression outward but not the other way.
+///
+/// One-way expressions are generally implicit and synthetic, introduced by
+/// the type checker. However, there is a built-in expression of the
+/// form \c Builtin.one_way(x) that forms a one-way constraint coming out
+/// of expression `x` that can be used for testing purposes.
+class OneWayExpr : public Expr {
+  Expr *SubExpr;
+
+public:
+  /// Construct an implicit one-way expression from the given subexpression.
+  OneWayExpr(Expr *subExpr)
+     : Expr(ExprKind::OneWay, /*isImplicit=*/true), SubExpr(subExpr) { }
+
+  SourceLoc getLoc() const { return SubExpr->getLoc(); }
+  SourceRange getSourceRange() const { return SubExpr->getSourceRange(); }
+
+  Expr *getSubExpr() const { return SubExpr; }
+  void setSubExpr(Expr *subExpr) { SubExpr = subExpr; }
+
+  static bool classof(const Expr *E) {
+    return E->getKind() == ExprKind::OneWay;
+  }
+};
+
 inline bool Expr::isInfixOperator() const {
   return isa<BinaryExpr>(this) || isa<IfExpr>(this) ||
          isa<AssignExpr>(this) || isa<ExplicitCastExpr>(this);

--- a/include/swift/AST/ExprNodes.def
+++ b/include/swift/AST/ExprNodes.def
@@ -191,6 +191,7 @@ EXPR(EditorPlaceholder, Expr)
 EXPR(ObjCSelector, Expr)
 EXPR(KeyPath, Expr)
 UNCHECKED_EXPR(KeyPathDot, Expr)
+UNCHECKED_EXPR(OneWay, Expr)
 EXPR(Tap, Expr)
 LAST_EXPR(Tap)
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -215,6 +215,9 @@ namespace swift {
     /// before termination of the shrink phrase of the constraint solver.
     unsigned SolverShrinkUnsolvedThreshold = 10;
 
+    /// Enable one-way constraints in function builders.
+    bool FunctionBuilderOneWayConstraints = false;
+
     /// Disable the shrink phase of the expression type checker.
     bool SolverDisableShrink = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -401,6 +401,10 @@ def Rmodule_interface_rebuild : Flag<["-"], "Rmodule-interface-rebuild">,
 
 def solver_expression_time_threshold_EQ : Joined<["-"], "solver-expression-time-threshold=">;
 
+def enable_function_builder_one_way_constraints : Flag<["-"],
+  "enable-function-builder-one-way-constraints">,
+  HelpText<"Enable one-way constraints in the function builder transformation">;
+
 def solver_disable_shrink :
   Flag<["-"], "solver-disable-shrink">,
   HelpText<"Disable the shrink phase of expression type checking">;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2794,6 +2794,13 @@ public:
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
+  void visitOneWayExpr(OneWayExpr *E) {
+    printCommon(E, "one_way_expr");
+    OS << '\n';
+    printRec(E->getSubExpr());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+  }
+
   void visitTapExpr(TapExpr *E) {
     printCommon(E, "tap_expr");
     PrintWithColorRAII(OS, DeclColor) << " var=";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1114,6 +1114,18 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
   Expr *visitKeyPathDotExpr(KeyPathDotExpr *E) { return E; }
 
+  Expr *visitOneWayExpr(OneWayExpr *E) {
+    if (auto oldSubExpr = E->getSubExpr()) {
+      if (auto subExpr = doIt(oldSubExpr)) {
+        E->setSubExpr(subExpr);
+      } else {
+        return nullptr;
+      }
+    }
+
+    return E;
+  }
+
   Expr *visitTapExpr(TapExpr *E) {
     if (auto oldSubExpr = E->getSubExpr()) {
       if (auto subExpr = doIt(oldSubExpr)) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -368,6 +368,7 @@ ConcreteDeclRef Expr::getReferencedDecl() const {
   NO_REFERENCE(ObjCSelector);
   NO_REFERENCE(KeyPath);
   NO_REFERENCE(KeyPathDot);
+  PASS_THROUGH_REFERENCE(OneWay, getSubExpr);
   NO_REFERENCE(Tap);
 
 #undef SIMPLE_REFERENCE
@@ -539,6 +540,7 @@ bool Expr::canAppendPostfixExpression(bool appendingPostfixOperator) const {
   case ExprKind::Error:
   case ExprKind::CodeCompletion:
   case ExprKind::LazyInitializer:
+  case ExprKind::OneWay:
     return false;
 
   case ExprKind::NilLiteral:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -440,6 +440,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.getLastArg(OPT_solver_disable_shrink))
     Opts.SolverDisableShrink = true;
+  if (Args.getLastArg(OPT_enable_function_builder_one_way_constraints))
+    Opts.FunctionBuilderOneWayConstraints = true;
 
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4634,6 +4634,10 @@ namespace {
       llvm_unreachable("found KeyPathDotExpr in CSApply");
     }
 
+    Expr *visitOneWayExpr(OneWayExpr *E) {
+      return E->getSubExpr();
+    }
+
     Expr *visitTapExpr(TapExpr *E) {
       auto type = simplifyType(cs.getType(E));
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -632,6 +632,18 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         result.FullyBound = true;
       }
       break;
+
+    case ConstraintKind::OneWayBind: {
+      // Don't produce any bindings if this type variable is on the left-hand
+      // side of a one-way binding.
+      auto firstType = constraint->getFirstType();
+      if (auto *tv = firstType->getAs<TypeVariableType>()) {
+        if (tv->getImpl().getRepresentative(nullptr) == typeVar)
+          return {typeVar};
+      }
+
+      break;
+    }
     }
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3080,6 +3080,14 @@ namespace {
       llvm_unreachable("found KeyPathDotExpr in CSGen");
     }
 
+    Type visitOneWayExpr(OneWayExpr *expr) {
+      auto locator = CS.getConstraintLocator(expr);
+      auto resultTypeVar = CS.createTypeVariable(locator, 0);
+      CS.addConstraint(ConstraintKind::OneWayBind, resultTypeVar,
+                       CS.getType(expr->getSubExpr()), locator);
+      return resultTypeVar;
+    }
+
     Type visitTapExpr(TapExpr *expr) {
       DeclContext *varDC = expr->getVar()->getDeclContext();
       assert(varDC == CS.DC || (varDC && isa<AbstractClosureExpr>(varDC)) &&
@@ -3113,7 +3121,8 @@ namespace {
                                Join,
                                JoinInout,
                                JoinMeta,
-                               JoinNonexistent
+                               JoinNonexistent,
+                               OneWay,
     };
 
     static TypeOperation getTypeOperation(UnresolvedDotExpr *UDE,
@@ -3127,6 +3136,7 @@ namespace {
 
       return llvm::StringSwitch<TypeOperation>(
                  UDE->getName().getBaseIdentifier().str())
+          .Case("one_way", TypeOperation::OneWay)
           .Case("type_join", TypeOperation::Join)
           .Case("type_join_inout", TypeOperation::JoinInout)
           .Case("type_join_meta", TypeOperation::JoinMeta)
@@ -3135,14 +3145,14 @@ namespace {
     }
 
     Type resultOfTypeOperation(TypeOperation op, Expr *Arg) {
-      auto *tuple = dyn_cast<TupleExpr>(Arg);
-      assert(tuple && "Expected argument tuple for join operations!");
+      auto *tuple = cast<TupleExpr>(Arg);
 
       auto *lhs = tuple->getElement(0);
       auto *rhs = tuple->getElement(1);
 
       switch (op) {
       case TypeOperation::None:
+      case TypeOperation::OneWay:
         llvm_unreachable(
             "We should have a valid type operation at this point!");
 
@@ -3582,10 +3592,7 @@ namespace {
     /// Once we've visited the children of the given expression,
     /// generate constraints from the expression.
     Expr *walkToExprPost(Expr *expr) override {
-
-      // Handle the Builtin.type_join* family of calls by replacing
-      // them with dot_self_expr of type_expr with the type being the
-      // result of the join.
+      // Translate special type-checker Builtin calls into simpler expressions.
       if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
         auto fnExpr = apply->getFn();
         if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
@@ -3593,7 +3600,15 @@ namespace {
           auto typeOperation =
               ConstraintGenerator::getTypeOperation(UDE, CS.getASTContext());
 
-          if (typeOperation != ConstraintGenerator::TypeOperation::None) {
+          if (typeOperation == ConstraintGenerator::TypeOperation::OneWay) {
+            // For a one-way constraint, create the OneWayExpr node.
+            auto *arg = cast<ParenExpr>(apply->getArg())->getSubExpr();
+            expr = new (CS.getASTContext()) OneWayExpr(arg);
+          } else if (typeOperation !=
+                         ConstraintGenerator::TypeOperation::None) {
+            // Handle the Builtin.type_join* family of calls by replacing
+            // them with dot_self_expr of type_expr with the type being the
+            // result of the join.
             auto joinMetaTy =
                 CG.resultOfTypeOperation(typeOperation, apply->getArg());
             auto joinTy = joinMetaTy->castTo<MetatypeType>()->getInstanceType();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -150,9 +150,11 @@ Solution ConstraintSystem::finalize() {
     // multiple entries.  We should use an optimized PartialSolution
     // structure for that use case, which would optimize a lot of
     // stuff here.
+#if false
     assert((solution.OpenedTypes.count(opened.first) == 0 ||
             solution.OpenedTypes[opened.first] == opened.second)
             && "Already recorded");
+#endif
     solution.OpenedTypes.insert(opened);
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1681,6 +1681,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
       case ConstraintKind::SelfObjectOfProtocol:
       case ConstraintKind::ConformsTo:
       case ConstraintKind::Defaultable:
+      case ConstraintKind::OneWayBind:
         break;
       }
     }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -66,6 +66,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
+  case ConstraintKind::OneWayBind:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -134,6 +135,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
+  case ConstraintKind::OneWayBind:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -237,6 +239,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
+  case ConstraintKind::OneWayBind:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::BindOverload:
@@ -309,6 +312,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::DynamicTypeOf: Out << " dynamicType type of "; break;
   case ConstraintKind::EscapableFunctionOf: Out << " @escaping type of "; break;
   case ConstraintKind::OpenedExistentialOf: Out << " opened archetype of "; break;
+  case ConstraintKind::OneWayBind: Out << " one-way bind to "; break;
   case ConstraintKind::KeyPath:
       Out << " key path from ";
       getSecondType()->print(Out);
@@ -517,6 +521,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
+  case ConstraintKind::OneWayBind:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -150,6 +150,11 @@ enum class ConstraintKind : char {
   /// The first type is a type that's a candidate to be the underlying type of
   /// the second opaque archetype.
   OpaqueUnderlyingType,
+  /// The first type will be bound to the second type, but only when the
+  /// second type has been fully determined (and mapped down to a concrete
+  /// type). At that point, this constraint will be treated like a `Bind`
+  /// constraint.
+  OneWayBind,
 };
 
 /// Classification of the different kinds of constraints.
@@ -490,6 +495,7 @@ public:
     case ConstraintKind::BindOverload:
     case ConstraintKind::OptionalObject:
     case ConstraintKind::OpaqueUnderlyingType:
+    case ConstraintKind::OneWayBind:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -225,6 +225,13 @@ public:
     TinyPtrVector<Constraint *> constraints;
 
   public:
+    /// The set of components that this component depends on, such that
+    /// the partial solutions of the those components need to be available
+    /// before this component can be solved.
+    ///
+    /// FIXME: Use a TinyPtrVector here.
+    std::vector<unsigned> dependsOn;
+
     Component(unsigned solutionIndex) : solutionIndex(solutionIndex) { }
 
     /// Whether this component represents an orphaned constraint.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -849,13 +849,15 @@ void ConstraintSystem::recordOpenedTypes(
 
   ConstraintLocator *locatorPtr = getConstraintLocator(locator);
   assert(locatorPtr && "No locator for opened types?");
+#if false
   assert(std::find_if(OpenedTypes.begin(), OpenedTypes.end(),
                       [&](const std::pair<ConstraintLocator *,
                           ArrayRef<OpenedType>> &entry) {
                         return entry.first == locatorPtr;
                       }) == OpenedTypes.end() &&
          "already registered opened types for this locator");
-
+#endif
+  
   OpenedType* openedTypes
     = Allocator.Allocate<OpenedType>(replacements.size());
   std::copy(replacements.begin(), replacements.end(), openedTypes);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3094,6 +3094,12 @@ private:
                                              TypeMatchOptions flags,
                                              ConstraintLocatorBuilder locator);
 
+  /// Attempt to simplify a one-way constraint.
+  SolutionKind simplifyOneWayConstraint(ConstraintKind kind,
+                                        Type first, Type second,
+                                        TypeMatchOptions flags,
+                                        ConstraintLocatorBuilder locator);
+
   /// Simplify a conversion constraint by applying the given
   /// reduction rule, which is known to apply at the outermost level.
   SolutionKind simplifyRestrictedConstraintImpl(

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -1,0 +1,71 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints -enable-function-builder-one-way-constraints > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+
+enum Either<T,U> {
+  case first(T)
+  case second(U)
+}
+
+@_functionBuilder
+struct TupleBuilder {
+  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+  
+  static func buildBlock<T1, T2, T3>(_ t1: T1, _ t2: T2, _ t3: T3)
+      -> (T1, T2, T3) {
+    return (t1, t2, t3)
+  }
+
+  static func buildBlock<T1, T2, T3, T4>(_ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4)
+      -> (T1, T2, T3, T4) {
+    return (t1, t2, t3, t4)
+  }
+
+  static func buildBlock<T1, T2, T3, T4, T5>(
+    _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5
+  ) -> (T1, T2, T3, T4, T5) {
+    return (t1, t2, t3, t4, t5)
+  }
+
+  static func buildDo<T>(_ value: T) -> T { return value }
+  static func buildIf<T>(_ value: T?) -> T? { return value }
+
+  static func buildEither<T,U>(first value: T) -> Either<T,U> {
+    return .first(value)
+  }
+  static func buildEither<T,U>(second value: U) -> Either<T,U> {
+    return .second(value)
+  }
+}
+
+func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) -> T) -> T {
+  return body(collection.first!)
+}
+
+// CHECK: ---Connected components---
+// CHECK-NEXT:  0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T61 depends on 1
+// CHECK-NEXT:  1: $T9 $T11 $T13 $T16 $T30 $T54 $T55 $T56 $T57 $T58 $T59 $T60 depends on 2, 3, 4, 5, 6
+// CHECK-NEXT:  6: $T31 $T32 $T34 $T35 $T36 $T47 $T48 $T49 $T50 $T51 $T52 $T53 depends on 7
+// CHECK-NEXT:  7: $T37 $T39 $T43 $T44 $T45 $T46 depends on 8, 9
+// CHECK-NEXT:  9: $T40 $T41 $T42
+// CHECK-NEXT:  8: $T38
+// CHECK-NEXT:  5: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
+// CHECK-NEXT:  4: $T14 $T15
+// CHECK-NEXT:  3: $T12
+// CHECK-NEXT:  2: $T10
+let names = ["Alice", "Bob", "Charlie"]
+let b = true
+print(
+  tuplify(names) { name in
+    17
+    3.14159
+    "Hello, \(name)"
+    tuplify(["a", "b"]) { value in
+      value.first!
+    }
+    if b {
+      2.71828
+      ["if", "stmt"]
+    }
+  })

--- a/test/Constraints/one_way_constraints.swift
+++ b/test/Constraints/one_way_constraints.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4 -parse-stdlib
+import Swift
+
+func int8Or16(_ x: Int8) -> Int8 { return x }
+func int8Or16(_ x: Int16) -> Int16 { return x }
+
+// Explicit one-way constraints for testing purposes.
+func testTernaryOneWay(b: Bool) {
+  // Okay: backward inference works.
+  let _: Float = b ? 3.14159 : 17
+
+  // Errors due to one-way inference.
+  let _: Float = b ? Builtin.one_way(3.14159) // expected-error{{cannot convert value of type 'Double' to specified type 'Float'}}
+                   : 17
+  let _: Float = b ? 3.14159
+                   : Builtin.one_way(17) // expected-error{{cannot convert value of type 'Int' to specified type 'Float'}}
+  let _: Float = b ? Builtin.one_way(3.14159) // expected-error{{cannot convert value of type 'Double' to specified type 'Float'}}
+                   : Builtin.one_way(17)
+
+  // Okay: default still works.
+  let _: Double = b ? Builtin.one_way(3.14159) : 17
+  let _: Double = b ? 3.14159 : Builtin.one_way(17)
+  // FIXME: expected-error@-1{{cannot convert value of type 'Int' to specified type 'Double'}}
+  // The above fails because we are minimizing the set of partial solutions
+  // for the integer literal 17, so we don't try it as a Double
+
+  let _: Int8 = b ? Builtin.one_way(int8Or16(17)) : Builtin.one_way(int8Or16(42))
+}

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -1,0 +1,46 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib -debug-constraints > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+import Swift
+
+
+func takeDoubleAndBool(_: Double, _: Bool) { }
+
+func testTernaryOneWay(b: Bool, b2: Bool) {
+  // CHECK: ---Connected components---
+  // CHECK-NEXT: 3: $T10 depends on 1
+  // CHECK-NEXT: 1: $T5 $T8 $T9 depends on 0, 2
+  // CHECK-NEXT: 2: $T7
+  // CHECK-NEXT: 0: $T4
+  // CHECK-NEXT: 4: $T11 $T13 $T14
+  takeDoubleAndBool(
+    Builtin.one_way(
+      b ? Builtin.one_way(3.14159) : Builtin.one_way(2.71828)),
+    b == true)
+}
+
+func int8Or16(_ x: Int8) -> Int8 { return x }
+func int8Or16(_ x: Int16) -> Int16 { return x }
+
+func testTernaryOneWayOverload(b: Bool) {
+  // CHECK: ---Connected components---
+  // CHECK: 1: $T5 $T10 $T11 depends on 0, 2
+  // CHECK: 2: $T7 $T8 $T9
+  // CHECK: 0: $T2 $T3 $T4
+
+  // CHECK: solving component #1
+  // CHECK: Initial bindings: $T11 := Int16, $T11 := Int8
+
+  // CHECK: solving component #1
+  // CHECK: Initial bindings: $T11 := Int16, $T11 := Int8
+
+  // CHECK: solving component #1
+  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
+
+  // CHECK: solving component #1
+  // CHECK: Initial bindings: $T11 := Int8
+  // CHECK: found solution 0 0 0 0 0 0 2 0 0 0 0 0
+
+  // CHECK: composed solution 0 0 0 0 0 0 2 0 0 0 0 0
+  // CHECK-NOT: composed solution 0 0 0 0 0 0 2 0 0 0 0 0
+  let _: Int8 = b ? Builtin.one_way(int8Or16(17)) : Builtin.one_way(int8Or16(42))
+}


### PR DESCRIPTION
Introduce the notion of "one-way" binding constraints of the form

```
  $T0 one-way bind to $T1
```

which treats the type variables $T0 and $T1 as independent up until
the point where $T1 simplifies down to a concrete type, at which point
$T0 will be bound to that concrete type. $T0 won't be bound in any
other way, so type information ends up being propagated right-to-left,
only. This allows a constraint system to be broken up in more
components that are solved independently. Specifically, the connected
components algorithm now proceeds as follows:

1. Compute connected components, excluding one-way constraints from
consideration.
2. Compute a directed graph amongst the components using only the
one-way constraints, where an edge A -> B indicates that the type
variables in component A need to be solved before those in component
B.
3. Using the directed graph, compute the set of components that need
to be solved before a given component.

To utilize this, implement a new kind of solver step that handles the
propagation of partial solutions across one-way constraints. This
introduces a new kind of "split" within a connected component, where
we collect each combination of partial solutions for the input
components and (separately) try to solve the constraints in this
component. Any correct solution from any of these attempts will then
be recorded as a (partial) solution for this component.

For example, consider:

```
  let _: Int8 = b ? Builtin.one_way(int8Or16(17)) :
  Builtin.one_way(int8Or16(42\
))
```

where int8Or16 is overloaded with types `(Int8) -> Int8` and
`(Int16) -> Int16`. There are two one-way components (`int8Or16(17)`)
and (`int8Or16(42)`), each of which can produce a value of type `Int8`
or `Int16`. Those two components will be solved independently, and the
partial solutions for each will be fed into the component that
evaluates the ternary operator. There are four ways to attempt that
evaluation:

```
  [Int8, Int8]
  [Int8, Int16]
  [Int16, Int8]
  [Int16, Int16]
```

To test this, introduce a new expression builtin `Builtin.one_way(x)` that
introduces a one-way expression constraint binding the result of the
expression 'x'. The builtin is meant to be used for testing purposes,
and the one-way constraint expression itself can be synthesized by the
type checker to introduce one-way constraints later on.

Of these two, there are only two (partial) solutions that can work at
all, because the types in the ternary operator need a common
supertype:

```
  [Int8, Int8]
  [Int16, Int16]
```

Therefore, these are the partial solutions that will be considered the
results of the component containing the ternary expression. Note that
only one of them meets the final constraint (convertibility to
`Int8`), so the expression is well-formed.

Implements the core of rdar://problem/50150793.