### PR TITLE
[Serialization] Fix off-by-one error in enum dependency analysis

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3684,7 +3684,7 @@ public:
     DeclName compoundName(ctx, baseName, argNames);
     DeclName name = argNames.empty() ? baseName : compoundName;
 
-    for (TypeID dependencyID : argNameAndDependencyIDs.slice(numArgNames+1)) {
+    for (TypeID dependencyID : argNameAndDependencyIDs.slice(numArgNames)) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
         return llvm::make_error<TypeError>(


### PR DESCRIPTION
No test case because it's very hard to control the dependency list for particular enum. All of the existing tests are pretty minimal, so if it wasn't failing already the first type is probably consistently something innocuous like the enum itself, but still.

Noticed by inspection.