### PR TITLE
[WIP] Associate messages with failures in debug info

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -318,6 +318,11 @@ BUILTIN_SIL_OPERATION(EndUnpairedAccess, "endUnpairedAccess", Special)
 /// Triggers a runtime failure if the condition is true.
 BUILTIN_SIL_OPERATION(CondFail, "condfail", Special)
 
+/// condfail(Int1, RawPointer) -> ()
+/// Triggers a runtime failure if the condition is true, with a
+/// reason message to encode in debug info
+BUILTIN_SIL_OPERATION(CondFailMessage, "condfail_message", Special)
+
 /// fixLifetime(T) -> ()
 /// Fixes the lifetime of any heap references in a value.
 BUILTIN_SIL_OPERATION(FixLifetime, "fixLifetime", Special)

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -67,6 +67,9 @@ ERROR(alignment_more_than_maximum,none,
       "@_alignment cannot increase alignment above maximum alignment of %0",
       (unsigned))
 
+WARNING(irgen_condfail_non_literal_message,none,
+        "condfail message did not evaluate to a literal string", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1774,16 +1774,21 @@ public:
   // Runtime failure
   //===--------------------------------------------------------------------===//
 
-  CondFailInst *createCondFail(SILLocation Loc, SILValue Operand,
-                               bool Inverted = false) {
+  CondFailInst *createCondFail(SILLocation Loc,
+                               SILValue Condition,
+                               bool Inverted = false,
+                               SILValue Message = SILValue(),
+                               ArrayRef<SILValue> MessageArguments = {}) {
     if (Inverted) {
-      SILType Ty = Operand->getType();
+      SILType Ty = Condition->getType();
       SILValue True(createIntegerLiteral(Loc, Ty, 1));
-      Operand =
-          createBuiltinBinaryFunction(Loc, "xor", Ty, Ty, {Operand, True});
+      Condition =
+          createBuiltinBinaryFunction(Loc, "xor", Ty, Ty, {Condition, True});
     }
-    return insert(new (getModule())
-                      CondFailInst(getSILDebugLocation(Loc), Operand));
+    
+    return insert(CondFailInst::create(getModule(),
+                                       getSILDebugLocation(Loc), Condition,
+                                       Message, MessageArguments));
   }
 
   BuiltinInst *createBuiltinTrap(SILLocation Loc) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2447,7 +2447,12 @@ SILCloner<ImplClass>::visitCondFailInst(CondFailInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createCondFail(getOpLocation(Inst->getLoc()),
-                                        getOpValue(Inst->getOperand())));
+                              getOpValue(Inst->getCondition()),
+                              /*inverted*/ false,
+                              Inst->getMessage()
+                                ? getOpValue(Inst->getMessage())
+                                : SILValue(),
+                              getOpValueArray<8>(Inst->getMessageArguments())));
 }
 
 template<typename ImplClass>

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 500; // dependency types for protocols
+const uint16_t SWIFTMODULE_VERSION_MINOR = 501; // cond_fail message
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1035,10 +1035,18 @@ static ValueDecl *getCanBeObjCClassOperation(ASTContext &Context,
 }
 
 static ValueDecl *getCondFailOperation(ASTContext &C, Identifier Id) {
-  // Int1 -> ()
+  // (Int1) -> ()
   auto CondTy = BuiltinIntegerType::get(1, C);
   auto VoidTy = TupleType::getEmpty(C);
   return getBuiltinFunction(Id, {CondTy}, VoidTy);
+}
+
+static ValueDecl *getCondFailMessageOperation(ASTContext &C, Identifier Id) {
+  // (Int1, RawPointer) -> ()
+  auto CondTy = BuiltinIntegerType::get(1, C);
+  auto MsgTy = C.TheRawPointerType;
+  auto VoidTy = TupleType::getEmpty(C);
+  return getBuiltinFunction(Id, {CondTy, MsgTy}, VoidTy);
 }
 
 static ValueDecl *getAssertConfOperation(ASTContext &C, Identifier Id) {
@@ -1894,6 +1902,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::CondFail:
     return getCondFailOperation(Context, Id);
+
+  case BuiltinValueKind::CondFailMessage:
+    return getCondFailMessageOperation(Context, Id);
 
   case BuiltinValueKind::AssertConf:
     return getAssertConfOperation(Context, Id);

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -73,7 +73,9 @@ public:
   /// In CodeView, since zero is not an artificial location, we emit the
   /// location of the unified trap block at the end of the fuction as an
   /// artificial inline location pointing to the user's instruction.
-  void setInlinedTrapLocation(IRBuilder &Builder, const SILDebugScope *Scope);
+  void setInlinedTrapLocation(IRBuilder &Builder, const SILDebugScope *Scope,
+                              SILLocation loc,
+                              StringRef message);
 
   /// Set the location for SWIFT_ENTRY_POINT_FUNCTION.
   void setEntryPointLoc(IRBuilder &Builder);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5426,7 +5426,7 @@ void IRGenSILFunction::visitDestroyAddrInst(swift::DestroyAddrInst *i) {
 }
 
 void IRGenSILFunction::visitCondFailInst(swift::CondFailInst *i) {
-  Explosion e = getLoweredExplosion(i->getOperand());
+  Explosion e = getLoweredExplosion(i->getCondition());
   llvm::Value *cond = e.claimNext();
 
   // Emit individual fail blocks so that we can map the failure back to a source

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -371,6 +371,18 @@ BuiltinInst::BuiltinInst(SILDebugLocation Loc, Identifier Name,
       Substitutions(Subs) {
 }
 
+CondFailInst *CondFailInst::create(SILModule &M,
+                                   SILDebugLocation DebugLoc,
+                                   SILValue Condition,
+                                   SILValue Message,
+                                   ArrayRef<SILValue> MessageArguments) {
+  auto Size = totalSizeToAlloc<swift::Operand>(1 + (Message ? 1 : 0)
+                                               + MessageArguments.size());
+  auto Buffer = M.allocateInst(Size, alignof(CondFailInst));
+  return ::new (Buffer) CondFailInst(
+                               DebugLoc, Condition, Message, MessageArguments);
+}
+
 InitBlockStorageHeaderInst *
 InitBlockStorageHeaderInst::create(SILFunction &F,
                                SILDebugLocation DebugLoc, SILValue BlockStorage,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1866,7 +1866,23 @@ public:
   }
 
   void visitCondFailInst(CondFailInst *FI) {
-    *this << getIDAndType(FI->getOperand());
+    *this << getIDAndType(FI->getCondition());
+    
+    if (auto message = FI->getMessage()) {
+      *this << ", " << getIDAndType(message);
+      
+      if (!FI->getMessageArguments().empty()) {
+        *this << '(';
+        interleave(FI->getMessageArguments().begin(),
+                   FI->getMessageArguments().end(),
+                   [&](SILValue v) {
+                     *this << getIDAndType(v);
+                   }, [&]{
+                     *this << ", ";
+                   });
+        *this << ')';
+      }
+    }
   }
   
   void visitIndexAddrInst(IndexAddrInst *IAI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3861,9 +3861,11 @@ public:
   }
 
   void checkCondFailInst(CondFailInst *CFI) {
-    require(CFI->getOperand()->getType()
+    require(CFI->getCondition()->getType()
               == SILType::getBuiltinIntegerType(1, F.getASTContext()),
             "cond_fail operand must be a Builtin.Int1");
+    
+#warning "todo: message validation"
   }
 
   void checkReturnInst(ReturnInst *RI) {

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -630,6 +630,19 @@ static ManagedValue emitBuiltinCondFail(SILGenFunction &SGF,
   return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
 }
 
+/// Specialized emitter for Builtin.condfail_message.
+static ManagedValue emitBuiltinCondFailMessage(SILGenFunction &SGF,
+                                        SILLocation loc,
+                                        SubstitutionMap substitutions,
+                                        ArrayRef<ManagedValue> args,
+                                        SGFContext C) {
+  assert(args.size() == 2 && "condfail should be given one argument");
+  
+  SGF.B.createCondFail(loc, args[0].getUnmanagedValue(), /*invert*/ false,
+                       args[1].getUnmanagedValue());
+  return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
+}
+
 /// Specialized emitter for Builtin.castReference.
 static ManagedValue
 emitBuiltinCastReference(SILGenFunction &SGF,

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -486,7 +486,7 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
   for (auto &Inst : BB)
     if (auto CF = dyn_cast<CondFailInst>(&Inst)) {
       // Try to match a cond_fail on "XOR , (SLE Start, End), 1".
-      if (match(CF->getOperand(),
+      if (match(CF->getCondition(),
                 m_ApplyInst(BuiltinValueKind::Xor,
                             m_ApplyInst(BuiltinValueKind::ICMP_SLE,
                                         m_Specific(Start),
@@ -496,14 +496,14 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
       // Inclusive ranges will have a check on the upper value (before adding
       // one).
       if (PreInclusiveEnd) {
-        if (match(CF->getOperand(),
+        if (match(CF->getCondition(),
                   m_ApplyInst(BuiltinValueKind::Xor,
                               m_ApplyInst(BuiltinValueKind::ICMP_SLE,
                                           m_Specific(Start),
                                           m_Specific(PreInclusiveEnd)),
                               m_One())))
           IsPreInclusiveEndLEQ = true;
-        if (match(CF->getOperand(),
+        if (match(CF->getCondition(),
                   m_ApplyInst(BuiltinValueKind::Xor,
                               m_ApplyInst(BuiltinValueKind::ICMP_SGT,
                                           m_Specific(End),

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -749,7 +749,7 @@ SILInstruction *SILCombiner::visitCondFailInst(CondFailInst *CFI) {
   if (RemoveCondFails)
     return eraseInstFromFunction(*CFI);
 
-  auto *I = dyn_cast<IntegerLiteralInst>(CFI->getOperand());
+  auto *I = dyn_cast<IntegerLiteralInst>(CFI->getCondition());
   if (!I)
     return nullptr;
 

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -194,7 +194,7 @@ public:
   }
 
   hash_code visitCondFailInst(CondFailInst *X) {
-    return llvm::hash_combine(X->getKind(), X->getOperand());
+    return llvm::hash_combine(X->getKind(), X->getCondition());
   }
 
   hash_code visitClassMethodInst(ClassMethodInst *X) {

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -134,7 +134,7 @@ static bool hasNoRelevantSideEffects(SILBasicBlock *BB) {
       // Even if we move the whole block across other code, it's still
       // guaranteed that the cond_fail is executed before the result of the
       // builtin is used.
-      auto *TEI = dyn_cast<TupleExtractInst>(CF->getOperand());
+      auto *TEI = dyn_cast<TupleExtractInst>(CF->getCondition());
       if (!TEI)
         return false;
       auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand());

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -220,7 +220,7 @@ static SILInstruction *getProducer(CondFailInst *CFI) {
   //   %1 = builtin "some_operation_with_overflow"
   //   %2 = tuple_extract %1
   //   %3 = cond_fail %2
-  SILValue FailCond = CFI->getOperand();
+  SILValue FailCond = CFI->getCondition();
   if (auto *TEI = dyn_cast<TupleExtractInst>(FailCond)) {
     if (auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand())) {
       return BI;

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -26,7 +26,7 @@ using namespace swift;
 /// Return true if the operand of the cond_fail instruction looks like
 /// the overflow bit of an arithmetic instruction.
 static bool hasOverflowConditionOperand(CondFailInst *CFI) {
-  if (auto *TEI = dyn_cast<TupleExtractInst>(CFI->getOperand()))
+  if (auto *TEI = dyn_cast<TupleExtractInst>(CFI->getCondition()))
     if (isa<BuiltinInst>(TEI->getOperand()))
       return true;
   return false;
@@ -101,7 +101,7 @@ public:
 
     // Merge conditions and remove the merged cond_fail instructions.
     for (unsigned I = 0, E = CondFailToMerge.size(); I != E; ++I) {
-      auto CurCond = CondFailToMerge[I]->getOperand();
+      auto CurCond = CondFailToMerge[I]->getCondition();
       if (MergedCond) {
         CurCond = Builder.createBuiltinBinaryFunction(Loc, "or",
                                                       CurCond->getType(),

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -499,7 +499,7 @@ public:
 
   bool tryToRemoveCondFail(CondFailInst *CFI) {
     // Extract the arithmetic operation from the condfail.
-    auto *TEI = dyn_cast<TupleExtractInst>(CFI->getOperand());
+    auto *TEI = dyn_cast<TupleExtractInst>(CFI->getCondition());
     if (!TEI) return false;
     auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand());
     if (!BI) return false;
@@ -623,7 +623,7 @@ public:
 
   void registerCondFailFormula(CondFailInst *CFI) {
     // Extract the arithmetic operation from the condfail.
-    if (auto *TEI = dyn_cast<TupleExtractInst>(CFI->getOperand())) {
+    if (auto *TEI = dyn_cast<TupleExtractInst>(CFI->getCondition())) {
       auto *BI = dyn_cast<BuiltinInst>(TEI->getOperand());
       if (!BI)
         return;
@@ -655,7 +655,7 @@ public:
     //  We can figure out that x - y will not underflow because of x >= y
     //  %usub_underflow = tuple_extract %usub_result : $(Builtin.Int64, Builtin.Int1), 1
     //  cond_fail %usub_underflow : $Builtin.Int1
-    if (auto *CMP = dyn_cast<BuiltinInst>(CFI->getOperand())) {
+    if (auto *CMP = dyn_cast<BuiltinInst>(CFI->getCondition())) {
       SILBasicBlock *TrueBB = nullptr;
       SILBasicBlock *FalseBB = CMP->getParent();
       addComparisonRelation(CMP, TrueBB, FalseBB);

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1384,14 +1384,14 @@ static CondFailInst *getUnConditionalFail(SILBasicBlock *BB, SILValue Cond,
     return nullptr;
   
   // The simple case: check if it is a "cond_fail 1".
-  auto *IL = dyn_cast<IntegerLiteralInst>(CondFail->getOperand());
+  auto *IL = dyn_cast<IntegerLiteralInst>(CondFail->getCondition());
   if (IL && IL->getValue() != 0)
     return CondFail;
 
   // Check if the cond_fail has the same condition as the cond_br in the
   // predecessor block.
   Cond = skipInvert(Cond, Inverted, false);
-  SILValue CondFailCond = skipInvert(CondFail->getOperand(), Inverted, false);
+  SILValue CondFailCond = skipInvert(CondFail->getCondition(), Inverted, false);
   if (Cond == CondFailCond && !Inverted)
     return CondFail;
   return nullptr;
@@ -2455,7 +2455,7 @@ static bool tryMoveCondFailToPreds(SILBasicBlock *BB) {
   // want to the optimization if the condition gets dead after moving the
   // cond_fail.
   bool inverted = false;
-  SILValue cond = skipInvert(CFI->getOperand(), inverted, true);
+  SILValue cond = skipInvert(CFI->getCondition(), inverted, true);
   if (!cond)
     return false;
   

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -114,7 +114,7 @@ swift::isInstructionTriviallyDead(SILInstruction *I) {
 
   // condfail instructions that obviously can't fail are dead.
   if (auto *CFI = dyn_cast<CondFailInst>(I))
-    if (auto *ILI = dyn_cast<IntegerLiteralInst>(CFI->getOperand()))
+    if (auto *ILI = dyn_cast<IntegerLiteralInst>(CFI->getCondition()))
       if (!ILI->getValue())
         return true;
 

--- a/test/IRGen/cond_fail_inline_scope.sil
+++ b/test/IRGen/cond_fail_inline_scope.sil
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-ir -gline-tables-only %s | %FileCheck %s
+
+import Builtin
+
+sil @after_trap : $() -> ()
+
+// CHECK-LABEL: define {{.*}}@cond_fail_message(i1)
+sil @cond_fail_message : $(Builtin.Int1) -> () {
+entry(%z : $Builtin.Int1):
+  %m = string_literal utf8 "this is the way the world ends"
+  // CHECK:   br i1 {{.*}}, label %[[TRAP:.*]], label %[[CONT:.*]], !dbg [[COND_FAIL_LOC:!.*]]
+  cond_fail %z : $Builtin.Int1, %m : $Builtin.RawPointer
+  // CHECK: ; <label>:[[CONT]]:
+  // CHECK:   call {{.*}} @after_trap(), !dbg [[APPLY_LOC:!.*]]
+  %f = function_ref @after_trap : $@convention(thin) () -> ()
+  %a = apply %f() : $@convention(thin) () -> ()
+  // CHECK:   ret void, !dbg [[RET_LOC:!.*]]
+  return undef : $()
+
+  // CHECK: ; <label>:[[TRAP]]:
+  // CHECK:   call void @llvm.trap(), !dbg [[TRAP_LOC:!.*]]
+}
+
+// CHECK-DAG: [[TRAP_LOC]] = !DILocation(line: 12, column: 3, scope: [[TRAP_SCOPE:!.*]], inlinedAt: [[TRAP_INLINED_LOC:!.*]])
+// CHECK-DAG: [[TRAP_SCOPE]] = distinct !DISubprogram(name: "this is the way the world ends"
+// CHECK-DAG: [[TRAP_INLINED_LOC]] = !DILocation(line: 12, column: 3, scope: [[FUNCTION_SCOPE:!.*]])
+// CHECK-DAG: [[FUNCTION_SCOPE]] = distinct !DISubprogram(name: "cond_fail_message"

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1624,6 +1624,20 @@ bb0(%0 : $A):
   return %20 : $()
 }
 
+// CHECK-LABEL: sil @test_cond_fail
+sil @test_cond_fail : $(Builtin.Int1) -> () {
+entry(%z : $Builtin.Int1):
+  %m = string_literal utf8 "this is the way the world ends"
+  %a = integer_literal $Builtin.Word, 1738
+  // CHECK: cond_fail [[COND:%.*]] : $Builtin.Int1
+  cond_fail %z : $Builtin.Int1
+  // CHECK: cond_fail [[COND]] : $Builtin.Int1, [[MESSAGE:%.*]] : $Builtin.RawPointer
+  cond_fail %z : $Builtin.Int1, %m : $Builtin.RawPointer
+  // CHECK: cond_fail [[COND]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer([[ARG:%.*]] : $Builtin.Word)
+  cond_fail %z : $Builtin.Int1, %m : $Builtin.RawPointer(%a : $Builtin.Word)
+  return undef : $()
+}
+
 // CHECK-LABEL: sil [dynamically_replacable] @test_dynamically_replaceable
 sil [dynamically_replacable] @test_dynamically_replaceable : $@convention(thin) () -> () {
 bb0:

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -23,6 +23,21 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return undef : $()
 }
 
+// CHECK-LABEL: sil [serialized] @test_cond_fail
+sil [serialized] @test_cond_fail : $(Builtin.Int1) -> () {
+entry(%z : $Builtin.Int1):
+  %m = string_literal utf8 "this is the way the world ends"
+  %a = integer_literal $Builtin.Word, 1738
+  // CHECK: cond_fail [[COND:%.*]] : $Builtin.Int1
+  cond_fail %z : $Builtin.Int1
+  // CHECK: cond_fail [[COND]] : $Builtin.Int1, [[MESSAGE:%.*]] : $Builtin.RawPointer
+  cond_fail %z : $Builtin.Int1, %m : $Builtin.RawPointer
+  // CHECK: cond_fail [[COND]] : $Builtin.Int1, [[MESSAGE]] : $Builtin.RawPointer([[ARG:%.*]] : $Builtin.Word)
+  cond_fail %z : $Builtin.Int1, %m : $Builtin.RawPointer(%a : $Builtin.Word)
+  return undef : $()
+}
+
+
 class TestArrayStorage {
   @_hasStorage var count: Int32
   init()


### PR DESCRIPTION
Based on @adrian-prantl's idea. Improve the experience of debugging Swift traps by encoding a reason message in the line table as the name of a fake inlined function, so that debuggers and DWARF-aware symbolicators like `addr2line` present the message in the backtrace, for example:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x0000000100001494 foo`main [inlined] freedom at foo.swift:45:1 [opt]
   42  	  Builtin.condfail_message(xcondition.value, message.value)
   43  	}
   44  	
-> 45  	myAssert(2 + 2 != 4, "too much freedom")
Target 0: (foo) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
  * frame #0: 0x0000000100001494 foo`main [inlined] too much freedom at foo.swift:45:1 [opt]
    frame #1: 0x0000000100001494 foo`main at foo.swift:45 [opt]
    frame #2: 0x00007fff72fddc49 libdyld.dylib`start + 1
    frame #3: 0x00007fff72fddc49 libdyld.dylib`start + 1
```

TODO:

- Should we mark up the inlined function scope with some sort of flag so that debuggers know it's a trap reason?
- For this to work in -Onone, we'd need a mandatory pass that cleans up `struct_extract (struct)` and `inttoptr (ptrtoint)` to be able to look through the abstraction of `String` and `StaticString` in transparent code.
- It would be interesting to also be able to support interpolating frame variable values in the message. Using something similar to what @ravikandhadai has done with `os_log`, we could potentially encode interpolated messages like `fatalError("foo \(x)")` in debug info by encoding `x` as a local variable of the inlined trap function location, allowing the debugger to try to find and present the value as part of the failure message.