### PR TITLE
[ast] Refactor Builtin printing logic from ASTPrinter -> BuiltinInst.

### DIFF
--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -17,10 +17,11 @@
 #ifndef SWIFT_AST_BUILTINS_H
 #define SWIFT_AST_BUILTINS_H
 
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Attributes.h"
-#include "swift/AST/Type.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -29,9 +30,17 @@ enum class AtomicOrdering;
 }
 
 namespace swift {
-  class ASTContext;
-  class Identifier;
-  class ValueDecl;
+
+class ASTContext;
+class Identifier;
+class ValueDecl;
+
+enum class BuiltinTypeKind : std::underlying_type<TypeKind>::type {
+#define TYPE(id, parent)
+#define BUILTIN_TYPE(id, parent)                                               \
+  id = std::underlying_type<TypeKind>::type(TypeKind::id),
+#include "swift/AST/TypeNodes.def"
+};
 
 /// Get the builtin type for the given name.
 ///
@@ -88,7 +97,6 @@ llvm::Intrinsic::ID getLLVMIntrinsicID(StringRef Name);
 /// overflow.
 llvm::Intrinsic::ID
 getLLVMIntrinsicIDForBuiltinWithOverflow(BuiltinValueKind ID);
-
 
 /// Create a ValueDecl for the builtin with the given name.
 ///

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -40,54 +40,60 @@
 #include "llvm/Support/TrailingObjects.h"
 
 namespace llvm {
-  struct fltSemantics;
-}
-namespace swift {
-  enum class AllocationArena;
-  class ArchetypeType;
-  class AssociatedTypeDecl;
-  class ASTContext;
-  class ClassDecl;
-  class DependentMemberType;
-  class GenericTypeParamDecl;
-  class GenericTypeParamType;
-  class GenericParamList;
-  class GenericSignature;
-  class GenericSignatureBuilder;
-  class Identifier;
-  class InOutType;
-  class OpaqueTypeDecl;
-  class OpenedArchetypeType;
-  enum class ReferenceCounting : uint8_t;
-  enum class ResilienceExpansion : unsigned;
-  class SILModule;
-  class SILType;
-  class TypeAliasDecl;
-  class TypeDecl;
-  class NominalTypeDecl;
-  class GenericTypeDecl;
-  class EnumDecl;
-  class EnumElementDecl;
-  class StructDecl;
-  class ProtocolDecl;
-  class TypeVariableType;
-  class ValueDecl;
-  class ModuleDecl;
-  class ModuleType;
-  class ProtocolConformance;
-  enum PointerTypeKind : unsigned;
-  struct ValueOwnershipKind;
+struct fltSemantics;
+} // namespace llvm
 
-  enum class TypeKind : uint8_t {
+namespace swift {
+
+enum class AllocationArena;
+class ArchetypeType;
+class AssociatedTypeDecl;
+class ASTContext;
+class ClassDecl;
+class DependentMemberType;
+class GenericTypeParamDecl;
+class GenericTypeParamType;
+class GenericParamList;
+class GenericSignature;
+class GenericSignatureBuilder;
+class Identifier;
+class InOutType;
+class OpaqueTypeDecl;
+class OpenedArchetypeType;
+enum class ReferenceCounting : uint8_t;
+enum class ResilienceExpansion : unsigned;
+class SILModule;
+class SILType;
+class TypeAliasDecl;
+class TypeDecl;
+class NominalTypeDecl;
+class GenericTypeDecl;
+class EnumDecl;
+class EnumElementDecl;
+class StructDecl;
+class ProtocolDecl;
+class TypeVariableType;
+class ValueDecl;
+class ModuleDecl;
+class ModuleType;
+class ProtocolConformance;
+enum PointerTypeKind : unsigned;
+struct ValueOwnershipKind;
+
+enum class TypeKind : uint8_t {
 #define TYPE(id, parent) id,
 #define LAST_TYPE(id) Last_Type = id,
 #define TYPE_RANGE(Id, FirstId, LastId) \
   First_##Id##Type = FirstId, Last_##Id##Type = LastId,
 #include "swift/AST/TypeNodes.def"
-  };
-  enum : unsigned { NumTypeKindBits =
-    countBitsUsed(static_cast<unsigned>(TypeKind::Last_Type)) };
-  
+};
+
+enum : unsigned {
+  NumTypeKindBits = countBitsUsed(static_cast<unsigned>(TypeKind::Last_Type))
+};
+
+enum class BuiltinTypeKind : std::underlying_type<TypeKind>::type;
+
 /// Various properties of types that are primarily defined recursively
 /// on structural types.
 class RecursiveTypeProperties {
@@ -1244,6 +1250,19 @@ public:
     return T->getKind() >= TypeKind::First_BuiltinType &&
            T->getKind() <= TypeKind::Last_BuiltinType;
   }
+
+  /// Return the "canonical" name for this builtin. E.x.:
+  ///
+  ///   BuiltinRawPointerType -> BUILTIN_TYPE_NAME_RAWPOINTER ->
+  ///   Builtin.RawPointer.
+  ///
+  /// If \p prependBuiltinNamespace is set to true, "Builtin." is left as a
+  /// prefix on the name. This is the default behavior. If the user asks, we
+  /// strip off the builtin prefix.
+  StringRef getTypeName(SmallVectorImpl<char> &result,
+                        bool prependBuiltinNamespace = true) const;
+
+  BuiltinTypeKind getBuiltinTypeKind() const;
 };
 DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinType, Type)
 

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -19,69 +19,104 @@
 namespace swift {
 
 /// The name of the standard library, which is a reserved module name.
-constexpr static const char STDLIB_NAME[] = "Swift";
+constexpr static const StringLiteral STDLIB_NAME = "Swift";
 /// The name of the Onone support library, which is a reserved module name.
-constexpr static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
+constexpr static const StringLiteral SWIFT_ONONE_SUPPORT = "SwiftOnoneSupport";
 /// The name of the SwiftShims module, which contains private stdlib decls.
-constexpr static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
+constexpr static const StringLiteral SWIFT_SHIMS_NAME = "SwiftShims";
 /// The name of the Builtin module, which contains Builtin functions.
-constexpr static const char BUILTIN_NAME[] = "Builtin";
+constexpr static const StringLiteral BUILTIN_NAME = "Builtin";
 /// The prefix of module names used by LLDB to capture Swift expressions
-constexpr static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] =
+constexpr static const StringLiteral LLDB_EXPRESSIONS_MODULE_NAME_PREFIX =
     "__lldb_expr_";
 
 /// The name of the fake module used to hold imported Objective-C things.
