### PR TITLE
[AutoDiff] Decouple test from stdlib dependency.

### DIFF
--- a/test/AutoDiff/Inputs/differentiable_attr_silgen_other_module.swift
+++ b/test/AutoDiff/Inputs/differentiable_attr_silgen_other_module.swift
@@ -1,0 +1,32 @@
+public struct Wrapper : Differentiable, AdditiveArithmetic {
+  public var x: Float
+  public init(_ x: Float) {
+    self.x = x
+  }
+
+  public static func + (lhs: Wrapper, rhs: Wrapper) -> Wrapper {
+    return Wrapper(lhs.x + rhs.x)
+  }
+
+  @differentiating(+)
+  public static func vjpAdd(lhs: Wrapper, rhs: Wrapper)
+    -> (value: Wrapper, pullback: (Wrapper) -> (Wrapper, Wrapper)) {
+    return (lhs + rhs, { v in (v, v) })
+  }
+
+  public static func * (lhs: Wrapper, rhs: Wrapper) -> Wrapper {
+    return Wrapper(lhs.x * rhs.x)
+  }
+
+  @differentiating(*)
+  public static func jvpMultiply(lhs: Wrapper, rhs: Wrapper)
+    -> (value: Wrapper, differential: (Wrapper, Wrapper) -> Wrapper) {
+    return (lhs * rhs, { dlhs, drhs in dlhs * rhs + lhs * drhs })
+  }
+
+  @differentiating(*)
+  public static func vjpMultiply(lhs: Wrapper, rhs: Wrapper)
+    -> (value: Wrapper, pullback: (Wrapper) -> (Wrapper, Wrapper)) {
+    return (lhs * rhs, { v in (v * rhs, v * lhs) })
+  }
+}

--- a/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
+++ b/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
@@ -1,17 +1,24 @@
-// RUN: %target-swift-frontend -emit-silgen -verify %s | %FileCheck %s -check-prefix=CHECK-SILGEN
-// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -primary-file %S/Inputs/differentiable_attr_silgen_other_module.swift -emit-module-path %t/differentiable_attr_silgen_other_module.swiftmodule
+// RUN: %target-swift-frontend -emit-silgen -verify -I %t -primary-file %s | %FileCheck %s -check-prefix=CHECK-SILGEN
+// RUN: %target-swift-frontend -emit-sil -verify -I %t -primary-file %s | %FileCheck %s -check-prefix=CHECK-SIL
 
-// After SILGen, SIL `[differentiable]` should have jvp/vjp names only if the AST `@differentiable` attribute does.
-// The differentiation pass is guaranteed to fill in jvp/vjp names.
+import differentiable_attr_silgen_other_module
 
-_ = gradient(at: Float(1)) { x in x + x * x }
+// After SILGen, SIL `[differentiable]` attribute should have JVP/VJP names
+// only if the AST `@differentiable` attribute does.
+// The differentiation pass is guaranteed to fill in SIL `[differentiable]`
+// attribute JVP/VJP names.
 
-// CHECK-SILGEN-LABEL: // static Float.* infix(_:_:)
-// CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK-SIL-LABEL: // static Float.* infix(_:_:)
-// CHECK-SIL-NEXT: sil public_external [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1moiyS2f_SftFZ__vjp_src_0_wrt_0_1] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1moiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1moiyS2f_SftFZ__vjp_src_0_wrt_0_1] @$sSf1moiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+_ = pullback(at: Wrapper(1)) { x in x + x * x }
 
-// CHECK-SILGEN-LABEL: // static Float.+ infix(_:_:)
-// CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0, 1] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
-// CHECK-SIL-LABEL: // static Float.+ infix(_:_:)
-// CHECK-SIL-NEXT: sil public_external [transparent] [serialized] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1poiyS2f_SftFZ__vjp_src_0_wrt_0_1] [differentiable source 0 wrt 0, 1 jvp @AD__$sSf1poiyS2f_SftFZ__jvp_src_0_wrt_0_1 vjp @AD__$sSf1poiyS2f_SftFZ__vjp_src_0_wrt_0_1] @$sSf1poiyS2f_SftFZ : $@convention(method) (Float, Float, @thin Float.Type) -> Float
+// CHECK-SILGEN-LABEL: // static Wrapper.* infix(_:_:)
+// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1] @$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+// CHECK-SIL-LABEL: // static Wrapper.* infix(_:_:)
+// CHECK-SIL-NEXT: sil [differentiable source 0 wrt 0, 1 jvp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__jvp_src_0_wrt_0_1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+
+// CHECK-SILGEN-LABEL: // static Wrapper.+ infix(_:_:)
+// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1] @$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+// CHECK-SIL-LABEL: // static Wrapper.+ infix(_:_:)
+// CHECK-SIL-NEXT: sil [differentiable source 0 wrt 0, 1 jvp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ__jvp_src_0_wrt_0_1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+


### PR DESCRIPTION
Decouple `test/AutoDiff/differentiable_attr_silgen_cross_module.swift` from stdlib dependency (`Float` operations).