### PR TITLE
utils: add CMake to Linux checkout

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -38,6 +38,10 @@
             "remote": { "id": "unicode-org/icu" },
             "platforms": [ "Linux" ]
         },
+        "cmake": {
+            "remote": { "id": "KitWare/CMake" },
+            "platforms": [ "Linux" ]
+        },
         "libcxx": {
             "remote": { "id": "apple/swift-libcxx" } },
         "clang-tools-extra": {
@@ -71,6 +75,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
+                "cmake": "v3.15.0",
                 "clang-tools-extra": "stable",
                 "libcxx": "stable",
                 "indexstore-db": "master",
@@ -94,6 +99,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
+                "cmake": "v3.15.0",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master"
             }
@@ -120,6 +126,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
+                "cmake": "v3.15.0",
                 "clang-tools-extra": "upstream-with-swift",
                 "libcxx": "upstream-with-swift",
                 "indexstore-db": "master",
@@ -143,6 +150,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
+                "cmake": "v3.15.0",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master"
             }


### PR DESCRIPTION
In order to prepare for a migration to CMake 3.15 to enable the use of
the new Swift support, we will add a build of CMake for Linux to ease
the transition.  This adds CMake to the checkout on Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
