### PR TITLE
[Testing QoI] Make the Windows link job test more robust

### DIFF
--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -1,2 +1,4 @@
-// RUN: env PATH= %swiftc_driver_plain -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
-// CHECK: clang++
+// RUN: %empty-directory(%t/DISTINCTIVE-WINDOWS-PATH/usr/bin)
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc)
+// RUN: env PATH= %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
+// CHECK: {{^}}clang++


### PR DESCRIPTION
Create a fake install location to ensure that the path to `clang++` is not hard coded.

This is fix based on feedback from @jrose-apple after #25972 and #25887.