### PR TITLE
[5.1] Sema: Don't mark the accessors of the storage wrapper transpare…

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -359,7 +359,8 @@ static void maybeMarkTransparent(AccessorDecl *accessor, ASTContext &ctx) {
 
       if (auto original = var->getOriginalWrappedProperty(
               PropertyWrapperSynthesizedPropertyKind::StorageWrapper)) {
-        if (var->getFormalAccess() < original->getFormalAccess())
+        auto backingVar = original->getPropertyWrapperBackingProperty();
+        if (backingVar->getFormalAccess() < var->getFormalAccess())
           return;
       }
     }

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -191,7 +191,7 @@ struct WrapperWithStorageValue<T> {
 
 struct UseWrapperWithStorageValue {
   // UseWrapperWithStorageValue._x.getter
-  // CHECK-LABEL: sil hidden [transparent] [ossa] @$s17property_wrappers26UseWrapperWithStorageValueV2$xAA0D0VySiGvg : $@convention(method) (UseWrapperWithStorageValue) -> Wrapper<Int>
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers26UseWrapperWithStorageValueV2$xAA0D0VySiGvg : $@convention(method) (UseWrapperWithStorageValue) -> Wrapper<Int>
   // CHECK-NOT: return
   // CHECK: function_ref @$s17property_wrappers23WrapperWithStorageValueV09projectedF0AA0C0VyxGvg
   @WrapperWithStorageValue(wrappedValue: 17) var x: Int
@@ -410,7 +410,44 @@ class TestResilientDI {
   }
 }
 
+@propertyWrapper
+public struct PublicWrapper<T> {
+  public var wrappedValue: T
 
+  public init(value: T) {
+    wrappedValue = value
+  }
+}
+
+@propertyWrapper
+public struct PublicWrapperWithStorageValue<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  public var projectedValue: PublicWrapper<T> {
+    return PublicWrapper(value: wrappedValue)
+  }
+}
+
+public class Container {
+  public init() {
+  }
+
+// The accessor cannot be serializable/transparent because it accesses an
+// internal var.
+// CHECK-LABEL: sil [ossa] @$s17property_wrappers9ContainerC10$dontCrashAA13PublicWrapperVySiGvg : $@convention(method) (@guaranteed Container) -> PublicWrapper<Int> {
+// CHECK: bb0(%0 : @guaranteed $Container):
+// CHECK:   ref_element_addr %0 : $Container, #Container._dontCrash
+  @PublicWrapperWithStorageValue(wrappedValue: 0) public var dontCrash : Int {
+    willSet {
+    }
+    didSet {
+    }
+  }
+}
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter


### PR DESCRIPTION
…nt if its

backing var has lower visibility than the var

Scope: Any use of the storage wrapper accessor of a property wrapper in another
(non-resilient) module might cause a compiler crash in optimized mode because an
internal property is accessed from inlined code.

The fix is to not mark accessors as transparent/inlinable.

Risk: Low. Accessors of storage wrappers of property wrappers are not
marked inlinable. The code is specific to property wrappers.

Testing: As part of the regression test

Reviewed: Doug G.

rdar://53574404