### PR TITLE
Use name mangling to disambiguate field names when types are anonymous.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -18,6 +18,7 @@
 #include "ImporterImpl.h"
 #include "swift/Strings.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Builtins.h"
@@ -1073,7 +1074,8 @@ getAccessorDeclarationName(clang::ASTContext &Ctx,
                            const char *suffix) {
   std::string id;
   llvm::raw_string_ostream IdStream(id);
-  IdStream << "$" << structDecl->getName()
+  Mangle::ASTMangler mangler;
+  IdStream << "$" << mangler.mangleDeclAsUSR(structDecl, "")
            << "$" << fieldDecl->getName()
            << "$" << suffix;
 

--- a/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
+++ b/test/ClangImporter/Inputs/custom-modules/IndirectFields.h
@@ -7,6 +7,26 @@ struct StructWithIndirectField {
     int d : 3; /* Imported as a computed property */
 };
 
+struct StructWithIndirectField2 {
+  union {
+    unsigned v;
+    struct {
+      unsigned x : 8;
+      unsigned y : 8;
+    };
+  };
+};
+
+struct StructWithIndirectField2Copy {
+  union {
+    unsigned v;
+    struct {
+      unsigned x : 16;
+      unsigned y : 16;
+    };
+  };
+};
+
 union UnionWithIndirectField {
     struct {
         int a;

--- a/test/ClangImporter/indirect_field_codegen.swift
+++ b/test/ClangImporter/indirect_field_codegen.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-silgen -I %S/Inputs/custom-modules %s | %FileCheck %s
+
+// https://bugs.swift.org/browse/SR-10571
+
+import IndirectFields
+
+extension StructWithIndirectField2Copy {
+  init(x: UInt32, y: UInt32) {
+    self.init(.init(v: x + y))
+  }
+
+  init(s: StructWithIndirectField2) {
+    self.init(x: s.x, y: s.y)
+  }
+}
+
+// The names look complex because we assign names to unnamed unions/structs
+// using a mangling scheme which the Swift demangler doesn't understand.
+
+// CHECK-DAG: sil shared @$So24StructWithIndirectField2V34__Unnamed_union___Anonymous_field0V02__e10_struct___G7_field1V$x$getter : $@convention(c) (StructWithIndirectField2.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> UInt32
+
+// CHECK-DAG: sil shared @$So24StructWithIndirectField2V34__Unnamed_union___Anonymous_field0V02__e10_struct___G7_field1V$y$getter : $@convention(c) (StructWithIndirectField2.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> UInt32
+
+// CHECK-DAG: sil shared @$So28StructWithIndirectField2CopyV34__Unnamed_union___Anonymous_field0V02__f10_struct___H7_field1V$x$getter : $@convention(c) (StructWithIndirectField2Copy.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> UInt32
+
+// CHECK-DAG: sil shared @$So28StructWithIndirectField2CopyV34__Unnamed_union___Anonymous_field0V02__f10_struct___H7_field1V$x$setter : $@convention(c) (UInt32, @inout StructWithIndirectField2Copy.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> ()
+
+// CHECK-DAG: sil shared @$So28StructWithIndirectField2CopyV34__Unnamed_union___Anonymous_field0V02__f10_struct___H7_field1V$y$getter : $@convention(c) (StructWithIndirectField2Copy.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> UInt32
+
+// CHECK-DAG: sil shared @$So28StructWithIndirectField2CopyV34__Unnamed_union___Anonymous_field0V02__f10_struct___H7_field1V$y$setter : $@convention(c) (UInt32, @inout StructWithIndirectField2Copy.__Unnamed_union___Anonymous_field0.__Unnamed_struct___Anonymous_field1) -> ()
+
+func test() -> UInt32 {
+  var s = StructWithIndirectField2Copy(x: 1, y: 2)
+  s.x = 10
+  s.y = 11
+  return s.x + s.y
+}

--- a/test/ClangImporter/inlinable_bitfields.swift
+++ b/test/ClangImporter/inlinable_bitfields.swift
@@ -10,4 +10,4 @@ public func g(_ m: MM) -> UInt32 {
 
 // Just make sure this is a definition and not a declaration...
 
-// CHECK: define internal{{( zeroext)?}} i32 @"$ModRM$rm$getter"
+// CHECK: define internal{{( zeroext)?}} i32 @"$So5ModRMV$rm$getter"

--- a/test/multifile/batch_mode_external_definitions.swift
+++ b/test/multifile/batch_mode_external_definitions.swift
@@ -19,8 +19,8 @@
 //
 // CHECK-FIELD1-ONLY: sil_stage canonical
 // CHECK-FIELD1-ONLY: use_extern_struct_field_1
-// CHECK-FIELD1-ONLY: sil shared{{.*}}extern_struct$field$getter
-// CHECK-FIELD1-ONLY-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-FIELD1-ONLY: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-FIELD1-ONLY-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 // CHECK-FIELD1-ONLY: sil_stage canonical
 // CHECK-FIELD1-ONLY-NOT: use_extern_struct_field_2
 // CHECK-FIELD1-ONLY-NOT: sil shared{{.*}}extern_struct$field$getter
@@ -30,33 +30,33 @@
 // CHECK-FIELD1-ONLY-REORDER-NOT: sil shared{{.*}}extern_struct$field$getter
 // CHECK-FIELD1-ONLY-REORDER: sil_stage canonical
 // CHECK-FIELD1-ONLY-REORDER: use_extern_struct_field_1
-// CHECK-FIELD1-ONLY-REORDER: sil shared{{.*}}extern_struct$field$getter
-// CHECK-FIELD1-ONLY-REORDER-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-FIELD1-ONLY-REORDER: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-FIELD1-ONLY-REORDER-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 //
 // CHECK-FIELD2-ONLY: sil_stage canonical
 // CHECK-FIELD2-ONLY-NOT: use_extern_struct_field_1
 // CHECK-FIELD2-ONLY-NOT: sil shared{{.*}}extern_struct$field$getter
 // CHECK-FIELD2-ONLY: sil_stage canonical
 // CHECK-FIELD2-ONLY: use_extern_struct_field_2
-// CHECK-FIELD2-ONLY: sil shared{{.*}}extern_struct$field$getter
-// CHECK-FIELD2-ONLY-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-FIELD2-ONLY: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-FIELD2-ONLY-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 //
 // CHECK-FIELD2-ONLY-REORDER: sil_stage canonical
 // CHECK-FIELD2-ONLY-REORDER: use_extern_struct_field_2
-// CHECK-FIELD2-ONLY-REORDER: sil shared{{.*}}extern_struct$field$getter
-// CHECK-FIELD2-ONLY-REORDER-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-FIELD2-ONLY-REORDER: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-FIELD2-ONLY-REORDER-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 // CHECK-FIELD2-ONLY-REORDER: sil_stage canonical
 // CHECK-FIELD2-ONLY-REORDER-NOT: use_extern_struct_field_1
 // CHECK-FIELD2-ONLY-REORDER-NOT: sil shared{{.*}}extern_struct$field$getter
 //
 // CHECK-BOTH-FIELDS: sil_stage canonical
 // CHECK-BOTH-FIELDS: use_extern_struct_field_1
-// CHECK-BOTH-FIELDS: sil shared{{.*}}extern_struct$field$getter
-// CHECK-BOTH-FIELDS-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-BOTH-FIELDS: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-BOTH-FIELDS-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 // CHECK-BOTH-FIELDS: sil_stage canonical
 // CHECK-BOTH-FIELDS: use_extern_struct_field_2
-// CHECK-BOTH-FIELDS: sil shared{{.*}}extern_struct$field$getter
-// CHECK-BOTH-FIELDS-NOT: sil shared{{.*}}extern_struct$field$getter
+// CHECK-BOTH-FIELDS: sil shared{{.*}}@$So13extern_structV$field$getter
+// CHECK-BOTH-FIELDS-NOT: sil shared{{.*}}@$So13extern_structV$field$getter
 //
 // CHECK-NEITHER-FIELD: sil_stage canonical
 // CHECK-NEITHER-FIELD-NOT: use_extern_struct_field_1


### PR DESCRIPTION
Resolves [SR-10571](https://bugs.swift.org/browse/SR-10571) and rdar://problem/50337188.