### PR TITLE
[ConstraintSystem][SE-0249] Key Path Expressions as Functions

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3690,14 +3690,20 @@ public:
   }
 };
 
-
-/// This is a closure of the contained subexpression that is formed
-/// when a scalar expression is converted to @autoclosure function type.
-/// For example:
+/// This is an implicit closure of the contained subexpression that is usually
+/// formed when a scalar expression is converted to @autoclosure function type.
 /// \code
 ///   func f(x : @autoclosure () -> Int)
 ///   f(42)  // AutoclosureExpr convert from Int to ()->Int
 /// \endcode
+///
+///  They are also created when key path expressions are converted to function
+///  type, in which case, a pair of nested implicit closures are formed:
+/// \code
+///   { $kp$ in { $0[keyPath: $kp$] } }( \(E) )
+/// \endcode
+/// This is to ensure side effects of the key path expression (mainly indices in
+/// subscripts) are only evaluated once.
 class AutoClosureExpr : public AbstractClosureExpr {
   BraceStmt *Body;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4451,11 +4451,10 @@ namespace {
           FunctionType::get({ FunctionType::Param(baseTy) }, leafTy);
       auto closure = new (ctx)
           AutoClosureExpr(E, leafTy, discriminator, cs.DC);
-      auto param = new (ctx)
-          ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
-                    /*argument label*/ SourceLoc(), Identifier(),
-                    /*parameter name*/ SourceLoc(), ctx.getIdentifier("$0"),
-                    closure);
+      auto param = new (ctx) ParamDecl(
+          ParamDecl::Specifier::Default, SourceLoc(),
+          /*argument label*/ SourceLoc(), Identifier(),
+          /*parameter name*/ SourceLoc(), ctx.getIdentifier("$0"), closure);
       param->setType(baseTy);
       param->setInterfaceType(baseTy->mapTypeOutOfContext());
 
@@ -4466,11 +4465,11 @@ namespace {
           FunctionType::get({ FunctionType::Param(keyPathTy) }, closureTy);
       auto outerClosure = new (ctx)
           AutoClosureExpr(closure, closureTy, discriminator, cs.DC);
-      auto outerParam = new (ctx)
-          ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
-                    /*argument label*/ SourceLoc(), Identifier(),
-                    /*parameter name*/ SourceLoc(), ctx.getIdentifier("$kp$"),
-                    outerClosure);
+      auto outerParam =
+          new (ctx) ParamDecl(ParamDecl::Specifier::Default, SourceLoc(),
+                              /*argument label*/ SourceLoc(), Identifier(),
+                              /*parameter name*/ SourceLoc(),
+                              ctx.getIdentifier("$kp$"), outerClosure);
       outerParam->setType(keyPathTy);
       outerParam->setInterfaceType(keyPathTy->mapTypeOutOfContext());
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4199,9 +4199,18 @@ namespace {
 
       // Resolve each of the components.
       bool didOptionalChain = false;
-      auto keyPathTy = cs.getType(E)->castTo<BoundGenericType>();
-      Type baseTy = keyPathTy->getGenericArgs()[0];
-      Type leafTy = keyPathTy->getGenericArgs()[1];
+      bool isFunctionType = false;
+      Type baseTy, leafTy;
+      Type exprType = cs.getType(E);
+      if (auto fnTy = exprType->getAs<FunctionType>()) {
+        baseTy = fnTy->getParams()[0].getPlainType();
+        leafTy = fnTy->getResult();
+        isFunctionType = true;
+      } else {
+        auto keyPathTy = exprType->castTo<BoundGenericType>();
+        baseTy = keyPathTy->getGenericArgs()[0];
+        leafTy = keyPathTy->getGenericArgs()[1];
+      }
 
       // Updates the constraint system with the type of the last resolved
       // component. We do it this way because we sometimes insert new
@@ -4406,7 +4415,46 @@ namespace {
       // key path.
       assert(!baseTy || baseTy->hasUnresolvedType()
              || baseTy->getWithoutSpecifierType()->isEqual(leafTy));
-      return E;
+
+      if (!isFunctionType)
+        return E;
+
+      // Construct an implicit closure which applies this KeyPath.
+      auto resultTy = cs.getType(E);
+      auto &ctx = cs.getASTContext();
+      auto toFunc = exprType->getAs<FunctionType>();
+      auto argTy = toFunc->getParams()[0].getPlainType();
+      auto discriminator = AutoClosureExpr::InvalidDiscriminator;
+      auto closure = new (ctx)
+          AutoClosureExpr(E, toFunc->getResult(), discriminator, cs.DC);
+      auto param = new (ctx) ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
+                                       SourceLoc(), Identifier(), SourceLoc(),
+                                       ctx.getIdentifier("$0"), closure);
+      param->setType(argTy);
+      param->setInterfaceType(argTy->mapTypeOutOfContext());
+      auto *paramRef = new (ctx)
+          DeclRefExpr(param, DeclNameLoc(E->getLoc()), /*Implicit=*/true);
+      paramRef->setType(argTy);
+      cs.cacheType(paramRef);
+
+      if (resultTy->is<FunctionType>()) {
+        auto kpDecl = cs.getASTContext().getKeyPathDecl();
+        E->setType(BoundGenericType::get(kpDecl, nullptr,
+                                         {argTy, toFunc->getResult()}));
+        cs.cacheType(E);
+      }
+      auto *application = new (ctx)
+          KeyPathApplicationExpr(paramRef, E->getStartLoc(), E, E->getEndLoc(),
+                                 toFunc->getResult(), /*implicit=*/true);
+      cs.cacheType(application);
+      closure->setParameterList(ParameterList::create(ctx, {param}));
+      closure->setBody(application);
+
+      if (!resultTy->is<FunctionType>())
+        resultTy = toFunc->withExtInfo(toFunc->getExtInfo().withThrows(false));
+      closure->setType(resultTy);
+      cs.cacheType(closure);
+      return coerceToType(closure, exprType, cs.getConstraintLocator(E));
     }
 
     KeyPathExpr::Component

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1060,7 +1060,7 @@ namespace {
 
       // Add the member constraint for a subscript declaration.
       // FIXME: weak name!
-      auto memberTy = CS.createTypeVariable(resultLocator, TVO_CanBindToNoEscape);
+      auto memberTy = CS.createTypeVariable(memberLocator, TVO_CanBindToNoEscape);
 
       // FIXME: synthesizeMaterializeForSet() wants to statically dispatch to
       // a known subscript here. This might be cleaner if we split off a new

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3065,7 +3065,7 @@ namespace {
       auto rvalueBase = CS.createTypeVariable(baseLocator,
                                               TVO_CanBindToNoEscape);
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
-      
+
       // The result is a KeyPath from the root to the end component.
       Type kpTy;
       if (didOptionalChain) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3067,18 +3067,12 @@ namespace {
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
 
       // The result is a KeyPath from the root to the end component.
-      Type kpTy;
-      if (didOptionalChain) {
-        // Optional-chaining key paths are always read-only.
-        kpTy = BoundGenericType::get(kpDecl, Type(), {root, rvalueBase});
-      } else {
-        // The type of key path depends on the overloads chosen for the key
-        // path components.
-        auto typeLoc =
-            CS.getConstraintLocator(locator, ConstraintLocator::KeyPathType);
-        kpTy = CS.createTypeVariable(typeLoc, TVO_CanBindToNoEscape);
-        CS.addKeyPathConstraint(kpTy, root, rvalueBase, locator);
-      }
+      // The type of key path depends on the overloads chosen for the key
+      // path components.
+      auto typeLoc =
+          CS.getConstraintLocator(locator, ConstraintLocator::KeyPathType);
+      Type kpTy = CS.createTypeVariable(typeLoc, TVO_CanBindToNoEscape);
+      CS.addKeyPathConstraint(kpTy, root, rvalueBase, locator);
       return kpTy;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3013,7 +3013,7 @@ namespace {
                 
         case KeyPathExpr::Component::Kind::OptionalChain: {
           didOptionalChain = true;
-          
+
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
           auto rvalueTy = CS.createTypeVariable(resultLocator,
@@ -3027,10 +3027,9 @@ namespace {
           auto optionalObjTy = CS.createTypeVariable(resultLocator,
                                                      TVO_CanBindToLValue |
                                                      TVO_CanBindToNoEscape);
-          
+
           CS.addConstraint(ConstraintKind::OptionalObject, base, optionalObjTy,
                            resultLocator);
-          
           base = optionalObjTy;
           break;
         }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1104,6 +1104,17 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
         ++score1;
       continue;
     }
+
+    // If one is a function type and the other is a key path, prefer the other.
+    if (type1->is<FunctionType>() != type2->is<FunctionType>()) {
+      auto anyKeyPathTy =
+          cs.DC->getASTContext().getAnyKeyPathDecl()->getDeclaredType();
+
+      if (tc.isSubtypeOf(type1, anyKeyPathTy, cs.DC))
+        ++score1;
+      else if (tc.isSubtypeOf(type2, anyKeyPathTy, cs.DC))
+        ++score2;
+    }
     
     // FIXME:
     // This terrible hack is in place to support equality comparisons of non-

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1105,17 +1105,6 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       continue;
     }
 
-    // If one is a function type and the other is a key path, prefer the other.
-    if (type1->is<FunctionType>() != type2->is<FunctionType>()) {
-      auto anyKeyPathTy =
-          cs.DC->getASTContext().getAnyKeyPathDecl()->getDeclaredType();
-
-      if (tc.isSubtypeOf(type1, anyKeyPathTy, cs.DC))
-        ++score1;
-      else if (tc.isSubtypeOf(type2, anyKeyPathTy, cs.DC))
-        ++score2;
-    }
-    
     // FIXME:
     // This terrible hack is in place to support equality comparisons of non-
     // equatable option types to 'nil'. Until we have a way to constrain a type

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5584,6 +5584,25 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
     }
   }
 
+  // If we're bound to a (Root) -> Value function type, use that for context.
+  if (auto fnTy = keyPathTy->getAs<FunctionType>()) {
+    if (fnTy->getParams().size() == 1) {
+      Type boundRoot = fnTy->getParams()[0].getPlainType();
+      Type boundValue = fnTy->getResult();
+
+      if (matchTypes(boundRoot, rootTy, ConstraintKind::Bind, subflags, locator)
+              .isFailure())
+        return SolutionKind::Error;
+
+      if (matchTypes(boundValue, valueTy, ConstraintKind::Bind, subflags,
+                     locator)
+              .isFailure())
+        return SolutionKind::Error;
+
+      return SolutionKind::Solved;
+    }
+  }
+
   // See if we resolved overloads for all the components involved.
   enum {
     ReadOnly,
@@ -5711,11 +5730,16 @@ done:
   
   auto resolvedKPTy = BoundGenericType::get(kpDecl, nullptr,
                                             {rootTy, valueTy});
-  // Let's check whether deduced key path type would match
-  // expected contextual one.
-  return matchTypes(
-      resolvedKPTy, keyPathTy, ConstraintKind::Bind, subflags,
-      locator.withPathElement(LocatorPathElt::getContextualType()));
+  Type fnType = FunctionType::get({AnyFunctionType::Param(rootTy)}, valueTy,
+                                  AnyFunctionType::ExtInfo().withThrows(false));
+  llvm::SmallVector<Constraint *, 2> constraints;
+  auto loc = locator.getBaseLocator();
+  constraints.push_back(Constraint::create(*this, ConstraintKind::Bind,
+                                           keyPathTy, resolvedKPTy, loc));
+  constraints.push_back(
+      Constraint::create(*this, ConstraintKind::Bind, keyPathTy, fnType, loc));
+  addDisjunctionConstraint(constraints, locator);
+  return SolutionKind::Solved;
 }
 
 ConstraintSystem::SolutionKind

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -201,7 +201,8 @@ enum class ConversionRestrictionKind {
   MetatypeToExistentialMetatype,
   /// Existential metatype to metatype conversion.
   ExistentialMetatypeToMetatype,
-  /// T -> U? value to optional conversion (or to implicitly unwrapped optional).
+  /// T -> U? value to optional conversion (or to implicitly unwrapped
+  /// optional).
   ValueToOptional,
   /// T? -> U? optional to optional conversion (or unchecked to unchecked).
   OptionalToOptional,
@@ -219,7 +220,7 @@ enum class ConversionRestrictionKind {
   CFTollFreeBridgeToObjC,
   /// Implicit conversion from an Objective-C class type to its
   /// toll-free-bridged CF type.
-  ObjCTollFreeBridgeToCF
+  ObjCTollFreeBridgeToCF,
 };
 
 /// Return a string representation of a conversion restriction.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -475,7 +475,7 @@ func g_2994(arg: Int) -> Double {
 }
 C_2994<S_2994>(arg: { (r: S_2994) in f_2994(arg: g_2994(arg: r.dataOffset)) }) // expected-error {{cannot convert value of type 'Double' to expected argument type 'String'}}
 
-let _ = { $0[$1] }(1, 1) // expected-error {{cannot subscript a value of incorrect or ambiguous type}}
+let _ = { $0[$1] }(1, 1) // expected-error {{value of type 'Int' has no subscripts}}
 let _ = { $0 = ($0 = {}) } // expected-error {{assigning a variable to itself}}
 let _ = { $0 = $0 = 42 } // expected-error {{assigning a variable to itself}}
 

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -35,3 +35,12 @@ let some = Some(keyPath: \Demo.here)
 // expected-note@-2 {{arguments to generic parameter 'Value' ('(() -> Void)?' and '((Any) -> Void)?') are expected to be equal}}
 // expected-error@-3 {{generic parameter 'V' could not be inferred}}
 // expected-note@-4 {{explicitly specify the generic arguments to fix this issue}}
+
+// SE-0249
+func testFunc() {
+  let _: (S) -> Int = \.i
+  _ = ([S]()).map(\.i)
+  _ = ([S]()).map(\.init)
+  // expected-error@-1 {{static member 'init' cannot be used on instance of type 'S'}}
+}
+>>>>>>> Add typechecking tests

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -40,7 +40,10 @@ let some = Some(keyPath: \Demo.here)
 func testFunc() {
   let _: (S) -> Int = \.i
   _ = ([S]()).map(\.i)
+
+  // FIXME: A terrible error, but the same as the pre-existing key path
+  // error in the similar situation: 'let _ = \S.init'.
   _ = ([S]()).map(\.init)
-  // expected-error@-1 {{static member 'init' cannot be used on instance of type 'S'}}
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
 }
 >>>>>>> Add typechecking tests

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -51,4 +51,3 @@ func testFunc() {
   let f = \S.i
   let _: (S) -> Int = f // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type '(S) -> Int'}}
 }
->>>>>>> Add typechecking tests

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -45,5 +45,10 @@ func testFunc() {
   // error in the similar situation: 'let _ = \S.init'.
   _ = ([S]()).map(\.init)
   // expected-error@-1 {{type of expression is ambiguous without more context}}
+
+  let kp = \S.i
+  let _: KeyPath<S, Int> = kp // works, because type defaults to KeyPath nominal
+  let f = \S.i
+  let _: (S) -> Int = f // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type '(S) -> Int'}}
 }
 >>>>>>> Add typechecking tests

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -465,7 +465,7 @@ struct Outer {
 }
 
 // rdar://problem/39514009 - don't crash when trying to diagnose members with special names
-print("hello")[0] // expected-error {{value of tuple type '()' has no member 'subscript'}}
+print("hello")[0] // expected-error {{value of type '()' has no subscripts}}
 
 
 func rdar40537782() {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -135,8 +135,9 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]
+  // FIXME: should be convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>}}
+  // expected-error@+1{{ambiguous}}
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
-  // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>}}
 
   let _: (A) -> Prop? = \.optProperty?
   let _: PartialKeyPath<A> = \.optProperty?

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -130,8 +130,6 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, Prop>' to specified type 'ReferenceWritableKeyPath<A, Prop>'}}
 
   let _: (A) -> A = \.[sub]
-  // FIXME: shouldn't be ambiguous
-  // expected-error@+1{{ambiguous}}
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -135,9 +135,8 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]
-  // FIXME: should be convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>}}
-  // expected-error@+1{{ambiguous}}
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
+  //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>'}}
 
   let _: (A) -> Prop? = \.optProperty?
   let _: PartialKeyPath<A> = \.optProperty?

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -122,18 +122,23 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   // expected-error@+1{{}}
   _ = \(() -> ()).noMember
 
+  let _: (A) -> Prop = \.property
   let _: PartialKeyPath<A> = \.property
   let _: KeyPath<A, Prop> = \.property
   let _: WritableKeyPath<A, Prop> = \.property
   let _: ReferenceWritableKeyPath<A, Prop> = \.property
   //expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, Prop>' to specified type 'ReferenceWritableKeyPath<A, Prop>'}}
 
+  let _: (A) -> A = \.[sub]
+  // FIXME: shouldn't be ambiguous
+  // expected-error@+1{{ambiguous}}
   let _: PartialKeyPath<A> = \.[sub]
   let _: KeyPath<A, A> = \.[sub]
   let _: WritableKeyPath<A, A> = \.[sub]
   let _: ReferenceWritableKeyPath<A, A> = \.[sub]
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<A, A>' to specified type 'ReferenceWritableKeyPath<A, A>}}
 
