### PR TITLE
[AutoDiff] Bring '@differentiable' conversion before noescape conversion.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -78,6 +78,13 @@ static bool checkNoEscapePartialApplyUse(Operand *oper, FollowUse followUses) {
     return false;
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  // Look through `autodiff_function`.
+  if (auto *ADFI = dyn_cast<AutoDiffFunctionInst>(user)) {
+    followUses(ADFI);
+    return false;
+  }
+
   // @noescape block storage can be passed as an Optional (Nullable).
   if (auto *EI = dyn_cast<EnumInst>(user)) {
     followUses(EI);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6465,6 +6465,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                                     InitializerKind::DefaultArgument);
     auto toEI = toFunc->getExtInfo();
     assert(toType->is<FunctionType>());
+
     // SWIFT_ENABLE_TENSORFLOW
     auto fromEI = fromFunc->getExtInfo();
     // Handle implicit conversion from @differentiable.
@@ -6474,6 +6475,18 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       expr = cs.cacheType(new (tc.Context)
           AutoDiffFunctionExtractOriginalExpr(expr, fromFunc));
     }
+    // Handle implicit conversion to @differentiable.
+    maybeDiagnoseUnsupportedFunctionConversion(cs, expr, toFunc);
+    if (!fromEI.isDifferentiable() && toEI.isDifferentiable()) {
+      auto newEI =
+          fromEI.withDifferentiabilityKind(toEI.getDifferentiabilityKind());
+      fromFunc = FunctionType::get(toFunc->getParams(), fromFunc->getResult())
+          ->withExtInfo(newEI)
+          ->castTo<FunctionType>();
+      expr = cs.cacheType(new (tc.Context)
+                              AutoDiffFunctionExpr(expr, fromFunc));
+    }
+
     // If we have a ClosureExpr, then we can safely propagate the 'no escape'
     // bit to the closure without invalidating prior analysis.
     fromEI = fromFunc->getExtInfo();
@@ -6506,26 +6519,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
 
     maybeDiagnoseUnsupportedFunctionConversion(cs, expr, toFunc);
 
