### PR TITLE
Fixes for mangling dependent protocol conformances

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -717,8 +717,9 @@ conformance within the witness table, identified by the dependent type and
 protocol. In all cases, the DEPENDENT-CONFORMANCE-INDEX is an INDEX value
 indicating the position of the appropriate value within the generic environment
 (for "HD") or witness table (for "HI" and "HA") when it is known to be at a
-fixed position. A position of zero is used to indicate "unknown"; all other
-values are adjusted by 1.
+fixed position. An index of 1 ("0_") is used to indicate "unknown"; all other
+values are adjusted by 2. That these indexes are not 0-based is a bug that's
+now codified into the ABI; the index 0 is therefore reserved.
 
 ::
 

--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -151,11 +151,6 @@ protected:
     Buffer << op;
     recordOpStat(op, OldPos);
   }
-  void appendOperator(StringRef op, int natural) {
-    size_t OldPos = Storage.size();
-    Buffer << op << natural << '_';
-    recordOpStat(op, OldPos);
-  }
   void appendOperator(StringRef op, Index index) {
     size_t OldPos = Storage.size();
     Buffer << op << index;

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -213,6 +213,7 @@ NODE(TypeMetadataInstantiationFunction)
 NODE(TypeMetadataSingletonInitializationCache)
 NODE(TypeMetadataLazyCache)
 NODE(UncurriedFunctionType)
+NODE(UnknownIndex)
 #define REF_STORAGE(Name, ...) NODE(Name)
 #include "swift/AST/ReferenceStorage.def"
 CONTEXT_NODE(UnsafeAddressor)

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -491,6 +491,7 @@ protected:
   int demangleNatural();
   int demangleIndex();
   NodePointer demangleIndexAsNode();
+  NodePointer demangleDependentConformanceIndex();
   NodePointer demangleIdentifier();
   NodePointer demangleOperatorIdentifier();
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -799,8 +799,10 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
     case TypeKind::BuiltinVector:
       appendType(cast<BuiltinVectorType>(tybase)->getElementType(),
                  forDecl);
+      // The mangling calls for using the actual element count, which we have
+      // to adjust by 1 in order to mangle it as an index.
       return appendOperator("Bv",
-                            cast<BuiltinVectorType>(tybase)->getNumElements());
+                  Index(cast<BuiltinVectorType>(tybase)->getNumElements() + 1));
     case TypeKind::TypeAlias: {
       assert(DWARFMangling && "sugared types are only legal for the debugger");
       auto aliasTy = cast<TypeAliasType>(tybase);
@@ -2556,7 +2558,7 @@ void ASTMangler::appendDependentProtocolConformance(
       auto index =
         conformanceRequirementIndex(entry,
                                     CurGenericSignature->getRequirements());
-      appendOperator("HD", index + 1);
+      appendOperator("HD", Index(index + 2));
       continue;
     }
 
@@ -2571,7 +2573,7 @@ void ASTMangler::appendDependentProtocolConformance(
       entry.first->isEqual(currentProtocol->getProtocolSelfType());
     if (isInheritedConformance) {
       appendProtocolName(entry.second);
-      appendOperator("HI", index + 1);
+      appendOperator("HI", Index(index + 2));
       continue;
     }
 
@@ -2583,7 +2585,7 @@ void ASTMangler::appendDependentProtocolConformance(
     // For non-resilient protocols, encode the index.
     bool isResilient =
       currentProtocol->isResilient(Mod, ResilienceExpansion::Maximal);
-    appendOperator("HA", isResilient ? 0 : index + 1);
+    appendOperator("HA", Index(isResilient ? 1 : index + 2));
   }
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2558,6 +2558,7 @@ void ASTMangler::appendDependentProtocolConformance(
       auto index =
         conformanceRequirementIndex(entry,
                                     CurGenericSignature->getRequirements());
+      // This is never an unknown index and so must be adjusted by 2 per ABI.
       appendOperator("HD", Index(index + 2));
       continue;
     }
@@ -2573,6 +2574,7 @@ void ASTMangler::appendDependentProtocolConformance(
       entry.first->isEqual(currentProtocol->getProtocolSelfType());
     if (isInheritedConformance) {
       appendProtocolName(entry.second);
+      // For now, this is never an unknown index and so must be adjusted by 2.
       appendOperator("HI", Index(index + 2));
       continue;
     }
@@ -2582,7 +2584,8 @@ void ASTMangler::appendDependentProtocolConformance(
     appendType(entry.first);
     appendProtocolName(entry.second);
 
-    // For non-resilient protocols, encode the index.
+    // For resilient protocols, the index is unknown, so we use the special
+    // value 1; otherwise we adjust by 2.
     bool isResilient =
       currentProtocol->isResilient(Mod, ResilienceExpansion::Maximal);
     appendOperator("HA", Index(isResilient ? 1 : index + 2));

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -228,6 +228,13 @@ private:
     Printer << ">";
   }
 
+  void printOptionalIndex(NodePointer node) {
+    assert(node->getKind() == Node::Kind::Index ||
+           node->getKind() == Node::Kind::UnknownIndex);
+    if (node->hasIndex())
+      Printer << "#" << node->getIndex() << " ";
+  }
+
   static bool isSwiftModule(NodePointer node) {
     return (node->getKind() == Node::Kind::Module &&
             node->getText() == STDLIB_NAME);
@@ -470,6 +477,7 @@ private:
 #define REF_STORAGE(Name, ...) \
     case Node::Kind::Name:
 #include "swift/AST/ReferenceStorage.def"
+    case Node::Kind::UnknownIndex:
     case Node::Kind::UnsafeAddressor:
     case Node::Kind::UnsafeMutableAddressor:
     case Node::Kind::ValueWitness:
@@ -1173,6 +1181,9 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::Index:
     Printer << Node->getIndex();
+    return nullptr;
+  case Node::Kind::UnknownIndex:
+    Printer << "unknown index";
     return nullptr;
   case Node::Kind::NoEscapeFunctionType:
     printFunctionType(nullptr, Node);
@@ -2237,20 +2248,21 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     return nullptr;
   case Node::Kind::DependentProtocolConformanceAssociated:
     Printer << "dependent associated protocol conformance ";
-    if (Node->hasIndex())
-      Printer << "#" << Node->getIndex() << " ";
-    printChildren(Node);
+    printOptionalIndex(Node->getChild(2));
+    print(Node->getChild(0));
+    print(Node->getChild(1));
     return nullptr;
   case Node::Kind::DependentProtocolConformanceInherited:
     Printer << "dependent inherited protocol conformance ";
-    if (Node->hasIndex())
-      Printer << "#" << Node->getIndex() << " ";
-    printChildren(Node);
+    printOptionalIndex(Node->getChild(2));
+    print(Node->getChild(0));
+    print(Node->getChild(1));
     return nullptr;
   case Node::Kind::DependentProtocolConformanceRoot:
-    Printer << "dependent root protocol conformance #" << Node->getIndex()
-      << " ";
-    printChildren(Node);
+    Printer << "dependent root protocol conformance ";
+    printOptionalIndex(Node->getChild(2));
+    print(Node->getChild(0));
+    print(Node->getChild(1));
     return nullptr;
   case Node::Kind::ProtocolConformanceRefInTypeModule:
     Printer << "protocol conformance ref (type's module) ";

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1609,6 +1609,10 @@ void Remangler::mangleIndex(Node *node) {
   mangleIndex(node->getIndex());
 }
 
+void Remangler::mangleUnknownIndex(Node *node) {
+  unreachable("should not be reached in an arbitrary context");
+}
+
 void Remangler::mangleProtocol(Node *node, EntityContext &ctx) {
   mangleNominalType(node, 'P', ctx);
 }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -233,6 +233,7 @@ class Remangler : public RemanglerBase {
       Buffer << (value - 1) << '_';
     }
   }
+  void mangleDependentConformanceIndex(Node *node);
 
   void mangleChildNodes(Node *node) {
     mangleNodes(node->begin(), node->end());
@@ -1340,6 +1341,10 @@ void Remangler::mangleIndex(Node *node) {
   unreachable("handled inline");
 }
 
+void Remangler::mangleUnknownIndex(Node *node) {
+  unreachable("handled inline");
+}
+
 void Remangler::mangleIVarInitializer(Node *node) {
   mangleSingleChildNode(node);
   Buffer << "fe";
@@ -1755,14 +1760,14 @@ void Remangler::mangleDependentProtocolConformanceRoot(Node *node) {
   mangleType(node->getChild(0));
   manglePureProtocol(node->getChild(1));
   Buffer << "HD";
-  mangleIndex(node->hasIndex() ? node->getIndex() + 1 : 0);
+  mangleDependentConformanceIndex(node->getChild(2));
 }
 
 void Remangler::mangleDependentProtocolConformanceInherited(Node *node) {
   mangleAnyProtocolConformance(node->getChild(0));
   manglePureProtocol(node->getChild(1));
   Buffer << "HI";
-  mangleIndex(node->hasIndex() ? node->getIndex() + 1 : 0);
+  mangleDependentConformanceIndex(node->getChild(2));
 }
 
 void Remangler::mangleDependentAssociatedConformance(Node *node) {
@@ -1774,7 +1779,14 @@ void Remangler::mangleDependentProtocolConformanceAssociated(Node *node) {
   mangleAnyProtocolConformance(node->getChild(0));
   mangleDependentAssociatedConformance(node->getChild(1));
   Buffer << "HA";
-  mangleIndex(node->hasIndex() ? node->getIndex() + 1 : 0);
+  mangleDependentConformanceIndex(node->getChild(2));
+}
+
+void Remangler::mangleDependentConformanceIndex(Node *node) {
+  assert(node->getKind() == Node::Kind::Index ||
+         node->getKind() == Node::Kind::UnknownIndex);
+  assert(node->hasIndex() == (node->getKind() == Node::Kind::Index));
+  mangleIndex(node->hasIndex() ? node->getIndex() + 2 : 1);
 }
 
 void Remangler::mangleAnyProtocolConformance(Node *node) {

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -349,3 +349,5 @@ $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
 $s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
 $s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
 $s18resilient_protocol24ResilientDerivedProtocolPxAA0c4BaseE0Tn --> associated conformance descriptor for resilient_protocol.ResilientDerivedProtocol.A: resilient_protocol.ResilientBaseProtocol
+$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF --> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]>
+$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>>

--- a/test/SILGen/Inputs/RetroactiveB.swift
+++ b/test/SILGen/Inputs/RetroactiveB.swift
@@ -1,3 +1,4 @@
 public struct X { }
 public struct Y { }
 public struct ExternalGeneric<Argument> {}
+public struct AnotherExternalGeneric<Argument> {}

--- a/test/SILGen/mangling_retroactive.swift
+++ b/test/SILGen/mangling_retroactive.swift
@@ -92,3 +92,15 @@ struct RequiresError<T> where T: Error { }
 extension ExternalGeneric: Error where Argument: Error { }
 func useRequiresError(_: RequiresError<ExternalGeneric<Error>>) {}
 // CHECK: sil hidden [ossa] @$s20mangling_retroactive16useRequiresErroryyAA0dE0Vy12RetroactiveB15ExternalGenericVys0E0_pGAIsAhAsAH_psAHHPyHC_HCg_GF
+
+// SR-10926
+protocol OurBaseProtocol: P {
+  associatedtype Assoc: P
+}
+protocol OurDerivedProtocol: OurBaseProtocol {}
+extension AnotherExternalGeneric: P where Argument: P {}
+enum OurType<Value: P> {
+  case value(Value)
+}
+func useDependentConformances<T: OurDerivedProtocol>(_: T.Type) -> OurType<AnotherExternalGeneric<T.Assoc>> {}
+// CHECK: sil hidden [ossa] @$s20mangling_retroactive24useDependentConformancesyAA7OurTypeOy12RetroactiveB22AnotherExternalGenericVy5AssocQzGAJ0H1A1PAAxAA0F15DerivedProtocolHD1_AA0f4BaseN0HI1_AikLHA2__HCg_GxmAaMRzlF


### PR DESCRIPTION
When we're mangling generic substitutions that contain references to concrete retroactive conformances, we mangle references to those conformances.  This exercises a particular production in the mangling grammar that is not very well tested by our normal practice: because it is specific to conformances that are (1) retroactive, (2) dependent, and yet (3) concrete, it essentially only kicks in on things like making standard library types conditionally conform to standard library protocols that they don't already conform to.

The demangler does not handle this production very well — in fact, it reliably crashes on every name the compiler would've spat out that used it.  We can fix this in the demangler, although it does require changing some bits of the demangler "AST" for these productions.

Unfortunately, we can't fix an apparent off-by-one bug in how the compiler actually uses these productions, which is now ABI.  Compilers with assertions enabled do attempt to demangle every name they mangle, so no such compiler can have generated a symbol using one of these productions — but of course most customers are using compilers with assertions disabled, so this crash is unreliable and we must simply document the current behavior.

Fixes [SR-10926](https://bugs.swift.org/browse/SR-10926).