### PR TITLE
[5.1] [ModuleInterface] Create module cache path if we install a forwarding module

### DIFF
--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -504,7 +504,7 @@ public:
       // Note that we don't assume cachePath is the same as the Clang
       // module cache path at this point.
       if (!moduleCachePath.empty())
-        (void)llvm::sys::fs::create_directory(moduleCachePath);
+        (void)llvm::sys::fs::create_directories(moduleCachePath);
 
       configureSubInvocationInputsAndOutputs(OutPath);
 
@@ -1266,6 +1266,10 @@ class ParseableInterfaceModuleLoaderImpl {
           addDependency(getFullDependencyPath(dep, SDKRelativeBuffer));
       depsAdjustedToMTime.push_back(adjustedDep);
     }
+
+    // Create the module cache if we haven't created it yet.
+    StringRef parentDir = path::parent_path(outputPath);
+    (void)llvm::sys::fs::create_directories(parentDir);
 
     auto hadError = withOutputFile(diags, outputPath,
       [&](llvm::raw_pwrite_stream &out) {

--- a/test/ParseableInterface/ModuleCache/prebuilt-module-cache-nonexistent-module-cache-path.swift
+++ b/test/ParseableInterface/ModuleCache/prebuilt-module-cache-nonexistent-module-cache-path.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// Create a prebuilt module cache and populate it with a prebuilt module.
+// RUN: %empty-directory(%t/prebuilt-cache)
+// RUN: %target-swift-frontend -parse-stdlib %S/Inputs/prebuilt-module-cache/Lib.swiftinterface -emit-module-path %t/prebuilt-cache/Lib.swiftmodule - -module-name Lib
+
+// Compile against the module with a module cache that does not exist
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/RandomPath/NonExistentCachePath -sdk %S/Inputs -I %S/Inputs/prebuilt-module-cache -prebuilt-module-cache-path %t/prebuilt-cache %s
+
+// Make sure we installed a forwarding module.
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/RandomPath/NonExistentCachePath/Lib-*.swiftmodule
+
+import Lib


### PR DESCRIPTION
If we are installing a forwarding module to something in the prebuilt
cache, make sure to create the module cache directory if it doesn't
exist.

rdar://53011893