### PR TITLE
Normalize Path Names in Sourcekit Diagnostics

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1824,8 +1824,9 @@ void SwiftEditorDocument::parse(ImmutableTextSnapshotRef Snapshot,
   // all tokens are visited and thus token collection is invalid
   CompInv.getLangOptions().CollectParsedToken = (SyntaxCache == nullptr);
   // Access to Impl.SyntaxInfo is guarded by Impl.AccessMtx
+  std::string ResolvedPath = SwiftLangSupport::resolvePathSymlinks(Impl.FilePath);
   Impl.SyntaxInfo.reset(
-    new SwiftDocumentSyntaxInfo(CompInv, Snapshot, Args, Impl.FilePath));
+    new SwiftDocumentSyntaxInfo(CompInv, Snapshot, Args, ResolvedPath));
 
   Impl.SyntaxInfo->parse();
 }


### PR DESCRIPTION
Always attempt to resolve/normalize the file name so that we only
produce a diagnostic for the resolved path rather than both the given
and resolved paths.

This mostly applies on Windows where a path like `C:\my\regular\path` gets normalized to `\\?\C:\my\regular\path` and a diagnostic gets produced for both of them.