### PR TITLE
[AST] Cache the override generic signatures

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -870,21 +870,6 @@ public:
   /// This guarantees that resulted \p names doesn't have duplicated names.
   void getVisibleTopLevelModuleNames(SmallVectorImpl<Identifier> &names) const;
 
-  struct OverrideSignatureKey {
-    GenericSignature *baseMethodSig;
-    GenericSignature *derivedClassSig;
-    Type superclassTy;
-
-    OverrideSignatureKey(GenericSignature *baseMethodSignature,
-                         GenericSignature *derivedClassSignature,
-                         Type superclassType)
-        : baseMethodSig(baseMethodSignature),
-          derivedClassSig(derivedClassSignature), superclassTy(superclassType) {
-    }
-  };
-
-  llvm::DenseMap<OverrideSignatureKey, GenericSignature *> overrideSigCache;
-
 private:
   /// Register the given generic signature builder to be used as the canonical
   /// generic signature builder for the given signature, if we don't already
@@ -953,40 +938,5 @@ private:
 };
 
 } // end namespace swift
-
-namespace llvm {
-template <> struct DenseMapInfo<swift::ASTContext::OverrideSignatureKey> {
-  using OverrideSignatureKey = swift::ASTContext::OverrideSignatureKey;
-  using Type = swift::Type;
-  using GenericSignature = swift::GenericSignature;
-
-  static bool isEqual(const OverrideSignatureKey lhs,
-                      const OverrideSignatureKey rhs) {
-    return lhs.baseMethodSig == rhs.baseMethodSig &&
-           lhs.derivedClassSig == rhs.derivedClassSig &&
-           lhs.superclassTy.getPointer() == rhs.superclassTy.getPointer();
-  }
-
-  static inline OverrideSignatureKey getEmptyKey() {
-    return OverrideSignatureKey(DenseMapInfo<GenericSignature *>::getEmptyKey(),
-                                DenseMapInfo<GenericSignature *>::getEmptyKey(),
-                                DenseMapInfo<Type>::getEmptyKey());
-  }
-
-  static inline OverrideSignatureKey getTombstoneKey() {
-    return OverrideSignatureKey(
-        DenseMapInfo<GenericSignature *>::getTombstoneKey(),
-        DenseMapInfo<GenericSignature *>::getTombstoneKey(),
-        DenseMapInfo<Type>::getTombstoneKey());
-  }
-
-  static unsigned getHashValue(const OverrideSignatureKey &Val) {
-    return hash_combine(
-        DenseMapInfo<GenericSignature *>::getHashValue(Val.baseMethodSig),
-        DenseMapInfo<GenericSignature *>::getHashValue(Val.derivedClassSig),
-        DenseMapInfo<Type>::getHashValue(Val.superclassTy));
-  }
-};
-} // namespace llvm
 
 #endif

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -869,6 +869,27 @@ public:
   /// This guarantees that resulted \p names doesn't have duplicated names.
   void getVisibleTopLevelModuleNames(SmallVectorImpl<Identifier> &names) const;
 
+  struct OverrideSignatureKey {
+    StringRef baseMethodSigString;
+    StringRef derivedClassSigString;
+    Type superclassTy;
+
+    OverrideSignatureKey(StringRef baseMethodSig, StringRef derivedClassSig,
+                         Type derivedClassSuperclassType)
+        : baseMethodSigString(baseMethodSig),
+          derivedClassSigString(derivedClassSig),
+          superclassTy(derivedClassSuperclassType) {}
+
+    bool isEqual(const OverrideSignatureKey other) {
+      return baseMethodSigString == other.baseMethodSigString &&
+             derivedClassSigString == other.derivedClassSigString &&
+             superclassTy.getString() == other.superclassTy.getString();
+    }
+  };
+
+  std::vector<std::pair<OverrideSignatureKey, GenericSignature *>>
+      overrideSigCache;
+
 private:
   /// Register the given generic signature builder to be used as the canonical
   /// generic signature builder for the given signature, if we don't already

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -964,7 +964,7 @@ template <> struct DenseMapInfo<swift::ASTContext::OverrideSignatureKey> {
                       const OverrideSignatureKey rhs) {
     return lhs.baseMethodSig == rhs.baseMethodSig &&
            lhs.derivedClassSig == rhs.derivedClassSig &&
-           lhs.superclassTy.getString() == rhs.superclassTy.getString();
+           lhs.superclassTy.getPointer() == rhs.superclassTy.getPointer();
   }
 
   static inline OverrideSignatureKey getEmptyKey() {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4340,6 +4340,107 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
   return genericSig;
 }
 
