### PR TITLE
[CSDiagnostics] Teach `missing explicit call` fix to account for defa…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2006,7 +2006,6 @@ bool MissingCallFailure::diagnoseAsError() {
     case ConstraintLocator::ContextualType:
     case ConstraintLocator::ApplyArgToParam: {
       auto fnType = getType(baseExpr)->castTo<FunctionType>();
-      assert(fnType->getNumParams() == 0);
       emitDiagnostic(baseExpr->getLoc(), diag::missing_nullary_call,
                      fnType->getResult())
           .fixItInsertAfter(baseExpr->getEndLoc(), "()");

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -35,6 +35,7 @@ func forgotCall() {
   // As a call
   f5(f4) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
   f6(f4, f2) // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}{{8-8=()}}
+  // expected-error@-1 {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{12-12=()}}
 
   // With overloading: only one succeeds.
   a = createB // expected-error{{function produces expected type 'B'; did you mean to call it with '()'?}}
@@ -302,4 +303,18 @@ func coalesceWithParensRootExprFix() {
   if !optionalBool { }  // expected-error{{value of optional type 'Bool?' must be unwrapped to a value of type 'Bool'}}
   // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}{{7-7=(}}{{19-19= ?? <#default value#>)}}
   // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}
+
+func test_explicit_call_with_overloads() {
+  func foo(_: Int) {}
+
+  struct S {
+    func foo(_: Int) -> Int { return 0 }
+    func foo(_: Int = 32, _: String = "hello") -> Int {
+      return 42
+    }
+  }
+
+  foo(S().foo)
+  // expected-error@-1 {{function produces expected type 'Int'; did you mean to call it with '()'?}} {{14-14=()}}
 }


### PR DESCRIPTION
…ults

Currently we only produce a fix if function type doesn't have any
parameters, but it should also account for function having defaults
for all of its parameters which would still allow for nullary call.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
