### PR TITLE
[AutoDiff] Diagnose partially-applied original + parameter subset thunk.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -478,9 +478,9 @@ NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not yet supported", ())
 // TODO(TF-642): Remove when `partial_apply` works with `@differentiable`
 // functions.
-NOTE(autodiff_cannot_index_subset_thunk_partial_applied_orig_fn,none,
-     "cannot convert a direct method reference to a `@differentiable` "
-     "function; please use an explicit closure instead", ())
+NOTE(autodiff_cannot_param_subset_thunk_partially_applied_orig_fn,none,
+     "cannot convert a direct method reference to a '@differentiable' "
+     "function; use an explicit closure instead", ())
 NOTE(autodiff_control_flow_not_supported,none,
      "cannot differentiate unsupported control flow", ())
 NOTE(autodiff_missing_return,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -476,6 +476,11 @@ NOTE(autodiff_cannot_differentiate_through_inout_arguments,none,
      "cannot differentiate through 'inout' arguments", ())
 NOTE(autodiff_class_member_not_supported,none,
      "differentiating class members is not yet supported", ())
+// TODO(TF-642): Remove when `partial_apply` works with `@differentiable`
+// functions.
+NOTE(autodiff_cannot_index_subset_thunk_partial_applied_orig_fn,none,
+     "cannot convert a direct method reference to a `@differentiable` "
+     "function; please use an explicit closure instead", ())
 NOTE(autodiff_control_flow_not_supported,none,
      "cannot differentiate unsupported control flow", ())
 NOTE(autodiff_missing_return,none,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6328,7 +6328,7 @@ ADContext::getOrCreateSubsetParametersThunkForAssociatedFunction(
           thunkType, fromInterfaceType, toInterfaceType, dynamicSelfType,
           module.getSwiftModule()) + "_" + desiredIndices.mangle() + "_" +
           thunkName;
-  thunkName += "_thunk";
+  thunkName += "_subset_parameters_thunk";
 
   auto loc = origFnOperand.getLoc();
   SILOptFunctionBuilder fb(getTransform());
@@ -6371,6 +6371,8 @@ ADContext::getOrCreateSubsetParametersThunkForAssociatedFunction(
 
   SmallVector<SILValue, 4> arguments;
   arguments.append(thunk->getArguments().begin(), thunk->getArguments().end());
+  assert(arguments.size() == assocFnType->getNumParameters() +
+                                 assocFnType->getNumIndirectFormalResults());
   auto *apply = builder.createApply(
       loc, assocRef, assocSubstMap, arguments, /*isNonThrowing*/ false);
 
@@ -6447,29 +6449,31 @@ SILValue ADContext::promoteToDifferentiableFunction(
             thunk->isBare(), thunk->isTransparent(), thunk->isSerialized(),
             thunk->isDynamicallyReplaceable(), ProfileCounter(),
             thunk->isThunk());
+        // If new thunk does not exist: clone the old thunk body, wrap the
+        // returned function value with an `autodiff_function` instructions,
+        // and process the `autodiff_function` instruction.
         if (newThunk->empty()) {
           newThunk->setOwnershipEliminated();
           SILFunctionCloner cloner(newThunk);
           cloner.cloneFunction(thunk);
-        }
 
-        auto *retInst =
-            cast<ReturnInst>(newThunk->findReturnBB()->getTerminator());
-        AutoDiffFunctionInst *adfi;
-        {
-          SILBuilder builder(retInst);
-          adfi = createAutoDiffFunction(builder, loc, parameterIndices,
-                                        differentiationOrder,
-                                        retInst->getOperand());
+          auto *retInst =
+              cast<ReturnInst>(newThunk->findReturnBB()->getTerminator());
+          SILBuilder thunkBuilder(retInst);
+          auto *adfi = createAutoDiffFunction(thunkBuilder, loc,
+                                              parameterIndices,
+                                              differentiationOrder,
+                                              retInst->getOperand());
           resultIndices[adfi] = resultIndex;
-          builder.createReturn(loc, adfi);
+          thunkBuilder.createReturn(loc, adfi);
+          retInst->eraseFromParent();
+
+          getAutoDiffFunctionInsts().push_back(adfi);
+          if (processAutoDiffFunctionInst(adfi))
+            return nullptr;
         }
-        retInst->eraseFromParent();
 
-        getAutoDiffFunctionInsts().push_back(adfi);
-        if (processAutoDiffFunctionInst(adfi))
-          return nullptr;
-
+        // Apply the new curry thunk.
         auto *newThunkRef = builder.createFunctionRef(loc, newThunk);
         SmallVector<SILValue, 8> arguments(ai->getArguments().begin(),
                                            ai->getArguments().end());
@@ -6506,11 +6510,31 @@ SILValue ADContext::promoteToDifferentiableFunction(
     // have smaller capacity than `actualIndices`. We expect this logic to go
     // away when we support `@differentiable` partial apply.
     // if (actualIndices != desiredIndices) { // TODO: Re-enable.
+    auto extendedDesiredIndices = desiredIndices.parameters->extendingCapacity(
+        getASTContext(), actualIndices.parameters->getCapacity());
     if (actualIndices.source != desiredIndices.source ||
-        !actualIndices.parameters->equals(
-            desiredIndices.parameters->extendingCapacity(getASTContext(),
-                actualIndices.parameters->getCapacity()))) {
-      assert(actualIndices.parameters->isSupersetOf(desiredIndices.parameters));
+        !actualIndices.parameters->equals(extendedDesiredIndices)) {
+      // Check if underlying original function reference has been partially
+      // applied with arguments. If so, produce an error: parameter subset
+      // thunks do not yet support this case because partially applied arguments
+      // cannot be propagated to parameter subset thunks.
+      auto didPartiallyApplyArguments = [](SILValue original) {
+        while (auto *pai =
+                   peerThroughFunctionConversions<PartialApplyInst>(original)) {
+          if (pai->getNumArguments() > 0)
+            return true;
+          original = pai->getOperand(0);
+        }
+        return false;
+      };
+      if (didPartiallyApplyArguments(origFnOperand)) {
+        emitNondifferentiabilityError(
+            origFnOperand, invoker,
+            diag::autodiff_cannot_index_subset_thunk_partial_applied_orig_fn);
+        return nullptr;
+      }
+      // Create the parameter subset thunk.
+      assert(actualIndices.parameters->isSupersetOf(extendedDesiredIndices));
       SILFunction *thunk;
       SubstitutionMap interfaceSubs;
       std::tie(thunk, interfaceSubs) =
@@ -6608,15 +6632,15 @@ bool ADContext::processAutoDiffFunctionInst(AutoDiffFunctionInst *adfi) {
          "some functions are already filled in but not all of them");
 
   SILFunction *parent = adfi->getFunction();
-  auto loc = parent->getLocation();
+  auto loc = adfi->getLoc();
   SILBuilder builder(adfi);
 
   auto differentiableFnValue =
       promoteToDifferentiableFunction(adfi, builder, loc, adfi);
+  processedAutoDiffFunctionInsts.insert(adfi);
   if (!differentiableFnValue)
     return true;
   // Mark `adfi` as processed so that it won't be reprocessed after deletion.
-  processedAutoDiffFunctionInsts.insert(adfi);
   // Replace all uses of `adfi`.
   adfi->replaceAllUsesWith(differentiableFnValue);
   adfi->eraseFromParent();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6893,7 +6893,6 @@ static Expr *finishApplyDynamicCallable(ExprRewriter &rewriter,
   auto params = methodType->getParams();
   assert(params.size() == 1 &&
          "Expected 'dynamicallyCall' method with one parameter");
-  auto argumentType = params[0].getParameterType();
   auto argumentLabel = params[0].getLabel();
   assert((argumentLabel == ctx.Id_withArguments ||
           argumentLabel == ctx.Id_withKeywordArguments) &&

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -171,7 +171,7 @@ struct TF_305 : Differentiable {
 }
 
 //===----------------------------------------------------------------------===//
-// Classes and existentials (not yet supported)
+// Classes (not yet supported)
 //===----------------------------------------------------------------------===//
 
 class Foo {
@@ -260,3 +260,14 @@ func nondiff(_ f: @differentiable (Float, @nondiff Float) -> Float) -> Float {
   // expected-error @+1 {{function is not differentiable}}
   return gradient(at: 2) { x in f(x * x, x) }
 }
+
+// Test parameter subset thunk + partially-applied original function.
+struct TF_675 : Differentiable {
+  @differentiable
+  // expected-note @+1 {{cannot convert a direct method reference to a '@differentiable' function; use an explicit closure instead}}
+  func method(_ x: Float) -> Float {
+    return x
+  }
+}
+// expected-error @+1 {{function is not differentiable}}
+let _: @differentiable (Float) -> Float = TF_675().method

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -177,8 +177,7 @@ struct TF_305 : Differentiable {
 class Foo {
   // FIXME: Figure out why diagnostics for direct references end up here, and
   // why they are duplicated.
-  // expected-error @+2 2 {{expression is not differentiable}}
-  // expected-note @+1 2 {{differentiating class members is not yet supported}}
+  // expected-note @+1 {{differentiating class members is not yet supported}}
   func class_method(_ x: Float) -> Float {
     return x
   }
@@ -193,6 +192,9 @@ func triesToDifferentiateClassMethod(x: Float) -> Float {
 }
 
 let _: @differentiable (Float) -> Float = Foo().class_method
+
+// expected-error @+1 {{function is not differentiable}}
+_ = gradient(at: .zero, in: Foo().class_method)
 
 //===----------------------------------------------------------------------===//
 // Unreachable


### PR DESCRIPTION
Fix differentiation transform crash regarding parameter subset thunks and
partially-applied original functions.

Currently, parameter subset thunks are not reabstraction thunks: they have
the exact desired parameter subset associated function type. This means that
partially-applied arguments for an original function cannot be propagated
to parameter subset thunks.

Various gardening included.

Resolves [TF-675](https://bugs.swift.org/browse/TF-675).
Eventual robust fix is [TF-642](https://bugs.swift.org/browse/TF-642): `partial_apply` of `@differentiable` functions.

---

Depends on https://github.com/apple/swift/pull/26291.