### PR TITLE
[AutoDiff] Enable class method differentiation.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -451,6 +451,9 @@ NOTE(autodiff_cannot_differentiate_writes_to_mutable_captures,none,
 NOTE(autodiff_protocol_member_not_differentiable,none,
      "member is not differentiable because the corresponding protocol "
      "requirement is not '@differentiable'", ())
+NOTE(autodiff_class_member_not_differentiable,none,
+     "member is not differentiable because the corresponding class member "
+     "is not '@differentiable'", ())
 NOTE(autodiff_protocol_member_subset_indices_not_differentiable,none,
      "member is differentiable only with respect to a smaller subset of "
      "arguments", ())
@@ -483,6 +486,9 @@ NOTE(autodiff_cannot_param_subset_thunk_partially_applied_orig_fn,none,
      "function; use an explicit closure instead", ())
 NOTE(autodiff_control_flow_not_supported,none,
      "cannot differentiate unsupported control flow", ())
+// TODO(TF-645): Remove when differentiation supports `ref_element_addr`.
+NOTE(autodiff_class_property_not_supported,none,
+     "differentiating class properties is not yet supported", ())
 NOTE(autodiff_missing_return,none,
      "missing return for differentiation", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2787,6 +2787,8 @@ ERROR(differentiable_attr_function_not_same_type_context,none,
 ERROR(differentiable_attr_specified_not_function,none,
       "%0 is not a function to be used as associated differentiation function",
       (DeclName))
+ERROR(differentiable_attr_class_derivative_not_final,none,
+      "class member derivative must be final", ())
 ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in '@differentiable' "
       "attribute", (DeclName))
@@ -2806,14 +2808,19 @@ ERROR(differentiable_attr_protocol_req_assoc_func,none,
 ERROR(differentiable_attr_stored_property_variable_unsupported,none,
       "'@differentiable' attribute on stored property cannot specify "
       "'jvp:' or 'vjp:'", ())
+ERROR(differentiable_attr_class_member_no_dynamic_self,none,
+      "'@differentiable' attribute cannot be declared on class methods "
+      "returning 'Self'", ())
+// TODO(TF-654): Remove when differentiation supports class initializers.
+ERROR(differentiable_attr_class_init_not_yet_supported,none,
+      "'@differentiable' attribute does not yet support class initializers",
+      ())
 ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_nongeneric_trailing_where,none,
       "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
 ERROR(differentiable_attr_layout_req_unsupported,none,
       "'@differentiable' attribute does not support layout requirements", ())
-ERROR(differentiable_attr_class_unsupported,none,
-      "class members cannot be marked with '@differentiable'", ())
 ERROR(overriding_decl_missing_differentiable_attr,none,
       "overriding declaration is missing attribute '%0'", (StringRef))
 NOTE(protocol_witness_missing_differentiable_attr,none,
@@ -2880,9 +2887,8 @@ ERROR(diff_params_clause_no_inferred_parameters,PointsToFirstBadToken,
       ())
 ERROR(diff_params_clause_inout_argument,none,
       "'inout' parameters (%0) cannot be differentiated with respect to", (Type))
-ERROR(diff_params_clause_cannot_diff_wrt_objects_or_existentials,none,
-      "class objects and protocol existentials (%0) cannot be differentiated "
-      "with respect to", (Type))
+ERROR(diff_params_clause_cannot_diff_wrt_existentials,none,
+      "cannot differentiate with respect to protocol existential (%0)", (Type))
 ERROR(diff_params_clause_cannot_diff_wrt_functions,none,
       "functions (%0) cannot be differentiated with respect to", (Type))
 ERROR(diff_params_clause_param_not_differentiable,none,

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -87,6 +87,20 @@ template <class T> class SILVTableVisitor {
     assert(!fd->hasClangNode());
 
     maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));
+
+    if (auto *DA = fd->getAttrs().getAttribute<DifferentiableAttr>()) {
+      auto jvpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+          AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
+          DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(jvpConstant, jvpConstant.requiresNewVTableEntry());
+
+      auto vjpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+          AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
+          DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(vjpConstant, vjpConstant.requiresNewVTableEntry());
+    }
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -88,19 +88,22 @@ template <class T> class SILVTableVisitor {
 
     maybeAddEntry(SILDeclRef(fd, SILDeclRef::Kind::Func));
 
-    if (auto *DA = fd->getAttrs().getAttribute<DifferentiableAttr>()) {
+    // SWIFT_ENABLE_TENSORFLOW
+    for (auto *DA : fd->getAttrs().getAttributes<DifferentiableAttr>()) {
+      auto constant = SILDeclRef(fd, SILDeclRef::Kind::Func);
       auto jvpConstant = constant.asAutoDiffAssociatedFunction(
           AutoDiffAssociatedFunctionIdentifier::get(
-          AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
-          DA->getParameterIndices(), fd->getASTContext()));
-      maybeAddEntry(jvpConstant, jvpConstant.requiresNewVTableEntry());
+              AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
+              DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(jvpConstant);
 
       auto vjpConstant = constant.asAutoDiffAssociatedFunction(
           AutoDiffAssociatedFunctionIdentifier::get(
-          AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
-          DA->getParameterIndices(), fd->getASTContext()));
-      maybeAddEntry(vjpConstant, vjpConstant.requiresNewVTableEntry());
+              AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
+              DA->getParameterIndices(), fd->getASTContext()));
+      maybeAddEntry(vjpConstant);
     }
+    // SWIFT_ENABLE_TENSORFLOW END
   }
 
   void maybeAddConstructor(ConstructorDecl *cd) {
@@ -111,6 +114,23 @@ template <class T> class SILVTableVisitor {
     // necessary for super.init chaining, which is sufficiently constrained
     // to never need dynamic dispatch.
     maybeAddEntry(SILDeclRef(cd, SILDeclRef::Kind::Allocator));
+
+    // SWIFT_ENABLE_TENSORFLOW
+    for (auto *DA : cd->getAttrs().getAttributes<DifferentiableAttr>()) {
+      auto constant = SILDeclRef(cd, SILDeclRef::Kind::Allocator);
+      auto jvpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+              AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
+              DA->getParameterIndices(), cd->getASTContext()));
+      maybeAddEntry(jvpConstant);
+
+      auto vjpConstant = constant.asAutoDiffAssociatedFunction(
+          AutoDiffAssociatedFunctionIdentifier::get(
+              AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,
+              DA->getParameterIndices(), cd->getASTContext()));
+      maybeAddEntry(vjpConstant);
+    }
+    // SWIFT_ENABLE_TENSORFLOW END
   }
 
   void maybeAddEntry(SILDeclRef declRef) {

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -178,7 +178,7 @@ private:
     auto funcDeclRef = SILDeclRef(func, kind);
     asDerived().addMethod(funcDeclRef);
 
-    if (auto *DA = func->getAttrs().getAttribute<DifferentiableAttr>()) {
+    for (auto *DA : func->getAttrs().getAttributes<DifferentiableAttr>()) {
       asDerived().addMethod(funcDeclRef.asAutoDiffAssociatedFunction(
           AutoDiffAssociatedFunctionIdentifier::get(
               AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -842,7 +842,7 @@ SILDeclRef SILDeclRef::getOverridden() const {
   if (!overridden)
     return SILDeclRef();
 
-  return SILDeclRef(overridden, kind, isCurried);
+  return SILDeclRef(overridden, kind, isCurried, isForeign, autoDiffAssociatedFunctionIdentifier);
 }
 
 SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
@@ -902,7 +902,7 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
 SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
   auto bestOverridden =
     getOverriddenWitnessTableEntry(cast<AbstractFunctionDecl>(getDecl()));
-  return SILDeclRef(bestOverridden, kind, isCurried);
+  return SILDeclRef(bestOverridden, kind, isCurried, isForeign, autoDiffAssociatedFunctionIdentifier);
 }
 
 AbstractFunctionDecl *SILDeclRef::getOverriddenWitnessTableEntry(

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -135,6 +135,9 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
   if (!name.empty()) {
     entry = &*M.FunctionTable.insert(std::make_pair(name, nullptr)).first;
     PrettyStackTraceSILFunction trace("creating", entry->getValue());
+    if (entry->getValue()) {
+      entry->getValue()->dump();
+    }
     assert(!entry->getValue() && "function already exists");
     name = entry->getKey();
   }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -147,6 +147,12 @@ public:
   SILFunction *getDynamicThunk(SILDeclRef constant,
                                CanSILFunctionType constantTy);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Get the autodiff associated function thunk for a JVP/VJP SILDeclRef.
+  /// Currently used only for JVP/VJP vtable entries.
+  SILFunction *getAutoDiffThunk(SILDeclRef constant,
+                                CanSILFunctionType constantTy);
+
   /// Emit a vtable thunk for a derived method if its natural abstraction level
   /// diverges from the overridden base method. If no thunking is needed,
   /// returns a static reference to the derived method.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4168,8 +4168,6 @@ getWitnessFunctionRef(SILGenFunction &SGF,
                             SILType::getPrimitiveObjectType(witnessFTy));
   }
   case WitnessDispatchKind::Class: {
-    // SWIFT_ENABLE_TENSORFLOW
-    assert(!witness.autoDiffAssociatedFunctionIdentifier);
     SILValue selfPtr = witnessParams.back().getValue();
     return SGF.emitClassMethodRef(loc, selfPtr, witness, witnessFTy);
   }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1156,6 +1156,11 @@ ADContext::emitNondifferentiabilityError(SILInstruction *inst,
     getADDebugStream() << "With invoker:\n" << invoker << '\n';
   });
   auto instLoc = inst->getLoc().getSourceLoc();
+  // If instruction does not have a valid location, use the function location
+  // as a fallback. Improves diagnostics for `ref_element_addr` generated in
+  // synthesized stored property getters.
+  if (instLoc.isInvalid())
+    instLoc = inst->getFunction()->getLocation().getSourceLoc();
   return emitNondifferentiabilityError(instLoc, invoker, diag,
                                        std::forward<U>(args)...);
 }
@@ -1566,8 +1571,10 @@ void DifferentiableActivityInfo::analyze(DominanceInfo *di,
   assert(usefulValueSets.empty());
   for (auto output : outputValues) {
     usefulValueSets.push_back({});
-    // If the output has an address type, propagate usefulness recursively.
-    if (output->getType().isAddress())
+    // If the output has an address or class type, propagate usefulness
+    // recursively.
+    if (output->getType().isAddress() ||
+        output->getType().isClassOrClassMetatype())
       propagateUsefulThroughBuffer(output, usefulValueSets.size() - 1);
     // Otherwise, just mark the output as useful.
     else
@@ -1702,7 +1709,8 @@ void DifferentiableActivityInfo::recursivelySetVaried(
 
 void DifferentiableActivityInfo::propagateUsefulThroughBuffer(
     SILValue value, unsigned dependentVariableIndex) {
-  assert(value->getType().isAddress());
+  assert(value->getType().isAddress() ||
+         value->getType().isClassOrClassMetatype());
   // Check whether value is already useful to prevent infinite recursion.
   if (isUseful(value, dependentVariableIndex))
     return;
@@ -2141,7 +2149,7 @@ emitAssociatedFunctionReference(
         /*differentiationOrder*/ 1, kind, builder.getModule(),
         LookUpConformanceInModule(builder.getModule().getSwiftModule()));
 
-    // Emit a witness_method instruction pointing at the associated function.
+    // Emit a `witness_method` instruction for the associated function.
     auto *autoDiffFuncId = AutoDiffAssociatedFunctionIdentifier::get(
         kind, /*differentiationOrder*/ 1, requirementParameterIndices,
         context.getASTContext());
@@ -2154,40 +2162,57 @@ emitAssociatedFunctionReference(
     return std::make_pair(convertedRef, requirementIndices);
   }
 
-  // Reject class methods.
+  // Find class method.
   if (auto *classMethodInst =
           peerThroughFunctionConversions<ClassMethodInst>(original)) {
     auto loc = classMethodInst->getLoc();
     auto methodRef = classMethodInst->getMember();
-    auto methodDecl = methodRef.getDecl();
+    auto *methodDecl = methodRef.getDecl();
     auto *diffAttr = methodDecl->getAttrs().getAttribute<DifferentiableAttr>();
     if (!diffAttr) {
-      context.emitNondifferentiabilityError(original, invoker,
-          diag::autodiff_protocol_member_not_differentiable);  // TODO: change to a class method diagnostic
+      context.emitNondifferentiabilityError(
+          original, invoker,
+          diag::autodiff_class_member_not_differentiable);
       return None;
     }
 
     auto *methodParameterIndices = diffAttr->getParameterIndices();
+    auto loweredMethodIndices = methodParameterIndices->getLowered(
+        context.getASTContext(),
+        methodDecl->getInterfaceType()->castTo<AnyFunctionType>());
+    SILAutoDiffIndices methodIndices(/*source*/ 0, loweredMethodIndices);
 
-    // TODO: need to check that the method parameter indices are compatible with
-    // the desired ones.
+    // NOTE: We need to extend the capacity of desired parameter indices to
+    // requirement parameter indices, because there's an argument count
+    // mismatch. When `@differentiable` partial apply is supported, this problem
+    // will go away.
+    if (desiredIndices.source != methodIndices.source ||
+        !desiredIndices.parameters->extendingCapacity(
+            context.getASTContext(),
+            methodIndices.parameters->getCapacity())
+                ->isSubsetOf(methodIndices.parameters)) {
+      context.emitNondifferentiabilityError(original, invoker,
+          diag::autodiff_protocol_member_subset_indices_not_differentiable);
+      return None;
+    }
 
     auto originalType = classMethodInst->getType().castTo<SILFunctionType>();
     auto assocType = originalType->getAutoDiffAssociatedFunctionType(
-        desiredIndices.parameters, desiredIndices.source,  // TODO: using desired here is very dangerous. should use the ones from the method declaration
+        methodIndices.parameters, methodIndices.source,
         /*differentiationOrder*/ 1, kind, builder.getModule(),
         LookUpConformanceInModule(builder.getModule().getSwiftModule()));
 
-    // Emit a class_method instruction pointing at the associated function.
+    // Emit a `class_method` instruction for the associated function.
     auto *autoDiffFuncId = AutoDiffAssociatedFunctionIdentifier::get(
         kind, /*differentiationOrder*/ 1, methodParameterIndices,
         context.getASTContext());
     auto *ref = builder.createClassMethod(
         loc, classMethodInst->getOperand(),
-        methodRef.asAutoDiffAssociatedFunction(autoDiffFuncId), SILType::getPrimitiveObjectType(assocType));
+        methodRef.asAutoDiffAssociatedFunction(autoDiffFuncId),
+        SILType::getPrimitiveObjectType(assocType));
     auto convertedRef =
         reapplyFunctionConversion(ref, classMethodInst, original, builder, loc);
-    return std::make_pair(convertedRef, desiredIndices);  // TODO: using desired here is very dangerous. should use the ones from the method declaration
+    return std::make_pair(convertedRef, methodIndices);
   }
 
   // Emit the general opaque function error.
@@ -5313,10 +5338,11 @@ public:
 #define NOT_DIFFERENTIABLE(INST, DIAG) \
   void visit##INST##Inst(INST##Inst *inst) { \
     getContext().emitNondifferentiabilityError( \
-        inst, getInvoker(), DIAG); \
+        inst, getInvoker(), diag::DIAG); \
     errorOccurred = true; \
     return; \
   }
+  NOT_DIFFERENTIABLE(RefElementAddr, autodiff_class_property_not_supported)
 #undef NOT_DIFFERENTIABLE
 
 #define NO_ADJOINT(INST) \
@@ -6365,6 +6391,14 @@ ADContext::getOrCreateSubsetParametersThunkForAssociatedFunction(
     assocRef = builder.createWitnessMethod(
         loc, assocMethodInst->getLookupType(),
         assocMethodInst->getConformance(), assocMethodInst->getMember(),
+        thunk->mapTypeIntoContext(assocMethodInst->getType()));
+  } else if (auto *assocMethodInst =
+                 peerThroughFunctionConversions<ClassMethodInst>(assocFn)) {
+    auto classOperand = thunk->getArgumentsWithoutIndirectResults().back();
+    auto classOperandType = assocMethodInst->getOperand()->getType();
+    assert(classOperand->getType() == classOperandType);
+    assocRef = builder.createClassMethod(
+        loc, classOperand, assocMethodInst->getMember(),
         thunk->mapTypeIntoContext(assocMethodInst->getType()));
   }
   assert(assocRef && "Expected associated function to be resolved");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2695,8 +2695,8 @@ TypeChecker::inferDifferentiableParameters(
       paramType = derivativeGenEnv->mapTypeIntoContext(paramType);
     else
       paramType = AFD->mapTypeIntoContext(paramType);
-    // Return false for class/existential types.
-    if (paramType->isAnyClassReferenceType() || paramType->isExistentialType())
+    // Return false for existential types.
+    if (paramType->isExistentialType())
       return false;
     // Return false for function types.
     if (paramType->is<AnyFunctionType>())
@@ -2803,6 +2803,14 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
 
   if (checkAccessControl(candidate))
     return nullptr;
+
+  // Derivatives of class members must be final.
+  if (original->getDeclContext()->getSelfClassDecl() &&
+      !candidate->isFinal()) {
+    TC.diagnose(nameLoc,
+                diag::differentiable_attr_class_derivative_not_final);
+    return nullptr;
+  }
 
   return candidate;
 }
@@ -3135,13 +3143,10 @@ static bool checkDifferentiationParameters(
           derivativeGenEnv->mapTypeIntoContext(wrtParamType);
     else
       wrtParamType = AFD->mapTypeIntoContext(wrtParamType);
-    // Parameter cannot have a class or existential type.
-    if ((!wrtParamType->hasTypeParameter() &&
-         wrtParamType->isAnyClassReferenceType()) ||
-        wrtParamType->isExistentialType()) {
+    // Parameter cannot have an existential type.
+    if (wrtParamType->isExistentialType()) {
       TC.diagnose(
-           loc,
-           diag::diff_params_clause_cannot_diff_wrt_objects_or_existentials,
+           loc, diag::diff_params_clause_cannot_diff_wrt_existentials,
            wrtParamType);
       return true;
     }
@@ -3183,13 +3188,10 @@ static bool checkTransposingParameters(
     SourceLoc loc = parsedWrtParams.empty()
         ? attrLoc
         : parsedWrtParams[i].getLoc();
-    // Parameter cannot have a class or existential type.
-    if ((!wrtParamType->hasTypeParameter() &&
-         wrtParamType->isAnyClassReferenceType()) ||
-         wrtParamType->isExistentialType()) {
-      TC.diagnose(
-          loc, diag::diff_params_clause_cannot_diff_wrt_objects_or_existentials,
-          wrtParamType);
+    // Parameter cannot have an existential type.
+    if (wrtParamType->isExistentialType()) {
+      TC.diagnose(loc, diag::diff_params_clause_cannot_diff_wrt_existentials,
+                  wrtParamType);
       return true;
     }
     // Parameter cannot have a function type.
@@ -3252,13 +3254,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  // // Class members are not supported by differentiation yet.
-  // if (original->getInnermostTypeContext() &&
-  //     isa<ClassDecl>(original->getInnermostTypeContext())) {
-  //   diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
-  //   return;
-  // }
-
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();
   bool isMethod = original->hasImplicitSelfDecl();
@@ -3276,14 +3271,41 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  // Start type-checking the arguments of the @differentiable attribute. This
-  // covers 'wrt:', 'jvp:', 'vjp:', and 'where', all of which are optional.
-
-  // `@differentiable` attributes on protocol requirements do not support
-  // JVP/VJP or 'where' clauses.
   bool isOriginalProtocolRequirement =
       isa<ProtocolDecl>(original->getDeclContext()) &&
       original->isProtocolRequirement();
+
+  bool isOriginalClassMember =
+      original->getDeclContext() &&
+      original->getDeclContext()->getSelfClassDecl();
+
+  // Diagnose invalid class conditions.
+  if (isOriginalClassMember) {
+    // Class methods returning dynamic `Self` are not supported.
+    // (For class methods, dynamic `Self` is supported only as the single
+    //  result - JVPs/VJPs would not type-check.
+    if (auto *originalFn = dyn_cast<FuncDecl>(original)) {
+      if (originalFn->hasDynamicSelfResult()) {
+        TC.diagnose(attr->getLocation(),
+                    diag::differentiable_attr_class_member_no_dynamic_self);
+        attr->setInvalid();
+        return;
+      }
+    }
+
+    // TODO(TF-654): Class initializers are not yet supported.
+    // Extra JVP/VJP type calculation logic is necessary because classes have
+    // both allocators and initializers.
+    if (auto *initDecl = dyn_cast<ConstructorDecl>(original)) {
+      TC.diagnose(attr->getLocation(),
+                  diag::differentiable_attr_class_init_not_yet_supported);
+      attr->setInvalid();
+      return;
+    }
+  }
+
+  // Start type-checking the arguments of the @differentiable attribute. This
+  // covers 'wrt:', 'jvp:', 'vjp:', and 'where', all of which are optional.
 
   // Handle 'where' clause, if it exists.
   // - Resolve attribute where clause requirements and store in the attribute

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3252,12 +3252,12 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return;
   }
 
-  // Class members are not supported by differentiation yet.
-  if (original->getInnermostTypeContext() &&
-      isa<ClassDecl>(original->getInnermostTypeContext())) {
-    diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
-    return;
-  }
+  // // Class members are not supported by differentiation yet.
+  // if (original->getInnermostTypeContext() &&
+  //     isa<ClassDecl>(original->getInnermostTypeContext())) {
+  //   diagnoseAndRemoveAttr(attr, diag::differentiable_attr_class_unsupported);
+  //   return;
+  // }
 
   TC.resolveDeclSignature(original);
   auto *originalFnTy = original->getInterfaceType()->castTo<AnyFunctionType>();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -603,16 +603,20 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
   if (!derivedAFD || !baseAFD)
     return false;
 
-  auto derivedDAs = derivedAFD->getAttrs().getAttributes<DifferentiableAttr>();
+  auto derivedDAs = derivedAFD->getAttrs()
+      .getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
   auto baseDAs = baseAFD->getAttrs().getAttributes<DifferentiableAttr>();
 
-  // Make sure all the differentiable attributes in `baseDecl` are
+  // Make sure all the `@differentiable` attributes in `baseDecl` are
   // also declared in `derivedDecl`.
-  for (auto baseDA : baseDAs) {
+  bool diagnosed = false;
+  for (auto *baseDA : baseDAs) {
     auto baseParameters = baseDA->getParameterIndices();
     auto defined = false;
     for (auto derivedDA : derivedDAs) {
       auto derivedParameters = derivedDA->getParameterIndices();
+      // If base and derived parameter indices are both defined, check whether
+      // base parameter indices are a subset of derived parameter indices.
       if (derivedParameters &&
           baseParameters &&
           AutoDiffIndexSubset::get(
@@ -622,43 +626,57 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
         defined = true;
         break;
       }
+      // Parameter indices may not be resolved because override matching happens
+      // before attribute checking for declaration type-checking.
+      // If parameter indices have not been resolved, avoid emitting diagnostic.
+      // Assume that attributes are valid.
+      if (!derivedParameters || !baseParameters) {
+        defined = true;
+        break;
+      }
     }
-    if (!defined) {
-      // Omit printing wrt clause if attribute differentiation parameters match
-      // inferred differentiation parameters.
-      auto *inferredParameters = TypeChecker::inferDifferentiableParameters(
-          derivedAFD, nullptr);
-      bool omitWrtClause = !baseParameters ||
-          baseParameters->parameters.count() ==
-          inferredParameters->parameters.count();
-      // Get `@differentiable` attribute description.
-      std::string baseDAString;
-      llvm::raw_string_ostream stream(baseDAString);
-      baseDA->print(stream, derivedDecl, omitWrtClause,
-                    /*omitAssociatedFunctions*/ true);
-      diags.diagnose(
-          derivedDecl, diag::overriding_decl_missing_differentiable_attr,
-          StringRef(stream.str()).trim());
-      return false;
-    }
+    if (defined)
+      continue;
+    diagnosed = true;
+    // Omit printing wrt clause if attribute differentiation parameters match
+    // inferred differentiation parameters.
+    auto *inferredParameters = TypeChecker::inferDifferentiableParameters(
+        derivedAFD, nullptr);
+    bool omitWrtClause = !baseParameters ||
+        baseParameters->parameters.count() ==
+        inferredParameters->parameters.count();
+    // Get `@differentiable` attribute description.
+    std::string baseDAString;
+    llvm::raw_string_ostream stream(baseDAString);
+    baseDA->print(stream, derivedDecl, omitWrtClause,
+                  /*omitAssociatedFunctions*/ true);
+    diags.diagnose(
+        derivedDecl, diag::overriding_decl_missing_differentiable_attr,
+        StringRef(stream.str()).trim());
+    diags.diagnose(baseDecl, diag::overridden_here);
   }
-
-  // If there is no differentiable attribute in `derivedDecl`, then
-  // overriding is not allowed.
-  if (derivedDAs.empty())
+  // If a diagnostic was produced, return false.
+  if (diagnosed)
     return false;
 
-  // Finally, go through all differentiable attributes in
-  // `derivedDecl` and check if they subsume any of the
-  // differentiable attributes in `baseDecl`.
+  // If there is no `@differentiable` attribute in `derivedDecl`, then
+  // overriding is not allowed.
+  auto *derivedDC = derivedDecl->getDeclContext();
+  auto *baseDC = baseDecl->getDeclContext();
+  if (derivedDC->getSelfClassDecl() && baseDC->getSelfClassDecl())
+    return false;
+
+  // Finally, go through all `@differentiable` attributes in `derivedDecl` and
+  // check if they subsume any of the `@differentiable` attributes in
+  // `baseDecl`.
   for (auto derivedDA : derivedDAs) {
     auto derivedParameters = derivedDA->getParameterIndices();
     auto overrides = true;
     for (auto baseDA : baseDAs) {
       auto baseParameters = baseDA->getParameterIndices();
-      // If the differentiable indices of `derivedDA` are a
-      // subset of those of `baseDA`, then `baseDA` subsumes
-      // `derivedDA` and the function is marked as overridden.
+      // If the parameter indices of `derivedDA` are a subset of those of
+      // `baseDA`, then `baseDA` subsumes `derivedDA` and the function is
+      // marked as overridden.
       if (derivedParameters &&
             baseParameters &&
             AutoDiffIndexSubset::get(
@@ -667,6 +685,9 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
                   ctx, baseParameters->parameters))) {
         overrides = false;
         break;
+      }
+      if (!derivedParameters && !baseParameters) {
+        assert(false);
       }
     }
     if (overrides)

--- a/test/AutoDiff/Inputs/class_method_thunk_other_module.swift
+++ b/test/AutoDiff/Inputs/class_method_thunk_other_module.swift
@@ -1,0 +1,36 @@
+class OtherModuleSuper {
+  @differentiable(jvp: jvpf, vjp: vjpf)
+  func f(_ x: Float) -> Float {
+    return 2 * x
+  }
+
+  final func jvpf(_ x: Float) -> (Float, (Float) -> Float) {
+    return (f(x), { v in 2 * v })
+  }
+
+  final func vjpf(_ x: Float) -> (Float, (Float) -> Float) {
+    return (f(x), { v in 2 * v })
+  }
+}
+
+class OtherModuleSubOverride : OtherModuleSuper {
+  @differentiable
+  override func f(_ x: Float) -> Float {
+    return 3 * x
+  }
+}
+
+class OtherModuleSubOverrideCustomDerivatives : OtherModuleSuper {
+  @differentiable(jvp: jvpf2, vjp: vjpf2)
+  override func f(_ x: Float) -> Float {
+    return 3 * x
+  }
+
+  final func jvpf2(_ x: Float) -> (Float, (Float) -> Float) {
+    return (f(x), { v in 3 * v })
+  }
+
+  final func vjpf2(_ x: Float) -> (Float, (Float) -> Float) {
+    return (f(x), { v in 3 * v })
+  }
+}

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -4,8 +4,6 @@
 // due to direct differentiation of reabstraction thunks, which emits errors
 // with unknown location.
 
-// Test unmet generic requirements.
-
 @differentiable
 func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
   // expected-error @+2 {{expression is not differentiable}}
@@ -13,6 +11,8 @@ func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
   return x + 1
 }
 _ = gradient(at: 1.0, in: generic)
+
+// Test unmet generic requirements.
 
 @differentiable(
   vjp: vjpWeirdExtraRequirements

--- a/test/AutoDiff/class_method.swift
+++ b/test/AutoDiff/class_method.swift
@@ -1,0 +1,353 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var ClassMethodTests = TestSuite("ClassMethods")
+
+ClassMethodTests.test("Final") {
+  final class Final : Differentiable {
+    func method(_ x: Float) -> Float {
+      return x * x
+    }
+  }
+
+  for i in -5...5 {
+    expectEqual(Float(i) * 2, gradient(at: Float(i)) { x in Final().method(x) })
+  }
+}
+
+ClassMethodTests.test("Simple") {
+  class Super {
+    @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
+    func f(_ x: Float) -> Float {
+      return 2 * x
+    }
+    final func jvpf(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 2 * v })
+    }
+    final func vjpf(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 2 * v })
+    }
+  }
+
+  class SubOverride : Super {
+    @differentiable(wrt: x)
+    override func f(_ x: Float) -> Float {
+      return 3 * x
+    }
+  }
+
+  class SubOverrideCustomDerivatives : Super {
+    @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+    override func f(_ x: Float) -> Float {
+      return 3 * x
+    }
+    final func jvpf2(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 3 * v })
+    }
+    final func vjpf2(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 3 * v })
+    }
+  }
+
+  func classValueWithGradient(_ c: Super) -> (Float, Float) {
+    return valueWithGradient(at: 1) { c.f($0) }
+  }
+  expectEqual((2, 2), classValueWithGradient(Super()))
+  expectEqual((3, 3), classValueWithGradient(SubOverride()))
+  expectEqual((3, 3), classValueWithGradient(SubOverrideCustomDerivatives()))
+}
+
+ClassMethodTests.test("SimpleWrtSelf") {
+  class Super : Differentiable {
+    var base: Float
+    // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
+    var _nontrivial: [Float] = []
+
+    // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
+    // TODO(TF-645): Remove `vjpInit` when differentiation supports `ref_element_addr`.
+    // @differentiable(vjp: vjpInit)
+    required init(base: Float) {
+      self.base = base
+    }
+    static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
+      return (Super(base: base), { x in x.base })
+    }
+
+    @differentiable(wrt: (self, x), jvp: jvpf, vjp: vjpf)
+    func f(_ x: Float) -> Float {
+      return base * x
+    }
+    final func jvpf(_ x: Float) -> (Float, (TangentVector, Float) -> Float) {
+      return (f(x), { (dself, dx) in dself.base * dx })
+    }
+    final func vjpf(_ x: Float) -> (Float, (Float) -> (TangentVector, Float)) {
+      let base = self.base
+      return (f(x), { v in
+        (TangentVector(base: v * x, _nontrivial: []), base * v)
+      })
+    }
+  }
+
+  class SubOverride : Super {
+    @differentiable(wrt: (self, x))
+    override func f(_ x: Float) -> Float {
+      return 3 * x
+    }
+  }
+
+  class SubOverrideCustomDerivatives : Super {
+    @differentiable(wrt: (self, x))
+    @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+    override func f(_ x: Float) -> Float {
+      return 3 * x
+    }
+    final func jvpf2(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 3 * v })
+    }
+    final func vjpf2(_ x: Float) -> (Float, (Float) -> Float) {
+      return (f(x), { v in 3 * v })
+    }
+  }
+
+  // TODO(TF-654): Uncomment when differentiation supports class initializers.
+  /*
+  let v = Super.TangentVector(base: 100, _nontrivial: [])
+  expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
+  expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))
+  expectEqual(100, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
+  */
+
+  func classValueWithGradient(_ c: Super) -> (Float, Float) {
+    return valueWithGradient(at: 1) { c.f($0) }
+  }
+  expectEqual((2, 2), classValueWithGradient(Super(base: 2)))
+  expectEqual((3, 3), classValueWithGradient(SubOverride(base: 2)))
+  expectEqual((3, 3), classValueWithGradient(SubOverrideCustomDerivatives(base: 2)))
+}
+
+ClassMethodTests.test("Generics") {
+  class Super<T : Differentiable & FloatingPoint> where T == T.TangentVector {
+    @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
+    func f(_ x: T) -> T {
+      return T(2) * x
+    }
+    final func jvpf(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+      return (f(x), { v in T(2) * v })
+    }
+    final func vjpf(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+      return (f(x), { v in T(2) * v })
+    }
+  }
+
+  class SubOverride<T : Differentiable & FloatingPoint> : Super<T> where T == T.TangentVector {
+    @differentiable(wrt: x)
+    override func f(_ x: T) -> T {
+      return x
+    }
+  }
+
+  class SubSpecializeOverride : Super<Float> {
+    @differentiable(wrt: x)
+    override func f(_ x: Float) -> Float {
+      return 3 * x
+    }
+  }
+
+  class SubOverrideCustomDerivatives<T : Differentiable & FloatingPoint> : Super<T> where T == T.TangentVector {
+    @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+    override func f(_ x: T) -> T {
+      return T(3) * x
+    }
+    final func jvpf2(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+      return (f(x), { v in T(3) * v })
+    }
+    final func vjpf2(_ x: T) -> (T, (T.TangentVector) -> T.TangentVector) {
+      return (f(x), { v in T(3) * v })
+    }
+  }
+
+  class SubSpecializeOverrideCustomDerivatives : Super<Float80> {
+    @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+    override func f(_ x: Float80) -> Float80 {
+      return 3 * x
+    }
+    final func jvpf2(_ x: Float80) -> (Float80, (Float80) -> Float80) {
+      return (f(x), { v in 3 * v })
+    }
+    final func vjpf2(_ x: Float80) -> (Float80, (Float80) -> Float80) {
+      return (f(x), { v in 3 * v })
+    }
+  }
+
+  func classValueWithGradient<T : Differentiable & FloatingPoint>(
+    _ c: Super<T>
+  ) -> (T, T) where T == T.TangentVector {
+    return valueWithGradient(at: T(1)) { c.f($0) }
+  }
+  expectEqual((2, 2), classValueWithGradient(Super<Float>()))
+  expectEqual((1, 1), classValueWithGradient(SubOverride<Float>()))
+  expectEqual((3, 3), classValueWithGradient(SubSpecializeOverride()))
+  expectEqual((3, 3), classValueWithGradient(SubOverrideCustomDerivatives<Float>()))
+  expectEqual((3, 3), classValueWithGradient(SubSpecializeOverrideCustomDerivatives()))
+}
+
+ClassMethodTests.test("Methods") {
+  class Super : Differentiable {
+    var base: Float
+    // Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
+    var _nontrivial: [Float] = []
+
+    // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
+    // TODO(TF-645): Remove `vjpInit` when differentiation supports `ref_element_addr`.
+    // @differentiable(vjp: vjpInit)
+    init(base: Float) {
+      self.base = base
+    }
+    static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
+      return (Super(base: base), { x in x.base })
+    }
+
+    @differentiable(vjp: vjpSquared)
+    func squared() -> Float { base * base }
+
+    final func vjpSquared() -> (Float, (Float) -> TangentVector) {
+      let base = self.base
+      return (base * base, { v in
+        TangentVector(base: 2 * base * v, _nontrivial: [])
+      })
+    }
+  }
+
+  class Sub1 : Super {
+    @differentiable(vjp: vjpSquared2)
+    override func squared() -> Float { base * base }
+    final func vjpSquared2() -> (Float, (Float) -> TangentVector) {
+      let base = self.base
+      return (base * base, { v in
+        TangentVector(base: 2 * base * v, _nontrivial: [])
+      })
+    }
+  }
+
+  func classValueWithGradient(_ c: Super) -> (Float, Super.TangentVector) {
+    return valueWithGradient(at: c) { c in c.squared() }
+  }
+
+  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
+  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared() })
+
+  // TODO(TF-647): Handle `unchecked_ref_cast` in `Sub1.init` during pullback generation.
+  // FIXME: `Super.init` VJP type mismatch for empty `Super.AllDifferentiableVariables`:
+  // SIL verification failed: VJP type does not match expected VJP type
+  //   $@convention(method) (Float, @thick Super.Type) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Float)
+  //   $@convention(method) (Float, @owned Super) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Float)
+  // expectEqual(4, gradient(at: 2) { x in Sub1(base: x).squared() })
+
+  expectEqual(Super.TangentVector(base: 4, _nontrivial: []),
+              gradient(at: Super(base: 2)) { foo in foo.squared() })
+  expectEqual(Sub1.TangentVector(base: 4, _nontrivial: []),
+              gradient(at: Sub1(base: 2)) { foo in foo.squared() })
+}
+
+ClassMethodTests.test("Properties") {
+  class Super : Differentiable {
+    var base: Float
+
+    // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
+    // TODO(TF-645): Remove `vjpInit` when differentiation supports `ref_element_addr`.
+    // @differentiable(vjp: vjpInit)
+    init(base: Float) { self.base = base }
+    static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
+      return (Super(base: base), { x in x.base })
+    }
+
+    @differentiable(vjp: vjpSquared)
+    var squared: Float { base * base }
+
+    final func vjpSquared() -> (Float, (Float) -> TangentVector) {
+      let base = self.base
+      return (base * base, { v in TangentVector(base: 2 * base * v) })
+    }
+  }
+
+  class Sub1 : Super {
+    // FIXME(TF-625): Crash due to `Super.AllDifferentiableVariables` abstraction pattern mismatch.
+    // SIL verification failed: vtable entry for #<anonymous function>Super.squared!getter.1.jvp.1.S must be ABI-compatible
+    //   ABI incompatible return values
+    //   @convention(method) (@guaranteed Super) -> (Float, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Float)
+    //   @convention(method) (@guaranteed Sub1) -> (Float, @owned @callee_guaranteed (Super.AllDifferentiableVariables) -> Float)
+    // @differentiable
+    // override var squared: Float { base * base }
+  }
+
+  func classValueWithGradient(_ c: Super) -> (Float, Super.TangentVector) {
+    return valueWithGradient(at: c) { c in c.squared }
+  }
+
+  // TODO(TF-654, TF-645): Uncomment when differentiation supports class initializers or `ref_element_addr`.
+  // expectEqual(4, gradient(at: 2) { x in Super(base: x).squared })
+  expectEqual(Super.TangentVector(base: 4),
+              gradient(at: Super(base: 2)) { foo in foo.squared })
+}
+
+ClassMethodTests.test("Capturing") {
+  class Multiplier {
+    var coefficient: Float
+    init(_ coefficient: Float) {
+      self.coefficient = coefficient
+    }
+
+    // Case 1: generated VJP.
+    @differentiable
+    func apply(to x: Float) -> Float {
+      return coefficient * x
+    }
+
+    // Case 2: custom VJP capturing `self`.
+    @differentiable(wrt: (x), vjp: vjpApply2)
+    func apply2(to x: Float) -> Float {
+      return coefficient * x
+    }
+    final func vjpApply2(to x: Float) -> (Float, (Float) -> Float) {
+      return (coefficient * x, { v in self.coefficient * v })
+    }
+
+    // Case 3: custom VJP capturing `self.coefficient`.
+    @differentiable(wrt: x, vjp: vjpApply3)
+    func apply3(to x: Float) -> Float {
+      return coefficient * x
+    }
+    final func vjpApply3(to x: Float) -> (Float, (Float) -> Float) {
+      let coefficient = self.coefficient
+      return (coefficient * x, { v in coefficient * v })
+    }
+  }
+
+  func f(_ x: Float) -> Float {
+    let m = Multiplier(10)
+    let result = m.apply(to: x)
+    m.coefficient += 1
+    return result
+  }
+  expectEqual(10, gradient(at: 1, in: f))
+
+  func f2(_ x: Float) -> Float {
+    let m = Multiplier(10)
+    let result = m.apply2(to: x)
+    m.coefficient += 1
+    return result
+  }
+  expectEqual(11, gradient(at: 1, in: f2))
+
+  func f3(_ x: Float) -> Float {
+    let m = Multiplier(10)
+    let result = m.apply3(to: x)
+    m.coefficient += 1
+    return result
+  }
+  expectEqual(10, gradient(at: 1, in: f3))
+}
+
+runAllTests()

