### PR TITLE
More lazy body synthesis

### DIFF
--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -301,7 +301,7 @@ SourceRange AbstractFunctionDeclScope::getChildlessSourceRange() const {
     assert(r.End.isValid());
     return r;
   }
-  return decl->getBody()->getSourceRange();
+  return decl->getBodySourceRange();
 }
 
 SourceRange AbstractFunctionParamsScope::getChildlessSourceRange() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -536,8 +536,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   auto body = BraceStmt::create(C, SourceLoc(), {assign, ret}, SourceLoc(),
                                 /*implicit*/ true);
   
-  ctorDecl->setBody(body);
-  ctorDecl->setBodyTypeCheckedIfPresent();
+  ctorDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
 
   return ctorDecl;
 }
@@ -612,8 +611,7 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
                                 /*implicit*/ true);
   
-  getterDecl->setBody(body);
-  getterDecl->setBodyTypeCheckedIfPresent();
+  getterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
 
   return getterDecl;
 }
@@ -689,8 +687,7 @@ static AccessorDecl *makeStructRawValueGetter(
   auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
                                 /*implicit*/ true);
   
-  getterDecl->setBody(body);
-  getterDecl->setBodyTypeCheckedIfPresent();
+  getterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
 
   return getterDecl;
 }
@@ -848,8 +845,7 @@ makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
     auto ret = new (C) ReturnStmt(SourceLoc(), expr);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
                                   /*implicit*/ true);
-    getterDecl->setBody(body);
-    getterDecl->setBodyTypeCheckedIfPresent();
+    getterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
     getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
   }
 
@@ -879,8 +875,7 @@ makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
 
     auto body = BraceStmt::create(C, SourceLoc(), { assign }, SourceLoc(),
                                   /*implicit*/ true);
-    setterDecl->setBody(body);
-    setterDecl->setBodyTypeCheckedIfPresent();
+    setterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
     setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
   }
 
@@ -956,8 +951,7 @@ makeUnionFieldAccessors(ClangImporter::Implementation &Impl,
     auto ret = new (C) ReturnStmt(SourceLoc(), reinterpreted);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc(),
                                   /*implicit*/ true);
-    getterDecl->setBody(body);
-    getterDecl->setBodyTypeCheckedIfPresent();
+    getterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
     getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
   }
 
@@ -1017,8 +1011,7 @@ makeUnionFieldAccessors(ClangImporter::Implementation &Impl,
 
     auto body = BraceStmt::create(C, SourceLoc(), { initialize }, SourceLoc(),
                                   /*implicit*/ true);
-    setterDecl->setBody(body);
-    setterDecl->setBodyTypeCheckedIfPresent();
+    setterDecl->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
     setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
   }
 
@@ -1282,8 +1275,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
   // Create the function body.
   auto body = BraceStmt::create(context, SourceLoc(), {assign, ret},
                                 SourceLoc());
-  constructor->setBody(body);
-  constructor->setBodyTypeCheckedIfPresent();
+  constructor->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
 
   // We're done.
   return constructor;
@@ -1401,8 +1393,7 @@ createValueConstructor(ClangImporter::Implementation &Impl,
 
     // Create the function body.
     auto body = BraceStmt::create(context, SourceLoc(), stmts, SourceLoc());
-    constructor->setBody(body);
-    constructor->setBodyTypeCheckedIfPresent();
+    constructor->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
   }
 
   // We're done.
@@ -1552,8 +1543,7 @@ static ConstructorDecl *createRawValueBridgingConstructor(
     auto ret = new (ctx) ReturnStmt(SourceLoc(), result, /*Implicit=*/true);
 
     auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());
-    init->setBody(body);
-    init->setBodyTypeCheckedIfPresent();
+    init->setBody(body, AbstractFunctionDecl::BodyKind::TypeChecked);
   }
 
   return init;
