### PR TITLE
[AutoDiff] Use ASTMangler for generated AD associated functions.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -164,7 +164,7 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   // Mangle the autodiff linear map (differential/pullback) with the given:
   // - Mangled original function name.
-  // - Associated function kind.
+  // - Linear map kind.
   // - Parameter/result indices.
   std::string mangleAutoDiffLinearMapHelper(
       StringRef name, AutoDiffLinearMapKind kind,

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -151,7 +151,17 @@ public:
                                              Type FromType, Type ToType,
                                              Type SelfType,
                                              ModuleDecl *Module);
-  
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // Mangle the autodiff associated function with the given:
+  // - Mangled original function name.
+  // - Associated function kind.
+  // - Parameter/result indices.
+  // - Flag representing whether the function is a differential/pullback.
+  std::string mangleAutoDiffAssociatedFunctionHelper(
+      StringRef name, AutoDiffAssociatedFunctionKind kind,
+      const SILAutoDiffIndices &indices, bool isLinearMap = false);
+
   std::string mangleKeyPathGetterThunkHelper(const AbstractStorageDecl *property,
                                              GenericSignature *signature,
                                              CanType baseType,

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -153,14 +153,22 @@ public:
                                              ModuleDecl *Module);
 
   // SWIFT_ENABLE_TENSORFLOW
-  // Mangle the autodiff associated function with the given:
+  // Mangle the autodiff associated function (JVP/VJP) with the given:
   // - Mangled original function name.
   // - Associated function kind.
   // - Parameter/result indices.
