### PR TITLE
 [CS] Add specific accessors for path element info

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1549,7 +1549,7 @@ namespace {
           [](ConstraintLocator *locator) -> unsigned {
         for (const auto &elt : locator->getPath()) {
           if (elt.getKind() == ConstraintLocator::KeyPathComponent)
-            return elt.getValue();
+            return elt.getKeyPathComponentIdx();
         }
         llvm_unreachable("no keypath component node");
       };

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -870,11 +870,9 @@ diagnoseUnresolvedDotExprTypeRequirementFailure(ConstraintSystem &cs,
   if (!locator)
     return false;
 
-  auto path = locator->getPath();
-  if (path.empty())
-    return false;
 
-  auto reqElt = path.back().getAs<LocatorPathElt::TypeParameterRequirement>();
+  auto reqElt =
+      locator->getLastElementAs<LocatorPathElt::TypeParameterRequirement>();
   if (!reqElt)
     return false;
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -175,7 +175,7 @@ void constraints::simplifyLocator(Expr *&anchor,
     case ConstraintLocator::NamedTupleElement:
     case ConstraintLocator::TupleElement: {
       // Extract tuple element.
-      unsigned index = path[0].getValue();
+      unsigned index = path[0].getTupleElementIdx();
       if (auto tupleExpr = dyn_cast<TupleExpr>(anchor)) {
         if (index < tupleExpr->getNumElements()) {
           anchor = tupleExpr->getElement(index);
@@ -197,7 +197,7 @@ void constraints::simplifyLocator(Expr *&anchor,
     case ConstraintLocator::ApplyArgToParam:
       // Extract tuple element.
       if (auto tupleExpr = dyn_cast<TupleExpr>(anchor)) {
-        unsigned index = path[0].getValue();
+        unsigned index = path[0].getArgIdx();
         if (index < tupleExpr->getNumElements()) {
           anchor = tupleExpr->getElement(index);
           path = path.slice(1);
@@ -207,7 +207,7 @@ void constraints::simplifyLocator(Expr *&anchor,
 
       // Extract subexpression in parentheses.
       if (auto parenExpr = dyn_cast<ParenExpr>(anchor)) {
-        assert(path[0].getValue() == 0);
+        assert(path[0].getArgIdx() == 0);
 
         anchor = parenExpr->getSubExpr();
         path = path.slice(1);
@@ -901,7 +901,7 @@ diagnoseUnresolvedDotExprTypeRequirementFailure(ConstraintSystem &cs,
 
   auto req = member->getAsGenericContext()
                  ->getGenericSignature()
-                 ->getRequirements()[last.getValue()];
+                 ->getRequirements()[last.getRequirementIdx()];
 
   Diag<Type, Type, Type, Type, StringRef> note;
   switch (req.getKind()) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -237,11 +237,8 @@ public:
     assert(isConditional() || Signature);
     assert(AffectedDecl);
 
-    auto path = locator->getPath();
-    assert(!path.empty());
-
-    auto last = path.back().castTo<LocatorPathElt::AnyRequirement>();
-    assert(last.getRequirementKind() == kind);
+    auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
+    assert(reqElt.getRequirementKind() == kind);
 
     // It's possible sometimes not to have no base expression.
     if (!expr)
@@ -252,8 +249,8 @@ public:
   }
 
   unsigned getRequirementIndex() const {
-    auto path = getLocator()->getPath();
-    auto reqElt = path.back().castTo<LocatorPathElt::AnyRequirement>();
+    auto reqElt =
+        getLocator()->castLastElementTo<LocatorPathElt::AnyRequirement>();
     return reqElt.getIndex();
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -243,7 +243,7 @@ public:
     auto &last = path.back();
     assert(last.isTypeParameterRequirement() ||
            last.isConditionalRequirement());
-    assert(static_cast<RequirementKind>(last.getValue2()) == kind);
+    assert(last.getRequirementKind() == kind);
 
     // It's possible sometimes not to have no base expression.
     if (!expr)
@@ -258,9 +258,7 @@ public:
     assert(!path.empty());
 
     auto &requirementLoc = path.back();
-    assert(requirementLoc.isTypeParameterRequirement() ||
-           requirementLoc.isConditionalRequirement());
-    return requirementLoc.getValue();
+    return requirementLoc.getRequirementIdx();
   }
 
   /// The generic base type where failing requirement comes from.

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -240,9 +240,7 @@ public:
     auto path = locator->getPath();
     assert(!path.empty());
 
-    auto &last = path.back();
-    assert(last.isTypeParameterRequirement() ||
-           last.isConditionalRequirement());
+    auto last = path.back().castTo<LocatorPathElt::AnyRequirement>();
     assert(last.getRequirementKind() == kind);
 
     // It's possible sometimes not to have no base expression.
@@ -255,10 +253,8 @@ public:
 
   unsigned getRequirementIndex() const {
     auto path = getLocator()->getPath();
-    assert(!path.empty());
-
-    auto &requirementLoc = path.back();
-    return requirementLoc.getRequirementIdx();
+    auto reqElt = path.back().castTo<LocatorPathElt::AnyRequirement>();
+    return reqElt.getIndex();
   }
 
   /// The generic base type where failing requirement comes from.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1787,9 +1787,8 @@ namespace {
           CS.addConstraint(ConstraintKind::Conversion,
                            CS.getType(element),
                            contextualArrayElementType,
-                           CS.getConstraintLocator(expr,
-                                                   LocatorPathElt::
-                                                    getTupleElement(index++)));
+                           CS.getConstraintLocator(
+                               expr, LocatorPathElt::TupleElement(index++)));
         }
         
         return contextualArrayType;
@@ -1816,8 +1815,7 @@ namespace {
                          CS.getType(element),
                          arrayElementTy,
                          CS.getConstraintLocator(
-                           expr,
-                           LocatorPathElt::getTupleElement(index++)));
+                           expr, LocatorPathElt::TupleElement(index++)));
       }
 
       // The array element type defaults to 'Any'.
@@ -1882,9 +1880,8 @@ namespace {
           CS.addConstraint(ConstraintKind::Conversion,
                            CS.getType(element),
                            contextualDictionaryElementType,
-                           CS.getConstraintLocator(expr,
-                                                   LocatorPathElt::
-                                                    getTupleElement(index++)));
+                           CS.getConstraintLocator(
+                               expr, LocatorPathElt::TupleElement(index++)));
         }
         
         return contextualDictionaryType;
@@ -1975,8 +1972,7 @@ namespace {
                            CS.getType(element),
                            elementTy,
                            CS.getConstraintLocator(
-                             expr,
-                             LocatorPathElt::getTupleElement(index++)));
+                               expr, LocatorPathElt::TupleElement(index++)));
       }
 
       // The dictionary key type defaults to 'AnyHashable'.
@@ -2022,7 +2018,7 @@ namespace {
 
       for (auto *param : *paramList) {
         auto *locator = CS.getConstraintLocator(
-            closureExpr, LocatorPathElt::getTupleElement(i++));
+            closureExpr, LocatorPathElt::TupleElement(i++));
         Type paramType, internalType;
 
         // If a type was explicitly specified, use its opened type.
@@ -2138,7 +2134,7 @@ namespace {
           auto &tupleElt = tuplePat->getElement(i);
           Type eltTy = getTypeForPattern(tupleElt.getPattern(),
                                          locator.withPathElement(
-                                           LocatorPathElt::getTupleElement(i)));
+                                           LocatorPathElt::TupleElement(i)));
           tupleTypeElts.push_back(TupleTypeElt(eltTy, tupleElt.getLabel()));
         }
         return TupleType::get(tupleTypeElts, CS.getASTContext());
@@ -2966,7 +2962,7 @@ namespace {
       for (unsigned i : indices(E->getComponents())) {
         auto &component = E->getComponents()[i];
         auto memberLocator = CS.getConstraintLocator(
-            locator, ConstraintLocator::PathElement::getKeyPathComponent(i));
+            locator, LocatorPathElt::KeyPathComponent(i));
         auto resultLocator = CS.getConstraintLocator(
             memberLocator, ConstraintLocator::KeyPathComponentResult);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -769,7 +769,7 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
       return std::make_tuple(nullptr, /*hasAppliedSelf=*/false, argLabels,
                              hasTrailingClosure, nullptr);
 
-    auto componentIndex = path[0].getValue();
+    auto componentIndex = path[0].getKeyPathComponentIdx();
     if (componentIndex >= keyPath->getComponents().size())
       return std::make_tuple(nullptr, /*hasAppliedSelf=*/false, argLabels,
                              hasTrailingClosure, nullptr);
@@ -2106,8 +2106,7 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
 
   auto *reqLoc = cs.getConstraintLocator(anchor, path);
 
-  auto reqKind = static_cast<RequirementKind>(req.getValue2());
-  switch (reqKind) {
+  switch (req.getRequirementKind()) {
   case RequirementKind::SameType: {
     return SkipSameTypeRequirement::create(cs, type1, type2, reqLoc);
   }
@@ -5692,7 +5691,8 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
     if (locator->getAnchor() == keyPath
         && locator->getPath().size() <= 2
         && locator->getPath()[0].getKind() == ConstraintLocator::KeyPathComponent) {
-      choices[locator->getPath()[0].getValue()] = resolvedItem->Choice;
+      auto idx = locator->getPath()[0].getKeyPathComponentIdx();
+      choices[idx] = resolvedItem->Choice;
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -763,13 +763,17 @@ getCalleeDeclAndArgs(ConstraintSystem &cs,
         isa<CallExpr>(callExpr) ? cast<CallExpr>(callExpr)->getDirectCallee()
                                 : callExpr);
   } else if (auto keyPath = dyn_cast<KeyPathExpr>(callExpr)) {
-    if (path.size() != 2 ||
-        path[0].getKind() != ConstraintLocator::KeyPathComponent ||
-        path[1].getKind() != ConstraintLocator::ApplyArgument)
+    if (path.size() != 2)
       return std::make_tuple(nullptr, /*hasAppliedSelf=*/false, argLabels,
                              hasTrailingClosure, nullptr);
 
-    auto componentIndex = path[0].getKeyPathComponentIdx();
+    // We must have a KeyPathComponent followed by an ApplyArgument.
+    auto componentElt = path[0].getAs<LocatorPathElt::KeyPathComponent>();
+    if (!componentElt || path[1].getKind() != ConstraintLocator::ApplyArgument)
+      return std::make_tuple(nullptr, /*hasAppliedSelf=*/false, argLabels,
+                             hasTrailingClosure, nullptr);
+
+    auto componentIndex = componentElt->getIndex();
     if (componentIndex >= keyPath->getComponents().size())
       return std::make_tuple(nullptr, /*hasAppliedSelf=*/false, argLabels,
                              hasTrailingClosure, nullptr);
@@ -1006,9 +1010,8 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
 
     // Compare each of the bound arguments for this parameter.
     for (auto argIdx : parameterBindings[paramIdx]) {
-      auto loc = locator.withPathElement(LocatorPathElt::
-                                            getApplyArgToParam(argIdx,
-                                                               paramIdx));
+      auto loc = locator.withPathElement(
+          LocatorPathElt::ApplyArgToParam(argIdx, paramIdx));
       auto argTy = argsWithLabels[argIdx].getOldType();
 
       bool matchingAutoClosureResult = param.isAutoClosure();
@@ -1103,7 +1106,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
       // Compare the element types.
       auto result = matchTypes(elt1.getType(), elt2.getType(), kind, subflags,
                                locator.withPathElement(
-                                           LocatorPathElt::getTupleElement(i)));
+                                           LocatorPathElt::TupleElement(i)));
       if (result.isFailure())
         return result;
     }
@@ -1164,7 +1167,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
     const auto &elt2 = tuple2->getElement(idx2);
     auto result = matchTypes(elt1.getType(), elt2.getType(), subKind, subflags,
                        locator.withPathElement(
-                                        LocatorPathElt::getTupleElement(idx1)));
+                                        LocatorPathElt::TupleElement(idx1)));
     if (result.isFailure())
       return result;
   }
