### PR TITLE
Dump PrettyStackTrace on Ctrl-T in a frontend job

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1607,6 +1607,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
                            const char *Argv0, void *MainAddr,
                            FrontendObserver *observer) {
   INITIALIZE_LLVM();
+  llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
   PrintingDiagnosticConsumer PDC;
 


### PR DESCRIPTION
It'll dump it for all the frontend jobs spawned from a driver, too, but then the driver will buffer the response, so it's not that useful.

Requires LLVM [r365911](https://reviews.llvm.org/D63750).