### PR TITLE
Don’t try to build static stdlibs on macOS package bots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1131,8 +1131,6 @@ lldb-use-system-debugserver
 lldb-build-type=Release
 verbose-build
 build-ninja
-build-swift-static-stdlib
-build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 playgroundsupport-build-type=Release
 


### PR DESCRIPTION
These have not been supported since ABI stability and we recently added an error that causes some tests to fail.

This is a mildly quick-and-dirty fix to unblock the package bots; we should probably modify the cmake scripts to not build the static variants of these libraries for Darwin platforms even if they're requested. Otherwise we will need to modify additional presets, including some that are shared between Darwin and other platforms.

I have not been able to test this locally, so I'm going to ask Swift CI to build a macOS toolchain with this PR. If it succeeds, this should be safe to merge.