@@ -1293,7 +1296,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, Expr *anchor,
 
   for (unsigned i = args.size(), n = params.size(); i != n; ++i) {
     auto *argLoc = cs.getConstraintLocator(
-        anchor, LocatorPathElt::getSynthesizedArgument(i));
+        anchor, LocatorPathElt::SynthesizedArgument(i));
     args.push_back(params[i].withType(cs.createTypeVariable(argLoc,
                                                       TVO_CanBindToNoEscape)));
   }
@@ -1441,7 +1444,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     // arguments, this makes it easier to diagnose cases where we attempt
     // a single tuple element formed when no arguments were present.
     auto argLoc = argumentLocator.withPathElement(
-        LocatorPathElt::getSynthesizedArgument(0));
+        LocatorPathElt::SynthesizedArgument(0));
     auto *typeVar = createTypeVariable(getConstraintLocator(argLoc),
                                        TVO_CanBindToNoEscape);
     params.emplace_back(typeVar);
@@ -1582,7 +1585,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                              (func1Params.size() == 1
                               ? argumentLocator
                               : argumentLocator.withPathElement(
-                                LocatorPathElt::getTupleElement(i))));
+                                LocatorPathElt::TupleElement(i))));
     if (result.isFailure())
       return result;
   }
@@ -1638,7 +1641,7 @@ static ConstraintSystem::TypeMatchResult matchDeepTypeArguments(
   for (unsigned i = 0, n = args1.size(); i != n; ++i) {
     auto result = cs.matchTypes(
         args1[i], args2[i], ConstraintKind::Bind, subflags,
-        locator.withPathElement(LocatorPathElt::getGenericArgument(i)));
+        locator.withPathElement(LocatorPathElt::GenericArgument(i)));
 
     if (result.isFailure()) {
       recordMismatch(i);
@@ -1747,8 +1750,7 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
   if (shouldAttemptFixes()) {
     bool forRequirement = false;
     if (auto last = locator.last()) {
-      forRequirement = last->isTypeParameterRequirement() ||
-                       last->isConditionalRequirement();
+      forRequirement = last->is<LocatorPathElt::AnyRequirement>();
     }
 
     // Optionals and arrays have a lot of special diagnostics and only one
@@ -2092,7 +2094,7 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   if (type1->isTypeVariableOrMember() || type2->isTypeVariableOrMember())
     return nullptr;
 
-  auto req = path.back();
+  auto req = path.back().castTo<LocatorPathElt::AnyRequirement>();
   if (req.isConditionalRequirement()) {
     // path is - ... -> open generic -> type req # -> cond req #,
     // to identify type requirement we only need `open generic -> type req #`
@@ -2451,7 +2453,7 @@ bool ConstraintSystem::repairFailures(
 
   case ConstraintLocator::FunctionArgument: {
     auto *argLoc = getConstraintLocator(
-        locator.withPathElement(LocatorPathElt::getSynthesizedArgument(0)));
+        locator.withPathElement(LocatorPathElt::SynthesizedArgument(0)));
 
     // Let's drop the last element which points to a single argument
     // and see if this is a contextual mismatch.
@@ -2501,7 +2503,8 @@ bool ConstraintSystem::repairFailures(
     if (lhs->hasDependentMember() || rhs->hasDependentMember())
       break;
 
-    auto reqKind = static_cast<RequirementKind>(elt.getValue2());
+    auto reqElt = elt.castTo<LocatorPathElt::AnyRequirement>();
+    auto reqKind = reqElt.getRequirementKind();
     if (hasFixedRequirement(lhs, reqKind, rhs))
       return true;
 
@@ -3716,7 +3719,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       for (const auto &req : conformance.getConditionalRequirements()) {
         addConstraint(req,
                       locator.withPathElement(
-                          LocatorPathElt::getConditionalRequirementComponent(
+                          LocatorPathElt::ConditionalRequirement(
                               index++, req.getKind())));
       }
     }
@@ -3763,8 +3766,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // optional doesn't; suggest forcing if that's the case.
     auto result = simplifyConformsToConstraint(
         optionalObjectType, protocol, kind,
-        locator.withPathElement(LocatorPathElt::getGenericArgument(0)),
-        subflags);
+        locator.withPathElement(LocatorPathElt::GenericArgument(0)), subflags);
     if (result == SolutionKind::Solved) {
       auto *fix = ForceOptional::create(*this, type, optionalObjectType,
                                         getConstraintLocator(locator));
@@ -3795,8 +3797,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (path.empty())
       return SolutionKind::Error;
 
-    if (path.back().isTypeParameterRequirement() ||
-        path.back().isConditionalRequirement()) {
+    if (path.back().is<LocatorPathElt::AnyRequirement>()) {
       if (auto *fix =
               fixRequirementFailure(*this, type, protocolTy, anchor, path)) {
         if (!recordFix(fix)) {
@@ -4519,7 +4520,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // double check here that given keypath is appropriate for it.
     if (memberLocator && memberLocator->isForKeyPathDynamicMemberLookup()) {
       auto path = memberLocator->getPath();
-      auto *keyPath = path.back().getKeyPath();
+      auto kpElt = path.back().castTo<LocatorPathElt::KeyPathDynamicMember>();
+      auto *keyPath = kpElt.getKeyPathDecl();
       if (auto *storage = dyn_cast<AbstractStorageDecl>(decl)) {
         // If this is an attempt to access read-only member via
         // writable key path, let's fail this choice early.
@@ -5492,9 +5494,8 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
           // [AnyObject]
           addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[0],
                         TC.Context.getAnyObjectType(),
-                        getConstraintLocator(
-                          locator.withPathElement(
-                                       LocatorPathElt::getGenericArgument(0))));
+                        getConstraintLocator(locator.withPathElement(
+                            LocatorPathElt::GenericArgument(0))));
         } else if (fromBGT->getDecl() == TC.Context.getDictionaryDecl()) {
           // [NSObject : AnyObject]
           auto NSObjectType = TC.getNSObjectType(DC);
@@ -5507,13 +5508,13 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
                         NSObjectType,
                         getConstraintLocator(
                           locator.withPathElement(
-                            LocatorPathElt::getGenericArgument(0))));
+                            LocatorPathElt::GenericArgument(0))));
 
           addConstraint(ConstraintKind::Bind, fromBGT->getGenericArgs()[1],
                         TC.Context.getAnyObjectType(),
                         getConstraintLocator(
                           locator.withPathElement(
-                            LocatorPathElt::getGenericArgument(1))));
+                            LocatorPathElt::GenericArgument(1))));
         } else if (fromBGT->getDecl() == TC.Context.getSetDecl()) {
           auto NSObjectType = TC.getNSObjectType(DC);
           if (!NSObjectType) {
@@ -5524,7 +5525,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
                         NSObjectType,
                         getConstraintLocator(
                           locator.withPathElement(
-                            LocatorPathElt::getGenericArgument(0))));
+                            LocatorPathElt::GenericArgument(0))));
         } else {
           // Nothing special to do; matchTypes will match generic arguments.
         }
