### PR TITLE
[5.1] [runtime] Handle same-type constraints when resolving generic params

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3641,6 +3641,11 @@ public:
     return cd->getKind() >= ContextDescriptorKind::Type_First
         && cd->getKind() <= ContextDescriptorKind::Type_Last;
   }
+
+#ifndef NDEBUG
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
+                            "Only meant for use in the debugger");
+#endif
 };
 
 using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
@@ -4242,6 +4247,11 @@ public:
   static bool classof(const TargetContextDescriptor<Runtime> *cd) {
     return cd->getKind() == ContextDescriptorKind::Enum;
   }
+
+#ifndef NDEBUG
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
+                            "Only meant for use in the debugger");
+#endif
 };
 
 using EnumDescriptor = TargetEnumDescriptor<InProcess>;

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2478,6 +2478,12 @@ struct TargetContextDescriptor {
               ? genericContext->getGenericContextHeader().NumParams
               : 0;
   }
+
+#ifndef NDEBUG
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
+                            "only for use in the debugger");
+#endif
+
 private:
   TargetContextDescriptor(const TargetContextDescriptor &) = delete;
   TargetContextDescriptor(TargetContextDescriptor &&) = delete;
@@ -3646,11 +3652,6 @@ public:
     return cd->getKind() >= ContextDescriptorKind::Type_First
         && cd->getKind() <= ContextDescriptorKind::Type_Last;
   }
-
-#ifndef NDEBUG
-  LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
-                            "Only meant for use in the debugger");
-#endif
 };
 
 using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3362,6 +3362,11 @@ public:
   explicit operator bool() const {
     return Function != nullptr;
   }
+
+  /// For debugging purposes only.
+  explicit operator void*() const {
+    return reinterpret_cast<void *>(Function);
+  }
   
   /// Invoke with an array of arguments of dynamic size.
   MetadataResponse operator()(MetadataRequest request,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3946,20 +3946,33 @@ void Metadata::dump() const {
   printf("TargetMetadata.\n");
   printf("Kind: %s.\n", getStringForMetadataKind(getKind()).data());
   printf("Value Witnesses: %p.\n", getValueWitnesses());
-  printf("Class Object: %p.\n", getClassObject());
-  printf("Type Context Description: %p.\n", getTypeContextDescriptor());
+
+  auto *contextDescriptor = getTypeContextDescriptor();
+  printf("Name: %s.\n", contextDescriptor->Name.get());
+  printf("Type Context Description: %p.\n", contextDescriptor);
   printf("Generic Args: %p.\n", getGenericArgs());
+
+#if SWIFT_OBJC_INTEROP
+  if (auto *classObject = getClassObject()) {
+    printf("ObjC Name: %s.\n", class_getName(
+        reinterpret_cast<Class>(const_cast<ClassMetadata *>(classObject))));
+    printf("Class Object: %p.\n", classObject);
+  }
+#endif
 }
 
 template <>
 LLVM_ATTRIBUTE_USED
-void TypeContextDescriptor::dump() const {
+void ContextDescriptor::dump() const {
   printf("TargetTypeContextDescriptor.\n");
   printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());
-  printf("Name: %s.\n", Name.get());
-  printf("Access function: %p.\n", static_cast<void *>(getAccessFunction()));
-  printf("Fields: %p.\n", Fields.get());
+  if (auto *typeDescriptor = dyn_cast<TypeContextDescriptor>(this)) {
+    printf("Name: %s.\n", typeDescriptor->Name.get());
+    printf("Fields: %p.\n", typeDescriptor->Fields.get());
+    printf("Access function: %p.\n",
+           static_cast<void *>(typeDescriptor->getAccessFunction()));
+  }
 }
 
 template<>

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3935,6 +3935,10 @@ StringRef swift::getStringForMetadataKind(MetadataKind kind) {
   }
 }
 
+/***************************************************************************/
+/*** Debugging dump methods ************************************************/
+/***************************************************************************/
+
 #ifndef NDEBUG
 template <>
 LLVM_ATTRIBUTE_USED
@@ -3945,6 +3949,33 @@ void Metadata::dump() const {
   printf("Class Object: %p.\n", getClassObject());
   printf("Type Context Description: %p.\n", getTypeContextDescriptor());
   printf("Generic Args: %p.\n", getGenericArgs());
+}
+
+template <>
+LLVM_ATTRIBUTE_USED
+void TypeContextDescriptor::dump() const {
+  printf("TargetTypeContextDescriptor.\n");
+  printf("Flags: 0x%x.\n", this->Flags);
+  printf("Parent: %p.\n", this->Parent.get());
+  printf("Name: %s.\n", Name.get());
+  printf("Access function: %p.\n", getAccessFunction());
+  printf("Fields: %p.\n", Fields.get());
+}
+
+template<>
+LLVM_ATTRIBUTE_USED
+void EnumDescriptor::dump() const {
+  printf("TargetEnumDescriptor.\n");
+  printf("Flags: 0x%x.\n", this->Flags);
+  printf("Parent: %p.\n", this->Parent.get());
+  printf("Name: %s.\n", Name.get());
+  printf("Access function: %p.\n", getAccessFunction());
+  printf("Fields: %p.\n", Fields.get());
+  printf("NumPayloadCasesAndPayloadSizeOffset: 0x%08x "
+         "(payload cases: %u - payload size offset: %u).\n",
+         NumPayloadCasesAndPayloadSizeOffset,
+         getNumPayloadCases(), getPayloadSizeOffset());
+  printf("NumEmptyCases: %u\n", NumEmptyCases);
 }
 #endif
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3955,10 +3955,10 @@ template <>
 LLVM_ATTRIBUTE_USED
 void TypeContextDescriptor::dump() const {
   printf("TargetTypeContextDescriptor.\n");
-  printf("Flags: 0x%x.\n", this->Flags);
+  printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());
   printf("Name: %s.\n", Name.get());
