### PR TITLE
[AST] Emit vtable thunk if base method's generic requirements are not satisfied by derived

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -899,8 +899,8 @@ public:
   CanGenericSignature getExistentialSignature(CanType existential,
                                               ModuleDecl *mod);
 
-  GenericSignature *getOverrideGenericSignature(ValueDecl *base,
-                                                ValueDecl *derived);
+  GenericSignature *getOverrideGenericSignature(const ValueDecl *base,
+                                                const ValueDecl *derived);
 
   enum class OverrideGenericSignatureReqCheck {
     /// Base method's generic requirements are satisifed by derived method
@@ -911,8 +911,8 @@ public:
   };
 
   bool overrideGenericSignatureReqsSatisfied(
-      ValueDecl *base, ValueDecl *derived,
-      OverrideGenericSignatureReqCheck direction);
+      const ValueDecl *base, const ValueDecl *derived,
+      const OverrideGenericSignatureReqCheck direction);
 
   /// Whether our effective Swift version is at least 'major'.
   ///

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -902,6 +902,18 @@ public:
   GenericSignature *getOverrideGenericSignature(ValueDecl *base,
                                                 ValueDecl *derived);
 
+  enum class OverrideGenericSignatureReqCheck {
+    /// Base method's generic requirements are satisifed by derived method
+    BaseReqSatisfiedByDerived,
+
+    /// Derived method's generic requirements are satisifed by base method
+    DerivedReqSatisfiedByBase
+  };
+
+  bool overrideGenericSignatureReqsSatisfied(
+      ValueDecl *base, ValueDecl *derived,
+      OverrideGenericSignatureReqCheck direction);
+
   /// Whether our effective Swift version is at least 'major'.
   ///
   /// This is usually the check you want; for example, when introducing

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4487,6 +4487,23 @@ GenericSignature *ASTContext::getOverrideGenericSignature(ValueDecl *base,
   return genericSig;
 }
 
+bool ASTContext::overrideGenericSignatureReqsSatisfied(
+    ValueDecl *base, ValueDecl *derived,
+    OverrideGenericSignatureReqCheck direction) {
+  auto sig = getOverrideGenericSignature(base, derived);
+  if (!sig)
+    return false;
+
+  auto derivedSig = derived->getAsGenericContext()->getGenericSignature();
+
+  switch (direction) {
+  case OverrideGenericSignatureReqCheck::BaseReqSatisfiedByDerived:
+    return sig->requirementsNotSatisfiedBy(derivedSig).empty();
+  case OverrideGenericSignatureReqCheck::DerivedReqSatisfiedByBase:
+    return derivedSig->requirementsNotSatisfiedBy(sig).empty();
+  }
+}
+
 SILLayout *SILLayout::get(ASTContext &C,
                           CanGenericSignature Generics,
                           ArrayRef<SILField> Fields) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4385,8 +4385,9 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
   return genericSig;
 }
 
