### PR TITLE
IDE+Evaluator: converge multiple type relation checks into a single sema request, NFC

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -51,8 +51,6 @@ namespace swift {
 
   bool canPossiblyEqual(Type T1, Type T2, DeclContext &DC);
 
-  bool canPossiblyConvertTo(Type T1, Type T2, DeclContext &DC);
-
   void collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                         llvm::SmallDenseMap<ValueDecl*, ValueDecl*> &DefaultMap);
 

--- a/include/swift/Sema/IDETypeCheckingRequestIDZone.def
+++ b/include/swift/Sema/IDETypeCheckingRequestIDZone.def
@@ -15,3 +15,4 @@
 //
 //===----------------------------------------------------------------------===//
 SWIFT_TYPEID(IsDeclApplicableRequest)
+SWIFT_TYPEID(TypeRelationCheckRequest)

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -327,7 +327,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
         case RequirementKind::Superclass:
           // FIXME: This could be more accurate; check
           // conformance instead of subtyping
-          if (!canPossiblyConvertTo(First, Second, *DC))
+          if (!isConvertibleTo(First, Second, /*openArchetypes=*/true, *DC))
             return true;
           else if (!isConvertibleTo(First, Second, /*openArchetypes=*/false,
                                     *DC))
@@ -750,4 +750,24 @@ bool swift::isMemberDeclApplied(const DeclContext *DC, Type BaseTy,
                                 const ValueDecl *VD) {
   return evaluateOrDefault(DC->getASTContext().evaluator,
     IsDeclApplicableRequest(DeclApplicabilityOwner(DC, BaseTy, VD)), false);
+}
+
+bool swift::canPossiblyEqual(Type T1, Type T2, DeclContext &DC) {
+   return evaluateOrDefault(DC.getASTContext().evaluator,
+     TypeRelationCheckRequest(TypeRelationCheckInput(&DC, T1, T2,
+       TypeRelation::PossiblyEqualTo, true)), false);
+}
+
+
+bool swift::isEqual(Type T1, Type T2, DeclContext &DC) {
+  return evaluateOrDefault(DC.getASTContext().evaluator,
+    TypeRelationCheckRequest(TypeRelationCheckInput(&DC, T1, T2,
+      TypeRelation::EqualTo, true)), false);
+}
+
+bool swift::isConvertibleTo(Type T1, Type T2, bool openArchetypes,
+                            DeclContext &DC) {
+  return evaluateOrDefault(DC.getASTContext().evaluator,
+    TypeRelationCheckRequest(TypeRelationCheckInput(&DC, T1, T2,
+      TypeRelation::ConvertTo, openArchetypes)), false);
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3769,29 +3769,12 @@ bool swift::areGenericRequirementsSatisfied(
   return CS.solveSingle().hasValue();
 }
 
-static bool canSatisfy(Type type1, Type type2, bool openArchetypes,
+bool swift::canSatisfy(Type type1, Type type2, bool openArchetypes,
                        ConstraintKind kind, DeclContext *dc) {
   std::unique_ptr<TypeChecker> CreatedTC;
   auto &TC = TypeChecker::createForContext(dc->getASTContext());
   return TC.typesSatisfyConstraint(type1, type2, openArchetypes, kind, dc,
                                    /*unwrappedIUO=*/nullptr);
-}
-
-bool swift::canPossiblyEqual(Type T1, Type T2, DeclContext &DC) {
-  return canSatisfy(T1, T2, true, ConstraintKind::Bind, &DC);
-}
-
-bool swift::canPossiblyConvertTo(Type T1, Type T2, DeclContext &DC) {
-  return canSatisfy(T1, T2, true, ConstraintKind::Conversion, &DC);
-}
-
-bool swift::isEqual(Type T1, Type T2, DeclContext &DC) {
-  return T1->isEqual(T2);
-}
-
-bool swift::isConvertibleTo(Type T1, Type T2, bool openArchetypes,
-                            DeclContext &DC) {
-  return canSatisfy(T1, T2, openArchetypes, ConstraintKind::Conversion, &DC);
 }
 
 void swift::eraseOpenedExistentials(ConstraintSystem &CS, Expr *&expr) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2172,6 +2172,8 @@ bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      const SubstitutionMap &Substitutions,
                                      bool isExtension);
 
+bool canSatisfy(Type type1, Type type2, bool openArchetypes,
+                constraints::ConstraintKind kind, DeclContext *dc);
 } // end namespace swift
 
 #endif

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -969,6 +969,7 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
     return true;
 
   ASTContext &Ctx = CI.getASTContext();
+  registerIDERequestFunctions(Ctx.evaluator);
   (void)createTypeChecker(Ctx);
 
   SourceTextInfo IFaceInfo;


### PR DESCRIPTION
From libIDE, the utility functions will invoke the request in the implementation.