### PR TITLE
[android] Include api-level.h for Android and C++ interop.

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -23,6 +23,10 @@
 #include "SwiftStddef.h"
 #include "Visibility.h"
 
+#if defined(__ANDROID__)
+#include <android/api-level.h>
+#endif
+
 #if __has_feature(nullability)
 #pragma clang assume_nonnull begin
 #endif


### PR DESCRIPTION
When the header was used in Android, the usage of `__ANDROID_API__` was
not set if the compiler wasn't setting it externally. There was a check
for `__ANDROID_API__,` which defaulted to zero, and so it didn't pass. The
external function definition was not being done, but in C mode, it
didn't matter because implicit functions are allowed. That's not true in
C++ mode, which fails to compile any code that tries to include this
header.

The solution is including `android/api-level.h` which will define
`__ANDROID_API__` to a very high value if it is not defined already (which
is the default behaviour in the NDK).

