### PR TITLE
Update example code to compile with Swift 5.0/5.1

### DIFF
--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -78,7 +78,8 @@
 ///     {
 ///       func makeIterator() -> LazyScanIterator<Base.Iterator, ResultElement> {
 ///         return LazyScanIterator(
-///           nextElement: initial, base: base.makeIterator(), nextPartialResult: nextPartialResult)
+///           nextElement: initial, base: base.makeIterator(),
+///           nextPartialResult: nextPartialResult)
 ///       }
 ///       let initial: ResultElement
 ///       let base: Base

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -86,7 +86,7 @@
 ///         (ResultElement, Base.Element) -> ResultElement
 ///     }
 ///
-/// // and finally, we can give all lazy sequences a lazy `scan` method:
+/// and finally, we can give all lazy sequences a lazy `scan` method:
 ///     
 ///     extension LazySequenceProtocol {
 ///       /// Returns a sequence containing the results of

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -68,14 +68,9 @@
 ///           return result
 ///         }
 ///       }
-///       init(nextElement: ResultElement?, base: Base, _ nextPartialResult: @escaping (ResultElement, Base.Element) -> ResultElement) {
-///         self.nextElement = nextElement
-///         self.base = base
-///         self.nextPartialResult = nextPartialResult
-///       }
-///       private var nextElement: ResultElement? // The next result of next().
-///       private var base: Base                  // The underlying iterator.
-///       private let nextPartialResult: (ResultElement, Base.Element) -> ResultElement
+///       var nextElement: ResultElement? // The next result of next().
+///       var base: Base                  // The underlying iterator.
+///       let nextPartialResult: (ResultElement, Base.Element) -> ResultElement
 ///     }
 ///     
 ///     struct LazyScanSequence<Base: Sequence, ResultElement>
@@ -83,21 +78,15 @@
 ///     {
 ///       func makeIterator() -> LazyScanIterator<Base.Iterator, ResultElement> {
 ///         return LazyScanIterator(
-///           nextElement: initial, base: base.makeIterator(), nextPartialResult)
+///           nextElement: initial, base: base.makeIterator(), nextPartialResult: nextPartialResult)
 ///       }
-///       init(initial: ResultElement, base: Base, _ nextPartialResult: @escaping (ResultElement, Base.Element) -> ResultElement) {
-///         self.initial = initial
-///         self.base = base
-///         self.nextPartialResult = nextPartialResult
-///       }
-///
-///       private let initial: ResultElement
-///       private let base: Base
-///       private let nextPartialResult:
+///       let initial: ResultElement
+///       let base: Base
+///       let nextPartialResult:
 ///         (ResultElement, Base.Element) -> ResultElement
 ///     }
 ///
-/// and finally, we can give all lazy sequences a lazy `scan` method:
+/// // and finally, we can give all lazy sequences a lazy `scan` method:
 ///     
 ///     extension LazySequenceProtocol {
 ///       /// Returns a sequence containing the results of
@@ -115,7 +104,7 @@
 ///         _ nextPartialResult: @escaping (ResultElement, Element) -> ResultElement
 ///       ) -> LazyScanSequence<Self, ResultElement> {
 ///         return LazyScanSequence(
-///           initial: initial, base: self, nextPartialResult)
+///           initial: initial, base: self, nextPartialResult: nextPartialResult)
 ///       }
 ///     }
 ///

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -68,6 +68,11 @@
 ///           return result
 ///         }
 ///       }
+///       init(nextElement: ResultElement?, base: Base, _ nextPartialResult: @escaping (ResultElement, Base.Element) -> ResultElement) {
+///         self.nextElement = nextElement
+///         self.base = base
+///         self.nextPartialResult = nextPartialResult
+///       }
 ///       private var nextElement: ResultElement? // The next result of next().
 ///       private var base: Base                  // The underlying iterator.
 ///       private let nextPartialResult: (ResultElement, Base.Element) -> ResultElement
@@ -80,6 +85,12 @@
 ///         return LazyScanIterator(
 ///           nextElement: initial, base: base.makeIterator(), nextPartialResult)
 ///       }
+///       init(initial: ResultElement, base: Base, _ nextPartialResult: @escaping (ResultElement, Base.Element) -> ResultElement) {
+///         self.initial = initial
+///         self.base = base
+///         self.nextPartialResult = nextPartialResult
+///       }
+///
 ///       private let initial: ResultElement
 ///       private let base: Base
 ///       private let nextPartialResult:
@@ -101,7 +112,7 @@
 ///       /// - Complexity: O(1)
 ///       func scan<ResultElement>(
 ///         _ initial: ResultElement,
-///         _ nextPartialResult: (ResultElement, Element) -> ResultElement
+///         _ nextPartialResult: @escaping (ResultElement, Element) -> ResultElement
 ///       ) -> LazyScanSequence<Self, ResultElement> {
 ///         return LazyScanSequence(
 ///           initial: initial, base: self, nextPartialResult)


### PR DESCRIPTION
Update LazySequence documentation sample code for the "we can build a sequence that lazily computes the elements in the result of `scan`" example so that it will compile and work for Swift 5.0 & 5.1