### PR TITLE
[runtime] Handle same-type constraints when resolving generic params

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2485,6 +2485,12 @@ struct TargetContextDescriptor {
               ? genericContext->getGenericContextHeader().NumParams
               : 0;
   }
+
+#ifndef NDEBUG
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
+                            "only for use in the debugger");
+#endif
+
 private:
   TargetContextDescriptor(const TargetContextDescriptor &) = delete;
   TargetContextDescriptor(TargetContextDescriptor &&) = delete;
@@ -3649,11 +3655,6 @@ public:
     return cd->getKind() >= ContextDescriptorKind::Type_First
         && cd->getKind() <= ContextDescriptorKind::Type_Last;
   }
-
-#ifndef NDEBUG
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
-                            "Only meant for use in the debugger");
-#endif
 };
 
 using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3945,20 +3945,33 @@ void Metadata::dump() const {
   printf("TargetMetadata.\n");
   printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
   printf("Value Witnesses: %p.\n", getValueWitnesses());
-  printf("Class Object: %p.\n", getClassObject());
-  printf("Type Context Description: %p.\n", getTypeContextDescriptor());
+
+  auto *contextDescriptor = getTypeContextDescriptor();
+  printf("Name: %s.\n", contextDescriptor->Name.get());
+  printf("Type Context Description: %p.\n", contextDescriptor);
   printf("Generic Args: %p.\n", getGenericArgs());
+
+#if SWIFT_OBJC_INTEROP
+  if (auto *classObject = getClassObject()) {
+    printf("ObjC Name: %s.\n", class_getName(
+        reinterpret_cast<Class>(const_cast<ClassMetadata *>(classObject))));
+    printf("Class Object: %p.\n", classObject);
+  }
+#endif
 }
 
 template <>
 LLVM_ATTRIBUTE_USED
-void TypeContextDescriptor::dump() const {
+void ContextDescriptor::dump() const {
   printf("TargetTypeContextDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());
-  printf("Name: %s.\n", Name.get());
-  printf("Access function: %p.\n", static_cast<void *>(getAccessFunction()));
-  printf("Fields: %p.\n", Fields.get());
+  if (auto *typeDescriptor = dyn_cast<TypeContextDescriptor>(this)) {
+    printf("Name: %s.\n", typeDescriptor->Name.get());
+    printf("Fields: %p.\n", typeDescriptor->Fields.get());
+    printf("Access function: %p.\n",
+           static_cast<void *>(typeDescriptor->getAccessFunction()));
+  }
 }
 
 template<>

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -309,7 +309,8 @@ public:
     ///
     /// \returns a pair containing the number of key generic parameters in
     /// the path up to this point.
-    unsigned buildDescriptorPath(const ContextDescriptor *context) const;
+    unsigned buildDescriptorPath(const ContextDescriptor *context,
+                                 Demangler &demangler) const;
 
     /// Builds a path from the generic environment.
     unsigned buildEnvironmentPath(

--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -105,6 +105,8 @@ protocol HasAssoc {
   associatedtype Assoc
 }
 
+class SeparateGenericSuperclass<T> {}
+
 enum Container<T : TagProtocol> {
   class _Superclass {}
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO9_SubclassCMn" =
@@ -127,18 +129,23 @@ enum Container<T : TagProtocol> {
   // CHECK-CONSTANTS-SAME: @"symbolic _____yx_G 15nested_generics9ContainerO11_SuperclassC"
   class _Subclass2<U: Collection>: _Superclass where T == U.Element {}
 
-
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO10_Subclass3CMn" =
-  // FIXME: That "qd__" still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic _____y______qd__G 15nested_generics9ContainerO18_GenericSuperclassC AA5OuterO"
   class _GenericSuperclass<U> {}
   class _Subclass3<U>: _GenericSuperclass<U> where T == Outer {}
 
+  class MoreNesting {
+    // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO11MoreNestingC9_SubclassCMn" =
+    // CHECK-CONSTANTS-SAME: @"symbolic _____y______G 15nested_generics9ContainerO11_SuperclassC AA5OuterO"
+    class _Subclass<U>: _Superclass where T == Outer {}
+  }
+
+  // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO24_SeparateGenericSubclassCMn" =
+  // CHECK-CONSTANTS-SAME: @"symbolic _____yxSgG 15nested_generics25SeparateGenericSuperclassC"
+  class _SeparateGenericSubclass: SeparateGenericSuperclass<T?> {}
+
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO6FieldsVMF" =
   // CHECK-CONSTANTS-SAME: @"symbolic _____ 15nested_generics5OuterO"
-  // FIXME: This still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic qd__"
   struct Fields<U> where T == Outer {
     var x: T
@@ -146,8 +153,6 @@ enum Container<T : TagProtocol> {
   }
 
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO5CasesOMF" =
-  // FIXME: This still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic qd__"
   enum Cases<U> where T == Outer {
     case a(T)


### PR DESCRIPTION
Generic parameters for a context are normally classified as "key", meaning they have actual metadata provided at runtime, or non-key, meaning they're derivable from somewhere else. However, a nested context or constrained extension can take what would be a "key" parameter in a parent context and make it non-key in a child context. This messes with the mapping between the (depth, index) representation of generic parameters and the flat list of generic arguments. Fix this by (1) consistently substituting out extension contexts with the contexts of the extended types, and (2) <del>checking if a same-type constraint was (2a) newly applied in a particular context, and (2b) constrains a parent's generic parameter</del> using the most nested context to decide which parameters are key, instead of the context a parameter was originally introduced in.

Note that this may have problems if/when extensions start introducing their *own* generic parameters (\*cough* #25263 \*cough*). For now I tried to be consistent with what was there.

rdar://problem/52364601