### PR TITLE
[5.1] Driver: Don't imply -enable-anonymous-context-mangled-names with optimizations enabled, even if -g is used.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -251,7 +251,11 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   // -g implies -enable-anonymous-context-mangled-names, because the extra
   // metadata aids debugging.
   if (inputArgs.hasArg(options::OPT_g)) {
-    arguments.push_back("-enable-anonymous-context-mangled-names");
+    // But don't add the option in optimized builds: it would prevent dead code
+    // stripping of unused metadata.
+    auto OptArg = inputArgs.getLastArgNoClaim(options::OPT_O_Group);
+    if (!OptArg || OptArg->getOption().matches(options::OPT_Onone))
+      arguments.push_back("-enable-anonymous-context-mangled-names");
   }
 
   // Pass through any subsystem flags.

--- a/test/Driver/debug_anonymous_context_metadata.swift
+++ b/test/Driver/debug_anonymous_context_metadata.swift
@@ -1,4 +1,10 @@
 // RUN: %target-swiftc_driver -### -g %s 2>&1 | %FileCheck %s
+// RUN: %target-swiftc_driver -### -g -Onone %s 2>&1 | %FileCheck -check-prefix=CHECK-ONONE %s
+// RUN: %target-swiftc_driver -### -g -O %s 2>&1 | %FileCheck -check-prefix=CHECK-O %s
+// RUN: %target-swiftc_driver -### -g -Osize %s 2>&1 | %FileCheck -check-prefix=CHECK-OSIZE %s
 
 // CHECK: -enable-anonymous-context-mangled-names
+// CHECK-ONONE: -enable-anonymous-context-mangled-names
+// CHECK-O-NOT: -enable-anonymous-context-mangled-names
+// CHECK-OSIZE-NOT: -enable-anonymous-context-mangled-names
 

--- a/test/IRGen/lazy_metadata_with-g.swift
+++ b/test/IRGen/lazy_metadata_with-g.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swiftc_driver -parse-as-library -module-name=test -target x86_64-apple-macosx10.15 -wmo -O -g -emit-ir %s  | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// Check that the compiler does not emit any metadata for Mystruct and
+// Teststruct, even with -g.
+// This is also a driver issue, so we are testing with %target-swiftc_driver
+// and not just with %target-swift-frontend.
+
+// CHECK: ModuleID
+
+// CHECK-NOT: Mystruct
+// CHECK-NOT: Teststruct
+// CHECK-NOT: define
+
+// CHECK: DICompileUnit
+
+protocol P {
+}
+
+struct Mystruct : P {
+}
+
+
+struct Teststruct {
+
+  static var testvar: some P {
+    return Mystruct()
+  }
+}
+


### PR DESCRIPTION
The option -enable-anonymous-context-mangled-names prevents stripping of dead metadata to improve debuggability.
But with optimizations enabled, we do a lot of dead code stripping which affects debuggability anyway.

This change enables complete removal of unused code and metadata.

Scope: Only affects release builds with -g. It has an effect on the debuggability of release-executables, as we now remove all unused metadata and this metadata is not available for the debugger anymore.

Issue: rdar://problem/48123944

Risk: Low. It does not change how code is generated, just what (unused) metadata is kept alive in release builds.

Reviewed by: @DougGregor