### PR TITLE
[Build System: CMake] Include the stdlib/toolchain directory before the stdlib/public directory (5.1 branch).

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -113,7 +113,9 @@ if(SWIFT_STDLIB_ENABLE_SIB_TARGETS)
 endif()
 swift_create_stdlib_targets("swift-test-stdlib" "" FALSE)
 
+# FIXME: Include the toolchain directory before the public directory. Otherwise
+# the clang resource directory symlink stops installing correctly.
+add_subdirectory(toolchain)
 add_subdirectory(public)
 add_subdirectory(private)
-add_subdirectory(toolchain)
 add_subdirectory(tools)


### PR DESCRIPTION
Copy of #26362 for the 5.1 branch.