### PR TITLE
[Diagnostics] Port invalid reference to `mutating` member diagnostics to new framework

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -644,16 +644,16 @@ bool SkipUnhandledConstructInFunctionBuilder::diagnose(Expr *root,
   return failure.diagnose(asNote);
 }
 
-bool AllowMutatingMemberOrRValueBase::diagnose(Expr *root, bool asNote) const {
+bool AllowMutatingMemberOnRValueBase::diagnose(Expr *root, bool asNote) const {
   auto &cs = getConstraintSystem();
   MutatingMemberRefOnImmutableBase failure(root, cs, getMember(), getLocator());
   return failure.diagnose(asNote);
 }
 
-AllowMutatingMemberOrRValueBase *
-AllowMutatingMemberOrRValueBase::create(ConstraintSystem &cs, Type baseType,
+AllowMutatingMemberOnRValueBase *
+AllowMutatingMemberOnRValueBase::create(ConstraintSystem &cs, Type baseType,
                                         ValueDecl *member, DeclName name,
                                         ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowMutatingMemberOrRValueBase(cs, baseType, member, name, locator);
+      AllowMutatingMemberOnRValueBase(cs, baseType, member, name, locator);
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -645,7 +645,9 @@ bool SkipUnhandledConstructInFunctionBuilder::diagnose(Expr *root,
 }
 
 bool AllowMutatingMemberOrRValueBase::diagnose(Expr *root, bool asNote) const {
-  return false;
+  auto &cs = getConstraintSystem();
+  MutatingMemberRefOnImmutableBase failure(root, cs, getMember(), getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowMutatingMemberOrRValueBase *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -643,3 +643,15 @@ bool SkipUnhandledConstructInFunctionBuilder::diagnose(Expr *root,
       root, getConstraintSystem(), unhandled, builder, getLocator());
   return failure.diagnose(asNote);
 }
+
+bool AllowMutatingMemberOrRValueBase::diagnose(Expr *root, bool asNote) const {
+  return false;
+}
+
+AllowMutatingMemberOrRValueBase *
+AllowMutatingMemberOrRValueBase::create(ConstraintSystem &cs, Type baseType,
+                                        ValueDecl *member, DeclName name,
+                                        ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowMutatingMemberOrRValueBase(cs, baseType, member, name, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -342,14 +342,16 @@ AllowMemberRefOnExistential::create(ConstraintSystem &cs, Type baseType,
 }
 
 bool AllowMemberRefOnExistential::diagnose(Expr *root, bool asNote) const {
-  auto failure = InvalidMemberRefOnExistential(root, getConstraintSystem(),
-                                               BaseType, Name, getLocator());
+  auto failure =
+      InvalidMemberRefOnExistential(root, getConstraintSystem(), getBaseType(),
+                                    getMemberName(), getLocator());
   return failure.diagnose(asNote);
 }
 
 bool AllowTypeOrInstanceMember::diagnose(Expr *root, bool asNote) const {
   auto failure = AllowTypeOrInstanceMemberFailure(
-      root, getConstraintSystem(), BaseType, Member, UsedName, getLocator());
+      root, getConstraintSystem(), getBaseType(), getMember(), getMemberName(),
+      getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -472,15 +474,17 @@ MoveOutOfOrderArgument *MoveOutOfOrderArgument::create(
 }
 
 bool AllowInaccessibleMember::diagnose(Expr *root, bool asNote) const {
-  InaccessibleMemberFailure failure(root, getConstraintSystem(), Member,
+  InaccessibleMemberFailure failure(root, getConstraintSystem(), getMember(),
                                     getLocator());
   return failure.diagnose(asNote);
 }
 
 AllowInaccessibleMember *
-AllowInaccessibleMember::create(ConstraintSystem &cs, ValueDecl *member,
+AllowInaccessibleMember::create(ConstraintSystem &cs, Type baseType,
+                                ValueDecl *member, DeclName name,
                                 ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AllowInaccessibleMember(cs, member, locator);
+  return new (cs.getAllocator())
+      AllowInaccessibleMember(cs, baseType, member, name, locator);
 }
 
 bool AllowAnyObjectKeyPathRoot::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -179,6 +179,10 @@ enum class FixKind : uint8_t {
   /// matches up with a
   /// parameter that has a function builder.
   SkipUnhandledConstructInFunctionBuilder,
+
+  /// Allow invalid reference to a member declared as `mutating`
+  /// when base is an r-value type.
+  AllowMutatingMemberOrRValueBase,
 };
 
 class ConstraintFix {
@@ -856,6 +860,25 @@ private:
                                      bool isStaticallyDerived,
                                      SourceRange baseRange,
                                      ConstraintLocator *locator);
+};
+
+class AllowMutatingMemberOrRValueBase final : public AllowInvalidMemberRef {
+  AllowMutatingMemberOrRValueBase(ConstraintSystem &cs, Type baseType,
+                                  ValueDecl *member, DeclName name,
+                                  ConstraintLocator *locator)
+      : AllowInvalidMemberRef(cs, FixKind::AllowMutatingMemberOrRValueBase,
+                              baseType, member, name, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow `mutating` method on r-value base";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static AllowMutatingMemberOrRValueBase *
+  create(ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclName name,
+         ConstraintLocator *locator);
 };
 
 class AllowClosureParamDestructuring final : public ConstraintFix {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -182,7 +182,7 @@ enum class FixKind : uint8_t {
 
   /// Allow invalid reference to a member declared as `mutating`
   /// when base is an r-value type.
-  AllowMutatingMemberOrRValueBase,
+  AllowMutatingMemberOnRValueBase,
 };
 
 class ConstraintFix {
@@ -862,11 +862,11 @@ private:
                                      ConstraintLocator *locator);
 };
 
-class AllowMutatingMemberOrRValueBase final : public AllowInvalidMemberRef {
-  AllowMutatingMemberOrRValueBase(ConstraintSystem &cs, Type baseType,
+class AllowMutatingMemberOnRValueBase final : public AllowInvalidMemberRef {
+  AllowMutatingMemberOnRValueBase(ConstraintSystem &cs, Type baseType,
                                   ValueDecl *member, DeclName name,
                                   ConstraintLocator *locator)
-      : AllowInvalidMemberRef(cs, FixKind::AllowMutatingMemberOrRValueBase,
+      : AllowInvalidMemberRef(cs, FixKind::AllowMutatingMemberOnRValueBase,
                               baseType, member, name, locator) {}
 
 public:
@@ -876,7 +876,7 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static AllowMutatingMemberOrRValueBase *
+  static AllowMutatingMemberOnRValueBase *
   create(ConstraintSystem &cs, Type baseType, ValueDecl *member, DeclName name,
          ConstraintLocator *locator);
 };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4750,7 +4750,8 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
 
     case MemberLookupResult::UR_Inaccessible:
       assert(choice.isDecl());
-      return AllowInaccessibleMember::create(cs, choice.getDecl(), locator);
+      return AllowInaccessibleMember::create(cs, baseTy, choice.getDecl(),
+                                             memberName, locator);
 
     case MemberLookupResult::UR_UnavailableInExistential: {
       return choice.isDecl()

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4761,7 +4761,13 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
     }
 
     case MemberLookupResult::UR_MutatingMemberOnRValue:
-    case MemberLookupResult::UR_MutatingGetterOnRValue:
+    case MemberLookupResult::UR_MutatingGetterOnRValue: {
+      return choice.isDecl()
+                 ? AllowMutatingMemberOrRValueBase::create(
+                       cs, baseTy, choice.getDecl(), memberName, locator)
+                 : nullptr;
+    }
+
     case MemberLookupResult::UR_LabelMismatch:
     // TODO(diagnostics): Add a new fix that is suggests to
     // add `subscript(dynamicMember: {Writable}KeyPath<T, U>)`
@@ -6929,6 +6935,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::ExplicitlySpecifyGenericArguments:
   case FixKind::GenericArgumentsMismatch:
+  case FixKind::AllowMutatingMemberOrRValueBase:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4763,7 +4763,7 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
     case MemberLookupResult::UR_MutatingMemberOnRValue:
     case MemberLookupResult::UR_MutatingGetterOnRValue: {
       return choice.isDecl()
-                 ? AllowMutatingMemberOrRValueBase::create(
+                 ? AllowMutatingMemberOnRValueBase::create(
                        cs, baseTy, choice.getDecl(), memberName, locator)
                  : nullptr;
     }
@@ -6935,7 +6935,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowInvalidRefInKeyPath:
   case FixKind::ExplicitlySpecifyGenericArguments:
   case FixKind::GenericArgumentsMismatch:
-  case FixKind::AllowMutatingMemberOrRValueBase:
+  case FixKind::AllowMutatingMemberOnRValueBase:
     llvm_unreachable("handled elsewhere");
   }
 


### PR DESCRIPTION
Originally CSDiag had to guess whether this is a problem by trying to lookup member
name again and do ad-hoc argument to parameter matching, but new diagnostic framework
provides a more convenient way to archive this by introducing (disabled by default)
overload choice with associated fix, so solver could do the argument matching and
check whether member fits into larger expression.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
