### PR TITLE
test: adjust the test for MS ABI

### DIFF
--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -3,8 +3,8 @@
 import CXXInterop
 
 // CHECK-LABEL: define hidden swiftcc void @"$s6cxx_ir13indirectUsageyyF"()
-// CHECK: %0 = call %"class.ns::T"* @_Z5makeTv()
-// CHECK: call void @_Z4useTPN2ns1TE(%"class.ns::T"* %2)
+// CHECK: %0 = call %"class.ns::T"* @{{_Z5makeTv|"\?makeT@@YAPE?AVT@ns@@XZ"}}()
+// CHECK: call void @{{_Z4useTPN2ns1TE|"\?useT@@YAXPE?AVT@ns@@@Z"}}(%"class.ns::T"* %2)
 func indirectUsage() {
   useT(makeT())
 }


### PR DESCRIPTION
The decoration scheme on the Microsoft ABI is different than the itanium
style used on macOS and Linux.  Account for that in the test patterns.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
