### PR TITLE
test: fix the test on Windows

### DIFF
--- a/test/IRGen/builtin_vector.sil
+++ b/test/IRGen/builtin_vector.sil
@@ -5,7 +5,7 @@
 
 import Builtin
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc <4 x i32> @vector_int_add(<4 x i32>, <4 x i32>) {{.*}} {
+// CHECK-LABEL: define{{( protected| dllexport)?}} swiftcc <4 x i32> @vector_int_add(<4 x i32>, <4 x i32>) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: %2 = add <4 x i32> %0, %1
 // CHECK-NEXT: ret <4 x i32> %2
@@ -16,7 +16,7 @@ bb0(%0 : $Builtin.Vec4xInt32, %1 : $Builtin.Vec4xInt32):
   return %2 : $Builtin.Vec4xInt32
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc <4 x float> @vector_float_add(<4 x float>, <4 x float>) {{.*}} {
+// CHECK-LABEL: define{{( protected| dllexport)?}} swiftcc <4 x float> @vector_float_add(<4 x float>, <4 x float>) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: %2 = fadd <4 x float> %0, %1
 // CHECK-NEXT: ret <4 x float> %2


### PR DESCRIPTION
Fix the test to pass on Windows.  `protected` is limited to ELF targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
