### PR TITLE
[SR-10979] Add fix-it for missing operator

### DIFF
--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -11,7 +11,27 @@ struct Y {}
 
 func +(lhs: X, rhs: X) -> X {} // okay
 
-func +++(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}
+func <=>(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
+
+extension X {
+    static func <=>(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
+}
+
+extension X {
+    struct Z {
+        static func <=> (lhs: Z, rhs: Z) -> Z {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
+    }
+}
+
+extension X {
+    static prefix func <=>(lhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=prefix operator <=> : <# Precedence Group #>\n}}
+}
+
+extension X {
+    struct ZZ {
+        static prefix func <=>(lhs: ZZ) -> ZZ {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=prefix operator <=> : <# Precedence Group #>\n}}
+    }
+}
 
 infix operator ++++ : ReallyHighPrecedence
 precedencegroup ReallyHighPrecedence {


### PR DESCRIPTION
This PR adds fix-it for operator functions when operator is not declared.

Resolves [SR-10979](https://bugs.swift.org/browse/SR-10979).