### PR TITLE
Ignore unresolved imports in @_implementationOnly consistency checking

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -564,6 +564,9 @@ void swift::checkInconsistentImplementationOnlyImports(ModuleDecl *MainModule) {
         continue;
 
       ModuleDecl *module = nextImport->getModule();
+      if (!module)
+        continue;
+
       if (nextImport->getAttrs().hasAttribute<ImplementationOnlyAttr>()) {
         // We saw an implementation-only import.
         bool isNew =

--- a/validation-test/NameBinding/inconsistent-implementation-only-errors.swift
+++ b/validation-test/NameBinding/inconsistent-implementation-only-errors.swift
@@ -1,0 +1,9 @@
+// Just check that we don't crash (rdar://problem/52943397)
+
+// RUN: not %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck -show-diagnostics-after-fatal %s
+
+@_implementationOnly import Swift
+import ThisModuleDoesNotExist
+@_implementationOnly import ThisModuleDoesNotExist
+@_implementationOnly import NeitherDoesThisOne


### PR DESCRIPTION
Unresolved imports all have the "same" ModuleDecl: `nullptr`. But that's not really an inconsistency, and even if there *is* a true inconsistency among unresolved imports, it can be dealt with when the developer fixes their search paths. (Or the imports. Whichever is wrong.)

rdar://problem/52943397