### PR TITLE
[5.1][CSFix] Delay `missing unwrap` locator simplification until diagnostic

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -797,6 +797,14 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
 
   auto *anchor = getAnchor();
 
+  // If this is an unresolved member expr e.g. `.foo` its
+  // base type is going to be the same as result type minus
+  // r-value adjustment because base could be an l-value type.
+  // We want to fix both cases by only diagnose one of them,
+  // otherwise this is just going to result in a duplcate diagnostic.
+  if (getLocator()->isLastElement(ConstraintLocator::UnresolvedMember))
+    return false;
+
   if (auto assignExpr = dyn_cast<AssignExpr>(anchor))
     anchor = assignExpr->getSrc();
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -74,9 +74,8 @@ bool ForceOptional::diagnose(Expr *root, bool asNote) const {
 ForceOptional *ForceOptional::create(ConstraintSystem &cs, Type baseType,
                                      Type unwrappedType,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator()) ForceOptional(
-      cs, baseType, unwrappedType,
-      cs.getConstraintLocator(simplifyLocatorToAnchor(cs, locator)));
+  return new (cs.getAllocator())
+      ForceOptional(cs, baseType, unwrappedType, locator);
 }
 
 bool UnwrapOptionalBase::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -168,22 +168,22 @@ bool ConstraintLocator::isForKeyPathComponent() const {
   });
 }
 
-static bool isLastElement(const ConstraintLocator *locator,
-                          ConstraintLocator::PathElementKind expectedKind) {
-  auto path = locator->getPath();
+bool ConstraintLocator::isLastElement(
+    ConstraintLocator::PathElementKind expectedKind) const {
+  auto path = getPath();
   return !path.empty() && path.back().getKind() == expectedKind;
 }
 
 bool ConstraintLocator::isForGenericParameter() const {
-  return isLastElement(this, ConstraintLocator::GenericParameter);
+  return isLastElement(ConstraintLocator::GenericParameter);
 }
 
 bool ConstraintLocator::isForSequenceElementType() const {
-  return isLastElement(this, ConstraintLocator::SequenceElementType);
+  return isLastElement(ConstraintLocator::SequenceElementType);
 }
 
 bool ConstraintLocator::isForContextualType() const {
-  return isLastElement(this, ConstraintLocator::ContextualType);
+  return isLastElement(ConstraintLocator::ContextualType);
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -585,6 +585,10 @@ public:
   /// Determine whether this locator points to the contextual type.
   bool isForContextualType() const;
 
+  /// Check whether the last element in the path of this locator
+  /// is of a given kind.
+  bool isLastElement(ConstraintLocator::PathElementKind kind) const;
+
   /// If this locator points to generic parameter return its type.
   GenericTypeParamType *getGenericParameter() const;
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -357,3 +357,19 @@ struct S {
     }
   }
 }
+
+// rdar://problem/53238058 - Crash in getCalleeLocator while trying to produce a diagnostic about missing optional unwrap
+//                           associated with an argument to a call
+
+func rdar_53238058() {
+  struct S {
+    init(_: Double) {}
+    init<T>(_ value: T) where T : BinaryFloatingPoint {}
+  }
+
+  func test(_ str: String) {
+    _ = S(Double(str)) // expected-error {{value of optional type 'Double?' must be unwrapped to a value of type 'Double'}}
+    // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+}


### PR DESCRIPTION
- **Explanation**:

Instead of keeping two locators in the fix let's store only the
original locator and simplify it later in process of emitting
a diagnostic. That helps to avoid some duplicate work as well
as makes sure that locators supplied to the diagnostic always
have an anchor.

- **Issue**: rdar://problem/53238058, rdar://problem/53344815

- **Scope**: Constraint solver in diagnostic mode.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @DougGregor

Resolves: rdar://problem/53344815
Resolves: rdar://problem/53238058
(cherry picked from commit 795a84ae6e5d57721be275cccfdca1d82c89173b)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
