### PR TITLE
[test] Re-enable deserialize_appkit.sil

### DIFF
--- a/test/SIL/Serialization/deserialize_appkit.sil
+++ b/test/SIL/Serialization/deserialize_appkit.sil
@@ -6,6 +6,3 @@
 // REQUIRES: OS=macosx
 
 // CHECK-NOT: Unknown
-
-// FIXME: rdar://23805004 Non-fragile shared functions are incorrectly being referenced in fragile functions
-// REQUIRES: rdar23805004


### PR DESCRIPTION
It appears to be working again. I don't know what we did, but let's not regress in the future!

rdar://problem/47200045