### PR TITLE
Fix vim comment syntax highlighting.

### DIFF
--- a/utils/vim/syntax/sil.vim
+++ b/utils/vim/syntax/sil.vim
@@ -61,8 +61,8 @@ syn keyword swiftImport import skipwhite nextgroup=swiftImportModule
 syn match swiftImportModule /\<[A-Za-z_][A-Za-z_0-9]*\>/ contained nextgroup=swiftImportComponent
 syn match swiftImportComponent /\.\<[A-Za-z_][A-Za-z_0-9]*\>/ contained nextgroup=swiftImportComponent
 
-syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftLineComment,swiftTodo
-syn region swiftLineComment start="//" end="$" contains=swiftComment,swiftTodo
+syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftTodo
+syn region swiftLineComment start="//" end="$" contains=swiftTodo
 
 syn match swiftLineComment   /^#!.*/
 syn match swiftTypeName  /\<[A-Z][a-zA-Z_0-9]*\>/

--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -158,8 +158,8 @@ syn region swiftParenthesisRegion matchgroup=NONE start=/(/ end=/)/ contains=TOP
 
 syn region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolationRegion
 syn region swiftInterpolationRegion matchgroup=swiftInterpolation start=/\\(/ end=/)/ contained contains=TOP
-syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftLineComment,swiftTodo
-syn region swiftLineComment start="//" end="$" contains=swiftComment,swiftTodo
+syn region swiftComment start="/\*" end="\*/" contains=swiftComment,swiftTodo
+syn region swiftLineComment start="//" end="$" contains=swiftTodo
 
 syn match swiftDecimal /[+\-]\?\<\([0-9][0-9_]*\)\([.][0-9_]*\)\?\([eE][+\-]\?[0-9][0-9_]*\)\?\>/
 syn match swiftHex /[+\-]\?\<0x[0-9A-Fa-f][0-9A-Fa-f_]*\(\([.][0-9A-Fa-f_]*\)\?[pP][+\-]\?[0-9][0-9_]*\)\?\>/


### PR DESCRIPTION
This change is motivated by highlighting for `test/Interpreter/SDK/lib.swift`. It contains the line
```swift
// CHECK: the magic word is ///* magic *///
```
which without this change leaves the rest of the file highlighted as commented out. `swiftComment` cannot contain `swiftLineComment`, or else this:
```swift
/* // */ hello
```
gets incorrectly highlighted as if "hello" was commented out. Similarly, `swiftLineComment` cannot contain `swiftComment`, or else this:
```swift
// /*
*/
```
gets incorrectly highlighted as if `*/` was closing a comment, when actually it should be a syntax error.