### PR TITLE
Fix usage of uninitialized memory in swift_addNewDSOImage.

### DIFF
--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -76,10 +76,15 @@ void initializeDynamicReplacementLookup();
 
 // Callbacks to register metadata from an image to the runtime.
 void addImageProtocolsBlockCallback(const void *start, uintptr_t size);
+void addImageProtocolsBlockCallbackUnsafe(const void *start, uintptr_t size);
 void addImageProtocolConformanceBlockCallback(const void *start,
                                               uintptr_t size);
+void addImageProtocolConformanceBlockCallbackUnsafe(const void *start,
+                                                    uintptr_t size);
 void addImageTypeMetadataRecordBlockCallback(const void *start,
                                              uintptr_t size);
+void addImageTypeMetadataRecordBlockCallbackUnsafe(const void *start,
+                                                   uintptr_t size);
 void addImageDynamicReplacementBlockCallback(const void *start, uintptr_t size,
                                              const void *start2,
                                              uintptr_t size2);

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -48,8 +48,8 @@ void swift::initializeProtocolLookup() {
     const swift::MetadataSections::Range &protocols =
       sections->swift5_protocols;
     if (protocols.length)
-      addImageProtocolsBlockCallback(reinterpret_cast<void *>(protocols.start),
-                                     protocols.length);
+      addImageProtocolsBlockCallbackUnsafe(
+          reinterpret_cast<void *>(protocols.start), protocols.length);
 
     if (sections->next == registered)
       break;
@@ -63,8 +63,8 @@ void swift::initializeProtocolConformanceLookup() {
     const swift::MetadataSections::Range &conformances =
         sections->swift5_protocol_conformances;
     if (conformances.length)
-      addImageProtocolConformanceBlockCallback(reinterpret_cast<void *>(conformances.start),
-                                               conformances.length);
+      addImageProtocolConformanceBlockCallbackUnsafe(
+          reinterpret_cast<void *>(conformances.start), conformances.length);
 
     if (sections->next == registered)
       break;
@@ -78,8 +78,8 @@ void swift::initializeTypeMetadataRecordLookup() {
     const swift::MetadataSections::Range &type_metadata =
         sections->swift5_type_metadata;
     if (type_metadata.length)
-      addImageTypeMetadataRecordBlockCallback(reinterpret_cast<void *>(type_metadata.start),
-                                              type_metadata.length);
+      addImageTypeMetadataRecordBlockCallbackUnsafe(
+          reinterpret_cast<void *>(type_metadata.start), type_metadata.length);
 
     if (sections->next == registered)
       break;

--- a/stdlib/public/runtime/ImageInspectionELF.cpp
+++ b/stdlib/public/runtime/ImageInspectionELF.cpp
@@ -48,8 +48,8 @@ void swift::initializeProtocolLookup() {
     const swift::MetadataSections::Range &protocols =
         sections->swift5_protocols;
     if (protocols.length)
-      addImageProtocolsBlockCallback(reinterpret_cast<void *>(protocols.start),
-                                     protocols.length);
+      addImageProtocolsBlockCallbackUnsafe(
+          reinterpret_cast<void *>(protocols.start), protocols.length);
 
     if (sections->next == registered)
       break;
@@ -62,8 +62,8 @@ void swift::initializeProtocolConformanceLookup() {
     const swift::MetadataSections::Range &conformances =
         sections->swift5_protocol_conformances;
     if (conformances.length)
-      addImageProtocolConformanceBlockCallback(reinterpret_cast<void *>(conformances.start),
-                                               conformances.length);
+      addImageProtocolConformanceBlockCallbackUnsafe(
+          reinterpret_cast<void *>(conformances.start), conformances.length);
 
     if (sections->next == registered)
       break;
@@ -77,8 +77,8 @@ void swift::initializeTypeMetadataRecordLookup() {
     const swift::MetadataSections::Range &type_metadata =
         sections->swift5_type_metadata;
     if (type_metadata.length)
-      addImageTypeMetadataRecordBlockCallback(reinterpret_cast<void *>(type_metadata.start),
-                                              type_metadata.length);
+      addImageTypeMetadataRecordBlockCallbackUnsafe(
+          reinterpret_cast<void *>(type_metadata.start), type_metadata.length);
 
     if (sections->next == registered)
       break;

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -133,20 +133,19 @@ void addImageCallback2Sections(const mach_header *mh, intptr_t vmaddr_slide) {
 #endif
 
 void swift::initializeProtocolLookup() {
-  REGISTER_FUNC(
-    addImageCallback<TextSegment, ProtocolsSection,
-                     addImageProtocolsBlockCallback>);
+  REGISTER_FUNC(addImageCallback<TextSegment, ProtocolsSection,
+                                 addImageProtocolsBlockCallbackUnsafe>);
 }
 
 void swift::initializeProtocolConformanceLookup() {
   REGISTER_FUNC(
-    addImageCallback<TextSegment, ProtocolConformancesSection,
-                     addImageProtocolConformanceBlockCallback>);
+      addImageCallback<TextSegment, ProtocolConformancesSection,
+                       addImageProtocolConformanceBlockCallbackUnsafe>);
 }
 void swift::initializeTypeMetadataRecordLookup() {
   REGISTER_FUNC(
-    addImageCallback<TextSegment, TypeMetadataRecordSection,
-                     addImageTypeMetadataRecordBlockCallback>);
+      addImageCallback<TextSegment, TypeMetadataRecordSection,
+                       addImageTypeMetadataRecordBlockCallbackUnsafe>);
 }
 
 void swift::initializeDynamicReplacementLookup() {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -214,8 +214,8 @@ _registerTypeMetadataRecords(TypeMetadataPrivateState &T,
   T.SectionsToScan.push_back(TypeMetadataSection{begin, end});
 }
 
-void swift::addImageTypeMetadataRecordBlockCallback(const void *records,
-                                                    uintptr_t recordsSize) {
+void swift::addImageTypeMetadataRecordBlockCallbackUnsafe(
+    const void *records, uintptr_t recordsSize) {
   assert(recordsSize % sizeof(TypeMetadataRecord) == 0
          && "weird-sized type metadata section?!");
 
@@ -232,6 +232,12 @@ void swift::addImageTypeMetadataRecordBlockCallback(const void *records,
   // TypeMetadataRecords.
   _registerTypeMetadataRecords(TypeMetadataRecords.unsafeGetAlreadyInitialized(),
                                recordsBegin, recordsEnd);
+}
+
+void swift::addImageTypeMetadataRecordBlockCallback(const void *records,
+                                                    uintptr_t recordsSize) {
+  TypeMetadataRecords.get();
+  addImageTypeMetadataRecordBlockCallbackUnsafe(records, recordsSize);
 }
 
 void
@@ -694,8 +700,8 @@ _registerProtocols(ProtocolMetadataPrivateState &C,
   C.SectionsToScan.push_back(ProtocolSection{begin, end});
 }
 
-void swift::addImageProtocolsBlockCallback(const void *protocols,
-                                           uintptr_t protocolsSize) {
+void swift::addImageProtocolsBlockCallbackUnsafe(const void *protocols,
+                                                 uintptr_t protocolsSize) {
   assert(protocolsSize % sizeof(ProtocolRecord) == 0 &&
          "protocols section not a multiple of ProtocolRecord");
 
@@ -709,6 +715,12 @@ void swift::addImageProtocolsBlockCallback(const void *protocols,
   // Conformance cache should always be sufficiently initialized by this point.
   _registerProtocols(Protocols.unsafeGetAlreadyInitialized(),
                      recordsBegin, recordsEnd);
+}
+
+void swift::addImageProtocolsBlockCallback(const void *protocols,
+                                           uintptr_t protocolsSize) {
+  Protocols.get();
+  addImageProtocolsBlockCallbackUnsafe(protocols, protocolsSize);
 }
 
 void swift::swift_registerProtocols(const ProtocolRecord *begin,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -327,8 +327,8 @@ _registerProtocolConformances(ConformanceState &C,
   C.SectionsToScan.push_back(ConformanceSection{begin, end});
 }
 
-void swift::addImageProtocolConformanceBlockCallback(const void *conformances,
-                                                   uintptr_t conformancesSize) {
+void swift::addImageProtocolConformanceBlockCallbackUnsafe(
+    const void *conformances, uintptr_t conformancesSize) {
   assert(conformancesSize % sizeof(ProtocolConformanceRecord) == 0 &&
          "conformances section not a multiple of ProtocolConformanceRecord");
 
@@ -343,6 +343,13 @@ void swift::addImageProtocolConformanceBlockCallback(const void *conformances,
   // Conformance cache should always be sufficiently initialized by this point.
   _registerProtocolConformances(Conformances.unsafeGetAlreadyInitialized(),
                                 recordsBegin, recordsEnd);
+}
+
+void swift::addImageProtocolConformanceBlockCallback(
+    const void *conformances, uintptr_t conformancesSize) {
+  Conformances.get();
+  addImageProtocolConformanceBlockCallbackUnsafe(conformances,
+                                                 conformancesSize);
 }
 
 void

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -10,8 +10,6 @@
 // REQUIRES: CPU=x86_64
 // UNSUPPORTED: remote_run
 
-// XFAIL: linux
-
 func sayHello() {
   print("Hello")
 }


### PR DESCRIPTION
This has an upstream PR: https://github.com/apple/swift/pull/26275, but that hasn't merged yet. Trying to get it in tensorflow branch sooner to support leak-checking.