### PR TITLE
 Remove InoutAliasingAssumption, improving EscapeAnalysis.

### DIFF
--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -17,18 +17,6 @@
 
 namespace swift {
 
-enum class InoutAliasingAssumption {
-  /// Assume that an inout indirect parameter may alias other objects.
-  /// This is the safe assumption an optimization should make if it may break
-  /// memory safety in case the inout aliasing rule is violation.
-  Aliasing,
-
-  /// Assume that an inout indirect parameter cannot alias other objects.
-  /// Optimizations should only use this if they can guarantee that they will
-  /// not break memory safety even if the inout aliasing rule is violated.
-  NotAliasing
-};
-
 /// Conventions for apply operands and function-entry arguments in SIL.
 ///
 /// This is simply a union of ParameterConvention and ResultConvention
@@ -141,11 +129,8 @@ struct SILArgumentConvention {
     llvm_unreachable("covered switch isn't covered?!");
   }
 
-  /// Returns true if \p Value is a not-aliasing indirect parameter.
-  /// The \p isInoutAliasing specifies what to assume about the inout
-  /// convention.
-  /// See InoutAliasingAssumption.
-  bool isNotAliasedIndirectParameter(InoutAliasingAssumption isInoutAliasing) {
+  /// Returns true if \p Value is a non-aliasing indirect parameter.
+  bool isExclusiveIndirectParameter() {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
     case SILArgumentConvention::Indirect_In_Constant:
@@ -154,7 +139,7 @@ struct SILArgumentConvention {
       return true;
 
     case SILArgumentConvention::Indirect_Inout:
-      return isInoutAliasing == InoutAliasingAssumption::NotAliasing;
+      return true;
 
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Unowned:

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -439,7 +439,7 @@ public:
         case EscapeState::Return:
           return false;
         case EscapeState::Arguments:
-          return !isNotAliasingArgument(V);
+          return !isExclusiveArgument(V);
         case EscapeState::Global:
           return true;
       }

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -24,18 +24,12 @@ namespace swift {
 
 /// Returns true if \p V is a function argument which may not alias to
 /// any other pointer in the function.
-/// The \p assumeInoutIsNotAliasing specifies in no-aliasing is assumed for
-/// the @inout convention. See swift::isNotAliasedIndirectParameter().
-bool isNotAliasingArgument(SILValue V, InoutAliasingAssumption isInoutAliasing =
-                                         InoutAliasingAssumption::Aliasing);
+bool isExclusiveArgument(SILValue V);
 
 /// Returns true if \p V is local inside its function. This means its underlying
 /// object either is a non-aliasing function argument or a locally allocated
 /// object.
-/// The \p assumeInoutIsNotAliasing specifies in no-aliasing is assumed for
-/// the @inout convention. See swift::isNotAliasedIndirectParameter().
-bool pointsToLocalObject(SILValue V, InoutAliasingAssumption isInoutAliasing =
-                                         InoutAliasingAssumption::Aliasing);
+bool pointsToLocalObject(SILValue V);
 
 enum class IsZeroKind {
   Zero,

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -128,7 +128,7 @@ static bool isFunctionArgument(SILValue V) {
 static bool isIdentifiableObject(SILValue V) {
   if (isa<AllocationInst>(V) || isa<LiteralInst>(V))
     return true;
-  if (isNotAliasingArgument(V))
+  if (isExclusiveArgument(V))
     return true;
   return false;
 }
@@ -178,8 +178,7 @@ static bool isLocalLiteral(SILValue V) {
 /// Is this a value that can be unambiguously identified as being defined at the
 /// function level.
 static bool isIdentifiedFunctionLocal(SILValue V) {
-  return isa<AllocationInst>(*V) || isNotAliasingArgument(V) ||
-         isLocalLiteral(V);
+  return isa<AllocationInst>(*V) || isExclusiveArgument(V) || isLocalLiteral(V);
 }
 
 /// Returns true if we can prove that the two input SILValues which do not equal

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -600,7 +600,6 @@ bool EscapeAnalysis::ConnectionGraph::isReachable(CGNode *From, CGNode *To) {
   return false;
 }
 
-
 //===----------------------------------------------------------------------===//
 //                      Dumping, Viewing and Verification
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1413,8 +1413,13 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
         // the object itself (because it will be a dangling pointer after
         // deallocation).
         CGNode *CapturedByDeinit = ConGraph->getContentNode(AddrNode);
+        // Get the content node for the object's properties. The object header
+        // itself cannot escape from the deinit.
         CapturedByDeinit = ConGraph->getContentNode(CapturedByDeinit);
         if (deinitIsKnownToNotCapture(OpV)) {
+          // Presumably this is necessary because, even though the deinit
+          // doesn't escape the immediate properties of this class, it may
+          // indirectly escape some other memory content(?)
           CapturedByDeinit = ConGraph->getContentNode(CapturedByDeinit);
         }
         ConGraph->setEscapesGlobal(CapturedByDeinit);

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -14,7 +14,6 @@
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
-#include "swift/SILOptimizer/Analysis/ValueTracking.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SIL/SILArgument.h"
@@ -1848,7 +1847,7 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
 
   // First check if there are escape paths which we don't explicitly see
   // in the graph.
-  if (Node->escapesInsideFunction(isNotAliasingArgument(V)))
+  if (Node->escapesInsideFunction())
     return true;
 
   // No hidden escapes: check if the Node is reachable from the UsePoint.
@@ -1868,7 +1867,7 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
   // As V1's content node is the same as V's content node, we also make the
   // check for the content node.
   CGNode *ContentNode = ConGraph->getContentNode(Node);
-  if (ContentNode->escapesInsideFunction(false))
+  if (ContentNode->escapesInsideFunction())
     return true;
 
   if (ConGraph->isUsePoint(UsePoint, ContentNode))
@@ -1948,10 +1947,10 @@ bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
     return true;
 
   // Finish the check for one value being a non-escaping local object.
-  if (isLocal1 && Node1->escapesInsideFunction(isNotAliasingArgument(V1)))
+  if (isLocal1 && Node1->escapesInsideFunction())
     isLocal1 = false;
 
-  if (isLocal2 && Node2->escapesInsideFunction(isNotAliasingArgument(V2)))
+  if (isLocal2 && Node2->escapesInsideFunction())
     isLocal2 = false;
 
   if (!isLocal1 && !isLocal2)

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -23,14 +23,12 @@
 using namespace swift;
 using namespace swift::PatternMatch;
 
-bool swift::isNotAliasingArgument(SILValue V,
-                                  InoutAliasingAssumption isInoutAliasing) {
+bool swift::isExclusiveArgument(SILValue V) {
   auto *Arg = dyn_cast<SILFunctionArgument>(V);
   if (!Arg)
     return false;
 
-  SILArgumentConvention Conv = Arg->getArgumentConvention();
-  return Conv.isNotAliasedIndirectParameter(isInoutAliasing);
+  return Arg->getArgumentConvention().isExclusiveIndirectParameter();
 }
 
 /// Check if the parameter \V is based on a local object, e.g. it is an
@@ -81,10 +79,9 @@ static bool isLocalObject(SILValue Obj) {
   return true;
 }
 
-bool swift::pointsToLocalObject(SILValue V,
-                                InoutAliasingAssumption isInoutAliasing) {
+bool swift::pointsToLocalObject(SILValue V) {
   V = getUnderlyingObject(V);
-  return isLocalObject(V) || isNotAliasingArgument(V, isInoutAliasing);
+  return isLocalObject(V) || isExclusiveArgument(V);
 }
 
 /// Check if the value \p Value is known to be zero, non-zero or unknown.

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -110,12 +110,12 @@ bb1(%1 : $*Builtin.NativeObject, %2 : $*Builtin.NativeObject):
 
 // Assume that inout arguments alias to preserve memory safety.
 //
-// CHECK-LABEL: @inout_args_may_alias
+// CHECK-LABEL: @inout_args_may_not_alias
 // CHECK: PAIR #1.
 // CHECK-NEXT: %0 = argument of bb0
 // CHECK-NEXT: %1 = argument of bb0
-// CHECK-NEXT: MayAlias
-sil @inout_args_may_alias: $@convention(thin) (@inout Builtin.NativeObject, @inout Builtin.NativeObject) -> () {
+// CHECK-NEXT: NoAlias
+sil @inout_args_may_not_alias: $@convention(thin) (@inout Builtin.NativeObject, @inout Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   %2 = tuple()
   return %2 : $()

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -588,8 +588,9 @@ bb5:
 // CHECK: store
 // CHECK-NOT: = load
 // CHECK: bb2:
-// CHECK: bb3:
-// CHECK: = load
+// CHECK: bb3({{.*}}):
+// CHECK-NOT: = load
+// CHECK-LABEL: } // end sil function 'load_to_load_conflicting_branches_diamond'
 sil @load_to_load_conflicting_branches_diamond : $@convention(thin) (@inout Builtin.Int32) -> () {
 // %0                                             // users: %1, %4, %9, %11, %16, %21
 bb0(%0 : $*Builtin.Int32):

--- a/test/SILOptimizer/unsafebufferpointer.swift
+++ b/test/SILOptimizer/unsafebufferpointer.swift
@@ -14,9 +14,9 @@ public func testIteration(_ p: UnsafeBufferPointer<Int>) -> Int {
 // Check for an optimal loop kernel
 // CHECK:       phi
 // CHECK-NEXT:  phi
+// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  bitcast
 // CHECK-NEXT:  load
-// CHECK-NEXT:  getelementptr
 // CHECK-NEXT:  add
 // CHECK-NEXT:  icmp
 // CHECK-NEXT:  br


### PR DESCRIPTION
Simplifies isNotAliasingArgument and pointsToLocalObject APIs.
    
Rename to isExclusiveArgument to avoid double-negative bugs.
    
The motivation is to simplify the APIs, but a side effect is that
EscapeAnlysis will no longer consider @inout arguments to be aliasing
with other indirect arguments or globals. This is valid since
exclusivity has been fully enforced for at least a major release cycle.

(Only the third commit is specific to this PR; I'm still waiting on review for the previous PRs.)