### PR TITLE
[Parse][IDE] Fix document structure request output for interpolated string literals

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -242,6 +242,7 @@ class ModelASTWalker : public ASTWalker {
   const LangOptions &LangOpts;
   const SourceManager &SM;
   unsigned BufferID;
+  ASTContext &Ctx;
   std::vector<StructureElement> SubStructureStack;
   SourceLoc LastLoc;
   static const std::regex &getURLRegex(StringRef Protocol);
@@ -262,6 +263,7 @@ public:
         LangOpts(File.getASTContext().LangOpts),
         SM(File.getASTContext().SourceMgr),
         BufferID(File.getBufferID().getValue()),
+        Ctx(File.getASTContext()),
         Walker(Walker) { }
 
   // FIXME: Remove this
@@ -521,13 +523,14 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     SN.BodyRange = innerCharSourceRangeFromSourceRange(SM, E->getSourceRange());
     pushStructureNode(SN, E);
   } else if (auto *Tup = dyn_cast<TupleExpr>(E)) {
+    auto *ParentE = Parent.getAsExpr();
     if (isCurrentCallArgExpr(Tup)) {
       for (unsigned I = 0; I < Tup->getNumElements(); ++ I) {
         SourceLoc NameLoc = Tup->getElementNameLoc(I);
         if (NameLoc.isValid())
           passTokenNodesUntil(NameLoc, PassNodesBehavior::ExcludeNodeAtLocation);
       }
-    } else {
+    } else if (!ParentE || !isa<InterpolatedStringLiteralExpr>(ParentE)) {
       SyntaxStructureNode SN;
       SN.Kind = SyntaxStructureKind::TupleExpression;
       SN.Range = charSourceRangeFromSourceRange(SM, Tup->getSourceRange());
@@ -562,6 +565,18 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
       subExpr->walk(*this);
     }
     return { false, walkToExprPost(SE) };
+  } else if (auto *ISL = dyn_cast<InterpolatedStringLiteralExpr>(E)) {
+    // Don't visit the child expressions directly. Instead visit the arguments
+    // of each appendStringLiteral/appendInterpolation CallExpr so we don't
+    // try to output structure nodes for those calls.
+    llvm::SaveAndRestore<ASTWalker::ParentTy> SetParent(Parent, E);
+    ISL->forEachSegment(Ctx, [&](bool isInterpolation, CallExpr *CE) {
+      if (isInterpolation) {
+        if (auto *Arg = CE->getArg())
+          Arg->walk(*this);
+      }
+    });
+    return { false, walkToExprPost(E) };
   }
 
   return { true, E };
@@ -1166,7 +1181,8 @@ bool ModelASTWalker::shouldPassBraceStructureNode(BraceStmt *S) {
   return (!dyn_cast_or_null<AbstractFunctionDecl>(Parent.getAsDecl()) &&
           !dyn_cast_or_null<TopLevelCodeDecl>(Parent.getAsDecl()) &&
           !dyn_cast_or_null<CaseStmt>(Parent.getAsStmt()) &&
-          S->getSourceRange().isValid());
+          S->getSourceRange().isValid() &&
+          !S->isImplicit());
 }
 
 ModelASTWalker::PassUntilResult

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1916,7 +1916,6 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // The start location of the entire string literal.
   SourceLoc Loc = Tok.getLoc();
-  SourceLoc EndLoc = Loc.getAdvancedLoc(Tok.getLength());
 
   StringRef OpenDelimiterStr, OpenQuoteStr, CloseQuoteStr, CloseDelimiterStr;
   unsigned DelimiterLength = Tok.getCustomDelimiterLen();
@@ -2036,8 +2035,8 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     Status = parseStringSegments(Segments, EntireTok, InterpolationVar, 
                                  Stmts, LiteralCapacity, InterpolationCount);
 
-    auto Body = BraceStmt::create(Context, Loc, Stmts, EndLoc,
-                                  /*implicit=*/false);
+    auto Body = BraceStmt::create(Context, Loc, Stmts, /*endLoc=*/Loc,
+                                  /*implicit=*/true);
     AppendingExpr = new (Context) TapExpr(nullptr, Body);
   }
 

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -306,5 +306,27 @@ enum FooEnum {
 }
 // CHECK: }</enum>
 
+firstCall("\(1)", 1)
+// CHECK: <call><name>firstCall</name>(<arg>"\(1)"</arg>, <arg>1</arg>)</call>
+
+secondCall("\(a: {struct Foo {let x = 10}; return Foo().x}())", 1)
+// CHECK: <call><name>secondCall</name>(<arg>"\(a: <call><name><closure><brace>{<struct>struct <name>Foo</name> {<property>let <name>x</name> = 10</property>}</struct>; return <call><name>Foo</name>()</call>.x}</brace></closure></name>()</call>)"</arg>, <arg>1</arg>)</call>
+
+thirdCall("""
+\("""
+  \({
+  return a()
+  }())
+  """)
+""")
+// CHECK: <call><name>thirdCall</name>("""
+// CHECK-NEXT: \("""
+// CHECK-NEXT:   \(<call><name><closure>{
+// CHECK-NEXT:   return <call><name>a</name>()</call>
+// CHECK-NEXT:   }</closure></name>()</call>)
+// CHECK-NEXT:   """)
+// CHECK-NEXT: """)</call>
+
 fourthCall(a: @escaping () -> Int)
 // CHECK: <call><name>fourthCall</name>(<arg><name>a</name>: @escaping () -> Int</arg>)</call>
+


### PR DESCRIPTION
`InterpolatedStringLiteralExpr` has a `TapExpr`, which contains a `BraceStmt` containing the `CallExpr`s to the builder appendInterpolation/appendStringLiteral methods used to construct the final string. This is all implementation detail, but the `BraceStmt` wasn't marked implicit and had a valid (but incorrect) source range, so the document structure request treated it as any other `BraceStmt` and made a structure node for it. The invalid range ended up tripping an assertion in the document structure walker in `swift-ide-test`.

This patch corrects the `BraceStmt`s produced when parsing interpolated strings to be marked implicit and have the correct range (endloc pointing at the start of the last token - the string itself), and also updates `ModelASTWalker` to skip over the internal details of interpolated strings when walking them (the call and args of the `CallExpr`s were also being emitted as structure nodes).

Resolves https://bugs.swift.org/browse/SR-11099
Resolves rdar://problem/55183943