### PR TITLE
[Glibc] Add missing entry for link.h

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -319,6 +319,10 @@ module SwiftGlibc [system] {
       header "${GLIBC_INCLUDE_PATH}/dirent.h"
       export *
     }
+    module dl {
+      header "${GLIBC_INCLUDE_PATH}/link.h"
+      export *
+    }
     module dlfcn {
       header "${GLIBC_INCLUDE_PATH}/dlfcn.h"
       export *


### PR DESCRIPTION
Add missing entry for link.h

For example, this is needed for adding support for Linux to SwiftReflectionTest.