### PR TITLE
[AutoDiff] Disallow JVP/VJP in protocol requirement `@differentiable`…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2784,8 +2784,12 @@ ERROR(differentiable_attr_invalid_access,none,
 ERROR(differentiable_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))
-ERROR(differentiable_attr_protocol_where_clause,none,
-      "'where' clauses cannot be used in a '@differentiable' attribute on a protocol requirement", ())
+ERROR(differentiable_attr_protocol_req_where_clause,none,
+      "'@differentiable' attribute on protocol requirement cannot specify "
+      "'where' clause", ())
+ERROR(differentiable_attr_protocol_req_assoc_func,none,
+      "'@differentiable' attribute on protocol requirement cannot specify "
+      "'jvp:' or 'vjp:'", ())
 ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_nongeneric_trailing_where,none,

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -612,7 +612,7 @@ func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
   return x
 }
 
-protocol DifferentiableAttrRequirements : Differentiable {
+protocol ProtocolRequirements : Differentiable {
   // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Float)'}}
   @differentiable
   init(x: Float, y: Float)
@@ -638,8 +638,13 @@ protocol DifferentiableAttrRequirements : Differentiable {
   func f2(_ x: Float, _ y: Float) -> Float
 }
 
-// expected-error @+1 {{does not conform to protocol 'DifferentiableAttrRequirements'}}
-struct DiffAttrConformanceErrors : DifferentiableAttrRequirements {
+protocol ProtocolRequirementsRefined : ProtocolRequirements {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float
+}
+
+// expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
+struct DiffAttrConformanceErrors : ProtocolRequirements {
   var x: Float
   var y: Float
 
@@ -681,6 +686,31 @@ struct DiffAttrConformanceErrors : DifferentiableAttrRequirements {
   func f2(_ x: Float, _ y: Float) -> Float {
     return x + y
   }
+}
+
+protocol ProtocolRequirementsWithDefault_NoConformingTypes {
+  @differentiable
+  func f1(_ x: Float) -> Float
+}
+extension ProtocolRequirementsWithDefault_NoConformingTypes {
+  // TODO(TF-650): It would be nice to diagnose protocol default implementation
+  // with missing `@differentiable` attribute.
+  func f1(_ x: Float) -> Float { x }
+}
+
+protocol ProtocolRequirementsWithDefault {
+  // expected-note @+2 {{protocol requires function 'f1'}}
+  @differentiable
+  func f1(_ x: Float) -> Float
+}
+extension ProtocolRequirementsWithDefault {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float { x }
+}
+// expected-error @+1 {{type 'DiffAttrConformanceErrors2' does not conform to protocol 'ProtocolRequirementsWithDefault'}}
+struct DiffAttrConformanceErrors2 : ProtocolRequirementsWithDefault {
+  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  func f1(_ x: Float) -> Float { x }
 }
 
 protocol NotRefiningDiffable {
@@ -846,17 +876,7 @@ func inout2(x: Float, y: inout Float) -> Float {
   let _ = x + y
 }
 
-
-// Missing `@differentiable` attribute, without printing the 'wrt' arguments.
-
-protocol DifferentiableWhereClause: Differentiable {
-  associatedtype Scalar
-
-  @differentiable(where Scalar: Differentiable) // expected-error {{'where' clauses cannot be used in a '@differentiable' attribute on a protocol requirement}}
-  func test(value: Scalar) -> Float
-}
-
-// Missing a `@differentiable` attribute.
+// Test refining protocol requirements with `@differentiable` attribute.
 
 public protocol Distribution {
   associatedtype Value
@@ -870,18 +890,25 @@ public protocol DifferentiableDistribution: Differentiable, Distribution {
 
 public protocol MissingDifferentiableDistribution: DifferentiableDistribution
   where Value: Differentiable {
-  func logProbability(of value: Value) -> Float // expected-note {{candidate is missing attribute '@differentiable(wrt: self)'}}
+  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: self)'}}
+  func logProbability(of value: Value) -> Float
 }
 
-// Missing `@differentiable` attribute, without printing the 'wrt' arguments.
+// Test protocol requirement `@differentiable` attribute unsupported features.
 
-protocol Example: Differentiable {
-  associatedtype Scalar: Differentiable
+protocol ProtocolRequirementUnsupported : Differentiable {
+  associatedtype Scalar
 
-  @differentiable
-  func test(value: Scalar) -> Float
+  // expected-error @+1 {{'@differentiable' attribute on protocol requirement cannot specify 'where' clause}}
+  @differentiable(where Scalar: Differentiable)
+  func unsupportedWhereClause(value: Scalar) -> Float
+
+  // expected-error @+1 {{'@differentiable' attribute on protocol requirement cannot specify 'jvp:' or 'vjp:'}}
+  @differentiable(wrt: x, jvp: dfoo, vjp: dfoo)
+  func unsupportedDerivatives(_ x: Float) -> Float
 }
-
-protocol MissingDifferentiableTest: Example {
-  func test(value: Scalar) -> Float // expected-note {{candidate is missing attribute '@differentiable'}}
+extension ProtocolRequirementUnsupported {
+  func dfoo(_ x: Float) -> (Float, (Float) -> Float) {
+    (x, { $0 })
+  }
 }


### PR DESCRIPTION
… attribute.

Protocol requirements cannot specify `jvp:` or `vjp:` in `@differentiable`
attribute. This is because all witnesses must specify a `@differentiable`
attribute with the same configuration, so all witnesses will have their own
JVP/VJP (either specified or generated).

Resolves [TF-651](https://bugs.swift.org/browse/TF-651) - see bug description for examples.

Expose [TF-650](https://bugs.swift.org/browse/TF-650): diagnose protocol default implementations missing
`@differentiable` attribute.