### PR TITLE
[IDE] Fix SyntaxModel crash due to out-of-order walking of EnumElementDecls

### DIFF
--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -18,6 +18,15 @@ struct S {
   var a, b : Int
 }
 
+enum EnumWhereCaseHasADefaultedFunctionTypeParam {
+// CHECK: <kw>enum</kw> EnumWhereCaseHasADefaultedFunctionTypeParam {
+  case foo(x: () -> () = {
+  // CHECK: <kw>case</kw> foo(x: () -> () = {
+    func inner(x: S) {}
+    // CHECK: <kw>func</kw> inner(x: <type>S</type>) {}
+  })
+}
+
 enum EnumWithDerivedEquatableConformance : Int {
 // CHECK-LABEL: <kw>enum</kw> EnumWithDerivedEquatableConformance : {{(<type>)}}Int{{(</type>)?}} {
   case CaseA

--- a/test/IDE/coloring_invalid.swift
+++ b/test/IDE/coloring_invalid.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+
+public enum Result {
+// CHECK: <attr-builtin>public</attr-builtin> <kw>enum</kw> Result {
+  case success(a b = {
+// CHECK: <kw>case</kw> success(a b = {
+
+@available(*)
+// CHECK: <attr-builtin>@available</attr-builtin>(*)
+func materialize
+// CHECK: <kw>func</kw> materialize

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -293,3 +293,15 @@ myFunc(foo: 0,
        bar: baz == 0)
 // CHECK: <call><name>myFunc</name>(<arg><name>foo</name>: 0</arg>,
 // CHECK:        <arg><name>bar</name>: baz == 0</arg>)</call>
+
+
+enum FooEnum {
+// CHECK: <enum>enum <name>FooEnum</name> {
+  case blah(x: () -> () = {
+  // CHECK: <enum-case>case <enum-elem><name>blah(<param><name>x</name>: <type>() -> ()</type> = <closure><brace>{
+    @Tuples func foo(x: MyStruc) {}
+    // CHECK: @Tuples <ffunc>func <name>foo(<param><name>x</name>: <type>MyStruc</type></param>)</name> {}</ffunc>
+  })
+  // CHECK: }</brace></closure></param>)</name></enum-elem></enum-case>
+}
+// CHECK: }</enum>

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1269,18 +1269,20 @@
               key.offset: 2011,
               key.length: 13,
               key.nameoffset: 2011,
-              key.namelength: 13
+              key.namelength: 13,
+              key.substructure: [
+                {
+                  key.kind: source.lang.swift.decl.var.parameter,
+                  key.name: "arg",
+                  key.offset: 2015,
+                  key.length: 8,
+                  key.typename: "Int",
+                  key.nameoffset: 2015,
+                  key.namelength: 3
+                }
+              ]
             }
           ]
-        },
-        {
-          key.kind: source.lang.swift.decl.var.parameter,
-          key.name: "arg",
-          key.offset: 2015,
-          key.length: 8,
-          key.typename: "Int",
-          key.nameoffset: 2015,
-          key.namelength: 3
         }
       ]
     },

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1269,18 +1269,20 @@
               key.offset: 2011,
               key.length: 13,
               key.nameoffset: 2011,
-              key.namelength: 13
+              key.namelength: 13,
+              key.substructure: [
+                {
+                  key.kind: source.lang.swift.decl.var.parameter,
+                  key.name: "arg",
+                  key.offset: 2015,
+                  key.length: 8,
+                  key.typename: "Int",
+                  key.nameoffset: 2015,
+                  key.namelength: 3
+                }
+              ]
             }
           ]
-        },
-        {
-          key.kind: source.lang.swift.decl.var.parameter,
-          key.name: "arg",
-          key.offset: 2015,
-          key.length: 8,
-          key.typename: "Int",
-          key.nameoffset: 2015,
-          key.namelength: 3
         }
       ]
     },

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1269,18 +1269,20 @@
               key.offset: 2011,
               key.length: 13,
               key.nameoffset: 2011,
-              key.namelength: 13
+              key.namelength: 13,
+              key.substructure: [
+                {
+                  key.kind: source.lang.swift.decl.var.parameter,
+                  key.name: "arg",
+                  key.offset: 2015,
+                  key.length: 8,
+                  key.typename: "Int",
+                  key.nameoffset: 2015,
+                  key.namelength: 3
+                }
+              ]
             }
           ]
-        },
-        {
-          key.kind: source.lang.swift.decl.var.parameter,
-          key.name: "arg",
-          key.offset: 2015,
-          key.length: 8,
-          key.typename: "Int",
-          key.nameoffset: 2015,
-          key.namelength: 3
         }
       ]
     },

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -595,6 +595,26 @@ internal enum Colors {
             key.attribute: source.decl.attribute.internal
           }
         ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.accessibility: source.lang.swift.accessibility.internal,
+        key.setter_accessibility: source.lang.swift.accessibility.internal,
+        key.name: "p2",
+        key.offset: 559,
+        key.length: 24,
+        key.typename: "(Int, Int)",
+        key.nameoffset: 568,
+        key.namelength: 2,
+        key.docoffset: 527,
+        key.doclength: 19,
+        key.attributes: [
+          {
+            key.offset: 550,
+            key.length: 8,
+            key.attribute: source.decl.attribute.internal
+          }
+        ]
       }
     ]
   },

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -467,7 +467,9 @@ UIdent SwiftLangSupport::getUIDForSyntaxNodeKind(SyntaxNodeKind SC) {
     return KindObjectLiteral;
   }
 
-  llvm_unreachable("Unhandled SyntaxNodeKind in switch.");
+  // Default to a known kind to prevent crashing in non-asserts builds
+  assert(0 && "Unhandled SyntaxNodeKind in switch.");
+  return KindIdentifier;
 }
 
 UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(


### PR DESCRIPTION
`ModelASTWalker` was previously constructing `SyntaxNode`s for `EnumElementDecl`s manually when visiting their associated `EnumCaseDecl` so that they would appear as its children rather than its siblings. It wasn't actually walking these nodes though, so missed handling some things, e.g. closures passed as default argument values. It was also still walking the same `EnumElementDecl`s again in the sibling position. Because the `TokenNode`s in the range of each `EnumElementDecl` were consumed when they were manually constructed, this second visit was triggering some recently added assertions in the handling of custom attributes, which expected the corresponding `TokenNode`s to still be present.

Resolves rdar://problem/53313197