### PR TITLE
[AutoDiff] Simplify AD-related SILGen logic.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -826,8 +826,6 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
               expectedJVPType);
         }
         silDiffAttr->setJVPName(jvpThunk->getName());
-        // Unset JVP so that TBDGen triggers.
-        diffAttr->setJVPFunction(nullptr);
       }
       // Thunk VJP method, if it is defined.
       if (auto *vjpDecl = diffAttr->getVJPFunction()) {
@@ -845,8 +843,6 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
               expectedVJPType);
         }
         silDiffAttr->setVJPName(vjpThunk->getName());
-        // Unset VJP so that TBDGen triggers.
-        diffAttr->setVJPFunction(nullptr);
       }
     }
   }

--- a/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
+++ b/test/AutoDiff/differentiable_attr_silgen_cross_module.swift
@@ -5,20 +5,23 @@
 
 import differentiable_attr_silgen_other_module
 
-// After SILGen, SIL `[differentiable]` attribute should have JVP/VJP names
-// only if the AST `@differentiable` attribute does.
-// The differentiation pass is guaranteed to fill in SIL `[differentiable]`
-// attribute JVP/VJP names.
+// After SILGen, a SIL `[differentiable]` attribute on a function from the
+// current module should have JVP/VJP names only if the AST `@differentiable`
+// attribute does.
+
+// For external functions, `[differentiable]` attribute JVP/VJP names should
+// always exist. The differentiation pass is guaranteed to fill in
+// `[differentiable]` attribute JVP/VJP names.
 
 _ = pullback(at: Wrapper(1)) { x in x + x * x }
 
 // CHECK-SILGEN-LABEL: // static Wrapper.* infix(_:_:)
-// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1] @$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1 jvp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__jvp_src_0_wrt_0_1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
 // CHECK-SIL-LABEL: // static Wrapper.* infix(_:_:)
 // CHECK-SIL-NEXT: sil [differentiable source 0 wrt 0, 1 jvp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__jvp_src_0_wrt_0_1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1moiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
 
 // CHECK-SILGEN-LABEL: // static Wrapper.+ infix(_:_:)
-// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1] @$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
+// CHECK-SILGEN-NEXT: sil [differentiable source 0 wrt 0, 1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
 // CHECK-SIL-LABEL: // static Wrapper.+ infix(_:_:)
 // CHECK-SIL-NEXT: sil [differentiable source 0 wrt 0, 1 jvp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ__jvp_src_0_wrt_0_1 vjp @AD__$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ__vjp_src_0_wrt_0_1] @$s39differentiable_attr_silgen_other_module7WrapperV1poiyA2C_ACtFZ : $@convention(method) (Wrapper, Wrapper, @thin Wrapper.Type) -> Wrapper
 


### PR DESCRIPTION
- Do not unset `@differentiable` attribute functions for consistent
  same-module and cross-module `[differentiable]` SILGen behavior.
- Always create vtable entry thunks for JVPs/VJPs.
  - Previously, vtable entry thunks were conditionally generated
    based on an ad-hoc condition.
- Update tests.

Todo: remove JVP/VJP names from `[differentiable]` attribute.