-constexpr static const char MANGLING_MODULE_OBJC[] = "__C";
+constexpr static const StringLiteral MANGLING_MODULE_OBJC = "__C";
 /// The name of the fake module used to hold synthesized ClangImporter things.
-constexpr static const char MANGLING_MODULE_CLANG_IMPORTER[] =
+constexpr static const StringLiteral MANGLING_MODULE_CLANG_IMPORTER =
     "__C_Synthesized";
 
-/// The name of the Builtin type prefix
-constexpr static const char BUILTIN_TYPE_NAME_PREFIX[] = "Builtin.";
-/// The name of the Builtin type for Int
-constexpr static const char BUILTIN_TYPE_NAME_INT[] = "Builtin.Int";
-/// The name of the Builtin type for Int8
-constexpr static const char BUILTIN_TYPE_NAME_INT8[] = "Builtin.Int8";
-/// The name of the Builtin type for Int16
-constexpr static const char BUILTIN_TYPE_NAME_INT16[] = "Builtin.Int16";
-/// The name of the Builtin type for Int32
-constexpr static const char BUILTIN_TYPE_NAME_INT32[] = "Builtin.Int32";
-/// The name of the Builtin type for Int64
-constexpr static const char BUILTIN_TYPE_NAME_INT64[] = "Builtin.Int64";
-/// The name of the Builtin type for Int128
-constexpr static const char BUILTIN_TYPE_NAME_INT128[] = "Builtin.Int128";
-/// The name of the Builtin type for Int256
-constexpr static const char BUILTIN_TYPE_NAME_INT256[] = "Builtin.Int256";
-/// The name of the Builtin type for Int512
-constexpr static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
-/// The name of the Builtin type for IntLiteral
-constexpr static const char BUILTIN_TYPE_NAME_INTLITERAL[] =
-    "Builtin.IntLiteral";
-/// The name of the Builtin type for Float
-constexpr static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.FPIEEE";
-/// The name of the Builtin type for NativeObject
-constexpr static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] =
-    "Builtin.NativeObject";
-/// The name of the Builtin type for BridgeObject
-constexpr static const char BUILTIN_TYPE_NAME_BRIDGEOBJECT[] =
-    "Builtin.BridgeObject";
-/// The name of the Builtin type for RawPointer
-constexpr static const char BUILTIN_TYPE_NAME_RAWPOINTER[] =
-    "Builtin.RawPointer";
-/// The name of the Builtin type for UnsafeValueBuffer
-constexpr static const char BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER[] =
-    "Builtin.UnsafeValueBuffer";
-/// The name of the Builtin type for UnknownObject
-constexpr static const char BUILTIN_TYPE_NAME_UNKNOWNOBJECT[] =
-    "Builtin.UnknownObject";
-/// The name of the Builtin type for Vector
-constexpr static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
-/// The name of the Builtin type for SILToken
-constexpr static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
-/// The name of the Builtin type for Word
-constexpr static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
-constexpr static StringLiteral SEMANTICS_PROGRAMTERMINATION_POINT =
+constexpr static const StringLiteral SEMANTICS_PROGRAMTERMINATION_POINT =
     "programtermination_point";
