### PR TITLE
Stop adding accessors to their parent DeclContext

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -221,6 +221,15 @@ public:
   /// bodies of closures that have not yet been type checked.
   virtual bool shouldWalkIntoNonSingleExpressionClosure() { return true; }
 
+  /// This method configures whether the walker should exhibit the legacy
+  /// behavior where accessors appear as peers of their storage, rather
+  /// than children nested inside of it.
+  ///
+  /// Please don't write new ASTWalker implementations that override this
+  /// method to return true; instead, refactor existing code as needed
+  /// until eventually we can remove this altogether.
+  virtual bool shouldWalkAccessorsTheOldWay() { return false; }
+
   /// walkToParameterListPre - This method is called when first visiting a
   /// ParameterList, before walking into its parameters.  If it returns false,
   /// the subtree is skipped.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7037,22 +7037,14 @@ class MissingMemberDecl : public Decl {
   }
 public:
   static MissingMemberDecl *
-  forMethod(ASTContext &ctx, DeclContext *DC, DeclName name,
-            bool hasNormalVTableEntry) {
-    assert(!name || name.isCompoundName());
-    return new (ctx) MissingMemberDecl(DC, name, hasNormalVTableEntry, 0);
-  }
+  create(ASTContext &ctx, DeclContext *DC, DeclName name,
+         unsigned numVTableEntries, bool hasStorage) {
+    assert(!numVTableEntries || isa<ProtocolDecl>(DC) || isa<ClassDecl>(DC) &&
+           "Only classes and protocols have vtable/witness table entries");
+    assert(!hasStorage || !isa<ProtocolDecl>(DC) &&
+           "Protocols cannot have missing stored properties");
 
-  static MissingMemberDecl *
-  forInitializer(ASTContext &ctx, DeclContext *DC, DeclName name,
-                 bool hasVTableEntry) {
-    unsigned entries = hasVTableEntry ? 1 : 0;
-    return new (ctx) MissingMemberDecl(DC, name, entries, 0);
-  }
-  
-  static MissingMemberDecl *
-  forStoredProperty(ASTContext &ctx, DeclContext *DC, DeclName name) {
-    return new (ctx) MissingMemberDecl(DC, name, 0, 1);
+    return new (ctx) MissingMemberDecl(DC, name, numVTableEntries, hasStorage);
   }
 
   DeclName getFullName() const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5853,10 +5853,6 @@ public:
     return cast_or_null<AbstractFunctionDecl>(ValueDecl::getOverriddenDecl());
   }
 
-  /// Returns true if a function declaration overrides a given
-  /// method from its direct or indirect superclass.
-  bool isOverridingDecl(const AbstractFunctionDecl *method) const;
-
   /// Whether the declaration is later overridden in the module
   ///
   /// Overrides are resolved during type checking; only query this field after

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -275,6 +275,8 @@ class NameMatcher: public ASTWalker {
   std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override;
   bool shouldWalkIntoGenericParams() override { return true; }
 
+  // FIXME: Remove this
+  bool shouldWalkAccessorsTheOldWay() override { return true; }
 
 public:
   explicit NameMatcher(SourceFile &SrcFile) : SrcFile(SrcFile) { }

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 504; // distinguish implicit raw values for enum cases
+const uint16_t SWIFTMODULE_VERSION_MINOR = 505; // track vtable entries for storage
 
 using DeclIDField = BCFixed<31>;
 
@@ -1064,6 +1064,7 @@ namespace decls_block {
     AccessLevelField, // setter access, if applicable
     DeclIDField, // opaque return type decl
     BCFixed<2>,  // # of property wrapper backing properties
+    BCVBR<4>, // total number of vtable entries introduced by all accessors
     BCArray<TypeIDField> // accessors, backing properties, and dependencies
   >;
 
@@ -1224,6 +1225,7 @@ namespace decls_block {
     StaticSpellingKindField,    // is subscript static?
     BCVBR<5>,    // number of parameter name components
     DeclIDField, // opaque return type decl
+    BCFixed<8>, // total number of vtable entries introduced by all accessors
     BCArray<IdentifierIDField> // name components,
                                // followed by DeclID accessors,
                                // followed by TypeID dependencies

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3179,6 +3179,12 @@ void PrintAST::visitModuleDecl(ModuleDecl *decl) { }
 void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
   Printer << "/* placeholder for ";
   recordDeclLoc(decl, [&]{ Printer << decl->getFullName(); });
+  unsigned numVTableEntries = decl->getNumberOfVTableEntries();
+  if (numVTableEntries > 0)
+    Printer << " (vtable entries: " << numVTableEntries << ")";
+  unsigned numFieldOffsetVectorEntries = decl->getNumberOfFieldOffsetVectorEntries();
+  if (numFieldOffsetVectorEntries > 0)
+    Printer << " (field offsets: " << numFieldOffsetVectorEntries << ")";
   Printer << " */";
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -740,6 +740,7 @@ void IterableDeclContext::addMember(Decl *member, Decl *Hint) {
 }
 
 void IterableDeclContext::addMemberSilently(Decl *member, Decl *hint) const {
+  assert(!isa<AccessorDecl>(member) && "Accessors should not be added here");
   assert(!member->NextDecl && "Already added to a container");
 
   // If there is a hint decl that specifies where to add this, just

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1672,7 +1672,21 @@ bool FileUnit::walk(ASTWalker &walker) {
     
     if (D->walk(walker))
       return true;
+
+    if (walker.shouldWalkAccessorsTheOldWay()) {
+      // Pretend that accessors share a parent with the storage.
+      //
+      // FIXME: Update existing ASTWalkers to deal with accessors appearing as
+      // children of the storage instead.
+      if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+        for (auto AD : ASD->getAllAccessors()) {
+          if (AD->walk(walker))
+            return true;
+        }
+      }
+    }
   }
+
   return false;
 }
 
@@ -1686,6 +1700,19 @@ bool SourceFile::walk(ASTWalker &walker) {
 
     if (D->walk(walker))
       return true;
+
+    if (walker.shouldWalkAccessorsTheOldWay()) {
+      // Pretend that accessors share a parent with the storage.
+      //
+      // FIXME: Update existing ASTWalkers to deal with accessors appearing as
+      // children of the storage instead.
+      if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+        for (auto AD : ASD->getAllAccessors()) {
+          if (AD->walk(walker))
+            return true;
+        }
+      }
+    }
   }
   return false;
 }

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -141,6 +141,12 @@ BraceStmt::BraceStmt(SourceLoc lbloc, ArrayRef<ASTNode> elts,
   Bits.BraceStmt.NumElements = elts.size();
   std::uninitialized_copy(elts.begin(), elts.end(),
                           getTrailingObjects<ASTNode>());
+
+#ifndef NDEBUG
+  for (auto elt : elts)
+    if (auto *decl = elt.dyn_cast<Decl *>())
+      assert(!isa<AccessorDecl>(decl) && "accessors should not be added here");
+#endif
 }
 
 BraceStmt *BraceStmt::create(ASTContext &ctx, SourceLoc lbloc,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -593,9 +593,9 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
 //   }
 // Unlike a standard init(rawValue:) enum initializer, this does a reinterpret
 // cast in order to preserve unknown or future cases from C.
-static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
-                                            EnumDecl *enumDecl,
-                                            VarDecl *rawValueDecl) {
+static void makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
+                                   EnumDecl *enumDecl,
+                                   VarDecl *rawValueDecl) {
   ASTContext &C = Impl.SwiftContext;
 
   auto rawTy = enumDecl->getRawType();
@@ -623,7 +623,6 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
   makeComputed(rawValueDecl, getterDecl, nullptr);
-  return getterDecl;
 }
 
 /// Synthesizer for the rawValue getter for an imported struct.
