### PR TITLE
Move tensorflow commit for the shape inference API

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -400,7 +400,7 @@
                 "icu": "release-61-1",
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-07-10-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-07-10-a",
-                "tensorflow": "ebc41609e27dcf0998d8970e77a2e1f53e13ac86",
+                "tensorflow": "b89808261726d50241dbedd16ac99367403650ef",
                 "tensorflow-swift-apis": "4656fe74edcdd73d819435235254d1ec9c1dd6ff",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-07-10-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-07-10-a"


### PR DESCRIPTION
Moves the tensorflow commit to https://github.com/tensorflow/tensorflow/commit/b89808261726d50241dbedd16ac99367403650ef, where a new experimental shape inference API is introduced.
