### PR TITLE
[5.1][CodeCompletion] Add defensive nullptr check

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -415,15 +415,15 @@ bool collectPossibleCalleesForApply(
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(fnExpr)) {
     if (auto *decl = DRE->getDecl()) {
-      auto declType = decl->getInterfaceType();
-      if (auto *funcType = declType->getAs<AnyFunctionType>())
-        candidates.emplace_back(funcType, decl);
+      if (decl->hasInterfaceType())
+        if (auto *funcType = decl->getInterfaceType()->getAs<AnyFunctionType>())
+          candidates.emplace_back(funcType, decl);
     }
   } else if (auto *OSRE = dyn_cast<OverloadSetRefExpr>(fnExpr)) {
     for (auto *decl : OSRE->getDecls()) {
-      auto declType = decl->getInterfaceType();
-      if (auto *funcType = declType->getAs<AnyFunctionType>())
-        candidates.emplace_back(funcType, decl);
+      if (decl->hasInterfaceType())
+        if (auto *funcType = decl->getInterfaceType()->getAs<AnyFunctionType>())
+          candidates.emplace_back(funcType, decl);
     }
   } else if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fnExpr)) {
     collectPossibleCalleesByQualifiedLookup(


### PR DESCRIPTION
Cherry-pick of #25876 reviewed by @benlangmuir 

* **Explanation**: We've seen several crash logs for null pointer dereferencing in code-completion logic. Although we haven't found reproducer for this, add defensive nullptr check to prevent crash.
* **Scope**: Context-type analysis in code-completion
* **Issue**: rdar://problem/51599533
* **Risk**: Low. This patch just turns a crash to "No Completion"
* **Test**: Passed current test cases. No regression test added because we haven't been able to find reproducer
* **Reviewer**: Ben Langmuir (@benlangmuir)
