### PR TITLE
[5.1] Check default init before synthesizing wrapper backing properties.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5809,7 +5809,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
     return nullptr;
 
   // If there is no '=' on the pattern, there was no initial value.
-  if (PBD->getPatternList()[0].getEqualLoc().isInvalid())
+  if (PBD->getPatternList()[0].getEqualLoc().isInvalid()
+      && !PBD->isDefaultInitializable())
     return nullptr;
 
   ASTContext &ctx = var->getASTContext();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1786,6 +1786,18 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   // Take the initializer from the original property.
   auto parentPBD = var->getParentPatternBinding();
   unsigned patternNumber = parentPBD->getPatternEntryIndexForVarDecl(var);
+  
+  // Force the default initializer to come into existence, if there is one,
+  // and the wrapper doesn't provide its own.
+  if (!parentPBD->isInitialized(patternNumber)
+      && parentPBD->isDefaultInitializable(patternNumber)
+      && !wrapperInfo.defaultInit) {
+    auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
+    auto ty = parentPBD->getPattern(patternNumber)->getType();
+    if (auto defaultInit = tc.buildDefaultInitializer(ty))
+      parentPBD->setInit(patternNumber, defaultInit);
+  }
+  
   if (parentPBD->isInitialized(patternNumber) &&
       !parentPBD->isInitializerChecked(patternNumber)) {
     auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -636,10 +636,10 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
 }
 
 /// Build a default initializer for the given type.
-static Expr *buildDefaultInitializer(TypeChecker &tc, Type type) {
+Expr *TypeChecker::buildDefaultInitializer(Type type) {
   // Default-initialize optional types and weak values to 'nil'.
   if (type->getReferenceStorageReferent()->getOptionalObjectType())
-    return new (tc.Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
+    return new (Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
 
   // Build tuple literals for tuple types.
   if (auto tupleType = type->getAs<TupleType>()) {
@@ -648,14 +648,14 @@ static Expr *buildDefaultInitializer(TypeChecker &tc, Type type) {
       if (elt.isVararg())
         return nullptr;
 
-      auto eltInit = buildDefaultInitializer(tc, elt.getType());
+      auto eltInit = buildDefaultInitializer(elt.getType());
       if (!eltInit)
         return nullptr;
 
       inits.push_back(eltInit);
     }
 
-    return TupleExpr::createImplicit(tc.Context, inits, { });
+    return TupleExpr::createImplicit(Context, inits, { });
   }
 
   // We don't default-initialize anything else.
@@ -2297,7 +2297,7 @@ public:
         }
 
         auto type = PBD->getPattern(i)->getType();
-        if (auto defaultInit = buildDefaultInitializer(TC, type)) {
+        if (auto defaultInit = TC.buildDefaultInitializer(type)) {
           // If we got a default initializer, install it and re-type-check it
           // to make sure it is properly coerced to the pattern type.
           PBD->setInit(i, defaultInit);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -672,10 +672,14 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
               = var->getAttachedPropertyWrapperTypeInfo(i).wrappedValueInit) {
         argName = init->getFullName().getArgumentNames()[0];
       }
+      
+      auto endLoc = initializer->getEndLoc();
+      if (endLoc.isInvalid() && startLoc.isValid())
+        endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
       initializer = CallExpr::create(
          ctx, typeExpr, startLoc, {initializer}, {argName},
-         {initializer->getStartLoc()}, initializer->getEndLoc(),
+         {initializer->getStartLoc()}, endLoc,
          nullptr, /*implicit=*/true);
       continue;
     }
@@ -700,10 +704,14 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
       elementNames.push_back(Identifier());
       elementLocs.push_back(SourceLoc());
     }
+    
+    auto endLoc = attr->getArg()->getEndLoc();
+    if (endLoc.isInvalid() && startLoc.isValid())
+      endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
     initializer = CallExpr::create(
         ctx, typeExpr, startLoc, elements, elementNames, elementLocs,
-        attr->getArg()->getEndLoc(), nullptr, /*implicit=*/true);
+        endLoc, nullptr, /*implicit=*/true);
   }
   
   return initializer;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1924,6 +1924,8 @@ public:
                                 FragileFunctionKind Kind,
                                 bool TreatUsableFromInlineAsPublic);
 
+  Expr *buildDefaultInitializer(Type type);
+  
 private:
   bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
                                       const DeclContext *DC,

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -360,7 +360,8 @@ func testOptIntStruct() {
   print("\n## OptIntStruct")
 
   let use = OptIntStruct()
-  // CHECK-NEXT:   .. init Optional(42)
+  // CHECK-NEXT:   .. init nil
+  // CHECK-NEXT:   .. set Optional(42)
 }
 
 testIntStruct()


### PR DESCRIPTION
Fixes a regression where the compiler would reject something like:

```
  @State var x: Int?
```

as not having an initializer, even though an Int? property ought to default to nil.
rdar://problem/53504653

Scope: Regression from previous betas

Issue: rdar://problem/53504653

Risk: Low

Reviewed by: @slavapestov 