### PR TITLE
[5.1] Fix SourceKit crash in ModelASTWalker::handleSpecialDeclAttribute

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1039,12 +1039,13 @@ bool ModelASTWalker::handleSpecialDeclAttribute(const DeclAttribute *D,
         if (!Arg->walk(*this))
           return false;
       }
-    } else {
+    } else if (!TokenNodes.empty()) {
       auto Next = TokenNodes.front();
-      TokenNodes = TokenNodes.drop_front();
-      assert(Next.Range.getStart() == D->getRangeWithAt().Start);
-      if (!passNode({SyntaxNodeKind::AttributeBuiltin, Next.Range}))
-        return false;
+      if (Next.Range.getStart() == D->getRangeWithAt().Start) {
+        TokenNodes = TokenNodes.drop_front();
+        if (!passNode({SyntaxNodeKind::AttributeBuiltin, Next.Range}))
+          return false;
+      }
     }
     if (!passTokenNodesUntil(D->getRange().End, PassNodesBehavior::IncludeNodeAtLocation))
       return false;

--- a/test/IDE/coloring_invalid.swift
+++ b/test/IDE/coloring_invalid.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+
+public enum Result {
+// CHECK: <attr-builtin>public</attr-builtin> <kw>enum</kw> Result {
+  case success(a b = {
+// CHECK: <kw>case</kw> success(a b = {
+
+@available(*)
+// CHECK: <attr-id>@available</attr-id>(*)
+func materialize
+// CHECK: <kw>func</kw> materialize

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -402,7 +402,9 @@ UIdent SwiftLangSupport::getUIDForSyntaxNodeKind(SyntaxNodeKind SC) {
     return KindObjectLiteral;
   }
 
-  llvm_unreachable("Unhandled SyntaxNodeKind in switch.");
+  // Default to a known kind to prevent crashing in non-asserts builds
+  assert(0 && "Unhandled SyntaxNodeKind in switch.");
+  return KindIdentifier;
 }
 
 UIdent SwiftLangSupport::getUIDForSyntaxStructureKind(


### PR DESCRIPTION
- **Radar**: rdar://problem/53313197
- **Explanation**:
    The below swift code causes SourceKit to crash when it tries to provide syntax coloring or structure information:
    ```
    public enum Result {
      case success(a b = {
        @available(*)
        func materialize
    ```
    This is due to the code handling availability attributes assuming the AST is walked in source order, and that the tokens corresponding to the visited availability attribute will still be in the token worklist. This is not the case in the example above. When visiting an enum case, the SyntaxModelWalker produces syntax structure nodes for the enum case itself and each of its enum elements (i.e. the a, b, and c in  `case a, b, c` and `success` in the example above) which it reports as child nodes of the enum case. It then consumes all tokens up to the end of the enum case (from `case` to the end of the file in the example above) as it assumes its manual handling of enum elements covered everything. After visiting the enum case, the walker then visits each of the enum elements that the walker already handled in advance, as they're actually siblings in the AST. When the availability attribute is encountered, the handleSpecialDeclAttributes method is invoked and tries to pop an `@available` token from the token worklist, but it's empty.

    In a non-asserts build it would pop and return an invalid token, which caused SourceKit to crash when it tried to determine the SyntaxNode's kind.

* **Scope**: This crashes SourceKit whenever opening a file that contains availability attributes, and that the ModelASTWalker visits out of order (the enum case example above is the only example I'm aware of, but there may be others)
* **Origination**: The offending code was introduces when adding support for Custom attributes (to support property wrappers and function builders).
* **Risk**: Low, this is a targeted defensive fix that simple checks the token worklist is non-empty and that the next item on the list is actually the `@available` token, rather than assuming this is the case. It also makes SourceKit handle unknown syntax node kinds gracefully. 
* **Testing**: Added and ran a regression test and manually tried out the change in Xcode.
* **Reviewed by**: Argyrios Kyrtzidis

Resolves  rdar://problem/53313197
