### PR TITLE
[ConstraintSystem] Refactor argument information collection and use it in more places

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3225,15 +3225,14 @@ namespace {
       llvm_unreachable("unhandled operation");
     }
 
-    void associateArgumentLabels(Expr *fn,
-                                 ConstraintSystem::ArgumentLabelState labels,
+    void associateArgumentLabels(Expr *fn, ConstraintSystem::ArgumentInfo info,
                                  bool labelsArePermanent = true) {
       fn = getArgumentLabelTargetExpr(fn);
 
       // Record the labels.
       if (!labelsArePermanent)
-        labels.Labels = CS.allocateCopy(labels.Labels);
-      CS.ArgumentLabels[CS.getConstraintLocator(fn)] = labels;
+        info.Labels = CS.allocateCopy(info.Labels);
+      CS.ArgumentInfos[fn] = info;
     }
   };
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3227,18 +3227,11 @@ namespace {
     void associateArgumentLabels(Expr *expr,
                                  ConstraintSystem::ArgumentInfo info,
                                  bool labelsArePermanent = true) {
-      ConstraintLocator *locator = nullptr;
-      if (auto *apply = dyn_cast<ApplyExpr>(expr)) {
-        auto *fnExpr = getArgumentLabelTargetExpr(apply->getFn());
-        locator = CS.getConstraintLocator(fnExpr);
-      } else {
-        locator = CS.getCalleeLocator(expr);
-      }
-
+      assert(expr);
       // Record the labels.
       if (!labelsArePermanent)
         info.Labels = CS.allocateCopy(info.Labels);
-      CS.ArgumentInfos[locator] = info;
+      CS.ArgumentInfos[CS.getArgumentInfoLocator(expr)] = info;
     }
   };
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -719,8 +719,7 @@ matchCallArguments(ArrayRef<AnyFunctionType::Param> args,
 static std::tuple<ValueDecl *, bool, ArrayRef<Identifier>, bool,
                   ConstraintLocator *>
 getCalleeDeclAndArgs(ConstraintSystem &cs,
-                     ConstraintLocatorBuilder callBuilder,
-                     SmallVectorImpl<Identifier> &argLabelsScratch) {
+                     ConstraintLocatorBuilder callBuilder) {
   ArrayRef<Identifier> argLabels;
   bool hasTrailingClosure = false;
   ConstraintLocator *targetLocator = nullptr;
@@ -925,12 +924,11 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
   ValueDecl *callee;
   bool hasAppliedSelf;
   ArrayRef<Identifier> argLabels;
-  SmallVector<Identifier, 2> argLabelsScratch;
   bool hasTrailingClosure = false;
   ConstraintLocator *calleeLocator;
   std::tie(callee, hasAppliedSelf, argLabels, hasTrailingClosure,
            calleeLocator) =
-    getCalleeDeclAndArgs(cs, locator, argLabelsScratch);
+    getCalleeDeclAndArgs(cs, locator);
 
   ParameterListInfo paramInfo(params, callee, hasAppliedSelf);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2784,12 +2784,11 @@ void ConstraintSystem::generateConstraints(
 }
 
 Optional<ConstraintSystem::ArgumentInfo>
-ConstraintSystem::getArgumentInfo(const ConstraintLocatorBuilder builder) {
-  Expr *anchor = builder.getAnchor();
+ConstraintSystem::getArgumentInfo(ConstraintLocator *locator) {
+  Expr *anchor = locator->getAnchor();
   if (!anchor)
     return None;
 
-  ConstraintLocator *locator = nullptr;
   if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
     auto *fnExpr = getArgumentLabelTargetExpr(apply->getFn());
     locator = getConstraintLocator(fnExpr);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2780,23 +2780,25 @@ void ConstraintSystem::generateConstraints(
   }
 }
 
-Optional<ConstraintSystem::ArgumentInfo>
-ConstraintSystem::getArgumentInfo(ConstraintLocator *locator) {
-  Expr *anchor = locator->getAnchor();
+ConstraintLocator *ConstraintSystem::getArgumentInfoLocator(Expr *anchor) {
   if (!anchor)
-    return None;
+    return nullptr;
 
   if (auto *apply = dyn_cast<ApplyExpr>(anchor)) {
     auto *fnExpr = getArgumentLabelTargetExpr(apply->getFn());
-    locator = getConstraintLocator(fnExpr);
-  } else {
-    locator = getCalleeLocator(anchor);
+    return getConstraintLocator(fnExpr);
   }
 
-  auto known = ArgumentInfos.find(locator);
-  if (known != ArgumentInfos.end())
-    return known->second;
+  return getCalleeLocator(anchor);
+}
 
+Optional<ConstraintSystem::ArgumentInfo>
+ConstraintSystem::getArgumentInfo(ConstraintLocator *locator) {
+  if (auto *infoLocator = getArgumentInfoLocator(locator->getAnchor())) {
+    auto known = ArgumentInfos.find(infoLocator);
+    if (known != ArgumentInfos.end())
+      return known->second;
+  }
   return None;
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -435,23 +435,20 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(Expr *expr) {
     expr = fnExpr->getSemanticsProvidingExpr();
   }
 
-  auto *locator = getConstraintLocator(expr);
-  if (auto *ude = dyn_cast<UnresolvedDotExpr>(expr)) {
-    if (TC.getSelfForInitDelegationInConstructor(DC, ude)) {
-      return getConstraintLocator(locator,
-                                  ConstraintLocator::ConstructorMember);
-    } else {
-      return getConstraintLocator(locator, ConstraintLocator::Member);
-    }
+  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+    return getConstraintLocator(
+        expr, TC.getSelfForInitDelegationInConstructor(DC, UDE)
+                  ? ConstraintLocator::ConstructorMember
+                  : ConstraintLocator::Member);
   }
 
   if (isa<UnresolvedMemberExpr>(expr))
-    return getConstraintLocator(locator, ConstraintLocator::UnresolvedMember);
+    return getConstraintLocator(expr, ConstraintLocator::UnresolvedMember);
 
   if (isa<MemberRefExpr>(expr))
-    return getConstraintLocator(locator, ConstraintLocator::Member);
+    return getConstraintLocator(expr, ConstraintLocator::Member);
 
-  return locator;
+  return getConstraintLocator(expr);
 }
 
 Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1553,19 +1553,15 @@ public:
     bool HasTrailingClosure;
   };
 
-  /// A mapping from the constraint anchors for references to various
+  /// A mapping from the constraint locators for references to various
   /// names (e.g., member references, normal name references, possible
   /// constructions) to the argument labels provided in the call to
   /// that locator.
-  llvm::DenseMap<Expr *, ArgumentInfo> ArgumentInfos;
+  llvm::DenseMap<ConstraintLocator *, ArgumentInfo> ArgumentInfos;
 
   /// Retrieve the argument info that is associated with a member
-  /// reference at the given anchor expression.
-  Optional<ArgumentInfo> getArgumentInfo(Expr *anchor) const;
-  /// Retrieve the argument info that is associated with a member
   /// reference at the given locator.
-  Optional<ArgumentInfo>
-  getArgumentInfo(ConstraintLocatorBuilder locator) const;
+  Optional<ArgumentInfo> getArgumentInfo(ConstraintLocatorBuilder locator);
 
   ResolvedOverloadSetListItem *getResolvedOverloadSets() const {
     return resolvedOverloadSets;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1544,7 +1544,7 @@ public:
   /// The current solver state.
   ///
   /// This will be non-null when we're actively solving the constraint
-  /// system, and carries temporary state related to the scurrent path
+  /// system, and carries temporary state related to the current path
   /// we're exploring.
   SolverState *solverState = nullptr;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1544,20 +1544,28 @@ public:
   /// The current solver state.
   ///
   /// This will be non-null when we're actively solving the constraint
-  /// system, and carries temporary state related to the current path
+  /// system, and carries temporary state related to the scurrent path
   /// we're exploring.
   SolverState *solverState = nullptr;
 
-  struct ArgumentLabelState {
+  struct ArgumentInfo {
     ArrayRef<Identifier> Labels;
     bool HasTrailingClosure;
   };
 
-  /// A mapping from the constraint locators for references to various
+  /// A mapping from the constraint anchors for references to various
   /// names (e.g., member references, normal name references, possible
   /// constructions) to the argument labels provided in the call to
   /// that locator.
-  llvm::DenseMap<ConstraintLocator *, ArgumentLabelState> ArgumentLabels;
+  llvm::DenseMap<Expr *, ArgumentInfo> ArgumentInfos;
+
+  /// Retrieve the argument info that is associated with a member
+  /// reference at the given anchor expression.
+  Optional<ArgumentInfo> getArgumentInfo(Expr *anchor) const;
+  /// Retrieve the argument info that is associated with a member
+  /// reference at the given locator.
+  Optional<ArgumentInfo>
+  getArgumentInfo(ConstraintLocatorBuilder locator) const;
 
   ResolvedOverloadSetListItem *getResolvedOverloadSets() const {
     return resolvedOverloadSets;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1561,7 +1561,7 @@ public:
 
   /// Retrieve the argument info that is associated with a member
   /// reference at the given locator.
-  Optional<ArgumentInfo> getArgumentInfo(ConstraintLocatorBuilder locator);
+  Optional<ArgumentInfo> getArgumentInfo(ConstraintLocator *locator);
 
   ResolvedOverloadSetListItem *getResolvedOverloadSets() const {
     return resolvedOverloadSets;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1559,6 +1559,10 @@ public:
   /// that locator.
   llvm::DenseMap<ConstraintLocator *, ArgumentInfo> ArgumentInfos;
 
+  /// Form a locator with given anchor which then could be used
+  /// to retrieve argument information cached in the constraint system.
+  ConstraintLocator *getArgumentInfoLocator(Expr *anchor);
+
   /// Retrieve the argument info that is associated with a member
   /// reference at the given locator.
   Optional<ArgumentInfo> getArgumentInfo(ConstraintLocator *locator);


### PR DESCRIPTION
Since argument information covers all of the expressions now, we should use it
while trying to match arguments to parameters instead of manually recollecting
the same information based on locator.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
