### PR TITLE
[android] Remove dependency from SwiftShims to Libc

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -23,10 +23,6 @@
 #include "SwiftStddef.h"
 #include "Visibility.h"
 
-#if defined(__ANDROID__)
-#include <android/api-level.h>
-#endif
-
 #if __has_feature(nullability)
 #pragma clang assume_nonnull begin
 #endif
@@ -112,7 +108,7 @@ static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
    || defined(__HAIKU__) || defined(__FreeBSD__)
 static inline __swift_size_t _swift_stdlib_malloc_size(const void *ptr) {
 #if defined(__ANDROID__)
-#if __ANDROID_API__ >= 17
+#if !defined(__ANDROID_API__) || __ANDROID_API__ >= 17
   extern __swift_size_t malloc_usable_size(const void *ptr);
 #endif
 #else


### PR DESCRIPTION
Seems that SwiftShims cannot import some system headers (checked by a
test in test/ParseableInterface/ModuleCache/SystemDependencies). So
adding <android/api-level.h> is not going to work.

The change reproduces the only piece necessary from the header, which is
interpreting that if no __ANDROID_API__ is defined, the level should be
the maximum allowed.