### PR TITLE
[5.1] IDE: always print custom attributes associated with function builder

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -349,10 +349,17 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   AttributeVector attributes;
   AttributeVector modifiers;
 
+  CustomAttr *FuncBuilderAttr = nullptr;
+  if (auto *VD = dyn_cast_or_null<ValueDecl>(D)) {
+    FuncBuilderAttr = VD->getAttachedFunctionBuilder();
+  }
   for (auto DA : llvm::reverse(FlattenedAttrs)) {
+    // Always print function builder attribute.
+    bool isFunctionBuilderAttr = DA == FuncBuilderAttr;
     if (!Options.PrintImplicitAttrs && DA->isImplicit())
       continue;
     if (!Options.PrintUserInaccessibleAttrs &&
+        !isFunctionBuilderAttr &&
         DeclAttribute::isUserInaccessible(DA->getKind()))
       continue;
     if (Options.excludeAttrKind(DA->getKind()))

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -25,6 +25,13 @@ public func returnsAlias() -> Alias<Int> {
   return (0, 0)
 }
 
+@_functionBuilder
+struct BridgeBuilder {}
+
+public struct City {
+  public init(@BridgeBuilder builder: () -> ()) {}
+}
+
 // CHECK1:      /// Alias comment
 // CHECK1-NEXT: typealias Alias<T> = (T, T)
 
@@ -34,6 +41,8 @@ public func returnsAlias() -> Alias<Int> {
 // CHECK1-NEXT:   /// foo2 comment from C1
 // CHECK1-NEXT:   public func foo2()
 // CHECK1-NEXT: }
+
+// CHECK1: public init(@print_swift_module.BridgeBuilder builder: () -> ())
 
 // CHECK1:      public protocol P1 {
 // CHECK1-NEXT:   /// foo1 comment from P1


### PR DESCRIPTION
Explanation: In IDE interface generation, we should always print the function builder attributes for
the parameters that accept DSL style input. This patch changes the Swift ASTPrinter to always print an 
attribute if it's associated with a function builder.
Scope: IDE/Swift Interface Generation
Issue: rdar://51592635
Risk: Very Low
Testing: Regression tests added
Reviewer: Argyrios Kyrtzidis (@akyrtzi) and Jordan Rose (@jrose-apple)


