### PR TITLE
[5.1] [Parse] Implement "missing 'func' keyword" diagnostic with a fix-it

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -213,7 +213,7 @@ ERROR(expected_decl,none,
 ERROR(expected_identifier_in_decl,none,
       "expected identifier in %0 declaration", (StringRef))
 ERROR(expected_keyword_in_decl,none,
-      "expected '%0' keyword in %1 declaration", (StringRef, StringRef))
+      "expected '%0' keyword in %1 declaration", (StringRef, DescriptiveDeclKind))
 ERROR(number_cant_start_decl_name,none,
       "%0 name can only start with a letter or underscore, not a number",
       (StringRef))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -212,6 +212,8 @@ ERROR(expected_decl,none,
       "expected declaration", ())
 ERROR(expected_identifier_in_decl,none,
       "expected identifier in %0 declaration", (StringRef))
+ERROR(expected_keyword_in_decl,none,
+      "expected '%0' keyword in %1 declaration", (StringRef, StringRef))
 ERROR(number_cant_start_decl_name,none,
       "%0 name can only start with a letter or underscore, not a number",
       (StringRef))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -867,6 +867,7 @@ public:
   }
 
   ParserResult<Decl> parseDecl(ParseDeclOptions Flags,
+                               bool IsAtStartOfLineOrPreviousHadSemi,
                                llvm::function_ref<void(Decl*)> Handler);
 
   void parseDeclDelayed();
@@ -992,7 +993,8 @@ public:
                SmallVectorImpl<Decl *> &Decls,
                SourceLoc StaticLoc,
                StaticSpellingKind StaticSpelling,
-               SourceLoc TryLoc);
+               SourceLoc TryLoc,
+               bool HasLetOrVarKeyword = true);
 
   void consumeGetSetBody(AbstractFunctionDecl *AFD, SourceLoc LBLoc);
 
