### PR TITLE
Add importing cxx function decls and the basic requisite AbstractionPattern support.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -26,9 +26,10 @@ namespace llvm {
 }
 
 namespace clang {
-  class ValueDecl;
+  class CXXMethodDecl;
   class ObjCMethodDecl;
   class Type;
+  class ValueDecl;
 }
 
 namespace swift {
@@ -178,6 +179,15 @@ class AbstractionPattern {
     /// type.  ObjCMethod is valid.  OtherData is an encoded foreign
     /// error index.
     ObjCMethodType,
+    /// The uncurried imported type of a C++ method. OrigType is valid and is a
+    /// function type. CXXMethod is valid.
+    CXXMethodType,
+    /// The curried imported type of a C++ method. OrigType is valid and is a
+    /// function type. CXXMethod is valid.
+    CurriedCXXMethodType,
+    /// The partially-applied curried imported type of a C++ method. OrigType is
+    /// valid and is a function type. CXXMethod is valid.
+    PartialCurriedCXXMethodType,
   };
 
   class EncodedForeignErrorInfo {
@@ -234,6 +244,7 @@ class AbstractionPattern {
   union {
     const clang::Type *ClangType;
     const clang::ObjCMethodDecl *ObjCMethod;
+    const clang::CXXMethodDecl *CXXMethod;
     const AbstractionPattern *OrigTupleElements;
   };
   CanGenericSignature GenericSig;
@@ -259,6 +270,18 @@ class AbstractionPattern {
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+      return true;
+
+    default:
+      return false;
+    }
+  }
+
+  bool hasStoredCXXMethod() const {
+    switch (getKind()) {
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       return true;
 
     default:
@@ -327,6 +350,12 @@ class AbstractionPattern {
     OtherData = memberStatus.getRawValue();
   }
 
+  void initCXXMethod(CanGenericSignature signature, CanType origType,
+                     const clang::CXXMethodDecl *method, Kind kind) {
+    initSwiftType(signature, origType, kind);
+    CXXMethod = method;
+  }
+
   AbstractionPattern() {}
   explicit AbstractionPattern(Kind kind) : TheKind(unsigned(kind)) {}
 
@@ -354,17 +383,29 @@ public:
   }
 
   bool hasGenericSignature() const {
-    return (getKind() == Kind::Type ||
-            getKind() == Kind::Discard ||
-            hasStoredClangType() ||
-            hasStoredObjCMethod());
+    switch (getKind()) {
+    case Kind::Type:
+    case Kind::Discard:
+    case Kind::ClangType:
+    case Kind::CFunctionAsMethodType:
+    case Kind::CurriedCFunctionAsMethodType:
+    case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CurriedObjCMethodType:
+    case Kind::PartialCurriedObjCMethodType:
+    case Kind::ObjCMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
+      return true;
+    case Kind::Invalid:
+    case Kind::Opaque:
+    case Kind::Tuple:
+      return false;
+    }
   }
 
   CanGenericSignature getGenericSignature() const {
-    assert(getKind() == Kind::Type ||
-           getKind() == Kind::Discard ||
-           hasStoredClangType() ||
-           hasStoredObjCMethod());
+    assert(hasGenericSignature());
     return CanGenericSignature(GenericSig);
   }
   
@@ -417,6 +458,41 @@ public:
   static AbstractionPattern
   getCurriedCFunctionAsMethod(CanType origType,
                               const AbstractFunctionDecl *function);
+
+  /// Return an abstraction pattern for the curried type of a C++ method.
+  static AbstractionPattern
+  getCurriedCXXMethod(CanType origType, const AbstractFunctionDecl *function);
+
+  /// Return an abstraction pattern for the uncurried type of a C++ method.
+  ///
+  /// For example, if the original function is:
+  ///   void Refrigerator::SetTemperature(RefrigeratorCompartment compartment,
+  ///                                     Temperature temperature);
+  /// then the uncurried type is:
+  ///   ((RefrigeratorCompartment, Temperature), Refrigerator) -> ()
+  static AbstractionPattern getCXXMethod(CanType origType,
+                                         const clang::CXXMethodDecl *method) {
+    assert(isa<AnyFunctionType>(origType));
+    AbstractionPattern pattern;
+    pattern.initCXXMethod(nullptr, origType, method, Kind::CXXMethodType);
+    return pattern;
+  }
+
+  /// Return an abstraction pattern for the curried type of a C++ method.
+  ///
+  /// For example, if the original function is:
+  ///   void Refrigerator::SetTemperature(RefrigeratorCompartment compartment,
+  ///                                     Temperature temperature);
+  /// then the curried type:
+  ///   (Refrigerator) -> (Compartment, Temperature) -> ()
+  static AbstractionPattern
+  getCurriedCXXMethod(CanType origType, const clang::CXXMethodDecl *method) {
+    assert(isa<AnyFunctionType>(origType));
+    AbstractionPattern pattern;
+    pattern.initCXXMethod(nullptr, origType, method,
+                          Kind::CurriedCXXMethodType);
+    return pattern;
+  }
 
   /// For a C-function-as-method pattern,
   /// get the index of the C function parameter that was imported as the
@@ -497,6 +573,24 @@ private:
     return pattern;
   }
 
+  /// Return an abstraction pattern for the partially-applied curried
+  /// type of an C++ method.
+  ///
+  /// For example, if the original function is:
+  ///   void Refrigerator::SetTemperature(RefrigeratorCompartment compartment,
+  ///                                     Temperature temperature);
+  /// then the partially-applied curried type is:
+  ///   (Compartment, Temperature) -> ()
+  static AbstractionPattern
+  getPartialCurriedCXXMethod(CanGenericSignature signature, CanType origType,
+                             const clang::CXXMethodDecl *method) {
+    assert(isa<AnyFunctionType>(origType));
+    AbstractionPattern pattern;
+    pattern.initCXXMethod(signature, origType, method,
+                          Kind::PartialCurriedCXXMethodType);
+    return pattern;
+  }
+
 public:
   /// Return an abstraction pattern for the type of an Objective-C method.
   static AbstractionPattern
@@ -520,18 +614,13 @@ private:
   /// current Objective-C method.
   AbstractionPattern getObjCMethodSelfPattern(CanType paramType) const;
 
-  /// Return a pattern corresponding to the formal parameters of the
-  /// current Objective-C method.
-  AbstractionPattern getObjCMethodFormalParamPattern(CanType paramType) const;
-  
   /// Return a pattern corresponding to the 'self' parameter of the
   /// current C function imported as a method.
   AbstractionPattern getCFunctionAsMethodSelfPattern(CanType paramType) const;
-  
-  /// Return a pattern corresponding to the formal parameters of the
-  /// current C function imported as a method.
-  AbstractionPattern getCFunctionAsMethodFormalParamPattern(CanType paramType)
-    const;
+
+  /// Return a pattern corresponding to the 'self' parameter of the
+  /// current C++ method.
+  AbstractionPattern getCXXMethodSelfPattern(CanType paramType) const;
 
 public:
   /// Return an abstraction pattern with an added level of optionality.
@@ -606,6 +695,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
     case Kind::Type:
     case Kind::Discard:
       return OrigType;
@@ -637,6 +729,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
     case Kind::Type:
     case Kind::Discard:
       assert(signature || !type->hasTypeParameter());
@@ -669,6 +764,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       return true;
     }
     llvm_unreachable("bad kind");
@@ -702,6 +800,18 @@ public:
     return ObjCMethod;
   }
 
