### PR TITLE
[5.1] Print attributes on enum cases correctly (like 'indirect')

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -951,7 +951,8 @@ void PrintAST::printAttributes(const Decl *D) {
 
     // If the declaration is implicitly @objc, print the attribute now.
     if (auto VD = dyn_cast<ValueDecl>(D)) {
-      if (VD->isObjC() && !VD->getAttrs().hasAttribute<ObjCAttr>()) {
+      if (VD->isObjC() && !isa<EnumElementDecl>(VD) &&
+          !VD->getAttrs().hasAttribute<ObjCAttr>()) {
         Printer.printAttrName("@objc");
         Printer << " ";
       }
@@ -2920,8 +2921,8 @@ void PrintAST::visitEnumCaseDecl(EnumCaseDecl *decl) {
   if (!elems.empty()) {
     // Documentation comments over the case are attached to the enum elements.
     printDocumentationComment(elems[0]);
+    printAttributes(elems[0]);
   }
-  printAttributes(decl);
   Printer << tok::kw_case << " ";
 
   interleave(elems.begin(), elems.end(),

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2896,6 +2896,16 @@ public:
       verifyParsedBase(UED);
     }
 
+    void verifyParsed(EnumCaseDecl *D) {
+      PrettyStackTraceDecl debugStack("verifying EnumCaseDecl", D);
+      if (!D->getAttrs().isEmpty()) {
+        Out << "EnumCaseDecl should not have attributes";
+        abort();
+      }
+
+      verifyParsedBase(D);
+    }
+
     void verifyParsed(AbstractFunctionDecl *AFD) {
       PrettyStackTraceDecl debugStack("verifying AbstractFunctionDecl", AFD);
 

--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -37,3 +37,43 @@ public enum FutureproofEnum: Int {
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
 }
+
+// CHECK-LABEL: indirect public enum FutureproofIndirectEnum
+public indirect enum FutureproofIndirectEnum {
+  // CHECK-NEXT: case a{{$}}
+  case a
+  // CHECK-NEXT: case b(Swift.Int){{$}}
+  case b(Int)
+  // CHECK-NEXT: case c{{$}}
+  case c
+}
+
+// CHECK-LABEL: indirect public enum FrozenIndirectEnum
+@_frozen public indirect enum FrozenIndirectEnum {
+  // CHECK-NEXT: case a{{$}}
+  case a
+  // CHECK-NEXT: case b(Swift.Int){{$}}
+  case b(Int)
+  // CHECK-NEXT: case c{{$}}
+  case c
+}
+
+// CHECK-LABEL: public enum FutureproofIndirectCaseEnum
+public enum FutureproofIndirectCaseEnum {
+  // CHECK-NEXT: {{^}} case a{{$}}
+  case a
+  // CHECK-NEXT: indirect case b(Swift.Int){{$}}
+  indirect case b(Int)
+  // CHECK-NEXT: {{^}} case c{{$}}
+  case c
+}
+
+// CHECK-LABEL: public enum FrozenIndirectCaseEnum
+@_frozen public enum FrozenIndirectCaseEnum {
+  // CHECK-NEXT: {{^}} case a{{$}}
+  case a
+  // CHECK-NEXT: indirect case b(Swift.Int){{$}}
+  indirect case b(Int)
+  // CHECK-NEXT: {{^}} case c{{$}}
+  case c
+}

--- a/test/ParseableInterface/enums-layout.swift
+++ b/test/ParseableInterface/enums-layout.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
-// RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
 
 import Lib
 
@@ -34,3 +34,39 @@ func testFrozenObjCEnum() -> FrozenObjCEnum {
   // CHECK: ret i{{32|64}} 10
   return .b
 } // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: define{{.+}}testFutureproofIndirectEnum
+func testFutureproofIndirectEnum() -> FutureproofIndirectEnum {
+  // CHECK: [[CASE:%.+]] = load i32, i32* @"$s3Lib23FutureproofIndirectEnumO1cyA2CmFWC"
+  // CHECK: [[METADATA_RESPONSE:%.+]] = tail call swiftcc %swift.metadata_response @"$s3Lib23FutureproofIndirectEnumOMa"
+  // CHECK: [[METADATA:%.+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+  // CHECK: call void {{%.+}}(%swift.opaque* noalias %0, i32 [[CASE]], %swift.type* [[METADATA]])
+  // CHECK-NEXT: ret void
+  return .c
+}
+
+// CHECK-LABEL: define{{.+}}testFrozenIndirectEnum
+func testFrozenIndirectEnum() -> FrozenIndirectEnum {
+  // Whether this is "1" or "2" depends on whether the reserved ObjC tagged
+  // pointer bit is the top or bottom bit on this platform.
+  // CHECK: ret i{{32|64}} {{1|2}}
+  return .c
+}
+
+// CHECK-LABEL: define{{.+}}testFutureproofIndirectCaseEnum
+func testFutureproofIndirectCaseEnum() -> FutureproofIndirectCaseEnum {
+  // CHECK: [[CASE:%.+]] = load i32, i32* @"$s3Lib27FutureproofIndirectCaseEnumO1cyA2CmFWC"
+  // CHECK: [[METADATA_RESPONSE:%.+]] = tail call swiftcc %swift.metadata_response @"$s3Lib27FutureproofIndirectCaseEnumOMa"
+  // CHECK: [[METADATA:%.+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+  // CHECK: call void {{%.+}}(%swift.opaque* noalias %0, i32 [[CASE]], %swift.type* [[METADATA]])
+  // CHECK-NEXT: ret void
+  return .c
+}
+
+// CHECK-LABEL: define{{.+}}testFrozenIndirectCaseEnum
+func testFrozenIndirectCaseEnum() -> FrozenIndirectCaseEnum {
+  // Whether this is "1" or "2" depends on whether the reserved ObjC tagged
+  // pointer bit is the top or bottom bit on this platform.
+  // CHECK: ret i{{32|64}} {{1|2}}
+  return .c
+}


### PR DESCRIPTION
**Explanation**: Attributes and modifiers for enum cases were not getting printed when an enum was printed directly from source. This includes a particular very important modifier, `indirect`, which affects the layout of the enum. Consequently, module interfaces generated from libraries using `indirect` cases were incorrectly describing the ABI of the library when compiled using whole-module optimization. (It only affects WMO because in non-WMO builds module interface generation doesn't have access to the source.)

**Scope**: Affects all places where enums are printed with multiple elements on one line. (If elements are always split to separate `case` declarations, the bug also does not occur.) The most important is module interfaces

**Issue**: rdar://problem/53329452

**Risk**: Low. Enum elements can have very few attributes to begin with, and all of them are important to print.

**Testing**: Verified that this fixes the described issue and that this issue is responsible for the miscompile described in the Radar; added a compiler regression test (with further tests coming on master).

**Reviewed by**: @harlanhaskins