### PR TITLE
[CMake][NFC] Remove unused logic to choose swift component

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1741,10 +1741,6 @@ function(add_swift_target_library name)
     set(SWIFTLIB_TARGET_LIBRARY TRUE)
   endif()
 
-  if(NOT SWIFTLIB_TARGET_LIBRARY)
-    set(SWIFTLIB_INSTALL_IN_COMPONENT dev)
-  endif()
-
   # If target SDKs are not specified, build for all known SDKs.
   if("${SWIFTLIB_TARGET_SDKS}" STREQUAL "")
     set(SWIFTLIB_TARGET_SDKS ${SWIFT_SDKS})


### PR DESCRIPTION
add_swift_target_library should always have `TARGET_LIBRARY` set. A few
lines down, there is a precondition that makes sure that it is set. This
check and subsequent assignment of `SWIFTLIB_INSTALL_IN_TARGET` should
never get triggered.

cc @compnerd @gottesmm @Rostepher 
