### PR TITLE
[Diagnostics][Darwin] Diagnose libarclite not found on darwin toolchain

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -114,6 +114,9 @@ ERROR(error_sdk_too_old,none,
 ERROR(error_ios_maximum_deployment_32,none,
       "iOS %0 does not support 32-bit programs", (unsigned))
 
+ERROR(error_arclite_not_found_when_link_objc_runtime,none,
+"unable to find the 'arclite' library", ())
+
 ERROR(error_two_files_same_name,none,
       "filename \"%0\" used twice: '%1' and '%2'",
       (StringRef, StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -114,8 +114,9 @@ ERROR(error_sdk_too_old,none,
 ERROR(error_ios_maximum_deployment_32,none,
       "iOS %0 does not support 32-bit programs", (unsigned))
 
-ERROR(error_arclite_not_found_when_link_objc_runtime,none,
-"unable to find the 'arclite' library", ())
+WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
+      "Unable to find Objective-C runtime support library 'arclite'. "
+      "consider '-no-link-objc-runtime' flag", ())
 
 ERROR(error_two_files_same_name,none,
       "filename \"%0\" used twice: '%1' and '%2'",

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -115,8 +115,8 @@ ERROR(error_ios_maximum_deployment_32,none,
       "iOS %0 does not support 32-bit programs", (unsigned))
 
 WARNING(warn_arclite_not_found_when_link_objc_runtime,none,
-      "Unable to find Objective-C runtime support library 'arclite'. "
-      "consider '-no-link-objc-runtime' flag", ())
+        "unable to find Objective-C runtime support library 'arclite'; "
+        "pass '-no-link-objc-runtime' to silence this warning", ())
 
 ERROR(error_two_files_same_name,none,
       "filename \"%0\" used twice: '%1' and '%2'",

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -336,16 +336,18 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
     llvm::SmallString<128> ARCLiteLib;
     findARCLiteLibPath(*this, ARCLiteLib);
 
-    llvm::sys::path::append(ARCLiteLib, "libarclite_");
-    ARCLiteLib += getPlatformNameForTriple(Triple);
-    ARCLiteLib += ".a";
-    
-    Arguments.push_back("-force_load");
-    Arguments.push_back(context.Args.MakeArgString(ARCLiteLib));
-    
-    // Arclite depends on CoreFoundation.
-    Arguments.push_back("-framework");
-    Arguments.push_back("CoreFoundation");
+    if (!ARCLiteLib.empty()) {
+      llvm::sys::path::append(ARCLiteLib, "libarclite_");
+      ARCLiteLib += getPlatformNameForTriple(Triple);
+      ARCLiteLib += ".a";
+
+      Arguments.push_back("-force_load");
+      Arguments.push_back(context.Args.MakeArgString(ARCLiteLib));
+
+      // Arclite depends on CoreFoundation.
+      Arguments.push_back("-framework");
+      Arguments.push_back("CoreFoundation");
+    }
   }
 
   for (const Arg *arg :
@@ -599,7 +601,7 @@ static void validateLinkObjcRuntimeARCLiteLib(const toolchains::Darwin &TC,
     
     if (ARCLiteLib.empty()) {
       diags.diagnose(SourceLoc(),
-                     diag::error_arclite_not_found_when_link_objc_runtime);
+                     diag::warn_arclite_not_found_when_link_objc_runtime);
     }
   }
 }

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -28,7 +28,7 @@
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
 // RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s 
-// CHECK-L2-ENV: warning: Unable to find Objective-C runtime support library 'arclite'. consider '-no-link-objc-runtime' flag
+// CHECK-L2-ENV: warning: unable to find Objective-C runtime support library 'arclite'; pass '-no-link-objc-runtime' to silence this warning
 // CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
@@ -53,7 +53,7 @@
 // CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
 
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
-// CHECK-COMPLEX: warning: Unable to find Objective-C runtime support library 'arclite'. consider '-no-link-objc-runtime' flag
+// CHECK-COMPLEX: warning: unable to find Objective-C runtime support library 'arclite'; pass '-no-link-objc-runtime' to silence this warning
 // CHECK-COMPLEX: -F /foo/
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -27,9 +27,8 @@
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2 %s
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
-// RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2-ENV %s
-// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
-
+// RUN: not env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s
+// CHECK-L2-ENV: error: unable to find the 'arclite' library
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // CHECK-NO-FRAMEWORKS-NOT: DYLD_FRAMEWORK_PATH
@@ -51,12 +50,8 @@
 // CHECK-F2-ENV: #
 // CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
 
-// RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s | %FileCheck -check-prefix=CHECK-COMPLEX %s
-// CHECK-COMPLEX: -F /foo/
-// CHECK-COMPLEX: -F /bar/
-// CHECK-COMPLEX: #
-// CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
-// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
+// RUN: not env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
+// CHECK-COMPLEX: error: unable to find the 'arclite' library
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -27,8 +27,10 @@
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2 %s
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
-// RUN: not env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s
-// CHECK-L2-ENV: error: unable to find the 'arclite' library
+// RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s 
+// CHECK-L2-ENV: warning: Unable to find Objective-C runtime support library 'arclite'. consider '-no-link-objc-runtime' flag
+// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
+
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
 // CHECK-NO-FRAMEWORKS-NOT: DYLD_FRAMEWORK_PATH
@@ -50,8 +52,13 @@
 // CHECK-F2-ENV: #
 // CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
 
-// RUN: not env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
-// CHECK-COMPLEX: error: unable to find the 'arclite' library
+// RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
+// CHECK-COMPLEX: warning: Unable to find Objective-C runtime support library 'arclite'. consider '-no-link-objc-runtime' flag
+// CHECK-COMPLEX: -F /foo/
+// CHECK-COMPLEX: -F /bar/
+// CHECK-COMPLEX: #
+// CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
+// CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}


### PR DESCRIPTION
Hey guys :)
Note a FIXME comment about diagnostics that could be done when linking to objc runtime, but the place was not a good one to emit diagnostics since it is in the construct invocation. 
And since now there is a method in the toolchain to perform validations, thought that may be a good idea to handle that diagnostic there.

What do you think? cc @jrose-apple @brentdax 

Obs: not sure if this diagnose message is good, maybe could be a better one :))