### PR TITLE
[Tests] Fix tests where "CHECK" and similar file check commands are used without a colon.

### DIFF
--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -38,7 +38,7 @@ func foo() {
   //       are contiguous.
   // CHECK: call {{.*}} @"$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF"{{.*}}, !dbg ![[DIV:[0-9]+]]
   // CHECK-NEXT: unreachable, !dbg ![[DIV]]
-  // CHECK sdiv i64 %0, %1, !dbg ![[DIV]]
+  // CHECK: sdiv i64 %0, %1, !dbg ![[DIV]]
   // CHECK: call void @llvm.trap(), !dbg ![[INLINEDADD:[0-9]+]]
   // CHECK-NEXT: unreachable, !dbg ![[INLINEDADD]]
 

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -6,7 +6,7 @@
 
 // CHECK-LABEL: define hidden swiftcc float @"$s8test_v7k9addFloats{{.*}}"(float, float)
 // CHECK: fadd float %0, %1
-// CHECK ret float
+// CHECK: ret float
 // V7K-LABEL: _$s8test_v7k9addFloats{{.*}}
 // V7K: vadd.f32 s0, s0, s1
 func addFloats(x: Float, y : Float) -> Float {

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -497,7 +497,7 @@ bb0(%0 : $SinglePayloadNoXI2):
 sil @single_payload_no_xi_switch : $@convention(thin) (SinglePayloadNoXI2) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadNoXI2):
-// CHECK;   %2 = trunc i8
+// CHECK:   %2 = trunc i8
 // CHECK:   br i1 %2, label %[[TAGS:[0-9]+]], label %[[X_DEST:[0-9]+]]
 // CHECK: ; <label>:[[TAGS]]
 // CHECK:   switch [[WORD]] %0, label %[[DFLT:[0-9]+]] [

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -68,7 +68,7 @@ extension Bas : NSRuncing {
 
 // CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas3Bas_$_objc_protocols" = private constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 1,
-// CHECK;   [1 x { i8*, i8*, i8* }] [
+// CHECK:   [1 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast (void (i8*, i8*)* @"$s18objc_protocols_Bas0C0C0a1_B0E3fooyyFTo" to i8*) }
 // CHECK:   ]
 // CHECK: }, section "__DATA, __objc_const", align 8

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -65,17 +65,17 @@ extension SubMultiConf {
 }
 class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class/Swift | SubMultiConf | [[SubMultiConf_USR:.*]] | Def
   // CHECK: [[@LINE-1]]:7 | instance-method/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
-    // CHECK-NEXT RelOver | instance-method/Swift | foo() | [[P2_foo_USR]]
-    // CHECK-NEXT RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
+    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P2_foo_USR]]
+    // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK: [[@LINE-4]]:7 | instance-method/Swift | foo() | [[P2_ext_foo_USR]] | Impl,RelOver,RelCont | rel: 2
-    // CHECK-NEXT RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
-    // CHECK-NEXT RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
+    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
+    // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK: [[@LINE-7]]:7 | instance-method/Swift | meth1() | [[SubMultiConf_ext_meth1_USR]] | Impl,RelOver,RelCont | rel: 2
-    // CHECK-NEXT RelOver | instance-method/Swift | meth1() | [[P3_meth1_USR]]
-    // CHECK-NEXT RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
+    // CHECK-NEXT: RelOver | instance-method/Swift | meth1() | [[P3_meth1_USR]]
+    // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK: [[@LINE-10]]:7 | instance-method/Swift | meth2() | [[BaseMultiConf_meth2_USR]] | Impl,RelOver,RelCont | rel: 2
-    // CHECK-NEXT RelOver | instance-method/Swift | meth2() | [[P3_meth2_USR]]
-    // CHECK-NEXT RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
+    // CHECK-NEXT: RelOver | instance-method/Swift | meth2() | [[P3_meth2_USR]]
+    // CHECK-NEXT: RelCont | class/Swift | SubMultiConf | [[SubMultiConf_USR]]
   // CHECK-NOT: [[@LINE-13]]:7 | instance-method
 }
 

