### PR TITLE
ClangImporter: silence error on outdated PCH files

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -826,10 +826,15 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   };
   ctx.InitBuiltinTypes(CI.getTarget());
 
+  auto failureCapabilities =
+    clang::ASTReader::ARR_Missing |
+    clang::ASTReader::ARR_OutOfDate |
+    clang::ASTReader::ARR_VersionMismatch;
+
   auto result = Reader->ReadAST(PCHFilename,
                   clang::serialization::MK_PCH,
                   clang::SourceLocation(),
-                  clang::ASTReader::ARR_None);
+                  failureCapabilities);
   switch (result) {
   case clang::ASTReader::Success:
     return true;

--- a/test/ClangImporter/Inputs/pch-loading-error.h
+++ b/test/ClangImporter/Inputs/pch-loading-error.h
@@ -1,0 +1,5 @@
+// Dummy file to test PCH loading errors
+
+int c_func(int x) {
+  return x + 27;
+}

--- a/test/ClangImporter/pch-loading-error.swift
+++ b/test/ClangImporter/pch-loading-error.swift
@@ -1,0 +1,16 @@
+// Check that there are no errors printed when trying to load an outdated PCH file
+// rdar://problem/53312911
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/pch-loading-error.h %t/pch-loading-error.h
+// RUN: %target-swift-frontend -parse-as-library -module-name=pch_loading_error -emit-sil %s -enable-objc-interop -import-objc-header %t/pch-loading-error.h -pch-output-dir %t/pch
+// RUN: %S/../ParseableInterface/ModuleCache/Inputs/make-old.py %t/pch/*
+// RUN: echo "// force newer header than pch" >> %t/pch-loading-error.h
+// RUN: %target-swift-frontend -parse-as-library -module-name=pch_loading_error -emit-sil %s -enable-objc-interop -import-objc-header %t/pch-loading-error.h -pch-output-dir %t/pch 2>&1 | %FileCheck %s
+// RUN: %S/../ParseableInterface/ModuleCache/Inputs/check-is-new.py %t/pch/*
+
+// CHECK-NOT: fatal error
+
+public func mytest(x: Int32) -> Int32 {
+  return c_func(x)
+}


### PR DESCRIPTION
Notify clang that we handle outdate PCH files on the client side so there's no need to display the misleading "fatal error: file '...' has been modified since the precompiled header '...' was built".

rdar://problem/35036656