### PR TITLE
Driver: normalise linker triple on all android targets

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -362,12 +362,22 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
 
 std::string toolchains::Android::getTargetForLinker() const {
   const llvm::Triple &T = getTriple();
-  if (T.getArch() == llvm::Triple::arm &&
-      T.getSubArch() == llvm::Triple::SubArchType::ARMSubArch_v7)
-    // Explicitly set the linker target to "androideabi", as opposed to the
-    // llvm::Triple representation of "armv7-none-linux-android".
-    return "armv7-none-linux-androideabi";
-  return T.str();
+  switch (T.getArch()) {
+  default:
+    // FIXME: we should just abort on an unsupported target
+    return T.str();
+  case llvm::Triple::arm:
+  case llvm::Triple::thumb:
+    // Current Android NDK versions only support ARMv7+.  Always assume ARMv7+
+    // for the arm/thumb target.
+    return "armv7-unknown-linux-androideabi";
+  case llvm::Triple::aarch64:
+    return "aarch64-unknown-linux-android";
+  case llvm::Triple::x86:
+    return "i686-unknown-linux-android";
+  case llvm::Triple::x86_64:
+    return "x86_64-unknown-linux-android";
+  }
 }
 
 bool toolchains::Android::shouldProvideRPathToLinker() const { return false; }

--- a/test/Driver/android-link.swift
+++ b/test/Driver/android-link.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift_driver_plain --driver-mode=swiftc -target armv7-none-linux-androideabihf -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-ARMv7
+// CHECK-ARMv7: clang{{(.exe)?"?}} -target armv7-unknown-linux-androideabi
+
+// RUN: %swift_driver_plain --driver-mode=swiftc -target aarch64-mone-linux-androideabi -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-ARM64
+// CHECK-ARM64: clang{{(.exe)?"?}} -target aarch64-unknown-linux-android
+
+// RUN: %swift_driver_plain --driver-mode=swiftc -target x86_64-none-linux-androideabi -emit-executable %s -### 2>&1 | %FileCheck %s -check-prefix CHECK-X64
+// CHECK-X64: clang{{(.exe)?"?}} -target x86_64-unknown-linux-android
+

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -219,7 +219,7 @@
 // ANDROID-armv7-DAG: [[OBJECTFILE]]
 // ANDROID-armv7-DAG: -lswiftCore
 // ANDROID-armv7-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift]]
-// ANDROID-armv7-DAG: -target armv7-none-linux-androideabi
+// ANDROID-armv7-DAG: -target armv7-unknown-linux-androideabi
 // ANDROID-armv7-DAG: -F foo -iframework car -F cdr
 // ANDROID-armv7-DAG: -framework bar
 // ANDROID-armv7-DAG: -L baz


### PR DESCRIPTION
Currently we only support building for android armv7, arm64, x86,
x86_64.  In the future, if support for MIPS and MIPS64 is added, we
should normalise those as well.  This is needed to support compilation
against modern NDKs.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
