### PR TITLE
SR-8467: Fixing crash on AnyFunctionType::getExtInfo

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2430,9 +2430,12 @@ public:
     }
     // Printing a function type doesn't indicate whether it's escaping because it doesn't 
     // matter in 99% of contexts. AbstractClosureExpr nodes are one of the only exceptions.
-    if (auto Ty = GetTypeOfExpr(E))
-      if (!Ty->getAs<AnyFunctionType>()->getExtInfo().isNoEscape())
-        PrintWithColorRAII(OS, ClosureModifierColor) << " escaping";
+    if (auto Ty = GetTypeOfExpr(E)) {
+      if (auto fType = Ty->getAs<AnyFunctionType>()) {
+        if (!fType->getExtInfo().isNoEscape())
+          PrintWithColorRAII(OS, ClosureModifierColor) << " escaping";
+      }
+    }
 
     return OS;
   }

--- a/validation-test/compiler_crashers_2_fixed/sr8467-0-invalid-read-get-extra-info.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr8467-0-invalid-read-get-extra-info.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -dump-ast
+let h={0(

--- a/validation-test/compiler_crashers_2_fixed/sr8467-1-invalid-read-get-extra-info.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr8467-1-invalid-read-get-extra-info.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -dump-ast
+let pq = {
+  return $0 ?? nil
+}

--- a/validation-test/compiler_crashers_2_fixed/sr8467-2-invalid-read-get-extra-info.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr8467-2-invalid-read-get-extra-info.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -dump-ast
+{(x)->i in

--- a/validation-test/compiler_crashers_2_fixed/sr8467-3-invalid-read-get-extra-info.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr8467-3-invalid-read-get-extra-info.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -dump-ast
+var:Int->Int={}

--- a/validation-test/compiler_crashers_2_fixed/sr8467-4-invalid-read-get-extra-info.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr8467-4-invalid-read-get-extra-info.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not %target-swift-frontend %s -dump-ast
+{(v:T)in


### PR DESCRIPTION
Resolves [SR-8467](https://bugs.swift.org/browse/SR-8467).
The type of the expression is an error type `(closure_expr type='<<error type>>'` on those cases. 
So, the `!Ty->getAs<AnyFunctionType>()->getExtInfo().isNoEscape()` was assuming that it was always a FunctionType and crashing because of that. 
This fix was just to check if the type is actually a function type.

All the files on the SR ticket were added as tests.
cc @jrose-apple 