### PR TITLE
Import namespaces as EnumDecl.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1486,6 +1486,7 @@ ASTMangler::getSpecialManglingContext(const ValueDecl *decl,
         hasNameForLinkage = !clangDecl->getDeclName().isEmpty();
       if (hasNameForLinkage) {
         auto *clangDC = clangDecl->getDeclContext();
+        if (isa<clang::NamespaceDecl>(clangDC)) return None;
         assert(clangDC->getRedeclContext()->isTranslationUnit() &&
                "non-top-level Clang types not supported yet");
         (void)clangDC;
@@ -1828,6 +1829,10 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
     } else if (isa<clang::TypedefNameDecl>(namedDecl) ||
                isa<clang::ObjCCompatibleAliasDecl>(namedDecl)) {
       appendOperator("a");
+    } else if (isa<clang::NamespaceDecl>(namedDecl)) {
+      // Note: Namespaces are not really structs, but since namespaces are
+      // imported as enums, be consistent.
+      appendOperator("V");
     } else {
       llvm_unreachable("unknown imported Clang type");
     }

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -11,3 +11,7 @@ struct Basic {
 };
 
 Basic makeA();
+
+ns::T* makeT();
+void useT(ns::T* v);
+using namespacedT = ns::T;

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -emit-ir -o - -primary-file %s | %FileCheck %s
+
+import CXXInterop
+
+// CHECK-LABEL: define hidden swiftcc void @"$s6cxx_ir13indirectUsageyyF"()
+// CHECK: %0 = call %"class.ns::T"* @_Z5makeTv()
+// CHECK: call void @_Z4useTPN2ns1TE(%"class.ns::T"* %2)
+func indirectUsage() {
+  useT(makeT())
+}
+
+// CHECK: define hidden swiftcc void @"$s6cxx_ir24namespaceManglesIntoName3argySo2nsV1TV_tF"
+func namespaceManglesIntoName(arg: namespacedT) {
+}


### PR DESCRIPTION
The most basic support for using types that happen to reside in a namespace.

Known problems:
- Multiple clang modules will import the same namespace as potentially different decls. This will only be a problem when namespaces support looking up decls.
- Cannot directly access the imported namespace or any of the functions defined on it through the normal lookup process.