### PR TITLE
Dynamic cast optimizer: Consider CF conversions via superclasses.

### DIFF
--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -354,3 +354,8 @@ public func testConditionalBridgedCastFromSwiftToNSObjectDerivedClass(_ s: Strin
 public func testForcedBridgedCastFromSwiftToNSObjectDerivedClass(_ s: String) -> MyString {
     return s as! MyString
 }
+
+// rdar://problem/51078136
+func foo(x: CFMutableDictionary) -> [AnyHashable:AnyObject]? {
+  return x as? [AnyHashable:AnyObject]
+}


### PR DESCRIPTION
A conversion from, e.g., CFMutableDictionary to NSDictionary is still a CF bridging conversion,
even though it doesn't go directly through CFMutableDictionary's own bridged class type.
Fixes rdar://problem/51078136.
