### PR TITLE
[5.1] [Type checker] Classes don't need backing properties to create their implicit constructors

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5240,7 +5240,6 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
     }
 
   } else {
-    SmallPtrSet<VarDecl *, 4> backingStorageVars;
     for (auto member : decl->getMembers()) {
       if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
         // Initializers that were synthesized to fulfill derived conformances
@@ -5263,17 +5262,9 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
       }
 
       if (auto var = dyn_cast<VarDecl>(member)) {
-        // If this variable has a property wrapper, go validate it to ensure
-        // that we create the backing storage property.
-        if (auto backingVar = var->getPropertyWrapperBackingProperty()) {
-          validateDecl(var);
-          maybeAddAccessorsToStorage(var);
-
-          backingStorageVars.insert(backingVar);
-        }
-
-        // Ignore the backing storage for properties with attached wrappers.
-        if (backingStorageVars.count(var) > 0)
+        // If this is a backing storage property for a property wrapper,
+        // skip it.
+        if (var->getOriginalWrappedProperty())
           continue;
 
         if (var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true)) {

--- a/validation-test/compiler_crashers_2_fixed/0199-rdar52679284.swift
+++ b/validation-test/compiler_crashers_2_fixed/0199-rdar52679284.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck %s -verify
+
+public protocol MyBindableObject {}
+
+@propertyWrapper
+public struct MyBinding<T> where T : MyBindableObject { // expected-error{{internal initializer 'init(wrappedValue:)' cannot have more restrictive access than its enclosing property wrapper type 'MyBinding' (which is public)}}
+    public var wrappedValue: T
+}
+class BeaconDetector: MyBindableObject {
+    @MyBinding var detector = BeaconDetector()
+    init() {
+        detector.undefined = 45 // expected-error{{value of type 'BeaconDetector' has no member 'undefined'}}
+    }
+}


### PR DESCRIPTION
Fixes a crash caused by an undiagnosed cycle, rdar://problem/52679284.
