### PR TITLE
Fix -require-explicit-availability to handle unavailable decls correctly

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2837,7 +2837,9 @@ void swift::checkExplicitAvailability(Decl *decl) {
   // Warn on decls without an introduction version.
   auto &ctx = decl->getASTContext();
   auto safeRangeUnderApprox = AvailabilityInference::availableRange(decl, ctx);
-  if (!safeRangeUnderApprox.getOSVersion().hasLowerEndpoint()) {
+  if (!safeRangeUnderApprox.getOSVersion().hasLowerEndpoint() &&
+      !decl->getAttrs().isUnavailable(ctx)) {
+
     auto diag = decl->diagnose(diag::public_decl_needs_availability);
 
     auto suggestPlatform = decl->getASTContext().LangOpts.RequireExplicitAvailabilityTarget;

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -13,8 +13,14 @@ func bar() { } // expected-warning {{public declarations should have an availabi
 @available(macOS 10.1, *)
 public func ok() { }
 
+@available(macOS, unavailable)
+public func unavailableOk() { }
+
 @available(macOS, deprecated: 10.10)
 public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+
+@available(iOS 9.0, *)
+public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
 
 func privateFunc() { }
 


### PR DESCRIPTION
The CLI option `-require-explicit-availability` should now correctly consider unavailable decl as having an explicit introduction version and not show incorrect warnings.