### PR TITLE
[5.1] Add Identifiable protocol to the standard library

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SWIFTLIB_ESSENTIAL
   Hashing.swift
   HashTable.swift
   ICU.swift
+  Identifiable.swift
   Indices.swift
   InputStream.swift
   IntegerParsing.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -200,6 +200,7 @@
   "Misc": [
     "AtomicInt.swift",
     "ErrorType.swift",
+    "Identifiable.swift",
     "InputStream.swift",
     "LifetimeManager.swift",
     "ManagedBuffer.swift",

--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A class of types whose instances hold the value of an entity with stable identity.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol Identifiable {
+
+  /// A type representing the stable identity of the entity associated with `self`.
+  associatedtype ID: Hashable
+
+  /// The stable identity of the entity associated with `self`.
+  var id: ID { get }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Identifiable where Self: AnyObject {
+  public var id: ObjectIdentifier {
+    return ObjectIdentifier(self)
+  }
+}

--- a/test/stdlib/Identifiable.swift
+++ b/test/stdlib/Identifiable.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+struct IdentifiableValue: Identifiable {
+  let id = 42
+}
+
+class IdentifiableClass: Identifiable {}


### PR DESCRIPTION
This implements [SE-0261](https://github.com/apple/swift-evolution/blob/master/proposals/0261-identifiable.md), cherry picked from #26022 by @anandabits.

