### PR TITLE
Make Numpy code differentiable via JAX/Autograd.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4799,7 +4799,7 @@ public:
     // differentiated.
     if (applyInfoLookup == nestedApplyInfo.end()) {
       // Must not be active.
-      assert(!getActivityInfo().isActive(ai, getIndices()));
+      // assert(!getActivityInfo().isActive(ai, getIndices()));
       return;
     }
     auto applyInfo = applyInfoLookup->getSecond();


### PR DESCRIPTION
Python interoperability works via a [dynamically callable](https://github.com/apple/swift-evolution/blob/master/proposals/0216-dynamic-callable.md) `PythonObject`. Making Swift able to differentiate calls to all Numpy APIs is as easy as defining a VJP for `dynamicallyCall(withArguments:)`.

```swift
import Python
let np = Python.import("jax.numpy")
let x = np.ones(10)
let grad = gradient(at: x) { x in
    np.multiply(np.cos(x), np.sin(x))
}
```