### PR TITLE
IRGen: simplify enum payload value extraction using gather bits

### DIFF
--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -164,6 +164,10 @@ public:
                                    const SpareBitVector &spareBits,
                                    unsigned firstBitOffset,
                                    unsigned bitWidth) const;
+private:
+  /// Calculate the total number of bits this payload requires.
+  /// This will always be a multiple of 8.
+  unsigned getAllocSizeInBits(const llvm::DataLayout &DL) const;
 };
   
 }


### PR DESCRIPTION
Use the 'gather bits' function to implement extractValue. This
will make it easier to transition to big-endian spare bit masks
on big-endian platforms.