### PR TITLE
[build-script] Remove support for building LLDB with Xcode

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -298,7 +298,6 @@ class BuildScriptInvocation(object):
             "--swift-build-type", args.swift_build_variant,
             "--swift-stdlib-build-type", args.swift_stdlib_build_variant,
             "--lldb-build-type", args.lldb_build_variant,
-            "--lldb-build-with-xcode", args.lldb_build_with_xcode,
             "--foundation-build-type", args.foundation_build_variant,
             "--libdispatch-build-type", args.libdispatch_build_variant,
             "--libicu-build-type", args.libicu_build_variant,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -53,7 +53,6 @@ KNOWN_SETTINGS=(
     ninja-bin                   ""               "the path to Ninja tool"
     cmark-build-type            "Debug"          "the CMake build variant for CommonMark (Debug, RelWithDebInfo, Release, MinSizeRel).  Defaults to Debug."
     lldb-extra-cmake-args       ""               "extra command line args to pass to lldb cmake"
-    lldb-extra-xcodebuild-args  ""               "extra command line args to pass to lldb xcodebuild"
     lldb-test-cc                ""               "CC to use for building LLDB testsuite test inferiors.  Defaults to just-built, in-tree clang.  If set to 'host-toolchain', sets it to same as host-cc."
     lldb-test-with-curses       ""               "run test lldb test runner using curses terminal control"
     lldb-test-swift-only        "0"              "when running lldb tests, only include Swift-specific tests"
@@ -74,7 +73,6 @@ KNOWN_SETTINGS=(
     swift-stdlib-enable-assertions "1"           "enable assertions in Swift"
     swift-stdlib-use-nonatomic-rc "0"            "build the Swift stdlib and overlays with nonatomic reference count operations enabled"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
-    lldb-build-with-xcode       "0"              "Use xcodebuild to build LLDB, instead of CMake"
     llbuild-build-type          "Debug"          "the CMake build variant for llbuild"
     foundation-build-type       "Debug"          "the build variant for Foundation"
     libdispatch-build-type      "Debug"          "the build variant for libdispatch"
@@ -1929,64 +1927,6 @@ function set_swiftevolve_build_command() {
     swiftevolve_build_command=("${stresstester_build_script_helper_command[@]}")
 }
 
-# Construct the appropriate options to pass to an Xcode
-# build of any LLDB target.
-function set_lldb_xcodebuild_options() {
-    llvm_build_dir=$(build_directory ${host} llvm)
-    cmark_build_dir=$(build_directory ${host} cmark)
-    lldb_build_dir=$(build_directory ${host} lldb)
-    swift_build_dir=$(build_directory ${host} swift)
-
-    lldb_xcodebuild_options=(
-        LLDB_PATH_TO_LLVM_SOURCE="${LLVM_SOURCE_DIR}"
-        LLDB_PATH_TO_CLANG_SOURCE="${CLANG_SOURCE_DIR}"
-        LLDB_PATH_TO_SWIFT_SOURCE="${SWIFT_SOURCE_DIR}"
-        LLDB_PATH_TO_LLVM_BUILD="${llvm_build_dir}"
-        LLDB_PATH_TO_CLANG_BUILD="${llvm_build_dir}"
-        LLDB_PATH_TO_SWIFT_BUILD="${swift_build_dir}"
-        LLDB_IS_BUILDBOT_BUILD="${LLDB_IS_BUILDBOT_BUILD}"
-        LLDB_BUILD_DATE="\"${LLDB_BUILD_DATE}\""
-        SYMROOT="${lldb_build_dir}"
-        OBJROOT="${lldb_build_dir}"
-        -UseNewBuildSystem=NO
-        ${LLDB_EXTRA_XCODEBUILD_ARGS}
-        MACOSX_DEPLOYMENT_TARGET=10.13
-    )
-    if [[ "${LLDB_NO_DEBUGSERVER}" ]] ; then
-        lldb_xcodebuild_options=(
-            "${lldb_xcodebuild_options[@]}"
-            DEBUGSERVER_DISABLE_CODESIGN="1"
-            DEBUGSERVER_DELETE_AFTER_BUILD="1"
-        )
-    fi
-    if [[ "${LLDB_USE_SYSTEM_DEBUGSERVER}" ]] ; then
-        lldb_xcodebuild_options=(
-            "${lldb_xcodebuild_options[@]}"
-            DEBUGSERVER_USE_FROM_SYSTEM="1"
-        )
-    fi
-    if [[ "${ENABLE_ASAN}" ]] ; then
-	lldb_xcodebuild_options=(
-	    "${lldb_xcodebuild_options[@]}"
-	    ENABLE_ADDRESS_SANITIZER="YES"
-	    -enableAddressSanitizer=YES
-	)
-    fi
-    if [[ "${ENABLE_UBSAN}" ]] ; then
-	lldb_xcodebuild_options=(
-	    "${lldb_xcodebuild_options[@]}"
-	    ENABLE_UNDEFINED_BEHAVIOR_SANITIZER="YES"
-	    -enableUndefinedBehaviorSanitizer=YES
-	)
-    fi
-    if [[ "$(true_false ${LLDB_ASSERTIONS})" == "FALSE" ]]; then
-	lldb_xcodebuild_options=(
-	    "${lldb_xcodebuild_options[@]}"
-	    OTHER_CFLAGS="-DNDEBUG"
-	)
-    fi
-}
-
 #
 # Configure and build each product
 #
@@ -2517,49 +2457,36 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Get the build date
                 LLDB_BUILD_DATE=$(date +%Y-%m-%d)
 
-                using_xcodebuild="FALSE"
-                if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
-                    using_xcodebuild="TRUE"
+
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                  cmake_cache="Apple-lldb-macOS.cmake"
+                else
+                  cmake_cache="Apple-lldb-Linux.cmake"
                 fi
 
-                if [[ "${using_xcodebuild}" == "TRUE" ]] ; then
-                  # Set up flags to pass to xcodebuild
-                  set_lldb_xcodebuild_options
-                  set_lldb_build_mode
-                  with_pushd ${source_dir} \
-                      call xcodebuild -target desktop -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
-                  continue
-                else
-                  if [[ "$(uname -s)" == "Darwin" ]] ; then
-                    cmake_cache="Apple-lldb-macOS.cmake"
-                  else
-                    cmake_cache="Apple-lldb-Linux.cmake"
-                  fi
+                cmake_options=(
+                    "${cmake_options[@]}"
+                    -C${LLDB_SOURCE_DIR}/cmake/caches/${cmake_cache}
+                    -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
+                    -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
+                    -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
+                    -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
+                    -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
+                    -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
+                    -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
+                    -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
+                    -DLLDB_IS_BUILDBOT_BUILD:BOOL="${LLDB_IS_BUILDBOT_BUILD}"
+                    -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
+                    -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=1
+                    -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
+                )
 
-                  cmake_options=(
-                      "${cmake_options[@]}"
-                      -C${LLDB_SOURCE_DIR}/cmake/caches/${cmake_cache}
-                      -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
-                      -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
-                      -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
-                      -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                      -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
-                      -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
-                      -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
-                      -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                      -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
-                      -DLLDB_IS_BUILDBOT_BUILD:BOOL="${LLDB_IS_BUILDBOT_BUILD}"
-                      -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
-                      -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=1
-                      -DLLDB_INCLUDE_TESTS:BOOL=$(false_true ${BUILD_TOOLCHAIN_ONLY})
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                  cmake_options+=(
+                    -DLLDB_CODESIGN_IDENTITY=""
+                    -DLLDB_USE_SYSTEM_DEBUGSERVER:BOOL="${LLDB_USE_SYSTEM_DEBUGSERVER}"
                   )
-
-                  if [[ "$(uname -s)" == "Darwin" ]] ; then
-                    cmake_options+=(
-                      -DLLDB_CODESIGN_IDENTITY=""
-                      -DLLDB_USE_SYSTEM_DEBUGSERVER:BOOL="${LLDB_USE_SYSTEM_DEBUGSERVER}"
-                    )
-                  fi
                 fi
                 ;;
             llbuild)
@@ -3055,34 +2982,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 swift_build_dir=$(build_directory ${host} swift)
                 module_cache="${build_dir}/module-cache"
 
-                using_xcodebuild="FALSE"
-                if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
-                    using_xcodebuild="TRUE"
-                fi
-
-
-                # Run the unittests.
-                # FIXME: The xcode build project currently doesn't know how to run the lit style tests.
-                if [[ "$using_xcodebuild" == "TRUE" ]] ; then
-                    set_lldb_xcodebuild_options
-                    set_lldb_build_mode
-                    # Run the LLDB unittests (gtests).
-                    with_pushd ${LLDB_SOURCE_DIR} \
-                               call xcodebuild -scheme lldb-gtest -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
-                    rc=$?
-                    if [[ "$rc" -ne 0 ]] ; then
-                        >&2 echo "error: LLDB gtests failed"
-                        exit 1
-                    fi
-                fi
-
-                # Setup lldb executable path
-                if [[ "$using_xcodebuild" == "TRUE" ]] ; then
-                    lldb_executable="${lldb_build_dir}"/${LLDB_BUILD_MODE}/lldb
-                else
-                    lldb_executable="${lldb_build_dir}"/bin/lldb
-                fi
-
+                lldb_executable="${lldb_build_dir}"/bin/lldb
                 results_dir="${lldb_build_dir}/test-results"
 
                 # Handle test results formatter
@@ -3155,10 +3055,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 call mkdir -p "${results_dir}"
 
-                if [[ "$using_xcodebuild" == "TRUE" ]] ; then
-                    LLDB_DOTEST_CC_OPTS="${LLDB_DOTEST_CC_OPTS} --filecheck $(build_directory $LOCAL_HOST llvm)/bin/FileCheck --dsymutil $(build_directory $LOCAL_HOST llvm)/bin/dsymutil"
-                fi
-
                 # Prefer to use lldb-dotest, as building it guarantees that we build all
                 # test dependencies. Ultimately we want to delete as much lldb-specific logic
                 # from this file as possible and just have a single call to lldb-dotest.
@@ -3168,65 +3064,32 @@ for host in "${ALL_HOSTS[@]}"; do
                     LLVM_LIT_ARGS="${LLVM_LIT_ARGS} -j $(sysctl hw.physicalcpu | awk -v N=${BUILD_JOBS} '{ print (N < $2) ? N : $2 }')"
                 fi
 
-		if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "TRUE" ]]; then
-		    LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --filter=[sS]wift"
-		fi
+                if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "TRUE" ]]; then
+                    LLVM_LIT_ARGS="${LLVM_LIT_ARGS} --filter=[sS]wift"
+                fi
 
                 # Record the times test took and report the slowest.
                 LLVM_LIT_ARGS="${LLVM_LIT_ARGS} -v --time-tests"
