### PR TITLE
Merge swift & clang vfs in ClangImporter

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -91,10 +91,6 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         "is deprecated and will be removed in a later version of Swift",
         (StringRef, Identifier))
 
-WARNING(clang_vfs_overlay_is_ignored,none,
-        "ignoring '-ivfsoverlay' options provided to '-Xcc' in favor of "
-        "'-vfsoverlay'", ())
-
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -100,10 +100,6 @@ public:
   /// When set, don't enforce warnings with -Werror.
   bool DebuggerSupport = false;
 
-  /// When set, clobber the Clang instance's virtual file system with the Swift
-  /// virtual file system.
-  bool ForceUseSwiftVirtualFileSystem = false;
-
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1018,17 +1018,10 @@ ClangImporter::create(ASTContext &ctx,
 
   // Set up the file manager.
   {
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS;
-    if (!ctx.SearchPathOpts.VFSOverlayFiles.empty() ||
-        importerOpts.ForceUseSwiftVirtualFileSystem) {
-      // If the clang instance has overlays it means the user has provided
-      // -ivfsoverlay options.  We're going to clobber their file system with
-      // the Swift file system, so warn about it.
-      if (!instance.getHeaderSearchOpts().VFSOverlayFiles.empty()) {
-        ctx.Diags.diagnose(SourceLoc(), diag::clang_vfs_overlay_is_ignored);
-      }
-      VFS = ctx.SourceMgr.getFileSystem();
-    }
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
+        clang::createVFSFromCompilerInvocation(instance.getInvocation(),
+                                               instance.getDiagnostics(),
+                                               ctx.SourceMgr.getFileSystem());
     instance.createFileManager(std::move(VFS));
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -235,9 +235,6 @@ static bool loadAndValidateVFSOverlay(
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &BaseFS,
     const llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> &OverlayFS,
     DiagnosticEngine &Diag) {
-  // FIXME: It should be possible to allow chained lookup of later VFS overlays
-  // through the mapping defined by earlier overlays.
-  // See rdar://problem/39440687
   auto Buffer = BaseFS->getBufferForFile(File);
   if (!Buffer) {
     Diag.diagnose(SourceLoc(), diag::cannot_open_file, File,

--- a/test/Frontend/Inputs/vfs/a-modulemap
+++ b/test/Frontend/Inputs/vfs/a-modulemap
@@ -1,3 +1,7 @@
 module VFSMappedModule {
   header "VFSMappedModule.h"
 }
+
+module YetAnotherVFSMappedModule {
+  header "YetAnotherVFSMappedModule.h"
+}

--- a/test/Frontend/Inputs/vfs/b-header
+++ b/test/Frontend/Inputs/vfs/b-header
@@ -1,0 +1,1 @@
+#define MAJOR_SUCCESS 1

--- a/test/Frontend/Inputs/vfs/quaternary-vfsoverlay.yaml
+++ b/test/Frontend/Inputs/vfs/quaternary-vfsoverlay.yaml
@@ -1,0 +1,17 @@
+{
+  'version': 0,
+  'use-external-names': false,
+  'roots': [
+    {
+      'name': 'OUT_DIR', 'type': 'directory',
+      'contents': [
+        { 'name': 'YetAnotherVFSMappedModule.h', 'type': 'file',
+          'external-contents': 'INPUT_DIR/vfs/b-header'
+        },
+        { 'name': 'YetAnotherVFSMappedModule.framework/Headers/VFSMappedModule.h', 'type': 'file',
+          'external-contents': 'INPUT_DIR/vfs/b-header'
+        },
+      ]
+    },
+  ]
+}

--- a/test/Frontend/vfs.swift
+++ b/test/Frontend/vfs.swift
@@ -2,6 +2,7 @@
 // RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/vfsoverlay.yaml > %t/overlay.yaml
 // RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/secondary-vfsoverlay.yaml > %t/secondary-overlay.yaml
 // RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/tertiary-vfsoverlay.yaml > %t/tertiary-overlay.yaml
+// RUN: sed -e "s|INPUT_DIR|%/S/Inputs|g" -e "s|OUT_DIR|%/t|g" %S/Inputs/vfs/quaternary-vfsoverlay.yaml > %t/quaternary-vfsoverlay.yaml
 
 // RUN: not %target-swift-frontend -vfsoverlay %/t/overlay.yaml -typecheck %s %/t/mapped-file.swift -serialize-diagnostics-path %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
 // RUN: c-index-test -read-diagnostics %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
@@ -20,10 +21,11 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -Xcc -ivfsoverlay -Xcc %/t/overlay.yaml -typecheck %/s
 
 // If we see -ivfsoverlay and -vfsoverlay, we'll clobber Clang's VFS with our own.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %/t/overlay.yaml -Xcc -ivfsoverlay -Xcc %/t/overlay.yaml -typecheck %/s  2>&1 | %FileCheck -check-prefix=WARN_VFS_CLOBBERED %s
-
-// WARN_VFS_CLOBBERED: warning: ignoring '-ivfsoverlay' options provided to '-Xcc' in favor of '-vfsoverlay'
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -DTEST_VFS_CLANG_IMPORTER_MERGE -vfsoverlay %/t/overlay.yaml -Xcc -ivfsoverlay -Xcc %/t/quaternary-vfsoverlay.yaml -typecheck %/s  2>&1
 
 #if TEST_VFS_CLANG_IMPORTER
 import VFSMappedModule
+#if TEST_VFS_CLANG_IMPORTER_MERGE
+import YetAnotherVFSMappedModule
+#endif
 #endif

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -950,7 +950,6 @@ ASTUnitRef ASTProducer::createASTUnit(
 
   if (fileSystem != llvm::vfs::getRealFileSystem()) {
     CompIns.getSourceMgr().setFileSystem(fileSystem);
-    Invocation.getClangImporterOptions().ForceUseSwiftVirtualFileSystem = true;
   }
 
   if (CompIns.setup(Invocation)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -200,7 +200,6 @@ static bool swiftCodeCompleteImpl(
 
   if (FileSystem != llvm::vfs::getRealFileSystem()) {
     CI.getSourceMgr().setFileSystem(FileSystem);
-    Invocation.getClangImporterOptions().ForceUseSwiftVirtualFileSystem = true;
   }
 
   if (CI.setup(Invocation)) {


### PR DESCRIPTION
This is #25953 but for master-next. I had to revert these changes on master because we couldn't take its dependencies in LLVM and Clang without them ending up on the release branch (because stable is an alias for the release branch). 

> The clang importer has to deal with two virtual file systems, one coming
> from clang, and one coming from swift. Currently, if both are set, we
> emit a diagnostic that we'll pick the swift one.
> 
> This commit changes that, by merging the two virtual file systems into a
> single overlay file system, and using that. To make this possible, we
> always initialize the file manager with an overlay file system. In the
> clang importer, we then create a new overlay file system, starting with
> the one coming from clang, and adding overlays from swift on top.
> 
> The motivation for this change is the reproducer infrastructure in LLDB,
> which adds a third virtual file system to the mix.