@@ -1911,8 +1901,8 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
 
   auto ret = new (C) ReturnStmt(SourceLoc(), domainDeclRef);
   getterDecl->setBody(
-      BraceStmt::create(C, SourceLoc(), {ret}, SourceLoc(), isImplicit));
-  getterDecl->setBodyTypeCheckedIfPresent();
+      BraceStmt::create(C, SourceLoc(), {ret}, SourceLoc(), isImplicit),
+      AbstractFunctionDecl::BodyKind::TypeChecked);
 
   return true;
 }
@@ -8268,8 +8258,8 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
     // Finally, set the body.
     func->setBody(BraceStmt::create(C, SourceLoc(),
                                     ASTNode(ret),
-                                    SourceLoc()));
-    func->setBodyTypeCheckedIfPresent();
+                                    SourceLoc()),
+                  AbstractFunctionDecl::BodyKind::TypeChecked);
   }
 
   // Mark the function transparent so that we inline it away completely.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1159,10 +1159,6 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
 
   makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
-  // Don't bother synthesizing the body if we've already finished type-checking.
-  if (Impl.hasFinishedTypeChecking())
-    return { getterDecl, setterDecl };
-  
   // Synthesize the getter body
   {
     auto cGetterSelfId = nullptr;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -454,9 +454,6 @@ public:
   // Mapping from imported types to their raw value types.
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
 
-  // Mapping from imported types to their init(rawValue:) initializers.
-  llvm::DenseMap<const NominalTypeDecl *, ConstructorDecl *> RawInits;
-
   clang::CompilerInstance *getClangInstance() {
     return Instance.get();
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1168,10 +1168,6 @@ public:
            "already have a type resolver");
     typeResolver.setPointerAndInt(newResolver, true);
   }
-  bool hasBegunTypeChecking() const { return typeResolver.getInt(); }
-  bool hasFinishedTypeChecking() const {
-    return hasBegunTypeChecking() && !getTypeResolver();
-  }
 
   /// Allocate a new delayed conformance ID with the given set of
   /// conformances.

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -350,7 +350,7 @@ public:
     //  }
     if (auto FD = dyn_cast_or_null<AccessorDecl>(Start.getAsDecl())) {
       if (FD->isGetter() && FD->getAccessorKeywordLoc().isInvalid()) {
-        if (SM.getLineNumber(FD->getBody()->getLBraceLoc()) == Line)
+        if (SM.getLineNumber(FD->getBodySourceRange().Start) == Line)
           return false;
       }
     }

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1333,15 +1333,13 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       DiffItem->RightComment, /*From String*/false,
       /*No expression to wrap*/nullptr);
 
-    if (auto *BD = AFD->getBody()) {
-      auto BL = BD->getLBraceLoc();
-      if (BL.isValid()) {
-        // Insert the local variable declaration after the opening brace.
-        Editor.insertAfterToken(BL,
-          (llvm::Twine("\n// Local variable inserted by Swift 4.2 migrator.") +
-           "\nlet " + VariableName + " = " + Info.getFuncName() + "(" +
-           VariableName + ")\n").str());
-      }
+    auto BL = AFD->getBodySourceRange().Start;
+    if (BL.isValid()) {
+      // Insert the local variable declaration after the opening brace.
+      Editor.insertAfterToken(BL,
+        (llvm::Twine("\n// Local variable inserted by Swift 4.2 migrator.") +
+         "\nlet " + VariableName + " = " + Info.getFuncName() + "(" +
+         VariableName + ")\n").str());
     }
   }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -991,7 +991,7 @@ ParserResult<Stmt> Parser::parseStmtDefer() {
     tempDecl->setBody(Body.get());
   }
   
-  SourceLoc loc = tempDecl->getBody()->getStartLoc();
+  SourceLoc loc = tempDecl->getBodySourceRange().Start;
 
   // Form the call, which will be emitted on any path that needs to run the
   // code.

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -39,7 +39,8 @@ static bool canDeriveConformance(NominalTypeDecl *type) {
 }
 
 /// Derive the implementation of allCases for a "simple" no-payload enum.