@@ -1551,7 +1550,6 @@ static void makeStructRawValued(
   structDecl->addMember(initRawValue);
   structDecl->addMember(patternBinding);
   structDecl->addMember(var);
-  structDecl->addMember(varGetter);
 
   addSynthesizedTypealias(structDecl, ctx.Id_RawValue, underlyingType);
   Impl.RawTypes[structDecl] = underlyingType;
@@ -1702,7 +1700,6 @@ static void makeStructRawValuedWithBridge(
   structDecl->addMember(storedVar);
   structDecl->addMember(computedPatternBinding);
   structDecl->addMember(computedVar);
-  structDecl->addMember(computedVarGetter);
 
   addSynthesizedTypealias(structDecl, ctx.Id_RawValue, bridgedType);
   Impl.RawTypes[structDecl] = bridgedType;
@@ -1983,7 +1980,6 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   getterDecl->setIsDynamic(false);
 
   swiftDecl->addMember(errorDomainPropertyDecl);
-  swiftDecl->addMember(getterDecl);
   makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
 
   getterDecl->setImplicit();
@@ -2915,10 +2911,9 @@ namespace {
             C, StaticSpellingKind::None, varPattern, /*InitExpr*/ nullptr,
             enumDecl);
 
-        auto rawValueGetter = makeEnumRawValueGetter(Impl, enumDecl, rawValue);
+        makeEnumRawValueGetter(Impl, enumDecl, rawValue);
 
         enumDecl->addMember(rawValueConstructor);
-        enumDecl->addMember(rawValueGetter);
         enumDecl->addMember(rawValue);
         enumDecl->addMember(rawValueBinding);
 
@@ -3117,8 +3112,6 @@ namespace {
           auto addDecl = [&](NominalTypeDecl *nominal, Decl *decl) {
             if (!decl) return;
             nominal->addMember(decl);
-            if (auto *var = dyn_cast<VarDecl>(decl))
-              nominal->addMember(var->getGetter());
           };
 
           addDecl(result, enumeratorDecl);
@@ -8512,11 +8505,13 @@ bool ClangImporter::Implementation::addMemberAndAlternatesToExtension(
   member = findMemberThatWillLandInAnExtensionContext(member);
   if (!member || member->getDeclContext() != ext)
     return true;
-  ext->addMember(member);
+  if (!isa<AccessorDecl>(member))
+    ext->addMember(member);
 
   for (auto alternate : getAlternateDecls(member)) {
     if (alternate->getDeclContext() == ext)
-      ext->addMember(alternate);
+      if (!isa<AccessorDecl>(alternate))
+        ext->addMember(alternate);
   }
   return true;
 }

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -45,6 +45,10 @@ public:
   bool isDone() const { return Cancelled; }
 
 private:
+
+  // FIXME: Remove this
+  bool shouldWalkAccessorsTheOldWay() override { return true; }
+
   bool shouldWalkIntoGenericParams() override {
     return SEWalker.shouldWalkIntoGenericParams();
   }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -264,6 +264,9 @@ public:
         BufferID(File.getBufferID().getValue()),
         Walker(Walker) { }
 
+  // FIXME: Remove this
+  bool shouldWalkAccessorsTheOldWay() override { return true; }
+
   void visitSourceFile(SourceFile &SrcFile, ArrayRef<SyntaxNode> Tokens);
 
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1019,7 +1019,9 @@ public:
     // Collect global variables for static properties.
     // FIXME: We can't statically emit a global variable for generic properties.
     if (vd->isStatic() && vd->hasStorage()) {
-      return emitTypeMemberGlobalVariable(SGM, vd);
+      emitTypeMemberGlobalVariable(SGM, vd);
+      visitAccessors(vd);
+      return;
     }
 
     visitAbstractStorageDecl(vd);
@@ -1027,7 +1029,6 @@ public:
 
   void visitSubscriptDecl(SubscriptDecl *sd) {
     SGM.emitDefaultArgGenerators(sd, sd->getIndices());
-
     visitAbstractStorageDecl(sd);
   }
 
@@ -1035,8 +1036,14 @@ public:
     // FIXME: Default implementations in protocols.
     if (asd->isObjC() && !isa<ProtocolDecl>(asd->getDeclContext()))
       SGM.emitObjCPropertyMethodThunks(asd);
-    
+
     SGM.tryEmitPropertyDescriptor(asd);
+    visitAccessors(asd);
+  }
+
+  void visitAccessors(AbstractStorageDecl *asd) {
+    for (auto *accessor : asd->getAllAccessors())
+      visitFuncDecl(accessor);
   }
 };
 
@@ -1137,8 +1144,11 @@ public:
           vd->hasDidSetOrWillSetDynamicReplacement();
       assert((vd->isStatic() || hasDidSetOrWillSetDynamicReplacement) &&
              "stored property in extension?!");
-      if (!hasDidSetOrWillSetDynamicReplacement)
-        return emitTypeMemberGlobalVariable(SGM, vd);
+      if (!hasDidSetOrWillSetDynamicReplacement) {
+        emitTypeMemberGlobalVariable(SGM, vd);
+        visitAccessors(vd);
+        return;
+      }
     }
     visitAbstractStorageDecl(vd);
   }
@@ -1153,11 +1163,17 @@ public:
     llvm_unreachable("enum elements aren't allowed in extensions");
   }
 