@@ -5546,9 +5547,8 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
     if (auto toElement = isArrayType(unwrappedToType)) {
       countOptionalInjections();
       return simplifyBridgingConstraint(
-                                      *fromElement, *toElement, subflags,
-                                      locator.withPathElement(
-                                        LocatorPathElt::getGenericArgument(0)));
+          *fromElement, *toElement, subflags,
+          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
     }
   }
 
@@ -5558,11 +5558,11 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
       addExplicitConversionConstraint(fromKeyValue->first, toKeyValue->first,
                                       /*allowFixes=*/false,
                                       locator.withPathElement(
-                                        LocatorPathElt::getGenericArgument(0)));
+                                        LocatorPathElt::GenericArgument(0)));
       addExplicitConversionConstraint(fromKeyValue->second, toKeyValue->second,
                                       /*allowFixes=*/false,
                                       locator.withPathElement(
-                                        LocatorPathElt::getGenericArgument(0)));
+                                        LocatorPathElt::GenericArgument(0)));
       countOptionalInjections();
       return SolutionKind::Solved;
     }
@@ -5573,9 +5573,8 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
     if (auto toElement = isSetType(unwrappedToType)) {
       countOptionalInjections();
       return simplifyBridgingConstraint(
-                                      *fromElement, *toElement, subflags,
-                                      locator.withPathElement(
-                                        LocatorPathElt::getGenericArgument(0)));
+          *fromElement, *toElement, subflags,
+          locator.withPathElement(LocatorPathElt::GenericArgument(0)));
     }
   }
 
