### PR TITLE
Sema: Don't mark the accessors of the storage wrapper transparent if its backing var has lower visibility than the var

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -352,7 +352,8 @@ static void maybeMarkTransparent(AccessorDecl *accessor, ASTContext &ctx) {
 
       if (auto original = var->getOriginalWrappedProperty(
               PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
-        if (var->getFormalAccess() < original->getFormalAccess())
+        auto backingVar = original->getPropertyWrapperBackingProperty();
+        if (backingVar->getFormalAccess() < var->getFormalAccess())
           return;
       }
     }


### PR DESCRIPTION

rdar://53574404