### PR TITLE
[CSDiag] Add a new diagnostic for @propertyWrapper implicit init call missing arguments

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4521,6 +4521,9 @@ WARNING(property_wrapper_init_initialValue,none,
         ())
 ERROR(property_wrapper_projection_value_missing,none,
       "could not find projection value property %0", (Identifier))
+ERROR(property_wrapper_missing_arg_init, none, "missing argument for parameter "
+      "%0 in property wrapper initializer; add 'wrappedValue' and %0 "
+      "arguments in '@%1(...)'", (Identifier, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: function builder diagnostics

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3362,21 +3362,15 @@ public:
       return false;
 
     auto nominalDecl = instanceTy->getAnyNominal();
-    if (!nominalDecl)
+    if (!(nominalDecl &&
+          nominalDecl->getAttrs().hasAttribute<PropertyWrapperAttr>()))
       return false;
 
-    if (!nominalDecl->getAttrs().hasAttribute<PropertyWrapperAttr>())
-      return false;
+    if (auto *parentExpr = CandidateInfo.CS.getParentExpr(FnExpr)) {
+      return parentExpr->isImplicit() && isa<CallExpr>(parentExpr);
+    }
 
-    auto parent = CandidateInfo.CS.getParentExpr(FnExpr);
-    if (!parent)
-      return false;
-
-    auto CE = dyn_cast<CallExpr>(parent);
-    if (!CE)
-      return false;
-
-    return CE->isImplicit();
+    return false;
   }
 
   bool missingLabel(unsigned paramIdx) override {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3358,9 +3358,9 @@ public:
 
   bool isPropertyWrapperImplicitInit() {
     if (auto TE = dyn_cast<TypeExpr>(FnExpr)) {
-      if (auto info = TE->getInstanceType()
-                          ->getAnyNominal()
-                          ->getPropertyWrapperTypeInfo()) {
+      if (TE->getInstanceType()
+              ->getAnyNominal()
+              ->getPropertyWrapperTypeInfo()) {
         if (auto parent = CandidateInfo.CS.getParentExpr(FnExpr)) {
           if (auto CE = dyn_cast<CallExpr>(parent)) {
             return CE->isImplicit();

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3353,19 +3353,30 @@ public:
   }
 
   bool isPropertyWrapperImplicitInit() {
-    if (auto TE = dyn_cast<TypeExpr>(FnExpr)) {
-      if (TE->getInstanceType()
-              ->getAnyNominal()
-              ->getAttrs()
-              .hasAttribute<PropertyWrapperAttr>()) {
-        if (auto parent = CandidateInfo.CS.getParentExpr(FnExpr)) {
-          if (auto CE = dyn_cast<CallExpr>(parent)) {
-            return CE->isImplicit();
-          }
-        }
-      }
-    }
-    return false;
+    auto TE = dyn_cast<TypeExpr>(FnExpr);
+    if (!TE)
+      return false;
+
+    auto instanceTy = TE->getInstanceType();
+    if (!instanceTy)
+      return false;
+
+    auto nominalDecl = instanceTy->getAnyNominal();
+    if (!nominalDecl)
+      return false;
+
+    if (!nominalDecl->getAttrs().hasAttribute<PropertyWrapperAttr>())
+      return false;
+
+    auto parent = CandidateInfo.CS.getParentExpr(FnExpr);
+    if (!parent)
+      return false;
+
+    auto CE = dyn_cast<CallExpr>(parent);
+    if (!CE)
+      return false;
+
+    return CE->isImplicit();
   }
 
   bool missingLabel(unsigned paramIdx) override {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3356,7 +3356,8 @@ public:
     if (auto TE = dyn_cast<TypeExpr>(FnExpr)) {
       if (TE->getInstanceType()
               ->getAnyNominal()
-              ->getPropertyWrapperTypeInfo()) {
+              ->getAttrs()
+              .hasAttribute<PropertyWrapperAttr>()) {
         if (auto parent = CandidateInfo.CS.getParentExpr(FnExpr)) {
           if (auto CE = dyn_cast<CallExpr>(parent)) {
             return CE->isImplicit();

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1095,7 +1095,7 @@ struct InvalidPropertyDelegateUse {
 // SR-11060
 
 class SR_11060_Class {
-  @SR_11060_Wrapper var property: Int = 1234 // expected-error {{missing argument for parameter 'string' in call}}{{20-20=(string: <#String#>)}}
+  @SR_11060_Wrapper var property: Int = 1234 // expected-error {{missing argument for parameter 'string' in property wrapper initializer; add 'wrappedValue' and 'string' arguments in '@SR_11060_Wrapper(...)'}}
 }
 
 @propertyWrapper
@@ -1106,3 +1106,4 @@ struct SR_11060_Wrapper {
     self.wrappedValue = wrappedValue
   }
 }
+

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1091,3 +1091,18 @@ struct InvalidPropertyDelegateUse {
     self.x.foo() // expected-error {{value of type 'Int' has no member 'foo'}}
   }
 }
+
+// SR-11060
+
+class SR_11060_Class {
+  @SR_11060_Wrapper var property: Int = 1234 // expected-error {{missing argument for parameter 'string' in call}}{{20-20=(string: <#String#>)}}
+}
+
+@propertyWrapper
+struct SR_11060_Wrapper {
+  var wrappedValue: Int
+  
+  init(wrappedValue: Int, string: String) { // expected-note {{'init(wrappedValue:string:)' declared here}}
+    self.wrappedValue = wrappedValue
+  }
+}


### PR DESCRIPTION
We were emitting the fix-it in the wrong location for an implicitly generated `@propertyWrapper` initializer call expression, because `missingArgument()` was not handling it correctly.

```swift
class Foo {
  @Bar var property: Int = 1234
                               ^
                                , string: <#String#>
}

@propertyWrapper
struct Bar {
  var wrappedValue: Int

  init(wrappedValue: Int, string: String) {
    self.wrappedValue = wrappedValue
  }
}
```

Since emitting the correct fix-it is a bit tricky, this PR adds a new tailored diagnostic for this scenario.

Resolves [SR-11060](https://bugs.swift.org/browse/SR-11060).
Resolves rdar://problem/52593306