### PR TITLE
[C++ Interop] Implement lookup within namespace.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3657,7 +3657,7 @@ ClangImporter::Implementation::loadNamedMembers(
 
   clang::ASTContext &clangCtx = getClangASTContext();
 
-  assert(isa<clang::ObjCContainerDecl>(CD));
+  assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD));
 
   TinyPtrVector<ValueDecl *> Members;
   for (auto entry : table->lookup(SerializedSwiftName(N),

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -195,6 +195,14 @@ translateDeclToContext(clang::NamedDecl *decl) {
     return None;
   }
 
+  // Namespace declaration.
+  if (auto namespaceDecl = dyn_cast<clang::NamespaceDecl>(decl)) {
+    if (namespaceDecl->getIdentifier())
+      return std::make_pair(SwiftLookupTable::ContextKind::Tag,
+                            namespaceDecl->getName());
+    return None;
+  }
+
   // Objective-C class context.
   if (auto objcClass = dyn_cast<clang::ObjCInterfaceDecl>(decl))
     return std::make_pair(SwiftLookupTable::ContextKind::ObjCClass,
@@ -229,6 +237,11 @@ auto SwiftLookupTable::translateDeclContext(const clang::DeclContext *dc)
   // Tag declaration context.
   if (auto tag = dyn_cast<clang::TagDecl>(dc))
     return translateDeclToContext(const_cast<clang::TagDecl *>(tag));
+
+  // Namespace declaration context.
+  if (auto namespaceDecl = dyn_cast<clang::NamespaceDecl>(dc))
+    return translateDeclToContext(
+        const_cast<clang::NamespaceDecl *>(namespaceDecl));
 
   // Objective-C class context.
   if (auto objcClass = dyn_cast<clang::ObjCInterfaceDecl>(dc))
@@ -1672,7 +1685,7 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   // Walk the members of any context that can have nested members.
   if (isa<clang::TagDecl>(named) || isa<clang::ObjCInterfaceDecl>(named) ||
       isa<clang::ObjCProtocolDecl>(named) ||
-      isa<clang::ObjCCategoryDecl>(named)) {
+      isa<clang::ObjCCategoryDecl>(named) || isa<clang::NamespaceDecl>(named)) {
     clang::DeclContext *dc = cast<clang::DeclContext>(named);
     for (auto member : dc->decls()) {
       if (auto namedMember = dyn_cast<clang::NamedDecl>(member))

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -3,6 +3,8 @@
 // Ensure c++ features are used.
 namespace ns {
 class T {};
+
+T *doMakeT();
 } // namespace ns
 
 struct Basic {

--- a/test/ClangImporter/cxx_interop.swift
+++ b/test/ClangImporter/cxx_interop.swift
@@ -9,3 +9,9 @@ do {
   tmp.a = 3
   tmp.b = nil
 }
+
+// Namespace lookup
+func namespaceLookup() -> UnsafeMutablePointer<ns.T> {
+  var tmp: UnsafeMutablePointer<ns.T> = ns.doMakeT()!
+  return tmp
+}

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -13,6 +13,13 @@ func indirectUsage() {
 func namespaceManglesIntoName(arg: namespacedT) {
 }
 
+// CHECK-LABEL: define hidden swiftcc void @"$s6cxx_ir14accessNSMemberyyF"()
+// CHECK: %0 = call %"class.ns::T"* @{{_ZN2ns7doMakeTEv|"\?doMakeT@ns@@YAPEAVT@1@XZ"}}()
+// CHECK: call void @{{_Z4useTPN2ns1TE|"\?useT@@YAXPE?AVT@ns@@@Z"}}(%"class.ns::T"* %2)
+func accessNSMember() {
+  useT(ns.doMakeT())
+}
+
 // CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir12basicMethods1as5Int32VSpySo0D0VG_tF"(i8*)
 // CHECK: [[THIS_PTR1:%.*]] = bitcast i8* %0 to %TSo7MethodsV*
 // CHECK: [[THIS_PTR2:%.*]] = bitcast %TSo7MethodsV* [[THIS_PTR1]] to %class.Methods*


### PR DESCRIPTION
Known problems:
- For the same namespace in multiple c++ modules, it will be subtly confused when doing
  lookup.