-  void visitAbstractStorageDecl(AbstractStorageDecl *vd) {
-    if (vd->isObjC())
-      SGM.emitObjCPropertyMethodThunks(vd);
+  void visitAbstractStorageDecl(AbstractStorageDecl *asd) {
+    if (asd->isObjC())
+      SGM.emitObjCPropertyMethodThunks(asd);
     
-    SGM.tryEmitPropertyDescriptor(vd);
+    SGM.tryEmitPropertyDescriptor(asd);
+    visitAccessors(asd);
+  }
+
+  void visitAccessors(AbstractStorageDecl *asd) {
+    for (auto *accessor : asd->getAllAccessors())
+      visitFuncDecl(accessor);
   }
 };
 

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -275,7 +275,9 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
                                ClassDecl *CD,
                                ClassHierarchyAnalysis::ClassList &Subs) {
   ClassMethodInst *CMI = cast<ClassMethodInst>(AI.getCallee());
-  auto *Method = CMI->getMember().getFuncDecl();
+  auto *Method = CMI->getMember().getAbstractFunctionDecl();
+  assert(Method && "not a function");
+
   const DeclContext *DC = AI.getModule().getAssociatedContext();
 
   if (CD->isFinal())

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -110,7 +110,7 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 
   getterDecl->setBodySynthesizer(&deriveCaseIterable_enum_getter);
 
-  addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
+  addMembersToConformanceContext({propDecl, pbDecl});
 
   return propDecl;
 }

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -182,7 +182,6 @@ static ValueDecl *deriveProperty(DerivedConformance &derived, Type type,
   synthesizer(getterDecl);
 
   auto *dc = cast<IterableDeclContext>(derived.ConformanceDecl);
-  dc->addMember(getterDecl);
   dc->addMember(propDecl);
   dc->addMember(pbDecl);
   return propDecl;

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1224,7 +1224,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   C.addSynthesizedDecl(hashValueDecl);
   C.addSynthesizedDecl(getterDecl);
 
-  derived.addMembersToConformanceContext({getterDecl, hashValueDecl, patDecl});
+  derived.addMembersToConformanceContext({hashValueDecl, patDecl});
   return hashValueDecl;
 }
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -106,7 +106,7 @@ deriveBridgedNSError_enum_nsErrorDomain(
       propDecl, stringTy);
   getterDecl->setBodySynthesizer(synthesizer);
 
-  derived.addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
+  derived.addMembersToConformanceContext({propDecl, pbDecl});
 
   return propDecl;
 }

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -181,7 +181,7 @@ static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
   // the raw value without function call overhead.
   maybeMarkAsInlinable(derived, getterDecl);
 
-  derived.addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
+  derived.addMembersToConformanceContext({propDecl, pbDecl});
 
   return propDecl;
 }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -884,18 +884,21 @@ public:
 void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
   class ExpressionFinder : public ASTWalker {
   private:
+    ASTContext &ctx;
     std::mt19937_64 RNG;
     bool HighPerformance;
     unsigned TmpNameIndex = 0;
 
   public:
-    ExpressionFinder(bool HP) : HighPerformance(HP) {}
+    ExpressionFinder(ASTContext &ctx, bool HP) : ctx(ctx), HighPerformance(HP) {}
+
+    // FIXME: Remove this
+    bool shouldWalkAccessorsTheOldWay() override { return true; }
 
     bool walkToDeclPre(Decl *D) override {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (BraceStmt *Body = FD->getBody()) {
-            ASTContext &ctx = FD->getASTContext();
             Instrumenter I(ctx, FD, RNG, HighPerformance, TmpNameIndex);
             BraceStmt *NewBody = I.transformBraceStmt(Body);
             if (NewBody != Body) {
@@ -908,7 +911,6 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
       } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
-            ASTContext &ctx = static_cast<Decl *>(TLCD)->getASTContext();
             Instrumenter I(ctx, TLCD, RNG, HighPerformance, TmpNameIndex);
             BraceStmt *NewBody = I.transformBraceStmt(Body, true);
             if (NewBody != Body) {
@@ -924,8 +926,6 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
     }
   };
 
-  ExpressionFinder EF(HighPerformance);
-  for (Decl *D : SF.Decls) {
-    D->walk(EF);
-  }
+  ExpressionFinder EF(SF.getASTContext(), HighPerformance);
+  SF.walk(EF);
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2314,6 +2314,11 @@ public:
         = TC.getFragileFunctionKind(DC);
   }
 
+  // FIXME: Remove this
+  bool shouldWalkAccessorsTheOldWay() override {
+    return true;
+  }
+
   bool shouldWalkIntoNonSingleExpressionClosure() override {
     return false;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2660,6 +2660,10 @@ public:
 
     if (VD->getAttrs().hasAttribute<DynamicReplacementAttr>())
       TC.checkDynamicReplacementAttribute(VD);
+
+    // Now check all the accessors.
+    for (auto *accessor : VD->getAllAccessors())
+      visit(accessor);
   }
 
   void visitBoundVars(Pattern *P) {
@@ -2877,6 +2881,10 @@ public:
         SD->diagnose(diag::dynamic_self_in_mutable_subscript);
       }
     }
+
+    // Now check all the accessors.
+    for (auto *accessor : SD->getAllAccessors())
+      visit(accessor);
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2640,10 +2640,11 @@ public:
         getActualCtorInitializerKind(storedInitKind);
 
     DeclDeserializationError::Flags errorFlags;
+    unsigned numVTableEntries = 0;
     if (initKind == CtorInitializerKind::Designated)
       errorFlags |= DeclDeserializationError::DesignatedInitializer;
     if (needsNewVTableEntry) {
-      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+      numVTableEntries = 1;
       DeclAttributes attrs;
       attrs.setRawAttributeChain(DAttrs);
     }
@@ -2651,14 +2652,16 @@ public:
     auto overridden = MF.getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name, errorFlags);
+      return llvm::make_error<OverrideError>(
+          name, errorFlags, numVTableEntries);
     }
 
     for (auto dependencyID : argNameAndDependencyIDs.slice(numArgNames)) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
         return llvm::make_error<TypeError>(
-            name, takeErrorInfo(dependency.takeError()), errorFlags);
+            name, takeErrorInfo(dependency.takeError()),
+            errorFlags, numVTableEntries);
       }
     }
 
@@ -2742,6 +2745,7 @@ public:
     TypeID interfaceTypeID;
     ModuleFile::AccessorRecord accessors;
     DeclID overriddenID, opaqueReturnTypeID;
