### PR TITLE
[5.1] Replace all 9999 availability in non-stdlib tests. (#26109)

### DIFF
--- a/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
@@ -9,18 +9,18 @@ extension Int: P {
 
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func bar(_ x: Int) -> some P {
   return x
 }
 
 struct Container {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func bar(_ x: Int) -> some P {
     return x
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   var computedProperty : some P {
     get {
       return 2
@@ -30,7 +30,7 @@ struct Container {
     }
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   subscript(_ x: Int) -> some P {
     get {
       return 2
@@ -49,12 +49,12 @@ extension Int : Q {}
 
 public protocol Assoc {
   associatedtype A = Int
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func act() -> A
 }
 
 struct Test : Assoc {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func act() -> some Q {
     return 1
   }

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque1.swift
@@ -1,29 +1,29 @@
 protocol P {
-  func myValue() -> Int
+  func myValue() -> Int64
 }
 
-extension Int: P {
-  public func myValue() -> Int {
+extension Int64: P {
+  public func myValue() -> Int64 {
     return self
   }
 
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-func bar(_ x: Int) -> some P {
+func bar(_ x: Int64) -> some P {
   return x
 }
 
 struct Container {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  func bar(_ x: Int) -> some P {
+  func bar(_ x: Int64) -> some P {
     return x
   }
 
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   var computedProperty : some P {
     get {
-      return 2
+      return Int64(2)
     }
     set {
       print("original \(newValue)")
@@ -33,7 +33,7 @@ struct Container {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   subscript(_ x: Int) -> some P {
     get {
-      return 2
+      return Int64(2)
     }
     set {
       print("original \(newValue)")
@@ -45,7 +45,7 @@ protocol Q {}
 
 struct NewType : Q {}
 
-extension Int : Q {}
+extension Int64 : Q {}
 
 public protocol Assoc {
   associatedtype A = Int
@@ -56,6 +56,6 @@ public protocol Assoc {
 struct Test : Assoc {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func act() -> some Q {
-    return 1
+    return Int64(1)
   }
 }

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
@@ -8,20 +8,20 @@ struct Pair : P {
   }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for:bar(_:))
 func _replacement_bar(y x: Int) -> some P {
   return Pair()
 }
 
 extension Container {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for:bar(_:))
   func _replacement_bar(y x: Int) -> some P {
     return Pair()
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for: computedProperty)
   var _replacement_computedProperty : some P {
      get {
@@ -32,7 +32,7 @@ extension Container {
      }
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for: subscript(_:))
   subscript(y x: Int) -> some P {
     get {
@@ -45,7 +45,7 @@ extension Container {
 }
 
 extension Test {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for: act)
   func act_r() -> some Q {
     return NewType()

--- a/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_opaque2.swift
@@ -1,23 +1,23 @@
 @_private(sourceFile: "TestOpaque1.swift") import TestOpaque1
 
 struct Pair : P {
-  var x = 0
-  var y = 1
-  func myValue() -> Int{
+  var x = Int64(0)
+  var y = Int64(1)
+  func myValue() -> Int64 {
     return y
   }
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for:bar(_:))
-func _replacement_bar(y x: Int) -> some P {
+func _replacement_bar(y x: Int64) -> some P {
   return Pair()
 }
 
 extension Container {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for:bar(_:))
-  func _replacement_bar(y x: Int) -> some P {
+  func _replacement_bar(y x: Int64) -> some P {
     return Pair()
   }
 

--- a/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
+++ b/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
@@ -31,7 +31,7 @@ private func test<T: NSObject & NSCoding>(type: T.Type) {
 // Test all the classes listed in SwiftNativeNSXXXBase.mm.gyb except for
 // NSEnumerator (which doesn't conform to NSCoding).
 
-if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   testSuite.test("NSArray") {
     test(type: NSArray.self)
   }

--- a/test/Interpreter/SDK/check_class_for_archiving.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving.swift
@@ -52,7 +52,7 @@ print("DerivedClassWithName: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeye
 // CHECK: NSKeyedUnarchiver: 0
 print("NSKeyedUnarchiver: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(NSKeyedUnarchiver.self, operation: op))")
 
-if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   // CHECK: PrivateClass: 2
   print("PrivateClass: \(NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(PrivateClass.self, operation: op))")
   // CHECK: GenericClass: 1

--- a/test/Interpreter/SDK/check_class_for_archiving_log.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving_log.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 // A tricky way to make the FileCheck tests conditional on the OS version.
-if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   print("-check-prefix=CHECK")
 } else {
   // Disable the checks for older OSes because of rdar://problem/50504765

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -179,7 +179,7 @@ testSuite.test("GenericMangled")
                 reason: "objc_getClass hook not present"))
   .requireOwnProcess()
   .code {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
   requireClass(named:   "_TtC4main24ConstrainedSwiftSubclass",
                demangledName: "main.ConstrainedSwiftSubclass")
   requireClass(named:   "_TtC4main26ConstrainedSwiftSuperclass",
@@ -226,7 +226,7 @@ testSuite.test("ResilientNSObject")
                 reason: "objc_getClass hook not present"))
   .requireOwnProcess()
   .code {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
   requireClass(named: "_TtC4main27ResilientSubclassOfNSObject",
                demangledName: "main.ResilientSubclassOfNSObject")
   requireClass(named: "_TtC4main34ResilientSubclassOfGenericNSObject",

--- a/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_A.swift
+++ b/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_A.swift
@@ -7,23 +7,23 @@ func replaceable1_r() -> Int {
   return 2
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 dynamic func bar1(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for: bar1(_:))
 func bar1_r(_ x: Int) -> some P {
   return Pair()
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 dynamic func bar2(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for: bar2(_:))
 func bar2_r(_ x: Int) -> some P {
   return Pair()

--- a/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_B.swift
+++ b/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_B.swift
@@ -7,12 +7,12 @@ func replaceable2_r() -> Int {
   return 3
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 dynamic func bar3(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for: bar3(_:))
 func bar3_r(_ x: Int) -> some P {
   return Pair()

--- a/test/Interpreter/dynamic_replacement_multifile/main.swift
+++ b/test/Interpreter/dynamic_replacement_multifile/main.swift
@@ -34,12 +34,12 @@ struct Pair {
 
 extension Pair : P {}
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 dynamic func bar(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @_dynamicReplacement(for: bar(_:))
 func bar_r(_ x: Int) -> some P {
   return Pair()
@@ -52,13 +52,12 @@ DynamicallyReplaceable.test("DynamicallyReplaceable") {
   expectEqual(2, replaceable1())
   expectEqual(3, replaceable2())
   expectEqual(7, replaceableInOtherFile())
-  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
     expectEqual(16, MemoryLayout.size(ofValue: bar(5)))
     expectEqual(16, MemoryLayout.size(ofValue: bar1(5)))
     expectEqual(16, MemoryLayout.size(ofValue: bar2(5)))
     expectEqual(16, MemoryLayout.size(ofValue: bar3(5)))
   }
-
 }
 
 runAllTests()

--- a/test/Interpreter/dynamic_replacement_opaque_result.swift
+++ b/test/Interpreter/dynamic_replacement_opaque_result.swift
@@ -36,7 +36,7 @@ func testAssociatedType<T: Assoc> (_ t: T) {
   print(T.A.self)
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func test() {
   print(MemoryLayout.size(ofValue: bar(5)))
   print(MemoryLayout.size(ofValue: Container().bar(5)))
@@ -56,7 +56,7 @@ func test() {
 // CHECK: 2
 // CHECK: 8
 // CHECK: 2
-if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
   test()
 } else {
   print("8 8 5 5 8 2 8 2")
@@ -82,7 +82,7 @@ executablePath.removeLast(4)
 // CHECK: 16
 // CHECK: 1
 // CHECK: NewType
-if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
   test()
   testAssociatedType(Test())
 } else {

--- a/test/Interpreter/dynamic_replacement_opaque_result2.swift
+++ b/test/Interpreter/dynamic_replacement_opaque_result2.swift
@@ -10,7 +10,7 @@
 public protocol Assoc {
   associatedtype A = Int
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   func act() -> A
 }
 
@@ -29,14 +29,14 @@ extension Int : P {
 struct Pair : P {}
 
 struct Test : Assoc {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   dynamic func act() -> some P {
     return 1
   }
 }
 
 extension Test {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @_dynamicReplacement(for: act)
   func act_r() -> some P {
     return Pair()
@@ -46,7 +46,7 @@ extension Test {
 func test() {
   let t = Test()
   // CHECK: Pair
-  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
     testAssociatedType(t)
   } else {
     print("Pair")

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -1,40 +1,40 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 protocol P {
   associatedtype AT
   func foo() -> AT
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 struct Adapter<T: P>: P {
   var inner: T
 
-  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
   func foo() -> some P {
     return inner
   }
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 extension P {
-  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
   func foo() -> some P {
     return Adapter(inner: self)
   }
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 func getPAT<T: P>(_: T.Type) -> Any.Type {
   return T.AT.self
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 extension Int: P { }
 
 // CHECK: {{Adapter<Int>|too old}}
-if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   print(getPAT(Int.self))
 } else {
   print("i'm getting too old for this sh")

--- a/test/ParseableInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ParseableInterface/Inputs/opaque-result-types-client.swift
@@ -13,7 +13,7 @@ func getAssocSubscriptType<T: AssocTypeInference>(_ x: T) -> T.AssocSubscript {
 struct MyFoo: Foo {}
 struct YourFoo: Foo {}
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 func someTypeIsTheSame() {
   var a = foo(0)
   a = foo(0)

--- a/test/ParseableInterface/opaque-result-types.swift
+++ b/test/ParseableInterface/opaque-result-types.swift
@@ -7,19 +7,19 @@ public protocol Foo {}
 extension Int: Foo {}
 
 // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
 // CHECK-LABEL: @inlinable public func foo(_: Swift.String) -> some OpaqueResultTypes.Foo {
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
 // CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T : OpaqueResultTypes.Foo
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
@@ -35,53 +35,53 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
   // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public struct Bas: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -91,37 +91,37 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo(_ x: U) -> some OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -131,11 +131,11 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T, U>
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public var prop: some Foo {
     return 123
   }
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public subscript() -> some Foo {
     return 123
   }
@@ -145,87 +145,87 @@ public struct Bar<T>: AssocTypeInference {
   // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct Zim: AssocTypeInference {
   public init() {}
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public struct Zang: AssocTypeInference {
     public init() {}
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public subscript() -> some Foo {
       return 123
     }
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
 
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -235,11 +235,11 @@ public struct Zim: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<U>
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public var prop: some Foo {
     return 123
   }
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public subscript() -> some Foo {
     return 123
   }

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -101,7 +101,7 @@ private struct Parent<Unused> {
 
 AssociatedTypeDemangleTests.test("nested private generic types in associated type witnesses") {
   // Fixed in custom runtimes.
-  if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, * ) {}
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, * ) {}
   // Fixed in Swift 5.1+ runtimes.
   else if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {}
   // Bug is still present in Swift 5.0 runtime.

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -101,19 +101,19 @@ class InternalType {}
 
 extension InternalType {}
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension PSuper {
   func futureFoo() {}
 }
 
 public class FutureContainer {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public func futureFoo() {}
-  @available(macOS 9999, *)
+  @available(macOS 10.15, *)
   public func NotfutureFoo() {}
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension FutureContainer: P1 {}
 
 extension FutureContainer: P2 {}

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1186,11 +1186,10 @@
           "usr": "s:4cake6PSuperPAAE9futureFooyyF",
           "moduleName": "cake",
           "genericSig": "<τ_0_0 where τ_0_0 : PSuper>",
-          "isABIPlaceholder": true,
-          "intro_Macosx": "9999",
-          "intro_iOS": "9999",
-          "intro_tvOS": "9999",
-          "intro_watchOS": "9999",
+          "intro_Macosx": "10.15",
+          "intro_iOS": "13",
+          "intro_tvOS": "13",
+          "intro_watchOS": "6",
           "funcSelfKind": "NonMutating"
         }
       ],
@@ -1337,11 +1336,10 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC9futureFooyyF",
           "moduleName": "cake",
-          "isABIPlaceholder": true,
-          "intro_Macosx": "9999",
-          "intro_iOS": "9999",
-          "intro_tvOS": "9999",
-          "intro_watchOS": "9999",
+          "intro_Macosx": "10.15",
+          "intro_iOS": "13",
+          "intro_tvOS": "13",
+          "intro_watchOS": "6",
           "declAttributes": [
             "Available",
             "Available",
@@ -1364,7 +1362,7 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC12NotfutureFooyyF",
           "moduleName": "cake",
-          "intro_Macosx": "9999",
+          "intro_Macosx": "10.15",
           "declAttributes": [
             "Available"
           ],
@@ -1379,8 +1377,7 @@
           "kind": "Conformance",
           "name": "P1",
           "printedName": "P1",
-          "usr": "s:4cake2P1P",
-          "isABIPlaceholder": true
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1085,11 +1085,10 @@
           "usr": "s:4cake6PSuperPAAE9futureFooyyF",
           "moduleName": "cake",
           "genericSig": "<Self where Self : PSuper>",
-          "isABIPlaceholder": true,
-          "intro_Macosx": "9999",
-          "intro_iOS": "9999",
-          "intro_tvOS": "9999",
-          "intro_watchOS": "9999",
+          "intro_Macosx": "10.15",
+          "intro_iOS": "13",
+          "intro_tvOS": "13",
+          "intro_watchOS": "6",
           "funcSelfKind": "NonMutating"
         }
       ],
@@ -1199,11 +1198,10 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC9futureFooyyF",
           "moduleName": "cake",
-          "isABIPlaceholder": true,
-          "intro_Macosx": "9999",
-          "intro_iOS": "9999",
-          "intro_tvOS": "9999",
-          "intro_watchOS": "9999",
+          "intro_Macosx": "10.15",
+          "intro_iOS": "13",
+          "intro_tvOS": "13",
+          "intro_watchOS": "6",
           "declAttributes": [
             "Available",
             "Available",
@@ -1226,7 +1224,7 @@
           "declKind": "Func",
           "usr": "s:4cake15FutureContainerC12NotfutureFooyyF",
           "moduleName": "cake",
-          "intro_Macosx": "9999",
+          "intro_Macosx": "10.15",
           "declAttributes": [
             "Available"
           ],
@@ -1241,8 +1239,7 @@
           "kind": "Conformance",
           "name": "P1",
           "printedName": "P1",
-          "usr": "s:4cake2P1P",
-          "isABIPlaceholder": true
+          "usr": "s:4cake2P1P"
         },
         {
           "kind": "Conformance",


### PR DESCRIPTION
Replace all 9999 availability in non-stdlib tests with the appropriate platform availability.

https://github.com/apple/swift/pull/26109 cherry-picked for 5.1 branch.

**Explanation:** We still have 9999 availability sprinkled throughout the tests and standard library. This change replaces all the non-stdlib test availability with the appropriate macOS, iOS, tvOS and watchOS versions. It's important to get these changes landed before people start adding features synced with future Swift versions to avoid ambiguity.

**Scope:** Availability annotations only, only in tests.

**Risk:** Low. In some cases, it's possible that tests that previously ran or did not run could be enabled or disabled due to availability changes, but we already landed this on master and have let is shake out for a couple days.

**Testing:** Full integration testing.

**Reviewer:** @jckarter 

**Radar:** <rdar://problem/53163936>