### PR TITLE
test: adjust declaration to be portable (NFCI)

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/UnimportableMembersUser.h
+++ b/test/ClangImporter/Inputs/custom-modules/UnimportableMembersUser.h
@@ -1,5 +1,5 @@
 @import UnimportableMembers;
 
 @interface DesignatedInitializerInAnotherModule (/*evil class extension*/)
-- (instancetype)initFromOtherModule:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initFromOtherModule:(intptr_t)x __attribute__((objc_designated_initializer));
 @end


### PR DESCRIPTION
`long` is teated as `Int32` on Windows x86_64.  `intptr_t` will be
mapped to `Int` and `Int64`.  This fixes the failing test on Windows
which is LLP64 and should be equivalent on LP64 targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