-                if [[ "$using_xcodebuild" == "FALSE" ]] ; then
-                    with_pushd ${lldb_build_dir} \
-                        call ${NINJA_BIN} -j ${BUILD_JOBS} unittests/LLDBUnitTests
-                    with_pushd ${lldb_build_dir} \
-                        call ${NINJA_BIN} -j ${BUILD_JOBS} lldb-test-deps
+                with_pushd ${lldb_build_dir} \
+                    call ${NINJA_BIN} -j ${BUILD_JOBS} unittests/LLDBUnitTests
+                with_pushd ${lldb_build_dir} \
+                    call ${NINJA_BIN} -j ${BUILD_JOBS} lldb-test-deps
+                with_pushd ${results_dir} \
+                    call "${llvm_build_dir}/bin/llvm-lit" \
+                         "${lldb_build_dir}/lit" \
+                         ${LLVM_LIT_ARGS} \
+                         --xunit-xml-output=${results_dir}/results.xml \
+                         --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -t -E \"${DOTEST_EXTRA}\""
+                if [[ -x "${LLDB_TEST_SWIFT_COMPATIBILITY}" ]] ; then
+                    echo "Running LLDB swift compatibility tests against" \
+                         "${LLDB_TEST_SWIFT_COMPATIBILITY}"
                     with_pushd ${results_dir} \
