### PR TITLE
[AutoDiff] Fix JVP/VJPEmitter substitution map.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2789,8 +2789,12 @@ private:
   static SubstitutionMap getSubstitutionMap(SILFunction *original,
                                             SILFunction *vjp) {
     auto substMap = original->getForwardingSubstitutionMap();
-    if (auto *vjpGenEnv = vjp->getGenericEnvironment())
-      substMap = substMap.subst(vjpGenEnv->getForwardingSubstitutionMap());
+    if (auto *vjpGenEnv = vjp->getGenericEnvironment()) {
+      auto vjpSubstMap = vjpGenEnv->getForwardingSubstitutionMap();
+      substMap = SubstitutionMap::get(
+          vjpGenEnv->getGenericSignature(), QuerySubstitutionMap{vjpSubstMap},
+          LookUpConformanceInSubstitutionMap(vjpSubstMap));
+    }
     return substMap;
   }
 
@@ -3026,7 +3030,7 @@ private:
     auto enumLoweredTy = getNominalDeclLoweredType(succEnum);
     auto *enumEltDecl =
         pullbackInfo.lookUpPredecessorEnumElement(predBB, succBB);
-    auto enumEltType = remapType(
+    auto enumEltType = getOpType(
         enumLoweredTy.getEnumElementType(enumEltDecl, getModule()));
     // If the enum element type does not have a box type (i.e. the enum case is
     // not indirect), then directly create an enum.
@@ -3459,8 +3463,12 @@ private:
   static SubstitutionMap getSubstitutionMap(SILFunction *original,
                                             SILFunction *jvp) {
     auto substMap = original->getForwardingSubstitutionMap();
-    if (auto *jvpGenEnv = jvp->getGenericEnvironment())
-      substMap = substMap.subst(jvpGenEnv->getForwardingSubstitutionMap());
+    if (auto *jvpGenEnv = jvp->getGenericEnvironment()) {
+      auto jvpSubstMap = jvpGenEnv->getForwardingSubstitutionMap();
+      substMap = SubstitutionMap::get(
+          jvpGenEnv->getGenericSignature(), QuerySubstitutionMap{jvpSubstMap},
+          LookUpConformanceInSubstitutionMap(jvpSubstMap));
+    }
     return substMap;
   }
 

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -151,7 +151,7 @@ func TF_523_f(_ x: TF_523_Struct) -> Float {
   return x.a * 2
 }
 
-// TF_534: Thunk substitution map remapping.
+// TF-534: Thunk substitution map remapping.
 protocol TF_534_Layer : Differentiable {
   associatedtype Input : Differentiable
   associatedtype Output : Differentiable
@@ -167,6 +167,20 @@ func TF_534<Model: TF_534_Layer>(
   return valueWithPullback(at: model) { model -> Model.Output in
     return model(inputs)
   }.0
+}
+
+// TF-652: Test VJPEmitter substitution map generic signature.
+// The substitution map should have the VJP's generic signature, not the
+// original function's.
+struct TF_652<Scalar> {}
+extension TF_652 : Differentiable where Scalar : FloatingPoint {}
+
+@differentiable(wrt: x where Scalar: FloatingPoint)
+func test<Scalar: Numeric>(x: TF_652<Scalar>) -> TF_652<Scalar> {
+  for _ in 0..<10 {
+    let _ = x
+  }
+  return x
 }
 
 // TODO: add more tests.


### PR DESCRIPTION
`TypeSubstCloner` substitution map should use generic signature
of the JVP/VJP, not the original function.

Resolves [TF-652](https://bugs.swift.org/browse/TF-652).