### PR TITLE
[stdlib] Simplify __SwiftNativeNSArrayWithContiguousStorage.count

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -40,11 +40,6 @@ internal final class __EmptyArrayStorage
     return try body(UnsafeBufferPointer(start: nil, count: 0))
   }
 
-  @nonobjc
-  override internal func _getNonVerbatimBridgedCount() -> Int {
-    return 0
-  }
-
   override internal func _getNonVerbatimBridgingBuffer() -> _BridgingBuffer {
     return _BridgingBuffer(0)
   }
@@ -109,17 +104,6 @@ internal final class _ContiguousArrayStorage<
       defer { _fixLifetime(self) }
       try body(UnsafeBufferPointer(start: elements, count: count))
     }
-  }
-
-  /// Returns the number of elements in the array.
-  ///
-  /// - Precondition: `Element` is bridged non-verbatim.
-  @nonobjc
-  override internal func _getNonVerbatimBridgedCount() -> Int {
-    _internalInvariant(
-      !_isBridgedVerbatimToObjectiveC(Element.self),
-      "Verbatim bridging should be handled separately")
-    return countAndCapacity.count
   }
 
   /// Bridge array elements and return a new buffer that owns them.

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -232,13 +232,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
   /// bridging of array elements.
   @objc
   internal override var count: Int {
-    if let bridgedStorage = _heapBufferBridged {
-      return _BridgingBuffer(bridgedStorage).count
-    }
-
-    // Check if elements are bridged verbatim.
-    return _nativeStorage._withVerbatimBridgedUnsafeBuffer { $0.count }
-      ?? _nativeStorage._getNonVerbatimBridgedCount()
+    return _nativeStorage.countAndCapacity.count
   }
 }
 #else
@@ -292,12 +286,6 @@ internal class __ContiguousArrayStorageBase
   ) rethrows -> R? {
     _internalInvariantFailure(
       "Concrete subclasses must implement _withVerbatimBridgedUnsafeBuffer")
-  }
-
-  @nonobjc
-  internal func _getNonVerbatimBridgedCount() -> Int {
-    _internalInvariantFailure(
-      "Concrete subclasses must implement _getNonVerbatimBridgedCount")
   }
 
   internal func _getNonVerbatimBridgingBuffer() -> _BridgingBuffer {


### PR DESCRIPTION
There is what looks like unnecessary levels of indirection in the implementation of `NSArray.count` on the native Array storage class. Remove it.