### PR TITLE
[stdlib] Change documented behavior of FloatingPoint.significand

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -468,7 +468,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// is defined as follows:
   ///
   /// - If `x` is zero, then `x.significand` is 0.0.
-  /// - If `x` is infinity, then `x.significand` is 1.0.
+  /// - If `x` is infinite, then `x.significand` is infinity.
   /// - If `x` is NaN, then `x.significand` is NaN.
   /// - Note: The significand is frequently also called the *mantissa*, but
   ///   significand is the preferred terminology in the [IEEE 754

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -786,7 +786,7 @@ extension ${Self}: BinaryFloatingPoint {
   /// is defined as follows:
   ///
   /// - If `x` is zero, then `x.significand` is 0.0.
-  /// - If `x` is infinity, then `x.significand` is 1.0.
+  /// - If `x` is infinite, then `x.significand` is infinity.
   /// - If `x` is NaN, then `x.significand` is NaN.
   /// - Note: The significand is frequently also called the *mantissa*, but
   ///   significand is the preferred terminology in the [IEEE 754


### PR DESCRIPTION
<!-- What's in this pull request? -->
A seemingly innocuous but actually nontrivial change.

In SE-0067, the intended behavior of `significand` for exceptional values was as follows:

> - If `x` is zero, then `x.significand` is 0.0.
> - If `x` is infinity, then `x.significand` is 1.0.
> - If `x` is NaN, then `x.significand` is NaN.

However, the actual behavior of `significand` is as follows:

```swift
Float.infinity.significand  // +inf
Double.infinity.significand // +inf
// (etc.)
```

To align the actual behavior with the intended one would have been easy enough before ABI stability: the branch for finite normal values works just fine for infinite values in producing the desired result. However, the function is `@inlinable` and we've shipped the existing behavior, so observably changing the actual behavior now is somewhat suboptimal from that standpoint.

On the other hand, it's perfectly defensible for infinite values to have an infinite significand. The documentation currently states:

> If a type’s radix is 2, then for finite nonzero numbers, the significand is in the range `1.0 ..< 2.0`.

With the current actual behavior, we can make another guarantee: for infinite, zero, or NaN values, the significand is _not_ in the range `1.0 ..< 2.0`.

In any case, we've got to reconcile the documented behavior with the actual behavior one way or another.

---

> (Not tackled here: the documentation for `FloatingPoint` requirements is repeated in two places; this should be unnecessary and is liable to fall out of sync.)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->