### PR TITLE
[Windows] Create symlinks properly in sema_symlink.swift

### DIFF
--- a/test/Inputs/symlink.py
+++ b/test/Inputs/symlink.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+import os
+
+if len(sys.argv) < 3:
+    print('Too few args to ' + sys.argv[0])
+    print('Usage: symlink.py <link_points_to> <link_path> [--dir | --file]')
+    sys.exit(1)
+
+points_to = sys.argv[1]
+link_path = sys.argv[2]
+
+if sys.platform == 'win32':
+    points_to = points_to.replace('/', '\\')
+    link_path = link_path.replace('/', '\\')
+    if len(sys.argv) >= 4 and sys.argv[3] == '--dir':
+        is_dir = True
+    elif len(sys.argv) >= 4 and sys.argv[3] == '--file':
+        is_dir = False
+    else:
+        is_dir = os.path.isdir(sys.argv[1])
+
+    # Windows symlink support was introduced in python 3.2
+    subprocess.check_call(['cmd.exe', '/C', 'mklink ' + ('/D' if is_dir else ''), link_path, points_to])
+else:
+    os.symlink(points_to, link_path)

--- a/test/SourceKit/CursorInfo/cursor_symlink.swift
+++ b/test/SourceKit/CursorInfo/cursor_symlink.swift
@@ -1,8 +1,6 @@
-// ln doesn't create a proper symlink on Windows
-// XFAIL: windows
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo = 0" > %t.dir/real.swift
-// RUN: ln -s %t.dir/real.swift %t.dir/linked.swift
+// RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=cursor -pos=1:5 %t.dir/linked.swift -- %t.dir/real.swift | %FileCheck %s
 // RUN: %sourcekitd-test -req=cursor -pos=1:5 %t.dir/real.swift -- %t.dir/linked.swift | %FileCheck %s
 

--- a/test/SourceKit/Sema/sema_symlink.swift
+++ b/test/SourceKit/Sema/sema_symlink.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t.dir)
 // RUN: echo "let foo: Int = goo" > %t.dir/real.swift
-// RUN: ln -s %t.dir/real.swift %t.dir/linked.swift
+// RUN: %{python} %S/../../Inputs/symlink.py %t.dir/real.swift %t.dir/linked.swift
 // RUN: %sourcekitd-test -req=sema %t.dir/linked.swift -- %t.dir/real.swift | %sed_clean > %t.link.response
 // RUN: diff -u %s.response %t.link.response
 // RUN: %sourcekitd-test -req=sema %t.dir/real.swift -- %t.dir/linked.swift | %sed_clean > %t.real.response


### PR DESCRIPTION
~~The mingw `ln -s` doesn't make a proper symlink on Windows. Thus add a
substitution to use `cmd.exe /C mklink ...` on Windows. Since cmd can't
handle forward slashes, also add a platform specific path separator `%|`
which resolves to `/` or `||` depending on platform.~~

~~I'm not particularly attached to the `%|` syntax, I originally did `%/` but that conflicts with the lit built in `%/t`~~


The mingw `ln -s` doesn't make a proper symlink on Windows. Instead add a
script to use `cmd.exe /C mklink ...` on Windows.
