### PR TITLE
Remove doc comments from concrete floating-point types

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1615,64 +1615,15 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - If `x` is Float.pi, `x.significand` is `1.10010010000111111011011` in
   ///   binary, and `x.significandWidth` is 23.
   var significandWidth: Int { get }
-
-  /*  TODO: Implement these once it becomes possible to do so. (Requires
-   *  revised Integer protocol).
-  func isEqual<Other: BinaryFloatingPoint>(to other: Other) -> Bool
-
-  func isLess<Other: BinaryFloatingPoint>(than other: Other) -> Bool
-
-  func isLessThanOrEqualTo<Other: BinaryFloatingPoint>(other: Other) -> Bool
-
-  func isTotallyOrdered<Other: BinaryFloatingPoint>(belowOrEqualTo other: Other) -> Bool
-  */
 }
 
 extension FloatingPoint {
 
-  /// The unit in the last place of 1.0.
-  ///
-  /// The positive difference between 1.0 and the next greater representable
-  /// number. The `ulpOfOne` constant corresponds to the C macros
-  /// `FLT_EPSILON`, `DBL_EPSILON`, and others with a similar purpose.
   @inlinable // FIXME(sil-serialize-all)
   public static var ulpOfOne: Self {
     return (1 as Self).ulp
   }
 
-  /// Returns this value rounded to an integral value using the specified
-  /// rounding rule.
-  ///
-  /// The following example rounds a value using four different rounding rules:
-  ///
-  ///     let x = 6.5
-  ///
-  ///     // Equivalent to the C 'round' function:
-  ///     print(x.rounded(.toNearestOrAwayFromZero))
-  ///     // Prints "7.0"
-  ///
-  ///     // Equivalent to the C 'trunc' function:
-  ///     print(x.rounded(.towardZero))
-  ///     // Prints "6.0"
-  ///
-  ///     // Equivalent to the C 'ceil' function:
-  ///     print(x.rounded(.up))
-  ///     // Prints "7.0"
-  ///
-  ///     // Equivalent to the C 'floor' function:
-  ///     print(x.rounded(.down))
-  ///     // Prints "6.0"
-  ///
-  /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `rounded()`
-  /// method instead.
-  ///
-  ///     print(x.rounded())
-  ///     // Prints "7.0"
-  ///
-  /// - Parameter rule: The rounding rule to use.
-  /// - Returns: The integral value found by rounding using `rule`.
   @_transparent
   public func rounded(_ rule: FloatingPointRoundingRule) -> Self {
     var lhs = self
@@ -1680,67 +1631,16 @@ extension FloatingPoint {
     return lhs
   }
 
-  /// Returns this value rounded to an integral value using "schoolbook
-  /// rounding."
-  ///
-  /// The `rounded()` method uses the `.toNearestOrAwayFromZero` rounding rule,
-  /// where a value halfway between two integral values is rounded to the one
-  /// with greater magnitude. The following example rounds several values
-  /// using this default rule:
-  ///
-  ///     (5.2).rounded()
-  ///     // 5.0
-  ///     (5.5).rounded()
-  ///     // 6.0
-  ///     (-5.2).rounded()
-  ///     // -5.0
-  ///     (-5.5).rounded()
-  ///     // -6.0
-  ///
-  /// To specify an alternative rule for rounding, use the `rounded(_:)` method
-  /// instead.
-  ///
-  /// - Returns: The nearest integral value, or, if two integral values are
-  ///   equally close, the integral value with greater magnitude.
   @_transparent
   public func rounded() -> Self {
     return rounded(.toNearestOrAwayFromZero)
   }
 
-  /// Rounds this value to an integral value using "schoolbook rounding."
-  ///
-  /// The `round()` method uses the `.toNearestOrAwayFromZero` rounding rule,
-  /// where a value halfway between two integral values is rounded to the one
-  /// with greater magnitude. The following example rounds several values
-  /// using this default rule:
-  ///
-  ///     var x = 5.2
-  ///     x.round()
-  ///     // x == 5.0
-  ///     var y = 5.5
-  ///     y.round()
-  ///     // y == 6.0
-  ///     var z = -5.5
-  ///     z.round()
-  ///     // z == -6.0
-  ///
-  /// To specify an alternative rule for rounding, use the `round(_:)` method
-  /// instead.
   @_transparent
   public mutating func round() {
     round(.toNearestOrAwayFromZero)
   }
 
-  /// The greatest representable value that compares less than this value.
-  ///
-  /// For any finite value `x`, `x.nextDown` is less than `x`. For `nan` or
-  /// `-infinity`, `x.nextDown` is `x` itself. The following special cases
-  /// also apply:
-  ///
-  /// - If `x` is `infinity`, then `x.nextDown` is `greatestFiniteMagnitude`.
-  /// - If `x` is `leastNonzeroMagnitude`, then `x.nextDown` is `0.0`.
-  /// - If `x` is zero, then `x.nextDown` is `-leastNonzeroMagnitude`.
-  /// - If `x` is `-greatestFiniteMagnitude`, then `x.nextDown` is `-infinity`.
   @inlinable // FIXME(inline-always)
   public var nextDown: Self {
     @inline(__always)
@@ -1749,37 +1649,6 @@ extension FloatingPoint {
     }
   }
 
-  /// Returns the remainder of this value divided by the given value using
-  /// truncating division.
-  ///
-  /// Performing truncating division with floating-point values results in a
-  /// truncated integer quotient and a remainder. For values `x` and `y` and
-  /// their truncated integer quotient `q`, the remainder `r` satisfies
-  /// `x == y * q + r`.
-  ///
-  /// The following example calculates the truncating remainder of dividing
-  /// 8.625 by 0.75:
-  ///
-  ///     let x = 8.625
-  ///     print(x / 0.75)
-  ///     // Prints "11.5"
-  ///
-  ///     let q = (x / 0.75).rounded(.towardZero)
-  ///     // q == 11.0
-  ///     let r = x.truncatingRemainder(dividingBy: 0.75)
-  ///     // r == 0.375
-  ///
-  ///     let x1 = 0.75 * q + r
-  ///     // x1 == 8.625
-  ///
-  /// If this value and `other` are both finite numbers, the truncating
-  /// remainder has the same sign as this value and is strictly smaller in
-  /// magnitude than `other`. The `truncatingRemainder(dividingBy:)` method
-  /// is always exact.
-  ///
-  /// - Parameter other: The value to use when dividing this value.
-  /// - Returns: The remainder of this value divided by `other` using
-  ///   truncating division.
   @inlinable // FIXME(inline-always)
   @inline(__always)
   public func truncatingRemainder(dividingBy other: Self) -> Self {
@@ -1788,38 +1657,6 @@ extension FloatingPoint {
     return lhs
   }
 
-  /// Returns the remainder of this value divided by the given value.
-  ///
-  /// For two finite values `x` and `y`, the remainder `r` of dividing `x` by
-  /// `y` satisfies `x == y * q + r`, where `q` is the integer nearest to
-  /// `x / y`. If `x / y` is exactly halfway between two integers, `q` is
-  /// chosen to be even. Note that `q` is *not* `x / y` computed in
-  /// floating-point arithmetic, and that `q` may not be representable in any
-  /// available integer type.
-  ///
-  /// The following example calculates the remainder of dividing 8.625 by 0.75:
-  ///
-  ///     let x = 8.625
-  ///     print(x / 0.75)
-  ///     // Prints "11.5"
-  ///
-  ///     let q = (x / 0.75).rounded(.toNearestOrEven)
-  ///     // q == 12.0
-  ///     let r = x.remainder(dividingBy: 0.75)
-  ///     // r == -0.375
-  ///
-  ///     let x1 = 0.75 * q + r
-  ///     // x1 == 8.625
-  ///
-  /// If this value and `other` are finite numbers, the remainder is in the
-  /// closed range `-abs(other / 2)...abs(other / 2)`. The
-  /// `remainder(dividingBy:)` method is always exact. This method implements
-  /// the remainder operation defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: The value to use when dividing this value.
-  /// - Returns: The remainder of this value divided by `other`.
   @inlinable // FIXME(inline-always)
   @inline(__always)
   public func remainder(dividingBy other: Self) -> Self {
@@ -1828,20 +1665,6 @@ extension FloatingPoint {
     return lhs
   }
 
-  /// Returns the square root of the value, rounded to a representable value.
-  ///
-  /// The following example declares a function that calculates the length of
-  /// the hypotenuse of a right triangle given its two perpendicular sides.
-  ///
-  ///     func hypotenuse(_ a: Double, _ b: Double) -> Double {
-  ///         return (a * a + b * b).squareRoot()
-  ///     }
-  ///
-  ///     let (dx, dy) = (3.0, 4.0)
-  ///     let distance = hypotenuse(dx, dy)
-  ///     // distance == 5.0
-  ///
-  /// - Returns: The square root of the value.
   @_transparent
   public func squareRoot( ) -> Self {
     var lhs = self
@@ -1849,19 +1672,6 @@ extension FloatingPoint {
     return lhs
   }
 
-  /// Returns the result of adding the product of the two given values to this
-  /// value, computed without intermediate rounding.
-  ///
-  /// This method is equivalent to the C `fma` function and implements the
-  /// `fusedMultiplyAdd` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - lhs: One of the values to multiply before adding to this value.
-  ///   - rhs: The other value to multiply.
-  /// - Returns: The product of `lhs` and `rhs`, added to this value.
   @_transparent
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
@@ -1869,148 +1679,30 @@ extension FloatingPoint {
     return addend
   }
 
-  /// Returns the lesser of the two given values.
-  ///
-  /// This method returns the minimum of two values, preserving order and
-  /// eliminating NaN when possible. For two values `x` and `y`, the result of
-  /// `minimum(x, y)` is `x` if `x <= y`, `y` if `y < x`, or whichever of `x`
-  /// or `y` is a number if the other is a quiet NaN. If both `x` and `y` are
-  /// NaN, or either `x` or `y` is a signaling NaN, the result is NaN.
-  ///
-  ///     Double.minimum(10.0, -25.0)
-  ///     // -25.0
-  ///     Double.minimum(10.0, .nan)
-  ///     // 10.0
-  ///     Double.minimum(.nan, -25.0)
-  ///     // -25.0
-  ///     Double.minimum(.nan, .nan)
-  ///     // nan
-  ///
-  /// The `minimum` method implements the `minNum` operation defined by the
-  /// [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - x: A floating-point value.
-  ///   - y: Another floating-point value.
-  /// - Returns: The minimum of `x` and `y`, or whichever is a number if the
-  ///   other is NaN.
   @inlinable
   public static func minimum(_ x: Self, _ y: Self) -> Self {
     if x <= y || y.isNaN { return x }
     return y
   }
 
-  /// Returns the greater of the two given values.
-  ///
-  /// This method returns the maximum of two values, preserving order and
-  /// eliminating NaN when possible. For two values `x` and `y`, the result of
-  /// `maximum(x, y)` is `x` if `x > y`, `y` if `x <= y`, or whichever of `x`
-  /// or `y` is a number if the other is a quiet NaN. If both `x` and `y` are
-  /// NaN, or either `x` or `y` is a signaling NaN, the result is NaN.
-  ///
-  ///     Double.maximum(10.0, -25.0)
-  ///     // 10.0
-  ///     Double.maximum(10.0, .nan)
-  ///     // 10.0
-  ///     Double.maximum(.nan, -25.0)
-  ///     // -25.0
-  ///     Double.maximum(.nan, .nan)
-  ///     // nan
-  ///
-  /// The `maximum` method implements the `maxNum` operation defined by the
-  /// [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - x: A floating-point value.
-  ///   - y: Another floating-point value.
-  /// - Returns: The greater of `x` and `y`, or whichever is a number if the
-  ///   other is NaN.
   @inlinable
   public static func maximum(_ x: Self, _ y: Self) -> Self {
     if x > y || y.isNaN { return x }
     return y
   }
 
-  /// Returns the value with lesser magnitude.
-  ///
-  /// This method returns the value with lesser magnitude of the two given
-  /// values, preserving order and eliminating NaN when possible. For two
-  /// values `x` and `y`, the result of `minimumMagnitude(x, y)` is `x` if
-  /// `x.magnitude <= y.magnitude`, `y` if `y.magnitude < x.magnitude`, or
-  /// whichever of `x` or `y` is a number if the other is a quiet NaN. If both
-  /// `x` and `y` are NaN, or either `x` or `y` is a signaling NaN, the result
-  /// is NaN.
-  ///
-  ///     Double.minimumMagnitude(10.0, -25.0)
-  ///     // 10.0
-  ///     Double.minimumMagnitude(10.0, .nan)
-  ///     // 10.0
-  ///     Double.minimumMagnitude(.nan, -25.0)
-  ///     // -25.0
-  ///     Double.minimumMagnitude(.nan, .nan)
-  ///     // nan
-  ///
-  /// The `minimumMagnitude` method implements the `minNumMag` operation
-  /// defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - x: A floating-point value.
-  ///   - y: Another floating-point value.
-  /// - Returns: Whichever of `x` or `y` has lesser magnitude, or whichever is
-  ///   a number if the other is NaN.
   @inlinable
   public static func minimumMagnitude(_ x: Self, _ y: Self) -> Self {
     if x.magnitude <= y.magnitude || y.isNaN { return x }
     return y
   }
 
-  /// Returns the value with greater magnitude.
-  ///
-  /// This method returns the value with greater magnitude of the two given
-  /// values, preserving order and eliminating NaN when possible. For two
-  /// values `x` and `y`, the result of `maximumMagnitude(x, y)` is `x` if
-  /// `x.magnitude > y.magnitude`, `y` if `x.magnitude <= y.magnitude`, or
-  /// whichever of `x` or `y` is a number if the other is a quiet NaN. If both
-  /// `x` and `y` are NaN, or either `x` or `y` is a signaling NaN, the result
-  /// is NaN.
-  ///
-  ///     Double.maximumMagnitude(10.0, -25.0)
-  ///     // -25.0
-  ///     Double.maximumMagnitude(10.0, .nan)
-  ///     // 10.0
-  ///     Double.maximumMagnitude(.nan, -25.0)
-  ///     // -25.0
-  ///     Double.maximumMagnitude(.nan, .nan)
-  ///     // nan
-  ///
-  /// The `maximumMagnitude` method implements the `maxNumMag` operation
-  /// defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - x: A floating-point value.
-  ///   - y: Another floating-point value.
-  /// - Returns: Whichever of `x` or `y` has greater magnitude, or whichever is
-  ///   a number if the other is NaN.
   @inlinable
   public static func maximumMagnitude(_ x: Self, _ y: Self) -> Self {
     if x.magnitude > y.magnitude || y.isNaN { return x }
     return y
   }
 
-  /// The classification of this value.
-  ///
-  /// A value's `floatingPointClass` property describes its "class" as
-  /// described by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   @inlinable
   public var floatingPointClass: FloatingPointClassification {
     if isSignalingNaN { return .signalingNaN }
@@ -2024,40 +1716,16 @@ extension FloatingPoint {
 
 extension BinaryFloatingPoint {
 
-  /// The radix, or base of exponentiation, for this floating-point type.
-  ///
-  /// All binary floating-point types have a radix of 2. The magnitude of a
-  /// floating-point value `x` of type `F` can be calculated by using the
-  /// following formula, where `**` is exponentiation:
-  ///
-  ///     let magnitude = x.significand * F.radix ** x.exponent
   @inlinable @inline(__always)
   public static var radix: Int { return 2 }
 
-  /// Creates a new floating-point value using the sign of one value and the
-  /// magnitude of another.
-  ///
-  /// The following example uses this initializer to create a new `Double`
-  /// instance with the sign of `a` and the magnitude of `b`:
-  ///
-  ///     let a = -21.5
-  ///     let b = 305.15
-  ///     let c = Double(signOf: a, magnitudeOf: b)
-  ///     print(c)
-  ///     // Prints "-305.15"
-  ///
-  /// This initializer implements the IEEE 754 `copysign` operation.
-  ///
-  /// - Parameters:
-  ///   - signOf: A value from which to use the sign. The result of the
-  ///     initializer has the same sign as `signOf`.
-  ///   - magnitudeOf: A value from which to use the magnitude. The result of
-  ///     the initializer has the same magnitude as `magnitudeOf`.
   @inlinable
   public init(signOf: Self, magnitudeOf: Self) {
-    self.init(sign: signOf.sign,
+    self.init(
+      sign: signOf.sign,
       exponentBitPattern: magnitudeOf.exponentBitPattern,
-      significandBitPattern: magnitudeOf.significandBitPattern)
+      significandBitPattern: magnitudeOf.significandBitPattern
+    )
   }
 
   @inlinable
@@ -2220,29 +1888,7 @@ extension BinaryFloatingPoint {
     guard exact else { return nil }
     self = value_
   }
-
-  /// Returns a Boolean value indicating whether this instance should precede
-  /// or tie positions with the given value in an ascending sort.
-  ///
-  /// This relation is a refinement of the less-than-or-equal-to operator
-  /// (`<=`) that provides a total order on all values of the type, including
-  /// signed zeros and NaNs.
-  ///
-  /// The following example uses `isTotallyOrdered(belowOrEqualTo:)` to sort an
-  /// array of floating-point values, including some that are NaN:
-  ///
-  ///     var numbers = [2.5, 21.25, 3.0, .nan, -9.5]
-  ///     numbers.sort { !$1.isTotallyOrdered(belowOrEqualTo: $0) }
-  ///     // numbers == [-9.5, 2.5, 3.0, 21.25, NaN]
-  ///
-  /// The `isTotallyOrdered(belowOrEqualTo:)` method implements the total order
-  /// relation as defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: A floating-point value to compare to this value.
-  /// - Returns: `true` if this value is ordered below or the same as `other`
-  ///   in a total ordering of the floating-point type; otherwise, `false`.
+  
   @inlinable
   public func isTotallyOrdered(belowOrEqualTo other: Self) -> Bool {
     // Quick return when possible.

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1197,13 +1197,27 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   var floatingPointClass: FloatingPointClassification { get }
 
   /// A Boolean value indicating whether the instance's representation is in
-  /// the canonical form.
+  /// its canonical form.
   ///
   /// The [IEEE 754 specification][spec] defines a *canonical*, or preferred,
-  /// encoding of a floating-point value's representation. Every `Float` or
-  /// `Double` value is canonical, but noncanonical values of the `Float80`
-  /// type exist, and noncanonical values may exist for other types that
-  /// conform to the `FloatingPoint` protocol.
+  /// encoding of a floating-point value. On platforms that fully support
+  /// IEEE 754, every `Float` or `Double` value is canonical, but
+  /// non-canonical values can exist on other platforms or for other types.
+  /// Some examples:
+  ///
+  /// - On platforms that flush subnormal numbers to zero (such as armv7
+  ///   with the default floating-point environment), Swift interprets
+  ///   subnormal `Float` and `Double` values as non-canonical zeros.
+  ///   (In Swift 5.1 and earlier, isCanonical returns `true` for these
+  ///   values. This is a bug.)
+  ///
+  /// - On i386 and x86_64, `Float80` has a number of non-canonical
+  ///   encodings. "Pseudo-NaNs", "pseudo-infinities", and "unnormals" are
+  ///   interpreted as non-canonical NaN encodings. "Pseudo-denormals" are
+  ///   interpreted as non-canonical encodings of subnormal values.
+  ///
+  /// - Decimal floating-point admits a large number of non-canonical
+  ///   encodings. Consult the IEEE 754 standard for additional details.
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   var isCanonical: Bool { get }

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1216,7 +1216,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///   interpreted as non-canonical NaN encodings. "Pseudo-denormals" are
   ///   interpreted as non-canonical encodings of subnormal values.
   ///
-  /// - Decimal floating-point admits a large number of non-canonical
+  /// - Decimal floating-point types admit a large number of non-canonical
   ///   encodings. Consult the IEEE 754 standard for additional details.
   ///
   /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1208,7 +1208,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// - On platforms that flush subnormal numbers to zero (such as armv7
   ///   with the default floating-point environment), Swift interprets
   ///   subnormal `Float` and `Double` values as non-canonical zeros.
-  ///   (In Swift 5.1 and earlier, isCanonical returns `true` for these
+  ///   (In Swift 5.1 and earlier, `isCanonical` is `true` for these
   ///   values. This is a bug.)
   ///
   /// - On i386 and x86_64, `Float80` has a number of non-canonical

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1209,7 +1209,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///   with the default floating-point environment), Swift interprets
   ///   subnormal `Float` and `Double` values as non-canonical zeros.
   ///   (In Swift 5.1 and earlier, `isCanonical` is `true` for these
-  ///   values. This is a bug.)
+  ///   values, which is the incorrect value.)
   ///
   /// - On i386 and x86_64, `Float80` has a number of non-canonical
   ///   encodings. "Pseudo-NaNs", "pseudo-infinities", and "unnormals" are

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -609,7 +609,24 @@ extension ${Self}: BinaryFloatingPoint {
     }
     self = result
   }
-
+  
+  /// Creates a NaN ("not a number") value with the specified payload.
+  ///
+  /// NaN values compare not equal to every value, including themselves. Most
+  /// operations with a NaN operand produce a NaN result. Don't use the
+  /// equal-to operator (`==`) to test whether a value is NaN. Instead, use
+  /// the value's `isNaN` property.
+  ///
+  ///     let x = ${Self}(nan: 0, signaling: false)
+  ///     print(x == .nan)
+  ///     // Prints "false"
+  ///     print(x.isNaN)
+  ///     // Prints "true"
+  ///
+  /// - Parameters:
+  ///   - payload: The payload to use for the new NaN value.
+  ///   - signaling: Pass `true` to create a signaling NaN or `false` to create
+  ///     a quiet NaN.
   @inlinable
   public init(nan payload: RawSignificand, signaling: Bool) {
     // We use significandBitCount - 2 bits for NaN payload.

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -63,7 +63,6 @@ public struct ${Self} {
   public // @testable
   var _value: Builtin.FPIEEE${bits}
 
-  /// Creates a value initialized to zero.
   @_transparent
   public init() {
     let zero: Int64 = 0
@@ -115,59 +114,25 @@ extension ${Self}: TextOutputStreamable {
 
 extension ${Self}: BinaryFloatingPoint {
 
-  /// A type that can represent the absolute value of any possible value of
-  /// this type.
+  // Floating-point types are always symmetric, so Magnitude is Self.
   public typealias Magnitude = ${Self}
 
-  /// A type that can represent any written exponent.
   public typealias Exponent = Int
 
-  /// A type that represents the encoded significand of a value.
   public typealias RawSignificand = ${RawSignificand}
 
-  /// The number of bits used to represent the type's exponent.
-  ///
-  /// A binary floating-point type's `exponentBitCount` imposes a limit on the
-  /// range of the exponent for normal, finite values. The *exponent bias* of
-  /// a type `F` can be calculated as the following, where `**` is
-  /// exponentiation:
-  ///
-  ///     let bias = 2 ** (F.exponentBitCount - 1) - 1
-  ///
-  /// The least normal exponent for values of the type `F` is `1 - bias`, and
-  /// the largest finite exponent is `bias`. An all-zeros exponent is reserved
-  /// for subnormals and zeros, and an all-ones exponent is reserved for
-  /// infinity and NaN.
-  ///
-  /// For example, the `Float` type has an `exponentBitCount` of 8, which gives
-  /// an exponent bias of `127` by the calculation above.
-  ///
-  ///     let bias = 2 ** (Float.exponentBitCount - 1) - 1
-  ///     // bias == 127
-  ///     print(Float.greatestFiniteMagnitude.exponent)
-  ///     // Prints "127"
-  ///     print(Float.leastNormalMagnitude.exponent)
-  ///     // Prints "-126"
   @inlinable
   public static var exponentBitCount: Int {
     return ${ExponentBitCount}
   }
 
-  /// The available number of fractional significand bits.
-  ///
-  /// For fixed-width floating-point types, this is the actual number of
-  /// fractional significand bits.
-  ///
-  /// For extensible floating-point types, `significandBitCount` should be the
-  /// maximum allowed significand width (without counting any leading integral
-  /// bit of the significand). If there is no upper limit, then
-  /// `significandBitCount` should be `Int.max`.
 %if bits == 80:
-  ///
-  /// `Float80.significandBitCount` is 63, even though 64 bits are used to
-  /// store the significand in the memory representation of a `Float80`
-  /// instance. Unlike other floating-point types, the `Float80` type
-  /// explicitly stores the leading integral significand bit.
+  // `Float80.significandBitCount` is 63, even though 64 bits are used to
+  // store the significand in the memory representation of a `Float80`
+  // instance. Unlike other floating-point types, the `Float80` type
+  // explicitly stores the leading integral significand bit; we abstract
+  // that away to present the same user-facing interface as the floating-
+  // point types.
 %end
   @inlinable
   public static var significandBitCount: Int {
@@ -231,89 +196,60 @@ extension ${Self}: BinaryFloatingPoint {
     self.init(Builtin.bitcast_Int${bits}_FPIEEE${bits}(bitPattern._value))
   }
 
-  /// The sign of the floating-point value.
-  ///
-  /// The `sign` property is `.minus` if the value's signbit is set, and
-  /// `.plus` otherwise. For example:
-  ///
-  ///     let x = -33.375
-  ///     // x.sign == .minus
-  ///
-  /// Do not use this property to check whether a floating point value is
-  /// negative. For a value `x`, the comparison `x.sign == .minus` is not
-  /// necessarily the same as `x < 0`. In particular, `x.sign == .minus` if
-  /// `x` is -0, and while `x < 0` is always `false` if `x` is NaN, `x.sign`
-  /// could be either `.plus` or `.minus`.
   @inlinable
   public var sign: FloatingPointSign {
     let shift = ${Self}.significandBitCount + ${Self}.exponentBitCount
-    return FloatingPointSign(rawValue: Int(bitPattern &>> ${RawSignificand}(shift)))!
+    return FloatingPointSign(
+      rawValue: Int(bitPattern &>> ${RawSignificand}(shift))
+    )!
   }
 
   @available(*, unavailable, renamed: "sign")
   public var isSignMinus: Bool { Builtin.unreachable() }
 
-  /// The raw encoding of the value's exponent field.
-  ///
-  /// This value is unadjusted by the type's exponent bias.
   @inlinable
   public var exponentBitPattern: UInt {
     return UInt(bitPattern &>> UInt${bits}(${Self}.significandBitCount)) &
       ${Self}._infinityExponent
   }
 
-  /// The raw encoding of the value's significand field.
-  ///
-  /// The `significandBitPattern` property does not include the leading
-  /// integral bit of the significand, even for types like `Float80` that
-  /// store it explicitly.
   @inlinable
   public var significandBitPattern: ${RawSignificand} {
     return ${RawSignificand}(bitPattern) & ${Self}._significandMask
   }
 
-  /// Creates a new instance from the specified sign and bit patterns.
-  ///
-  /// The values passed as `exponentBitPattern` and `significandBitPattern` are
-  /// interpreted in the binary interchange format defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - sign: The sign of the new value.
-  ///   - exponentBitPattern: The bit pattern to use for the exponent field of
-  ///     the new value.
-  ///   - significandBitPattern: The bit pattern to use for the significand
-  ///     field of the new value.
   @inlinable
-  public init(sign: FloatingPointSign,
-              exponentBitPattern: UInt,
-              significandBitPattern: ${RawSignificand}) {
+  public init(
+    sign: FloatingPointSign,
+    exponentBitPattern: UInt,
+    significandBitPattern: ${RawSignificand}
+  ) {
     let signShift = ${Self}.significandBitCount + ${Self}.exponentBitCount
     let sign = UInt${bits}(sign == .minus ? 1 : 0)
     let exponent = UInt${bits}(
-      exponentBitPattern & ${Self}._infinityExponent)
+      exponentBitPattern & ${Self}._infinityExponent
+    )
     let significand = UInt${bits}(
-      significandBitPattern & ${Self}._significandMask)
+      significandBitPattern & ${Self}._significandMask
+    )
     self.init(bitPattern:
       sign &<< UInt${bits}(signShift) |
       exponent &<< UInt${bits}(${Self}.significandBitCount) |
-      significand)
+      significand
+    )
   }
 
-  /// A Boolean value indicating whether the instance's representation is in
-  /// the canonical form.
-  ///
-  /// The [IEEE 754 specification][spec] defines a *canonical*, or preferred,
-  /// encoding of a floating-point value's representation. Every `Float` or
-  /// `Double` value is canonical, but noncanonical values of the `Float80`
-  /// type exist, and noncanonical values may exist for other types that
-  /// conform to the `FloatingPoint` protocol.
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   @inlinable
   public var isCanonical: Bool {
+    // All Float and Double encodings are canonical in IEEE 754.
+    //
+    // On platforms that do not support subnormals, we treat them as
+    // non-canonical encodings of zero.
+    if Self.leastNonzeroMagnitude == Self.leastNormalMagnitude {
+      if exponentBitPattern == 0 && significandBitPattern != 0 {
+        return false
+      }
+    }
     return true
   }
 %else:
@@ -356,19 +292,6 @@ extension ${Self}: BinaryFloatingPoint {
     return unsafeBitCast(self, to: _Representation.self)
   }
 
-  /// The sign of the floating-point value.
-  ///
-  /// The `sign` property is `.minus` if the value's signbit is set, and
-  /// `.plus` otherwise. For example:
-  ///
-  ///     let x = -33.375
-  ///     // x.sign == .minus
-  ///
-  /// Do not use this property to check whether a floating point value is
-  /// negative. For a value `x`, the comparison `x.sign == .minus` is not
-  /// necessarily the same as `x < 0`. In particular, `x.sign == .minus` if
-  /// `x` is -0, and while `x < 0` is always `false` if `x` is NaN, `x.sign`
-  /// could be either `.plus` or `.minus`.
   @inlinable
   public var sign: FloatingPointSign {
     return _representation.sign
@@ -379,9 +302,6 @@ extension ${Self}: BinaryFloatingPoint {
     @inline(__always) get { return 1 &<< 63 }
   }
 
-  /// The raw encoding of the value's exponent field.
-  ///
-  /// This value is unadjusted by the type's exponent bias.
   @inlinable
   public var exponentBitPattern: UInt {
     let provisional = _representation.exponentBitPattern
@@ -406,11 +326,6 @@ extension ${Self}: BinaryFloatingPoint {
     return provisional
   }
 
-  /// The raw encoding of the value's significand field.
-  ///
-  /// The `significandBitPattern` property does not include the leading
-  /// integral bit of the significand, even for types like `Float80` that
-  /// store it explicitly.
   @inlinable
   public var significandBitPattern: UInt64 {
     if _representation.exponentBitPattern > 0 &&
@@ -425,20 +340,6 @@ extension ${Self}: BinaryFloatingPoint {
     return _representation.explicitSignificand & Float80._significandMask
   }
 
-  /// Creates a new instance from the specified sign and bit patterns.
-  ///
-  /// The values passed as `exponentBitPattern` and `significandBitPattern` are
-  /// interpreted in the binary interchange format defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - sign: The sign of the new value.
-  ///   - exponentBitPattern: The bit pattern to use for the exponent field of
-  ///     the new value.
-  ///   - significandBitPattern: The bit pattern to use for the significand
-  ///     field of the new value.
   @inlinable
   public init(sign: FloatingPointSign,
               exponentBitPattern: UInt,
@@ -452,16 +353,6 @@ extension ${Self}: BinaryFloatingPoint {
     self = unsafeBitCast(rep, to: Float80.self)
   }
 
-  /// A Boolean value indicating whether the instance's representation is in
-  /// the canonical form.
-  ///
-  /// The [IEEE 754 specification][spec] defines a *canonical*, or preferred,
-  /// encoding of a floating-point value's representation. Every `Float` or
-  /// `Double` value is canonical, but noncanonical values of the `Float80`
-  /// type exist, and noncanonical values may exist for other types that
-  /// conform to the `FloatingPoint` protocol.
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   @inlinable
   public var isCanonical: Bool {
     if exponentBitPattern == 0 {
@@ -475,86 +366,44 @@ extension ${Self}: BinaryFloatingPoint {
   }
 %end
 
-  /// Positive infinity.
-  ///
-  /// Infinity compares greater than all finite numbers and equal to other
-  /// infinite values.
-  ///
-  ///     let x = Double.greatestFiniteMagnitude
-  ///     let y = x * 2
-  ///     // y == Double.infinity
-  ///     // y > x
   @inlinable
   public static var infinity: ${Self} {
 %if bits == 32:
-    return ${Self}(bitPattern: 0b0_11111111_00000000000000000000000)
+    return ${Self}(bitPattern: 0x7f800000)
 %elif bits == 64:
-    return ${Self}(
-      bitPattern: 0b0_11111111111_0000000000000000000000000000000000000000000000000000)
+    return ${Self}(bitPattern: 0x7ff0000000000000)
 %elif bits == 80:
     let rep = _Representation(
       explicitSignificand: ${Self}._explicitBitMask,
-      signAndExponent: 0b0_111111111111111)
+      signAndExponent: 0x7fff
+    )
     return unsafeBitCast(rep, to: ${Self}.self)
 %else:
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: _infinityExponent,
-      significandBitPattern: 0)
+      significandBitPattern: 0
+    )
 %end
   }
 
-  /// A quiet NaN ("not a number").
-  ///
-  /// A NaN compares not equal, not greater than, and not less than every
-  /// value, including itself. Passing a NaN to an operation generally results
-  /// in NaN.
-  ///
-  ///     let x = 1.21
-  ///     // x > Double.nan == false
-  ///     // x < Double.nan == false
-  ///     // x == Double.nan == false
-  ///
-  /// Because a NaN always compares not equal to itself, to test whether a
-  /// floating-point value is NaN, use its `isNaN` property instead of the
-  /// equal-to operator (`==`). In the following example, `y` is NaN.
-  ///
-  ///     let y = x + Double.nan
-  ///     print(y == Double.nan)
-  ///     // Prints "false"
-  ///     print(y.isNaN)
-  ///     // Prints "true"
   @inlinable
   public static var nan: ${Self} {
 %if bits == 32:
-    return ${Self}(bitPattern: 0b0_11111111_10000000000000000000000)
+    return ${Self}(bitPattern: 0x7fc00000)
 %elif bits == 64:
-    return ${Self}(
-      bitPattern: 0b0_11111111111_1000000000000000000000000000000000000000000000000000)
+    return ${Self}(bitPattern: 0x7ff8000000000000)
 %elif bits == 80:
     let rep = _Representation(
       explicitSignificand: ${Self}._explicitBitMask | ${Self}._quietNaNMask,
-      signAndExponent: 0b0_111111111111111)
+      signAndExponent: 0x7fff
+    )
     return unsafeBitCast(rep, to: ${Self}.self)
 %else:
     return ${Self}(nan: 0, signaling: false)
 %end
   }
 
-  /// A signaling NaN ("not a number").
-  ///
-  /// The default IEEE 754 behavior of operations involving a signaling NaN is
-  /// to raise the Invalid flag in the floating-point environment and return a
-  /// quiet NaN.
-  ///
-  /// Operations on types conforming to the `FloatingPoint` protocol should
-  /// support this behavior, but they might also support other options. For
-  /// example, it would be reasonable to implement alternative operations in
-  /// which operating on a signaling NaN triggers a runtime error or results
-  /// in a diagnostic for debugging purposes. Types that implement alternative
-  /// behaviors for a signaling NaN must document the departure.
-  ///
-  /// Other than these signaling operations, a signaling NaN behaves in the
-  /// same manner as a quiet NaN.
   @inlinable
   public static var signalingNaN: ${Self} {
     return ${Self}(nan: 0, signaling: true)
@@ -563,14 +412,6 @@ extension ${Self}: BinaryFloatingPoint {
   @available(*, unavailable, renamed: "nan")
   public static var quietNaN: ${Self} { Builtin.unreachable() }
 
-  /// The greatest finite number representable by this type.
-  ///
-  /// This value compares greater than or equal to all finite numbers, but less
-  /// than `infinity`.
-  ///
-  /// This value corresponds to type-specific C macros such as `FLT_MAX` and
-  /// `DBL_MAX`. The naming of those macros is slightly misleading, because
-  /// `infinity` is greater than this value.
   @inlinable
   public static var greatestFiniteMagnitude: ${Self} {
 %if bits == 32:
@@ -580,21 +421,14 @@ extension ${Self}: BinaryFloatingPoint {
 %elif bits == 80:
     return 0x1.fffffffffffffffep16383
 %else:
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: _infinityExponent - 1,
-      significandBitPattern: _significandMask)
+      significandBitPattern: _significandMask
+    )
 %end
   }
 
-  /// The mathematical constant pi.
-  ///
-  /// This value should be rounded toward zero to keep user computations with
-  /// angles from inadvertently ending up in the wrong quadrant. A type that
-  /// conforms to the `FloatingPoint` protocol provides the value for `pi` at
-  /// its best possible precision.
-  ///
-  ///     print(Double.pi)
-  ///     // Prints "3.14159265358979"
   @inlinable
   public static var pi: ${Self} {
 %if bits == 32:
@@ -611,25 +445,6 @@ extension ${Self}: BinaryFloatingPoint {
 %end
   }
 
-  /// The unit in the last place of this value.
-  ///
-  /// This is the unit of the least significant digit in this value's
-  /// significand. For most numbers `x`, this is the difference between `x`
-  /// and the next greater (in magnitude) representable number. There are some
-  /// edge cases to be aware of:
-  ///
-  /// - If `x` is not a finite number, then `x.ulp` is NaN.
-  /// - If `x` is very small in magnitude, then `x.ulp` may be a subnormal
-  ///   number. If a type does not support subnormals, `x.ulp` may be rounded
-  ///   to zero.
-  /// - `greatestFiniteMagnitude.ulp` is a finite number, even though the next
-  ///   greater representable value is `infinity`.
-  ///
-  /// This quantity, or a related quantity, is sometimes called *epsilon* or
-  /// *machine epsilon.* Avoid that name because it has different meanings in
-  /// different languages, which can lead to confusion, and because it
-  /// suggests that it is a good tolerance to use for comparisons, which it
-  /// almost never is.
   @inlinable
   public var ulp: ${Self} {
 %if bits != 80:
@@ -647,32 +462,29 @@ extension ${Self}: BinaryFloatingPoint {
       // exponent and construct it with a significand of zero.
       let ulpExponent =
         exponentBitPattern - UInt(${Self}.significandBitCount)
-      return ${Self}(sign: .plus,
+      return ${Self}(
+        sign: .plus,
         exponentBitPattern: ulpExponent,
-        significandBitPattern: 0)
+        significandBitPattern: 0
+      )
     }
     if exponentBitPattern >= 1 {
       // self is normal but ulp is subnormal.
       let ulpShift = ${RawSignificand}(exponentBitPattern - 1)
-      return ${Self}(sign: .plus,
+      return ${Self}(
+        sign: .plus,
         exponentBitPattern: 0,
-        significandBitPattern: 1 &<< ulpShift)
+        significandBitPattern: 1 &<< ulpShift
+      )
     }
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: 0,
-      significandBitPattern: 1)
+      significandBitPattern: 1
+    )
 %end
   }
 
-  /// The least positive normal number.
-  ///
-  /// This value compares less than or equal to all positive normal numbers.
-  /// There may be smaller positive numbers, but they are *subnormal*, meaning
-  /// that they are represented with less precision than normal numbers.
-  ///
-  /// This value corresponds to type-specific C macros such as `FLT_MIN` and
-  /// `DBL_MIN`. The naming of those macros is slightly misleading, because
-  /// subnormals, zeros, and negative numbers are smaller than this value.
   @inlinable
   public static var leastNormalMagnitude: ${Self} {
 %if bits == 32:
@@ -682,21 +494,17 @@ extension ${Self}: BinaryFloatingPoint {
 %elif bits == 80:
     return 0x1p-16382
 %else:
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: 1,
       significandBitPattern: 0)
 %end
   }
 
-  /// The least positive number.
-  ///
-  /// This value compares less than or equal to all positive numbers, but
-  /// greater than zero. If the type supports subnormal values,
-  /// `leastNonzeroMagnitude` is smaller than `leastNormalMagnitude`;
-  /// otherwise they are equal.
   @inlinable
   public static var leastNonzeroMagnitude: ${Self} {
 #if arch(arm)
+    // On 32b arm, the default FPCR has subnormals flushed to zero.
     return leastNormalMagnitude
 #else
 %if bits == 32:
@@ -706,9 +514,11 @@ extension ${Self}: BinaryFloatingPoint {
 %elif bits == 80:
     return 0x1p-16445
 %else:
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: 0,
-      significandBitPattern: 1)
+      significandBitPattern: 1
+    )
 %end
 #endif
   }
@@ -729,32 +539,6 @@ extension ${Self}: BinaryFloatingPoint {
 %end
   }
 
-  /// The exponent of the floating-point value.
-  ///
-  /// The *exponent* of a floating-point value is the integer part of the
-  /// logarithm of the value's magnitude. For a value `x` of a floating-point
-  /// type `F`, the magnitude can be calculated as the following, where `**`
-  /// is exponentiation:
-  ///
-  ///     let magnitude = x.significand * F.radix ** x.exponent
-  ///
-  /// In the next example, `y` has a value of `21.5`, which is encoded as
-  /// `1.34375 * 2 ** 4`. The significand of `y` is therefore 1.34375.
-  ///
-  ///     let y: Double = 21.5
-  ///     // y.significand == 1.34375
-  ///     // y.exponent == 4
-  ///     // Double.radix == 2
-  ///
-  /// The `exponent` property has the following edge cases:
-  ///
-  /// - If `x` is zero, then `x.exponent` is `Int.min`.
-  /// - If `x` is +/-infinity or NaN, then `x.exponent` is `Int.max`
-  ///
-  /// This property implements the `logB` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   @inlinable
   public var exponent: Int {
     if !isFinite { return .max }
@@ -766,34 +550,6 @@ extension ${Self}: BinaryFloatingPoint {
     return provisional + 1 - shift
   }
 
-  /// The significand of the floating-point value.
-  ///
-  /// The magnitude of a floating-point value `x` of type `F` can be calculated
-  /// by using the following formula, where `**` is exponentiation:
-  ///
-  ///     let magnitude = x.significand * F.radix ** x.exponent
-  ///
-  /// In the next example, `y` has a value of `21.5`, which is encoded as
-  /// `1.34375 * 2 ** 4`. The significand of `y` is therefore 1.34375.
-  ///
-  ///     let y: Double = 21.5
-  ///     // y.significand == 1.34375
-  ///     // y.exponent == 4
-  ///     // Double.radix == 2
-  ///
-  /// If a type's radix is 2, then for finite nonzero numbers, the significand
-  /// is in the range `1.0 ..< 2.0`. For other values of `x`, `x.significand`
-  /// is defined as follows:
-  ///
-  /// - If `x` is zero, then `x.significand` is 0.0.
-  /// - If `x` is infinite, then `x.significand` is infinity.
-  /// - If `x` is NaN, then `x.significand` is NaN.
-  /// - Note: The significand is frequently also called the *mantissa*, but
-  ///   significand is the preferred terminology in the [IEEE 754
-  ///   specification][spec], to allay confusion with the use of mantissa for
-  ///   the fractional part of a logarithm.
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
   @inlinable
   public var significand: ${Self} {
     if isNaN { return self }
@@ -805,59 +561,20 @@ extension ${Self}: BinaryFloatingPoint {
     if isSubnormal {
       let shift =
         ${Self}.significandBitCount - significandBitPattern._binaryLogarithm()
-      return ${Self}(sign: .plus,
+      return ${Self}(
+        sign: .plus,
         exponentBitPattern: ${Self}._exponentBias,
-        significandBitPattern: significandBitPattern &<< shift)
+        significandBitPattern: significandBitPattern &<< shift
+      )
     }
     // zero or infinity.
-    return ${Self}(sign: .plus,
+    return ${Self}(
+      sign: .plus,
       exponentBitPattern: exponentBitPattern,
-      significandBitPattern: 0)
+      significandBitPattern: 0
+    )
   }
 
-  /// Creates a new value from the given sign, exponent, and significand.
-  ///
-  /// The following example uses this initializer to create a new `Double`
-  /// instance. `Double` is a binary floating-point type that has a radix of
-  /// `2`.
-  ///
-  ///     let x = Double(sign: .plus, exponent: -2, significand: 1.5)
-  ///     // x == 0.375
-  ///
-  /// This initializer is equivalent to the following calculation, where `**`
-  /// is exponentiation, computed as if by a single, correctly rounded,
-  /// floating-point operation:
-  ///
-  ///     let sign: FloatingPointSign = .plus
-  ///     let exponent = -2
-  ///     let significand = 1.5
-  ///     let y = (sign == .minus ? -1 : 1) * significand * Double.radix ** exponent
-  ///     // y == 0.375
-  ///
-  /// As with any basic operation, if this value is outside the representable
-  /// range of the type, overflow or underflow occurs, and zero, a subnormal
-  /// value, or infinity may result. In addition, there are two other edge
-  /// cases:
-  ///
-  /// - If the value you pass to `significand` is zero or infinite, the result
-  ///   is zero or infinite, regardless of the value of `exponent`.
-  /// - If the value you pass to `significand` is NaN, the result is NaN.
-  ///
-  /// For any floating-point value `x` of type `F`, the result of the following
-  /// is equal to `x`, with the distinction that the result is canonicalized
-  /// if `x` is in a noncanonical encoding:
-  ///
-  ///     let x0 = F(sign: x.sign, exponent: x.exponent, significand: x.significand)
-  ///
-  /// This initializer implements the `scaleB` operation defined by the [IEEE
-  /// 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameters:
-  ///   - sign: The sign to use for the new value.
-  ///   - exponent: The new value's exponent.
-  ///   - significand: The new value's significand.
   @inlinable
   public init(sign: FloatingPointSign, exponent: Int, significand: ${Self}) {
     var result = significand
@@ -883,31 +600,16 @@ extension ${Self}: BinaryFloatingPoint {
           clamped -= greatestFiniteExponent
         }
       }
-      let scale = ${Self}(sign: .plus,
+      let scale = ${Self}(
+        sign: .plus,
         exponentBitPattern: UInt(Int(${Self}._exponentBias) + clamped),
-        significandBitPattern: 0)
+        significandBitPattern: 0
+      )
       result = result * scale
     }
     self = result
   }
 
-  /// Creates a NaN ("not a number") value with the specified payload.
-  ///
-  /// NaN values compare not equal to every value, including themselves. Most
-  /// operations with a NaN operand produce a NaN result. Don't use the
-  /// equal-to operator (`==`) to test whether a value is NaN. Instead, use
-  /// the value's `isNaN` property.
-  ///
-  ///     let x = ${Self}(nan: 0, signaling: false)
-  ///     print(x == .nan)
-  ///     // Prints "false"
-  ///     print(x.isNaN)
-  ///     // Prints "true"
-  ///
-  /// - Parameters:
-  ///   - payload: The payload to use for the new NaN value.
-  ///   - signaling: Pass `true` to create a signaling NaN or `false` to create
-  ///     a quiet NaN.
   @inlinable
   public init(nan payload: RawSignificand, signaling: Bool) {
     // We use significandBitCount - 2 bits for NaN payload.
@@ -915,21 +617,13 @@ extension ${Self}: BinaryFloatingPoint {
       "NaN payload is not encodable.")
     var significand = payload
     significand |= ${Self}._quietNaNMask &>> (signaling ? 1 : 0)
-    self.init(sign: .plus,
-              exponentBitPattern: ${Self}._infinityExponent,
-              significandBitPattern: significand)
+    self.init(
+      sign: .plus,
+      exponentBitPattern: ${Self}._infinityExponent,
+      significandBitPattern: significand
+    )
   }
 
-  /// The least representable value that compares greater than this value.
-  ///
-  /// For any finite value `x`, `x.nextUp` is greater than `x`. For `nan` or
-  /// `infinity`, `x.nextUp` is `x` itself. The following special cases also
-  /// apply:
-  ///
-  /// - If `x` is `-infinity`, then `x.nextUp` is `-greatestFiniteMagnitude`.
-  /// - If `x` is `-leastNonzeroMagnitude`, then `x.nextUp` is `-0.0`.
-  /// - If `x` is zero, then `x.nextUp` is `leastNonzeroMagnitude`.
-  /// - If `x` is `greatestFiniteMagnitude`, then `x.nextUp` is `infinity`.
   @inlinable
   public var nextUp: ${Self} {
 %if bits != 80:
@@ -982,40 +676,6 @@ extension ${Self}: BinaryFloatingPoint {
     _value = Builtin.int_copysign_FPIEEE${bits}(mag._value, sign._value)
   }
 
-  /// Rounds the value to an integral value using the specified rounding rule.
-  ///
-  /// The following example rounds a value using four different rounding rules:
-  ///
-  ///     // Equivalent to the C 'round' function:
-  ///     var w = 6.5
-  ///     w.round(.toNearestOrAwayFromZero)
-  ///     // w == 7.0
-  ///
-  ///     // Equivalent to the C 'trunc' function:
-  ///     var x = 6.5
-  ///     x.round(.towardZero)
-  ///     // x == 6.0
-  ///
-  ///     // Equivalent to the C 'ceil' function:
-  ///     var y = 6.5
-  ///     y.round(.up)
-  ///     // y == 7.0
-  ///
-  ///     // Equivalent to the C 'floor' function:
-  ///     var z = 6.5
-  ///     z.round(.down)
-  ///     // z == 6.0
-  ///
-  /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `round()` method
-  /// instead.
-  ///
-  ///     var w1 = 6.5
-  ///     w1.round()
-  ///     // w1 == 7.0
-  ///
-  /// - Parameter rule: The rounding rule to use.
   @_transparent
   public mutating func round(_ rule: FloatingPointRoundingRule) {
     switch rule {
@@ -1050,14 +710,6 @@ extension ${Self}: BinaryFloatingPoint {
     self.round(rule)
   }
 
-  /// Replaces this value with its additive inverse.
-  ///
-  /// The result is always exact. This example uses the `negate()` method to
-  /// negate the value of the variable `x`:
-  ///
-  ///     var x = 21.5
-  ///     x.negate()
-  ///     // x == -21.5
   @_transparent
   public mutating func negate() {
     _value = Builtin.fneg_FPIEEE${bits}(self._value)
@@ -1083,192 +735,43 @@ extension ${Self}: BinaryFloatingPoint {
     lhs._value = Builtin.fdiv_FPIEEE${bits}(lhs._value, rhs._value)
   }
 
-  /// Replaces this value with the remainder of itself divided by the given
-  /// value.
-  ///
-  /// For two finite values `x` and `y`, the remainder `r` of dividing `x` by
-  /// `y` satisfies `x == y * q + r`, where `q` is the integer nearest to
-  /// `x / y`. If `x / y` is exactly halfway between two integers, `q` is
-  /// chosen to be even. Note that `q` is *not* `x / y` computed in
-  /// floating-point arithmetic, and that `q` may not be representable in any
-  /// available integer type.
-  ///
-  /// The following example calculates the remainder of dividing 8.625 by 0.75:
-  ///
-  ///     var x = 8.625
-  ///     print(x / 0.75)
-  ///     // Prints "11.5"
-  ///
-  ///     let q = (x / 0.75).rounded(.toNearestOrEven)
-  ///     // q == 12.0
-  ///     x.formRemainder(dividingBy: 0.75)
-  ///     // x == -0.375
-  ///
-  ///     let x1 = 0.75 * q + x
-  ///     // x1 == 8.625
-  ///
-  /// If this value and `other` are finite numbers, the remainder is in the
-  /// closed range `-abs(other / 2)...abs(other / 2)`. The
-  /// `formRemainder(dividingBy:)` method is always exact.
-  ///
-  /// - Parameter other: The value to use when dividing this value.
   @inlinable // FIXME(inline-always)
   @inline(__always)
   public mutating func formRemainder(dividingBy other: ${Self}) {
     self = _swift_stdlib_remainder${cFuncSuffix}(self, other)
   }
 
-  /// Replaces this value with the remainder of itself divided by the given
-  /// value using truncating division.
-  ///
-  /// Performing truncating division with floating-point values results in a
-  /// truncated integer quotient and a remainder. For values `x` and `y` and
-  /// their truncated integer quotient `q`, the remainder `r` satisfies
-  /// `x == y * q + r`.
-  ///
-  /// The following example calculates the truncating remainder of dividing
-  /// 8.625 by 0.75:
-  ///
-  ///     var x = 8.625
-  ///     print(x / 0.75)
-  ///     // Prints "11.5"
-  ///
-  ///     let q = (x / 0.75).rounded(.towardZero)
-  ///     // q == 11.0
-  ///     x.formTruncatingRemainder(dividingBy: 0.75)
-  ///     // x == 0.375
-  ///
-  ///     let x1 = 0.75 * q + x
-  ///     // x1 == 8.625
-  ///
-  /// If this value and `other` are both finite numbers, the truncating
-  /// remainder has the same sign as this value and is strictly smaller in
-  /// magnitude than `other`. The `formTruncatingRemainder(dividingBy:)`
-  /// method is always exact.
-  ///
-  /// - Parameter other: The value to use when dividing this value.
   @inlinable // FIXME(inline-always)
   @inline(__always)
   public mutating func formTruncatingRemainder(dividingBy other: ${Self}) {
     _value = Builtin.frem_FPIEEE${bits}(self._value, other._value)
   }
 
-  /// Replaces this value with its square root, rounded to a representable
-  /// value.
   @_transparent
   public mutating func formSquareRoot( ) {
     self = _swift_stdlib_squareRoot${cFuncSuffix}(self)
   }
 
-  /// Adds the product of the two given values to this value in place, computed
-  /// without intermediate rounding.
-  ///
-  /// - Parameters:
-  ///   - lhs: One of the values to multiply before adding to this value.
-  ///   - rhs: The other value to multiply.
   @_transparent
   public mutating func addProduct(_ lhs: ${Self}, _ rhs: ${Self}) {
     _value = Builtin.int_fma_FPIEEE${bits}(lhs._value, rhs._value, _value)
   }
 
-  /// Returns a Boolean value indicating whether this instance is equal to the
-  /// given value.
-  ///
-  /// This method serves as the basis for the equal-to operator (`==`) for
-  /// floating-point values. When comparing two values with this method, `-0`
-  /// is equal to `+0`. NaN is not equal to any value, including itself. For
-  /// example:
-  ///
-  ///     let x = 15.0
-  ///     x.isEqual(to: 15.0)
-  ///     // true
-  ///     x.isEqual(to: .nan)
-  ///     // false
-  ///     Double.nan.isEqual(to: .nan)
-  ///     // false
-  ///
-  /// The `isEqual(to:)` method implements the equality predicate defined by
-  /// the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: The value to compare with this value.
-  /// - Returns: `true` if `other` has the same value as this instance;
-  ///   otherwise, `false`.
   @_transparent
   public func isEqual(to other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_oeq_FPIEEE${bits}(self._value, other._value))
   }
 
-  /// Returns a Boolean value indicating whether this instance is less than the
-  /// given value.
-  ///
-  /// This method serves as the basis for the less-than operator (`<`) for
-  /// floating-point values. Some special cases apply:
-  ///
-  /// - Because NaN compares not less than nor greater than any value, this
-  ///   method returns `false` when called on NaN or when NaN is passed as
-  ///   `other`.
-  /// - `-infinity` compares less than all values except for itself and NaN.
-  /// - Every value except for NaN and `+infinity` compares less than
-  ///   `+infinity`.
-  ///
-  ///     let x = 15.0
-  ///     x.isLess(than: 20.0)
-  ///     // true
-  ///     x.isLess(than: .nan)
-  ///     // false
-  ///     Double.nan.isLess(than: x)
-  ///     // false
-  ///
-  /// The `isLess(than:)` method implements the less-than predicate defined by
-  /// the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: The value to compare with this value.
-  /// - Returns: `true` if `other` is less than this value; otherwise, `false`.
   @_transparent
   public func isLess(than other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_olt_FPIEEE${bits}(self._value, other._value))
   }
 
-  /// Returns a Boolean value indicating whether this instance is less than or
-  /// equal to the given value.
-  ///
-  /// This method serves as the basis for the less-than-or-equal-to operator
-  /// (`<=`) for floating-point values. Some special cases apply:
-  ///
-  /// - Because NaN is incomparable with any value, this method returns `false`
-  ///   when called on NaN or when NaN is passed as `other`.
-  /// - `-infinity` compares less than or equal to all values except NaN.
-  /// - Every value except NaN compares less than or equal to `+infinity`.
-  ///
-  ///     let x = 15.0
-  ///     x.isLessThanOrEqualTo(20.0)
-  ///     // true
-  ///     x.isLessThanOrEqualTo(.nan)
-  ///     // false
-  ///     Double.nan.isLessThanOrEqualTo(x)
-  ///     // false
-  ///
-  /// The `isLessThanOrEqualTo(_:)` method implements the less-than-or-equal
-  /// predicate defined by the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  ///
-  /// - Parameter other: The value to compare with this value.
-  /// - Returns: `true` if `other` is less than this value; otherwise, `false`.
   @_transparent
   public func isLessThanOrEqualTo(_ other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_ole_FPIEEE${bits}(self._value, other._value))
   }
 
-  /// A Boolean value indicating whether this instance is normal.
-  ///
-  /// A *normal* value is a finite number that uses the full precision
-  /// available to values of a type. Zero is neither a normal nor a subnormal
-  /// number.
   @inlinable // FIXME(inline-always)
   public var isNormal: Bool {
     @inline(__always)
@@ -1277,10 +780,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether this instance is finite.
-  ///
-  /// All values other than NaN and infinity are considered finite, whether
-  /// normal or subnormal.
   @inlinable // FIXME(inline-always)
   public var isFinite: Bool {
     @inline(__always)
@@ -1289,15 +788,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether the instance is equal to zero.
-  ///
-  /// The `isZero` property of a value `x` is `true` when `x` represents either
-  /// `-0.0` or `+0.0`. `x.isZero` is equivalent to the following comparison:
-  /// `x == 0.0`.
-  ///
-  ///     let x = -0.0
-  ///     x.isZero        // true
-  ///     x == 0.0        // true
   @inlinable // FIXME(inline-always)
   public var isZero: Bool {
     @inline(__always)
@@ -1306,15 +796,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether the instance is subnormal.
-  ///
-  /// A *subnormal* value is a nonzero number that has a lesser magnitude than
-  /// the smallest normal number. Subnormal values do not use the full
-  /// precision available to values of a type.
-  ///
-  /// Zero is neither a normal nor a subnormal number. Subnormal numbers are
-  /// often called *denormal* or *denormalized*---these are different names
-  /// for the same concept.
   @inlinable // FIXME(inline-always)
   public var isSubnormal:  Bool {
     @inline(__always)
@@ -1323,10 +804,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether the instance is infinite.
-  ///
-  /// Note that `isFinite` and `isInfinite` do not form a dichotomy, because
-  /// they are not total: If `x` is `NaN`, then both properties are `false`.
   @inlinable // FIXME(inline-always)
   public var isInfinite:  Bool {
     @inline(__always)
@@ -1335,29 +812,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether the instance is NaN ("not a number").
-  ///
-  /// Because NaN is not equal to any value, including NaN, use this property
-  /// instead of the equal-to operator (`==`) or not-equal-to operator (`!=`)
-  /// to test whether a value is or is not NaN. For example:
-  ///
-  ///     let x = 0.0
-  ///     let y = x * .infinity
-  ///     // y is a NaN
-  ///
-  ///     // Comparing with the equal-to operator never returns 'true'
-  ///     print(x == Double.nan)
-  ///     // Prints "false"
-  ///     print(y == Double.nan)
-  ///     // Prints "false"
-  ///
-  ///     // Test with the 'isNaN' property instead
-  ///     print(x.isNaN)
-  ///     // Prints "false"
-  ///     print(y.isNaN)
-  ///     // Prints "true"
-  ///
-  /// This property is `true` for both quiet and signaling NaNs.
   @inlinable // FIXME(inline-always)
   public var isNaN:  Bool {
     @inline(__always)
@@ -1366,10 +820,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// A Boolean value indicating whether the instance is a signaling NaN.
-  ///
-  /// Signaling NaNs typically raise the Invalid flag when used in general
-  /// computing operations.
   @inlinable // FIXME(inline-always)
   public var isSignalingNaN: Bool {
     @inline(__always)
@@ -1378,25 +828,6 @@ extension ${Self}: BinaryFloatingPoint {
     }
   }
 
-  /// The floating-point value with the same sign and exponent as this value,
-  /// but with a significand of 1.0.
-  ///
-  /// A *binade* is a set of binary floating-point values that all have the
-  /// same sign and exponent. The `binade` property is a member of the same
-  /// binade as this value, but with a unit significand.
-  ///
-  /// In this example, `x` has a value of `21.5`, which is stored as
-  /// `1.34375 * 2**4`, where `**` is exponentiation. Therefore, `x.binade` is
-  /// equal to `1.0 * 2**4`, or `16.0`.
-  ///
-  ///     let x = 21.5
-  ///     // x.significand == 1.34375
-  ///     // x.exponent == 4
-  ///
-  ///     let y = x.binade
-  ///     // y == 16.0
-  ///     // y.significand == 1.0
-  ///     // y.exponent == 4
   @inlinable
   public var binade: ${Self} {
 %if bits != 80:
@@ -1424,20 +855,6 @@ extension ${Self}: BinaryFloatingPoint {
 %end
   }
 
-  /// The number of bits required to represent the value's significand.
-  ///
-  /// If this value is a finite nonzero number, `significandWidth` is the
-  /// number of fractional bits required to represent the value of
-  /// `significand`; otherwise, `significandWidth` is -1. The value of
-  /// `significandWidth` is always -1 or between zero and
-  /// `significandBitCount`. For example:
-  ///
-  /// - For any representable power of two, `significandWidth` is zero, because
-  ///   `significand` is `1.0`.
-  /// - If `x` is 10, `x.significand` is `1.01` in binary, so
-  ///   `x.significandWidth` is 2.
-  /// - If `x` is Float.pi, `x.significand` is `1.10010010000111111011011` in
-  ///   binary, and `x.significandWidth` is 23.
   @inlinable
   public var significandWidth: Int {
     let trailingZeroBits = significandBitPattern.trailingZeroBitCount
@@ -1452,19 +869,6 @@ extension ${Self}: BinaryFloatingPoint {
     return -1
   }
 
-  /// Creates a new value from the given floating-point literal.
-  ///
-  /// Do not call this initializer directly. It is used by the compiler when
-  /// you create a new `${Self}` instance by using a floating-point literal.
-  /// Instead, create a new value by using a literal.
-  ///
-  /// In this example, the assignment to the `x` constant calls this
-  /// initializer behind the scenes.
-  ///
-  ///     let x: ${Self} = 21.25
-  ///     // x == 21.25
-  ///
-  /// - Parameter value: The new floating-point value.
   @inlinable // FIXME(inline-always)
   @inline(__always)
   public init(floatLiteral value: ${Self}) {
@@ -1479,19 +883,6 @@ extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLite
     self = ${Self}(Builtin.itofp_with_overflow_IntLiteral_FPIEEE${bits}(value))
   }
 
-  /// Creates a new value from the given integer literal.
-  ///
-  /// Do not call this initializer directly. It is used by the compiler when
-  /// you create a new `${Self}` instance by using an integer literal.
-  /// Instead, create a new value by using a literal.
-  ///
-  /// In this example, the assignment to the `x` constant calls this
-  /// initializer behind the scenes.
-  ///
-  ///     let x: ${Self} = 100
-  ///     // x == 100.0
-  ///
-  /// - Parameter value: The new value.
   @_transparent
   public init(integerLiteral value: Int64) {
     self = ${Self}(Builtin.sitofp_Int64_FPIEEE${bits}(value._value))
@@ -1542,11 +933,6 @@ extension ${Self}: _ExpressibleByBuiltinFloatLiteral {
 % end
 
 extension ${Self}: Hashable {
-  /// Hashes the essential components of this value by feeding them into the
-  /// given hasher.
-  ///
-  /// - Parameter hasher: The hasher to use when combining the components
-  ///   of this instance.
   @inlinable
   public func hash(into hasher: inout Hasher) {
     var v = self
@@ -1589,26 +975,6 @@ extension ${Self}: _HasCustomAnyHashableRepresentation {
 }
 
 extension ${Self} {
-  /// The magnitude of this value.
-  ///
-  /// For any value `x`, `x.magnitude.sign` is `.plus`. If `x` is not NaN,
-  /// `x.magnitude` is the absolute value of `x`.
-  ///
-  /// The global `abs(_:)` function provides more familiar syntax when you need
-  /// to find an absolute value. In addition, because `abs(_:)` always returns
-  /// a value of the same type, even in a generic context, using the function
-  /// instead of the `magnitude` property is encouraged.
-  ///
-  ///     let targetDistance: ${Self} = 5.25
-  ///     let throwDistance: ${Self} = 5.5
-  ///
-  ///     let margin = targetDistance - throwDistance
-  ///     // margin == -0.25
-  ///     // margin.magnitude == 0.25
-  ///
-  ///     // Use 'abs(_:)' instead of 'magnitude'
-  ///     print("Missed the target by \(abs(margin)) meters.")
-  ///     // Prints "Missed the target by 0.25 meters."
   @inlinable // FIXME(inline-always)
   public var magnitude: ${Self} {
     @inline(__always)
@@ -1779,41 +1145,11 @@ extension ${Self} {
 //===----------------------------------------------------------------------===//
 
 extension ${Self}: Strideable {
-  /// Returns the distance from this value to the specified value.
-  ///
-  /// For two values `x` and `y`, the result of `x.distance(to: y)` is equal to
-  /// `y - x`---a distance `d` such that `x.advanced(by: d)` approximates `y`.
-  /// For example:
-  ///
-  ///     let x = 21.5
-  ///     let d = x.distance(to: 15.0)
-  ///     // d == -6.5
-  ///
-  ///     print(x.advanced(by: d))
-  ///     // Prints "15.0"
-  ///
-  /// - Parameter other: A value to calculate the distance to.
-  /// - Returns: The distance between this value and `other`.
   @_transparent
   public func distance(to other: ${Self}) -> ${Self} {
     return other - self
   }
 
-  /// Returns a new value advanced by the given distance.
-  ///
-  /// For two values `x` and `d`, the result of a `x.advanced(by: d)` is equal
-  /// to `x + d`---a new value `y` such that `x.distance(to: y)` approximates
-  /// `d`. For example:
-  ///
-  ///     let x = 21.5
-  ///     let y = x.advanced(by: -6.5)
-  ///     // y == 15.0
-  ///
-  ///     print(x.distance(to: y))
-  ///     // Prints "-6.5"
-  ///
-  /// - Parameter amount: The distance to advance this value.
-  /// - Returns: A new value that is `amount` added to this value.
   @_transparent
   public func advanced(by amount: ${Self}) -> ${Self} {
     return self + amount


### PR DESCRIPTION
... when they are already present on the protocol. I don't *think* that we need them anymore for xcode documentation purposes. There are reasonable arguments both ways on this:
1. when you're editing the concrete implementations, it's sometimes nice to have the doc comment right there.
2. but it needlessly repetitive, and introduces the opportunity for comments to get out of sync.
3. it also adds noise; it would be nice for information density if the implementation only had implementation notes.

Also includes some minor formatting fixups, and a bugfix for isCanonical on platforms that do not support subnormals (armv7, currently, which is sufficiently minor that I'm OK with stealth fixing it like this).