### PR TITLE
[NFC] Don't use LLVM_ALIGNAS

### DIFF
--- a/include/swift/ABI/TrailingObjects.h
+++ b/include/swift/ABI/TrailingObjects.h
@@ -97,27 +97,20 @@ protected:
   template <typename T> struct OverloadToken {};
 };
 
-/// This helper template works-around MSVC 2013's lack of useful
-/// alignas() support. The argument to LLVM_ALIGNAS(), in MSVC, is
-/// required to be a literal integer. But, you *can* use template
-/// specialization to select between a bunch of different LLVM_ALIGNAS
-/// expressions...
 template <int Align>
 class TrailingObjectsAligner : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(1) TrailingObjectsAligner<1> : public TrailingObjectsBase {};
+class alignas(1) TrailingObjectsAligner<1> : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(2) TrailingObjectsAligner<2> : public TrailingObjectsBase {};
+class alignas(2) TrailingObjectsAligner<2> : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(4) TrailingObjectsAligner<4> : public TrailingObjectsBase {};
+class alignas(4) TrailingObjectsAligner<4> : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(8) TrailingObjectsAligner<8> : public TrailingObjectsBase {};
+class alignas(8) TrailingObjectsAligner<8> : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(16) TrailingObjectsAligner<16> : public TrailingObjectsBase {
-};
+class alignas(16) TrailingObjectsAligner<16> : public TrailingObjectsBase {};
 template <>
-class LLVM_ALIGNAS(32) TrailingObjectsAligner<32> : public TrailingObjectsBase {
-};
+class alignas(32) TrailingObjectsAligner<32> : public TrailingObjectsBase {};
 
 // Just a little helper for transforming a type pack into the same
 // number of a different type. e.g.:

--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -104,8 +104,7 @@ template <class Members>
 class BasicExternalUnion {
 
   /// The value storage.
-  LLVM_ALIGNAS(Members::Info::alignment)
-  char Storage[Members::Info::size];
+  alignas(Members::Info::alignment) char Storage[Members::Info::size];
 
   template <class T>
   static constexpr int maybeIndexOfMember() {

--- a/include/swift/Basic/PrefixMap.h
+++ b/include/swift/Basic/PrefixMap.h
@@ -66,8 +66,7 @@ public:
 private:
   template <typename T>
   union UninitializedStorage {
-    LLVM_ALIGNAS(alignof(T))
-    char Storage[sizeof(T)];
+    alignas(T) char Storage[sizeof(T)];
 
     template <typename... A>
     void emplace(A && ...value) {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5034,7 +5034,7 @@ namespace {
 
 // A statically-allocated pool.  It's zero-initialized, so this
 // doesn't cost us anything in binary size.
-LLVM_ALIGNAS(alignof(void*)) static char InitialAllocationPool[64*1024];
+alignas(void *) static char InitialAllocationPool[64 * 1024];
 static std::atomic<PoolRange>
 AllocationPool{PoolRange{InitialAllocationPool,
                          sizeof(InitialAllocationPool)}};


### PR DESCRIPTION
It's not useful anymore, and I'm about to remove it in upstream.
