### PR TITLE
[5.1] Sema: Substitute the root generic param when transforming OpaqueArchetypes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3310,6 +3310,9 @@ ERROR(trailing_closure_requires_parens,none,
       "trailing closure requires parentheses for disambiguation in this"
       " context", ())
 
+ERROR(opaque_type_var_no_init,none,
+      "property declares an opaque return type, but has no initializer "
+      "expression from which to infer an underlying type", ())
 ERROR(opaque_type_no_underlying_type_candidates,none,
       "function declares an opaque return type, but has no return statements "
       "in its body from which to infer an underlying type", ())
@@ -3321,6 +3324,9 @@ NOTE(opaque_type_underlying_type_candidate_here,none,
 ERROR(opaque_type_self_referential_underlying_type,none,
       "function opaque return type was inferred as %0, which defines the "
       "opaque type in terms of itself", (Type))
+ERROR(opaque_type_var_no_underlying_type,none,
+      "property declares an opaque return type, but cannot infer the "
+      "underlying type from its initializer expression", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Patterns

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5131,6 +5131,10 @@ public:
   /// base.
   Type substBaseType(Type base, LookupConformanceFn lookupConformance);
 
+  /// Substitute the root generic type, looking up the chain of associated types.
+  /// Returns null if the member could not be found in the new root.
+  Type substRootParam(Type newRoot, LookupConformanceFn lookupConformance);
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::DependentMember;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -124,7 +124,7 @@ Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
 Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
   auto archetype = cast<ArchetypeType>(type);
   if (isa<OpaqueTypeArchetypeType>(archetype->getRoot()))
-    return type;
+    return Type();
   
   return archetype->getInterfaceType();
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3259,8 +3259,9 @@ static Type substType(Type derivedType,
       return None;
 
     // If we have a substitution for this type, use it.
-    if (auto known = substitutions(substOrig))
+    if (auto known = substitutions(substOrig)) {
       return known;
+    }
 
     // If we failed to substitute a generic type parameter, give up.
     if (isa<GenericTypeParamType>(substOrig)) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2972,7 +2972,8 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
   // Produce a failed result.
   auto failed = [&]() -> Type {
-    if (!options.contains(SubstFlags::UseErrorType)) return Type();
+    if (!options.contains(SubstFlags::UseErrorType))
+      return Type();
 
     Type baseType = ErrorType::get(substBase ? substBase : origBase);
     if (assocType)
@@ -3104,6 +3105,19 @@ Type DependentMemberType::substBaseType(Type substBase,
 
   return getMemberForBaseType(lookupConformance, getBase(), substBase,
                               getAssocType(), getName(), None);
+}
+
+Type DependentMemberType::substRootParam(Type newRoot,
+                                         LookupConformanceFn lookupConformance){
+  auto base = getBase();
+  if (auto param = base->getAs<GenericTypeParamType>()) {
+    return substBaseType(newRoot, lookupConformance);
+  }
+  if (auto depMem = base->getAs<DependentMemberType>()) {
+    return substBaseType(depMem->substRootParam(newRoot, lookupConformance),
+                         lookupConformance);
+  }
+  return Type();
 }
 
 static Type substGenericFunctionType(GenericFunctionType *genericFnType,
@@ -3876,7 +3890,7 @@ case TypeKind::Id:
     }
     
     // Substitute the new root into the root of the interface type.
-    return nestedType->getInterfaceType()->substBaseType(substRoot,
+    return nestedType->getInterfaceType()->substRootParam(substRoot,
         LookUpConformanceInModule(root->getDecl()->getModuleContext()));
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1164,7 +1164,8 @@ ConstraintSystem::solveImpl(Expr *&expr,
     auto constraintKind = ConstraintKind::Conversion;
     
     if ((getContextualTypePurpose() == CTP_ReturnStmt ||
-         getContextualTypePurpose() == CTP_ReturnSingleExpr)
+         getContextualTypePurpose() == CTP_ReturnSingleExpr ||
+         getContextualTypePurpose() == CTP_Initialization)
         && Options.contains(ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType))
       constraintKind = ConstraintKind::OpaqueUnderlyingType;
     

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2652,8 +2652,11 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         initType = patternType;
 
         // Add a conversion constraint between the types.
-        cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
-                         patternType, Locator, /*isFavored*/true);
+        if (!cs.Options.contains(
+                   ConstraintSystemFlags::UnderlyingTypeForOpaqueReturnType)) {
+          cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
+                           patternType, Locator, /*isFavored*/true);
+        }
       }
 
       // The expression has been pre-checked; save it in case we fail later.
@@ -2765,6 +2768,13 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     // If we already had an error, don't repeat the problem.
     if (contextualType.getType()->hasError())
       return true;
+    
+    // Allow the initializer expression to establish the underlying type of an
+    // opaque type.
+    if (auto opaqueType = pattern->getType()->getAs<OpaqueTypeArchetypeType>()){
+      flags |= TypeCheckExprFlags::ConvertTypeIsOpaqueReturnType;
+      flags -= TypeCheckExprFlags::ConvertTypeIsOnlyAHint;
+    }
 
     // Only provide a TypeLoc if it makes sense to allow diagnostics.
     if (auto *typedPattern = dyn_cast<TypedPattern>(pattern)) {
@@ -2849,10 +2859,35 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   PBD->setPattern(patternNumber, pattern, initContext);
   PBD->setInit(patternNumber, init);
 
+  // Bind a property with an opaque return type to the underlying type
+  // given by the initializer.
+  if (auto var = pattern->getSingleVar()) {
+    if (auto opaque = var->getOpaqueResultTypeDecl()) {
+      if (auto convertedInit = dyn_cast<UnderlyingToOpaqueExpr>(init)) {
+        auto underlyingType = convertedInit->getSubExpr()->getType()
+            ->mapTypeOutOfContext();
+        auto underlyingSubs = SubstitutionMap::get(
+          opaque->getOpaqueInterfaceGenericSignature(),
+          [&](SubstitutableType *t) -> Type {
+            if (t->isEqual(opaque->getUnderlyingInterfaceType())) {
+              return underlyingType;
+            }
+            return Type(t);
+          },
+          LookUpConformanceInModule(opaque->getModuleContext()));
+        
+        opaque->setUnderlyingTypeSubstitutions(underlyingSubs);
+      } else {
+        diagnose(var->getLoc(), diag::opaque_type_var_no_underlying_type);
+      }
+    }
+  }
+  
   if (hadError)
     PBD->setInvalid();
 
   PBD->setInitializerChecked(patternNumber);
+  
   return hadError;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2344,6 +2344,12 @@ public:
           if (!var->hasType())
             var->markInvalid();
         };
+        
+        // Properties with an opaque return type need an initializer to
+        // determine their underlying type.
+        if (var->getOpaqueResultTypeDecl()) {
+          TC.diagnose(var->getLoc(), diag::opaque_type_var_no_init);
+        }
 
         // Non-member observing properties need an initializer.
         if (var->getWriteImpl() == WriteImplKind::StoredWithObservers &&
@@ -2402,8 +2408,9 @@ public:
       if (!PBD->isInitialized(i))
         continue;
 
-      if (!PBD->isInitializerChecked(i))
+      if (!PBD->isInitializerChecked(i)) {
         TC.typeCheckPatternBinding(PBD, i);
+      }
 
       if (!PBD->isInvalid()) {
         auto &entry = PBD->getPatternList()[i];

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -697,7 +697,8 @@ static bool validateTypedPattern(TypeChecker &TC,
       auto opaqueTy = TC.getOrCreateOpaqueResultType(resolution,
                                                      named->getDecl(),
                                                      opaqueRepr);
-      TL.setType(opaqueTy);
+      TL.setType(named->getDecl()->getDeclContext()
+                                 ->mapTypeIntoContext(opaqueTy));
       hadError = opaqueTy->hasError();
     } else {
       TC.diagnose(TP->getLoc(), diag::opaque_type_unsupported_pattern);

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -192,3 +192,9 @@ struct X<T: R, U: R>: R {
   }
 }
 
+var globalOProp: some O = 0
+
+struct OpaqueProps {
+  static var staticOProp: some O = 0
+  var instanceOProp: some O = 0
+}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -427,3 +427,48 @@ struct Foo {
   var instanceVar: some P = 17
   let instanceLet: some P = 38
 }
+
+protocol P_52528543 {
+  init()
+
+  associatedtype A: Q_52528543
+
+  var a: A { get }
+}
+
+protocol Q_52528543 {
+  associatedtype B // expected-note 2 {{associated type 'B'}}
+
+  var b: B { get }
+}
+
+extension P_52528543 {
+  func frob(a_b: A.B) -> some P_52528543 { return self }
+}
+
+func foo<T: P_52528543>(x: T) -> some P_52528543 {
+  return x
+    .frob(a_b: x.a.b)
+    .frob(a_b: x.a.b) // expected-error {{cannot convert}}
+}
+
+struct GenericFoo<T: P_52528543, U: P_52528543> {
+  let x: some P_52528543 = T()
+  let y: some P_52528543 = U()
+
+  mutating func bump() {
+    var xab = f_52528543(x: x)
+    xab = f_52528543(x: y) // expected-error{{cannot assign}}
+  }
+}
+
+func f_52528543<T: P_52528543>(x: T) -> T.A.B { return x.a.b }
+
+func opaque_52528543<T: P_52528543>(x: T) -> some P_52528543 { return x }
+
+func invoke_52528543<T: P_52528543, U: P_52528543>(x: T, y: U) {
+  let x2 = opaque_52528543(x: x)
+  let y2 = opaque_52528543(x: y)
+  var xab = f_52528543(x: x2)
+  xab = f_52528543(x: y2) // expected-error{{cannot assign}}
+}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -12,10 +12,9 @@ extension Array: P, Q { func paul() {}; mutating func priscilla() {}; func quinn
 class C {}
 class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {} }
 
-// TODO: Should be valid
-
-let property: some P = 1 // TODO expected-error{{cannot convert}}
-let deflessProperty: some P // TODO e/xpected-error{{butz}}
+let property: some P = 1
+let deflessLet: some P // expected-error{{has no initializer}}
+var deflessVar: some P // expected-error{{has no initializer}}
 
 struct GenericProperty<T: P> {
   var x: T
@@ -159,7 +158,6 @@ func typeIdentity() {
 
   // The opaque type should expose the members implied by its protocol
   // constraints
-  // TODO: associated types
   do {
     var a = alice()
     a.paul()
@@ -417,4 +415,15 @@ func testCoercionDiagnostics() {
   // FIXME: It would be nice to show the "from" info here as well.
   opaqueOpt = bar() // expected-error {{cannot assign value of type 'some P' to type '(some P)?'}} {{none}}
   opaqueOpt = () // expected-error {{cannot assign value of type '()' to type '(some P)?'}} {{none}}
+}
+
+var globalVar: some P = 17
+let globalLet: some P = 38
+
+struct Foo {
+  static var staticVar: some P = 17
+  static let staticLet: some P = 38
+
+  var instanceVar: some P = 17
+  let instanceLet: some P = 38
 }


### PR DESCRIPTION
Explanation: For a nested associated type of an opaque archetype, the code would incorrectly substitute the immediate parent of the associated type with the root, causing crashes during substitution when
the substitution failed unexpectedly.

Scope: Fixes a compiler crash when type checking large expressions involving opaque result types.

Issue: rdar://problem/52528543

Risk: Low, targeted correctness fix that should only affect code involving nested associated types of opaque types

Testing: Swift CI

Reviewed by: @xedin 

(This PR depends on and includes the commits from https://github.com/apple/swift/pull/25961. 
ad5f324 is the commit specific to this issue.)