### PR TITLE
[SE-0258] Check for an invalid property wrapper type definition.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2603,6 +2603,9 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
         for (unsigned i : indices(wrappedVar->getAttachedPropertyWrappers())) {
           auto wrapperInfo = wrappedVar->getAttachedPropertyWrapperTypeInfo(i);
+          if (!wrapperInfo)
+            break;
+
           Type memberType =
               cs->createTypeVariable(emptyLocator, TVO_CanBindToLValue);
           cs->addValueMemberConstraint(

--- a/validation-test/compiler_crashers_2_fixed/0198-rdar52081852.swift
+++ b/validation-test/compiler_crashers_2_fixed/0198-rdar52081852.swift
@@ -1,0 +1,41 @@
+// RUN: not %target-swift-frontend -typecheck %s
+@propertyWrapper
+public struct Wrapper<T> {
+    public var wrappedV: T // part-way through typing wrappedValue
+    
+    public init(initialValue: T) {
+        self.value = initialValue
+    }
+    
+    public init(body: () -> T) {
+        self.value = body()
+    }
+}
+
+var globalInt: Int { return 17 }
+
+public struct HasWrappers {
+    @Wrapper
+    public var x: Int = globalInt
+    
+    @Wrapper(body: { globalInt })
+    public var y: Int
+    
+    @Wrapper(body: {
+        struct Inner {
+            @Wrapper
+            var x: Int = globalInt
+        }
+        return Inner().x + globalInt
+    })
+    public var z: Int
+    
+    func backingUse() {
+        _ = $y.value + $z.value + x + $x.value
+    }
+}
+
+func useMemberwiseInits(i: Int) {
+    _ = HasWrappers(x: i)
+    _ = HasWrappers(y: Wrapper(initialValue: i))
+}


### PR DESCRIPTION
Fixes the crash-on-invalid in rdar://problem/52081852.
