### PR TITLE
[Driver] Improve Android Toolchain compatibility (don't merge)

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -147,7 +147,10 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   case OutputInfo::Mode::SingleCompile:
   case OutputInfo::Mode::BatchModeCompile:
     arguments.push_back("-target");
-    arguments.push_back(inputArgs.MakeArgString(Triple.str()));
+    // The NDK toolchain produces triples with API_LEVEL at the end, like
+    // "armv7-none-linux-android21", but swiftc doesn't recognise them.
+    std::string triple = Triple.str();
+    arguments.push_back(inputArgs.MakeArgString(triple.substr(0, triple.find_last_not_of("0123456789") + 1)));
     break;
   }
 

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -353,7 +353,11 @@ std::string toolchains::Android::getTargetForLinker() const {
     // Explicitly set the linker target to "androideabi", as opposed to the
     // llvm::Triple representation of "armv7-none-linux-android".
     return "armv7-none-linux-androideabi";
-  return T.str();
+  
+  // The NDK toolchain produces triples with API_LEVEL at the end, like
+  // "armv7-none-linux-android21", but swiftc doesn't recognise them.
+  std::string triple = T.str();
+  return triple.substr(0, triple.find_last_not_of("0123456789") + 1);
 }
 
 bool toolchains::Android::shouldProvideRPathToLinker() const { return false; }


### PR DESCRIPTION
`swiftc` breaks when calling it from a CMake context with the `-DCMAKE_TOOLCHAIN_FILE` parameter referencing the Android NDK's CMake toolchain. (This is something you'd want to do when building libdispatch or Foundation). The issue listed is `<unknown>:0: error: unable to load standard library for target 'x86_64-none-linux-android21'`

By removing the Android API level number from the end of the LLVM triple in the swift driver we can ensure the triple containing the API level still gets provided to `clang` for C compilation without breaking `swiftc`.

Note: this change only affects Android. I am pretty sure there are no other Android triples that end with a number that we'd be breaking here.


EDIT: closing this in favour of https://github.com/apple/swift-corelibs-libdispatch/pull/508