### PR TITLE
[DNM: ASTScope lookup] Fix backwards PatternBindingEntry::getSourceRange

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3643,8 +3643,8 @@ public:
 
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
-
-      if (!D->getSourceRange().isValid()) {
+      const auto SR = D->getSourceRange();
+      if (!SR.isValid()) {
         // We don't care about source ranges on implicitly-generated
         // decls.
         if (D->isImplicit())
@@ -3655,8 +3655,16 @@ public:
         Out << "\n";
         abort();
       }
-      checkSourceRanges(D->getSourceRange(), Parent,
-                        [&]{ D->print(Out); });
+      // ASTScope lookup depends on Decls having correct ordering.
+      // Move the order check to isGoodSourceRange after extending
+      // the invariant to Exprs, etc., per rdar://53637494
+      if (Ctx.SourceMgr.isBeforeInBuffer(SR.End, SR.Start)) {
+        Out << "backwards source range for decl: ";
+        D->print(Out);
+        Out << "\n";
+        abort();
+      }
+      checkSourceRanges(SR, Parent, [&] { D->print(Out); });
     }
 
     /// Verify that the given source ranges is contained within the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1429,8 +1429,11 @@ VarDecl *PatternBindingEntry::getAnchoringVarDecl() const {
 }
 
 SourceRange PatternBindingEntry::getSourceRange(bool omitAccessors) const {
-  // Patterns end at the initializer, if present.
-  SourceLoc endLoc = getOrigInitRange().End;
+  // A CustomAttr for a property wrapper can have an initializer that comes
+  // before the pattern.
+  const bool initializerFollows = getEqualLoc().isValid();
+  // Patterns end at a following initializer
+  SourceLoc endLoc = initializerFollows ? getOrigInitRange().End : SourceLoc();
 
   // If we're not banned from handling accessors, they follow the initializer.
   if (!omitAccessors) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
`PatternBindingEntry::getSourceRange` uses the end of the initializer for the end of the range. But, if the initializer is a property wrapper, the initializer comes before the start of the `PatternBindingEntry.` Prevent the  computation from using such an initializer. 

At present, this change isn't quite ready for prime time because uses a check that bypasses the `SourceManager::isBeforeInBuffer` abstraction, since I don't see how to get the `SourceManager` into play where it is needed.

In addition to a fix being needed for ASTScope lookup, this fix will be needed to address part of rdar://53637494