### PR TITLE
[5.1] [Serialization] Preserve whether a raw value is explicit

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 499; // remove 'requires stored property inits'
+const uint16_t SWIFTMODULE_VERSION_MINOR = 500; // distinguish implicit raw values for enum cases
 
 using DeclIDField = BCFixed<31>;
 
@@ -1190,6 +1190,7 @@ namespace decls_block {
     BCFixed<1>,  // implicit?
     BCFixed<1>,  // has payload?
     EnumElementRawValueKindField,  // raw value kind
+    BCFixed<1>,  // implicit raw value?
     BCFixed<1>,  // negative raw value?
     IdentifierIDField, // raw value
     BCFixed<1>,   // default argument resilience expansion

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3668,7 +3668,7 @@ public:
   Expected<Decl *> deserializeEnumElement(ArrayRef<uint64_t> scratch,
                                           StringRef blobData) {
     DeclContextID contextID;
-    bool isImplicit; bool hasPayload; bool isNegative;
+    bool isImplicit, hasPayload, isRawValueImplicit, isNegative;
     unsigned rawValueKindID;
     IdentifierID rawValueData;
     uint8_t rawResilienceExpansion;
@@ -3677,7 +3677,8 @@ public:
 
     decls_block::EnumElementLayout::readRecord(scratch, contextID,
                                                isImplicit, hasPayload,
-                                               rawValueKindID, isNegative,
+                                               rawValueKindID,
+                                               isRawValueImplicit, isNegative,
                                                rawValueData,
                                                rawResilienceExpansion,
                                                numArgNames,
@@ -3724,7 +3725,7 @@ public:
     case EnumElementRawValueKind::IntegerLiteral: {
       auto literalText = MF.getIdentifierText(rawValueData);
       auto literal = new (ctx) IntegerLiteralExpr(literalText, SourceLoc(),
-                                                  /*implicit*/ true);
+                                                  isRawValueImplicit);
       if (isNegative)
         literal->setNegative(SourceLoc());
       elem->setRawValueExpr(literal);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3618,15 +3618,16 @@ void Serializer::writeDecl(const Decl *D) {
 
     // We only serialize the raw values of @objc enums, because they're part
     // of the ABI. That isn't the case for Swift enums.
-    auto RawValueKind = EnumElementRawValueKind::None;
-    bool Negative = false;
+    auto rawValueKind = EnumElementRawValueKind::None;
+    bool isNegative = false, isRawValueImplicit = false;
     StringRef RawValueText;
     if (elem->getParentEnum()->isObjC()) {
       // Currently ObjC enums always have integer raw values.
-      RawValueKind = EnumElementRawValueKind::IntegerLiteral;
+      rawValueKind = EnumElementRawValueKind::IntegerLiteral;
       auto ILE = cast<IntegerLiteralExpr>(elem->getRawValueExpr());
       RawValueText = ILE->getDigitsText();
-      Negative = ILE->isNegative();
+      isNegative = ILE->isNegative();
+      isRawValueImplicit = ILE->isImplicit();
     }
 
     uint8_t rawResilienceExpansion =
@@ -3637,8 +3638,9 @@ void Serializer::writeDecl(const Decl *D) {
                                   contextID,
                                   elem->isImplicit(),
                                   elem->hasAssociatedValues(),
-                                  (unsigned)RawValueKind,
-                                  Negative,
+                                  (unsigned)rawValueKind,
+                                  isRawValueImplicit,
+                                  isNegative,
                                   addUniquedStringRef(RawValueText),
                                   rawResilienceExpansion,
                                   elem->getFullName().getArgumentNames().size()+1,

--- a/test/ParseableInterface/Inputs/enums-layout-helper.swift
+++ b/test/ParseableInterface/Inputs/enums-layout-helper.swift
@@ -6,6 +6,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FrozenEnum : Swift.Int
@@ -16,6 +18,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FutureproofObjCEnum : Swift.Int
@@ -26,6 +30,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: public enum FrozenObjCEnum : Swift.Int
@@ -36,6 +42,8 @@ public enum FutureproofEnum: Int {
   case b = 10
   // CHECK-NEXT: case c = 100{{$}}
   case c = 100
+  // CHECK-NEXT: case d{{$}}
+  case d
 }
 
 // CHECK-LABEL: indirect public enum FutureproofIndirectEnum

--- a/test/ParseableInterface/enums-layout.swift
+++ b/test/ParseableInterface/enums-layout.swift
@@ -1,7 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-interface-path %t/Lib.swiftinterface -typecheck -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
+// RUN: %target-build-swift -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
+
+// Try again using a single-frontend build.
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -force-single-frontend-invocation -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
+// RUN: %FileCheck %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
+// RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
+
 
 import Lib
 


### PR DESCRIPTION
- **Explanation**: `@objc` enums defined in Swift are supposed to be compatible with enums defined in C, which includes using the cases' raw values as the representation of the enum. That means that any module interface that defines an `@objc` enum must include raw values. Unfortunately, in a non-WMO build, all raw values were being treated as "implicit", i.e. "not user-written", and so were being excluded from the interface. This patch changes serialization logic to preserve whether a raw value was user-written.

- **Scope**: Affects printing of `@objc` enums in general, but is actually an ABI issue for module interfaces generated from non-WMO builds. However, most module interfaces will come from WMO builds because that's Xcode's default for Release configurations.

- **Issue**: rdar://problem/53469608

- **Risk**: Low. We already print this info in some configurations; now we can print it in more configurations.

- **Testing**: Improved the compiler regression tests

- **Reviewed by**: @harlanhaskins, @slavapestov