### PR TITLE
Sema: Fix crash in addImplicitConstructors() [5.1]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2662,7 +2662,7 @@ swift::createDesignatedInitOverride(TypeChecker &tc,
   // like 'class A : B<Int>'.
   for (auto *decl : *bodyParams) {
     auto paramTy = decl->getInterfaceType();
-    auto substTy = paramTy.subst(subMap);
+    auto substTy = paramTy.subst(subMap, SubstFlags::UseErrorType);
     decl->setInterfaceType(substTy);
     decl->getTypeLoc() = TypeLoc::withoutLoc(substTy);
   }

--- a/validation-test/compiler_crashers_2_fixed/0200-rdar48994748.swift
+++ b/validation-test/compiler_crashers_2_fixed/0200-rdar48994748.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol P {
+  associatedtype T
+}
+
+class G<T : P> {
+  init(_: T.T) {}
+}
+
+class Sub : G<S> {}
+
+struct S : P {}
+
+Sub()


### PR DESCRIPTION
Fixes <rdar://problem/48994748>. I accidentally "fixed" this as part of a larger refactoring on master. This patch just backports the relevant part and adds a test case.