### PR TITLE
[NameLookup, ASTScope] Add localizableMemberCount to IterableDeclContext.

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -692,6 +692,13 @@ class IterableDeclContext {
   /// member loading, as a key when doing lookup in this IDC.
   serialization::DeclID SerialID;
 
+  /// Because \c parseDelayedDecl and lazy member adding can add members *after*
+  /// an \c ASTScope tree is created, there must be some way for the tree to
+  /// detect when a member has been added. A bit would suffice,
+  /// but would be more fragile, The scope code could count the members each
+  /// time, but I think it's a better trade to just keep a count here.
+  unsigned memberCount = 0;
+
   template<class A, class B, class C>
   friend struct ::llvm::cast_convert_val;
 
@@ -720,6 +727,9 @@ public:
   /// Add a member to this context. If the hint decl is specified, the new decl
   /// is inserted immediately after the hint.
   void addMember(Decl *member, Decl *hint = nullptr);
+
+  /// See \c memberCount
+  unsigned getMemberCount() const { return memberCount; }
 
   /// Check whether there are lazily-loaded members.
   bool hasLazyMembers() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -716,6 +716,7 @@ DeclRange IterableDeclContext::getMembers() const {
 void IterableDeclContext::addMember(Decl *member, Decl *Hint) {
   // Add the member to the list of declarations without notification.
   addMemberSilently(member, Hint);
+  ++memberCount;
 
   // Notify our parent declaration that we have added the member, which can
   // be used to update the lookup tables.


### PR DESCRIPTION
Because delayed parsing can add a member to an `IterableDeclContext`, the ASTScope tree must be able to quickly detect when this has happened, so it can rebuild as needed. So, add a counter for that to `IterableDeclContext`. We *might* be able to get by with just a bit, but a counter is more robust.