### PR TITLE
[Evaluator] Simplify template signature for SimpleRequest.

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -32,9 +32,8 @@ class ValueDecl;
 /// Request the AccessLevel of the given ValueDecl.
 class AccessLevelRequest :
     public SimpleRequest<AccessLevelRequest,
-                         CacheKind::SeparatelyCached,
-                         AccessLevel,
-                         ValueDecl *> {
+                         AccessLevel(ValueDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -61,9 +60,8 @@ public:
 /// the accessibility of mutating accessors.
 class SetterAccessLevelRequest :
     public SimpleRequest<SetterAccessLevelRequest,
-                         CacheKind::SeparatelyCached,
-                         AccessLevel,
-                         AbstractStorageDecl *> {
+                         AccessLevel(AbstractStorageDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -88,9 +86,8 @@ public:
 /// Request the Default and Max AccessLevels of the given ExtensionDecl.
 class DefaultAndMaxAccessLevelRequest :
     public SimpleRequest<DefaultAndMaxAccessLevelRequest,
-                         CacheKind::SeparatelyCached,
-                         std::pair<AccessLevel, AccessLevel>,
-                         ExtensionDecl *> {
+                         std::pair<AccessLevel, AccessLevel>(ExtensionDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
   using DefaultAndMax = std::pair<AccessLevel, AccessLevel>;

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -56,10 +56,10 @@ using DirectlyReferencedTypeDecls = llvm::TinyPtrVector<TypeDecl *>;
 /// The inherited declaration of \c D at index 1 is the typealias Alias.
 class InheritedDeclsReferencedRequest :
   public SimpleRequest<InheritedDeclsReferencedRequest,
-                       CacheKind::Uncached, // FIXME: Cache these
-                       DirectlyReferencedTypeDecls,
-                       llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
-                       unsigned>
+                       DirectlyReferencedTypeDecls(
+                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
+                         unsigned),
+                       CacheKind::Uncached> // FIXME: Cache these
 {
   /// Retrieve the TypeLoc for this inherited type.
   TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
@@ -107,9 +107,8 @@ public:
 /// using another instance of this request.
 class UnderlyingTypeDeclsReferencedRequest :
   public SimpleRequest<UnderlyingTypeDeclsReferencedRequest,
-                       CacheKind::Uncached, // FIXME: Cache these
-                       DirectlyReferencedTypeDecls,
-                       TypeAliasDecl *>
+                       DirectlyReferencedTypeDecls(TypeAliasDecl *),
+                       CacheKind::Uncached> // FIXME: Cache these
 {
 public:
   using SimpleRequest::SimpleRequest;
@@ -134,9 +133,8 @@ public:
 /// Request the superclass declaration for the given class.
 class SuperclassDeclRequest :
     public SimpleRequest<SuperclassDeclRequest,
-                         CacheKind::SeparatelyCached,
-                         ClassDecl *,
-                         NominalTypeDecl *> {
+                         ClassDecl *(NominalTypeDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -161,9 +159,8 @@ public:
 /// Request the nominal declaration extended by a given extension declaration.
 class ExtendedNominalRequest :
     public SimpleRequest<ExtendedNominalRequest,
-                         CacheKind::SeparatelyCached,
-                         NominalTypeDecl *,
-                         ExtensionDecl *> {
+                         NominalTypeDecl *(ExtensionDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -194,9 +191,9 @@ struct SelfBounds {
 /// constraints in the "where" clause of a protocol extension.
 class SelfBoundsFromWhereClauseRequest :
     public SimpleRequest<SelfBoundsFromWhereClauseRequest,
-                         CacheKind::Uncached,
-                         SelfBounds,
-                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *>> {
+                         SelfBounds(llvm::PointerUnion<TypeDecl *,
+                                    ExtensionDecl *>),
+                         CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -219,9 +216,8 @@ public:
 /// clause of an extension.
 class TypeDeclsFromWhereClauseRequest :
     public SimpleRequest<TypeDeclsFromWhereClauseRequest,
-                         CacheKind::Uncached,
-                         DirectlyReferencedTypeDecls,
-                         ExtensionDecl *> {
+                         DirectlyReferencedTypeDecls(ExtensionDecl *),
+                         CacheKind::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -243,10 +239,8 @@ public:
 /// refers.
 class CustomAttrNominalRequest :
     public SimpleRequest<CustomAttrNominalRequest,
-                         CacheKind::Cached,
-                         NominalTypeDecl *,
-                         CustomAttr *,
-                         DeclContext *> {
+                         NominalTypeDecl *(CustomAttr *, DeclContext *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -47,11 +47,10 @@ enum class CacheKind {
 /// the given type.
 ///
 /// \tparam Derived The final, derived class type for the request.
+/// \tparam Signature The signature of the request, described as a
+/// function type whose inputs (\c Inputs) are the parameter types and
+/// whose output (\c Output) is the result of evaluating this request.
 /// \tparam Caching Describes how the output value is cached, if at all.
-/// \tparam Output The type of the result produced by evaluating this request.
-/// \tparam Inputs The types of the inputs to this request, i.e., the values
-/// that comprise the request itself. These will determine the uniqueness of
-/// the request.
 ///
 /// The \c Derived class needs to implement several operations. The most
 /// important one takes an evaluator and the input values, then computes the
@@ -84,9 +83,12 @@ enum class CacheKind {
 ///   Optional<Output> getCachedResult() const;
 ///   void cacheResult(Output value) const;
 /// \endcode
+template<typename Derived, typename Signature, CacheKind Caching>
+class SimpleRequest;
+
 template<typename Derived, CacheKind Caching, typename Output,
          typename ...Inputs>
-class SimpleRequest {
+class SimpleRequest<Derived, Output(Inputs...), Caching> {
   std::tuple<Inputs...> storage;
 
   Derived &asDerived() {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -48,11 +48,10 @@ void simple_display(
 /// given declaration.
 class InheritedTypeRequest :
     public SimpleRequest<InheritedTypeRequest,
-                         CacheKind::SeparatelyCached,
-                         Type,
-                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
-                         unsigned,
-                         TypeResolutionStage>
+                         Type(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
+                              unsigned,
+                              TypeResolutionStage),
+                         CacheKind::SeparatelyCached>
 {
   /// Retrieve the TypeLoc for this inherited type.
   TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
@@ -85,10 +84,8 @@ public:
 /// Request the superclass type for the given class.
 class SuperclassTypeRequest :
     public SimpleRequest<SuperclassTypeRequest,
-                         CacheKind::SeparatelyCached,
-                         Type,
-                         NominalTypeDecl *,
-                         TypeResolutionStage> {
+                         Type(NominalTypeDecl *, TypeResolutionStage),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -114,10 +111,8 @@ public:
 /// Request the raw type of the given enum.
 class EnumRawTypeRequest :
     public SimpleRequest<EnumRawTypeRequest,
-                         CacheKind::SeparatelyCached,
-                         Type,
-                         EnumDecl *,
-                         TypeResolutionStage> {
+                         Type(EnumDecl *, TypeResolutionStage),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -144,9 +139,8 @@ public:
 /// by the given declaration.
 class OverriddenDeclsRequest
   : public SimpleRequest<OverriddenDeclsRequest,
-                         CacheKind::SeparatelyCached,
-                         llvm::TinyPtrVector<ValueDecl *>,
-                         ValueDecl *> {
+                         llvm::TinyPtrVector<ValueDecl *>(ValueDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -171,9 +165,8 @@ public:
 /// Determine whether the given declaration is exposed to Objective-C.
 class IsObjCRequest :
     public SimpleRequest<IsObjCRequest,
-                         CacheKind::SeparatelyCached,
-                         bool,
-                         ValueDecl *> {
+                         bool(ValueDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -197,9 +190,8 @@ public:
 /// Determine whether the given declaration is 'final'.
 class IsFinalRequest :
     public SimpleRequest<IsFinalRequest,
-                         CacheKind::SeparatelyCached,
-                         bool,
-                         ValueDecl *> {
+                         bool(ValueDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -223,9 +215,8 @@ public:
 /// Determine whether the given declaration is 'dynamic''.
 class IsDynamicRequest :
     public SimpleRequest<IsDynamicRequest,
-                         CacheKind::SeparatelyCached,
-                         bool,
-                         ValueDecl *> {
+                         bool(ValueDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -249,9 +240,8 @@ public:
 /// Compute the requirements that describe a protocol.
 class RequirementSignatureRequest :
     public SimpleRequest<RequirementSignatureRequest,
-                         CacheKind::SeparatelyCached,
-                         ArrayRef<Requirement>,
-                         ProtocolDecl *> {
+                         ArrayRef<Requirement>(ProtocolDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -275,9 +265,8 @@ public:
 /// Compute the default definition type of an associated type.
 class DefaultDefinitionTypeRequest :
     public SimpleRequest<DefaultDefinitionTypeRequest,
-                         CacheKind::Cached,
-                         Type,
-                         AssociatedTypeDecl *> {
+                         Type(AssociatedTypeDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -338,11 +327,9 @@ void simple_display(llvm::raw_ostream &out, const WhereClauseOwner &owner);
 /// Retrieve a requirement from the where clause of the given declaration.
 class RequirementRequest :
     public SimpleRequest<RequirementRequest,
-                         CacheKind::SeparatelyCached,
-                         Requirement,
-                         WhereClauseOwner,
-                         unsigned,
-                         TypeResolutionStage> {
+                         Requirement(WhereClauseOwner, unsigned,
+                                     TypeResolutionStage),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -383,9 +370,8 @@ public:
 /// Generate the USR for the given declaration.
 class USRGenerationRequest :
     public SimpleRequest<USRGenerationRequest,
-                         CacheKind::Cached,
-                         std::string,
-                         const ValueDecl*>
+                         std::string(const ValueDecl*),
+                         CacheKind::Cached>
 {
 public:
   using SimpleRequest::SimpleRequest;
@@ -408,9 +394,8 @@ public:
 /// Generate the mangling for the given local type declaration.
 class MangleLocalTypeDeclRequest :
     public SimpleRequest<MangleLocalTypeDeclRequest,
-                         CacheKind::Cached,
-                         std::string,
-                         const TypeDecl*>
+                         std::string(const TypeDecl*),
+                         CacheKind::Cached>
 {
 public:
   using SimpleRequest::SimpleRequest;
@@ -435,8 +420,9 @@ class TypeChecker;
 
 // Find the type in the cache or look it up
 class DefaultTypeRequest
-    : public SimpleRequest<DefaultTypeRequest, CacheKind::SeparatelyCached,
-                           Type, KnownProtocolKind, const DeclContext *> {
+    : public SimpleRequest<DefaultTypeRequest,
+                           Type(KnownProtocolKind, const DeclContext *),
+                           CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -475,9 +461,8 @@ private:
 /// Retrieve information about a property wrapper type.
 class PropertyWrapperTypeInfoRequest
   : public SimpleRequest<PropertyWrapperTypeInfoRequest,
-                         CacheKind::Cached,
-                         PropertyWrapperTypeInfo,
-                         NominalTypeDecl *> {
+                         PropertyWrapperTypeInfo(NominalTypeDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -501,9 +486,8 @@ public:
 /// refers.
 class AttachedPropertyWrappersRequest :
     public SimpleRequest<AttachedPropertyWrappersRequest,
-                         CacheKind::Cached,
-                         llvm::TinyPtrVector<CustomAttr *>,
-                         VarDecl *> {
+                         llvm::TinyPtrVector<CustomAttr *>(VarDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -527,9 +511,8 @@ public:
 /// that is attached to the given variable.
 class AttachedPropertyWrapperTypeRequest :
     public SimpleRequest<AttachedPropertyWrapperTypeRequest,
-                         CacheKind::Cached,
-                         Type,
-                         VarDecl *, unsigned> {
+                         Type(VarDecl *, unsigned),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -553,9 +536,8 @@ public:
 /// refers.
 class PropertyWrapperBackingPropertyTypeRequest :
     public SimpleRequest<PropertyWrapperBackingPropertyTypeRequest,
-                         CacheKind::Cached,
-                         Type,
-                         VarDecl *> {
+                         Type(VarDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -579,9 +561,8 @@ public:
 /// attached property wrappers.
 class PropertyWrapperBackingPropertyInfoRequest :
     public SimpleRequest<PropertyWrapperBackingPropertyInfoRequest,
-                         CacheKind::Cached,
-                         PropertyWrapperBackingPropertyInfo,
-                         VarDecl *> {
+                         PropertyWrapperBackingPropertyInfo(VarDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -604,9 +585,8 @@ public:
 /// Retrieve the structural type of an alias type.
 class StructuralTypeRequest :
     public SimpleRequest<StructuralTypeRequest,
-                         CacheKind::Cached,
-                         Type,
-                         TypeAliasDecl*> {
+                         Type(TypeAliasDecl*),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -629,9 +609,8 @@ public:
 /// given declaration.
 class AttachedFunctionBuilderRequest :
     public SimpleRequest<AttachedFunctionBuilderRequest,
-                         CacheKind::Cached,
-                         CustomAttr *,
-                         ValueDecl *> {
+                         CustomAttr *(ValueDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -655,9 +634,8 @@ public:
 /// if any.
 class FunctionBuilderTypeRequest :
     public SimpleRequest<FunctionBuilderTypeRequest,
-                         CacheKind::Cached,
-                         Type,
-                         ValueDecl *> {
+                         Type(ValueDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -679,9 +657,8 @@ public:
 /// Request a function's self access kind.
 class SelfAccessKindRequest :
     public SimpleRequest<SelfAccessKindRequest,
-                         CacheKind::SeparatelyCached,
-                         SelfAccessKind,
-                         FuncDecl *> {
+                         SelfAccessKind(FuncDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -706,8 +683,8 @@ public:
 /// Request whether the storage has a mutating getter.
 class IsGetterMutatingRequest :
     public SimpleRequest<IsGetterMutatingRequest,
-                         CacheKind::SeparatelyCached,
-                         bool, AbstractStorageDecl *> {
+                         bool(AbstractStorageDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -732,8 +709,8 @@ public:
 /// Request whether the storage has a mutating getter.
 class IsSetterMutatingRequest :
     public SimpleRequest<IsSetterMutatingRequest,
-                         CacheKind::SeparatelyCached,
-                         bool, AbstractStorageDecl *> {
+                         bool(AbstractStorageDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -758,9 +735,8 @@ public:
 /// Request whether reading the storage yields a borrowed value.
 class OpaqueReadOwnershipRequest :
     public SimpleRequest<OpaqueReadOwnershipRequest,
-                         CacheKind::SeparatelyCached,
-                         OpaqueReadOwnership,
-                         AbstractStorageDecl *> {
+                         OpaqueReadOwnership(AbstractStorageDecl *),
+                         CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -785,9 +761,8 @@ public:
 /// Request to build the underlying storage for a lazy property.
 class LazyStoragePropertyRequest :
     public SimpleRequest<LazyStoragePropertyRequest,
-                         CacheKind::Cached,
-                         VarDecl *,
-                         VarDecl *> {
+                         VarDecl *(VarDecl *),
+                         CacheKind::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -84,9 +84,10 @@ void simple_display(llvm::raw_ostream &out, ArithmeticExpr *expr) {
 /// Rule to evaluate the value of the expression.
 template<typename Derived, CacheKind Caching>
 struct EvaluationRule
-  : public SimpleRequest<Derived, Caching, double, ArithmeticExpr *>
+  : public SimpleRequest<Derived, double(ArithmeticExpr *), Caching>
 {
-  using SimpleRequest<Derived, Caching, double, ArithmeticExpr *>::SimpleRequest;
+  using SimpleRequest<Derived, double(ArithmeticExpr *), Caching>
+      ::SimpleRequest;
 
   llvm::Expected<double>
   evaluate(Evaluator &evaluator, ArithmeticExpr *expr) const {


### PR DESCRIPTION
Encode the input and output parameters for a SimpleRequest instance in a
function type and move the CacheKind to the end, making it easier to
sort out inputs from outputs:

```
  class DefaultTypeRequest
    : public SimpleRequest<DefaultTypeRequest,
                           Type(KnownProtocolKind, const DeclContext *),
                           CacheKind::SeparatelyCached>
```
