### PR TITLE
Update coverage options for fuzzing to match clang.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1130,9 +1130,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
     // Automatically set coverage flags, unless coverage type was explicitly
     // requested.
+    // Updated to match clang at Jul 2019.
     Opts.SanitizeCoverage.IndirectCalls = true;
     Opts.SanitizeCoverage.TraceCmp = true;
-    Opts.SanitizeCoverage.TracePCGuard = true;
+    Opts.SanitizeCoverage.PCTable = true;
+    if (Triple.isOSLinux()) {
+      Opts.SanitizeCoverage.StackDepth = true;
+    }
+    Opts.SanitizeCoverage.Inline8bitCounters = true;
     Opts.SanitizeCoverage.CoverageType = llvm::SanitizerCoverageOptions::SCK_Edge;
   }
 

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -39,6 +39,6 @@ test()
 // FIXME: We need a way to distinguish the different types of coverage instrumentation
 // that isn't really fragile. For now just check there's at least one call to the function
 // used to increment coverage count at a particular PC.
-// SANCOV: call void @__sanitizer_cov
-
 // SANCOV_TRACE_CMP: call void @__sanitizer_cov_trace_cmp
+
+// SANCOV: call void @__sanitizer_cov


### PR DESCRIPTION
Some of the sanitizer tests were crashing due to "-fsanitize-coverage=trace-pc-guard" which comes from setting "TracePCGuard" on Opts.SanitizeCoverage. I pulled the current options from clang.