### PR TITLE
[SE-0258] Diagnose uses of property wrappers in top-level code.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4463,6 +4463,8 @@ NOTE(property_wrapper_declared_here,none,
 
 ERROR(property_wrapper_local,none,
       "property wrappers are not yet supported on local properties", ())
+ERROR(property_wrapper_top_level,none,
+      "property wrappers are not yet supported in top-level code", ())
 ERROR(property_wrapper_let, none,
       "property wrapper can only be applied to a 'var'",
       ())

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -401,6 +401,12 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       continue;
     }
 
+    // Nor does top-level code.
+    if (var->getDeclContext()->isModuleScopeContext()) {
+      ctx.Diags.diagnose(attr->getLocation(), diag::property_wrapper_top_level);
+      continue;
+    }
+
     // Check that the variable is part of a single-variable pattern.
     auto binding = var->getParentPatternBinding();
     if (!binding || binding->getSingleVar() != var) {

--- a/test/decl/var/property_wrappers_top_level.swift
+++ b/test/decl/var/property_wrappers_top_level.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s -verify -module-name main
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+  init(initialValue: T) {
+    wrappedValue = initialValue
+  }
+}
+
+// expected-error@+1{{property wrappers are not yet supported in top-level code}}
+@Wrapper var value: Int = 17
+
+func f() { }
+f()


### PR DESCRIPTION
We don't current support property wrappers at the top level, so
error on them (rather than crashing later).
Fixes rdar://problem/51538524.
