### PR TITLE
Correctly distinguish between tuple fields and associated values in patterns

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3389,6 +3389,18 @@ ERROR(pattern_type_mismatch_context,none,
 
 ERROR(tuple_pattern_in_non_tuple_context,none,
       "tuple pattern cannot match values of the non-tuple type %0", (Type))
+WARNING(matching_pattern_with_many_assoc_values, none,
+        "cannot match several associated values at once, "
+        "implicitly tupling the associated values and trying to match that "
+        "instead", ())
+WARNING(matching_tuple_pattern_with_many_assoc_values,none,
+        "a tuple pattern cannot match several associated values at once, "
+        "implicitly tupling the associated values and trying to match "
+        "that instead", ())
+WARNING(matching_many_patterns_with_tupled_assoc_value,none,
+        "the enum case has a single tuple as an associated value, but "
+        "there are several patterns here, implicitly tupling the patterns "
+        "and trying to match that instead", ())
 ERROR(closure_argument_list_tuple,none,
       "contextual closure type %0 expects %1 argument%s1, "
       "but %2 %select{were|was}3 used in closure body", (Type, unsigned, unsigned, bool))

--- a/include/swift/AST/PatternNodes.def
+++ b/include/swift/AST/PatternNodes.def
@@ -32,17 +32,19 @@
 #define LAST_PATTERN(Id)
 #endif
 
-PATTERN(Paren, Pattern)
-PATTERN(Tuple, Pattern)
-PATTERN(Named, Pattern)
-PATTERN(Any, Pattern)
-PATTERN(Typed, Pattern)
-PATTERN(Var, Pattern)
-REFUTABLE_PATTERN(Is, Pattern)
-REFUTABLE_PATTERN(EnumElement, Pattern)
-REFUTABLE_PATTERN(OptionalSome, Pattern)
-REFUTABLE_PATTERN(Bool, Pattern)
-REFUTABLE_PATTERN(Expr, Pattern)
+// Metavars: x (variable), pat (pattern), e (expression)
+PATTERN(Paren, Pattern) // (pat)
+PATTERN(Tuple, Pattern) // (pat1, ..., patN), N >= 1
+PATTERN(Named, Pattern) // let pat, var pat
+PATTERN(Any, Pattern)   // _
+PATTERN(Typed, Pattern) // pat : type
+PATTERN(Var, Pattern)   // x
+REFUTABLE_PATTERN(Is, Pattern)           // x is myclass
+REFUTABLE_PATTERN(EnumElement, Pattern)  // .mycase(pat1, ..., patN)
+                                         // MyType.mycase(pat1, ..., patN)
+REFUTABLE_PATTERN(OptionalSome, Pattern) // pat?  nil
+REFUTABLE_PATTERN(Bool, Pattern)         // true, false
+REFUTABLE_PATTERN(Expr, Pattern)         // e
 LAST_PATTERN(Expr)
 
 #undef REFUTABLE_PATTERN

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1020,6 +1020,46 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
   llvm_unreachable("bad pattern kind!");
 }
 
