### PR TITLE
AST: add a workaround for VS2017

### DIFF
--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -113,7 +113,9 @@ namespace detail {
 
   /// Extract the first, nearest source location from a tuple.
   template<unsigned Index, typename ...Types,
-           typename = typename std::enable_if<Index < sizeof...(Types)>::type>
+           typename = typename std::enable_if<sizeof...(Types) - Index
+                                                  ? true
+                                                  : false>::type>
   SourceLoc extractNearestSourceLocTuple(const std::tuple<Types...> &value) {
     SourceLoc loc = maybeExtractNearestSourceLoc(std::get<Index>(value));
     if (loc.isValid())


### PR DESCRIPTION
Unfortunately, VS2017 does not support the SFINAE expression.  This
means that it attempts to parse the `Index < sizeof...(Types)` as a
template parameter resulting in a parse failure.  This normalises the
constraint to `0 < sizeof...(Types) - Index`
(`sizeof...(Types) - Index > 0`) which is then wrapped into a ternary to
explicitly convert it to a boolean.  This repairs the builds on VS2017.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
