### PR TITLE
[AutoDiff] Fix a potential use-after-free and a potential memory leak.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6298,7 +6298,7 @@ ADContext::getOrCreateSubsetParametersThunkForLinearMap(
     auto result = allResults[mapOriginalParameterIndex(i)];
     if (desiredIndices.isWrtParameter(i)) {
       if (result->getType().isObject())
-         results.push_back(result);
+        results.push_back(result);
     }
     // Otherwise, cleanup the unused results.
     else {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4546,9 +4546,6 @@ public:
         auto adjBuf = getAdjointBuffer(origEntry, origParam);
         if (errorOccurred)
           return;
-        if (adjBuf->getType().isLoadable(getPullback()))
-          builder.createRetainValueAddr(pbLoc, adjBuf,
-                                        builder.getDefaultAtomicity());
         indParamAdjoints.push_back(adjBuf);
       }
     };

--- a/test/AutoDiff/witness_method_autodiff.sil
+++ b/test/AutoDiff/witness_method_autodiff.sil
@@ -38,11 +38,18 @@ bb0(%0 : $*T):
 }
 
 // CHECK-LABEL: sil @differentiatePartiallyAppliedWitnessMethod
+// CHECK: bb0([[ARG:%.*]] : $*T):
 // CHECK:  [[ORIG_REF:%.*]] = witness_method $T, #DiffReq.f!1
 // CHECK:  [[ORIG_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[ORIG_REF]]<T>(%0)
 // CHECK:  [[JVP_REF:%.*]] = witness_method $T, #DiffReq.f!1.jvp.1.SU
-// CHECK:  [[JVP_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[JVP_REF]]<T>(%0)
+// CHECK:  [[ARGCOPY1:%.*]] = alloc_stack $T
+// CHECK:  copy_addr [[ARG]] to [initialization] [[ARGCOPY1]] : $*T
+// CHECK:  [[JVP_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[JVP_REF]]<T>([[ARGCOPY1]])
+// CHECK:  dealloc_stack [[ARGCOPY1]]
 // CHECK:  [[VJP_REF:%.*]] = witness_method $T, #DiffReq.f!1.vjp.1.SU
-// CHECK:  [[VJP_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[VJP_REF]]<T>(%0)
-// CHECK:  = autodiff_function [wrt 0] [order 1] [[ORIG_REF_PARTIALLY_APPLIED]] : {{.*}} with {[[JVP_REF_PARTIALLY_APPLIED]] : {{.*}}, [[VJP_REF_PARTIALLY_APPLIED]] : {{.*}}}
+// CHECK:  [[ARGCOPY2:%.*]] = alloc_stack $T
+// CHECK:  copy_addr [[ARG]] to [initialization] [[ARGCOPY2]] : $*T
+// CHECK:  [[VJP_REF_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[VJP_REF]]<T>([[ARGCOPY2]])
+// CHECK:  dealloc_stack [[ARGCOPY2]]
+// CHECK:  autodiff_function [wrt 0] [order 1] [[ORIG_REF_PARTIALLY_APPLIED]] : {{.*}} with {[[JVP_REF_PARTIALLY_APPLIED]] : {{.*}}, [[VJP_REF_PARTIALLY_APPLIED]] : {{.*}}}
 // CHECK: } // end sil function 'differentiatePartiallyAppliedWitnessMethod'


### PR DESCRIPTION
In e8a53ae, fix a use-after-free when a function being differentiated captures an address-only value. The fix is to create a copied buffer for address-only `partial_apply` arguments during `reapplyFunctionConversions`.
In d14bb7f, fix a memory leak when a pullback returns a loadable value indirectly.
In c95b6bd, remove `emitCleanup` and use `SILBuilder::emitDestroyAddrAndFold` and `SILBuilder::emitReleaseValueAndFold` for code clarity.

Luckily, neither of the memory issues has occurred yet partly because we have not migrated to [ad-all-indirect](https://github.com/rxwei/swift/tree/ad-all-indirect) yet.