### PR TITLE
[android] Fix test setup for Android to avoid using -sdk.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1115,7 +1115,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_build_swift = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk,
+        '-Xcc', '--sysroot={}'.format(config.variant_sdk),
+        '-Xclang-linker', '--sysroot={}'.format(config.variant_sdk),
         '-tools-directory', tools_directory,
         android_include_paths_opt, android_link_paths_opt,
         '-use-ld=%s' % config.android_linker_name,
@@ -1131,7 +1132,6 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.swift,
         '-frontend',
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk,
         android_include_paths_opt, android_link_paths_opt,
         resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_frontend_test_options])
@@ -1153,7 +1153,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_swiftc_driver = ' '.join([
         config.swiftc,
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk,
+        '-Xcc', '--sysroot={}'.format(config.variant_sdk),
+        '-Xclang-linker', '--sysroot={}'.format(config.variant_sdk),
         '-tools-directory', tools_directory,
         android_link_paths_opt, resource_dir_opt, mcp_opt,
         '-use-ld=%s' % config.android_linker_name])


### PR DESCRIPTION
The recently introduced changes to make the -sdk also the resource
directory broke the tests in Android, since -sdk was being used because
it is passed as --sysroot to child invocations, which was convinient.

This commit removes those usages in the test suite, and switches to use
--sysroot for the compiler and the linker. Even if in Android only the
linker bit is necessary (since the NDK headers are somewhere different,
and are passed as -I parameters to Swift).

This should remove all the failing test in Android ARMv7 and AArch64 CI machines.
