### PR TITLE
[ASTScope lookup] Fix  backwards PatternBindingEntry::getSourceRange

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1981,10 +1981,9 @@ public:
     InitExpr.EqualLoc = equalLoc;
   }
 
-  /// Retrieve the initializer as it was written in the source.
-  Expr *getInitAsWritten() const {
-    return InitContextAndIsText.getInt() ? nullptr : InitExpr.Node;
-  }
+  /// Retrieve the initializer after the =, if any, as it was written in the
+  /// source.
+  Expr *getOrigInitAsWritten() const;
 
   bool isInitializerChecked() const {
     return PatternAndFlags.getInt().contains(Flags::Checked);
@@ -2013,7 +2012,15 @@ public:
     InitContextAndIsText.setPointer(dc);
   }
 
-  /// Retrieve the source range covered by this pattern binding.
+  SourceLoc getStartLoc() const;
+
+  /// Retrieve the end location covered by this pattern binding entry.
+  ///
+  /// \param omitAccessors Whether the computation should omit the accessors
+  /// from the source range.
+  SourceLoc getEndLoc(bool omitAccessors = false) const;
+
+  /// Retrieve the source range covered by this pattern binding entry.
   ///
   /// \param omitAccessors Whether the computation should omit the accessors
   /// from the source range.
@@ -2021,6 +2028,13 @@ public:
 
   const CaptureInfo &getCaptureInfo() const { return Captures; }
   void setCaptureInfo(const CaptureInfo &captures) { Captures = captures; }