-    // SWIFT_ENABLE_TENSORFLOW
-    auto toEINoADConversion =
-        toEI.withDifferentiabilityKind(fromEI.getDifferentiabilityKind());
-    auto toFuncNoADConversion = toFunc->withExtInfo(toEINoADConversion);
-    if (toEI.isDifferentiable() && !fromEI.isDifferentiable())
-      toFuncNoADConversion =
-          toFuncNoADConversion->getWithoutDifferentiability();
-    expr = cs.cacheType(new (tc.Context)
-                            FunctionConversionExpr(expr,
-                                                   toFuncNoADConversion));
-
-    // Make the conversion to @differentiable happen after all other conversions,
-    // because some of the other conversions are not currently supported on
-    // @differentiable functions. (e.g. escape_to_noescape).
-    // After we do support those conversions, the order will no longer matter.
-    if (!fromEI.isDifferentiable() && toEI.isDifferentiable())
-      expr = cs.cacheType(new (tc.Context)
-                              AutoDiffFunctionExpr(expr, toFunc));
-
-    return expr;
+    return cs.cacheType(new (tc.Context)
+                            FunctionConversionExpr(expr, toType));
   }
 
   // Coercions from one metatype to another.

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -175,7 +175,10 @@ struct TF_305 : Differentiable {
 //===----------------------------------------------------------------------===//
 
 class Foo {
-  // @differentiable cannot be put here. It's rejected by Sema already.
+  // FIXME: Figure out why diagnostics for direct references end up here, and
+  // why they are duplicated.
+  // expected-error @+2 2 {{expression is not differentiable}}
+  // expected-note @+1 2 {{differentiating class members is not yet supported}}
   func class_method(_ x: Float) -> Float {
     return x
   }
@@ -189,9 +192,7 @@ func triesToDifferentiateClassMethod(x: Float) -> Float {
   return Foo().class_method(x)
 }
 
-// expected-error @+2 {{function is not differentiable}}
-// expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
-_ = gradient(at: .zero, in: Foo().class_method)
+let _: @differentiable (Float) -> Float = Foo().class_method
 
 //===----------------------------------------------------------------------===//
 // Unreachable

--- a/test/AutoDiff/autodiff_function_silgen.swift
+++ b/test/AutoDiff/autodiff_function_silgen.swift
@@ -22,8 +22,8 @@ func apply() {
 // CHECK-AST:              (autodiff_function_extract_original implicit type='(Float) -> (Float)'
 // CHECK-AST:                (declref_expr type='@differentiable (Float) -> (Float)'
 // CHECK-AST-LABEL:  (func_decl {{.*}} "apply()"
-// CHECK-AST:          (autodiff_function implicit type='@differentiable (Float) -> (Float)'
-// CHECK-AST:            (function_conversion_expr implicit type='(Float) -> (Float)'
+// CHECK-AST:          (function_conversion_expr implicit type='@differentiable (Float) -> (Float)'
+// CHECK-AST:            (autodiff_function implicit type='@differentiable (Float) -> Float'
 // CHECK-AST:              (declref_expr type='(Float) -> Float'
 
 // CHECK-SILGEN-LABEL: @{{.*}}myfunction{{.*}}

--- a/test/AutoDiff/closures.swift
+++ b/test/AutoDiff/closures.swift
@@ -23,7 +23,7 @@ public func closureCaptureMutable() {
 }
 
 // CHECK-LABEL: @AD__{{.*}}closureCaptureMutable{{.*}}___vjp_src_0_wrt_0
-// CHECK: bb0({{%.*}} : $Float, [[INOUT_ARG:%.*]] : $*Float):
+// CHECK: bb0({{%.*}} : $Float, [[INOUT_ARG:%.*]] : ${ var Float }):
 // CHECK:   [[ADJOINT:%.*]] = function_ref @AD__{{.*}}closureCaptureMutabley{{.*}}___pullback_src_0_wrt_0
 // CHECK:   {{.*}} = partial_apply [callee_guaranteed] [[ADJOINT]]({{.*}})
 

--- a/test/AutoDiff/differentiable_func_sil_diagnostics.swift
+++ b/test/AutoDiff/differentiable_func_sil_diagnostics.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// This test file contains SIL diagnostics tests for differentiable functions
+// such as escaping capture errors.
+// NOTE: Only add tests for errors that would occur after the differentiation 
+// transform.
+
+func nonescapingArgument(f: @differentiable (Float, Float) -> Float) -> Float {
+  return gradient(at: 1) { x in f(x, x) }
+}
+
+// expected-note @+2 {{parameter 'f' is implicitly non-escaping}}
+func nonescapingArgumentError(
+  f: @differentiable (Float, Float) -> Float
+) -> @differentiable (Float) -> Float{
+  // expected-error @+2 {{escaping closure captures non-escaping parameter 'f'}}
+  // expected-note @+1 {{captured here}}
+  return { x in f(x, x) }
+}

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -21,6 +21,16 @@ let _: @differentiable(linear) (Float) -> Float
 // Function conversion
 //===----------------------------------------------------------------------===//
 
+func nonescapingArgument(f: @differentiable (Float, Float) -> Float) -> Float {
+  return gradient(at: 1) { x in f(x, x) }
+}
+
+func nonescapingArgumentError(
+  f: @differentiable (Float, Float) -> Float
+) -> @differentiable (Float) -> Float{
+  return { x in f(x, x) }
+}
+
 func takesOpaqueClosure(f: @escaping (Float) -> Float) {
   // expected-note @-1 {{did you mean to take a '@differentiable' closure?}} {{38-38=@differentiable }}
   // expected-error @+1 {{a '@differentiable' function can only be formed from a reference to a 'func' or a literal closure}}

--- a/test/AutoDiff/differentiable_func_type_type_checking.swift
+++ b/test/AutoDiff/differentiable_func_type_type_checking.swift
@@ -21,16 +21,6 @@ let _: @differentiable(linear) (Float) -> Float
 // Function conversion
 //===----------------------------------------------------------------------===//
 
-func nonescapingArgument(f: @differentiable (Float, Float) -> Float) -> Float {
-  return gradient(at: 1) { x in f(x, x) }
-}
-
-func nonescapingArgumentError(
-  f: @differentiable (Float, Float) -> Float
-) -> @differentiable (Float) -> Float{
-  return { x in f(x, x) }
-}
-
 func takesOpaqueClosure(f: @escaping (Float) -> Float) {
   // expected-note @-1 {{did you mean to take a '@differentiable' closure?}} {{38-38=@differentiable }}
   // expected-error @+1 {{a '@differentiable' function can only be formed from a reference to a 'func' or a literal closure}}

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -52,7 +52,7 @@ struct SupervisedTrainer<Model : Layer> {
   var model: Model
   var lossFunction: @differentiable (Model.Output, Model.Output) -> Float
   func fit(y: Model.Output) {
-    _ = gradient(at: y) { y in return lossFunction(y, y) }
+    _ = gradient(at: y) { y in return self.lossFunction(y, y) }
   }
 }
 

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -61,7 +61,7 @@ LeakCheckingTests.test("BasicVarLeakChecking") {
   }
 
   // TODO: Fix memory leak.
-  testWithLeakChecking(expectedLeakCount: 1) {
+  testWithLeakChecking(expectedLeakCount: 0) {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
 
@@ -72,7 +72,7 @@ LeakCheckingTests.test("BasicVarLeakChecking") {
   }
 
   // TODO: Fix memory leak.
-  testWithLeakChecking(expectedLeakCount: 1) {
+  testWithLeakChecking(expectedLeakCount: 0) {
     var model = ExampleLeakModel()
     var x: Tracked<Float> = 1.0
     _ = model.gradient { m in
@@ -83,7 +83,7 @@ LeakCheckingTests.test("BasicVarLeakChecking") {
   }
 
   // TODO: Fix memory leak.
-  testWithLeakChecking(expectedLeakCount: 2) {
+  testWithLeakChecking(expectedLeakCount: 1) {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
     _ = model.gradient { m in

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -60,8 +60,7 @@ LeakCheckingTests.test("BasicVarLeakChecking") {
     _ = model.gradient(at: x) { m, x in m.applied(to: x) }
   }
 
-  // TODO: Fix memory leak.
-  testWithLeakChecking(expectedLeakCount: 0) {
+  testWithLeakChecking {
     var model = ExampleLeakModel()
     let x: Tracked<Float> = 1.0
 
@@ -71,8 +70,7 @@ LeakCheckingTests.test("BasicVarLeakChecking") {
     }
   }
 
-  // TODO: Fix memory leak.
-  testWithLeakChecking(expectedLeakCount: 0) {
+  testWithLeakChecking {
     var model = ExampleLeakModel()
     var x: Tracked<Float> = 1.0
     _ = model.gradient { m in

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -46,9 +46,8 @@ public func test1() -> Vector {
 // CHECK-LABEL: @{{.*}}test1{{.*}}
 // CHECK: [[CLOSURE:%.*]] = function_ref @{{.*}}test1{{.*}}foo{{.*}} : $@convention(thin) (Vector) -> Float
 // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (Vector) -> Float to $@callee_guaranteed (Vector) -> Float
-// CHECK: [[CLOSURE_THICK_NOESC:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_THICK]] : $@callee_guaranteed (Vector) -> Float to $@noescape @callee_guaranteed (Vector) -> Float
-// CHECK: autodiff_function [wrt 0] [order 1] [[CLOSURE_THICK_NOESC]] : $@noescape @callee_guaranteed (Vector) -> Float
-
+// CHECK: [[CLOSURE_DIFF:%.*]] = autodiff_function [wrt 0] [order 1] [[CLOSURE_THICK]] : $@callee_guaranteed (Vector) -> Float
+// CHECK: [[CLOSURE_DIFF_NOESC:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE_DIFF]] : $@differentiable @callee_guaranteed (Vector) -> Float to $@differentiable @noescape @callee_guaranteed (Vector) -> Float
 
 // TF-189: `TF189` is a non-trivial type but `TF189.AllDifferentiableVariables` is trivial.
 // Should pass verification.


### PR DESCRIPTION
Before this patch, implicit conversions to `@differentiable` happens on top of `convert_escape_to_noescape`. This caused associated functions produce by the differentiation transform to be leaked, because the function conversion reapplication logic in the differentiation transform did not release the thick associated functions where the original was released before converting them to noescape. This is best illustrated as code:

```
f = partial_apply ...
strong_retain f
f' = convert_escape_to_noescape f
diff_f = autodiff_function f'
...
strong_release f
strong_release f
```

... after differentiation transform:

```
f = partial_apply ...
strong_retain f
f' = convert_escape_to_noescape f
jvp = partial_apply ...
jvp' = convert_escape_to_noescape jvp
vjp = partial_apply ...
vjp' = convert_escape_to_noescape vjp
diff_f = autodiff_function f' with {jvp', vjp'}
...
*** jvp and vjp are leaked! ***
strong_release f
strong_release f
```

This patch brings `@differentiable` function conversion before noescape conversion, so that SILGen emits a `strong_release` on the entire `@differentiable` function (produced by `autodiff_function`) before turning it into a `@differentiable @noescape` closure, illustrated below:

```
f = partial_apply ...
jvp = partial_apply ...
vjp = partial_apply ...
diff_f = autodiff_function f with {jvp, vjp}
strong_retain diff_f
diff_f' = convert_escape_to_noescape diff_f
...
strong_release diff_f
strong_release diff_f
```

Resolves [TF-550](https://bugs.swift.org/browse/TF-550).
