### PR TITLE
[Qol] Driver toolchain validate args

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -585,7 +585,7 @@ bool toolchains::Darwin::shouldStoreInvocationInDebugInfo() const {
   return false;
 }
 
-static void validateDeploymentTarget(const toolchains::Darwin& TC,
+static void validateDeploymentTarget(const toolchains::Darwin &TC,
                                      DiagnosticEngine &diags,
                                      const llvm::opt::ArgList &args) {
   // Check minimum supported OS versions.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -588,34 +588,34 @@ bool toolchains::Darwin::shouldStoreInvocationInDebugInfo() const {
 static void validateDeploymentTarget(const toolchains::Darwin& TC,
                                      DiagnosticEngine &diags,
                                      const llvm::opt::ArgList &args) {
-    // Check minimum supported OS versions.
-    auto triple = TC.getTriple();
-    if (triple.isMacOSX()) {
-        if (triple.isMacOSXVersionLT(10, 9))
-            diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                           "OS X 10.9");
-    } else if (triple.isiOS()) {
-        if (triple.isTvOS()) {
-            if (triple.isOSVersionLT(9, 0)) {
-                diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                               "tvOS 9.0");
-                return;
-            }
-        }
-        if (triple.isOSVersionLT(7))
-            diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                           "iOS 7");
-        if (triple.isArch32Bit() && !triple.isOSVersionLT(11)) {
-            diags.diagnose(SourceLoc(), diag::error_ios_maximum_deployment_32,
-                           triple.getOSMajorVersion());
-        }
-    } else if (triple.isWatchOS()) {
-        if (triple.isOSVersionLT(2, 0)) {
-            diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                           "watchOS 2.0");
-            return;
-        }
+  // Check minimum supported OS versions.
+  auto triple = TC.getTriple();
+  if (triple.isMacOSX()) {
+    if (triple.isMacOSXVersionLT(10, 9))
+      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
+                     "OS X 10.9");
+  } else if (triple.isiOS()) {
+    if (triple.isTvOS()) {
+      if (triple.isOSVersionLT(9, 0)) {
+        diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
+                       "tvOS 9.0");
+        return;
+      }
     }
