### PR TITLE
[AutoDiff] Constrain wrt parameters to conform to `Differentiable`.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -241,6 +241,19 @@ getAssociatedFunctionGenericSignature(SILDifferentiableAttr *attr,
       GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
   for (auto &req : attr->getRequirements())
     builder.addRequirement(req, source, original->getModule().getSwiftModule());
+  // Constrain all wrt parameters to conform to `Differentiable`.
+  auto &ctx = original->getASTContext();
+  auto *diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
+  auto paramIndexSet = attr->getIndices().parameters;
+  for (unsigned paramIdx : paramIndexSet->getIndices()) {
+    if (!paramIndexSet->contains(paramIdx))
+      continue;
+    auto paramType =
+        original->getConventions().getSILArgumentType(paramIdx).getASTType();
+    Requirement req(RequirementKind::Conformance, paramType,
+                    diffableProto->getDeclaredType());
+    builder.addRequirement(req, source, original->getModule().getSwiftModule());
+  }
   return std::move(builder)
       .computeGenericSignature(SourceLoc(), /*allowConcreteGenericParams=*/true)
       ->getCanonicalSignature();
@@ -2868,11 +2881,17 @@ public:
     auto origTy = original->getLoweredFunctionType();
     auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
 
+    auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+
     // RAII that pushes the original function's generic signature to
     // `module.Types` so that the calls `module.Types.getTypeLowering()` below
-    // will know the original function's generic parameter types.
+    // will know the pullback's generic parameter types.
     Lowering::GenericContextScope genericContextScope(
-        module.Types, origTy->getGenericSignature());
+        module.Types, pbGenericSig);
+
+    auto *pbGenericEnv = pbGenericSig
+        ? pbGenericSig->createGenericEnvironment()
+        : nullptr;
 
     // Given a type, returns its formal SIL parameter info.
     auto getTangentParameterInfoForOriginalResult = [&](
@@ -2964,10 +2983,6 @@ public:
         mangler.mangleAutoDiffLinearMapHelper(
             original->getName(), AutoDiffLinearMapKind::Pullback,
             indices)).str();
-    auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
-    auto *pbGenericEnv = pbGenericSig
-        ? pbGenericSig->createGenericEnvironment()
-        : nullptr;
     auto pbType = SILFunctionType::get(
         pbGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
         origTy->getCalleeConvention(), pbParams, {}, adjResults, None,
@@ -3290,7 +3305,7 @@ public:
     auto original = getOpValue(ai->getCallee());
     auto functionSource = original;
     SILValue vjpValue;
-    // If functionSource is a @differentiable function, just extract it.
+    // If `functionSource` is a `@differentiable` function, just extract it.
     auto originalFnTy = original->getType().castTo<SILFunctionType>();
     if (originalFnTy->isDifferentiable()) {
       auto paramIndices = originalFnTy->getDifferentiationParameterIndices();
@@ -3525,12 +3540,6 @@ public:
     auto origTy = original->getLoweredFunctionType();
     auto lookupConformance = LookUpConformanceInModule(module.getSwiftModule());
 
-    // RAII that pushes the original function's generic signature to
-    // `module.Types` so that the calls `module.Types.getTypeLowering()` below
-    // will know the original function's generic parameter types.
-    Lowering::GenericContextScope genericContextScope(
-        module.Types, origTy->getGenericSignature());
-
     SmallVector<SILParameterInfo, 8> diffParams;
     SmallVector<SILResultInfo, 8> diffResults;
     auto origParams = origTy->getParameters();
@@ -3557,6 +3566,13 @@ public:
             original->getName(), AutoDiffLinearMapKind::Differential,
             indices)).str();
     auto diffGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+
+    // RAII that pushes the original function's generic signature to
+    // `module.Types` so that the calls `module.Types.getTypeLowering()` below
+    // will know the differential's generic parameter types.
+    Lowering::GenericContextScope genericContextScope(
+        module.Types, diffGenericSig);
+
     auto *diffGenericEnv = diffGenericSig
         ? diffGenericSig->createGenericEnvironment()
         : nullptr;
@@ -5979,7 +5995,7 @@ static SILFunction *createEmptyJVP(
 
   // RAII that pushes the original function's generic signature to
   // `module.Types` so that the calls `module.Types.getTypeLowering()` below
-  // will know the VJP's generic parameter types.
+  // will know the JVP's generic parameter types.
   Lowering::GenericContextScope genericContextScope(
       module.Types, jvpGenericSig);
 

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -12,7 +12,9 @@ func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
 }
 _ = gradient(at: 1.0, in: generic)
 