--- a/test/AutoDiff/class_method_thunk/main.swift
+++ b/test/AutoDiff/class_method_thunk/main.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/../Inputs/class_method_thunk_other_module.swift %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var ClassMethodThunkTests = TestSuite("ClassMethodThunks")
+
+func classValueWithGradient(_ c: OtherModuleSuper) -> (Float, Float) {
+  return valueWithGradient(at: 1) { c.f($0) }
+}
+
+ClassMethodThunkTests.test("CrossModuleClassMethodThunks") {
+  expectEqual((2, 2), classValueWithGradient(OtherModuleSuper()))
+  expectEqual((3, 3), classValueWithGradient(OtherModuleSubOverride()))
+  expectEqual((3, 3), classValueWithGradient(OtherModuleSubOverrideCustomDerivatives()))
+}
+
+runAllTests()

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -69,15 +69,14 @@ protocol WrtOnlySelfProtocol : Differentiable {
   func method() -> Float
 }
 
-class Class {}
-// expected-error @+1 {{class objects and protocol existentials ('Class') cannot be differentiated with respect to}}
+class Class : Differentiable {}
 @differentiable(wrt: x)
 func invalidDiffWrtClass(_ x: Class) -> Class {
   return x
 }
 
 protocol Proto {}
-// expected-error @+1 {{class objects and protocol existentials ('Proto') cannot be differentiated with respect to}}
+// expected-error @+1 {{cannot differentiate with respect to protocol existential ('Proto')}}
 @differentiable(wrt: x)
 func invalidDiffWrtExistential(_ x: Proto) -> Proto {
   return x
@@ -247,10 +246,8 @@ func jvpAmbiguousVJP(x: Float) -> (Float, (Float) -> Float) {
   return (x, { $0 })
 }
 
-// TF-153: Class methods are not supported yet.
-class Foo {
+class DifferentiableClassMethod {
   // Direct differentiation case.
-  // expected-error @+1 {{class members cannot be marked with '@differentiable'}}
   @differentiable
   func foo(_ x: Float) -> Float {
     return x
@@ -605,7 +602,6 @@ func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
   return x
 }
 
-// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
 @differentiable(where T : AnyObject)
 func invalidAnyObjectRequirement<T : Differentiable>(x: T) -> T {
   return x
@@ -634,7 +630,8 @@ protocol ProtocolRequirements : Differentiable {
   @differentiable(wrt: x)
   func amb(x: Float, y: Int) -> Float
 
-  // expected-note @+2 {{protocol requires function 'f1'}}
+  // expected-note @+3 {{protocol requires function 'f1'}}
+  // expected-note @+2 {{overridden declaration is here}}
   @differentiable(wrt: (self, x))
   func f1(_ x: Float) -> Float
 
@@ -889,11 +886,13 @@ public protocol Distribution {
 }
 
 public protocol DifferentiableDistribution: Differentiable, Distribution {
+  // expected-note @+2 {{overridden declaration is here}}
   @differentiable(wrt: self)
   func logProbability(of value: Value) -> Float
 }
 
-public protocol MissingDifferentiableDistribution: DifferentiableDistribution
+// Adding a more general `@differentiable` attribute.
+public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
   where Value: Differentiable {
   // expected-error @+1 {{overriding declaration is missing attribute '@differentiable(wrt: self)'}}
   func logProbability(of value: Value) -> Float
@@ -916,4 +915,51 @@ extension ProtocolRequirementUnsupported {
   func dfoo(_ x: Float) -> (Float, (Float) -> Float) {
     (x, { $0 })
   }
+}
+
+// Classes.
+
+class Super : Differentiable {
+  var base: Float
+
+  // NOTE(TF-654): Class initializers are not yet supported.
+  // expected-error @+1 {{'@differentiable' attribute does not yet support class initializers}}
+  @differentiable
+  init(base: Float) {
+    self.base = base
+  }
+
+  @differentiable(wrt: (self, x))
+  @differentiable(wrt: x, vjp: vjp)
+  // expected-note @+1 2 {{overridden declaration is here}}
+  func testMissingAttributes(_ x: Float) -> Float { x }
+
+  @differentiable(wrt: x, vjp: vjp)
+  func testSuperclassDerivatives(_ x: Float) -> Float { x }
+
+  final func vjp(_ x: Float) -> (Float, (Float) -> Float) {
+    fatalError()
+  }
+
+  // expected-error @+1 {{'@differentiable' attribute cannot be declared on class methods returning 'Self'}}
+  @differentiable(vjp: vjpDynamicSelfResult)
+  func dynamicSelfResult() -> Self { self }
+
+  // TODO(TF-632): Fix "'TangentVector' is not a member type of 'Self'" diagnostic.
+  // The underlying error should appear instead:
+  // "covariant 'Self' can only appear at the top level of method result type".
+  // expected-error @+1 2 {{'TangentVector' is not a member type of 'Self'}}
+  func vjpDynamicSelfResult() -> (Self, (Self.TangentVector) -> Self.TangentVector) {
+    return (self, { $0 })
+  }
+}
+
+class Sub : Super {
+  // expected-error @+2 {{overriding declaration is missing attribute '@differentiable(wrt: x)'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
+  override func testMissingAttributes(_ x: Float) -> Float { x }
+
+  // expected-error @+1 {{'vjp' is not defined in the current type context}}
+  @differentiable(wrt: x, vjp: vjp)
+  override func testSuperclassDerivatives(_ x: Float) -> Float { x }
 }

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -347,3 +347,26 @@ func two6(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Flo
 func two7(x: Float, y: Float) -> (value: Float, pullback: (Float) -> (Float, Float)) {
   return (x + y, { ($0, $0) })
 }
+
+// Test class methods.
+
+class Super {
+  @differentiable
+  func foo(_ x: Float) -> Float {
+    return x
+  }
+
+  @differentiating(foo)
+  func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (foo(x), { v in v })
+  }
+}
+
+class Sub : Super {
+  // TODO(TF-649): Enable `@differentiating` to override original functions from superclass.
+  // expected-error @+1 {{'foo' is not defined in the current type context}}
+  @differentiating(foo)
+  override func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+    return (foo(x), { v in v })
+  }
+}

--- a/test/AutoDiff/vtable_silgen.swift
+++ b/test/AutoDiff/vtable_silgen.swift
@@ -1,0 +1,150 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+// Test JVP/VJP vtable entries for class members:
+// - Methods.
+// - Accessors (from properties and subscripts).
+// - Constructors.
+
+class Super : Differentiable {
+  var base: Float
+  // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
+  var _nontrivial: [Float] = []
+
+  // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
+  // TODO(TF-645): Remove `vjpInit` when differentiation supports `ref_element_addr`.
+  // @differentiable(vjp: vjpInit)
+  init(base: Float) {
+    self.base = base
+  }
+  static func vjpInit(base: Float) -> (Super, (TangentVector) -> Float) {
+    return (Super(base: base), { x in x.base })
+  }
+
+  @differentiable(vjp: vjpProperty)
+  var property: Float { base }
+  final func vjpProperty() -> (Float, (Float) -> TangentVector) {
+    return (property, { _ in .zero })
+  }
+
+  @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
+  func f(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+  final func jvpf(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
+    return (f(x, y), { v in v * y })
+  }
+  final func vjpf(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float)) {
+    return (f(x, y), { v in v * y })
+  }
+
+  @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
+  subscript(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+}
+
+class Sub : Super {
+  // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
+  // TODO(TF-645): Remove `vjpInit2` when differentiation supports `ref_element_addr`.
+  // @differentiable(vjp: vjpInit2)
+  override init(base: Float) {
+    super.init(base: base)
+    self.base = base
+  }
+  static func vjpInit2(base: Float) -> (Sub, (TangentVector) -> Float) {
+    return (Sub(base: base), { x in x.base })
+  }
+
+  @differentiable(vjp: vjpProperty2)
+  override var property: Float { base }
+  final func vjpProperty2() -> (Float, (Float) -> TangentVector) {
+    return (property, { _ in .zero })
+  }
+
+  @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+  // New `@differentiable` attribute.
+  @differentiable(wrt: (x, y))
+  override func f(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+  final func jvpf2(_ x: Float, _ y: Float) -> (Float, (Float) -> Float) {
+    return (f(x, y), { v in v * y })
+  }
+  final func vjpf2(_ x: Float, _ y: Float) -> (Float, (Float) -> (Float)) {
+    return (f(x, y), { v in v * y })
+  }
+
+  @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
+  override subscript(_ x: Float, _ y: Float) -> Float {
+    return x * y
+  }
+}
+
+class SubSub : Sub {}
+
+// CHECK-LABEL: sil_vtable Super {
+// CHECK-NEXT:   #Super.base!getter.1: (Super) -> () -> Float : @$s13vtable_silgen5SuperC4baseSfvg
+// CHECK-NEXT:   #Super.base!setter.1: (Super) -> (Float) -> () : @$s13vtable_silgen5SuperC4baseSfvs
+// CHECK-NEXT:   #Super.base!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC4baseSfvM
+// CHECK-NEXT:   #Super._nontrivial!getter.1: (Super) -> () -> [Float] : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvg
+// CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvs
+// CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvM
+// CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s13vtable_silgen5SuperC4baseACSf_tcfC
+// CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s13vtable_silgen5SuperC8propertySfvg
+// CHECK-NEXT:   #Super.property!getter.1.jvp.1.S: (Super) -> () -> Float : @AD__$s13vtable_silgen5SuperC8propertySfvg__jvp_src_0_wrt_0_thunk
+// CHECK-NEXT:   #Super.property!getter.1.vjp.1.S: (Super) -> () -> Float : @$s13vtable_silgen5SuperC11vjpPropertySf_AC26AllDifferentiableVariablesVSfctyF
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperC1fyS2f_SftF
+// CHECK-NEXT:   #Super.f!1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperC4jvpfySf_S2fctSf_SftF
+// CHECK-NEXT:   #Super.f!1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperC4vjpfySf_S2fctSf_SftF
+// CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperCyS2f_Sftcig
+// CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperC4jvpfySf_S2fctSf_SftF
+// CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen5SuperC4vjpfySf_S2fctSf_SftF
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s13vtable_silgen5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF
+// CHECK-NEXT:   #Super.deinit!deallocator.1: @$s13vtable_silgen5SuperCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable Sub {
+// CHECK-NEXT:   #Super.base!getter.1: (Super) -> () -> Float : @$s13vtable_silgen5SuperC4baseSfvg [inherited]
+// CHECK-NEXT:   #Super.base!setter.1: (Super) -> (Float) -> () : @$s13vtable_silgen5SuperC4baseSfvs [inherited]
+// CHECK-NEXT:   #Super.base!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC4baseSfvM [inherited]
+// CHECK-NEXT:   #Super._nontrivial!getter.1: (Super) -> () -> [Float] : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvg [inherited]
+// CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvs [inherited]
+// CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvM [inherited]
+// CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s13vtable_silgen3SubC4baseACSf_tcfC [override]
+// CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s13vtable_silgen3SubC8propertySfvg [override]
+// CHECK-NEXT:   #Super.property!getter.1.jvp.1.S: (Super) -> () -> Float : @AD__$s13vtable_silgen3SubC8propertySfvg__jvp_src_0_wrt_0_thunk [override]
+// CHECK-NEXT:   #Super.property!getter.1.vjp.1.S: (Super) -> () -> Float : @$s13vtable_silgen3SubC12vjpProperty2Sf_AA5SuperC26AllDifferentiableVariablesVSfctyF [override]
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC1fyS2f_SftF [override]
+// CHECK-NEXT:   #Super.f!1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5jvpf2ySf_S2fctSf_SftF [override]
+// CHECK-NEXT:   #Super.f!1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5vjpf2ySf_S2fctSf_SftF [override]
+// CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubCyS2f_Sftcig [override]
+// CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5jvpf2ySf_S2fctSf_SftF [override]
+// CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5vjpf2ySf_S2fctSf_SftF [override]
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s13vtable_silgen5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF [inherited]
+// CHECK-NEXT:   #Sub.f!1.jvp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s13vtable_silgen3SubC1fyS2f_SftF__jvp_src_0_wrt_0_1_thunk
+// CHECK-NEXT:   #Sub.f!1.vjp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s13vtable_silgen3SubC1fyS2f_SftF__vjp_src_0_wrt_0_1_thunk
+// CHECK-NEXT:   #Sub.deinit!deallocator.1: @$s13vtable_silgen3SubCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable SubSub {
+// CHECK-NEXT:   #Super.base!getter.1: (Super) -> () -> Float : @$s13vtable_silgen5SuperC4baseSfvg [inherited]
+// CHECK-NEXT:   #Super.base!setter.1: (Super) -> (Float) -> () : @$s13vtable_silgen5SuperC4baseSfvs [inherited]
+// CHECK-NEXT:   #Super.base!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC4baseSfvM [inherited]
+// CHECK-NEXT:   #Super._nontrivial!getter.1: (Super) -> () -> [Float] : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvg [inherited]
+// CHECK-NEXT:   #Super._nontrivial!setter.1: (Super) -> ([Float]) -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvs [inherited]
+// CHECK-NEXT:   #Super._nontrivial!modify.1: (Super) -> () -> () : @$s13vtable_silgen5SuperC11_nontrivialSaySfGvM [inherited]
+// CHECK-NEXT:   #Super.init!allocator.1: (Super.Type) -> (Float) -> Super : @$s13vtable_silgen03SubC0C4baseACSf_tcfC [override]
+// CHECK-NEXT:   #Super.property!getter.1: (Super) -> () -> Float : @$s13vtable_silgen3SubC8propertySfvg [inherited]
+// CHECK-NEXT:   #Super.property!getter.1.jvp.1.S: (Super) -> () -> Float : @AD__$s13vtable_silgen3SubC8propertySfvg__jvp_src_0_wrt_0_thunk [inherited]
+// CHECK-NEXT:   #Super.property!getter.1.vjp.1.S: (Super) -> () -> Float : @$s13vtable_silgen3SubC12vjpProperty2Sf_AA5SuperC26AllDifferentiableVariablesVSfctyF [inherited]
+// CHECK-NEXT:   #Super.f!1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC1fyS2f_SftF [inherited]
+// CHECK-NEXT:   #Super.f!1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5jvpf2ySf_S2fctSf_SftF [inherited]
+// CHECK-NEXT:   #Super.f!1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5vjpf2ySf_S2fctSf_SftF [inherited]
+// CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubCyS2f_Sftcig [inherited]
+// CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5jvpf2ySf_S2fctSf_SftF [inherited]
+// CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @$s13vtable_silgen3SubC5vjpf2ySf_S2fctSf_SftF [inherited]
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s13vtable_silgen5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF [inherited]
+// CHECK-NEXT:   #Sub.f!1.jvp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s13vtable_silgen3SubC1fyS2f_SftF__jvp_src_0_wrt_0_1_thunk [inherited]
+// CHECK-NEXT:   #Sub.f!1.vjp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s13vtable_silgen3SubC1fyS2f_SftF__vjp_src_0_wrt_0_1_thunk [inherited]
+// CHECK-NEXT:   #SubSub.deinit!deallocator.1: @$s13vtable_silgen03SubC0CfD
+// CHECK-NEXT: }


### PR DESCRIPTION
Class members (methods, accessors, constructors) with `@differentiable` attributes now have vtable entries.

Class member JVPs/VJPs are required to be `final` to simplify the semantics of overriding JVP/VJP declarations.

Extend differentiation transform to emit JVPs/VJPs for `class_method` instructions.

Resolves [TF-631](https://bugs.swift.org/browse/TF-631).
Todos regarding class differentiation support at [TF-37](https://bugs.swift.org/browse/TF-37).

---

Example:
```swift
class Super {
  @differentiable(wrt: x, jvp: jvpf, vjp: vjpf)
  func f(_ x: Float) -> Float {
    return 2 * x
  }
  final func jvpf(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 2 * v })
  }
  final func vjpf(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 2 * v })
  }
}

class SubOverride : Super {
  @differentiable(wrt: x)
  override func f(_ x: Float) -> Float {
    return 3 * x
  }
}

class SubOverrideCustomDerivatives : Super {
  @differentiable(wrt: x, jvp: jvpf2, vjp: vjpf2)
  override func f(_ x: Float) -> Float {
    return 3 * x
  }
  final func jvpf2(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 3 * v })
  }
  final func vjpf2(_ x: Float) -> (Float, (Float) -> Float) {
    return (f(x), { v in 3 * v })
  }
}

func classValueWithGradient(_ c: Super) -> (Float, Float) {
  return valueWithGradient(at: 1) { c.f($0) }
}
expectEqual((2, 2), classValueWithGradient(Super()))
expectEqual((3, 3), classValueWithGradient(SubOverride()))
expectEqual((3, 3), classValueWithGradient(SubOverrideCustomDerivatives()))
```

---

Extends work by @marcrasi in https://github.com/apple/swift/pull/24975.