### PR TITLE
Fix ARCSequenceOpts handle of is_escaping_closure

### DIFF
--- a/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
@@ -77,7 +77,7 @@ ARCMatchingSetBuilder::matchIncrementsToDecrements() {
 
     bool BUCodeMotionSafe = (*BURefCountState)->second.isCodeMotionSafe();
     LLVM_DEBUG(llvm::dbgs() << "        BOTTOM UP CODEMOTIONSAFE: "
-                            << (BUIsKnownSafe ? "true" : "false") << "\n");
+                            << (BUCodeMotionSafe ? "true" : "false") << "\n");
     Flags.CodeMotionSafe &= BUCodeMotionSafe;
 
     // Now that we know we have an inst, grab the decrement.
@@ -161,7 +161,7 @@ ARCMatchingSetBuilder::matchDecrementsToIncrements() {
 
     bool TDCodeMotionSafe = (*TDRefCountState)->second.isCodeMotionSafe();
     LLVM_DEBUG(llvm::dbgs() << "        TOP DOWN CODEMOTIONSAFE: "
-                            << (TDIsKnownSafe ? "true" : "false") << "\n");
+                            << (TDCodeMotionSafe ? "true" : "false") << "\n");
     Flags.CodeMotionSafe &= TDCodeMotionSafe;
 
     // Now that we know we have an inst, grab the decrement.

--- a/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
+++ b/test/SILOptimizer/arcsequenceopts_uniquecheck.sil
@@ -104,3 +104,27 @@ bb0(%0 : $*C, %1 : $*C):
   strong_release %2 : $C
   return %4 : $Builtin.Int1
 }
+
+// Similarly, do not remove a retain/release pair that spans an
+// is_escaping_closure instruction. This would fail to catch closures
+// that are returned from the function.
+// <rdar://problem/52803634>
+
+// thunk for @callee_guaranteed () -> ()
+sil shared [transparent] [serializable] [reabstraction_thunk] [without_actually_escaping] @$sIg_Ieg_TR : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> () {
+bb0(%0 : $@noescape @callee_guaranteed () -> ()):
+  %1 = apply %0() : $@noescape @callee_guaranteed () -> ()
+  return %1 : $()
+}
+
+sil hidden [noinline] @testEscapingClosure : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> @owned @callee_guaranteed () -> () {
+bb0(%0 : $@noescape @callee_guaranteed () -> ()):
+  %1 = function_ref @$sIg_Ieg_TR : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  %3 = mark_dependence %2 : $@callee_guaranteed () -> () on %0 : $@noescape @callee_guaranteed () -> ()
+  strong_retain %3 : $@callee_guaranteed () -> ()
+  %5 = is_escaping_closure %3 : $@callee_guaranteed () -> ()
+  strong_release %3 : $@callee_guaranteed () -> ()
+  cond_fail %5 : $Builtin.Int1
+  return %3 : $@callee_guaranteed () -> ()
+}


### PR DESCRIPTION
Handle is_escaping_closure like an RC-checking instructions.  It looks
like it "may-decrement" RC because: if the object must be live after
the instruction and the subsequent local release, then it expects the
refcount to be greater than one. In other words, do not remove a
retain/release pair that spans an is_escaping_closure
instruction.

This would otherwise fail to catch closures that are returned
from the function.

The following retain/release pair cannot be removed:

%me = partial_apply
retain %me
is_escaping_closure %me
release %me
return %me

Fixes <rdar://problem/52803634>