+  /// Return whether this abstraction pattern represents a C++ method.
+  /// If so, it is legal to call getCXXMethod().
+  bool isCXXMethod() const {
+    return (getKind() == Kind::CXXMethodType ||
+            getKind() == Kind::CurriedCXXMethodType);
+  }
+
+  const clang::CXXMethodDecl *getCXXMethod() const {
+    assert(hasStoredCXXMethod());
+    return CXXMethod;
+  }
+
   EncodedForeignErrorInfo getEncodedForeignErrorInfo() const {
     assert(hasStoredForeignErrorInfo());
     return EncodedForeignErrorInfo::fromOpaqueValue(OtherData);
@@ -721,6 +831,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       return false;
     case Kind::PartialCurriedObjCMethodType:
     case Kind::CurriedObjCMethodType:
@@ -749,6 +862,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
     case Kind::Type:
     case Kind::Discard:
       return dyn_cast<TYPE>(getType());
@@ -774,6 +890,9 @@ public:
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       // We assume that the Clang type might provide additional structure.
       return false;
     case Kind::Type:
@@ -798,6 +917,9 @@ public:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::ObjCMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       return false;
     case Kind::Tuple:
       return true;
@@ -820,6 +942,9 @@ public:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
     case Kind::ObjCMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
       llvm_unreachable("pattern is not a tuple");      
     case Kind::Tuple:
       return getNumTupleElements_Stored();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3251,6 +3251,7 @@ namespace {
 
       // Import each of the members.
       SmallVector<VarDecl *, 4> members;
+      SmallVector<FuncDecl *, 4> methods;
       SmallVector<ConstructorDecl *, 4> ctors;
 
       // FIXME: Import anonymous union fields and support field access when
@@ -3315,6 +3316,10 @@ namespace {
           continue;
         }
 
+        if (auto MD = dyn_cast<FuncDecl>(member)) {
+          methods.push_back(MD);
+          continue;
+        }
         auto VD = cast<VarDecl>(member);
 
         if (isa<clang::IndirectFieldDecl>(nd) || decl->isUnion()) {
@@ -3392,9 +3397,13 @@ namespace {
       for (auto member : members) {
         result->addMember(member);
       }
-      
+
       for (auto ctor : ctors) {
         result->addMember(ctor);
+      }
+
+      for (auto method : methods) {
+        result->addMember(method);
       }
 
       result->setHasUnreferenceableStorage(hasUnreferenceableStorage);
@@ -3691,6 +3700,19 @@ namespace {
                                               /*throws*/ false,
                                               dc, decl);
 
+      if (auto *mdecl = dyn_cast<clang::CXXMethodDecl>(decl)) {
+        if (!mdecl->isStatic()) {
+          // Workaround until proper const support is handled: Force
+          // everything to be mutating. This implicitly makes the parameter
+          // indirect.
+          result->setSelfAccessKind(SelfAccessKind::Mutating);
+          // "self" is the first argument.
+          result->setSelfIndex(0);
+        } else {
+          result->setStatic();
+          result->setImportAsStaticMember();
+        }
+      }
       result->computeType();
       result->setValidationToChecked();
       result->setIsObjC(false);
@@ -3732,8 +3754,7 @@ namespace {
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
-      // FIXME: Import C++ member functions as methods.
-      return nullptr;
+      return VisitFunctionDecl(decl);
     }
 
     Decl *VisitFieldDecl(const clang::FieldDecl *decl) {

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -16,13 +16,14 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "libsil"
-#include "swift/SIL/TypeLowering.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/SIL/TypeLowering.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "llvm/Support/Debug.h"
@@ -153,6 +154,13 @@ AbstractionPattern::getCurriedCFunctionAsMethod(CanType origType,
 }
 
 AbstractionPattern
+AbstractionPattern::getCurriedCXXMethod(CanType origType,
+                                        const AbstractFunctionDecl *function) {
+  auto clangMethod = cast<clang::CXXMethodDecl>(function->getClangDecl());
+  return getCurriedCXXMethod(origType, clangMethod);
+}
+
+AbstractionPattern
 AbstractionPattern::getOptional(AbstractionPattern object) {
   switch (object.getKind()) {
   case Kind::Invalid:
@@ -164,6 +172,9 @@ AbstractionPattern::getOptional(AbstractionPattern object) {
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::ObjCMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
     llvm_unreachable("cannot add optionality to non-type abstraction");
   case Kind::Opaque:
     return AbstractionPattern::getOpaque();
@@ -223,6 +234,9 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::CFunctionAsMethodType:
   case Kind::ObjCMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
     return false;
   case Kind::Opaque:
     return true;
@@ -285,6 +299,9 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::CFunctionAsMethodType:
   case Kind::ObjCMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
     llvm_unreachable("function types are not tuples");
   case Kind::Opaque:
     return *this;
@@ -341,6 +358,25 @@ AbstractionPattern::getCFunctionAsMethodSelfPattern(CanType selfType) const {
                            getGenericSignatureForFunctionComponent(), selfType);
 }
 
+AbstractionPattern
+AbstractionPattern::getCXXMethodSelfPattern(CanType selfType) const {
+  assert(hasStoredCXXMethod());
+  auto CXXMethod = getCXXMethod();
+  if (CXXMethod->isInstance()) {
+    // Use the clang type for the receiver type.  If this is ever
+    // insufficient --- if we have interesting bridging to do to
+    // 'self' --- we have the right information to be more exact.
+    auto clangSelfType =
+        CXXMethod->getThisType(CXXMethod->getASTContext()).getTypePtr();
+    return AbstractionPattern(getGenericSignatureForFunctionComponent(),
+                              selfType, clangSelfType);
+  }
+  // The formal metatype parameter to a C++ function imported as a static method
+  // is dropped on the floor. Leave it untransformed.
+  return AbstractionPattern::getDiscard(
+      getGenericSignatureForFunctionComponent(), selfType);
+}
+
 static CanType getResultType(CanType type) {
   return cast<AnyFunctionType>(type).getResult();
 }
@@ -368,6 +404,11 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
                               getResultType(getType()),
                               clangFunctionType->getReturnType().getTypePtr());    
   }
+  case Kind::CXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+    return AbstractionPattern(getGenericSignatureForFunctionComponent(),
+                              getResultType(getType()),
+                              getCXXMethod()->getReturnType().getTypePtr());
   case Kind::CurriedObjCMethodType:
     return getPartialCurriedObjCMethod(
                               getGenericSignatureForFunctionComponent(),
@@ -380,6 +421,9 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
                                       getResultType(getType()),
                                       getClangType(),
                                       getImportAsMemberStatus());
+  case Kind::CurriedCXXMethodType:
+    return getPartialCurriedCXXMethod(getGenericSignatureForFunctionComponent(),
+                                      getResultType(getType()), getCXXMethod());
   case Kind::PartialCurriedObjCMethodType:
   case Kind::ObjCMethodType:
     return AbstractionPattern(getGenericSignatureForFunctionComponent(),
@@ -405,6 +449,11 @@ AbstractionPattern::getFunctionParamType(unsigned index) const {
     auto params = cast<AnyFunctionType>(getType()).getParams();
     assert(params.size() == 1);
     return getCFunctionAsMethodSelfPattern(params[0].getParameterType());
+  }
+  case Kind::CurriedCXXMethodType: {
+    auto params = cast<AnyFunctionType>(getType()).getParams();
+    assert(params.size() == 1);
+    return getCXXMethodSelfPattern(params[0].getParameterType());
   }
   case Kind::CFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType: {
@@ -434,6 +483,31 @@ AbstractionPattern::getFunctionParamType(unsigned index) const {
     return AbstractionPattern(getGenericSignatureForFunctionComponent(),
                               paramType,
                      getClangFunctionParameterType(getClangType(), clangIndex));
+  }
+  case Kind::CXXMethodType:
+  case Kind::PartialCurriedCXXMethodType: {
+    auto params = cast<AnyFunctionType>(getType()).getParams();
+
+    // Only the full method type has a 'self' parameter.
+    if (getKind() == Kind::CXXMethodType) {
+      assert(params.size() > 0);
+
+      // The last parameter is 'self'.
+      if (index == params.size() - 1) {
+        return getCXXMethodSelfPattern(params.back().getParameterType());
+      }
+    }
+
+    // A parameter of type () does not correspond to a Clang parameter.
+    auto paramType = params[index].getParameterType();
+    if (paramType->isVoid())
+      return AbstractionPattern(paramType);
+
+    // Otherwise, we're talking about the formal parameter clause.
+    auto methodType = getCXXMethod()->getType().getTypePtr();
+    return AbstractionPattern(getGenericSignatureForFunctionComponent(),
+                              paramType,
+                              getClangFunctionParameterType(methodType, index));
   }
   case Kind::CurriedObjCMethodType: {
     auto params = cast<AnyFunctionType>(getType()).getParams();
@@ -509,6 +583,9 @@ AbstractionPattern AbstractionPattern::getOptionalObjectType() const {
   case Kind::CFunctionAsMethodType:
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
   case Kind::Tuple:
     llvm_unreachable("pattern for function or tuple cannot be for optional");
 
@@ -545,6 +622,9 @@ AbstractionPattern AbstractionPattern::getReferenceStorageReferentType() const {
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
   case Kind::Tuple:
     return *this;
   case Kind::Type:
@@ -600,12 +680,21 @@ void AbstractionPattern::print(raw_ostream &out) const {
   case Kind::CurriedCFunctionAsMethodType:
   case Kind::PartialCurriedCFunctionAsMethodType:
   case Kind::CFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
     out << (getKind() == Kind::ClangType
               ? "AP::ClangType(" :
             getKind() == Kind::CurriedCFunctionAsMethodType
               ? "AP::CurriedCFunctionAsMethodType(" :
             getKind() == Kind::CFunctionAsMethodType
-              ? "AP::CFunctionAsMethodType("
+              ? "AP::CFunctionAsMethodType(" :
+            getKind() == Kind::CXXMethodType
+              ? "AP::CXXMethodType(" :
+            getKind() == Kind::CurriedCXXMethodType
+              ? "AP::CurriedCXXMethodType(" :
+            getKind() == Kind::PartialCurriedCXXMethodType
+              ? "AP::PartialCurriedCXXMethodType("
               : "AP::PartialCurriedCFunctionAsMethodType(");
     getType().dump(out);
     out << ", ";

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -27,6 +27,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
 #include "llvm/Support/CommandLine.h"
@@ -223,6 +224,7 @@ enum class ConventionsKind : uint8_t {
   ObjCSelectorFamily = 5,
   Deallocator = 6,
   Capture = 7,
+  CXXMethod = 8,
 };
 
 class Conventions {
@@ -1640,6 +1642,28 @@ public:
   }
 };
 
+/// Conventions based on C++ method declarations.
+class CXXMethodConventions : public CFunctionTypeConventions {
+  using super = CFunctionTypeConventions;
+  const clang::CXXMethodDecl *TheDecl;
+
+public:
+  CXXMethodConventions(const clang::CXXMethodDecl *decl)
+      : CFunctionTypeConventions(
+            ConventionsKind::CXXMethod,
+            decl->getType()->castAs<clang::FunctionType>()),
+        TheDecl(decl) {}
+  ParameterConvention
+  getIndirectSelfParameter(const AbstractionPattern &type) const override {
+    if (TheDecl->isConst())
+      return ParameterConvention::Indirect_In_Guaranteed;
+    return ParameterConvention::Indirect_Inout;
+  }
+  static bool classof(const Conventions *C) {
+    return C->getKind() == ConventionsKind::CXXMethod;
+  }
+};
+
 } // end anonymous namespace
 
 /// Given that we have an imported Clang declaration, deduce the
@@ -1657,6 +1681,16 @@ getSILFunctionTypeForClangDecl(SILModule &M, const clang::Decl *clangDecl,
     return getSILFunctionType(M, origPattern, substInterfaceType, extInfo,
                               ObjCMethodConventions(method), foreignInfo,
                               constant, constant, None,
+                              /*witnessMethodConformance=*/None);
+  }
+
+  if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
+    AbstractionPattern origPattern =
+        AbstractionPattern::getCXXMethod(origType, method);
+    auto conventions = CXXMethodConventions(method);
+    return getSILFunctionType(M, origPattern, substInterfaceType, extInfo,
+                              conventions, foreignInfo, constant, constant,
+                              None,
                               /*witnessMethodConformance=*/None);
   }
 
@@ -2592,9 +2626,15 @@ getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
       // C function imported as a function.
       return AbstractionPattern(fnType, value->getType().getTypePtr());
     } else {
-      // C function imported as a method.
       assert(numParameterLists == 2);
-      return AbstractionPattern::getCurriedCFunctionAsMethod(fnType, bridgedFn);
+      if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
+        // C++ method.
+        return AbstractionPattern::getCurriedCXXMethod(fnType, bridgedFn);
+      } else {
+        // C function imported as a method.
+        return AbstractionPattern::getCurriedCFunctionAsMethod(fnType,
+                                                               bridgedFn);
+      }
     }
   }
 

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -15,3 +15,15 @@ Basic makeA();
 ns::T* makeT();
 void useT(ns::T* v);
 using namespacedT = ns::T;
+
+class Methods {
+ public:
+  virtual ~Methods();
+
+  int SimpleMethod(int);
+
+  int SimpleConstMethod(int) const;
+  int some_value;
+
+  static int SimpleStaticMethod(int);
+};

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -12,3 +12,28 @@ func indirectUsage() {
 // CHECK: define hidden swiftcc void @"$s6cxx_ir24namespaceManglesIntoName3argySo2nsV1TV_tF"
 func namespaceManglesIntoName(arg: namespacedT) {
 }
+
+// CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir12basicMethods1as5Int32VSpySo0D0VG_tF"(i8*)
+// CHECK: [[THIS_PTR1:%.*]] = bitcast i8* %0 to %TSo7MethodsV*
+// CHECK: [[THIS_PTR2:%.*]] = bitcast %TSo7MethodsV* [[THIS_PTR1]] to %class.Methods*
+// CHECK: [[RESULT:%.*]] = call i32 @_ZN7Methods12SimpleMethodEi(%class.Methods* [[THIS_PTR2]], i32 4)
+// CHECK: ret i32 [[RESULT]]
+func basicMethods(a: UnsafeMutablePointer<Methods>) -> Int32 {
+  return a.pointee.SimpleMethod(4)
+}
+
+// CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir17basicMethodsConst1as5Int32VSpySo0D0VG_tF"(i8*)
+// CHECK: [[THIS_PTR1:%.*]] = bitcast i8* %0 to %TSo7MethodsV*
+// CHECK: [[THIS_PTR2:%.*]] = bitcast %TSo7MethodsV* [[THIS_PTR1]] to %class.Methods*
+// CHECK: [[RESULT:%.*]] = call i32 @_ZNK7Methods17SimpleConstMethodEi(%class.Methods* [[THIS_PTR2]], i32 3)
+// CHECK: ret i32 [[RESULT]]
+func basicMethodsConst(a: UnsafeMutablePointer<Methods>) -> Int32 {
+  return a.pointee.SimpleConstMethod(3)
+}
+
+// CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir18basicMethodsStatics5Int32VyF"()
+// CHECK: [[RESULT:%.*]] = call i32 @_ZN7Methods18SimpleStaticMethodEi(i32 5)
+// CHECK: ret i32 [[RESULT]]
+func basicMethodsStatic() -> Int32 {
+  return Methods.SimpleStaticMethod(5)
+}


### PR DESCRIPTION
Known issues so far:
- Type-checking doesn't seem to know the c++ rules for selecting const
 vs non-const.
- The convention for passing arguments doesn't appear correct yet.
- Objective-c++ details are not handled yet.
- Methods on base classes and virtual functions will not be found.
- Const methods cannot be marked as non-mutating. This is because the
fact that self is indirect is getting lost in the lowering process (becomes `@in`)

This is just some ImportDecl.cpp changes and CXXMethodConventions + the boilerplate in AbstractionPattern. There will probably need to be more to fully support methods.
