### PR TITLE
[Gardening] Replaced many instances of ' : ' with ': '

### DIFF
--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -14,12 +14,12 @@ extension Unicode {
   public enum ASCII {}
 }
 
-extension Unicode.ASCII : Unicode.Encoding {
+extension Unicode.ASCII: Unicode.Encoding {
   public typealias CodeUnit = UInt8
   public typealias EncodedScalar = CollectionOfOne<CodeUnit>
 
   @inlinable
-  public static var encodedReplacementCharacter : EncodedScalar {
+  public static var encodedReplacementCharacter: EncodedScalar {
     return EncodedScalar(0x1a) // U+001A SUBSTITUTE; best we can do for ASCII
   }
 
@@ -51,7 +51,7 @@ extension Unicode.ASCII : Unicode.Encoding {
 
   @inline(__always)
   @inlinable
-  public static func transcode<FromEncoding : Unicode.Encoding>(
+  public static func transcode<FromEncoding: Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF16.self) {
@@ -78,12 +78,12 @@ extension Unicode.ASCII : Unicode.Encoding {
   public typealias ReverseParser = Parser
 }
 
-extension Unicode.ASCII.Parser : Unicode.Parser {
+extension Unicode.ASCII.Parser: Unicode.Parser {
   public typealias Encoding = Unicode.ASCII
 
   /// Parses a single Unicode scalar value from `input`.
   @inlinable
-  public mutating func parseScalar<I : IteratorProtocol>(
+  public mutating func parseScalar<I: IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>
   where I.Element == Encoding.CodeUnit {

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -17,7 +17,7 @@
 ///   - y: Another value to compare.
 /// - Returns: The lesser of `x` and `y`. If `x` is equal to `y`, returns `x`.
 @inlinable // protocol-only
-public func min<T : Comparable>(_ x: T, _ y: T) -> T {
+public func min<T: Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y` we pick `x`.
   // This preserves any pre-existing order in case `T` has identity,
   // which is important for e.g. the stability of sorting algorithms.
@@ -35,7 +35,7 @@ public func min<T : Comparable>(_ x: T, _ y: T) -> T {
 /// - Returns: The least of all the arguments. If there are multiple equal
 ///   least arguments, the result is the first one.
 @inlinable // protocol-only
-public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
+public func min<T: Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var minValue = min(min(x, y), z)
   // In case `value == minValue`, we pick `minValue`. See min(_:_:).
   for value in rest where value < minValue {
@@ -51,7 +51,7 @@ public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 ///   - y: Another value to compare.
 /// - Returns: The greater of `x` and `y`. If `x` is equal to `y`, returns `y`.
 @inlinable // protocol-only
-public func max<T : Comparable>(_ x: T, _ y: T) -> T {
+public func max<T: Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y`, we pick `y`. See min(_:_:).
   return y >= x ? y : x
 }
@@ -66,7 +66,7 @@ public func max<T : Comparable>(_ x: T, _ y: T) -> T {
 /// - Returns: The greatest of all the arguments. If there are multiple equal
 ///   greatest arguments, the result is the last one.
 @inlinable // protocol-only
-public func max<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
+public func max<T: Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var maxValue = max(max(x, y), z)
   // In case `value == maxValue`, we pick `value`. See min(_:_:).
   for value in rest where value >= maxValue {

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -21,9 +21,9 @@ public protocol _HasCustomAnyHashableRepresentation {
   /// needs to be boxed into `AnyHashable` using the static
   /// type that introduces the `Hashable` conformance.
   ///
-  ///     class Base : Hashable {}
-  ///     class Derived1 : Base {}
-  ///     class Derived2 : Base, _HasCustomAnyHashableRepresentation {
+  ///     class Base: Hashable {}
+  ///     class Derived1: Base {}
+  ///     class Derived2: Base, _HasCustomAnyHashableRepresentation {
   ///       func _toCustomAnyHashable() -> AnyHashable? {
   ///         // `Derived2` is canonicalized to `Derived1`.
   ///         let customRepresentation = Derived1()
@@ -62,14 +62,14 @@ extension _AnyHashableBox {
   }
 }
 
-internal struct _ConcreteHashableBox<Base : Hashable> : _AnyHashableBox {
+internal struct _ConcreteHashableBox<Base: Hashable>: _AnyHashableBox {
   internal var _baseHashable: Base
 
   internal init(_ base: Base) {
     self._baseHashable = base
   }
 
-  internal func _unbox<T : Hashable>() -> T? {
+  internal func _unbox<T: Hashable>() -> T? {
     return (self as _AnyHashableBox as? _ConcreteHashableBox<T>)?._baseHashable
   }
 
@@ -134,7 +134,7 @@ public struct AnyHashable {
   /// Creates a type-erased hashable value that wraps the given instance.
   ///
   /// - Parameter base: A hashable value to wrap.
-  public init<H : Hashable>(_ base: H) {
+  public init<H: Hashable>(_ base: H) {
     if let custom =
       (base as? _HasCustomAnyHashableRepresentation)?._toCustomAnyHashable() {
       self = custom
@@ -147,7 +147,7 @@ public struct AnyHashable {
       storingResultInto: &self)
   }
 
-  internal init<H : Hashable>(_usingDefaultRepresentationOf base: H) {
+  internal init<H: Hashable>(_usingDefaultRepresentationOf base: H) {
     self._box = _ConcreteHashableBox(base)
   }
 
@@ -187,7 +187,7 @@ public struct AnyHashable {
   }
 }
 
-extension AnyHashable : Equatable {
+extension AnyHashable: Equatable {
   /// Returns a Boolean value indicating whether two type-erased hashable
   /// instances wrap the same type and value.
   ///
@@ -203,7 +203,7 @@ extension AnyHashable : Equatable {
   }
 }
 
-extension AnyHashable : Hashable {
+extension AnyHashable: Hashable {
   /// The hash value.
   public var hashValue: Int {
     return _box._canonicalBox._hashValue
@@ -223,19 +223,19 @@ extension AnyHashable : Hashable {
   }
 }
 
-extension AnyHashable : CustomStringConvertible {
+extension AnyHashable: CustomStringConvertible {
   public var description: String {
     return String(describing: base)
   }
 }
 
-extension AnyHashable : CustomDebugStringConvertible {
+extension AnyHashable: CustomDebugStringConvertible {
   public var debugDescription: String {
     return "AnyHashable(" + String(reflecting: base) + ")"
   }
 }
 
-extension AnyHashable : CustomReflectable {
+extension AnyHashable: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(
       self,
@@ -250,7 +250,7 @@ extension AnyHashable : CustomReflectable {
 /// conformance, if it exists.
 /// Called by AnyHashableSupport.cpp.
 @_silgen_name("_swift_makeAnyHashableUsingDefaultRepresentation")
-internal func _makeAnyHashableUsingDefaultRepresentation<H : Hashable>(
+internal func _makeAnyHashableUsingDefaultRepresentation<H: Hashable>(
   of value: H,
   storingResultInto result: UnsafeMutablePointer<AnyHashable>
 ) {
@@ -259,20 +259,20 @@ internal func _makeAnyHashableUsingDefaultRepresentation<H : Hashable>(
 
 /// Provided by AnyHashable.cpp.
 @_silgen_name("_swift_makeAnyHashableUpcastingToHashableBaseType")
-internal func _makeAnyHashableUpcastingToHashableBaseType<H : Hashable>(
+internal func _makeAnyHashableUpcastingToHashableBaseType<H: Hashable>(
   _ value: H,
   storingResultInto result: UnsafeMutablePointer<AnyHashable>
 )
 
 @inlinable
 public // COMPILER_INTRINSIC
-func _convertToAnyHashable<H : Hashable>(_ value: H) -> AnyHashable {
+func _convertToAnyHashable<H: Hashable>(_ value: H) -> AnyHashable {
   return AnyHashable(value)
 }
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_convertToAnyHashableIndirect")
-internal func _convertToAnyHashableIndirect<H : Hashable>(
+internal func _convertToAnyHashableIndirect<H: Hashable>(
   _ value: H,
   _ target: UnsafeMutablePointer<AnyHashable>
 ) {

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1891,7 +1891,7 @@ internal struct _ArrayAnyHashableBox<Element: Hashable>
     return hasher._finalize()
   }
 
-  internal func _unbox<T : Hashable>() -> T? {
+  internal func _unbox<T: Hashable>() -> T? {
     return _value as? T
   }
 

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -24,7 +24,7 @@ internal typealias _ArrayBridgeStorage
 
 @usableFromInline
 @frozen
-internal struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
+internal struct _ArrayBuffer<Element>: _ArrayBufferProtocol {
 
   /// Create an empty buffer.
   @inlinable

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -71,7 +71,7 @@ where Indices == Range<Int> {
     _ subrange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: __owned C
-  ) where C : Collection, C.Element == Element
+  ) where C: Collection, C.Element == Element
 
   /// Returns a `_SliceBuffer` containing the elements in `bounds`.
   subscript(bounds: Range<Int>) -> _SliceBuffer<Element> { get }
@@ -144,7 +144,7 @@ extension _ArrayBufferProtocol where Indices == Range<Int>{
     _ subrange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: __owned C
-  ) where C : Collection, C.Element == Element {
+  ) where C: Collection, C.Element == Element {
     _internalInvariant(startIndex == 0, "_SliceBuffer should override this function.")
     let oldCount = self.count
     let eraseCount = subrange.count

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -140,7 +140,7 @@ public struct Bool {
   }
 }
 
-extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLiteral {
+extension Bool: _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLiteral {
   @_transparent
   public init(_builtinBooleanLiteral value: Builtin.Int1) {
     self._value = value
@@ -170,7 +170,7 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   }
 }
 
-extension Bool : CustomStringConvertible {
+extension Bool: CustomStringConvertible {
   /// A textual representation of the Boolean value.
   @inlinable
   public var description: String {
@@ -197,7 +197,7 @@ extension Bool: Hashable {
   }
 }
 
-extension Bool : LosslessStringConvertible {
+extension Bool: LosslessStringConvertible {
   /// Creates a new Boolean value from the given string.
   ///
   /// If the `description` value is any string other than `"true"` or

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -16,7 +16,7 @@
 /// or NSDictionary will be the result of calling `_bridgeToObjectiveC`
 /// on each element of the source container.
 public protocol _ObjectiveCBridgeable {
-  associatedtype _ObjectiveCType : AnyObject
+  associatedtype _ObjectiveCType: AnyObject
 
   /// Convert `self` to Objective-C.
   func _bridgeToObjectiveC() -> _ObjectiveCType

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -231,13 +231,13 @@ public func _unsafeReferenceCast<T, U>(_ x: T, to: U.Type) -> U {
 ///   - type: The type `T` to which `x` is cast.
 /// - Returns: The instance `x`, cast to type `T`.
 @_transparent
-public func unsafeDowncast<T : AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
+public func unsafeDowncast<T: AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
   _debugPrecondition(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
 }
 
 @_transparent
-public func _unsafeUncheckedDowncast<T : AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
+public func _unsafeUncheckedDowncast<T: AnyObject>(_ x: AnyObject, to type: T.Type) -> T {
   _internalInvariant(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
 }
@@ -778,7 +778,7 @@ func _trueAfterDiagnostics() -> Builtin.Int1 {
 ///         }
 ///     }
 ///
-///     class EmojiSmiley : Smiley {
+///     class EmojiSmiley: Smiley {
 ///          override class var text: String {
 ///             return "😀"
 ///         }

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -140,7 +140,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF8)
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable // Fold away specializations
-  public static func decodeCString<Encoding : _UnicodeEncoding>(
+  public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: UnsafePointer<Encoding.CodeUnit>?,
     as encoding: Encoding.Type,
     repairingInvalidCodeUnits isRepairing: Bool = true

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -189,7 +189,7 @@ extension OpaquePointer: Hashable {
   }
 }
 
-extension OpaquePointer : CustomDebugStringConvertible {
+extension OpaquePointer: CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {
     return _rawPointerToString(_rawValue)
@@ -246,7 +246,7 @@ public struct CVaListPointer {
   }
 }
 
-extension CVaListPointer : CustomDebugStringConvertible {
+extension CVaListPointer: CustomDebugStringConvertible {
   public var debugDescription: String {
     return "(\(_value.__stack.debugDescription), " +
            "\(_value.__gr_top.debugDescription), " +
@@ -270,7 +270,7 @@ public struct CVaListPointer {
   }
 }
 
-extension CVaListPointer : CustomDebugStringConvertible {
+extension CVaListPointer: CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
   public var debugDescription: String {
     return _value.debugDescription

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -185,16 +185,16 @@ extension Character :
   }
 }
 
-extension Character : CustomStringConvertible {
+extension Character: CustomStringConvertible {
  @inlinable
  public var description: String {
    return _str
  }
 }
 
-extension Character : LosslessStringConvertible { }
+extension Character: LosslessStringConvertible { }
 
-extension Character : CustomDebugStringConvertible {
+extension Character: CustomDebugStringConvertible {
  /// A textual representation of the character, suitable for debugging.
  public var debugDescription: String {
    return _str.debugDescription
@@ -211,7 +211,7 @@ extension String {
   }
 }
 
-extension Character : Equatable {
+extension Character: Equatable {
   @inlinable @inline(__always)
   @_effects(readonly)
   public static func == (lhs: Character, rhs: Character) -> Bool {
@@ -219,7 +219,7 @@ extension Character : Equatable {
   }
 }
 
-extension Character : Comparable {
+extension Character: Comparable {
   @inlinable @inline(__always)
   @_effects(readonly)
   public static func < (lhs: Character, rhs: Character) -> Bool {

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -126,7 +126,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger {
   public typealias Iterator = IndexingIterator<ClosedRange<Bound>>
 }
 
-extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
+extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
   @frozen // FIXME(resilience)
   public enum Index {
     case pastEnd
@@ -134,7 +134,7 @@ extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
   }
 }
 
-extension ClosedRange.Index : Comparable {
+extension ClosedRange.Index: Comparable {
   @inlinable
   public static func == (
     lhs: ClosedRange<Bound>.Index,
@@ -188,7 +188,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger, Bound: Hashable {
 // FIXME: this should only be conformance to RandomAccessCollection but
 // the compiler balks without all 3
 extension ClosedRange: Collection, BidirectionalCollection, RandomAccessCollection
-where Bound : Strideable, Bound.Stride : SignedInteger
+where Bound: Strideable, Bound.Stride: SignedInteger
 {
   // while a ClosedRange can't be empty, a _slice_ of a ClosedRange can,
   // so ClosedRange can't be its own self-slice unlike Range
@@ -368,7 +368,7 @@ extension ClosedRange: Hashable where Bound: Hashable {
   }
 }
 
-extension ClosedRange : CustomStringConvertible {
+extension ClosedRange: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation...
   public var description: String {
@@ -376,7 +376,7 @@ extension ClosedRange : CustomStringConvertible {
   }
 }
 
-extension ClosedRange : CustomDebugStringConvertible {
+extension ClosedRange: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
     return "ClosedRange(\(String(reflecting: lowerBound))"
@@ -384,7 +384,7 @@ extension ClosedRange : CustomDebugStringConvertible {
   }
 }
 
-extension ClosedRange : CustomReflectable {
+extension ClosedRange: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(
       self, children: ["lowerBound": lowerBound, "upperBound": upperBound])
@@ -425,7 +425,7 @@ extension ClosedRange {
   }
 }
 
-extension ClosedRange where Bound: Strideable, Bound.Stride : SignedInteger {  
+extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
   /// Creates an instance equivalent to the given `Range`.
   ///
   /// - Parameter other: A `Range` to convert to a `ClosedRange` instance.
@@ -461,7 +461,7 @@ extension ClosedRange {
 // Note: this is not for compatibility only, it is considered a useful
 // shorthand. TODO: Add documentation
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
-  where Bound.Stride : SignedInteger
+  where Bound.Stride: SignedInteger
 
 extension ClosedRange: Decodable where Bound: Decodable {
   public init(from decoder: Decoder) throws {

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -26,7 +26,7 @@ import SwiftShims
 /// It's a class, and I don't want to pay for the dynamic dispatch overhead.
 @usableFromInline
 @frozen
-internal struct _CocoaArrayWrapper : RandomAccessCollection {
+internal struct _CocoaArrayWrapper: RandomAccessCollection {
   @usableFromInline
   typealias Indices = Range<Int>
 

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -107,7 +107,7 @@ public protocol Encoder {
   var codingPath: [CodingKey] { get }
 
   /// Any contextual information set by the user for encoding.
-  var userInfo: [CodingUserInfoKey : Any] { get }
+  var userInfo: [CodingUserInfoKey: Any] { get }
 
   /// Returns an encoding container appropriate for holding multiple values
   /// keyed by the given key type.
@@ -149,7 +149,7 @@ public protocol Decoder {
   var codingPath: [CodingKey] { get }
 
   /// Any contextual information set by the user for decoding.
-  var userInfo: [CodingUserInfoKey : Any] { get }
+  var userInfo: [CodingUserInfoKey: Any] { get }
 
   /// Returns the data stored in this decoder as represented in a container
   /// keyed by the given key type.
@@ -187,7 +187,7 @@ public protocol Decoder {
 /// Encoders should provide types conforming to
 /// `KeyedEncodingContainerProtocol` for their format.
 public protocol KeyedEncodingContainerProtocol {
-  associatedtype Key : CodingKey
+  associatedtype Key: CodingKey
 
   /// The path of coding keys taken to get to this point in encoding.
   var codingPath: [CodingKey] { get }
@@ -215,7 +215,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws
+  mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws
 
   /// Encodes a reference to the given object only if it is encoded
   /// unconditionally elsewhere in the payload (previously, or in the future).
@@ -227,7 +227,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the object with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeConditional<T : AnyObject & Encodable>(
+  mutating func encodeConditional<T: AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
 
 % for type in codable_types:
@@ -246,7 +246,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeIfPresent<T : Encodable>(
+  mutating func encodeIfPresent<T: Encodable>(
     _ value: T?, forKey key: Key) throws
 
   /// Stores a keyed encoding container for the given key and returns it.
@@ -287,7 +287,7 @@ public protocol KeyedEncodingContainerProtocol {
 
 /// A concrete container that provides a view into an encoder's storage, making
 /// the encoded properties of an encodable type accessible by keys.
-public struct KeyedEncodingContainer<K : CodingKey> :
+public struct KeyedEncodingContainer<K: CodingKey> :
   KeyedEncodingContainerProtocol
 {
   public typealias Key = K
@@ -299,7 +299,7 @@ public struct KeyedEncodingContainer<K : CodingKey> :
   /// Creates a new instance with the given container.
   ///
   /// - parameter container: The container to hold.
-  public init<Container : KeyedEncodingContainerProtocol>(
+  public init<Container: KeyedEncodingContainerProtocol>(
     _ container: Container) where Container.Key == Key
   {
     _box = _KeyedEncodingContainerBox(container)
@@ -337,7 +337,7 @@ public struct KeyedEncodingContainer<K : CodingKey> :
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encode<T : Encodable>(
+  public mutating func encode<T: Encodable>(
     _ value: T, forKey key: Key) throws
   {
     try _box.encode(value, forKey: key)
@@ -353,7 +353,7 @@ public struct KeyedEncodingContainer<K : CodingKey> :
   /// - parameter key: The key to associate the object with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encodeConditional<T : AnyObject & Encodable>(
+  public mutating func encodeConditional<T: AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
   {
     try _box.encodeConditional(object, forKey: key)
@@ -379,7 +379,7 @@ public struct KeyedEncodingContainer<K : CodingKey> :
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encodeIfPresent<T : Encodable>(
+  public mutating func encodeIfPresent<T: Encodable>(
     _ value: T?, forKey key: Key) throws
   {
     try _box.encodeIfPresent(value, forKey: key)
@@ -433,7 +433,7 @@ public struct KeyedEncodingContainer<K : CodingKey> :
 /// Decoders should provide types conforming to `UnkeyedDecodingContainer` for
 /// their format.
 public protocol KeyedDecodingContainerProtocol {
-  associatedtype Key : CodingKey
+  associatedtype Key: CodingKey
 
   /// The path of coding keys taken to get to this point in decoding.
   var codingPath: [CodingKey] { get }
@@ -492,7 +492,7 @@ public protocol KeyedDecodingContainerProtocol {
   ///   for the given key.
   /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for
   ///   the given key.
-  func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T
+  func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T
 
 % for type in codable_types:
   /// Decodes a value of the given type for the given key, if present.
@@ -524,7 +524,7 @@ public protocol KeyedDecodingContainerProtocol {
   ///   the value is a null value.
   /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
   ///   is not convertible to the requested type.
-  func decodeIfPresent<T : Decodable>(
+  func decodeIfPresent<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T?
 
   /// Returns the data stored for the given key as represented in a container
@@ -579,7 +579,7 @@ public protocol KeyedDecodingContainerProtocol {
 
 /// A concrete container that provides a view into a decoder's storage, making
 /// the encoded properties of a decodable type accessible by keys.
-public struct KeyedDecodingContainer<K : CodingKey> :
+public struct KeyedDecodingContainer<K: CodingKey> :
   KeyedDecodingContainerProtocol
 {
   public typealias Key = K
@@ -591,7 +591,7 @@ public struct KeyedDecodingContainer<K : CodingKey> :
   /// Creates a new instance with the given container.
   ///
   /// - parameter container: The container to hold.
-  public init<Container : KeyedDecodingContainerProtocol>(
+  public init<Container: KeyedDecodingContainerProtocol>(
     _ container: Container) where Container.Key == Key
   {
     _box = _KeyedDecodingContainerBox(container)
@@ -664,7 +664,7 @@ public struct KeyedDecodingContainer<K : CodingKey> :
   ///   for the given key.
   /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for
   ///   the given key.
-  public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+  public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
     return try _box.decode(T.self, forKey: key)
   }
 
@@ -702,7 +702,7 @@ public struct KeyedDecodingContainer<K : CodingKey> :
   ///   the value is a null value.
   /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
   ///   is not convertible to the requested type.
-  public func decodeIfPresent<T : Decodable>(
+  public func decodeIfPresent<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T?
   {
     return try _box.decodeIfPresent(T.self, forKey: key)
@@ -799,7 +799,7 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter value: The value to encode.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encode<T : Encodable>(_ value: T) throws
+  mutating func encode<T: Encodable>(_ value: T) throws
 
   /// Encodes a reference to the given object only if it is encoded
   /// unconditionally elsewhere in the payload (previously, or in the future).
@@ -813,14 +813,14 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter object: The object to encode.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeConditional<T : AnyObject & Encodable>(_ object: T) throws
+  mutating func encodeConditional<T: AnyObject & Encodable>(_ object: T) throws
 
 % for type in codable_types:
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T : Sequence>(
+  mutating func encode<T: Sequence>(
     contentsOf sequence: T) throws where T.Element == ${type}
 % end
 
@@ -828,8 +828,8 @@ public protocol UnkeyedEncodingContainer {
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Element : Encodable
+  mutating func encode<T: Sequence>(
+    contentsOf sequence: T) throws where T.Element: Encodable
 
   /// Encodes a nested container keyed by the given type and returns it.
   ///
@@ -903,7 +903,7 @@ public protocol UnkeyedDecodingContainer {
   ///   is not convertible to the requested type.
   /// - throws: `DecodingError.valueNotFound` if the encountered encoded value
   ///   is null, or of there are no more values to decode.
-  mutating func decode<T : Decodable>(_ type: T.Type) throws -> T
+  mutating func decode<T: Decodable>(_ type: T.Type) throws -> T
 
 % for type in codable_types:
   /// Decodes a value of the given type, if present.
@@ -931,7 +931,7 @@ public protocol UnkeyedDecodingContainer {
   ///   is a null value, or if there are no more elements to decode.
   /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
   ///   is not convertible to the requested type.
-  mutating func decodeIfPresent<T : Decodable>(_ type: T.Type) throws -> T?
+  mutating func decodeIfPresent<T: Decodable>(_ type: T.Type) throws -> T?
 
   /// Decodes a nested container keyed by the given type.
   ///
@@ -994,7 +994,7 @@ public protocol SingleValueEncodingContainer {
   ///   the current context for this format.
   /// - precondition: May not be called after a previous `self.encode(_:)`
   ///   call.
-  mutating func encode<T : Encodable>(_ value: T) throws
+  mutating func encode<T: Encodable>(_ value: T) throws
 }
 
 /// A container that can support the storage and direct decoding of a single
@@ -1028,7 +1028,7 @@ public protocol SingleValueDecodingContainer {
   ///   cannot be converted to the requested type.
   /// - throws: `DecodingError.valueNotFound` if the encountered encoded value
   ///   is null.
-  func decode<T : Decodable>(_ type: T.Type) throws -> T
+  func decode<T: Decodable>(_ type: T.Type) throws -> T
 }
 
 //===----------------------------------------------------------------------===//
@@ -1036,7 +1036,7 @@ public protocol SingleValueDecodingContainer {
 //===----------------------------------------------------------------------===//
 
 /// A user-defined key for providing context during encoding and decoding.
-public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
+public struct CodingUserInfoKey: RawRepresentable, Equatable, Hashable {
   public typealias RawValue = String
 
   /// The key's string value.
@@ -1079,7 +1079,7 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 //===----------------------------------------------------------------------===//
 
 /// An error that occurs during the encoding of a value.
-public enum EncodingError : Error {
+public enum EncodingError: Error {
   /// The context in which the error occurred.
   public struct Context {
     /// The path of coding keys taken to get to the point of the failing encode
@@ -1145,7 +1145,7 @@ public enum EncodingError : Error {
       case .invalidValue(_, let c): context = c
       }
 
-      var userInfo: [String : Any] = [
+      var userInfo: [String: Any] = [
         "NSCodingPath": context.codingPath,
         "NSDebugDescription": context.debugDescription
       ]
@@ -1162,7 +1162,7 @@ public enum EncodingError : Error {
 }
 
 /// An error that occurs during the decoding of a value.
-public enum DecodingError : Error {
+public enum DecodingError: Error {
   /// The context in which the error occurred.
   public struct Context {
     /// The path of coding keys taken to get to the point of the failing decode
@@ -1251,7 +1251,7 @@ public enum DecodingError : Error {
       case .dataCorrupted(   let c): context = c
       }
 
-      var userInfo: [String : Any] = [
+      var userInfo: [String: Any] = [
         "NSCodingPath": context.codingPath,
         "NSDebugDescription": context.debugDescription
       ]
@@ -1269,7 +1269,7 @@ public enum DecodingError : Error {
 
 // The following extensions allow for easier error construction.
 
-internal struct _GenericIndexKey : CodingKey {
+internal struct _GenericIndexKey: CodingKey {
     internal var stringValue: String
     internal var intValue: Int?
 
@@ -1296,7 +1296,7 @@ extension DecodingError {
   /// - param debugDescription: A description of the error to aid in debugging.
   ///
   /// - Returns: A new `.dataCorrupted` error with the given information.
-  public static func dataCorruptedError<C : KeyedDecodingContainerProtocol>(
+  public static func dataCorruptedError<C: KeyedDecodingContainerProtocol>(
     forKey key: C.Key, in container: C, debugDescription: String
   ) -> DecodingError {
     let context = DecodingError.Context(
@@ -1351,7 +1351,7 @@ extension DecodingError {
 // Keyed Encoding Container Implementations
 //===----------------------------------------------------------------------===//
 
-internal class _KeyedEncodingContainerBase<Key : CodingKey> {
+internal class _KeyedEncodingContainerBase<Key: CodingKey> {
   internal init(){}
 
   deinit {}
@@ -1371,11 +1371,11 @@ internal class _KeyedEncodingContainerBase<Key : CodingKey> {
   }
 % end
 
-  internal func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+  internal func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
   }
 
-  internal func encodeConditional<T : AnyObject & Encodable>(
+  internal func encodeConditional<T: AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
   {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
@@ -1387,7 +1387,7 @@ internal class _KeyedEncodingContainerBase<Key : CodingKey> {
   }
 % end
 
-  internal func encodeIfPresent<T : Encodable>(
+  internal func encodeIfPresent<T: Encodable>(
     _ value: T?, forKey key: Key) throws
   {
     fatalError("_KeyedEncodingContainerBase cannot be used directly.")
@@ -1414,8 +1414,8 @@ internal class _KeyedEncodingContainerBase<Key : CodingKey> {
 }
 
 internal final class _KeyedEncodingContainerBox<
-  Concrete : KeyedEncodingContainerProtocol
-> : _KeyedEncodingContainerBase<Concrete.Key> {
+  Concrete: KeyedEncodingContainerProtocol
+>: _KeyedEncodingContainerBase<Concrete.Key> {
   typealias Key = Concrete.Key
 
   internal var concrete: Concrete
@@ -1438,13 +1438,13 @@ internal final class _KeyedEncodingContainerBox<
   }
 % end
 
-  override internal func encode<T : Encodable>(
+  override internal func encode<T: Encodable>(
     _ value: T, forKey key: Key) throws
   {
     try concrete.encode(value, forKey: key)
   }
 
-  override internal func encodeConditional<T : AnyObject & Encodable>(
+  override internal func encodeConditional<T: AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
   {
     try concrete.encodeConditional(object, forKey: key)
@@ -1458,7 +1458,7 @@ internal final class _KeyedEncodingContainerBox<
   }
 % end
 
-  override internal func encodeIfPresent<T : Encodable>(
+  override internal func encodeIfPresent<T: Encodable>(
     _ value: T?, forKey key: Key) throws
   {
     try concrete.encodeIfPresent(value, forKey: key)
@@ -1485,7 +1485,7 @@ internal final class _KeyedEncodingContainerBox<
   }
 }
 
-internal class _KeyedDecodingContainerBase<Key : CodingKey> {
+internal class _KeyedDecodingContainerBase<Key: CodingKey> {
   internal init(){}
 
   deinit {}
@@ -1514,7 +1514,7 @@ internal class _KeyedDecodingContainerBase<Key : CodingKey> {
   }
 % end
 
-  internal func decode<T : Decodable>(
+  internal func decode<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T
   {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
@@ -1528,7 +1528,7 @@ internal class _KeyedDecodingContainerBase<Key : CodingKey> {
   }
 % end
 
-  internal func decodeIfPresent<T : Decodable>(
+  internal func decodeIfPresent<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T?
   {
     fatalError("_KeyedDecodingContainerBase cannot be used directly.")
@@ -1556,8 +1556,8 @@ internal class _KeyedDecodingContainerBase<Key : CodingKey> {
 }
 
 internal final class _KeyedDecodingContainerBox<
-  Concrete : KeyedDecodingContainerProtocol
-> : _KeyedDecodingContainerBase<Concrete.Key> {
+  Concrete: KeyedDecodingContainerProtocol
+>: _KeyedDecodingContainerBase<Concrete.Key> {
   typealias Key = Concrete.Key
 
   internal var concrete: Concrete
@@ -1590,7 +1590,7 @@ internal final class _KeyedDecodingContainerBox<
   }
 % end
 
-  override internal func decode<T : Decodable>(
+  override internal func decode<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T
   {
     return try concrete.decode(T.self, forKey: key)
@@ -1604,7 +1604,7 @@ internal final class _KeyedDecodingContainerBox<
   }
 % end
 
-  override internal func decodeIfPresent<T : Decodable>(
+  override internal func decodeIfPresent<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T?
   {
     return try concrete.decodeIfPresent(T.self, forKey: key)
@@ -1636,7 +1636,7 @@ internal final class _KeyedDecodingContainerBox<
 //===----------------------------------------------------------------------===//
 
 % for type in codable_types:
-extension ${type} : Codable {
+extension ${type}: Codable {
   /// Creates a new instance by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1659,7 +1659,7 @@ extension ${type} : Codable {
   }
 }
 
-extension RawRepresentable where RawValue == ${type}, Self : Encodable {
+extension RawRepresentable where RawValue == ${type}, Self: Encodable {
   /// Encodes this value into the given encoder, when the type's `RawValue`
   /// is `${type}`.
   ///
@@ -1673,7 +1673,7 @@ extension RawRepresentable where RawValue == ${type}, Self : Encodable {
   }
 }
 
-extension RawRepresentable where RawValue == ${type}, Self : Decodable {
+extension RawRepresentable where RawValue == ${type}, Self: Decodable {
   /// Creates a new instance by decoding from the given decoder, when the
   /// type's `RawValue` is `${type}`.
   ///
@@ -1699,7 +1699,7 @@ extension RawRepresentable where RawValue == ${type}, Self : Decodable {
 // Optional/Collection Type Conformances
 //===----------------------------------------------------------------------===//
 
-extension Optional : Encodable where Wrapped : Encodable {
+extension Optional: Encodable where Wrapped: Encodable {
   /// Encodes this optional value into the given encoder.
   ///
   /// This function throws an error if any values are invalid for the given
@@ -1715,7 +1715,7 @@ extension Optional : Encodable where Wrapped : Encodable {
   }
 }
 
-extension Optional : Decodable where Wrapped : Decodable {
+extension Optional: Decodable where Wrapped: Decodable {
   /// Creates a new instance by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1733,7 +1733,7 @@ extension Optional : Decodable where Wrapped : Decodable {
   }
 }
 
-extension Array : Encodable where Element : Encodable {
+extension Array: Encodable where Element: Encodable {
   /// Encodes the elements of this array into the given encoder in an unkeyed
   /// container.
   ///
@@ -1749,7 +1749,7 @@ extension Array : Encodable where Element : Encodable {
   }
 }
 
-extension Array : Decodable where Element : Decodable {
+extension Array: Decodable where Element: Decodable {
   /// Creates a new array by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1767,7 +1767,7 @@ extension Array : Decodable where Element : Decodable {
   }
 }
 
-extension ContiguousArray : Encodable where Element : Encodable {
+extension ContiguousArray: Encodable where Element: Encodable {
   /// Encodes the elements of this contiguous array into the given encoder
   /// in an unkeyed container.
   ///
@@ -1783,7 +1783,7 @@ extension ContiguousArray : Encodable where Element : Encodable {
   }
 }
 
-extension ContiguousArray : Decodable where Element : Decodable {
+extension ContiguousArray: Decodable where Element: Decodable {
   /// Creates a new contiguous array by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1801,7 +1801,7 @@ extension ContiguousArray : Decodable where Element : Decodable {
   }
 }
 
-extension Set : Encodable where Element : Encodable {
+extension Set: Encodable where Element: Encodable {
   /// Encodes the elements of this set into the given encoder in an unkeyed
   /// container.
   ///
@@ -1817,7 +1817,7 @@ extension Set : Encodable where Element : Encodable {
   }
 }
 
-extension Set : Decodable where Element : Decodable {
+extension Set: Decodable where Element: Decodable {
   /// Creates a new set by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1836,7 +1836,7 @@ extension Set : Decodable where Element : Decodable {
 }
 
 /// A wrapper for dictionary keys which are Strings or Ints.
-internal struct _DictionaryCodingKey : CodingKey {
+internal struct _DictionaryCodingKey: CodingKey {
   internal let stringValue: String
   internal let intValue: Int?
 
@@ -1851,7 +1851,7 @@ internal struct _DictionaryCodingKey : CodingKey {
   }
 }
 
-extension Dictionary : Encodable where Key : Encodable, Value : Encodable {
+extension Dictionary: Encodable where Key: Encodable, Value: Encodable {
   /// Encodes the contents of this dictionary into the given encoder.
   ///
   /// If the dictionary uses `String` or `Int` keys, the contents are encoded
@@ -1890,7 +1890,7 @@ extension Dictionary : Encodable where Key : Encodable, Value : Encodable {
   }
 }
 
-extension Dictionary : Decodable where Key : Decodable, Value : Decodable {
+extension Dictionary: Decodable where Key: Decodable, Value: Decodable {
   /// Creates a new dictionary by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or
@@ -1967,7 +1967,7 @@ extension Dictionary : Decodable where Key : Decodable, Value : Decodable {
 // Default implementation of encodeConditional(_:forKey:) in terms of
 // encode(_:forKey:)
 extension KeyedEncodingContainerProtocol {
-  public mutating func encodeConditional<T : AnyObject & Encodable>(
+  public mutating func encodeConditional<T: AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
   {
     try encode(object, forKey: key)
@@ -1986,7 +1986,7 @@ extension KeyedEncodingContainerProtocol {
   }
 % end
 
-  public mutating func encodeIfPresent<T : Encodable>(
+  public mutating func encodeIfPresent<T: Encodable>(
     _ value: T?, forKey key: Key) throws
   {
     guard let value = value else { return }
@@ -2007,7 +2007,7 @@ extension KeyedDecodingContainerProtocol {
   }
 % end
 
-  public func decodeIfPresent<T : Decodable>(
+  public func decodeIfPresent<T: Decodable>(
     _ type: T.Type, forKey key: Key) throws -> T?
   {
     guard try self.contains(key) && !self.decodeNil(forKey: key)
@@ -2019,14 +2019,14 @@ extension KeyedDecodingContainerProtocol {
 // Default implementation of encodeConditional(_:) in terms of encode(_:),
 // and encode(contentsOf:) in terms of encode(_:) loop.
 extension UnkeyedEncodingContainer {
-  public mutating func encodeConditional<T : AnyObject & Encodable>(
+  public mutating func encodeConditional<T: AnyObject & Encodable>(
     _ object: T) throws
   {
     try self.encode(object)
   }
 
 % for type in codable_types:
-  public mutating func encode<T : Sequence>(
+  public mutating func encode<T: Sequence>(
     contentsOf sequence: T) throws where T.Element == ${type}
   {
     for element in sequence {
@@ -2035,8 +2035,8 @@ extension UnkeyedEncodingContainer {
   }
 % end
 
-  public mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Element : Encodable
+  public mutating func encode<T: Sequence>(
+    contentsOf sequence: T) throws where T.Element: Encodable
   {
     for element in sequence {
       try self.encode(element)
@@ -2056,7 +2056,7 @@ extension UnkeyedDecodingContainer {
   }
 % end
 
-  public mutating func decodeIfPresent<T : Decodable>(
+  public mutating func decodeIfPresent<T: Decodable>(
     _ type: T.Type) throws -> T?
   {
     guard try !self.isAtEnd && !self.decodeNil() else { return nil }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -66,7 +66,7 @@
 ///     // Prints "15.0"
 ///     // Prints "20.0"
 @frozen
-public struct IndexingIterator<Elements : Collection> {
+public struct IndexingIterator<Elements: Collection> {
   @usableFromInline
   internal let _elements: Elements
   @usableFromInline
@@ -346,7 +346,7 @@ public protocol Collection: Sequence {
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript
   /// argument.
-  associatedtype Index : Comparable
+  associatedtype Index: Comparable
 
   /// The position of the first element in a nonempty collection.
   ///
@@ -457,7 +457,7 @@ public protocol Collection: Sequence {
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
-  associatedtype Indices : Collection = DefaultIndices<Self>
+  associatedtype Indices: Collection = DefaultIndices<Self>
     where Indices.Element == Index, 
           Indices.Index == Index,
           Indices.SubSequence == Indices
@@ -1571,7 +1571,7 @@ extension Collection {
   }
 }
 
-extension Collection where Element : Equatable {
+extension Collection where Element: Equatable {
   /// Returns the longest possible subsequences of the collection, in order,
   /// around elements equal to the given element.
   ///

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -36,7 +36,7 @@ extension BidirectionalCollection {
 // firstIndex(of:)/firstIndex(where:)
 //===----------------------------------------------------------------------===//
 
-extension Collection where Element : Equatable {
+extension Collection where Element: Equatable {
   /// Returns the first index where the specified value appears in the
   /// collection.
   ///
@@ -179,7 +179,7 @@ extension BidirectionalCollection {
   }
 }
 
-extension BidirectionalCollection where Element : Equatable {
+extension BidirectionalCollection where Element: Equatable {
   /// Returns the last index where the specified value appears in the
   /// collection.
   ///
@@ -277,7 +277,7 @@ extension MutableCollection {
   }  
 }
 
-extension MutableCollection where Self : BidirectionalCollection {
+extension MutableCollection where Self: BidirectionalCollection {
   /// Reorders the elements of the collection such that all the elements
   /// that match the given predicate are after all the elements that don't
   /// match.
@@ -427,7 +427,7 @@ extension Sequence {
   }
 }
 
-extension MutableCollection where Self : RandomAccessCollection {
+extension MutableCollection where Self: RandomAccessCollection {
   /// Shuffles the collection in place, using the given generator as a source
   /// for randomness.
   ///

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -158,14 +158,14 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   }
 }
 
-extension CollectionOfOne : CustomDebugStringConvertible {
+extension CollectionOfOne: CustomDebugStringConvertible {
   /// A textual representation of the collection, suitable for debugging.
   public var debugDescription: String {
     return "CollectionOfOne(\(String(reflecting: _element)))"
   }
 }
 
-extension CollectionOfOne : CustomReflectable {
+extension CollectionOfOne: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: ["element": _element])
   }

--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -135,7 +135,7 @@
 ///   (`FloatingPoint.nan`) compares as neither less than, greater than, nor
 ///   equal to any normal floating-point value. Exceptional values need not
 ///   take part in the strict total order.
-public protocol Comparable : Equatable {
+public protocol Comparable: Equatable {
   /// Returns a Boolean value indicating whether the value of the first
   /// argument is less than that of the second argument.
   ///

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -149,8 +149,8 @@ public protocol RawRepresentable {
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
 @inlinable // trivial-implementation
-public func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
-  where T.RawValue : Equatable {
+public func == <T: RawRepresentable>(lhs: T, rhs: T) -> Bool
+  where T.RawValue: Equatable {
   return lhs.rawValue == rhs.rawValue
 }
 
@@ -160,21 +160,21 @@ public func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
 @inlinable // trivial-implementation
-public func != <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
-  where T.RawValue : Equatable {
+public func != <T: RawRepresentable>(lhs: T, rhs: T) -> Bool
+  where T.RawValue: Equatable {
   return lhs.rawValue != rhs.rawValue
 }
 
 // This overload is needed for ambiguity resolution against the
-// implementation of != for T : Equatable
+// implementation of != for T: Equatable
 /// Returns a Boolean value indicating whether the two arguments are not equal.
 ///
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
 @inlinable // trivial-implementation
-public func != <T : Equatable>(lhs: T, rhs: T) -> Bool
-  where T : RawRepresentable, T.RawValue : Equatable {
+public func != <T: Equatable>(lhs: T, rhs: T) -> Bool
+  where T: RawRepresentable, T.RawValue: Equatable {
   return lhs.rawValue != rhs.rawValue
 }
 
@@ -298,7 +298,7 @@ public protocol ExpressibleByIntegerLiteral {
   ///
   /// The standard library integer and floating-point types are all valid types
   /// for `IntegerLiteralType`.
-  associatedtype IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral
+  associatedtype IntegerLiteralType: _ExpressibleByBuiltinIntegerLiteral
 
   /// Creates an instance initialized to the specified integer value.
   ///
@@ -341,7 +341,7 @@ public protocol ExpressibleByFloatLiteral {
   ///
   /// Valid types for `FloatLiteralType` are `Float`, `Double`, and `Float80`
   /// where available.
-  associatedtype FloatLiteralType : _ExpressibleByBuiltinFloatLiteral
+  associatedtype FloatLiteralType: _ExpressibleByBuiltinFloatLiteral
   
   /// Creates an instance initialized to the specified floating-point value.
   ///
@@ -373,7 +373,7 @@ public protocol _ExpressibleByBuiltinBooleanLiteral {
 /// of your type with the given Boolean value.
 public protocol ExpressibleByBooleanLiteral {
   /// A type that represents a Boolean literal, such as `Bool`.
-  associatedtype BooleanLiteralType : _ExpressibleByBuiltinBooleanLiteral
+  associatedtype BooleanLiteralType: _ExpressibleByBuiltinBooleanLiteral
 
   /// Creates an instance initialized to the given Boolean value.
   ///
@@ -416,7 +416,7 @@ public protocol ExpressibleByUnicodeScalarLiteral {
   ///
   /// Valid types for `UnicodeScalarLiteralType` are `Unicode.Scalar`,
   /// `Character`, `String`, and `StaticString`.
-  associatedtype UnicodeScalarLiteralType : _ExpressibleByBuiltinUnicodeScalarLiteral
+  associatedtype UnicodeScalarLiteralType: _ExpressibleByBuiltinUnicodeScalarLiteral
 
   /// Creates an instance initialized to the given value.
   ///
@@ -509,7 +509,7 @@ public protocol ExpressibleByStringLiteral
   /// A type that represents a string literal.
   ///
   /// Valid types for `StringLiteralType` are `String` and `StaticString`.
-  associatedtype StringLiteralType : _ExpressibleByBuiltinStringLiteral
+  associatedtype StringLiteralType: _ExpressibleByBuiltinStringLiteral
   
   /// Creates an instance initialized to the given string value.
   ///
@@ -766,7 +766,7 @@ public protocol ExpressibleByStringInterpolation
   ///
   /// The `StringLiteralType` of an interpolation type must match the
   /// `StringLiteralType` of the conforming type.
-  associatedtype StringInterpolation : StringInterpolationProtocol
+  associatedtype StringInterpolation: StringInterpolationProtocol
     = DefaultStringInterpolation
     where StringInterpolation.StringLiteralType == StringLiteralType
 
@@ -883,7 +883,7 @@ extension ExpressibleByStringInterpolation
 /// `try` or one of its variants.
 public protocol StringInterpolationProtocol {
   /// The type that should be used for literal segments.
-  associatedtype StringLiteralType : _ExpressibleByBuiltinStringLiteral
+  associatedtype StringLiteralType: _ExpressibleByBuiltinStringLiteral
 
   /// Creates an empty instance ready to be filled with string literal content.
   /// 

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -60,7 +60,7 @@ internal final class __EmptyArrayStorage
 /// The empty array prototype.  We use the same object for all empty
 /// `[Native]Array<Element>`s.
 @inlinable
-internal var _emptyArrayStorage : __EmptyArrayStorage {
+internal var _emptyArrayStorage: __EmptyArrayStorage {
   return Builtin.bridgeFromRawPointer(
     Builtin.addressof(&_swiftEmptyArrayStorage))
 }
@@ -70,7 +70,7 @@ internal var _emptyArrayStorage : __EmptyArrayStorage {
 @usableFromInline
 internal final class _ContiguousArrayStorage<
   Element
-> : __ContiguousArrayStorageBase {
+>: __ContiguousArrayStorageBase {
 
   @inlinable
   deinit {
@@ -149,14 +149,14 @@ internal final class _ContiguousArrayStorage<
   }
 
   @inlinable
-  internal final var _elementPointer : UnsafeMutablePointer<Element> {
+  internal final var _elementPointer: UnsafeMutablePointer<Element> {
     return UnsafeMutablePointer(Builtin.projectTailElems(self, Element.self))
   }
 }
 
 @usableFromInline
 @frozen
-internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
+internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
   /// Make a buffer with uninitialized elements.  After using this
   /// method, you must either initialize the `count` elements at the
@@ -349,7 +349,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// `0 ≤ index < count`.
   @inlinable
   @inline(__always)
-  internal func _checkValidSubscript(_ index : Int) {
+  internal func _checkValidSubscript(_ index: Int) {
     _precondition(
       (index >= 0) && (index < count),
       "Index out of range"
@@ -493,7 +493,7 @@ internal struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
 
 /// Append the elements of `rhs` to `lhs`.
 @inlinable
-internal func += <Element, C : Collection>(
+internal func += <Element, C: Collection>(
   lhs: inout _ContiguousArrayBuffer<Element>, rhs: __owned C
 ) where C.Element == Element {
 
@@ -525,7 +525,7 @@ internal func += <Element, C : Collection>(
   _precondition(writtenUpTo == buf.endIndex, "rhs overreported its count")    
 }
 
-extension _ContiguousArrayBuffer : RandomAccessCollection {
+extension _ContiguousArrayBuffer: RandomAccessCollection {
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
@@ -556,7 +556,7 @@ extension Sequence {
 
 @inlinable
 internal func _copySequenceToContiguousArray<
-  S : Sequence
+  S: Sequence
 >(_ source: S) -> ContiguousArray<S.Element> {
   let initialCapacity = source.underestimatedCount
   var builder =
@@ -604,7 +604,7 @@ extension _ContiguousArrayBuffer {
 /// should be changed to use _UnsafePartiallyInitializedContiguousArrayBuffer.
 @inlinable
 internal func _copyCollectionToContiguousArray<
-  C : Collection
+  C: Collection
 >(_ source: C) -> ContiguousArray<C.Element>
 {
   let count: Int = numericCast(source.count)

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -125,7 +125,7 @@ public enum _DebuggerSupport {
     return true
   }
 
-  private static func printForDebuggerImpl<StreamType : TextOutputStream>(
+  private static func printForDebuggerImpl<StreamType: TextOutputStream>(
     value: Any?,
     mirror: Mirror,
     name: String?,
@@ -261,6 +261,6 @@ public func _debuggerTestingCheckExpect(_: String, _: String) { }
 @_silgen_name("swift_retainCount")
 public func _getRetainCount(_ Value: AnyObject) -> UInt
 @_silgen_name("swift_unownedRetainCount")
-public func _getUnownedRetainCount(_ Value : AnyObject) -> UInt
+public func _getUnownedRetainCount(_ Value: AnyObject) -> UInt
 @_silgen_name("swift_weakRetainCount")
-public func _getWeakRetainCount(_ Value : AnyObject) -> UInt
+public func _getWeakRetainCount(_ Value: AnyObject) -> UInt

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -140,7 +140,7 @@ extension BidirectionalCollection {
   }
 }
 
-extension BidirectionalCollection where Element : Equatable {
+extension BidirectionalCollection where Element: Equatable {
   /// Returns the difference needed to produce this collection's ordered
   /// elements from the given collection.
   ///
@@ -215,8 +215,8 @@ fileprivate func _myers<C,D>(
   using cmp: (C.Element, D.Element) -> Bool
 ) -> CollectionDifference<C.Element>
   where
-    C : BidirectionalCollection,
-    D : BidirectionalCollection,
+    C: BidirectionalCollection,
+    D: BidirectionalCollection,
     C.Element == D.Element
 {
 
@@ -334,7 +334,7 @@ fileprivate func _myers<C,D>(
    * necessary) is significantly less than the worst-case n² memory use of the
    * descent algorithm.
    */
-  func _withContiguousStorage<C : Collection, R>(
+  func _withContiguousStorage<C: Collection, R>(
     for values: C,
     _ body: (UnsafeBufferPointer<C.Element>) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -27,7 +27,7 @@
 /// - Returns: The instance passed as `value`.
 @discardableResult
 @_semantics("optimize.sil.specialize.generic.never")
-public func dump<T, TargetStream : TextOutputStream>(
+public func dump<T, TargetStream: TextOutputStream>(
   _ value: T,
   to target: inout TargetStream,
   name: String? = nil,
@@ -36,7 +36,7 @@ public func dump<T, TargetStream : TextOutputStream>(
   maxItems: Int = .max
 ) -> T {
   var maxItemCounter = maxItems
-  var visitedItems = [ObjectIdentifier : Int]()
+  var visitedItems = [ObjectIdentifier: Int]()
   target._lock()
   defer { target._unlock() }
   _dump_unlocked(
@@ -84,14 +84,14 @@ public func dump<T>(
 
 /// Dump an object's contents. User code should use dump().
 @_semantics("optimize.sil.specialize.generic.never")
-internal func _dump_unlocked<TargetStream : TextOutputStream>(
+internal func _dump_unlocked<TargetStream: TextOutputStream>(
   _ value: Any,
   to target: inout TargetStream,
   name: String?,
   indent: Int,
   maxDepth: Int,
   maxItemCounter: inout Int,
-  visitedItems: inout [ObjectIdentifier : Int]
+  visitedItems: inout [ObjectIdentifier: Int]
 ) {
   guard maxItemCounter > 0 else { return }
   maxItemCounter -= 1
@@ -183,13 +183,13 @@ internal func _dump_unlocked<TargetStream : TextOutputStream>(
 /// Dump information about an object's superclass, given a mirror reflecting
 /// that superclass.
 @_semantics("optimize.sil.specialize.generic.never")
-internal func _dumpSuperclass_unlocked<TargetStream : TextOutputStream>(
+internal func _dumpSuperclass_unlocked<TargetStream: TextOutputStream>(
   mirror: Mirror,
   to target: inout TargetStream,
   indent: Int,
   maxDepth: Int,
   maxItemCounter: inout Int,
-  visitedItems: inout [ObjectIdentifier : Int]
+  visitedItems: inout [ObjectIdentifier: Int]
 ) {
   guard maxItemCounter > 0 else { return }
   maxItemCounter -= 1

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -164,7 +164,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 }
 
-extension EmptyCollection : Equatable {
+extension EmptyCollection: Equatable {
   @inlinable // trivial-implementation
   public static func == (
     lhs: EmptyCollection<Element>, rhs: EmptyCollection<Element>

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -135,32 +135,32 @@ extension Error {
 // Helper functions for the C++ runtime to have easy access to embedded error,
 // domain, code, and userInfo as Objective-C values.
 @_silgen_name("")
-internal func _getErrorDomainNSString<T : Error>(_ x: UnsafePointer<T>)
+internal func _getErrorDomainNSString<T: Error>(_ x: UnsafePointer<T>)
 -> AnyObject {
   return x.pointee._domain._bridgeToObjectiveCImpl()
 }
 
 @_silgen_name("")
-internal func _getErrorCode<T : Error>(_ x: UnsafePointer<T>) -> Int {
+internal func _getErrorCode<T: Error>(_ x: UnsafePointer<T>) -> Int {
   return x.pointee._code
 }
 
 @_silgen_name("")
-internal func _getErrorUserInfoNSDictionary<T : Error>(_ x: UnsafePointer<T>)
+internal func _getErrorUserInfoNSDictionary<T: Error>(_ x: UnsafePointer<T>)
 -> AnyObject? {
   return x.pointee._userInfo.map { $0 as AnyObject }
 }
 
 // Called by the casting machinery to extract an NSError from an Error value.
 @_silgen_name("")
-internal func _getErrorEmbeddedNSErrorIndirect<T : Error>(
+internal func _getErrorEmbeddedNSErrorIndirect<T: Error>(
     _ x: UnsafePointer<T>) -> AnyObject? {
   return x.pointee._getEmbeddedNSError()
 }
 
 /// Called by compiler-generated code to extract an NSError from an Error value.
 public // COMPILER_INTRINSIC
-func _getErrorEmbeddedNSError<T : Error>(_ x: T)
+func _getErrorEmbeddedNSError<T: Error>(_ x: T)
 -> AnyObject? {
   return x._getEmbeddedNSError()
 }
@@ -203,7 +203,7 @@ public func _errorInMain(_ error: Error) {
 /// Runtime function to determine the default code for an Error-conforming type.
 /// Called by the Foundation overlay.
 @_silgen_name("_swift_stdlib_getDefaultErrorCode")
-public func _getDefaultErrorCode<T : Error>(_ error: T) -> Int
+public func _getDefaultErrorCode<T: Error>(_ error: T) -> Int
 
 extension Error {
   public var _code: Int {

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -68,7 +68,7 @@ public struct AnyIterator<Element> {
   ///
   /// - Parameter base: An iterator to type-erase.
   @inlinable
-  public init<I : IteratorProtocol>(_ base: I) where I.Element == Element {
+  public init<I: IteratorProtocol>(_ base: I) where I.Element == Element {
     self._box = _IteratorBox(base)
   }
 
@@ -116,7 +116,7 @@ extension AnyIterator: Sequence { }
 
 @usableFromInline
 @frozen
-internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
+internal struct _ClosureBasedIterator<Element>: IteratorProtocol {
   @inlinable
   internal init(_ body: @escaping () -> Element?) {
     self._body = body
@@ -129,7 +129,7 @@ internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
 
 @_fixed_layout
 @usableFromInline
-internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
+internal class _AnyIteratorBoxBase<Element>: IteratorProtocol {
   @inlinable // FIXME(sil-serialize-all)
   internal init() {}
 
@@ -148,8 +148,8 @@ internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
 @_fixed_layout
 @usableFromInline
 internal final class _IteratorBox<
-  Base : IteratorProtocol
-> : _AnyIteratorBoxBase<Base.Element> {
+  Base: IteratorProtocol
+>: _AnyIteratorBoxBase<Base.Element> {
   @inlinable
   internal init(_ base: Base) { self._base = base }
   @inlinable // FIXME(sil-serialize-all)
@@ -170,7 +170,7 @@ internal final class _IteratorBox<
 %   if Kind == 'Sequence':
 internal class _AnySequenceBox<Element>
 %   elif Kind == 'Collection':
-internal class _AnyCollectionBox<Element> : _AnySequenceBox<Element>
+internal class _AnyCollectionBox<Element>: _AnySequenceBox<Element>
 %   elif Kind == 'BidirectionalCollection':
 internal class _AnyBidirectionalCollectionBox<Element>
   : _AnyCollectionBox<Element>
@@ -425,7 +425,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
 @_fixed_layout
 @usableFromInline
-internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
+internal final class _${Kind}Box<S: ${Kind}>: _Any${Kind}Box<S.Element>
 {
   @usableFromInline
   internal typealias Element = S.Element
@@ -673,7 +673,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
 
 @usableFromInline
 @frozen
-internal struct _ClosureBasedSequence<Iterator : IteratorProtocol> {
+internal struct _ClosureBasedSequence<Iterator: IteratorProtocol> {
   @usableFromInline
   internal var _makeUnderlyingIterator: () -> Iterator
 
@@ -703,7 +703,7 @@ public struct AnySequence<Element> {
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
   @inlinable
-  public init<I : IteratorProtocol>(
+  public init<I: IteratorProtocol>(
     _ makeUnderlyingIterator: @escaping () -> I
   ) where I.Element == Element {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
@@ -720,7 +720,7 @@ extension  AnySequence: Sequence {
 
   /// Creates a new sequence that wraps and forwards operations to `base`.
   @inlinable
-  public init<S : Sequence>(_ base: S)
+  public init<S: Sequence>(_ base: S)
     where
     S.Element == Element {
     self._box = _SequenceBox(_base: base)
@@ -841,10 +841,10 @@ extension Any${Kind} {
 //===----------------------------------------------------------------------===//
 
 @usableFromInline
-internal protocol _AnyIndexBox : class {
+internal protocol _AnyIndexBox: class {
   var _typeID: ObjectIdentifier { get }
 
-  func _unbox<T : Comparable>() -> T?
+  func _unbox<T: Comparable>() -> T?
 
   func _isEqual(to rhs: _AnyIndexBox) -> Bool
 
@@ -873,7 +873,7 @@ internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
   }
 
   @inlinable
-  internal func _unbox<T : Comparable>() -> T? {
+  internal func _unbox<T: Comparable>() -> T? {
     return (self as _AnyIndexBox as? _IndexBox<T>)?._base
   }
 
@@ -896,7 +896,7 @@ public struct AnyIndex {
 
   /// Creates a new index wrapping `base`.
   @inlinable
-  public init<BaseIndex : Comparable>(_ base: BaseIndex) {
+  public init<BaseIndex: Comparable>(_ base: BaseIndex) {
     self._box = _IndexBox(_base: base)
   }
 
@@ -911,7 +911,7 @@ public struct AnyIndex {
   }
 }
 
-extension AnyIndex : Comparable {
+extension AnyIndex: Comparable {
   /// Returns a Boolean value indicating whether two indices wrap equal
   /// underlying indices.
   ///
@@ -945,7 +945,7 @@ extension AnyIndex : Comparable {
 //===----------------------------------------------------------------------===//
 
 public // @testable
-protocol _AnyCollectionProtocol : Collection {
+protocol _AnyCollectionProtocol: Collection {
   /// Identifies the underlying collection stored by `self`. Instances
   /// copied or upgraded/downgraded from one another have the same `_boxID`.
   var _boxID: ObjectIdentifier { get }
@@ -986,7 +986,7 @@ extension ${Self}: ${SelfProtocol} {
   /// - Complexity: O(1).
   @inline(__always)
   @inlinable
-  public init<C : ${SubProtocol}>(_ base: C) where C.Element == Element {
+  public init<C: ${SubProtocol}>(_ base: C) where C.Element == Element {
     // Traversal: ${Traversal}
     // SubTraversal: ${SubTraversal}
     self._box = _${SubProtocol}Box<C>(

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -296,8 +296,8 @@ extension LazyFilterCollection: Collection {
 
 extension LazyFilterCollection: LazyCollectionProtocol { }
 
-extension LazyFilterCollection : BidirectionalCollection
-  where Base : BidirectionalCollection {
+extension LazyFilterCollection: BidirectionalCollection
+  where Base: BidirectionalCollection {
 
   @inlinable // lazy-performance
   public func index(before i: Index) -> Index {

--- a/stdlib/public/core/FixedArray.swift
+++ b/stdlib/public/core/FixedArray.swift
@@ -42,14 +42,14 @@ extension _FixedArray16 {
   }
 }
 
-extension _FixedArray16 : RandomAccessCollection, MutableCollection {
+extension _FixedArray16: RandomAccessCollection, MutableCollection {
   internal typealias Index = Int
 
-  internal var startIndex : Index {
+  internal var startIndex: Index {
     return 0
   }
 
-  internal var endIndex : Index {
+  internal var endIndex: Index {
     return count
   }
 
@@ -59,7 +59,7 @@ extension _FixedArray16 : RandomAccessCollection, MutableCollection {
       let count = self.count // for exclusive access
       _internalInvariant(i >= 0 && i < count)
       let res: T = withUnsafeBytes(of: storage) {
-        (rawPtr : UnsafeRawBufferPointer) -> T in
+        (rawPtr: UnsafeRawBufferPointer) -> T in
         let stride = MemoryLayout<T>.stride
         _internalInvariant(rawPtr.count == 16*stride, "layout mismatch?")
         let bufPtr = UnsafeBufferPointer(
@@ -97,7 +97,7 @@ extension _FixedArray16 {
   }
 }
 
-extension _FixedArray16 where T : ExpressibleByIntegerLiteral {
+extension _FixedArray16 where T: ExpressibleByIntegerLiteral {
   @inline(__always)
   internal init(count: Int) {
     _internalInvariant(count >= 0 && count <= _FixedArray16.capacity)

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -95,7 +95,7 @@ extension FlattenSequence: Sequence {
   }
 }
 
-extension Sequence where Element : Sequence {
+extension Sequence where Element: Sequence {
   /// Returns the elements of this sequence of sequences, concatenated.
   ///
   /// In this example, an array of three ranges is flattened so that the
@@ -125,7 +125,7 @@ extension Sequence where Element : Sequence {
   }
 }
 
-extension LazySequenceProtocol where Element : Sequence {
+extension LazySequenceProtocol where Element: Sequence {
   /// Returns a lazy sequence that concatenates the elements of this sequence of
   /// sequences.
   @inlinable // lazy-performance
@@ -161,7 +161,7 @@ extension FlattenSequence where Base: Collection, Base.Element: Collection {
   }
 }
 
-extension FlattenSequence.Index : Equatable where Base: Collection, Base.Element: Collection {
+extension FlattenSequence.Index: Equatable where Base: Collection, Base.Element: Collection {
   @inlinable // lazy-performance
   public static func == (
     lhs: FlattenCollection<Base>.Index,
@@ -171,7 +171,7 @@ extension FlattenSequence.Index : Equatable where Base: Collection, Base.Element
   }
 }
 
-extension FlattenSequence.Index : Comparable where Base: Collection, Base.Element: Collection {
+extension FlattenSequence.Index: Comparable where Base: Collection, Base.Element: Collection {
   @inlinable // lazy-performance
   public static func < (
     lhs: FlattenCollection<Base>.Index,
@@ -195,8 +195,8 @@ extension FlattenSequence.Index : Comparable where Base: Collection, Base.Elemen
   }
 }
 
-extension FlattenSequence.Index : Hashable
-  where Base: Collection, Base.Element: Collection, Base.Index : Hashable, Base.Element.Index : Hashable {
+extension FlattenSequence.Index: Hashable
+  where Base: Collection, Base.Element: Collection, Base.Index: Hashable, Base.Element.Index: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
@@ -399,8 +399,8 @@ extension FlattenCollection: Collection {
   }
 }
 
-extension FlattenCollection : BidirectionalCollection
-  where Base : BidirectionalCollection, Base.Element : BidirectionalCollection {
+extension FlattenCollection: BidirectionalCollection
+  where Base: BidirectionalCollection, Base.Element: BidirectionalCollection {
 
   // FIXME(performance): swift-3-indexing-model: add custom advance/distance
   // methods that skip over inner collections when random-access

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -158,7 +158,7 @@
 ///     print("Average: \(average)°F in \(validTemps.count) " +
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
-public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
+public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
                                 where Magnitude == Self {
 
   /// A type that can represent any written exponent.
@@ -244,14 +244,14 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// with more trailing zeros in its significand bit pattern.
   ///
   /// - Parameter value: The integer to convert to a floating-point value.
-  init<Source : BinaryInteger>(_ value: Source)
+  init<Source: BinaryInteger>(_ value: Source)
 
   /// Creates a new value, if the given integer can be represented exactly.
   ///
   /// If the given integer cannot be represented exactly, the result is `nil`.
   ///
   /// - Parameter value: The integer to convert to a floating-point value.
-  init?<Source : BinaryInteger>(exactly value: Source)
+  init?<Source: BinaryInteger>(exactly value: Source)
 
   /// The radix, or base of exponentiation, for a floating-point type.
   ///
@@ -1512,7 +1512,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// with more trailing zeros in its significand bit pattern.
   ///
   /// - Parameter value: A floating-point value to be converted.
-  init<Source : BinaryFloatingPoint>(_ value: Source)
+  init<Source: BinaryFloatingPoint>(_ value: Source)
 
   /// Creates a new instance from the given value, if it can be represented
   /// exactly.
@@ -1522,7 +1522,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// represented exactly if its payload cannot be encoded exactly.
   ///
   /// - Parameter value: A floating-point value to be converted.
-  init?<Source : BinaryFloatingPoint>(exactly value: Source)
+  init?<Source: BinaryFloatingPoint>(exactly value: Source)
 
   /// The number of bits used to represent the type's exponent.
   ///
@@ -2062,7 +2062,7 @@ extension BinaryFloatingPoint {
 
   @inlinable
   public // @testable
-  static func _convert<Source : BinaryFloatingPoint>(
+  static func _convert<Source: BinaryFloatingPoint>(
     from source: Source
   ) -> (value: Self, exact: Bool) {
     guard _fastPath(!source.isZero) else {
@@ -2203,7 +2203,7 @@ extension BinaryFloatingPoint {
   ///
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
-  public init<Source : BinaryFloatingPoint>(_ value: Source) {
+  public init<Source: BinaryFloatingPoint>(_ value: Source) {
     self = Self._convert(from: value).value
   }
 
@@ -2215,7 +2215,7 @@ extension BinaryFloatingPoint {
   ///
   /// - Parameter value: A floating-point value to be converted.
   @inlinable
-  public init?<Source : BinaryFloatingPoint>(exactly value: Source) {
+  public init?<Source: BinaryFloatingPoint>(exactly value: Source) {
     let (value_, exact) = Self._convert(from: value)
     guard exact else { return nil }
     self = value_
@@ -2268,11 +2268,11 @@ extension BinaryFloatingPoint {
   }
 }
 
-extension BinaryFloatingPoint where Self.RawSignificand : FixedWidthInteger {
+extension BinaryFloatingPoint where Self.RawSignificand: FixedWidthInteger {
   
   @inlinable
   public // @testable
-  static func _convert<Source : BinaryInteger>(
+  static func _convert<Source: BinaryInteger>(
     from source: Source
   ) -> (value: Self, exact: Bool) {
     //  Useful constants:
@@ -2335,7 +2335,7 @@ extension BinaryFloatingPoint where Self.RawSignificand : FixedWidthInteger {
   ///
   /// - Parameter value: The integer to convert to a floating-point value.
   @inlinable
-  public init<Source : BinaryInteger>(_ value: Source) {
+  public init<Source: BinaryInteger>(_ value: Source) {
     self = Self._convert(from: value).value
   }
   
@@ -2345,7 +2345,7 @@ extension BinaryFloatingPoint where Self.RawSignificand : FixedWidthInteger {
   ///
   /// - Parameter value: The integer to convert to a floating-point value.
   @inlinable
-  public init?<Source : BinaryInteger>(exactly value: Source) {
+  public init?<Source: BinaryInteger>(exactly value: Source) {
     let (value_, exact) = Self._convert(from: value)
     guard exact else { return nil }
     self = value_

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -43,7 +43,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 % end
 
 //===--- Parsing ----------------------------------------------------------===//
-extension ${Self} : LosslessStringConvertible {
+extension ${Self}: LosslessStringConvertible {
   /// Creates a new instance from the given string.
   ///
   /// The string passed as `text` can represent a real number in decimal or
@@ -128,7 +128,7 @@ extension ${Self} : LosslessStringConvertible {
   public init?<S: StringProtocol>(_ text: S) {
     let u8 = text.utf8
 
-    let (result, n) : (${Self}, Int) = text.withCString { chars in
+    let (result, n): (${Self}, Int) = text.withCString { chars in
       var result: ${Self} = 0
       let endPtr = withUnsafeMutablePointer(to: &result) {
         _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, $0)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -77,7 +77,7 @@ public struct ${Self} {
   }
 }
 
-extension ${Self} : CustomStringConvertible {
+extension ${Self}: CustomStringConvertible {
   /// A textual representation of the value.
   public var description: String {
     if isNaN {
@@ -92,7 +92,7 @@ extension ${Self} : CustomStringConvertible {
   }
 }
 
-extension ${Self} : CustomDebugStringConvertible {
+extension ${Self}: CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
   public var debugDescription: String {
     var (buffer, length) = _float${bits}ToString(self, debug: true)
@@ -103,8 +103,8 @@ extension ${Self} : CustomDebugStringConvertible {
   }
 }
 
-extension ${Self} : TextOutputStreamable {
-  public func write<Target>(to target: inout Target) where Target : TextOutputStream {
+extension ${Self}: TextOutputStreamable {
+  public func write<Target>(to target: inout Target) where Target: TextOutputStream {
     var (buffer, length) = _float${bits}ToString(self, debug: true)
     buffer.withBytes { (bufferPtr) in
       let bufPtr = UnsafeBufferPointer(start: bufferPtr, count: length)
@@ -1472,7 +1472,7 @@ extension ${Self}: BinaryFloatingPoint {
   }
 }
 
-extension ${Self} : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLiteral {
+extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLiteral {
   @_transparent
   public
   init(_builtinIntegerLiteral value: Builtin.IntLiteral){
@@ -1503,7 +1503,7 @@ extension ${Self} : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLit
 % end
 
 % builtinFloatLiteralBits = 80
-extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
+extension ${Self}: _ExpressibleByBuiltinFloatLiteral {
   @_transparent
   public
   init(_builtinFloatLiteral value: Builtin.FPIEEE${builtinFloatLiteralBits}) {
@@ -1522,7 +1522,7 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
 #else
 
 % builtinFloatLiteralBits = 64
-extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
+extension ${Self}: _ExpressibleByBuiltinFloatLiteral {
   @_transparent
   public
   init(_builtinFloatLiteral value: Builtin.FPIEEE${builtinFloatLiteralBits}) {
@@ -1541,7 +1541,7 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
 #endif
 % end
 
-extension ${Self} : Hashable {
+extension ${Self}: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
@@ -1645,7 +1645,7 @@ extension ${Self} {
   // falling back on the generic _convert operation otherwise.
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init<Source : BinaryInteger>(_ value: Source) {
+  public init<Source: BinaryInteger>(_ value: Source) {
     if value.bitWidth <= ${word_bits} {
       if Source.isSigned {
         let asInt = Int(truncatingIfNeeded: value)
@@ -1778,7 +1778,7 @@ extension ${Self} {
 // Strideable Conformance
 //===----------------------------------------------------------------------===//
 
-extension ${Self} : Strideable {
+extension ${Self}: Strideable {
   /// Returns the distance from this value to the specified value.
   ///
   /// For two values `x` and `y`, the result of `x.distance(to: y)` is equal to
@@ -1926,14 +1926,14 @@ public struct ${Self} {
 @_transparent
 @available(*, unavailable,
   message: "For floating point numbers use truncatingRemainder instead")
-public func % <T : BinaryFloatingPoint>(lhs: T, rhs: T) -> T {
+public func % <T: BinaryFloatingPoint>(lhs: T, rhs: T) -> T {
   fatalError("% is not available.")
 }
 
 @_transparent
 @available(*, unavailable,
   message: "For floating point numbers use formTruncatingRemainder instead")
-public func %= <T : BinaryFloatingPoint> (lhs: inout T, rhs: T) {
+public func %= <T: BinaryFloatingPoint> (lhs: inout T, rhs: T) {
   fatalError("%= is not available.")
 }
 

--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -101,7 +101,7 @@
 ///         print("New tap detected at (\(nextTap.x), \(nextTap.y)).")
 ///     }
 ///     // Prints "New tap detected at (0, 1).")
-public protocol Hashable : Equatable {
+public protocol Hashable: Equatable {
   /// The hash value.
   ///
   /// Hash values are not guaranteed to be equal across different executions of
@@ -151,7 +151,7 @@ public func _hashValue<H: Hashable>(for value: H) -> Int {
 
 // Called by the SwiftValue implementation.
 @_silgen_name("_swift_stdlib_Hashable_isEqual_indirect")
-internal func Hashable_isEqual_indirect<T : Hashable>(
+internal func Hashable_isEqual_indirect<T: Hashable>(
   _ lhs: UnsafePointer<T>,
   _ rhs: UnsafePointer<T>
 ) -> Bool {
@@ -160,7 +160,7 @@ internal func Hashable_isEqual_indirect<T : Hashable>(
 
 // Called by the SwiftValue implementation.
 @_silgen_name("_swift_stdlib_Hashable_hashValue_indirect")
-internal func Hashable_hashValue_indirect<T : Hashable>(
+internal func Hashable_hashValue_indirect<T: Hashable>(
   _ value: UnsafePointer<T>
 ) -> Int {
   return value.pointee.hashValue

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -19,7 +19,7 @@ internal func _ascii16(_ c: Unicode.Scalar) -> UTF16.CodeUnit {
 
 @inlinable
 @inline(__always)
-internal func _asciiDigit<CodeUnit : UnsignedInteger, Result : BinaryInteger>(
+internal func _asciiDigit<CodeUnit: UnsignedInteger, Result: BinaryInteger>(
   codeUnit u_: CodeUnit, radix: Result
 ) -> Result? {
   let digit = _ascii16("0")..._ascii16("9")
@@ -39,11 +39,11 @@ internal func _asciiDigit<CodeUnit : UnsignedInteger, Result : BinaryInteger>(
 @inlinable
 @inline(__always)
 internal func _parseUnsignedASCII<
-  Rest : IteratorProtocol, Result: FixedWidthInteger
+  Rest: IteratorProtocol, Result: FixedWidthInteger
 >(
   first: Rest.Element, rest: inout Rest, radix: Result, positive: Bool
 ) -> Result?
-where Rest.Element : UnsignedInteger {
+where Rest.Element: UnsignedInteger {
   let r0 = _asciiDigit(codeUnit: first, radix: radix)
   guard _fastPath(r0 != nil), var result = r0 else { return nil }
   if !positive {
@@ -75,11 +75,11 @@ where Rest.Element : UnsignedInteger {
 @inlinable
 @inline(__always)
 internal func _parseASCII<
-  CodeUnits : IteratorProtocol, Result: FixedWidthInteger
+  CodeUnits: IteratorProtocol, Result: FixedWidthInteger
 >(
   codeUnits: inout CodeUnits, radix: Result
 ) -> Result?
-where CodeUnits.Element : UnsignedInteger {
+where CodeUnits.Element: UnsignedInteger {
   let c0_ = codeUnits.next()
   guard _fastPath(c0_ != nil), let c0 = c0_ else { return nil }
   if _fastPath(c0 != _ascii16("+") && c0 != _ascii16("-")) {
@@ -106,11 +106,11 @@ extension FixedWidthInteger {
   @inline(never)
   @usableFromInline
   internal static func _parseASCIISlowPath<
-    CodeUnits : IteratorProtocol, Result: FixedWidthInteger
+    CodeUnits: IteratorProtocol, Result: FixedWidthInteger
   >(
     codeUnits: inout CodeUnits, radix: Result
   ) -> Result?
-  where CodeUnits.Element : UnsignedInteger {
+  where CodeUnits.Element: UnsignedInteger {
     return _parseASCII(codeUnits: &codeUnits, radix: radix)
   }
 
@@ -148,7 +148,7 @@ extension FixedWidthInteger {
   ///     value. `radix` must be in the range `2...36`. The default is 10.
   @inlinable // @specializable
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  public init?<S : StringProtocol>(_ text: S, radix: Int = 10) {
+  public init?<S: StringProtocol>(_ text: S, radix: Int = 10) {
     _precondition(2...36 ~= radix, "Radix not in range 2...36")
 
     if let str = text as? String, str._guts.isFastUTF8 {

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -30,12 +30,12 @@ class struct(object):
     return 'struct(%r)' % self.__dict__
 
 binaryArithmetic = {
-  'Numeric' : [
+  'Numeric': [
     struct(operator='+', name='adding',      firstArg='_',  llvmName='add', kind='+'),
     struct(operator='-', name='subtracting', firstArg='_',  llvmName='sub', kind='-'),
     struct(operator='*', name='multiplied',  firstArg='by', llvmName='mul', kind='*'),
   ],
-  'BinaryInteger' : [
+  'BinaryInteger': [
     struct(operator='/', name='divided',     firstArg='by', llvmName='div', kind='/'),
     struct(operator='%', name='remainder',   firstArg='dividingBy', llvmName='rem', kind='/'),
   ],
@@ -1115,7 +1115,7 @@ public struct ${Self}
   }
 
 %   if Self in ['Int32', 'Int64']:
-%     Floating = {32 : 'Float', 64 : 'Double'}[bits]
+%     Floating = {32: 'Float', 64: 'Double'}[bits]
   @available(*, unavailable,
     message: "Please use ${Self}(bitPattern: ${OtherSelf}) in combination with ${Floating}.bitPattern property.")
   public init(bitPattern x: ${Floating}) {
@@ -1334,7 +1334,7 @@ ${assignmentOperatorComment(x.operator, True)}
   /// The bit width of ${Article.lower()} `${Self}` instance is ${bits}.
 %   end
   @_transparent
-  public static var bitWidth : Int { return ${bits} }
+  public static var bitWidth: Int { return ${bits} }
 
   /// The number of leading zeros in this value's binary representation.
   ///
@@ -1385,7 +1385,7 @@ ${assignmentOperatorComment(x.operator, True)}
 
   /// A type that represents the words of this integer.
   @frozen
-  public struct Words : RandomAccessCollection {
+  public struct Words: RandomAccessCollection {
     public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>
 
@@ -1627,7 +1627,7 @@ ${assignmentOperatorComment(x.operator, True)}
 }
 %# end of concrete type: ${Self}
 
-extension ${Self} : Hashable {
+extension ${Self}: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
@@ -1653,7 +1653,7 @@ extension ${Self} : Hashable {
   }
 }
 
-extension ${Self} : _HasCustomAnyHashableRepresentation {
+extension ${Self}: _HasCustomAnyHashableRepresentation {
   // Not @inlinable
   public func _toCustomAnyHashable() -> AnyHashable? {
     return AnyHashable(_box: _IntegerAnyHashableBox(self))

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -16,7 +16,7 @@
 
 // FIXME(integers): This should go in the stdlib separately, probably.
 extension ExpressibleByIntegerLiteral
-  where Self : _ExpressibleByBuiltinIntegerLiteral {
+  where Self: _ExpressibleByBuiltinIntegerLiteral {
   @_transparent
   public init(integerLiteral value: Self) {
     self = value
@@ -61,7 +61,7 @@ extension ExpressibleByIntegerLiteral
 /// implement the required operators, and provide a static `zero` property
 /// using a type that can represent the magnitude of any value of your custom
 /// type.
-public protocol AdditiveArithmetic : Equatable {
+public protocol AdditiveArithmetic: Equatable {
   /// The zero value.
   ///
   /// Zero is the identity element for addition. For any value,
@@ -140,7 +140,7 @@ public extension AdditiveArithmetic {
   }
 }
 
-public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
+public extension AdditiveArithmetic where Self: ExpressibleByIntegerLiteral {
   /// The zero value.
   ///
   /// Zero is the identity element for addition. For any value,
@@ -190,7 +190,7 @@ public extension AdditiveArithmetic where Self : ExpressibleByIntegerLiteral {
 /// the required initializer and operators, and provide a `magnitude` property
 /// using a type that can represent the magnitude of any value of your custom
 /// type.
-public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
+public protocol Numeric: AdditiveArithmetic, ExpressibleByIntegerLiteral {
   /// Creates a new instance from the given integer, if it can be represented
   /// exactly.
   ///
@@ -206,11 +206,11 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
   ///     // y == nil
   ///
   /// - Parameter source: A value to convert to this type.
-  init?<T : BinaryInteger>(exactly source: T)
+  init?<T: BinaryInteger>(exactly source: T)
 
   /// A type that can represent the absolute value of any possible value of the
   /// conforming type.
-  associatedtype Magnitude : Comparable, Numeric
+  associatedtype Magnitude: Comparable, Numeric
 
   /// The magnitude of this value.
   ///
@@ -282,7 +282,7 @@ public protocol Numeric : AdditiveArithmetic, ExpressibleByIntegerLiteral {
 ///     let x = Int.min
 ///     let y = -x
 ///     // Overflow error
-public protocol SignedNumeric : Numeric {
+public protocol SignedNumeric: Numeric {
   /// Returns the additive inverse of the specified value.
   ///
   /// The negation operator (prefix `-`) returns the additive inverse of its
@@ -382,7 +382,7 @@ extension SignedNumeric {
 /// - Parameter x: A signed number.
 /// - Returns: The absolute value of `x`.
 @inlinable
-public func abs<T : SignedNumeric & Comparable>(_ x: T) -> T {
+public func abs<T: SignedNumeric & Comparable>(_ x: T) -> T {
   if T.self == T.Magnitude.self {
     return unsafeBitCast(x.magnitude, to: T.self)
   }
@@ -570,7 +570,7 @@ extension AdditiveArithmetic {
 ///     // Prints "23 is greater than -23."
 public protocol BinaryInteger :
   Hashable, Numeric, CustomStringConvertible, Strideable
-  where Magnitude : BinaryInteger, Magnitude.Magnitude == Magnitude
+  where Magnitude: BinaryInteger, Magnitude.Magnitude == Magnitude
 {
   /// A Boolean value indicating whether this type is a signed integer type.
   ///
@@ -592,7 +592,7 @@ public protocol BinaryInteger :
   ///     // y == nil
   ///
   /// - Parameter source: A floating-point value to convert to an integer.
-  init?<T : BinaryFloatingPoint>(exactly source: T)
+  init?<T: BinaryFloatingPoint>(exactly source: T)
 
   /// Creates an integer from the given floating-point value, rounding toward
   /// zero.
@@ -614,7 +614,7 @@ public protocol BinaryInteger :
   /// - Parameter source: A floating-point value to convert to an integer.
   ///   `source` must be representable in this type after rounding toward
   ///   zero.
-  init<T : BinaryFloatingPoint>(_ source: T)
+  init<T: BinaryFloatingPoint>(_ source: T)
 
   /// Creates a new instance from the given integer.
   ///
@@ -631,7 +631,7 @@ public protocol BinaryInteger :
   ///
   /// - Parameter source: An integer to convert. `source` must be representable
   ///   in this type.
-  init<T : BinaryInteger>(_ source: T)
+  init<T: BinaryInteger>(_ source: T)
 
   /// Creates a new instance from the bit pattern of the given instance by
   /// sign-extending or truncating to fit this type.
@@ -669,7 +669,7 @@ public protocol BinaryInteger :
   ///     // 'y' has a binary representation of 11111111_11101011
   ///
   /// - Parameter source: An integer to convert to this type.
-  init<T : BinaryInteger>(truncatingIfNeeded source: T)
+  init<T: BinaryInteger>(truncatingIfNeeded source: T)
 
   /// Creates a new instance with the representable value that's closest to the
   /// given integer.
@@ -691,13 +691,13 @@ public protocol BinaryInteger :
   ///     // y == 0
   ///
   /// - Parameter source: An integer to convert to this type.
-  init<T : BinaryInteger>(clamping source: T)
+  init<T: BinaryInteger>(clamping source: T)
 
   /// A type that represents the words of a binary integer.
   ///
   /// The `Words` type must conform to the `RandomAccessCollection` protocol
   /// with an `Element` type of `UInt` and `Index` type of `Int.
-  associatedtype Words : RandomAccessCollection
+  associatedtype Words: RandomAccessCollection
       where Words.Element == UInt, Words.Index == Int
 
   /// A collection containing the words of this value's binary
@@ -1657,7 +1657,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   public static func == <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
@@ -1714,7 +1714,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_transparent
   public static func != <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
     return !(lhs == rhs)
   }
@@ -1730,7 +1730,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @_transparent
-  public static func < <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func < <Other: BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
     if lhsNegative != rhsNegative { return lhsNegative }
@@ -1772,7 +1772,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @_transparent
-  public static func <= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func <= <Other: BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(rhs < lhs)
   }
 
@@ -1787,7 +1787,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @_transparent
-  public static func >= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func >= <Other: BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(lhs < rhs)
   }
 
@@ -1802,7 +1802,7 @@ extension BinaryInteger {
   ///   - lhs: An integer to compare.
   ///   - rhs: Another integer to compare.
   @_transparent
-  public static func > <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
+  public static func > <Other: BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return rhs < lhs
   }
 }
@@ -1814,12 +1814,12 @@ extension BinaryInteger {
 // another, but the compiler choses the second one, and that results in infinite
 // recursion.
 //
-//     <T : Comparable>(T, T) -> Bool
-//     <T : BinaryInteger, U : BinaryInteger>(T, U) -> Bool
+//     <T: Comparable>(T, T) -> Bool
+//     <T: BinaryInteger, U: BinaryInteger>(T, U) -> Bool
 //
 // so we define:
 //
-//     <T : BinaryInteger>(T, T) -> Bool
+//     <T: BinaryInteger>(T, T) -> Bool
 //
 //===----------------------------------------------------------------------===//
 
@@ -1913,9 +1913,9 @@ extension BinaryInteger {
 /// customization points for arithmetic operations. When you provide just those
 /// methods, the standard library provides default implementations for all
 /// other arithmetic methods and operators.
-public protocol FixedWidthInteger : BinaryInteger, LosslessStringConvertible
-where Magnitude : FixedWidthInteger & UnsignedInteger,
-      Stride : FixedWidthInteger & SignedInteger {
+public protocol FixedWidthInteger: BinaryInteger, LosslessStringConvertible
+where Magnitude: FixedWidthInteger & UnsignedInteger,
+      Stride: FixedWidthInteger & SignedInteger {
   /// The number of bits used for the underlying binary representation of
   /// values of this type.
   ///
@@ -2469,7 +2469,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func &>> <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
     return lhs &>> Self(truncatingIfNeeded: rhs)
   }
@@ -2505,7 +2505,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func &>>= <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: inout Self, rhs: Other) {
     lhs = lhs &>> rhs
   }
@@ -2589,7 +2589,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func &<< <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
     return lhs &<< Self(truncatingIfNeeded: rhs)
   }
@@ -2625,7 +2625,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func &<<= <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: inout Self, rhs: Other) {
     lhs = lhs &<< rhs
   }
@@ -2869,7 +2869,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func >> <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
     var lhs = lhs
     _nonMaskingRightShiftGeneric(&lhs, rhs)
@@ -2879,14 +2879,14 @@ extension FixedWidthInteger {
   @_transparent
   @_semantics("optimize.sil.specialize.generic.partial.never")
   public static func >>= <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: inout Self, rhs: Other) {
     _nonMaskingRightShiftGeneric(&lhs, rhs)
   }
 
   @_transparent
   public static func _nonMaskingRightShiftGeneric <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(_ lhs: inout Self, _ rhs: Other) {
     let shift = rhs < -Self.bitWidth ? -Self.bitWidth
                 : rhs > Self.bitWidth ? Self.bitWidth
@@ -2956,7 +2956,7 @@ extension FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
   public static func << <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
     var lhs = lhs
     _nonMaskingLeftShiftGeneric(&lhs, rhs)
@@ -2966,14 +2966,14 @@ extension FixedWidthInteger {
   @_transparent
   @_semantics("optimize.sil.specialize.generic.partial.never")
   public static func <<= <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(lhs: inout Self, rhs: Other) {
     _nonMaskingLeftShiftGeneric(&lhs, rhs)
   }
 
   @_transparent
   public static func _nonMaskingLeftShiftGeneric <
-    Other : BinaryInteger
+    Other: BinaryInteger
   >(_ lhs: inout Self, _ rhs: Other) {
     let shift = rhs < -Self.bitWidth ? -Self.bitWidth
                 : rhs > Self.bitWidth ? Self.bitWidth
@@ -3003,7 +3003,7 @@ extension FixedWidthInteger {
   @inlinable
   @_semantics("optimize.sil.specialize.generic.partial.never")
   public // @testable
-  static func _convert<Source : BinaryFloatingPoint>(
+  static func _convert<Source: BinaryFloatingPoint>(
     from source: Source
   ) -> (value: Self?, exact: Bool) {
     guard _fastPath(!source.isZero) else { return (0, true) }
@@ -3054,7 +3054,7 @@ extension FixedWidthInteger {
   @inlinable
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
-  public init<T : BinaryFloatingPoint>(_ source: T) {
+  public init<T: BinaryFloatingPoint>(_ source: T) {
     guard let value = Self._convert(from: source).value else {
       fatalError("""
         \(T.self) value cannot be converted to \(Self.self) because it is \
@@ -3080,7 +3080,7 @@ extension FixedWidthInteger {
   /// - Parameter source: A floating-point value to convert to an integer.
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable
-  public init?<T : BinaryFloatingPoint>(exactly source: T) {
+  public init?<T: BinaryFloatingPoint>(exactly source: T) {
     let (temporary, exact) = Self._convert(from: source)
     guard exact, let value = temporary else {
       return nil
@@ -3110,7 +3110,7 @@ extension FixedWidthInteger {
   /// - Parameter source: An integer to convert to this type.
   @inlinable
   @_semantics("optimize.sil.specialize.generic.partial.never")
-  public init<Other : BinaryInteger>(clamping source: Other) {
+  public init<Other: BinaryInteger>(clamping source: Other) {
     if _slowPath(source < Self.min) {
       self = Self.min
     }
@@ -3158,7 +3158,7 @@ extension FixedWidthInteger {
   /// - Parameter source: An integer to convert to this type.
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init<T : BinaryInteger>(truncatingIfNeeded source: T) {
+  public init<T: BinaryInteger>(truncatingIfNeeded source: T) {
     if Self.bitWidth <= Int.bitWidth {
       self = Self(_truncatingBits: source._lowWord)
     }
@@ -3386,7 +3386,7 @@ extension FixedWidthInteger {
 //===----------------------------------------------------------------------===//
 
 /// An integer type that can represent only nonnegative values.
-public protocol UnsignedInteger : BinaryInteger { }
+public protocol UnsignedInteger: BinaryInteger { }
 
 extension UnsignedInteger {
   /// The magnitude of this value.
@@ -3414,7 +3414,7 @@ extension UnsignedInteger {
   }
 }
 
-extension UnsignedInteger where Self : FixedWidthInteger {
+extension UnsignedInteger where Self: FixedWidthInteger {
   /// Creates a new instance from the given integer.
   ///
   /// Use this initializer to convert from another integer type when you know
@@ -3437,7 +3437,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init<T : BinaryInteger>(_ source: T) {
+  public init<T: BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned {
       _precondition(source >= (0 as T), "Negative value is not representable")
@@ -3468,7 +3468,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init?<T : BinaryInteger>(exactly source: T) {
+  public init?<T: BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source < (0 as T) {
       return nil
@@ -3501,7 +3501,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
 //===----------------------------------------------------------------------===//
 
 /// An integer type that can represent both positive and negative values.
-public protocol SignedInteger : BinaryInteger, SignedNumeric {
+public protocol SignedInteger: BinaryInteger, SignedNumeric {
   // These requirements are for the source code compatibility with Swift 3
   static func _maskingAdd(_ lhs: Self, _ rhs: Self) -> Self
   static func _maskingSubtract(_ lhs: Self, _ rhs: Self) -> Self
@@ -3518,7 +3518,7 @@ extension SignedInteger {
   }
 }
 
-extension SignedInteger where Self : FixedWidthInteger {
+extension SignedInteger where Self: FixedWidthInteger {
   /// Creates a new instance from the given integer.
   ///
   /// Use this initializer to convert from another integer type when you know
@@ -3541,7 +3541,7 @@ extension SignedInteger where Self : FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init<T : BinaryInteger>(_ source: T) {
+  public init<T: BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth {
       _precondition(source >= Self.min,
@@ -3574,7 +3574,7 @@ extension SignedInteger where Self : FixedWidthInteger {
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable // FIXME(inline-always)
   @inline(__always)
-  public init?<T : BinaryInteger>(exactly source: T) {
+  public init?<T: BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth && source < Self.min {
       return nil
@@ -3638,13 +3638,13 @@ extension SignedInteger where Self : FixedWidthInteger {
 /// - Parameter x: The integer to convert, and instance of type `T`.
 /// - Returns: The value of `x` converted to type `U`.
 @inlinable
-public func numericCast<T : BinaryInteger, U : BinaryInteger>(_ x: T) -> U {
+public func numericCast<T: BinaryInteger, U: BinaryInteger>(_ x: T) -> U {
   return U(x)
 }
 
 // FIXME(integers): Absence of &+ causes ambiguity in the code like the
 // following:
-//    func f<T : SignedInteger>(_ x: T, _ y: T) {
+//    func f<T: SignedInteger>(_ x: T, _ y: T) {
 //      var _  = (x &+ (y - 1)) < x
 //    }
 //  Compiler output:
@@ -3663,7 +3663,7 @@ extension SignedInteger {
   }
 }
 
-extension SignedInteger where Self : FixedWidthInteger {
+extension SignedInteger where Self: FixedWidthInteger {
   // This overload is supposed to break the ambiguity between the
   // implementations on SignedInteger and FixedWidthInteger
   @_transparent

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -13,7 +13,7 @@
 /// A sequence that presents the elements of a base sequence of sequences
 /// concatenated using a given separator.
 @frozen // lazy-performance
-public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
+public struct JoinedSequence<Base: Sequence> where Base.Element: Sequence {
 
   public typealias Element = Base.Element.Element
   
@@ -27,7 +27,7 @@ public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
   ///
   /// - Complexity: O(`separator.count`).
   @inlinable // lazy-performance
-  public init<Separator : Sequence>(base: Base, separator: Separator)
+  public init<Separator: Sequence>(base: Base, separator: Separator)
     where Separator.Element == Element {
     self._base = base
     self._separator = ContiguousArray(separator)
@@ -155,7 +155,7 @@ extension JoinedSequence: Sequence {
   }
 }
   
-extension Sequence where Element : Sequence {
+extension Sequence where Element: Sequence {
   /// Returns the concatenated elements of this sequence of sequences,
   /// inserting the given separator between each element.
   ///
@@ -171,7 +171,7 @@ extension Sequence where Element : Sequence {
   ///   sequence's elements.
   /// - Returns: The joined sequence of elements.
   @inlinable // lazy-performance
-  public __consuming func joined<Separator : Sequence>(
+  public __consuming func joined<Separator: Sequence>(
     separator: Separator
   ) -> JoinedSequence<Self>
     where Separator.Element == Element.Element {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -340,7 +340,7 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
 /// with reference semantics.
 public class ReferenceWritableKeyPath<
   Root, Value
-> : WritableKeyPath<Root, Value> {
+>: WritableKeyPath<Root, Value> {
   // MARK: Implementation detail
 
   internal final override class var kind: Kind { return .reference }
@@ -3052,7 +3052,7 @@ internal func _getKeyPathClassAndInstanceSizeFromPattern(
           alignmentMask: MemoryLayout<Int>._alignmentMask)
 }
 
-internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
+internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
   var destData: UnsafeMutableRawBufferPointer
   var genericEnvironment: UnsafeRawPointer?
   let patternArgs: UnsafeRawPointer?

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -73,7 +73,7 @@
 ///     print(pairs.elements)
 ///     // Prints "[(1, 2), (1, 1), (3, 4), (2, 1)]"
 @frozen // trivial-implementation
-public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
+public struct KeyValuePairs<Key, Value>: ExpressibleByDictionaryLiteral {
   @usableFromInline // trivial-implementation
   internal let _elements: [(Key, Value)]
 
@@ -90,7 +90,7 @@ public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
 
 /// `Collection` conformance that allows `KeyValuePairs` to
 /// interoperate with the rest of the standard library.
-extension KeyValuePairs : RandomAccessCollection {
+extension KeyValuePairs: RandomAccessCollection {
   /// The element type of a `KeyValuePairs`: a tuple containing an
   /// individual key-value pair.
   public typealias Element = (key: Key, value: Value)

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 public protocol LazyCollectionProtocol: Collection, LazySequenceProtocol 
-where Elements : Collection {	}
+where Elements: Collection {	}
 
 extension LazyCollectionProtocol {		
    // Lazy things are already lazy		
@@ -36,7 +36,7 @@ extension LazyCollectionProtocol {
 /// - See also: `LazySequenceProtocol`, `LazyCollection`
 public typealias LazyCollection<T: Collection> = LazySequence<T>
 
-extension LazyCollection : Collection {
+extension LazyCollection: Collection {
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
@@ -147,16 +147,16 @@ extension LazyCollection : Collection {
 
 extension LazyCollection: LazyCollectionProtocol { }
 
-extension LazyCollection : BidirectionalCollection
-  where Base : BidirectionalCollection {
+extension LazyCollection: BidirectionalCollection
+  where Base: BidirectionalCollection {
   @inlinable
   public func index(before i: Index) -> Index {
     return _base.index(before: i)
   }
 }
 
-extension LazyCollection : RandomAccessCollection
-  where Base : RandomAccessCollection {}
+extension LazyCollection: RandomAccessCollection
+  where Base: RandomAccessCollection {}
 
 extension Slice: LazySequenceProtocol where Base: LazySequenceProtocol { }
 extension ReversedCollection: LazySequenceProtocol where Base: LazySequenceProtocol { }

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -60,7 +60,7 @@
 /// we can build a sequence that lazily computes the elements in the
 /// result of `scan`:
 ///
-///     struct LazyScanIterator<Base : IteratorProtocol, ResultElement>
+///     struct LazyScanIterator<Base: IteratorProtocol, ResultElement>
 ///       : IteratorProtocol {
 ///       mutating func next() -> ResultElement? {
 ///         return nextElement.map { result in
@@ -128,7 +128,7 @@
 ///   [We don't recommend that you use `map` this way, because it
 ///   creates and discards an array. `sum` would be better implemented
 ///   using `reduce`].
-public protocol LazySequenceProtocol : Sequence {
+public protocol LazySequenceProtocol: Sequence {
   /// A `Sequence` that can contain the same elements as this one,
   /// possibly with a simpler type.
   ///
@@ -178,7 +178,7 @@ extension LazySequenceProtocol where Elements: LazySequenceProtocol {
 ///
 /// - See also: `LazySequenceProtocol`
 @frozen // lazy-performance
-public struct LazySequence<Base : Sequence> {
+public struct LazySequence<Base: Sequence> {
   @usableFromInline
   internal var _base: Base
 

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -551,7 +551,7 @@ extension ManagedBufferPointer: Equatable {
 /// - Returns: `true` if `object` is known to have a single strong reference;
 ///   otherwise, `false`.
 @inlinable
-public func isKnownUniquelyReferenced<T : AnyObject>(_ object: inout T) -> Bool
+public func isKnownUniquelyReferenced<T: AnyObject>(_ object: inout T) -> Bool
 {
   return _isUnique(&object)
 }
@@ -587,7 +587,7 @@ public func isKnownUniquelyReferenced<T : AnyObject>(_ object: inout T) -> Bool
 /// - Returns: `true` if `object` is known to have a single strong reference;
 ///   otherwise, `false`. If `object` is `nil`, the return value is `false`.
 @inlinable
-public func isKnownUniquelyReferenced<T : AnyObject>(
+public func isKnownUniquelyReferenced<T: AnyObject>(
   _ object: inout T?
 ) -> Bool {
   return _isUnique(&object)

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -15,7 +15,7 @@
 /// These elements are computed lazily, each time they're read, by
 /// calling the transform function on a base element.
 @frozen
-public struct LazyMapSequence<Base : Sequence, Element> {
+public struct LazyMapSequence<Base: Sequence, Element> {
 
   public typealias Elements = LazyMapSequence
 
@@ -168,8 +168,8 @@ extension LazyMapCollection: Collection {
   }
 }
 
-extension LazyMapCollection : BidirectionalCollection
-  where Base : BidirectionalCollection {
+extension LazyMapCollection: BidirectionalCollection
+  where Base: BidirectionalCollection {
 
   /// A value less than or equal to the number of elements in the collection.
   ///
@@ -187,8 +187,8 @@ extension LazyMapCollection : BidirectionalCollection
 
 extension LazyMapCollection: LazyCollectionProtocol { }
 
-extension LazyMapCollection : RandomAccessCollection
-  where Base : RandomAccessCollection { }
+extension LazyMapCollection: RandomAccessCollection
+  where Base: RandomAccessCollection { }
 
 //===--- Support for s.lazy -----------------------------------------------===//
 

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -42,23 +42,23 @@ public typealias LazyDropWhileIndex<T> = LazyDropWhileCollection<T>.Index where 
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyDropWhileCollection")
 public typealias LazyDropWhileBidirectionalCollection<T> = LazyDropWhileCollection<T> where T: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyFilterCollection")
-public typealias LazyFilterBidirectionalCollection<T> = LazyFilterCollection<T> where T : BidirectionalCollection
+public typealias LazyFilterBidirectionalCollection<T> = LazyFilterCollection<T> where T: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyMapSequence.Iterator")
 public typealias LazyMapIterator<T, E> = LazyMapSequence<T, E>.Iterator where T: Sequence
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyMapCollection")
-public typealias LazyMapBidirectionalCollection<T, E> = LazyMapCollection<T, E> where T : BidirectionalCollection
+public typealias LazyMapBidirectionalCollection<T, E> = LazyMapCollection<T, E> where T: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyMapCollection")
-public typealias LazyMapRandomAccessCollection<T, E> = LazyMapCollection<T, E> where T : RandomAccessCollection
+public typealias LazyMapRandomAccessCollection<T, E> = LazyMapCollection<T, E> where T: RandomAccessCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyCollection")
-public typealias LazyBidirectionalCollection<T> = LazyCollection<T> where T : BidirectionalCollection
+public typealias LazyBidirectionalCollection<T> = LazyCollection<T> where T: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "LazyCollection")
-public typealias LazyRandomAccessCollection<T> = LazyCollection<T> where T : RandomAccessCollection
+public typealias LazyRandomAccessCollection<T> = LazyCollection<T> where T: RandomAccessCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "FlattenCollection.Index")
-public typealias FlattenCollectionIndex<T> = FlattenCollection<T>.Index where T : Collection, T.Element : Collection
+public typealias FlattenCollectionIndex<T> = FlattenCollection<T>.Index where T: Collection, T.Element: Collection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "FlattenCollection.Index")
-public typealias FlattenBidirectionalCollectionIndex<T> = FlattenCollection<T>.Index where T : BidirectionalCollection, T.Element : BidirectionalCollection
+public typealias FlattenBidirectionalCollectionIndex<T> = FlattenCollection<T>.Index where T: BidirectionalCollection, T.Element: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "FlattenCollection")
-public typealias FlattenBidirectionalCollection<T> = FlattenCollection<T> where T : BidirectionalCollection, T.Element : BidirectionalCollection
+public typealias FlattenBidirectionalCollection<T> = FlattenCollection<T> where T: BidirectionalCollection, T.Element: BidirectionalCollection
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "JoinedSequence.Iterator")
 public typealias JoinedIterator<T: Sequence> = JoinedSequence<T>.Iterator where T.Element: Sequence
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "Zip2Sequence.Iterator")
@@ -74,31 +74,31 @@ public typealias ReversedRandomAccessCollection<T: RandomAccessCollection> = Rev
 @available(swift, deprecated: 4.2, obsoleted: 5.0, renamed: "ReversedCollection.Index")
 public typealias ReversedIndex<T: BidirectionalCollection> = ReversedCollection<T>.Index
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias BidirectionalSlice<T> = Slice<T> where T : BidirectionalCollection
+public typealias BidirectionalSlice<T> = Slice<T> where T: BidirectionalCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias RandomAccessSlice<T> = Slice<T> where T : RandomAccessCollection
+public typealias RandomAccessSlice<T> = Slice<T> where T: RandomAccessCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias RangeReplaceableSlice<T> = Slice<T> where T : RangeReplaceableCollection
+public typealias RangeReplaceableSlice<T> = Slice<T> where T: RangeReplaceableCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias RangeReplaceableBidirectionalSlice<T> = Slice<T> where T : RangeReplaceableCollection & BidirectionalCollection
+public typealias RangeReplaceableBidirectionalSlice<T> = Slice<T> where T: RangeReplaceableCollection & BidirectionalCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias RangeReplaceableRandomAccessSlice<T> = Slice<T> where T : RangeReplaceableCollection & RandomAccessCollection
+public typealias RangeReplaceableRandomAccessSlice<T> = Slice<T> where T: RangeReplaceableCollection & RandomAccessCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableSlice<T> = Slice<T> where T : MutableCollection
+public typealias MutableSlice<T> = Slice<T> where T: MutableCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableBidirectionalSlice<T> = Slice<T> where T : MutableCollection & BidirectionalCollection
+public typealias MutableBidirectionalSlice<T> = Slice<T> where T: MutableCollection & BidirectionalCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableRandomAccessSlice<T> = Slice<T> where T : MutableCollection & RandomAccessCollection
+public typealias MutableRandomAccessSlice<T> = Slice<T> where T: MutableCollection & RandomAccessCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableRangeReplaceableSlice<T> = Slice<T> where T : MutableCollection & RangeReplaceableCollection
+public typealias MutableRangeReplaceableSlice<T> = Slice<T> where T: MutableCollection & RangeReplaceableCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableRangeReplaceableBidirectionalSlice<T> = Slice<T> where T : MutableCollection & RangeReplaceableCollection & BidirectionalCollection
+public typealias MutableRangeReplaceableBidirectionalSlice<T> = Slice<T> where T: MutableCollection & RangeReplaceableCollection & BidirectionalCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "Slice")
-public typealias MutableRangeReplaceableRandomAccessSlice<T> = Slice<T> where T : MutableCollection & RangeReplaceableCollection & RandomAccessCollection
+public typealias MutableRangeReplaceableRandomAccessSlice<T> = Slice<T> where T: MutableCollection & RangeReplaceableCollection & RandomAccessCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "DefaultIndices")
-public typealias DefaultBidirectionalIndices<T> = DefaultIndices<T> where T : BidirectionalCollection
+public typealias DefaultBidirectionalIndices<T> = DefaultIndices<T> where T: BidirectionalCollection
 @available(swift, deprecated: 4.0, obsoleted: 5.0, renamed: "DefaultIndices")
-public typealias DefaultRandomAccessIndices<T> = DefaultIndices<T> where T : RandomAccessCollection
+public typealias DefaultRandomAccessIndices<T> = DefaultIndices<T> where T: RandomAccessCollection
 
 // Deprecated by SE-0115.
 @available(swift, deprecated: 3.0, obsoleted: 5.0, renamed: "ExpressibleByNilLiteral")
@@ -157,7 +157,7 @@ public typealias ClosedRangeIndex<T> = ClosedRange<T>.Index where T: Strideable,
 @available(*, unavailable, renamed: "Optional")
 public typealias ImplicitlyUnwrappedOptional<Wrapped> = Optional<Wrapped>
 
-extension Range where Bound: Strideable, Bound.Stride : SignedInteger {
+extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
   /// Now that Range is conditionally a collection when Bound: Strideable,
   /// CountableRange is no longer needed. This is a deprecated initializer
   /// for any remaining uses of Range(countableRange).
@@ -167,7 +167,7 @@ extension Range where Bound: Strideable, Bound.Stride : SignedInteger {
   }  
 }
 
-extension ClosedRange where Bound: Strideable, Bound.Stride : SignedInteger {
+extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
   /// Now that Range is conditionally a collection when Bound: Strideable,
   /// CountableRange is no longer needed. This is a deprecated initializer
   /// for any remaining uses of Range(countableRange).
@@ -236,7 +236,7 @@ extension String {
   }
 }
 
-extension String.UnicodeScalarView : _CustomPlaygroundQuickLookable {
+extension String.UnicodeScalarView: _CustomPlaygroundQuickLookable {
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnicodeScalarView.customPlaygroundQuickLook will be removed in Swift 5.0")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
@@ -255,14 +255,14 @@ public typealias UTF32 = Unicode.UTF32
 public typealias UnicodeScalar = Unicode.Scalar
 
 
-extension String.UTF16View : _CustomPlaygroundQuickLookable {
+extension String.UTF16View: _CustomPlaygroundQuickLookable {
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF16View.customPlaygroundQuickLook will be removed in Swift 5.0")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
   }
 }
 
-extension String.UTF8View : _CustomPlaygroundQuickLookable {
+extension String.UTF8View: _CustomPlaygroundQuickLookable {
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF8View.customPlaygroundQuickLook will be removed in Swift 5.0")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
@@ -309,7 +309,7 @@ extension Substring {
   }
 }
 
-extension Substring : _CustomPlaygroundQuickLookable {
+extension Substring: _CustomPlaygroundQuickLookable {
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "Substring.customPlaygroundQuickLook will be removed in Swift 5.0")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return String(self).customPlaygroundQuickLook
@@ -378,7 +378,7 @@ extension UnsafeMutablePointer {
   ///   type.
   // This is fundamentally unsafe since collections can underreport their count.
   @available(swift, deprecated: 4.2, obsoleted: 5.0, message: "it will be removed in Swift 5.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead")
-  public func initialize<C : Collection>(from source: C)
+  public func initialize<C: Collection>(from source: C)
     where C.Element == Pointee {
     let buf = UnsafeMutableBufferPointer(start: self, count: numericCast(source.count))
     var (remainders,writtenUpTo) = source._copyContents(initializing: buf)
@@ -390,19 +390,19 @@ extension UnsafeMutablePointer {
 
 extension UnsafeMutableRawPointer {
   @available(*, unavailable, renamed: "init(mutating:)")
-  public init(_ from : UnsafeRawPointer) { Builtin.unreachable() }
+  public init(_ from: UnsafeRawPointer) { Builtin.unreachable() }
 
   @available(*, unavailable, renamed: "init(mutating:)")
-  public init?(_ from : UnsafeRawPointer?) { Builtin.unreachable() }
+  public init?(_ from: UnsafeRawPointer?) { Builtin.unreachable() }
 
   @available(*, unavailable, renamed: "init(mutating:)")
-  public init<T>(_ from : UnsafePointer<T>) { Builtin.unreachable() }
+  public init<T>(_ from: UnsafePointer<T>) { Builtin.unreachable() }
 
   @available(*, unavailable, renamed: "init(mutating:)")
-  public init?<T>(_ from : UnsafePointer<T>?) { Builtin.unreachable() }
+  public init?<T>(_ from: UnsafePointer<T>?) { Builtin.unreachable() }
 }
 
-extension UnsafeRawPointer : _CustomPlaygroundQuickLookable {
+extension UnsafeRawPointer: _CustomPlaygroundQuickLookable {
   internal var summary: String {
     let ptrValue = UInt64(
       bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
@@ -417,7 +417,7 @@ extension UnsafeRawPointer : _CustomPlaygroundQuickLookable {
   }
 }
 
-extension UnsafeMutableRawPointer : _CustomPlaygroundQuickLookable {
+extension UnsafeMutableRawPointer: _CustomPlaygroundQuickLookable {
   private var summary: String {
     let ptrValue = UInt64(
       bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
@@ -496,7 +496,7 @@ extension UnsafeMutableRawPointer {
 
   @available(swift, deprecated: 4.1, obsoleted: 5.0, message: "it will be removed in Swift 5.0.  Please use 'UnsafeMutableRawBufferPointer.initialize(from:)' instead")
   @discardableResult
-  public func initializeMemory<C : Collection>(
+  public func initializeMemory<C: Collection>(
     as type: C.Element.Type, from source: C
   ) -> UnsafeMutablePointer<C.Element> {
     // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -212,7 +212,7 @@ public struct Mirror {
   ///   - ancestorRepresentation: The means of generating the subject's
   ///     ancestor representation. `ancestorRepresentation` is ignored if
   ///     `subject` is not a class instance. The default is `.generated`.
-  public init<Subject, C : Collection>(
+  public init<Subject, C: Collection>(
     _ subject: Subject,
     children: C,
     displayStyle: DisplayStyle? = nil,
@@ -256,7 +256,7 @@ public struct Mirror {
   ///   - ancestorRepresentation: The means of generating the subject's
   ///     ancestor representation. `ancestorRepresentation` is ignored if
   ///     `subject` is not a class instance. The default is `.generated`.
-  public init<Subject, C : Collection>(
+  public init<Subject, C: Collection>(
     _ subject: Subject,
     unlabeledChildren: C,
     displayStyle: DisplayStyle? = nil,
@@ -361,7 +361,7 @@ public protocol CustomReflectable {
 /// A type that explicitly supplies its own mirror, but whose
 /// descendant classes are not represented in the mirror unless they
 /// also override `customMirror`.
-public protocol CustomLeafReflectable : CustomReflectable {}
+public protocol CustomLeafReflectable: CustomReflectable {}
 
 //===--- Addressing -------------------------------------------------------===//
 
@@ -374,11 +374,11 @@ public protocol MirrorPath {
   // FIXME(ABI)#49 (Sealed Protocols): this protocol should be "non-open" and
   // you shouldn't be able to create conformances.
 }
-extension Int : MirrorPath {}
-extension String : MirrorPath {}
+extension Int: MirrorPath {}
+extension String: MirrorPath {}
 
 extension Mirror {
-  internal struct _Dummy : CustomReflectable {
+  internal struct _Dummy: CustomReflectable {
       internal init(mirror: Mirror) {
       self.mirror = mirror
     }
@@ -694,13 +694,13 @@ extension String {
 }
 
 /// Reflection for `Mirror` itself.
-extension Mirror : CustomStringConvertible {
+extension Mirror: CustomStringConvertible {
   public var description: String {
     return "Mirror for \(self.subjectType)"
   }
 }
 
-extension Mirror : CustomReflectable {
+extension Mirror: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [:])
   }

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -37,14 +37,14 @@ for self_ty in all_integer_types(word_bits):
 
 %for Type in Types:
 
-extension ${Type[0]} : CustomReflectable {
+extension ${Type[0]}: CustomReflectable {
   /// A mirror that reflects the `${Type[0]}` instance.
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: EmptyCollection<Void>())
   }
 }
 
-extension ${Type[0]} : _CustomPlaygroundQuickLookable {
+extension ${Type[0]}: _CustomPlaygroundQuickLookable {
   /// A custom playground Quick Look for the `${Type[0]}` instance.
   @available(*, deprecated, message: "${Type[0]}.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
@@ -54,7 +54,7 @@ extension ${Type[0]} : _CustomPlaygroundQuickLookable {
 % end
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-extension Float80 : CustomReflectable {
+extension Float80: CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: EmptyCollection<Void>())

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -99,7 +99,7 @@ where Base: _SwiftNewtypeWrapper & Hashable, Base.RawValue: Hashable {
 }
 
 #if _runtime(_ObjC)
-extension _SwiftNewtypeWrapper where Self.RawValue : _ObjectiveCBridgeable {
+extension _SwiftNewtypeWrapper where Self.RawValue: _ObjectiveCBridgeable {
   // Note: This is the only default typealias for _ObjectiveCType, because
   // constrained extensions aren't allowed to define types in different ways.
   // Fortunately the others don't need it.

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -61,7 +61,7 @@ public struct ObjectIdentifier {
   }
 }
 
-extension ObjectIdentifier : CustomDebugStringConvertible {
+extension ObjectIdentifier: CustomDebugStringConvertible {
   /// A textual representation of the identifier, suitable for debugging.
   public var debugDescription: String {
     return "ObjectIdentifier(\(_rawPointerToString(_value)))"

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -83,7 +83,7 @@
 ///         print("Add more to your cart for free priority shipping!")
 ///     }
 ///     // Prints "You've earned free priority shipping!"
-public protocol OptionSet : SetAlgebra, RawRepresentable {
+public protocol OptionSet: SetAlgebra, RawRepresentable {
   // We can't constrain the associated Element type to be the same as
   // Self, but we can do almost as well with a default and a
   // constrained extension
@@ -326,7 +326,7 @@ extension OptionSet where Element == Self {
 /// - Note: A type conforming to `OptionSet` can implement any of
 ///   these initializers or methods, and those implementations will be
 ///   used in lieu of these defaults.
-extension OptionSet where RawValue : FixedWidthInteger {
+extension OptionSet where RawValue: FixedWidthInteger {
   /// Creates an empty option set.
   ///
   /// This initializer creates an option set with a raw value of zero.

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -119,7 +119,7 @@
 /// Unconditionally unwrapping a `nil` instance with `!` triggers a runtime
 /// error.
 @frozen
-public enum Optional<Wrapped> : ExpressibleByNilLiteral {
+public enum Optional<Wrapped>: ExpressibleByNilLiteral {
   // The compiler has special knowledge of Optional<Wrapped>, including the fact
   // that it is an `enum` with cases named `none` and `some`.
 
@@ -264,7 +264,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   }
 }
 
-extension Optional : CustomDebugStringConvertible {
+extension Optional: CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
   public var debugDescription: String {
     switch self {
@@ -279,7 +279,7 @@ extension Optional : CustomDebugStringConvertible {
   }
 }
 
-extension Optional : CustomReflectable {
+extension Optional: CustomReflectable {
   public var customMirror: Mirror {
     switch self {
     case .some(let value):
@@ -319,7 +319,7 @@ func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
   }
 }
 
-extension Optional : Equatable where Wrapped : Equatable {
+extension Optional: Equatable where Wrapped: Equatable {
   /// Returns a Boolean value indicating whether two optional instances are
   /// equal.
   ///
@@ -398,7 +398,7 @@ extension Optional: Hashable where Wrapped: Hashable {
 // Enable pattern matching against the nil literal, even if the element type
 // isn't equatable.
 @frozen
-public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
+public struct _OptionalNilComparisonType: ExpressibleByNilLiteral {
   /// Create an instance initialized with `nil`.
   @_transparent
   public init(nilLiteral: ()) {
@@ -675,9 +675,9 @@ public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T?)
 //===----------------------------------------------------------------------===//
 
 #if _runtime(_ObjC)
-extension Optional : _ObjectiveCBridgeable {
+extension Optional: _ObjectiveCBridgeable {
   // The object that represents `none` for an Optional of this type.
-  internal static var _nilSentinel : AnyObject {
+  internal static var _nilSentinel: AnyObject {
     @_silgen_name("_swift_Foundation_getOptionalNilSentinelObject")
     get
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -102,7 +102,7 @@ extension TextOutputStream {
 public protocol TextOutputStreamable {
   /// Writes a textual representation of this instance into the given output
   /// stream.
-  func write<Target : TextOutputStream>(to target: inout Target)
+  func write<Target: TextOutputStream>(to target: inout Target)
 }
 
 /// A type with a customized textual representation.
@@ -182,7 +182,7 @@ public protocol CustomStringConvertible {
 /// The description property of a conforming type must be a value-preserving
 /// representation of the original value. As such, it should be possible to
 /// re-create an instance from its string representation.
-public protocol LosslessStringConvertible : CustomStringConvertible {
+public protocol LosslessStringConvertible: CustomStringConvertible {
   /// Instantiates an instance of the conforming type from a string
   /// representation.
   init?(_ description: String)
@@ -281,7 +281,7 @@ internal func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 
 /// Do our best to print a value that cannot be printed directly.
 @_semantics("optimize.sil.specialize.generic.never")
-internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
+internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream,
     isDebugPrint: Bool
 ) {
@@ -376,7 +376,7 @@ internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
 
 @usableFromInline
 @_semantics("optimize.sil.specialize.generic.never")
-internal func _print_unlocked<T, TargetStream : TextOutputStream>(
+internal func _print_unlocked<T, TargetStream: TextOutputStream>(
   _ value: T, _ target: inout TargetStream
 ) {
   // Optional has no representation suitable for display; therefore,
@@ -414,7 +414,7 @@ internal func _print_unlocked<T, TargetStream : TextOutputStream>(
 
 @_semantics("optimize.sil.specialize.generic.never")
 @inline(never)
-public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(
+public func _debugPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ target: inout TargetStream
 ) {
   if let debugPrintableObject = value as? CustomDebugStringConvertible {
@@ -437,7 +437,7 @@ public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(
 }
 
 @_semantics("optimize.sil.specialize.generic.never")
-internal func _dumpPrint_unlocked<T, TargetStream : TextOutputStream>(
+internal func _dumpPrint_unlocked<T, TargetStream: TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream
 ) {
   if let displayStyle = mirror.displayStyle {
@@ -507,7 +507,7 @@ internal func _dumpPrint_unlocked<T, TargetStream : TextOutputStream>(
 // OutputStreams
 //===----------------------------------------------------------------------===//
 
-internal struct _Stdout : TextOutputStream {
+internal struct _Stdout: TextOutputStream {
   internal init() {}
 
   internal mutating func _lock() {
@@ -528,7 +528,7 @@ internal struct _Stdout : TextOutputStream {
   }
 }
 
-extension String : TextOutputStream {
+extension String: TextOutputStream {
   /// Appends the given string to this string.
   ///
   /// - Parameter other: A string to append.
@@ -545,41 +545,41 @@ extension String : TextOutputStream {
 // Streamables
 //===----------------------------------------------------------------------===//
 
-extension String : TextOutputStreamable {
+extension String: TextOutputStreamable {
   /// Writes the string into the given output stream.
   ///
   /// - Parameter target: An output stream.
-  public func write<Target : TextOutputStream>(to target: inout Target) {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
     target.write(self)
   }
 }
 
-extension Character : TextOutputStreamable {
+extension Character: TextOutputStreamable {
   /// Writes the character into the given output stream.
   ///
   /// - Parameter target: An output stream.
-  public func write<Target : TextOutputStream>(to target: inout Target) {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
     target.write(String(self))
   }
 }
 
-extension Unicode.Scalar : TextOutputStreamable {
+extension Unicode.Scalar: TextOutputStreamable {
   /// Writes the textual representation of the Unicode scalar into the given
   /// output stream.
   ///
   /// - Parameter target: An output stream.
-  public func write<Target : TextOutputStream>(to target: inout Target) {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
     target.write(String(Character(self)))
   }
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook : ((String) -> Void)? = nil
+public var _playgroundPrintHook: ((String) -> Void)? = nil
 
 internal struct _TeeStream<
-  L : TextOutputStream,
-  R : TextOutputStream
-> : TextOutputStream {
+  L: TextOutputStream,
+  R: TextOutputStream
+>: TextOutputStream {
 
   internal init(left: L, right: R) {
     self.left = left

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -32,7 +32,7 @@ extension _Pointer {
   ///
   /// - Parameter from: The opaque pointer to convert to a typed pointer.
   @_transparent
-  public init(_ from : OpaquePointer) {
+  public init(_ from: OpaquePointer) {
     self.init(from._rawValue)
   }
 
@@ -41,7 +41,7 @@ extension _Pointer {
   /// - Parameter from: The opaque pointer to convert to a typed pointer. If
   ///   `from` is `nil`, the result of this initializer is `nil`.
   @_transparent
-  public init?(_ from : OpaquePointer?) {
+  public init?(_ from: OpaquePointer?) {
     guard let unwrapped = from else { return nil }
     self.init(unwrapped)
   }
@@ -265,7 +265,7 @@ extension UInt {
 }
 
 // Pointer arithmetic operators (formerly via Strideable)
-extension Strideable where Self : _Pointer {
+extension Strideable where Self: _Pointer {
   @_transparent
   public static func + (lhs: Self, rhs: Self.Stride) -> Self {
     return lhs.advanced(by: rhs)
@@ -301,8 +301,8 @@ extension Strideable where Self : _Pointer {
 @_transparent
 public // COMPILER_INTRINSIC
 func _convertPointerToPointerArgument<
-  FromPointer : _Pointer,
-  ToPointer : _Pointer
+  FromPointer: _Pointer,
+  ToPointer: _Pointer
 >(_ from: FromPointer) -> ToPointer {
   return ToPointer(from._rawValue)
 }
@@ -311,7 +311,7 @@ func _convertPointerToPointerArgument<
 @_transparent
 public // COMPILER_INTRINSIC
 func _convertInOutToPointerArgument<
-  ToPointer : _Pointer
+  ToPointer: _Pointer
 >(_ from: Builtin.RawPointer) -> ToPointer {
   return ToPointer(from)
 }
@@ -346,7 +346,7 @@ func _convertConstArrayToPointerArgument<
 public // COMPILER_INTRINSIC
 func _convertMutableArrayToPointerArgument<
   FromElement,
-  ToPointer : _Pointer
+  ToPointer: _Pointer
 >(_ a: inout [FromElement]) -> (AnyObject?, ToPointer) {
   // TODO: Putting a canary at the end of the array in checked builds might
   // be a good idea
@@ -361,7 +361,7 @@ func _convertMutableArrayToPointerArgument<
 /// Derive a UTF-8 pointer argument from a value string parameter.
 public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<
-  ToPointer : _Pointer
+  ToPointer: _Pointer
 >(_ str: String) -> (AnyObject?, ToPointer) {
   let utf8 = Array(str.utf8CString)
   return _convertConstArrayToPointerArgument(utf8)

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -318,7 +318,7 @@ public typealias AnyClass = AnyObject.Type
 ///   - lhs: A value to compare.
 ///   - rhs: Another value to compare.
 @_transparent
-public func ~= <T : Equatable>(a: T, b: T) -> Bool {
+public func ~= <T: Equatable>(a: T, b: T) -> Bool {
   return a == b
 }
 
@@ -382,7 +382,7 @@ precedencegroup BitwiseShiftPrecedence {
 // Standard postfix operators.
 postfix operator ++
 postfix operator --
-postfix operator ... : Comparable
+postfix operator ...: Comparable
 
 // Optional<T> unwrapping operator is built into the compiler as a part of
 // postfix expression grammar.
@@ -392,71 +392,71 @@ postfix operator ... : Comparable
 // Standard prefix operators.
 prefix operator ++
 prefix operator --
-prefix operator ! : Bool
-prefix operator ~ : BinaryInteger
-prefix operator + : AdditiveArithmetic
-prefix operator - : SignedNumeric
-prefix operator ... : Comparable
-prefix operator ..< : Comparable
+prefix operator !: Bool
+prefix operator ~: BinaryInteger
+prefix operator +: AdditiveArithmetic
+prefix operator -: SignedNumeric
+prefix operator ...: Comparable
+prefix operator ..<: Comparable
 
 // Standard infix operators.
 
 // "Exponentiative"
 
-infix operator  << : BitwiseShiftPrecedence, BinaryInteger
-infix operator &<< : BitwiseShiftPrecedence, FixedWidthInteger
-infix operator  >> : BitwiseShiftPrecedence, BinaryInteger
-infix operator &>> : BitwiseShiftPrecedence, FixedWidthInteger
+infix operator  <<: BitwiseShiftPrecedence, BinaryInteger
+infix operator &<<: BitwiseShiftPrecedence, FixedWidthInteger
+infix operator  >>: BitwiseShiftPrecedence, BinaryInteger
+infix operator &>>: BitwiseShiftPrecedence, FixedWidthInteger
 
 // "Multiplicative"
 
-infix operator   * : MultiplicationPrecedence, Numeric
-infix operator  &* : MultiplicationPrecedence, FixedWidthInteger
-infix operator   / : MultiplicationPrecedence, BinaryInteger, FloatingPoint
-infix operator   % : MultiplicationPrecedence, BinaryInteger
-infix operator   & : MultiplicationPrecedence, BinaryInteger
+infix operator   *: MultiplicationPrecedence, Numeric
+infix operator  &*: MultiplicationPrecedence, FixedWidthInteger
+infix operator   /: MultiplicationPrecedence, BinaryInteger, FloatingPoint
+infix operator   %: MultiplicationPrecedence, BinaryInteger
+infix operator   &: MultiplicationPrecedence, BinaryInteger
 
 // "Additive"
 
-infix operator   + : AdditionPrecedence, AdditiveArithmetic, String, Array, Strideable
-infix operator  &+ : AdditionPrecedence, FixedWidthInteger
-infix operator   - : AdditionPrecedence, AdditiveArithmetic, Strideable
-infix operator  &- : AdditionPrecedence, FixedWidthInteger
-infix operator   | : AdditionPrecedence, BinaryInteger
-infix operator   ^ : AdditionPrecedence, BinaryInteger
+infix operator   +: AdditionPrecedence, AdditiveArithmetic, String, Array, Strideable
+infix operator  &+: AdditionPrecedence, FixedWidthInteger
+infix operator   -: AdditionPrecedence, AdditiveArithmetic, Strideable
+infix operator  &-: AdditionPrecedence, FixedWidthInteger
+infix operator   |: AdditionPrecedence, BinaryInteger
+infix operator   ^: AdditionPrecedence, BinaryInteger
 
 // FIXME: is this the right precedence level for "..." ?
-infix operator  ... : RangeFormationPrecedence, Comparable
-infix operator  ..< : RangeFormationPrecedence, Comparable
+infix operator  ...: RangeFormationPrecedence, Comparable
+infix operator  ..<: RangeFormationPrecedence, Comparable
 
 // The cast operators 'as' and 'is' are hardcoded as if they had the
 // following attributes:
-// infix operator as : CastingPrecedence
+// infix operator as: CastingPrecedence
 
 // "Coalescing"
 
-infix operator ?? : NilCoalescingPrecedence
+infix operator ??: NilCoalescingPrecedence
 
 // "Comparative"
 
-infix operator  <  : ComparisonPrecedence, Comparable
-infix operator  <= : ComparisonPrecedence, Comparable
-infix operator  >  : ComparisonPrecedence, Comparable
-infix operator  >= : ComparisonPrecedence, Comparable
-infix operator  == : ComparisonPrecedence, Equatable
-infix operator  != : ComparisonPrecedence, Equatable
-infix operator === : ComparisonPrecedence
-infix operator !== : ComparisonPrecedence
+infix operator  <: ComparisonPrecedence, Comparable
+infix operator  <=: ComparisonPrecedence, Comparable
+infix operator  >: ComparisonPrecedence, Comparable
+infix operator  >=: ComparisonPrecedence, Comparable
+infix operator  ==: ComparisonPrecedence, Equatable
+infix operator  !=: ComparisonPrecedence, Equatable
+infix operator ===: ComparisonPrecedence
+infix operator !==: ComparisonPrecedence
 // FIXME: ~= will be built into the compiler.
-infix operator  ~= : ComparisonPrecedence
+infix operator  ~=: ComparisonPrecedence
 
 // "Conjunctive"
 
-infix operator && : LogicalConjunctionPrecedence, Bool
+infix operator &&: LogicalConjunctionPrecedence, Bool
 
 // "Disjunctive"
 
-infix operator || : LogicalDisjunctionPrecedence, Bool
+infix operator ||: LogicalDisjunctionPrecedence, Bool
 
 // User-defined ternary operators are not supported. The ? : operator is
 // hardcoded as if it had the following attributes:
@@ -464,25 +464,25 @@ infix operator || : LogicalDisjunctionPrecedence, Bool
 
 // User-defined assignment operators are not supported. The = operator is
 // hardcoded as if it had the following attributes:
-// infix operator = : AssignmentPrecedence
+// infix operator =: AssignmentPrecedence
 
 // Compound
 
-infix operator   *= : AssignmentPrecedence, Numeric
-infix operator  &*= : AssignmentPrecedence, FixedWidthInteger
-infix operator   /= : AssignmentPrecedence, BinaryInteger
-infix operator   %= : AssignmentPrecedence, BinaryInteger
-infix operator   += : AssignmentPrecedence, AdditiveArithmetic, String, Array, Strideable
-infix operator  &+= : AssignmentPrecedence, FixedWidthInteger
-infix operator   -= : AssignmentPrecedence, AdditiveArithmetic, Strideable
-infix operator  &-= : AssignmentPrecedence, FixedWidthInteger
-infix operator  <<= : AssignmentPrecedence, BinaryInteger
-infix operator &<<= : AssignmentPrecedence, FixedWidthInteger
-infix operator  >>= : AssignmentPrecedence, BinaryInteger
-infix operator &>>= : AssignmentPrecedence, FixedWidthInteger
-infix operator   &= : AssignmentPrecedence, BinaryInteger
-infix operator   ^= : AssignmentPrecedence, BinaryInteger
-infix operator   |= : AssignmentPrecedence, BinaryInteger
+infix operator   *=: AssignmentPrecedence, Numeric
+infix operator  &*=: AssignmentPrecedence, FixedWidthInteger
+infix operator   /=: AssignmentPrecedence, BinaryInteger
+infix operator   %=: AssignmentPrecedence, BinaryInteger
+infix operator   +=: AssignmentPrecedence, AdditiveArithmetic, String, Array, Strideable
+infix operator  &+=: AssignmentPrecedence, FixedWidthInteger
+infix operator   -=: AssignmentPrecedence, AdditiveArithmetic, Strideable
+infix operator  &-=: AssignmentPrecedence, FixedWidthInteger
+infix operator  <<=: AssignmentPrecedence, BinaryInteger
+infix operator &<<=: AssignmentPrecedence, FixedWidthInteger
+infix operator  >>=: AssignmentPrecedence, BinaryInteger
+infix operator &>>=: AssignmentPrecedence, FixedWidthInteger
+infix operator   &=: AssignmentPrecedence, BinaryInteger
+infix operator   ^=: AssignmentPrecedence, BinaryInteger
+infix operator   |=: AssignmentPrecedence, BinaryInteger
 
 // Workaround for <rdar://problem/14011860> SubTLF: Default
 // implementations in protocols.  Library authors should ensure

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -158,7 +158,7 @@ public func debugPrint(
 ///     default is a newline (`"\n"`).
 ///   - output: An output stream to receive the text representation of each
 ///     item.
-public func print<Target : TextOutputStream>(
+public func print<Target: TextOutputStream>(
   _ items: Any...,
   separator: String = " ",
   terminator: String = "\n",
@@ -205,7 +205,7 @@ public func print<Target : TextOutputStream>(
 ///     default is a newline (`"\n"`).
 ///   - output: An output stream to receive the text representation of each
 ///     item.
-public func debugPrint<Target : TextOutputStream>(
+public func debugPrint<Target: TextOutputStream>(
   _ items: Any...,
   separator: String = " ",
   terminator: String = "\n",
@@ -214,7 +214,7 @@ public func debugPrint<Target : TextOutputStream>(
   _debugPrint(items, separator: separator, terminator: terminator, to: &output)
 }
 
-internal func _print<Target : TextOutputStream>(
+internal func _print<Target: TextOutputStream>(
   _ items: [Any],
   separator: String = " ",
   terminator: String = "\n",
@@ -231,7 +231,7 @@ internal func _print<Target : TextOutputStream>(
   output.write(terminator)
 }
 
-internal func _debugPrint<Target : TextOutputStream>(
+internal func _debugPrint<Target: TextOutputStream>(
   _ items: [Any],
   separator: String = " ",
   terminator: String = "\n",

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -145,7 +145,7 @@ extension RandomNumberGenerator {
 /// - Linux platforms use `getrandom(2)` when available; otherwise, they read
 ///   from `/dev/urandom`.
 @frozen
-public struct SystemRandomNumberGenerator : RandomNumberGenerator {
+public struct SystemRandomNumberGenerator: RandomNumberGenerator {
   /// Creates a new instance of the system's default random number generator.
   @inlinable
   public init() { }

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -268,13 +268,13 @@ extension RandomAccessCollection {
 
 // Provides an alternative default associated type witness for Indices
 // for random access collections with strideable indices.
-extension RandomAccessCollection where Index : Strideable, Index.Stride == Int {
+extension RandomAccessCollection where Index: Strideable, Index.Stride == Int {
   @_implements(Collection, Indices)
   public typealias _Default_Indices = Range<Index>
 }
 
 extension RandomAccessCollection
-where Index : Strideable, 
+where Index: Strideable,
       Index.Stride == Int,
       Indices == Range<Index> {
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -126,7 +126,7 @@ extension RangeExpression {
 /// you need to iterate over consecutive floating-point values, see the
 /// `stride(from:to:by:)` function.
 @frozen
-public struct Range<Bound : Comparable> {
+public struct Range<Bound: Comparable> {
   /// The range's lower bound.
   ///
   /// In an empty range, `lowerBound` is equal to `upperBound`.
@@ -181,13 +181,13 @@ public struct Range<Bound : Comparable> {
 }
 
 extension Range: Sequence
-where Bound: Strideable, Bound.Stride : SignedInteger {
+where Bound: Strideable, Bound.Stride: SignedInteger {
   public typealias Element = Bound
   public typealias Iterator = IndexingIterator<Range<Bound>>
 }
 
 extension Range: Collection, BidirectionalCollection, RandomAccessCollection
-where Bound : Strideable, Bound.Stride : SignedInteger
+where Bound: Strideable, Bound.Stride: SignedInteger
 {
   /// A type that represents a position in the range.
   public typealias Index = Bound
@@ -278,7 +278,7 @@ where Bound : Strideable, Bound.Stride : SignedInteger
   }
 }
 
-extension Range where Bound: Strideable, Bound.Stride : SignedInteger {  
+extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
   /// Creates an instance equivalent to the given `ClosedRange`.
   ///
   /// - Parameter other: A closed range to convert to a `Range` instance.
@@ -344,7 +344,7 @@ extension Range {
   }
 }
 
-extension Range : CustomStringConvertible {
+extension Range: CustomStringConvertible {
   /// A textual representation of the range.
   @inlinable // trivial-implementation
   public var description: String {
@@ -352,7 +352,7 @@ extension Range : CustomStringConvertible {
   }
 }
 
-extension Range : CustomDebugStringConvertible {
+extension Range: CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
   public var debugDescription: String {
     return "Range(\(String(reflecting: lowerBound))"
@@ -360,7 +360,7 @@ extension Range : CustomDebugStringConvertible {
   }
 }
 
-extension Range : CustomReflectable {
+extension Range: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(
       self, children: ["lowerBound": lowerBound, "upperBound": upperBound])
@@ -642,7 +642,7 @@ extension PartialRangeFrom: RangeExpression {
 }
 
 extension PartialRangeFrom: Sequence
-  where Bound : Strideable, Bound.Stride : SignedInteger
+  where Bound: Strideable, Bound.Stride: SignedInteger
 {
   public typealias Element = Bound
 
@@ -969,9 +969,9 @@ extension Range {
 // Note: this is not for compatibility only, it is considered a useful
 // shorthand. TODO: Add documentation
 public typealias CountableRange<Bound: Strideable> = Range<Bound>
-  where Bound.Stride : SignedInteger
+  where Bound.Stride: SignedInteger
 
 // Note: this is not for compatibility only, it is considered a useful
 // shorthand. TODO: Add documentation
 public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
-  where Bound.Stride : SignedInteger
+  where Bound.Stride: SignedInteger

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -61,8 +61,8 @@
 /// `replaceSubrange(_:with:)` with an empty collection for the `newElements`
 /// parameter. You can override any of the protocol's required methods to
 /// provide your own custom implementation.
-public protocol RangeReplaceableCollection : Collection
-  where SubSequence : RangeReplaceableCollection {
+public protocol RangeReplaceableCollection: Collection
+  where SubSequence: RangeReplaceableCollection {
   // FIXME: Associated type inference requires this.
   override associatedtype SubSequence
 
@@ -110,7 +110,7 @@ public protocol RangeReplaceableCollection : Collection
   mutating func replaceSubrange<C>(
     _ subrange: Range<Index>,
     with newElements: __owned C
-  ) where C : Collection, C.Element == Element
+  ) where C: Collection, C.Element == Element
 
   /// Prepares the collection to store the specified number of elements, when
   /// doing so is appropriate for the underlying type.
@@ -147,7 +147,7 @@ public protocol RangeReplaceableCollection : Collection
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
   ///   `elements` must be finite.
-  init<S : Sequence>(_ elements: S)
+  init<S: Sequence>(_ elements: S)
     where S.Element == Element
 
   /// Adds an element to the end of the collection.
@@ -185,7 +185,7 @@ public protocol RangeReplaceableCollection : Collection
   /// - Parameter newElements: The elements to append to the collection.
   ///
   /// - Complexity: O(*m*), where *m* is the length of `newElements`.
-  mutating func append<S : Sequence>(contentsOf newElements: __owned S)
+  mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element
   // FIXME(ABI)#166 (Evolution): Consider replacing .append(contentsOf) with +=
   // suggestion in SE-91
@@ -240,7 +240,7 @@ public protocol RangeReplaceableCollection : Collection
   /// - Complexity: O(*n* + *m*), where *n* is length of this collection and
   ///   *m* is the length of `newElements`. If `i == endIndex`, this method
   ///   is equivalent to `append(contentsOf:)`.
-  mutating func insert<S : Collection>(contentsOf newElements: __owned S, at i: Index)
+  mutating func insert<S: Collection>(contentsOf newElements: __owned S, at i: Index)
     where S.Element == Element
 
   /// Removes and returns the element at the specified position.
@@ -401,7 +401,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
   @inlinable
-  public init<S : Sequence>(_ elements: S)
+  public init<S: Sequence>(_ elements: S)
     where S.Element == Element {
     self.init()
     append(contentsOf: elements)
@@ -446,7 +446,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Complexity: O(*m*), where *m* is the length of `newElements`.
   @inlinable
-  public mutating func append<S : Sequence>(contentsOf newElements: __owned S)
+  public mutating func append<S: Sequence>(contentsOf newElements: __owned S)
     where S.Element == Element {
 
     let approximateCapacity = self.count +
@@ -513,7 +513,7 @@ extension RangeReplaceableCollection {
   ///   *m* is the length of `newElements`. If `i == endIndex`, this method
   ///   is equivalent to `append(contentsOf:)`.
   @inlinable
-  public mutating func insert<C : Collection>(
+  public mutating func insert<C: Collection>(
     contentsOf newElements: __owned C, at i: Index
   ) where C.Element == Element {
     replaceSubrange(i..<i, with: newElements)
@@ -789,7 +789,7 @@ extension RangeReplaceableCollection {
 }
 
 extension RangeReplaceableCollection
-  where Self : BidirectionalCollection, SubSequence == Self {
+  where Self: BidirectionalCollection, SubSequence == Self {
 
   @inlinable
   public mutating func _customRemoveLast() -> Element? {
@@ -805,7 +805,7 @@ extension RangeReplaceableCollection
   }
 }
 
-extension RangeReplaceableCollection where Self : BidirectionalCollection {
+extension RangeReplaceableCollection where Self: BidirectionalCollection {
   /// Removes and returns the last element of the collection.
   ///
   /// Calling this method may invalidate all saved indices of this
@@ -876,7 +876,7 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
 
 /// Ambiguity breakers.
 extension RangeReplaceableCollection
-where Self : BidirectionalCollection, SubSequence == Self {
+where Self: BidirectionalCollection, SubSequence == Self {
   /// Removes and returns the last element of the collection.
   ///
   /// Calling this method may invalidate all saved indices of this
@@ -965,7 +965,7 @@ extension RangeReplaceableCollection {
   ///   - rhs: A collection or finite sequence.
   @inlinable
   public static func + <
-    Other : Sequence
+    Other: Sequence
   >(lhs: Self, rhs: Other) -> Self
   where Element == Other.Element {
     var lhs = lhs
@@ -994,7 +994,7 @@ extension RangeReplaceableCollection {
   ///   - rhs: A range-replaceable collection.
   @inlinable
   public static func + <
-    Other : Sequence
+    Other: Sequence
   >(lhs: Other, rhs: Self) -> Self
   where Element == Other.Element {
     var result = Self()
@@ -1023,7 +1023,7 @@ extension RangeReplaceableCollection {
   ///   argument.
   @inlinable
   public static func += <
-    Other : Sequence
+    Other: Sequence
   >(lhs: inout Self, rhs: Other)
   where Element == Other.Element {
     lhs.append(contentsOf: rhs)
@@ -1049,7 +1049,7 @@ extension RangeReplaceableCollection {
   ///   - rhs: Another range-replaceable collection.
   @inlinable
   public static func + <
-    Other : RangeReplaceableCollection
+    Other: RangeReplaceableCollection
   >(lhs: Self, rhs: Other) -> Self
   where Element == Other.Element {
     var lhs = lhs

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -33,7 +33,7 @@
 internal func _collectAllReferencesInsideObjectImpl(
   _ value: Any,
   references: inout [UnsafeRawPointer],
-  visitedItems: inout [ObjectIdentifier : Int]
+  visitedItems: inout [ObjectIdentifier: Int]
 ) {
   // Use the structural reflection and ignore any
   // custom reflectable overrides.
@@ -109,7 +109,7 @@ struct _RuntimeFunctionCounters {
     _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
   public static let numRuntimeFunctionCounters =
     _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
-  public static let runtimeFunctionNameToIndex: [String : Int] =
+  public static let runtimeFunctionNameToIndex: [String: Int] =
     getRuntimeFunctionNameToIndex()
 
   /// Get the names of all runtime functions whose calls are being
@@ -122,7 +122,7 @@ struct _RuntimeFunctionCounters {
     let names = _RuntimeFunctionCounters._getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
       _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
-    var functionNames : [String] = []
+    var functionNames: [String] = []
     functionNames.reserveCapacity(numRuntimeFunctionCounters)
     for index in 0..<numRuntimeFunctionCounters {
       let name = String(cString: names[index])
@@ -155,7 +155,7 @@ struct _RuntimeFunctionCounters {
   /// Collect all references inside the object using Mirrors.
   public static func collectAllReferencesInsideObject(_ value: Any) ->
     [UnsafeRawPointer] {
-    var visited : [ObjectIdentifier : Int] = [:]
+    var visited: [ObjectIdentifier: Int] = [:]
     var references: [UnsafeRawPointer] = []
     _collectAllReferencesInsideObjectImpl(
       value, references: &references, visitedItems: &visited)
@@ -163,11 +163,11 @@ struct _RuntimeFunctionCounters {
   }
 
   /// Build a map from counter name to counter index inside the state struct.
-  internal static func getRuntimeFunctionNameToIndex() -> [String : Int] {
+  internal static func getRuntimeFunctionNameToIndex() -> [String: Int] {
     let runtimeFunctionNames = _RuntimeFunctionCounters.getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
       _RuntimeFunctionCounters.getNumRuntimeFunctionCounters()
-    var runtimeFunctionNameToIndex : [String : Int] = [:]
+    var runtimeFunctionNameToIndex: [String: Int] = [:]
     runtimeFunctionNameToIndex.reserveCapacity(numRuntimeFunctionCounters)
 
     for index in 0..<numRuntimeFunctionCounters {
@@ -181,15 +181,15 @@ struct _RuntimeFunctionCounters {
 /// This protocol defines a set of operations for accessing runtime function
 /// counters statistics.
 public // @testable
-protocol _RuntimeFunctionCountersStats : CustomDebugStringConvertible {
+protocol _RuntimeFunctionCountersStats: CustomDebugStringConvertible {
   init()
 
   /// Dump the current state of all counters.
-  func dump<T : TextOutputStream>(skipUnchanged: Bool, to: inout T)
+  func dump<T: TextOutputStream>(skipUnchanged: Bool, to: inout T)
 
   /// Dump the diff between the current state and a different state of all
   /// counters.
-  func dumpDiff<T : TextOutputStream>(
+  func dumpDiff<T: TextOutputStream>(
     _ after: Self, skipUnchanged: Bool, to: inout T
   )
 
@@ -375,7 +375,7 @@ extension _RuntimeFunctionCountersStats {
   typealias Counters = _RuntimeFunctionCounters
   @inline(never)
   public // @testable
-  func dump<T : TextOutputStream>(skipUnchanged: Bool, to: inout T) {
+  func dump<T: TextOutputStream>(skipUnchanged: Bool, to: inout T) {
     for i in 0..<Counters.numRuntimeFunctionCounters {
       if skipUnchanged && self[i] == 0 {
         continue
@@ -390,7 +390,7 @@ extension _RuntimeFunctionCountersStats {
 
   @inline(never)
   public // @testable
-  func dumpDiff<T : TextOutputStream>(
+  func dumpDiff<T: TextOutputStream>(
     _ after: Self, skipUnchanged: Bool, to: inout T
   ) {
     for i in 0..<Counters.numRuntimeFunctionCounters {

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -10,19 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-infix operator .== : ComparisonPrecedence
-infix operator .!= : ComparisonPrecedence
-infix operator .< : ComparisonPrecedence
-infix operator .<= : ComparisonPrecedence
-infix operator .> : ComparisonPrecedence
-infix operator .>= : ComparisonPrecedence
+infix operator .==: ComparisonPrecedence
+infix operator .!=: ComparisonPrecedence
+infix operator .<: ComparisonPrecedence
+infix operator .<=: ComparisonPrecedence
+infix operator .>: ComparisonPrecedence
+infix operator .>=: ComparisonPrecedence
 
-infix operator .& : LogicalConjunctionPrecedence
-infix operator .^ : LogicalDisjunctionPrecedence
-infix operator .| : LogicalDisjunctionPrecedence
-infix operator .&= : AssignmentPrecedence
-infix operator .^= : AssignmentPrecedence
-infix operator .|= : AssignmentPrecedence
+infix operator .&: LogicalConjunctionPrecedence
+infix operator .^: LogicalDisjunctionPrecedence
+infix operator .|: LogicalDisjunctionPrecedence
+infix operator .&=: AssignmentPrecedence
+infix operator .^=: AssignmentPrecedence
+infix operator .|=: AssignmentPrecedence
 prefix operator .!
 
 /// A type that can function as storage for a SIMD vector type.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -328,10 +328,10 @@ public protocol Sequence {
 
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
-  associatedtype Iterator : IteratorProtocol where Iterator.Element == Element
+  associatedtype Iterator: IteratorProtocol where Iterator.Element == Element
 
   /// A type that represents a subsequence of some of the sequence's elements.
-  // associatedtype SubSequence : Sequence = AnySequence<Element>
+  // associatedtype SubSequence: Sequence = AnySequence<Element>
   //   where Element == SubSequence.Element,
   //         SubSequence.SubSequence == SubSequence
   // typealias SubSequence = AnySequence<Element>
@@ -753,7 +753,7 @@ extension Sequence {
   }
 }
 
-extension Sequence where Element : Equatable {
+extension Sequence where Element: Equatable {
   /// Returns the longest possible subsequences of the sequence, in order,
   /// around elements equal to the given element.
   ///
@@ -1133,7 +1133,7 @@ extension Sequence {
 ///
 ///     for x in IteratorSequence(i) { ... }
 @frozen
-public struct IteratorSequence<Base : IteratorProtocol> {
+public struct IteratorSequence<Base: IteratorProtocol> {
   @usableFromInline
   internal var _base: Base
 

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -335,7 +335,7 @@ extension Sequence {
   }
 }
 
-extension Sequence where Element : Equatable {
+extension Sequence where Element: Equatable {
   /// Returns a Boolean value indicating whether this sequence and another
   /// sequence contain the same elements in the same order.
   ///
@@ -430,7 +430,7 @@ extension Sequence {
   }
 }
 
-extension Sequence where Element : Comparable {
+extension Sequence where Element: Comparable {
   /// Returns a Boolean value indicating whether the sequence precedes another
   /// sequence in a lexicographical (dictionary) ordering, using the
   /// less-than operator (`<`) to compare elements.
@@ -544,7 +544,7 @@ extension Sequence {
   }
 }
 
-extension Sequence where Element : Equatable {
+extension Sequence where Element: Equatable {
   /// Returns a Boolean value indicating whether the sequence contains the
   /// given element.
   ///
@@ -751,7 +751,7 @@ extension Sequence {
   /// - Complexity: O(*m* + *n*), where *n* is the length of this sequence
   ///   and *m* is the length of the result.
   @inlinable
-  public func flatMap<SegmentOfResult : Sequence>(
+  public func flatMap<SegmentOfResult: Sequence>(
     _ transform: (Element) throws -> SegmentOfResult
   ) rethrows -> [SegmentOfResult.Element] {
     var result: [SegmentOfResult.Element] = []

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -52,7 +52,7 @@
 /// - `x.isStrictSuperset(of: y)` if and only if
 ///   `x.isSuperset(of: y) && x != y`
 /// - `x.isStrictSubset(of: y)` if and only if `x.isSubset(of: y) && x != y`
-public protocol SetAlgebra : Equatable, ExpressibleByArrayLiteral {  
+public protocol SetAlgebra: Equatable, ExpressibleByArrayLiteral {
   /// A type for which the conforming type provides a containment test.
   associatedtype Element
   
@@ -370,7 +370,7 @@ public protocol SetAlgebra : Equatable, ExpressibleByArrayLiteral {
   ///     // Prints "[6, 0, 1, 3]"
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
-  init<S : Sequence>(_ sequence: __owned S) where S.Element == Element
+  init<S: Sequence>(_ sequence: __owned S) where S.Element == Element
 
   /// Removes the elements of the given set from this set.
   ///
@@ -406,7 +406,7 @@ extension SetAlgebra {
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
   @inlinable // protocol-only
-  public init<S : Sequence>(_ sequence: __owned S)
+  public init<S: Sequence>(_ sequence: __owned S)
     where S.Element == Element {
     self.init()
     for e in sequence { insert(e) }

--- a/stdlib/public/core/SetAnyHashableExtensions.swift
+++ b/stdlib/public/core/SetAnyHashableExtensions.swift
@@ -16,7 +16,7 @@
 
 extension Set where Element == AnyHashable {
   @inlinable
-  public mutating func insert<ConcreteElement : Hashable>(
+  public mutating func insert<ConcreteElement: Hashable>(
     _ newMember: __owned ConcreteElement
   ) -> (inserted: Bool, memberAfterInsert: ConcreteElement) {
     let (inserted, memberAfterInsert) =
@@ -28,7 +28,7 @@ extension Set where Element == AnyHashable {
 
   @inlinable
   @discardableResult
-  public mutating func update<ConcreteElement : Hashable>(
+  public mutating func update<ConcreteElement: Hashable>(
     with newMember: __owned ConcreteElement
   ) -> ConcreteElement? {
     return update(with: AnyHashable(newMember))
@@ -37,7 +37,7 @@ extension Set where Element == AnyHashable {
 
   @inlinable
   @discardableResult
-  public mutating func remove<ConcreteElement : Hashable>(
+  public mutating func remove<ConcreteElement: Hashable>(
     _ member: ConcreteElement
   ) -> ConcreteElement? {
     return remove(AnyHashable(member))

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -289,7 +289,7 @@ extension Slice: RangeReplaceableCollection
   @inlinable // generic-performance
   public mutating func replaceSubrange<C>(
     _ subRange: Range<Index>, with newElements: C
-  ) where C : Collection, C.Element == Base.Element {
+  ) where C: Collection, C.Element == Base.Element {
 
     // FIXME: swift-3-indexing-model: range check.
     let sliceOffset =
@@ -354,7 +354,7 @@ extension Slice
   @inlinable // generic-performance
   public mutating func replaceSubrange<C>(
     _ subRange: Range<Index>, with newElements: C
-  ) where C : Collection, C.Element == Base.Element {
+  ) where C: Collection, C.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if subRange.lowerBound == _base.startIndex {
       let newSliceCount =
@@ -400,7 +400,7 @@ extension Slice
 
   @inlinable // generic-performance
   public mutating func insert<S>(contentsOf newElements: S, at i: Index)
-  where S : Collection, S.Element == Base.Element {
+  where S: Collection, S.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
       let newSliceCount = count + numericCast(newElements.count)

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -123,7 +123,7 @@ internal struct _SliceBuffer<Element>
     _ subrange: Range<Int>,
     with insertCount: Int,
     elementsOf newValues: __owned C
-  ) where C : Collection, C.Element == Element {
+  ) where C: Collection, C.Element == Element {
 
     _invariantCheck()
     _internalInvariant(insertCount <= numericCast(newValues.count))
@@ -286,7 +286,7 @@ internal struct _SliceBuffer<Element>
   /// Traps unless the given `index` is valid for subscripting, i.e.
   /// `startIndex ≤ index < endIndex`
   @inlinable
-  internal func _checkValidSubscript(_ index : Int) {
+  internal func _checkValidSubscript(_ index: Int) {
     _precondition(
       index >= startIndex && index < endIndex, "Index out of bounds")
   }

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -96,9 +96,9 @@
 ///   `Stride` type's implementations. If a type conforming to `Strideable` is
 ///   its own `Stride` type, it must provide concrete implementations of the
 ///   two operators to avoid infinite recursion.
-public protocol Strideable : Comparable {
+public protocol Strideable: Comparable {
   /// A type that represents the distance between two values.
-  associatedtype Stride : SignedNumeric, Comparable
+  associatedtype Stride: SignedNumeric, Comparable
 
   /// Returns the distance from this value to the given value, expressed as a 
   /// stride.
@@ -121,7 +121,7 @@ public protocol Strideable : Comparable {
   /// the addition operator (`+`) instead of this method.
   ///
   ///     func addOne<T: Strideable>(to x: T) -> T
-  ///         where T.Stride : ExpressibleByIntegerLiteral
+  ///         where T.Stride: ExpressibleByIntegerLiteral
   ///     {
   ///         return x.advanced(by: 1)
   ///     }
@@ -171,7 +171,7 @@ extension Strideable {
   }
 }
 
-extension Strideable where Stride : FloatingPoint {
+extension Strideable where Stride: FloatingPoint {
   @inlinable // protocol-only
   public static func _step(
     after current: (index: Int?, value: Self),
@@ -186,7 +186,7 @@ extension Strideable where Stride : FloatingPoint {
   }
 }
 
-extension Strideable where Self : FloatingPoint, Self == Stride {
+extension Strideable where Self: FloatingPoint, Self == Stride {
   @inlinable // protocol-only
   public static func _step(
     after current: (index: Int?, value: Self),
@@ -204,7 +204,7 @@ extension Strideable where Self : FloatingPoint, Self == Stride {
 
 /// An iterator for a `StrideTo` instance.
 @frozen
-public struct StrideToIterator<Element : Strideable> {
+public struct StrideToIterator<Element: Strideable> {
   @usableFromInline
   internal let _start: Element
 
@@ -247,7 +247,7 @@ extension StrideToIterator: IteratorProtocol {
 ///
 /// Use the `stride(from:to:by:)` function to create `StrideTo` instances.
 @frozen
-public struct StrideTo<Element : Strideable> {
+public struct StrideTo<Element: Strideable> {
   @usableFromInline
   internal let _start: Element
 
@@ -308,8 +308,8 @@ extension StrideTo: CustomReflectable {
 
 // FIXME(conditional-conformances): This does not yet compile (SR-6474).
 #if false
-extension StrideTo : RandomAccessCollection
-where Element.Stride : BinaryInteger {
+extension StrideTo: RandomAccessCollection
+where Element.Stride: BinaryInteger {
   public typealias Index = Int
   public typealias SubSequence = Slice<StrideTo<Element>>
   public typealias Indices = Range<Int>
@@ -405,7 +405,7 @@ public func stride<T>(
 
 /// An iterator for a `StrideThrough` instance.
 @frozen
-public struct StrideThroughIterator<Element : Strideable> {
+public struct StrideThroughIterator<Element: Strideable> {
   @usableFromInline
   internal let _start: Element
 
@@ -517,8 +517,8 @@ extension StrideThrough: CustomReflectable {
 
 // FIXME(conditional-conformances): This does not yet compile (SR-6474).
 #if false
-extension StrideThrough : RandomAccessCollection
-where Element.Stride : BinaryInteger {
+extension StrideThrough: RandomAccessCollection
+where Element.Stride: BinaryInteger {
   public typealias Index = ClosedRangeIndex<Int>
   public typealias SubSequence = Slice<StrideThrough<Element>>
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -894,7 +894,7 @@ extension String {
   /// Creates an instance from the description of a given
   /// `LosslessStringConvertible` instance.
   @inlinable @inline(__always)
-  public init<T : LosslessStringConvertible>(_ value: T) {
+  public init<T: LosslessStringConvertible>(_ value: T) {
     self = value.description
   }
 }

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -158,11 +158,11 @@ internal func _cocoaGetCStringTrampoline(
 // Conversion from NSString to Swift's native representation.
 //
 
-private var kCFStringEncodingASCII : _swift_shims_CFStringEncoding {
+private var kCFStringEncodingASCII: _swift_shims_CFStringEncoding {
   @inline(__always) get { return 0x0600 }
 }
 
-private var kCFStringEncodingUTF8 : _swift_shims_CFStringEncoding {
+private var kCFStringEncodingUTF8: _swift_shims_CFStringEncoding {
   @inline(__always) get { return 0x8000100 }
 }
 

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -64,7 +64,7 @@ extension StringProtocol {
   }
 }
 
-extension String : Equatable {
+extension String: Equatable {
   @inlinable @inline(__always) // For the bitwise comparision
   @_effects(readonly)
   @_semantics("string.equals")
@@ -73,7 +73,7 @@ extension String : Equatable {
   }
 }
 
-extension String : Comparable {
+extension String: Comparable {
   @inlinable @inline(__always) // For the bitwise comparision
   @_effects(readonly)
   public static func < (lhs: String, rhs: String) -> Bool {
@@ -81,4 +81,4 @@ extension String : Comparable {
   }
 }
 
-extension Substring : Equatable {}
+extension Substring: Equatable {}

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -246,7 +246,7 @@ extension _StringGuts {
   internal mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Character {
+  ) where C: Collection, C.Iterator.Element == Character {
     if isUniqueNative {
       if let replStr = newElements as? String, replStr._guts.isFastUTF8 {
         replStr._guts.withFastUTF8 {

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -12,7 +12,7 @@
 
 import SwiftShims
 
-extension String : Hashable {
+extension String: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -181,7 +181,7 @@ extension String {
   ///   - uppercase: Pass `true` to use uppercase letters to represent numerals
   ///     greater than 9, or `false` to use lowercase letters. The default is
   ///     `false`.
-  public init<T : BinaryInteger>(
+  public init<T: BinaryInteger>(
     _ value: T, radix: Int = 10, uppercase: Bool = false
   ) {
     self = value._description(radix: radix, uppercase: uppercase)

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -21,18 +21,18 @@ public protocol StringProtocol
   Hashable, Comparable
   where Iterator.Element == Character,
         Index == String.Index,
-        SubSequence : StringProtocol,
+        SubSequence: StringProtocol,
         StringInterpolation == DefaultStringInterpolation
 {
-  associatedtype UTF8View : /*Bidirectional*/Collection
+  associatedtype UTF8View: /*Bidirectional*/Collection
   where UTF8View.Element == UInt8, // Unicode.UTF8.CodeUnit
         UTF8View.Index == Index
 
-  associatedtype UTF16View : BidirectionalCollection
+  associatedtype UTF16View: BidirectionalCollection
   where UTF16View.Element == UInt16, // Unicode.UTF16.CodeUnit
         UTF16View.Index == Index
 
-  associatedtype UnicodeScalarView : BidirectionalCollection
+  associatedtype UnicodeScalarView: BidirectionalCollection
   where UnicodeScalarView.Element == Unicode.Scalar,
         UnicodeScalarView.Index == Index
 

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -33,8 +33,8 @@ extension String: RangeReplaceableCollection {
 
   // This initializer disambiguates between the following intitializers, now
   // that String conforms to Collection:
-  // - init<T>(_ value: T) where T : LosslessStringConvertible
-  // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
+  // - init<T>(_ value: T) where T: LosslessStringConvertible
+  // - init<S>(_ characters: S) where S: Sequence, S.Element == Character
 
   /// Creates a new string containing the characters in the given sequence.
   ///
@@ -53,7 +53,7 @@ extension String: RangeReplaceableCollection {
   ///   characters.
   @_specialize(where S == String)
   @_specialize(where S == Substring)
-  public init<S : Sequence & LosslessStringConvertible>(_ other: S)
+  public init<S: Sequence & LosslessStringConvertible>(_ other: S)
   where S.Element == Character {
     if let str = other as? String {
       self = str
@@ -80,7 +80,7 @@ extension String: RangeReplaceableCollection {
   @_specialize(where S == String)
   @_specialize(where S == Substring)
   @_specialize(where S == Array<Character>)
-  public init<S : Sequence>(_ characters: S)
+  public init<S: Sequence>(_ characters: S)
   where S.Iterator.Element == Character {
     if let str = characters as? String {
       self = str
@@ -162,7 +162,7 @@ extension String: RangeReplaceableCollection {
   @_specialize(where S == String)
   @_specialize(where S == Substring)
   @_specialize(where S == Array<Character>)
-  public mutating func append<S : Sequence>(contentsOf newElements: S)
+  public mutating func append<S: Sequence>(contentsOf newElements: S)
   where S.Iterator.Element == Character {
     if let str = newElements as? String {
       self.append(str)
@@ -197,7 +197,7 @@ extension String: RangeReplaceableCollection {
   public mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Character {
+  ) where C: Collection, C.Iterator.Element == Character {
     _guts.replaceSubrange(bounds, with: newElements)
   }
 
@@ -233,7 +233,7 @@ extension String: RangeReplaceableCollection {
   @_specialize(where S == String)
   @_specialize(where S == Substring)
   @_specialize(where S == Array<Character>)
-  public mutating func insert<S : Collection>(
+  public mutating func insert<S: Collection>(
     contentsOf newElements: S, at i: Index
   ) where S.Element == Character {
     self.replaceSubrange(i..<i, with: newElements)
@@ -324,14 +324,14 @@ extension String {
   // This is needed because of the issue described in SR-4660 which causes
   // source compatibility issues when String becomes a collection
   @_transparent
-  public func max<T : Comparable>(_ x: T, _ y: T) -> T {
+  public func max<T: Comparable>(_ x: T, _ y: T) -> T {
     return Swift.max(x,y)
   }
 
   // This is needed because of the issue described in SR-4660 which causes
   // source compatibility issues when String becomes a collection
   @_transparent
-  public func min<T : Comparable>(_ x: T, _ y: T) -> T {
+  public func min<T: Comparable>(_ x: T, _ y: T) -> T {
     return Swift.min(x,y)
   }
 }

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -16,7 +16,7 @@ import SwiftShims
 // want.
 #if _runtime(_ObjC)
 
-internal protocol _AbstractStringStorage : _NSCopying {
+internal protocol _AbstractStringStorage: _NSCopying {
   var asString: String { get }
   var count: Int { get }
   var isASCII: Bool { get }

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -407,7 +407,7 @@ extension String.UTF16View.Index {
 }
 
 // Reflection
-extension String.UTF16View : CustomReflectable {
+extension String.UTF16View: CustomReflectable {
   /// Returns a mirror that reflects the UTF-16 view of a string.
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -344,7 +344,7 @@ extension String.UTF8View.Index {
 }
 
 // Reflection
-extension String.UTF8View : CustomReflectable {
+extension String.UTF8View: CustomReflectable {
   /// Returns a mirror that reflects the UTF-8 view of a string.
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -246,7 +246,7 @@ extension String {
   }
 }
 
-extension String.UnicodeScalarView : RangeReplaceableCollection {
+extension String.UnicodeScalarView: RangeReplaceableCollection {
   /// Creates an empty view instance.
   @inlinable @inline(__always)
   public init() {
@@ -281,7 +281,7 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   /// - Parameter newElements: A sequence of Unicode scalar values.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting view.
-  public mutating func append<S : Sequence>(contentsOf newElements: S)
+  public mutating func append<S: Sequence>(contentsOf newElements: S)
   where S.Element == Unicode.Scalar {
     // TODO(String performance): Skip extra String allocation
     let scalars = String(decoding: newElements.map { $0.value }, as: UTF32.self)
@@ -306,7 +306,7 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   public mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,
     with newElements: C
-  ) where C : Collection, C.Element == Unicode.Scalar {
+  ) where C: Collection, C.Element == Unicode.Scalar {
     // TODO(String performance): Skip extra String and Array allocation
 
     let utf8Replacement = newElements.flatMap { String($0).utf8 }
@@ -383,7 +383,7 @@ extension String.UnicodeScalarIndex {
 }
 
 // Reflection
-extension String.UnicodeScalarView : CustomReflectable {
+extension String.UnicodeScalarView: CustomReflectable {
   /// Returns a mirror that reflects the Unicode scalars view of a string.
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -207,7 +207,7 @@ extension Substring: StringProtocol {
   public mutating func replaceSubrange<C>(
     _ bounds: Range<Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Iterator.Element {
+  ) where C: Collection, C.Iterator.Element == Iterator.Element {
     _slice.replaceSubrange(bounds, with: newElements)
   }
 
@@ -307,20 +307,20 @@ extension Substring: StringProtocol {
   }
 }
 
-extension Substring : CustomReflectable {
+extension Substring: CustomReflectable {
  public var customMirror: Mirror { return String(self).customMirror }
 }
 
-extension Substring : CustomStringConvertible {
+extension Substring: CustomStringConvertible {
   @inlinable @inline(__always)
   public var description: String { return String(self) }
 }
 
-extension Substring : CustomDebugStringConvertible {
+extension Substring: CustomDebugStringConvertible {
   public var debugDescription: String { return String(self).debugDescription }
 }
 
-extension Substring : LosslessStringConvertible {
+extension Substring: LosslessStringConvertible {
   @inlinable
   public init(_ content: String) {
     self = content[...]
@@ -335,7 +335,7 @@ extension Substring {
   }
 }
 
-extension Substring.UTF8View : BidirectionalCollection {
+extension Substring.UTF8View: BidirectionalCollection {
   public typealias Index = String.UTF8View.Index
   public typealias Indices = String.UTF8View.Indices
   public typealias Element = String.UTF8View.Element
@@ -461,7 +461,7 @@ extension Substring {
   }
 }
 
-extension Substring.UTF16View : BidirectionalCollection {
+extension Substring.UTF16View: BidirectionalCollection {
   public typealias Index = String.UTF16View.Index
   public typealias Indices = String.UTF16View.Indices
   public typealias Element = String.UTF16View.Element
@@ -587,7 +587,7 @@ extension Substring {
   }
 }
 
-extension Substring.UnicodeScalarView : BidirectionalCollection {
+extension Substring.UnicodeScalarView: BidirectionalCollection {
   public typealias Index = String.UnicodeScalarView.Index
   public typealias Indices = String.UnicodeScalarView.Indices
   public typealias Element = String.UnicodeScalarView.Element
@@ -699,22 +699,22 @@ extension String {
 }
 
 // FIXME: The other String views should be RangeReplaceable too.
-extension Substring.UnicodeScalarView : RangeReplaceableCollection {
+extension Substring.UnicodeScalarView: RangeReplaceableCollection {
   @inlinable
   public init() { _slice = Slice.init() }
 
-  public mutating func replaceSubrange<C : Collection>(
+  public mutating func replaceSubrange<C: Collection>(
     _ target: Range<Index>, with replacement: C
   ) where C.Element == Element {
     _slice.replaceSubrange(target, with: replacement)
   }
 }
 
-extension Substring : RangeReplaceableCollection {
+extension Substring: RangeReplaceableCollection {
   @_specialize(where S == String)
   @_specialize(where S == Substring)
   @_specialize(where S == Array<Character>)
-  public init<S : Sequence>(_ elements: S)
+  public init<S: Sequence>(_ elements: S)
   where S.Element == Character {
     if let str = elements as? String {
       self = str[...]
@@ -728,7 +728,7 @@ extension Substring : RangeReplaceableCollection {
   }
 
   @inlinable // specialize
-  public mutating func append<S : Sequence>(contentsOf elements: S)
+  public mutating func append<S: Sequence>(contentsOf elements: S)
   where S.Element == Character {
     var string = String(self)
     self = Substring() // Keep unique storage if possible
@@ -753,33 +753,33 @@ extension Substring {
   }
 }
 
-extension Substring : TextOutputStream {
+extension Substring: TextOutputStream {
   public mutating func write(_ other: String) {
     append(contentsOf: other)
   }
 }
 
-extension Substring : TextOutputStreamable {
+extension Substring: TextOutputStreamable {
   @inlinable // specializable
-  public func write<Target : TextOutputStream>(to target: inout Target) {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
     target.write(String(self))
   }
 }
 
-extension Substring : ExpressibleByUnicodeScalarLiteral {
+extension Substring: ExpressibleByUnicodeScalarLiteral {
   @inlinable
   public init(unicodeScalarLiteral value: String) {
      self.init(value)
   }
 }
-extension Substring : ExpressibleByExtendedGraphemeClusterLiteral {
+extension Substring: ExpressibleByExtendedGraphemeClusterLiteral {
   @inlinable
   public init(extendedGraphemeClusterLiteral value: String) {
      self.init(value)
   }
 }
 
-extension Substring : ExpressibleByStringLiteral {
+extension Substring: ExpressibleByStringLiteral {
   @inlinable
   public init(stringLiteral value: String) {
      self.init(value)

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -62,7 +62,7 @@ internal class __SwiftNativeNSArrayWithContiguousStorage
 }
 
 // Implement the APIs required by NSArray 
-extension __SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
+extension __SwiftNativeNSArrayWithContiguousStorage: _NSArrayCore {
   @objc internal var count: Int {
     return withUnsafeBufferOfObjects { $0.count }
   }

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -108,7 +108,7 @@ public func >=(lhs: (), rhs: ()) -> Bool {
 % for arity in range(2,7):
 %   typeParams = [chr(ord("A") + i) for i in range(arity)]
 %   tupleT = "({})".format(",".join(typeParams))
-%   equatableTypeParams = ", ".join(["{} : Equatable".format(c) for c in typeParams])
+%   equatableTypeParams = ", ".join(["{}: Equatable".format(c) for c in typeParams])
 
 %   originalTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity))))
 %   greaterTuple = "(\"a\", {})".format(", ".join(map(str, range(1, arity - 1) + [arity])))
@@ -171,7 +171,7 @@ public func != <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool 
   )
 }
 
-%   comparableTypeParams = ", ".join(["{} : Comparable".format(c) for c in typeParams])
+%   comparableTypeParams = ", ".join(["{}: Comparable".format(c) for c in typeParams])
 %   for op, phrase in comparableOperators:
 /// Returns a Boolean value indicating whether the first tuple is ordered
 /// ${phrase} the second in a lexicographical ordering.

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -35,11 +35,11 @@ public struct _UIntBuffer<Element: UnsignedInteger & FixedWidthInteger> {
   }
 }
 
-extension _UIntBuffer : Sequence {
+extension _UIntBuffer: Sequence {
   public typealias SubSequence = Slice<_UIntBuffer>
   
   @frozen
-  public struct Iterator : IteratorProtocol, Sequence {
+  public struct Iterator: IteratorProtocol, Sequence {
     @inlinable
     @inline(__always)
     public init(_ x: _UIntBuffer) { _impl = x }
@@ -65,9 +65,9 @@ extension _UIntBuffer : Sequence {
   }
 }
 
-extension _UIntBuffer : Collection {  
+extension _UIntBuffer: Collection {
   @frozen
-  public struct Index : Comparable {
+  public struct Index: Comparable {
     @usableFromInline
     internal var bitOffset: UInt8
     
@@ -85,13 +85,13 @@ extension _UIntBuffer : Collection {
   }
 
   @inlinable
-  public var startIndex : Index {
+  public var startIndex: Index {
     @inline(__always)
     get { return Index(bitOffset: 0) }
   }
   
   @inlinable
-  public var endIndex : Index {
+  public var endIndex: Index {
     @inline(__always)
     get { return Index(bitOffset: _bitCount) }
   }
@@ -103,7 +103,7 @@ extension _UIntBuffer : Collection {
   }
 
   @inlinable
-  internal var _elementWidth : UInt8 {
+  internal var _elementWidth: UInt8 {
     return UInt8(truncatingIfNeeded: Element.bitWidth)
   }
   
@@ -116,7 +116,7 @@ extension _UIntBuffer : Collection {
   }
 }
 
-extension _UIntBuffer : BidirectionalCollection {
+extension _UIntBuffer: BidirectionalCollection {
   @inlinable
   @inline(__always)
   public func index(before i: Index) -> Index {
@@ -124,7 +124,7 @@ extension _UIntBuffer : BidirectionalCollection {
   }
 }
 
-extension _UIntBuffer : RandomAccessCollection {
+extension _UIntBuffer: RandomAccessCollection {
   public typealias Indices = DefaultIndices<_UIntBuffer>
   
   @inlinable
@@ -167,7 +167,7 @@ extension Range {
   }
 }
 
-extension _UIntBuffer : RangeReplaceableCollection {
+extension _UIntBuffer: RangeReplaceableCollection {
   @inlinable
   @inline(__always)
   public init() {

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -155,7 +155,7 @@ extension Unicode.UTF16 {
 
   @inlinable
   public // @testable
-  static func _copy<T : _StringElement, U : _StringElement>(
+  static func _copy<T: _StringElement, U: _StringElement>(
     source: UnsafeMutablePointer<T>,
     destination: UnsafeMutablePointer<U>,
     count: Int
@@ -210,8 +210,8 @@ extension Unicode.UTF16 {
   ///   `nil`.
   @inlinable
   public static func transcodedLength<
-    Input : IteratorProtocol,
-    Encoding : Unicode.Encoding
+    Input: IteratorProtocol,
+    Encoding: Unicode.Encoding
   >(
     of input: Input,
     decodedAs sourceEncoding: Encoding.Type,
@@ -259,7 +259,7 @@ extension Unicode.UTF16 {
   }
 }
 
-extension Unicode.UTF16 : Unicode.Encoding {
+extension Unicode.UTF16: Unicode.Encoding {
   public typealias CodeUnit = UInt16
   public typealias EncodedScalar = _UIntBuffer<UInt16>
 
@@ -269,7 +269,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
   }
   
   @inlinable
-  public static var encodedReplacementCharacter : EncodedScalar {
+  public static var encodedReplacementCharacter: EncodedScalar {
     return EncodedScalar(_storage: 0xFFFD, _bitCount: 16)
   }
 
@@ -327,7 +327,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
 
   @inlinable
   @inline(__always)
-  public static func transcode<FromEncoding : Unicode.Encoding>(
+  public static func transcode<FromEncoding: Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF8.self) {
@@ -386,7 +386,7 @@ extension Unicode.UTF16 : Unicode.Encoding {
   }
 }
 
-extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
+extension UTF16.ReverseParser: Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF16
 
   @inlinable
@@ -409,7 +409,7 @@ extension UTF16.ReverseParser : Unicode.Parser, _UTFParser {
   }
 }
 
-extension Unicode.UTF16.ForwardParser : Unicode.Parser, _UTFParser {
+extension Unicode.UTF16.ForwardParser: Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF16
   
   @inlinable

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -16,7 +16,7 @@ extension Unicode {
   }
 }
 
-extension Unicode.UTF32 : Unicode.Encoding {
+extension Unicode.UTF32: Unicode.Encoding {
   public typealias CodeUnit = UInt32
   public typealias EncodedScalar = CollectionOfOne<UInt32>
 
@@ -26,7 +26,7 @@ extension Unicode.UTF32 : Unicode.Encoding {
   }
 
   @inlinable
-  public static var encodedReplacementCharacter : EncodedScalar {
+  public static var encodedReplacementCharacter: EncodedScalar {
     return EncodedScalar(_replacementCodeUnit)
   }
 
@@ -66,12 +66,12 @@ extension Unicode.UTF32 : Unicode.Encoding {
   public typealias ReverseParser = Parser
 }
 
-extension UTF32.Parser : Unicode.Parser {
+extension UTF32.Parser: Unicode.Parser {
   public typealias Encoding = Unicode.UTF32
 
   /// Parses a single Unicode scalar value from `input`.
   @inlinable
-  public mutating func parseScalar<I : IteratorProtocol>(
+  public mutating func parseScalar<I: IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>
   where I.Element == Encoding.CodeUnit {

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -50,12 +50,12 @@ extension Unicode.UTF8 {
   }
 }
 
-extension Unicode.UTF8 : _UnicodeEncoding {
+extension Unicode.UTF8: _UnicodeEncoding {
   public typealias CodeUnit = UInt8
   public typealias EncodedScalar = _ValidUTF8Buffer
 
   @inlinable
-  public static var encodedReplacementCharacter : EncodedScalar {
+  public static var encodedReplacementCharacter: EncodedScalar {
     return EncodedScalar.encodedReplacementCharacter
   }
 
@@ -131,7 +131,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
 
   @inlinable
   @inline(__always)
-  public static func transcode<FromEncoding : _UnicodeEncoding>(
+  public static func transcode<FromEncoding: _UnicodeEncoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     if _fastPath(FromEncoding.self == UTF16.self) {
@@ -180,7 +180,7 @@ extension Unicode.UTF8 : _UnicodeEncoding {
   }
 }
 
-extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
+extension UTF8.ReverseParser: Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF8
   @inline(__always)
   @inlinable
@@ -256,7 +256,7 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
   }
 }
 
-extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
+extension Unicode.UTF8.ForwardParser: Unicode.Parser, _UTFParser {
   public typealias Encoding = Unicode.UTF8
 
   @inline(__always)

--- a/stdlib/public/core/UTFEncoding.swift
+++ b/stdlib/public/core/UTFEncoding.swift
@@ -17,7 +17,7 @@
 
 
 public protocol _UTFParser {
-  associatedtype Encoding : _UnicodeEncoding
+  associatedtype Encoding: _UnicodeEncoding
 
   func _parseMultipleCodeUnits() -> (isValid: Bool, bitCount: UInt8)
   func _bufferedScalar(bitCount: UInt8) -> Encoding.EncodedScalar
@@ -26,11 +26,11 @@ public protocol _UTFParser {
 }
 
 extension _UTFParser
-where Encoding.EncodedScalar : RangeReplaceableCollection {
+where Encoding.EncodedScalar: RangeReplaceableCollection {
 
   @inlinable
   @inline(__always)
-  public mutating func parseScalar<I : IteratorProtocol>(
+  public mutating func parseScalar<I: IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>
     where I.Element == Encoding.CodeUnit {

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -101,7 +101,7 @@ public typealias UnfoldFirstSequence<T> = UnfoldSequence<T, (T?, Bool)>
 /// Instances of `UnfoldSequence` are created with the functions
 /// `sequence(first:next:)` and `sequence(state:next:)`.
 @frozen // generic-performance
-public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
+public struct UnfoldSequence<Element, State>: Sequence, IteratorProtocol {
   @inlinable // generic-performance
   public mutating func next() -> Element? {
     guard !_done else { return nil }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -21,7 +21,7 @@ import SwiftShims
 /// an indication that no more Unicode scalars are available, or an indication
 /// of a decoding error.
 @frozen
-public enum UnicodeDecodingResult : Equatable {
+public enum UnicodeDecodingResult: Equatable {
   /// A decoded Unicode scalar value.
   case scalarValue(Unicode.Scalar)
   
@@ -58,7 +58,7 @@ public enum UnicodeDecodingResult : Equatable {
 /// UTF-8, UTF-16, and UTF-32 encoding schemes as the `UTF8`, `UTF16`, and
 /// `UTF32` types, respectively. Use the `Unicode.Scalar` type to work with
 /// decoded Unicode scalar values.
-public protocol UnicodeCodec : Unicode.Encoding {
+public protocol UnicodeCodec: Unicode.Encoding {
 
   /// Creates an instance of the codec.
   init()
@@ -103,7 +103,7 @@ public protocol UnicodeCodec : Unicode.Encoding {
   /// - Returns: A `UnicodeDecodingResult` instance, representing the next
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
-  mutating func decode<I : IteratorProtocol>(
+  mutating func decode<I: IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit
 
@@ -139,7 +139,7 @@ public protocol UnicodeCodec : Unicode.Encoding {
 
 /// A codec for translating between Unicode scalar values and UTF-8 code
 /// units.
-extension Unicode.UTF8 : UnicodeCodec {
+extension Unicode.UTF8: UnicodeCodec {
   /// Creates an instance of the UTF-8 codec.
   @inlinable
   public init() { self = ._swift3Buffer(ForwardParser()) }
@@ -187,7 +187,7 @@ extension Unicode.UTF8 : UnicodeCodec {
   ///   UTF sequence has been fully decoded.
   @inlinable
   @inline(__always)
-  public mutating func decode<I : IteratorProtocol>(
+  public mutating func decode<I: IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
     guard case ._swift3Buffer(var parser) = self else {
@@ -316,7 +316,7 @@ extension Unicode.UTF8 : UnicodeCodec {
 
 /// A codec for translating between Unicode scalar values and UTF-16 code
 /// units.
-extension Unicode.UTF16 : UnicodeCodec {
+extension Unicode.UTF16: UnicodeCodec {
   /// Creates an instance of the UTF-16 codec.
   @inlinable
   public init() { self = ._swift3Buffer(ForwardParser()) }
@@ -363,7 +363,7 @@ extension Unicode.UTF16 : UnicodeCodec {
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
   @inlinable
-  public mutating func decode<I : IteratorProtocol>(
+  public mutating func decode<I: IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
     guard case ._swift3Buffer(var parser) = self else {
@@ -381,7 +381,7 @@ extension Unicode.UTF16 : UnicodeCodec {
   /// units it spanned in the input.  This function may consume more code
   /// units than required for this scalar.
   @inlinable
-  internal mutating func _decodeOne<I : IteratorProtocol>(
+  internal mutating func _decodeOne<I: IteratorProtocol>(
     _ input: inout I
   ) -> (UnicodeDecodingResult, Int) where I.Element == CodeUnit {
     let result = decode(&input)
@@ -428,7 +428,7 @@ extension Unicode.UTF16 : UnicodeCodec {
 
 /// A codec for translating between Unicode scalar values and UTF-32 code
 /// units.
-extension Unicode.UTF32 : UnicodeCodec {
+extension Unicode.UTF32: UnicodeCodec {
   /// Creates an instance of the UTF-32 codec.
   @inlinable
   public init() { self = ._swift3Codec }
@@ -475,7 +475,7 @@ extension Unicode.UTF32 : UnicodeCodec {
   ///   Unicode scalar, an indication of an error, or an indication that the
   ///   UTF sequence has been fully decoded.
   @inlinable
-  public mutating func decode<I : IteratorProtocol>(
+  public mutating func decode<I: IteratorProtocol>(
     _ input: inout I
   ) -> UnicodeDecodingResult where I.Element == CodeUnit {
     var parser = ForwardParser()
@@ -550,9 +550,9 @@ extension Unicode.UTF32 : UnicodeCodec {
 @inlinable
 @inline(__always)
 public func transcode<
-  Input : IteratorProtocol,
-  InputEncoding : Unicode.Encoding,
-  OutputEncoding : Unicode.Encoding
+  Input: IteratorProtocol,
+  InputEncoding: Unicode.Encoding,
+  OutputEncoding: Unicode.Encoding
 >(
   _ input: Input,
   from inputEncoding: InputEncoding.Type,
@@ -596,7 +596,7 @@ protocol _StringElement {
   static func _fromUTF16CodeUnit(_ utf16: UTF16.CodeUnit) -> Self
 }
 
-extension UTF16.CodeUnit : _StringElement {
+extension UTF16.CodeUnit: _StringElement {
   @inlinable
   public // @testable
   static func _toUTF16CodeUnit(_ x: UTF16.CodeUnit) -> UTF16.CodeUnit {
@@ -611,7 +611,7 @@ extension UTF16.CodeUnit : _StringElement {
   }
 }
 
-extension UTF8.CodeUnit : _StringElement {
+extension UTF8.CodeUnit: _StringElement {
   @inlinable
   public // @testable
   static func _toUTF16CodeUnit(_ x: UTF8.CodeUnit) -> UTF16.CodeUnit {
@@ -663,9 +663,9 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
   stopOnError: Bool
 ) -> Bool
   where
-  Input : IteratorProtocol,
-  InputEncoding : UnicodeCodec,
-  OutputEncoding : UnicodeCodec,
+  Input: IteratorProtocol,
+  InputEncoding: UnicodeCodec,
+  OutputEncoding: UnicodeCodec,
   InputEncoding.CodeUnit == Input.Element {
   Builtin.unreachable()
 }

--- a/stdlib/public/core/UnicodeEncoding.swift
+++ b/stdlib/public/core/UnicodeEncoding.swift
@@ -12,10 +12,10 @@
 
 public protocol _UnicodeEncoding {
   /// The basic unit of encoding
-  associatedtype CodeUnit : UnsignedInteger, FixedWidthInteger
+  associatedtype CodeUnit: UnsignedInteger, FixedWidthInteger
   
   /// A valid scalar value as represented in this encoding
-  associatedtype EncodedScalar : BidirectionalCollection
+  associatedtype EncodedScalar: BidirectionalCollection
     where EncodedScalar.Iterator.Element == CodeUnit
 
   /// A unicode scalar value to be used when repairing
@@ -23,7 +23,7 @@ public protocol _UnicodeEncoding {
   ///
   /// If the Unicode replacement character U+FFFD is representable in this
   /// encoding, `encodedReplacementCharacter` encodes that scalar value.
-  static var encodedReplacementCharacter : EncodedScalar { get }
+  static var encodedReplacementCharacter: EncodedScalar { get }
 
   /// Converts from encoded to encoding-independent representation
   static func decode(_ content: EncodedScalar) -> Unicode.Scalar
@@ -37,18 +37,18 @@ public protocol _UnicodeEncoding {
   ///
   /// A default implementation of this method will be provided 
   /// automatically for any conforming type that does not implement one.
-  static func transcode<FromEncoding : Unicode.Encoding>(
+  static func transcode<FromEncoding: Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar?
 
   /// A type that can be used to parse `CodeUnits` into
   /// `EncodedScalar`s.
-  associatedtype ForwardParser : Unicode.Parser
+  associatedtype ForwardParser: Unicode.Parser
     where ForwardParser.Encoding == Self
   
   /// A type that can be used to parse a reversed sequence of
   /// `CodeUnits` into `EncodedScalar`s.
-  associatedtype ReverseParser : Unicode.Parser
+  associatedtype ReverseParser: Unicode.Parser
     where ReverseParser.Encoding == Self
 
   //===--------------------------------------------------------------------===//
@@ -66,7 +66,7 @@ extension _UnicodeEncoding {
   public static func _isScalar(_ x: CodeUnit) -> Bool { return false }
 
   @inlinable
-  public static func transcode<FromEncoding : Unicode.Encoding>(
+  public static func transcode<FromEncoding: Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar? {
     return encode(FromEncoding.decode(content))
@@ -84,7 +84,7 @@ extension _UnicodeEncoding {
   /// `encodedReplacementCharacter` if the scalar can't be represented in this
   /// encoding.
   @inlinable
-  internal static func _transcode<FromEncoding : Unicode.Encoding>(
+  internal static func _transcode<FromEncoding: Unicode.Encoding>(
     _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
   ) -> EncodedScalar {
     return transcode(content, from: FromEncoding.self)

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -43,14 +43,14 @@ extension Unicode {
 /// scalar values.
 public protocol _UnicodeParser {
   /// The encoding with which this parser is associated
-  associatedtype Encoding : _UnicodeEncoding
+  associatedtype Encoding: _UnicodeEncoding
 
   /// Constructs an instance that can be used to begin parsing `CodeUnit`s at
   /// any Unicode scalar boundary.
   init()
 
   /// Parses a single Unicode scalar value from `input`.
-  mutating func parseScalar<I : IteratorProtocol>(
+  mutating func parseScalar<I: IteratorProtocol>(
     from input: inout I
   ) -> Unicode.ParseResult<Encoding.EncodedScalar>
   where I.Element == Encoding.CodeUnit

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -274,7 +274,7 @@ extension Unicode.Scalar :
   }
 }
 
-extension Unicode.Scalar : CustomStringConvertible, CustomDebugStringConvertible {
+extension Unicode.Scalar: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the Unicode scalar.
   @inlinable
   public var description: String {
@@ -288,7 +288,7 @@ extension Unicode.Scalar : CustomStringConvertible, CustomDebugStringConvertible
   }
 }
 
-extension Unicode.Scalar : LosslessStringConvertible {
+extension Unicode.Scalar: LosslessStringConvertible {
   @inlinable
   public init?(_ description: String) {
     let scalars = description.unicodeScalars
@@ -299,7 +299,7 @@ extension Unicode.Scalar : LosslessStringConvertible {
   }
 }
 
-extension Unicode.Scalar : Hashable {
+extension Unicode.Scalar: Hashable {
   /// Hashes the essential components of this value by feeding them into the
   /// given hasher.
   ///
@@ -371,14 +371,14 @@ extension UInt64 {
   }
 }
 
-extension Unicode.Scalar : Equatable {
+extension Unicode.Scalar: Equatable {
   @inlinable
   public static func == (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
     return lhs.value == rhs.value
   }
 }
 
-extension Unicode.Scalar : Comparable {
+extension Unicode.Scalar: Comparable {
   @inlinable
   public static func < (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
     return lhs.value < rhs.value
@@ -402,7 +402,7 @@ extension Unicode.Scalar {
   }
 }
 
-extension Unicode.Scalar.UTF16View : RandomAccessCollection {
+extension Unicode.Scalar.UTF16View: RandomAccessCollection {
 
   public typealias Indices = Range<Int>
 
@@ -452,7 +452,7 @@ extension Unicode.Scalar {
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension Unicode.Scalar.UTF8View : RandomAccessCollection {
+extension Unicode.Scalar.UTF8View: RandomAccessCollection {
   public typealias Indices = Range<Int>
 
   /// The position of the first code unit.

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -15,7 +15,7 @@
 /// When you use this type, you become partially responsible for
 /// keeping the object alive.
 @frozen
-public struct Unmanaged<Instance : AnyObject> {
+public struct Unmanaged<Instance: AnyObject> {
   @usableFromInline
   internal unowned(unsafe) var _value: Instance
 
@@ -194,7 +194,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///        }
   ///    }
   ///
-  ///    func doSomething(_ u : Unmanaged<Owned>) {
+  ///    func doSomething(_ u: Unmanaged<Owned>) {
   ///      u._withUnsafeGuaranteedRef {
   ///        $0.doSomething()
   ///      }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -694,7 +694,7 @@ extension Unsafe${Mutable}BufferPointer {
   }
 }
 
-extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
+extension Unsafe${Mutable}BufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -215,7 +215,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
 
   /// Creates an `UnsafePointer` from a builtin raw pointer.
   @_transparent
-  public init(_ _rawValue : Builtin.RawPointer) {
+  public init(_ _rawValue: Builtin.RawPointer) {
     self._rawValue = _rawValue
   }
 
@@ -317,7 +317,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
   }
 
   @inlinable // unsafe-performance
-  internal static var _max : UnsafePointer {
+  internal static var _max: UnsafePointer {
     return UnsafePointer(
       bitPattern: 0 as Int &- MemoryLayout<Pointee>.stride
     )._unsafelyUnwrappedUnchecked
@@ -521,7 +521,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
 
   /// Creates an `UnsafeMutablePointer` from a builtin raw pointer.
   @_transparent
-  public init(_ _rawValue : Builtin.RawPointer) {
+  public init(_ _rawValue: Builtin.RawPointer) {
     self._rawValue = _rawValue
   }
 
@@ -974,7 +974,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   }
 
   @inlinable // unsafe-performance
-  internal static var _max : UnsafeMutablePointer {
+  internal static var _max: UnsafeMutablePointer {
     return UnsafeMutablePointer(
       bitPattern: 0 as Int &- MemoryLayout<Pointee>.stride
     )._unsafelyUnwrappedUnchecked

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -402,7 +402,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter source: A collection of `UInt8` elements. `source.count` must
   ///   be less than or equal to this buffer's `count`.
   @inlinable
-  public func copyBytes<C : Collection>(from source: C
+  public func copyBytes<C: Collection>(from source: C
   ) where C.Element == UInt8 {
     _debugPrecondition(source.count <= self.count,
       "${Self}.copyBytes source has too many elements")
@@ -677,7 +677,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 }
 
-extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
+extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
   public var debugDescription: String {
     return "${Self}"

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -36,11 +36,11 @@ public struct _ValidUTF8Buffer {
   }
 }
 
-extension _ValidUTF8Buffer : Sequence {
+extension _ValidUTF8Buffer: Sequence {
   public typealias SubSequence = Slice<_ValidUTF8Buffer>
 
   @frozen
-  public struct Iterator : IteratorProtocol, Sequence {
+  public struct Iterator: IteratorProtocol, Sequence {
     @inlinable
     public init(_ x: _ValidUTF8Buffer) { _biasedBits = x._biasedBits }
 
@@ -60,9 +60,9 @@ extension _ValidUTF8Buffer : Sequence {
   }
 }
 
-extension _ValidUTF8Buffer : Collection {
+extension _ValidUTF8Buffer: Collection {
   @frozen
-  public struct Index : Comparable {
+  public struct Index: Comparable {
     @usableFromInline
     internal var _biasedBits: UInt32
 
@@ -80,22 +80,22 @@ extension _ValidUTF8Buffer : Collection {
   }
 
   @inlinable
-  public var startIndex : Index {
+  public var startIndex: Index {
     return Index(_biasedBits: _biasedBits)
   }
 
   @inlinable
-  public var endIndex : Index {
+  public var endIndex: Index {
     return Index(_biasedBits: 0)
   }
 
   @inlinable
-  public var count : Int {
+  public var count: Int {
     return UInt32.bitWidth &>> 3 &- _biasedBits.leadingZeroBitCount &>> 3
   }
 
   @inlinable
-  public var isEmpty : Bool {
+  public var isEmpty: Bool {
     return _biasedBits == 0
   }
 
@@ -111,7 +111,7 @@ extension _ValidUTF8Buffer : Collection {
   }
 }
 
-extension _ValidUTF8Buffer : BidirectionalCollection {
+extension _ValidUTF8Buffer: BidirectionalCollection {
   @inlinable
   public func index(before i: Index) -> Index {
     let offset = _ValidUTF8Buffer(_biasedBits: i._biasedBits).count
@@ -120,7 +120,7 @@ extension _ValidUTF8Buffer : BidirectionalCollection {
   }
 }
 
-extension _ValidUTF8Buffer : RandomAccessCollection {
+extension _ValidUTF8Buffer: RandomAccessCollection {
   public typealias Indices = DefaultIndices<_ValidUTF8Buffer>
 
   @inlinable
@@ -144,7 +144,7 @@ extension _ValidUTF8Buffer : RandomAccessCollection {
   }
 }
 
-extension _ValidUTF8Buffer : RangeReplaceableCollection {
+extension _ValidUTF8Buffer: RangeReplaceableCollection {
   @inlinable
   public init() {
     _biasedBits = 0
@@ -211,7 +211,7 @@ extension _ValidUTF8Buffer {
 
 extension _ValidUTF8Buffer {
   @inlinable
-  public static var encodedReplacementCharacter : _ValidUTF8Buffer {
+  public static var encodedReplacementCharacter: _ValidUTF8Buffer {
     return _ValidUTF8Buffer(_biasedBits: 0xBD_BF_EF &+ 0x01_01_01)
   }
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -53,11 +53,11 @@ public protocol CVarArg {
 /// Floating point types need to be passed differently on x86_64
 /// systems.  CoreGraphics uses this to make CGFloat work properly.
 public // SPI(CoreGraphics)
-protocol _CVarArgPassedAsDouble : CVarArg {}
+protocol _CVarArgPassedAsDouble: CVarArg {}
 
 /// Some types require alignment greater than Int on some architectures.
 public // SPI(CoreGraphics)
-protocol _CVarArgAligned : CVarArg {
+protocol _CVarArgAligned: CVarArg {
   /// Returns the required alignment in bytes of
   /// the value returned by `_cVarArgEncoding`.
   var _cVarArgAlignment: Int { get }
@@ -215,7 +215,7 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
 // encoding.
 
 // Signed types
-extension Int : CVarArg {
+extension Int: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -224,13 +224,13 @@ extension Int : CVarArg {
   }
 }
 
-extension Bool : CVarArg {
+extension Bool: CVarArg {
   public var _cVarArgEncoding: [Int] {
     return _encodeBitsAsWords(_VAInt(self ? 1:0))
   }
 }
 
-extension Int64 : CVarArg, _CVarArgAligned {
+extension Int64: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -247,7 +247,7 @@ extension Int64 : CVarArg, _CVarArgAligned {
   }
 }
 
-extension Int32 : CVarArg {
+extension Int32: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -256,7 +256,7 @@ extension Int32 : CVarArg {
   }
 }
 
-extension Int16 : CVarArg {
+extension Int16: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -265,7 +265,7 @@ extension Int16 : CVarArg {
   }
 }
 
-extension Int8 : CVarArg {
+extension Int8: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -275,7 +275,7 @@ extension Int8 : CVarArg {
 }
 
 // Unsigned types
-extension UInt : CVarArg {
+extension UInt: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -284,7 +284,7 @@ extension UInt : CVarArg {
   }
 }
 
-extension UInt64 : CVarArg, _CVarArgAligned {
+extension UInt64: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -301,7 +301,7 @@ extension UInt64 : CVarArg, _CVarArgAligned {
   }
 }
 
-extension UInt32 : CVarArg {
+extension UInt32: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -310,7 +310,7 @@ extension UInt32 : CVarArg {
   }
 }
 
-extension UInt16 : CVarArg {
+extension UInt16: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -319,7 +319,7 @@ extension UInt16 : CVarArg {
   }
 }
 
-extension UInt8 : CVarArg {
+extension UInt8: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -328,7 +328,7 @@ extension UInt8 : CVarArg {
   }
 }
 
-extension OpaquePointer : CVarArg {
+extension OpaquePointer: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -337,7 +337,7 @@ extension OpaquePointer : CVarArg {
   }
 }
 
-extension UnsafePointer : CVarArg {
+extension UnsafePointer: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -346,7 +346,7 @@ extension UnsafePointer : CVarArg {
   }
 }
 
-extension UnsafeMutablePointer : CVarArg {
+extension UnsafeMutablePointer: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -356,7 +356,7 @@ extension UnsafeMutablePointer : CVarArg {
 }
 
 #if _runtime(_ObjC)
-extension AutoreleasingUnsafeMutablePointer : CVarArg {
+extension AutoreleasingUnsafeMutablePointer: CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable
@@ -366,7 +366,7 @@ extension AutoreleasingUnsafeMutablePointer : CVarArg {
 }
 #endif
 
-extension Float : _CVarArgPassedAsDouble, _CVarArgAligned {
+extension Float: _CVarArgPassedAsDouble, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -383,7 +383,7 @@ extension Float : _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
+extension Double: _CVarArgPassedAsDouble, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // c-abi
@@ -401,7 +401,7 @@ extension Double : _CVarArgPassedAsDouble, _CVarArgAligned {
 }
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
-extension Float80 : CVarArg, _CVarArgAligned {
+extension Float80: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -14,8 +14,8 @@
 internal func _writeBackMutableSlice<C, Slice_>(
   _ self_: inout C, bounds: Range<C.Index>, slice: Slice_
 ) where
-  C : MutableCollection,
-  Slice_ : Collection,
+  C: MutableCollection,
+  Slice_: Collection,
   C.Element == Slice_.Element,
   C.Index == Slice_.Index {
 

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -68,7 +68,7 @@ public func zip<Sequence1, Sequence2>(
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
 @frozen // generic-performance
-public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
+public struct Zip2Sequence<Sequence1: Sequence, Sequence2: Sequence> {
   @usableFromInline // generic-performance
   internal let _sequence1: Sequence1
   @usableFromInline // generic-performance


### PR DESCRIPTION
Following guidance from Karoy that the current stdlib style is not to put a space before most colons (https://twitter.com/lorentey/status/1151899985849417728?s=20), this PR adjusts many instances of " : " to be ": ".

There are two notable exceptions:

1. Use of the ternary operator is an entirely different context and has been left untouched.

2. Some instances of conformance are written such that the colon is the first thing on a new line. This wasn't common, but I can see this as being sufficiently different to be changed separately if at all.
