### PR TITLE
[AutoDiff][SIL] Improve JVP/VJP type mismatch verification error.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1491,7 +1491,9 @@ public:
             adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::JVP, F.getModule(),
             LookUpConformanceInModule(F.getModule().getSwiftModule()));
-        require(expectedJVPType == jvpType, "Unexpected JVP function type");
+        requireSameType(SILType::getPrimitiveObjectType(jvpType),
+                        SILType::getPrimitiveObjectType(expectedJVPType),
+                        "JVP type does not match expected JVP type");
         auto vjpType = pair.second->getType().getAs<SILFunctionType>();
         require(vjpType, "The VJP function must have a function type");
         require(!vjpType->isDifferentiable(),
@@ -1500,7 +1502,9 @@ public:
             adfi->getParameterIndices(), /*resultIndex*/ 0, order,
             AutoDiffAssociatedFunctionKind::VJP, F.getModule(),
             LookUpConformanceInModule(F.getModule().getSwiftModule()));
-        require(expectedVJPType == vjpType, "Unexpected VJP function type");
+        requireSameType(SILType::getPrimitiveObjectType(vjpType),
+                        SILType::getPrimitiveObjectType(expectedVJPType),
+                        "VJP type does not match expected VJP type");
       }
     }
   }


### PR DESCRIPTION
Show expected vs actual JVP/VJP types when they do not match.

---

```
Before:
SIL verification failed: Unexpected VJP function type: expectedVJPType == vjpType

After:
SIL verification failed: VJP type does not match expected VJP type
  $@convention(method) (Float, @thick Super.Type) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Float)
  $@convention(method) (Float, @owned Super) -> (@owned Super, @owned @callee_guaranteed (@guaranteed Super.AllDifferentiableVariables) -> Float)
```