### PR TITLE
[5.1][CodeCompletion] Expr context type analysis for failed array literal expression

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -664,6 +664,21 @@ class ExprContextAnalyzer {
       analyzeApplyExpr(Parent);
       break;
     }
+    case ExprKind::Array: {
+      if (auto type = ParsedExpr->getType()) {
+        recordPossibleType(type);
+        break;
+      }
+
+      // Check context types of the array literal expression.
+      ExprContextInfo arrayCtxtInfo(DC, Parent);
+      for (auto arrayT : arrayCtxtInfo.getPossibleTypes()) {
+        if (auto boundGenericT = arrayT->getAs<BoundGenericType>())
+          if (boundGenericT->getDecl() == Context.getArrayDecl())
+            recordPossibleType(boundGenericT->getGenericArgs()[0]);
+      }
+      break;
+    }
     case ExprKind::Assign: {
       auto *AE = cast<AssignExpr>(Parent);
 
@@ -867,6 +882,7 @@ public:
         case ExprKind::Binary:
         case ExprKind::PrefixUnary:
         case ExprKind::Assign:
+        case ExprKind::Array:
           return true;
         case ExprKind::UnresolvedMember:
           return true;

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -82,6 +82,14 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_AFTERPAREN_2 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_SECOND | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SECOND
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_SKIPPED | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SKIPPED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_1_AFTERPAREN_1 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_1_AFTERPAREN_2 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_1_SECOND | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SECOND
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_1_SKIPPED | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SKIPPED
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_2_AFTERPAREN_1 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_2_AFTERPAREN_2 | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_AFTERPAREN_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_2_SECOND | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SECOND
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IMPLICIT_MEMBER_ARRAY_2_SKIPPED | %FileCheck %s -check-prefix=IMPLICIT_MEMBER_SKIPPED
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARCHETYPE_GENERIC_1 | %FileCheck %s -check-prefix=ARCHETYPE_GENERIC_1
 
@@ -687,6 +695,39 @@ func testImplicitMember() {
 // IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg3: [#Argument name#];
 // IMPLICIT_MEMBER_SKIPPED: Keyword/ExprSpecific:               arg4: [#Argument name#];
 // IMPLICIT_MEMBER_SKIPPED: End completions
+}
+func testImplicitMemberInArrayLiteral() {
+  struct Receiver {
+    init(_: [TestStaticMemberCall]) {}
+    init(arg1: Int, arg2: [TestStaticMemberCall]) {}
+  }
+
+  Receiver([
+    .create1(x: 1),
+    .create1(#^IMPLICIT_MEMBER_ARRAY_1_AFTERPAREN_1^#),
+    // Same as IMPLICIT_MEMBER_AFTERPAREN_1.
+  ])
+  Receiver([
+    .create2(#^IMPLICIT_MEMBER_ARRAY_1_AFTERPAREN_2^#),
+    // Same as IMPLICIT_MEMBER_AFTERPAREN_2.
+    .create2(1, #^IMPLICIT_MEMBER_ARRAY_1_SECOND^#
+    // Same as IMPLICIT_MEMBER_SECOND.
+  ])
+  Receiver(arg1: 12, arg2: [
+    .create2(1, arg3: 2, #^IMPLICIT_MEMBER_ARRAY_1_SKIPPED^#
+    // Same as IMPLICIT_MEMBER_SKIPPED.
+    .create1(x: 12)
+  ])
+  let _: [TestStaticMemberCall] = [
+    .create1(#^IMPLICIT_MEMBER_ARRAY_2_AFTERPAREN_1^#),
+    // Same as STATIC_METHOD_AFTERPAREN_1.
+    .create2(#^IMPLICIT_MEMBER_ARRAY_2_AFTERPAREN_2^#),
+    // Same as STATIC_METHOD_AFTERPAREN_2.
+    .create2(1, #^IMPLICIT_MEMBER_ARRAY_2_SECOND^#),
+    // Same as STATIC_METHOD_SECOND.
+    .create2(1, arg3: 2, #^IMPLICIT_MEMBER_ARRAY_2_SKIPPED^#),
+    // Same as STATIC_METHOD_SKIPPED.
+  ]
 }
 
 struct Wrap<T> {

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -373,12 +373,12 @@ func f() -> SomeEnum1 {
   return .#^UNRESOLVED_27^#
 }
 
-let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], Op2: [.Option4])
+let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], [.Option4])
 
 let TopLevelVar2 = OptionSetTaker1([.#^UNRESOLVED_29^#])
 
-let TopLevelVar3 = OptionSetTaker7([.Option1], Op2: [.#^UNRESOLVED_30^#])
-let TopLevelVar4 = OptionSetTaker7([.Option1], Op2: [.Option4, .#^UNRESOLVED_31^#])
+let TopLevelVar3 = OptionSetTaker7([.Option1], [.#^UNRESOLVED_30^#])
+let TopLevelVar4 = OptionSetTaker7([.Option1], [.Option4, .#^UNRESOLVED_31^#])
 
 let _: [SomeEnum1] = [.#^UNRESOLVED_32^#]
 let _: [SomeEnum1] = [.South, .#^UNRESOLVED_33^#]


### PR DESCRIPTION
Cherry-pick of #26236 into swift-5.1-branch reviewed by @benlangmuir 

* **Explaination**: This patch enables call argument completion for implicit member expression in array literal. Previously, code-completion used to fail if the surrounding array literal is not type-checked. With this patch, type context analyzer is now able to analyze the expected type in the array literal.
* **Scope**: Code completion in array literal
* **Issue**: rdar://problem/50696432
* **Risk**: Low. Simple code pure addition
* **Testing**: Added regression test cases
* **Reviewers**: Ben Langmuir (@benlangmuir)