### PR TITLE
Sort `DeclAttributeAndRange`s Deterministically

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1080,10 +1080,13 @@ bool ModelASTWalker::handleAttrRanges(ArrayRef<DeclAttributeAndRange> DeclRanges
 
   SmallVector<DeclAttributeAndRange, 4> SortedRanges(DeclRanges.begin(),
                                                      DeclRanges.end());
-  std::sort(SortedRanges.begin(), SortedRanges.end(),
-            [&](DeclAttributeAndRange LHS, DeclAttributeAndRange RHS) {
-    return SM.isBeforeInBuffer(LHS.second.Start, RHS.second.End);
-  });
+  std::sort(
+      SortedRanges.begin(), SortedRanges.end(),
+      [&](DeclAttributeAndRange LHS, DeclAttributeAndRange RHS) {
+        // Since attributes don't overlap it's safe to compare just by the
+        // range's Start
+        return SM.isBeforeInBuffer(LHS.second.Start, RHS.second.Start);
+      });
   // Handle duplicate synthesized attributes due to * in @available
   auto NewEnd = std::unique(SortedRanges.begin(), SortedRanges.end(),
                             [&](DeclAttributeAndRange LHS, DeclAttributeAndRange RHS) {


### PR DESCRIPTION
Comparing the start and end of ranges doesn't work in all cases since
both a < b and b < a can be true if a = b. This behavior was causing an
assertion fail in the Windows standard library which while sorting,
asserts that if `a < b`, then  `!(b < a)` in debug mode.

Since ranges don't overlap otherwise, comparing just the starts of the
ranges will properly sort them.
