### PR TITLE
[ModuleInterface] Honor -disable-modules-validate-system-headers

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -74,6 +74,13 @@ public:
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;
 
+  /// When set, don't validate module system dependencies.
+  ///
+  /// If a system header is modified and this is not set, the compiler will
+  /// rebuild PCMs and compiled swiftmodules that depend on them, just like it
+  /// would for a non-system header.
+  bool DisableModulesValidateSystemDependencies = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {
@@ -96,6 +103,7 @@ public:
     for (auto RuntimeLibraryImportPath : RuntimeLibraryImportPaths) {
       Code = hash_combine(Code, RuntimeLibraryImportPath);
     }
+    Code = hash_combine(Code, DisableModulesValidateSystemDependencies);
     return Code;
   }
 };

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -90,10 +90,6 @@ public:
   /// If true ignore the swift bridged attribute.
   bool DisableSwiftBridgeAttr = false;
 
-  /// When set, don't validate module system headers. If a header is modified
-  /// and this is not set, clang will rebuild the module.
-  bool DisableModulesValidateSystemHeaders = false;
-
   /// When set, don't look for or load overlays.
   bool DisableOverlayModules = false;
 
@@ -121,7 +117,6 @@ public:
     Code = hash_combine(Code, ImportForwardDeclarations);
     Code = hash_combine(Code, InferImportAsMember);
     Code = hash_combine(Code, DisableSwiftBridgeAttr);
-    Code = hash_combine(Code, DisableModulesValidateSystemHeaders);
     Code = hash_combine(Code, DisableOverlayModules);
     return Code;
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -642,7 +642,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     invocationArgStrs.back().append(moduleCachePath);
   }
 
