### PR TITLE
[CMake] Remove TARGET_LIBRARY option from add_swift_target_library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,8 +1065,7 @@ endif()
 #
 # We must include stdlib/ before tools/ because stdlib/CMakeLists.txt
 # declares the swift-stdlib-* set of targets. These targets will then
-# implicitly depend on any targets declared with IS_STDLIB or
-# TARGET_LIBRARY.
+# implicitly depend on any targets declared with IS_STDLIB.
 #
 # One such library that declares IS_STDLIB is SwiftSyntax, living in
 # tools/SwiftSyntax. If we include stdlib/ after tools/,

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1549,7 +1549,6 @@ endfunction()
 #     [INSTALL]
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
-#     [TARGET_LIBRARY]
 #     [INSTALL_WITH_SHARED]
 #     INSTALL_IN_COMPONENT comp
 #     DEPLOYMENT_VERSION_OSX version
@@ -1630,17 +1629,13 @@ endfunction()
 #
 # IS_STDLIB
 #   Treat the library as a part of the Swift standard library.
-#   IS_STDLIB implies TARGET_LIBRARY.
 #
 # IS_STDLIB_CORE
 #   Compile as the Swift standard library core.
 #
 # IS_SDK_OVERLAY
 #   Treat the library as a part of the Swift SDK overlay.
-#   IS_SDK_OVERLAY implies TARGET_LIBRARY and IS_STDLIB.
-#
-# TARGET_LIBRARY
-#   Build library for the target SDKs.
+#   IS_SDK_OVERLAY implies IS_STDLIB.
 #
 # INSTALL_IN_COMPONENT comp
 #   The Swift installation component that this library belongs to.
@@ -1674,7 +1669,6 @@ function(add_swift_target_library name)
         OBJECT_LIBRARY
         SHARED
         STATIC
