### PR TITLE
ClangImporter: search for `glbc.modulemap` in the SDK

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -413,27 +413,38 @@ void ClangImporter::clearTypeResolver() {
 /// compiling for, and is not included in the resource directory with the other
 /// implicit module maps. It's at {freebsd|linux}/{arch}/glibc.modulemap.
 static Optional<StringRef>
-getGlibcModuleMapPath(StringRef resourceDir, llvm::Triple triple,
-                      SmallVectorImpl<char> &scratch) {
-  if (resourceDir.empty())
-    return None;
+getGlibcModuleMapPath(SearchPathOptions& Opts, llvm::Triple triple,
+                      SmallVectorImpl<char> &buffer) {
+  StringRef platform = swift::getPlatformNameForTriple(triple);
+  StringRef arch = swift::getMajorArchitectureName(triple);
 
-  scratch.append(resourceDir.begin(), resourceDir.end());
-  llvm::sys::path::append(
-      scratch,
-      swift::getPlatformNameForTriple(triple),
-      swift::getMajorArchitectureName(triple),
-      "glibc.modulemap");
+  if (!Opts.SDKPath.empty()) {
+    buffer.clear();
+    buffer.append(Opts.SDKPath.begin(), Opts.SDKPath.end());
+    llvm::sys::path::append(buffer, "usr", "lib", "swift");
+    llvm::sys::path::append(buffer, platform, arch, "glibc.modulemap");
 
-  // Only specify the module map if that file actually exists.
-  // It may not--for example in the case that
-  // `swiftc -target x86_64-unknown-linux-gnu -emit-ir` is invoked using
-  // a Swift compiler not built for Linux targets.
-  if (llvm::sys::fs::exists(scratch)) {
-    return StringRef(scratch.data(), scratch.size());
-  } else {
-    return None;
+    // Only specify the module map if that file actually exists.  It may not;
+    // for example in the case that `swiftc -target x86_64-unknown-linux-gnu
+    // -emit-ir` is invoked using a Swift compiler not built for Linux targets.
+    if (llvm::sys::fs::exists(buffer))
+      return StringRef(buffer.data(), buffer.size());
   }
+
+  if (!Opts.RuntimeResourcePath.empty()) {
+    buffer.clear();
+    buffer.append(Opts.RuntimeResourcePath.begin(),
+                  Opts.RuntimeResourcePath.end());
+    llvm::sys::path::append(buffer, platform, arch, "glibc.modulemap");
+
+    // Only specify the module map if that file actually exists.  It may not;
+    // for example in the case that `swiftc -target x86_64-unknown-linux-gnu
+    // -emit-ir` is invoked using a Swift compiler not built for Linux targets.
+    if (llvm::sys::fs::exists(buffer))
+      return StringRef(buffer.data(), buffer.size());
+  }
+
+  return None;
 }
 
 static void
@@ -606,9 +617,8 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       }
     }
 
-    SmallString<128> GlibcModuleMapPath;
-    if (auto path = getGlibcModuleMapPath(searchPathOpts.RuntimeResourcePath,
-                                          triple, GlibcModuleMapPath)) {
+    SmallString<128> buffer;
+    if (auto path = getGlibcModuleMapPath(searchPathOpts, triple, buffer)) {
       invocationArgStrs.push_back((Twine("-fmodule-map-file=") + *path).str());
     } else {
       // FIXME: Emit a warning of some kind.


### PR DESCRIPTION
When cross-compiling with a swift built for another target or when
building with a pure toolchain without the resource directory containing
host content, the modulemap required for Linux may not be found.  In
such a case, we should also look for the content in the SDK if one is
provided.  This improves the behaviour of `swiftc` for Linux with a
standalone SDK.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
