### PR TITLE
SwiftShims: restrict AArch64 workaround to C++

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1496,6 +1496,7 @@ _Static_assert(_Alignof(InlineRefCounts) == _Alignof(__swift_uintptr_t),
 #endif
 
 #if defined(_WIN32) && defined(_M_ARM64)
+#if defined(__cplusplus)
 namespace std {
 template <>
 inline void _Atomic_storage<swift::SideTableRefCountBits, 16>::_Unlock() const noexcept {
@@ -1504,6 +1505,7 @@ inline void _Atomic_storage<swift::SideTableRefCountBits, 16>::_Unlock() const n
   __dmb(0x8);
 }
 }
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
`RefCount.h` can be included in a C context - e.g. building the
SwiftShims module.  Restrict the C++ overloads to the C++ context only.
This partially improves the build for Windows ARM64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
