### PR TITLE
IRGen: Use correct archetype conformance code path for opaque associated types.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1690,8 +1690,6 @@ namespace {
       auto opaqueType = O->getDeclaredInterfaceType()
                          ->castTo<OpaqueTypeArchetypeType>();
       
-      
-      
       for (auto proto : opaqueType->getConformsTo()) {
         auto conformance = ProtocolConformanceRef(proto);
         auto underlyingConformance = conformance

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1566,17 +1566,6 @@ void WitnessTableBuilder::defineAssociatedTypeWitnessTableAccessFunction(
   IGF.bindLocalTypeDataFromTypeMetadata(ConcreteType, IsExact, self,
                                         MetadataState::Abstract);
 
-  // If the associated type is opaque, use the runtime to fetch the conformance.
-  if (associatedRootOpaqueType) {
-    assert(associatedType == CanType(associatedRootOpaqueType)
-           && "associated type is nested type of opaque type?! not implemented");
-    auto wtable = emitOpaqueTypeWitnessTableRef(IGF,
-                          CanOpaqueTypeArchetypeType(associatedRootOpaqueType),
-                          associatedProtocol);
-    IGF.Builder.CreateRet(wtable);
-    return;
-  }
-  
   // Find abstract conformances.
   // TODO: provide an API to find the best metadata path to the conformance
   // and decide whether it's expensive enough to be worth caching.

--- a/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
+++ b/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %s | %FileCheck %s
+
+protocol Butt { }
+
+protocol Tubb: Butt { }
+
+protocol P {
+  associatedtype A: Butt
+  associatedtype B: Butt
+  func foo(_ x: A) -> B
+}
+
+struct Foo<T: Tubb>: P {
+  func foo(_ x: T) -> some Tubb { return x }
+}
+
+// CHECK-LABEL: define {{.*}} @"$s030opaque_result_type_associated_C17_conformance_path3FooVyxGAA1PAA1B_AA4ButtPWT"
+// CHECK: [[TUBB_CONFORMANCE:%.*]] = call swiftcc i8** @swift_getOpaqueTypeConformance({{.*}}, i{{.*}} 1)
+// CHECK: [[BUTT_CONFORMANCE_ADDR:%.*]] = getelementptr {{.*}} [[TUBB_CONFORMANCE]], i32 1
+// CHECK: [[BUTT_CONFORMANCE_LOAD:%.*]] = load {{.*}} [[BUTT_CONFORMANCE_ADDR]]
+// CHECK: [[BUTT_CONFORMANCE:%.*]] = bitcast {{.*}} [[BUTT_CONFORMANCE_LOAD]]
+// CHECK: ret {{.*}} [[BUTT_CONFORMANCE]]


### PR DESCRIPTION
The code here was not correct in a situation where an opaque type had constraints that were
refinements of the protocol requirements of an associated type, as in:

```
protocol ParentProtocol {}
protocol SubProtocol: ParentProtocol {}

protocol P {
  associatedtype A: ParentProtocol
  func foo() -> A
}

struct S: P {
  func foo() -> some SubProtocol
}
```

because it assumed that the conformance could be found directly on the opaque type instead of
potentially via an arbitrary MetadataPath. Falling through to the code that already correctly
handles archetype conformances right below the removed code does the right thing. Fixes
rdar://problem/53081207.