+  let _: (A) -> Prop? = \.optProperty?
   let _: PartialKeyPath<A> = \.optProperty?
   let _: KeyPath<A, Prop?> = \.optProperty?
   // expected-error@+1{{cannot convert}}
@@ -141,6 +146,7 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<A, Prop?> = \.optProperty?
 
+  let _: (A) -> A? = \.optProperty?[sub]
   let _: PartialKeyPath<A> = \.optProperty?[sub]
   let _: KeyPath<A, A?> = \.optProperty?[sub]
   // expected-error@+1{{cannot convert}}
@@ -153,18 +159,21 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _: KeyPath<A, Prop?> = \.property[optSub]?.optProperty!
   let _: KeyPath<A, A?> = \.property[optSub]?.optProperty![sub]
 
+  let _: (C<A>) -> A = \.value
   let _: PartialKeyPath<C<A>> = \.value
   let _: KeyPath<C<A>, A> = \.value
   let _: WritableKeyPath<C<A>, A> = \.value
   let _: ReferenceWritableKeyPath<C<A>, A> = \.value
   // expected-error@-1 {{cannot convert value of type 'WritableKeyPath<C<A>, A>' to specified type 'ReferenceWritableKeyPath<C<A>, A>'}}
 
+  let _: (C<A>) -> A = \C.value
   let _: PartialKeyPath<C<A>> = \C.value
   let _: KeyPath<C<A>, A> = \C.value
   let _: WritableKeyPath<C<A>, A> = \C.value
   // expected-error@+1{{cannot convert}}
   let _: ReferenceWritableKeyPath<C<A>, A> = \C.value
 