@@ -5688,11 +5687,12 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
   for (auto resolvedItem = resolvedOverloadSets; resolvedItem;
        resolvedItem = resolvedItem->Previous) {
     auto locator = resolvedItem->Locator;
-    if (locator->getAnchor() == keyPath
-        && locator->getPath().size() <= 2
-        && locator->getPath()[0].getKind() == ConstraintLocator::KeyPathComponent) {
-      auto idx = locator->getPath()[0].getKeyPathComponentIdx();
-      choices[idx] = resolvedItem->Choice;
+    auto path = locator->getPath();
+    if (locator->getAnchor() != keyPath || path.size() > 2)
+      continue;
+
+    if (auto kpElt = path[0].getAs<LocatorPathElt::KeyPathComponent>()) {
+      choices[kpElt->getIndex()] = resolvedItem->Choice;
     }
   }
 
@@ -5804,7 +5804,7 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       auto storage = dyn_cast<AbstractStorageDecl>(choices[i].getDecl());
 
       auto *componentLoc = getConstraintLocator(
-          locator.withPathElement(LocatorPathElt::getKeyPathComponent(i)));
+          locator.withPathElement(LocatorPathElt::KeyPathComponent(i)));
 
       if (auto *fix = AllowInvalidRefInKeyPath::forRef(
               *this, choices[i].getDecl(), componentLoc)) {
@@ -6626,7 +6626,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
     auto param = func1->getParams()[i];
     auto paramType = param.getPlainType();
     auto locatorBuilder =
-    locator.withPathElement(LocatorPathElt::getTupleElement(i));
+        locator.withPathElement(LocatorPathElt::TupleElement(i));
     addConstraint(ConstraintKind::ArgumentConversion, paramType,
                   argumentType, locatorBuilder);
   }
@@ -6769,7 +6769,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                             generic2->getGenericArgs()[0],
                             matchKind, subflags,
                             locator.withPathElement(
-                              LocatorPathElt::getGenericArgument(0)));
+                              LocatorPathElt::GenericArgument(0)));
       }
     }
 
@@ -6899,7 +6899,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       matchKind,
                       subflags,
                       locator.withPathElement(
-                        ConstraintLocator::PathElement::getGenericArgument(0)));
+                          LocatorPathElt::GenericArgument(0)));
   }
 
   // K1 < K2 && V1 < V2 || K1 bridges to K2 && V1 bridges to V2 ===> 
@@ -6917,15 +6917,15 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     increaseScore(SK_CollectionUpcastConversion);
     // The source key and value types must be subtypes of the destination
     // key and value types, respectively.
-    auto result = matchTypes(key1, key2, subMatchKind, subflags,
-                             locator.withPathElement(
-                    ConstraintLocator::PathElement::getGenericArgument(0)));
+    auto result =
+        matchTypes(key1, key2, subMatchKind, subflags,
+                   locator.withPathElement(LocatorPathElt::GenericArgument(0)));
     if (result.isFailure())
       return result;
 
