### PR TITLE
Don't allow overloading by opaque types with different constraints.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2334,7 +2334,7 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
     // Functions and subscripts cannot overload differing only in opaque return
     // types. Replace the opaque type with `Any`.
     if (auto opaque = type->getAs<OpaqueTypeArchetypeType>()) {
-      type = opaque->getExistentialType();
+      type = ProtocolCompositionType::get(ctx, {}, /*hasAnyObject*/ false);
     }
 
     return mapSignatureParamType(ctx, type);

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -286,10 +286,11 @@ var DoesNotConformComputedProp: some P {
 }
 */
 
-func redeclaration() -> some P { return 0 } // expected-note{{previously declared}}
+func redeclaration() -> some P { return 0 } // expected-note 2{{previously declared}}
 func redeclaration() -> some P { return 0 } // expected-error{{redeclaration}}
-func redeclaration() -> some Q { return 0 }
+func redeclaration() -> some Q { return 0 } // expected-error{{redeclaration}}
 func redeclaration() -> P { return 0 }
+func redeclaration() -> Any { return 0 }
 
 var redeclaredProp: some P { return 0 } // expected-note 3{{previously declared}}
 var redeclaredProp: some P { return 0 } // expected-error{{redeclaration}}
@@ -297,9 +298,9 @@ var redeclaredProp: some Q { return 0 } // expected-error{{redeclaration}}
 var redeclaredProp: P { return 0 } // expected-error{{redeclaration}}
 
 struct RedeclarationTest {
-  func redeclaration() -> some P { return 0 } // expected-note{{previously declared}}
+  func redeclaration() -> some P { return 0 } // expected-note 2{{previously declared}}
   func redeclaration() -> some P { return 0 } // expected-error{{redeclaration}}
-  func redeclaration() -> some Q { return 0 }
+  func redeclaration() -> some Q { return 0 } // expected-error{{redeclaration}}
   func redeclaration() -> P { return 0 }
 
   var redeclaredProp: some P { return 0 } // expected-note 3{{previously declared}}
@@ -307,9 +308,9 @@ struct RedeclarationTest {
   var redeclaredProp: some Q { return 0 } // expected-error{{redeclaration}}
   var redeclaredProp: P { return 0 } // expected-error{{redeclaration}}
 
-  subscript(redeclared _: Int) -> some P { return 0 } // expected-note{{previously declared}}
+  subscript(redeclared _: Int) -> some P { return 0 } // expected-note 2{{previously declared}}
   subscript(redeclared _: Int) -> some P { return 0 } // expected-error{{redeclaration}}
-  subscript(redeclared _: Int) -> some Q { return 0 }
+  subscript(redeclared _: Int) -> some Q { return 0 } // expected-error{{redeclaration}}
   subscript(redeclared _: Int) -> P { return 0 }
 }
 


### PR DESCRIPTION
Explanation: The compiler would crash if overloaded functions differed only in opaque return type, because the symbols mangled the same. This patch disallows this overloading.

Scope: Turns a crash into a diagnostic.

SR Issue: SR-10725 | rdar://problem/50987172

Risk: Low, small bug fix

Testing: Swift CI

Reviewed by: @slavapestov 