### PR TITLE
Properly Compare True and False Order in Sourcekit

### DIFF
--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -7,7 +7,7 @@ func test() {
 
 }
 
-// XFAIL: broken_std_regex, linux
+// XFAIL: broken_std_regex
 // RUN: %sourcekitd-test -req=complete -req-opts=hidelowpriority=0 -pos=7:1 %s -- %s > %t.orig
 // RUN: %FileCheck -check-prefix=NAME %s < %t.orig
 // Make sure the order is as below, foo(Int) should come before foo(String).

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -817,7 +817,7 @@ static int compareLiterals(Item &a_, Item &b_) {
 
   // Sort true before false instead of alphabetically.
   if (cast<Result>(a_).value->getLiteralKind() == CodeCompletionLiteralKind::BooleanLiteral)
-    return a_.name > b_.name;
+    return b_.name.compare(a_.name);
 
   return 0;
 }


### PR DESCRIPTION
Comparing "false" > "true" will return 0, which when returned by compare
indicates the two are equal which will result in a non deterministic
ordering of "false" and "true". Using `.compare` returns a negative number
as expected.