### PR TITLE
Platform: start using autolink on Windows

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -15,6 +15,8 @@ module WinSDK [system] [extern_c] {
     header "WinSock2.h"
     header "WS2tcpip.h"
     export *
+
+    link "WS2_32.lib"
   }
 
   module core {
@@ -58,9 +60,12 @@ module WinSDK [system] [extern_c] {
       export *
     }
 
+    // iphlpapi.dll
     module iphlp {
       header "iphlpapi.h"
       export *
+
+      link "iphlpapi.lib"
     }
 
     // api-ms-win-core-libloader-l1-1-0.dll
@@ -120,6 +125,8 @@ module WinSDK [system] [extern_c] {
   module DbgHelp {
     header "DbgHelp.h"
     export *
+
+    link "DbgHelp.lib"
   }
 
   module Shell {
@@ -130,6 +137,8 @@ module WinSDK [system] [extern_c] {
   module ShellAPI {
     header "Shlwapi.h"
     export *
+
+    link "ShLwApi.lib"
   }
 
   module User {
@@ -140,6 +149,8 @@ module WinSDK [system] [extern_c] {
   module WinCrypt {
     header "wincrypt.h"
     export *
+
+    link "Crypt32.lib"
   }
 }
 


### PR DESCRIPTION
Be more aggressive about using the autolinking functionality of modules
on Windows.  This makes it easier to use WinSDK in Swift as the link
dependencies are implicitly taken care of.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
