### PR TITLE
[Serialization] Preserve whether a raw value is explicit

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 503; // remove 'requires stored property inits'
+const uint16_t SWIFTMODULE_VERSION_MINOR = 504; // distinguish implicit raw values for enum cases
 
 using DeclIDField = BCFixed<31>;
 
@@ -1194,6 +1194,7 @@ namespace decls_block {
     BCFixed<1>,  // implicit?
     BCFixed<1>,  // has payload?
     EnumElementRawValueKindField,  // raw value kind
+    BCFixed<1>,  // implicit raw value?
     BCFixed<1>,  // negative raw value?
     IdentifierIDField, // raw value
     BCVBR<5>, // number of parameter name components

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3663,7 +3663,7 @@ public:
   Expected<Decl *> deserializeEnumElement(ArrayRef<uint64_t> scratch,
                                           StringRef blobData) {
     DeclContextID contextID;
-    bool isImplicit; bool hasPayload; bool isNegative;
+    bool isImplicit, hasPayload, isRawValueImplicit, isNegative;
     unsigned rawValueKindID;
     IdentifierID rawValueData;
     unsigned numArgNames;
@@ -3671,7 +3671,8 @@ public:
 
     decls_block::EnumElementLayout::readRecord(scratch, contextID,
                                                isImplicit, hasPayload,
-                                               rawValueKindID, isNegative,
+                                               rawValueKindID,
+                                               isRawValueImplicit, isNegative,
                                                rawValueData,
                                                numArgNames,
                                                argNameAndDependencyIDs);
@@ -3717,7 +3718,7 @@ public:
     case EnumElementRawValueKind::IntegerLiteral: {
       auto literalText = MF.getIdentifierText(rawValueData);
       auto literal = new (ctx) IntegerLiteralExpr(literalText, SourceLoc(),
-                                                  /*implicit*/ true);
+                                                  isRawValueImplicit);
       if (isNegative)
         literal->setNegative(SourceLoc());
       elem->setRawValueExpr(literal);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3586,15 +3586,16 @@ public:
 
     // We only serialize the raw values of @objc enums, because they're part
     // of the ABI. That isn't the case for Swift enums.
-    auto RawValueKind = EnumElementRawValueKind::None;
-    bool Negative = false;
+    auto rawValueKind = EnumElementRawValueKind::None;
+    bool isNegative = false, isRawValueImplicit = false;
     StringRef RawValueText;
     if (elem->getParentEnum()->isObjC()) {
       // Currently ObjC enums always have integer raw values.
-      RawValueKind = EnumElementRawValueKind::IntegerLiteral;
+      rawValueKind = EnumElementRawValueKind::IntegerLiteral;
       auto ILE = cast<IntegerLiteralExpr>(elem->getRawValueExpr());
       RawValueText = ILE->getDigitsText();
-      Negative = ILE->isNegative();
+      isNegative = ILE->isNegative();
+      isRawValueImplicit = ILE->isImplicit();
     }
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[EnumElementLayout::Code];
@@ -3602,8 +3603,9 @@ public:
                                   contextID,
                                   elem->isImplicit(),
                                   elem->hasAssociatedValues(),
-                                  (unsigned)RawValueKind,
-                                  Negative,
+                                  (unsigned)rawValueKind,
+                                  isRawValueImplicit,
+                                  isNegative,
                                   S.addUniquedStringRef(RawValueText),
                                   elem->getFullName().getArgumentNames().size()+1,
                                   nameComponentsAndDependencies);

--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -6,6 +6,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FrozenEnum : Swift.Int
@@ -16,6 +18,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FutureproofObjCEnum : Swift.Int32
@@ -26,6 +30,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FrozenObjCEnum : Swift.Int32
@@ -36,6 +42,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: indirect public enum FutureproofIndirectEnum

--- a/test/ParseableInterface/enums-layout.swift
+++ b/test/ParseableInterface/enums-layout.swift
@@ -1,7 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
+// RUN: %target-build-swift -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
+
+// Try again using a single-frontend build.
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -force-single-frontend-invocation -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
+// RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
+// RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
+
 
 import Lib
 


### PR DESCRIPTION
...which allows the AST printer to correctly choose whether to print it, which means it can be printed in a module interface in a non-WMO build, which is necessary for `@objc` enums to have a correct run-time representation when clients use that interface.

rdar://problem/53469608