### PR TITLE
[5.1] Replace stdlib and test/stdlib 9999 availability. (#26108)

### DIFF
--- a/stdlib/public/Darwin/Compression/Compression.swift
+++ b/stdlib/public/Darwin/Compression/Compression.swift
@@ -15,7 +15,7 @@ import Foundation
 @_exported import Compression
 
 /// Compression algorithms, wraps the C API constants.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum Algorithm: CaseIterable, RawRepresentable {
 
   /// LZFSE
@@ -51,7 +51,7 @@ public enum Algorithm: CaseIterable, RawRepresentable {
 }
 
 /// Compression filter direction of operation, compress/decompress
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum FilterOperation: RawRepresentable {
 
   /// Compress raw data to a compressed payload
@@ -77,7 +77,7 @@ public enum FilterOperation: RawRepresentable {
 }
 
 /// Compression errors
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum FilterError: Error {
 
   /// Filter failed to initialize,
@@ -90,7 +90,7 @@ public enum FilterError: Error {
   case invalidData
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension compression_stream {
 
   /// Initialize a compression_stream struct
@@ -112,7 +112,7 @@ extension compression_stream {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public class OutputFilter {
   private var _stream: compression_stream
   private var _buf: UnsafeMutablePointer<UInt8>
@@ -226,7 +226,7 @@ public class OutputFilter {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public class InputFilter<D: DataProtocol> {
 
   // Internal buffer to read bytes from a DataProtocol implementation

--- a/stdlib/public/Darwin/Network/NWConnection.swift
+++ b/stdlib/public/Darwin/Network/NWConnection.swift
@@ -110,7 +110,7 @@ public final class NWConnection : CustomDebugStringConvertible {
 	/// Retrieve the maximum datagram size that can be sent
 	/// on the connection. Any datagrams sent should be less
 	/// than or equal to this size.
-	@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+	@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 	public var maximumDatagramSize: Int {
 		get {
 			return Int(nw_connection_get_maximum_datagram_size(self.nw))

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -103,7 +103,7 @@ extension String.Index {
   ///     `sourcePosition` must be a valid index of at least one of the views
   ///     of `target`.
   ///   - target: The string referenced by the resulting index.
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   public init?<S: StringProtocol>(
     _ sourcePosition: String.Index, within target: S
   ) {

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -435,7 +435,7 @@ extension Unicode.Scalar.UTF16View : RandomAccessCollection {
 }
 
 extension Unicode.Scalar {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @frozen
   public struct UTF8View {
     @inlinable
@@ -446,12 +446,12 @@ extension Unicode.Scalar {
     internal var value: Unicode.Scalar
   }
 
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @inlinable
   public var utf8: UTF8View { return UTF8View(value: self) }
 }
 
-@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Unicode.Scalar.UTF8View : RandomAccessCollection {
   public typealias Indices = Range<Int>
 

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -417,7 +417,7 @@ UnicodeScalarTests.test("LosslessStringConvertible") {
   checkLosslessStringConvertible((0...127).map { UnicodeScalar(Int($0))! })
 }
 
-if #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
   UnicodeScalarTests.test("Views") {
     let scalars = baseScalars + continuingScalars
     for scalar in scalars {

--- a/test/stdlib/Compression.swift
+++ b/test/stdlib/Compression.swift
@@ -29,7 +29,7 @@ class DataSource {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 func ofiltercompress_ifilterdecompress(
   _ contents: Data, using algo: Algorithm
 ) throws -> Bool {
@@ -61,7 +61,7 @@ func ofiltercompress_ifilterdecompress(
   return contents == decompressed
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 func ifiltercompress_ofilterdecompress(
   _ contents: Data, using algo: Algorithm
 ) throws -> Bool {
@@ -113,7 +113,7 @@ func randomString(withBlockLength n: Int) -> String {
 
 let tests = TestSuite("Compression")
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) {
 
   do {
     for blockLength in [0, 1, 2, 5, 10, 100] {

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -572,7 +572,7 @@ ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/validCount") 
 }
 
 ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/reassignBuffer") {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+  guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else {
     // When back-deployed to 5.0, this coding error does not get detected.
     return
   }

--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -123,7 +123,7 @@ print("target removed")
 
 // The following tests are only expected to pass when running with the
 // Swift 5.1 and later libraries.
-if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   print("-check-prefix=CHECK-51")
 } else {
   print("-check-prefix=DONT-CHECK")

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -77,7 +77,7 @@ StringBridgeTests.test("Tagged NSString") {
 
 func returnOne<T>(_ t: T) -> Int { return 1 }
 StringBridgeTests.test("Character from NSString") {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+  guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
 
   // NOTE: Using hard-coded literals to directly construct NSStrings
   let ns1 = "A" as NSString

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -200,7 +200,7 @@ StringIndexTests.test("Scalar Align UTF-8 indices") {
 #if _runtime(_ObjC)
 import Foundation
 StringIndexTests.test("String.Index(_:within) / Range<String.Index>(_:in:)") {
-  guard #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) else {
+  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
     return
   }
 
@@ -308,7 +308,7 @@ StringIndexTests.test("Exhaustive Index Interchange") {
     file: String = #file,
     line: UInt = #line
   ) {
-    guard #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) else {
+    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
       return
     }
 

--- a/test/stdlib/TestAffineTransform.swift
+++ b/test/stdlib/TestAffineTransform.swift
@@ -316,7 +316,7 @@ class TestAffineTransform : TestAffineTransformSuper {
     }
     
     func test_hashing() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
 
         // the transforms are made up and the values don't matter
         let a = AffineTransform(m11: 1.0, m12: 2.5, m21: 66.2, m22: 40.2, tX: -5.5, tY: 3.7)

--- a/test/stdlib/TestDateInterval.swift
+++ b/test/stdlib/TestDateInterval.swift
@@ -66,7 +66,7 @@ class TestDateInterval : TestDateIntervalSuper {
     }
 
     func test_hashing() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
 
         let start1a = dateWithString("2019-04-04 17:09:23 -0700")
         let start1b = dateWithString("2019-04-04 17:09:23 -0700")

--- a/test/stdlib/TestIndexPath.swift
+++ b/test/stdlib/TestIndexPath.swift
@@ -222,7 +222,7 @@ class TestIndexPath: TestIndexPathSuper {
     }
     
     func testHashing() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
         let samples: [IndexPath] = [
             [],
             [1],

--- a/test/stdlib/TestMeasurement.swift
+++ b/test/stdlib/TestMeasurement.swift
@@ -152,7 +152,7 @@ class TestMeasurement : TestMeasurementSuper {
     }
 
     func testHashing() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
         let lengths: [[Measurement<UnitLength>]] = [
             [
                 Measurement(value: 5, unit: UnitLength.kilometers),

--- a/test/stdlib/TestNotification.swift
+++ b/test/stdlib/TestNotification.swift
@@ -34,7 +34,7 @@ class TestNotification : TestNotificationSuper {
     }
 
     func test_hashing() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
 
         let o1 = NSObject()
         let o2 = NSObject()

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -874,7 +874,7 @@ PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPr
 PropertyListEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestPropertyListEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 PropertyListEncoderTests.test("testEncodingTopLevelNullableType") { TestPropertyListEncoder().testEncodingTopLevelNullableType() }
 PropertyListEncoderTests.test("testEncodingMultipleNestedContainersWithTheSameTopLevelKey") {
-  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  if #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) {
     TestPropertyListEncoder().testEncodingMultipleNestedContainersWithTheSameTopLevelKey()
   }
 }

--- a/test/stdlib/TestUUID.swift
+++ b/test/stdlib/TestUUID.swift
@@ -85,7 +85,7 @@ class TestUUID : TestUUIDSuper {
     }
     
     func test_hash() {
-        guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else { return }
+        guard #available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *) else { return }
         let values: [UUID] = [
             // This list takes a UUID and tweaks every byte while
             // leaving the version/variant intact.

--- a/test/stdlib/Unicode.swift
+++ b/test/stdlib/Unicode.swift
@@ -63,7 +63,7 @@ typealias UTF16 = Unicode.UTF16
 typealias UTF32 = Unicode.UTF32
 
 UnicodeAPIs.test("UTF-8 and UTF-16 queries") {
-  guard #available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *) else {
+  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
     return
   }
   let str = "abéÏ01😓🎃👨‍👨‍👧‍👦アイウエオ"


### PR DESCRIPTION
* Replace stdlib and test/stdlib 9999 availability.

macOS 9999 -> macOS 10.15
iOS 9999 -> iOS 13
tvOS 9999 -> tvOS 13
watchOS 9999 -> watchOS 6

* Restore the pre-10.15 version of public init?(_: NSRange, in: __shared String)

We need this to allow master to work on 10.14 systems (in particular, to allow PR testing to work correctly without disabling back-deployment tests).

Cherry-pick of https://github.com/apple/swift/pull/26108

**Explanation:** We still have 9999 availability sprinkled throughout the tests and standard library. This change replaces all the standard library availability with the appropriate macOS, iOS, tvOS and watchOS versions. It's important to get these changes landed *before* people start adding features synced with future Swift versions to avoid ambiguity.

**Scope:** Availability annotations only, except that we had to add a fallback implementation of an internal method that will never actually be called in a built standard lib (which is always in-sync with the host OS platform), but is necessary for PR testing to work (because we're testing a 10.15 stdlib on a 10.14 host).

**Risk:** Low. This should not have any effect on actually released stdlibs or toolchains, since they already have availability annotated.

**Testing:** Full integration testing.

**Reviewer:** @lorentey, @milseman 

**Radar:** <rdar://problem/53163787>