### PR TITLE
[ModuleInterface] Support classes with missing designated inits

### DIFF
--- a/include/swift/AST/DiagnosticsModuleDiffer.def
+++ b/include/swift/AST/DiagnosticsModuleDiffer.def
@@ -98,6 +98,10 @@ ERROR(objc_name_change,none,"%0 has ObjC name change from %1 to %2", (StringRef,
 
 ERROR(desig_init_added,none,"%0 has been added as a designated initializer to an open class", (StringRef))
 
+ERROR(added_invisible_designated_init,none,"%0 has new designated initializers that are not visible to clients", (StringRef))
+
+ERROR(not_inheriting_convenience_inits,none,"%0 no longer inherits convenience inits from its superclass", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -156,6 +156,29 @@ public:
   void cacheResult(ClassDecl *value) const;
 };
 
+/// Requests whether or not this class has designated initializers that are
+/// not public or @usableFromInline.
+class HasMissingDesignatedInitializersRequest :
+    public SimpleRequest<HasMissingDesignatedInitializersRequest,
+                         bool(ClassDecl *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool>
+  evaluate(Evaluator &evaluator, ClassDecl *subject) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+  Optional<bool> getCachedResult() const;
+  void cacheResult(bool) const;
+};
+
 /// Request the nominal declaration extended by a given extension declaration.
 class ExtendedNominalRequest :
     public SimpleRequest<ExtendedNominalRequest,

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -39,6 +39,9 @@ SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest,
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, SuperclassDeclRequest, ClassDecl *(NominalTypeDecl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, HasMissingDesignatedInitializersRequest,
+              bool(ClassDecl *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, TypeDeclsFromWhereClauseRequest,
               DirectlyReferencedTypeDecls(ExtensionDecl *), Uncached,
               NoLocationInfo)

--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -132,6 +132,8 @@ KEY_BOOL(HasStorage, hasStorage)
 KEY_BOOL(ReqNewWitnessTableEntry, reqNewWitnessTableEntry)
 KEY_BOOL(IsABIPlaceholder, isABIPlaceholder)
 KEY_BOOL(IsExternal, isExternal)
+KEY_BOOL(HasMissingDesignatedInitializers, hasMissingDesignatedInitializers)
+KEY_BOOL(InheritsConvenienceInitializers, inheritsConvenienceInitializers)
 
 KEY(kind)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -969,6 +969,22 @@ void PrintAST::printAttributes(const Decl *D) {
         Printer << " ";
       }
     }
+
+    // If the declaration has designated inits that won't be visible to
+    // clients, or if it inherits superclass convenience initializers,
+    // then print those attributes specially.
+    if (auto CD = dyn_cast<ClassDecl>(D)) {
+      if (Options.PrintImplicitAttrs) {
+        if (CD->inheritsSuperclassInitializers()) {
+          Printer.printAttrName("@_inheritsConvenienceInitializers");
+          Printer << " ";
+        }
+        if (CD->hasMissingDesignatedInitializers()) {
+          Printer.printAttrName("@_hasMissingDesignatedInitializers");
+          Printer << " ";
+        }
+      }
+    }
   }
 
   D->getAttrs().print(Printer, Options, D);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4088,15 +4088,11 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   return DD;
 }
 
