### PR TITLE
IDE+Evaluator: refactor the implementation of two type checker utilities to evaluator requests. NFC

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -611,7 +611,6 @@ inline T *staticCastHelper(const Type &Ty) {
 template <typename T>
 using TypeArrayView = ArrayRefView<Type, T*, staticCastHelper,
                                    /*AllowOrigAccess*/true>;
-
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -224,6 +224,7 @@ FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 #include "swift/AST/AccessTypeIDZone.def"
 #include "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/AST/TypeCheckerTypeIDZone.def"
+#include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #include "swift/IDE/IDERequestIDZone.def"
 #undef SWIFT_TYPEID
 

--- a/include/swift/Sema/IDETypeCheckingRequestIDZone.def
+++ b/include/swift/Sema/IDETypeCheckingRequestIDZone.def
@@ -1,0 +1,17 @@
+//===-------- IDETypeCheckingIDZone.def -------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the types in the IDE requests
+//  TypeID zone, for use with the TypeID template.
+//
+//===----------------------------------------------------------------------===//
+SWIFT_TYPEID(IsDeclApplicableRequest)

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -1,0 +1,107 @@
+//===----- IDETypeCheckingRequests.h - IDE type-check Requests --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines IDE type checking request using the evaluator model.
+//  The file needs to exist in sema because it needs internal implementation
+//  of the type checker to fulfill some requests
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_IDE_TYPE_CHECKING_REQUESTS_H
+#define SWIFT_IDE_TYPE_CHECKING_REQUESTS_H
+
+#include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/Evaluator.h"
+#include "swift/AST/SimpleRequest.h"
+#include "swift/AST/TypeCheckRequests.h"
+
+namespace swift {
+//----------------------------------------------------------------------------//
+// Decl applicability checking
+//----------------------------------------------------------------------------//
+struct DeclApplicabilityOwner {
+  const DeclContext *DC;
+  const Type Ty;
+  const Decl *ExtensionOrMember;
+
+  DeclApplicabilityOwner(const DeclContext *DC, Type Ty, const ExtensionDecl *ED):
+    DC(DC), Ty(Ty), ExtensionOrMember(ED) {}
+  DeclApplicabilityOwner(const DeclContext *DC, Type Ty, const ValueDecl *VD):
+    DC(DC), Ty(Ty), ExtensionOrMember(VD) {}
+
+  friend llvm::hash_code hash_value(const DeclApplicabilityOwner &CI) {
+    return hash_combine(hash_value(CI.Ty.getPointer()),
+                        hash_value(CI.ExtensionOrMember));
+  }
+
+  friend bool operator==(const DeclApplicabilityOwner &lhs,
+                         const DeclApplicabilityOwner &rhs) {
+    return lhs.Ty.getPointer() == rhs.Ty.getPointer() &&
+      lhs.ExtensionOrMember == rhs.ExtensionOrMember;
+  }
+
+  friend bool operator!=(const DeclApplicabilityOwner &lhs,
+                         const DeclApplicabilityOwner &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend void simple_display(llvm::raw_ostream &out,
+                             const DeclApplicabilityOwner &owner) {
+    out << "Checking if ";
+    simple_display(out, owner.ExtensionOrMember);
+    out << " is applicable for ";
+    simple_display(out, owner.Ty);
+  }
+};
+
+class IsDeclApplicableRequest:
+    public SimpleRequest<IsDeclApplicableRequest,
+                         bool(DeclApplicabilityOwner),
+                         CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool> evaluate(Evaluator &evaluator,
+                                DeclApplicabilityOwner Owner) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+  // Source location
+  SourceLoc getNearestLoc() const { return SourceLoc(); };
+};
+
+
+/// The zone number for the IDE.
+#define SWIFT_IDE_TYPE_CHECK_REQUESTS_TYPEID_ZONE 97
+#define SWIFT_TYPEID_ZONE SWIFT_IDE_TYPE_CHECK_REQUESTS_TYPEID_ZONE
+#define SWIFT_TYPEID_HEADER "swift/Sema/IDETypeCheckingRequestIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+
+// Set up reporting of evaluated requests.
+#define SWIFT_TYPEID(RequestType)                                \
+template<>                                                       \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
+                            const RequestType &request) {        \
+  ++stats.getFrontendCounters().RequestType;                     \
+}
+#include "swift/Sema/IDETypeCheckingRequestIDZone.def"
+#undef SWIFT_TYPEID
+
+} // end namespace swift
+
+#endif // SWIFT_IDE_REQUESTS_H

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -401,6 +401,12 @@ namespace swift {
   /// The ASTContext will automatically call these upon construction.
   void registerIDERequestFunctions(Evaluator &evaluator);
 
+  /// Register type check request functions for IDE's usage with the evaluator.
+  ///
+  /// The ASTContext will automatically call these upon construction.
+  /// Calling registerIDERequestFunctions will invoke this function as well.
+  void registerIDETypeCheckRequestFunctions(Evaluator &evaluator);
+
 } // end namespace swift
 
 #endif // SWIFT_SUBSYSTEMS_H

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -189,9 +189,10 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
                                 Diagnostics));
   registerTypeCheckerRequestFunctions(Context->evaluator);
 
