### PR TITLE
Check default init before synthesizing wrapper backing properties.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5821,7 +5821,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
     return nullptr;
 
   // If there is no '=' on the pattern, there was no initial value.
-  if (PBD->getPatternList()[0].getEqualLoc().isInvalid())
+  if (PBD->getPatternList()[0].getEqualLoc().isInvalid()
+      && !PBD->isDefaultInitializable())
     return nullptr;
 
   ASTContext &ctx = var->getASTContext();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -642,10 +642,10 @@ TypeChecker::handleSILGenericParams(GenericParamList *genericParams,
 }
 
 /// Build a default initializer for the given type.
-static Expr *buildDefaultInitializer(TypeChecker &tc, Type type) {
+Expr *TypeChecker::buildDefaultInitializer(Type type) {
   // Default-initialize optional types and weak values to 'nil'.
   if (type->getReferenceStorageReferent()->getOptionalObjectType())
-    return new (tc.Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
+    return new (Context) NilLiteralExpr(SourceLoc(), /*Implicit=*/true);
 
   // Build tuple literals for tuple types.
   if (auto tupleType = type->getAs<TupleType>()) {
@@ -654,14 +654,14 @@ static Expr *buildDefaultInitializer(TypeChecker &tc, Type type) {
       if (elt.isVararg())
         return nullptr;
 
-      auto eltInit = buildDefaultInitializer(tc, elt.getType());
+      auto eltInit = buildDefaultInitializer(elt.getType());
       if (!eltInit)
         return nullptr;
 
       inits.push_back(eltInit);
     }
 
-    return TupleExpr::createImplicit(tc.Context, inits, { });
+    return TupleExpr::createImplicit(Context, inits, { });
   }
 
   // We don't default-initialize anything else.
@@ -2629,7 +2629,7 @@ public:
           PBD->getPattern(i)->hasStorage() &&
           !PBD->getPattern(i)->getType()->hasError()) {
         auto type = PBD->getPattern(i)->getType();
-        if (auto defaultInit = buildDefaultInitializer(TC, type)) {
+        if (auto defaultInit = TC.buildDefaultInitializer(type)) {
           // If we got a default initializer, install it and re-type-check it
           // to make sure it is properly coerced to the pattern type.
           PBD->setInit(i, defaultInit);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -666,10 +666,14 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
               = var->getAttachedPropertyWrapperTypeInfo(i).wrappedValueInit) {
         argName = init->getFullName().getArgumentNames()[0];
       }
+      
+      auto endLoc = initializer->getEndLoc();
+      if (endLoc.isInvalid() && startLoc.isValid())
+        endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
       initializer = CallExpr::create(
          ctx, typeExpr, startLoc, {initializer}, {argName},
-         {initializer->getStartLoc()}, initializer->getEndLoc(),
+         {initializer->getStartLoc()}, endLoc,
          nullptr, /*implicit=*/true);
       continue;
     }
@@ -694,10 +698,14 @@ Expr *swift::buildPropertyWrapperInitialValueCall(
       elementNames.push_back(Identifier());
       elementLocs.push_back(SourceLoc());
     }
+    
+    auto endLoc = attr->getArg()->getEndLoc();
+    if (endLoc.isInvalid() && startLoc.isValid())
+      endLoc = wrapperAttrs[i]->getTypeLoc().getSourceRange().End;
 
     initializer = CallExpr::create(
         ctx, typeExpr, startLoc, elements, elementNames, elementLocs,
-        attr->getArg()->getEndLoc(), nullptr, /*implicit=*/true);
+        endLoc, nullptr, /*implicit=*/true);
   }
   
   return initializer;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1799,6 +1799,8 @@ public:
                                 FragileFunctionKind Kind,
                                 bool TreatUsableFromInlineAsPublic);
 
+  Expr *buildDefaultInitializer(Type type);
+  
 private:
   bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
                                       const DeclContext *DC,

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -360,7 +360,24 @@ func testOptIntStruct() {
   print("\n## OptIntStruct")
 
   let use = OptIntStruct()
-  // CHECK-NEXT:   .. init Optional(42)
+  // CHECK-NEXT:   .. init nil
+  // CHECK-NEXT:   .. set Optional(42)
+}
+
+// rdar://problem/53504653
+
+struct DefaultNilOptIntStruct {
+  @Wrapper var wrapped: Int?
+
+  init() {
+  }
+}
+func testDefaultNilOptIntStruct() {
+  // CHECK: ## DefaultNilOptIntStruct
+  print("\n## DefaultNilOptIntStruct")
+
+  let use = DefaultNilOptIntStruct()
+  // CHECK-NEXT:   .. init nil
 }
 
 testIntStruct()
@@ -369,3 +386,4 @@ testRefStruct()
 testGenericClass()
 testDefaultInit()
 testOptIntStruct()
+testDefaultNilOptIntStruct()


### PR DESCRIPTION
Fixes a regression where the compiler would reject something like:

  @State var x: Int?

as not having an initializer, even though an Int? property ought to default to nil.
rdar://problem/53504653