### PR TITLE
[Darwin] Fix ABI breaks introduced since 5.0

### DIFF
--- a/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/Darwin/CoreGraphics/CGFloat.swift.gyb
@@ -397,7 +397,7 @@ extension CGFloat : Hashable {
     hasher.combine(native)
   }
 
-  @inlinable @_transparent
+  @_alwaysEmitIntoClient @inlinable // Introduced in 5.1
   public func _rawHashValue(seed: Int) -> Int {
     return native._rawHashValue(seed: seed)
   }

--- a/stdlib/public/Darwin/Foundation/NSStringEncodings.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringEncodings.swift
@@ -51,11 +51,31 @@ extension String {
 }
 
 extension String.Encoding : Hashable {
+    public var hashValue: Int {
+        // Note: This is effectively the same hashValue definition that
+        // RawRepresentable provides on its own. We only need to keep this to
+        // ensure ABI compatibility with 5.0.
+        return rawValue.hashValue
+    }
+
+    @_alwaysEmitIntoClient // Introduced in 5.1
     public func hash(into hasher: inout Hasher) {
+        // Note: `hash(only:)` is only defined here because we also define
+        // `hashValue`.
+        //
+        // In 5.0, `hash(into:)` was resolved to RawRepresentable's functionally
+        // equivalent definition; we added this definition in 5.1 to make it
+        // clear this `hash(into:)` isn't synthesized by the compiler.
+        // (Otherwise someone may be tempted to define it, possibly breaking the
+        // hash encoding and thus the ABI. RawRepresentable's definition is
+        // inlinable.)
         hasher.combine(rawValue)
     }
 
     public static func ==(lhs: String.Encoding, rhs: String.Encoding) -> Bool {
+        // Note: This is effectively the same == definition that
+        // RawRepresentable provides on its own. We only need to keep this to
+        // ensure ABI compatibility with 5.0.
         return lhs.rawValue == rhs.rawValue
     }
 }


### PR DESCRIPTION
(cherry picked from commit 9e94afdf835746b22d7dc6d3459074a4cecc3921)

A couple of tiny ABI-breaking changes slipped in during the early days of 5.1 development.

* `String.Encoding.hashValue` got replaced with `hash(into:)`, which would normally be fine. However, the type conforms to `RawRepresentable`, and that protocol provides its own definitions for `Hashable`/`Equatable`, preventing the compiler from synthesizing the hashing counterparts as usual.

* `CGFloat._rawHashValue(seed:)` needs to be always emitted into the client.

rdar://problem/52847498