-// Test unmet generic requirements.
+//===----------------------------------------------------------------------===//
+// Unmet generic requirements
+//===----------------------------------------------------------------------===//
 
 @differentiable(
   vjp: vjpWeirdExtraRequirements
@@ -67,3 +69,22 @@ struct TF8Struct<Scalar> : TF8Proto where Scalar : FloatingPoint & Differentiabl
 }
 
 _ = gradient(at: 1.0, in: { x in x.squareRoot() })
+
+//===----------------------------------------------------------------------===//
+// Add `Differentiable` conformance for generic wrt parameters
+//===----------------------------------------------------------------------===//
+
+func id<T>(_ x: T) -> T { x }
+let _: @differentiable (Float) -> Float = { x in id(x) }
+
+struct TF_691<Scalar> {
+  var x: Scalar
+  init(_ x: Scalar) {
+    self.x = x
+  }
+}
+extension TF_691: Differentiable where Scalar: Differentiable {}
+
+func identity<T>(_ x: TF_691<T>) -> TF_691<T> { x }
+let _: @differentiable (Float) -> TF_691<Float> = { x in identity(TF_691(x)) }
+let _: @differentiable (Float) -> TF_691<Float> = { x in id(TF_691(x)) }


### PR DESCRIPTION
Constrain all wrt parameters to conform to `Differentiable` when computing
AD associated function generic signatures.

This fixes crashes when differentiating generic original functions that
do not constrain parameters to be `Differentiable`, e.g. an unconstrained
identity function.

Resolves [TF-691](https://bugs.swift.org/browse/TF-691).

---

```swift
func id<T>(_ x: T) -> T { x }
print(gradient(at: 0, in: { x in id(x) }))
```

Before:
```console
$ swift tf-691.swift
Stack dump:
0.	Program arguments: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-07-25-a.xctoolchain/usr/bin/swift -frontend -interpret tf-691.swift -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -module-name main
1.	Swift version 5.1-dev (LLVM 200186e28b, Swift 3416770d73)
2.	While running pass #28 SILModuleTransform "Differentiation".
0  swift                    0x000000010ae97ad5 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift                    0x000000010ae96b18 llvm::sys::RunSignalHandlers() + 248
2  swift                    0x000000010ae980c8 SignalHandler(int) + 264
3  libsystem_platform.dylib 0x00007fff65936b5d _sigtramp + 29
4  libsystem_platform.dylib 0x00007fc6038c0430 _sigtramp + 2650314992
5  swift                    0x0000000107a8a803 (anonymous namespace)::SILTypeSubstituter::substSILFunctionType(swift::CanTypeWrapper<swift::SILFunctionType>) + 243
6  swift                    0x0000000107a8a6d7 swift::SILFunctionType::substGenericArgs(swift::SILModule&, swift::SubstitutionMap) + 231
7  swift                    0x0000000107afc59d swift::SILType::substGenericArgs(swift::SILModule&, swift::SubstitutionMap) const + 77
8  swift                    0x0000000107ab1dc6 swift::PartialApplyInst::create(swift::SILDebugLocation, swift::SILValue, llvm::ArrayRef<swift::SILValue>, swift::SubstitutionMap, swift::ParameterConvention, swift::SILFunction&, swift::SILOpenedArchetypesState&, swift::GenericSpecializationInformation const*, swift::PartialApplyInst::OnStackKind) + 70
9  swift                    0x00000001077cfc1d swift::SILInstructionVisitor<(anonymous namespace)::VJPEmitter, void>::visit(swift::SILInstruction*) + 50573
10 swift                    0x00000001077af6b8 (anonymous namespace)::ADContext::processDifferentiableAttribute(swift::SILFunction*, swift::SILDifferentiableAttr*, (anonymous namespace)::DifferentiationInvoker) + 10856
11 swift                    0x00000001077fe1ca (anonymous namespace)::ADContext::promoteToDifferentiableFunction(swift::AutoDiffFunctionInst*, swift::SILBuilder&, swift::SILLocation, (anonymous namespace)::DifferentiationInvoker) + 4954
12 swift                    0x00000001077b263a (anonymous namespace)::ADContext::processAutoDiffFunctionInst(swift::AutoDiffFunctionInst*) + 378
13 swift                    0x00000001077ac501 (anonymous namespace)::Differentiation::run() + 2913
```

After:
```console
$ swift tf-691.swift
1.0
```