### PR TITLE
[AutoDiff] Show unmet `@differentiable` attribute requirements.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -459,9 +459,9 @@ NOTE(autodiff_member_subset_indices_not_differentiable,none,
      "arguments", ())
 NOTE(autodiff_function_nondiff_parameter_not_differentiable,none,
      "cannot differentiate with respect to a '@nondiff' parameter", ())
-NOTE(autodiff_function_assoc_func_requirements_unmet,none,
+NOTE(autodiff_function_assoc_func_unmet_requirements,none,
      "function call is not differentiable because generic requirements are not "
-     "met", ())
+     "met: '%0'", (StringRef))
 NOTE(autodiff_opaque_function_not_differentiable,none,
      "opaque non-'@differentiable' function is not differentiable", ())
 NOTE(autodiff_property_not_differentiable,none,

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -30,7 +30,7 @@ func vjpWeirdExtraRequirements<
 }
 func weirdWrapper<T : Differentiable>(_ x: T) -> T {
   // expected-error @+2 {{expression is not differentiable}}
-  // expected-note @+1 {{function call is not differentiable because generic requirements are not met}}
+  // expected-note @+1 {{function call is not differentiable because generic requirements are not met: 'T : CaseIterable, T.AllCases : ExpressibleByStringLiteral'}}
   return weird(x)
 }
 _ = gradient(at: Float(1), in: { x in weirdWrapper(x) })


### PR DESCRIPTION
Show unmet `@differentiable` attribute requirements in diagnostic for
easier debugging.

---

Contrived example:
```swift
@differentiable(where T == T.TangentVector)
func foo<T: Differentiable>(_ x: T) -> T {
  x
}

func bar<T: Differentiable>(_ x: T) -> T {
  foo(x)  
}

struct Foo : Differentiable {}
_ = pullback(at: Foo(), in: { x in bar(x) })
```
```console
# Before:
test.swift:9:3: error: expression is not differentiable
  foo(x)
  ^
test.swift:9:3: note: function call is not differentiable because generic requirements are not met
  foo(x)
  ^
```
```console
# After:
test.swift:9:3: error: expression is not differentiable
  foo(x)
  ^
test.swift:9:3: note: function call is not differentiable because generic requirements are not met: 'T == T.TangentVector'
  foo(x)
  ^
```