### PR TITLE
[Parser] Added diagnostic for redundant escaped identifier

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -102,6 +102,9 @@ ERROR(line_directive_line_zero,none,
 WARNING(escaped_parameter_name,none,
         "keyword '%0' does not need to be escaped in argument list",
         (StringRef))
+WARNING(redundant_escaped_identifier,none,
+        "identifier '%0' does not need to be escaped",
+        (StringRef))
 
 ERROR(forbidden_interpolated_string,none,
       "%0 cannot be an interpolated string literal", (StringRef))

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -356,7 +356,9 @@ public:
   /// Determines if the given string is a valid non-operator
   /// identifier, without escaping characters.
   static bool isIdentifier(StringRef identifier);
-
+  
+  static bool isAccessor(StringRef identifier);
+  
   /// Determine the token kind of the string, given that it is a valid
   /// non-operator identifier. Return tok::identifier if the string is not a
   /// reserved word.

--- a/test/Parse/escaped_identifiers.swift
+++ b/test/Parse/escaped_identifiers.swift
@@ -1,25 +1,26 @@
 // RUN: %target-typecheck-verify-swift
 
-func `protocol`() {}
+func `protocol`() {} // no-warning
 
-`protocol`()
+`protocol`() // no-warning
 
-class `Type` {}
+class `Type` {} // expected-warning {{identifier 'Type' does not need to be escaped}}
+// expected-warning@-1 {{identifier 'Type' does not need to be escaped}}
 
-var `class` = `Type`.self
+var `class` = `Type`.self // expected-warning {{identifier 'Type' does not need to be escaped}}
 
-func foo() {}
+func foo() {} // no-warning
 
-`foo`()
+`foo`() // expected-warning {{identifier 'foo' does not need to be escaped}}
 
 // Escaping suppresses identifier contextualization.
 var get: (() -> ()) -> () = { $0() }
 
 var applyGet: Int {
-  `get` { }
+  `get` { } // no-warning
   return 0
 }
 
-enum `switch` {}
+enum `switch` {} // no-warning
 
-typealias `Self` = Int
+typealias `Self` = Int // no-warning


### PR DESCRIPTION
Added diagnostic for redundant escaped identifier. A warning is raised when the escaped identifier name is not a keyword or accessor. 

The reason accessor's are included is because although you can create a variable with name "get" without escaping, there are situations such as the code sample below where escaping is required.

```swift
// Escaping suppresses identifier contextualization.
var get: (() -> ()) -> () = { $0() }

var applyGet: Int {
  `get` { } // no-warning
   return 0
}
```

Resolves [SR-11092](https://bugs.swift.org/browse/SR-11092).