+
+/// The name of the Builtin type prefix
+constexpr static const StringLiteral BUILTIN_TYPE_NAME_PREFIX = "Builtin.";
+
+/// A composition class containing a StringLiteral for the names of
+/// Swift builtins. The reason we use this is to ensure that we when
+/// necessary slice off the "Builtin." prefix from these names in a
+/// constexpr way from a global constant string.
+///
+/// NOTE: StringLiteral is a weird class to compose with. For this to
+/// work properly, one must always initialize these classes using an
+/// initializer list as shown below.
+struct BuiltinNameStringLiteral {
+  const StringLiteral literal;
+
+  constexpr operator StringRef() const { return literal; }
+  constexpr const StringRef getWithoutPrefix() const {
+    return literal.drop_front(BUILTIN_TYPE_NAME_PREFIX.size());
+  }
+};
+
+/// The name of the Builtin type for Int
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT = {
+    "Builtin.Int"};
+/// The name of the Builtin type for Int8
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT8 = {
+    "Builtin.Int8"};
+/// The name of the Builtin type for Int16
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT16 = {
+    "Builtin.Int16"};
+/// The name of the Builtin type for Int32
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT32 = {
+    "Builtin.Int32"};
+/// The name of the Builtin type for Int64
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT64 = {
+    "Builtin.Int64"};
+/// The name of the Builtin type for Int128
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT128 = {
+    "Builtin.Int128"};
+/// The name of the Builtin type for Int256
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT256 = {
+    "Builtin.Int256"};
+/// The name of the Builtin type for Int512
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INT512 = {
+    "Builtin.Int512"};
+/// The name of the Builtin type for IntLiteral
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_INTLITERAL = {
+    "Builtin.IntLiteral"};
+/// The name of the Builtin type for IEEE Floating point types.
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_FLOAT = {
+    "Builtin.FPIEEE"};
+// The name of the builtin type for power pc specific floating point types.
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_FLOAT_PPC = {
+    "Builtin.FPPPC"};
+/// The name of the Builtin type for NativeObject
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_NATIVEOBJECT = {
+    "Builtin.NativeObject"};
+/// The name of the Builtin type for BridgeObject
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_BRIDGEOBJECT = {
+    "Builtin.BridgeObject"};
+/// The name of the Builtin type for RawPointer
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_RAWPOINTER = {
+    "Builtin.RawPointer"};
+/// The name of the Builtin type for UnsafeValueBuffer
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER =
+    {"Builtin.UnsafeValueBuffer"};
+/// The name of the Builtin type for UnknownObject
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_UNKNOWNOBJECT = {
+    "Builtin.UnknownObject"};
+/// The name of the Builtin type for Vector
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_VEC = {
+    "Builtin.Vec"};
+/// The name of the Builtin type for SILToken
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_SILTOKEN = {
+    "Builtin.SILToken"};
+/// The name of the Builtin type for Word
+constexpr static BuiltinNameStringLiteral BUILTIN_TYPE_NAME_WORD = {
+    "Builtin.Word"};
+
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -102,7 +102,7 @@ ASTBuilder::createBuiltinType(StringRef builtinName,
 
     ModuleDecl::AccessPathTy accessPath;
     StringRef strippedName =
-          builtinName.drop_front(strlen(BUILTIN_TYPE_NAME_PREFIX));
+        builtinName.drop_front(BUILTIN_TYPE_NAME_PREFIX.size());
     Ctx.TheBuiltinModule->lookupValue(accessPath,
                                       Ctx.getIdentifier(strippedName),
                                       NLKind::QualifiedLookup,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3576,69 +3576,26 @@ public:
       Printer << "_";
   }
 
-  void visitBuiltinRawPointerType(BuiltinRawPointerType *T) {
-    Printer << BUILTIN_TYPE_NAME_RAWPOINTER;
-  }
+#ifdef ASTPRINTER_HANDLE_BUILTINTYPE
+#error "ASTPRINTER_HANDLE_BUILTINTYPE should not be defined?!"
+#endif
 
-  void visitBuiltinNativeObjectType(BuiltinNativeObjectType *T) {
-    Printer << BUILTIN_TYPE_NAME_NATIVEOBJECT;
+#define ASTPRINTER_PRINT_BUILTINTYPE(NAME)                                     \
+  void visit##NAME(NAME *T) {                                                  \
+    SmallString<32> buffer;                                                    \
+    T->getTypeName(buffer);                                                    \
+    Printer << buffer;                                                         \
   }
-
-  void visitBuiltinUnknownObjectType(BuiltinUnknownObjectType *T) {
-    Printer << BUILTIN_TYPE_NAME_UNKNOWNOBJECT;
-  }
-
-  void visitBuiltinBridgeObjectType(BuiltinBridgeObjectType *T) {
-    Printer << BUILTIN_TYPE_NAME_BRIDGEOBJECT;
-  }
-
-  void visitBuiltinUnsafeValueBufferType(BuiltinUnsafeValueBufferType *T) {
-    Printer << BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER;
-  }
-
-  void visitBuiltinIntegerLiteralType(BuiltinIntegerLiteralType *T) {
-    Printer << BUILTIN_TYPE_NAME_INTLITERAL;
-  }
-
-  void visitBuiltinVectorType(BuiltinVectorType *T) {
-    llvm::SmallString<32> UnderlyingStrVec;
-    StringRef UnderlyingStr;
-    {
-      // FIXME: Ugly hack: remove the .Builtin from the element type.
-      {
-        llvm::raw_svector_ostream UnderlyingOS(UnderlyingStrVec);
-        T->getElementType().print(UnderlyingOS);
-      }
-      if (UnderlyingStrVec.startswith(BUILTIN_TYPE_NAME_PREFIX))
-        UnderlyingStr = UnderlyingStrVec.substr(8);
-      else
-        UnderlyingStr = UnderlyingStrVec;
-    }
-
-    Printer << BUILTIN_TYPE_NAME_VEC << T->getNumElements() << "x" << UnderlyingStr;
-  }
-
-  void visitBuiltinIntegerType(BuiltinIntegerType *T) {
-    auto width = T->getWidth();
-    if (width.isFixedWidth()) {
-      Printer << BUILTIN_TYPE_NAME_INT << width.getFixedWidth();
-    } else if (width.isPointerWidth()) {
-      Printer << BUILTIN_TYPE_NAME_WORD;
-    } else {
-      llvm_unreachable("impossible bit width");
-    }
-  }
-
-  void visitBuiltinFloatType(BuiltinFloatType *T) {
-    switch (T->getFPKind()) {
-    case BuiltinFloatType::IEEE16:  Printer << "Builtin.FPIEEE16"; return;
-    case BuiltinFloatType::IEEE32:  Printer << "Builtin.FPIEEE32"; return;
-    case BuiltinFloatType::IEEE64:  Printer << "Builtin.FPIEEE64"; return;
-    case BuiltinFloatType::IEEE80:  Printer << "Builtin.FPIEEE80"; return;
-    case BuiltinFloatType::IEEE128: Printer << "Builtin.FPIEEE128"; return;
-    case BuiltinFloatType::PPC128:  Printer << "Builtin.FPPPC128"; return;
-    }
-  }
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinRawPointerType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinNativeObjectType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinUnknownObjectType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinBridgeObjectType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinUnsafeValueBufferType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinIntegerLiteralType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinVectorType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinIntegerType)
+  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinFloatType)
+#undef ASTPRINTER_PRINT_BUILTINTYPE
 
   void visitSILTokenType(SILTokenType *T) {
     Printer << BUILTIN_TYPE_NAME_SILTOKEN;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -14,13 +14,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/GenericSignatureBuilder.h"
-#include "swift/Basic/LLVMContext.h"
-#include "swift/AST/ASTContext.h"
 #include "swift/AST/Builtins.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
-#include "swift/AST/GenericEnvironment.h"
+#include "swift/Basic/LLVMContext.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/Attributes.h"
@@ -2007,4 +2008,104 @@ StringRef swift::getBuiltinName(BuiltinValueKind ID) {
 #include "swift/AST/Builtins.def"
   }
   llvm_unreachable("bad BuiltinValueKind");
+}
+
+BuiltinTypeKind BuiltinType::getBuiltinTypeKind() const {
+  // If we do not have a vector or an integer our job is easy.
+  return BuiltinTypeKind(std::underlying_type<TypeKind>::type(getKind()));
+}
+
+StringRef BuiltinType::getTypeName(SmallVectorImpl<char> &result,
+                                   bool prependBuiltinNamespace) const {
+#ifdef MAYBE_GET_NAMESPACED_BUILTIN
+#error                                                                         \
+    "We define MAYBE_GET_NAMESPACED_BUILTIN here. Do not define before this?!"
+#endif
+#define MAYBE_GET_NAMESPACED_BUILTIN(NAME)                                     \
+  ((prependBuiltinNamespace) ? NAME : NAME.getWithoutPrefix())
+
+  llvm::raw_svector_ostream printer(result);
+  switch (getBuiltinTypeKind()) {
+  case BuiltinTypeKind::BuiltinRawPointer:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_RAWPOINTER);
+    break;
+  case BuiltinTypeKind::BuiltinNativeObject:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_NATIVEOBJECT);
+    break;
+  case BuiltinTypeKind::BuiltinUnknownObject:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_UNKNOWNOBJECT);
+    break;
+  case BuiltinTypeKind::BuiltinBridgeObject:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_BRIDGEOBJECT);
+    break;
+  case BuiltinTypeKind::BuiltinUnsafeValueBuffer:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(
+        BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER);
+    break;
+  case BuiltinTypeKind::BuiltinIntegerLiteral:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_INTLITERAL);
+    break;
+  case BuiltinTypeKind::BuiltinVector: {
+    const auto *t = cast<const BuiltinVectorType>(this);
+    llvm::SmallString<32> UnderlyingStrVec;
+    StringRef UnderlyingStr;
+    {
+      // FIXME: Ugly hack: remove the .Builtin from the element type.
+      {
+        llvm::raw_svector_ostream UnderlyingOS(UnderlyingStrVec);
+        t->getElementType().print(UnderlyingOS);
+      }
+      if (UnderlyingStrVec.startswith(BUILTIN_TYPE_NAME_PREFIX))
+        UnderlyingStr = UnderlyingStrVec.substr(8);
+      else
+        UnderlyingStr = UnderlyingStrVec;
+    }
+
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_VEC)
+            << t->getNumElements() << "x" << UnderlyingStr;
+    break;
+  }
+  case BuiltinTypeKind::BuiltinInteger: {
+    auto width = cast<const BuiltinIntegerType>(this)->getWidth();
+    if (width.isFixedWidth()) {
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_INT)
+              << width.getFixedWidth();
+      break;
+    }
+
+    if (width.isPointerWidth()) {
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_WORD);
+      break;
+    }
+
+    llvm_unreachable("impossible bit width");
+  }
+  case BuiltinTypeKind::BuiltinFloat: {
+    switch (cast<const BuiltinFloatType>(this)->getFPKind()) {
+    case BuiltinFloatType::IEEE16:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT) << "16";
+      break;
+    case BuiltinFloatType::IEEE32:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT) << "32";
+      break;
+    case BuiltinFloatType::IEEE64:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT) << "64";
+      break;
+    case BuiltinFloatType::IEEE80:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT) << "80";
+      break;
+    case BuiltinFloatType::IEEE128:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT) << "128";
+      break;
+    case BuiltinFloatType::PPC128:
+      printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FLOAT_PPC)
+              << "128";
+      break;
+    }
+    break;
+  }
+  }
+#undef MAYBE_GET_NAMESPACED_BUILTIN
+
+  return printer.str();
 }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1147,7 +1147,8 @@ NodePointer Demangler::demangleBuiltinType() {
       name.append(BUILTIN_TYPE_NAME_VEC, *this);
       name.append(elts, *this);
       name.push_back('x', *this);
-      name.append(EltType->getText().substr(strlen(BUILTIN_TYPE_NAME_PREFIX)), *this);
+      name.append(EltType->getText().substr(BUILTIN_TYPE_NAME_PREFIX.size()),
+                  *this);
       Ty = createNode(Node::Kind::BuiltinTypeName, name);
       break;
     }