+  let _: (Prop) -> B = \.nonMutatingProperty
   let _: PartialKeyPath<Prop> = \.nonMutatingProperty
   let _: KeyPath<Prop, B> = \.nonMutatingProperty
   let _: WritableKeyPath<Prop, B> = \.nonMutatingProperty
@@ -704,6 +713,8 @@ var identity8: PartialKeyPath = \Container.self
 var identity9: PartialKeyPath<Container> = \Container.self
 var identity10: PartialKeyPath<Container> = \.self
 var identity11: AnyKeyPath = \Container.self
+var identity12: (Container) -> Container = \Container.self
+var identity13: (Container) -> Container = \.self
 
 var interleavedIdentityComponents = \Container.self.base.self?.self.i.self
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -926,6 +926,52 @@ keyPath.test("let-ness") {
   expectNotNil(\Point.secretlyMutableHypotenuse as? WritableKeyPath)
 }
 
+keyPath.test("key path literal closures") {
+  // Property access
+  let fnX: (C<String>) -> Int = \C<String>.x
+  let fnY: (C<String>) -> LifetimeTracked? = \C<String>.y
+  let fnZ: (C<String>) -> String = \C<String>.z
+  let fnImmutable: (C<String>) -> String = \C<String>.immutable
+  let fnSecretlyMutable: (C<String>) -> String = \C<String>.secretlyMutable
+  let fnComputed: (C<String>) -> String = \C<String>.computed
+  
+  let lifetime = LifetimeTracked(249)
+  let base = C(x: 1, y: lifetime, z: "SE-0249")
+
+  expectEqual(1, fnX(base))
+  expectEqual(lifetime, fnY(base))
+  expectEqual("SE-0249", fnZ(base))
+  expectEqual("1 Optional(249) SE-0249", fnImmutable(base))
+  expectEqual("1 Optional(249) SE-0249", fnSecretlyMutable(base))
+  expectEqual("SE-0249", fnComputed(base))
+  
+  // Subscripts
+  var callsToComputeIndex = 0
+  func computeIndexWithSideEffect(_ i: Int) -> Int {
+    callsToComputeIndex += 1
+    return -i
+  }
+  
+  let fnSubscriptResultA: (Subscripts<String>) -> SubscriptResult<String, Int>
+    = \Subscripts<String>.["A", computeIndexWithSideEffect(13)]
+  let fnSubscriptResultB: (Subscripts<String>) -> SubscriptResult<String, Int>
+    = \Subscripts<String>.["B", computeIndexWithSideEffect(42)]
+  
+  let subscripts = Subscripts<String>()
+  
+  expectEqual("A", fnSubscriptResultA(subscripts).left)
+  expectEqual(-13, fnSubscriptResultA(subscripts).right)
+  
+  expectEqual("B", fnSubscriptResultB(subscripts).left)
+  expectEqual(-42, fnSubscriptResultB(subscripts).right)
+  
+  // Did we compute the indices once per closure construction, or once per
+  // closure application?
+  // FIXME: Currently fails.
+  // expectEqual(2, callsToComputeIndex)
+  expectEqual(4, callsToComputeIndex)
+}
+
 // SR-6096
 
 protocol Protocol6096 {}

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -967,9 +967,7 @@ keyPath.test("key path literal closures") {
   
   // Did we compute the indices once per closure construction, or once per
   // closure application?
-  // FIXME: Currently fails.
-  // expectEqual(2, callsToComputeIndex)
-  expectEqual(4, callsToComputeIndex)
+  expectEqual(2, callsToComputeIndex)
 }
 
 // SR-6096


### PR DESCRIPTION
This builds on @brentdax's work in https://github.com/apple/swift/pull/23435 to handle optional chaining key paths as both KeyPath BGTs and as function types, and also does away with explicit disjunctions to determine which kind of type to turn the key path literal into, so ought to be more performant.

There is a single test diagnosis that gets worse here (a contextual type which matches root/value but specifies an incorrect writability is now ambiguous because the diagnostic path goes into the old CSDiag stuff, and the first step is to discard contextual type, and then the remainder is entirely ambiguous). The solution is future work to improve key path diagnoses in general, I think.