### PR TITLE
[5.1] Remove incorrect assertion in SIL verifier for assign_by_wrapper

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1966,13 +1966,9 @@ public:
             "assign instruction can only exist in raw SIL");
     require(Dest->getType().isAddress(), "Must store to an address dest");
 
-    unsigned indirectInitResults = Src->getType().isAddress() ? 1 : 0;
-
     SILValue initFn = AI->getInitializer();
     CanSILFunctionType initTy = initFn->getType().castTo<SILFunctionType>();
     SILFunctionConventions initConv(initTy, AI->getModule());
-    require(initConv.getNumIndirectSILResults() == indirectInitResults,
-            "init function has wrong number of indirect results");
     unsigned firstArgIdx = initConv.getSILArgIndexOfFirstParam();
     require(initConv.getNumSILArguments() == firstArgIdx + 1,
             "init function has wrong number of arguments");

--- a/test/SILGen/Inputs/property_wrapper_defs.swift
+++ b/test/SILGen/Inputs/property_wrapper_defs.swift
@@ -1,0 +1,18 @@
+@propertyWrapper
+public struct MyPublished<Value> {
+	private var stored: Value
+	
+	public var wrappedValue: Value {
+		get { stored }
+		set { stored = newValue }
+	}		
+
+	public init(initialValue: Value) {
+		stored = initialValue
+	}
+
+	public var projectedValue: Self {
+		mutating get { self }
+		set { self = newValue }
+	}
+}

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-silgen | %FileCheck %s
-// FIXME: switch to %target-swift-emit-silgen once we have syntax tree support
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
 
 @propertyWrapper
 struct Wrapper<T> {

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/property_wrapper_defs.swift
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t | %FileCheck %s
+import property_wrapper_defs
 
 @propertyWrapper
 struct Wrapper<T> {
@@ -406,6 +409,20 @@ struct WithTuples {
 		return .init()
 	}
 }
+
+// Resilience with DI of wrapperValue assignments.
+// rdar://problem/52467175
+class TestResilientDI {
+  @MyPublished var data: Int? = nil
+
+	// CHECK: assign_by_wrapper {{%.*}} : $Optional<Int> to {{%.*}} : $*MyPublished<Optional<Int>>, init {{%.*}} : $@callee_guaranteed (Optional<Int>) -> @out MyPublished<Optional<Int>>, set {{%.*}} : $@callee_guaranteed (Optional<Int>) -> ()
+
+  func doSomething() {
+    self.data = Int()
+  }
+}
+
+
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter


### PR DESCRIPTION
The assertion was checking that the number of indirect result types
matched up with the number of indirect input types, which is... not
correct. The correct checks are later on, and the actual SIL itself is
correct. Fixes rdar://problem/52467175.