### PR TITLE
IRGen: fix enum bit packing on big-endian platforms.

### DIFF
--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -61,6 +61,16 @@ public:
   ClusteredBitVector(ClusteredBitVector &&other)
     : Bits(std::move(other.Bits)) {}
 
+  /// Create a new ClusteredBitVector from the provided APInt,
+  /// with a size of 0 if the optional does not have a value.
+  ClusteredBitVector(const llvm::Optional<APInt> &bits)
+    : Bits(bits) {}
+
+  /// Create a new ClusteredBitVector from the provided APInt,
+  /// with a size of 0 if the optional does not have a value.
+  ClusteredBitVector(llvm::Optional<APInt> &&bits)
+    : Bits(std::move(bits)) {}
+
   ClusteredBitVector &operator=(const ClusteredBitVector &other) {
     this->Bits = other.Bits;
     return *this;

--- a/lib/IRGen/BitPatternBuilder.h
+++ b/lib/IRGen/BitPatternBuilder.h
@@ -1,0 +1,170 @@
+//===--- BitPatternBuilder.h - Create masks for composite types -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "swift/Basic/ClusteredBitVector.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+namespace irgen {
+
+/// BitPatternBuilder is a class to help with the construction of
+/// bit masks for composite types. The class should be constructed
+/// using the byte order of the target platform. Elements added
+/// to the class must mask an entire element in a composite type.
+/// These elements must be byte aligned. For example, if you want
+/// to add a 64-bit integer to the bit pattern with the low 32
+/// bits set to 1 and the high 32 bits set to 0 then you must create
+/// a 64-bit APInt and append it in its entirety rather than calling
+/// the appendSetBits and appendClearBits helper functions which
+/// would not be portable across architectures using different byte
+/// orders.
+///
+/// Example construction of a mask for a struct:
+///
+///   // Type T that we are generating a mask for:
+///   struct T {
+///     uint8_t a;
+///     uint8_t b;
+///     uint16_t c;
+///   };
+///
+///   // Code to generate the mask:
+///   auto mask = BitPatternBuilder(isLittleEndian());
+///   mask.appendSetBits(8);             // mask T.a with 0xff
+///   mask.appendClearBits(8);           // mask T.b with 0x00
+///   mask.append(APInt(16, 0x1177ULL)); // mask T.c with 0x1177
+///
+///   // Little-endian result:
+///   mask.build(); // 0x117700ff [ ff 00 77 11 ]
+///
+///   // Big-endian result:
+///   mask.build(); // 0xff001177 [ ff 00 11 77 ]
+///
+class BitPatternBuilder {
+  using APInt = llvm::APInt;
+
+  // An array of masks that, when combined, will form the mask for a
+  // composite value. Generally these correspond to elements in a
+  // struct (or class, tuple etc.).
+  llvm::SmallVector<APInt, 8> Elements;
+
+  // Little-endian byte order implies that elements should be
+  // appended to the most significant bit. If this flag is false
+  // then elements should be appended to the least signficant
+  // bit (big-endian byte order).
+  bool LittleEndian;
+
+  // The combined size of the elements added so far in bits.
+  unsigned Size = 0;
+public:
+  /// Create a new BitPatternBuilder with either a little-endian
+  /// (true) or big-endian (false) byte order.
+  BitPatternBuilder(bool littleEndian) : LittleEndian(littleEndian) {}
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(const APInt &value) {
+    assert(value.getBitWidth() % 8 == 0);
+    Size += value.getBitWidth();
+    Elements.push_back(value);
+  }
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(APInt &&value) {
+    assert(value.getBitWidth() % 8 == 0);
+    Size += value.getBitWidth();
+    Elements.push_back(std::move(value));
+  }
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(const ClusteredBitVector &value) {
+    assert(value.size() % 8 == 0);
+    if (!value.empty()) {
+      Size += value.size();
+      Elements.push_back(value.asAPInt());
+    }
+  }
+
+  /// Append the given number of set (1) bits to the bit pattern. The
+  /// number of bits must be a multiple of 8 and mask a whole number
+  /// of element types.
+  void appendSetBits(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    if (numBits) {
+      Size += numBits;
+      Elements.push_back(APInt::getAllOnesValue(numBits));
+    }
+  }
+
+  /// Append the given number of clear (0) bits to the bit pattern. The
+  /// number of bits must be a multiple of 8 and mask a whole number
+  /// of element types.
+  void appendClearBits(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    if (numBits) {
+      Size += numBits;
+      Elements.push_back(APInt::getNullValue(numBits));
+    }
+  }
+
+  /// Append set (1) bits to the bit pattern until it reaches the
+  /// given size in bits. The total number of bits must be a
+  /// multiple of 8.
+  void padWithSetBitsTo(unsigned totalSizeInBits) {
+    assert(totalSizeInBits % 8 == 0);
+    assert(totalSizeInBits >= Size);
+    appendSetBits(totalSizeInBits - Size);
+  }
+
+  /// Append clear (0) bits to the bit pattern until it reaches the
+  /// given size in bits. The total number of bits must be a
+  /// multiple of 8.
+  void padWithClearBitsTo(unsigned totalSizeInBits) {
+    assert(totalSizeInBits % 8 == 0);
+    assert(totalSizeInBits >= Size);
+    appendClearBits(totalSizeInBits - Size);
+  }
+
+  /// Build the complete mask for the composite type. If the mask has a
+  /// length of 0 then the optional will not contain a value. Otherwise
+  /// the option will contain a value that is the combined length of
+  /// the elements appended to the builder. The mask represents is an
+  /// integer in the target byte order.
+  llvm::Optional<APInt> build() const {
+    if (Size == 0) {
+      return llvm::Optional<APInt>();
+    }
+    auto result = APInt::getNullValue(Size);
+    unsigned offset = 0;
+    for (const auto &e : Elements) {
+      unsigned index = offset;
+      if (!LittleEndian) {
+        index = Size - offset - e.getBitWidth();
+      }
+      result.insertBits(e, index);
+      offset += e.getBitWidth();
+    }
+    assert(offset == Size);
+    return result;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+

--- a/lib/IRGen/BitPatternReader.h
+++ b/lib/IRGen/BitPatternReader.h
@@ -1,0 +1,82 @@
+//===--- BitPatternReader.h - Split bit patterns into chunks. -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "swift/Basic/ClusteredBitVector.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Optional.h"
+
+namespace swift {
+namespace irgen {
+
+/// BitPatternReader allows an APInt to be read from in chunks.
+/// Chunks may be read starting from either the least significant bit
+/// (little-endian) or the most significant bit (big-endian).
+///
+/// This is useful when interpreting an APInt as a multi-byte mask
+/// that needs to be applied to a value with a composite type.
+///
+/// Example:
+///
+///   // big-endian
+///   auto x = BitPatternReader(APInt(32, 0x1234), false);
+///   x.read(16) // 0x12
+///   x.read(8)  // 0x3
+///   x.read(8)  // 0x4
+///
+///   // little-endian
+///   auto y = BitPatternReader(APInt(32, 0x1234), true);
+///   y.read(16) // 0x34
+///   y.read(8)  // 0x2
+///   y.read(8)  // 0x1
+///
+class BitPatternReader {
+  using APInt = llvm::APInt;
+
+  const APInt Value;
+  const bool LittleEndian;
+  unsigned Offset = 0;
+public:
+  /// If the reader is in little-endian mode then bits will be read
+  /// from the least significant to the most significant. Otherwise
+  /// they will be read from the most significant to the least
+  /// significant.
+  BitPatternReader(const APInt &value, bool littleEndian) :
+      Value(value),
+      LittleEndian(littleEndian) {}
+
+  /// Read the given number of bits from the unread part of the
+  /// underlying value and adjust the remaining value as appropriate.
+  APInt read(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    assert(Value.getBitWidth() >= Offset + numBits);
+    unsigned offset = Offset;
+    if (!LittleEndian) {
+      offset = Value.getBitWidth() - offset - numBits;
+    }
+    Offset += numBits;
+    return Value.extractBits(numBits, offset);
+  }
+
+  // Skip the number of bits provided.
+  void skip(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    assert(Value.getBitWidth() >= Offset + numBits);
+    Offset += numBits;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -10,10 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "BitPatternReader.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
 #include "GenEnum.h"
 #include "IRGenModule.h"
+
+#include <algorithm>
 #include <map>
 
 using namespace swift;
@@ -37,6 +40,23 @@ static llvm::Type *getPayloadType(EnumPayload::LazyValue value) {
   return value.dyn_cast<llvm::Value *>()->getType();
 }
 
+// Clear bits starting from the most significant until the number
+// of set bits in the value is less than or equal to numSetBits.
+//
+// For example: getLowestNSetBits(0x11111100, 2) = 0x00001100
+static llvm::APInt getLowestNSetBits(llvm::APInt value,
+                                     unsigned numSetBits) {
+  // TODO: optimize
+  for (unsigned i = 0; i < value.getBitWidth(); ++i) {
+    if (numSetBits == 0) {
+      value.clearBit(i);
+    } else if (value[i]) {
+      numSetBits -= 1;
+    }
+  }
+  return value;
+}
+
 EnumPayload EnumPayload::zero(IRGenModule &IGM, EnumPayloadSchema schema) {
   // We don't need to create any values yet; they can be filled in when
   // real values are inserted.
@@ -48,18 +68,19 @@ EnumPayload EnumPayload::zero(IRGenModule &IGM, EnumPayloadSchema schema) {
 }
 
 EnumPayload EnumPayload::fromBitPattern(IRGenModule &IGM,
-                                        APInt bitPattern,
+                                        const APInt &bitPattern,
                                         EnumPayloadSchema schema) {
+  auto maskReader = BitPatternReader(bitPattern, IGM.Triple.isLittleEndian());
+
   EnumPayload result;
-  
   schema.forEachType(IGM, [&](llvm::Type *type) {
     unsigned bitSize = IGM.DataLayout.getTypeSizeInBits(type);
 
     llvm::IntegerType *intTy
       = llvm::IntegerType::get(IGM.getLLVMContext(), bitSize);
-    
+
     // Take some bits off of the bottom of the pattern.
-    auto bits = bitPattern.zextOrTrunc(bitSize);
+    auto bits = maskReader.read(bitSize);
     auto val = llvm::ConstantInt::get(intTy, bits);
     if (val->getType() != type) {
       if (type->isPointerTy())
@@ -67,164 +88,68 @@ EnumPayload EnumPayload::fromBitPattern(IRGenModule &IGM,
       else
         val = llvm::ConstantExpr::getBitCast(val, type);
     }
-    
+
     result.PayloadValues.push_back(val);
-    
-    // Shift the remaining bits down.
-    bitPattern = bitPattern.lshr(bitSize);
   });
-    
+
   return result;
 }
 
-// Fn: void(LazyValue &payloadValue, unsigned payloadBitWidth,
-//          unsigned payloadValueOffset, unsigned valueBitWidth,
-//          unsigned valueOffset)
-template<typename Fn>
-static void withValueInPayload(IRGenFunction &IGF,
-                               const EnumPayload &payload,
-                               llvm::Type *valueType,
-                               int numBitsUsedInValue,
+/// Create a mask for an element with the given type at the provided
+/// offset into the payload. The offset and size are in bits but
+/// must be a multiple of 8 (i.e. byte aligned).
+static APInt createElementMask(const llvm::DataLayout &DL,
+                               llvm::Type *type,
                                unsigned payloadOffset,
-                               Fn &&f) {
-  auto &DataLayout = IGF.IGM.DataLayout;
-  int valueTypeBitWidth = DataLayout.getTypeSizeInBits(valueType);
-  int valueBitWidth =
-      numBitsUsedInValue < 0 ? valueTypeBitWidth : numBitsUsedInValue;
-  assert(numBitsUsedInValue <= valueTypeBitWidth);
+                               unsigned payloadSizeInBits) {
+  // Create a mask for the bytes that make up the stored element
+  // by zero extending the element's mask to its storage size.
+  // This makes the mask valid regardless of endianness.
+  auto elSize = DL.getTypeSizeInBits(type);
+  auto elStoreSize = DL.getTypeStoreSizeInBits(type);
+  auto elMask = APInt::getLowBitsSet(elStoreSize, elSize);
 
-  // Find the elements we need to touch.
-  // TODO: Linear search through the payload elements is lame.
-  MutableArrayRef<EnumPayload::LazyValue> payloads = payload.PayloadValues;
-  llvm::Type *payloadType;
-  int payloadBitWidth;
-  int valueOffset = 0, payloadValueOffset = payloadOffset;
-  for (;;) {
-    payloadType = getPayloadType(payloads.front());
-    payloadBitWidth = IGF.IGM.DataLayout.getTypeSizeInBits(payloadType);
-    
-    // Does this element overlap the area we need to touch?
-    if (payloadValueOffset < payloadBitWidth) {
-      // See how much of the value we can fit here.
-      int valueChunkWidth = payloadBitWidth - payloadValueOffset;
-      valueChunkWidth = std::min(valueChunkWidth, valueBitWidth - valueOffset);
-    
-      f(payloads.front(),
-        payloadBitWidth, payloadValueOffset,
-        valueTypeBitWidth, valueOffset);
-      
-      // If we used the entire value, we're done.
-      valueOffset += valueChunkWidth;
-      if (valueOffset >= valueBitWidth)
-        return;
-    }
-    
-    payloadValueOffset = std::max(payloadValueOffset - payloadBitWidth, 0);
-    payloads = payloads.slice(1);
+  // Pad the valueMask so that it can be applied to the entire
+  // payload.
+  auto mask = APInt::getNullValue(payloadSizeInBits);
+  auto offset = payloadOffset;
+  if (DL.isBigEndian()) {
+    offset = payloadSizeInBits - payloadOffset - elStoreSize;
   }
+  mask.insertBits(elMask, offset);
+  return mask;
 }
 
 void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
-                              unsigned payloadOffset,
-                              int numBitsUsedInValue) {
-  withValueInPayload(IGF, *this, value->getType(), numBitsUsedInValue, payloadOffset,
-    [&](LazyValue &payloadValue,
-        unsigned payloadBitWidth,
-        unsigned payloadValueOffset,
-        unsigned valueBitWidth,
-        unsigned valueOffset) {
-      auto payloadType = getPayloadType(payloadValue);
-      // See if the value matches the payload type exactly. In this case we
-      // don't need to do any work to use the value.
-      if (payloadValueOffset == 0 && valueOffset == 0) {
-        if (value->getType() == payloadType) {
-          payloadValue = value;
-          return;
-        }
-        // If only the width matches exactly, we can still do a bitcast.
-        if (payloadBitWidth == valueBitWidth) {
-          auto bitcast = IGF.Builder.CreateBitOrPointerCast(value, payloadType);
-          payloadValue = bitcast;
-          return;
-        }
-      }
-      
-      // Select out the chunk of the value to merge with the existing payload.
-      llvm::Value *subvalue = value;
-      
-      auto valueIntTy =
-        llvm::IntegerType::get(IGF.IGM.getLLVMContext(), valueBitWidth);
-      auto payloadIntTy =
-        llvm::IntegerType::get(IGF.IGM.getLLVMContext(), payloadBitWidth);
-      auto payloadTy = getPayloadType(payloadValue);
-      subvalue = IGF.Builder.CreateBitOrPointerCast(subvalue, valueIntTy);
-      if (valueOffset > 0)
-        subvalue = IGF.Builder.CreateLShr(subvalue,
-                               llvm::ConstantInt::get(valueIntTy, valueOffset));
-      subvalue = IGF.Builder.CreateZExtOrTrunc(subvalue, payloadIntTy);
-      if (IGF.IGM.Triple.isLittleEndian()) {
-        if (payloadValueOffset > 0)
-          subvalue = IGF.Builder.CreateShl(subvalue,
-                        llvm::ConstantInt::get(payloadIntTy, payloadValueOffset));
-      } else {
-        if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
-            payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
-          unsigned shiftBitWidth = valueBitWidth;
-          if (valueBitWidth == 1) {
-            shiftBitWidth = 8;
-          }
-          subvalue = IGF.Builder.CreateShl(subvalue,
-            llvm::ConstantInt::get(payloadIntTy, (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
-        }
-      }
+                              unsigned payloadOffset) {
+  auto &DL = IGF.IGM.DataLayout;
 
-      // If there hasn't yet been a value stored here, we can use the adjusted
-      // value directly.
-      if (payloadValue.is<llvm::Type *>()) {
-        payloadValue = IGF.Builder.CreateBitOrPointerCast(subvalue, payloadTy);
-      }
-      // Otherwise, bitwise-or it in, brazenly assuming there are zeroes
-      // underneath.
-      else {
-        // TODO: This creates a bunch of bitcasting noise for non-integer
-        // payload fields.
-        auto lastValue = payloadValue.get<llvm::Value *>();
-        lastValue = IGF.Builder.CreateBitOrPointerCast(lastValue, payloadIntTy);
-        lastValue = IGF.Builder.CreateOr(lastValue, subvalue);
-        payloadValue = IGF.Builder.CreateBitOrPointerCast(lastValue, payloadTy);
-      }
-    });
+  // Create a mask for the value we are going to insert.
+  auto type = value->getType();
+  auto payloadSize = getAllocSizeInBits(DL);
+  auto mask = createElementMask(DL, type, payloadOffset, payloadSize);
+
+  // Scatter the value into the payload.
+  emitScatterBits(IGF, mask, value);
 }
 
 llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
                                        unsigned payloadOffset) const {
   auto &DL = IGF.IGM.DataLayout;
-  auto &C = IGF.IGM.getLLVMContext();
 
-  // Create a mask for the bytes that make up the stored value by
-  // by zero extending the value mask to its storage size.
-  // This makes the mask valid regardless of endianness.
-  auto valueSize = DL.getTypeSizeInBits(type);
-  auto valueMask = APInt::getLowBitsSet(DL.getTypeStoreSizeInBits(type),
-                                        valueSize);
-
-  // Pad the valueMask so that it can be applied to the entire
-  // payload.
-  auto payloadMask = APInt::getNullValue(getAllocSizeInBits(DL));
-  payloadMask.insertBits(valueMask, payloadOffset);
+  // Create a mask for the value we are going to extract.
+  auto payloadSize = getAllocSizeInBits(DL);
+  auto mask = createElementMask(DL, type, payloadOffset, payloadSize);
 
   // Convert the payload mask into a SpareBitVector.
   // TODO: make emitGatherSpareBits take an APInt and delete.
-  auto mask = SpareBitVector::fromAPInt(std::move(payloadMask));
+  auto bits = SpareBitVector::fromAPInt(std::move(mask));
 
   // Gather the value from the payload.
-  auto value = emitGatherSpareBits(IGF, mask, 0, valueSize);
+  auto valueSize = DL.getTypeSizeInBits(type);
+  auto value = emitGatherSpareBits(IGF, bits, 0, valueSize);
 
   // Convert the integer value to the required type.
-  if (DL.getTypeSizeInBits(value->getType()) > valueSize) {
-    auto intTy = llvm::IntegerType::get(C, valueSize);
-    value = IGF.Builder.CreateTrunc(value, intTy);
-  }
   if (value->getType() != type) {
     value = IGF.Builder.CreateBitOrPointerCast(value, type);
   }
@@ -361,20 +286,22 @@ void EnumPayload::emitSwitch(IRGenFunction &IGF,
   }
 
   // Otherwise emit a switch statement.
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &C = IGF.IGM.getLLVMContext();
   unsigned numBits = mask.countPopulation();
   auto target = emitGatherSpareBits(IGF, SpareBitVector::fromAPInt(mask),
                                     0, numBits);
   auto swi = IGF.Builder.CreateSwitch(target, dflt.getPointer(), cases.size());
   for (auto &c : cases) {
-    auto value = llvm::ConstantInt::get(context, gatherBits(mask, c.first));
+    auto value = llvm::ConstantInt::get(C, gatherBits(mask, c.first));
     swi->addCase(value, c.second);
   }
   assert(IGF.Builder.hasPostTerminatorIP());
 }
 
 llvm::Value *
-EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
+EnumPayload::emitCompare(IRGenFunction &IGF,
+                         const APInt &mask,
+                         const APInt &value) const {
   // Succeed trivially for an empty payload, or if the payload is masked
   // out completely.
   if (PayloadValues.empty() || mask == 0)
@@ -382,20 +309,20 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
 
   assert((~mask & value) == 0
          && "value has masked out bits set?!");
-  
+
   auto &DL = IGF.IGM.DataLayout;
+  auto valueReader = BitPatternReader(value, DL.isLittleEndian());
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   llvm::Value *condition = nullptr;
   for (auto &pv : PayloadValues) {
     auto v = forcePayloadValue(pv);
     unsigned size = DL.getTypeSizeInBits(v->getType());
 
     // Break off a piece of the mask and value.
-    auto maskPiece = mask.zextOrTrunc(size);
-    auto valuePiece = value.zextOrTrunc(size);
-    
-    mask = mask.lshr(size);
-    value = value.lshr(size);
-    
+    auto maskPiece = maskReader.read(size);
+    auto valuePiece = valueReader.read(size);
+
     // If this piece is zero, it doesn't affect the comparison.
     if (maskPiece == 0)
       continue;
@@ -432,19 +359,20 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
 }
 
 void
-EnumPayload::emitApplyAndMask(IRGenFunction &IGF, APInt mask) {
+EnumPayload::emitApplyAndMask(IRGenFunction &IGF, const APInt &mask) {
   // Early exit if the mask has no effect.
   if (mask.isAllOnesValue())
     return;
 
   auto &DL = IGF.IGM.DataLayout;
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   for (auto &pv : PayloadValues) {
     auto payloadTy = getPayloadType(pv);
     unsigned size = DL.getTypeSizeInBits(payloadTy);
 
-    // Break off a chunk of the mask.
-    auto maskPiece = mask.zextOrTrunc(size);
-    mask = mask.lshr(size);
+    // Read a chunk of the mask.
+    auto maskPiece = maskReader.read(size);
     
     // If this piece is all ones, it has no effect.
     if (maskPiece.isAllOnesValue())
@@ -473,19 +401,20 @@ EnumPayload::emitApplyAndMask(IRGenFunction &IGF, APInt mask) {
 }
 
 void
-EnumPayload::emitApplyOrMask(IRGenFunction &IGF, APInt mask) {
+EnumPayload::emitApplyOrMask(IRGenFunction &IGF, const APInt &mask) {
   // Early exit if the mask has no effect.
   if (mask == 0)
     return;
 
   auto &DL = IGF.IGM.DataLayout;
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   for (auto &pv : PayloadValues) {
     auto payloadTy = getPayloadType(pv);
     unsigned size = DL.getTypeSizeInBits(payloadTy);
 
-    // Break off a chunk of the mask.
-    auto maskPiece = mask.zextOrTrunc(size);
-    mask = mask.lshr(size);
+    // Read a chunk of the mask.
+    auto maskPiece = maskReader.read(size);
 
     // If this piece is zero, it has no effect.
     if (maskPiece == 0)
@@ -543,57 +472,119 @@ EnumPayload::emitApplyOrMask(IRGenFunction &IGF,
   }
 }
 
+void EnumPayload::emitScatterBits(IRGenFunction &IGF,
+                                  const APInt &mask,
+                                  llvm::Value *value) {
+  auto &DL = IGF.IGM.DataLayout;
+  auto &B = IGF.Builder;
+
+  unsigned valueBits = DL.getTypeSizeInBits(value->getType());
+  auto totalBits = std::min(valueBits, mask.countPopulation());
+  auto maskReader = BitPatternReader(getLowestNSetBits(mask, totalBits),
+                                     DL.isLittleEndian());
+  auto usedBits = 0u;
+  for (auto &pv : PayloadValues) {
+    auto partType = getPayloadType(pv);
+    auto partSize = DL.getTypeSizeInBits(partType);
+    auto partMask = maskReader.read(partSize);
+
+    // Skip this element if there are no set bits in the mask.
+    if (partMask == 0) {
+      continue;
+    }
+
+    // Calculate the number of bits we are going to scatter.
+    auto partCount = partMask.countPopulation();
+
+    // Scatter bits from the source into the bits specified by the mask.
+    auto offset = usedBits;
+    if (DL.isBigEndian()) {
+      offset = totalBits - partCount - usedBits;
+    }
+    auto partValue = irgen::emitScatterBits(IGF, partMask, value, offset);
+
+    // If necessary OR with the existing value.
+    if (auto existingValue = pv.dyn_cast<llvm::Value*>()) {
+      if (partType != partValue->getType()) {
+        existingValue = B.CreateBitOrPointerCast(existingValue,
+                                                 partValue->getType());
+      }
+      partValue = B.CreateOr(partValue, existingValue);
+    }
+
+    // Convert the integer result to the target type.
+    if (partType != partValue->getType()) {
+      partValue = B.CreateBitOrPointerCast(partValue, partType);
+    }
+
+    // Update this payload element.
+    pv = partValue;
+
+    // Update our position in the source integer.
+    usedBits += partCount;
+    if (usedBits >= totalBits) {
+      break;
+    }
+  }
+}
+
 llvm::Value *
 EnumPayload::emitGatherSpareBits(IRGenFunction &IGF,
                                  const SpareBitVector &spareBits,
                                  unsigned firstBitOffset,
-                                 unsigned bitWidth) const {
+                                 unsigned resultBitWidth) const {
   auto &DL = IGF.IGM.DataLayout;
-  unsigned payloadOffset = 0;
+  auto &C = IGF.IGM.getLLVMContext();
+
+  auto mask = getLowestNSetBits(spareBits.asAPInt(),
+                                resultBitWidth - firstBitOffset);
+  auto bitWidth = mask.countPopulation();
+  auto spareBitReader = BitPatternReader(std::move(mask),
+                                         DL.isLittleEndian());
+  auto usedBits = firstBitOffset;
+
   llvm::Value *spareBitValue = nullptr;
-  auto destTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), bitWidth);
   for (auto &pv : PayloadValues) {
     // If this value is zero, it has nothing to add to the spare bits.
     auto v = pv.dyn_cast<llvm::Value*>();
     if (!v) {
-      payloadOffset += DL.getTypeSizeInBits(pv.get<llvm::Type*>());
+      spareBitReader.skip(DL.getTypeSizeInBits(pv.get<llvm::Type*>()));
       continue;
     }
-    
-    unsigned size = DL.getTypeSizeInBits(v->getType());
+
     // Slice the spare bit vector.
-    // FIXME: this is inefficient.
-    auto spareBitsPart = SpareBitVector::getConstant(size, false);
-    unsigned numBitsInPart = 0;
-    for (unsigned i = 0; i < size; ++i)
-      if (spareBits[payloadOffset + i]) {
-        spareBitsPart.setBit(i);
-        ++numBitsInPart;
-      }
-    
-    payloadOffset += size;
-    
+    unsigned size = DL.getTypeSizeInBits(v->getType());
+    auto spareBitsPart = spareBitReader.read(size);
+    unsigned numBitsInPart = spareBitsPart.countPopulation();
+
     // If there were no spare bits in this part, it has nothing to add.
     if (numBitsInPart == 0)
       continue;
-    
-    if (firstBitOffset >= bitWidth)
+
+    if (usedBits >= bitWidth)
       break;
 
+    unsigned offset = usedBits;
+    if (DL.isBigEndian()) {
+      offset = bitWidth - usedBits - numBitsInPart;
+    }
     // Get the spare bits from this part.
-    auto bits = irgen::emitGatherBits(IGF, spareBitsPart.asAPInt(),
-                                      v, firstBitOffset, bitWidth);
-    firstBitOffset += numBitsInPart;
-    
+    auto bits = irgen::emitGatherBits(IGF, spareBitsPart,
+                                      v, offset, resultBitWidth);
+    usedBits += numBitsInPart;
+
     // Accumulate it into the full set.
-    if (!spareBitValue)
-      spareBitValue = bits;
-    else
-      spareBitValue = IGF.Builder.CreateOr(spareBitValue, bits);
+    if (spareBitValue) {
+      bits = IGF.Builder.CreateOr(spareBitValue, bits);
+    }
+    spareBitValue = bits;
   }
-  if (!spareBitValue)
-    return llvm::ConstantInt::get(destTy, 0);
-  return spareBitValue;
+  auto destTy = llvm::IntegerType::get(C, resultBitWidth);
+  if (spareBitValue) {
+    assert(spareBitValue->getType() == destTy);
+    return spareBitValue;
+  }
+  return llvm::ConstantInt::get(destTy, 0);
 }
 
 unsigned EnumPayload::getAllocSizeInBits(const llvm::DataLayout &DL) const {

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -95,9 +95,9 @@ public:
 
   /// Generate an enum payload containing the given bit pattern.
   static EnumPayload fromBitPattern(IRGenModule &IGM,
-                                    APInt bitPattern,
+                                    const APInt &bitPattern,
                                     EnumPayloadSchema schema);
-  
+
   /// Insert a value into the enum payload.
   ///
   /// The current payload value at the given offset is assumed to be zero.
@@ -105,8 +105,7 @@ public:
   /// that need storing in \p value otherwise the full bit-width of \p value
   /// will be stored.
   void insertValue(IRGenFunction &IGF,
-                   llvm::Value *value, unsigned bitOffset,
-                   int numBitsUsedInValue = -1);
+                   llvm::Value *value, unsigned bitOffset);
   
   /// Extract a value from the enum payload.
   llvm::Value *extractValue(IRGenFunction &IGF,
@@ -147,18 +146,25 @@ public:
   
   /// Emit an equality comparison operation that payload & mask == value.
   llvm::Value *emitCompare(IRGenFunction &IGF,
-                           APInt mask,
-                           APInt value) const;
+                           const APInt &mask,
+                           const APInt &value) const;
   
   /// Apply an AND mask to the payload.
-  void emitApplyAndMask(IRGenFunction &IGF, APInt mask);
+  void emitApplyAndMask(IRGenFunction &IGF, const APInt &mask);
   
   /// Apply an OR mask to the payload.
-  void emitApplyOrMask(IRGenFunction &IGF, APInt mask);
+  void emitApplyOrMask(IRGenFunction &IGF, const APInt &mask);
   
   /// Apply an OR mask to the payload.
   void emitApplyOrMask(IRGenFunction &IGF, EnumPayload mask);
-  
+
+  /// Scatter the bits in value to the bit positions indicated by the
+  /// mask. The new bits are added using OR, so an emitApplyAndMask
+  /// call should be used first if existing bits need to be cleared.
+  void emitScatterBits(IRGenFunction &IGF,
+                       const APInt &mask,
+                       llvm::Value *value);
+
   /// Gather bits from an enum payload based on a spare bit mask.
   llvm::Value *emitGatherSpareBits(IRGenFunction &IGF,
                                    const SpareBitVector &spareBits,

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -213,10 +213,11 @@ public:
   ///   SpareBitVector spareBits;
   ///   for (EnumElementDecl *elt : u->getAllElements())
   ///     getFragileTypeInfo(elt->getArgumentType())
-  ///       .applyFixedSpareBitsMask(spareBits);
+  ///       .applyFixedSpareBitsMask(IGM, spareBits);
   ///
   /// and end up with a spare bits mask for the entire enum.
-  void applyFixedSpareBitsMask(SpareBitVector &mask) const;
+  void applyFixedSpareBitsMask(const IRGenModule &IGM,
+                               SpareBitVector &mask) const;
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -115,6 +115,7 @@
 #include "llvm/Support/Compiler.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 
+#include "BitPatternBuilder.h"
 #include "GenDecl.h"
 #include "GenMeta.h"
 #include "GenProto.h"
@@ -140,17 +141,6 @@ static llvm::Constant *emitEnumLayoutFlags(IRGenModule &IGM, bool isVWTMutable){
   if (isVWTMutable) flags |= EnumLayoutFlags::IsVWTMutable;
 
   return IGM.getSize(Size(uintptr_t(flags)));
-}
-
-static SpareBitVector
-getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
-  if (startBit == 0) {
-    return SpareBitVector::fromAPInt(bits);
-  }
-  SpareBitVector result;
-  result.appendClearBits(startBit);
-  result.append(SpareBitVector::fromAPInt(bits));
-  return result;
 }
 
 static IsABIAccessible_t
@@ -980,10 +970,9 @@ namespace {
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
-      auto bits
-        = getBitVectorFromAPInt(getDiscriminatorIdxConst(theCase)->getValue());
-      bits.extendWithClearBits(cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits());
-      return bits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
+      auto val = getDiscriminatorIdxConst(theCase)->getValue();
+      return ClusteredBitVector::fromAPInt(val.zextOrSelf(size.getValueInBits()));
     }
 
     ClusteredBitVector
@@ -3187,90 +3176,64 @@ namespace {
         return APInt::getAllOnesValue(totalSize);
       auto baseMask =
         getFixedPayloadTypeInfo().getFixedExtraInhabitantMask(IGM);
-      
-      if (baseMask.getBitWidth() < totalSize)
-        baseMask = baseMask.zext(totalSize)
-         | APInt::getHighBitsSet(totalSize, totalSize - baseMask.getBitWidth());
-      
-      return baseMask;
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      mask.append(baseMask);
+      mask.padWithSetBitsTo(totalSize);
+      return mask.build().getValue();
     }
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
       APInt payloadPart, extraPart;
       std::tie(payloadPart, extraPart) = getNoPayloadCaseValue(theCase);
-      ClusteredBitVector bits;
-
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
       if (PayloadBitCount > 0)
-        bits = getBitVectorFromAPInt(payloadPart);
+        value.append(payloadPart);
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount > 0) {
-        ClusteredBitVector extraBits = getBitVectorFromAPInt(extraPart,
-                                                             bits.size());
-        bits.extendWithClearBits(totalSize);
-        extraBits.extendWithClearBits(totalSize);
-        bits |= extraBits;
-      } else {
-        assert(totalSize == bits.size());
+        auto paddedWidth = size.getValueInBits() - PayloadBitCount;
+        value.append(extraPart.zextOrSelf(paddedWidth));
       }
-      return bits;
+      return value.build();
     }
 
     ClusteredBitVector
     getBitMaskForNoPayloadElements() const override {
       // Use the extra inhabitants mask from the payload.
       auto &payloadTI = getFixedPayloadTypeInfo();
-      APInt extraInhabitantsMaskInt;
 
-      // If we used extra inhabitants from the payload, then we can use the
-      // payload's mask to find the bits we need to test.
-      auto extraDiscriminatorBits = (~APInt(8, 0));
-      if (payloadTI.getFixedSize().getValueInBits() != 0)
-        extraDiscriminatorBits =
-          extraDiscriminatorBits.zextOrTrunc(
-              payloadTI.getFixedSize().getValueInBits());
-      if (getNumExtraInhabitantTagValues() > 0) {
-        extraInhabitantsMaskInt = payloadTI.getFixedExtraInhabitantMask(IGM);
-        // If we have more no-payload cases than extra inhabitants, also
-        // mask in up to four bytes for discriminators we generate using
-        // extra tag bits.
-        if (ExtraTagBitCount > 0) {
-          extraInhabitantsMaskInt |= extraDiscriminatorBits;
-        }
-      } else {
-        // If we only use extra tag bits, then we need that extra tag plus
-        // up to four bytes of discriminator.
-        extraInhabitantsMaskInt = extraDiscriminatorBits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      if (Size payloadSize = payloadTI.getFixedSize()) {
+        auto payloadMask = APInt::getNullValue(payloadSize.getValueInBits());
+        if (getNumExtraInhabitantTagValues() > 0)
+          payloadMask |= payloadTI.getFixedExtraInhabitantMask(IGM);
+        if (ExtraTagBitCount > 0)
+          payloadMask |= 0xffffffffULL;
+        mask.append(std::move(payloadMask));
       }
-      auto extraInhabitantsMask
-        = getBitVectorFromAPInt(extraInhabitantsMaskInt);
-      
-      // Extend to include the extra tag bits, which are always significant.
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-      extraInhabitantsMask.extendWithSetBits(totalSize);
-      return extraInhabitantsMask;
+      if (ExtraTagBitCount > 0) {
+        mask.padWithSetBitsTo(size.getValueInBits());
+      }
+      return mask.build();
     }
 
     ClusteredBitVector getTagBitsForPayloads() const override {
       // We only have tag bits if we spilled extra bits.
-      ClusteredBitVector result;
-      unsigned payloadSize
-        = getFixedPayloadTypeInfo().getFixedSize().getValueInBits();
-      result.appendClearBits(payloadSize);
+      auto tagBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      Size payloadSize = getFixedPayloadTypeInfo().getFixedSize();
+      tagBits.appendClearBits(payloadSize.getValueInBits());
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-
+      Size totalSize = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount) {
-        result.appendSetBits(ExtraTagBitCount);
-        result.extendWithClearBits(totalSize);
+        Size extraTagSize = totalSize - payloadSize;
+        tagBits.append(APInt(extraTagSize.getValueInBits(),
+                             (1U << ExtraTagBitCount) - 1));
       } else {
         assert(payloadSize == totalSize);
       }
-      return result;
+      return tagBits.build();
     }
   };
 
@@ -3602,18 +3565,14 @@ namespace {
     EnumPayload getEmptyCasePayload(IRGenFunction &IGF,
                                     llvm::Value *tag,
                                     llvm::Value *tagIndex) const {
-      SpareBitVector commonSpareBits = CommonSpareBits;
-      commonSpareBits.flipAll();
-
-      EnumPayload result = interleaveSpareBits(IGF, PayloadSchema,
-                                               commonSpareBits, tagIndex);
-      result.emitApplyOrMask(IGF,
-                             interleaveSpareBits(IGF, PayloadSchema,
-                                                 PayloadTagBits, tag));
-
+      auto result = EnumPayload::zero(IGF.IGM, PayloadSchema);
+      if (!CommonSpareBits.empty())
+        result.emitScatterBits(IGF, ~CommonSpareBits.asAPInt(), tagIndex);
+      if (!PayloadTagBits.empty())
+        result.emitScatterBits(IGF, PayloadTagBits.asAPInt(), tag);
       return result;
     }
-    
+
     struct DestructuredLoadableEnum {
       EnumPayload payload;
       llvm::Value *extraTagBits;
@@ -4224,17 +4183,10 @@ namespace {
         payload = getEmptyCasePayload(IGF, tag, tagIndex);
       } else if (!CommonSpareBits.empty()) {
         // Otherwise the payload is just the index.
+        auto mask = APInt::getLowBitsSet(CommonSpareBits.size(),
+                                         std::min(32U, numCaseBits));
         payload = EnumPayload::zero(IGM, PayloadSchema);
-        if (!IGF.IGM.Triple.isLittleEndian()) {
-          if (IGF.IGM.Triple.isArch64Bit() && numCaseBits >= 64) {
-            // Need to set the full 64-bit chunk on big-endian systems.
-            tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
-          }
-	}
-        // We know we won't use more than numCaseBits from tagIndex's value:
-        // We made sure of this in the logic above.
-        payload.insertValue(IGF, tagIndex, 0,
-                            numCaseBits >= 32 ? -1 : numCaseBits);
+        payload.emitScatterBits(IGF, mask, tagIndex);
       }
 
       // If the tag bits do not fit in the spare bits, the remaining tag bits
@@ -4856,10 +4808,7 @@ namespace {
         payload.emitApplyAndMask(IGF, spareBitMask);
 
         // Store the tag into the spare bits.
-        payload.emitApplyOrMask(IGF,
-                                interleaveSpareBits(IGF, PayloadSchema,
-                                                    PayloadTagBits,
-                                                    spareTagBits));
+        payload.emitScatterBits(IGF, PayloadTagBits.asAPInt(), spareTagBits);
 
         // Store the payload back.
         payload.store(IGF, payloadAddr);
@@ -5216,8 +5165,8 @@ namespace {
       if (CommonSpareBits.count()) {
         // Factor the index value into parts to scatter into the payload and
         // to store in the extra tag bits, if any.
-        EnumPayload payload =
-          interleaveSpareBits(IGF, PayloadSchema, CommonSpareBits, indexValue);
+        auto payload = EnumPayload::zero(IGM, PayloadSchema);
+        payload.emitScatterBits(IGF, CommonSpareBits.asAPInt(), indexValue);
         payload.store(IGF, projectPayload(IGF, dest));
         if (getExtraTagBitCountForExtraInhabitants() > 0) {
           auto tagBits = IGF.Builder.CreateLShr(indexValue,
@@ -5272,11 +5221,10 @@ namespace {
       auto tagBits = CommonSpareBits.asAPInt();
       auto fixedTI = cast<FixedTypeInfo>(TI);
       if (getExtraTagBitCountForExtraInhabitants() > 0) {
-        auto bitSize = fixedTI->getFixedSize().getValueInBits();
-        tagBits = tagBits.zext(bitSize);
-        auto extraTagMask = APInt::getAllOnesValue(bitSize)
-          .shl(CommonSpareBits.size());
-        tagBits |= extraTagMask;
+        auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+        mask.append(CommonSpareBits);
+        mask.padWithSetBitsTo(fixedTI->getFixedSize().getValueInBits());
+        tagBits = mask.build().getValue();
       }
       return tagBits;
     }
@@ -5321,30 +5269,28 @@ namespace {
       auto extraTagMask = getExtraTagBitCountForExtraInhabitants() >= 32
         ? ~0u : (1 << getExtraTagBitCountForExtraInhabitants()) - 1;
 
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
       if (auto payloadBitCount = CommonSpareBits.count()) {
         auto payloadTagMask = payloadBitCount >= 32
           ? ~0u : (1 << payloadBitCount) - 1;
         auto payloadPart = mask & payloadTagMask;
-        auto payloadBits = scatterBits(CommonSpareBits.asAPInt().zextOrTrunc(bits),
+        auto payloadBits = scatterBits(CommonSpareBits.asAPInt(),
                                        payloadPart);
+        value.append(payloadBits);
         if (getExtraTagBitCountForExtraInhabitants() > 0) {
-          auto extraBits = APInt(bits,
-                                 (mask >> payloadBitCount) & extraTagMask)
-            .shl(CommonSpareBits.size());
-          payloadBits |= extraBits;
+          value.append(APInt(bits - CommonSpareBits.size(),
+                             (mask >> payloadBitCount) & extraTagMask));
         }
-        return payloadBits;
       } else {
-        auto value = APInt(bits, mask & extraTagMask);
-        return value.shl(CommonSpareBits.size());
+        value.appendClearBits(CommonSpareBits.size());
+        value.append(APInt(bits - CommonSpareBits.size(), mask & extraTagMask));
       }
+      return value.build().getValue();
     }
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
       assert(TIK >= Fixed);
-
-      APInt payloadPart, extraPart;
 
       auto emptyI = std::find_if(ElementsWithNoPayload.begin(),
                                  ElementsWithNoPayload.end(),
@@ -5353,24 +5299,19 @@ namespace {
 
       unsigned index = emptyI - ElementsWithNoPayload.begin();
 
+      APInt payloadPart, extraPart;
       std::tie(payloadPart, extraPart) = getNoPayloadCaseValue(index);
-      ClusteredBitVector bits;
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      if (PayloadBitCount > 0)
+        value.append(payloadPart);
 
-      if (!CommonSpareBits.empty())
-        bits = getBitVectorFromAPInt(payloadPart);
-
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount > 0) {
-        ClusteredBitVector extraBits =
-          getBitVectorFromAPInt(extraPart, bits.size());
-        bits.extendWithClearBits(totalSize);
-        extraBits.extendWithClearBits(totalSize);
-        bits |= extraBits;
-      } else {
-        assert(totalSize == bits.size());
+        auto paddedWidth = size.getValueInBits() - PayloadBitCount;
+        auto extraPadded = extraPart.zextOrSelf(paddedWidth);
+        value.append(std::move(extraPadded));
       }
-      return bits;
+      return value.build();
     }
 
     ClusteredBitVector
@@ -5386,19 +5327,22 @@ namespace {
 
     ClusteredBitVector getTagBitsForPayloads() const override {
       assert(TIK >= Fixed);
-      
-      ClusteredBitVector result = PayloadTagBits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-
-      if (ExtraTagBitCount) {
-        result.appendSetBits(ExtraTagBitCount);
-        result.extendWithClearBits(totalSize);
-      } else {
-        assert(PayloadTagBits.size() == totalSize);
+      if (ExtraTagBitCount == 0) {
+        assert(PayloadTagBits.size() == size.getValueInBits());
+        return PayloadTagBits;
       }
-      return result;
+
+      // Build a mask containing the tag bits for the payload and those
+      // spilled into the extra tag.
+      auto tagBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      tagBits.append(PayloadTagBits);
+
+      // Set tag bits in extra tag to 1.
+      unsigned extraTagSize = size.getValueInBits() - PayloadTagBits.size();
+      tagBits.append(APInt(extraTagSize, (1U << ExtraTagBitCount) - 1U));
+      return tagBits.build();
     }
   };
 
@@ -6273,16 +6217,15 @@ NoPayloadEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
   // Unused tag bits in the physical size can be used as spare bits.
   // TODO: We can use all values greater than the largest discriminator as
   // extra inhabitants, not just those made available by spare bits.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(usedTagBits);
-  spareBits.extendWithSetBits(tagSize.getValueInBits());
+  auto spareBits = SpareBitVector::fromAPInt(
+      APInt::getBitsSetFrom(tagSize.getValueInBits(), usedTagBits));
 
   Alignment alignment(tagSize.getValue());
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/true, alignment);
 
   return registerEnumTypeInfo(new LoadableEnumTypeInfo(*this,
-                                   enumTy, tagSize, std::move(spareBits),
-                                   alignment, IsPOD, AlwaysFixedSize));
+                              enumTy, tagSize, std::move(spareBits),
+                              alignment, IsPOD, AlwaysFixedSize));
 }
 
 TypeInfo *
@@ -6381,18 +6324,19 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeFixedLayout(
   // sets to be able to reason about how many spare bits from the payload type
   // we can forward. If we spilled tag bits, however, we can offer the unused
   // bits we have in that byte.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(payloadTI.getFixedSize().getValueInBits());
-  if (ExtraTagBitCount > 0) {
-    spareBits.appendClearBits(ExtraTagBitCount);
-    spareBits.appendSetBits(extraTagByteCount * 8 - ExtraTagBitCount);
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+  if (auto size = payloadTI.getFixedSize().getValueInBits()) {
+    spareBits.appendClearBits(size);
   }
-  
+  if (ExtraTagBitCount > 0) {
+    auto paddedSize = extraTagByteCount * 8;
+    spareBits.append(APInt::getBitsSetFrom(paddedSize, ExtraTagBitCount));
+  }
   auto alignment = payloadTI.getFixedAlignment();
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/true, alignment);
 
   getFixedEnumTypeInfo(
-      enumTy, Size(sizeWithTag), std::move(spareBits), alignment,
+      enumTy, Size(sizeWithTag), spareBits.build(), alignment,
       payloadTI.isPOD(ResilienceExpansion::Maximal),
       payloadTI.isBitwiseTakable(ResilienceExpansion::Maximal));
   if (TIK >= Loadable && CopyDestroyKind == Normal) {
@@ -6478,8 +6422,11 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
     // if the type is layout-dependent. (Even when the runtime does, it will
     // likely only track a subset of the spare bits.)
     if (!AllowFixedLayoutOptimizations || TIK < Loadable) {
-      if (CommonSpareBits.size() < payloadBits)
+      if (CommonSpareBits.size() < payloadBits) {
+        // All bits are zero so we don't have to worry about endianness.
+        assert(CommonSpareBits.none());
         CommonSpareBits.extendWithClearBits(payloadBits);
+      }
       continue;
     }
 
@@ -6491,7 +6438,7 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
     // they can contain Obj-C tagged pointers. To handle this case
     // correctly, we get spare bits from the unsubstituted type.
     auto &fixedOrigTI = cast<FixedTypeInfo>(*elt.origTI);
-    fixedOrigTI.applyFixedSpareBitsMask(CommonSpareBits);
+    fixedOrigTI.applyFixedSpareBitsMask(IGM, CommonSpareBits);
   }
 
   unsigned commonSpareBitCount = CommonSpareBits.count();
@@ -6542,12 +6489,19 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
   if (numTagBits >= commonSpareBitCount) {
     PayloadTagBits = CommonSpareBits;
 
+    auto builder = BitPatternBuilder(IGM.Triple.isLittleEndian());
     // We're using all of the common spare bits as tag bits, so none
     // of them are spare; nor are the extra tag bits.
-    spareBits.appendClearBits(CommonSpareBits.size() + ExtraTagBitCount);
+    builder.appendClearBits(CommonSpareBits.size());
 
     // The remaining bits in the extra tag bytes are spare.
-    spareBits.appendSetBits(extraTagByteCount * 8 - ExtraTagBitCount);
+    if (ExtraTagBitCount) {
+      builder.append(APInt::getBitsSetFrom(extraTagByteCount * 8,
+                                           ExtraTagBitCount));
+    }
+
+    // Set the spare bit mask.
+    spareBits = builder.build();
 
   // Otherwise, we need to construct a new bitset that doesn't
   // include the bits we aren't using.
@@ -6694,7 +6648,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
                llvm::dbgs() << ":\n";);
 
     SpareBitVector spareBits;
-    fixedTI->applyFixedSpareBitsMask(spareBits);
+    fixedTI->applyFixedSpareBitsMask(IGM, spareBits);
 
     auto bitMask = strategy->getBitMaskForNoPayloadElements();
     assert(bitMask.size() == fixedTI->getFixedSize().getValueInBits());
@@ -6832,16 +6786,16 @@ llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
                                    llvm::Value *source,
                                    unsigned resultLowBit,
                                    unsigned resultBitWidth) {
-  auto &builder = IGF.Builder;
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &B = IGF.Builder;
+  auto &C = IGF.IGM.getLLVMContext();
   assert(mask.getBitWidth() == source->getType()->getIntegerBitWidth()
     && "source and mask must have same width");
 
   // The source and mask need to be at least as wide as the result so
   // that bits can be shifted into the correct position.
-  auto destTy = llvm::IntegerType::get(context, resultBitWidth);
+  auto destTy = llvm::IntegerType::get(C, resultBitWidth);
   if (mask.getBitWidth() < resultBitWidth) {
-    source = builder.CreateZExt(source, destTy);
+    source = B.CreateZExt(source, destTy);
     mask = mask.zext(resultBitWidth);
   }
 
@@ -6862,25 +6816,25 @@ llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
     int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
     if (offset > 0) {
       uint64_t shift = uint64_t(offset);
-      part = builder.CreateLShr(part, shift);
+      part = B.CreateLShr(part, shift);
       partMask.lshrInPlace(shift);
     } else if (offset < 0) {
       uint64_t shift = uint64_t(-offset);
-      part = builder.CreateShl(part, shift);
+      part = B.CreateShl(part, shift);
       partMask <<= shift;
     }
 
     // Truncate the output to the result size.
     if (partMask.getBitWidth() > resultBitWidth) {
       partMask = partMask.trunc(resultBitWidth);
-      part = builder.CreateTrunc(part, destTy);
+      part = B.CreateTrunc(part, destTy);
     }
 
     // Mask out selected bits.
-    part = builder.CreateAnd(part, partMask);
+    part = B.CreateAnd(part, partMask);
 
     // Accumulate the result.
-    result = result ? builder.CreateOr(result, part) : part;
+    result = result ? B.CreateOr(result, part) : part;
 
     // Update the offset and remaining mask.
     usedBits += partMask.countPopulation();
@@ -6896,16 +6850,43 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
                                     llvm::APInt mask,
                                     llvm::Value *source,
                                     unsigned packedLowBit) {
-  auto &builder = IGF.Builder;
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &DL = IGF.IGM.DataLayout;
+  auto &B = IGF.Builder;
+  auto &C = IGF.IGM.getLLVMContext();
 
-  // Expand the packed bits to the destination type.
-  auto destTy = llvm::IntegerType::get(context, mask.getBitWidth());
-  source = builder.CreateZExtOrTrunc(source, destTy);
+  // Expand or contract the packed bits to the destination type.
+  auto bitSize = mask.getBitWidth();
+  auto sourceTy = dyn_cast<llvm::IntegerType>(source->getType());
+  if (!sourceTy) {
+    auto numBits = DL.getTypeSizeInBits(source->getType());
+    sourceTy = llvm::IntegerType::get(C, numBits);
+    source = B.CreateBitOrPointerCast(source, sourceTy);
+  }
+  assert(packedLowBit < sourceTy->getBitWidth() &&
+      "packedLowBit out of range");
+
+  auto destTy = llvm::IntegerType::get(C, bitSize);
+  auto usedBits = int64_t(packedLowBit);
+  if (usedBits > 0 && sourceTy->getBitWidth() > bitSize) {
+    // Need to shift before truncation if the packed value is wider
+    // than the mask.
+    source = B.CreateLShr(source, uint64_t(usedBits));
+    usedBits = 0;
+  }
+  if (sourceTy->getBitWidth() != bitSize) {
+    source = B.CreateZExtOrTrunc(source, destTy);
+  }
+
+  // No need to AND with the mask if the whole source can just be
+  // shifted into place.
+  // TODO: could do more to avoid inserting unnecessary ANDs. For
+  // example we could take into account the packedLowBit.
+  auto unknownBits = std::min(sourceTy->getBitWidth(), bitSize);
+  bool needMask = !(mask.isShiftedMask() &&
+                    mask.countPopulation() >= unknownBits);
 
   // Shift each set of contiguous set bits into position and
   // accumulate them into the result.
-  int64_t usedBits = packedLowBit;
   llvm::Value *result = nullptr;
   while (mask != 0) {
     // Isolate the rightmost run of contiguous set bits.
@@ -6919,16 +6900,18 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
     llvm::Value *part = source;
     int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
     if (offset > 0) {
-      part = builder.CreateShl(part, uint64_t(offset));
+      part = B.CreateShl(part, uint64_t(offset));
     } else if (offset < 0) {
-      part = builder.CreateLShr(part, uint64_t(-offset));
+      part = B.CreateLShr(part, uint64_t(-offset));
     }
 
     // Mask out selected bits.
-    part = builder.CreateAnd(part, partMask);
+    if (needMask) {
+      part = B.CreateAnd(part, partMask);
+    }
 
     // Accumulate the result.
-    result = result ? builder.CreateOr(result, part) : part;
+    result = result ? B.CreateOr(result, part) : part;
 
     // Update the offset and remaining mask.
     usedBits += partMask.countPopulation();
@@ -6967,54 +6950,6 @@ llvm::APInt irgen::scatterBits(const llvm::APInt &mask, unsigned value) {
     }
     value >>= 1;
   }
-  return result;
-}
-
-/// A version of the above where the tag value is dynamic.
-EnumPayload irgen::interleaveSpareBits(IRGenFunction &IGF,
-                                       const EnumPayloadSchema &schema,
-                                       const SpareBitVector &spareBitVector,
-                                       llvm::Value *value) {
-  EnumPayload result;
-  APInt spareBits = spareBitVector.asAPInt();
-
-  unsigned usedBits = 0;
-
-  auto &DL = IGF.IGM.DataLayout;
-  schema.forEachType(IGF.IGM, [&](llvm::Type *type) {
-    unsigned bitSize = DL.getTypeSizeInBits(type);
-
-    // Take some bits off of the bottom of the pattern.
-    auto spareBitsChunk = SpareBitVector::fromAPInt(
-        spareBits.zextOrTrunc(bitSize));
-
-    if (usedBits >= 32 || spareBitsChunk.count() == 0) {
-      result.PayloadValues.push_back(type);
-    } else {
-      llvm::Value *payloadValue = value;
-      if (usedBits > 0) {
-        payloadValue = IGF.Builder.CreateLShr(payloadValue,
-                       llvm::ConstantInt::get(IGF.IGM.Int32Ty, usedBits));
-      }
-      payloadValue = emitScatterBits(IGF, spareBitsChunk.asAPInt(),
-                                     payloadValue, 0);
-      if (payloadValue->getType() != type) {
-        if (type->isPointerTy())
-          payloadValue = IGF.Builder.CreateIntToPtr(payloadValue, type);
-        else
-          payloadValue = IGF.Builder.CreateBitCast(payloadValue, type);
-      }
-
-      result.PayloadValues.push_back(payloadValue);
-    }
-    
-    // Shift the remaining bits down.
-    spareBits = spareBits.lshr(bitSize);
-
-    // Consume bits from the input value.
-    usedBits += spareBitsChunk.count();
-  });
-
   return result;
 }
 

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -90,12 +90,6 @@ void emitStoreEnumTagToAddress(IRGenFunction &IGF,
                                 SILType enumTy,
                                 Address enumAddr,
                                 EnumElementDecl *theCase);
-  
-/// Unpack bits from value and scatter them into the masked bits.
-EnumPayload interleaveSpareBits(IRGenFunction &IGF,
-                                const EnumPayloadSchema &schema,
-                                const SpareBitVector &spareBitVector,
-                                llvm::Value *value);
 
 /// Pack masked bits into the low bits of an integer value.
 /// Equivalent to a parallel bit extract instruction (PEXT),

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -30,6 +30,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "BitPatternBuilder.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
@@ -583,8 +584,11 @@ namespace {
                               .getFixedExtraInhabitantMask(IGM);
 
       // Zext out to the size of the existential.
-      bits = bits.zextOrTrunc(asDerived().getFixedSize().getValueInBits());
-      return bits;
+      auto totalSize = asDerived().getFixedSize().getValueInBits();
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      mask.append(bits);
+      mask.padWithClearBitsTo(totalSize);
+      return mask.build().getValue();
     }
   };
 
@@ -649,8 +653,10 @@ namespace {
                                                      ReferenceOwnership::Name, \
                                                      Refcounting); \
         /* Zext out to the size of the existential. */ \
-        bits = bits.zextOrTrunc(getFixedSize().getValueInBits()); \
-        return bits; \
+        auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian()); \
+        mask.append(bits); \
+        mask.padWithClearBitsTo(getFixedSize().getValueInBits()); \
+        return mask.build().getValue(); \
       } else { \
         return Super::getFixedExtraInhabitantMask(IGM); \
       } \
@@ -922,10 +928,11 @@ public:
     return getHeapObjectFixedExtraInhabitantValue(IGM, bits, index, offset);
   }
   APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
-    auto mask = APInt::getAllOnesValue(IGM.getPointerSize().getValueInBits());
-    mask = mask.zext(getFixedSize().getValueInBits());
-    mask = mask.shl(getLayout().getMetadataRefOffset(IGM).getValueInBits());
-    return mask;
+    auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    mask.appendClearBits(getLayout().getMetadataRefOffset(IGM).getValueInBits());
+    mask.appendSetBits(IGM.getPointerSize().getValueInBits());
+    mask.padWithClearBitsTo(getFixedSize().getValueInBits());
+    return mask.build().getValue();
   }
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                        Address src, SILType T,
@@ -1135,17 +1142,20 @@ public:
   const TypeInfo * \
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
-                                                     ReferenceOwnership::Name, \
-                                                     Refcounting); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
+                                                   ReferenceOwnership::Name, \
+                                                   Refcounting); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     return AddressOnly##Name##ClassExistentialTypeInfo::create( \
                                                  getStoredProtocols(), \
                                                  storageTy, \
-                                                 std::move(spareBits), \
+                                                 spareBits.build(), \
                                                  getFixedSize(), \
                                                  getFixedAlignment(), \
                                                  Refcounting, \
@@ -1157,18 +1167,21 @@ public:
   const TypeInfo * \
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
-                                                     ReferenceOwnership::Name, \
-                                                     Refcounting); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
+                                                   ReferenceOwnership::Name, \
+                                                   Refcounting); \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     if (TC.IGM.isLoadableReferenceAddressOnly(Refcounting)) { \
       return AddressOnly##Name##ClassExistentialTypeInfo::create( \
                                                    getStoredProtocols(), \
                                                    storageTy, \
-                                                   std::move(spareBits), \
+                                                   spareBits.build(), \
                                                    getFixedSize(), \
                                                    getFixedAlignment(), \
                                                    Refcounting, \
@@ -1178,7 +1191,7 @@ public:
                                                    getStoredProtocols(), \
                                                    getValueType(), \
                                                    storageTy, \
-                                                   std::move(spareBits), \
+                                                   spareBits.build(), \
                                                    getFixedSize(), \
                                                    getFixedAlignment(), \
                                                    Refcounting, \
@@ -1191,11 +1204,14 @@ public:
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
     assert(Refcounting == ReferenceCounting::Native); \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
                                                    ReferenceOwnership::Name, \
                                                    ReferenceCounting::Native); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     return Loadable##Name##ClassExistentialTypeInfo::create( \
@@ -1414,7 +1430,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     Alignment align = IGM.getPointerAlignment();
     Size size = classFields.size() * IGM.getPointerSize();
 
-    SpareBitVector spareBits;
+    auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
 
     // The class pointer is an unknown heap object, so it may be a tagged
     // pointer, if the platform has those.
@@ -1430,9 +1446,8 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     for (unsigned i = 1, e = classFields.size(); i < e; ++i) {
       spareBits.append(IGM.getWitnessTablePtrSpareBits());
     }
-
     return ClassExistentialTypeInfo::create(protosWithWitnessTables, type,
-                                            size, std::move(spareBits), align,
+                                            size, spareBits.build(), align,
                                             refcounting);
   }
 
@@ -1446,23 +1461,11 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
   Size size = opaque.getSize(IGM);
   // There are spare bits in the metadata pointer and witness table pointers
   // consistent with a native object reference.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(size.getValueInBits());
-  /* TODO: There are spare bits we could theoretically use in the type metadata
-     and witness table pointers, but opaque existentials are currently address-
-     only, and we can't soundly take advantage of spare bits for in-memory
-     representations.
-   
-  auto metadataOffset = opaque.getMetadataRefOffset(IGM);
-  spareBits.appendClearBits(metadataOffset.getValueInBits());
-  auto typeSpareBits = IGM.getHeapObjectSpareBits();
-  spareBits.append(typeSpareBits);
-  auto witnessSpareBits =
-    IGM.getWitnessTablePtrSpareBits();
-  for (unsigned i = 0, e = protosWithWitnessTables.size(); i < e; ++i)
-    spareBits.append(witnessSpareBits);
-  assert(spareBits.size() == size.getValueInBits());
-   */
+  // TODO: There are spare bits we could theoretically use in the type metadata
+  // and witness table pointers, but opaque existentials are currently address-
+  // only, and we can't soundly take advantage of spare bits for in-memory
+  // representations.
+  auto spareBits = SpareBitVector::getConstant(size.getValueInBits(), false);
   return OpaqueExistentialTypeInfo::create(protosWithWitnessTables, type, size,
                                            std::move(spareBits),
                                            align);
@@ -1491,12 +1494,12 @@ TypeConverter::convertExistentialMetatypeType(ExistentialMetatypeType *T) {
   SmallVector<const ProtocolDecl *, 4> protosWithWitnessTables;
   SmallVector<llvm::Type*, 4> fields;
 
-  SpareBitVector spareBits;
-
   assert(T->getRepresentation() != MetatypeRepresentation::Thin &&
          "existential metatypes cannot have thin representation");
   auto &baseTI = cast<LoadableTypeInfo>(getMetatypeTypeInfo(T->getRepresentation()));
   fields.push_back(baseTI.getStorageType());
+
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
   spareBits.append(baseTI.getSpareBits());
 
   for (auto protoTy : layout.getProtocols()) {
@@ -1517,7 +1520,7 @@ TypeConverter::convertExistentialMetatypeType(ExistentialMetatypeType *T) {
   Alignment align = IGM.getPointerAlignment();
 
   return ExistentialMetatypeTypeInfo::create(protosWithWitnessTables, type,
-                                             size, std::move(spareBits), align,
+                                             size, spareBits.build(), align,
                                              baseTI);
 }
 

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_IRGEN_GENRECORD_H
 #define SWIFT_IRGEN_GENRECORD_H
 
+#include "BitPatternBuilder.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "Explosion.h"
@@ -598,27 +599,32 @@ public:
     // inhabitants.
     auto &field = *asImpl().getFixedExtraInhabitantProvidingField(IGM);
     auto &fieldTI = cast<FixedTypeInfo>(field.getTypeInfo());
-    APInt fieldValue = fieldTI.getFixedExtraInhabitantValue(IGM, bits, index);
-    return fieldValue.shl(field.getFixedByteOffset().getValueInBits());
+    auto fieldSize = fieldTI.getFixedExtraInhabitantMask(IGM).getBitWidth();
+
+    auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    value.appendClearBits(field.getFixedByteOffset().getValueInBits());
+    value.append(fieldTI.getFixedExtraInhabitantValue(IGM, fieldSize, index));
+    value.padWithClearBitsTo(bits);
+    return value.build().getValue();
   }
 
   APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
     auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM);
     if (!field)
       return APInt();
-    
+
     const FixedTypeInfo &fieldTI
       = cast<FixedTypeInfo>(field->getTypeInfo());
     auto targetSize = asImpl().getFixedSize().getValueInBits();
-    
+
     if (fieldTI.isKnownEmpty(ResilienceExpansion::Maximal))
       return APInt(targetSize, 0);
-    
-    APInt fieldMask = fieldTI.getFixedExtraInhabitantMask(IGM);
-    if (targetSize > fieldMask.getBitWidth())
-      fieldMask = fieldMask.zext(targetSize);
-    fieldMask = fieldMask.shl(field->getFixedByteOffset().getValueInBits());
-    return fieldMask;
+
+    auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    mask.appendClearBits(field->getFixedByteOffset().getValueInBits());
+    mask.append(fieldTI.getFixedExtraInhabitantMask(IGM));
+    mask.padWithClearBitsTo(targetSize);
+    return mask.build().getValue();
   }
 
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 
+#include "BitPatternBuilder.h"
 #include "FixedTypeInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
@@ -363,24 +364,9 @@ void StructLayoutBuilder::setAsBodyOfStruct(llvm::StructType *type) const {
 
 /// Return the spare bit mask of the structure built so far.
 SpareBitVector StructLayoutBuilder::getSpareBits() const {
-  // Calculate the size up front to reduce possible allocations.
-  unsigned numBits = 0;
-  for (auto &v : CurSpareBits) {
-    numBits += v.size();
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+  for (const auto &v : CurSpareBits) {
+    spareBits.append(v);
   }
-  if (numBits == 0) {
-    return SpareBitVector();
-  }
-  // Assemble the spare bit mask.
-  auto mask = llvm::APInt::getNullValue(numBits);
-  unsigned offset = 0;
-  for (auto &v : CurSpareBits) {
-    if (v.size() == 0) {
-      continue;
-    }
-    mask.insertBits(v.asAPInt(), offset);
-    offset += v.size();
-  }
-  assert(offset == numBits);
-  return SpareBitVector::fromAPInt(std::move(mask));
+  return spareBits.build();
 }

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -51,12 +51,10 @@ static inline void storeEnumElement(uint8_t *dst,
     memcpy(dst, &value, 4);
     return;
   }
-  // Store value into first word of destination. Set the rest of the
-  // destination to zero.
-  // NOTE: this is likely to change on big-endian systems.
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-  memset(&dst[0], 0, size);
-  memcpy(&dst[std::min(size - 4, size_t(4))], &value, 4);
+  // Store zero extended value in the destination.
+#if defined(__BIG_ENDIAN__)
+  memset(&dst[0], 0, size - 4);
+  memcpy(&dst[size - 4], &value, 4);
 #else
   memcpy(&dst[0], &value, 4);
   memset(&dst[4], 0, size - 4);
@@ -92,10 +90,9 @@ static inline uint32_t loadEnumElement(const uint8_t *src,
     memcpy(&result, src, 4);
     return result;
   }
-  // Load value from the first word of the source.
-  // NOTE: this is likely to change on big-endian systems.
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-  memcpy(&result, &src[std::min(size - 4, size_t(4))], 4);
+  // Load value by truncating the source to 4 bytes.
+#if defined(__BIG_ENDIAN__)
+  memcpy(&result, &src[size - 4], 4);
 #else
   memcpy(&result, &src[0], 4);
 #endif

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2516,10 +2516,9 @@ entry(%x : $Int32):
   %c = tuple (%b : $Optional<()>, %x : $Int32)
   // CHECK-64: [[INT_ZEXT:%.*]] = zext i32 %0 to i64
   // CHECK-64: [[INT_SHL:%.*]] = shl i64 [[INT_ZEXT]], 32
-  // CHECK-64: [[COMBINE:%.*]] = or i64 0, [[INT_SHL]]
   %d = enum $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt.1, %c : $(Optional<()>, Int32)
-  // CHECK-64: [[BIT:%.*]] = trunc i64 [[COMBINE]] to i1
-  // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[COMBINE]], 32
+  // CHECK-64: [[BIT:%.*]] = trunc i64 [[INT_SHL]] to i1
+  // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[INT_SHL]], 32
   // CHECK-64: [[INT:%.*]] = trunc i64 [[INT_SHR]] to i32
   %e = unchecked_enum_data %d : $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt.1
   return %d : $Optional<(Optional<()>, Int32)>

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -581,7 +581,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = and i64 [[SPARE_TAG_TMP2]], -4611686018427387904
 
 //   -- Apply the new spare bits
-// CHECK-NEXT: [[SECOND_NEW:%.*]] = or i64 [[SECOND_PROJ]], [[SPARE_TAG_TMP]]
+// CHECK-NEXT: [[SECOND_NEW:%.*]] = or i64 [[SPARE_TAG_TMP]], [[SECOND_PROJ]]
 
 //   -- Store the payload back
 // CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
@@ -647,7 +647,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = shl i64 [[SPARE_TAG_TMP2]], 63
 //                                                                -- 0x8000000000000000
 // CHECK-NEXT: [[SPARE_TAG:%.*]] = and i64 [[SPARE_TAG_TMP:%.*]], -9223372036854775808
-// CHECK-NEXT: [[PAYLOAD_NEW:%.*]] = or i64 [[PAYLOAD_PROJ]], [[SPARE_TAG]]
+// CHECK-NEXT: [[PAYLOAD_NEW:%.*]] = or i64 [[SPARE_TAG]], [[PAYLOAD_PROJ]]
 
 //   -- Store the payload
 // CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* %0 to i64*


### PR DESCRIPTION
This change modifies spare bit masks so that they are arranged in
the byte order of the target platform. It also modifies and
consolidates the code that gathers and scatters bits into enum
values.

All enum-related validation tests are now passing on IBM Z (s390x)
which is a big-endian platform.