+    if (triple.isOSVersionLT(7))
+      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
+                     "iOS 7");
+    if (triple.isArch32Bit() && !triple.isOSVersionLT(11)) {
+      diags.diagnose(SourceLoc(), diag::error_ios_maximum_deployment_32,
+                     triple.getOSMajorVersion());
+    }
+  } else if (triple.isWatchOS()) {
+    if (triple.isOSVersionLT(2, 0)) {
+      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
+                     "watchOS 2.0");
+      return;
+    }
+  }
 }
 
 void 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -123,10 +123,10 @@ static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
                                        const ArgList &args) {
   if (!args.hasArgNoClaim(options::OPT_import_objc_header))
     return;
-  
+
   if (args.hasArgNoClaim(options::OPT_import_underlying_module))
     diags.diagnose({}, diag::error_framework_bridging_header);
-  
+
   if (args.hasArgNoClaim(options::OPT_emit_module_interface,
                          options::OPT_emit_module_interface_path)) {
     diags.diagnose({}, diag::error_bridging_header_module_interface);

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -119,56 +119,6 @@ ArrayRef<const char *> Driver::getArgsWithoutProgramNameAndDriverMode(
   return Args;
 }
 
-static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
-                                       const ArgList &args) {
-  if (!args.hasArgNoClaim(options::OPT_import_objc_header))
-    return;
-
-  if (args.hasArgNoClaim(options::OPT_import_underlying_module))
-    diags.diagnose({}, diag::error_framework_bridging_header);
-
-  if (args.hasArgNoClaim(options::OPT_emit_module_interface,
-                         options::OPT_emit_module_interface_path)) {
-    diags.diagnose({}, diag::error_bridging_header_module_interface);
-  }
-}
-
-static void validateDeploymentTarget(DiagnosticEngine &diags,
-                                     const ArgList &args) {
-  const Arg *A = args.getLastArg(options::OPT_target);
-  if (!A)
-    return;
-
-  // Check minimum supported OS versions.
-  llvm::Triple triple(llvm::Triple::normalize(A->getValue()));
-  if (triple.isMacOSX()) {
-    if (triple.isMacOSXVersionLT(10, 9))
-      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                     "OS X 10.9");
-  } else if (triple.isiOS()) {
-    if (triple.isTvOS()) {
-      if (triple.isOSVersionLT(9, 0)) {
-        diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                       "tvOS 9.0");
-        return;
-      }
-    }
-    if (triple.isOSVersionLT(7))
-      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                     "iOS 7");
-    if (triple.isArch32Bit() && !triple.isOSVersionLT(11)) {
-      diags.diagnose(SourceLoc(), diag::error_ios_maximum_deployment_32,
-                     triple.getOSMajorVersion());
-    }
-  } else if (triple.isWatchOS()) {
-    if (triple.isOSVersionLT(2, 0)) {
-      diags.diagnose(SourceLoc(), diag::error_os_minimum_deployment,
-                     "watchOS 2.0");
-      return;
-    }
-  }
-}
-
 static void validateWarningControlArgs(DiagnosticEngine &diags,
                                        const ArgList &args) {
   if (args.hasArg(options::OPT_suppress_warnings) &&
@@ -258,10 +208,23 @@ static void validateAutolinkingArgs(DiagnosticEngine &diags,
                  forceLoadArg->getSpelling(), incrementalArg->getSpelling());
 }
 
+static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
+                                       const ArgList &args) {
+    if (!args.hasArgNoClaim(options::OPT_import_objc_header))
+        return;
+    
+    if (args.hasArgNoClaim(options::OPT_import_underlying_module))
+        diags.diagnose({}, diag::error_framework_bridging_header);
+    
+    if (args.hasArgNoClaim(options::OPT_emit_module_interface,
+                           options::OPT_emit_module_interface_path)) {
+        diags.diagnose({}, diag::error_bridging_header_module_interface);
+    }
+}
+
 /// Perform miscellaneous early validation of arguments.
 static void validateArgs(DiagnosticEngine &diags, const ArgList &args) {
   validateBridgingHeaderArgs(diags, args);
-  validateDeploymentTarget(diags, args);
   validateWarningControlArgs(diags, args);
   validateProfilingArgs(diags, args);
   validateDebugInfoArgs(diags, args);
@@ -820,7 +783,6 @@ Driver::buildCompilation(const ToolChain &TC,
   std::unique_ptr<DerivedArgList> TranslatedArgList(
       translateInputAndPathArgs(*ArgList, workingDirectory));
 
-  // TODO: We should check which validations could be moved to toolchain specific classes.
   validateArgs(Diags, *TranslatedArgList);
     
   // Perform toolchain specific args validation.

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -119,6 +119,20 @@ ArrayRef<const char *> Driver::getArgsWithoutProgramNameAndDriverMode(
   return Args;
 }
 
+static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
+                                       const ArgList &args) {
+  if (!args.hasArgNoClaim(options::OPT_import_objc_header))
+    return;
+  
+  if (args.hasArgNoClaim(options::OPT_import_underlying_module))
+    diags.diagnose({}, diag::error_framework_bridging_header);
+  
+  if (args.hasArgNoClaim(options::OPT_emit_module_interface,
+                         options::OPT_emit_module_interface_path)) {
+    diags.diagnose({}, diag::error_bridging_header_module_interface);
+  }
+}
+
 static void validateWarningControlArgs(DiagnosticEngine &diags,
                                        const ArgList &args) {
   if (args.hasArg(options::OPT_suppress_warnings) &&
@@ -206,20 +220,6 @@ static void validateAutolinkingArgs(DiagnosticEngine &diags,
   // check somewhere else).
   diags.diagnose(SourceLoc(), diag::error_option_not_supported,
                  forceLoadArg->getSpelling(), incrementalArg->getSpelling());
-}
-
-static void validateBridgingHeaderArgs(DiagnosticEngine &diags,
-                                       const ArgList &args) {
-    if (!args.hasArgNoClaim(options::OPT_import_objc_header))
-        return;
-    
-    if (args.hasArgNoClaim(options::OPT_import_underlying_module))
-        diags.diagnose({}, diag::error_framework_bridging_header);
-    
-    if (args.hasArgNoClaim(options::OPT_emit_module_interface,
-                           options::OPT_emit_module_interface_path)) {
-        diags.diagnose({}, diag::error_bridging_header_module_interface);
-    }
 }
 
 /// Perform miscellaneous early validation of arguments.


### PR DESCRIPTION
This is a clean up of TODO from #26136 

I'm not really sure if `validateSearchPathArgs` is darwin specific. 
But the other ones not moved, I think are for all platforms.

cc @jrose-apple @brentdax 