### PR TITLE
[AutoDiff] Constrain wrt parameters to conform to `Differentiable`.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4228,11 +4228,11 @@ public:
       AutoDiffIndexSubset *parameterIndices, unsigned resultIndex,
       unsigned differentiationOrder, AutoDiffAssociatedFunctionKind kind,
       SILModule &module, LookupConformanceFn lookupConformance,
-      CanGenericSignature whereClauseGenericSignature = nullptr);
+      CanGenericSignature associatedFunctionGenericSignature = nullptr);
 
   /// Returns a bit vector that specifices which parameters you can
   /// differentiate with respect to for this differentiable function type. (e.g.
-  /// which parameters are not @nondiff). The function type must be
+  /// which parameters are not `@nondiff`). The function type must be
   /// differentiable.
   AutoDiffIndexSubset *getDifferentiationParameterIndices();
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -153,7 +153,7 @@ CanSILFunctionType SILFunctionType::getWithoutDifferentiability() {
 // Returns the canonical generic signature for an autodiff associated function
 // given an existing associated function generic signature. All differentiation
 // parameters are constrained to conform to `Differentiable`.
-static CanGenericSignature getAssociatedFunctionGenericSignature(
+static CanGenericSignature getAutoDiffAssociatedFunctionGenericSignature(
     CanGenericSignature assocFnGenSig,
     ArrayRef<SILParameterInfo> originalParameters,
     AutoDiffIndexSubset *parameterIndices, SILModule &module) {
@@ -208,7 +208,7 @@ CanSILFunctionType SILFunctionType::getAutoDiffAssociatedFunctionType(
   // Get the canonical associated function generic signature.
   if (!assocFnGenSig)
     assocFnGenSig = getGenericSignature();
-  assocFnGenSig = getAssociatedFunctionGenericSignature(
+  assocFnGenSig = getAutoDiffAssociatedFunctionGenericSignature(
       assocFnGenSig, getParameters(), parameterIndices, module);
   Lowering::GenericContextScope genericContextScope(module.Types,
                                                     assocFnGenSig);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -816,8 +816,7 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
         auto *jvpFn = getFunction(SILDeclRef(jvpDecl), NotForDefinition);
         if (jvpFn->getLoweredFunctionType() != expectedJVPType) {
           jvpThunk = getOrCreateAutoDiffAssociatedFunctionThunk(
-              F, indices, jvpFn, AutoDiffAssociatedFunctionKind::JVP,
-              jvpFn->isSerialized());
+              F, indices, jvpFn, AutoDiffAssociatedFunctionKind::JVP);
         } else {
           auto *id = AutoDiffAssociatedFunctionIdentifier::get(
               AutoDiffAssociatedFunctionKind::JVP, /*differentiationOrder*/ 1,
@@ -836,8 +835,7 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
         auto *vjpFn = getFunction(SILDeclRef(vjpDecl), NotForDefinition);
         if (vjpFn->getLoweredFunctionType() != expectedVJPType) {
           vjpThunk = getOrCreateAutoDiffAssociatedFunctionThunk(
-              F, indices, vjpFn, AutoDiffAssociatedFunctionKind::VJP,
-              vjpFn->isSerialized());
+              F, indices, vjpFn, AutoDiffAssociatedFunctionKind::VJP);
         } else {
           auto *id = AutoDiffAssociatedFunctionIdentifier::get(
               AutoDiffAssociatedFunctionKind::VJP, /*differentiationOrder*/ 1,

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -187,8 +187,7 @@ public:
   /// - The last result in the returned pullback.
   SILFunction *getOrCreateAutoDiffAssociatedFunctionThunk(
       SILFunction *original, SILAutoDiffIndices &indices,
-      SILFunction *assocFn, AutoDiffAssociatedFunctionKind assocFnKind,
-      IsSerialized_t isSerialized);
+      SILFunction *assocFn, AutoDiffAssociatedFunctionKind assocFnKind);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3687,8 +3687,7 @@ static void forwardFunctionArgumentsConvertingOwnership(
 SILFunction *
 SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
     SILFunction *original, SILAutoDiffIndices &indices,
-    SILFunction *assocFn, AutoDiffAssociatedFunctionKind assocFnKind,
-    IsSerialized_t isSerialized) {
+    SILFunction *assocFn, AutoDiffAssociatedFunctionKind assocFnKind) {
   auto assocFnType = assocFn->getLoweredFunctionType();
 
   Mangle::ASTMangler mangler;

--- a/test/AutoDiff/autodiff_indirect_diagnostics.swift
+++ b/test/AutoDiff/autodiff_indirect_diagnostics.swift
@@ -89,10 +89,6 @@ let _: @differentiable (Float) -> TF_687<Any> = { x in TF_687<Any>(x, dummy: x) 
 // Add `Differentiable` conformance for generic wrt parameters
 //===----------------------------------------------------------------------===//
 
-// FIXME(TF-697): The tests below were fixed by
-// https://github.com/apple/swift/pull/26406, which was reverted because it
-// introduced TF-697.
-/*
 func id<T>(_ x: T) -> T { x }
 let _: @differentiable (Float) -> Float = { x in id(x) }
 
@@ -107,4 +103,3 @@ extension TF_691: Differentiable where Scalar: Differentiable {}
 func identity<T>(_ x: TF_691<T>) -> TF_691<T> { x }
 let _: @differentiable (Float) -> TF_691<Float> = { x in identity(TF_691(x)) }
 let _: @differentiable (Float) -> TF_691<Float> = { x in id(TF_691(x)) }
-*/


### PR DESCRIPTION
Constrain all wrt parameters to conform to `Differentiable` when computing
AD associated function generic signatures.

This fixes crashes when differentiating generic original functions that
do not constrain parameters to be `Differentiable`, e.g. an unconstrained
identity function.

Gardening included:
- Remove unused `isSerialized` flag from
  `SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk`.
- Rename `whereClauseGenericSignature` in SIL to
  `associatedFunctionGenericSignature`.
  - The generic signature does not necessarily come from the `where`
    clause of a `[differentiable]` attribute.

Resolves [TF-691](https://bugs.swift.org/projects/TF/issues/TF-691) and [TF-697](https://bugs.swift.org/projects/TF/issues/TF-697).

---

[TF-691](https://bugs.swift.org/projects/TF/issues/TF-691) reproducer:

```swift
// tf-691.swift
func id<T>(_ x: T) -> T { x }
print(gradient(at: 0, in: { x in id(x) }))
```

Before:
```console
$ swift tf-691.swift
Stack dump:
0.	Program arguments: /Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-07-25-a.xctoolchain/usr/bin/swift -frontend -interpret tf-691.swift -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -color-diagnostics -module-name main
1.	Swift version 5.1-dev (LLVM 200186e28b, Swift 3416770d73)
2.	While running pass #28 SILModuleTransform "Differentiation".
0  swift                    0x000000010ae97ad5 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift                    0x000000010ae96b18 llvm::sys::RunSignalHandlers() + 248
2  swift                    0x000000010ae980c8 SignalHandler(int) + 264
3  libsystem_platform.dylib 0x00007fff65936b5d _sigtramp + 29
4  libsystem_platform.dylib 0x00007fc6038c0430 _sigtramp + 2650314992
5  swift                    0x0000000107a8a803 (anonymous namespace)::SILTypeSubstituter::substSILFunctionType(swift::CanTypeWrapper<swift::SILFunctionType>) + 243
6  swift                    0x0000000107a8a6d7 swift::SILFunctionType::substGenericArgs(swift::SILModule&, swift::SubstitutionMap) + 231
7  swift                    0x0000000107afc59d swift::SILType::substGenericArgs(swift::SILModule&, swift::SubstitutionMap) const + 77
8  swift                    0x0000000107ab1dc6 swift::PartialApplyInst::create(swift::SILDebugLocation, swift::SILValue, llvm::ArrayRef<swift::SILValue>, swift::SubstitutionMap, swift::ParameterConvention, swift::SILFunction&, swift::SILOpenedArchetypesState&, swift::GenericSpecializationInformation const*, swift::PartialApplyInst::OnStackKind) + 70
9  swift                    0x00000001077cfc1d swift::SILInstructionVisitor<(anonymous namespace)::VJPEmitter, void>::visit(swift::SILInstruction*) + 50573
10 swift                    0x00000001077af6b8 (anonymous namespace)::ADContext::processDifferentiableAttribute(swift::SILFunction*, swift::SILDifferentiableAttr*, (anonymous namespace)::DifferentiationInvoker) + 10856
11 swift                    0x00000001077fe1ca (anonymous namespace)::ADContext::promoteToDifferentiableFunction(swift::AutoDiffFunctionInst*, swift::SILBuilder&, swift::SILLocation, (anonymous namespace)::DifferentiationInvoker) + 4954
12 swift                    0x00000001077b263a (anonymous namespace)::ADContext::processAutoDiffFunctionInst(swift::AutoDiffFunctionInst*) + 378
13 swift                    0x00000001077ac501 (anonymous namespace)::Differentiation::run() + 2913
```

After:
```console
$ swift tf-691.swift
1.0
```
---

[TF-697](https://bugs.swift.org/projects/TF/issues/TF-697) reproducer:

```swift
// tf-697.swift
// TF-697: Test generic requirements of generated AD associated function.
protocol Module: Differentiable where AllDifferentiableVariables == TangentVector {
  associatedtype Input
  associatedtype Output: Differentiable

  @differentiable(wrt: self)
  func callAsFunction(_ input: Input) -> Output
}
protocol Layer: Module where Input: Differentiable {
  @differentiable
  func callLayer(_ input: Input) -> Output
}
struct Sequential<Layer1: Module, Layer2: Layer>: Module
  where Layer1.Output == Layer2.Input {
  var layer1: Layer1
  var layer2: Layer2

  @differentiable(wrt: self)
  func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
      layer2(layer1(input))
  }
}
extension Sequential: Layer where Layer1: Layer {
  @differentiable
  func callAsFunction(_ input: Layer1.Input) -> Layer2.Output {
      layer2(layer1(input))
  }
}
```

Before:
```console
$ swift tf-697.swift
SIL verification failed: JVP type does not match expected JVP type
  $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Module, τ_0_1 : Layer, τ_0_0.AllDifferentiableVariables == τ_0_0.TangentVector.AllDifferentiableVariables, τ_0_0.Input : Differentiable, τ_0_0.Output == τ_0_1.Input, τ_0_0.AllDifferentiableVariables.VectorSpaceScalar == τ_0_1.AllDifferentiableVariables.VectorSpaceScalar> (@in_guaranteed τ_0_0.Input, @in_guaranteed Sequential<τ_0_0, τ_0_1>) -> (@out τ_0_1.Output, @owned @callee_guaranteed (@in_guaranteed Sequential<τ_0_0, τ_0_1>.AllDifferentiableVariables) -> @out τ_0_1.Output.TangentVector)
  $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Module, τ_0_1 : Layer, τ_0_0.AllDifferentiableVariables == τ_0_0.TangentVector.AllDifferentiableVariables, τ_0_0.Output == τ_0_1.Input, τ_0_0.AllDifferentiableVariables.VectorSpaceScalar == τ_0_1.AllDifferentiableVariables.VectorSpaceScalar> (@in_guaranteed τ_0_0.Input, @in_guaranteed Sequential<τ_0_0, τ_0_1>) -> (@out τ_0_1.Output, @owned @callee_guaranteed (@in_guaranteed Sequential<τ_0_0, τ_0_1>.AllDifferentiableVariables) -> @out τ_0_1.Output.TangentVector)
...
```

After:
```console
$ swift tf-697.swift
# No error.
```