### PR TITLE
[5.1] [Name lookup] Deduplicate nominal declarations found via resolveTypeDeclsToNominal

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1713,12 +1713,17 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
                           SmallVectorImpl<ModuleDecl *> &modulesFound,
                           bool &anyObject,
                           llvm::SmallPtrSetImpl<TypeAliasDecl *> &typealiases) {
+  SmallPtrSet<NominalTypeDecl *, 4> knownNominalDecls;
   TinyPtrVector<NominalTypeDecl *> nominalDecls;
+  auto addNominalDecl = [&](NominalTypeDecl *nominal) {
+    if (knownNominalDecls.insert(nominal).second)
+      nominalDecls.push_back(nominal);
+  };
 
   for (auto typeDecl : typeDecls) {
     // Nominal type declarations get copied directly.
     if (auto nominalDecl = dyn_cast<NominalTypeDecl>(typeDecl)) {
-      nominalDecls.push_back(nominalDecl);
+      addNominalDecl(nominalDecl);
       continue;
     }
 
@@ -1735,9 +1740,9 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
       auto underlyingNominalReferences
         = resolveTypeDeclsToNominal(evaluator, ctx, underlyingTypeReferences,
                                     modulesFound, anyObject, typealiases);
-      nominalDecls.insert(nominalDecls.end(),
-                          underlyingNominalReferences.begin(),
-                          underlyingNominalReferences.end());
+      std::for_each(underlyingNominalReferences.begin(),
+                    underlyingNominalReferences.end(),
+                    addNominalDecl);
 
       // Recognize Swift.AnyObject directly.
       if (typealias->getName().is("AnyObject")) {

--- a/test/NameBinding/Inputs/property_wrappers_A.swift
+++ b/test/NameBinding/Inputs/property_wrappers_A.swift
@@ -1,0 +1,8 @@
+@propertyWrapper
+public struct Wrapper<Value> {
+	public var wrappedValue: Value
+
+	public init(wrappedValue: Value) {
+		self.wrappedValue = wrappedValue
+	}
+}

--- a/test/NameBinding/Inputs/property_wrappers_B.swift
+++ b/test/NameBinding/Inputs/property_wrappers_B.swift
@@ -1,0 +1,3 @@
+import property_wrappers_A
+
+public typealias Wrapper = property_wrappers_A.Wrapper

--- a/test/NameBinding/property_wrappers_ambig.swift
+++ b/test/NameBinding/property_wrappers_ambig.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/property_wrappers_A.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/property_wrappers_B.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t %s
+import property_wrappers_A
+import property_wrappers_B
+
+struct Test {
+  @Wrapper var x: Int = 17
+}


### PR DESCRIPTION
Perform basic deduplication of the nominal type declarations found via
resolveTypeDeclsToNominal(). Fixes rdar://problem/53164203
