### PR TITLE
Adding -nostdinc++ to Android build of Swift.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -324,6 +324,7 @@ function(_add_variant_c_compile_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
+    list(APPEND result -nostdinc++)
     swift_android_libcxx_include_paths(CFLAGS_CXX_INCLUDES)
     swift_android_include_for_arch("${CFLAGS_ARCH}" "${CFLAGS_ARCH}_INCLUDE")
     foreach(path IN LISTS CFLAGS_CXX_INCLUDES ${CFLAGS_ARCH}_INCLUDE)


### PR DESCRIPTION
On Android, we explicitly setup the include paths for the C++ headers. As a result, we do not want to pick up any system headers that the toolchain may have visible to it. If this flag is not added then clang will look in the wrong places to get the headers for things like stddef etc.





