### PR TITLE
[AutoDiff] Add a missing cleanup for a zero value with differentiating 'store'.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -5411,6 +5411,7 @@ public:
         ValueWithCleanup(adjVal, valueCleanup)));
     // Set the buffer to zero, with a cleanup.
     emitZeroIndirect(bufType.getASTType(), adjBuf, si->getLoc());
+    adjBuf.setCleanup(makeCleanup(adjBuf, emitCleanup));
   }
 
   /// Handle `copy_addr` instruction.

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -68,6 +68,10 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK:   [[ZERO_GETTER:%.*]] = function_ref @$s11refcounting6VectorV4zeroACvgZ
 // CHECK:   [[ZERO:%.*]] = apply [[ZERO_GETTER]]({{%.*}}) : $@convention(method) (@thin Vector.Type) -> @owned Vector
 // CHECK:   store [[ZERO]] to [[BUF_ACCESS]] : $*Vector
+// CHECK:   load [[BUF]] : $*Vector
+// CHECK:   [[ZERO_GETTER:%.*]] = function_ref @$s11refcounting6VectorV4zeroACvgZ
+// CHECK:   [[ZERO:%.*]] = apply [[ZERO_GETTER]]({{%.*}}) : $@convention(method) (@thin Vector.Type) -> @owned Vector
+// CHECK:   store [[ZERO]] to [[BUF]] : $*Vector
 // CHECK:   retain_value [[SEED:%.*]] : $Vector
 // CHECK:   release_value [[SEED:%.*]] : $Vector
 // CHECK:   destroy_addr [[BUF]] : $*Vector
@@ -95,7 +99,6 @@ _ = pullback(at: Vector.zero, in: testOwnedVector)
 // CHECK-NOT:   release_value [[PULLBACK0]]
 // CHECK-NOT:   release_value [[PB_STRUCT]]
 // CHECK: }
-
 
 func side_effect_release_zero(_ x: Vector) -> Vector {
   var a = x


### PR DESCRIPTION
Zeros emitted when differentiating a `store` needs to be cleaned up.