### PR TITLE
Sema: Substitute the root generic param when transforming OpaqueArchetypes.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5119,6 +5119,10 @@ public:
   /// base.
   Type substBaseType(Type base, LookupConformanceFn lookupConformance);
 
+  /// Substitute the root generic type, looking up the chain of associated types.
+  /// Returns null if the member could not be found in the new root.
+  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance);
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::DependentMember;

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -413,3 +413,27 @@ struct Foo {
   var instanceVar: some P = 17
   let instanceLet: some P = 38
 }
+
+protocol P_52528543 {
+  init()
+
+  associatedtype A: Q_52528543
+
+  var a: A { get }
+}
+
+protocol Q_52528543 {
+  associatedtype B // expected-note 2 {{associated type 'B'}}
+
+  var b: B { get }
+}
+
+extension P_52528543 {
+  func frob(a_b: A.B) -> some P_52528543 { return self }
+}
+
+func foo<T: P_52528543>(x: T) -> some P_52528543 {
+  return x
+    .frob(a_b: x.a.b)
+    .frob(a_b: x.a.b) // expected-error {{cannot convert}}
+}


### PR DESCRIPTION
For a nested associated type of an opaque archetype, the code would incorrectly substitute the
immediate parent of the associated type with the root, causing crashes during substitution when
the substitution failed unexpectedly. rdar://problem/52528543