-  // Migrator and indexing need some IDE requests.
+  // Migrator, indexing and typo correction need some IDE requests.
   if (Invocation.getMigratorOptions().shouldRunMigrator() ||
-      !Invocation.getFrontendOptions().IndexStorePath.empty()) {
+      !Invocation.getFrontendOptions().IndexStorePath.empty() ||
+      Invocation.getLangOptions().TypoCorrectionLimit) {
     registerIDERequestFunctions(Context->evaluator);
   }
   if (setUpModuleLoaders())

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -46,6 +46,7 @@ reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 void swift::registerIDERequestFunctions(Evaluator &evaluator) {
   evaluator.registerRequestFunctions(SWIFT_IDE_REQUESTS_TYPEID_ZONE,
                                      ideRequestFunctions);
+  registerIDETypeCheckRequestFunctions(evaluator);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Sema/IDETypeCheckingRequests.h"
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/IDE/IDERequests.h"
 #include "swift/Parse/Lexer.h"
@@ -755,4 +756,16 @@ collectAllOverriddenDecls(ValueDecl *VD, bool IncludeProtocolRequirements,
   return evaluateOrDefault(VD->getASTContext().evaluator,
     CollectOverriddenDeclsRequest(OverridenDeclsOwner(VD,
       IncludeProtocolRequirements, Transitive)), ArrayRef<ValueDecl*>());
+}
+
+bool swift::isExtensionApplied(const DeclContext *DC, Type BaseTy,
+                               const ExtensionDecl *ED) {
+  return evaluateOrDefault(DC->getASTContext().evaluator,
+    IsDeclApplicableRequest(DeclApplicabilityOwner(DC, BaseTy, ED)), false);
+}
+
+bool swift::isMemberDeclApplied(const DeclContext *DC, Type BaseTy,
+                                const ValueDecl *VD) {
+  return evaluateOrDefault(DC->getASTContext().evaluator,
+    IsDeclApplicableRequest(DeclApplicabilityOwner(DC, BaseTy, VD)), false);
 }

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -61,6 +61,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckSwitchStmt.cpp
   TypeCheckType.cpp
   TypeChecker.cpp
+  IDETypeCheckingRequests.cpp
 
   ${EXTRA_TYPECHECKER_FLAGS})
 target_link_libraries(swiftSema PRIVATE

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTPrinter.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Sema/IDETypeCheckingRequests.h"
+#include "swift/Subsystems.h"
+#include "TypeChecker.h"
+
+using namespace swift;
+
+namespace swift {
+// Implement the IDE type zone.
+#define SWIFT_TYPEID_ZONE SWIFT_IDE_TYPE_CHECK_REQUESTS_TYPEID_ZONE
+#define SWIFT_TYPEID_HEADER "swift/Sema/IDETypeCheckingRequestIDZone.def"
+#include "swift/Basic/ImplementTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+}
+
+// Define request evaluation functions for each of the IDE type check requests.
+static AbstractRequestFunction *ideTypeCheckRequestFunctions[] = {
+#define SWIFT_TYPEID(Name)                                    \
+reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
+#include "swift/Sema/IDETypeCheckingRequestIDZone.def"
+#undef SWIFT_TYPEID
+};
+
+void swift::registerIDETypeCheckRequestFunctions(Evaluator &evaluator) {
+  evaluator.registerRequestFunctions(SWIFT_IDE_TYPE_CHECK_REQUESTS_TYPEID_ZONE,
+                                     ideTypeCheckRequestFunctions);
+}
+
+static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
+                                       const ExtensionDecl *ED) {
+  // We can't do anything if the base type has unbound generic parameters.
+  // We can't leak type variables into another constraint system.
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType() ||
+      BaseTy->hasUnresolvedType() || BaseTy->hasError())
+    return true;
+
+  if (!ED->isConstrainedExtension())
+    return true;
+
+  TypeChecker *TC = &TypeChecker::createForContext((DC->getASTContext()));
+  TC->validateExtension(const_cast<ExtensionDecl *>(ED));
+
+  GenericSignature *genericSig = ED->getGenericSignature();
+  SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
+      DC->getParentModule(), ED->getExtendedNominal());
+  return areGenericRequirementsSatisfied(DC, genericSig, substMap,
+                                         /*isExtension=*/true);
+}
+
+static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
+                                        const ValueDecl *VD) {
+  // We can't leak type variables into another constraint system.
+  // We can't do anything if the base type has unbound generic parameters.
+  if (BaseTy->hasTypeVariable() || BaseTy->hasUnboundGenericType()||
+      BaseTy->hasUnresolvedType() || BaseTy->hasError())
+    return true;
+
+  const GenericContext *genericDecl = VD->getAsGenericContext();
+  if (!genericDecl)
+    return true;
+  const GenericSignature *genericSig = genericDecl->getGenericSignature();
+  if (!genericSig)
+    return true;
+
+  SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
+      DC->getParentModule(), VD->getDeclContext());
+  return areGenericRequirementsSatisfied(DC, genericSig, substMap,
+                                         /*isExtension=*/false);
+}
+
+llvm::Expected<bool>
+IsDeclApplicableRequest::evaluate(Evaluator &evaluator,
+                                  DeclApplicabilityOwner Owner) const {
+  if (auto *VD = dyn_cast<ValueDecl>(Owner.ExtensionOrMember)) {
+    return isMemberDeclAppliedInternal(Owner.DC, Owner.Ty, VD);
+  } else if (auto *ED = dyn_cast<ExtensionDecl>(Owner.ExtensionOrMember)) {
+    return isExtensionAppliedInternal(Owner.DC, Owner.Ty, ED);
+  } else {
+    llvm_unreachable("unhandled decl kind");
+  }
+}

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2144,6 +2144,11 @@ bool fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
                             Optional<ObjCSelector> targetNameOpt,
                             bool ignoreImpliedName = false);
 
