### PR TITLE
[windows][test] Improve line-directive test for Windows.

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -11,6 +11,7 @@
 #
 # ----------------------------------------------------------------------------
 from __future__ import print_function
+
 import bisect
 import os
 import re
@@ -646,10 +647,9 @@ def run():
     ... // End:
     ... ''')
     >>> long_output.flush()
-    >>> long_output_result = subprocess.check_output(sys.executable + ' ' +
-    ...    __file__ + ' ' + long_output.name + ' -- ' + "echo '" +
-    ...    long_output.name + ":112:27: error:'",
-    ...    shell=True).rstrip()
+    >>> long_output_result = subprocess.check_output([sys.executable,
+    ...    __file__, long_output.name, '--',
+    ...    'echo', long_output.name + ':112:27: error:']).rstrip()
     >>> print(long_output_result)
     /public/core/Map.swift.gyb:117:27: error:
     >>> target1.close()


### PR DESCRIPTION
The line directive test was using a command for one of the tests. The
command was being built as a string, instead of relaying on Python
multi-platform command building from arrays. Additionally the command
itself was being escaped with single quotes, which in Windows mean
nothing and were ending in the output of the command.

The changes switches the string building for an array, and leaves the
string building and escaping to Python, and additionally implements a
workaround for Windows not treating the command line like Linux do.

This should fix the failing test in Azure.
