### PR TITLE
[build-script] Pass Swift_DIR to standalone LLDB build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2471,11 +2471,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLDB_SWIFTC:PATH="$(build_directory ${LOCAL_HOST} swift)/bin/swiftc"
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
-                    -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm
-                    -DLLDB_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
+                    -DClang_DIR:PATH=${llvm_build_dir}/lib/cmake/clang
+                    -DSwift_DIR:PATH=${swift_build_dir}/lib/cmake/swift
                     -DLLDB_PATH_TO_SWIFT_SOURCE:PATH="${SWIFT_SOURCE_DIR}"
-                    -DLLDB_PATH_TO_SWIFT_BUILD:PATH="${swift_build_dir}"
                     -DLLDB_IS_BUILDBOT_BUILD:BOOL="${LLDB_IS_BUILDBOT_BUILD}"
                     -DLLDB_BUILD_DATE:STRING="\"${LLDB_BUILD_DATE}\""
                     -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=1


### PR DESCRIPTION
Upstream we changed the LLDB standalone build to use LLVM_DIR and
Clang_DIR to find LLVM and Clang respectively. This commit does the same
for Swift, making everything use Swift_DIR instead of our hand-rolled
variables.