+bool areGenericRequirementsSatisfied(const DeclContext *DC,
+                                     const GenericSignature *sig,
+                                     const SubstitutionMap &Substitutions,
+                                     bool isExtension);
+
 } // end namespace swift
 
 #endif

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -212,6 +212,7 @@ static bool swiftCodeCompleteImpl(
       *CI.getASTContext().getClangModuleLoader());
   SwiftConsumer.setContext(&CI.getASTContext(), &Invocation,
                            &CompletionContext);
+  registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   SwiftConsumer.clearContext();
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -81,6 +81,7 @@ static bool swiftConformingMethodListImpl(
     // FIXME: error?
     return true;
   }
+  registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
   return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -467,6 +467,7 @@ SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
     ErrorMsg = "Error during invocation setup";
     return nullptr;
   }
+  registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   ASTContext &Ctx = CI.getASTContext();
   CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -80,6 +80,7 @@ static bool swiftTypeContextInfoImpl(SwiftLangSupport &Lang,
     // FIXME: error?
     return true;
   }
+  registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
   return true;


### PR DESCRIPTION
IDE functionality needs some internal type checking logics, e.g. checking
whether an extension is applicable to a concrete type. We used to directly
expose an header from sema called IDETypeChecking.h so that IDE functionalities
could invoke these APIs. The goal of the commit and following commits is to
expose evaluator requests instead of directly exposing function entry points from
sema so that we could later move IDETypeChecking.h to libIDE and implement these functions
by internally evaluating these requests.