@@ -1020,7 +1022,8 @@ public:
   ParserResult<FuncDecl> parseDeclFunc(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        ParseDeclOptions Flags,
-                                       DeclAttributes &Attributes);
+                                       DeclAttributes &Attributes,
+                                       bool HasFuncKeyword = true);
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
   bool parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3014,15 +3014,15 @@ Parser::parseDecl(ParseDeclOptions Flags,
         DescriptiveDeclKind DescriptiveKind;
 
         switch (StaticSpelling) {
-          case StaticSpellingKind::None:
-            DescriptiveKind = DescriptiveDeclKind::Property;
-            break;
-          case StaticSpellingKind::KeywordStatic:
-            DescriptiveKind = DescriptiveDeclKind::StaticProperty;
-            break;
-          case StaticSpellingKind::KeywordClass:
-            llvm_unreachable("kw_class is only parsed as a modifier if it's "
-                             "followed by a keyword");
+        case StaticSpellingKind::None:
+          DescriptiveKind = DescriptiveDeclKind::Property;
+          break;
+        case StaticSpellingKind::KeywordStatic:
+          DescriptiveKind = DescriptiveDeclKind::StaticProperty;
+          break;
+        case StaticSpellingKind::KeywordClass:
+          llvm_unreachable("kw_class is only parsed as a modifier if it's "
+                           "followed by a keyword");
         }
 
         diagnose(Tok.getLoc(), diag::expected_keyword_in_decl, "var",
@@ -3043,15 +3043,15 @@ Parser::parseDecl(ParseDeclOptions Flags,
           DescriptiveKind = DescriptiveDeclKind::OperatorFunction;
         } else {
           switch (StaticSpelling) {
-            case StaticSpellingKind::None:
-              DescriptiveKind = DescriptiveDeclKind::Method;
-              break;
-            case StaticSpellingKind::KeywordStatic:
-              DescriptiveKind = DescriptiveDeclKind::StaticMethod;
-              break;
-            case StaticSpellingKind::KeywordClass:
-              llvm_unreachable("kw_class is only parsed as a modifier if it's "
-                               "followed by a keyword");
+          case StaticSpellingKind::None:
+            DescriptiveKind = DescriptiveDeclKind::Method;
+            break;
+          case StaticSpellingKind::KeywordStatic:
+            DescriptiveKind = DescriptiveDeclKind::StaticMethod;
+            break;
+          case StaticSpellingKind::KeywordClass:
+            llvm_unreachable("kw_class is only parsed as a modifier if it's "
+                             "followed by a keyword");
           }
         }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3002,15 +3002,25 @@ Parser::parseDecl(ParseDeclOptions Flags,
       // Must not confuse it with trailing closure syntax, so we only
       // recover in contexts where there can be no statements.
 
-      if ((Tok.isIdentifierOrUnderscore() &&
-           peekToken().isAny(tok::colon, tok::equal, tok::comma)) ||
-          Tok.is(tok::l_paren)) {
+      const bool IsProbablyVarDecl =
+          Tok.isIdentifierOrUnderscore() &&
+          peekToken().isAny(tok::colon, tok::equal, tok::comma);
+
+      const bool IsProbablyTupleDecl =
+          Tok.is(tok::l_paren) && peekToken().isIdentifierOrUnderscore();
+
+      if (IsProbablyVarDecl || IsProbablyTupleDecl) {
         diagnose(Tok.getLoc(), diag::expected_keyword_in_decl, "var",
                  "property")
             .fixItInsert(Tok.getLoc(), "var ");
         parseLetOrVar(/*HasLetOrVarKeyword=*/false);
         break;
-      } else if (Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator()) {
+      }
+
+      const bool IsProbablyFuncDecl =
+          Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator();
+
+      if (IsProbablyFuncDecl) {
         diagnose(Tok.getLoc(), diag::expected_keyword_in_decl, "func",
                  "function")
             .fixItInsert(Tok.getLoc(), "func ");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -2766,6 +2766,7 @@ void Parser::delayParseFromBeginningToHere(ParserPosition BeginParserPosition,
 /// \endverbatim
 ParserResult<Decl>
 Parser::parseDecl(ParseDeclOptions Flags,
+                  bool IsAtStartOfLineOrPreviousHadSemi,
                   llvm::function_ref<void(Decl*)> Handler) {
   ParserPosition BeginParserPosition;
   if (isCodeCompletionFirstPass())
@@ -2854,6 +2855,30 @@ Parser::parseDecl(ParseDeclOptions Flags,
   auto OrigTok = Tok;
   bool MayNeedOverrideCompletion = false;
 
+  auto parseLetOrVar = [&](bool HasLetOrVarKeyword) {
+    // Collect all modifiers into a modifier list.
+    DeclParsingContext.setCreateSyntax(SyntaxKind::VariableDecl);
+    llvm::SmallVector<Decl *, 4> Entries;
+    DeclResult = parseDeclVar(Flags, Attributes, Entries, StaticLoc,
+                              StaticSpelling, tryLoc, HasLetOrVarKeyword);
+    StaticLoc = SourceLoc(); // we handled static if present.
+    MayNeedOverrideCompletion = true;
+    if (DeclResult.hasCodeCompletion() && isCodeCompletionFirstPass())
+      return;
+    std::for_each(Entries.begin(), Entries.end(), Handler);
+    if (auto *D = DeclResult.getPtrOrNull())
+      markWasHandled(D);
+  };
+
+  auto parseFunc = [&](bool HasFuncKeyword) {
+    // Collect all modifiers into a modifier list.
+    DeclParsingContext.setCreateSyntax(SyntaxKind::FunctionDecl);
+    DeclResult = parseDeclFunc(StaticLoc, StaticSpelling, Flags, Attributes,
+                               HasFuncKeyword);
+    StaticLoc = SourceLoc(); // we handled static if present.
+    MayNeedOverrideCompletion = true;
+  };
+
   switch (Tok.getKind()) {
   case tok::kw_import:
     DeclParsingContext.setCreateSyntax(SyntaxKind::ImportDecl);
@@ -2865,18 +2890,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     break;
   case tok::kw_let:
   case tok::kw_var: {
-    // Collect all modifiers into a modifier list.
-    DeclParsingContext.setCreateSyntax(SyntaxKind::VariableDecl);
-    llvm::SmallVector<Decl *, 4> Entries;
-    DeclResult = parseDeclVar(Flags, Attributes, Entries, StaticLoc,
-                              StaticSpelling, tryLoc);
-    StaticLoc = SourceLoc(); // we handled static if present.
-    MayNeedOverrideCompletion = true;
-    if (DeclResult.hasCodeCompletion() && isCodeCompletionFirstPass())
-      break;
-    std::for_each(Entries.begin(), Entries.end(), Handler);
-    if (auto *D = DeclResult.getPtrOrNull())
-      markWasHandled(D);
+    parseLetOrVar(/*HasLetOrVarKeyword=*/true);
     break;
   }
   case tok::kw_typealias:
@@ -2932,11 +2946,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     DeclResult = parseDeclProtocol(Flags, Attributes);
     break;
   case tok::kw_func:
-    // Collect all modifiers into a modifier list.
-    DeclParsingContext.setCreateSyntax(SyntaxKind::FunctionDecl);
-    DeclResult = parseDeclFunc(StaticLoc, StaticSpelling, Flags, Attributes);
-    StaticLoc = SourceLoc(); // we handled static if present.
-    MayNeedOverrideCompletion = true;
+    parseFunc(/*HasFuncKeyword=*/true);
     break;
   case tok::kw_subscript: {
     DeclParsingContext.setCreateSyntax(SyntaxKind::SubscriptDecl);
@@ -2982,6 +2992,33 @@ Parser::parseDecl(ParseDeclOptions Flags,
 
   // Obvious nonsense.
   default:
+
+    if (Flags.contains(PD_HasContainerType) &&
+        IsAtStartOfLineOrPreviousHadSemi) {
+
+      // Emit diagnostics if we meet an identifier/operator where a declaration
+      // is expected, perhaps the user forgot the 'func' or 'var' keyword.
+      //
+      // Must not confuse it with trailing closure syntax, so we only
+      // recover in contexts where there can be no statements.
+
+      if ((Tok.isIdentifierOrUnderscore() &&
+           peekToken().isAny(tok::colon, tok::equal, tok::comma)) ||
+          Tok.is(tok::l_paren)) {
+        diagnose(Tok.getLoc(), diag::expected_keyword_in_decl, "var",
+                 "property")
+            .fixItInsert(Tok.getLoc(), "var ");
+        parseLetOrVar(/*HasLetOrVarKeyword=*/false);
+        break;
+      } else if (Tok.isIdentifierOrUnderscore() || Tok.isAnyOperator()) {
+        diagnose(Tok.getLoc(), diag::expected_keyword_in_decl, "func",
+                 "function")
+            .fixItInsert(Tok.getLoc(), "func ");
+        parseFunc(/*HasFuncKeyword=*/false);
+        break;
+      }
+    }
+
     diagnose(Tok, diag::expected_decl);
 
     if (CurDeclContext) {
@@ -3166,7 +3203,9 @@ void Parser::parseDeclDelayed() {
   Scope S(this, DelayedState->takeScope());
   ContextChange CC(*this, DelayedState->ParentContext);
 
-  parseDecl(ParseDeclOptions(DelayedState->Flags), [&](Decl *D) {
+  parseDecl(ParseDeclOptions(DelayedState->Flags),
+            /*IsAtStartOfLineOrPreviousHadSemi=*/true,
+            [&](Decl *D) {
     if (auto *parent = DelayedState->ParentContext) {
       if (auto *NTD = dyn_cast<NominalTypeDecl>(parent)) {
         NTD->addMember(D);
@@ -3515,7 +3554,9 @@ ParserStatus Parser::parseDeclItem(bool &PreviousHadSemi,
 
   // If the previous declaration didn't have a semicolon and this new
   // declaration doesn't start a line, complain.
-  if (!PreviousHadSemi && !Tok.isAtStartOfLine() && !Tok.is(tok::unknown)) {
+  const bool IsAtStartOfLineOrPreviousHadSemi =
+      PreviousHadSemi || Tok.isAtStartOfLine() || Tok.is(tok::unknown);
+  if (!IsAtStartOfLineOrPreviousHadSemi) {
     auto endOfPrevious = getEndOfPreviousLoc();
     diagnose(endOfPrevious, diag::declaration_same_line_without_semi)
       .fixItInsert(endOfPrevious, ";");
@@ -3534,7 +3575,7 @@ ParserStatus Parser::parseDeclItem(bool &PreviousHadSemi,
   if (loadCurrentSyntaxNodeFromCache()) {
     return ParserStatus();
   }
-  Result = parseDecl(Options, handler);
+  Result = parseDecl(Options, IsAtStartOfLineOrPreviousHadSemi, handler);
   if (Result.isParseError())
     skipUntilDeclRBrace(tok::semi, tok::pound_endif);
   SourceLoc SemiLoc;
@@ -5179,7 +5220,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
                      SmallVectorImpl<Decl *> &Decls,
                      SourceLoc StaticLoc,
                      StaticSpellingKind StaticSpelling,
-                     SourceLoc TryLoc) {
+                     SourceLoc TryLoc,
+                     bool HasLetOrVarKeyword) {
   assert(StaticLoc.isInvalid() || StaticSpelling != StaticSpellingKind::None);
 
   if (StaticLoc.isValid()) {
@@ -5197,9 +5239,11 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     }
   }
 
-  bool isLet = Tok.is(tok::kw_let);
-  assert(Tok.getKind() == tok::kw_let || Tok.getKind() == tok::kw_var);
-  SourceLoc VarLoc = consumeToken();
+  bool isLet = HasLetOrVarKeyword && Tok.is(tok::kw_let);
+  assert(!HasLetOrVarKeyword || Tok.getKind() == tok::kw_let ||
+         Tok.getKind() == tok::kw_var);
+
+  SourceLoc VarLoc = HasLetOrVarKeyword ? consumeToken() : Tok.getLoc();
 
   // If this is a var in the top-level of script/repl source file, wrap the
   // PatternBindingDecl in a TopLevelCodeDecl, since it represents executable
@@ -5509,9 +5553,11 @@ void Parser::consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
 /// \endverbatim
 ///
 /// \note The caller of this method must ensure that the next token is 'func'.
-ParserResult<FuncDecl>
-Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
-                      ParseDeclOptions Flags, DeclAttributes &Attributes) {
+ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
+                                             StaticSpellingKind StaticSpelling,
+                                             ParseDeclOptions Flags,
+                                             DeclAttributes &Attributes,
+                                             bool HasFuncKeyword) {
   assert(StaticLoc.isInvalid() || StaticSpelling != StaticSpellingKind::None);
 
   if (StaticLoc.isValid()) {
@@ -5533,7 +5579,8 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     }
   }
 
-  SourceLoc FuncLoc = consumeToken(tok::kw_func);
+  SourceLoc FuncLoc =
+      HasFuncKeyword ? consumeToken(tok::kw_func) : Tok.getLoc();
 
   // Parse function name.
   Identifier SimpleName;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -356,7 +356,9 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
     // If the previous statement didn't have a semicolon and this new
     // statement doesn't start a line, complain.
-    if (!PreviousHadSemi && !Tok.isAtStartOfLine()) {
+    const bool IsAtStartOfLineOrPreviousHadSemi =
+        PreviousHadSemi || Tok.isAtStartOfLine();
+    if (!IsAtStartOfLineOrPreviousHadSemi) {
       SourceLoc EndOfPreviousLoc = getEndOfPreviousLoc();
       diagnose(EndOfPreviousLoc, diag::statement_same_line_without_semi)
         .fixItInsert(EndOfPreviousLoc, ";");
@@ -410,6 +412,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       SmallVector<Decl*, 8> TmpDecls;
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
+                    IsAtStartOfLineOrPreviousHadSemi,
                     [&](Decl *D) {TmpDecls.push_back(D);});
       BraceItemsStatus |= DeclResult;
       if (DeclResult.isParseError()) {

--- a/test/Parse/ConditionalCompilation/stmt_in_type.swift
+++ b/test/Parse/ConditionalCompilation/stmt_in_type.swift
@@ -8,6 +8,6 @@ struct S1 { // expected-note {{in declaration of 'S1'}}
 #if FOO
   return 1; // expected-error {{expected declaration}}
 #elseif BAR
-  foo(); // expected-error {{expected 'func' keyword in function declaration}}
+  foo(); // expected-error {{expected 'func' keyword in instance method declaration}}
 #endif
 }

--- a/test/Parse/ConditionalCompilation/stmt_in_type.swift
+++ b/test/Parse/ConditionalCompilation/stmt_in_type.swift
@@ -4,10 +4,10 @@
 
 func foo() {}
 
-struct S1 { // expected-note 2 {{in declaration of 'S1'}}
+struct S1 { // expected-note {{in declaration of 'S1'}}
 #if FOO
   return 1; // expected-error {{expected declaration}}
 #elseif BAR
-  foo(); // expected-error {{expected declaration}}
+  foo(); // expected-error {{expected 'func' keyword in function declaration}}
 #endif
 }

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -36,7 +36,7 @@ struct Bar {
   _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
               // expected-error @-1 {{property declaration does not bind any variables}}
 
-  ((x, y), z) = ((1, 2), 3) // expected-error {{expected 'var' keyword in property declaration}}
-
+  (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  
   a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 }

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://bugs.swift.org/browse/SR-10477
+
+protocol Brew { // expected-note {{in declaration of 'Brew'}}
+  tripel() -> Int // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+
+  quadrupel: Int { get } // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+
+  static + (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in function declaration}} {{10-10=func }}
+
+  * (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+                                   // expected-error @-1 {{operator '*' declared in protocol must be 'static'}} {{3-3=static }}
+
+  ipa: Int { get }; apa: Float { get }
+  // expected-error @-1 {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  // expected-error @-2 {{expected 'var' keyword in property declaration}} {{21-21=var }}
+
+  stout: Int { get } porter: Float { get }
+  // expected-error @-1 {{expected 'var' keyword in property declaration}} {{3-3=var }}
+  // expected-error @-2 {{expected declaration}}
+  // expected-error @-3 {{consecutive declarations on a line must be separated by ';'}}
+}
+
+infix operator %%
+
+struct Bar {
+  fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+
+  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+                                      // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
+                                      // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
+    lhs + lhs + rhs + rhs
+  }
+
+  _: Int = 42 // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+              // expected-error @-1 {{property declaration does not bind any variables}}
+
+  ((x, y), z) = ((1, 2), 3) // expected-error {{expected 'var' keyword in property declaration}}
+
+  a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+}

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -51,3 +51,13 @@ class Baz {
 
   static staticProperty: Int { 0 } // expected-error {{expected 'var' keyword in static property declaration}} {{10-10=var }}
 }
+
+class C1 {
+  class classMethod() {} // expected-error {{expected '{' in class}}
+}
+
+class C2 {
+  class classProperty: Int { 0 } // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
+                                 // expected-note @-1 {{in declaration of 'classProperty'}}
+                                 // expected-error @-2 {{expected declaration}}
+}

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -3,13 +3,13 @@
 // https://bugs.swift.org/browse/SR-10477
 
 protocol Brew { // expected-note {{in declaration of 'Brew'}}
-  tripel() -> Int // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+  tripel() -> Int // expected-error {{expected 'func' keyword in instance method declaration}} {{3-3=func }}
 
   quadrupel: Int { get } // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  static + (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in function declaration}} {{10-10=func }}
+  static + (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in operator function declaration}} {{10-10=func }}
 
-  * (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+  * (lhs: Self, rhs: Self) -> Self // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
                                    // expected-error @-1 {{operator '*' declared in protocol must be 'static'}} {{3-3=static }}
 
   ipa: Int { get }; apa: Float { get }
@@ -27,7 +27,7 @@ infix operator %%
 struct Bar {
   fisr = 0x5F3759DF // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
 
-  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in function declaration}} {{3-3=func }}
+  %%<T: Brew> (lhs: T, rhs: T) -> T { // expected-error {{expected 'func' keyword in operator function declaration}} {{3-3=func }}
                                       // expected-error @-1 {{operator '%%' declared in type 'Bar' must be 'static'}}
                                       // expected-error @-2 {{member operator '%%' must have at least one argument of type 'Bar'}}
     lhs + lhs + rhs + rhs
@@ -39,4 +39,15 @@ struct Bar {
   (light, dark) = (100, 200)// expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
   
   a, b: Int // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+}
+
+class Baz {
+
+  instanceMethod() {} // expected-error {{expected 'func' keyword in instance method declaration}} {{3-3=func }}
+
+  static staticMethod() {} // expected-error {{expected 'func' keyword in static method declaration}} {{10-10=func }}
+
+  instanceProperty: Int { 0 } // expected-error {{expected 'var' keyword in property declaration}} {{3-3=var }}
+
+  static staticProperty: Int { 0 } // expected-error {{expected 'var' keyword in static property declaration}} {{10-10=var }}
 }

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -24,6 +24,13 @@ x x // expected-error{{consecutive statements}} {{2-2=;}}
 
 // rdar://19582475
 public struct S { // expected-note{{in declaration of 'S'}}
+// expected-error@+8{{expected 'func' keyword in function declaration}}
+// expected-error@+7{{operator '/' declared in type 'S' must be 'static'}}
+// expected-error@+6{{expected '(' in argument list of function declaration}}
+// expected-error@+5{{operators must have one or two arguments}}
+// expected-error@+4{{member operator '/()' must have at least one argument of type 'S'}}
+// expected-error@+3{{expected '{' in body of function declaration}}
+// expected-error@+2{{consecutive declarations on a line must be separated by ';}}
 // expected-error@+1{{expected declaration}}
 / ###line 25 "line-directive.swift"
 }

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -24,7 +24,7 @@ x x // expected-error{{consecutive statements}} {{2-2=;}}
 
 // rdar://19582475
 public struct S { // expected-note{{in declaration of 'S'}}
-// expected-error@+8{{expected 'func' keyword in function declaration}}
+// expected-error@+8{{expected 'func' keyword in operator function declaration}}
 // expected-error@+7{{operator '/' declared in type 'S' must be 'static'}}
 // expected-error@+6{{expected '(' in argument list of function declaration}}
 // expected-error@+5{{operators must have one or two arguments}}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -542,14 +542,14 @@ func use_BracesInsideNominalDecl1() {
 
 class SR771 {
     print("No one else was in the room where it happened") // expected-note {{'print()' previously declared here}}
-    // expected-error @-1 {{expected 'func' keyword in function declaration}}
+    // expected-error @-1 {{expected 'func' keyword in instance method declaration}}
     // expected-error @-2 {{expected '{' in body of function declaration}}
     // expected-error @-3 {{expected parameter name followed by ':'}}
 }
 
 extension SR771 {
     print("The room where it happened, the room where it happened")
-    // expected-error @-1 {{expected 'func' keyword in function declaration}}
+    // expected-error @-1 {{expected 'func' keyword in instance method declaration}}
     // expected-error @-2 {{invalid redeclaration of 'print()'}}
     // expected-error @-3 {{expected parameter name followed by ':'}}
 }
@@ -558,7 +558,7 @@ extension SR771 {
 //===--- Recovery for wrong decl introducer keyword.
 
 class WrongDeclIntroducerKeyword1 {
-  notAKeyword() {} // expected-error {{expected 'func' keyword in function declaration}}
+  notAKeyword() {} // expected-error {{expected 'func' keyword in instance method declaration}}
   func foo() {}
   class func bar() {}
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -540,19 +540,25 @@ func use_BracesInsideNominalDecl1() {
   var _ : BracesInsideNominalDecl1.A // no-error
 }
 
-class SR771 { // expected-note {{in declaration of 'SR771'}}
-    print("No one else was in the room where it happened") // expected-error {{expected declaration}}
+class SR771 {
+    print("No one else was in the room where it happened") // expected-note {{'print()' previously declared here}}
+    // expected-error @-1 {{expected 'func' keyword in function declaration}}
+    // expected-error @-2 {{expected '{' in body of function declaration}}
+    // expected-error @-3 {{expected parameter name followed by ':'}}
 }
 
-extension SR771 { // expected-note {{in extension of 'SR771'}}
-    print("The room where it happened, the room where it happened") // expected-error {{expected declaration}}
+extension SR771 {
+    print("The room where it happened, the room where it happened")
+    // expected-error @-1 {{expected 'func' keyword in function declaration}}
+    // expected-error @-2 {{invalid redeclaration of 'print()'}}
+    // expected-error @-3 {{expected parameter name followed by ':'}}
 }
 
 
 //===--- Recovery for wrong decl introducer keyword.
 
-class WrongDeclIntroducerKeyword1 { // expected-note{{in declaration of 'WrongDeclIntroducerKeyword1'}}
-  notAKeyword() {} // expected-error {{expected declaration}}
+class WrongDeclIntroducerKeyword1 {
+  notAKeyword() {} // expected-error {{expected 'func' keyword in function declaration}}
   func foo() {}
   class func bar() {}
 }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -505,8 +505,10 @@ func test_recovery_missing_name_2(let: Int) {} // expected-error {{'let' as a pa
 // expected-error @-1 {{expected parameter name followed by ':'}}
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function
-struct F { // expected-note 1 {{in declaration of 'F'}}
-  mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{expected declaration}}
+struct F {
+  mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}}
+                                   // expected-note@-1 2 {{modifier already specified here}}
+                                   // expected-error@-2 {{expected 'func' keyword in function declaration}}
   }
   
   mutating nonmutating func g() {}  // expected-error {{method must not be declared both mutating and nonmutating}}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -508,7 +508,7 @@ func test_recovery_missing_name_2(let: Int) {} // expected-error {{'let' as a pa
 struct F {
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}}
                                    // expected-note@-1 2 {{modifier already specified here}}
-                                   // expected-error@-2 {{expected 'func' keyword in function declaration}}
+                                   // expected-error@-2 {{expected 'func' keyword in instance method declaration}}
   }
   
   mutating nonmutating func g() {}  // expected-error {{method must not be declared both mutating and nonmutating}}

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1177,7 +1177,40 @@
       key.nameoffset: 1796,
       key.namelength: 1,
       key.bodyoffset: 1799,
-      key.bodylength: 109
+      key.bodylength: 109,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "init(x:y:)",
+          key.offset: 1882,
+          key.length: 25,
+          key.nameoffset: 1882,
+          key.namelength: 22,
+          key.bodyoffset: 1906,
+          key.bodylength: 0,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "x",
+              key.offset: 1889,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1889,
+              key.namelength: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "y",
+              key.offset: 1897,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1897,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -1417,14 +1450,13 @@
       key.line: 116,
       key.column: 1,
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected declaration",
+      key.description: "expected 'func' keyword in function declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-      key.diagnostics: [
+      key.fixits: [
         {
-          key.line: 114,
-          key.column: 7,
-          key.severity: source.diagnostic.severity.note,
-          key.description: "in declaration of 'C'"
+          key.offset: 1882,
+          key.length: 0,
+          key.sourcetext: "func "
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1450,7 +1450,7 @@
       key.line: 116,
       key.column: 1,
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected 'func' keyword in function declaration",
+      key.description: "expected 'func' keyword in instance method declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
       key.fixits: [
         {

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1453,7 +1453,7 @@
       key.column: 1,
       key.filepath: "-foobar",
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected 'func' keyword in function declaration",
+      key.description: "expected 'func' keyword in instance method declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
       key.fixits: [
         {

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1177,7 +1177,40 @@
       key.nameoffset: 1796,
       key.namelength: 1,
       key.bodyoffset: 1799,
-      key.bodylength: 109
+      key.bodylength: 109,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "init(x:y:)",
+          key.offset: 1882,
+          key.length: 25,
+          key.nameoffset: 1882,
+          key.namelength: 22,
+          key.bodyoffset: 1906,
+          key.bodylength: 0,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "x",
+              key.offset: 1889,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1889,
+              key.namelength: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "y",
+              key.offset: 1897,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1897,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -1420,15 +1453,13 @@
       key.column: 1,
       key.filepath: "-foobar",
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected declaration",
+      key.description: "expected 'func' keyword in function declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-      key.diagnostics: [
+      key.fixits: [
         {
-          key.line: 114,
-          key.column: 7,
-          key.filepath: "-foobar",
-          key.severity: source.diagnostic.severity.note,
-          key.description: "in declaration of 'C'"
+          key.offset: 1882,
+          key.length: 0,
+          key.sourcetext: "func "
         }
       ]
     }

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1453,7 +1453,7 @@
       key.column: 1,
       key.filepath: main.swift,
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected 'func' keyword in function declaration",
+      key.description: "expected 'func' keyword in instance method declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
       key.fixits: [
         {

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1177,7 +1177,40 @@
       key.nameoffset: 1796,
       key.namelength: 1,
       key.bodyoffset: 1799,
-      key.bodylength: 109
+      key.bodylength: 109,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.function.method.instance,
+          key.accessibility: source.lang.swift.accessibility.internal,
+          key.name: "init(x:y:)",
+          key.offset: 1882,
+          key.length: 25,
+          key.nameoffset: 1882,
+          key.namelength: 22,
+          key.bodyoffset: 1906,
+          key.bodylength: 0,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "x",
+              key.offset: 1889,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1889,
+              key.namelength: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.var.parameter,
+              key.name: "y",
+              key.offset: 1897,
+              key.length: 6,
+              key.typename: "Int",
+              key.nameoffset: 1897,
+              key.namelength: 1
+            }
+          ]
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.var.global,
@@ -1420,15 +1453,13 @@
       key.column: 1,
       key.filepath: main.swift,
       key.severity: source.diagnostic.severity.error,
-      key.description: "expected declaration",
+      key.description: "expected 'func' keyword in function declaration",
       key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-      key.diagnostics: [
+      key.fixits: [
         {
-          key.line: 114,
-          key.column: 7,
-          key.filepath: main.swift,
-          key.severity: source.diagnostic.severity.note,
-          key.description: "in declaration of 'C'"
+          key.offset: 1882,
+          key.length: 0,
+          key.sourcetext: "func "
         }
       ]
     }

--- a/test/incrParse/funcs.swift
+++ b/test/incrParse/funcs.swift
@@ -16,11 +16,11 @@ class InvalidFuncDecls {
   func parensAdded<<ADD_FUNC_PARENS<|||()>>> {
   }
 
-  func openingBraceAdded() <<ADD_OPENING_BRACE|||{>>>
+  func openingBraceAdded() <<ADD_OPENING_BRACE<|||{>>>
 
   func closingBraceAdded() {
 
-  <<ADD_ClOSING_BRACE|||}>>>
+  <<ADD_ClOSING_BRACE<|||}>>>
 
   <<REMOVE_FUNC_KEYWORD<func|||>>> funcKeywordRemoved() {
 


### PR DESCRIPTION
* **Explanation**: Recover parsing if we meet and identifier/operator where a declaration is expected as if there's a method or property declaration there, show a diagnostic and suggest to insert `func` or `var` before the identifier.
* **Scope**: Only affects invalid code in containers (i. e. protocols, types and extensions, not top-level code or function bodies), provides more useful diagnostics than just "expected declaration". Now with property wrappers coming in, code like `@State isOn = false` will appear more often, and it should be handled in a friendly manner.
* **Risk**: Relatively low. Some messed up code may receive a pile of new error messages like below, but I believe it's rare. There was only a couple of such cases in the test suite, the rest of the tests that needed to be adjusted only got improved diagnostics.
https://github.com/apple/swift/blob/3954a4a57b8e253c77cb27393614e056735d3b5d/test/Parse/line-directive.swift#L26-L36
* **Issue**: [SR-10477](https://bugs.swift.org/browse/SR-10477)
* **Testing**: Added tests for different kinds of declarations with missing keywords.
* **Reviewers**: @jrose-apple @akyrtzi