### PR TITLE
[Parser] Diagnose use of subscript inside an array literal

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -763,7 +763,9 @@ ERROR(extra_rbracket,PointsToFirstBadToken,
 ERROR(extra_colon,PointsToFirstBadToken,
       "unexpected ':' in type; did you mean to write a dictionary type?", ())
 WARNING(subscript_collection_element_invalid_index, none,
-       "index '%0' in subscript expression is out of bounds", (StringRef))
+        "index '%0' in subscript expression is out of bounds", (StringRef))
+NOTE(subscript_collection_element_fix_it, none, "did you mean to write two "
+     "array literals instead?", ())
 
 // Tuple Types
 ERROR(expected_rparen_tuple_type_list,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -765,7 +765,9 @@ ERROR(extra_colon,PointsToFirstBadToken,
 WARNING(subscript_array_element, none,
         "unexpected subscript in array literal; did you mean to write two "
         "separate elements instead?", ())
-NOTE(subscript_array_element_fix_it, none,
+NOTE(subscript_array_element_fix_it_add_comma, none, "Add a separator between "
+     "the elements", ())
+NOTE(subscript_array_element_fix_it_remove_space, none,
      "Remove the space between the elements to silence this warning", ())
 
 // Tuple Types

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -762,6 +762,8 @@ ERROR(extra_rbracket,PointsToFirstBadToken,
       "unexpected ']' in type; did you mean to write an array type?", ())
 ERROR(extra_colon,PointsToFirstBadToken,
       "unexpected ':' in type; did you mean to write a dictionary type?", ())
+WARNING(subscript_collection_element_invalid_index, none,
+       "index '%0' in subscript expression is out of bounds", (StringRef))
 
 // Tuple Types
 ERROR(expected_rparen_tuple_type_list,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -762,10 +762,11 @@ ERROR(extra_rbracket,PointsToFirstBadToken,
       "unexpected ']' in type; did you mean to write an array type?", ())
 ERROR(extra_colon,PointsToFirstBadToken,
       "unexpected ':' in type; did you mean to write a dictionary type?", ())
-WARNING(subscript_collection_element_invalid_index, none,
-        "index '%0' in subscript expression is out of bounds", (StringRef))
-NOTE(subscript_collection_element_fix_it, none, "did you mean to write two "
-     "array literals instead?", ())
+WARNING(subscript_array_element, none,
+        "unexpected subscript in array literal, did you mean to write two "
+        "separate elements instead?", ())
+NOTE(subscript_array_element_fix_it, none,
+     "Remove the space between the elements to silence this warning", ())
 
 // Tuple Types
 ERROR(expected_rparen_tuple_type_list,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -763,7 +763,7 @@ ERROR(extra_rbracket,PointsToFirstBadToken,
 ERROR(extra_colon,PointsToFirstBadToken,
       "unexpected ':' in type; did you mean to write a dictionary type?", ())
 WARNING(subscript_array_element, none,
-        "unexpected subscript in array literal, did you mean to write two "
+        "unexpected subscript in array literal; did you mean to write two "
         "separate elements instead?", ())
 NOTE(subscript_array_element_fix_it, none,
      "Remove the space between the elements to silence this warning", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -765,10 +765,10 @@ ERROR(extra_colon,PointsToFirstBadToken,
 WARNING(subscript_array_element, none,
         "unexpected subscript in array literal; did you mean to write two "
         "separate elements instead?", ())
-NOTE(subscript_array_element_fix_it_add_comma, none, "Add a separator between "
+NOTE(subscript_array_element_fix_it_add_comma, none, "add a separator between "
      "the elements", ())
 NOTE(subscript_array_element_fix_it_remove_space, none,
-     "Remove the space between the elements to silence this warning", ())
+     "remove the space between the elements to silence this warning", ())
 
 // Tuple Types
 ERROR(expected_rparen_tuple_type_list,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1435,6 +1435,8 @@ public:
 
   UnresolvedDeclRefExpr *parseExprOperator();
 
+  void validateCollectionElement(ParserResult<Expr> element);
+
   //===--------------------------------------------------------------------===//
   // Statement Parsing
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3497,15 +3497,16 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
 
   auto startLocOfSubscript = subscriptExpr->getIndex()->getStartLoc();
   auto endLocOfArray = arrayExpr->getEndLoc();
+  auto locForEndOfTokenArray = L->getLocForEndOfToken(SourceMgr, endLocOfArray);
 
-  if (L->getLocForEndOfToken(SourceMgr, endLocOfArray) != startLocOfSubscript) {
+  if (locForEndOfTokenArray != startLocOfSubscript) {
     auto subscriptLoc = subscriptExpr->getLoc();
     diagnose(subscriptLoc, diag::subscript_array_element)
         .highlight(subscriptExpr->getSourceRange());
     diagnose(subscriptLoc, diag::subscript_array_element_fix_it_add_comma)
         .fixItInsertAfter(endLocOfArray, ",");
     diagnose(subscriptLoc, diag::subscript_array_element_fix_it_remove_space)
-        .fixItRemoveChars(endLocOfArray.getAdvancedLoc(1), startLocOfSubscript);
+        .fixItRemoveChars(locForEndOfTokenArray, startLocOfSubscript);
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3499,15 +3499,13 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
   auto endLocOfArray = arrayExpr->getEndLoc();
 
   if (L->getLocForEndOfToken(SourceMgr, endLocOfArray) != startLocOfSubscript) {
-    auto diag =
-        diagnose(subscriptExpr->getLoc(), diag::subscript_array_element);
-    diag.highlight(subscriptExpr->getSourceRange());
-    diag.fixItInsertAfter(endLocOfArray, ",");
-    diag.flush();
-
-    auto note =
-        diagnose(subscriptExpr->getLoc(), diag::subscript_array_element_fix_it);
-    note.fixItRemoveChars(endLocOfArray.getAdvancedLoc(1), startLocOfSubscript);
+    auto subscriptLoc = subscriptExpr->getLoc();
+    diagnose(subscriptLoc, diag::subscript_array_element)
+        .highlight(subscriptExpr->getSourceRange());
+    diagnose(subscriptLoc, diag::subscript_array_element_fix_it_add_comma)
+        .fixItInsertAfter(endLocOfArray, ",");
+    diagnose(subscriptLoc, diag::subscript_array_element_fix_it_remove_space)
+        .fixItRemoveChars(endLocOfArray.getAdvancedLoc(1), startLocOfSubscript);
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3508,6 +3508,8 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
     auto note =
         diagnose(subscriptExpr->getLoc(), diag::subscript_array_element_fix_it);
     note.fixItRemoveChars(endLocOfArray.getAdvancedLoc(1), startLocOfSubscript);
+
+    element.setIsParseError();
   }
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3509,6 +3509,12 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
                          diag::subscript_collection_element_invalid_index,
                          indexExpr->getDigitsText());
     diag.highlight(subscriptExpr->getSourceRange());
+    diag.flush();
+
+    auto note = diagnose(subscriptExpr->getLoc(),
+                         diag::subscript_collection_element_fix_it);
+    note.fixItInsertAfter(baseExpr->getRBracketLoc(), ",");
+
     element.setIsParseError();
   }
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3508,8 +3508,6 @@ void Parser::validateCollectionElement(ParserResult<Expr> element) {
     auto note =
         diagnose(subscriptExpr->getLoc(), diag::subscript_array_element_fix_it);
     note.fixItRemoveChars(endLocOfArray.getAdvancedLoc(1), startLocOfSubscript);
-
-    element.setIsParseError();
   }
 }
 

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -116,7 +116,5 @@ func passAssocType<T : HasAssocType>(_ t: T) {
 
 // SR-11134
 
-let sr_11134_1 = [["a"][0]] // Ok
-let sr_11134_2 = [["a"][1]] // expected-warning {{index '1' in subscript expression is out of bounds}} // expected-note {{did you mean to write two array literals instead?}}{{24-24=,}}
-let sr_11134_3 = [[1, 1, 1], [], [4, 5, 6, 7], [0], [], [] [42]] // expected-warning {{index '42' in subscript expression is out of bounds}} // expected-note {{did you mean to write two array literals instead?}}{{59-59=,}}
-
+let sr_11134_1 = [[1, 2, 3][0]] // ok
+let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal, did you mean to write two separate elements instead?}}{{28-28=,}} // expected-note {{Remove the space between the elements to silence this warning}} {{28-29=}}

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -120,4 +120,8 @@ let sr_11134_1 = [[1, 2, 3][0]] // ok
 let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}
 // expected-note@-1 {{add a separator between the elements}}{{28-28=,}}
 // expected-note@-2 {{remove the space between the elements to silence this warning}}{{28-29=}}
-
+let sr_11134_3 = [
+  [1, 2, 3] [1] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}
+// expected-note@-1 {{add a separator between the elements}}{{12-12=,}}
+// expected-note@-2 {{remove the space between the elements to silence this warning}}{{12-13=}}
+]

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -117,6 +117,6 @@ func passAssocType<T : HasAssocType>(_ t: T) {
 // SR-11134
 
 let sr_11134_1 = [["a"][0]] // Ok
-let sr_11134_2 = [["a"][1]] // expected-warning {{index '1' in subscript expression is out of bounds}}
+let sr_11134_2 = [["a"][1]] // expected-warning {{index '1' in subscript expression is out of bounds}} // expected-note {{did you mean to write two array literals instead?}}{{24-24=,}}
+let sr_11134_3 = [[1, 1, 1], [], [4, 5, 6, 7], [0], [], [] [42]] // expected-warning {{index '42' in subscript expression is out of bounds}} // expected-note {{did you mean to write two array literals instead?}}{{59-59=,}}
 
-let sr_11134_3 = [[1, 1, 1], [], [4, 5, 6, 7], [0], [], [] [42]] // expected-warning {{index '42' in subscript expression is out of bounds}}

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -118,6 +118,6 @@ func passAssocType<T : HasAssocType>(_ t: T) {
 
 let sr_11134_1 = [[1, 2, 3][0]] // ok
 let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}
-// expected-note@-1 {{Add a separator between the elements}}{{28-28=,}}
-// expected-note@-2 {{Remove the space between the elements to silence this warning}}{{28-29=}}
+// expected-note@-1 {{add a separator between the elements}}{{28-28=,}}
+// expected-note@-2 {{remove the space between the elements to silence this warning}}{{28-29=}}
 

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -117,4 +117,4 @@ func passAssocType<T : HasAssocType>(_ t: T) {
 // SR-11134
 
 let sr_11134_1 = [[1, 2, 3][0]] // ok
-let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal, did you mean to write two separate elements instead?}}{{28-28=,}} // expected-note {{Remove the space between the elements to silence this warning}} {{28-29=}}
+let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}{{28-28=,}} // expected-note {{Remove the space between the elements to silence this warning}} {{28-29=}}

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -114,3 +114,9 @@ func passAssocType<T : HasAssocType>(_ t: T) {
   takesAssocType(t, [T.A](), [T.A?]())
 }
 
+// SR-11134
+
+let sr_11134_1 = [["a"][0]] // Ok
+let sr_11134_2 = [["a"][1]] // expected-warning {{index '1' in subscript expression is out of bounds}}
+
+let sr_11134_3 = [[1, 1, 1], [], [4, 5, 6, 7], [0], [], [] [42]] // expected-warning {{index '42' in subscript expression is out of bounds}}

--- a/test/type/array.swift
+++ b/test/type/array.swift
@@ -117,4 +117,7 @@ func passAssocType<T : HasAssocType>(_ t: T) {
 // SR-11134
 
 let sr_11134_1 = [[1, 2, 3][0]] // ok
-let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}{{28-28=,}} // expected-note {{Remove the space between the elements to silence this warning}} {{28-29=}}
+let sr_11134_2 = [[1, 2, 3] [1]] // expected-warning {{unexpected subscript in array literal; did you mean to write two separate elements instead?}}
+// expected-note@-1 {{Add a separator between the elements}}{{28-28=,}}
+// expected-note@-2 {{Remove the space between the elements to silence this warning}}{{28-29=}}
+


### PR DESCRIPTION
This PR adds a new method to the parser to validate the element in an array if it's a subscript.

For example:

```swift
warning: unexpected subscript in array literal; did you mean to write two separate elements instead?
note: Add a separator between the elements
note: Remove the space between the elements to silence this warning

let array = [[1, 1, 1], [], [4, 5, 6, 7] [0], [], [], [42]]
```
Resolves [SR-11134](https://bugs.swift.org/browse/SR-11134).