--- a/test/SILGen/dynamic_accessors.swift
+++ b/test/SILGen/dynamic_accessors.swift
@@ -10,7 +10,7 @@ public class MyObjCClass {
     // CHECK: }
     get { return 4 }
 
-    // CHECK-LABEL sil [thunk] [ossa] @$s17dynamic_accessors11MyObjCClassC1aSivsTo : $@convention(objc_method) (Int, MyObjCClass) -> () {
+    // CHECK-LABEL: sil [thunk] [ossa] @$s17dynamic_accessors11MyObjCClassC1aSivsTo : $@convention(objc_method) (Int, MyObjCClass) -> () {
     // CHECK: function_ref @$s17dynamic_accessors11MyObjCClassC1aSivs
     // CHECK: }
     set {}

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -349,7 +349,7 @@ class Derived : Base {
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s12dynamic_self7DerivedC38superCallFromMethodReturningSelfStaticACXDyFZ : $@convention(method) (@thick Derived.Type) -> @owned Derived
-  // CHECK; [[DYNAMIC_SELF:%.*]] = unchecked_trivial_bit_cast %0 : $@thick Derived.Type to $@thick @synamic_self Derived.Type
+  // CHECK: [[DYNAMIC_SELF:%.*]] = unchecked_trivial_bit_cast %0 : $@thick Derived.Type to $@thick @dynamic_self Derived.Type
   // CHECK: [[SUPER:%.*]] = upcast [[DYNAMIC_SELF]] : $@thick @dynamic_self Derived.Type to $@thick Base.Type
   // CHECK: [[METHOD:%.*]] = function_ref @$s12dynamic_self4BaseC17returnsSelfStaticACXDyFZ
   // CHECK: apply [[METHOD]]([[SUPER]])

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -124,7 +124,7 @@ func objc_protocol_partial_apply(_ x: NSRuncing) {
   // FIXME: rdar://21289579
   // _ = NSRuncing.runce
 }
-// CHECK : } // end sil function '$s14objc_protocols0A23_protocol_partial_applyyyAA9NSRuncing_pF'
+// CHECK: } // end sil function '$s14objc_protocols0A23_protocol_partial_applyyyAA9NSRuncing_pF'
 
 // CHECK-LABEL: sil hidden [ossa] @$s14objc_protocols0A21_protocol_composition{{[_0-9a-zA-Z]*}}F
 func objc_protocol_composition(_ x: NSRuncing & NSFunging) {

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -40,7 +40,7 @@ func valueToValue(x: C) -> some Q {
 
 // CHECK-LABEL: sil hidden {{.*}}13reabstraction1xQr
 func reabstraction(x: @escaping () -> ()) -> some Any {
-  // CHECK [[UNDERLYING:%.*]] = unchecked_addr_cast %0 : ${{.*}} to $*@callee_guaranteed () -> @out ()
+  // CHECK: [[UNDERLYING:%.*]] = unchecked_addr_cast %0 : ${{.*}} to $*@callee_guaranteed () -> @out ()
   // CHECK: [[VALUE_COPY:%.*]] = copy_value %1
   // CHECK: [[VALUE_REABSTRACT:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[VALUE_COPY]])
   // CHECK: store [[VALUE_REABSTRACT]] to [init] [[UNDERLYING]]

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -930,16 +930,16 @@ func s460______________foo<Element>(p: UnsafePointer<Element>) -> UnsafeBufferPo
 // Test emitNativeToCBridgedNonoptionalValue.
 // ---
 // CHECK-objc-LABEL: sil hidden @$s20opaque_values_silgen21s470________nativeToC7fromAnyyXlyp_tF : $@convention(thin) (@in_guaranteed Any) -> @owned AnyObject {
-// CHECK-objc bb0(%0 : $Any):
-// CHECK-objc [[BORROW:%.*]] = begin_borrow %0 : $Any
-// CHECK-objc [[SRC:%.*]] = copy_value [[BORROW]] : $Any
-// CHECK-objc [[OPEN:%.*]] = open_existential_opaque [[SRC]] : $Any to $@opened
-// CHECK-objc [[COPY:%.*]] = copy_value [[OPEN]] : $@opened
-// CHECK-objc [[F:%.*]] = function_ref @$ss27_bridgeAnythingToObjectiveCyyXlxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
-// CHECK-objc [[RET:%.*]] = apply [[F]]<@opened("{{.*}}") Any>([[COPY]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
-// CHECK-objc destroy_value [[SRC]] : $Any
-// CHECK-objc destroy_value %0 : $Any
-// CHECK-objc return [[RET]] : $AnyObject
+// CHECK-objc: bb0(%0 : $Any):
+// CHECK-objc: [[BORROW:%.*]] = begin_borrow %0 : $Any
+// CHECK-objc: [[SRC:%.*]] = copy_value [[BORROW]] : $Any
+// CHECK-objc: [[OPEN:%.*]] = open_existential_opaque [[SRC]] : $Any to $@opened
+// CHECK-objc: [[COPY:%.*]] = copy_value [[OPEN]] : $@opened
+// CHECK-objc: [[F:%.*]] = function_ref @$ss27_bridgeAnythingToObjectiveCyyXlxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+// CHECK-objc: [[RET:%.*]] = apply [[F]]<@opened("{{.*}}") Any>([[COPY]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @owned AnyObject
+// CHECK-objc: destroy_value [[SRC]] : $Any
+// CHECK-objc: destroy_value %0 : $Any
+// CHECK-objc: return [[RET]] : $AnyObject
 // CHECK-objc-LABEL: } // end sil function '$s20opaque_values_silgen21s470________nativeToC7fromAnyyXlyp_tF'
 #if _runtime(_ObjC)
 func s470________nativeToC(fromAny any: Any) -> AnyObject {

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -610,7 +610,7 @@ func test_isa_class_2(x: B) -> AnyObject {
     return y
 
   // CHECK: [[NO_CASE3]]:
-  // CHECK    destroy_value [[CAST_E_COPY]]
+  // CHECK:    destroy_value [[CAST_E_COPY]]
   // CHECK:   br [[NEXT_CASE:bb[0-9]+]]
 
   // CHECK: [[IS_NOT_E]]([[NOCAST_E:%.*]] : @guaranteed $B):

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -154,7 +154,7 @@ func test5() {
     
     // CHECK: [[CASE2]]([[INCOMING_N:%.*]] : $Int):
     // CHECK:   [[Z:%.*]] = function_ref @$s18switch_fallthrough1zyySiF
-    // CHECK    apply [[Z]]([[INCOMING_N]]) : $@convention(thin) (Int) -> ()
+    // CHECK:    apply [[Z]]([[INCOMING_N]]) : $@convention(thin) (Int) -> ()
     // CHECK:   br [[CONT:bb[0-9]+]]
     z(n)
   case (_, _):

--- a/test/SILOptimizer/allocstack_hoisting.sil
+++ b/test/SILOptimizer/allocstack_hoisting.sil
@@ -125,7 +125,7 @@ bb3:
 // CHECK-NOT: dealloc_stack
 // CHECK: bb2
 // CHECK: bb3:
-// CHECK  dealloc_stack [[FIXED]]
+// CHECK:  dealloc_stack [[FIXED]]
 // CHECK: dealloc_stack [[AS2]]
 // CHECK: dealloc_stack [[AS]]
 // CHECK:   return

--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -47,7 +47,7 @@ public func test_scalar_strng() -> String {
 
 // NOTE: 7450828190687388257.byteSwapped = 0x61 'a', 0x62 'b', 0x63 'c', 0x64 'd', 0xC3 0xA8 'è', 0x66 'f', 0x67 'g', ...
 // NOTE: 1684234849 = 0x64636261, 1734781123 = 0x6766a8c3
-// CHECK-LABEL test_strng_concat_smol
+// CHECK-LABEL: test_strng_concat_smol
 // CHECK: ret { i32, i32, i32 } { i32 1684234849, i32 1734781123,
 public func test_strng_concat_smol() -> String {
   return "a" + "bc" + "dèf" + "gĥ"
@@ -55,7 +55,7 @@ public func test_strng_concat_smol() -> String {
 
 // NOTE: 11 = code-unit length
 // NOTE: 20 = native bias
-// CHECK-LABEL test_strng_concat_not_quite_smol
+// CHECK-LABEL: test_strng_concat_not_quite_smol
 // CHECK: ret { i32, i32, i32 } { i32 11, i32 sub (i32 {{.*}}, i32 20)
 public func test_strng_concat_not_quite_smol() -> String {
   return "a" + "bc" + "dèf" + "ghī"
@@ -63,7 +63,7 @@ public func test_strng_concat_not_quite_smol() -> String {
 
 // NOTE: 23 = code-unit length
 // NOTE: 20 = native bias
-// CHECK-LABEL test_strng_concat_large
+// CHECK-LABEL: test_strng_concat_large
 // CHECK: ret { i32, i32, i32 } { i32 23, i32 sub (i32 {{.*}}, i32 20)
 public func test_strng_concat_large() -> String {
   return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"

--- a/test/SILOptimizer/concat_string_literals.64.swift
+++ b/test/SILOptimizer/concat_string_literals.64.swift
@@ -42,14 +42,14 @@ public func test_scalar_strng() -> String {
 }
 
 // NOTE: 7450828190687388257.byteSwapped = 0x61 'a', 0x62 'b', 0x63 'c', 0x64 'd', 0xC3 0xA8 'è', 0x66 'f', 0x67 'g', ...
-// CHECK-LABEL test_strng_concat_smol
+// CHECK-LABEL: test_strng_concat_smol
 // CHECK:  ret { i64, %swift.bridge* } { i64 7450828190687388257, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }
 public func test_strng_concat_smol() -> String {
   return "a" + "bc" + "dèf" + "ghī"
 }
 
 // NOTE: 1152921504606846999 = 23 (code-unit length) | `isTailAllocated` perf flag
-// CHECK-LABEL test_strng_concat_large
+// CHECK-LABEL: test_strng_concat_large
 // CHECK:  ret { i64, %swift.bridge* } { i64 1152921504606846999, %swift.bridge* inttoptr {{.*}}i64 -{{[0-9]+}}{{.*}} to %swift.bridge*) }
 public func test_strng_concat_large() -> String {
   return "a" + "bc" + "dèf" + "ghī" + "jklmn" + "o" + "𝛒qr"

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -495,7 +495,7 @@ bb3:
 
 // Test stack allocation and memory access.
 
-// CHECK-LABEL @interpretLoadStore
+// CHECK-LABEL: @interpretLoadStore
 sil hidden @interpretLoadStore : $@convention(thin) () -> Builtin.Int64 {
 bb0:
   %0 = alloc_stack $Builtin.Int64, var, name "i"
@@ -506,7 +506,7 @@ bb0:
   return %3 : $Builtin.Int64
 } // CHECK: Returns int: 11
 
-// CHECK-LABEL @interpretBeginEndAccess
+// CHECK-LABEL: @interpretBeginEndAccess
 sil hidden @interpretBeginEndAccess : $@convention(thin) () -> Builtin.Int64 {
 bb0:
   %0 = alloc_stack $Builtin.Int64, var, name "i"

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1031,7 +1031,7 @@ bb2:
 //
 // CHECK-LABEL: dead_store_inout_stack_alias
 // CHECK: bb0
-// CHECK : struct_element_addr
+// CHECK: struct_element_addr
 // CHECK-NOT: {{ store}}
 // CHECK: load
 sil hidden @dead_store_inout_stack_alias : $@convention(thin) (@inout A) -> () {

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -176,7 +176,7 @@ bb12:                                             // Preds: bb3
 // CHECK: bb3
 // CHECK: class_method
 // CHECK: br bb1
-// CHECK }
+// CHECK: }
 // devirt_jump_thread.double (devirt_jump_thread.FooClass) -> Swift.Int32
 sil @_TF18devirt_jump_thread6doubleFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
@@ -230,7 +230,7 @@ bb6:                                              // Preds: bb1
 // CHECK: bb1(%{{.*}} : $Int32):
 // CHECK: checked_cast_br
 // CHECK: bb2(%{{.*}} : $Int32):
-// CHECK }
+// CHECK: }
 sil @_TF18devirt_jump_thread6dont_jump_thread_alloc_stackFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
   checked_cast_br [exact] %0 : $FooClass to $FooClass, bb3, bb4 // id: %1
@@ -284,7 +284,7 @@ bb6:                                              // Preds: bb1
 // CHECK: bb1(%{{.*}} : $Int32):
 // CHECK: checked_cast_br
 // CHECK: bb2(%{{.*}} : $Int32):
-// CHECK }
+// CHECK: }
 sil @_TF18devirt_jump_thread6dont_jump_thread_objc_methodFCS_8FooClassSi : $@convention(thin) (@guaranteed FooClass) -> Int32 {
 bb0(%0 : $FooClass):
   %100 = alloc_ref $Bar

--- a/test/SILOptimizer/existential_transform_extras.sil
+++ b/test/SILOptimizer/existential_transform_extras.sil
@@ -69,7 +69,7 @@ bb0:
 // CHECK:  destroy_addr
 // CHECK:  dealloc_stack
 // CHECK:  return
-// CHECK-LABEL :} // end sil function '$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF'
+// CHECK-LABEL: } // end sil function '$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF'
 sil public_external [serialized] @$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF : $@convention(thin) (@inout P) -> Int32 {
 bb0(%0 : $*P):
   debug_value_addr %0 : $*P, var, name "a", argno 1

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1172,7 +1172,7 @@ bb0:
 // CHECK-LABEL: sil @test_thin_convert_function_inline
 // CHECK-NEXT: bb0
 // CHECK-NEXT: [[RES:%.*]] = integer_literal $Builtin.Int32, 1
-// CHECK-NEXT  return [[RES]]
+// CHECK-NEXT:  return [[RES]]
 sil @test_thin_convert_function_inline : $@convention(thin) () -> Builtin.Int32 {
 bb0:
   %0 = function_ref @return_one : $@convention(thin) () -> Builtin.Int32

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -734,7 +734,7 @@ bb0(%0 : @owned $CP):
 // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
 // CHECK:   [[ARG1_COPY_COPY:%.*]] = copy_value [[ARG1_COPY]]
 // CHECK:   open_existential_ref [[ARG1_COPY_COPY]] : $CP to $@opened([[N1:".*"]]) CP
-// CHECK" } // end sil function '_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_'
+// CHECK: } // end sil function '_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_'
 sil [ossa] @_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_ : $@convention(thin) (@owned CP, @owned CP) -> () {
 bb0(%0 : @owned $CP, %1 : @owned $CP):
   %4 = function_ref @_TF2t222inner_open_existentialFT2cpPS_2CP__T_ : $@convention(thin) (@owned CP) -> ()
@@ -1197,7 +1197,7 @@ bb0:
 // CHECK-LABEL: sil [ossa] @test_thin_convert_function_inline
 // CHECK-NEXT: bb0
 // CHECK-NEXT: [[RES:%.*]] = integer_literal $Builtin.Int32, 1
-// CHECK-NEXT  return [[RES]]
+// CHECK-NEXT:  return [[RES]]
 sil [ossa] @test_thin_convert_function_inline : $@convention(thin) () -> Builtin.Int32 {
 bb0:
   %0 = function_ref @return_one : $@convention(thin) () -> Builtin.Int32

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -723,7 +723,7 @@ bb2:
 // CHECK: bb0(%0 : $AnyObject):
 // CHECK-NOT:  retain
 // CHECK:      [[A:%.*]] = alloc_stack $Int64
-// CHECK-NEXT  dealloc_stack [[A]] : $*Int64
+// CHECK-NEXT:  dealloc_stack [[A]] : $*Int64
 // CHECK-NOT:  release
 // CHECK-LABEL: } // end sil function 'testReleaseHoistDeallocStack'
 sil @testReleaseHoistDeallocStack : $@convention(thin) (AnyObject)->() {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -622,7 +622,7 @@ sil @test_closure : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NOT:  strong_release
 // CHECK:      bb2:
 // CHECK-NEXT:   strong_release %0
-// CHECK         return
+// CHECK:         return
 sil @dead_closure_elimination : $@convention(thin) (@owned C) -> () {
 bb0(%0 : $C):
   %1 = function_ref @test_closure : $@convention(thin) (@guaranteed C) -> ()

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -224,7 +224,7 @@ enum AddressOnlyError : Error {
 // CHECK-LABEL: sil @unconditional_checked_cast_addr_address_only_type
 // CHECK: alloc_stack $Error
 // CHECK: alloc_stack $AddressOnlyError
-// CHECK  copy_addr
+// CHECK:  copy_addr
 // CHECK: alloc_existential_box
 // CHECK: project_existential_box
 // CHECK: copy_addr

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -128,7 +128,7 @@ bb3(%6 : $Builtin.Int32):
 // CHECK: bb0([[ARG:%.*]] : $Builtin.Int1):
 // CHECK:   [[ZERO:%.*]] =  integer_literal $Builtin.Int1, 0
 // CHECK:   [[EXPECT:%.*]] = builtin "int_expect_Int1"([[ARG]] : $Builtin.Int1, [[ZERO]]
-// CHECK    cond_br [[EXPECT]], bb2, bb1
+// CHECK:    cond_br [[EXPECT]], bb2, bb1
 // CHECK: bb1:
 // CHECK:   integer_literal {{.*}} 2
 // CHECK:   br


### PR DESCRIPTION
This commit updates all test where // CHECK(-*) is not immediately followed by a colon or it is followed by some other symbol. All such lines will not be checked by FileCheck and so were ignored until now. 

The following lines also look like they need fixing, but I am not sure how to fix it.

https://github.com/apple/swift/blob/44f85d209080d6cf6347fbe6f582f4994a5ac814/test/stdlib/NewString.swift#L139

https://github.com/apple/swift/blob/44f85d209080d6cf6347fbe6f582f4994a5ac814/test/SILOptimizer/loop-region-analysis.sil#L656
