### PR TITLE
[Constraint graph] Reimplement connected components using union-find.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -164,12 +164,6 @@ void SplitterStep::computeFollowupSteps(
       componentSteps[known->second]->record(typeVar);
       continue;
     }
-
-    // Otherwise, associate it with all of the component steps,
-    // expect for components with orphaned constraints, they are
-    // not supposed to have any type variables.
-    for (unsigned i = 0; i != firstOrphanedComponent; ++i)
-      componentSteps[i]->record(typeVar);
   }
 
   // Transfer all of the constraints from the work list to

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -123,6 +123,16 @@ void SplitterStep::computeFollowupSteps(
         CS, i, &Components[i], orphaned, PartialSolutions[i]));
   }
 
+  // Transfer any remaining constraints from the work list to the first
+  // component, which is arbitrary but prevents them from being visited
+  // again.
+  auto &workList = CS.InactiveConstraints;
+  while (!workList.empty()) {
+    auto *constraint = &workList.front();
+    workList.pop_front();
+    componentSteps[0]->record(constraint);
+  }
+
   if (isDebugMode()) {
     auto &log = getDebugLogger();
     // Verify that the constraint graph is valid.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -662,6 +662,9 @@ private:
       // Disable all of the overload choices which are different from
       // the one which is currently picked for representative.
       for (auto *constraint : disjunction->getNestedConstraints()) {
+        if (constraint->getKind() != ConstraintKind::BindOverload)
+          continue;
+
         auto choice = constraint->getOverloadChoice();
         if (!choice.isDecl() || choice.getDecl() == representative.getDecl())
           continue;

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -386,7 +386,6 @@ public:
     record(orphaned);
   }
 
-private:
   /// Record a constraint as associated with this step.
   void record(Constraint *constraint) {
     Constraints->push_back(constraint);

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -211,11 +211,6 @@ public:
 
     /// The constraints in this component.
     TinyPtrVector<Constraint *> constraints;
-
-    /// Whether this component represents an orphaned constraint.
-    bool isOrphanedConstraint() const {
-      return typeVars.empty();
-    }
   };
 
   /// Compute the connected components of the graph.

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Compiler.h"
 #include <functional>
 #include <utility>
@@ -202,20 +203,30 @@ public:
     return TypeVariables;
   }
 
+  /// Describes a single component, as produced by the connected components
+  /// algorithm.
+  struct Component {
+    /// The type variables in this component.
+    TinyPtrVector<TypeVariableType *> typeVars;
+
+    /// The constraints in this component.
+    TinyPtrVector<Constraint *> constraints;
+
+    /// Whether this component represents an orphaned constraint.
+    bool isOrphanedConstraint() const {
+      return typeVars.empty();
+    }
+  };
+
   /// Compute the connected components of the graph.
   ///
   /// \param typeVars The type variables that should be included in the
   /// set of connected components that are returned.
   ///
-  /// \param components Receives the component numbers for each type variable
-  /// in \c typeVars.
-  ///
-  /// \returns the number of connected components in the graph, which includes
-  /// one component for each of the constraints produced by
-  /// \c getOrphanedConstraints().
-  unsigned computeConnectedComponents(
-             std::vector<TypeVariableType *> &typeVars,
-             std::vector<unsigned> &components);
+  /// \returns the connected components of the graph, where each component
+  /// contains the type variables and constraints specific to that component.
+  SmallVector<Component, 1> computeConnectedComponents(
+             ArrayRef<TypeVariableType *> typeVars);
 
   /// Retrieve the set of "orphaned" constraints, which are known to the
   /// constraint graph but have no type variables to anchor them.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1290,6 +1290,7 @@ private:
     ///
     /// \param constraint The newly generated constraint.
     void addGeneratedConstraint(Constraint *constraint) {
+      assert(constraint && "Null generated constraint?");
       generatedConstraints.push_back(constraint);
     }
 


### PR DESCRIPTION
Replace the depth-first-search--based connected components algorithm
with one based on union-find, which makes it easier to initially
exclude some constraints and then add them in later.

Also clean up the interface to the connected-components algorithm to be
more self-contained, producing a vector containing each of the actual
components (where each is defined by a list of type variables and a list
of constraints). This simplifies the contract with the client
(SplitterStep) and eliminates a bunch of separate mapping steps to
interpret the results.

All of this is staging to take advantage of one-way constraints. It should
have little practical effect otherwise, except make the code clearer.