### PR TITLE
[CodeCompletion] Keep typealias in override completion

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -403,6 +403,10 @@ struct PrintOptions {
   /// The information for converting archetypes to specialized types.
   llvm::Optional<TypeTransformContext> TransformContext;
 
+  /// Whether to keep Typealias when printing type transformed by
+  /// \c TrancformContext.
+  bool ForceKeepTypealiasTypeInTransformation = false;
+
   bool PrintAsMember = false;
   
   /// Whether to print parameter specifiers as 'let' and 'var'.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -149,6 +149,8 @@ enum class SubstFlags {
   DesugarMemberTypes = 0x04,
   /// Substitute types involving opaque type archetypes.
   SubstituteOpaqueArchetypes = 0x08,
+  /// Force to preserve Typealias type.
+  ForceKeepTypealias = 0x10,
 };
 
 /// Options for performing substitutions into a type.
@@ -275,7 +277,8 @@ public:
   /// handles desugaring.
   ///
   /// \returns the result of transforming the type.
-  Type transformRec(llvm::function_ref<Optional<Type>(TypeBase *)> fn) const;
+  Type transformRec(llvm::function_ref<Optional<Type>(TypeBase *)> fn,
+                    bool forcePreserveTypealias = false) const;
 
   /// Look through the given type and its children and apply fn to them.
   void visit(llvm::function_ref<void (Type)> fn) const {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2080,9 +2080,8 @@ public:
 
         // Pass in DesugarMemberTypes so that we see the actual
         // concrete type witnesses instead of type alias types.
-        T = T.subst(Subs,
-                    (SubstFlags::DesugarMemberTypes |
-                     SubstFlags::UseErrorType));
+        T = T.subst(Subs, SubstFlags::DesugarMemberTypes |
+                    SubstFlags::UseErrorType | SubstFlags::ForceKeepTypealias);
       }
     }
 
@@ -4191,8 +4190,10 @@ public:
       DeclPrinter Printer(
           OS, getOpaqueResultTypeLoc(VD, Reason, dynamicLookupInfo));
       PrintOptions Options;
-      if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
+      if (auto transformType = CurrDeclContext->getDeclaredTypeInContext()) {
         Options.setBaseType(transformType);
+        Options.ForceKeepTypealiasTypeInTransformation = true;
+      }
       Options.PrintImplicitAttrs = false;
       Options.ExclusiveAttrList.push_back(TAK_escaping);
       Options.ExclusiveAttrList.push_back(TAK_autoclosure);

--- a/test/IDE/complete_opaque_result.swift
+++ b/test/IDE/complete_opaque_result.swift
@@ -111,9 +111,8 @@ class TestClass :
     HasAssocWithDefault,
     HasAssocWithConstraintAndDefault {
   #^OVERRIDE_TestClass^#
-// OVERRIDE: found code completion token OVERRIDE_[[BASETYPE:[A-Za-z0-9]+]] at
 // OVERRIDE: Begin completions
-// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocPlain() -> [[BASETYPE]].AssocPlain {|};
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocPlain() -> AssocPlain {|};
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> some MyProtocol {|};
 // OVERRIDE-DAG: Decl[InstanceVar]/Super:            var valAssocWithSuperClassConstraint: some MyClass;
 // OVERRIDE-DAG: Decl[Subscript]/Super:              subscript<T>(idx: T) -> some MyClass & MyProtocol where T : Comparable {|};
@@ -136,7 +135,7 @@ class HasTypealias : HasAssocWithConformanceConstraint {
   typealias AssocWithConformanceConstraint = ConcreteMyProtocol
   #^OVERRIDE_HasTypealias^#
 // OVERRIDE_HasTypealias: Begin completions
-// OVERRIDE_HasTypealias-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> ConcreteMyProtocol {|};
+// OVERRIDE_HasTypealias-DAG: Decl[InstanceMethod]/Super:         func returnAssocWithConformanceConstraint(fn: (Int) -> Int) -> AssocWithConformanceConstraint {|};
 // OVERRIDE_HasTypealias: End completions
 }
 

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -850,7 +850,7 @@ struct MissingAssoc: AssocAndMethod {
   func #^MISSING_ASSOC_1^#
 }
 // MISSING_ASSOC_1: Begin completions
-// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f1(_: MissingAssoc.T) {|};
-// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f2(_: MissingAssoc.U) {|};
-// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f3(_: MissingAssoc.V) {|};
+// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f1(_: T) {|};
+// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f2(_: U) {|};
+// MISSING_ASSOC_1-DAG: Decl[InstanceMethod]/Super:         f3(_: V) {|};
 // MISSING_ASSOC_1: End completions

--- a/test/IDE/complete_override_typealias.swift
+++ b/test/IDE/complete_override_typealias.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_1 | %FileCheck %s -check-prefix=OVERRIDE_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_2 | %FileCheck %s -check-prefix=OVERRIDE_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_3 | %FileCheck %s -check-prefix=OVERRIDE_3
+
+struct Generic<T> {}
+
+protocol MyProtocol {
+  associatedtype Result
+  typealias Arg1 = Generic<Self>
+  typealias Arg2<X> = Generic<X>
+  func foo<U>(arg1: Arg1, arg2: Arg2<U>, arg3: Arg2<Int>, arg4: [Arg1], arg5: Arg2<U>? arg6: Generic<Arg2<Generic<Arg2<Int>>>>) -> Result
+  func bar() -> Result
+}
+
+struct MyStruct1 : MyProtocol {
+  // No 'Result' witness.
+  func #^OVERRIDE_1^#
+}
+
+struct MyStruct2 : MyProtocol {
+  // Explicit 'Result' witness by 'typealias'.
+  typealias Result = String
+  func #^OVERRIDE_2^#
+}
+
+struct MyStruct3 : MyProtocol {
+  // Implicit 'Result' witness by inference.
+  func bar() -> String
+  func #^OVERRIDE_3^#
+}
+
+// OVERRIDE_1: Begin completions, 2 items
+// OVERRIDE_1-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: Arg1, arg2: Arg2<U>, arg3: Arg2<Int>, arg4: [Arg1], arg5: Arg2<U>?, arg6: Generic<Arg2<Generic<Arg2<Int>>>>) -> Result {|};
+// OVERRIDE_1-DAG: Decl[InstanceMethod]/Super: bar() -> Result {|};
+// OVERRIDE_1: End completions
+
+// OVERRIDE_2: Begin completions, 2 items
+// OVERRIDE_2-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: Arg1, arg2: Arg2<U>, arg3: Arg2<Int>, arg4: [Arg1], arg5: Arg2<U>?, arg6: Generic<Arg2<Generic<Arg2<Int>>>>) -> Result {|};
+// OVERRIDE_2-DAG: Decl[InstanceMethod]/Super: bar() -> Result {|};
+// OVERRIDE_2: End completions
+
+// OVERRIDE_3-DAG: Begin completions, 1 items
+// OVERRIDE_3-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: Arg1, arg2: Arg2<U>, arg3: Arg2<Int>, arg4: [Arg1], arg5: Arg2<U>?, arg6: Generic<Arg2<Generic<Arg2<Int>>>>) -> String {|};
+// OVERRIDE_3-DAG: End completions
+


### PR DESCRIPTION
* Keep transformed generic arguments in `transformRec()` instead of losing the sugar
* Skip printing context type when printing its member type.

For now, this is enabled only for override completion, to minimize the effect of this PR.

rdar://problem/45313760