-void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl, void *) {
+std::pair<BraceStmt *, bool>
+deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto *parentEnum = parentDC->getSelfEnumDecl();
   auto enumTy = parentDC->getDeclaredTypeInContext();
@@ -57,7 +58,7 @@ void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl, void *) {
   auto *returnStmt = new (C) ReturnStmt(SourceLoc(), arrayExpr);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                  SourceLoc());
-  funcDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 static ArraySliceType *computeAllCasesType(NominalTypeDecl *enumDecl) {

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -553,7 +553,8 @@ lookupVarDeclForCodingKeysCase(DeclContext *conformanceDC,
 /// Synthesizes the body for `func encode(to encoder: Encoder) throws`.
 ///
 /// \param encodeDecl The function decl whose body to synthesize.
-static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -712,7 +713,7 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *)
 
   auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
                                  /*implicit=*/true);
-  encodeDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Synthesizes a function declaration for `encode(to: Encoder) throws` with a
@@ -778,7 +779,8 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
 /// Synthesizes the body for `init(from decoder: Decoder) throws`.
 ///
 /// \param initDecl The function decl whose body to synthesize.
-static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
   // struct Foo : Codable {
   //   var x: Int
   //   var y: String
@@ -992,7 +994,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
 
   auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
                                  /*implicit=*/true);
-  initDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Synthesizes a function declaration for `init(from: Decoder) throws` with a

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -29,7 +29,8 @@ using namespace swift;
 /// Sets the body of the given function to `return nil`.
 ///
 /// \param funcDecl The function whose body to set.
-static void deriveNilReturn(AbstractFunctionDecl *funcDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveNilReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -37,13 +38,14 @@ static void deriveNilReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *returnStmt = new (C) ReturnStmt(SourceLoc(), nilExpr);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                  SourceLoc());
-  funcDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Sets the body of the given function to `return self.rawValue`.
 ///
 /// \param funcDecl The function whose body to set.
-static void deriveRawValueReturn(AbstractFunctionDecl *funcDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveRawValueReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *parentDC = funcDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -55,14 +57,15 @@ static void deriveRawValueReturn(AbstractFunctionDecl *funcDecl, void *) {
   auto *returnStmt = new (C) ReturnStmt(SourceLoc(), memberRef);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                  SourceLoc());
-  funcDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Sets the body of the given function to `self.init(rawValue:)`, passing along
 /// the parameter of the given constructor.
 ///
 /// \param initDecl The constructor whose body to set.
-static void deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   auto *parentDC = initDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
@@ -96,7 +99,7 @@ static void deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
 
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(callExpr),
                                  SourceLoc());
-  initDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Synthesizes a constructor declaration with the given parameter name and
@@ -189,7 +192,7 @@ static ValueDecl *deriveProperty(DerivedConformance &derived, Type type,
 /// switching on `self`.
 ///
 /// \param strValDecl The function whose body to set.
-static void
+static std::pair<BraceStmt *, bool>
 deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
   // enum SomeEnum {
   //   case A, B, C
@@ -247,14 +250,14 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
     body = BraceStmt::create(C, SourceLoc(), ASTNode(switchStmt), SourceLoc());
   }
 
-  strValDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Sets the body of the given constructor to initialize `self` based on the
 /// value of the given string param.
 ///
 /// \param initDecl The function whose body to set.
-static void
+static std::pair<BraceStmt *, bool>
 deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
   // enum SomeEnum {
   //   case A, B, C
@@ -279,8 +282,7 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
 
   auto elements = enumDecl->getAllElements();
   if (elements.empty() /* empty enum */) {
-    deriveNilReturn(initDecl, nullptr);
-    return;
+    return deriveNilReturn(initDecl, nullptr);
   }
 
   auto *selfRef = DerivedConformance::createSelfDeclRef(initDecl);
@@ -327,7 +329,7 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
                                         SourceLoc(), C);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(switchStmt),
                                  SourceLoc());
-  initDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 /// Returns whether the given enum is eligible for CodingKey synthesis.

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -27,8 +27,9 @@
 using namespace swift;
 using namespace swift::objc_translation;
 
