### PR TITLE
[AutoDiff] Gardening.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1561,7 +1561,14 @@ public:
                                     Optional<DeclNameWithLoc> vjp,
                                     ArrayRef<Requirement> requirements);
 
+  /// Get the optional 'jvp:' function name and location.
+  /// Use this instead of `getJVPFunction` to check whether the attribute has a
+  /// registered JVP.
   Optional<DeclNameWithLoc> getJVP() const { return JVP; }
+
+  /// Get the optional 'vjp:' function name and location.
+  /// Use this instead of `getVJPFunction` to check whether the attribute has a
+  /// registered VJP.
   Optional<DeclNameWithLoc> getVJP() const { return VJP; }
 
   AutoDiffParameterIndices *getParameterIndices() const {

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -460,12 +460,10 @@ NOTE(autodiff_when_differentiating_function_definition,none,
      "when differentiating this function definition", ())
 NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
      "cannot differentiate through 'inout' arguments", ())
-NOTE(autodiff_control_flow_not_supported,none,
-     "differentiating control flow is not yet supported", ())
-NOTE(autodiff_loops_not_supported,none,
-     "differentiating loops is not yet supported", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not yet supported", ())
+NOTE(autodiff_control_flow_not_supported,none,
+     "cannot differentiate unsupported control flow", ())
 NOTE(autodiff_missing_return,none,
      "missing return for differentiation", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2797,7 +2797,7 @@ ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_nongeneric_trailing_where,none,
       "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
-ERROR(differentiable_attr_unsupported_req_kind,none,
+ERROR(differentiable_attr_layout_req_unsupported,none,
       "'@differentiable' attribute does not support layout requirements", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2790,16 +2790,17 @@ ERROR(differentiable_attr_protocol_req_where_clause,none,
 ERROR(differentiable_attr_protocol_req_assoc_func,none,
       "'@differentiable' attribute on protocol requirement cannot specify "
       "'jvp:' or 'vjp:'", ())
+ERROR(differentiable_attr_stored_property_variable_unsupported,none,
+      "'@differentiable' attribute on stored property cannot specify "
+      "'jvp:' or 'vjp:'", ())
 ERROR(differentiable_attr_empty_where_clause,none,
       "empty 'where' clause in '@differentiable' attribute", ())
 ERROR(differentiable_attr_nongeneric_trailing_where,none,
       "trailing 'where' clause in '@differentiable' attribute of non-generic function %0", (DeclName))
 ERROR(differentiable_attr_unsupported_req_kind,none,
-      "layout requirement are not supported by '@differentiable' attribute", ())
+      "'@differentiable' attribute does not support layout requirements", ())
 ERROR(differentiable_attr_class_unsupported,none,
       "class members cannot be marked with '@differentiable'", ())
-ERROR(differentiable_attr_stored_property_variable_unsupported,none,
-      "'jvp:' or 'vjp:' cannot be specified for stored properties", ())
 ERROR(overriding_decl_missing_differentiable_attr,none,
       "overriding declaration is missing attribute '%0'", (StringRef))
 NOTE(protocol_witness_missing_differentiable_attr,none,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -488,18 +488,27 @@ static void printDifferentiableAttrArguments(
   if (!omitWrtClause) {
     auto diffParamsString = getDifferentiationParametersClauseString(
         original, attr->getParameterIndices(), attr->getParsedParameters());
-    printCommaIfNecessary();
-    stream << diffParamsString;
+    // Check whether differentiation parameter clause is empty.
+    // Handles edge case where resolved parameter indices are unset and
+    // parsed parameters are empty. This case should never trigger for
+    // user-visible printing.
+    if (!diffParamsString.empty()) {
+      printCommaIfNecessary();
+      stream << diffParamsString;
+    }
   }
-  // Print jvp function name.
-  if (auto jvp = attr->getJVP()) {
-    printCommaIfNecessary();
-    stream << "jvp: " << jvp->Name;
-  }
-  // Print vjp function name.
-  if (auto vjp = attr->getVJP()) {
-    printCommaIfNecessary();
-    stream << "vjp: " << vjp->Name;
+  // Print associated function names, unless they are to be omitted.
+  if (!omitAssociatedFunctions) {
+    // Print jvp function name, if specified.
+    if (auto jvp = attr->getJVP()) {
+      printCommaIfNecessary();
+      stream << "jvp: " << jvp->Name;
+    }
+    // Print vjp function name, if specified.
+    if (auto vjp = attr->getVJP()) {
+      printCommaIfNecessary();
+      stream << "vjp: " << vjp->Name;
+    }
   }
   // Print 'where' clause, if any.
   // First, filter out requirements satisfied by the original function's

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1160,7 +1160,7 @@ bool Parser::parseDifferentiableAttributeArguments(
     SmallVector<RequirementRepr, 4> requirements;
     bool firstTypeInComplete;
     parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete,
-                            /*AllowLayoutConstraints=*/false);
+                            /*AllowLayoutConstraints*/ true);
     whereClause = TrailingWhereClause::create(Context, whereLoc, requirements);
   }
   return false;

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -97,10 +97,12 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       auto *AFD = constant.getAbstractFunctionDecl();
       auto selfParamIndex =
           F->getLoweredFunctionType()->getNumParameters() - 1;
-      if (AFD && AFD->isInstanceMember() &&
+      auto isSelfReorderedMethod =
+          AFD && AFD->isInstanceMember() &&
           F->getLoweredFunctionType()->hasSelfParam() &&
           indices.isWrtParameter(selfParamIndex) &&
-          indices.parameters->getNumIndices() > 1) {
+          indices.parameters->getNumIndices() > 1;
+      if (isSelfReorderedMethod) {
         auto &ctx = F->getASTContext();
         if (A->getJVPFunction())
           jvpName = ctx.getIdentifier(

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3449,7 +3449,6 @@ SILGenFunction::getOrCreateAutoDiffLinearMapReorderingThunk(
     SmallVector<SILValue, 8> tmpValues;
     forwardFunctionArguments(
         thunkSGF, loc, linearMapFnType, params, tmpValues);
-    // argValues.append(tmpValues.begin() + 1, tmpValues.end());
     argValues.push_back(tmpValues.back());
     argValues.append(tmpValues.begin(), tmpValues.end() - 1);
     break;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2165,9 +2165,9 @@ emitAssociatedFunctionReference(
                                           loweredRequirementIndices);
 
     // NOTE: We need to extend the capacity of desired parameter indices to
-    // requirement parameter indices, because there's a argument count mismatch.
-    // When `@differentiable` partial apply is supported, this problem will go
-    // away.
+    // requirement parameter indices, because there's an argument count
+    // mismatch. When `partial_apply` supports `@differentiable` values, this
+    // problem will go away.
     if (desiredIndices.source != requirementIndices.source ||
         !desiredIndices.parameters->extendingCapacity(
             context.getASTContext(),

--- a/test/AutoDiff/control_flow_diagnostics.swift
+++ b/test/AutoDiff/control_flow_diagnostics.swift
@@ -80,7 +80,7 @@ func nested_loop(_ x: Float) -> Float {
 func withoutDerivative<T : Differentiable, R: Differentiable>(
   at x: T, in body: (T) throws -> R
 ) rethrows -> R {
-  // expected-note @+1 {{differentiating control flow is not yet supported}}
+  // expected-note @+1 {{cannot differentiate unsupported control flow}}
   try body(x)
 }
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -605,8 +605,13 @@ func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
   return x
 }
 
-// expected-error @+2 {{layout constraints are only allowed inside '_specialize' attributes}}
-// expected-error @+1 {{empty 'where' clause in '@differentiable' attribute}}
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@differentiable(where T : AnyObject)
+func invalidAnyObjectRequirement<T : Differentiable>(x: T) -> T {
+  return x
+}
+
+// expected-error @+1 {{'@differentiable' attribute does not support layout requirements}}
 @differentiable(where Scalar : _Trivial)
 func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
   return x

--- a/test/AutoDiff/differentiating_attr_type_checking.swift
+++ b/test/AutoDiff/differentiating_attr_type_checking.swift
@@ -298,7 +298,7 @@ func vjpConsistent(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
 
 // Test usage of `@differentiable` on a stored property
 struct PropertyDiff : Differentiable & AdditiveArithmetic {
-    // expected-error @+1 {{'jvp:' or 'vjp:' cannot be specified for stored properties}}
+    // expected-error @+1 {{'@differentiable' attribute on stored property cannot specify 'jvp:' or 'vjp:'}}
     @differentiable(vjp: vjpPropertyA)
     var a: Float = 1
     typealias TangentVector = PropertyDiff


### PR DESCRIPTION
- Clarify various comments.
- Clarify various diagnostic messages.
- Fix `omitAssociatedFunctions` flag in `@differentiable` attribute printing.

---

These changes were factored out of a larger upcoming PR.