### PR TITLE
Fix typo introduced in PR #25845.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -724,7 +724,7 @@ void ModuleFile::readGenericRequirements(
 
     scratch.clear();
     unsigned recordID = fatalIfUnexpected(
-        DeclTypeCursor.readRecord(entry.ID, scratch, &blobData));
+        Cursor.readRecord(entry.ID, scratch, &blobData));
     switch (recordID) {
     case GENERIC_REQUIREMENT: {
       uint8_t rawKind;


### PR DESCRIPTION
This should fix:
```
Record kind for a SIL instruction is not supported.
UNREACHABLE executed at /home/parkers/swift-source/swift/lib/Serialization/DeserializeSIL.cpp:1006!
```