### PR TITLE
Revert "[AutoDiff] Constrain wrt parameters to conform to `Differenti…

### DIFF
--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -12,9 +12,7 @@ func generic<T: Differentiable & FloatingPoint>(_ x: T) -> T {
 }
 _ = gradient(at: 1.0, in: generic)
 
-//===----------------------------------------------------------------------===//
-// Unmet generic requirements
-//===----------------------------------------------------------------------===//
+// Test unmet generic requirements.
 
 @differentiable(
   vjp: vjpWeirdExtraRequirements
@@ -91,6 +89,10 @@ let _: @differentiable (Float) -> TF_687<Any> = { x in TF_687<Any>(x, dummy: x) 
 // Add `Differentiable` conformance for generic wrt parameters
 //===----------------------------------------------------------------------===//
 
+// FIXME(TF-697): The tests below were fixed by
+// https://github.com/apple/swift/pull/26406, which was reverted because it
+// introduced TF-697.
+/*
 func id<T>(_ x: T) -> T { x }
 let _: @differentiable (Float) -> Float = { x in id(x) }
 
@@ -105,3 +107,4 @@ extension TF_691: Differentiable where Scalar: Differentiable {}
 func identity<T>(_ x: TF_691<T>) -> TF_691<T> { x }
 let _: @differentiable (Float) -> TF_691<Float> = { x in identity(TF_691(x)) }
 let _: @differentiable (Float) -> TF_691<Float> = { x in id(TF_691(x)) }
+*/


### PR DESCRIPTION
…able`. (#26406)"

This reverts commit 6f58fd4684ab4970b9d634346619ddc948f6a1db.

https://github.com/apple/swift/pull/26406 introduced [TF-697](https://bugs.swift.org/browse/TF-697); reverting it until the issue is fixed.
Add testcase for [TF-697](https://bugs.swift.org/browse/TF-697) to prevent future regressions.