### PR TITLE
[CodeSynth] NFC: Simplify diagnostic output

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4483,7 +4483,7 @@ NOTE(property_wrapper_declared_here,none,
 
 ERROR(property_wrapper_mutating_get_composed_to_get_only,none,
       "property wrapper %0 with a mutating getter cannot be composed inside "
-      "get-only property wrapper %1", (Type, Type))
+      "get-only property wrapper %1", (TypeLoc, TypeLoc))
 
 ERROR(property_wrapper_local,none,
       "property wrappers are not yet supported on local properties", ())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1890,8 +1890,8 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
       auto &ctx = var->getASTContext();
       ctx.Diags.diagnose(var->getAttachedPropertyWrappers()[i]->getLocation(),
                diag::property_wrapper_mutating_get_composed_to_get_only,
-               var->getAttachedPropertyWrappers()[i]->getTypeLoc().getType(),
-               var->getAttachedPropertyWrappers()[i-1]->getTypeLoc().getType());
+               var->getAttachedPropertyWrappers()[i]->getTypeLoc(),
+               var->getAttachedPropertyWrappers()[i-1]->getTypeLoc());
 
       return None;
     }


### PR DESCRIPTION
This helps `var->dump()` not crash.