### PR TITLE
[AutoDiff] Simplify SIL `[differentiable]` attribute.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -120,16 +120,14 @@ private:
 /// AD pass does not use or synthesize them.
 ///
 /// Example:
-///   sil [differentiable jvp @foo_jvp vjp @foo_vjp] @foo
-///     : $(Float) -> Float { ... }
+///   sil [differentiable wrt 0] @foo : $(Float) -> Float
+///   sil [differentiable wrt 0 where T : Differentiable] @foo : $(T) -> T
 class SILDifferentiableAttr final {
   friend SILFunction;
 
 private:
   /// The AD indices.
   SILAutoDiffIndices indices;
-  /// The JVP and VJP function names.
-  StringRef JVPName, VJPName;
   /// The trailing constraint clause.
   TrailingWhereClause *WhereClause = nullptr;
   /// The number of constraint clause requirements.
@@ -144,33 +142,19 @@ private:
   }
 
   SILDifferentiableAttr(const SILAutoDiffIndices &indices,
-                        StringRef jvpName,
-                        StringRef vjpName,
                         TrailingWhereClause *whereClause);
 
   SILDifferentiableAttr(const SILAutoDiffIndices &indices,
-                        StringRef jvpName,
-                        StringRef vjpName,
                         ArrayRef<Requirement> requirements);
 
 public:
   static SILDifferentiableAttr *create(
       SILModule &M, const SILAutoDiffIndices &indices,
-      StringRef jvpName = StringRef(), StringRef vjpName = StringRef(),
       TrailingWhereClause *whereClause = nullptr);
 
   static SILDifferentiableAttr *create(
       SILModule &M, const SILAutoDiffIndices &indices,
-      ArrayRef<Requirement> requirements, StringRef jvpName = StringRef(),
-      StringRef vjpName = StringRef());
-
-  bool hasJVP() const { return !JVPName.empty(); }
-  StringRef getJVPName() const { assert(hasJVP()); return JVPName; }
-  void setJVPName(StringRef name) { JVPName = name; }
-
-  bool hasVJP() const { return !VJPName.empty(); }
-  StringRef getVJPName() const { assert(hasVJP()); return VJPName; }
-  void setVJPName(StringRef name) { VJPName = name; }
+      ArrayRef<Requirement> requirements);
 
   SILFunction *getOriginal() const { return Original; }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -59,48 +59,36 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 /// SWIFT_ENABLE_TENSORFLOW
 SILDifferentiableAttr::
 SILDifferentiableAttr(const SILAutoDiffIndices &indices,
-                      StringRef jvpName,
-                      StringRef vjpName,
                       TrailingWhereClause *whereClause)
-  : indices(indices), JVPName(jvpName), VJPName(vjpName),
-    WhereClause(whereClause),
+  : indices(indices), WhereClause(whereClause),
     NumRequirements(whereClause ? whereClause->getRequirements().size() : 0) {}
 
 SILDifferentiableAttr::
 SILDifferentiableAttr(const SILAutoDiffIndices &indices,
-                      StringRef jvpName,
-                      StringRef vjpName,
                       ArrayRef<Requirement> requirements)
