### PR TITLE
[TSan] Re-enable tsan-norace-deinit-run-time.swift

### DIFF
--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -1,11 +1,8 @@
 // RUN: %target-swiftc_driver %s -g -sanitize=thread %import-libdispatch -target %sanitizers-target-triple -o %t_tsan-binary
 // RUN: %target-codesign %t_tsan-binary
-// RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --implicit-check-not='ThreadSanitizer'
+// RUN: env %env-TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | %FileCheck %s --dump-input=fail --implicit-check-not='ThreadSanitizer'
 // REQUIRES: executable_test
 // REQUIRES: tsan_runtime
-
-// Failing sporadically in CI
-// REQUIRES: rdar51804988
 
 // FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
 // don't support TSan.


### PR DESCRIPTION
Second attempt for re-enabling this test. The reason for the previous
attempt failing was that I fixed the issue on the [swift-5.1-branch],
however, I was too eager to re-enable the test and did so before the fix
made it into the [stable] branch. (It took more than a week!)

Fix:          78a6606f4 (Wed Jun 26 16:11:18 2019 -0700)
Merge commit: b3ec1d1c7 (Mon Jul  1 18:20:29 2019 -0700)

Attempt 1: https://github.com/apple/swift/pull/25766
Revert: https://github.com/apple/swift/pull/25911

rdar://51804988
rdar://48680098
