### PR TITLE
[Reproducers] Add FileCollector support to DependencyTracker

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -24,6 +24,10 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
+namespace llvm {
+class FileCollector;
+}
+
 namespace clang {
 class DependencyCollector;
 }
@@ -53,8 +57,9 @@ enum class Bridgeability : unsigned {
 class DependencyTracker {
   std::shared_ptr<clang::DependencyCollector> clangCollector;
 public:
-
-  explicit DependencyTracker(bool TrackSystemDeps);
+  explicit DependencyTracker(
+      bool TrackSystemDeps,
+      std::shared_ptr<llvm::FileCollector> FileCollector = {});
 
   /// Adds a file as a dependency.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -23,6 +23,7 @@
 
 namespace llvm {
   class Triple;
+  class FileCollector;
   template<typename Fn> class function_ref;
 }
 
@@ -117,7 +118,8 @@ public:
   /// Create a new clang::DependencyCollector customized to
   /// ClangImporter's specific uses.
   static std::shared_ptr<clang::DependencyCollector>
-  createDependencyCollector(bool TrackSystemDeps);
+  createDependencyCollector(bool TrackSystemDeps,
+                            std::shared_ptr<llvm::FileCollector> FileCollector);
 
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -18,17 +18,21 @@
 #include "clang/Frontend/Utils.h"
 #include "swift/ClangImporter/ClangImporter.h"
 
+namespace llvm {
+class FileCollector;
+}
+
 namespace swift {
 
-DependencyTracker::DependencyTracker(bool TrackSystemDeps)
-  // NB: The ClangImporter believes it's responsible for the construction of
-  // this instance, and it static_cast<>s the instance pointer to its own
-  // subclass based on that belief. If you change this to be some other
-  // instance, you will need to change ClangImporter's code to handle the
-  // difference.
-  : clangCollector(ClangImporter::createDependencyCollector(TrackSystemDeps))
-{
-}
+DependencyTracker::DependencyTracker(
+    bool TrackSystemDeps, std::shared_ptr<llvm::FileCollector> FileCollector)
+    // NB: The ClangImporter believes it's responsible for the construction of
+    // this instance, and it static_cast<>s the instance pointer to its own
+    // subclass based on that belief. If you change this to be some other
+    // instance, you will need to change ClangImporter's code to handle the
+    // difference.
+    : clangCollector(ClangImporter::createDependencyCollector(TrackSystemDeps,
+                                                              FileCollector)) {}
 
 void
 DependencyTracker::addDependency(StringRef File, bool IsSystem) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -320,6 +320,8 @@ private:
 class ClangImporterDependencyCollector : public clang::DependencyCollector
 {
   llvm::StringSet<> ExcludedPaths;
+  /// The FileCollector is used by LLDB to generate reproducers. It's not used
+  /// by Swift to track dependencies.
   std::shared_ptr<llvm::FileCollector> FileCollector;
   const bool TrackSystemDeps;
 


### PR DESCRIPTION
For reproducers in LLDB, we need to collect module dependency
information coming from the clang importer. However, we cannot override
the dependency collector, like we do in LLDB, because its interface is
completely hidden in the clang importer. The solution is to pass the
FileCollector through the DependencyTracker.