### PR TITLE
[C++ Interop] Uninhabited enums are still possible.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -134,7 +134,10 @@ bool TypeBase::isUninhabited() {
   // Empty enum declarations are uninhabited
   if (auto nominalDecl = getAnyNominal())
     if (auto enumDecl = dyn_cast<EnumDecl>(nominalDecl))
-      if (enumDecl->getAllElements().empty())
+      // Objective-C enums may be allowed to hold any value representable by
+      // the underlying type, but only if they come from clang.
+      if (enumDecl->getAllElements().empty() &&
+          !(enumDecl->isObjC() && enumDecl->hasClangNode()))
         return true;
   return false;
 }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -804,7 +804,6 @@ namespace {
                              std::move(WithNoPayload))
     {
       assert(ElementsWithPayload.empty());
-      assert(!ElementsWithNoPayload.empty());
     }
 
     bool needsPayloadSizeInMetadata() const override { return false; }
@@ -1164,7 +1163,6 @@ namespace {
                                       std::move(WithNoPayload))
     {
       assert(ElementsWithPayload.empty());
-      assert(!ElementsWithNoPayload.empty());
     }
 
     TypeInfo *completeEnumTypeLayout(TypeConverter &TC,

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -34,3 +34,5 @@ class Methods2 {
 public:
   int SimpleMethod(int);
 };
+
+enum __attribute__((enum_extensibility(open))) OpenEmptyEnum : char {};

--- a/test/ClangImporter/enum-cxx.swift
+++ b/test/ClangImporter/enum-cxx.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -o - | %FileCheck %s
+
+import CXXInterop
+
+// CHECK-LABEL: define hidden swiftcc i8 @"$s4main19testEmptyEnumImport5values4Int8VSo04OpencD0V_tF"(i8)
+// CHECK:  %1 = call swiftcc i8 @"$sSo13OpenEmptyEnumV8rawValues4Int8Vvg"(i8 %0)
+// CHECK:  ret i8 %1
+func testEmptyEnumImport(value: OpenEmptyEnum) -> Int8 {
+  // Should still compile even though the enum is uninhabited in c++.
+  return value.rawValue
+}


### PR DESCRIPTION
Fix bug where uninhabited c++ enums were causing the swift compiler to insert unreachable statements and issue warnings. Note: this is c++ only because c doesn't allow uninhabited enums.