-        TARGET_LIBRARY
         INSTALL_WITH_SHARED)
   set(SWIFTLIB_single_parameter_options
         DEPLOYMENT_VERSION_IOS
@@ -1727,7 +1721,6 @@ function(add_swift_target_library name)
   if(SWIFTLIB_IS_SDK_OVERLAY)
     set(SWIFTLIB_HAS_SWIFT_CONTENT TRUE)
     set(SWIFTLIB_IS_STDLIB TRUE)
-    set(SWIFTLIB_TARGET_LIBRARY TRUE)
 
     # Install to sdk-overlay by default, but don't hardcode it
     if(NOT SWIFTLIB_INSTALL_IN_COMPONENT)
@@ -1738,7 +1731,6 @@ function(add_swift_target_library name)
   # Standard library is always a target library.
   if(SWIFTLIB_IS_STDLIB)
     set(SWIFTLIB_HAS_SWIFT_CONTENT TRUE)
-    set(SWIFTLIB_TARGET_LIBRARY TRUE)
   endif()
 
   # If target SDKs are not specified, build for all known SDKs.
@@ -1777,9 +1769,6 @@ function(add_swift_target_library name)
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
-
-  precondition(SWIFTLIB_TARGET_LIBRARY
-    MESSAGE "TARGET_LIBRARY not inferred in add_swift_target_library?!")
 
   # In the standard library and overlays, warn about implicit overrides
   # as a reminder to consider when inherited protocols need different
@@ -1972,6 +1961,7 @@ function(add_swift_target_library name)
         ${SWIFTLIB_OBJECT_LIBRARY_keyword}
         ${SWIFTLIB_INSTALL_WITH_SHARED_keyword}
         ${SWIFTLIB_SOURCES}
+        TARGET_LIBRARY
         MODULE_TARGET ${MODULE_VARIANT_NAME}
         SDK ${sdk}
         ARCHITECTURE ${arch}
@@ -1991,7 +1981,6 @@ function(add_swift_target_library name)
         ${SWIFTLIB_IS_STDLIB_keyword}
         ${SWIFTLIB_IS_STDLIB_CORE_keyword}
         ${SWIFTLIB_IS_SDK_OVERLAY_keyword}
-        ${SWIFTLIB_TARGET_LIBRARY_keyword}
         ${SWIFTLIB_FORCE_BUILD_OPTIMIZED_keyword}
         ${SWIFTLIB_NOSWIFTRT_keyword}
         DARWIN_INSTALL_NAME_DIR "${SWIFTLIB_DARWIN_INSTALL_NAME_DIR}"

--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_swift_target_library(swiftOSLogPrototype
   IS_SDK_OVERLAY
   SHARED
-  TARGET_LIBRARY
 
   OSLog.swift
   OSLogMessage.swift

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -20,7 +20,7 @@ if (LLVM_ENABLE_ASSERTIONS)
 endif(LLVM_ENABLE_ASSERTIONS)
 
 if(SWIFT_BUILD_STDLIB)
-  add_swift_target_library(swiftReflection STATIC TARGET_LIBRARY
+  add_swift_target_library(swiftReflection STATIC
     ${swiftReflection_SOURCES}
     C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftCore_EXPORTS
     LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -2,7 +2,7 @@
 # always built as a shared library.
 if(SWIFT_BUILD_DYNAMIC_STDLIB)
   add_swift_target_library(swiftRemoteMirror
-                           SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
+                           SHARED DONT_EMBED_BITCODE NOSWIFTRT
                            SwiftRemoteMirror.cpp
                            LINK_LIBRARIES
                              swiftReflection

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -94,7 +94,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   string(TOLOWER "${sdk}" lowercase_sdk)
 
   # These two libraries are only used with the static swiftcore
-  add_swift_target_library(swiftImageInspectionShared TARGET_LIBRARY STATIC
+  add_swift_target_library(swiftImageInspectionShared STATIC
     ImageInspectionELF.cpp
     C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
     LINK_FLAGS ${swift_runtime_linker_flags}
@@ -151,7 +151,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   endforeach()
   add_dependencies(static_binary_magic ${swift_image_inspection_static_primary_arch})
 
-  add_swift_target_library(swiftImageInspectionSharedObject OBJECT_LIBRARY TARGET_LIBRARY
+  add_swift_target_library(swiftImageInspectionSharedObject OBJECT_LIBRARY
     ImageInspectionELF.cpp
     C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
     LINK_FLAGS ${swift_runtime_linker_flags}
@@ -159,7 +159,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
     INSTALL_IN_COMPONENT never_install)
 endif()
 
-add_swift_target_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY
+add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_sources}
   ${swift_runtime_objc_sources}
   ${swift_runtime_leaks_sources}

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_stubs_c_compile_flags -I${SWIFT_SOURCE_DIR}/include)
 
 add_swift_target_library(swiftStdlibStubs
-                  OBJECT_LIBRARY TARGET_LIBRARY
+                  OBJECT_LIBRARY
                     ${swift_stubs_sources}
                     ${swift_stubs_objc_sources}
                     ${swift_stubs_unicode_normalization_sources}

--- a/stdlib/toolchain/Compatibility50/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility50/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(library_name "swiftCompatibility50")
 
-add_swift_target_library("${library_name}" STATIC TARGET_LIBRARY
+add_swift_target_library("${library_name}" STATIC
   ProtocolConformance.cpp
   Overrides.cpp
 

--- a/stdlib/toolchain/CompatibilityDynamicReplacements/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilityDynamicReplacements/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(library_name "swiftCompatibilityDynamicReplacements")
 
-add_swift_target_library("${library_name}" STATIC TARGET_LIBRARY
+add_swift_target_library("${library_name}" STATIC
   DynamicReplaceable.cpp
 
   TARGET_SDKS ${SWIFT_APPLE_PLATFORMS}


### PR DESCRIPTION
If you're calling add_swift_target_library, you already know it's a
target library.

This is a follow up to what was discussed in #26312.

cc @compnerd @Rostepher @gottesmm 
