### PR TITLE
[SE-0258] Fix a few more crashes involving property wrappers in invalid code

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5905,7 +5905,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
 
         // ... producing a value of the same nominal type as the innermost
         // property wrapper.
-        if (call->getType()->getAnyNominal() != innermostNominal)
+        if (!call->getType() ||
+            call->getType()->getAnyNominal() != innermostNominal)
           return { true, E };
 
         // Find the implicit initialValue argument.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5912,9 +5912,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
         if (auto tuple = dyn_cast<TupleExpr>(call->getArg())) {
           ASTContext &ctx = innermostNominal->getASTContext();
           for (unsigned i : range(tuple->getNumElements())) {
-            if ((tuple->getElementName(i) == ctx.Id_wrappedValue ||
-                 tuple->getElementName(i) == ctx.Id_initialValue) &&
-                tuple->getElementNameLoc(i).isInvalid()) {
+            if (tuple->getElementName(i) == ctx.Id_wrappedValue ||
+                tuple->getElementName(i) == ctx.Id_initialValue) {
               initArg = tuple->getElement(i);
               return { false, E };
             }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -903,6 +903,18 @@ struct TestAlias {
   @Alias var foo = 17
 }
 
+// rdar://problem/52969503 - crash due to invalid source ranges in ill-formed
+// code.
+@propertyWrapper
+struct Wrap52969503<T> {
+  var wrappedValue: T
+
+  init(blah: Int, wrappedValue: T) { }
+}
+
+struct Test52969503 {
+  @Wrap52969503(blah: 5) var foo: Int = 1 // expected-error{{argument 'blah' must precede argument 'wrappedValue'}}
+}
 
 
 // 

--- a/validation-test/compiler_crashers_2_fixed/0201-rdar53120878.swift
+++ b/validation-test/compiler_crashers_2_fixed/0201-rdar53120878.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend -typecheck %s
+public struct Use { @Wrap var value: some Doubl = 1.0 }
+@propertyWrapper public struct Wrap { public var wrappedValue: Double }
+

--- a/validation-test/compiler_crashers_2_fixed/0202-rdar53183030.swift
+++ b/validation-test/compiler_crashers_2_fixed/0202-rdar53183030.swift
@@ -1,0 +1,21 @@
+// RUN: not %target-swift-frontend -typecheck %s
+protocol MyBindableObject {}
+
+@propertyWrapper
+struct MyBinding<T> where T : MyBindableObject {
+    public var wrappedV: T
+    public var wrapperValue: MyBinding<T> {
+        return self
+    }
+    public init(initialValue: T) {
+        self.value = initialValue
+    }
+}
+class BeaconDetector: MyBindableObject {
+    struct ContentView {
+        @MyBinding var detector = BeaconDetector()
+        func foo() {
+            _ = detector.undefined == 1
+        }
+    }
+}


### PR DESCRIPTION
Fix a few small issues that could cause crashes with property wrappers:

* Provide source locations for synthesized initializer calls (fixes rdar://problem/52969503 and rdar://problem/53183030)
* Check for a NULL type before digging into an expression to find the type-checked "initial value" (fixes rdar://problem/53120878)