### PR TITLE
[CSDiagnostics] Use special error message when call didn't match exactly

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -58,6 +58,9 @@ ERROR(ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 ERROR(no_overloads_match_exactly_in_call,none,
       "no exact matches in call to %0 %1",
+      (DescriptiveDeclKind, DeclName))
+ERROR(no_overloads_match_exactly_in_call_no_labels,none,
+      "no exact matches in call to %0 %1",
       (DescriptiveDeclKind, DeclBaseName))
 ERROR(no_overloads_match_exactly_in_call_special,none,
       "no exact matches in call to %0",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -56,6 +56,12 @@ ERROR(ambiguous_member_overload_set,none,
       "ambiguous reference to member %0", (DeclName))
 ERROR(ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
+ERROR(no_overloads_match_exactly_in_call,none,
+      "no exact matches in call to %0 %1",
+      (DescriptiveDeclKind, DeclBaseName))
+ERROR(no_overloads_match_exactly_in_call_special,none,
+      "no exact matches in call to %0",
+      (DescriptiveDeclKind))
 
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2490,8 +2490,16 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
                   diag::could_not_find_subscript_member_did_you_mean,
                   getType(UDE->getBase()));
     } else {
-      TC.diagnose(commonAnchor->getLoc(), diag::ambiguous_reference_to_decl,
-                  decl->getDescriptiveKind(), decl->getFullName());
+      auto name = decl->getBaseName();
+      if (name.isSpecial()) {
+        TC.diagnose(commonAnchor->getLoc(),
+                    diag::no_overloads_match_exactly_in_call_special,
+                    decl->getDescriptiveKind());
+      } else {
+        TC.diagnose(commonAnchor->getLoc(),
+                    diag::no_overloads_match_exactly_in_call,
+                    decl->getDescriptiveKind(), name);
+      }
     }
 
     for (const auto &viable : viableSolutions) {

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -236,13 +236,9 @@ extension P4 where Self.AssocP4 == Bool {
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  // FIXME: Both of the 'ambiguous' examples below are indeed ambiguous,
-  //        because they don't match on conformance and same-type
-  //        requirement of different overloads, but diagnostic
-  //        could be improved to point out exactly what is missing in each case.
-  s4a.extP4a() // expected-error{{ambiguous reference to instance method 'extP4a()'}}
+  s4a.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{ambiguous reference to instance method 'extP4a()'}}
+  s4c.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -236,9 +236,9 @@ extension P4 where Self.AssocP4 == Bool {
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
+  s4a.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a()'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a'}}
+  s4c.extP4a() // expected-error{{no exact matches in call to instance method 'extP4a()'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
@@ -4,8 +4,8 @@ extension BinaryInteger {
   init(bytes: [UInt8]) { fatalError() }
 
   init<S: Sequence>(bytes: S) where S.Iterator.Element == UInt8 {
-    self.init(bytes // expected-error {{ambiguous reference to initializer 'init(_:)'}}
-// expected-note@-1 {{}}
+    self.init(bytes // expected-error {{no exact matches in call to initializer}}
+    // expected-note@-1 {{}}
 
 extension
 // expected-error@-1 {{declaration is only valid at file scope}}


### PR DESCRIPTION
For multiple solutions with fixes for the same call, replace
`ambiguous reference` diagnostic with the one that explicitly
mentions that there are no exact matches, and provide partially
matched candidates as notes.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