-  // - Flag representing whether the function is a differential/pullback.
   std::string mangleAutoDiffAssociatedFunctionHelper(
       StringRef name, AutoDiffAssociatedFunctionKind kind,
-      const SILAutoDiffIndices &indices, bool isLinearMap = false);
+      const SILAutoDiffIndices &indices);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // Mangle the autodiff linear map (differential/pullback) with the given:
+  // - Mangled original function name.
+  // - Associated function kind.
+  // - Parameter/result indices.
+  std::string mangleAutoDiffLinearMapHelper(
+      StringRef name, AutoDiffAssociatedFunctionKind kind,
+      const SILAutoDiffIndices &indices);
 
   std::string mangleKeyPathGetterThunkHelper(const AbstractStorageDecl *property,
                                              GenericSignature *signature,

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -167,7 +167,7 @@ public:
   // - Associated function kind.
   // - Parameter/result indices.
   std::string mangleAutoDiffLinearMapHelper(
-      StringRef name, AutoDiffAssociatedFunctionKind kind,
+      StringRef name, AutoDiffLinearMapKind kind,
       const SILAutoDiffIndices &indices);
 
   std::string mangleKeyPathGetterThunkHelper(const AbstractStorageDecl *property,

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -546,6 +546,20 @@ struct AutoDiffAssociatedFunctionKind {
   operator innerty() const { return rawValue; }
 };
 
+/// The kind of an linear map.
+struct AutoDiffLinearMapKind {
+  enum innerty : uint8_t {
+     // The differential function.
+     Differential = 0,
+     // The pullback function.
+     Pullback = 1
+  } rawValue;
+
+  AutoDiffLinearMapKind() = default;
+  AutoDiffLinearMapKind(innerty rawValue) : rawValue(rawValue) {}
+  operator innerty() const { return rawValue; }
+};
+
 /// In conjunction with the original function decl, identifies an associated
 /// autodiff function.
 ///

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -371,26 +371,41 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
 
 std::string ASTMangler::mangleAutoDiffAssociatedFunctionHelper(
     StringRef name, AutoDiffAssociatedFunctionKind kind,
-    const SILAutoDiffIndices &indices, bool isLinearMap) {
+    const SILAutoDiffIndices &indices) {
   // TODO(TF-20): Make the mangling scheme robust.
   // TODO(TF-680): Mangle `@differentiable` atttribute requirements as well.
   beginManglingWithoutPrefix();
 
-  Buffer << "AD__";
-  Buffer << name;
-  Buffer << '_';
+  Buffer << "AD__" << name << '_';
   switch (kind) {
   case AutoDiffAssociatedFunctionKind::JVP:
-    if (isLinearMap)
-      Buffer << "_differential_";
-    else
-      Buffer << "_jvp_";
+    Buffer << "_jvp_";
     break;
   case AutoDiffAssociatedFunctionKind::VJP:
-    if (isLinearMap)
-      Buffer << "_pullback_";
-    else
-      Buffer << "_vjp_";
+    Buffer << "_vjp_";
+    break;
+  }
+  Buffer << indices.mangle();
+
+  auto result = Storage.str().str();
+  Storage.clear();
+  return result;
+}
+
+std::string ASTMangler::mangleAutoDiffLinearMapHelper(
+    StringRef name, AutoDiffAssociatedFunctionKind kind,
+    const SILAutoDiffIndices &indices) {
+  // TODO(TF-20): Make the mangling scheme robust.
+  // TODO(TF-680): Mangle `@differentiable` atttribute requirements as well.
+  beginManglingWithoutPrefix();
+
+  Buffer << "AD__" << name << '_';
+  switch (kind) {
+  case AutoDiffAssociatedFunctionKind::JVP:
+    Buffer << "_differential_";
+    break;
+  case AutoDiffAssociatedFunctionKind::VJP:
+    Buffer << "_pullback_";
     break;
   }
   Buffer << indices.mangle();

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -393,7 +393,7 @@ std::string ASTMangler::mangleAutoDiffAssociatedFunctionHelper(
 }
 
 std::string ASTMangler::mangleAutoDiffLinearMapHelper(
-    StringRef name, AutoDiffAssociatedFunctionKind kind,
+    StringRef name, AutoDiffLinearMapKind kind,
     const SILAutoDiffIndices &indices) {
   // TODO(TF-20): Make the mangling scheme robust.
   // TODO(TF-680): Mangle `@differentiable` atttribute requirements as well.
@@ -401,10 +401,10 @@ std::string ASTMangler::mangleAutoDiffLinearMapHelper(
 
   Buffer << "AD__" << name << '_';
   switch (kind) {
-  case AutoDiffAssociatedFunctionKind::JVP:
+  case AutoDiffLinearMapKind::Differential:
     Buffer << "_differential_";
     break;
-  case AutoDiffAssociatedFunctionKind::VJP:
+  case AutoDiffLinearMapKind::Pullback:
     Buffer << "_pullback_";
     break;
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -369,6 +369,37 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   return finalize();
 }
 
+std::string ASTMangler::mangleAutoDiffAssociatedFunctionHelper(
+    StringRef name, AutoDiffAssociatedFunctionKind kind,
+    const SILAutoDiffIndices &indices, bool isLinearMap) {
+  // TODO(TF-20): Make the mangling scheme robust.
+  // TODO(TF-680): Mangle `@differentiable` atttribute requirements as well.
+  beginManglingWithoutPrefix();
+
+  Buffer << "AD__";
+  Buffer << name;
+  Buffer << '_';
+  switch (kind) {
+  case AutoDiffAssociatedFunctionKind::JVP:
+    if (isLinearMap)
+      Buffer << "_differential_";
+    else
+      Buffer << "_jvp_";
+    break;
+  case AutoDiffAssociatedFunctionKind::VJP:
+    if (isLinearMap)
+      Buffer << "_pullback_";
+    else
+      Buffer << "_vjp_";
+    break;
+  }
+  Buffer << indices.mangle();
+
+  auto result = Storage.str().str();
+  Storage.clear();
+  return result;
+}
+
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
   PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
                                         "mangling type for debugger", Ty);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3508,18 +3508,10 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionReorderingThunk(
     IsSerialized_t isSerialized) {
   auto assocFnType = assocFn->getLoweredFunctionType();
 
-  std::string name;
-  switch (assocFnKind) {
-  case AutoDiffAssociatedFunctionKind::JVP:
-    name = "jvp";
-    break;
-  case AutoDiffAssociatedFunctionKind::VJP:
-    name = "vjp";
-    break;
-  }
-  name = getASTContext().getIdentifier(
-      "AD__" + original->getName().str() + "__" + name + "_" +
-      indices.mangle()).str();
+  Mangle::ASTMangler mangler;
+  auto name = getASTContext().getIdentifier(
+      mangler.mangleAutoDiffAssociatedFunctionHelper(
+          original->getName(), assocFnKind, indices)).str();
 
   Lowering::GenericContextScope genericContextScope(
       Types, assocFnType->getGenericSignature());

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6147,7 +6147,7 @@ ADContext::getOrCreateSubsetParametersThunkForLinearMap(
       /*withoutActuallyEscaping*/ true,
       DifferentiationThunkKind::Reabstraction);
 
-  // TODO: Use more principled mangling.
+  // TODO(TF-685): Use more principled mangling for thunks.
   std::string thunkName;
   switch (kind) {
     case AutoDiffAssociatedFunctionKind::JVP:
@@ -6413,7 +6413,7 @@ ADContext::getOrCreateSubsetParametersThunkForAssociatedFunction(
         ->getAbstractFunctionDecl()->getNameStr();
   }
   assert(!origName.empty() && "Original function name could not be resolved");
-  // TODO: Use more principled mangling.
+  // TODO(TF-685): Use more principled mangling for thunks.
   std::string thunkName;
   switch (kind) {
     case AutoDiffAssociatedFunctionKind::JVP:
@@ -6536,6 +6536,7 @@ SILValue ADContext::promoteToDifferentiableFunction(
     if (auto *thunkRef = dyn_cast<FunctionRefInst>(ai->getCallee())) {
       SILAutoDiffIndices desiredIndices(resultIndex, parameterIndices);
       auto *thunk = thunkRef->getReferencedFunctionOrNull();
+      // TODO(TF-685): Use more principled mangling for thunks.
       auto newThunkName = "AD__" + thunk->getName().str() +
           "__differentiable_curry_thunk_" + desiredIndices.mangle();
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2961,9 +2961,9 @@ public:
 
     Mangle::ASTMangler mangler;
     auto pbName = original->getASTContext().getIdentifier(
-        mangler.mangleAutoDiffAssociatedFunctionHelper(
+        mangler.mangleAutoDiffLinearMapHelper(
             original->getName(), AutoDiffAssociatedFunctionKind::VJP,
-            indices, /*isLinearMap*/ true)).str();
+            indices)).str();
     auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
     auto *pbGenericEnv = pbGenericSig
         ? pbGenericSig->createGenericEnvironment()
@@ -3553,9 +3553,9 @@ public:
     }
     Mangle::ASTMangler mangler;
     auto diffName = original->getASTContext().getIdentifier(
-        mangler.mangleAutoDiffAssociatedFunctionHelper(
+        mangler.mangleAutoDiffLinearMapHelper(
             original->getName(), AutoDiffAssociatedFunctionKind::JVP,
-            indices, /*isLinearMap*/ true)).str();
+            indices)).str();
     auto diffGenericSig = getAssociatedFunctionGenericSignature(attr, original);
     auto *diffGenericEnv = diffGenericSig
         ? diffGenericSig->createGenericEnvironment()

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -2962,7 +2962,7 @@ public:
     Mangle::ASTMangler mangler;
     auto pbName = original->getASTContext().getIdentifier(
         mangler.mangleAutoDiffLinearMapHelper(
-            original->getName(), AutoDiffAssociatedFunctionKind::VJP,
+            original->getName(), AutoDiffLinearMapKind::Pullback,
             indices)).str();
     auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
     auto *pbGenericEnv = pbGenericSig
@@ -3554,7 +3554,7 @@ public:
     Mangle::ASTMangler mangler;
     auto diffName = original->getASTContext().getIdentifier(
         mangler.mangleAutoDiffLinearMapHelper(
-            original->getName(), AutoDiffAssociatedFunctionKind::JVP,
+            original->getName(), AutoDiffLinearMapKind::Differential,
             indices)).str();
     auto diffGenericSig = getAssociatedFunctionGenericSignature(attr, original);
     auto *diffGenericEnv = diffGenericSig

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -35,16 +35,6 @@ func weirdWrapper<T : Differentiable>(_ x: T) -> T {
 }
 _ = gradient(at: Float(1), in: { x in weirdWrapper(x) })
 
-/*
-// FIXME(TF-482): This currently crashes during differentiation transform.
-// because `T` is not constrained to `Differentiable` in generated
-// `[differentiable]` attribute.
-@differentiable
-func directMissingConformance<T>(_ x: T) -> T {
-  return x
-}
-*/
-
 @differentiable
 func direct<T : Differentiable>(_ x: T) -> T {
   return x

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -613,6 +613,12 @@ func invalidRequirementLayout<Scalar>(x: Scalar) -> Scalar {
   return x
 }
 
+// expected-error @+1 {{no differentiation parameters could be inferred; must differentiate with respect to at least one parameter conforming to 'Differentiable'}}
+@differentiable
+func missingConformance<T>(_ x: T) -> T {
+  return x
+}
+
 protocol ProtocolRequirements : Differentiable {
   // expected-note @+2 {{protocol requires initializer 'init(x:y:)' with type '(x: Float, y: Float)'}}
   @differentiable


### PR DESCRIPTION
Use ASTMangler for generated AD associated functions:
JVPs, VJPs, differentials, pullbacks.

This centralizes the ad-hoc mangling logic scattered throughout the codebase.

Todos:
- [TF-680](https://bugs.swift.org/browse/TF-680): Mangle `@differentiable` attribute requirements.
- [TF-685](https://bugs.swift.org/browse/TF-685): Use ASTMangler for AD-related thunks.
- [TF-686](https://bugs.swift.org/browse/TF-686): Make Demangler/Remangler work with AD-generated functions.