### PR TITLE
Lazily synthesize yet more function bodies

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5773,6 +5773,11 @@ public:
     setBodyKind(BodyKind::Unparsed);
   }
 
+  /// Provide the parsed body for the function.
+  void setBodyParsed(BraceStmt *S) {
+    setBody(S, BodyKind::Parsed);
+  }
+
   /// Note that parsing for the body was delayed.
   ///
   /// The function should return the body statement and a flag indicating

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3777,7 +3777,7 @@ DestructorDecl *ClassDecl::getDestructor() {
 
 /// Synthesizer callback for an empty implicit function body.
 static std::pair<BraceStmt *, bool>
-synthesizeEmplyFunctionBody(AbstractFunctionDecl *afd, void *context) {
+synthesizeEmptyFunctionBody(AbstractFunctionDecl *afd, void *context) {
   ASTContext &ctx = afd->getASTContext();
   return { BraceStmt::create(ctx, afd->getLoc(), { }, afd->getLoc(), true),
            /*isTypeChecked=*/true };
@@ -3794,7 +3794,7 @@ void ClassDecl::addImplicitDestructor() {
   DD->setValidationToChecked();
 
   // Synthesize an empty body for the destructor as needed.
-  DD->setBodySynthesizer(synthesizeEmplyFunctionBody);
+  DD->setBodySynthesizer(synthesizeEmptyFunctionBody);
   addMember(DD);
 
   // Propagate access control and versioned-ness.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4636,9 +4636,9 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
                 Indices, ElementTy, StaticLoc, Flags, AccessorKind::Get,
                 storage, this, /*AccessorKeywordLoc*/ SourceLoc());
             CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
-            getter->setBody(BraceStmt::create(Context, Tok.getLoc(),
-                                              ASTNode(CCE), Tok.getLoc(),
-                                              /*implicit*/ true));
+            getter->setBodyParsed(BraceStmt::create(Context, Tok.getLoc(),
+                                                    ASTNode(CCE), Tok.getLoc(),
+                                                    /*implicit*/ true));
             accessors.add(getter);
             CodeCompletion->setParsedDecl(getter);
           } else {
@@ -5763,7 +5763,7 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   ParserResult<BraceStmt> Body = parseBraceItemList(diag::invalid_diagnostic);
   if (!Body.isNull()) {
     BraceStmt * BS = Body.get();
-    AFD->setBody(BS);
+    AFD->setBodyParsed(BS);
 
     // If the body consists of a single expression, turn it into a return
     // statement.
@@ -5853,7 +5853,7 @@ bool Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
     // FIXME: Should do some sort of error recovery here?
     return true;
   } else {
-    AFD->setBody(Body.get());
+    AFD->setBodyParsed(Body.get());
   }
 
   return false;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -988,7 +988,7 @@ ParserResult<Stmt> Parser::parseStmtDefer() {
     if (Body.isNull())
       return nullptr;
     Status |= Body;
-    tempDecl->setBody(Body.get());
+    tempDecl->setBodyParsed(Body.get());
   }
   
   SourceLoc loc = tempDecl->getBodySourceRange().Start;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5613,7 +5613,7 @@ void TypeChecker::defineDefaultConstructor(NominalTypeDecl *decl) {
   if (auto *classDecl = dyn_cast<ClassDecl>(decl)) {
     // If the class has a superclass, we should have either inherited it's
     // designated initializers or diagnosed the absence of our own.
-    if (classDecl->getSuperclass())
+    if (classDecl->hasSuperclass())
       return;
   }
 


### PR DESCRIPTION
Lazy synthesis for a few simple cases that likely don't matter for performance, but are nonetheless nice to get away from ad hoc mutation of function bodies:

* Bodies of implicitly-defined class deinitializers
* Bodies of default initializers