### PR TITLE
[5.1][SourceKit] Fix placeholder expansion not working inside #if

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -195,3 +195,24 @@ singleExprClosureMultiArg(1) {
 // CHECK: withtrail {
 // CHECK-NEXT: <#code#>
 }
+
+func active() {
+  foo(<#T##value: Foo##Foo#>)
+  // CHECK: foo(Foo)
+}
+func activeWithTrailing() {
+  forEach(<#T##() -> ()#>)
+  // CHECK: forEach {
+  // CHECK-NEXT: <#code#>
+}
+#if false
+func inactive() {
+  foo(<#T##value: Foo##Foo#>)
+  // CHECK: foo(Foo)
+}
+func inactiveWithTrailing() {
+  forEach(<#T##() -> ()#>)
+  // CHECK: forEach {
+  // CHECK-NEXT: <#code#>
+}
+#endif


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/26036 from master

- **Issue**: rdar://problem/51995648
- **Explanation**:
    All editor placeholder expansions inside #if blocks were failing. For example, with the below placeholder produced by code completion:
   
    ```
    #if DEBUG
    func test2() {
        [1,2,3].filter(<#T##isIncluded: (Int) throws -> Bool##(Int) throws -> Bool#>)
    }
    #endif
    ```
    the expansion was failing and Xcode would simply insert the placeholder content verbatim:

    ```
    [1,2,3].filter(#T##isIncluded: (Int) throws -> Bool##(Int) throws -> Bool#)
    ```
    rather than expanding successfully as it does outside of `#if` blocks:

    ```
    [1,2,3].filter { (<#Int#>) -> Bool in
        <#code#>
    }
    ```

    This was failing because the `PlaceholderFinder` `ASTWalker` wasn't walking into the clauses of `IfConfigDecl`s, so didn't find them. Additionally the `CallExprFinder` walker (used to determine if expansions should use trailing closure syntax) wasn't configured to walk into inactive if-config clauses, so expansions weren't using trailing closure syntax in inactive regions.

- **Scope**: This issue affects all editor placeholder expansions inside of #if blocks
- **Risk**: Low. The fix is limited to SourceKit's placeholder expansion request, and only affects the behavior on placeholders within `#if` blocks.
- **Origination**: Placeholder expansion never worked in inactive `#if` blocks, but used to work in active `#if` blocks prior to Xcode 10.2. The offending change was that `#if` conditions are no longer evaluated when parsing to produce an AST for SourceKit's purely syntactic requests (including placeholder expansion) so there aren't any active clauses anymore.
- **Testing**: Added regression tests and manually checked it behaves correctly in Xcode
- **Reviewer**: Xi Ge (in the master PR)

Resolves rdar://problem/51995648