-GenericSignature *ASTContext::getOverrideGenericSignature(ValueDecl *base,
-                                                          ValueDecl *derived) {
+GenericSignature *
+ASTContext::getOverrideGenericSignature(const ValueDecl *base,
+                                        const ValueDecl *derived) {
   auto baseGenericCtx = base->getAsGenericContext();
   auto &ctx = base->getASTContext();
 
@@ -4488,8 +4489,8 @@ GenericSignature *ASTContext::getOverrideGenericSignature(ValueDecl *base,
 }
 
 bool ASTContext::overrideGenericSignatureReqsSatisfied(
-    ValueDecl *base, ValueDecl *derived,
-    OverrideGenericSignatureReqCheck direction) {
+    const ValueDecl *base, const ValueDecl *derived,
+    const OverrideGenericSignatureReqCheck direction) {
   auto sig = getOverrideGenericSignature(base, derived);
   if (!sig)
     return true;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4492,7 +4492,7 @@ bool ASTContext::overrideGenericSignatureReqsSatisfied(
     OverrideGenericSignatureReqCheck direction) {
   auto sig = getOverrideGenericSignature(base, derived);
   if (!sig)
-    return false;
+    return true;
 
   auto derivedSig = derived->getAsGenericContext()->getGenericSignature();
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6473,6 +6473,13 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
   auto baseInterfaceTy = base->getInterfaceType();
   auto derivedInterfaceTy = decl->getInterfaceType();
 
+  auto sig = ctx.getOverrideGenericSignature(base, (ValueDecl *)decl);
+
+  if (sig &&
+      !sig->requirementsNotSatisfiedBy(decl->getGenericSignature()).empty()) {
+    return true;
+  }
+
   auto selfInterfaceTy = decl->getDeclContext()->getDeclaredInterfaceType();
 
   auto overrideInterfaceTy = selfInterfaceTy->adjustSuperclassMemberDeclType(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6475,7 +6475,7 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
 
   using Direction = ASTContext::OverrideGenericSignatureReqCheck;
   if (!ctx.overrideGenericSignatureReqsSatisfied(
-          base, (ValueDecl *)decl, Direction::BaseReqSatisfiedByDerived)) {
+          base, decl, Direction::BaseReqSatisfiedByDerived)) {
     return true;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6473,10 +6473,9 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
   auto baseInterfaceTy = base->getInterfaceType();
   auto derivedInterfaceTy = decl->getInterfaceType();
 
-  auto sig = ctx.getOverrideGenericSignature(base, (ValueDecl *)decl);
-
-  if (sig &&
-      !sig->requirementsNotSatisfiedBy(decl->getGenericSignature()).empty()) {
+  using Direction = ASTContext::OverrideGenericSignatureReqCheck;
+  if (!ctx.overrideGenericSignatureReqsSatisfied(
+          base, (ValueDecl *)decl, Direction::BaseReqSatisfiedByDerived)) {
     return true;
   }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -111,16 +111,15 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
 
   // If base method's generic requirements are not satisfied by the derived
   // method then we need a thunk.
-  auto sig = getASTContext().getOverrideGenericSignature(base.getDecl(),
-                                                         derived.getDecl());
-  auto derivedSig =
-      derived.getDecl()->getAsGenericContext()->getGenericSignature();
-  auto needsThunk = sig && !sig->requirementsNotSatisfiedBy(derivedSig).empty();
+  using Direction = ASTContext::OverrideGenericSignatureReqCheck;
+  auto doesNotHaveGenericRequirementDifference =
+      getASTContext().overrideGenericSignatureReqsSatisfied(
+          baseDecl, derivedDecl, Direction::BaseReqSatisfiedByDerived);
 
   // The override member type is semantically a subtype of the base
   // member type. If the override is ABI compatible, we do not need
   // a thunk.
-  if (!needsThunk && !baseLessVisibleThanDerived &&
+  if (doesNotHaveGenericRequirementDifference && !baseLessVisibleThanDerived &&
       M.Types.checkFunctionForABIDifferences(derivedInfo.SILFnType,
                                              overrideInfo.SILFnType) ==
           TypeConverter::ABIDifference::Trivial)

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -129,6 +129,16 @@ class F: D {
   override func i4(x: Int, y: Int) -> Int {}
 }
 
+protocol Proto {}
+
+class G {
+  func foo<T: Proto>(arg: T) {}
+}
+
+class H: G {
+  override func foo<T>(arg: T) {}
+}
+
 // This test is incorrect in semantic SIL today. But it will be fixed in
 // forthcoming commits.
 //
@@ -303,6 +313,10 @@ class Noot : Aap {
 // CHECK:         #B.i2!1: {{.*}} : @$s13vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
 // CHECK:         #B.i3!1: {{.*}} : @$s13vtable_thunks1F{{[A-Z0-9a-z_]*}}FTV
 // CHECK:         #B.i4!1: {{.*}} : @$s13vtable_thunks1F{{[A-Z0-9a-z_]*}}F
+
+// CHECK-LABEL: sil_vtable H {
+// CHECK:  #G.foo!1: <T where T : Proto> (G) -> (T) -> () : @$s13vtable_thunks1H{{[A-Z0-9a-z_]*}}tlF [override]
+// CHECK:  #H.foo!1: <T> (H) -> (T) -> () : @$s13vtable_thunks1H{{[A-Z0-9a-z_]*}}tlF
 
 // CHECK-LABEL: sil_vtable NoThrowVariance {
 // CHECK:         #ThrowVariance.mightThrow!1: {{.*}} : @$s13vtable_thunks{{[A-Z0-9a-z_]*}}F

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -315,7 +315,7 @@ class Noot : Aap {
 // CHECK:         #B.i4!1: {{.*}} : @$s13vtable_thunks1F{{[A-Z0-9a-z_]*}}F
 
 // CHECK-LABEL: sil_vtable H {
-// CHECK:  #G.foo!1: <T where T : Proto> (G) -> (T) -> () : @$s13vtable_thunks1H{{[A-Z0-9a-z_]*}}tlF [override]
+// CHECK:  #G.foo!1: <T where T : Proto> (G) -> (T) -> () : @$s13vtable_thunks1H{{[A-Z0-9a-z_]*}}FTV [override]
 // CHECK:  #H.foo!1: <T> (H) -> (T) -> () : @$s13vtable_thunks1H{{[A-Z0-9a-z_]*}}tlF
 
 // CHECK-LABEL: sil_vtable NoThrowVariance {


### PR DESCRIPTION
Follow up to #24484. Emit a vtable entry if base method's generic requirements are not satisfied by the derived method.