### PR TITLE
[5.1][ConstraintSystem] Don't attempt dynamic member lookup on invalid base

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4681,6 +4681,10 @@ fixMemberRef(ConstraintSystem &cs, Type baseTy,
     switch (*reason) {
     case MemberLookupResult::UR_InstanceMemberOnType:
     case MemberLookupResult::UR_TypeMemberOnInstance: {
+      if (choice.getKind() == OverloadChoiceKind::DynamicMemberLookup ||
+          choice.getKind() == OverloadChoiceKind::KeyPathDynamicMemberLookup)
+        return nullptr;
+
       return choice.isDecl()
                  ? AllowTypeOrInstanceMember::create(
                        cs, baseTy, choice.getDecl(), memberName, locator)

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar48994658.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar48994658.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Ref<Value> {
+  static func foo(_ value: Int) {} // expected-note {{declared here}}
+}
+
+@dynamicMemberLookup
+protocol RefConvertible {
+  associatedtype Value
+
+  var ref: Ref<Value> { get }
+
+  subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> Ref<T> { get }
+}
+
+extension RefConvertible {
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> Ref<T> {
+    return .init()
+  }
+}
+
+extension Ref : RefConvertible {
+  var ref: Ref { return self }
+}
+
+func rdar_48994658() {
+  Ref.foo() // expected-error {{missing argument for parameter #1 in call}}
+}


### PR DESCRIPTION
- **Explanation**:

If `subscript(dynamicMember:)` is unviable because it's either
an instance method referenced on type or static method
referenced on an instance of type, attempting dynamic
member lookup would be incorrect since it's unclear
what is intended.

- **Issue**: rdar://problem/48994658

- **Scope**: Constraint solver in diagnostic mode.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @DougGregor

Resolves: rdar://problem/48994658
(cherry picked from commit cd07652f223782e8be9f2152915412822c5592a6)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
