### PR TITLE
[refactoring] Fix error when renaming nested type at constructor - init() has no declaration location

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -784,7 +784,7 @@ bool RefactoringActionLocalRename::performChange() {
   CursorInfoResolver Resolver(*TheFile);
   ResolvedCursorInfo CursorInfo = Resolver.resolve(StartLoc);
   if (CursorInfo.isValid() && CursorInfo.ValueD) {
-    ValueDecl *VD = CursorInfo.ValueD;
+    ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
     llvm::SmallVector<DeclContext *, 8> Scopes;
     analyzeRenameScope(VD, DiagEngine, Scopes);
     if (Scopes.empty())
@@ -3352,7 +3352,7 @@ int swift::ide::findLocalRenameRanges(
     Diags.diagnose(StartLoc, diag::unresolved_location);
     return true;
   }
-  ValueDecl *VD = CursorInfo.ValueD;
+  ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
   llvm::SmallVector<DeclContext *, 8> Scopes;
   analyzeRenameScope(VD, Diags, Scopes);
   if (Scopes.empty())

--- a/test/refactoring/rename/Outputs/basic/C1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/C1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/E1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/E1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/S1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/S1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/SLocal.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/SLocal.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/SLocal_init.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/SLocal_init.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/SP1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/SP1.swift.expected
@@ -14,16 +14,16 @@ func test() {
   local(a: SLocal(x: S1()))
 }
 
-guard let <base>top</base> = Optional.some("top") else {
+guard let top = Optional.some("top") else {
   fatalError()
 }
-print(<base>top</base>)
+print(top)
 
 protocol P1 {}
 struct Test {
   var test: P1 {
-    struct SP1: P1 {}
-    return SP1()
+    struct new_SP1: P1 {}
+    return new_SP1()
   }
 }
 

--- a/test/refactoring/rename/Outputs/basic/foo4.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/foo4.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/foo4_multi.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/foo4_multi.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/local.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/local.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic/top_level.swift.expected
+++ b/test/refactoring/rename/Outputs/basic/top_level.swift.expected
@@ -19,3 +19,11 @@ guard let bottom = Optional.some("top") else {
 }
 print(bottom)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/C1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/C1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/E1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/E1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/S1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/S1.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/SLocal.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/SLocal.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/SLocal_init.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/SLocal_init.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/SP1.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/SP1.swift.expected
@@ -14,16 +14,16 @@ func test() {
   local(a: SLocal(x: S1()))
 }
 
-guard let <base>top</base> = Optional.some("top") else {
+guard let top = Optional.some("top") else {
   fatalError()
 }
-print(<base>top</base>)
+print(top)
 
 protocol P1 {}
 struct Test {
   var test: P1 {
-    struct SP1: P1 {}
-    return SP1()
+    struct <base>SP1</base>: P1 {}
+    return <base>SP1</base>()
   }
 }
 

--- a/test/refactoring/rename/Outputs/basic_ranges/foo4.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/foo4.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/Outputs/basic_ranges/local.swift.expected
+++ b/test/refactoring/rename/Outputs/basic_ranges/local.swift.expected
@@ -19,3 +19,11 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+

--- a/test/refactoring/rename/basic.swift
+++ b/test/refactoring/rename/basic.swift
@@ -19,6 +19,14 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
+protocol P1 {}
+struct Test {
+  var test: P1 {
+    struct SP1: P1 {}
+    return SP1()
+  }
+}
+
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -rename -source-filename %s -pos=2:15 -new-name new_S1 >> %t.result/S1.swift
 // RUN: diff -u %S/Outputs/basic/S1.swift.expected %t.result/S1.swift
@@ -46,6 +54,8 @@ print(top)
 // RUN: diff -u %S/Outputs/basic/local.swift.expected %t.result/local.swift
 // RUN: %refactor -rename -source-filename %s -pos=20:7 -new-name 'bottom' > %t.result/top_level.swift
 // RUN: diff -u %S/Outputs/basic/top_level.swift.expected %t.result/top_level.swift
+// RUN: %refactor -rename -source-filename %s -pos=26:12 -new-name new_SP1 > %t.result/SP1.swift
+// RUN: diff -u %S/Outputs/basic/SP1.swift.expected %t.result/SP1.swift
 // RUN: %empty-directory(%t.ranges)
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:15 > %t.ranges/S1.swift
 // RUN: diff -u %S/Outputs/basic_ranges/S1.swift.expected %t.ranges/S1.swift
@@ -71,3 +81,5 @@ print(top)
 // RUN: diff -u %S/Outputs/basic_ranges/local.swift.expected %t.ranges/local.swift
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=20:7 > %t.result/top_level.swift
 // RUN: diff -u %S/Outputs/basic_ranges/top_level.swift.expected %t.result/top_level.swift
+// RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=26:12 > %t.result/SP1.swift
+// RUN: diff -u %S/Outputs/basic_ranges/SP1.swift.expected %t.result/SP1.swift


### PR DESCRIPTION
```
protocol P1 {}
struct Test {
  var test: P1 {
    struct SP1: P1 {}
    return SP1()
  }
}
```
Renaming `SPR1` on line 5 was incorrectly trying to rename the initializer instead of the type.

Resolves [SR-11077](https://bugs.swift.org/browse/SR-11077).

cc @nathawes 