### PR TITLE
[presets] Add clang install to bots that test indexstore-db/sourcekit-lsp

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -18,6 +18,9 @@ dash-dash
 
 swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;toolchain-tools;testsuite-tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;
 
+[preset: mixin_buildbot_install_components_with_clang]
+swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -322,7 +325,9 @@ tvos
 watchos
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base_all_platforms
+mixin-preset=
+    buildbot_incremental_base_all_platforms
+    mixin_buildbot_install_components_with_clang
 
 build-subdir=buildbot_incremental
 
@@ -351,6 +356,7 @@ skip-test-watchos
 install-swift
 install-llbuild
 install-swiftpm
+install-libcxx
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA,xcode]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
@@ -518,6 +524,7 @@ swift-stdlib-build-type=RelWithDebInfo
 mixin-preset=
     buildbot_incremental_base
     lldb-smoketest,tools=RA
+    mixin_buildbot_install_components_with_clang
 build-subdir=buildbot_incremental
 
 # We build release+asserts.
@@ -551,6 +558,7 @@ sourcekit-lsp
 install-swift
 install-llbuild
 install-swiftpm
+install-libcxx
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -717,8 +725,14 @@ swift-enable-ast-verifier=0
 #===------------------------------------------------------------------------===#
 # Linux Builders
 #===------------------------------------------------------------------------===#
+[preset: mixin_linux_install_components_with_clang]
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-inproc
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+
 [preset: mixin_linux_installation]
-mixin-preset=mixin_lightweight_assertions
+mixin-preset=
+    mixin_lightweight_assertions
+    mixin_linux_install_components_with_clang
 
 llbuild
 swiftpm
@@ -736,8 +750,6 @@ install-swiftpm
 install-xctest
 install-libicu
 install-prefix=/usr
-swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
 install-libcxx
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
@@ -993,7 +1005,9 @@ build-ninja
 reconfigure
 
 [preset: buildbot_incremental_linux]
-mixin-preset=buildbot_incremental_linux_base
+mixin-preset=
+    buildbot_incremental_linux_base
+    mixin_linux_install_components_with_clang
 build-subdir=buildbot_incremental
 
 libicu
@@ -1013,6 +1027,7 @@ install-swiftpm
 install-foundation
 install-libdispatch
 install-xctest
+install-libcxx
 
 [preset: buildbot_incremental_linux,long_test]
 mixin-preset=buildbot_incremental_linux
@@ -1104,6 +1119,7 @@ sourcekit-lsp=0
 # OS X Package Builders
 #===------------------------------------------------------------------------===#
 [preset: mixin_osx_package_base]
+mixin-preset=mixin_buildbot_install_components_with_clang
 ios
 tvos
 watchos
@@ -1143,6 +1159,7 @@ skip-install-swiftsyntax-module
 install-skstresstester
 install-swiftevolve
 install-playgroundsupport
+install-libcxx
 
 install-destdir=%(install_destdir)s
 
@@ -1165,10 +1182,6 @@ toolchain-benchmarks
 
 # If someone uses this for incremental builds, force reconfiguration.
 reconfigure
-
-swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
-install-libcxx
 
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s
@@ -1345,6 +1358,7 @@ swift-stdlib-build-type=Release
 mixin-preset=
     buildbot_incremental_base_all_platforms
     lldb-smoketest,tools=RA
+    mixin_buildbot_install_components_with_clang
 
 build-subdir=buildbot_incremental
 
@@ -1363,6 +1377,7 @@ sourcekit-lsp
 install-swift
 install-llbuild
 install-swiftpm
+install-libcxx
 
 # Build Playground support
 playgroundsupport
@@ -1409,7 +1424,9 @@ skip-test-osx
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_swiftpm_macos_platform,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base
+mixin-preset=
+    buildbot_incremental_base
+    mixin_buildbot_install_components_with_clang
 
 build-subdir=buildbot_incremental
 
@@ -1426,6 +1443,7 @@ sourcekit-lsp
 install-swift
 install-llbuild
 install-swiftpm
+install-libcxx
 
 dash-dash
 
@@ -1438,7 +1456,9 @@ skip-test-llbuild
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_swiftpm_linux_platform,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base
+mixin-preset=
+    buildbot_incremental_base
+    mixin_linux_install_components_with_clang
 
 build-subdir=buildbot_incremental
 
@@ -1460,6 +1480,7 @@ install-swiftpm
 install-foundation
 install-libdispatch
 install-xctest
+install-libcxx
 
 skip-test-swift
 skip-test-cmark
@@ -1510,6 +1531,7 @@ sourcekit-lsp
 install-swift
 install-llbuild
 install-swiftpm
+install-libcxx
 
 skip-test-swift
 skip-test-cmark
@@ -1517,7 +1539,9 @@ skip-test-llbuild
 skip-test-swiftpm
 
 [preset: buildbot_swiftpm_package_macos]
-mixin-preset=buildbot_swiftpm_package_base
+mixin-preset=
+    buildbot_swiftpm_package_base
+    mixin_buildbot_install_components_with_clang
 
 # Build stdlib for all platforms.
 ios
@@ -1525,7 +1549,9 @@ tvos
 watchos
 
 [preset: buildbot_swiftpm_package_linux]
-mixin-preset=buildbot_swiftpm_package_base
+mixin-preset=
+    buildbot_swiftpm_package_base
+    mixin_linux_install_components_with_clang
 
 libdispatch
 foundation

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -335,6 +335,8 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+libcxx
+
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
@@ -551,6 +553,7 @@ verbose-build
 # Build ninja while we are at it
 build-ninja
 
+libcxx
 llbuild
 swiftpm
 indexstore-db
@@ -1010,6 +1013,7 @@ mixin-preset=
     mixin_linux_install_components_with_clang
 build-subdir=buildbot_incremental
 
+libcxx
 libicu
 llbuild
 swiftpm
@@ -1366,6 +1370,8 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+libcxx
+
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
@@ -1434,6 +1440,8 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+libcxx
+
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
@@ -1472,6 +1480,7 @@ xctest
 foundation
 libdispatch
 llbuild
+libcxx
 sourcekit-lsp
 
 install-swift
@@ -1523,6 +1532,7 @@ build-subdir=buildbot_incremental
 release
 assertions
 
+libcxx
 llbuild
 swiftpm
 indexstore-db


### PR DESCRIPTION
At a minimum, we need to install `libIndexStore` to enable testing the indexer, but it's better to also include `clang`, `clangd`, and `libcxx`, since (a) this makes these bots closer to the config of the "package" bots, and (b) this lets us enable all of our indexer tests that require clang[d]. This commit copies the `swift-install-components` and `llvm-install-components` from the package bots.

In addition to the sourcekit-lsp/indexstore-db PR test bots, this affects the following bots that test indexstore-db and didn't already install clang:

* Linux
  * incremental
  * incremental long test
  * swiftpm PR test
* macOS
  * PR test
  * PR smoke test
  * incremental
  * swiftpm PR test

Based on looking at recent build logs for the package bots, this should only add <5 seconds to the incremental build.