### PR TITLE
[WIP] [Remote] Assume clients can deal with non-key generic parameters

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2301,11 +2301,6 @@ private:
           if (!builtArg)
             return {};
           builtSubsts.push_back(builtArg);
-        } else {
-          // TODO: If the key argument has been concretized by a same-type
-          // constraint, that should be reflected in the built nominal type
-          // decl's generic constraints. This isn't handled correctly yet.
-          return {};
         }
         break;
         

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -272,3 +272,60 @@ public struct RefersToOtherAssocType {
   var x: OpaqueWitness.A
   var y: OpaqueWitness.A
 }
+
+
+public protocol STSTagProtocol {}
+public struct STSOuter : STSTagProtocol {}
+
+public enum STSContainer<T : STSTagProtocol> {
+  public class Superclass {}
+  public class Subclass<U>: Superclass where T == STSOuter {
+    public class ExtraNested: Superclass {}
+  }
+
+  public class GenericSuperclass<U> {}
+  public class Subclass2<U>: GenericSuperclass<U> where T == STSOuter {}
+
+  public class Subclass3<U: Collection>: Superclass where T == U.Element {}
+
+  public class MoreNesting<X> {
+    public class Subclass<U>: Superclass where T == STSOuter {}
+  }
+
+  public struct Fields<U> where T == STSOuter {
+    var x: T?
+    var y: U?
+  }
+
+  public enum Cases<U> where T == STSOuter {
+    case a(T)
+    case b(U)
+  }
+}
+
+// A new type with an easily-recognizable, easily-strippable suffix character.
+public enum STSContainer℠<T : STSTagProtocol> {
+  public class Superclass {}
+  public class GenericSuperclass<U> {}
+}
+extension STSContainer℠ where T == STSOuter {
+  public class Subclass<U>: Superclass {
+    public class ExtraNested: Superclass {}
+  }
+
+  public class Subclass2<U>: GenericSuperclass<U> {}
+
+  public class MoreNesting<X> {
+    public class Subclass<U>: Superclass {}
+  }
+
+  public struct Fields<U> {
+    var x: T?
+    var y: U?
+  }
+
+  public enum Cases<U> {
+    case a(T)
+    case b(U)
+  }
+}

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,7 +1,7 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
-// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) -binary-filename %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) -binary-filename %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)
@@ -1188,3 +1188,56 @@ BO
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+
+12TypeLowering12STSContainerO8SubclassCyAA8STSOuterV_SiG
+// CHECK-LABEL: (bound_generic_class TypeLowering.STSContainer.Subclass
+//  CHECK-NEXT:   (struct Swift.Int)
+//  CHECK-NEXT:   (bound_generic_enum TypeLowering.STSContainer
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter)))
+//  CHECK-NEXT: (reference kind=strong refcounting=native)
+
+12TypeLowering0017STSContainer_swCgOA2A8STSOuterVRszrlE8SubclassCyAE_SiG
+// CHECK-LABEL: (bound_generic_class (extension in TypeLowering):TypeLowering.STSContainer℠< where A == TypeLowering.STSOuter>.Subclass
+//  CHECK-NEXT:   (struct Swift.Int)
+//  CHECK-NEXT:   (bound_generic_enum TypeLowering.STSContainer℠
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter)))
+//  CHECK-NEXT: (reference kind=strong refcounting=native)
+
+12TypeLowering12STSContainerO9Subclass2CyAA8STSOuterV_SiG
+// CHECK-LABEL: (bound_generic_class TypeLowering.STSContainer.Subclass2
+//  CHECK-NEXT:   (struct Swift.Int)
+//  CHECK-NEXT:   (bound_generic_enum TypeLowering.STSContainer
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter)))
+//  CHECK-NEXT: (reference kind=strong refcounting=native)
+
+12TypeLowering0017STSContainer_swCgOA2A8STSOuterVRszrlE9Subclass2CyAE_SiG
+// CHECK-LABEL: (bound_generic_class (extension in TypeLowering):TypeLowering.STSContainer℠< where A == TypeLowering.STSOuter>.Subclass2
+//  CHECK-NEXT:   (struct Swift.Int)
+//  CHECK-NEXT:   (bound_generic_enum TypeLowering.STSContainer℠
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter)))
+//  CHECK-NEXT: (reference kind=strong refcounting=native)
+
+12TypeLowering12STSContainerO9Subclass3CyAA8STSOuterV_SayAGGG
+// CHECK-LABEL: (bound_generic_class TypeLowering.STSContainer.Subclass3
+//  CHECK-NEXT:   (bound_generic_struct Swift.Array
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter))
+//  CHECK-NEXT:   (bound_generic_enum TypeLowering.STSContainer
+//  CHECK-NEXT:     (struct TypeLowering.STSOuter)))
+//  CHECK-NEXT: (reference kind=strong refcounting=native)
+
+s13nominal_types12STSContainerO8SubclassC11ExtraNestedCyAA8STSOuterV_Si_G
+// CHECK-LABEL: FIXME: finish the rest of these once the above ones are working
+
+s13nominal_types0017STSContainer_swCgOA2A8STSOuterVRszrlE8SubclassC11ExtraNestedCyAE_Si_G
+
+s13nominal_types12STSContainerO11MoreNestingC8SubclassCyAA8STSOuterV_Sb_SiG
+
+s13nominal_types0017STSContainer_swCgOA2A8STSOuterVRszrlE11MoreNestingC8SubclassCyAE_Sb_SiG
+
+s13nominal_types12STSContainerO6FieldsVyAA8STSOuterV_SiG
+
+s13nominal_types0017STSContainer_swCgOA2A8STSOuterVRszrlE6FieldsVyAE_SiG
+
+s13nominal_types12STSContainerO5CasesOyAA8STSOuterV_SiG
+
+s13nominal_types0017STSContainer_swCgOA2A8STSOuterVRszrlE5CasesOyAE_SiG