-    switch (matchTypes(value1, value2, subMatchKind, subflags,
-                       locator.withPathElement(
-                  ConstraintLocator::PathElement::getGenericArgument(1)))) {
+    switch (matchTypes(
+        value1, value2, subMatchKind, subflags,
+        locator.withPathElement(LocatorPathElt::GenericArgument(1)))) {
     case SolutionKind::Solved:
       return result;
 
@@ -6947,8 +6947,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       baseType2,
                       matchKind,
                       subflags,
-                      locator.withPathElement(
-                    ConstraintLocator::PathElement::getGenericArgument(0)));
+                      locator.withPathElement(LocatorPathElt::GenericArgument(0)));
   }
 
   // T1 <c T2 && T2 : Hashable ===> T1 <c AnyHashable

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1229,7 +1229,7 @@ ConstraintSystem::solveImpl(Expr *&expr,
     bool isForSingleExprFunction =
         getContextualTypePurpose() == CTP_ReturnSingleExpr;
     auto *convertTypeLocator = getConstraintLocator(
-        expr, LocatorPathElt::getContextualType(isForSingleExprFunction));
+        expr, LocatorPathElt::ContextualType(isForSingleExprFunction));
 
     if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
       convertType = convertType.transform([&](Type type) -> Type {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -195,9 +195,7 @@ bool ConstraintLocator::isForContextualType() const {
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
-  auto path = getPath();
-  assert(!path.empty());
-  return path.back().castTo<LocatorPathElt::GenericParameter>().getType();
+  return castLastElementTo<LocatorPathElt::GenericParameter>().getType();
 }
 
 void ConstraintLocator::dump(SourceManager *sm) {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -510,6 +510,27 @@ public:
   /// is of a given kind.
   bool isLastElement(ConstraintLocator::PathElementKind kind) const;
 
+  /// Attempts to cast the last path element of the locator to a specific
+  /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or
+  /// the locator has no path elements.
+  template <class T>
+  Optional<T> getLastElementAs() const {
+    auto path = getPath();
+    if (path.empty())
+      return None;
+
+    return path.back().getAs<T>();
+  }
+
+  /// Casts the last path element of the locator to a specific \c LocatorPathElt
+  /// subclass, asserting that it has at least one element.
+  template <class T>
+  T castLastElementTo() const {
+    auto path = getPath();
+    assert(!path.empty() && "Expected at least one path element!");
+    return path.back().castTo<T>();
+  }
+
   /// If this locator points to generic parameter return its type.
   GenericTypeParamType *getGenericParameter() const;
 
@@ -578,7 +599,8 @@ using LocatorPathElt = ConstraintLocator::PathElement;
 
 // Disallow direct uses of isa/cast/dyn_cast on LocatorPathElt in favor of using
 // is/castTo/getAs. This allows us to work with Optional<T> rather than pointers
-// for getAs.
+// for getAs, and maintains consistency with ConstraintLocator's
+// isLastElement/castLastElementTo/getLastElementAs members.
 template <class X>
 inline bool
 isa(const LocatorPathElt &) = delete; // Use LocatorPathElt::is instead.

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -531,6 +531,63 @@ public:
     return path.back().castTo<T>();
   }
 
+  using PathIterator = ArrayRef<PathElement>::iterator;
+  using PathReverseIterator = ArrayRef<PathElement>::reverse_iterator;
+
+  /// Attempts to find the first element in the locator's path that is a
+  /// specific \c LocatorPathElt subclass, returning \c None if no such element
+  /// exists.
+  ///
+  /// \param iter A reference to an iterator which will be used to iterate
+  /// over the locator's path.
+  template <class T>
+  Optional<T> findFirst(PathIterator &iter) const {
+    auto path = getPath();
+    auto end = path.end();
+    assert(iter >= path.begin() && iter <= end);
+
+    for (; iter != end; ++iter)
+      if (auto elt = iter->getAs<T>())
+        return elt;
+    return None;
+  }
+
+  /// Attempts to find the first element in the locator's path that is a
+  /// specific \c LocatorPathElt subclass, returning \c None if no such element
+  /// exists.
+  template <class T>
+  Optional<T> findFirst() const {
+    auto iter = getPath().begin();
+    return findFirst<T>(iter);
+  }
+
+  /// Attempts to find the last element in the locator's path that is a
+  /// specific \c LocatorPathElt subclass, returning \c None if no such element
+  /// exists.
+  ///
+  /// \param iter A reference to a reverse iterator which will be used to
+  /// iterate over the locator's path.
+  template <class T>
+  Optional<T> findLast(PathReverseIterator &iter) const {
+    auto path = getPath();
+    auto end = path.rend();
+    assert(iter >= path.rbegin() && iter <= end);
+
+    for (; iter != end; ++iter)
+      if (auto elt = iter->getAs<T>())
+        return elt;
+    return None;
+  }
+
+  /// Attempts to find the last element in the locator's path that is a
+  /// specific \c LocatorPathElt subclass, returning \c None if no such element
+  /// exists.
+  template <class T>
+  Optional<T> findLast() const {
+    auto iter = getPath().rbegin();
+    return findLast<T>(iter);
+  }
+
   /// If this locator points to generic parameter return its type.
   GenericTypeParamType *getGenericParameter() const;
 

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -314,14 +314,17 @@ public:
     {
       assert(numNumericValuesInPathElement(kind) == 1 &&
              "Path element kind does not require 1 value");
+      assert(value == getValue(0) && "value truncated");
     }
 
-    PathElement(PathElementKind kind, unsigned value1, unsigned value2)
-      : storage(encodeStorage(kind, value1 << 16 | value2)),
+    PathElement(PathElementKind kind, unsigned value0, unsigned value1)
+      : storage(encodeStorage(kind, value0 << 16 | value1)),
         storedKind(StoredKindAndValue)
     {
       assert(numNumericValuesInPathElement(kind) == 2 &&
              "Path element kind does not require 2 values");
+      assert(value0 == getValue(0) && "value0 truncated");
+      assert(value1 == getValue(1) && "value1 truncated");
     }
 
     PathElement(GenericSignature *sig)

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -327,17 +327,43 @@ public:
       assert(value1 == getValue(1) && "value1 truncated");
     }
 
-    PathElement(GenericSignature *sig)
-        : storage((reinterpret_cast<uintptr_t>(sig) >> 3)),
-          storedKind(StoredGenericSignature) {}
+    /// Store a path element with an associated pointer, accessible using
+    /// \c getStoredPointer.
+    template <typename T>
+    PathElement(StoredKind storedKind, T *ptr)
+        : storage((reinterpret_cast<uintptr_t>(ptr) >> 3)),
+          storedKind(storedKind) {
+      assert(ptr == getStoredPointer<T>());
+    }
 
-    PathElement(const NominalTypeDecl *keyPath)
-        : storage((reinterpret_cast<uintptr_t>(keyPath) >> 3)),
-          storedKind(StoredKeyPathDynamicMemberBase) {}
+    /// Retrieve an associated pointer for the element. The type \c T must match
+    /// the type used when creating the path element.
+    template <typename T>
+    T *getStoredPointer() const {
+      assert(storedKind != StoredKindAndValue);
+      return reinterpret_cast<T *>(storage << 3);
+    }
 
     friend class ConstraintLocator;
 
   public:
+    class ApplyArgToParam;
+    class SynthesizedArgument;
+    class AnyTupleElement;
+    class TupleElement;
+    class NamedTupleElement;
+    class KeyPathComponent;
+    class GenericArgument;
+    class AnyRequirement;
+    class ConditionalRequirement;
+    class TypeParameterRequirement;
+    class ContextualType;
+    class Witness;
+    class Requirement;
+    class GenericParameter;
+    class OpenedGeneric;
+    class KeyPathDynamicMember;
+
     PathElement(PathElementKind kind)
       : storage(encodeStorage(kind, 0)), storedKind(StoredKindAndValue)
     {
@@ -345,100 +371,23 @@ public:
              "Path element requires value");
     }
 