-static void deriveBodyBridgedNSError_enum_nsErrorDomain(
-                    AbstractFunctionDecl *domainDecl, void *) {
+static std::pair<BraceStmt *, bool>
+deriveBodyBridgedNSError_enum_nsErrorDomain(AbstractFunctionDecl *domainDecl,
+                                            void *) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {
@@ -50,11 +51,11 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
     new (C) ReturnStmt(SourceLoc(), initReflectingCall, /*implicit*/ true);
 
   auto body = BraceStmt::create(C, SourceLoc(), ASTNode(ret), SourceLoc());
-
-  domainDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
-static void deriveBodyBridgedNSError_printAsObjCEnum_nsErrorDomain(
+static std::pair<BraceStmt *, bool>
+deriveBodyBridgedNSError_printAsObjCEnum_nsErrorDomain(
                     AbstractFunctionDecl *domainDecl, void *) {
   // enum SomeEnum {
   //   @derived
@@ -75,12 +76,13 @@ static void deriveBodyBridgedNSError_printAsObjCEnum_nsErrorDomain(
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(ret),
                                 SourceLoc());
-  domainDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 static ValueDecl *
-deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived,
-                        void (*synthesizer)(AbstractFunctionDecl *, void*)) {
+deriveBridgedNSError_enum_nsErrorDomain(
+    DerivedConformance &derived,
+    std::pair<BraceStmt *, bool> (*synthesizer)(AbstractFunctionDecl *, void*)) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -59,8 +59,8 @@ static Type deriveRawRepresentable_Raw(DerivedConformance &derived) {
   return derived.getConformanceContext()->mapTypeIntoContext(rawInterfaceType);
 }
 
-static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl,
-                                           void *) {
+static std::pair<BraceStmt *, bool>
+deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
   // enum SomeEnum : SomeType {
   //   case A = 111, B = 222
   //   @derived
@@ -108,8 +108,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl,
     auto returnStmt = new (C) ReturnStmt(SourceLoc(), call);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                   SourceLoc());
-    toRawDecl->setBody(body);
-    return;
+    return { body, /*isTypeChecked=*/false };
   }
 
   Type enumType = parentDC->getDeclaredTypeInContext();
@@ -140,7 +139,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl,
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(switchStmt),
                                 SourceLoc());
-  toRawDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 static void maybeMarkAsInlinable(DerivedConformance &derived,
@@ -267,7 +266,7 @@ static bool checkAvailability(const EnumElementDecl* elt, ASTContext &C,
   return true;
 }
 
-static void
+static std::pair<BraceStmt *, bool>
 deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   // enum SomeEnum : SomeType {
   //   case A = 111, B = 222
@@ -405,7 +404,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(switchStmt),
                                 SourceLoc());
-  initDecl->setBody(body);
+  return { body, /*isTypeChecked=*/false };
 }
 
 static ConstructorDecl *

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5653,8 +5653,8 @@ void TypeChecker::defineDefaultConstructor(NominalTypeDecl *decl) {
   // Create an empty body for the default constructor.
   SmallVector<ASTNode, 1> stmts;
   stmts.push_back(new (Context) ReturnStmt(decl->getLoc(), nullptr));
-  ctor->setBody(BraceStmt::create(Context, SourceLoc(), stmts, SourceLoc()));
-  ctor->setBodyTypeCheckedIfPresent();
+  ctor->setBody(BraceStmt::create(Context, SourceLoc(), stmts, SourceLoc()),
+                AbstractFunctionDecl::BodyKind::TypeChecked);
 }
 
 static void validateAttributes(TypeChecker &TC, Decl *D) {


### PR DESCRIPTION
Start improving lazy synthesis of function bodies:

* Don't ask for a complete function body when we only need the source range
* Don't have lazy body synthesizers mutate the function; return the synthesized body along with a flag indicating whether it is already type checked
* Switch all Clang importer-synthesized bodies over to lazy synthesizers