-                        call "${llvm_build_dir}/bin/llvm-lit" \
-                             "${lldb_build_dir}/lit" \
-                             ${LLVM_LIT_ARGS} \
-                             --xunit-xml-output=${results_dir}/results.xml \
-                             --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -t -E \"${DOTEST_EXTRA}\""
-                    if [[ -x "${LLDB_TEST_SWIFT_COMPATIBILITY}" ]] ; then
-                        echo "Running LLDB swift compatibility tests against" \
-                             "${LLDB_TEST_SWIFT_COMPATIBILITY}"
-                        with_pushd ${results_dir} \
-                           call "${llvm_build_dir}/bin/llvm-lit" \
-                                "${lldb_build_dir}/lit" \
-                                ${LLVM_LIT_ARGS} \
-                                --xunit-xml-output=${results_dir}/results.xml \
-                                --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -G swift-history --swift-compiler \"${LLDB_TEST_SWIFT_COMPATIBILITY}\" -t -E \"${DOTEST_EXTRA}\"" --filter=compat
-                    fi
-                else
-                    with_pushd "${results_dir}" \
-                        call env SWIFTC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
-                        SWIFTLIBS="${swift_build_dir}/lib/swift" \
-                        "${LLDB_SOURCE_DIR}"/test/dotest.py \
-                        --executable "${lldb_executable}" \
-                        ${LLDB_TEST_DEBUG_SERVER} \
-                        ${LLDB_TEST_SUBDIR_CLAUSE} \
-                        ${LLDB_TEST_CATEGORIES} \
-                        ${LLDB_DOTEST_CC_OPTS} \
-                        ${LLDB_FORMATTER_OPTS} \
-                        --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
-                        -t -E "${DOTEST_EXTRA}"
-                    if [[ -x "${LLDB_TEST_SWIFT_COMPATIBILITY}" ]] ; then
-                        echo "Running LLDB swift compatibility tests against" \
-                             "${LLDB_TEST_SWIFT_COMPATIBILITY}"
-                        call env SWIFTC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
-                             SWIFTLIBS="${swift_build_dir}/lib/swift" \
-                             "${LLDB_SOURCE_DIR}"/test/dotest.py \
-                             --executable "${lldb_executable}" \
-                             ${LLDB_TEST_DEBUG_SERVER} \
-                             ${LLDB_TEST_SUBDIR_CLAUSE} \
-                             ${LLDB_TEST_CATEGORIES} \
-                             ${LLDB_DOTEST_CC_OPTS} \
-                             ${LLDB_FORMATTER_OPTS} \
-                             --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
-                             -G swift-history \
-                             --swift-compiler "${LLDB_TEST_SWIFT_COMPATIBILITY}" \
-                             -t -E "${DOTEST_EXTRA}"
-                    fi
+                       call "${llvm_build_dir}/bin/llvm-lit" \
+                            "${lldb_build_dir}/lit" \
+                            ${LLVM_LIT_ARGS} \
+                            --xunit-xml-output=${results_dir}/results.xml \
+                            --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -G swift-history --swift-compiler \"${LLDB_TEST_SWIFT_COMPATIBILITY}\" -t -E \"${DOTEST_EXTRA}\"" --filter=compat
                 fi
-
                 continue
                 ;;
             llbuild)
@@ -3572,25 +3435,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_DESTDIR}" ]] ; then
                     echo "--install-destdir is required to install products."
                     exit 1
-                fi
-                if [[ "$using_xcodebuild" == "TRUE" ]] ; then
-                    case ${host} in
-                        linux-*)
-                        ;;
-                        freebsd-*)
-                        ;;
-                        cygwin-*)
-                        ;;
-                        haiku-*)
-                        ;;
-                        macosx-*)
-                            set_lldb_xcodebuild_options
-                            set_lldb_build_mode
-                            with_pushd ${LLDB_SOURCE_DIR} \
-                                       call xcodebuild -target toolchain -configuration ${LLDB_BUILD_MODE} install ${lldb_xcodebuild_options[@]} DSTROOT="${host_install_destdir}" LLDB_TOOLCHAIN_PREFIX="${TOOLCHAIN_PREFIX}"
-                            continue
-                        ;;
-                    esac
                 fi
                 ;;
             swiftpm)


### PR DESCRIPTION
Remove support from build-script to build LLDB with the soon-to-be-removed Xcode project. 