--- a/lib/SwiftDemangle/MangleHack.cpp
+++ b/lib/SwiftDemangle/MangleHack.cpp
@@ -56,7 +56,7 @@ _swift_mangleSimpleClass(const char *module, const char *class_) {
   size_t moduleLength = strlen(module);
   size_t classLength = strlen(class_);
   char *value = nullptr;
-  if (strcmp(module, swift::STDLIB_NAME) == 0) {
+  if (swift::STDLIB_NAME.compare(module) == 0) {
     int result = asprintf(&value, "_TtCs%zu%s", classLength, class_);
     assert(result > 0);
     (void)result;
@@ -75,7 +75,7 @@ _swift_mangleSimpleProtocol(const char *module, const char *protocol) {
   size_t moduleLength = strlen(module);
   size_t protocolLength = strlen(protocol);
   char *value = nullptr;
-  if (strcmp(module, swift::STDLIB_NAME) == 0) {
+  if (swift::STDLIB_NAME.compare(module) == 0) {
     int result = asprintf(&value, "_TtPs%zu%s_", protocolLength, protocol);
     assert(result > 0);
     (void)result;

--- a/stdlib/public/Darwin/XCTest/XCTestCaseAdditions.mm
+++ b/stdlib/public/Darwin/XCTest/XCTestCaseAdditions.mm
@@ -73,7 +73,8 @@ static bool demangleSimpleClass(const char *mangledName,
 
     // Module name
     if (strncmp(m, "Ss", 2) == 0) {
-      moduleName = strdup(swift::STDLIB_NAME);
+      moduleName =
+          strndup(swift::STDLIB_NAME.data(), swift::STDLIB_NAME.size());
       assert(moduleName);
       m += 2;
     } else {


### PR DESCRIPTION
This is so I can use this functionality later to stringly convert polymorphic builtins into other statically overloaded builtins by munging names.

In terms of the ASTPrinter, I rewrote it to use the BuiltinInst part.