### PR TITLE
[CMake][NFC] Support cmake install components for targets with multiple target files

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1512,10 +1512,9 @@ function(add_swift_host_library name)
 
   if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     swift_install_in_component(TARGETS ${name}
-                               ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
-                               LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
-                               RUNTIME DESTINATION bin
-                               COMPONENT dev)
+      ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
+      LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
+      RUNTIME DESTINATION bin COMPONENT dev)
   endif()
 
   swift_is_installing_component(dev is_installing)
@@ -2139,10 +2138,15 @@ function(add_swift_target_library name)
 
       if(sdk STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
         swift_install_in_component(TARGETS ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}
-                                   RUNTIME DESTINATION "bin"
-                                   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
-                                   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
-                                   COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                   RUNTIME
+                                     DESTINATION "bin"
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                   LIBRARY
+                                     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                   ARCHIVE
+                                     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
                                    PERMISSIONS ${file_permissions})
       else()
         swift_install_in_component(FILES "${UNIVERSAL_LIBRARY_NAME}"
@@ -2423,8 +2427,9 @@ function(add_swift_host_tool executable)
     ${ASHT_UNPARSED_ARGUMENTS})
 
   swift_install_in_component(TARGETS ${executable}
-                             RUNTIME DESTINATION bin
-                             COMPONENT ${ASHT_SWIFT_COMPONENT})
+                             RUNTIME
+                               DESTINATION bin
+                               COMPONENT ${ASHT_SWIFT_COMPONENT})
 
   swift_is_installing_component(${ASHT_SWIFT_COMPONENT} is_installing)
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -7,6 +7,9 @@ target_link_libraries(swiftDemangle PRIVATE
   swiftDemangling)
 
 swift_install_in_component(TARGETS swiftDemangle
-                           LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-                           ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-                           COMPONENT compiler)
+  LIBRARY
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+    COMPONENT compiler
+  ARCHIVE
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+    COMPONENT compiler)

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -189,10 +189,15 @@ macro(add_sourcekit_library name)
     endif()
   endif()
   swift_install_in_component(TARGETS ${name}
-                             LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-                             ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-                             RUNTIME DESTINATION "bin"
-                             COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
+    LIBRARY
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+    ARCHIVE
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+    RUNTIME
+      DESTINATION "bin"
+      COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
   swift_install_in_component(FILES ${SOURCEKITLIB_HEADERS}
                              DESTINATION "include/SourceKit"
                              COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
@@ -341,11 +346,18 @@ macro(add_sourcekit_framework name)
                           MACOSX_FRAMEWORK_BUNDLE_VERSION "${SOURCEKIT_VERSION_STRING}"
                           PUBLIC_HEADER "${headers}")
     swift_install_in_component(TARGETS ${name}
-                               FRAMEWORK DESTINATION lib${LLVM_LIBDIR_SUFFIX}
-                               LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
-                               ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
-                               RUNTIME DESTINATION bin
-                               COMPONENT ${SOURCEKITFW_INSTALL_IN_COMPONENT})
+                               FRAMEWORK
+                                 DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+                                 COMPONENT ${SOURCEKITFW_INSTALL_IN_COMPONENT}
+                               LIBRARY
+                                 DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+                                 COMPONENT ${SOURCEKITFW_INSTALL_IN_COMPONENT}
+                               ARCHIVE
+                                 DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+                                 COMPONENT ${SOURCEKITFW_INSTALL_IN_COMPONENT}
+                               RUNTIME
+                                 DESTINATION bin
+                                 COMPONENT ${SOURCEKITFW_INSTALL_IN_COMPONENT})
   else()
     set_output_directory(${name}
         BINARY_DIR ${framework_location}

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -25,5 +25,6 @@ if(SWIFT_ANALYZE_CODE_COVERAGE)
 endif()
 
 swift_install_in_component(TARGETS complete-test
-                           RUNTIME DESTINATION bin
-                           COMPONENT tools)
+                           RUNTIME
+                             DESTINATION bin
+                             COMPONENT tools)

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -28,6 +28,7 @@ if(HAVE_UNICODE_LIBEDIT)
   endif()
 
   swift_install_in_component(TARGETS sourcekitd-repl
-                             RUNTIME DESTINATION bin
-                             COMPONENT tools)
+                             RUNTIME
+                               DESTINATION bin
+                               COMPONENT tools)
 endif()

--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -33,5 +33,6 @@ if(SWIFT_ANALYZE_CODE_COVERAGE)
 endif()
 
 swift_install_in_component(TARGETS sourcekitd-test
-                           RUNTIME DESTINATION bin
-                           COMPONENT tools)
+                           RUNTIME
+                             DESTINATION bin
+                             COMPONENT tools)


### PR DESCRIPTION
The major change here is a follow up to https://github.com/apple/swift/pull/24168, in which I added support to the build system to use cmake's component system for installation. The only major change is making sure that the installation rules are correct for installing targets with multiple output files.

When installing a target, you could have multiple target files with
different rules for installation. For example, you can specify rules for
`RUNTIME` files (binaries, dlls), `LIBRARY` files (dylibs, shared objects), `ARCHIVE` files, etc.
Each of these can take several options, e.g. `DESTINATION`. When you want to specify
the install component for a target, each of the different target file
rules need to have their own `COMPONENT` field. If not, they end up as
"Unspecified" which means they will not get installed with the
associated swift component.

cc @compnerd @gottesmm @Rostepher 