### PR TITLE
Have getInterfaceGenDocumentName return an absolute path on Windows

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -301,10 +301,11 @@ static void skt_main(skt_args *args) {
   return;
 }
 
-static inline const char *getInterfaceGenDocumentName() {
-  // Absolute "path" so that handleTestInvocation doesn't try to make it
-  // absolute.
-  return "/<interface-gen>";
+static inline std::string getInterfaceGenDocumentName() {
+  // "Absolute path" on all platforms since handleTestInvocation will attempt to make this absolute
+  llvm::SmallString<64> path = llvm::StringRef("/<interface-gen>");
+  llvm::sys::fs::make_absolute(path);
+  return path.str();
 }
 
 static int printAnnotations();
@@ -859,7 +860,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
                                             RequestEditorOpenHeaderInterface);
     }
 
-    sourcekitd_request_dictionary_set_string(Req, KeyName, getInterfaceGenDocumentName());
+    sourcekitd_request_dictionary_set_string(Req, KeyName, getInterfaceGenDocumentName().c_str());
     if (!Opts.ModuleGroupName.empty())
       sourcekitd_request_dictionary_set_string(Req, KeyGroupName,
                                                Opts.ModuleGroupName.c_str());


### PR DESCRIPTION
`/<interface-gen>` doesn't count as an absolute path on Windows as it
gets normalized to `[current-drive]:/<interface-gen>`. Calling into
make_absolute adds some unfortunate complexity, but will work on all
platforms.