-  : indices(indices), JVPName(jvpName), VJPName(vjpName),
-    NumRequirements(requirements.size()) {
+  : indices(indices), NumRequirements(requirements.size()) {
   std::copy(requirements.begin(), requirements.end(), getRequirementsData());
 }
 
 SILDifferentiableAttr *
 SILDifferentiableAttr::create(SILModule &M,
                               const SILAutoDiffIndices &indices,
-                              StringRef jvpName,
-                              StringRef vjpName,
                               TrailingWhereClause *whereClause) {
   unsigned size = sizeof(SILDifferentiableAttr);
   if (whereClause)
     size += whereClause->getRequirements().size() * sizeof(Requirement);
   void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
-  return ::new (mem)
-      SILDifferentiableAttr(indices, jvpName, vjpName, whereClause);
+  return ::new (mem) SILDifferentiableAttr(indices, whereClause);
 }
 
 SILDifferentiableAttr *
 SILDifferentiableAttr::create(SILModule &M,
                               const SILAutoDiffIndices &indices,
-                              ArrayRef<Requirement> requirements,
-                              StringRef jvpName,
-                              StringRef vjpName) {
+                              ArrayRef<Requirement> requirements) {
   unsigned size = sizeof(SILDifferentiableAttr) +
       requirements.size() * sizeof(Requirement);
   void *mem = M.allocate(size, alignof(SILDifferentiableAttr));
-  return ::new (mem)
-      SILDifferentiableAttr(indices, jvpName, vjpName, requirements);
+  return ::new (mem) SILDifferentiableAttr(indices, requirements);
 }
 
 void SILDifferentiableAttr::setRequirements(

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -92,26 +92,8 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
           F->getASTContext(),
           decl->getInterfaceType()->castTo<AnyFunctionType>());
       SILAutoDiffIndices indices(/*source*/ 0, loweredParamIndices);
-      // Get JVP/VJP names.
-      std::string jvpName, vjpName;
-      auto &ctx = F->getASTContext();
-      if (auto *jvpFn = A->getJVPFunction()) {
-        Mangle::ASTMangler mangler;
-        jvpName = ctx.getIdentifier(
-            mangler.mangleAutoDiffAssociatedFunctionHelper(
-                constant.mangle(), AutoDiffAssociatedFunctionKind::JVP,
-                indices)).str();
-      }
-      if (auto *vjpFn = A->getVJPFunction()) {
-        Mangle::ASTMangler mangler;
-        vjpName = ctx.getIdentifier(
-            mangler.mangleAutoDiffAssociatedFunctionHelper(
-                constant.mangle(), AutoDiffAssociatedFunctionKind::VJP,
-                indices)).str();
-      }
       auto *silDiffAttr = SILDifferentiableAttr::create(
-          M, indices, A->getRequirements(), M.allocateCopy(jvpName),
-          M.allocateCopy(vjpName));
+          M, indices, A->getRequirements());
 #ifndef NDEBUG
       // Verify that no existing attributes have the same indices.
       for (auto *existingAttr : F->getDifferentiableAttrs()) {

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3124,12 +3124,6 @@ void SILDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   interleave(indices.parameters->getIndices(),
              [&](unsigned index) { OS << index; },
              [&] { OS << ", "; });
-  if (!JVPName.empty()) {
-    OS << " jvp @" << JVPName;
-  }
-  if (!VJPName.empty()) {
-    OS << " vjp @" << VJPName;
-  }
   if (!getRequirements().empty()) {
     OS << " where ";
     SILFunction *original = getOriginal();

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4659,10 +4659,6 @@ public:
     // Parameter indices must be specified.
     require(!Attr.getIndices().parameters->isEmpty(),
             "Parameter indices cannot be empty");
-    // JVP and VJP must be specified in canonical SIL.
-    if (F->getModule().getStage() == SILStage::Canonical)
-      require(!Attr.getJVPName().empty() && !Attr.getVJPName().empty(),
-              "JVP and VJP must be specified in canonical SIL");
     // Verify if specified parameter indices are valid.
     auto numParams = countParams(F->getLoweredFunctionType());
     int lastIndex = -1;
@@ -4672,11 +4668,6 @@ public:
       require(currentIdx > lastIndex, "Parameter indices not ascending.");
       lastIndex = currentIdx;
     }
-    // TODO: Verify if the specified JVP/VJP function has the right signature.
-    // SIL function verification runs right after a function is parsed.
-    // However, the JVP/VJP function may come after the this function. Without
-    // changing the compiler too much, is there a way to verify this at a module
-    // level, after everything is parsed?
   }
 
   struct VerifyFlowSensitiveRulesDetails {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -825,7 +825,6 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
               constant.asAutoDiffAssociatedFunction(id), jvpFn,
               expectedJVPType);
         }