+
+private:
+  SourceLoc getLastAccessorEndLoc() const;
+
+  /// Get the end location of an intiaiizer that comes *after* the pattern.
+  /// (Property wrappers introduce initializers that come before.)
+  SourceLoc getPostfixInitEndLoc() const;
 };
 
 /// This decl contains a pattern and optional initializer for a set

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -183,6 +183,8 @@ void simple_display(
 
 /// Given the initializer for the given property with an attached property
 /// wrapper, dig out the original initialization expression.
+/// Cannot just dig out the getOrigInit() value because this function checks
+/// types, etc. Erroneous code won't return a result from here.
 Expr *findOriginalPropertyWrapperInitialValue(VarDecl *var, Expr *init);
 
 } // end namespace swift

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -906,8 +906,16 @@ namespace {
       for (auto entry : PBD->getPatternList()) {
         OS << '\n';
         printRec(entry.getPattern());
+        if (entry.getOrigInit()) {
+          OS << '\n';
+          OS.indent(Indent + 2);
+          OS << "Original init:\n";
+          printRec(entry.getOrigInit());
+        }
         if (entry.getInit()) {
           OS << '\n';
+          OS.indent(Indent + 2);
+          OS << "Processed init:\n";
           printRec(entry.getInit());
         }
       }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -629,8 +629,8 @@ ASTScopeImpl *PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
   // initializer (because of InterpolatedLiteralStrings and EditorPlaceHolders),
   // so compute it ourselves.
   SourceLoc initializerEnd;
-  if (patternEntry.getInitAsWritten() &&
-      patternEntry.getInitAsWritten()->getSourceRange().isValid()) {
+  if (patternEntry.getOrigInitAsWritten() &&
+      patternEntry.getOrigInitAsWritten()->getSourceRange().isValid()) {
     auto *initializer =
         scopeCreator.createSubtree<PatternEntryInitializerScope>(
             this, decl, patternEntryIndex, vis);
@@ -649,8 +649,8 @@ ASTScopeImpl *
 PatternEntryInitializerScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   // Create a child for the initializer expression.
-  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getInitAsWritten(),
-                                         this, scopeCreator);
+  ASTVisitorForScopeCreation().visitExpr(
+      getPatternEntry().getOrigInitAsWritten(), this, scopeCreator);
   return this;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -629,8 +629,8 @@ ASTScopeImpl *PatternEntryDeclScope::expandAScopeThatCreatesANewInsertionPoint(
   // initializer (because of InterpolatedLiteralStrings and EditorPlaceHolders),
   // so compute it ourselves.
   SourceLoc initializerEnd;
-  if (patternEntry.getOrigInitAsWritten() &&
-      patternEntry.getOrigInitAsWritten()->getSourceRange().isValid()) {
+  if (patternEntry.getOrigInit() &&
+      patternEntry.getOrigInit()->getSourceRange().isValid()) {
     auto *initializer =
         scopeCreator.createSubtree<PatternEntryInitializerScope>(
             this, decl, patternEntryIndex, vis);
@@ -649,8 +649,8 @@ ASTScopeImpl *
 PatternEntryInitializerScope::expandAScopeThatCreatesANewInsertionPoint(
     ScopeCreator &scopeCreator) {
   // Create a child for the initializer expression.
-  ASTVisitorForScopeCreation().visitExpr(
-      getPatternEntry().getOrigInitAsWritten(), this, scopeCreator);
+  ASTVisitorForScopeCreation().visitExpr(getPatternEntry().getOrigInit(), this,
+                                         scopeCreator);
   return this;
 }
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -213,7 +213,7 @@ SourceRange PatternEntryDeclScope::getChildlessSourceRange() const {
 }
 
 SourceRange PatternEntryInitializerScope::getChildlessSourceRange() const {
-  return getPatternEntry().getInitAsWritten()->getSourceRange();
+  return getPatternEntry().getOrigInitAsWritten()->getSourceRange();
 }
 
 SourceRange PatternEntryUseScope::getChildlessSourceRange() const {

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -213,7 +213,7 @@ SourceRange PatternEntryDeclScope::getChildlessSourceRange() const {
 }
 
 SourceRange PatternEntryInitializerScope::getChildlessSourceRange() const {
-  return getPatternEntry().getOrigInitAsWritten()->getSourceRange();
+  return getPatternEntry().getOrigInit()->getSourceRange();
 }
 
 SourceRange PatternEntryUseScope::getChildlessSourceRange() const {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3643,8 +3643,8 @@ public:
 
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
-
-      if (!D->getSourceRange().isValid()) {
+      const auto SR = D->getSourceRange();
+      if (!SR.isValid()) {
         // We don't care about source ranges on implicitly-generated
         // decls.
         if (D->isImplicit())
@@ -3655,8 +3655,16 @@ public:
         Out << "\n";
         abort();
       }
-      checkSourceRanges(D->getSourceRange(), Parent,
-                        [&]{ D->print(Out); });
+      // ASTScope lookup depends on Decls having correct ordering.
+      // Move the order check to isGoodSourceRange after extending
+      // the invariant to Exprs, etc., per rdar://53637494
+      if (Ctx.SourceMgr.isBeforeInBuffer(SR.End, SR.Start)) {
+        Out << "backwards source range for decl: ";
+        D->print(Out);
+        Out << "\n";
+        abort();
+      }
+      checkSourceRanges(SR, Parent, [&] { D->print(Out); });
     }
 
     /// Verify that the given source ranges is contained within the

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5858,7 +5858,8 @@ Expr *swift::findOriginalPropertyWrapperInitialValue(VarDecl *var,
     return nullptr;
 
   // If there is no '=' on the pattern, there was no initial value.
-  if (PBD->getPatternList()[0].getEqualLoc().isInvalid())
+  if (PBD->getPatternList()[0].getEqualLoc().isInvalid()
+      && !PBD->isDefaultInitializable())
     return nullptr;
 
   ASTContext &ctx = var->getASTContext();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5222,7 +5222,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       PBDEntries.back().setEqualLoc(EqualLoc);
 
       ParserResult<Expr> init = parseExpr(diag::expected_init_value);
-      
+      PBDEntries.back().setOrigInit(init.getPtrOrNull());
+
       // If this Pattern binding was not supposed to have an initializer, but it
       // did, diagnose this and remove it.
       if (Flags & PD_DisallowInit && init.isNonNull()) {


### PR DESCRIPTION
PatternBindingEntry::getSourceRange uses the end of the initializer for the end of the range. But, if the initializer is a property wrapper, the initializer comes before the start of the PatternBindingEntry. Prevent the computation from using such an initializer.

The first commit adds a check on Decl::getSourceRange to ASTVerifier to ensure that the start is not after the end. This comment causes two tests to fail:

- test/decl/var/property_wrappers.swift, and
- test/SourceKit/CursorInfo/cursor_info_property_wrappers.swift.

Someday, we should extend the check to `Exprs`, etc., but that is a lot more work since their `getSourceRange` functions also produce backwards ranges, but that invariant is not needed for the `ASTScope` work.

The second commit fixes the source range computation for `PatternBindingEntry`s.

In addition to a fix being needed for ASTScope lookup, this fix will be needed to address part of rdar://53637494