### PR TITLE
[Diagnostics] Improve diagnostic when using == instead of = for defau…

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -848,6 +848,8 @@ ERROR(expected_parameter_name,PointsToFirstBadToken,
       "expected parameter name followed by ':'", ())
 ERROR(expected_parameter_colon,PointsToFirstBadToken,
       "expected ':' following argument label and parameter name", ())
+ERROR(expected_assignment_instead_of_comparison_operator,none,
+      "expected '=' instead of '==' to assign default value for parameter", ())
 ERROR(missing_parameter_type,PointsToFirstBadToken,
       "parameter requires an explicit type", ())
 ERROR(multiple_parameter_ellipsis,none,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -366,7 +366,13 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       } else {
         // Otherwise, we're not sure what is going on, but this doesn't smell
         // like a parameter.
-        diagnose(Tok, diag::expected_parameter_name);
+        if (Tok.isBinaryOperator() && Tok.getText() == "==") {
+          diagnose(Tok,
+                   diag::expected_assignment_instead_of_comparison_operator)
+              .fixItReplace(Tok.getLoc(), "=");
+        } else {
+          diagnose(Tok, diag::expected_parameter_name);
+        }
         param.isInvalid = true;
         param.FirstNameLoc = Tok.getLoc();
         TokReceiver->registerTokenKindChange(param.FirstNameLoc,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -67,10 +67,12 @@ void Parser::DefaultArgumentInfo::setFunctionContext(
 static ParserStatus parseDefaultArgument(
     Parser &P, Parser::DefaultArgumentInfo *defaultArgs, unsigned argIndex,
     Expr *&init, bool &hasInheritedDefaultArg,
-    Parser::ParameterContextKind paramContext, tok assignmentTok) {
+    Parser::ParameterContextKind paramContext) {
   SyntaxParsingContext DefaultArgContext(P.SyntaxContext,
                                          SyntaxKind::InitializerClause);
-  SourceLoc equalLoc = P.consumeToken(assignmentTok);
+  assert(P.Tok.is(tok::equal) ||
+       (P.Tok.isBinaryOperator() && P.Tok.getText() == "=="));
+  SourceLoc equalLoc = P.consumeToken();
 
   if (P.SF.Kind == SourceFileKind::Interface) {
     // Swift module interfaces don't synthesize inherited intializers and
@@ -394,7 +396,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
       status |= parseDefaultArgument(
           *this, defaultArgs, defaultArgIndex, param.DefaultArg,
-          param.hasInheritedDefaultArg, paramContext, Tok.getKind());
+          param.hasInheritedDefaultArg, paramContext);
 
       if (param.EllipsisLoc.isValid() && param.DefaultArg) {
         // The range of the complete default argument.

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -817,6 +817,5 @@ func f() {
 
 
 // <rdar://problem/22478168> | SR-11006
-// expected-error@+2 {{expected '=' instead of '==' to assign default value for parameter}} {{21-23==}}
-// expected-error@+1 {{expected ',' separator}}
+// expected-error@+1 {{expected '=' instead of '==' to assign default value for parameter}} {{21-23==}}
 func SR11006(a: Int == 0) {}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -814,3 +814,9 @@ func postfixDot(a : String) {
 func f() {
   _ = ClassWithStaticDecls.  // expected-error {{expected member name following '.'}}
 }
+
+
+// <rdar://problem/22478168> | SR-11006
+// expected-error@+2 {{expected '=' instead of '==' to assign default value for parameter}} {{21-23==}}
+// expected-error@+1 {{expected ',' separator}}
+func SR11006(a: Int == 0) {}


### PR DESCRIPTION
…lt function argument.

Resolves [SR-11006](https://bugs.swift.org/browse/SR-11006).