-        silDiffAttr->setJVPName(jvpThunk->getName());
       }
       // Thunk VJP method, if it is defined.
       if (auto *vjpDecl = diffAttr->getVJPFunction()) {
@@ -842,7 +841,6 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
               constant.asAutoDiffAssociatedFunction(id), vjpFn,
               expectedVJPType);
         }
-        silDiffAttr->setVJPName(vjpThunk->getName());
       }
     }
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -651,17 +651,12 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     assert(kind == SIL_DIFFERENTIABLE_ATTR &&
            "Missing differentiable attribute");
 
-    uint64_t jvpNameId;
-    uint64_t vjpNameId;
     unsigned source;
     ArrayRef<uint64_t> rawParameterIndices;
     SmallVector<Requirement, 8> requirements;
 
-    SILDifferentiableAttrLayout::readRecord(scratch, jvpNameId, vjpNameId,
-                                            source, rawParameterIndices);
-
-    StringRef jvpName = MF->getIdentifier(jvpNameId).str();
-    StringRef vjpName = MF->getIdentifier(vjpNameId).str();
+    SILDifferentiableAttrLayout::readRecord(
+        scratch, source, rawParameterIndices);
 
     SmallVector<unsigned, 8> parameterIndices(rawParameterIndices.begin(),
                                               rawParameterIndices.end());
@@ -671,8 +666,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     SILAutoDiffIndices indices(source, parameterIndexSubset);
     MF->readGenericRequirements(requirements, SILCursor);
 
-    auto *attr = SILDifferentiableAttr::create(SILMod, indices, requirements,
-                                               jvpName, vjpName);
+    auto *attr = SILDifferentiableAttr::create(SILMod, indices, requirements);
     fn->addDifferentiableAttr(attr);
   }
 

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -316,8 +316,6 @@ namespace sil_block {
   // SWIFT_ENABLE_TENSORFLOW
   using SILDifferentiableAttrLayout = BCRecordLayout<
     SIL_DIFFERENTIABLE_ATTR,
-    IdentifierIDField,    // JVP name.
-    IdentifierIDField,    // VJP name.
     BCVBR<8>,             // Result index.
     BCArray<ValueIDField> // Parameter indices.
   >;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -433,27 +433,16 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   }
 
   // SWIFT_ENABLE_TENSORFLOW
-  auto &Ctx = F.getASTContext();
   for (auto *DA : F.getDifferentiableAttrs()) {
     unsigned differentiableAttrAbbrCode =
         SILAbbrCodes[SILDifferentiableAttrLayout::Code];
-
-    if (F.getModule().getStage() == SILStage::Canonical)
-      assert(DA->hasJVP() && DA->hasVJP() &&
-             "JVP and VJP must exist in canonical SIL");
 
     auto &indices = DA->getIndices();
     SmallVector<unsigned, 8> parameters(indices.parameters->begin(),
                                         indices.parameters->end());
     SILDifferentiableAttrLayout::emitRecord(
-        Out, ScratchRecord, differentiableAttrAbbrCode,
-        DA->hasJVP()
-            ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getJVPName()))
-            : IdentifierID(),
-        DA->hasVJP()
-            ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getVJPName()))
-            : IdentifierID(),
-        indices.source, parameters);
+        Out, ScratchRecord, differentiableAttrAbbrCode, indices.source,
+        parameters);
     S.writeGenericRequirements(DA->getRequirements(), SILAbbrCodes);
   }
 


### PR DESCRIPTION
Remove JVP/VJP names from SIL `[differentiable]` attribute.
They are no longer necessary because JVPs/VJPs are always thunked,
so the only possible JVP/VJP names are the generated mangled names.

---

Todo: update tests.
This PR depends on https://github.com/apple/swift/pull/26430; rebase and test after it is merged.