### PR TITLE
[simplify-cfg] Use a SmallSetVector instead of a vector + sortUnique.

### DIFF
--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -140,9 +140,13 @@ void swift::erasePhiArgument(SILBasicBlock *block, unsigned argIndex) {
   // Determine the set of predecessors in case any predecessor has
   // two edges to this block (e.g. a conditional branch where both
   // sides reach this block).
-  SmallVector<SILBasicBlock *, 8> predBlocks(block->pred_begin(),
-                                             block->pred_end());
-  sortUnique(predBlocks);
+  //
+  // NOTE: This needs to be a SmallSetVector since we need both uniqueness /and/
+  // insertion order. Otherwise non-determinism can result.
+  SmallSetVector<SILBasicBlock *, 8> predBlocks;
+
+  for (auto *pred : block->getPredecessorBlocks())
+    predBlocks.insert(pred);
 
   for (auto *pred : predBlocks)
     deleteEdgeValue(pred->getTerminator(), block, argIndex);


### PR DESCRIPTION
This originally used a SmallSetVector before a refactoring that I did. I changed
it to a vector + sortUnique since AFAIKT it only needed uniqueness, not
insertion order... turns out I was wrong. I added a comment here explaining that
this has to be a SetVector to preserve both uniqueness and insertion order.

rdar://53401018
