### PR TITLE
Driver: look for the runtime object in the SDK

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1168,6 +1168,11 @@ void ToolChain::getResourceDirPath(SmallVectorImpl<char> &resourceDirPath,
   if (const Arg *A = args.getLastArg(options::OPT_resource_dir)) {
     StringRef value = A->getValue();
     resourceDirPath.append(value.begin(), value.end());
+  } else if (!getTriple().isOSDarwin() && args.hasArg(options::OPT_sdk)) {
+    StringRef value = args.getLastArg(options::OPT_sdk)->getValue();
+    resourceDirPath.append(value.begin(), value.end());
+    llvm::sys::path::append(resourceDirPath, "usr", "lib",
+                            shared ? "swift" : "swift_static");
   } else {
     auto programPath = getDriver().getSwiftProgramPath();
     resourceDirPath.append(programPath.begin(), programPath.end());

--- a/test/Driver/sdk.swift
+++ b/test/Driver/sdk.swift
@@ -1,7 +1,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9     -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix OSX
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu    -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix LINUX 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu    -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix LINUX
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-freebsd      -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix FREEBSD
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix WINDOWS 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-windows-msvc -g -sdk %S/../Inputs/clang-importer-sdk %s 2>&1 | %FileCheck %s --check-prefix WINDOWS
 
 // RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-apple-macosx10.9  -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix OSX
 // RUN: env SDKROOT=%S/../Inputs/clang-importer-sdk %swiftc_driver_plain -target x86_64-unknown-linux-gnu -g -driver-print-jobs %s 2>&1 | %FileCheck %s --check-prefix LINUX
@@ -42,7 +42,7 @@
 // WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
 // WINDOWS-NEXT: bin{{/|\\\\}}swift
 // WINDOWS: -sdk {{.*}}/Inputs/clang-importer-sdk
-// WINDOWS: {{.*}}swiftrt.o
+// WINDOWS: {{.*}}Inputs/clang-importer-sdk{{.*}}swiftrt.o
 // WINDOWS: {{-I}} {{.*}}/Inputs/clang-importer-sdk
 
 // RUN: %swift_driver -driver-print-jobs -repl -sdk %S/Inputs/nonexistent-sdk 2>&1 | %FileCheck %s --check-prefix=SDKWARNING
@@ -55,3 +55,4 @@
 // RUN: %swiftc_driver -driver-print-jobs -typecheck -sdk %S/../Inputs/clang-importer-sdk -module-cache-path /path/to/cache %s 2>&1 | %FileCheck %s --check-prefix=CACHE-PATH
 
 // CACHE-PATH: -module-cache-path /path/to/cache
+


### PR DESCRIPTION
The runtime object is for the host, and is part of the SDK.  If `-sdk`
is passed, look for the runtime support object relative to the SDK root.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
