### PR TITLE
[test] Mark long collection tests as such

### DIFF
--- a/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
@@ -5,6 +5,7 @@
 // FIXME: the test is too slow when the standard library is not optimized.
 // rdar://problem/46878013
 // REQUIRES: optimized_stdlib
+// REQUIRES: long_test
 
 import SwiftPrivate
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -5,6 +5,7 @@
 // FIXME: the test is too slow when the standard library is not optimized.
 // rdar://problem/46878013
 // REQUIRES: optimized_stdlib
+// REQUIRES: long_test
 
 import SwiftPrivate
 import StdlibUnittest


### PR DESCRIPTION
The `FlattenCollection.swift.gyb` and `LazyFilterCollection.swift.gyb` tests are taking 1000+ seconds to execute, even with optimizations. It should be possible to shorten these, but meanwhile, mark them as long tests to speed up regular testing.

rdar://problem/52872766
rdar://problem/52873170