-
 bool ClassDecl::hasMissingDesignatedInitializers() const {
-  if (!Bits.ClassDecl.ComputedHasMissingDesignatedInitializers) {
-    auto *mutableThis = const_cast<ClassDecl *>(this);
-    mutableThis->Bits.ClassDecl.ComputedHasMissingDesignatedInitializers = 1;
-    (void)mutableThis->lookupDirect(DeclBaseName::createConstructor());
-  }
-
-  return Bits.ClassDecl.HasMissingDesignatedInitializers;
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      HasMissingDesignatedInitializersRequest{const_cast<ClassDecl *>(this)},
+      false);
 }
 
 bool ClassDecl::hasMissingVTableEntries() const {
@@ -4119,7 +4115,7 @@ bool ClassDecl::isIncompatibleWithWeakReferences() const {
   return false;
 }
 
-bool ClassDecl::inheritsSuperclassInitializers() {
+bool ClassDecl::inheritsSuperclassInitializers() const {
   // If there's no superclass, there's nothing to inherit.
   if (!getSuperclass())
     return false;

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -68,6 +68,47 @@ void SuperclassDeclRequest::cacheResult(ClassDecl *value) const {
 }
 
 //----------------------------------------------------------------------------//
+// Missing designated initializers computation
+//----------------------------------------------------------------------------//
+
+Optional<bool> HasMissingDesignatedInitializersRequest::getCachedResult() const {
+  auto classDecl = std::get<0>(getStorage());
+  return classDecl->getCachedHasMissingDesignatedInitializers();
+}
+
+void HasMissingDesignatedInitializersRequest::cacheResult(bool result) const {
+  auto classDecl = std::get<0>(getStorage());
+  classDecl->setHasMissingDesignatedInitializers(result);
+}
+
+llvm::Expected<bool>
+HasMissingDesignatedInitializersRequest::evaluate(Evaluator &evaluator,
+                                           ClassDecl *subject) const {
+  // Short-circuit and check for the attribute here.
+  if (subject->getAttrs().hasAttribute<HasMissingDesignatedInitializersAttr>())
+    return true;
+
+  AccessScope scope =
+    subject->getFormalAccessScope(/*useDC*/nullptr,
+                                  /*treatUsableFromInlineAsPublic*/true);
+  // This flag only makes sense for public types that will be written in the
+  // module.
+  if (!scope.isPublic())
+    return false;
+
+  auto constructors = subject->lookupDirect(DeclBaseName::createConstructor());
+  return llvm::any_of(constructors, [&](ValueDecl *decl) {
+    auto init = cast<ConstructorDecl>(decl);
+    if (!init->isDesignatedInit())
+      return false;
+    AccessScope scope =
+        init->getFormalAccessScope(/*useDC*/nullptr,
+                                   /*treatUsableFromInlineAsPublic*/true);
+    return !scope.isPublic();
+  });
+}
+
+//----------------------------------------------------------------------------//
 // Extended nominal computation.
 //----------------------------------------------------------------------------//
 Optional<NominalTypeDecl *> ExtendedNominalRequest::getCachedResult() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7638,7 +7638,8 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
         if (getClangModuleForDecl(theClass) == getClangModuleForDecl(method)) {
           if (auto swiftClass = castIgnoringCompatibilityAlias<ClassDecl>(
                   importDecl(theClass, CurrentVersion))) {
-            swiftClass->setHasMissingDesignatedInitializers();
+            SwiftContext.evaluator.cacheOutput(
+                HasMissingDesignatedInitializersRequest{swiftClass}, true);
           }
         }
       }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1000,13 +1000,18 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
 llvm::Expected<bool>
 InheritsSuperclassInitializersRequest::evaluate(Evaluator &eval,
                                                 ClassDecl *decl) const {
+  // Check if we parsed the @_inheritsConvenienceInitializers attribute.
+  if (decl->getAttrs().hasAttribute<InheritsConvenienceInitializersAttr>())
+    return true;
+
   auto superclass = decl->getSuperclass();
   assert(superclass);
 
   // If the superclass has known-missing designated initializers, inheriting
   // is unsafe.
   auto *superclassDecl = superclass->getClassOrBoundGenericClass();
-  if (superclassDecl->hasMissingDesignatedInitializers())
+  if (superclassDecl->getModuleContext() != decl->getParentModule() &&
+      superclassDecl->hasMissingDesignatedInitializers())
     return false;
 
   // If we're allowed to inherit designated initializers, then we can inherit

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1094,6 +1094,7 @@ static void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl) {
 
   auto *superclassDecl = classDecl->getSuperclassDecl();
   if (superclassDecl &&
+      superclassDecl->getModuleContext() != classDecl->getModuleContext() &&
       superclassDecl->hasMissingDesignatedInitializers())
     return;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3395,6 +3395,7 @@ public:
     DeclContextID contextID;
     bool isImplicit, isObjC;
     bool inheritsSuperclassInitializers;
+    bool hasMissingDesignatedInits;
     GenericSignatureID genericSigID;
     TypeID superclassID;
     uint8_t rawAccessLevel;
@@ -3403,6 +3404,7 @@ public:
     decls_block::ClassLayout::readRecord(scratch, nameID, contextID,
                                          isImplicit, isObjC,
                                          inheritsSuperclassInitializers,
+                                         hasMissingDesignatedInits,
                                          genericSigID, superclassID,
                                          rawAccessLevel, numConformances,
                                          numInheritedTypes,
@@ -3445,6 +3447,8 @@ public:
     theClass->setSuperclass(MF.getType(superclassID));
     ctx.evaluator.cacheOutput(InheritsSuperclassInitializersRequest{theClass},
                               std::move(inheritsSuperclassInitializers));
+    ctx.evaluator.cacheOutput(HasMissingDesignatedInitializersRequest{theClass},
+                              std::move(hasMissingDesignatedInits));
 
     handleInherited(theClass,
                     rawInheritedAndDependencyIDs.slice(0, numInheritedTypes));
@@ -5278,7 +5282,8 @@ Decl *handleErrorAndSupplyMissingClassMember(ASTContext &context,
   Decl *suppliedMissingMember = nullptr;
   auto handleMissingClassMember = [&](const DeclDeserializationError &error) {
     if (error.isDesignatedInitializer())
-      containingClass->setHasMissingDesignatedInitializers();
+      context.evaluator.cacheOutput(
+          HasMissingDesignatedInitializersRequest{containingClass}, true);
     if (error.getNumberOfVTableEntries() > 0)
       containingClass->setHasMissingVTableEntries();
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 525; // target formal type for casts
+const uint16_t SWIFTMODULE_VERSION_MINOR = 526; // @_hasMissingDesignatedInitializers
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1098,6 +1098,7 @@ namespace decls_block {
     BCFixed<1>,             // implicit?
     BCFixed<1>,             // explicitly objc?
     BCFixed<1>,             // inherits convenience initializers from its superclass?
+    BCFixed<1>,             // has missing designated initializers?
     GenericSignatureIDField, // generic environment
     TypeIDField,            // superclass
     AccessLevelField,       // access level

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3053,9 +3053,7 @@ public:
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(theClass->getFormalAccess());
 
-    bool inheritsSuperclassInitializers =
-        const_cast<ClassDecl *>(theClass)->
-          inheritsSuperclassInitializers();
+    auto mutableClass = const_cast<ClassDecl *>(theClass);
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[ClassLayout::Code];
     ClassLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -3063,7 +3061,8 @@ public:
                             contextID.getOpaqueValue(),
                             theClass->isImplicit(),
                             theClass->isObjC(),
-                            inheritsSuperclassInitializers,
+                            mutableClass->inheritsSuperclassInitializers(),
+                            mutableClass->hasMissingDesignatedInitializers(),
                             S.addGenericSignatureRef(
                                              theClass->getGenericSignature()),
                             S.addTypeRef(theClass->getSuperclass()),

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -452,7 +452,7 @@ class d0120_TestClassBase {
 }
 
 class d0121_TestClassDerived : d0120_TestClassBase {
-// PASS_COMMON-LABEL: {{^}}class d0121_TestClassDerived : d0120_TestClassBase {{{$}}
+// PASS_COMMON-LABEL: {{^}}@_inheritsConvenienceInitializers {{()?}}class d0121_TestClassDerived : d0120_TestClassBase {{{$}}
 
   required init() { super.init() }
 // PASS_COMMON-NEXT: {{^}}  required init(){{$}}
@@ -611,8 +611,8 @@ struct d0200_EscapedIdentifiers {
 // PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  typealias `protocol` = `class`{{$}}
 
   class `extension` : `class` {}
-// PASS_ONE_LINE_TYPE-DAG: {{^}}  class `extension` : d0200_EscapedIdentifiers.`class` {{{$}}
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  class `extension` : `class` {{{$}}
+// PASS_ONE_LINE_TYPE-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : d0200_EscapedIdentifiers.`class` {{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : `class` {{{$}}
 // PASS_COMMON:      {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}    {{(override )?}}init(){{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
@@ -748,7 +748,7 @@ class d0260_ExplodePattern_TestClassBase {
 }
 
 class d0261_ExplodePattern_TestClassDerived : d0260_ExplodePattern_TestClassBase {
-// PASS_EXPLODE_PATTERN-LABEL: {{^}}class d0261_ExplodePattern_TestClassDerived : d0260_ExplodePattern_TestClassBase {{{$}}
+// PASS_EXPLODE_PATTERN-LABEL: {{^}}@_inheritsConvenienceInitializers class d0261_ExplodePattern_TestClassDerived : d0260_ExplodePattern_TestClassBase {{{$}}
 
   override final var baseProp2: Int {
     get {
@@ -791,13 +791,13 @@ class ClassWithInheritance2 : FooProtocol, BarProtocol {}
 // PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance2 : FooProtocol, BarProtocol {{{$}}
 
 class ClassWithInheritance3 : FooClass {}
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance3 : FooClass {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance3 : FooClass {{{$}}
 
 class ClassWithInheritance4 : FooClass, FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance4 : FooClass, FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance4 : FooClass, FooProtocol {{{$}}
 
 class ClassWithInheritance5 : FooClass, FooProtocol, BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance5 : FooClass, FooProtocol, BarProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance5 : FooClass, FooProtocol, BarProtocol {{{$}}
 
 class ClassWithInheritance6 : QuxProtocol, SubFooProtocol {
   typealias Qux = Int

--- a/test/ModuleInterface/inherits-superclass-initializers-client.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers-client.swift
@@ -1,0 +1,41 @@
+// Compile the imported module to a .swiftinterface and ensure the convenience
+// init delegates through the subclasses correctly.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: rm %t/Module.swiftmodule
+// RUN: %target-build-swift %s -I %t -L %t -lModule -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main %t/%target-library-name(Module)
+// RUN: %target-run %t/main %t/%target-library-name(Module) | %FileCheck %s
+
+// Make sure the same error is emitted when importing a .swiftmodule
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/inherits-superclass-initializers.swift -emit-module-path %t/Module.swiftmodule -module-name Module -enable-library-evolution
+// RUN: %target-build-swift %s -I %t -L %t -lModule -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main %t/%target-library-name(Module)
+// RUN: %target-run %t/main %t/%target-library-name(Module) | %FileCheck %s
+
+import Module
+
+_ = Base()
+// CHECK: secret init from Base
+
+_ = Sub()
+// CHECK: secret init from Sub
+// CHECK: secret init from Base
+
+_ = SubSub()
+// CHECK: secret init from SubSub
+// CHECK: secret init from Sub
+// CHECK: secret init from Base
+
+test()
+// CHECK: secret init from Sub
+// CHECK: secret init from Base
+
+// CHECK: secret init from SubSub
+// CHECK: secret init from Sub
+// CHECK: secret init from Base
+
+// CHECK-NOT: public init

--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -1,0 +1,60 @@
+// Note: this test has a client: inherits-superclass-initializers-client.swift
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %FileCheck %s < %t/Module.swiftinterface
+
+// CHECK: @_hasMissingDesignatedInitializers open class Base {
+open class Base {
+  // CHECK-NEXT: public init(arg: Swift.Int)
+  public init(arg: Int) {
+    print("public init from Base")
+  }
+  // CHECK-NOT: init(secret: Swift.Int)
+  internal init(secret: Int) {
+    print("secret init from Base")
+  }
+
+  // CHECK: convenience public init()
+  public convenience init() {
+    self.init(secret: 4)
+  }
+
+// CHECK: }
+}
+
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub : Module.Base {
+public class Sub : Base {
+  // CHECK: override public init(arg: Swift.Int)
+  public override init(arg: Int) {
+    print("public init from Sub")
+    super.init(arg: arg)
+  }
+  // CHECK-NOT: init(secret: Swift.Int)
+  internal override init(secret: Int) {
+    print("secret init from Sub")
+    super.init(secret: secret)
+  }
+// CHECK: }
+}
+
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class SubSub : Module.Sub {
+public class SubSub: Sub {
+  // CHECK: override public init(arg: Swift.Int)
+  public override init(arg: Int) {
+    print("public init from SubSub")
+    super.init(arg: arg)
+  }
+  // CHECK-NOT: init(secret: Swift.Int)
+  internal override init(secret: Int) {
+    print("secret init from SubSub")
+    super.init(secret: secret)
+  }
+// CHECK: }
+}
+
+@inlinable public func test() {
+  _ = Sub()
+  _ = SubSub()
+}

--- a/test/ModuleInterface/non-public-designated-inits-client.swift
+++ b/test/ModuleInterface/non-public-designated-inits-client.swift
@@ -1,0 +1,26 @@
+// Compile the imported module to a .swiftinterface and ensure the convenience
+// init cannot be called.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %S/non-public-designated-inits.swift -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t
+
+// Make sure the same error is emitted when importing a .swiftmodule
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Module.swiftmodule %S/non-public-designated-inits.swift -module-name Module -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck -verify %s -I %t
+
+import Module
+
+open class B : A {
+  var x: Int
+
+  public override init(_ x: Int) {
+    self.x = x
+    super.init(x)
+  }
+}
+
+print(B(hi: ())) // expected-error {{cannot convert value of type '()' to expected argument type 'Int'}}
+// expected-error @-1 {{extraneous argument label 'hi:' in call}}

--- a/test/ModuleInterface/non-public-designated-inits.swift
+++ b/test/ModuleInterface/non-public-designated-inits.swift
@@ -1,0 +1,21 @@
+// Note: This test has a client: non-public-designated-inits-client.swift
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %FileCheck %s < %t/Module.swiftinterface
+
+// CHECK: @_hasMissingDesignatedInitializers open class A {
+open class A {
+  // This is a non-public designated init, which means the convenience
+  // init should not be inheritable.
+  init() {}
+
+  // CHECK-NEXT: public init(_: Swift.Int)
+  public init(_: Int) {}
+
+  // CHECK-NEXT: convenience public init(hi: ())
+  public convenience init(hi: ()) { self.init() }
+
+// CHECK: }
+}

--- a/test/ModuleInterface/nsmanaged-attr.swift
+++ b/test/ModuleInterface/nsmanaged-attr.swift
@@ -16,7 +16,7 @@
 import CoreData
 import Foundation
 
-// CHECK: @objc public class MyObject : CoreData.NSManagedObject {
+// CHECK: @objc @_inheritsConvenienceInitializers public class MyObject : CoreData.NSManagedObject {
 public class MyObject: NSManagedObject {
   // CHECK: @objc @NSManaged dynamic public var myVar: Swift.String {
   // CHECK-NEXT: @objc get

--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -105,7 +105,26 @@ public protocol DerivedProtocolRequiementChanges: RequiementChanges {}
 
 public class SuperClassRemoval: C3 {}
 
-public class ClassToStruct {}
+public class ClassToStruct {
+  public init() {}
+}
+
+open class ClassWithMissingDesignatedInits {
+  internal init() {}
+  public convenience init(x: Int) { self.init() }
+}
+
+open class ClassWithoutMissingDesignatedInits {
+  public init() {}
+  public convenience init(x: Int) { self.init() }
+}
+
+public class SubclassWithMissingDesignatedInits: ClassWithMissingDesignatedInits {
+}
+
+public class SubclassWithoutMissingDesignatedInits: ClassWithoutMissingDesignatedInits {
+}
+
 public protocol ProtocolToEnum {}
 
 public class SuperClassChange: C7 {}

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -114,7 +114,30 @@ public protocol DerivedProtocolRequiementChanges: RequiementChanges {}
 
 public class SuperClassRemoval {}
 
-public struct ClassToStruct {}
+public struct ClassToStruct {
+  public init() {}
+}
+
+open class ClassWithMissingDesignatedInits {
+  // Remove the @_hasMissingDesignatedInitializers attribute
+  public init() {}
+  public convenience init(x: Int) { self.init() }
+}
+
+open class ClassWithoutMissingDesignatedInits {
+  // Add the @_hasMissingDesignatedInitializers attribute by adding an inaccessible
+  // init
+  public init() {}
+  public convenience init(x: Int) { self.init() }
+  internal init(y: Int) {}
+}
+
+public class SubclassWithMissingDesignatedInits: ClassWithMissingDesignatedInits {
+}
+
+public class SubclassWithoutMissingDesignatedInits: ClassWithoutMissingDesignatedInits {
+}
+
 public enum ProtocolToEnum {}
 
 public class SuperClassChange: C8 {}

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -60,6 +60,8 @@ cake: Class C0 is a new API without @available attribute
 cake: Class C5 is now without @objc
 cake: Class C8 is a new API without @available attribute
 cake: Constructor C1.init(_:) is a new API without @available attribute
+cake: Constructor ClassWithMissingDesignatedInits.init() is a new API without @available attribute
+cake: Constructor SubclassWithMissingDesignatedInits.init() is a new API without @available attribute
 cake: Enum IceKind is now without @frozen
 cake: EnumElement FrozenKind.AddedCase is a new API without @available attribute
 cake: Func C1.foo1() is now not static
@@ -102,10 +104,10 @@ cake: Struct fixedLayoutStruct has added a conformance to an existing protocol P
 cake: Struct fixedLayoutStruct has removed conformance to P1
 
 /* Protocol Requirement Change */
-cake: Accessor HasMutatingMethodClone.bar.Get() now requires  new witness table entry
+cake: Accessor HasMutatingMethodClone.bar.Get() now requires new witness table entry
 cake: AssociatedType AssociatedTypePro.T1 has removed default type Swift.Int
 cake: AssociatedType RequiementChanges.addedTypeWithoutDefault has been added as a protocol requirement
-cake: Func HasMutatingMethodClone.foo() now requires  new witness table entry
+cake: Func HasMutatingMethodClone.foo() now requires new witness table entry
 cake: Func RequiementChanges.addedFunc() has been added as a protocol requirement
 cake: Var RequiementChanges.addedVar has been added as a protocol requirement
 
@@ -113,4 +115,6 @@ cake: Var RequiementChanges.addedVar has been added as a protocol requirement
 cake: Class C4 has changed its super class from APINotesTest.OldType to APINotesTest.NewType
 cake: Class SubGenericClass has changed its super class from cake.GenericClass<cake.P1> to cake.GenericClass<cake.P2>
 cake: Class SuperClassRemoval has removed its super class cake.C3
+cake: Class SuperClassRemoval no longer inherits convenience inits from its superclass
 cake: Constructor AddingNewDesignatedInit.init(_:) has been added as a designated initializer to an open class
+cake: Constructor ClassWithMissingDesignatedInits.init() has been added as a designated initializer to an open class

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -64,7 +64,9 @@ cake: Accessor ClassWithOpenMember.property.Get() is no longer open for subclass
 cake: Class C4 has changed its super class from APINotesTest.OldType to APINotesTest.NewType
 cake: Class SubGenericClass has changed its super class from cake.GenericClass<cake.P1> to cake.GenericClass<cake.P2>
 cake: Class SuperClassRemoval has removed its super class cake.C3
+cake: Class SuperClassRemoval no longer inherits convenience inits from its superclass
 cake: Constructor AddingNewDesignatedInit.init(_:) has been added as a designated initializer to an open class
+cake: Constructor ClassWithMissingDesignatedInits.init() has been added as a designated initializer to an open class
 cake: Func ClassWithOpenMember.bar() is no longer open for subclassing
 cake: Func ClassWithOpenMember.foo() is no longer open for subclassing
 cake: Var ClassWithOpenMember.property is no longer open for subclassing

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -199,7 +199,8 @@
       "usr": "s:4cake2C0C",
       "moduleName": "cake",
       "genericSig": "<τ_0_0, τ_0_1, τ_0_2>",
-      "sugared_genericSig": "<T1, T2, T3>"
+      "sugared_genericSig": "<T1, T2, T3>",
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -428,6 +429,8 @@
       "usr": "s:4cake2C1C",
       "moduleName": "cake",
       "superclassUsr": "s:4cake2C0C",
+      "hasMissingDesignatedInitializers": true,
+      "inheritsConvenienceInitializers": true,
       "superclassNames": [
         "cake.C0<cake.S1, cake.S1, cake.S1>"
       ]
@@ -1330,7 +1333,8 @@
       "declAttributes": [
         "FixedLayout",
         "UsableFromInline"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -1387,6 +1391,7 @@
       "declKind": "Class",
       "usr": "s:4cake15FutureContainerC",
       "moduleName": "cake",
+      "hasMissingDesignatedInitializers": true,
       "conformances": [
         {
           "kind": "Conformance",
@@ -1418,7 +1423,8 @@
         "Available",
         "Available",
         "Available"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -1430,7 +1436,8 @@
       "intro_swift": "5",
       "declAttributes": [
         "Available"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -1482,7 +1489,8 @@
       "objc_name": "NewObjCClass",
       "declAttributes": [
         "ObjC"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -201,7 +201,8 @@
       "declKind": "Class",
       "usr": "s:4cake2C0C",
       "moduleName": "cake",
-      "genericSig": "<T1, T2, T3>"
+      "genericSig": "<T1, T2, T3>",
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeAlias",
@@ -425,6 +426,8 @@
       "usr": "s:4cake2C1C",
       "moduleName": "cake",
       "superclassUsr": "s:4cake2C0C",
+      "hasMissingDesignatedInitializers": true,
+      "inheritsConvenienceInitializers": true,
       "superclassNames": [
         "cake.C0<cake.S1, cake.S1, cake.S1>"
       ]
@@ -1235,6 +1238,7 @@
       "declKind": "Class",
       "usr": "s:4cake15FutureContainerC",
       "moduleName": "cake",
+      "hasMissingDesignatedInitializers": true,
       "conformances": [
         {
           "kind": "Conformance",
@@ -1266,7 +1270,8 @@
         "Available",
         "Available",
         "Available"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -1278,7 +1283,8 @@
       "intro_swift": "5",
       "declAttributes": [
         "Available"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",
@@ -1330,7 +1336,8 @@
       "objc_name": "NewObjCClass",
       "declAttributes": [
         "ObjC"
-      ]
+      ],
+      "hasMissingDesignatedInitializers": true
     },
     {
       "kind": "TypeDecl",

--- a/test/api-digester/Outputs/clang-module-dump.txt
+++ b/test/api-digester/Outputs/clang-module-dump.txt
@@ -119,6 +119,7 @@
         "Dynamic"
       ],
       "superclassUsr": "c:objc(cs)NSObject",
+      "inheritsConvenienceInitializers": true,
       "superclassNames": [
         "ObjectiveC.NSObject"
       ],
@@ -134,6 +135,24 @@
           "name": "NSObjectProtocol",
           "printedName": "NSObjectProtocol",
           "usr": "c:objc(pl)NSObject"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Equatable",
+          "printedName": "Equatable",
+          "usr": "s:SQ"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Hashable",
+          "printedName": "Hashable",
+          "usr": "s:SH"
+        },
+        {
+          "kind": "Conformance",
+          "name": "CVarArg",
+          "printedName": "CVarArg",
+          "usr": "s:s7CVarArgP"
         }
       ]
     },

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -4,8 +4,8 @@
 // RUN: %empty-directory(%t.module-cache)
 // RUN: %swift -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name cake
 // RUN: %swift -emit-module -o %t.mod2/cake.swiftmodule %S/Inputs/cake_current/cake.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name cake
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft > %t.dump1.json
-// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesLeft > %t.dump2.json
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester -dump-sdk -module cake -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod2 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result
 
 // RUN: %clang -E -P -x c %S/Outputs/Cake.txt -o - | sed '/^\s*$/d' > %t.expected

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1534,7 +1534,7 @@ class infer_instanceVar2<
 }
 
 class infer_instanceVar3 : Class_ObjC1 {
-// CHECK-LABEL: @objc class infer_instanceVar3 : Class_ObjC1 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_instanceVar3 : Class_ObjC1 {
 
   var v1: Int = 0
 // CHECK-LABEL: @objc @_hasInitialValue var v1: Int
@@ -1599,13 +1599,13 @@ protocol infer_throughConformanceProto1 {
 }
 
 class infer_class1 : PlainClass {}
-// CHECK-LABEL: {{^}}class infer_class1 : PlainClass {
+// CHECK-LABEL: {{^}}@_inheritsConvenienceInitializers class infer_class1 : PlainClass {
 
 class infer_class2 : Class_ObjC1 {}
-// CHECK-LABEL: @objc class infer_class2 : Class_ObjC1 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class2 : Class_ObjC1 {
 
 class infer_class3 : infer_class2 {}
-// CHECK-LABEL: @objc class infer_class3 : infer_class2 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class3 : infer_class2 {
 
 class infer_class4 : Protocol_Class1 {}
 // CHECK-LABEL: {{^}}class infer_class4 : Protocol_Class1 {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -126,7 +126,9 @@ SDKNodeTypeAlias::SDKNodeTypeAlias(SDKNodeInitInfo Info):
 SDKNodeDeclType::SDKNodeDeclType(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclType), SuperclassUsr(Info.SuperclassUsr),
   SuperclassNames(Info.SuperclassNames),
-  EnumRawTypeName(Info.EnumRawTypeName), IsExternal(Info.IsExternal) {}
+  EnumRawTypeName(Info.EnumRawTypeName), IsExternal(Info.IsExternal),
+  HasMissingDesignatedInitializers(Info.HasMissingDesignatedInitializers),
+  InheritsConvenienceInitializers(Info.InheritsConvenienceInitializers) {}
 
 SDKNodeConformance::SDKNodeConformance(SDKNodeInitInfo Info):
   SDKNode(Info, SDKNodeKind::Conformance),
@@ -1403,6 +1405,8 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
         SuperclassNames.push_back(getPrintedName(Ctx, T->getCanonicalType()));
       }
     }
+    HasMissingDesignatedInitializers = CD->hasMissingDesignatedInitializers();
+    InheritsConvenienceInitializers = CD->inheritsSuperclassInitializers();
   }
 
   if (auto *FD = dyn_cast<FuncDecl>(VD)) {
@@ -1975,6 +1979,10 @@ void SDKNodeDeclType::jsonize(json::Output &out) {
   output(out, KeyKind::KK_superclassUsr, SuperclassUsr);
   output(out, KeyKind::KK_enumRawTypeName, EnumRawTypeName);
   output(out, KeyKind::KK_isExternal, IsExternal);
+  output(out, KeyKind::KK_hasMissingDesignatedInitializers,
+         HasMissingDesignatedInitializers);
+  output(out, KeyKind::KK_inheritsConvenienceInitializers,
+         InheritsConvenienceInitializers);
   out.mapOptional(getKeyContent(Ctx, KeyKind::KK_superclassNames).data(), SuperclassNames);
   out.mapOptional(getKeyContent(Ctx, KeyKind::KK_conformances).data(), Conformances);
 }

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -524,6 +524,8 @@ class SDKNodeDeclType: public SDKNodeDecl {
   // Check whether the type declaration is pulled from an external module so we
   // can incorporate extensions in the interested module.
   bool IsExternal;
+  bool HasMissingDesignatedInitializers;
+  bool InheritsConvenienceInitializers;
 public:
   SDKNodeDeclType(SDKNodeInitInfo Info);
   static bool classof(const SDKNode *N);
@@ -547,6 +549,13 @@ public:
     assert(isEnum());
     return EnumRawTypeName;
   }
+
+  bool hasMissingDesignatedInitializers() const {
+    return HasMissingDesignatedInitializers;
+  };
+  bool inheritsConvenienceInitializers() const {
+    return InheritsConvenienceInitializers;
+  };
 
   Optional<SDKNodeDeclType*> getSuperclass() const;
 

--- a/tools/swift-api-digester/ModuleDiagsConsumer.cpp
+++ b/tools/swift-api-digester/ModuleDiagsConsumer.cpp
@@ -73,6 +73,8 @@ static StringRef getCategoryName(uint32_t ID) {
   case LocalDiagID::super_class_changed:
   case LocalDiagID::no_longer_open:
   case LocalDiagID::desig_init_added:
+  case LocalDiagID::added_invisible_designated_init:
+  case LocalDiagID::not_inheriting_convenience_inits:
     return "/* Class Inheritance Change */";
   default:
     return StringRef();

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -789,6 +789,22 @@ void swift::ide::api::SDKNodeDeclType::diagnose(SDKNode *Right) {
         emitDiag(Loc, diag::super_class_changed, LSuperClass, RSuperClass);
       }
     }
+
+    // Check for @_hasMissingDesignatedInitializers and
+    // @_inheritsConvenienceInitializers changes.
+    if (isOpen() && R->isOpen()) {
+      // It's not safe to add new, invisible designated inits to open
+      // classes.
+      if (!hasMissingDesignatedInitializers() &&
+          R->hasMissingDesignatedInitializers())
+        R->emitDiag(R->getLoc(), diag::added_invisible_designated_init);
+    }
+
+    // It's not safe to stop inheriting convenience inits, it changes
+    // the set of initializers that are available.
+    if (inheritsConvenienceInitializers() &&
+        !R->inheritsConvenienceInitializers())
+      R->emitDiag(R->getLoc(), diag::not_inheriting_convenience_inits);
     break;
   }
   default:


### PR DESCRIPTION
When a superclass in one module has a designated init that is non-public (or
@usableFromInline), and another class attempts to subclass that class from a
different module, we would have enough information in a binary module to
know that the class can't be subclassed because it's missing designated
initializers.

But if we're in a module interface, there's no indication that there was
an un-printed initializer. Introduce a new attribute
@_hasMissingDesignatedInits on classes that have non-public or usable
from inline designated initializers, and ensure that the bit is set when
we parse one.

Also, if a class inherits from something that has missing designated inits, but it overrides all designated initializers anyway, it should be allowed to inherit convenience inits _even if they're missing from the interface_. As such, add another attribute `@_inheritsSuperclassInitializers`, and promote the existing bit to an attribute. This'll ensure that we follow initializer inheritance the same way we would with bits in the serialized module.

Fixes rdar://51249311