### PR TITLE
Avoid uninitialized "random" bytes on Windows.

### DIFF
--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -54,6 +54,10 @@ void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
 
 SWIFT_RUNTIME_STDLIB_API
 void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
+  if (nbytes > ULONG_MAX) {
+    fatalError(0, "Fatal error: %zd exceeds ULONG_MAX\n", nbytes);
+  }
+
   NTSTATUS status = BCryptGenRandom(nullptr,
                                     static_cast<PUCHAR>(buf),
                                     static_cast<ULONG>(nbytes),


### PR DESCRIPTION
__swift_size_t on Windows is a size_t, which makes it potentially a
64-bit integer. ULONG, however, is always a 32-bit integer, and so this
cast risks shrinking the apparent size of the cbBuffer argument to
BCryptGenRandom. The effect of that will be to underfill the buffer,
leaving it full of uninitialized memory that we would treat as random.

The actual risk from this in the current implementation is basically
zero, as user code can only ever invoke this with an argument size of 8.
There's no good reason to leave this sharp edge on the API though.

/cc @compnerd who is probably best place to review this

I haven't tested this at all, not even to see if it compiles, as I don't have a windows dev environment around.