### PR TITLE
[Windows] Fix SourceKit/CompileNotifications/code-completion.swift

### DIFF
--- a/test/SourceKit/CompileNotifications/code-completion.swift
+++ b/test/SourceKit/CompileNotifications/code-completion.swift
@@ -1,7 +1,7 @@
 // RUN: %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
-// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}code-completion.swift",
+// COMPILE_1:  key.filepath: "{{.*}}SOURCE_DIR{{.*}}code-completion.swift",
 // COMPILE_1:  key.compileid: [[CID1:".*"]]
 // COMPILE_1: }
 // COMPILE_1: {


### PR DESCRIPTION
When Windows normalizes paths, it prefixes them with `\\?\`. Fix the regex
to allow this.