-  if (importerOpts.DisableModulesValidateSystemHeaders) {
+  if (ctx.SearchPathOpts.DisableModulesValidateSystemDependencies) {
     invocationArgStrs.push_back("-fno-modules-validate-system-headers");
   } else {
     invocationArgStrs.push_back("-fmodules-validate-system-headers");

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -583,8 +583,6 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.BridgingHeader = A->getValue();
   Opts.DisableSwiftBridgeAttr |= Args.hasArg(OPT_disable_swift_bridge_attr);
 
-  Opts.DisableModulesValidateSystemHeaders |= Args.hasArg(OPT_disable_modules_validate_system_headers);
-
   Opts.DisableOverlayModules |= Args.hasArg(OPT_emit_imported_modules);
 
   if (const Arg *A = Args.getLastArg(OPT_pch_output_dir)) {
@@ -636,6 +634,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
     Opts.RuntimeResourcePath = A->getValue();
 
   Opts.SkipRuntimeLibraryImportPaths |= Args.hasArg(OPT_nostdimport);
+
+  Opts.DisableModulesValidateSystemDependencies |=
+      Args.hasArg(OPT_disable_modules_validate_system_headers);
 
   // Opts.RuntimeIncludePath is set by calls to
   // setRuntimeIncludePath() or setMainExecutablePath().

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -85,6 +85,7 @@ struct ForwardingModule {
     std::string path;
     uint64_t size;
     uint64_t lastModificationTime;
+    bool isSDKRelative;
   };
   std::vector<Dependency> dependencies;
   unsigned version = 1;
@@ -99,8 +100,9 @@ struct ForwardingModule {
   static llvm::ErrorOr<ForwardingModule> load(const llvm::MemoryBuffer &buf);
 
   /// Adds a given dependency to the dependencies list.
-  void addDependency(StringRef path, uint64_t size, uint64_t modTime) {
-    dependencies.push_back({path.str(), size, modTime});
+  void addDependency(StringRef path, bool isSDKRelative, uint64_t size,
+                     uint64_t modTime) {
+    dependencies.push_back({path.str(), size, modTime, isSDKRelative});
   }
 };
 
@@ -116,6 +118,7 @@ namespace llvm {
         io.mapRequired("mtime", dep.lastModificationTime);
         io.mapRequired("path", dep.path);
         io.mapRequired("size", dep.size);
+        io.mapOptional("sdk_relative", dep.isSDKRelative, /*default*/false);
       }
     };
 
@@ -975,12 +978,9 @@ class ParseableInterfaceModuleLoaderImpl {
 
     // Next, check the dependencies in the forwarding file.
     for (auto &dep : fwd.dependencies) {
-      // Forwarding modules expand SDKRelative paths when generated, so are
-      // guaranteed to be absolute.
       deps.push_back(
         FileDependency::modTimeBased(
-          dep.path, /*isSDKRelative=*/false, dep.size,
-          dep.lastModificationTime));
+          dep.path, dep.isSDKRelative, dep.size, dep.lastModificationTime));
     }
     if (!dependenciesAreUpToDate(path, deps))
       return false;
@@ -1241,29 +1241,30 @@ class ParseableInterfaceModuleLoaderImpl {
 
     // FIXME: We need to avoid re-statting all these dependencies, otherwise
     //        we may record out-of-date information.
-    auto addDependency = [&](StringRef path) -> FileDependency {
-      auto status = fs.status(path);
+    SmallString<128> SDKRelativeBuffer;
+    auto addDependency = [&](FileDependency dep) -> FileDependency {
+      auto status = fs.status(getFullDependencyPath(dep, SDKRelativeBuffer));
       uint64_t mtime =
         status->getLastModificationTime().time_since_epoch().count();
-      fwd.addDependency(path, status->getSize(), mtime);
+      fwd.addDependency(dep.getPath(), dep.isSDKRelative(), status->getSize(),
+                        mtime);
 
       // Construct new FileDependency matching what we've added to the
-      // forwarding module. This is no longer SDK-relative because the absolute
-      // path has already been resolved.
-      return FileDependency::modTimeBased(path, /*isSDKRelative*/false,
+      // forwarding module.
+      return FileDependency::modTimeBased(dep.getPath(), dep.isSDKRelative(),
                                           status->getSize(), mtime);
     };
 
     // Add the prebuilt module as a dependency of the forwarding module, but
     // don't add it to the outer dependency list.
-    (void)addDependency(fwd.underlyingModulePath);
+    (void)addDependency(FileDependency::hashBased(fwd.underlyingModulePath,
+                                                  /*SDKRelative*/false,
+                                                  /*size*/0, /*hash*/0));
 
     // Add all the dependencies from the prebuilt module, and update our list
     // of dependencies to reflect what's recorded in the forwarding module.
-    SmallString<128> SDKRelativeBuffer;
     for (auto dep : deps) {
-      auto adjustedDep =
-          addDependency(getFullDependencyPath(dep, SDKRelativeBuffer));
+      auto adjustedDep = addDependency(dep);
       depsAdjustedToMTime.push_back(adjustedDep);
     }
 
@@ -1297,8 +1298,6 @@ class ParseableInterfaceModuleLoaderImpl {
   findOrBuildLoadableModule() {
 
     // Track system dependencies if the parent tracker is set to do so.
-    // FIXME: This means -track-system-dependencies isn't honored when the
-    // top-level invocation isn't tracking dependencies
     bool trackSystemDependencies = false;
     if (dependencyTracker) {
       auto ClangDependencyTracker = dependencyTracker->getClangCollector();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1765,8 +1765,15 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   if (Invocation.getFrontendOptions()
           .InputsAndOutputs.hasDependencyTrackerPath() ||
-      !Invocation.getFrontendOptions().IndexStorePath.empty())
-    Instance->createDependencyTracker(Invocation.getFrontendOptions().TrackSystemDeps);
+      !Invocation.getFrontendOptions().IndexStorePath.empty() ||
+      Invocation.getFrontendOptions().TrackSystemDeps) {
+    // Note that we're tracking dependencies even when we don't need to write
+    // them directly; in particular, -track-system-dependencies affects how
+    // module interfaces get loaded, and so we need to be consistently tracking
+    // system dependencies throughout the compiler.
+    Instance->createDependencyTracker(
+        Invocation.getFrontendOptions().TrackSystemDeps);
+  }
 
   if (Instance->setup(Invocation)) {
     return finishDiagProcessing(1);

--- a/test/ParseableInterface/ModuleCache/SDKDependencies-disable-validation.swift
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies-disable-validation.swift
@@ -1,0 +1,192 @@
+// RUN: %empty-directory(%t)
+
+// 1) Build a prebuilt cache for our SDK
+//
+// RUN: mkdir %t/MCP %t/prebuilt-cache %t/my-sdk
+// RUN: cp -r %S/Inputs/mock-sdk/. %t/my-sdk
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/ExportedLib.swiftmodule -track-system-dependencies -module-name ExportedLib %t/my-sdk/ExportedLib.swiftinterface
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/SdkLib.swiftmodule -track-system-dependencies -module-name SdkLib %t/my-sdk/SdkLib.swiftinterface
+//
+// Check the prebuilt modules don't contain dependencies in the module cache, prebuilt cache, or resource dir
+// RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/ExportedLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+// RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/SdkLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// PREBUILT: MODULE_BLOCK
+// PREBUILT-NOT: FILE_DEPENDENCY {{.*[/\\]MCP[/\\]}}
+// PREBUILT-NOT: FILE_DEPENDENCY {{.*[/\\]prebuilt-cache[/\\]}}
+// PREBUILD-NOT: FILE_DEPENDENCY {{.*[/\\]lib[/\\]swift[/\\]}}
+//
+// Re-build them in the opposite order
+// RUN: %empty-directory(%t/prebuilt-cache)
+// RUN: %empty-directory(%t/MCP)
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/SdkLib.swiftmodule -track-system-dependencies -module-name SdkLib %t/my-sdk/SdkLib.swiftinterface
+// RUN: %target-swift-frontend -build-module-from-parseable-interface -serialize-parseable-module-interface-dependency-hashes -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -I %t/my-sdk -module-cache-path %t/MCP -o %t/prebuilt-cache/ExportedLib.swiftmodule -track-system-dependencies -module-name ExportedLib %t/my-sdk/ExportedLib.swiftinterface
+//
+// Check they still don't contain dependencies in the module cache or prebuilt cache
+// RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/ExportedLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+// RUN: llvm-bcanalyzer -dump %t/prebuilt-cache/SdkLib.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '1: PASSED'
+
+
+// 2) Baseline check: Make sure we use the interface when not passing the prebuilt module cache path
+//
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
+//
+// Check SdkLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+//
+// Check they are *not* forwarding modules
+// RUN: not %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+// RUN: not %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check they don't contain dependencies in the module cache (..or prebuilt cache)
+// RUN: llvm-bcanalyzer -dump %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+// RUN: llvm-bcanalyzer -dump %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE-NEGATIVE
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
+//
+// DEPFILE-NEGATIVE-NOT: {{[/\\]MCP[/\\]}}
+// DEPFILE-NEGATIVE-NOT: {{[/\\]prebuilt-cache[/\\]}}
+//
+// DEPFILE-DAG: SomeCModule.h
+// DEPFILE-DAG: SdkLib.swiftinterface
+// DEPFILE-DAG: ExportedLib.swiftinterface
+// DEPFILE-DAG: SDKDependencies-disable-validation.swift
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: echo '2: PASSED'
+
+
+// 3) Baseline check: Make sure we use the the prebuilt module cache when using the SDK it was built with
+//
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
+//
+// Check SdkLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check they *are* forwarding modules
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check they contain the expected dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=EXLIB
+// RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=EXLIB,SDKLIB
+//
+// EXLIB: dependencies:
+// EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}module.modulemap'
+// EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}SomeCModule.h'
+// EXLIB-DAG: path: ExportedLib.swiftinterface
+// SDKLIB-DAG: SdkLib.swiftinterface
+//
+// Check they don't contain any dependencies from either cache other than themselves
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
+// RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=SdkLib
+//
+// NOCACHE: dependencies:
+// NOCACHE-NOT: {{[/\\]prebuilt-cache[/\\]}}
+// NOCACHE-NOT: {{[/\\]MCP[/\\]}}
+// NOCACHE: {{[/\\]prebuilt-cache[/\\]}}[[LIB_NAME]].swiftmodule
+// NOCACHE-NOT: {{[/\\]prebuilt-cache[/\\]}}
+// NOCACHE-NOT: {{[/\\]MCP[/\\]}}
+//
+// Check we didn't emit anything from the cache in the .d file either
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE-NEGATIVE
+// RUN: cat %t/dummy.d | %FileCheck %s -check-prefix=DEPFILE
+//
+// RUN: echo '3: PASSED'
+
+
+// 4) Now change the SDK's content WITHOUT clearing the module cache and check
+// that it doesn't change anything...
+//
+// RUN: echo "// size change" >> %t/my-sdk/SdkLib.swiftinterface
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
+//
+// Check SDKLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check that they're both still forwarding modules, because we didn't stat
+// the system dependencies.
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+//
+// Check ExportedLib still contains the same dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=EXLIB
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
+//
+// RUN: echo '4: PASSED'
+
+// 5) ...but if we clear the module cache and start over, we won't be using the
+// prebuilt module anymore for SDKLib.
+//
+// RUN: %empty-directory(%t/MCP)
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
+//
+// Check SDKLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check ExportedLib is still a forwarding module and SdkLib is not
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+// RUN: not %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+//
+// Check ExportedLib still contains the same dependencies
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=EXLIB
+// RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
+//
+// Check SdkLib doesn't contain dependencies in the module cache or prebuilt cache
+// RUN: llvm-bcanalyzer -dump %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefix=PREBUILT
+//
+// RUN: echo '5: PASSED'
+
+// 6) If we do one more change, we won't rebuild SdkLib *again*...
+//
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP/SdkLib-*.swiftmodule
+// RUN: echo "// size change" >> %t/my-sdk/SdkLib.swiftinterface
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
+//
+// Check SDKLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check ExportedLib is still a forwarding module and SdkLib is not
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+// RUN: not %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+//
+// Check SdkLib hasn't been rebuilt.
+// RUN: %{python} %S/Inputs/check-is-old.py %t/MCP/SdkLib-*.swiftmodule
+//
+// RUN: echo '6: PASSED'
+
+// 7) ...until we turn off -disable-modules-validate-system-headers.
+//
+// RUN: %{python} %S/Inputs/make-old.py %t/MCP/SdkLib-*.swiftmodule
+// RUN: echo "// size change" >> %t/my-sdk/SdkLib.swiftinterface
+// RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies %s
+//
+// Check SDKLib and ExportedLib are in the module cache
+// RUN: test -f %t/MCP/SdkLib-*.swiftmodule
+// RUN: test -f %t/MCP/ExportedLib-*.swiftmodule
+//
+// Check ExportedLib is still a forwarding module and SdkLib is not
+// RUN: %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/ExportedLib-*.swiftmodule
+// RUN: not %{python} %S/Inputs/check-is-forwarding-module.py %t/MCP/SdkLib-*.swiftmodule
+//
+// Check SdkLib has been rebuilt.
+// RUN: not %{python} %S/Inputs/check-is-old.py %t/MCP/SdkLib-*.swiftmodule
+//
+// RUN: echo '7: PASSED'
+
+
+import SdkLib
+
+func foo() -> ExportedInterface {
+	return x > 3 ? testValue : testValue2
+}

--- a/test/ParseableInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ParseableInterface/ModuleCache/SDKDependencies.swift
@@ -79,10 +79,10 @@
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=EXLIB,SDKLIB
 //
 // EXLIB: dependencies:
-// EXLIB-DAG: {{[/\\]my-sdk[/\\]usr[/\\]include[/\\]}}module.modulemap
-// EXLIB-DAG: {{[/\\]my-sdk[/\\]usr[/\\]include[/\\]}}SomeCModule.h
-// EXLIB-DAG: {{[/\\]my-sdk[/\\]}}ExportedLib.swiftinterface
-// SDKLIB-DAG: {{[/\\]my-sdk[/\\]}}SdkLib.swiftinterface
+// EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}module.modulemap'
+// EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}SomeCModule.h'
+// EXLIB-DAG: path: ExportedLib.swiftinterface
+// SDKLIB-DAG: SdkLib.swiftinterface
 //
 // Check they don't contain any dependencies from either cache other than themselves
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NOCACHE -DLIB_NAME=ExportedLib
@@ -122,10 +122,10 @@
 // RUN: cat %t/MCP/ExportedLib-*.swiftmodule | %FileCheck %s -check-prefix=NEW-EXLIB
 // RUN: cat %t/MCP/SdkLib-*.swiftmodule | %FileCheck %s -check-prefixes=NEW-EXLIB,NEW-SDKLIB
 //
-// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]usr[/\\]include[/\\]}}module.modulemap
-// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]usr[/\\]include[/\\]}}SomeCModule.h
-// NEW-EXLIB-DAG: {{[/\\]my-new-sdk[/\\]}}ExportedLib.swiftinterface
-// NEW-SDKLIB-DAG: {{[/\\]my-new-sdk[/\\]}}SdkLib.swiftinterface
+// NEW-EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}module.modulemap'
+// NEW-EXLIB-DAG: path: '{{usr[/\\]include[/\\]}}SomeCModule.h'
+// NEW-EXLIB-DAG: path: ExportedLib.swiftinterface
+// NEW-SDKLIB-DAG: path: SdkLib.swiftinterface
 //
 // Check they don't contain dependencies from the module cache, old prebuilt
 // cache, or new prebuilt cache


### PR DESCRIPTION
The point of this flag is to avoid re-checking the whole SDK on every build, since under many circumstances you can assume it hasn't changed. That worked for Clang modules, but Swift cached modules also end up with dependencies that shouldn't be updated.

rdar://problem/53279521