+namespace {
+
+/// We need to allow particular matches for backwards compatibility, so we
+/// "repair" the pattern if needed, so that the exhaustiveness checker receives
+/// well-formed input. Also emit diagnostics warning the user to fix their code.
+///
+/// See SR-11160 and SR-11212 for more discussion.
+//
+// type ~ (T1, ..., Tn) (n >= 2)
+//   1a. pat ~ ((P1, ..., Pm)) (m >= 2)
+//   1b. pat
+// type ~ ((T1, ..., Tn)) (n >= 2)
+//   2. pat ~ (P1, ..., Pm) (m >= 2)
+void implicitlyUntuplePatternIfApplicable(TypeChecker *TC,
+                                          Pattern *&enumElementInnerPat,
+                                          Type enumPayloadType) {
+  if (auto *tupleType = dyn_cast<TupleType>(enumPayloadType.getPointer())) {
+    if (tupleType->getNumElements() >= 2
+        && enumElementInnerPat->getKind() == PatternKind::Paren) {
+      auto *semantic = enumElementInnerPat->getSemanticsProvidingPattern();
+      if (auto *tuplePattern = dyn_cast<TuplePattern>(semantic)) {
+        if (tuplePattern->getNumElements() >= 2) {
+          TC->diagnose(tuplePattern->getLoc(),
+                       diag::matching_tuple_pattern_with_many_assoc_values);
+          enumElementInnerPat = semantic;
+        }
+      } else {
+        TC->diagnose(enumElementInnerPat->getLoc(),
+                     diag::matching_pattern_with_many_assoc_values);
+      }
+    }
+  } else if (auto *tupleType = enumPayloadType->getAs<TupleType>()) {
+    if (tupleType->getNumElements() >= 2
+        && enumElementInnerPat->getKind() == PatternKind::Tuple)
+      TC->diagnose(enumElementInnerPat->getLoc(),
+                   diag::matching_many_patterns_with_tupled_assoc_value);
+  }
+}
+}
+
 /// Perform top-down type coercion on the given pattern.
 bool TypeChecker::coercePatternToType(Pattern *&P, TypeResolution resolution,
                                       Type type,
@@ -1513,6 +1553,9 @@ recur:
       auto newSubOptions = subOptions;
       newSubOptions.setContext(TypeResolverContext::EnumPatternPayload);
       newSubOptions |= TypeResolutionFlags::FromNonInferredPattern;
+
+      ::implicitlyUntuplePatternIfApplicable(this, sub, elementType);
+
       if (coercePatternToType(sub, resolution, elementType, newSubOptions))
         return true;
       EEP->setSubPattern(sub);

--- a/test/Compatibility/implicit_tupling_untupling_codegen.swift
+++ b/test/Compatibility/implicit_tupling_untupling_codegen.swift
@@ -1,0 +1,149 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// Even though we test that type-checking and exhaustiveness checking work fine
+// in the presence of implicit tupling/untupling in exhaustive_switch.swift,
+// make sure that the "patched" patterns do not lead to incorrect codegen.
+
+enum Untupled {
+  case upair(Int, Int)
+}
+
+let u_ex = Untupled.upair(1, 2)
+
+func sr11212_content_untupled_pattern_tupled1(u: Untupled) -> (Int, Int) {
+  switch u { case .upair((let x, let y)): return (x, y) }
+}
+print(sr11212_content_untupled_pattern_tupled1(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_tupled2(u: Untupled) -> (Int, Int) {
+  switch u { case .upair(let (x, y)): return (x, y) }
+}
+print(sr11212_content_untupled_pattern_tupled2(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_tupled3(u: Untupled) -> (Int, Int) {
+  switch u { case let .upair((x, y)): return (x, y) }
+}
+print(sr11212_content_untupled_pattern_tupled3(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_untupled1(u: Untupled) -> (Int, Int) {
+  switch u { case .upair(let x, let y): return (x, y) }
+}
+print(sr11212_content_untupled_pattern_untupled1(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_untupled2(u: Untupled) -> (Int, Int) {
+    switch u { case let .upair(x, y): return (x, y) }
+}
+print(sr11212_content_untupled_pattern_untupled2(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_ambiguous1(u: Untupled) -> (Int, Int) {
+  switch u { case .upair(let u_): return u_ }
+}
+print(sr11212_content_untupled_pattern_ambiguous1(u: u_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_untupled_pattern_ambiguous2(u: Untupled) -> (Int, Int) {
+  switch u { case let .upair(u_): return u_ }
+}
+print(sr11212_content_untupled_pattern_ambiguous2(u: u_ex))
+// CHECK: (1, 2)
+
+enum Tupled {
+  case tpair((Int, Int))
+}
+
+let t_ex = Tupled.tpair((1, 2))
+
+func sr11212_content_tupled_pattern_tupled1(t: Tupled) -> (Int, Int) {
+  switch t { case .tpair((let x, let y)): return (x, y) }
+}
+print(sr11212_content_tupled_pattern_tupled1(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_tupled2(t: Tupled) -> (Int, Int) {
+  switch t { case .tpair(let (x, y)): return (x, y) }
+}
+print(sr11212_content_tupled_pattern_tupled2(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_tupled3(t: Tupled) -> (Int, Int) {
+  switch t { case let .tpair((x, y)): return (x, y) }
+}
+print(sr11212_content_tupled_pattern_tupled3(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_untupled1(t: Tupled) -> (Int, Int) {
+  switch t { case .tpair(let x, let y): return (x, y) }
+}
+print(sr11212_content_tupled_pattern_untupled1(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_untupled2(t: Tupled) -> (Int, Int) {
+  switch t { case let .tpair(x, y): return (x, y) }
+}
+print(sr11212_content_tupled_pattern_untupled2(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_ambiguous1(t: Tupled) -> (Int, Int) {
+  switch t { case .tpair(let t_): return t_ }
+}
+print(sr11212_content_tupled_pattern_ambiguous1(t: t_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_tupled_pattern_ambiguous2(t: Tupled) -> (Int, Int) {
+  switch t { case let .tpair(t_): return t_ }
+}
+print(sr11212_content_tupled_pattern_ambiguous2(t: t_ex))
+// CHECK: (1, 2)
+
+enum Box<T> {
+  case box(T)
+}
+
+let b_ex : Box<(Int, Int)> = Box.box((1, 2))
+
+func sr11212_content_generic_pattern_tupled1(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case .box((let x, let y)): return (x, y) }
+}
+print(sr11212_content_generic_pattern_tupled1(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_tupled2(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case .box(let (x, y)): return (x, y) }
+}
+print(sr11212_content_generic_pattern_tupled2(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_tupled3(b: Box<(Int, Int)>) -> (Int, Int) {
+ switch b { case let .box((x, y)): return (x, y) }
+}
+print(sr11212_content_generic_pattern_tupled3(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_untupled1(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case .box(let x, let y): return (x, y) }
+}
+print(sr11212_content_generic_pattern_untupled1(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_untupled2(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case let .box(x, y): return (x, y) }
+}
+print(sr11212_content_generic_pattern_untupled2(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_ambiguous1(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case .box(let b_): return b_ }
+}
+print(sr11212_content_generic_pattern_ambiguous1(b: b_ex))
+// CHECK: (1, 2)
+
+func sr11212_content_generic_pattern_ambiguous2(b: Box<(Int, Int)>) -> (Int, Int) {
+  switch b { case let .box(b_): return b_ }
+}
+print(sr11212_content_generic_pattern_ambiguous2(b: b_ex))
+// CHECK: (1, 2)

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -100,7 +100,7 @@ enum Voluntary<T> : Equatable {
       ()
 
     case .Twain(), // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
-         .Twain(_),
+         .Twain(_), // expected-warning {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
          .Twain(_, _),
          .Twain(_, _, _): // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
       ()
@@ -143,7 +143,7 @@ case Voluntary<Int>.Mere,
      .Mere(_):
   ()
 case .Twain,
-     .Twain(_),
+     .Twain(_), // expected-warning {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
      .Twain(_, _),
      .Twain(_, _, _): // expected-error{{tuple pattern has the wrong length for tuple type '(Int, Int)'}}
   ()

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -48,7 +48,7 @@ enum Result<T> {
   }
 }
 
-func overParenthesized() {
+func parenthesized() {
   // SR-7492: Space projection needs to treat extra paren-patterns explicitly.
   let x: Result<(Result<Int>, String)> = .Ok((.Ok(1), "World"))
   switch x {
@@ -1177,11 +1177,36 @@ func sr10301_as(_ foo: SR10301<String,(Int,Error)>) {
 }
 
 func sr11160() {
-    switch Optional<(Int, Int)>((5, 6)) { // expected-error {{switch must be exhaustive}}
-        // expected-note@-1 {{add missing case: '.some(_, _)'}}
-    case let b?: print(b)
-    case nil:    print(0)
-    }
+  switch Optional<(Int, Int)>((5, 6)) {
+  case let b?: print(b)
+  case nil:    print(0)
+  }
+}
+
+enum Z {
+  case z1(a: Int)
+  case z2(a: Int, b: Int)
+  case z3((c: Int, d: Int))
+}
+
+func sr11160_extra() {
+  switch Z.z1(a: 1) { // expected-error {{switch must be exhaustive}}
+                      // expected-note@-1 {{add missing case: '.z1(let a)'}}
+  case .z2(_, _): ()
+  case .z3(_): ()
+  }
+
+  switch Z.z1(a: 1) { // expected-error {{switch must be exhaustive}}
+                      // expected-note@-1 {{add missing case: '.z2(let a, let b)'}}
+  case .z1(_): ()
+  case .z3(_): ()
+  }
+
+  switch Z.z1(a: 1) { // expected-error {{switch must be exhaustive}}
+                      // expected-note@-1 {{add missing case: '.z3((let c, let d))'}}
+  case .z1(_):    ()
+  case .z2(_, _): ()
+  }
 }
 
 // SR-11212 tests: Some of the tests here rely on compiler bugs related to

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1215,8 +1215,7 @@ func sr11160_extra() {
 }
 
 // SR-11212 tests: Some of the tests here rely on compiler bugs related to
-// implicit (un)tupling in patterns. When you add a warning for the erroneous
-// cases, feel free to add expected notes as appropriate.
+// implicit (un)tupling in patterns.
 enum SR11212Tests {
 
   enum Untupled {
@@ -1226,12 +1225,14 @@ enum SR11212Tests {
   func sr11212_content_untupled_pattern_tupled(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair((let x, let y)): return (x, y)
+    // expected-warning@-1 {{a tuple pattern cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
 
   func sr11212_content_untupled_pattern_tupled_nested(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair(let (x, y)): return (x, y)
+    // expected-warning@-1 {{a tuple pattern cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
 
@@ -1244,6 +1245,7 @@ enum SR11212Tests {
   func sr11212_content_untupled_pattern_ambiguous(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair(let u_): return u_
+    // expected-warning@-1 {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
 
@@ -1266,6 +1268,7 @@ enum SR11212Tests {
   func sr11212_content_tupled_pattern_untupled(t: Tupled) -> (Int, Int) {
     switch t {
     case .tpair(let x, let y): return (x, y)
+    // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
     }
   }
 
@@ -1294,6 +1297,7 @@ enum SR11212Tests {
   func sr11212_content_generic_pattern_untupled(b: Box<(Int, Int)>) -> (Int, Int) {
     switch b {
     case .box(let x, let y): return (x, y)
+    // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
     }
   }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1178,6 +1178,11 @@ func sr10301_as(_ foo: SR10301<String,(Int,Error)>) {
 
 func sr11160() {
   switch Optional<(Int, Int)>((5, 6)) {
+  case .some((let a, let b)): print(a, b)
+  case nil:                   print(0)
+  }
+
+  switch Optional<(Int, Int)>((5, 6)) {
   case let b?: print(b)
   case nil:    print(0)
   }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1222,29 +1222,49 @@ enum SR11212Tests {
     case upair(Int, Int)
   }
 
-  func sr11212_content_untupled_pattern_tupled(u: Untupled) -> (Int, Int) {
+  func sr11212_content_untupled_pattern_tupled1(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair((let x, let y)): return (x, y)
     // expected-warning@-1 {{a tuple pattern cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
 
-  func sr11212_content_untupled_pattern_tupled_nested(u: Untupled) -> (Int, Int) {
+  func sr11212_content_untupled_pattern_tupled2(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair(let (x, y)): return (x, y)
     // expected-warning@-1 {{a tuple pattern cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
 
-  func sr11212_content_untupled_pattern_untupled(u: Untupled) -> (Int, Int) {
+  func sr11212_content_untupled_pattern_tupled3(u: Untupled) -> (Int, Int) {
+    switch u {
+    case let .upair((x, y)): return (x, y)
+    // expected-warning@-1 {{a tuple pattern cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
+    }
+  }
+
+  func sr11212_content_untupled_pattern_untupled1(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair(let x, let y): return (x, y)
     }
   }
 
-  func sr11212_content_untupled_pattern_ambiguous(u: Untupled) -> (Int, Int) {
+  func sr11212_content_untupled_pattern_untupled2(u: Untupled) -> (Int, Int) {
+      switch u {
+      case let .upair(x, y): return (x, y)
+      }
+  }
+
+  func sr11212_content_untupled_pattern_ambiguous1(u: Untupled) -> (Int, Int) {
     switch u {
     case .upair(let u_): return u_
+    // expected-warning@-1 {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
+    }
+  }
+
+  func sr11212_content_untupled_pattern_ambiguous2(u: Untupled) -> (Int, Int) {
+    switch u {
+    case let .upair(u_): return u_
     // expected-warning@-1 {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     }
   }
@@ -1253,28 +1273,47 @@ enum SR11212Tests {
     case tpair((Int, Int))
   }
 
-  func sr11212_content_tupled_pattern_tupled(t: Tupled) -> (Int, Int) {
+  func sr11212_content_tupled_pattern_tupled1(t: Tupled) -> (Int, Int) {
     switch t {
     case .tpair((let x, let y)): return (x, y)
     }
   }
 
-  func sr11212_content_tupled_pattern_tupled_nested(t: Tupled) -> (Int, Int) {
+  func sr11212_content_tupled_pattern_tupled2(t: Tupled) -> (Int, Int) {
     switch t {
     case .tpair(let (x, y)): return (x, y)
     }
   }
 
-  func sr11212_content_tupled_pattern_untupled(t: Tupled) -> (Int, Int) {
+  func sr11212_content_tupled_pattern_tupled3(t: Tupled) -> (Int, Int) {
+    switch t {
+    case let .tpair((x, y)): return (x, y)
+    }
+  }
+
+  func sr11212_content_tupled_pattern_untupled1(t: Tupled) -> (Int, Int) {
     switch t {
     case .tpair(let x, let y): return (x, y)
     // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
     }
   }
 
-  func sr11212_content_tupled_pattern_ambiguous(t: Tupled) -> (Int, Int) {
+  func sr11212_content_tupled_pattern_untupled2(t: Tupled) -> (Int, Int) {
+    switch t {
+    case let .tpair(x, y): return (x, y)
+    // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
+    }
+  }
+
+  func sr11212_content_tupled_pattern_ambiguous1(t: Tupled) -> (Int, Int) {
     switch t {
     case .tpair(let t_): return t_
+    }
+  }
+
+  func sr11212_content_tupled_pattern_ambiguous2(t: Tupled) -> (Int, Int) {
+    switch t {
+    case let .tpair(t_): return t_
     }
   }
 
@@ -1282,28 +1321,47 @@ enum SR11212Tests {
     case box(T)
   }
 
-  func sr11212_content_generic_pattern_tupled(b: Box<(Int, Int)>) -> (Int, Int) {
+  func sr11212_content_generic_pattern_tupled1(b: Box<(Int, Int)>) -> (Int, Int) {
     switch b {
     case .box((let x, let y)): return (x, y)
     }
   }
 
-  func sr11212_content_generic_pattern_tupled_nested(b: Box<(Int, Int)>) -> (Int, Int) {
+  func sr11212_content_generic_pattern_tupled2(b: Box<(Int, Int)>) -> (Int, Int) {
     switch b {
     case .box(let (x, y)): return (x, y)
     }
   }
 
-  func sr11212_content_generic_pattern_untupled(b: Box<(Int, Int)>) -> (Int, Int) {
+  func sr11212_content_generic_pattern_tupled3(b: Box<(Int, Int)>) -> (Int, Int) {
+   switch b {
+   case let .box((x, y)): return (x, y)
+   }
+  }
+
+  func sr11212_content_generic_pattern_untupled1(b: Box<(Int, Int)>) -> (Int, Int) {
     switch b {
     case .box(let x, let y): return (x, y)
     // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
     }
   }
 
-  func sr11212_content_generic_pattern_ambiguous(b: Box<(Int, Int)>) -> (Int, Int) {
+  func sr11212_content_generic_pattern_untupled2(b: Box<(Int, Int)>) -> (Int, Int) {
+    switch b {
+    case let .box(x, y): return (x, y)
+    // expected-warning@-1 {{the enum case has a single tuple as an associated value, but there are several patterns here, implicitly tupling the patterns and trying to match that instead}}
+    }
+  }
+
+  func sr11212_content_generic_pattern_ambiguous1(b: Box<(Int, Int)>) -> (Int, Int) {
     switch b {
     case .box(let b_): return b_
+    }
+  }
+
+  func sr11212_content_generic_pattern_ambiguous2(b: Box<(Int, Int)>) -> (Int, Int) {
+    switch b {
+    case let .box(b_): return b_
     }
   }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1216,6 +1216,8 @@ func sr11160_extra() {
 
 // SR-11212 tests: Some of the tests here rely on compiler bugs related to
 // implicit (un)tupling in patterns.
+//
+// Related codegen test: Compatibility/implicit_tupling_untupling_codegen.swift
 enum SR11212Tests {
 
   enum Untupled {

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1176,6 +1176,14 @@ func sr10301_as(_ foo: SR10301<String,(Int,Error)>) {
   }
 }
 
+func sr11160() {
+    switch Optional<(Int, Int)>((5, 6)) { // expected-error {{switch must be exhaustive}}
+        // expected-note@-1 {{add missing case: '.some(_, _)'}}
+    case let b?: print(b)
+    case nil:    print(0)
+    }
+}
+
 // SR-11212 tests: Some of the tests here rely on compiler bugs related to
 // implicit (un)tupling in patterns. When you add a warning for the erroneous
 // cases, feel free to add expected notes as appropriate.

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -275,7 +275,7 @@ func testDirection() {
     i = x
     break
 
-  case .NorthEast(let x):
+  case .NorthEast(let x): // expected-warning {{cannot match several associated values at once, implicitly tupling the associated values and trying to match that instead}}
     i = x.distanceEast
     break
   }


### PR DESCRIPTION
See the second commit message for more details.

I'm not sure whether I should've broken things up into multiple commits, since there are couple of unrelated things that I noticed and cleaned up, but they're not really related to the main content of the PR.

Fixes [SR-11160](https://bugs.swift.org/browse/SR-11160) and related rdar://problem/53312914.