### PR TITLE
tests: Make the test for lazy metadata emission a bit more complex

### DIFF
--- a/test/IRGen/lazy_metadata_with-g.swift
+++ b/test/IRGen/lazy_metadata_with-g.swift
@@ -1,30 +1,53 @@
 // RUN: %target-swiftc_driver -parse-as-library -module-name=test -target x86_64-apple-macosx10.15 -wmo -O -g -emit-ir %s  | %FileCheck %s
 // REQUIRES: OS=macosx
 
-// Check that the compiler does not emit any metadata for Mystruct and
-// Teststruct, even with -g.
+// Check that the compiler does not emit any metadata for unused internal
+// structs and enums, even with -g.
 // This is also a driver issue, so we are testing with %target-swiftc_driver
 // and not just with %target-swift-frontend.
 
 // CHECK: ModuleID
 
-// CHECK-NOT: Mystruct
-// CHECK-NOT: Teststruct
+// CHECK-NOT: Test
 // CHECK-NOT: define
 
 // CHECK: DICompileUnit
 
-protocol P {
+public protocol P {
+  func foo() -> Int
 }
 
-struct Mystruct : P {
+struct Teststruct1 : P {
+  func foo() -> Int { return 27 }
 }
 
 
-struct Teststruct {
+struct Teststruct : P {
 
   static var testvar: some P {
-    return Mystruct()
+    switch getit().e {
+      case .None:
+        return Teststruct1()
+      case .View(let v):
+        return v
+    }
   }
+
+  @inline(never)
+  static func getit() -> Teststruct2 {
+    return Teststruct2(e: .View(Teststruct1()))
+  }
+
+  func foo() -> Int { return 27 }
 }
 
+struct Teststruct2 : P {
+  enum Testenum {
+    case None
+    case View(Teststruct1)
+  }
+
+  var e: Testenum
+
+  func foo() -> Int { return 27 }
+}


### PR DESCRIPTION
To verify that we don't emit metadata for unused types in non-trivial scenarios.

Test for rdar://problem/52059864
