### PR TITLE
[SourceKit] Fix placeholder expansion not working inside #if

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -205,3 +205,24 @@ singleExprClosureMultiArg(1) {
 // CHECK: withtrail {
 // CHECK-NEXT: <#code#>
 }
+
+func active() {
+  foo(<#T##value: Foo##Foo#>)
+  // CHECK: foo(Foo)
+}
+func activeWithTrailing() {
+  forEach(<#T##() -> ()#>)
+  // CHECK: forEach {
+  // CHECK-NEXT: <#code#>
+}
+#if false
+func inactive() {
+  foo(<#T##value: Foo##Foo#>)
+  // CHECK: foo(Foo)
+}
+func inactiveWithTrailing() {
+  forEach(<#T##() -> ()#>)
+  // CHECK: forEach {
+  // CHECK-NEXT: <#code#>
+}
+#endif


### PR DESCRIPTION
Update the `PlaceholderFinder` `ASTWalker` to walk into the clauses of `IfConfigDecl`s. It wasn't previously, resulting in any placeholders there not being expanded.

Also update `CallExprFinder` (used to determine if expansions should use trailing closure syntax) to walk into inactive if-config clauses. Previously it only walked into active regions, so expansions would never use trailing closure syntax in inactive regions.

Resolves rdar://problem/51995648