### PR TITLE
[Parse] Factor out parsing access path when parsing ImportDecl

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -194,7 +194,7 @@ public:
 
   /// Complete the import decl with importable modules.
   virtual void
-  completeImportDecl(std::vector<std::pair<Identifier, SourceLoc>> &Path) {};
+  completeImportDecl(SmallVectorImpl<std::pair<Identifier, SourceLoc>> &Path){};
 
   /// Complete unresolved members after dot.
   virtual void completeUnresolvedMember(CodeCompletionExpr *E,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -966,8 +966,18 @@ public:
                                      TypeAttributes &Attributes);
   bool parseTypeAttribute(TypeAttributes &Attributes,
                           bool justChecking = false);
-  
-  
+
+  ParserStatus
+  parseAccessPath(SmallVectorImpl<ImportDecl::AccessPathElement> &AccessPath,
+                  const Diagnostic &D);
+
+  template <typename ...DiagArgTypes, typename ...ArgTypes>
+  ParserStatus
+  parseAccessPath(SmallVectorImpl<ImportDecl::AccessPathElement> &AccessPath,
+                  Diag<DiagArgTypes...> ID, ArgTypes... Args) {
+    return parseAccessPath(AccessPath, Diagnostic(ID, Args...));
+  }
+
   ParserResult<ImportDecl> parseDeclImport(ParseDeclOptions Flags,
                                            DeclAttributes &Attributes);
   ParserStatus parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1351,7 +1351,8 @@ public:
   void completeAccessorBeginning(CodeCompletionExpr *E) override;
 
   void completePoundAvailablePlatform() override;
-  void completeImportDecl(std::vector<std::pair<Identifier, SourceLoc>> &Path) override;
+  void completeImportDecl(
+      SmallVectorImpl<std::pair<Identifier, SourceLoc>> &Path) override;
   void completeUnresolvedMember(CodeCompletionExpr *E,
                                 SourceLoc DotLoc) override;
   void completeAssignmentRHS(AssignExpr *E) override;
@@ -4647,7 +4648,7 @@ void CodeCompletionCallbacksImpl::completeCaseStmtBeginning(CodeCompletionExpr *
 }
 
 void CodeCompletionCallbacksImpl::completeImportDecl(
-    std::vector<std::pair<Identifier, SourceLoc>> &Path) {
+    SmallVectorImpl<std::pair<Identifier, SourceLoc>> &Path) {
   Kind = CompletionKind::Import;
   CurDeclContext = P.CurDeclContext;
   DotLoc = Path.empty() ? SourceLoc() : Path.back().second;


### PR DESCRIPTION
If we [want to support module-qualified member access](https://forums.swift.org/t/how-to-unambiguously-refer-to-a-symbol-defined-in-an-extension-in-third-party-module/26869/3?u=broadway_lamb) sometime (I'm preparing a pitch actually),
we better reuse some of the code that parses import declarations for consistency.

This also replaces `std::vector` with `llvm::SmallVector` since most of the time access paths in import declarations consist of only one identifier.

cc @jrose-apple 