### PR TITLE
[Diagnostics] Don't filter overload set candidates based on labels in lookup

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1051,6 +1051,9 @@ ERROR(argument_out_of_order_unnamed_named,none,
 ERROR(argument_out_of_order_unnamed_unnamed,none,
       "unnamed argument #%0 must precede unnamed argument #%1",
       (unsigned, unsigned))
+NOTE(candidate_expected_different_labels,none,
+     "incorrect labels for candidate (have: '%0', expected: '%1')",
+     (StringRef, StringRef))
 
 ERROR(member_shadows_global_function,none,
       "use of %0 refers to %1 %2 rather than %3 %4 in %5 %6",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -741,7 +741,6 @@ void FailureDiagnosis::diagnoseUnviableLookupResults(
       return;
 
     switch (firstProblem) {
-    case MemberLookupResult::UR_LabelMismatch:
     case MemberLookupResult::UR_WritableKeyPathOnReadOnlyMember:
     case MemberLookupResult::UR_ReferenceWritableKeyPathOnMutatingMember:
     case MemberLookupResult::UR_KeyPathWithAnyObjectRootType:

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4191,7 +4191,7 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
   };
 
   SmallPtrSet<TypeBase *, 4> possibleTypes;
-  auto currentType = CS.getType(fnExpr);
+  auto currentType = CS.simplifyType(CS.getType(fnExpr));
 
   // If current type has type variables or unresolved types
   // let's try to re-typecheck it to see if we can get some

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -529,6 +529,7 @@ public:
       : FailureDiagnostic(root, cs, locator), CorrectLabels(labels) {}
 
   bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
 };
 
 /// Diagnose errors related to converting function type which

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4187,6 +4187,20 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   if (!instanceTy->mayHaveMembers())
     return result;
 
+  // If we have a simple name, determine whether there are argument
+  // labels we can use to restrict the set of lookup results.
+  if (baseObjTy->isAnyObject() && memberName.isSimpleName()) {
+    // If we're referencing AnyObject and we have argument labels, put
+    // the argument labels into the name: we don't want to look for
+    // anything else, because the cost of the general search is so
+    // high.
+    if (auto argumentLabels =
+            getArgumentLabels(*this, ConstraintLocatorBuilder(memberLocator))) {
+      memberName = DeclName(TC.Context, memberName.getBaseName(),
+                            argumentLabels->Labels);
+    }
+  }
+
   // Look for members within the base.
   LookupResult &lookup = lookupMember(instanceTy, memberName);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6072,14 +6072,20 @@ ConstraintSystem::simplifyApplicableFnConstraint(
 
   };
 
-  // If the right-hand side is a type variable, try to simplify the overload
-  // set.
-  if (auto typeVar = desugar2->getAs<TypeVariableType>()) {
-    Type newType2 = simplifyAppliedOverloads(typeVar, func1, locator);
-    if (!newType2)
-      return SolutionKind::Error;
+  // Don't attempt this optimization in "diagnostic mode" because
+  // in such mode we'd like to attempt all of the available
+  // overloads regardless of of problems related to missing or
+  // extraneous labels and/or arguments.
+  if (!(solverState && shouldAttemptFixes())) {
+    // If the right-hand side is a type variable,
+    // try to simplify the overload set.
+    if (auto typeVar = desugar2->getAs<TypeVariableType>()) {
+      Type newType2 = simplifyAppliedOverloads(typeVar, func1, locator);
+      if (!newType2)
+        return SolutionKind::Error;
 
-    desugar2 = newType2->getDesugaredType();
+      desugar2 = newType2->getDesugaredType();
+    }
   }
 
   // If right-hand side is a type variable, the constraint is unsolved.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -481,8 +481,8 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
   auto &ctx = CS.getASTContext();
 
   bool attemptFixes = CS.shouldAttemptFixes();
-  // Enable "fixed" overload choices in "diagnostic" mode.
-  if (!(attemptFixes && choice.hasFix()) && choice.isDisabled()) {
+  // Enable all disabled choices in "diagnostic" mode.
+  if (!attemptFixes && choice.isDisabled()) {
     if (isDebugMode()) {
       auto &log = getDebugLogger();
       log << "(skipping ";

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -886,9 +886,6 @@ struct MemberLookupResult {
   
   /// This enum tracks reasons why a candidate is not viable.
   enum UnviableReason {
-    /// Argument labels don't match.
-    UR_LabelMismatch,
-
     /// This uses a type like Self in its signature that cannot be used on an
     /// existential box.
     UR_UnavailableInExistential,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2594,15 +2594,11 @@ public:
   /// (as the function parameters) and the expected result type of the
   /// call.
   ///
-  /// \param argumentLabels The argument labels provided at the call site,
-  /// if known.
-  ///
   /// \returns \c fnType, or some simplified form of it if this function
   /// was able to find a single overload or derive some common structure
   /// among the overloads.
   Type simplifyAppliedOverloads(TypeVariableType *fnTypeVar,
                                 const FunctionType *argFnType,
-                                Optional<ArgumentLabelState> argumentLabels,
                                 ConstraintLocatorBuilder locator);
 
   /// Retrieve the type that will be used when matching the given overload.
@@ -3861,20 +3857,13 @@ matchCallArguments(ConstraintSystem &cs,
 /// subscript, etc.), find the underlying target expression.
 Expr *getArgumentLabelTargetExpr(Expr *fn);
 
-/// Returns true if a reference to a member on a given base type will apply its
-/// curried self parameter, assuming it has one.
+/// Returns true if a reference to a member on a given base type will apply
+/// its curried self parameter, assuming it has one.
 ///
-/// This is true for most member references, however isn't true for things like
-/// an instance member being referenced on a metatype, where the curried self
-/// parameter remains unapplied.
+/// This is true for most member references, however isn't true for things
+/// like an instance member being referenced on a metatype, where the
+/// curried self parameter remains unapplied.
 bool doesMemberRefApplyCurriedSelf(Type baseTy, const ValueDecl *decl);
-
-/// Attempt to prove that arguments with the given labels at the
-/// given parameter depth cannot be used with the given value.
-/// If this cannot be proven, conservatively returns true.
-bool areConservativelyCompatibleArgumentLabels(OverloadChoice choice,
-                                               ArrayRef<Identifier> labels,
-                                               bool hasTrailingClosure);
 
 /// Simplify the given locator by zeroing in on the most specific
 /// subexpression described by the locator.

--- a/test/ClangImporter/objc_diags.swift
+++ b/test/ClangImporter/objc_diags.swift
@@ -3,6 +3,6 @@
 import ObjectiveC
 
 func instanceMethod(_ b: B) {
-  b.method(1, 2.5) // expected-error {{argument labels '(_:, _:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'method' exist with these partially matching parameter lists: (Int32, onCat1: Double), (Int32, onExtA: Double), (Int32, onExtB: Double), (Int32, with: Double), (Int32, with: Float), (Int32, withDouble: Double), (Int32, withFloat: Float)}}
+  // Notes for labeling mismatch candidates are now attached to each individual declaration
+  b.method(1, 2.5) // expected-error {{no exact matches in call to instance method 'method'}}
 }

--- a/test/ClangImporter/objc_missing_designated_init.swift
+++ b/test/ClangImporter/objc_missing_designated_init.swift
@@ -3,57 +3,57 @@
 import UnimportableMembers
 import UnimportableMembersUser
 
-class IncompleteInitSubclassImplicit : IncompleteDesignatedInitializers {
+class IncompleteInitSubclassImplicit : IncompleteDesignatedInitializers { // expected-note 6 {{incorrect labels for candidate}}
   var myOneNewMember = 1
 }
 
 class IncompleteInitSubclass : IncompleteDesignatedInitializers {
-  override init(first: Int) {}
-  override init(second: Int) {}
+  override init(first: Int) {}  // expected-note 3 {{incorrect labels for candidate}}
+  override init(second: Int) {} // expected-note 3 {{incorrect labels for candidate}}
 }
 
-class IncompleteConvenienceInitSubclass : IncompleteConvenienceInitializers {}
+class IncompleteConvenienceInitSubclass : IncompleteConvenienceInitializers {} // expected-note 2 {{incorrect labels for candidate}}
 
-class IncompleteUnknownInitSubclass : IncompleteUnknownInitializers {}
+class IncompleteUnknownInitSubclass : IncompleteUnknownInitializers {} // expected-note 4 {{incorrect labels for candidate}}
 
-class IncompleteInitCategorySubclassImplicit : IncompleteDesignatedInitializersWithCategory {}
+class IncompleteInitCategorySubclassImplicit : IncompleteDesignatedInitializersWithCategory {} // expected-note 6 {{incorrect labels for candidate}}
 
 class IncompleteInitCategorySubclass : IncompleteDesignatedInitializersWithCategory {
-  override init(first: Int) {}
-  override init(second: Int) {}
+  override init(first: Int) {}  // expected-note 3 {{incorrect labels for candidate}}
+  override init(second: Int) {} // expected-note 3 {{incorrect labels for candidate}}
 }
 
-class DesignatedInitializerInAnotherModuleSubclass : DesignatedInitializerInAnotherModule {}
+class DesignatedInitializerInAnotherModuleSubclass : DesignatedInitializerInAnotherModule {} // expected-note 9 {{incorrect labels for candidate}}
 
 
 func testBaseClassesBehaveAsExpected() {
   _ = IncompleteDesignatedInitializers(first: 0) // okay
   _ = IncompleteDesignatedInitializers(second: 0) // okay
-  _ = IncompleteDesignatedInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteDesignatedInitializers(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteDesignatedInitializers(conveniently: 0) // okay
   _ = IncompleteDesignatedInitializers(category: 0) // okay
 
   _ = IncompleteConvenienceInitializers(first: 0) // okay
   _ = IncompleteConvenienceInitializers(second: 0) // okay
-  _ = IncompleteConvenienceInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteConvenienceInitializers(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteConvenienceInitializers(conveniently: 0) // okay
   _ = IncompleteConvenienceInitializers(category: 0) // okay
 
   _ = IncompleteUnknownInitializers(first: 0) // okay
   _ = IncompleteUnknownInitializers(second: 0) // okay
-  _ = IncompleteUnknownInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteUnknownInitializers(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteUnknownInitializers(conveniently: 0) // okay
   _ = IncompleteUnknownInitializers(category: 0) // okay
 
   _ = IncompleteDesignatedInitializersWithCategory(first: 0) // okay
   _ = IncompleteDesignatedInitializersWithCategory(second: 0) // okay
-  _ = IncompleteDesignatedInitializersWithCategory(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteDesignatedInitializersWithCategory(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteDesignatedInitializersWithCategory(conveniently: 0) // okay
   _ = IncompleteDesignatedInitializersWithCategory(category: 0) // okay
 
   _ = DesignatedInitializerInAnotherModule(first: 0) // okay
   _ = DesignatedInitializerInAnotherModule(second: 0) // okay
-  _ = DesignatedInitializerInAnotherModule(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModule(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = DesignatedInitializerInAnotherModule(conveniently: 0) // okay
   _ = DesignatedInitializerInAnotherModule(category: 0) // okay
   _ = DesignatedInitializerInAnotherModule(fromOtherModule: 0) // okay
@@ -62,44 +62,44 @@ func testBaseClassesBehaveAsExpected() {
 func testSubclasses() {
   _ = IncompleteInitSubclass(first: 0) // okay
   _ = IncompleteInitSubclass(second: 0) // okay
-  _ = IncompleteInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitSubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclass(missing: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitSubclass(conveniently: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitSubclass(category: 0) // expected-error {{no exact matches in call to initializer}}
 
   _ = IncompleteInitSubclassImplicit(first: 0) // okay
   _ = IncompleteInitSubclassImplicit(second: 0) // okay
-  _ = IncompleteInitSubclassImplicit(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitSubclassImplicit(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitSubclassImplicit(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitSubclassImplicit(missing: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitSubclassImplicit(conveniently: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitSubclassImplicit(category: 0) // expected-error {{no exact matches in call to initializer}}
 
   _ = IncompleteConvenienceInitSubclass(first: 0) // okay
   _ = IncompleteConvenienceInitSubclass(second: 0) // okay
-  _ = IncompleteConvenienceInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteConvenienceInitSubclass(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteConvenienceInitSubclass(conveniently: 0) // okay
   _ = IncompleteConvenienceInitSubclass(category: 0) // okay
 
   _ = IncompleteUnknownInitSubclass(first: 0) // okay
   _ = IncompleteUnknownInitSubclass(second: 0) // okay
-  _ = IncompleteUnknownInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteUnknownInitSubclass(missing: 0) // expected-error {{no exact matches in call to initializer}}
   _ = IncompleteUnknownInitSubclass(conveniently: 0) // okay
   _ = IncompleteUnknownInitSubclass(category: 0) // okay
 
   _ = IncompleteInitCategorySubclass(first: 0) // okay
   _ = IncompleteInitCategorySubclass(second: 0) // okay
-  _ = IncompleteInitCategorySubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitCategorySubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitCategorySubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclass(missing: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitCategorySubclass(conveniently: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitCategorySubclass(category: 0) // expected-error {{no exact matches in call to initializer}}
 
   _ = IncompleteInitCategorySubclassImplicit(first: 0) // okay
   _ = IncompleteInitCategorySubclassImplicit(second: 0) // okay
-  _ = IncompleteInitCategorySubclassImplicit(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitCategorySubclassImplicit(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = IncompleteInitCategorySubclassImplicit(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclassImplicit(missing: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitCategorySubclassImplicit(conveniently: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = IncompleteInitCategorySubclassImplicit(category: 0) // expected-error {{no exact matches in call to initializer}}
 
   _ = DesignatedInitializerInAnotherModuleSubclass(first: 0) // okay
   _ = DesignatedInitializerInAnotherModuleSubclass(second: 0) // okay
-  _ = DesignatedInitializerInAnotherModuleSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = DesignatedInitializerInAnotherModuleSubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
-  _ = DesignatedInitializerInAnotherModuleSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(missing: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(conveniently: 0) // expected-error {{no exact matches in call to initializer}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(category: 0) // expected-error {{no exact matches in call to initializer}}
   _ = DesignatedInitializerInAnotherModuleSubclass(fromOtherModule: 0) // okay
 }

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -352,7 +352,8 @@ func testDynamicSelf(_ queen: Bee, wobbler: NSWobbling) {
   // class itself.
   // FIXME: This should be accepted.
   let baseClass: ObjCParseExtras.Base.Type = ObjCParseExtras.Base.returnMyself()
-  // expected-error@-1 {{missing argument for parameter #1 in call}}
+  // expected-error@-1 {{instance member 'returnMyself' cannot be used on type 'Base'; did you mean to use a value of this type instead?}}
+  // expected-error@-2 {{cannot convert value of type 'Base?' to specified type 'Base.Type'}}
 }
 
 func testRepeatedProtocolAdoption(_ w: NSWindow) {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -182,8 +182,8 @@ func r22162441(_ lines: [String]) {
 
 func testMap() {
   let a = 42
-  [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'Double'}}
-  // expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: }}
+  [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Any' and 'Double'}}
+  // expected-note @-1 {{expected an argument list of type '(Double, Double)'}}
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -417,8 +417,8 @@ enum Color {
 
   static func rainbow() -> Color {}
   
-  static func overload(a : Int) -> Color {}
-  static func overload(b : Int) -> Color {}
+  static func overload(a : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
+  static func overload(b : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(b:)')}}
   
   static func frob(_ a : Int, b : inout Int) -> Color {}
   static var svar: Color { return .Red }
@@ -444,8 +444,7 @@ let _ : Color = .rainbow  // expected-error {{member 'rainbow' is a function; di
 let _: Color = .overload(a : 1.0)  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: Color = .overload(1.0)  // expected-error {{ambiguous reference to member 'overload'}}
 // expected-note @-1 {{overloads for 'overload' exist with these partially matching parameter lists: (a: Int), (b: Int)}}
-let _: Color = .overload(1)  // expected-error {{ambiguous reference to member 'overload'}}
-// expected-note @-1 {{overloads for 'overload' exist with these partially matching parameter lists: (a: Int), (b: Int)}}
+let _: Color = .overload(1)  // expected-error {{no exact matches in call to static method 'overload'}}
 let _: Color = .frob(1.0, &i) // expected-error {{missing argument label 'b:' in call}}
 let _: Color = .frob(1.0, b: &i) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: Color = .frob(1, i)  // expected-error {{missing argument label 'b:' in call}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -161,7 +161,10 @@ class r22409190ManagedBuffer<Value, Element> {
 class MyArrayBuffer<Element>: r22409190ManagedBuffer<UInt, Element> {
   deinit {
     self.withUnsafeMutablePointerToElements { elems -> Void in
-      elems.deinitialize(count: self.value)  // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Int'}}
+      // FIXME(diagnostics): Diagnostic regressed here from `cannot convert value of type 'UInt' to expected argument type 'Int'`.
+      // Once argument-to-parameter mismatch diagnostics are moved to the new diagnostic framework, we'll be able to restore
+      // original contextual conversion failure diagnostic here. Note that this only happens in Swift 4 mode.
+      elems.deinitialize(count: self.value)  // expected-error {{ambiguous reference to member 'deinitialize(count:)'}}
     }
   }
 }
@@ -648,7 +651,7 @@ let arr = [BottleLayout]()
 let layout = BottleLayout(count:1)
 let ix = arr.firstIndex(of:layout) // expected-error {{argument type 'BottleLayout' does not conform to expected type 'Equatable'}}
 
-let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{initializer 'init(_:)' requires that 'Unicode.Scalar' conform to 'BinaryInteger'}}
+let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{missing argument label 'ascii:' in call}}
 
 // https://bugs.swift.org/browse/SR-9068
 func compare<C: Collection, Key: Hashable, Value: Equatable>(c: C)

--- a/test/Constraints/overload_filtering_objc.swift
+++ b/test/Constraints/overload_filtering_objc.swift
@@ -19,10 +19,6 @@ import Foundation
 }
 
 func testOptional(obj: P) {
-  // FIXME: When we remove argument-label filtering from member name lookup,
-  // this will start failing and need to be replaced with "disabled disjunction
-  // term".
-  //
-  // CHECK-NOT: disjunction
+  // CHECK: disabled disjunction term $T2 bound to decl overload_filtering_objc.(file).P.opt(double:)
   _ = obj.opt?(1)
 }

--- a/test/Constraints/unchecked_optional.swift
+++ b/test/Constraints/unchecked_optional.swift
@@ -6,8 +6,8 @@ class A {
   func do_b(_ x: Int) {}
   func do_b(_ x: Float) {}
 
-  func do_c(x: Int) {}
-  func do_c(y: Int) {} 
+  func do_c(x: Int) {} // expected-note 2 {{incorrect labels for candidate (have: '(_:)', expected: '(x:)')}}
+  func do_c(y: Int) {} // expected-note 2 {{incorrect labels for candidate (have: '(_:)', expected: '(y:)')}}
 }
 
 func test0(_ a : A!) {
@@ -16,7 +16,7 @@ func test0(_ a : A!) {
   a.do_b(1)
   a.do_b(5.0)
 
-  a.do_c(1) // expected-error {{cannot invoke 'do_c' with an argument list of type '(Int)'}}
+  a.do_c(1) // expected-error {{no exact matches in call to instance method 'do_c'}}
   a.do_c(x: 1)
 }
 
@@ -26,7 +26,7 @@ func test1(_ a : A!) {
   a?.do_b(1)
   a?.do_b(5.0)
 
-  a?.do_c(1) // expected-error {{cannot invoke 'do_c' with an argument list of type '(Int)'}}
+  a?.do_c(1) // expected-error {{no exact matches in call to instance method 'do_c'}}
   a?.do_c(x: 1)
 }
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -134,8 +134,7 @@ func typeOfShadowing() {
   }
 
   // TODO: Errors need improving here.
-  _ = type(of: Gen<Foo>.Bar) // expected-error{{argument labels '(of:)' do not match any available overloads}}
-                             // expected-note@-1{{overloads for 'type' exist with these partially matching parameter lists: (T.Type), (fo: T.Type)}}
+  _ = type(of: Gen<Foo>.Bar) // expected-error{{incorrect argument label in call (have 'of:', expected 'fo:')}}
   _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or constructor call after type name}}
   // expected-note@-1{{add arguments after the type to construct a value of the type}}
   // expected-note@-2{{use '.self' to reference the type object}}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -26,10 +26,10 @@ struct S {
     f({x in x}, 2) // expected-error {{generic parameter 'T' could not be inferred}}
   }
   
-  func g<T>(_ a: T, _ b: Int) -> Void {}
+  func g<T>(_ a: T, _ b: Int) -> Void {} // expected-note {{in call to function 'g'}}
   func g(_ a: String) -> Void {}
   func test2() -> Void {
-    g(.notAThing, 7) // expected-error {{reference to member 'notAThing' cannot be resolved without a contextual type}}
+    g(.notAThing, 7) // expected-error {{generic parameter 'T' could not be inferred}}
   }
   
   func h(_ a: Int, _ b: Int) -> Void {}

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -113,7 +113,7 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeRawBufferPointer(start: rp, count: 1)
   _ = UnsafeMutableRawBufferPointer(mrbp)
   _ = UnsafeRawBufferPointer(mrbp)
-  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot invoke initializer for type 'UnsafeMutableRawBufferPointer' with an argument list of type '(UnsafeRawBufferPointer)'}} expected-note {{overloads for 'UnsafeMutableRawBufferPointer' exist with these partially matching parameter lists: (UnsafeMutableBufferPointer<T>), (UnsafeMutableRawBufferPointer)}}
+  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{missing argument label 'mutating:' in call}}
   _ = UnsafeRawBufferPointer(rbp)
   _ = UnsafeMutableRawBufferPointer(mbpi)
   _ = UnsafeRawBufferPointer(mbpi)

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
@@ -4,7 +4,7 @@ extension BinaryInteger {
   init(bytes: [UInt8]) { fatalError() }
 
   init<S: Sequence>(bytes: S) where S.Iterator.Element == UInt8 {
-    self.init(bytes // expected-error {{no exact matches in call to initializer}}
+    self.init(bytes // expected-error {{missing argument label 'integerLiteral:' in call}}
     // expected-note@-1 {{}}
 
 extension

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
@@ -4,7 +4,8 @@ extension BinaryInteger {
   init(bytes: [UInt8]) { fatalError() }
 
   init<S: Sequence>(bytes: S) where S.Iterator.Element == UInt8 {
-    self.init(bytes // expected-error {{missing argument label 'integerLiteral:' in call}}
+    // expected-note@-1 {{incorrect labels for candidate (have: '(_:)', expected: '(bytes:)')}}
+    self.init(bytes // expected-error {{no exact matches in call to initializer}}
     // expected-note@-1 {{}}
 
 extension


### PR DESCRIPTION
Unify label/argument filtering optimizations in `simplifyAppliedOverloads`
and remove duplicate logic from `performMemberLookup`. This allows
for better diagnostics and give more control over optimizations to the solver.

Resolves: [SR-11155](https://bugs.swift.org/browse/SR-11155)
Resolves: rdar://problem/53234368
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
