### PR TITLE
[CMake] Fix small bug in _add_swift_library_single

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1005,7 +1005,7 @@ function(_add_swift_library_single target name)
               ${SWIFTLIB_SINGLE_XCODE_WORKAROUND_SOURCES})
   if(("${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "ELF" OR
       "${SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_OBJECT_FORMAT}" STREQUAL "COFF") AND
-     SWIFTLIB_TARGET_LIBRARY)
+     SWIFTLIB_SINGLE_TARGET_LIBRARY)
     if("${libkind}" STREQUAL "SHARED" AND NOT SWIFTLIB_SINGLE_NOSWIFTRT)
       # TODO(compnerd) switch to the generator expression when cmake is upgraded
       # to a version which supports it.


### PR DESCRIPTION
This option should be `SWIFTLIB_SINGLE_TARGET_LIBRARY`. If you rely on
`SWIFTLIB_TARGET_LIBRARY`, you get whatever was set in add_swift_target_library.
While these should be the same, I'm trying to remove `SWIFTLIB_TARGET_LIBRARY`
entirely.