### PR TITLE
Restore more-correct behavior of getting the full contents of bridged NSStrings containing invalid UTF-8

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -248,7 +248,23 @@ extension _StringGuts {
   ) -> Int? {
     #if _runtime(_ObjC)
     // Currently, foreign  means NSString
-    return _cocoaStringCopyUTF8(_object.cocoaObject, into: mbp)
+    if let res = _cocoaStringCopyUTF8(_object.cocoaObject, into: mbp) {
+      return res
+    }
+    
+    // If the NSString contains invalid UTF8 (e.g. unpaired surrogates), we
+    // can get nil from cocoaStringCopyUTF8 in situations where a character by
+    // character loop would get something more useful like repaired contents
+    var ptr = mbp.baseAddress._unsafelyUnwrappedUnchecked
+    var numWritten = 0
+    for cu in String(self).utf8 {
+      guard numWritten < mbp.count else { return nil }
+      ptr.initialize(to: cu)
+      ptr += 1
+      numWritten += 1
+    }
+    
+    return numWritten
     #else
     fatalError("No foreign strings on Linux in this version of Swift")
     #endif

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -85,4 +85,13 @@ static inline BOOL NSStringBridgeTestEqual(NSString * _Nonnull a, NSString * _No
   return [a isEqual:b];
 }
 
+static inline NSString *getNSStringWithUnpairedSurrogate() {
+  unichar chars[16] = {
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
+    0xD800 };
+  return [NSString stringWithCharacters:chars length:1];
+}
+
 NS_ASSUME_NONNULL_END

--- a/test/stdlib/TestNSString.swift
+++ b/test/stdlib/TestNSString.swift
@@ -57,6 +57,11 @@ class TestNSString : TestNSStringSuper {
     string.enumerateSubstrings(in: middleIndex..<string.endIndex, options: .byLines) { (_, _, _, _) in }  //shouldn't crash
   }
   
+  func test_unpairedSurrogates() {
+    let evil = getNSStringWithUnpairedSurrogate();
+    print("\(evil)")
+  }
+  
 }
 
 #if !FOUNDATION_XCTEST
@@ -64,6 +69,9 @@ var NSStringTests = TestSuite("TestNSString")
 NSStringTests.test("test_equalOverflow") { TestNSString().test_equalOverflow() }
 NSStringTests.test("test_smallString_BOM") {
   TestNSString().test_smallString_BOM()
+}
+NSStringTests.test("test_unpairedSurrogates") {
+  TestNSString().test_unpairedSurrogates()
 }
 runAllTests()
 #endif


### PR DESCRIPTION
Fixes rdar://problem/53119693