### PR TITLE
[5.1][ConstraintSystem] `trySimplifyToExpr` shouldn't rely on locator bein…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -180,6 +180,12 @@ bool constraints::computeTupleShuffle(ArrayRef<TupleTypeElt> fromTuple,
 Expr *ConstraintLocatorBuilder::trySimplifyToExpr() const {
   SmallVector<LocatorPathElt, 4> pathBuffer;
   Expr *anchor = getLocatorParts(pathBuffer);
+  // Locators are not guaranteed to have an anchor
+  // if constraint system is used to verify generic
+  // requirements.
+  if (!anchor)
+    return nullptr;
+
   ArrayRef<LocatorPathElt> path = pathBuffer;
 
   Expr *targetAnchor;

--- a/test/Constraints/sr10728.swift
+++ b/test/Constraints/sr10728.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+typealias T1 = Int
+typealias T2 = Float
+typealias T3 = Bool
+
+protocol P {
+  associatedtype R
+  static var foo: (T1, (R) -> T2) { get }
+}
+
+extension P {
+  static func bind() -> (T1, (R) -> T3) {
+    return (1, { _ in true })
+  }
+}
+
+struct S: P {
+  typealias R = T3
+
+  static let foo: (T1, (R) -> T2) = bind()
+  // expected-error@-1 {{cannot convert value of type '(T1, (S.R) -> T3)' (aka '(Int, (Bool) -> Bool)') to specified type '(T1, (S.R) -> T2)' (aka '(Int, (Bool) -> Float)')}}
+}


### PR DESCRIPTION
…g always anchored

- **Explanation**:

If constraint system is used as part of the declaration checker to
e.g. verify generic requirements for a witness, locators are not going
to have an anchor.

- **Issue**: rdar://problem/50987089

- **Scope**: Diagnostics, when declaration checker validates generic requirements.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @DougGregor

Resolves: [SR-10728](https://bugs.swift.org/browse/SR-10728)
Resolves: rdar://problem/50987089
(cherry picked from commit ae5cce4a6adc55d7fb1dc20bf5e50c16df3e300f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
