### PR TITLE
AST: attempt to rewrite the expression to be more legible

### DIFF
--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -113,9 +113,7 @@ namespace detail {
 
   /// Extract the first, nearest source location from a tuple.
   template<unsigned Index, typename ...Types,
-           typename = typename std::enable_if<sizeof...(Types) - Index
-                                                  ? true
-                                                  : false>::type>
+           typename = typename std::enable_if<(Index < sizeof...(Types))>::type>
   SourceLoc extractNearestSourceLocTuple(const std::tuple<Types...> &value) {
     SourceLoc loc = maybeExtractNearestSourceLoc(std::get<Index>(value));
     if (loc.isValid())


### PR DESCRIPTION
This restores the original spelling of the restriction.  This is more
legible and may be something which VS2017 will handle properly.

Thanks to @drodriguez for suggesting this!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