+    unsigned numVTableEntries;
     ArrayRef<uint64_t> arrayFieldIDs;
 
     decls_block::VarLayout::readRecord(scratch, nameID, contextID,
@@ -2758,14 +2762,32 @@ public:
                                        rawAccessLevel, rawSetterAccessLevel,
                                        opaqueReturnTypeID,
                                        numBackingProperties,
+                                       numVTableEntries,
                                        arrayFieldIDs);
 
     Identifier name = MF.getIdentifier(nameID);
 
+    auto getErrorFlags = [&]() {
+      // Stored properties in classes still impact class object layout because
+      // their offset is computed and stored in the field offset vector.
+      DeclDeserializationError::Flags errorFlags;
+
+      if (!isStatic) {
+        auto actualReadImpl = getActualReadImplKind(readImpl);
+        if (actualReadImpl && *actualReadImpl == ReadImplKind::Stored) {
+          errorFlags |= DeclDeserializationError::Flag::NeedsFieldOffsetVectorEntry;
+        }
+      }
+
+      return errorFlags;
+    };
+
     Expected<Decl *> overridden = MF.getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name);
+
+      return llvm::make_error<OverrideError>(
+          name, getErrorFlags(), numVTableEntries);
     }
 
     // Extract the accessor IDs.
@@ -2781,19 +2803,9 @@ public:
     for (TypeID dependencyID : arrayFieldIDs) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
-        // Stored properties in classes still impact class object layout because
-        // their offset is computed and stored in the field offset vector.
-        DeclDeserializationError::Flags flags;
-
-        if (!isStatic) {
-          auto actualReadImpl = getActualReadImplKind(readImpl);
-          if (actualReadImpl && *actualReadImpl == ReadImplKind::Stored) {
-            flags |= DeclDeserializationError::Flag::NeedsFieldOffsetVectorEntry;
-          }
-        }
-
         return llvm::make_error<TypeError>(
-            name, takeErrorInfo(dependency.takeError()), flags);
+            name, takeErrorInfo(dependency.takeError()),
+            getErrorFlags(), numVTableEntries);
       }
     }
 
@@ -2991,22 +3003,21 @@ public:
                                           nameAndDependencyIDs);
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
-                                          isStatic, rawStaticSpelling, isObjC,
-                                          rawMutModifier,
-                                          hasForcedStaticDispatch, throws,
-                                          genericEnvID,
-                                          resultInterfaceTypeID,
-                                          overriddenID,
-                                          accessorStorageDeclID,
-                                          rawAccessorKind,
-                                          rawAccessLevel,
-                                          needsNewVTableEntry,
-                                          nameAndDependencyIDs);
+                                              isStatic, rawStaticSpelling, isObjC,
+                                              rawMutModifier,
+                                              hasForcedStaticDispatch, throws,
+                                              genericEnvID,
+                                              resultInterfaceTypeID,
+                                              overriddenID,
+                                              accessorStorageDeclID,
+                                              rawAccessorKind,
+                                              rawAccessLevel,
+                                              needsNewVTableEntry,
+                                              nameAndDependencyIDs);
     }
 
     DeclDeserializationError::Flags errorFlags;
-    if (needsNewVTableEntry)
-      errorFlags |= DeclDeserializationError::NeedsVTableEntry;
+    unsigned numVTableEntries = needsNewVTableEntry ? 1 : 0;
 
     // Parse the accessor-specific fields.
     AbstractStorageDecl *storage = nullptr;
@@ -3018,7 +3029,8 @@ public:
               dyn_cast_or_null<AbstractStorageDecl>(storageResult.get()))) {
         // FIXME: "TypeError" isn't exactly correct for this.
         return llvm::make_error<TypeError>(
-            DeclName(), takeErrorInfo(storageResult.takeError()), errorFlags);
+            DeclName(), takeErrorInfo(storageResult.takeError()),
+            errorFlags, numVTableEntries);
       }
 
       if (auto accessorKindResult = getActualAccessorKind(rawAccessorKind)) {
@@ -3075,7 +3087,8 @@ public:
         });
       }
       if (!canIgnoreMissingOverriddenDecl)
-        return llvm::make_error<OverrideError>(name, errorFlags);
+        return llvm::make_error<OverrideError>(
+            name, errorFlags, numVTableEntries);
 
       overridden = nullptr;
     }
@@ -3084,7 +3097,8 @@ public:
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
         return llvm::make_error<TypeError>(
-            name, takeErrorInfo(dependency.takeError()), errorFlags);
+            name, takeErrorInfo(dependency.takeError()),
+            errorFlags, numVTableEntries);
       }
     }
 
@@ -3689,6 +3703,14 @@ public:
     for (TypeID dependencyID : argNameAndDependencyIDs.slice(numArgNames+1)) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
+        // Enum elements never introduce missing members in their parent enum.
+        //
+        // A frozen enum cannot be laid out if its missing cases anyway,
+        // so the dependency mechanism ensures the entire enum fails to
+        // deserialize.
+        //
+        // For a resilient enum, we don't care and just drop the element
+        // and continue.
         return llvm::make_error<TypeError>(
           name, takeErrorInfo(dependency.takeError()));
       }
@@ -3747,6 +3769,7 @@ public:
     uint8_t rawAccessLevel, rawSetterAccessLevel, rawStaticSpelling;
     uint8_t opaqueReadOwnership, readImpl, writeImpl, readWriteImpl;
     unsigned numArgNames, numAccessors;
+    unsigned numVTableEntries;
     ArrayRef<uint64_t> argNameAndDependencyIDs;
 
     decls_block::SubscriptLayout::readRecord(scratch, contextID,
@@ -3761,6 +3784,7 @@ public:
                                              rawSetterAccessLevel,
                                              rawStaticSpelling, numArgNames,
                                              opaqueReturnTypeID,
+                                             numVTableEntries,
                                              argNameAndDependencyIDs);
     // Resolve the name ids.
     SmallVector<Identifier, 2> argNames;
@@ -3778,14 +3802,19 @@ public:
     Expected<Decl *> overridden = MF.getDeclChecked(overriddenID);
     if (!overridden) {
       llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(name);
+
+      DeclDeserializationError::Flags errorFlags;
+      return llvm::make_error<OverrideError>(
+          name, errorFlags, numVTableEntries);
     }
 
     for (TypeID dependencyID : argNameAndDependencyIDs) {
       auto dependency = MF.getTypeChecked(dependencyID);
       if (!dependency) {
+        DeclDeserializationError::Flags errorFlags;
         return llvm::make_error<TypeError>(
-            name, takeErrorInfo(dependency.takeError()));
+            name, takeErrorInfo(dependency.takeError()),
+            errorFlags, numVTableEntries);
       }
     }
 