-    PathElement(GenericTypeParamType *type)
-      : storage((reinterpret_cast<uintptr_t>(type) >> 3)),
-        storedKind(StoredGenericParameter)
-    {
-      static_assert(alignof(GenericTypeParamType) >= 4,
-                    "archetypes insufficiently aligned");
-      assert(getGenericParameter() == type);
-    }
-
-    PathElement(PathElementKind kind, ValueDecl *decl)
-      : storage((reinterpret_cast<uintptr_t>(decl) >> 3)),
-        storedKind(kind == Witness ? StoredWitness : StoredRequirement)
-    {
-      assert((kind == Witness || kind == Requirement) &&
-             "Not a witness element");
-      assert(((kind == Requirement && getRequirement() == decl) ||
-              (kind == Witness && getWitness() == decl)));
-    }
-
-    /// Retrieve a path element for a tuple element referred to by
-    /// its position.
-    static PathElement getTupleElement(unsigned position) {
-      return PathElement(TupleElement, position);
-    }
-
-    /// Retrieve a path element for a tuple element referred to by
-    /// its name.
-    static PathElement getNamedTupleElement(unsigned position) {
-      return PathElement(NamedTupleElement, position);
-    }
-
-    /// Retrieve a path element for an argument/parameter comparison in a
-    /// function application.
-    static PathElement getApplyArgToParam(unsigned argIdx, unsigned paramIdx) {
-      return PathElement(ApplyArgToParam, argIdx, paramIdx);
-    }
-
-    /// Retrieve a path element for a generic argument referred to by
-    /// its position.
-    static PathElement getGenericArgument(unsigned position) {
-      return PathElement(GenericArgument, position);
-    }
-    
-    /// Get a path element for a key path component.
-    static PathElement getKeyPathComponent(unsigned position) {
-      return PathElement(KeyPathComponent, position);
-    }
-
-    static PathElement getOpenedGeneric(GenericSignature *sig) {
-      return PathElement(sig);
-    }
-
-    /// Get a path element for a conditional requirement.
-    static PathElement
-    getConditionalRequirementComponent(unsigned index, RequirementKind kind) {
-      return PathElement(ConditionalRequirement, index,
-                         static_cast<unsigned>(kind));
-    }
-
-    static PathElement getTypeRequirementComponent(unsigned index,
-                                                   RequirementKind kind) {
-      return PathElement(TypeParameterRequirement, index,
-                         static_cast<unsigned>(kind));
-    }
-
-    static PathElement getSynthesizedArgument(unsigned position) {
-      return PathElement(SynthesizedArgument, position);
-    }
-
-    static PathElement getKeyPathDynamicMember(const NominalTypeDecl *base) {
-      return PathElement(base);
-    }
-
-    static PathElement getContextualType(bool isForSingleExprFunction = false) {
-      return PathElement(ContextualType, isForSingleExprFunction);
-    }
-
     /// Retrieve the kind of path element.
     PathElementKind getKind() const {
       switch (static_cast<StoredKind>(storedKind)) {
       case StoredGenericParameter:
-        return GenericParameter;
+        return PathElementKind::GenericParameter;
 
       case StoredRequirement:
-        return Requirement;
+        return PathElementKind::Requirement;
 
       case StoredWitness:
-        return Witness;
+        return PathElementKind::Witness;
 
       case StoredGenericSignature:
-        return OpenedGeneric;
+        return PathElementKind::OpenedGeneric;
 
       case StoredKeyPathDynamicMemberBase:
-        return KeyPathDynamicMember;
+        return PathElementKind::KeyPathDynamicMember;
 
       case StoredKindAndValue:
         return decodeStorage(storage).first;
@@ -447,101 +396,31 @@ public:
       llvm_unreachable("Unhandled StoredKind in switch.");
     }
 
-    /// Retrieve the index for a function argument path element.
-    unsigned getArgIdx() const {
-      assert((getKind() == ApplyArgToParam || isSynthesizedArgument()) &&
-             "Not an argument path element");
-      return getValue(0);
+    /// Attempts to cast the path element to a specific \c LocatorPathElt
+    /// subclass, returning \c None if unsuccessful.
+    template <class T>
+    Optional<T> getAs() const {
+      if (auto *result = dyn_cast<T>(this))
+        return *result;
+      return None;
     }
 
-    /// Retrieve the parameter index for an apply-arg-to-param path element.
-    unsigned getParamIdx() const {
-      assert(getKind() == ApplyArgToParam && "Not a parameter application");
-      return getValue(1);
-    }
+    /// Cast the path element to a specific \c LocatorPathElt subclass.
+    template <class T>
+    T castTo() const { return *cast<T>(this); }
 
-    /// Retrieve the index for a tuple element.
-    unsigned getTupleElementIdx() const {
-      assert((getKind() == TupleElement || getKind() == NamedTupleElement) &&
-             "Not a tuple element");
-      return getValue(0);
-    }
-
-    /// Retrieve the index for a key path component path element.
-    unsigned getKeyPathComponentIdx() const {
-      assert(isKeyPathComponent() && "Not a key path component");
-      return getValue(0);
-    }
-
-    /// Retrieve the index for a generic argument path element.
-    unsigned getGenericArgIdx() const {
-      assert(getKind() == GenericArgument && "Not a generic argument");
-      return getValue(0);
-    }
-
-    /// Retrieve the index for a generic requirement path element.
-    unsigned getRequirementIdx() const {
-      assert((isTypeParameterRequirement() || isConditionalRequirement()) &&
-             "Not a requirement");
-      return getValue(0);
-    }
-
-    /// Retrieve the kind of generic requirement path element.
-    RequirementKind getRequirementKind() const {
-      assert((isTypeParameterRequirement() || isConditionalRequirement()) &&
-             "Not a requirement");
-      return static_cast<RequirementKind>(getValue(1));
-    }
-
-    /// Retrieve the declaration for a witness path element.
-    ValueDecl *getWitness() const {
-      assert(getKind() == Witness && "Is not a witness");
-      return reinterpret_cast<ValueDecl *>(storage << 3);
-    }
-
-    /// Retrieve the actual archetype for a generic parameter path
-    /// element.
-    GenericTypeParamType *getGenericParameter() const {
-      assert(getKind() == GenericParameter &&
-             "Not a generic parameter path element");
-      return reinterpret_cast<GenericTypeParamType *>(storage << 3);
-    }
-
-    /// Retrieve the declaration for a requirement path element.
-    ValueDecl *getRequirement() const {
-      assert((static_cast<StoredKind>(storedKind) == StoredRequirement) &&
-             "Is not a requirement");
-      return reinterpret_cast<ValueDecl *>(storage << 3);
-    }
-
-    GenericSignature *getGenericSignature() const {
-      assert((static_cast<StoredKind>(storedKind) == StoredGenericSignature) &&
-             "Is not an opened generic");
-      return reinterpret_cast<GenericSignature *>(storage << 3);
-    }
-
-    NominalTypeDecl *getKeyPath() const {
-      assert((static_cast<StoredKind>(storedKind) ==
-              StoredKeyPathDynamicMemberBase) &&
-             "Is not a keypath dynamic member");
-      return reinterpret_cast<NominalTypeDecl *>(storage << 3);
-    }
+    /// Checks whether the path element is a specific \c LocatorPathElt
+    /// subclass.
+    template <class T>
+    bool is() const { return isa<T>(this); }
 
     /// Return the summary flags for this particular element.
     unsigned getNewSummaryFlags() const {
       return getSummaryFlagsForPathElement(getKind());
     }
 
-    bool isTypeParameterRequirement() const {
-      return getKind() == PathElementKind::TypeParameterRequirement;
-    }
-
     bool isConditionalRequirement() const {
       return getKind() == PathElementKind::ConditionalRequirement;
-    }
-
-    bool isSynthesizedArgument() const {
-      return getKind() == PathElementKind::SynthesizedArgument;
     }
 
     bool isKeyPathDynamicMember() const {
@@ -558,10 +437,7 @@ public:
 
     /// Determine whether this element points to the contextual type
     /// associated with result of a single expression function.
-    bool isResultOfSingleExprFunction() const {
-      return getKind() == PathElementKind::ContextualType ? bool(getValue(0))
-                                                          : false;
-    }
+    bool isResultOfSingleExprFunction() const;
   };
 
   /// Return the summary flags for an entire path.
@@ -699,6 +575,244 @@ private:
 };
 
 using LocatorPathElt = ConstraintLocator::PathElement;
+
+// Disallow direct uses of isa/cast/dyn_cast on LocatorPathElt in favor of using
+// is/castTo/getAs. This allows us to work with Optional<T> rather than pointers
+// for getAs.
+template <class X>
+inline bool
+isa(const LocatorPathElt &) = delete; // Use LocatorPathElt::is instead.
+
+template <class X>
+inline typename llvm::cast_retty<X, LocatorPathElt>::ret_type
+cast(const LocatorPathElt &) = delete; // Use LocatorPathElt::castTo instead.
+
+template <class X>
+inline typename llvm::cast_retty<X, LocatorPathElt>::ret_type
+dyn_cast(const LocatorPathElt &) = delete; // Use LocatorPathElt::getAs instead.
+
+
+// The following LocatorPathElt subclasses are used to expose accessors for
+// specific path element information. They shouldn't introduce additional
+// storage, as LocatorPathElt gets passed about by value.
+
+class LocatorPathElt::ApplyArgToParam final : public LocatorPathElt {
+public:
+  ApplyArgToParam(unsigned argIdx, unsigned paramIdx)
+      : LocatorPathElt(ConstraintLocator::ApplyArgToParam, argIdx, paramIdx) {}
+
+  unsigned getArgIdx() const { return getValue(0); }
+  unsigned getParamIdx() const { return getValue(1); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ApplyArgToParam;
+  }
+};
+
+class LocatorPathElt::SynthesizedArgument final : public LocatorPathElt {
+public:
+  SynthesizedArgument(unsigned index)
+      : LocatorPathElt(ConstraintLocator::SynthesizedArgument, index) {}
+
+  unsigned getIndex() const { return getValue(0); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::SynthesizedArgument;
+  }
+};
+
+/// Abstract superclass for any kind of tuple element.
+class LocatorPathElt::AnyTupleElement : public LocatorPathElt {
+protected:
+  AnyTupleElement(PathElementKind kind, unsigned index)
+      : LocatorPathElt(kind, index) {
+    assert(classof(this) && "classof needs updating");
+  }
+
+public:
+  unsigned getIndex() const { return getValue(0); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->is<LocatorPathElt::TupleElement>() ||
+           elt->is<LocatorPathElt::NamedTupleElement>();
+  }
+};
+
+class LocatorPathElt::TupleElement final
+    : public LocatorPathElt::AnyTupleElement {
+public:
+  TupleElement(unsigned index)
+      : AnyTupleElement(ConstraintLocator::TupleElement, index) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::TupleElement;
+  }
+};
+
+class LocatorPathElt::NamedTupleElement final
+    : public LocatorPathElt::AnyTupleElement {
+public:
+  NamedTupleElement(unsigned index)
+      : AnyTupleElement(ConstraintLocator::NamedTupleElement, index) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::NamedTupleElement;
+  }
+};
+
+class LocatorPathElt::KeyPathComponent final : public LocatorPathElt {
+public:
+  KeyPathComponent(unsigned index)
+      : LocatorPathElt(ConstraintLocator::KeyPathComponent, index) {}
+
+  unsigned getIndex() const { return getValue(0); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::KeyPathComponent;
+  }
+};
+
+class LocatorPathElt::GenericArgument final : public LocatorPathElt {
+public:
+  GenericArgument(unsigned index)
+      : LocatorPathElt(ConstraintLocator::GenericArgument, index) {}
+
+  unsigned getIndex() const { return getValue(0); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::GenericArgument;
+  }
+};
+
+/// Abstract superclass for any kind of element that describes a requirement
+/// placed on a type within a requirements clause.
+class LocatorPathElt::AnyRequirement : public LocatorPathElt {
+protected:
+  AnyRequirement(PathElementKind kind, unsigned index, RequirementKind reqKind)
+      : LocatorPathElt(kind, index, static_cast<unsigned>(reqKind)) {
+    assert(classof(this) && "classof needs updating");
+  }
+
+public:
+  unsigned getIndex() const { return getValue(0); }
+  RequirementKind getRequirementKind() const {
+    return static_cast<RequirementKind>(getValue(1));
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->is<LocatorPathElt::ConditionalRequirement>() ||
+           elt->is<LocatorPathElt::TypeParameterRequirement>();
+  }
+};
+
+class LocatorPathElt::ConditionalRequirement final
+    : public LocatorPathElt::AnyRequirement {
+public:
+  ConditionalRequirement(unsigned index, RequirementKind reqKind)
+      : AnyRequirement(ConstraintLocator::ConditionalRequirement, index,
+                       reqKind) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ConditionalRequirement;
+  }
+};
+
+class LocatorPathElt::TypeParameterRequirement final
+    : public LocatorPathElt::AnyRequirement {
+public:
+  TypeParameterRequirement(unsigned index, RequirementKind reqKind)
+      : AnyRequirement(ConstraintLocator::TypeParameterRequirement, index,
+                       reqKind) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::TypeParameterRequirement;
+  }
+};
+
+class LocatorPathElt::ContextualType final : public LocatorPathElt {
+public:
+  ContextualType(bool isForSingleExprFunction = false)
+      : LocatorPathElt(ConstraintLocator::ContextualType,
+                       isForSingleExprFunction) {}
+
+  /// Whether this element points to the contextual type associated with the
+  /// result of a single expression function.
+  bool isForSingleExprFunction() const { return bool(getValue(0)); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ContextualType;
+  }
+};
+
+class LocatorPathElt::Witness final : public LocatorPathElt {
+public:
+  Witness(ValueDecl *witness)
+      : LocatorPathElt(LocatorPathElt::StoredWitness, witness) {}
+
+  ValueDecl *getDecl() const { return getStoredPointer<ValueDecl>(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::Witness;
+  }
+};
+
+class LocatorPathElt::Requirement final : public LocatorPathElt {
+public:
+  Requirement(ValueDecl *decl)
+      : LocatorPathElt(LocatorPathElt::StoredRequirement, decl) {}
+
+  ValueDecl *getDecl() const { return getStoredPointer<ValueDecl>(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::Requirement;
+  }
+};
+
+class LocatorPathElt::GenericParameter final : public LocatorPathElt {
+public:
+  GenericParameter(GenericTypeParamType *type)
+      : LocatorPathElt(LocatorPathElt::StoredGenericParameter, type) {
+    static_assert(alignof(GenericTypeParamType) >= 4,
+                  "archetypes insufficiently aligned");
+  }
+
+  GenericTypeParamType *getType() const {
+    return getStoredPointer<GenericTypeParamType>();
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::GenericParameter;
+  }
+};
+
+class LocatorPathElt::OpenedGeneric final : public LocatorPathElt {
+public:
+  OpenedGeneric(GenericSignature *sig)
+      : LocatorPathElt(LocatorPathElt::StoredGenericSignature, sig) {}
+
+  GenericSignature *getSignature() const {
+    return getStoredPointer<GenericSignature>();
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::OpenedGeneric;
+  }
+};
+
+class LocatorPathElt::KeyPathDynamicMember final : public LocatorPathElt {
+public:
+  KeyPathDynamicMember(NominalTypeDecl *keyPathDecl)
+      : LocatorPathElt(LocatorPathElt::StoredKeyPathDynamicMemberBase,
+                       keyPathDecl) {}
+
+  NominalTypeDecl *getKeyPathDecl() const {
+    return getStoredPointer<NominalTypeDecl>();
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::KeyPathDynamicMember;
+  }
+};
 
 /// A simple stack-only builder object that constructs a
 /// constraint locator without allocating memory.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1089,8 +1089,8 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
 
   // Create the type variables for the generic parameters.
   for (auto gp : sig->getGenericParams()) {
-    auto *paramLocator =
-        getConstraintLocator(locator.withPathElement(LocatorPathElt(gp)));
+    auto *paramLocator = getConstraintLocator(
+        locator.withPathElement(LocatorPathElt::GenericParameter(gp)));
 
     auto typeVar = createTypeVariable(paramLocator, TVO_PrefersSubtypeBinding);
     auto result = replacements.insert(std::make_pair(
@@ -1101,7 +1101,7 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
   }
 
   auto *baseLocator = getConstraintLocator(
-      locator.withPathElement(LocatorPathElt::getOpenedGeneric(sig)));
+      locator.withPathElement(LocatorPathElt::OpenedGeneric(sig)));
 
   bindArchetypesFromContext(*this, outerDC, baseLocator, replacements);
 }
@@ -1141,9 +1141,9 @@ void ConstraintSystem::openGenericRequirements(
 
     addConstraint(
         *openedReq,
-        locator.withPathElement(LocatorPathElt::getOpenedGeneric(signature))
+        locator.withPathElement(LocatorPathElt::OpenedGeneric(signature))
             .withPathElement(
-                LocatorPathElt::getTypeRequirementComponent(pos, kind)));
+                LocatorPathElt::TypeParameterRequirement(pos, kind)));
   }
 }
 
