### PR TITLE
[5.1] Disable property wrapper composition.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4436,6 +4436,9 @@ ERROR(property_wrapper_attribute_not_on_property, none,
 NOTE(property_wrapper_declared_here,none,
      "property wrapper type %0 declared here", (DeclName))
 
+ERROR(property_wrapper_composition_not_implemented, none,
+      "multiple property wrappers are not supported", ())
+
 ERROR(property_wrapper_local,none,
       "property wrappers are not yet supported on local properties", ())
 ERROR(property_wrapper_top_level,none,

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -462,8 +462,15 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       ctx.Diags.diagnose(attr->getLocation(), diag::property_wrapper_computed);
       continue;
     }
-
+    
     result.push_back(mutableAttr);
+  }
+
+  // TODO: Property wrapper compositions do not yet compose correctly
+  // in all situtaions.
+  if (result.size() > 1) {
+    ctx.Diags.diagnose(result[result.size() - 2]->getLocation(),
+                       diag::property_wrapper_composition_not_implemented);
   }
 
   // Attributes are stored in reverse order in the AST, but we want them in

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -308,31 +308,33 @@ struct WrapperC<Value> {
   var wrappedValue: Value?
 }
 
+/* TODO: Reenable composed property wrappers
 struct CompositionMembers {
   // CompositionMembers.p1.getter
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p1SiSgvg : $@convention(method) (@guaranteed CompositionMembers) -> Optional<Int>
-  // CHECK: bb0([[SELF:%.*]] : @guaranteed $CompositionMembers):
-  // CHECK: [[P1:%.*]] = struct_extract [[SELF]] : $CompositionMembers, #CompositionMembers._p1
-  // CHECK: [[P1_VALUE:%.*]] = struct_extract [[P1]] : $WrapperA<WrapperB<WrapperC<Int>>>, #WrapperA.wrappedValue
-  // CHECK: [[P1_VALUE2:%.*]] = struct_extract [[P1_VALUE]] : $WrapperB<WrapperC<Int>>, #WrapperB.wrappedValue
-  // CHECK: [[P1_VALUE3:%.*]] = struct_extract [[P1_VALUE2]] : $WrapperC<Int>, #WrapperC.wrappedValue
-  // CHECK: return [[P1_VALUE3]] : $Optional<Int>
+  // C/HECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p1SiSgvg : $@convention(method) (@guaranteed CompositionMembers) -> Optional<Int>
+  // C/HECK: bb0([[SELF:%.*]] : @guaranteed $CompositionMembers):
+  // C/HECK: [[P1:%.*]] = struct_extract [[SELF]] : $CompositionMembers, #CompositionMembers._p1
+  // C/HECK: [[P1_VALUE:%.*]] = struct_extract [[P1]] : $WrapperA<WrapperB<WrapperC<Int>>>, #WrapperA.wrappedValue
+  // C/HECK: [[P1_VALUE2:%.*]] = struct_extract [[P1_VALUE]] : $WrapperB<WrapperC<Int>>, #WrapperB.wrappedValue
+  // C/HECK: [[P1_VALUE3:%.*]] = struct_extract [[P1_VALUE2]] : $WrapperC<Int>, #WrapperC.wrappedValue
+  // C/HECK: return [[P1_VALUE3]] : $Optional<Int>
   @WrapperA @WrapperB @WrapperC var p1: Int?
   @WrapperA @WrapperB @WrapperC var p2 = "Hello"
 
   // variable initialization expression of CompositionMembers.$p2
-  // CHECK-LABEL: sil hidden [transparent] [ossa] @$s17property_wrappers18CompositionMembersV3_p233_{{.*}}8WrapperAVyAA0N1BVyAA0N1CVySSGGGvpfi : $@convention(thin) () -> @owned Optional<String> {
-  // CHECK: %0 = string_literal utf8 "Hello"
+  // C/HECK-LABEL: sil hidden [transparent] [ossa] @$s17property_wrappers18CompositionMembersV3_p233_{{.*}}8WrapperAVyAA0N1BVyAA0N1CVySSGGGvpfi : $@convention(thin) () -> @owned Optional<String> {
+  // C/HECK: %0 = string_literal utf8 "Hello"
 
-  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p12p2ACSiSg_SSSgtcfC : $@convention(method) (Optional<Int>, @owned Optional<String>, @thin CompositionMembers.Type) -> @owned CompositionMembers
-  // CHECK: function_ref @$s17property_wrappers8WrapperCV12wrappedValueACyxGxSg_tcfC
-  // CHECK: function_ref @$s17property_wrappers8WrapperBV12wrappedValueACyxGx_tcfC
-  // CHECK: function_ref @$s17property_wrappers8WrapperAV12wrappedValueACyxGx_tcfC
+  // C/HECK-LABEL: sil hidden [ossa] @$s17property_wrappers18CompositionMembersV2p12p2ACSiSg_SSSgtcfC : $@convention(method) (Optional<Int>, @owned Optional<String>, @thin CompositionMembers.Type) -> @owned CompositionMembers
+  // C/HECK: function_ref @$s17property_wrappers8WrapperCV12wrappedValueACyxGxSg_tcfC
+  // C/HECK: function_ref @$s17property_wrappers8WrapperBV12wrappedValueACyxGx_tcfC
+  // C/HECK: function_ref @$s17property_wrappers8WrapperAV12wrappedValueACyxGx_tcfC
 }
 
 func testComposition() {
   _ = CompositionMembers(p1: nil)
 }
+*/
 
 // Observers with non-default mutatingness.
 @propertyWrapper

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -217,7 +217,7 @@ struct BadCombinations {
 
 struct MultipleWrappers {
   @Wrapper(stored: 17)
-  @WrapperWithInitialValue // expected-error{{extra argument 'wrappedValue' in call}}
+  @WrapperWithInitialValue // expected-error{{extra argument 'wrappedValue' in call}} expected-error{{multiple property wrappers are not supported}}
   var x: Int = 17
 
   @WrapperWithInitialValue // expected-error 2{{property wrapper can only apply to a single variable}}
@@ -959,11 +959,11 @@ struct WrapperE<Value> {
 }
 
 struct TestComposition {
-  @WrapperA @WrapperB @WrapperC var p1: Int?
-  @WrapperA @WrapperB @WrapperC var p2 = "Hello"
-  @WrapperD<WrapperE, Int, String> @WrapperE var p3: Int?
-  @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int?
-  @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'WrapperD<WrapperC, Int, String>'}}
+  @WrapperA @WrapperB @WrapperC var p1: Int? // expected-error{{multiple property wrappers are not supported}}
+  @WrapperA @WrapperB @WrapperC var p2 = "Hello" // expected-error{{multiple property wrappers are not supported}}
+  @WrapperD<WrapperE, Int, String> @WrapperE var p3: Int? // expected-error{{multiple property wrappers are not supported}}
+  @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int? // expected-error{{multiple property wrappers are not supported}}
+  @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{property type 'Int' does not match that of the 'wrappedValue' property of its wrapper type 'WrapperD<WrapperC, Int, String>'}} // expected-error{{multiple property wrappers are not supported}}
 
 	func triggerErrors(d: Double) {
 		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}}


### PR DESCRIPTION
Explanation: There are ABI-affecting bugs with property wrapper composition like SR-11138, so we should disable it until those bugs can be fixed.

Scope: Disables a feature with bugs that we might not be able to fix later because of ABI issues.

Risk: Low, disables a feature.

Issue: rdar://problem/53428736

Testing: Swift CI

Reviewed by: @jrose-apple