### PR TITLE
[AutoDiff] Gardening.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1601,9 +1601,17 @@ public:
     return ParameterIndices->parameters == other.ParameterIndices->parameters;
   }
 
+  /// Computes the derivative generic environment for the given
+  /// `@differentiable` attribute and original function.
+  GenericEnvironment *
+  computeDerivativeGenericEnvironment(AbstractFunctionDecl *original) const;
+
   // Print the attribute to the given stream.
+  // If `omitWrtClause` is true, omit printing the `wrt:` clause.
+  // If `omitAssociatedFunctions` is true, omit printing associated functions.
   void print(llvm::raw_ostream &OS, const Decl *D,
-             bool omitWrtClause = false) const;
+             bool omitWrtClause = false,
+             bool omitAssociatedFunctions = false) const;
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Differentiable;
@@ -1618,8 +1626,10 @@ public:
 ///   @differentiating(+, wrt: (lhs, rhs))
 class DifferentiatingAttr final
     : public DeclAttribute,
-      private llvm::TrailingObjects<DifferentiableAttr,
+      private llvm::TrailingObjects<DifferentiatingAttr,
                                     ParsedAutoDiffParameter> {
+  friend TrailingObjects;
+
   /// The original function name.
   DeclNameWithLoc Original;
   /// The original function, resolved by the type checker.
@@ -1690,8 +1700,10 @@ public:
 ///   @transposing(+, wrt: (lhs, rhs))
 class TransposingAttr final
       : public DeclAttribute,
-        private llvm::TrailingObjects<DifferentiableAttr,
+        private llvm::TrailingObjects<TransposingAttr,
                                       ParsedAutoDiffParameter> {
+  friend TrailingObjects;
+
   /// The base type of the original function.
   /// This is non-null only when the original function is not top-level (i.e. it
   /// is an instance/static method).

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2800,10 +2800,12 @@ ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
 ERROR(differentiable_attr_stored_property_variable_unsupported,none,
       "'jvp:' or 'vjp:' cannot be specified for stored properties", ())
+ERROR(overriding_decl_missing_differentiable_attr,none,
+      "overriding declaration is missing attribute '%0'", (StringRef))
 NOTE(protocol_witness_missing_differentiable_attr,none,
      "candidate is missing attribute '%0'", (StringRef))
 ERROR(linear_differentiable_type_disabled,none,
-      "cannot mark types as linear differentiable", ())
+      "'@differentiable(linear)' types are not yet supported", ())
 
 // @differentiating
 ERROR(differentiating_attr_expected_result_tuple,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2809,7 +2809,7 @@ static FuncDecl *resolveAutoDiffAssociatedFunction(
 
 // SWIFT_ENABLE_TENSORFLOW
 // Checks that the `candidate` function type equals the `required` function
-// type. Parameter labels are not checked.
+// type, disregarding parameter labels and tuple result labels.
 // `checkGenericSignature` is used to check generic signatures, if specified.
 // Otherwise, generic signatures are checked for equality.
 static bool checkFunctionSignature(
@@ -2817,9 +2817,15 @@ static bool checkFunctionSignature(
     Optional<std::function<bool(GenericSignature *, GenericSignature *)>>
         checkGenericSignature = None) {
   // Check that candidate is actually a function.
-  CanAnyFunctionType candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
+  auto candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
   if (!candidateFnTy)
     return false;
+
+  // Erase dynamic self types.
+  required = dyn_cast<AnyFunctionType>(
+      required->eraseDynamicSelfType()->getCanonicalType());
+  candidateFnTy = dyn_cast<AnyFunctionType>(
+      candidateFnTy->eraseDynamicSelfType()->getCanonicalType());
 
   // Check that generic signatures match.
   auto requiredGenSig = required.getOptGenericSignature();
@@ -2833,24 +2839,35 @@ static bool checkFunctionSignature(
     return false;
   }
 
-  // Check that parameters match.
-  if (candidateFnTy.getParams().size() != required.getParams().size())
+  // Check that parameter types match, disregarding labels.
+  if (required->getNumParams() != candidateFnTy->getNumParams())
     return false;
-  for (auto paramPair : llvm::zip(candidateFnTy.getParams(),
-                                  required.getParams())) {
-    // Check parameter types.
-    if (!std::get<0>(paramPair).getParameterType()->isEqual(
-            std::get<1>(paramPair).getParameterType()))
-      return false;
-  }
+  if (!std::equal(required->getParams().begin(), required->getParams().end(),
+                  candidateFnTy->getParams().begin(),
+                  [](AnyFunctionType::Param x, AnyFunctionType::Param y) {
+                    return x.getPlainType()->isEqual(y.getPlainType());
+                  }))
+    return false;
 
-  // If required result type is non-function, check that result types match
-  // exactly.
-  CanAnyFunctionType requiredResultFnTy =
-      dyn_cast<AnyFunctionType>(required.getResult());
-  if (!requiredResultFnTy)
-    return required.getResult()->eraseDynamicSelfType()->isEqual(
-        candidateFnTy.getResult()->eraseDynamicSelfType());
+  // If required result type is not a function type, check that result types
+  // match exactly.
+  auto requiredResultFnTy = dyn_cast<AnyFunctionType>(required.getResult());
+  if (!requiredResultFnTy) {
+    auto requiredResultTupleTy = dyn_cast<TupleType>(required.getResult());
+    auto candidateResultTupleTy =
+        dyn_cast<TupleType>(candidateFnTy.getResult());
+    if (!requiredResultTupleTy || !candidateResultTupleTy)
+      return required.getResult()->isEqual(candidateFnTy.getResult());
+    // If result types are tuple types, check that element types match,
+    // ignoring labels.
+    if (requiredResultTupleTy->getNumElements() !=
+        candidateResultTupleTy->getNumElements())
+      return false;
+    return std::equal(requiredResultTupleTy.getElementTypes().begin(),
+                      requiredResultTupleTy.getElementTypes().end(),
+                      candidateResultTupleTy.getElementTypes().begin(),
+                      [](CanType x, CanType y) { return x->isEqual(y); });
+  }
 
   // Required result type is a function. Recurse.
   return checkFunctionSignature(requiredResultFnTy, candidateFnTy.getResult());
@@ -3411,53 +3428,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     attr->setInvalid();
     return;
   }
-
-  // Checks that the `candidate` function type equals the `required` function
-  // type, disregarding parameter labels and tuple result labels.
-  std::function<bool(CanAnyFunctionType, CanType)> checkFunctionSignature;
-  checkFunctionSignature = [&](CanAnyFunctionType required,
-                               CanType candidate) -> bool {
-
-    // Check that candidate is actually a function.
-    CanAnyFunctionType candidateFnTy = dyn_cast<AnyFunctionType>(candidate);
-    if (!candidateFnTy)
-      return false;
-
-    // Check that generic signatures match.
-    if (candidateFnTy.getOptGenericSignature() !=
-        required.getOptGenericSignature())
-      return false;
-
-    // Check that parameter types match, disregarding labels.
-    if (!std::equal(required.getParams().begin(), required.getParams().end(),
-                    candidateFnTy.getParams().begin(),
-                    [](AnyFunctionType::Param x, AnyFunctionType::Param y) {
-                      return x.getPlainType()->isEqual(y.getPlainType());
-                    }))
-      return false;
-
-    // If required result type is non-function, check that result types match.
-    // If result types are tuple types, ignore labels.
-    CanAnyFunctionType requiredResultFnTy =
-        dyn_cast<AnyFunctionType>(required.getResult());
-    if (!requiredResultFnTy) {
-      auto requiredResultTupleTy = required.getResult()->getAs<TupleType>();
-      auto candidateResultTupleTy =
-          candidateFnTy.getResult()->getAs<TupleType>();
-      if (!requiredResultTupleTy || !candidateResultTupleTy)
-        return required.getResult()->isEqual(candidateFnTy.getResult());
-      // If result types are tuple types, check that element types match,
-      // ignoring labels.
-      return std::equal(requiredResultTupleTy->getElementTypes().begin(),
-                        requiredResultTupleTy->getElementTypes().end(),
-                        candidateResultTupleTy->getElementTypes().begin(),
-                        [](Type x, Type y) { return x->isEqual(y); });
-    }
-
-    // Required result type is a function. Recurse.
-    return checkFunctionSignature(requiredResultFnTy,
-                                  candidateFnTy.getResult());
-  };
 
   // Resolve the JVP declaration, if it exists.
   if (attr->getJVP()) {
@@ -4084,13 +4054,9 @@ void AttributeChecker::visitTransposingAttr(TransposingAttr *attr) {
 
   // Check if original function type matches expected original function type
   // we computed.
-  Optional<std::function<bool(GenericSignature *, GenericSignature *)>>
-     genericComparison;
-  genericComparison = [&](GenericSignature *a, GenericSignature *b) {
-    return a == b;
-  };
-  // TODO(bartchr): remove the lambda of `checkFunctionSignature` defined in
-  // `AttributeChecker::visitDifferentiableAttr`.
+  std::function<bool(GenericSignature *, GenericSignature *)>
+      genericComparison =
+          [&](GenericSignature *a, GenericSignature *b) { return a == b; };
   if (!checkFunctionSignature(
            cast<AnyFunctionType>(expectedOriginalFnType->getCanonicalType()),
            originalFn->getInterfaceType()->getCanonicalType(),

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -637,8 +637,7 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
       baseDA->print(stream, derivedDecl, omitWrtClause,
                     /*omitAssociatedFunctions*/ true);
       diags.diagnose(
-          derivedDecl,
-          diag::protocol_witness_missing_differentiable_attr,
+          derivedDecl, diag::overriding_decl_missing_differentiable_attr,
           StringRef(stream.str()).trim());
       return false;
     }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -634,7 +634,8 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
       // Get `@differentiable` attribute description.
       std::string baseDAString;
       llvm::raw_string_ostream stream(baseDAString);
-      baseDA->print(stream, derivedDecl, omitWrtClause);
+      baseDA->print(stream, derivedDecl, omitWrtClause,
+                    /*omitAssociatedFunctions*/ true);
       diags.diagnose(
           derivedDecl,
           diag::protocol_witness_missing_differentiable_attr,
@@ -833,7 +834,7 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
       continue;
 
     // SWIFT_ENABLE_TENSORFLOW
-    // Check whether the differentiable attribute allows overriding.
+    // Check whether the `@differentiable` attribute allows overriding.
     if (overridesDifferentiableAttribute(decl, parentDecl))
       continue;
     // SWIFT_ENABLE_TENSORFLOW END

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -574,9 +574,10 @@ swift::matchWitness(
     // a requirement, then an '@differentiable' attribute is added
     // automatically.
     ASTContext &ctx = witness->getASTContext();
+    auto witnessDiffAttrs = witnessAttrs
+        .getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
     for (auto *reqDiffAttr : reqAttrs.getAttributes<DifferentiableAttr>()) {
-      auto witnessDiffAttrs = witnessAttrs
-          .getAttributes<DifferentiableAttr, /*AllowInvalid*/ true>();
+      // TODO(TF-482): Also check whether generic requirements are the same.
       bool reqDiffAttrMatch = llvm::any_of(
           witnessDiffAttrs, [&](const DifferentiableAttr *witnessDiffAttr) {
             return witnessDiffAttr->getParameterIndices() &&
@@ -2034,30 +2035,6 @@ static void addOptionalityFixIts(
 
 }
 
-// SWIFT_ENABLE_TENSORFLOW
-// Compute the derivative generic environment for the given `@differentiable`
-// attribute and original function.
-static GenericEnvironment * computeDerivativeGenericEnvironment(
-    const DifferentiableAttr *attr, AbstractFunctionDecl *original) {
-  // If `@differentiable` attribute has no requirements, return original
-  // function's generic environment.
-  if (attr->getRequirements().empty())
-    return original->getGenericEnvironment();
-  // Otherwise, build derivative generic sigunature.
-  GenericSignatureBuilder builder(original->getASTContext());
-  // Add original function's generic signature.
-  builder.addGenericSignature(original->getGenericSignature());
-  using FloatingRequirementSource =
-      GenericSignatureBuilder::FloatingRequirementSource;
-  // Add `@differentiable` attribute requirements.
-  for (auto req : attr->getRequirements())
-    builder.addRequirement(req, FloatingRequirementSource::forAbstract(),
-                           original->getModuleContext());
-  auto *derivativeGenSig = std::move(builder).computeGenericSignature(
-      attr->getLocation(), /*allowConcreteGenericParams=*/true);
-  return derivativeGenSig->createGenericEnvironment();
-}
-
 /// Diagnose a requirement match, describing what went wrong (or not).
 static void
 diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
@@ -2212,7 +2189,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     // inferred differentiation parameters.
     auto *original = cast<AbstractFunctionDecl>(match.Witness);
     auto *whereClauseGenEnv =
-        computeDerivativeGenericEnvironment(reqAttr, original);
+        reqAttr->computeDerivativeGenericEnvironment(original);
     auto *inferredParameters = TypeChecker::inferDifferentiableParameters(
         original, whereClauseGenEnv);
     bool omitWrtClause = reqAttr->getParameterIndices()->parameters.count() ==
@@ -2220,7 +2197,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     // Get `@differentiable` attribute description.
     std::string reqDiffAttrString;
     llvm::raw_string_ostream stream(reqDiffAttrString);
-    reqAttr->print(stream, req, omitWrtClause);
+    reqAttr->print(stream, req, omitWrtClause,
+                   /*omitAssociatedFunctions*/ true);
     diags.diagnose(match.Witness,
                    diag::protocol_witness_missing_differentiable_attr,
                    StringRef(stream.str()).trim());

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -639,7 +639,7 @@ protocol ProtocolRequirements : Differentiable {
 }
 
 protocol ProtocolRequirementsRefined : ProtocolRequirements {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable'}}
   func f1(_ x: Float) -> Float
 }
 
@@ -890,7 +890,7 @@ public protocol DifferentiableDistribution: Differentiable, Distribution {
 
 public protocol MissingDifferentiableDistribution: DifferentiableDistribution
   where Value: Differentiable {
-  // expected-note @+1 {{candidate is missing attribute '@differentiable(wrt: self)'}}
+  // expected-error @+1 {{overriding declaration is missing attribute '@differentiable(wrt: self)'}}
   func logProbability(of value: Value) -> Float
 }
 

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -14,7 +14,7 @@ let _: @differentiable (NonDiffType) -> Float
 // expected-error @+1 {{result is not differentiable, but the function type is marked '@differentiable'}}
 let _: @differentiable (Float) -> NonDiffType
 
-// expected-error @+1 {{cannot mark types as linear differentiable}}
+// expected-error @+1 {{'@differentiable(linear)' types are not yet supported}}
 let _: @differentiable(linear) (Float) -> Float
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
- Deduplicate `checkFunctionSignature` function in TypeCheckAttr.cpp.
- Edit message `'@differentiable(linear)' types are not yet supported`.

Related to class method differentiation support ([TF-631](https://bugs.swift.org/browse/TF-631)):

- Move `DifferentiableAttr::computeDerivativeGenericEnvironment`
  to a shared location.
- Add `omitAssociatedFunctions` flag to `DifferentiableAttr`.
  Relevant for class methods, which can specify `jvp:` and `vjp:`.
- Emit error instead of note for ``overriding declaration missing `@differentiable` attribute``.