+GenericSignature *ASTContext::getOverrideGenericSignature(ValueDecl *base,
+                                                          ValueDecl *derived) {
+  auto baseGenericCtx = base->getAsGenericContext();
+  auto &ctx = base->getASTContext();
+
+  if (!baseGenericCtx) {
+    return nullptr;
+  }
+
+  auto baseClass = base->getDeclContext()->getSelfClassDecl();
+
+  if (!baseClass) {
+    return nullptr;
+  }
+
+  auto derivedClass = derived->getDeclContext()->getSelfClassDecl();
+  auto *baseClassSig = baseClass->getGenericSignature();
+
+  if (!derivedClass) {
+    return nullptr;
+  }
+
+  if (derivedClass->getSuperclass().isNull()) {
+    return nullptr;
+  }
+
+  if (derivedClass->getGenericSignature() == nullptr &&
+      !baseGenericCtx->isGeneric()) {
+    return nullptr;
+  }
+
+  auto subMap = derivedClass->getSuperclass()->getContextSubstitutionMap(
+      derivedClass->getModuleContext(), baseClass);
+
+  if (baseGenericCtx->getGenericSignature() == nullptr) {
+    return nullptr;
+  }
+  unsigned derivedDepth = 0;
+
+  auto key = OverrideSignatureKey(baseGenericCtx->getGenericSignature(),
+                                  derivedClass->getGenericSignature(),
+                                  derivedClass->getSuperclass());
+
+  if (overrideSigCache.count(key) == 1) {
+    return overrideSigCache.lookup(key);
+  }
+
+  if (auto *derivedSig = derivedClass->getGenericSignature())
+    derivedDepth = derivedSig->getGenericParams().back()->getDepth() + 1;
+
+  GenericSignatureBuilder builder(ctx);
+  builder.addGenericSignature(derivedClass->getGenericSignature());
+
+  if (auto derivedGenericCtx = derived->getAsGenericContext()) {
+    if (derivedGenericCtx->isGeneric()) {
+      for (auto param : *derivedGenericCtx->getGenericParams()) {
+        builder.addGenericParameter(param);
+      }
+    }
+  }
+
+  auto source =
+      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+
+  unsigned baseDepth = 0;
+
+  if (baseClassSig) {
+    baseDepth = baseClassSig->getGenericParams().back()->getDepth() + 1;
+  }
+
+  auto substFn = [&](SubstitutableType *type) -> Type {
+    auto *gp = cast<GenericTypeParamType>(type);
+
+    if (gp->getDepth() < baseDepth) {
+      return Type(gp).subst(subMap);
+    }
+
+    return CanGenericTypeParamType::get(
+        gp->getDepth() - baseDepth + derivedDepth, gp->getIndex(), ctx);
+  };
+
+  auto lookupConformanceFn =
+      [&](CanType depTy, Type substTy,
+          ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
+    if (auto conf = subMap.lookupConformance(depTy, proto))
+      return conf;
+
+    return ProtocolConformanceRef(proto);
+  };
+
+  for (auto reqt : baseGenericCtx->getGenericSignature()->getRequirements()) {
+    if (auto substReqt = reqt.subst(substFn, lookupConformanceFn)) {
+      builder.addRequirement(*substReqt, source, nullptr);
+    }
+  }
+
+  auto *genericSig = std::move(builder).computeGenericSignature(SourceLoc());
+  overrideSigCache.insert(std::make_pair(key, genericSig));
+  return genericSig;
+}
+
 SILLayout *SILLayout::get(ASTContext &C,
                           CanGenericSignature Generics,
                           ArrayRef<SILField> Fields) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -931,110 +931,6 @@ static void checkOverrideAccessControl(ValueDecl *baseDecl, ValueDecl *decl,
   }
 }
 
