### PR TITLE
Handle Windows Paths in CompileNotifications Tests

### DIFF
--- a/test/SourceKit/CompileNotifications/code-completion.swift
+++ b/test/SourceKit/CompileNotifications/code-completion.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}code-completion.swift",

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",

--- a/test/SourceKit/CompileNotifications/enable-disable.swift
+++ b/test/SourceKit/CompileNotifications/enable-disable.swift
@@ -6,15 +6,15 @@
 // NONE-NOT: compile-did-finish
 
 
-// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1
-// RUN: %sourcekitd-test -req=track-compiles == -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
+// RUN: %sourcekitd-test -req=track-compiles == -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // RUN: %sourcekitd-test -req=track-compiles \
 // RUN:     == -req=sema %s -- %s \
 // RUN:     == -req=track-compiles -req-opts=value=0 \
-// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1
+// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // RUN: %sourcekitd-test -req=sema %s -- %s \
 // RUN:     == -req=track-compiles -req-opts=value=1 \
-// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1
+// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}enable-disable.swift",

--- a/test/SourceKit/CompileNotifications/type-context-info.swift
+++ b/test/SourceKit/CompileNotifications/type-context-info.swift
@@ -1,7 +1,7 @@
-// RUN: %sourcekitd-test -req=track-compiles == -req=typecontextinfo %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=typecontextinfo %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
-// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}type-context-info.swift",
+// COMPILE_1:  key.filepath: "{{.*}}SOURCE_DIR{{.*}}type-context-info.swift",
 // COMPILE_1:  key.compileid: [[CID1:".*"]]
 // COMPILE_1: }
 // COMPILE_1: {


### PR DESCRIPTION
On Windows, JSON output creates paths with `\\` separators, so pass
--enable-yaml-compatibility to handle it properly.

Additionally, paths are normalized as `\\?\C:\...\...` on Windows, so update the regex to match.