### PR TITLE
Remove unused Foundation subclasses

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -305,17 +305,6 @@ internal class __SwiftNativeNSEnumerator {
   deinit {}
 }
 
-// FIXME(ABI)#60 : move into the Foundation overlay and remove 'open'
-@_fixed_layout
-@objc @_swift_native_objc_runtime_base(__SwiftNativeNSDataBase)
-open class __SwiftNativeNSData {
-  @inlinable
-  @objc public init() {}
-  @objc public init(coder: AnyObject) {}
-  @inlinable
-  deinit {}
-}
-
 //===----------------------------------------------------------------------===//
 // Support for reliable testing of the return-autoreleased optimization
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -50,7 +50,7 @@ using namespace swift;
 // NOTE: older runtimes called these _SwiftNativeNSXXXBase. The two must
 // coexist, so these were renamed. The old names must not be used in the new
 // runtime.
-% for Class in ('Array', 'Dictionary', 'Set', 'String', 'Enumerator', 'Data', 'IndexSet'):
+% for Class in ('Array', 'Dictionary', 'Set', 'String', 'Enumerator'):
 SWIFT_RUNTIME_STDLIB_API
 @interface __SwiftNativeNS${Class}Base : NS${Class}
 {

--- a/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
@@ -1,3 +1,4 @@
+Class __SwiftNativeNSData has been removed
 Func _collectReferencesInsideObject(_:) is a new API without @available attribute
 Func _loadDestroyTLSCounter() is a new API without @available attribute
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute

--- a/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
+++ b/test/stdlib/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m
@@ -69,8 +69,6 @@ BOOL TestSwiftNativeNSBase_UnwantedCdtors()
       @"__SwiftNativeNSSetBase",
       @"__SwiftNativeNSStringBase",
       @"__SwiftNativeNSEnumeratorBase",
-      @"__SwiftNativeNSDataBase",
-      @"__SwiftNativeNSIndexSetBase",
       nil];
 
   for (unsigned int i = 0; i < classCount; i++) {


### PR DESCRIPTION
Technically ABI, but impossible to reference without looking it up by name, and no apps are doing so