### PR TITLE
[5.1] Support unavailable and obsoleted attributes on extensions

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1062,7 +1062,14 @@ AvailableVersionComparison AvailableAttr::getVersionAvailability(
 
 const AvailableAttr *AvailableAttr::isUnavailable(const Decl *D) {
   ASTContext &ctx = D->getASTContext();
-  return D->getAttrs().getUnavailable(ctx);
+  if (auto attr = D->getAttrs().getUnavailable(ctx))
+    return attr;
+
+  // If D is an extension member, check if the extension is unavailable.
+  if (auto ext = dyn_cast<ExtensionDecl>(D->getDeclContext()))
+    return AvailableAttr::isUnavailable(ext);
+
+  return nullptr;
 }
 
 SpecializeAttr::SpecializeAttr(SourceLoc atLoc, SourceRange range,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1502,13 +1502,17 @@ static bool isInsideUnavailableDeclaration(SourceRange ReferenceRange,
 /// Returns true if the reference or any of its parents is an
 /// unconditional unavailable declaration for the same platform.
 static bool isInsideCompatibleUnavailableDeclaration(
-    SourceRange ReferenceRange, const DeclContext *ReferenceDC,
-    const AvailableAttr *attr) {
+    const ValueDecl *referencedD, SourceRange ReferenceRange,
+    const DeclContext *ReferenceDC, const AvailableAttr *attr) {
   if (!attr->isUnconditionallyUnavailable()) {
     return false;
   }
+
+  // Refuse calling unavailable functions from unavailable code,
+  // but allow the use of types.
   PlatformKind platform = attr->Platform;
-  if (platform == PlatformKind::none) {
+  if (platform == PlatformKind::none &&
+      !isa<TypeDecl>(referencedD)) {
     return false;
   }
 
@@ -2163,7 +2167,7 @@ bool swift::diagnoseExplicitUnavailability(
   // unavailability is OK -- the eventual caller can't call the
   // enclosing code in the same situations it wouldn't be able to
   // call this code.
-  if (isInsideCompatibleUnavailableDeclaration(R, DC, Attr)) {
+  if (isInsideCompatibleUnavailableDeclaration(D, R, DC, Attr)) {
     return false;
   }
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1087,3 +1087,16 @@ func rdar46348825_deprecated() {}
 @available(swift, obsoleted: 4.0, obsoleted: 4.0)
 // expected-warning@-1 {{'obsoleted' argument has already been specified}}
 func rdar46348825_obsoleted() {}
+
+// Referencing unavailable types in signatures of unavailable functions should be accepted
+@available(*, unavailable)
+protocol UnavailableProto {
+}
+
+@available(*, unavailable)
+func unavailableFunc(_ arg: UnavailableProto) -> UnavailableProto {}
+
+@available(*, unavailable)
+struct S {
+  var a: UnavailableProto
+}

--- a/test/attr/attr_availability_swift.swift
+++ b/test/attr/attr_availability_swift.swift
@@ -29,15 +29,15 @@ extension TestStruct {
   func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
 }
 
-@available(swift 400) // FIXME: This has no effect and should be complained about.
+@available(swift 400)
 extension TestStruct {
-  func doAnotherThing() {}
+  func doAnotherThing() {} // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
 }
 
 @available(macOS 10.11, *)
 func testMemberAvailability() {
   TestStruct().doTheThing() // expected-error {{'doTheThing()' is unavailable}}
-  TestStruct().doAnotherThing() // okay (for now)
+  TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
 }
 
 @available(swift 400) // FIXME: This has no effect and should be complained about.


### PR DESCRIPTION
Cherry-pick of #24997 for Swift 5.1.