--- a/test/RemoteAST/nominal_types.swift
+++ b/test/RemoteAST/nominal_types.swift
@@ -141,4 +141,94 @@ struct N {
 }
 N.testPrivate()
 
+
+protocol STSTagProtocol {}
+struct STSOuter : STSTagProtocol {}
+
+enum STSContainer<T : STSTagProtocol> {
+  class Superclass {}
+  class Subclass<U>: Superclass where T == STSOuter {
+    class ExtraNested: Superclass {}
+  }
+
+  class GenericSuperclass<U> {}
+  class Subclass2<U>: GenericSuperclass<U> where T == STSOuter {}
+
+  class Subclass3<U: Collection>: Superclass where T == U.Element {}
+
+  class MoreNesting<X> {
+    class Subclass<U>: Superclass where T == STSOuter {}
+  }
+
+  struct Fields<U> where T == STSOuter {
+    var x: T?
+    var y: U?
+  }
+
+  enum Cases<U> where T == STSOuter {
+    case a(T)
+    case b(U)
+  }
+}
+
+// A new type with an easily-recognizable, easily-strippable suffix character.
+enum STSContainer℠<T : STSTagProtocol> {
+  class Superclass {}
+  class GenericSuperclass<U> {}
+}
+extension STSContainer℠ where T == STSOuter {
+  class Subclass<U>: Superclass {
+    class ExtraNested: Superclass {}
+  }
+
+  class Subclass2<U>: GenericSuperclass<U> {}
+
+  class MoreNesting<X> {
+    class Subclass<U>: Superclass {}
+  }
+
+  struct Fields<U> {
+    var x: T?
+    var y: U?
+  }
+
+  enum Cases<U> {
+    case a(T)
+    case b(U)
+  }
+}
+
+printType(STSContainer<STSOuter>.Subclass<Int>.self)
+printType(STSContainer℠<STSOuter>.Subclass<Int>.self)
+// CHECK: STSContainer<STSOuter>.Subclass<Int>{{$}}
+// CHECK: STSContainer℠<STSOuter>.Subclass<Int>{{$}}
+
+printType(STSContainer<STSOuter>.Subclass2<Int>.self)
+printType(STSContainer℠<STSOuter>.Subclass2<Int>.self)
+// CHECK: STSContainer<STSOuter>.Subclass2<Int>{{$}}
+// CHECK: STSContainer℠<STSOuter>.Subclass2<Int>{{$}}
+
+printType(STSContainer<STSOuter>.Subclass3<[STSOuter]>.self)
+// CHECK: STSContainer<STSOuter>.Subclass3<Array<STSOuter>>{{$}}
+
+printType(STSContainer<STSOuter>.Subclass<Int>.ExtraNested.self)
+printType(STSContainer℠<STSOuter>.Subclass<Int>.ExtraNested.self)
+// CHECK: STSContainer<STSOuter>.Subclass<Int>.ExtraNested{{$}}
+// CHECK: STSContainer℠<STSOuter>.Subclass<Int>.ExtraNested{{$}}
+
+printType(STSContainer<STSOuter>.MoreNesting<Bool>.Subclass<Int>.self)
+printType(STSContainer℠<STSOuter>.MoreNesting<Bool>.Subclass<Int>.self)
+// CHECK: STSContainer<STSOuter>.MoreNesting<Bool>.Subclass<Int>{{$}}
+// CHECK: STSContainer℠<STSOuter>.MoreNesting<Bool>.Subclass<Int>{{$}}
+
+printType(STSContainer<STSOuter>.Fields<Int>.self)
+printType(STSContainer℠<STSOuter>.Fields<Int>.self)
+// CHECK: STSContainer<STSOuter>.Fields<Int>{{$}}
+// CHECK: STSContainer℠<STSOuter>.Fields<Int>{{$}}
+
+printType(STSContainer<STSOuter>.Cases<Int>.self)
+printType(STSContainer℠<STSOuter>.Cases<Int>.self)
+// CHECK: STSContainer<STSOuter>.Cases<Int>{{$}}
+// CHECK: STSContainer℠<STSOuter>.Cases<Int>{{$}}
+
 stopRemoteAST()


### PR DESCRIPTION
RemoteAST certainly can; it's got the information it needs in the regular AST. Unfortunately Remote Mirrors is still having problems, and someone else will need to dig into that.

Follow-up to #25984.