### PR TITLE
Extensions inherit the availability of the extended type

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1076,6 +1076,11 @@ const AvailableAttr *AvailableAttr::isUnavailable(const Decl *D) {
   if (auto ext = dyn_cast<ExtensionDecl>(D->getDeclContext()))
     return AvailableAttr::isUnavailable(ext);
 
+  // Extensions inherit the unavailability from the extended type.
+  if (auto *extension = dyn_cast<ExtensionDecl>(D))
+    if (auto *extended = extension->getExtendedNominal())
+      return AvailableAttr::isUnavailable(extended);
+
   return nullptr;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -644,6 +644,11 @@ bool Decl::isWeakImported(ModuleDecl *fromModule,
     return cast<ClassDecl>(dtor->getDeclContext())->isWeakImported(
         fromModule, fromContext);
 
+  if (auto *extension = dyn_cast<ExtensionDecl>(this))
+    if (auto *extended = extension->getExtendedNominal())
+      if (extended->isWeakImported(fromModule, fromContext))
+        return true;
+
   auto *dc = getDeclContext();
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))
     return ext->isWeakImported(fromModule, fromContext);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1604,11 +1604,14 @@ static Type resolveIdentTypeComponent(
 
 static bool diagnoseAvailability(IdentTypeRepr *IdType,
                                  DeclContext *DC,
-                                 bool AllowPotentiallyUnavailableProtocol) {
+                                 bool AllowPotentiallyUnavailableProtocol,
+                                 bool AllowPotentiallyUnavailable) {
   DeclAvailabilityFlags flags =
     DeclAvailabilityFlag::ContinueOnPotentialUnavailability;
   if (AllowPotentiallyUnavailableProtocol)
     flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
+  if (AllowPotentiallyUnavailable)
+    flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailable;
   ASTContext &ctx = DC->getASTContext();
   auto componentRange = IdType->getComponentRange();
   for (auto comp : componentRange) {
@@ -1694,7 +1697,8 @@ Type TypeChecker::resolveIdentifierType(
   if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
       !options.contains(TypeResolutionFlags::AllowUnavailable) &&
       diagnoseAvailability(IdType, DC,
-             options.contains(TypeResolutionFlags::AllowUnavailableProtocol))) {
+             options.contains(TypeResolutionFlags::AllowUnavailableProtocol),
+             options.is(TypeResolverContext::ExtensionBinding))) {
     Components.back()->setInvalid();
     return ErrorType::get(ctx);
   }

--- a/test/IRGen/Inputs/weak_import_availability_helper.swift
+++ b/test/IRGen/Inputs/weak_import_availability_helper.swift
@@ -12,6 +12,10 @@ public struct ConditionallyAvailableStruct {
   public func conditionallyAvailableMethod() {}
 }
 
+extension ConditionallyAvailableStruct {
+  public struct NestedStruct {}
+}
+
 public protocol AlwaysAvailableProtocol {}
 
 public struct AlwaysAvailableStruct {}

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -71,3 +71,10 @@ public func useConditionallyAvailableMethod(s: ConditionallyAvailableStruct) {
 
 // CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(%swift.opaque* noalias nocapture swiftself)
 // CHECK-NEW-LABEL: declare swiftcc void @"$s31weak_import_availability_helper28ConditionallyAvailableStructV013conditionallyF6MethodyyF"(%swift.opaque* noalias nocapture swiftself)
+
+@available(macOS 10.50, *)
+public func useConditionallyAvailableNestedStruct() {
+  blackHole(ConditionallyAvailableStruct.NestedStruct.self)
+}
+// CHECK-OLD-LABEL: declare extern_weak swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructV06NestedG0VMa"(i64)
+// CHECK-NEW-LABEL: declare swiftcc %swift.metadata_response @"$s31weak_import_availability_helper28ConditionallyAvailableStructV06NestedG0VMa"(i64)

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -928,8 +928,7 @@ func GenericSignature<T : ProtocolAvailableOn10_51>(_ t: T) { // expected-error 
 
 // Extensions
 
-extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
-    // expected-note@-1 {{add @available attribute to enclosing extension}}
+extension ClassAvailableOn10_51 { }
 
 @available(OSX, introduced: 10.51)
 extension ClassAvailableOn10_51 {
@@ -1606,4 +1605,61 @@ func useShortFormAvailable() {
       // expected-note@-1 {{add 'if #available' version check}}
 
   unavailableWins() // expected-error {{'unavailableWins()' is unavailable}}
+}
+
+// Test availability inherited by extensions
+@available(macOS, introduced: 10.30)
+func availableFrom10_30() {}
+
+@available(macOS, introduced: 10.60)
+func availableFrom10_60() {}
+
+@available(macOS, introduced: 10.10, deprecated: 10.40)
+func availablePre10_40() {}
+
+@available(macOS, introduced: 10.30, deprecated: 10.40)
+struct InheritedAvailabilityStruct {
+  func introFunc() {}
+}
+
+extension InheritedAvailabilityStruct { // expected-note{{add @available attribute to enclosing extension}}
+  func extensionFunc() { // expected-note{{add @available attribute to enclosing instance method}}
+    introFunc()
+    availableFrom10_30()
+    availableFrom10_60() // expected-error{{'availableFrom10_60()' is only available in macOS 10.60 or newer}}
+      // expected-note@-1{{add 'if #available' version check}}
+    availablePre10_40()
+  }
+}
+
+@available(macOS, unavailable)
+func unavailableOnMacOS() {}
+
+@available(macOS, unavailable)
+struct StructUnavailableOnMacOS {
+  func bar() {
+    unavailableOnMacOS()
+  }
+}
+
+extension StructUnavailableOnMacOS {
+  func foo() {
+    unavailableOnMacOS()
+  }
+}
+
+@available(macOS, deprecated: 10.0)
+func deprecatedOnMacOS() {}
+
+@available(macOS, deprecated: 10.0)
+struct StructDeprecatedOnMacOS {
+  func bar() {
+    deprecatedOnMacOS()
+  }
+}
+
+extension StructDeprecatedOnMacOS {
+  func foo() {
+    deprecatedOnMacOS()
+  }
 }

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -131,7 +131,7 @@ enum EnumWithDeprecatedCasePayload {
   case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn10_51)
 }
 
-extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51' was deprecated in macOS 10.51}}
+extension ClassDeprecatedIn10_51 {
 
 }
 


### PR DESCRIPTION
Automatically apply the availability of the extended type to its extensions. As such, there is no need to repeat the availability attribute on extensions for them to have the same availability.