### PR TITLE
[AutoDiff] Fix crash during generic curry thunk cloning.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.h
+++ b/lib/SILOptimizer/Mandatory/Differentiation.h
@@ -131,10 +131,6 @@ public:
     SILClonerWithScopes::postProcess(orig, cloned);
   }
 
-  void visit(SILInstruction *inst) {
-    TypeSubstCloner::visit(inst);
-  }
-
   void run() {
     auto &target = Builder.getFunction();
     auto *entry = target.createBasicBlock();

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -229,4 +229,22 @@ extension TF_682_Proto where Self : Differentiable,
   }
 }
 
+// TF-688: Test generic curry thunk cloning.
+public struct TF_688_Struct<Scalar> {
+  var x: Scalar
+}
+extension TF_688_Struct: Differentiable where Scalar: Differentiable {
+  @differentiable
+  public static func id(x: Self) -> Self {
+    return x
+  }
+}
+@differentiable(wrt: x)
+public func TF_688<Scalar: Differentiable>(
+  _ x: TF_688_Struct<Scalar>,
+  reduction: @differentiable (TF_688_Struct<Scalar>) -> TF_688_Struct<Scalar> = TF_688_Struct.id
+) -> TF_688_Struct<Scalar> {
+  reduction(x)
+}
+
 // TODO: add more tests.


### PR DESCRIPTION
Create simple `BasicTypeSubstCloner` inheriting from `TypeSubstCloner`.
Use `BasicTypeSubstCloner` to clone generic curry thunks, remapping types.

Resolves [TF-688](https://bugs.swift.org/browse/TF-688).

---

Context:
```swift
public struct Tensor<Scalar> {
  var x: Scalar
}
extension Tensor: Differentiable where Scalar: Differentiable {
  @differentiable
  public static func id(x: Self) -> Self {
    return x
  }
}

@differentiable(wrt: x)
public func test<Scalar: Differentiable>(
  _ x: Tensor<Scalar>,
  reduction: @differentiable (Tensor<Scalar>) -> Tensor<Scalar> = Tensor.id
) -> Tensor<Scalar> {
  reduction(x)
}
```
```console
$ swift tf-688.swift
SIL verification failed: generic function definition must have a generic environment: !FTy->isPolymorphic()
In function:
// AD__$s4main6TensorVAAs14DifferentiableRzlE2id1xACyxGAG_tFZTc__differentiable_curry_thunk_src_0_wrt_0
sil shared [serializable] [thunk] @AD__$s4main6TensorVAAs14DifferentiableRzlE2id1xACyxGAG_tFZTc__differentiable_curry_thunk_src_0_wrt_0 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@thin Tensor<τ_0_0>.Type) -> @owned @differentiable @callee_guaranteed (@in_guaranteed Tensor<τ_0_0>) -> @out Tensor<τ_0_0
```

The reproducer above crashes during the differentiation transform (`ADContext::promoteToDifferentiableFunction`) because curry thunks were cloned using `SILFunctionCloner` without accounting for generics.

With this patch, curry thunk cloning handles generics correctly by setting the new thunk's generic environment and remapping types with a `TypeSubstCloner` subclass.