### PR TITLE
Followup fixes for stored opaque-type properties.

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -124,7 +124,7 @@ Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
 Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
   auto archetype = cast<ArchetypeType>(type);
   if (isa<OpaqueTypeArchetypeType>(archetype->getRoot()))
-    return type;
+    return Type();
   
   return archetype->getInterfaceType();
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3278,8 +3278,9 @@ static Type substType(Type derivedType,
       return None;
 
     // If we have a substitution for this type, use it.
-    if (auto known = substitutions(substOrig))
+    if (auto known = substitutions(substOrig)) {
       return known;
+    }
 
     // If we failed to substitute a generic type parameter, give up.
     if (isa<GenericTypeParamType>(substOrig)) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -697,7 +697,8 @@ static bool validateTypedPattern(TypeChecker &TC,
       auto opaqueTy = TC.getOrCreateOpaqueResultType(resolution,
                                                      named->getDecl(),
                                                      opaqueRepr);
-      TL.setType(opaqueTy);
+      TL.setType(named->getDecl()->getDeclContext()
+                                 ->mapTypeIntoContext(opaqueTy));
       hadError = opaqueTy->hasError();
     } else {
       TC.diagnose(TP->getLoc(), diag::opaque_type_unsupported_pattern);

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -437,3 +437,24 @@ func foo<T: P_52528543>(x: T) -> some P_52528543 {
     .frob(a_b: x.a.b)
     .frob(a_b: x.a.b) // expected-error {{cannot convert}}
 }
+
+struct GenericFoo<T: P_52528543, U: P_52528543> {
+  let x: some P_52528543 = T()
+  let y: some P_52528543 = U()
+
+  mutating func bump() {
+    var xab = f_52528543(x: x)
+    xab = f_52528543(x: y) // expected-error{{cannot assign}}
+  }
+}
+
+func f_52528543<T: P_52528543>(x: T) -> T.A.B { return x.a.b }
+
+func opaque_52528543<T: P_52528543>(x: T) -> some P_52528543 { return x }
+
+func invoke_52528543<T: P_52528543, U: P_52528543>(x: T, y: U) {
+  let x2 = opaque_52528543(x: x)
+  let y2 = opaque_52528543(x: y)
+  var xab = f_52528543(x: x2)
+  xab = f_52528543(x: y2) // expected-error{{cannot assign}}
+}


### PR DESCRIPTION
- TypedPatterns expect to have a contextual type in generic contexts.
- mapTypeOutOfContext failed for NestedArchetypes under opaque archetypes.

rdar://problem/51127135