-static GenericSignature *getOverrideGenericSignature(ValueDecl *base,
-                                                     ValueDecl *derived) {
-  auto baseGenericCtx = base->getAsGenericContext();
-  auto &ctx = base->getASTContext();
-
-  if (!baseGenericCtx) {
-    return nullptr;
-  }
-
-  auto baseClass = base->getDeclContext()->getSelfClassDecl();
-
-  if (!baseClass) {
-    return nullptr;
-  }
-
-  auto derivedClass = derived->getDeclContext()->getSelfClassDecl();
-  auto *baseClassSig = baseClass->getGenericSignature();
-
-  if (!derivedClass) {
-    return nullptr;
-  }
-
-  if (derivedClass->getSuperclass().isNull()) {
-    return nullptr;
-  }
-
-  if (derivedClass->getGenericSignature() == nullptr &&
-      !baseGenericCtx->isGeneric()) {
-    return nullptr;
-  }
-
-  auto subMap = derivedClass->getSuperclass()->getContextSubstitutionMap(
-      derivedClass->getModuleContext(), baseClass);
-
-  if (baseGenericCtx->getGenericSignature() == nullptr) {
-    return nullptr;
-  }
-  unsigned derivedDepth = 0;
-
-  auto key = swift::ASTContext::OverrideSignatureKey(
-      baseGenericCtx->getGenericSignature()->getAsString(),
-      derivedClass->getGenericSignature()->getAsString(),
-      derivedClass->getSuperclass());
-
-  for (auto pair : ctx.overrideSigCache) {
-    if (pair.first.isEqual(key)) {
-      return pair.second;
-    }
-  }
-
-  if (auto *derivedSig = derivedClass->getGenericSignature())
-    derivedDepth = derivedSig->getGenericParams().back()->getDepth() + 1;
-
-  GenericSignatureBuilder builder(ctx);
-  builder.addGenericSignature(derivedClass->getGenericSignature());
-
-  if (auto derivedGenericCtx = derived->getAsGenericContext()) {
-    if (derivedGenericCtx->isGeneric()) {
-      for (auto param : *derivedGenericCtx->getGenericParams()) {
-        builder.addGenericParameter(param);
-      }
-    }
-  }
-
-  auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
-
-  unsigned baseDepth = 0;
-
-  if (baseClassSig) {
-    baseDepth = baseClassSig->getGenericParams().back()->getDepth() + 1;
-  }
-
-  auto substFn = [&](SubstitutableType *type) -> Type {
-    auto *gp = cast<GenericTypeParamType>(type);
-
-    if (gp->getDepth() < baseDepth) {
-      return Type(gp).subst(subMap);
-    }
-
-    return CanGenericTypeParamType::get(
-        gp->getDepth() - baseDepth + derivedDepth, gp->getIndex(), ctx);
-  };
-
-  auto lookupConformanceFn =
-      [&](CanType depTy, Type substTy,
-          ProtocolDecl *proto) -> Optional<ProtocolConformanceRef> {
-    if (auto conf = subMap.lookupConformance(depTy, proto))
-      return conf;
-
-    return ProtocolConformanceRef(proto);
-  };
-
-  for (auto reqt : baseGenericCtx->getGenericSignature()->getRequirements()) {
-    if (auto substReqt = reqt.subst(substFn, lookupConformanceFn)) {
-      builder.addRequirement(*substReqt, source, nullptr);
-    }
-  }
-
-  auto *genericSig = std::move(builder).computeGenericSignature(SourceLoc());
-  ctx.overrideSigCache.push_back(std::make_pair(key, genericSig));
-  return genericSig;
-}
-
 bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
                                     OverrideCheckingAttempt attempt) {
   auto &diags = ctx.Diags;
@@ -1057,7 +953,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
 
   if (baseGenericCtx && derivedGenericCtx) {
     // If the generic signatures are different, then complain
-    if (auto newSig = getOverrideGenericSignature(baseDecl, decl)) {
+    if (auto newSig = ctx.getOverrideGenericSignature(baseDecl, decl)) {
       if (auto derivedSig = derivedGenericCtx->getGenericSignature()) {
         auto requirementsSatisfied =
             derivedSig->requirementsNotSatisfiedBy(newSig).empty();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -970,6 +970,17 @@ static GenericSignature *getOverrideGenericSignature(ValueDecl *base,
   }
   unsigned derivedDepth = 0;
 
+  auto key = swift::ASTContext::OverrideSignatureKey(
+      baseGenericCtx->getGenericSignature()->getAsString(),
+      derivedClass->getGenericSignature()->getAsString(),
+      derivedClass->getSuperclass());
+
+  for (auto pair : ctx.overrideSigCache) {
+    if (pair.first.isEqual(key)) {
+      return pair.second;
+    }
+  }
+
   if (auto *derivedSig = derivedClass->getGenericSignature())
     derivedDepth = derivedSig->getGenericParams().back()->getDepth() + 1;
 
@@ -1020,6 +1031,7 @@ static GenericSignature *getOverrideGenericSignature(ValueDecl *base,
   }
 
   auto *genericSig = std::move(builder).computeGenericSignature(SourceLoc());
+  ctx.overrideSigCache.push_back(std::make_pair(key, genericSig));
   return genericSig;
 }
 


### PR DESCRIPTION
Follow up to #24484. 

There was a small performance regression due to creating many more GSBs when computing the override generic signature of methods. This PR adds a cache to the AST to prevent `getOverrideGenericSignature` from re-computing the generic signature for methods each time.