### PR TITLE
[5.1][AST] Use LookUpConformanceInModule to check if extension applied

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3643,7 +3643,9 @@ static bool areGenericRequirementsSatisfied(
 
   // For every requirement, add a constraint.
   for (auto Req : sig->getRequirements()) {
-    if (auto resolved = Req.subst(Substitutions)) {
+    if (auto resolved = Req.subst(
+          QuerySubstitutionMap{Substitutions},
+          LookUpConformanceInModule(DC->getParentModule()))) {
       CS.addConstraint(*resolved, Loc);
     } else if (isExtension) {
       return false;

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_OVERLOAD_ARG | %FileCheck %s -check-prefix=CONDITIONAL_OVERLOAD_ARG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_OVERLOAD_INIT_ARG | %FileCheck %s -check-prefix=CONDITIONAL_OVERLOAD_ARG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_INAPPLICABLE_ARG | %FileCheck %s -check-prefix=CONDITIONAL_INAPPLICABLE_ARG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITIONAL_DEPENDENT_TYPEALIAS | %FileCheck %s -check-prefix=CONDITIONAL_DEPENDENT_TYPEALIAS
 
 protocol SomeProto {
   associatedtype Assoc
@@ -126,4 +127,23 @@ func testVegetarian(chef: Chef<Vegetarian>) {
 
   chef.eat(.#^CONDITIONAL_INAPPLICABLE_ARG^#)
 // CONDITIONAL_INAPPLICABLE_ARG-NOT: Begin completion
+}
+
+// rdar://problem/53401609
+protocol MyProto {
+  associatedtype Index
+}
+extension MyProto where Index: Strideable, Index.Stride == Int {
+  func indices() {}
+}
+struct MyConcrete {}
+extension MyConcrete: MyProto {
+  typealias Index = Int
+}
+func testHasIndex(value: MyConcrete) {
+  value.#^CONDITIONAL_DEPENDENT_TYPEALIAS^#
+// CONDITIONAL_DEPENDENT_TYPEALIAS: Begin completions, 2 items
+// CONDITIONAL_DEPENDENT_TYPEALIAS-DAG: Keyword[self]/CurrNominal:          self[#MyConcrete#];
+// CONDITIONAL_DEPENDENT_TYPEALIAS-DAG: Decl[InstanceMethod]/Super:         indices()[#Void#];
+// CONDITIONAL_DEPENDENT_TYPEALIAS: End completions
 }


### PR DESCRIPTION
Cherry-pick of #26321 into swift-5.1-branch

* **Explanation**: If a extension have some requirements, we check if it's applied or not. However, it used to fail to classify as "applied" when the requirement has "chained" constraints like `Index : Strideable, Index.Stride == Int`. This patch fixes that by using `LookUpConformanceInModule` to check the conformance
* **Scope**: Inherited member lookup for code completion
* **Risk**: Low.
* **Issue**: rdar://problem/53401609
* **Testing**: Added regression test case
* **Reviewer**: Slava Pestov (@slavapestov)
