### PR TITLE
[Constraint graph] Gather type variables in equivalence class.

### DIFF
--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -497,18 +497,8 @@ void ConstraintGraph::gatherConstraints(
         break;
       }
 
-      ArrayRef<TypeVariableType *> adjTypeVarsToVisit;
-      switch (kind) {
-      case GatheringKind::EquivalenceClass:
-        adjTypeVarsToVisit = adjTypeVar;
-        break;
-
-      case GatheringKind::AllMentions:
-        adjTypeVarsToVisit
+      ArrayRef<TypeVariableType *> adjTypeVarsToVisit =
           = (*this)[CS.getRepresentative(adjTypeVar)].getEquivalenceClass();
-        break;
-      }
-
       for (auto adjTypeVarEquiv : adjTypeVarsToVisit) {
         if (!typeVars.insert(adjTypeVarEquiv).second)
           continue;


### PR DESCRIPTION
Experimental change to assess whether the difference in the number of scopes is attributable to this semantic change that happened to be part of https://github.com/apple/swift/pull/26347