### PR TITLE
[AutoDiff] Fix SIL `[differentiable]` parsing, gardening.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -237,6 +237,8 @@ public:
   unsigned size() { return parameters.size(); }
 };
 
+/// An efficient index subset data structure.
+/// Stores a bit vector representing set indices and a total capacity.
 class AutoDiffIndexSubset : public llvm::FoldingSetNode {
 public:
   typedef uint64_t BitWord;
@@ -271,6 +273,10 @@ private:
     return reinterpret_cast<const BitWord *>(this + 1);
   }
 
+  unsigned getNumBitWords() const {
+    return numBitWords;
+  }
+
   ArrayRef<BitWord> getBitWords() const {
     return {getBitWordsData(), getNumBitWords()};
   }
@@ -303,7 +309,7 @@ public:
   AutoDiffIndexSubset(const AutoDiffIndexSubset &) = delete;
   AutoDiffIndexSubset &operator=(const AutoDiffIndexSubset &) = delete;
 
-  // Defined in ASTContext.h.
+  // Defined in ASTContext.cpp.
   static AutoDiffIndexSubset *get(ASTContext &ctx,
                                   const SmallBitVector &indices);
 
@@ -327,10 +333,6 @@ public:
     SmallBitVector bitVec(capacity);
     bitVec.set(start, end);
     return get(ctx, bitVec);
-  }
-
-  unsigned getNumBitWords() const {
-    return numBitWords;
   }
 
   unsigned getCapacity() const {

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -273,10 +273,6 @@ private:
     return reinterpret_cast<const BitWord *>(this + 1);
   }
 
-  unsigned getNumBitWords() const {
-    return numBitWords;
-  }
-
   ArrayRef<BitWord> getBitWords() const {
     return {getBitWordsData(), getNumBitWords()};
   }
@@ -333,6 +329,13 @@ public:
     SmallBitVector bitVec(capacity);
     bitVec.set(start, end);
     return get(ctx, bitVec);
+  }
+
+  // Use `getCapacity()` to get the total index subset capacity.
+  // This is public only for unit testing
+  // (in unittests/AST/SILAutoDiffIndices.cpp).
+  unsigned getNumBitWords() const {
+    return numBitWords;
   }
 
   unsigned getCapacity() const {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -175,7 +175,7 @@ public:
   SILFunction *getOriginal() const { return Original; }
 
   const SILAutoDiffIndices &getIndices() const { return indices; }
-  void setIndices(const SILAutoDiffIndices &indices) {
+  void setIndices(SILAutoDiffIndices indices) {
     this->indices = indices;
   }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -175,7 +175,7 @@ public:
   SILFunction *getOriginal() const { return Original; }
 
   const SILAutoDiffIndices &getIndices() const { return indices; }
-  void setIndices(SILAutoDiffIndices indices) {
+  void setIndices(const SILAutoDiffIndices &indices) {
     this->indices = indices;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1091,8 +1091,7 @@ bool Parser::parseDifferentiableAttributeArguments(
       return errorAndSkipToEnd();
   }
 
-  // Function that parses a label and a function specifier,
-  // e.g. 'vjp: foo(_:)'.
+  // Function that parses a label and a function specifier, e.g. 'vjp: foo(_:)'.
   // Return true on error.
   auto parseFuncSpec = [&](StringRef label, DeclNameWithLoc &result,
                            bool &terminateParsingArgs) -> bool {

--- a/test/AutoDiff/differentiable_sil_attr_roundtrip.swift
+++ b/test/AutoDiff/differentiable_sil_attr_roundtrip.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-silgen %s -o %t/roundtrip.sil
+// RUN: %target-swift-frontend -emit-sil %t/roundtrip.sil
+
+// TF-656: Verify that `AutoDiffIndexSubset` for SIL `[differentiable]`
+// attribute is set correctly.
+
+// Otherwise, an assertion is triggered during the differentiation transform:
+// Assertion failed: (newCapacity >= capacity), function extendingCapacity
+// ... ADContext::promoteToDifferentiableFunction
+
+@differentiable(wrt: x)
+func TF_656(_ x: Float, _ y: Float) -> Float {
+  return x + y
+}
+_ = gradient(at: 1, in: { x in TF_656(x, 2) })


### PR DESCRIPTION
- Fix `AutoDiffIndexSubset` capacity, even when parsing bodiless functions.
- Various gardening.

Resolves [TF-656](https://bugs.swift.org/browse/TF-656).