### PR TITLE
[AutoDiff] Improve leak checking test robustness.

### DIFF
--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -1,4 +1,4 @@
-//===--- GenericLifetimeTracked.swift -------------------------------------===//
+//===--- DifferentiationUnittest.swift ------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -8,16 +8,21 @@ import DifferentiationUnittest
 
 var LeakCheckingTests = TestSuite("LeakChecking")
 
-/// Execute body, check expected leak count, and reset global leak count.
+/// Execute body and check expected leak count.
 func testWithLeakChecking(
   expectedLeakCount: Int = 0, file: String = #file, line: UInt = #line,
   _ body: () -> Void
 ) {
+  // Note: compare expected leak count with relative leak count after
+  // running `body`.
+  // This approach is more robust than comparing leak count with zero
+  // and resetting leak count to zero, which is stateful and causes issues.
+  let beforeLeakCount = _GlobalLeakCount.count
   body()
+  let leakCount = _GlobalLeakCount.count - beforeLeakCount
   expectEqual(
-    expectedLeakCount, _GlobalLeakCount.count, "Leak detected.",
+    expectedLeakCount, leakCount, "Leaks detected: \(leakCount)",
     file: file, line: line)
-  _GlobalLeakCount.count = 0
 }
 
 struct ExampleLeakModel : Differentiable {


### PR DESCRIPTION
Make `testWithLeakChecking` no longer stateful.

Without this patch, some leak-checking tests can impact the leak count
of other unrelated tests (perhaps due to concurrent testing).