### PR TITLE
[SE-0258] Don't ask for the nominal type decl of an unresolved property wrapper

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -640,7 +640,7 @@ getEnclosingSelfPropertyWrapperAccess(VarDecl *property, bool forProjected) {
     return None;
 
   // The pattern currently only works with the outermost property wrapper.
-  Type outermostWrapperType = property->getAttachedPropertyWrapperType(0);
+  Type outermostWrapperType = property->getPropertyWrapperBackingPropertyType();
   if (!outermostWrapperType)
     return None;
   NominalTypeDecl *wrapperTypeDecl = outermostWrapperType->getAnyNominal();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -513,13 +513,7 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   if (tc.validateType(customAttr->getTypeLoc(), resolution, options))
     return ErrorType::get(ctx);
 
-  Type customAttrType = customAttr->getTypeLoc().getType();
-  if (!customAttrType->getAnyNominal()) {
-    assert(ctx.Diags.hadAnyError());
-    return ErrorType::get(ctx);
-  }
-
-  return customAttrType;
+  return customAttr->getTypeLoc().getType();
 }
 
 llvm::Expected<Type>
@@ -531,7 +525,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     return rawTypeResult;
 
   Type rawType = *rawTypeResult;
-  if (!rawType)
+  if (!rawType || rawType->hasError())
     return Type();
 
   if (!rawType->hasUnboundGenericType())
@@ -578,7 +572,7 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     if (!rawWrapperType)
       return Type();
     
-    // Open the
+    // Open the type.
     Type openedWrapperType =
       cs.openUnboundGenericType(rawWrapperType, emptyLocator);
     if (!outermostOpenedWrapperType)

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -886,6 +886,17 @@ struct SomeA<T> {
 	}
 }
 
+// rdar://problem/51989272 - crash when the property wrapper is a generic type
+// alias
+typealias Alias<T> = WrapperWithInitialValue<T>
+
+struct TestAlias {
+  @Alias var foo = 17
+}
+
+
+
+// 
 // ---------------------------------------------------------------------------
 // Property wrapper composition
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Generic type aliases break this query; don't use it.
Fixes rdar://problem/51989272
