### PR TITLE
Upstream bug fix related to keyword argument dynamic callable.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6818,8 +6818,10 @@ ExprRewriter::finishApplyDynamicCallable(const Solution &solution,
       cs.setType(labelExpr, keyType);
       handleStringLiteralExpr(cast<LiteralExpr>(labelExpr));
 
-      Expr *pair =
-        TupleExpr::createImplicit(ctx, { labelExpr, arg->getElement(i) }, {});
+      Expr *valueExpr = coerceToType(arg->getElement(i), valueType, loc);
+      if (!valueExpr)
+        return nullptr;
+      Expr *pair = TupleExpr::createImplicit(ctx, {labelExpr, valueExpr}, {});
       auto eltTypes = { TupleTypeElt(keyType), TupleTypeElt(valueType) };
       cs.setType(pair, TupleType::get(eltTypes, ctx));
       dictElements.push_back(pair);

--- a/test/SILGen/dynamic_callable_attribute.swift
+++ b/test/SILGen/dynamic_callable_attribute.swift
@@ -24,3 +24,17 @@ public func foo(a: Callable) {
 // CHECK: [[DYN_CALL_2:%.*]] = function_ref @$s26dynamic_callable_attribute8CallableV15dynamicallyCall13withArgumentsySaySiG_tF
 // CHECK-NEXT: apply [[DYN_CALL_2]]
 // CHECK: [[DYN_CALL_3:%.*]] = function_ref @$s26dynamic_callable_attribute8CallableV15dynamicallyCall20withKeywordArgumentsys13KeyValuePairsVySSSiG_tF
+
+
+@dynamicCallable
+public struct Callable2 {
+  func dynamicallyCall(withKeywordArguments: KeyValuePairs<String, Any>) {}
+}
+
+// CHECK-LABEL: sil [ossa] @keywordCoerceBug
+// CHECK:[[DYN_CALL:%.*]] = function_ref @$s26dynamic_callable_attribute9Callable2V15dynamicallyCall20withKeywordArgumentsys13KeyValuePairsVySSypG_tF
+
+@_silgen_name("keywordCoerceBug")
+public func keywordCoerceBug(a: Callable2, s: Int) {
+  a(s)
+}


### PR DESCRIPTION
Failure to coerce the tuple dynamic callable parameter crashes the compiler.

The error looks like:
```
tuple_expr element type mismatch:
  field: Any
  element: Int
```