-  printf("Access function: %p.\n", getAccessFunction());
+  printf("Access function: %p.\n", static_cast<void *>(getAccessFunction()));
   printf("Fields: %p.\n", Fields.get());
 }
 
@@ -3966,13 +3966,13 @@ template<>
 LLVM_ATTRIBUTE_USED
 void EnumDescriptor::dump() const {
   printf("TargetEnumDescriptor.\n");
-  printf("Flags: 0x%x.\n", this->Flags);
+  printf("Flags: 0x%x.\n", this->Flags.getIntValue());
   printf("Parent: %p.\n", this->Parent.get());
   printf("Name: %s.\n", Name.get());
-  printf("Access function: %p.\n", getAccessFunction());
+  printf("Access function: %p.\n", static_cast<void *>(getAccessFunction()));
   printf("Fields: %p.\n", Fields.get());
   printf("NumPayloadCasesAndPayloadSizeOffset: 0x%08x "
-         "(payload cases: %u - payload size offset: %u).\n",
+         "(payload cases: %u - payload size offset: %zu).\n",
          NumPayloadCasesAndPayloadSizeOffset,
          getNumPayloadCases(), getPayloadSizeOffset());
   printf("NumEmptyCases: %u\n", NumEmptyCases);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -309,7 +309,8 @@ public:
     ///
     /// \returns a pair containing the number of key generic parameters in
     /// the path up to this point.
-    unsigned buildDescriptorPath(const ContextDescriptor *context) const;
+    unsigned buildDescriptorPath(const ContextDescriptor *context,
+                                 Demangler &demangler) const;
 
     /// Builds a path from the generic environment.
     unsigned buildEnvironmentPath(

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -328,7 +328,7 @@ getFieldAt(const Metadata *base, unsigned index) {
   const FieldDescriptor &descriptor = *fields;
   auto &field = descriptor.getFields()[index];
   // Bounds are always valid as the offset is constant.
-  auto name = field.getFieldName(0, 0, std::numeric_limits<uint64_t>::max());
+  auto name = field.getFieldName(0, 0, std::numeric_limits<uintptr_t>::max());
 
   // Enum cases don't always have types.
   if (!field.hasMangledTypeName())

--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -105,6 +105,8 @@ protocol HasAssoc {
   associatedtype Assoc
 }
 
+class SeparateGenericSuperclass<T> {}
+
 enum Container<T : TagProtocol> {
   class _Superclass {}
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO9_SubclassCMn" =
@@ -127,18 +129,23 @@ enum Container<T : TagProtocol> {
   // CHECK-CONSTANTS-SAME: @"symbolic _____yx_G 15nested_generics9ContainerO11_SuperclassC"
   class _Subclass2<U: Collection>: _Superclass where T == U.Element {}
 
-
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO10_Subclass3CMn" =
-  // FIXME: That "qd__" still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic _____y______qd__G 15nested_generics9ContainerO18_GenericSuperclassC AA5OuterO"
   class _GenericSuperclass<U> {}
   class _Subclass3<U>: _GenericSuperclass<U> where T == Outer {}
 
+  class MoreNesting {
+    // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO11MoreNestingC9_SubclassCMn" =
+    // CHECK-CONSTANTS-SAME: @"symbolic _____y______G 15nested_generics9ContainerO11_SuperclassC AA5OuterO"
+    class _Subclass<U>: _Superclass where T == Outer {}
+  }
+
+  // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO24_SeparateGenericSubclassCMn" =
+  // CHECK-CONSTANTS-SAME: @"symbolic _____yxSgG 15nested_generics25SeparateGenericSuperclassC"
+  class _SeparateGenericSubclass: SeparateGenericSuperclass<T?> {}
+
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO6FieldsVMF" =
   // CHECK-CONSTANTS-SAME: @"symbolic _____ 15nested_generics5OuterO"
-  // FIXME: This still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic qd__"
   struct Fields<U> where T == Outer {
     var x: T
@@ -146,8 +153,6 @@ enum Container<T : TagProtocol> {
   }
 
   // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO5CasesOMF" =
-  // FIXME: This still causes problems: it's (depth: 1, index: 0), but
-  // the runtime doesn't count the parameters at depth 0 correctly.
   // CHECK-CONSTANTS-SAME: @"symbolic qd__"
   enum Cases<U> where T == Outer {
     case a(T)


### PR DESCRIPTION
**Explanation**: Swift uses mangled names to encode references to types that can be resolved at run time. However, the runtime support for this wasn't doing so correctly when a nested generic context makes one of an outer context's generic parameters redundant with a same-type constraint. This patch fixes two ways in which that logic was incorrect: it wasn't following extensions back to the original type, and it wasn't looking at the innermost context to see if a type was redundant.

**Scope**: Affects how the runtime resolves generic parameters when referenced from the metadata of generic types.

**Issue**: rdar://problem/52364601

**Risk**: Medium. The scope is pretty broad here, even if working code shouldn't change behavior in practice. It's possible that an existing app is encountering this bug today but coincidentally "working" based on incorrect information, and that app could change behavior.

**Testing**: Added compiler regression tests.

**Reviewed by**: @jckarter, @DougGregor 