@@ -5414,21 +5443,13 @@ Decl *handleErrorAndSupplyMissingClassMember(ASTContext &context,
   auto handleMissingClassMember = [&](const DeclDeserializationError &error) {
     if (error.isDesignatedInitializer())
       containingClass->setHasMissingDesignatedInitializers();
-    if (error.needsVTableEntry())
+    if (error.getNumberOfVTableEntries() > 0)
       containingClass->setHasMissingVTableEntries();
 
-    if (error.getName().getBaseName() == DeclBaseName::createConstructor()) {
-      suppliedMissingMember = MissingMemberDecl::forInitializer(
-          context, containingClass, error.getName(), error.needsVTableEntry());
-    } else if (error.needsVTableEntry()) {
-      suppliedMissingMember = MissingMemberDecl::forMethod(
-          context, containingClass, error.getName(), error.needsVTableEntry());
-    } else if (error.needsFieldOffsetVectorEntry()) {
-      suppliedMissingMember = MissingMemberDecl::forStoredProperty(
-          context, containingClass, error.getName());
-    }
-    // FIXME: Handle other kinds of missing members: properties,
-    // subscripts, and methods that don't need vtable entries.
+    suppliedMissingMember = MissingMemberDecl::create(
+        context, containingClass, error.getName(),
+        error.getNumberOfVTableEntries(),
+        error.needsFieldOffsetVectorEntry());
   };
   llvm::handleAllErrors(std::move(error), handleMissingClassMember);
   return suppliedMissingMember;
@@ -5441,22 +5462,14 @@ Decl *handleErrorAndSupplyMissingProtoMember(ASTContext &context,
 
   auto handleMissingProtocolMember =
       [&](const DeclDeserializationError &error) {
-        if (error.needsVTableEntry())
+        assert(error.needsFieldOffsetVectorEntry() == 0);
+
+        if (error.getNumberOfVTableEntries() > 0)
           containingProto->setHasMissingRequirements(true);
 
-        if (error.getName().getBaseName() == DeclBaseName::createConstructor()) {
-          suppliedMissingMember = MissingMemberDecl::forInitializer(
-              context, containingProto, error.getName(),
-              error.needsVTableEntry());
-              return;
-        }
-        if (error.needsVTableEntry()) {
-          suppliedMissingMember = MissingMemberDecl::forMethod(
-              context, containingProto, error.getName(),
-              error.needsVTableEntry());
-        }
-        // FIXME: Handle other kinds of missing members: properties,
-        // subscripts, and methods that don't need vtable entries.
+        suppliedMissingMember = MissingMemberDecl::create(
+            context, containingProto, error.getName(),
+            error.getNumberOfVTableEntries(), 0);
       };
   llvm::handleAllErrors(std::move(error), handleMissingProtocolMember);
   return suppliedMissingMember;

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -236,14 +236,14 @@ class DeclDeserializationError : public llvm::ErrorInfoBase {
 public:
   enum Flag : unsigned {
     DesignatedInitializer = 1 << 0,
-    NeedsVTableEntry = 1 << 1,
-    NeedsFieldOffsetVectorEntry = 1 << 2,
+    NeedsFieldOffsetVectorEntry = 1 << 1,
   };
   using Flags = OptionSet<Flag>;
 
 protected:
   DeclName name;
   Flags flags;
+  uint8_t numVTableEntries = 0;
 
 public:
   DeclName getName() const {
@@ -253,8 +253,8 @@ public:
   bool isDesignatedInitializer() const {
     return flags.contains(Flag::DesignatedInitializer);
   }
-  bool needsVTableEntry() const {
-    return flags.contains(Flag::NeedsVTableEntry);
+  unsigned getNumberOfVTableEntries() const {
+    return numVTableEntries;
   }
   bool needsFieldOffsetVectorEntry() const {
     return flags.contains(Flag::NeedsFieldOffsetVectorEntry);
@@ -319,9 +319,11 @@ private:
   void anchor() override;
 
 public:
-  explicit OverrideError(DeclName name, Flags flags = {}) {
+  explicit OverrideError(DeclName name,
+                         Flags flags={}, unsigned numVTableEntries=0) {
     this->name = name;
     this->flags = flags;
+    this->numVTableEntries = numVTableEntries;
   }
 
   void log(raw_ostream &OS) const override {
@@ -341,10 +343,11 @@ class TypeError : public llvm::ErrorInfo<TypeError, DeclDeserializationError> {
   std::unique_ptr<ErrorInfoBase> underlyingReason;
 public:
   explicit TypeError(DeclName name, std::unique_ptr<ErrorInfoBase> reason,
-                     Flags flags = {})
+                     Flags flags={}, unsigned numVTableEntries=0)
       : underlyingReason(std::move(reason)) {
     this->name = name;
     this->flags = flags;
+    this->numVTableEntries = numVTableEntries;
   }
 
   void log(raw_ostream &OS) const override {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2841,6 +2841,13 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     InlinableBodyTextLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, body);
   }
 
+  unsigned getNumberOfRequiredVTableEntries(
+      const AbstractStorageDecl *storage) const {
+    unsigned count = 0;
+    // FIXME: Implement once accessors are no longer part of their parent.
+    return count;
+  }
+
 public:
   DeclSerializer(Serializer &S, DeclID id) : S(S), id(id) {}
   ~DeclSerializer() {
@@ -3368,6 +3375,8 @@ public:
 
     auto rawIntroducer = getRawStableVarDeclIntroducer(var->getIntroducer());
 
+    unsigned numVTableEntries = getNumberOfRequiredVTableEntries(var);
+
     unsigned abbrCode = S.DeclTypeAbbrCodes[VarLayout::Code];
     VarLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                           S.addDeclBaseNameRef(var->getName()),
@@ -3391,6 +3400,7 @@ public:
                           rawAccessLevel, rawSetterAccessLevel,
                           S.addDeclRef(var->getOpaqueResultTypeDecl()),
                           numBackingProperties,
+                          numVTableEntries,
                           arrayFields);
   }
 
@@ -3641,6 +3651,8 @@ public:
     uint8_t rawStaticSpelling =
       uint8_t(getStableStaticSpelling(subscript->getStaticSpelling()));
 
+    unsigned numVTableEntries = getNumberOfRequiredVTableEntries(subscript);
+
     unsigned abbrCode = S.DeclTypeAbbrCodes[SubscriptLayout::Code];
     SubscriptLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                 contextID,
@@ -3663,6 +3675,7 @@ public:
                                 subscript->
                                   getFullName().getArgumentNames().size(),
                                 S.addDeclRef(subscript->getOpaqueResultTypeDecl()),
+                                numVTableEntries,
                                 nameComponentsAndDependencies);
 
     writeGenericParams(subscript->getGenericParams());

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -251,10 +251,7 @@ void TBDGenVisitor::visitFuncDecl(FuncDecl *FD) {
 }
 
 void TBDGenVisitor::visitAccessorDecl(AccessorDecl *AD) {
-  // Do nothing: accessors are always nested within the storage decl, but
-  // sometimes appear outside it too. To avoid double-walking them, we
-  // explicitly visit them as members of the storage and ignore them when we
-  // visit them as part of the main walk, here.
+  llvm_unreachable("should not see an accessor here");
 }
 
 void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -26,40 +26,6 @@ public struct DidSetWillSetTests {
   }
 
   public var a: Int {
-    // This is the synthesized getter and setter for the willset/didset variable.
-
-    // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s9observers010DidSetWillC5TestsV1aSivg
-    // CHECK: bb0(%0 : $DidSetWillSetTests):
-    // CHECK-NEXT:   debug_value %0
-    // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
-    // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
-
-
-    // CHECK-LABEL: sil [ossa] @$s9observers010DidSetWillC5TestsV1aSivs
-    // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
-    // CHECK-NEXT: debug_value %0
-    // CHECK-NEXT: debug_value_addr %1
-
-    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
-    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-    // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
-    // CHECK-NEXT: end_access [[READ]]
-    // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
-
-    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
-    // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
-    // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-    // CHECK-NEXT: end_access [[WRITE]]
-    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-    // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
-    // CHECK-NEXT: end_access [[WRITE]]
-    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
-    // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-    // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-
     // CHECK-LABEL: sil private [ossa] @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
@@ -124,6 +90,40 @@ public struct DidSetWillSetTests {
       // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
     }
+
+    // This is the synthesized getter and setter for the willset/didset variable.
+
+    // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s9observers010DidSetWillC5TestsV1aSivg
+    // CHECK: bb0(%0 : $DidSetWillSetTests):
+    // CHECK-NEXT:   debug_value %0
+    // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
+
+
+    // CHECK-LABEL: sil [ossa] @$s9observers010DidSetWillC5TestsV1aSivs
+    // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+    // CHECK-NEXT: debug_value %0
+    // CHECK-NEXT: debug_value_addr %1
+
+    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[READ]]
+    // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
+
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
+    // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
+    // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s9observers010DidSetWillC5TestsV8testReadSiyF

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -92,18 +92,18 @@ public class Addressable<Element> : TestSubscriptable {
   }
 }
 
-// Addressable.subscript.getter with no attribute
-// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s15specialize_attr11AddressableCyxSicig : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> @out Element {
-
 // Addressable.subscript.unsafeAddressor with _specialize
 // CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] [ossa] @$s15specialize_attr11AddressableCyxSicilu : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafePointer<Element> {
-
-// Addressable.subscript.setter with no attribute
-// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s15specialize_attr11AddressableCyxSicis : $@convention(method) <Element> (@in Element, Int, @guaranteed Addressable<Element>) -> () {
 
 // Addressable.subscript.unsafeMutableAddressor with _specialize
 // CHECK-LABEL: sil [_specialize exported: false, kind: full, where Element == Int] [ossa] @$s15specialize_attr11AddressableCyxSiciau : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> UnsafeMutablePointer<Element> {
 
-// Addressable.subscript.materializeForSet with no attribute
+// Addressable.subscript.getter with no attribute
+// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s15specialize_attr11AddressableCyxSicig : $@convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> @out Element {
+
+// Addressable.subscript.setter with no attribute
+// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s15specialize_attr11AddressableCyxSicis : $@convention(method) <Element> (@in Element, Int, @guaranteed Addressable<Element>) -> () {
+
+// Addressable.subscript.modify with no attribute
 // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s15specialize_attr11AddressableCyxSiciM : $@yield_once @convention(method) <Element> (Int, @guaranteed Addressable<Element>) -> @yields @inout Element {
 

--- a/test/SILOptimizer/devirt_speculative_init.swift
+++ b/test/SILOptimizer/devirt_speculative_init.swift
@@ -1,0 +1,34 @@
+
+// RUN: %target-swift-frontend %s -parse-as-library -O -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-as-library -Osize -emit-sil
+//
+// Test speculative devirtualization.
+
+public class Cat {
+  var cats: Int
+
+  required init(cats: Int) {
+    self.cats = cats
+  }
+}
+
+public class BigCat : Cat {
+  required init(cats: Int) {
+    super.init(cats: cats)
+  }
+}
+
+public func make(type: Cat.Type, cats: Int) {
+  type.init(cats: cats)
+}
+
+// CHECK-LABEL: sil @$s23devirt_speculative_init4make4type4catsyAA3CatCm_SitF : $@convention(thin) (@thick Cat.Type, Int) -> ()
+// CHECK:   checked_cast_br [exact] %0 : $@thick Cat.Type to $@thick Cat.Type, bb2, bb3
+// CHECK: bb1:
+// CHECK:   return
+// CHECK: bb2({{%.*}} : $@thick Cat.Type):
+// CHECK:   alloc_ref $Cat
+// CHECK:   br bb1
+// CHECK: bb3:
+// CHECK:   alloc_ref $BigCat
+// CHECK:   br bb1

--- a/test/Serialization/Recovery/implementation-only-override.swift
+++ b/test/Serialization/Recovery/implementation-only-override.swift
@@ -15,12 +15,8 @@ import FooKit
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
 //  CHECK-NEXT:   @_implementationOnly func methodSECRET()
 //  CHECK-NEXT:   /* placeholder for roPropSECRET */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   /* placeholder for rwPropSECRET */
-//  CHECK-NEXT:   /* placeholder for _ */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   /* placeholder for subscript(_:) */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   @_implementationOnly override var redefinedPropSECRET: Parent?
 //  CHECK-NEXT: }
 public class GoodChild: Parent {
@@ -49,12 +45,8 @@ public class GoodChild: Parent {
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
 //  CHECK-NEXT:   @_implementationOnly func methodSECRET()
 //  CHECK-NEXT:   /* placeholder for roPropSECRET */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   /* placeholder for rwPropSECRET */
-//  CHECK-NEXT:   /* placeholder for _ */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   /* placeholder for subscript(_:) */
-//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   @_implementationOnly override var redefinedPropSECRET: Parent?
 //  CHECK-NEXT: }
 public class GoodGenericChild<Toy>: Parent {

--- a/test/Serialization/Recovery/implementation-only-override.swift
+++ b/test/Serialization/Recovery/implementation-only-override.swift
@@ -14,6 +14,13 @@ import FooKit
 //  CHECK-NEXT:   /* placeholder for init(SECRET:) */
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
 //  CHECK-NEXT:   @_implementationOnly func methodSECRET()
+//  CHECK-NEXT:   /* placeholder for roPropSECRET */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for rwPropSECRET */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for subscript(_:) */
+//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   @_implementationOnly override var redefinedPropSECRET: Parent?
 //  CHECK-NEXT: }
 public class GoodChild: Parent {
@@ -41,6 +48,13 @@ public class GoodChild: Parent {
 //  CHECK-NEXT:   /* placeholder for init(SECRET:) */
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
 //  CHECK-NEXT:   @_implementationOnly func methodSECRET()
+//  CHECK-NEXT:   /* placeholder for roPropSECRET */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for rwPropSECRET */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for _ */
+//  CHECK-NEXT:   /* placeholder for subscript(_:) */
+//  CHECK-NEXT:   /* placeholder for _ */
 //  CHECK-NEXT:   @_implementationOnly override var redefinedPropSECRET: Parent?
 //  CHECK-NEXT: }
 public class GoodGenericChild<Toy>: Parent {

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -98,6 +98,8 @@ public class A_Sub2: A_Sub {
 // CHECK-RECOVERY-NEXT: func nullabilityChangeMethod() -> Any?
 // CHECK-RECOVERY-NEXT: func typeChangeMethod() -> Any
 // CHECK-RECOVERY-NEXT: func disappearingMethodWithOverload()
+// CHECK-RECOVERY-NEXT: /* placeholder for disappearingProperty */
+// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -141,6 +143,8 @@ public class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
+// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -155,6 +159,8 @@ public class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
+// CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
+// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -169,6 +175,8 @@ public class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisap
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisappearsBase<Base> {
+// CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
+// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -183,6 +191,8 @@ public class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappear
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappearsBase<Base> {
+// CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
+// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -329,6 +339,7 @@ public class E1_MethodWithDisappearingType : MethodWithDisappearingType {
 // CHECK-NEXT: {{^}$}}
 
 // CHECK-RECOVERY-LABEL: class E1_MethodWithDisappearingType : MethodWithDisappearingType {
+// CHECK-RECOVERY-NEXT: /* placeholder for boxItUp() */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -99,7 +99,6 @@ public class A_Sub2: A_Sub {
 // CHECK-RECOVERY-NEXT: func typeChangeMethod() -> Any
 // CHECK-RECOVERY-NEXT: func disappearingMethodWithOverload()
 // CHECK-RECOVERY-NEXT: /* placeholder for disappearingProperty */
-// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -144,7 +143,6 @@ public class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
-// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -160,7 +158,6 @@ public class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
 
 // CHECK-RECOVERY-LABEL: class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
-// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -176,7 +173,6 @@ public class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisap
 
 // CHECK-RECOVERY-LABEL: class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisappearsBase<Base> {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
-// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
@@ -192,7 +188,6 @@ public class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappear
 
 // CHECK-RECOVERY-LABEL: class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappearsBase<Base> {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
-// CHECK-RECOVERY-NEXT: /* placeholder for _ */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: {{^}$}}
 

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -64,20 +64,20 @@ public protocol Proto {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   var unwrappedProp: UnwrappedInt? { get set }
   // CHECK: var wrappedProp: WrappedInt? { get set }
-  // CHECK-RECOVERY: /* placeholder for _ */
-  // CHECK-RECOVERY: /* placeholder for _ */
-  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
   var wrappedProp: WrappedInt? { get set }
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
   // CHECK-RECOVERY: func returnsUnwrappedMethod() -> Int32
   func returnsUnwrappedMethod() -> UnwrappedInt
   // CHECK: func returnsWrappedMethod() -> WrappedInt
-  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
+  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() (vtable entries: 1) */
   func returnsWrappedMethod() -> WrappedInt
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
   subscript(_: WrappedInt) -> () { get }
 
   // CHECK: init()
@@ -85,7 +85,7 @@ public protocol Proto {
   init()
 
   // CHECK: init(wrapped: WrappedInt)
-  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) (vtable entries: 1) */
   init(wrapped: WrappedInt)
 
   func lastMethod()

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -64,9 +64,7 @@ public protocol Proto {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   var unwrappedProp: UnwrappedInt? { get set }
   // CHECK: var wrappedProp: WrappedInt? { get set }
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for wrappedProp (vtable entries: 3) */
   var wrappedProp: WrappedInt? { get set }
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
@@ -77,7 +75,7 @@ public protocol Proto {
   func returnsWrappedMethod() -> WrappedInt
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for subscript(_:) (vtable entries: 1) */
   subscript(_: WrappedInt) -> () { get }
 
   // CHECK: init()

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -100,31 +100,32 @@ open class User {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   public var unwrappedProp: UnwrappedInt?
   // CHECK: var wrappedProp: WrappedInt?
-  // CHECK-RECOVERY: /* placeholder for _ */
-  // CHECK-RECOVERY: /* placeholder for _ */
-  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK_RECOVERY: /* placeholder for wrappedProp (field offsets: 1) */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
   public var wrappedProp: WrappedInt?
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
   // CHECK-RECOVERY: func returnsUnwrappedMethod() -> Int32
   public func returnsUnwrappedMethod() -> UnwrappedInt { fatalError() }
   // CHECK: func returnsWrappedMethod() -> WrappedInt
-  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() */
+  // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() (vtable entries: 1) */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
   // CHECK: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == UnwrappedInt
   // CHECK-RECOVERY: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
   public func constrainedUnwrapped<T: HasAssoc>(_: T) where T.Assoc == UnwrappedInt { fatalError() }
   // CHECK: func constrainedWrapped<T>(_: T) where T : HasAssoc, T.Assoc == WrappedInt
-  // CHECK-RECOVERY: /* placeholder for constrainedWrapped(_:) */
+  // CHECK-RECOVERY: /* placeholder for constrainedWrapped(_:) (vtable entries: 1) */
   public func constrainedWrapped<T: HasAssoc>(_: T) where T.Assoc == WrappedInt { fatalError() }
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
   public subscript(_: WrappedInt) -> () { return () }
 
   // CHECK: subscript<T>(_: T) -> () where T : HasAssoc, T.Assoc == WrappedInt { get }
-  // CHECK-RECOVERY: /* placeholder for _ */
+  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
   public subscript<T: HasAssoc>(_: T) -> () where T.Assoc == WrappedInt { return () }
 
   // CHECK: init()
@@ -132,7 +133,7 @@ open class User {
   public init() {}
 
   // CHECK: init(wrapped: WrappedInt)
-  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) (vtable entries: 1) */
   public init(wrapped: WrappedInt) {}
 
   // CHECK: convenience init(conveniently: Int)
@@ -144,11 +145,11 @@ open class User {
   public convenience init<T: HasAssoc>(generic: T) where T.Assoc == WrappedInt { self.init() }
 
   // CHECK: required init(wrappedRequired: WrappedInt)
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) (vtable entries: 1) */
   public required init(wrappedRequired: WrappedInt) {}
 
   // CHECK: {{^}} init(wrappedRequiredInSub: WrappedInt)
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequiredInSub:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequiredInSub:) (vtable entries: 1) */
   public init(wrappedRequiredInSub: WrappedInt) {}
 
   // CHECK: dynamic init(wrappedDynamic: WrappedInt)
@@ -247,15 +248,15 @@ open class UserDynamicConvenience {
 // CHECK-RECOVERY-LABEL: class UserSub
 open class UserSub : User {
   // CHECK: init(wrapped: WrappedInt?)
-  // CHECK-RECOVERY: /* placeholder for init(wrapped:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrapped:) (vtable entries: 1) */
   public override init(wrapped: WrappedInt?) { super.init() }
 
   // CHECK: required init(wrappedRequired: WrappedInt?)
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequired:) (vtable entries: 1) */
   public required init(wrappedRequired: WrappedInt?) { super.init() }
 
   // CHECK: required init(wrappedRequiredInSub: WrappedInt?)
-  // CHECK-RECOVERY: /* placeholder for init(wrappedRequiredInSub:) */
+  // CHECK-RECOVERY: /* placeholder for init(wrappedRequiredInSub:) (vtable entries: 1) */
   public required override init(wrappedRequiredInSub: WrappedInt?) { super.init() }
 
   // CHECK: required init(wrappedRequiredDynamic: WrappedInt)

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -100,10 +100,7 @@ open class User {
   // CHECK-RECOVERY: var unwrappedProp: Int32?
   public var unwrappedProp: UnwrappedInt?
   // CHECK: var wrappedProp: WrappedInt?
-  // CHECK_RECOVERY: /* placeholder for wrappedProp (field offsets: 1) */
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK_RECOVERY: /* placeholder for wrappedProp (vtable entries: 3) (field offsets: 1) */
   public var wrappedProp: WrappedInt?
 
   // CHECK: func returnsUnwrappedMethod() -> UnwrappedInt
@@ -121,11 +118,11 @@ open class User {
   public func constrainedWrapped<T: HasAssoc>(_: T) where T.Assoc == WrappedInt { fatalError() }
 
   // CHECK: subscript(_: WrappedInt) -> () { get }
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for subscript(_:) (vtable entries: 1) */
   public subscript(_: WrappedInt) -> () { return () }
 
   // CHECK: subscript<T>(_: T) -> () where T : HasAssoc, T.Assoc == WrappedInt { get }
-  // CHECK-RECOVERY: /* placeholder for _ (vtable entries: 1) */
+  // CHECK-RECOVERY: /* placeholder for subscript(_:) (vtable entries: 1) */
   public subscript<T: HasAssoc>(_: T) -> () where T.Assoc == WrappedInt { return () }
 
   // CHECK: init()

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -591,28 +591,6 @@
       key.namelength: 4
     },
     {
-      key.kind: source.lang.swift.expr.call,
-      key.name: "417",
-      key.offset: 1099,
-      key.length: 11,
-      key.nameoffset: 1099,
-      key.namelength: 3,
-      key.bodyoffset: 1103,
-      key.bodylength: 6,
-      key.substructure: [
-        {
-          key.kind: source.lang.swift.expr.argument,
-          key.name: "d",
-          key.offset: 1103,
-          key.length: 6,
-          key.nameoffset: 1103,
-          key.namelength: 1,
-          key.bodyoffset: 1106,
-          key.bodylength: 3
-        }
-      ]
-    },
-    {
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -591,28 +591,6 @@
       key.namelength: 4
     },
     {
-      key.kind: source.lang.swift.expr.call,
-      key.name: "417",
-      key.offset: 1099,
-      key.length: 11,
-      key.nameoffset: 1099,
-      key.namelength: 3,
-      key.bodyoffset: 1103,
-      key.bodylength: 6,
-      key.substructure: [
-        {
-          key.kind: source.lang.swift.expr.argument,
-          key.name: "d",
-          key.offset: 1103,
-          key.length: 6,
-          key.nameoffset: 1103,
-          key.namelength: 1,
-          key.bodyoffset: 1106,
-          key.bodylength: 3
-        }
-      ]
-    },
-    {
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -591,28 +591,6 @@
       key.namelength: 4
     },
     {
-      key.kind: source.lang.swift.expr.call,
-      key.name: "417",
-      key.offset: 1099,
-      key.length: 11,
-      key.nameoffset: 1099,
-      key.namelength: 3,
-      key.bodyoffset: 1103,
-      key.bodylength: 6,
-      key.substructure: [
-        {
-          key.kind: source.lang.swift.expr.argument,
-          key.name: "d",
-          key.offset: 1103,
-          key.length: 6,
-          key.nameoffset: 1103,
-          key.namelength: 1,
-          key.bodyoffset: 1106,
-          key.bodylength: 3
-        }
-      ]
-    },
-    {
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -405,7 +405,7 @@ var x23: Int, x24: Int { // expected-error{{'var' declarations with multiple var
 
 var x25: Int { // expected-error{{'var' declarations with multiple variables cannot have explicit getters/setters}}
   return 42
-}, x26: Int
+}, x26: Int // expected-warning{{variable 'x26' was never used; consider replacing with '_' or removing it}}
 
 // Properties of struct/enum/extensions
 struct S {


### PR DESCRIPTION
This will help with request-based accessor synthesis. It should also make it easier to lift the restriction on local variables not being allowed to use ‘lazy’ or property wrappers.