@@ -1746,7 +1746,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       addConstraint(ConstraintKind::ConformsTo, argType,
                     hashable->getDeclaredType(),
                     getConstraintLocator(
-                        locator, LocatorPathElt::getTupleElement(index)));
+                        locator, LocatorPathElt::TupleElement(index)));
     }
   };
 
@@ -1959,7 +1959,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
              "parameter is supposed to be a keypath");
 
       auto *keyPathLoc = getConstraintLocator(
-          locator, LocatorPathElt::getKeyPathDynamicMember(keyPathDecl));
+          locator, LocatorPathElt::KeyPathDynamicMember(keyPathDecl));
 
       auto rootTy = keyPathTy->getGenericArgs()[0];
       auto leafTy = keyPathTy->getGenericArgs()[1];

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2232,7 +2232,7 @@ Type TypeChecker::typeCheckExpressionImpl(Expr *&expr, DeclContext *dc,
   if (options.contains(TypeCheckExprFlags::ExpressionTypeMustBeOptional)) {
     assert(!convertTo && "convertType and type check options conflict");
     auto *convertTypeLocator =
-        cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
+        cs.getConstraintLocator(expr, LocatorPathElt::ContextualType());
     Type var = cs.createTypeVariable(convertTypeLocator, TVO_CanBindToNoEscape);
     convertTo = getOptionalType(expr->getLoc(), var);
   }
@@ -2636,8 +2636,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       assert(!expr->isSemanticallyInOutExpr());
 
       // Save the locator we're using for the expression.
-      Locator =
-          cs.getConstraintLocator(expr, LocatorPathElt::getContextualType());
+      Locator = cs.getConstraintLocator(expr, LocatorPathElt::ContextualType());
 
       // Collect constraints from the pattern.
       Type patternType = cs.generateConstraints(pattern, Locator);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -732,9 +732,8 @@ swift::matchWitness(TypeChecker &tc,
       selfTy = reqGenericEnv->mapTypeIntoContext(selfTy);
 
     // Open up the type of the requirement.
-    reqLocator = cs->getConstraintLocator(
-                     static_cast<Expr *>(nullptr),
-                     LocatorPathElt(ConstraintLocator::Requirement, req));
+    reqLocator = cs->getConstraintLocator(static_cast<Expr *>(nullptr),
+                                          LocatorPathElt::Requirement(req));
     OpenedTypeMap reqReplacements;
     std::tie(openedFullReqType, reqType)
       = cs->getTypeOfMemberReference(selfTy, req, dc,
@@ -767,9 +766,8 @@ swift::matchWitness(TypeChecker &tc,
     witnessType = witness->getInterfaceType();
     // FIXME: witness as a base locator?
     locator = cs->getConstraintLocator(nullptr);
-    witnessLocator = cs->getConstraintLocator(
-                       static_cast<Expr *>(nullptr),
-                       LocatorPathElt(ConstraintLocator::Witness, witness));
+    witnessLocator = cs->getConstraintLocator(static_cast<Expr *>(nullptr),
+                                              LocatorPathElt::Witness(witness));
     if (witness->getDeclContext()->isTypeContext()) {
       std::tie(openedFullWitnessType, openWitnessType) 
         = cs->getTypeOfMemberReference(selfTy, witness, dc,


### PR DESCRIPTION
This PR replaces the `getValue()` and `getValue2()` members on
`ConstraintLocator::PathElement` with specific accessors for each
expected path component kind. IMO this adds some clarity to the call
sites, especially for `getArgIdx()` and `getParamIdx()`.

In addition, this PR adds a couple of assertions to make sure we
don't truncate values when creating a path element.