### PR TITLE
[Foundation] Fallback to String description when bridging Error to NSError

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSError.swift
+++ b/stdlib/public/Darwin/Foundation/NSError.swift
@@ -239,7 +239,11 @@ public func _getErrorDefaultUserInfo<T: Error>(_ error: T)
 
           switch key {
           case NSLocalizedDescriptionKey:
-            return (error as? LocalizedError)?.errorDescription
+            if let description = (error as? LocalizedError)?.errorDescription {
+                return description
+            }
+            // Fallback to error's description if we don't have any localized description.
+            return String(describing: error)
 
           case NSLocalizedFailureReasonErrorKey:
             return (error as? LocalizedError)?.failureReason


### PR DESCRIPTION
This provides a better fallback value for Error's localizedDescription
when it is bridged to NSError, which is a huge improvement over today's
fallback value. This will hugely improve the error output of failing
tests when some code throws a non-localized error. Currently, the only
way to figure out the error is wrapping the test body in a do...catch
statment and then printing the error. For example, this is the output
of a failing test before the change:

```
Test Case '-[mypkgTests.mypkgTests testExample]' started.
<unknown>:0: error: -[mypkgTests.mypkgTests testExample] : failed: caught error: The operation couldn’t be completed. (mypkgTests.MyError error 0.)
Test Case '-[mypkgTests.mypkgTests testExample]' failed (0.062 seconds).
```

And this is the output after this change:

```
Test Case '-[mypkgTests.mypkgTests testExample]' started.
<unknown>:0: error: -[mypkgTests.mypkgTests testExample] : failed: caught error: uhOh("The toaster is broken!")
Test Case '-[mypkgTests.mypkgTests testExample]' failed (0.064 seconds).
```

<rdar://problem/30063715>
