### PR TITLE
[5.1] [SE-0258] Properly contextualize closures in property wrapper initialization

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1684,12 +1684,19 @@ static VarDecl *synthesizePropertyWrapperStorageWrapperProperty(
 static void typeCheckSynthesizedWrapperInitializer(
     PatternBindingDecl *pbd, VarDecl *backingVar, PatternBindingDecl *parentPBD,
     Expr *&initializer) {
-  DeclContext *dc = pbd->getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
+  // Figure out the context in which the initializer was written.
+  DeclContext *originalDC = parentPBD->getDeclContext();
+  if (!originalDC->isLocalContext()) {
+    auto initContext =
+        cast_or_null<PatternBindingInitializer>(parentPBD->getInitContext(0));
+    if (initContext)
+      originalDC = initContext;
+  }
 
   // Type-check the initialization.
+  ASTContext &ctx = pbd->getASTContext();
   auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
-  tc.typeCheckExpression(initializer, dc);
+  tc.typeCheckExpression(initializer, originalDC);
   if (auto initializerContext =
           dyn_cast_or_null<Initializer>(
             pbd->getPatternEntryForVarDecl(backingVar).getInitContext())) {

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -870,6 +870,22 @@ struct SR_10899_Usage {
   @SR_10899_Wrapper var thing: Bool // expected-error{{property type 'Bool' does not match that of the 'wrappedValue' property of its wrapper type 'SR_10899_Wrapper'}}
 }
 
+// SR-11061 / rdar://problem/52593304 assertion with DeclContext mismatches
+class SomeValue {
+	@SomeA(closure: { $0 }) var some: Int = 100
+}
+
+@propertyWrapper
+struct SomeA<T> {
+	var wrappedValue: T
+	let closure: (T) -> (T)
+
+	init(initialValue: T, closure: @escaping (T) -> (T)) {
+		self.wrappedValue = initialValue
+		self.closure = closure
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Property wrapper composition
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes SR-11061 / rdar://problem/52593304 / rdar://problem/52220881.
