### PR TITLE
[5.1] Fill in locs in implicit function builder exprs to satisfy code coverage

### DIFF
--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT_DOT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT_DOT
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_1 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_2 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_1 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_2 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_3 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_4 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_5 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
@@ -123,11 +123,9 @@ func acceptBuilder(@EnumToVoidBuilder body: () -> Void) {}
 
 func testContextualType() {
   acceptBuilder {
-// FIXME: This should suggest enum values.
     .#^CONTEXTUAL_TYPE_1^#
   }
   acceptBuilder {
-// FIXME: This should suggest enum values.
     .#^CONTEXTUAL_TYPE_2^#;
     .north;
   }

--- a/test/Profiler/coverage_function_builder.swift
+++ b/test/Profiler/coverage_function_builder.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_functon_builder %s | %FileCheck %s
+
+@_functionBuilder
+struct Summer {
+  static func buildBlock(_ x: Int...) -> Int {
+    return x.reduce(0, +)
+  }
+  static func buildIf(_ x: Int?) -> Int {
+    return x ?? 0
+  }
+}
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test0SiyF"
+@Summer
+func test0() -> Int {
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+3]]:2 : 0
+  18
+  12
+}
+
+// CHECK-LABEL: sil_coverage_map {{.*}} "$s24coverage_functon_builder5test1SiyF"
+@Summer
+func test1() -> Int {
+  // CHECK: [[@LINE-1]]:21 -> [[@LINE+7]]:2 : 0
+  18
+  12
+  if 7 < 23 {
+    11
+    8
+  }
+}


### PR DESCRIPTION
Fixes rdar://51612977.  Swift 5.1 version of #26223.