### PR TITLE
 AST: Catch re-entrant calls to getOrCreateGenericSignatureBuilder()

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -218,7 +218,7 @@ GenericSignature::getCanonical(TypeArrayView<GenericTypeParamType> params,
                     /*isKnownCanonical=*/true);
 
 #ifndef NDEBUG
-  if (skipValidation)
+  if (skipValidation || true)
     return CanGenericSignature(canSig);
 
   PrettyStackTraceGenericSignature debugStack("canonicalizing", canSig);


### PR DESCRIPTION
Returning a partially-built GSB here will produce incorrect
results because not all requirements from the signature have
been added yet.
    
Let's catch this instead of silently doing the wrong thing,
which can cause very hard to debug problems.
