### PR TITLE
IDE+Evaluator: refactor the implementation of two common IDE utilities to the evaluator model

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 SWIFT_TYPEID_NAMED(NominalTypeDecl *, NominalTypeDecl)
 SWIFT_TYPEID_NAMED(VarDecl *, VarDecl)
+SWIFT_TYPEID_NAMED(ValueDecl *, ValueDecl)
 SWIFT_TYPEID_NAMED(Decl *, Decl)
 SWIFT_TYPEID(Type)
 SWIFT_TYPEID(PropertyWrapperBackingPropertyInfo)

--- a/include/swift/IDE/IDERequestIDZone.def
+++ b/include/swift/IDE/IDERequestIDZone.def
@@ -16,3 +16,5 @@
 //===----------------------------------------------------------------------===//
 SWIFT_TYPEID(CursorInfoRequest)
 SWIFT_TYPEID(RangeInfoRequest)
+SWIFT_TYPEID(ProvideDefaultImplForRequest)
+SWIFT_TYPEID(CollectOverriddenDeclsRequest)

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -248,13 +248,12 @@ namespace swift {
   ///
   /// \returns the slice of Scratch
   ArrayRef<ValueDecl*>
-  canDeclProvideDefaultImplementationFor(ValueDecl* VD,
-                                         llvm::SmallVectorImpl<ValueDecl*> &Scratch);
+  canDeclProvideDefaultImplementationFor(ValueDecl* VD);
 
   /// Get decls that the given decl overrides, protocol requirements that
   ///   it serves as a default implementation of, and optionally protocol
   ///   requirements it satisfies in a conforming class
-  std::vector<ValueDecl*>
+  ArrayRef<ValueDecl*>
   collectAllOverriddenDecls(ValueDecl *VD,
                             bool IncludeProtocolRequirements = true,
                             bool Transitive = false);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -189,6 +189,11 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
                                 Diagnostics));
   registerTypeCheckerRequestFunctions(Context->evaluator);
 
+  // Migrator and indexing need some IDE requests.
+  if (Invocation.getMigratorOptions().shouldRunMigrator() ||
+      !Invocation.getFrontendOptions().IndexStorePath.empty()) {
+    registerIDERequestFunctions(Context->evaluator);
+  }
   if (setUpModuleLoaders())
     return true;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -274,6 +274,8 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   if (IsModuleIndexing) {
     if (CI.setup(Invocation))
       return;
+    // Indexing needs IDE requests
+    registerIDERequestFunctions(CI.getASTContext().evaluator);
     bool IsClangModule = (FileExt == ".pcm");
     if (IsClangModule) {
       IdxConsumer.failed("Clang module files are not supported");
@@ -292,7 +294,8 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
 
   if (CI.setup(Invocation))
     return;
-
+  // Indexing needs IDE requests
+  registerIDERequestFunctions(CI.getASTContext().evaluator);
   trace::TracedOperation TracedOp(trace::OperationKind::IndexSource);
   if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;


### PR DESCRIPTION
These APIs are 'canDeclProvideDefaultImplementationFor' and 'collectAllOverriddenDecls'.