### PR TITLE
[Sema] Allow unavailable extension of unavailable type in #if

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -860,6 +860,13 @@ static const Decl *findContainingDeclaration(SourceRange ReferenceRange,
   auto ContainsReferenceRange = [&](const Decl *D) -> bool {
     if (ReferenceRange.isInvalid())
       return false;
+
+    // Members of an active #if are represented both inside the
+    // IfConfigDecl and in the enclosing context. Skip over the IfConfigDecl
+    // so that that the member declaration is found rather the #if itself.
+    if (isa<IfConfigDecl>(D))
+      return false;
+
     return SM.rangeContains(D->getSourceRange(), ReferenceRange);
   };
 

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -198,3 +198,14 @@ extension TestStruct {
     introducedInExtensionMacOS()
   }
 }
+
+@available(macOS, unavailable)
+struct UnavailableStruct { }
+
+@available(macOS, unavailable)
+extension UnavailableStruct { } // no-error
+
+#if os(macOS)
+@available(macOS, unavailable)
+extension UnavailableStruct { } // no-error
+#endif


### PR DESCRIPTION
The compiler allows unavailable types to be extended as long as the
extension itself is marked unavailable:

@available(macOS, unavailable)
struct UnavailableStruct { }

@available(macOS, unavailable)
extension UnavailableStruct { } // no-error

However, this doesn't work when the extension is inside a #if. The
availability logic that finds the containing ExtensionDecl based on
a source range gets confused and finds the IfConfigDecl instead.

To fix this, change that logic to ignore IfConfigDecls. Members of
an active #if are also represented in the enclosing context, as
sibling of the IfConfigDecl, so the compiler will find the extension
declaration there.

rdar://problem/53079366