### PR TITLE
[5.1] Dynamic cast optimizer: Consider CF conversions via superclasses.

### DIFF
--- a/test/SILOptimizer/cast_folding_objc.swift
+++ b/test/SILOptimizer/cast_folding_objc.swift
@@ -352,3 +352,8 @@ public func testConditionalBridgedCastFromSwiftToNSObjectDerivedClass(_ s: Strin
 public func testForcedBridgedCastFromSwiftToNSObjectDerivedClass(_ s: String) -> MyString {
     return s as! MyString
 }
+
+// rdar://problem/51078136
+func foo(x: CFMutableDictionary) -> [AnyHashable:AnyObject]? {
+  return x as? [AnyHashable:AnyObject]
+}


### PR DESCRIPTION
Explanation: The cast optimizer would generate invalid SIL when a `CFMutable*` was bridged to the corresponding Swift value type bridged from the non-mutable class.

Scope: Small bug fix

Issue: rdar://problem/51078136

Risk: Low, isolated bug fix.

Testing: Swift CI

Reviewed by: @aschwaighofer 