### PR TITLE
[ASTScope lookup] Fix PatternBindingEntry initializer getters and rectify its source range

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1908,8 +1908,9 @@ class PatternBindingEntry {
     // initializer is ASTContext-allocated it is safe.
     
     /// Exactly the expr the programmer wrote
-    Expr *origInit;
-    /// Might be transformed, e.g. for a property wrapper
+    Expr *originalInit;
+    /// Might be transformed, e.g. for a property wrapper. In the absence of
+    /// transformation or synthesis, holds the expr as parsed.
     Expr *initAfterSynthesis;
     /// The location of the equal '=' token.
     SourceLoc EqualLoc;
@@ -1932,6 +1933,7 @@ class PatternBindingEntry {
   friend class PatternBindingInitializer;
 
 public:
+  /// \p E is the initializer as parsed.
   PatternBindingEntry(Pattern *P, SourceLoc EqualLoc, Expr *E,
                       DeclContext *InitContext)
     : PatternAndFlags(P, {}), InitExpr({E, E, EqualLoc}),
@@ -1955,7 +1957,7 @@ public:
   Expr *getExecutableInit() const {
     return isInitializerSubsumed() ? nullptr : getInit();
   }
-  SourceRange getOrigInitRange() const;
+  SourceRange getOriginalInitRange() const;
   void setInit(Expr *E);
 
   /// Gets the text of the initializer expression, stripping out inactive
@@ -1987,10 +1989,10 @@ public:
 
   /// Retrieve the initializer after the =, if any, as it was written in the
   /// source.
-  Expr *getOrigInit() const;
-  
+  Expr *getOriginalInit() const;
+
   /// Set the initializer after the = as it was written in the source.
-  void setOrigInit(Expr*);
+  void setOriginalInit(Expr *);
 
   bool isInitializerChecked() const {
     return PatternAndFlags.getInt().contains(Flags::Checked);
@@ -2120,9 +2122,9 @@ public:
   Expr *getExecutableInit(unsigned i) const {
     return getPatternList()[i].getExecutableInit();
   }
-  
-  SourceRange getOrigInitRange(unsigned i) const {
-    return getPatternList()[i].getOrigInitRange();
+
+  SourceRange getOriginalInitRange(unsigned i) const {
+    return getPatternList()[i].getOriginalInitRange();
   }
 
   void setInit(unsigned i, Expr *E) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1902,18 +1902,22 @@ class PatternBindingEntry {
   };
   llvm::PointerIntPair<Pattern *, 3, OptionSet<Flags>> PatternAndFlags;
 
-  struct ExprAndEqualLoc {
-    // When the initializer is removed we don't actually clear the pointer
+  struct InitializerAndEqualLoc {
+    // When the initializer is removed we don't actually clear the pointers
     // because we might need to get initializer's source range. Since the
     // initializer is ASTContext-allocated it is safe.
-    Expr *Node;
+    
+    /// Exactly the expr the programmer wrote
+    Expr *origInit;
+    /// Might be transformed, e.g. for a property wrapper
+    Expr *initAfterSynthesis;
     /// The location of the equal '=' token.
     SourceLoc EqualLoc;
   };
 
   union {
     /// The initializer expression and its '=' token loc.
-    ExprAndEqualLoc InitExpr;
+    InitializerAndEqualLoc InitExpr;
 
     /// The text of the initializer expression if deserialized from a module.
     StringRef InitStringRepresentation;
@@ -1930,7 +1934,7 @@ class PatternBindingEntry {
 public:
   PatternBindingEntry(Pattern *P, SourceLoc EqualLoc, Expr *E,
                       DeclContext *InitContext)
-    : PatternAndFlags(P, {}), InitExpr({E, EqualLoc}),
+    : PatternAndFlags(P, {}), InitExpr({E, E, EqualLoc}),
       InitContextAndIsText({InitContext, false}) {
   }
 
@@ -1944,7 +1948,7 @@ public:
     if (PatternAndFlags.getInt().contains(Flags::Removed) ||
         InitContextAndIsText.getInt())
       return nullptr;
-    return InitExpr.Node;
+    return InitExpr.initAfterSynthesis;
   }
   /// Retrieve the initializer if it should be executed to initialize this
   /// particular pattern binding.
@@ -1981,10 +1985,12 @@ public:
     InitExpr.EqualLoc = equalLoc;
   }
 
-  /// Retrieve the initializer as it was written in the source.
-  Expr *getInitAsWritten() const {
-    return InitContextAndIsText.getInt() ? nullptr : InitExpr.Node;
-  }
+  /// Retrieve the initializer after the =, if any, as it was written in the
+  /// source.
+  Expr *getOrigInit() const;
+  
+  /// Set the initializer after the = as it was written in the source.
+  void setOrigInit(Expr*);
 
   bool isInitializerChecked() const {
     return PatternAndFlags.getInt().contains(Flags::Checked);
@@ -2013,7 +2019,15 @@ public:
     InitContextAndIsText.setPointer(dc);
   }
 
-  /// Retrieve the source range covered by this pattern binding.
+  SourceLoc getStartLoc() const;
+
+  /// Retrieve the end location covered by this pattern binding entry.
+  ///
+  /// \param omitAccessors Whether the computation should omit the accessors
+  /// from the source range.
+  SourceLoc getEndLoc(bool omitAccessors = false) const;
+
+  /// Retrieve the source range covered by this pattern binding entry.
   ///
   /// \param omitAccessors Whether the computation should omit the accessors
   /// from the source range.
@@ -2021,6 +2035,9 @@ public:
 
   const CaptureInfo &getCaptureInfo() const { return Captures; }
   void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
+
+private:
+  SourceLoc getLastAccessorEndLoc() const;
 };
 
 /// This decl contains a pattern and optional initializer for a set

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -183,7 +183,8 @@ void simple_display(
 
 /// Given the initializer for the given property with an attached property
 /// wrapper, dig out the original initialization expression.
-/// Cannot just dig out the getOrigInit() value because this function checks
+///
+/// Cannot just dig out the getOriginalInit() value because this function checks
 /// types, etc. Erroneous code won't return a result from here.
 Expr *findOriginalPropertyWrapperInitialValue(VarDecl *var, Expr *init);
 

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -183,6 +183,8 @@ void simple_display(
 
 /// Given the initializer for the given property with an attached property
 /// wrapper, dig out the original initialization expression.
+/// Cannot just dig out the getOrigInit() value because this function checks
+/// types, etc. Erroneous code won't return a result from here.
 Expr *findOriginalPropertyWrapperInitialValue(VarDecl *var, Expr *init);
 
 } // end namespace swift

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -906,8 +906,16 @@ namespace {
       for (auto entry : PBD->getPatternList()) {
         OS << '\n';
         printRec(entry.getPattern());
+        if (entry.getOrigInit()) {
+          OS << '\n';
+          OS.indent(Indent + 2);
+          OS << "Original init:\n";
+          printRec(entry.getOrigInit());
+        }
         if (entry.getInit()) {
           OS << '\n';
+          OS.indent(Indent + 2);
+          OS << "Processed init:\n";
           printRec(entry.getInit());
         }
       }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -906,11 +906,11 @@ namespace {
       for (auto entry : PBD->getPatternList()) {
         OS << '\n';
         printRec(entry.getPattern());
-        if (entry.getOrigInit()) {
+        if (entry.getOriginalInit()) {
           OS << '\n';
           OS.indent(Indent + 2);
           OS << "Original init:\n";
-          printRec(entry.getOrigInit());
+          printRec(entry.getOriginalInit());
         }
         if (entry.getInit()) {
           OS << '\n';

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -629,8 +629,8 @@ ASTScopeImpl *PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
   // initializer (because of InterpolatedLiteralStrings and EditorPlaceHolders),
   // so compute it ourselves.
   SourceLoc initializerEnd;
-  if (patternEntry.getInitAsWritten() &&
-      patternEntry.getInitAsWritten()->getSourceRange().isValid()) {
+  if (patternEntry.getOrigInit() &&
+      patternEntry.getOrigInit()->getSourceRange().isValid()) {
     auto *initializer =
         scopeCreator.createSubtree<PatternEntryInitializerScope>(
             this, decl, patternEntryIndex, vis);
@@ -649,8 +649,8 @@ ASTScopeImpl *
 PatternEntryInitializerScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   // Create a child for the initializer expression.
-  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getInitAsWritten(),
-                                         this, scopeCreator);
+  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getOrigInit(), this,
+                                         scopeCreator);
   return this;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -629,8 +629,8 @@ ASTScopeImpl *PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
   // initializer (because of InterpolatedLiteralStrings and EditorPlaceHolders),
   // so compute it ourselves.
   SourceLoc initializerEnd;
-  if (patternEntry.getOrigInit() &&
-      patternEntry.getOrigInit()->getSourceRange().isValid()) {
+  if (patternEntry.getOriginalInit() &&
+      patternEntry.getOriginalInit()->getSourceRange().isValid()) {
     auto *initializer =
         scopeCreator.createSubtree<PatternEntryInitializerScope>(
             this, decl, patternEntryIndex, vis);
@@ -649,8 +649,8 @@ ASTScopeImpl *
 PatternEntryInitializerScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   // Create a child for the initializer expression.
-  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getOrigInit(), this,
-                                         scopeCreator);
+  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getOriginalInit(),
+                                         this, scopeCreator);
   return this;
 }
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -213,7 +213,7 @@ SourceRange PatternEntryDeclScope::getChildlessSourceRange() const {
 }
 
 SourceRange PatternEntryInitializerScope::getChildlessSourceRange() const {
-  return getPatternEntry().getInitAsWritten()->getSourceRange();
+  return getPatternEntry().getOrigInit()->getSourceRange();
 }
 
 SourceRange PatternEntryUseScope::getChildlessSourceRange() const {

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -213,7 +213,7 @@ SourceRange PatternEntryDeclScope::getChildlessSourceRange() const {
 }
 
 SourceRange PatternEntryInitializerScope::getChildlessSourceRange() const {
-  return getPatternEntry().getOrigInit()->getSourceRange();
+  return getPatternEntry().getOriginalInit()->getSourceRange();
 }
 
 SourceRange PatternEntryUseScope::getChildlessSourceRange() const {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3643,8 +3643,8 @@ public:
 
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
-
-      if (!D->getSourceRange().isValid()) {
+      const auto SR = D->getSourceRange();
+      if (!SR.isValid()) {
         // We don't care about source ranges on implicitly-generated
         // decls.
         if (D->isImplicit())
@@ -3655,8 +3655,16 @@ public:
         Out << "\n";
         abort();
       }
-      checkSourceRanges(D->getSourceRange(), Parent,
-                        [&]{ D->print(Out); });
+      // ASTScope lookup depends on Decls having correct ordering.
+      // Move the order check to isGoodSourceRange after extending
+      // the invariant to Exprs, etc., per rdar://53637494
+      if (Ctx.SourceMgr.isBeforeInBuffer(SR.End, SR.Start)) {
+        Out << "backwards source range for decl: ";
+        D->print(Out);
+        Out << "\n";
+        abort();
+      }
+      checkSourceRanges(SR, Parent, [&] { D->print(Out); });
     }
 
     /// Verify that the given source ranges is contained within the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1391,18 +1391,18 @@ unsigned PatternBindingDecl::getPatternEntryIndexForVarDecl(const VarDecl *VD) c
   return ~0U;
 }
 
-Expr *PatternBindingEntry::getOrigInit() const {
-  return InitContextAndIsText.getInt() ? nullptr : InitExpr.origInit;
+Expr *PatternBindingEntry::getOriginalInit() const {
+  return InitContextAndIsText.getInt() ? nullptr : InitExpr.originalInit;
 }
 
-SourceRange PatternBindingEntry::getOrigInitRange() const {
-  if (auto *i = getOrigInit())
+SourceRange PatternBindingEntry::getOriginalInitRange() const {
+  if (auto *i = getOriginalInit())
     return i->getSourceRange();
   return SourceRange();
 }
 
-void PatternBindingEntry::setOrigInit(Expr *E) {
-  InitExpr.origInit = E;
+void PatternBindingEntry::setOriginalInit(Expr *E) {
+  InitExpr.originalInit = E;
   InitContextAndIsText.setInt(false);
 }
 
@@ -1460,7 +1460,7 @@ SourceLoc PatternBindingEntry::getEndLoc(bool omitAccessors) const {
     if (lastAccessorEnd.isValid())
       return lastAccessorEnd;
   }
-  const auto initEnd = getOrigInitRange().End;
+  const auto initEnd = getOriginalInitRange().End;
   if (initEnd.isValid())
     return initEnd;
 
@@ -1492,7 +1492,7 @@ StringRef PatternBindingEntry::getInitStringRepresentation(
   if (InitContextAndIsText.getInt() && !InitStringRepresentation.empty())
     return InitStringRepresentation;
   auto &sourceMgr = getAnchoringVarDecl()->getASTContext().SourceMgr;
-  auto init = getInit();
+  auto init = getOriginalInit();
   return extractInlinableText(sourceMgr, init, scratch);
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5222,7 +5222,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       PBDEntries.back().setEqualLoc(EqualLoc);
 
       ParserResult<Expr> init = parseExpr(diag::expected_init_value);
-      
+      PBDEntries.back().setOrigInit(init.getPtrOrNull());
+
       // If this Pattern binding was not supposed to have an initializer, but it
       // did, diagnose this and remove it.
       if (Flags & PD_DisallowInit && init.isNonNull()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5222,7 +5222,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       PBDEntries.back().setEqualLoc(EqualLoc);
 
       ParserResult<Expr> init = parseExpr(diag::expected_init_value);
-      PBDEntries.back().setOrigInit(init.getPtrOrNull());
+      PBDEntries.back().setOriginalInit(init.getPtrOrNull());
 
       // If this Pattern binding was not supposed to have an initializer, but it
       // did, diagnose this and remove it.

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -435,7 +435,7 @@ public:
 
               SourceRange SR = PBD->getSourceRange();
               if (!SR.isValid()) {
-                SR = PBD->getOrigInitRange(0);
+                SR = PBD->getOriginalInitRange(0);
               }
 
               Added<Stmt *> LogBefore = buildLoggerCall(SR, true);


### PR DESCRIPTION
`PatternBindingEntry::getSourceRange` uses the end of the initializer for the end of the range. But, if the initializer is a property wrapper, the initializer comes before the start of the `PatternBindingEntry`. Prevent the computation from using such an initializer.

The first commit adds a check on `Decl::getSourceRange` to `ASTVerifier` to ensure that the start is not after the end. This comment causes two tests to fail:
- `test/decl/var/property_wrappers.swift`, and
- `test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift`.

Someday, we should extend the check to `Exprs`, etc., but that is a lot more work since their `getSourceRange` functions also produce backwards ranges, but that invariant is not needed for the `ASTScope` work.

The second commit fixes the source range computation for `PatternBindingEntry`s. In order to do so,  It changes the semantics of `PatternBindingEntry:: getInitAsWritten` to only return an initializer after the equals sign, and also renames it to `getOrigInitAsWritten`.

It also fixes a bug and extends the semantics of `findOriginalPropertyWrapperInitialValue` to return null if there is no wrapper instead of failing an assertion.

In addition to a fix being needed for ASTScope lookup, this fix will be needed to address part of rdar://53637494

EDIT: I have decided to split up what this PR did into two PRs: the first ( https://github.com/apple/swift/pull/26433 ) simply fixes the source range computation, the second clears up the initializer confusion. This one will become the second PR.

EDIT: The split didn't work,  so it's back to one! (PR, that is.)

Fixes rdar://53080185