### PR TITLE
[AST] Use LookUpConformanceInModule to check if extension applied

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3754,7 +3754,9 @@ bool swift::areGenericRequirementsSatisfied(
 
   // For every requirement, add a constraint.
   for (auto Req : sig->getRequirements()) {
-    if (auto resolved = Req.subst(Substitutions)) {
+    if (auto resolved = Req.subst(
+          QuerySubstitutionMap{Substitutions},
+          LookUpConformanceInModule(DC->getParentModule()))) {
       CS.addConstraint(*resolved, Loc);
     } else if (isExtension) {
       return false;

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_OVERLOAD_ARG | %FileCheck %s -check-prefix=CONDITIONAL_OVERLOAD_ARG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_OVERLOAD_INIT_ARG | %FileCheck %s -check-prefix=CONDITIONAL_OVERLOAD_ARG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_INAPPLICABLE_ARG | %FileCheck %s -check-prefix=CONDITIONAL_INAPPLICABLE_ARG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_DEPENDENT_TYPEALIAS | %FileCheck %s -check-prefix=CONDITIONAL_DEPENDENT_TYPEALIAS
 
 protocol SomeProto {
   associatedtype Assoc
@@ -126,4 +127,23 @@ func testVegetarian(chef: Chef<Vegetarian>) {
 
   chef.eat(.#^CONDITIONAL_INAPPLICABLE_ARG^#)
 // CONDITIONAL_INAPPLICABLE_ARG-NOT: Begin completion
+}
+
+// rdar://problem/53401609
+protocol MyProto {
+  associatedtype Index
+}
+extension MyProto where Index: Strideable, Index.Stride == Int {
+  func indices() {}
+}
+struct MyConcrete {}
+extension MyConcrete: MyProto {
+  typealias Index = Int
+}
+func testHasIndex(value: MyConcrete) {
+  value.#^CONDITIONAL_DEPENDENT_TYPEALIAS^#
+// CONDITIONAL_DEPENDENT_TYPEALIAS: Begin completions, 2 items
+// CONDITIONAL_DEPENDENT_TYPEALIAS-DAG: Keyword[self]/CurrNominal:          self[#MyConcrete#];
+// CONDITIONAL_DEPENDENT_TYPEALIAS-DAG: Decl[InstanceMethod]/Super:         indices()[#Void#];
+// CONDITIONAL_DEPENDENT_TYPEALIAS: End completions
 }


### PR DESCRIPTION
This fixes "is applicable" check for the code completion.

```swift
protocol MyProto {
  associatedtype Index
}
extension MyProto where Index: Strideable, Index.Stride == Int {
  func indices() {} // <------ THIS
}
struct MyConcrete {}
extension MyConcrete: MyProto {
  typealias Index = Int
}
func testHasIndex(value: MyConcrete) {
  value.#^COMPLETE^#
}
```
In this case, "is applicable" check for the protocol extension used to fail because substitution for `Self.Index.Stride` failed.

rdar://problem/53401609