### PR TITLE
[ConstraintSystem] Add a fix to ignore contextual type mismatch

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1853,6 +1853,10 @@ bool ContextualFailure::diagnoseAsError() {
 
   case ConstraintLocator::ContextualType: {
     auto &cs = getConstraintSystem();
+
+    if (diagnoseConversionToBool())
+      return true;
+
     if (auto msg = getDiagnosticFor(cs.getContextualTypePurpose(),
                                     /*forProtocol=*/false)) {
       diagnostic = *msg;
@@ -1893,6 +1897,49 @@ bool ContextualFailure::diagnoseMissingFunctionCall() const {
   tryComputedPropertyFixIts(anchor);
 
   return true;
+}
+
+bool ContextualFailure::diagnoseConversionToBool() const {
+  auto toType = getToType();
+  if (!toType->isBool())
+    return false;
+
+  auto *expr = getAnchor();
+  // Check for "=" converting to Bool.  The user probably meant ==.
+  if (auto *AE = dyn_cast<AssignExpr>(expr->getValueProvidingExpr())) {
+    emitDiagnostic(AE->getEqualLoc(), diag::use_of_equal_instead_of_equality)
+        .fixItReplace(AE->getEqualLoc(), "==")
+        .highlight(AE->getDest()->getLoc())
+        .highlight(AE->getSrc()->getLoc());
+    return true;
+  }
+
+  // If we're trying to convert something from optional type to Bool, then a
+  // comparison against nil was probably expected.
+  // TODO: It would be nice to handle "!x" --> x == false, but we have no way
+  // to get to the parent expr at present.
+  auto fromType = getFromType();
+  if (fromType->getOptionalObjectType()) {
+    StringRef prefix = "((";
+    StringRef suffix = ") != nil)";
+
+    // Check if we need the inner parentheses.
+    // Technically we only need them if there's something in 'expr' with
+    // lower precedence than '!=', but the code actually comes out nicer
+    // in most cases with parens on anything non-trivial.
+    if (expr->canAppendPostfixExpression()) {
+      prefix = prefix.drop_back();
+      suffix = suffix.drop_front();
+    }
+    // FIXME: The outer parentheses may be superfluous too.
+
+    emitDiagnostic(expr->getLoc(), diag::optional_used_as_boolean, fromType)
+        .fixItInsert(expr->getStartLoc(), prefix)
+        .fixItInsertAfter(expr->getEndLoc(), suffix);
+    return true;
+  }
+
+  return false;
 }
 
 bool ContextualFailure::trySequenceSubsequenceFixIts(InFlightDiagnostic &diag,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1858,19 +1858,6 @@ bool ContextualFailure::diagnoseAsError() {
     if (diagnoseConversionToBool())
       return true;
 
-    auto *fnType1 = getFromType()->getAs<FunctionType>();
-    auto *fnType2 = getToType()->getAs<FunctionType>();
-
-    if (fnType1 && fnType2) {
-      if (fnType1->throws() != fnType2->throws()) {
-        auto throwingTy = fnType1->throws() ? fnType1 : fnType2;
-        emitDiagnostic(anchor->getLoc(), diag::throws_functiontype_mismatch,
-                       throwingTy, throwingTy == fnType1 ? fnType2 : fnType1)
-            .highlight(anchor->getSourceRange());
-        return true;
-      }
-    }
-
     if (auto msg = getDiagnosticFor(getContextualTypePurpose(),
                                     /*forProtocol=*/false)) {
       diagnostic = *msg;
@@ -4082,5 +4069,12 @@ bool InvalidTupleSplatWithSingleParameterFailure::diagnoseAsError() {
   diagnostic.highlight(argExpr->getSourceRange())
       .fixItInsertAfter(argExpr->getStartLoc(), "(")
       .fixItInsert(argExpr->getEndLoc(), ")");
+  return true;
+}
+
+bool ThrowingFunctionConversionFailure::diagnoseAsError() {
+  auto *anchor = getAnchor();
+  emitDiagnostic(anchor->getLoc(), diag::throws_functiontype_mismatch,
+                 getFromType(), getToType());
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1857,6 +1857,19 @@ bool ContextualFailure::diagnoseAsError() {
     if (diagnoseConversionToBool())
       return true;
 
+    auto *fnType1 = getFromType()->getAs<FunctionType>();
+    auto *fnType2 = getToType()->getAs<FunctionType>();
+
+    if (fnType1 && fnType2) {
+      if (fnType1->throws() != fnType2->throws()) {
+        auto throwingTy = fnType1->throws() ? fnType1 : fnType2;
+        emitDiagnostic(anchor->getLoc(), diag::throws_functiontype_mismatch,
+                       throwingTy, throwingTy == fnType1 ? fnType2 : fnType1)
+            .highlight(anchor->getSourceRange());
+        return true;
+      }
+    }
+
     if (auto msg = getDiagnosticFor(cs.getContextualTypePurpose(),
                                     /*forProtocol=*/false)) {
       diagnostic = *msg;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2210,7 +2210,8 @@ bool ContextualFailure::trySequenceSubsequenceFixIts(
   // Wrap in String.init
   if (FromType->isEqual(Substring)) {
     if (ToType->isEqual(String)) {
-      auto range = getAnchor()->getSourceRange();
+      auto *anchor = getAnchor()->getSemanticsProvidingExpr();
+      auto range = anchor->getSourceRange();
       diagnostic.fixItInsert(range.Start, "String(");
       diagnostic.fixItInsertAfter(range.End, ")");
       return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -682,6 +682,10 @@ public:
   /// Produce a specialized diagnostic if this is an invalid conversion to Bool.
   bool diagnoseConversionToBool() const;
 
+  /// Produce a specialized diagnostic if this is an attempt to initialize
+  /// or convert an array literal to a dictionary e.g. `let _: [String: Int] = ["A", 0]`
+  bool diagnoseConversionToDictionary() const;
+
   /// Attempt to attach any relevant fix-its to already produced diagnostic.
   void tryFixIts(InFlightDiagnostic &diagnostic) const;
 
@@ -725,7 +729,17 @@ protected:
   /// conversion is possible.
   bool tryTypeCoercionFixIt(InFlightDiagnostic &diagnostic) const;
 
+  /// Check whether this contextual failure represents an invalid
+  /// conversion from array literal to dictionary.
+  static bool isInvalidDictionaryConversion(ConstraintSystem &cs, Expr *anchor,
+                                            Type contextualType);
+
 private:
+  ContextualTypePurpose getContextualTypePurpose() const {
+    auto &cs = getConstraintSystem();
+    return cs.getContextualTypePurpose();
+  }
+
   Type resolve(Type rawType) {
     auto type = resolveType(rawType)->getWithoutSpecifierType();
     if (auto *BGT = type->getAs<BoundGenericType>()) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -702,6 +702,19 @@ public:
   tryRawRepresentableFixIts(InFlightDiagnostic &diagnostic,
                             KnownProtocolKind rawRepresentablePrococol) const;
 
+  /// Attempts to add fix-its for these two mistakes:
+  ///
+  /// - Passing an integer with the right type but which is getting wrapped with
+  ///   a different integer type unnecessarily. The fixit removes the cast.
+  ///
+  /// - Passing an integer but expecting different integer type. The fixit adds
+  ///   a wrapping cast.
+  ///
+  /// - Return true on the fixit is added, false otherwise.
+  ///
+  /// This helps migration with SDK changes.
+  bool tryIntegerCastFixIts(InFlightDiagnostic &diagnostic) const;
+
 protected:
   /// Try to add a fix-it when converting between a collection and its slice
   /// type, such as String <-> Substring or (eventually) Array <-> ArraySlice
@@ -720,6 +733,12 @@ private:
   /// Try to add a fix-it to convert a stored property into a computed
   /// property
   void tryComputedPropertyFixIts(Expr *expr) const;
+
+  bool isIntegerType(Type type) const {
+    return conformsToKnownProtocol(
+        getConstraintSystem(), type,
+        KnownProtocolKind::ExpressibleByIntegerLiteral);
+  }
 
 protected:
   static Optional<Diag<Type, Type>>

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -683,7 +683,7 @@ public:
   bool diagnoseConversionToBool() const;
 
   /// Attempt to attach any relevant fix-its to already produced diagnostic.
-  bool tryFixIts(InFlightDiagnostic &diagnostic) const;
+  void tryFixIts(InFlightDiagnostic &diagnostic) const;
 
   /// Attempts to add fix-its for these two mistakes:
   ///
@@ -719,6 +719,11 @@ protected:
   /// Try to add a fix-it when converting between a collection and its slice
   /// type, such as String <-> Substring or (eventually) Array <-> ArraySlice
   bool trySequenceSubsequenceFixIts(InFlightDiagnostic &diagnostic) const;
+
+  /// Try to add a fix-it that suggests to explicitly use `as` or `as!`
+  /// to coerce one type to another if type-checker can prove that such
+  /// conversion is possible.
+  bool tryTypeCoercionFixIt(InFlightDiagnostic &diagnostic) const;
 
 private:
   Type resolve(Type rawType) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -698,6 +698,10 @@ private:
   /// Try to add a fix-it to convert a stored property into a computed
   /// property
   void tryComputedPropertyFixIts(Expr *expr) const;
+
+protected:
+  static Optional<Diag<Type, Type>>
+  getDiagnosticFor(ContextualTypePurpose context, bool forProtocol);
 };
 
 /// Diagnose failures related attempt to implicitly convert types which
@@ -1422,10 +1426,6 @@ public:
   }
 
   bool diagnoseAsError() override;
-
-private:
-  static Optional<Diag<Type, Type>>
-  getDiagnosticFor(ContextualTypePurpose purpose);
 };
 
 /// Diagnose generic argument omission e.g.

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -679,6 +679,9 @@ public:
   // then we probably meant to call the value.
   bool diagnoseMissingFunctionCall() const;
 
+  /// Produce a specialized diagnostic if this is an invalid conversion to Bool.
+  bool diagnoseConversionToBool() const;
+
   /// Try to add a fix-it when converting between a collection and its slice
   /// type, such as String <-> Substring or (eventually) Array <-> ArraySlice
   static bool trySequenceSubsequenceFixIts(InFlightDiagnostic &diag,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -744,6 +744,21 @@ bool AllowTupleSplatForSingleParameter::attempt(
   return cs.recordFix(fix);
 }
 
+bool DropThrowsAttribute::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
+  ThrowingFunctionConversionFailure failure(root, cs, getFromType(),
+                                            getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+DropThrowsAttribute *DropThrowsAttribute::create(ConstraintSystem &cs,
+                                                 FunctionType *fromType,
+                                                 FunctionType *toType,
+                                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      DropThrowsAttribute(cs, fromType, toType, locator);
+}
+
 bool IgnoreContextualType::diagnose(Expr *root, bool asNote) const {
   auto &cs = getConstraintSystem();
   ContextualFailure failure(root, cs, getFromType(), getToType(), getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -743,3 +743,17 @@ bool AllowTupleSplatForSingleParameter::attempt(
 
   return cs.recordFix(fix);
 }
+
+bool IgnoreContextualType::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
+  ContextualFailure failure(root, cs, getFromType(), getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
+                                                   Type resultTy,
+                                                   Type specifiedTy,
+                                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreContextualType(cs, resultTy, specifiedTy, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -494,6 +494,26 @@ public:
                                     ConstraintLocator *locator);
 };
 
+/// This is a contextual mismatch between throwing and non-throwing
+/// function types, repair it by dropping `throws` attribute.
+class DropThrowsAttribute final : public ContextualMismatch {
+  DropThrowsAttribute(ConstraintSystem &cs, FunctionType *fromType,
+                      FunctionType *toType, ConstraintLocator *locator)
+      : ContextualMismatch(cs, fromType, toType, locator) {
+    assert(fromType->throws() != toType->throws());
+  }
+
+public:
+  std::string getName() const override { return "drop 'throws' attribute"; }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static DropThrowsAttribute *create(ConstraintSystem &cs,
+                                     FunctionType *fromType,
+                                     FunctionType *toType,
+                                     ConstraintLocator *locator);
+};
+
 /// Append 'as! T' to force a downcast to the specified type.
 class ForceDowncast final : public ContextualMismatch {
   ForceDowncast(ConstraintSystem &cs, Type fromType, Type toType,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1282,6 +1282,23 @@ public:
                       ConstraintLocatorBuilder locator);
 };
 
+class IgnoreContextualType : public ContextualMismatch {
+  IgnoreContextualType(ConstraintSystem &cs, Type resultTy, Type specifiedTy,
+                       ConstraintLocator *locator)
+      : ContextualMismatch(cs, resultTy, specifiedTy, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore specified contextual type";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,
+                                      Type specifiedTy,
+                                      ConstraintLocator *locator);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2737,6 +2737,43 @@ bool constraints::isAutoClosureArgument(Expr *argExpr) {
   return false;
 }
 
+bool constraints::conformsToKnownProtocol(ConstraintSystem &cs, Type type,
+                                          KnownProtocolKind protocol) {
+  if (auto *proto = cs.TC.getProtocol(SourceLoc(), protocol))
+    return bool(TypeChecker::conformsToProtocol(
+        type, proto, cs.DC, ConformanceCheckFlags::InExpression));
+  return false;
+}
+
+/// Check whether given type conforms to `RawPepresentable` protocol
+/// and return the witness type.
+Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
+  auto &TC = cs.TC;
+  auto *DC = cs.DC;
+
+  auto rawReprType =
+      TC.getProtocol(SourceLoc(), KnownProtocolKind::RawRepresentable);
+  if (!rawReprType)
+    return Type();
+
+  auto conformance = TypeChecker::conformsToProtocol(
+      type, rawReprType, DC, ConformanceCheckFlags::InExpression);
+  if (!conformance)
+    return Type();
+
+  return conformance->getTypeWitnessByName(type, TC.Context.Id_RawValue);
+}
+
+Type constraints::isRawRepresentable(
+    ConstraintSystem &cs, Type type,
+    KnownProtocolKind rawRepresentableProtocol) {
+  Type rawTy = isRawRepresentable(cs, type);
+  if (!rawTy || !conformsToKnownProtocol(cs, rawTy, rawRepresentableProtocol))
+    return Type();
+
+  return rawTy;
+}
+
 void ConstraintSystem::generateConstraints(
     SmallVectorImpl<Constraint *> &constraints, Type type,
     ArrayRef<OverloadChoice> choices, DeclContext *useDC,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3922,6 +3922,18 @@ Expr *getArgumentExpr(Expr *expr, unsigned index);
 // }
 bool isAutoClosureArgument(Expr *argExpr);
 
+/// Check whether type conforms to a given known protocol.
+bool conformsToKnownProtocol(ConstraintSystem &cs, Type type,
+                             KnownProtocolKind protocol);
+
+/// Check whether given type conforms to `RawPepresentable` protocol
+/// and return witness type.
+Type isRawRepresentable(ConstraintSystem &cs, Type type);
+/// Check whether given type conforms to a specific known kind
+/// `RawPepresentable` protocol and return witness type.
+Type isRawRepresentable(ConstraintSystem &cs, Type type,
+                        KnownProtocolKind rawRepresentableProtocol);
+
 class DisjunctionChoice {
   unsigned Index;
   Constraint *Choice;

--- a/test/Compatibility/protocol_composition.swift
+++ b/test/Compatibility/protocol_composition.swift
@@ -36,6 +36,7 @@ typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1
 func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class type 'P2.Type?' cannot be used within a protocol-constrained type}}
   let _: (P1 & P2).Type? = x // expected-error {{cannot convert value of type 'P1' to specified type '(P1 & P2).Type?'}}
   let _: (P1 & P2).Type = x! // expected-error {{cannot force unwrap value of non-optional type 'P1'}}
+  // expected-error@-1 {{cannot convert value of type 'P1' to specified type '(P1 & P2).Type'}}
   let _: Int = x!.p1() // expected-error {{cannot force unwrap value of non-optional type 'P1'}} expected-error {{static member 'p1' cannot be used on instance of type 'P1'}}
   let _: Int? = x?.p2 // expected-error {{cannot use optional chaining on non-optional value of type 'P1'}}
                       // expected-error@-1 {{value of type 'P1' has no member 'p2'}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -576,7 +576,7 @@ extension A_SR_5030 {
   func foo() -> B_SR_5030<Int> {
     let tt : B_SR_5030<Int> = sr5030_exFalso()
     return tt.map { x in (idx: x) }
-    // expected-error@-1 {{cannot convert value of type '(idx: Int)' to closure result type 'Int'}}
+    // expected-error@-1 {{cannot convert return expression of type 'B_SR_5030<(idx: Int)>' to return type 'B_SR_5030<Int>'}}
   }
 }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -576,7 +576,7 @@ extension A_SR_5030 {
   func foo() -> B_SR_5030<Int> {
     let tt : B_SR_5030<Int> = sr5030_exFalso()
     return tt.map { x in (idx: x) }
-    // expected-error@-1 {{cannot convert return expression of type 'B_SR_5030<(idx: Int)>' to return type 'B_SR_5030<Int>'}}
+    // expected-error@-1 {{cannot convert value of type '(idx: Int)' to closure result type 'Int'}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -772,8 +772,8 @@ secondArgumentNotLabeled(10, 20)
 func testImplConversion(a : Float?) -> Bool {}
 func testImplConversion(a : Int?) -> Bool {
   let someInt = 42
-  let a : Int = testImplConversion(someInt) // expected-error {{argument labels '(_:)' do not match any available overloads}}
-  // expected-note @-1 {{overloads for 'testImplConversion' exist with these partially matching parameter lists: (a: Float?), (a: Int?)}}
+  let a : Int = testImplConversion(someInt) // expected-error {{missing argument label 'a:' in call}} {{36-36=a: }}
+  // expected-error@-2 {{cannot convert value of type 'Bool' to specified type 'Int'}}
 }
 
 // <rdar://problem/23752537> QoI: Bogus error message: Binary operator '&&' cannot be applied to two 'Bool' operands
@@ -801,7 +801,7 @@ func read2(_ p: UnsafeMutableRawPointer, maxLength: Int) {}
 func read<T : BinaryInteger>() -> T? {
   var buffer : T 
   let n = withUnsafeMutablePointer(to: &buffer) { (p) in
-    read2(UnsafePointer(p), maxLength: MemoryLayout<T>.size) // expected-error {{cannot convert value of type 'UnsafePointer<_>' to expected argument type 'UnsafeMutableRawPointer'}}
+    read2(UnsafePointer(p), maxLength: MemoryLayout<T>.size) // expected-error {{cannot convert value of type 'UnsafePointer<Pointee>' to expected argument type 'UnsafeMutableRawPointer'}}
   }
 }
 
@@ -1236,7 +1236,7 @@ let baz4: ((Swift.Error)) = (Error()) //expected-error {{value of type 'diagnost
 
 // SyntaxSugarTypes with unresolved types
 func takesGenericArray<T>(_ x: [T]) {}
-takesGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<_>'}}
+takesGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Element>'}}
 func takesNestedGenericArray<T>(_ x: [[T]]) {}
 takesNestedGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Array<_>>'}}
 func takesSetOfGenericArrays<T>(_ x: Set<[T]>) {}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -773,7 +773,7 @@ func testImplConversion(a : Float?) -> Bool {}
 func testImplConversion(a : Int?) -> Bool {
   let someInt = 42
   let a : Int = testImplConversion(someInt) // expected-error {{missing argument label 'a:' in call}} {{36-36=a: }}
-  // expected-error@-2 {{cannot convert value of type 'Bool' to specified type 'Int'}}
+  // expected-error@-1 {{cannot convert value of type 'Bool' to specified type 'Int'}}
 }
 
 // <rdar://problem/23752537> QoI: Bogus error message: Binary operator '&&' cannot be applied to two 'Bool' operands
@@ -1225,7 +1225,7 @@ func rdar43525641(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}
 rdar43525641(1, c: 2, 3) // Ok
 
 struct Array {}
-let foo: Swift.Array = Array() // expected-error {{cannot convert value of type 'diagnostics.Array' to specified type 'Swift.Array'}}
+let foo: Swift.Array = Array() // expected-error {{cannot convert value of type 'Array' to specified type 'Array<Any>'}}
 
 struct Error {}
 let bar: Swift.Error = Error() //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
@@ -1235,21 +1235,23 @@ let baz3: (Swift.Error) = (Error()) //expected-error {{value of type 'diagnostic
 let baz4: ((Swift.Error)) = (Error()) //expected-error {{value of type 'diagnostics.Error' does not conform to specified type 'Swift.Error'}}
 
 // SyntaxSugarTypes with unresolved types
+// TODO(diagnostics): It should be easy to improve messages here e.g. infer type of `Element` with a fix which would
+// add as many brackets as required by parameter type. It's a bit harder for dictionaries but should be doable.
 func takesGenericArray<T>(_ x: [T]) {}
 takesGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Element>'}}
 func takesNestedGenericArray<T>(_ x: [[T]]) {}
-takesNestedGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Array<_>>'}}
+takesNestedGenericArray(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Element>'}}
 func takesSetOfGenericArrays<T>(_ x: Set<[T]>) {}
-takesSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Set<Array<_>>'}}
+takesSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Set<Element>'}}
 func takesArrayOfSetOfGenericArrays<T>(_ x: [Set<[T]>]) {}
-takesArrayOfSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Set<Array<_>>>'}}
+takesArrayOfSetOfGenericArrays(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Element>'}}
 func takesArrayOfGenericOptionals<T>(_ x: [T?]) {}
-takesArrayOfGenericOptionals(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Optional<_>>'}}
+takesArrayOfGenericOptionals(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Array<Element>'}}
 func takesGenericDictionary<T, U>(_ x: [T : U]) {}
-takesGenericDictionary(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<_, _>'}}
+takesGenericDictionary(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<Key, Value>'}}
 typealias Z = Int
 func takesGenericDictionaryWithTypealias<T>(_ x: [T : Z]) {}
-takesGenericDictionaryWithTypealias(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<_, Z>'}}
+takesGenericDictionaryWithTypealias(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'Dictionary<Key, Value>'}}
 func takesGenericFunction<T>(_ x: ([T]) -> Void) {}
 takesGenericFunction(true) // expected-error {{cannot convert value of type 'Bool' to expected argument type '(Array<_>) -> Void'}}
 func takesTuple<T>(_ x: ([T], [T])) {}

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -63,7 +63,8 @@ var _: MyDictionary<String, Int>? = ["foo", 1]  // expected-error {{dictionary o
 var _: MyDictionary<String, Int>? = ["foo", 1, "bar", 42]  // expected-error {{dictionary of type 'MyDictionary<String, Int>' cannot be initialized with array literal}}
 // expected-note @-1 {{did you mean to use a dictionary literal instead?}} {{43-44=:}} {{53-54=:}}
 
-var _: MyDictionary<String, Int>? = ["foo", 1.0, 2]  // expected-error {{cannot convert value of type '[Any]' to specified type 'MyDictionary<String, Int>?'}}
+var _: MyDictionary<String, Int>? = ["foo", 1.0, 2]  // expected-error {{cannot convert value of type '[Double]' to specified type 'MyDictionary<String, Int>?'}}
+// expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Double'}}
 
 var _: MyDictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -146,14 +146,17 @@ struct Q {
 }
 let q = Q(s: nil)
 let a: Int? = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-note@-1{{chain the optional using '?'}}{{18-18=?}}
-// expected-note@-2{{force-unwrap using '!'}}{{18-18=!}}
+// expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int?'}}
+// expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
+// expected-note@-3{{force-unwrap using '!'}}{{18-18=!}}
 let b: Int = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-note@-1{{chain the optional using '?'}}{{17-17=?}}
-// expected-note@-2{{force-unwrap using '!'}}{{17-17=!}}
+// expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int'}}
+// expected-note@-2{{chain the optional using '?'}}{{17-17=?}}
+// expected-note@-3{{force-unwrap using '!'}}{{17-17=!}}
 let d: Int! = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-note@-1{{chain the optional using '?'}}{{18-18=?}}
-// expected-note@-2{{force-unwrap using '!'}}{{18-18=!}}
+// expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int?'}}
+// expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
+// expected-note@-3{{force-unwrap using '!'}}{{18-18=!}}
 let c = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
 // expected-note@-1{{chain the optional using '?' to access member 'utf8' only for non-'nil' base values}}{{12-12=?}}
 // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{12-12=!}}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -53,7 +53,7 @@ func process(_ line: UInt = #line) -> Int { return 0 }
 func dangerous() throws {}
 
 func test() {
-  process {         // expected-error {{invalid conversion from throwing function of type '() throws -> ()' to non-throwing function type '() -> Void'}}
+  process {         // expected-error {{invalid conversion from throwing function of type '() throws -> Void' to non-throwing function type '() -> Void'}}
     try dangerous()
     test()
   }

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -210,10 +210,8 @@ func conditionalDowncastToOptional(b: B?) -> D? {
 }
 
 func conditionalDowncastToObject(b: B?) -> D {
-  return b as? D! // expected-error {{value of optional type 'D?' must be unwrapped}}
-  // expected-note@-1{{coalesce}}
-  // expected-note@-2{{force-unwrap}}
-  // expected-warning@-3 {{using '!' here is deprecated and will be removed in a future release}}
+  return b as? D! // expected-error {{cannot convert return expression of type 'D??' to return type 'D'}}
+  // expected-warning@-1 {{using '!' here is deprecated and will be removed in a future release}}
 }
 
 // Ensure that we select the overload that does *not* involve forcing an IUO.

--- a/test/Constraints/rdar40002266.swift
+++ b/test/Constraints/rdar40002266.swift
@@ -5,7 +5,6 @@ import Foundation
 
 struct S {
   init<T: NSNumber>(_ num: T) {
-    self.init(num != 0) // expected-error {{binary operator '!=' cannot be applied to operands of type 'T' and 'Int'}}
-    // expected-note@-1 {{expected an argument list of type '(Self, Self)'}}
+    self.init(num != 0) // expected-error {{cannot convert value of type 'Bool' to expected argument type 'NSNumber'}}
   }
 }

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -60,7 +60,7 @@ func fail1<
 >(_ t: T, u: U) -> (X, Y)
   where T.Foo == X, U.Foo == Y, T.Foo == U.Foo { // expected-error{{'U.Foo' cannot be equal to both 'Y' and 'X'}}
   // expected-note@-1{{same-type constraint 'T.Foo' == 'X' written here}}
-  return (t.foo, u.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Y'}}
+  return (t.foo, u.foo) // expected-error{{cannot convert return expression of type '(X, X)' to return type '(X, Y)'}}
 }
 
 func fail2<
@@ -68,7 +68,7 @@ func fail2<
 >(_ t: T, u: U) -> (X, Y)
   where T.Foo == U.Foo, T.Foo == X, U.Foo == Y { // expected-error{{'U.Foo' cannot be equal to both 'Y' and 'X'}}
   // expected-note@-1{{same-type constraint 'T.Foo' == 'X' written here}}
-  return (t.foo, u.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Y'}}
+  return (t.foo, u.foo) // expected-error{{cannot convert return expression of type '(X, X)' to return type '(X, Y)'}}
 }
 
 func test4<T: Barrable>(_ t: T) -> Y where T.Bar == Y {
@@ -98,14 +98,14 @@ func fail4<T: Barrable>(_ t: T) -> (Y, Z)
   where
   T.Bar == Y, // expected-note{{same-type constraint 'T.Bar.Foo' == 'Y.Foo' (aka 'X') implied here}}
   T.Bar.Foo == Z { // expected-error{{'T.Bar.Foo' cannot be equal to both 'Z' and 'Y.Foo' (aka 'X')}}
-  return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
+  return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type '(Y, X)' to return type '(Y, Z)'}}
 }
 
 func fail5<T: Barrable>(_ t: T) -> (Y, Z)
   where
   T.Bar.Foo == Z, // expected-note{{same-type constraint 'T.Bar.Foo' == 'Z' written here}}
   T.Bar == Y { // expected-error{{'T.Bar.Foo' cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'}}
-  return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type 'X' to return type 'Z'}}
+  return (t.bar, t.bar.foo) // expected-error{{cannot convert return expression of type '(Y, X)' to return type '(Y, Z)'}}
 }
 
 func test8<T: Fooable>(_ t: T)

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -191,14 +191,14 @@ protocol Kingdom {
   associatedtype King
 }
 struct Victory<General> {
-  init<K: Kingdom>(_ king: K) where K.King == General {}
+  init<K: Kingdom>(_ king: K) where K.King == General {} // expected-note {{where 'General' = '(x: Int, y: Int)', 'K.King' = '(Int, Int)'}}
 }
 struct MagicKingdom<K> : Kingdom {
   typealias King = K
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{cannot convert return expression of type 'Victory<(Int, Int)>' to return type 'Victory<(x: Int, y: Int)>'}}
+  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
 }
 
 

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -191,14 +191,14 @@ protocol Kingdom {
   associatedtype King
 }
 struct Victory<General> {
-  init<K: Kingdom>(_ king: K) where K.King == General {} // expected-note {{where 'General' = '(x: Int, y: Int)', 'K.King' = '(Int, Int)'}}
+  init<K: Kingdom>(_ king: K) where K.King == General {}
 }
 struct MagicKingdom<K> : Kingdom {
   typealias King = K
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
+  return Victory(magify(pair)) // expected-error {{cannot convert return expression of type 'Victory<(Int, Int)>' to return type 'Victory<(x: Int, y: Int)>'}}
 }
 
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1411,7 +1411,7 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   }
 
   f2.forEach { (block: ((Bool, Bool)) -> ()) in
-  // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> ()' to expected argument type '(@escaping (Bool, Bool) -> ()) -> Void}}
+  // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> ()' to expected argument type '(@escaping (Bool, Bool) -> ()) throws -> Void'}}
     block(p)
     block((c, c))
     block(c, c)

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -65,7 +65,7 @@ func takeTuples<T, U>(_: (T, U), _: (U, T)) {
 func useTuples(_ x: Int, y: Float, z: (Float, Int)) {
   takeTuples((x, y), (y, x))
 
-  takeTuples((x, y), (x, y)) // expected-error{{cannot convert value of type 'Int' to expected argument type 'Float'}}
+  takeTuples((x, y), (x, y)) // expected-error{{cannot convert value of type '(Int, Float)' to expected argument type '(Float, Int)'}}
 
   // FIXME: Use 'z', which requires us to fix our tuple-conversion
   // representation.
@@ -267,7 +267,7 @@ func testGetVectorSize(_ vi: MyVector<Int>, vf: MyVector<Float>) {
   i = getVectorSize(vi)
   i = getVectorSize(vf)
 
-  getVectorSize(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'MyVector<_>'}}
+  getVectorSize(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'MyVector<T>'}}
 
   var x : X, y : Y
   x = ovlVector(vi)

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -94,7 +94,7 @@ func test(_ x: Int) {
 // CHECK: func <Func>bar</Func>(<Param>x</Param>: <iStruct@>Int</iStruct>) -> (<iStruct@>Int</iStruct>, <iStruct@>Float</iStruct>) {
 func bar(x: Int) -> (Int, Float) {
   // CHECK: <Ctor@[[@LINE-84]]:8-TypeAlias@[[@LINE-78]]:11>TypealiasForS</Ctor>()
-  TypealiasForS()
+  _ = TypealiasForS()
 }
 
 class C2 {

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -61,7 +61,7 @@ func retV() { return true } // expected-error {{unexpected non-void return value
 func retAI() -> Int {
     let a = [""]
     let b = [""]
-    return (a + b) // expected-error{{cannot convert return expression of type '[String]' to return type 'Int'}}
+    return (a + b) // expected-error{{cannot convert return expression of type 'Array<String>' to return type 'Int'}}
 }
 
 func bad_return1() {

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -93,6 +93,7 @@ class sr7440_Genre {
   static func fetch(_ iTunesGenre: sr7440_ITunesGenre) -> sr7440_Genre {
     return sr7440_Genre.fetch(genreID: iTunesGenre.genreID, name: iTunesGenre.name)
 // expected-error@-1 {{value of type 'sr7440_ITunesGenre' has no member 'genreID'; did you mean 'genre'?}}
+// expected-error@-2 {{cannot convert return expression of type '()' to return type 'sr7440_Genre'}}
   }
 }
 

--- a/test/TypeCoercion/overload_member.swift
+++ b/test/TypeCoercion/overload_member.swift
@@ -188,6 +188,7 @@ struct WeirdIvarLookupBehavior {
   static func static_f() {
     // FIXME: These diagnostics still suck.
     var a : X = clams // expected-error{{member 'clams' cannot be used on type 'WeirdIvarLookupBehavior'}}
+    // expected-error@-1 {{cannot convert value of type 'Y' to specified type 'X'}}
     var b : Y = clams // expected-error{{member 'clams' cannot be used on type 'WeirdIvarLookupBehavior'}}
   }
 }

--- a/test/TypeCoercion/overload_noncall.swift
+++ b/test/TypeCoercion/overload_noncall.swift
@@ -4,9 +4,9 @@ struct X { }
 struct Y { }
 struct Z { }
 
-func f0(_ x1: X, x2: X) -> X {} // expected-note{{found this candidate}}
-func f0(_ y1: Y, y2: Y) -> Y {} // expected-note{{found this candidate}}
-var f0 : X // expected-note {{found this candidate}} expected-note {{'f0' previously declared here}}
+func f0(_ x1: X, x2: X) -> X {}
+func f0(_ y1: Y, y2: Y) -> Y {}
+var f0 : X // expected-note {{'f0' previously declared here}}
 func f0_init(_ x: X, y: Y) -> X {}
 var f0 : (_ x : X, _ y : Y) -> X = f0_init // expected-error{{invalid redeclaration}}
 func f1(_ x: X) -> X {}
@@ -16,7 +16,7 @@ func f2(_ g: (_ x: X) -> X) -> ((_ y: Y) -> Y) { }
 func test_conv() {
   var _ : (_ x1 : X, _ x2 : X) -> X = f0
   var _ : (X, X) -> X = f0
-  var _ : (Y, X) -> X = f0 // expected-error{{ambiguous reference to member 'f0(_:x2:)'}}
+  var _ : (Y, X) -> X = f0 // expected-error{{cannot convert value of type 'X' to specified type '(Y, X) -> X'}}
   var _ : (X) -> X = f1
   var a7 : (X) -> (X) = f1
   var a8 : (_ x2 : X) -> (X) = f1

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -51,7 +51,7 @@ func partialApply2<T: Parallelogram>(_ t: T) {
 func barG<T>(_ t : T) throws -> T { return t }
 func fooG<T>(_ t : T) -> T { return t }
 
-var bGE: (_ i: Int) -> Int = barG // expected-error{{invalid conversion from throwing function of type '(_) throws -> _' to non-throwing function type '(Int) -> Int'}}
+var bGE: (_ i: Int) -> Int = barG // expected-error{{invalid conversion from throwing function of type '(Int) throws -> Int' to non-throwing function type '(Int) -> Int'}}
 var bg: (_ i: Int) throws -> Int = barG
 var fG: (_ i: Int) throws -> Int = fooG
 
@@ -69,15 +69,15 @@ func fooT(_ callback: () throws -> Bool) {} //OK
 func fooT(_ callback: () -> Bool) {}
 
 // Throwing and non-throwing types are not equivalent.
-struct X<T> { } // expected-note {{arguments to generic parameter 'T' ('(String) -> Int' and '(String) throws -> Int') are expected to be equal}}
-// expected-note@-1 {{arguments to generic parameter 'T' ('(String) throws -> Int' and '(String) -> Int') are expected to be equal}}
+struct X<T> { }
+
 func specializedOnFuncType1(_ x: X<(String) throws -> Int>) { }
 func specializedOnFuncType2(_ x: X<(String) -> Int>) { }
 func testSpecializedOnFuncType(_ xThrows: X<(String) throws -> Int>,
                                xNonThrows: X<(String) -> Int>) {
   specializedOnFuncType1(xThrows) // ok
-  specializedOnFuncType1(xNonThrows) // expected-error{{cannot convert value of type 'X<(String) -> Int>' to expected argument type 'X<(String) throws -> Int>'}}
-  specializedOnFuncType2(xThrows)  // expected-error{{cannot convert value of type 'X<(String) throws -> Int>' to expected argument type 'X<(String) -> Int>'}}
+  specializedOnFuncType1(xNonThrows) // expected-error{{invalid conversion from throwing function of type '(String) -> Int' to non-throwing function type '(String) throws -> Int'}}
+  specializedOnFuncType2(xThrows)  // expected-error{{invalid conversion from throwing function of type '(String) throws -> Int' to non-throwing function type '(String) -> Int'}}
   specializedOnFuncType2(xNonThrows) // ok
 }
 
@@ -85,7 +85,7 @@ func testSpecializedOnFuncType(_ xThrows: X<(String) throws -> Int>,
 func subtypeResult1(_ x: (String) -> ((Int) -> String)) { }
 func testSubtypeResult1(_ x1: (String) -> ((Int) throws -> String),
                         x2: (String) -> ((Int) -> String)) {
-  subtypeResult1(x1) // expected-error{{cannot convert value of type '(String) -> ((Int) throws -> String)' to expected argument type '(String) -> ((Int) -> String)'}}
+  subtypeResult1(x1) // expected-error{{invalid conversion from throwing function of type '(Int) throws -> String' to non-throwing function type '(Int) -> String'}}
   subtypeResult1(x2)
 }
 
@@ -106,7 +106,7 @@ func testSubtypeArgument1(_ x1: (_ fn: ((String) -> Int)) -> Int,
 func subtypeArgument2(_ x: (_ fn: ((String) throws -> Int)) -> Int) { }
 func testSubtypeArgument2(_ x1: (_ fn: ((String) -> Int)) -> Int,
                           x2: (_ fn: ((String) throws -> Int)) -> Int) {
-  subtypeArgument2(x1) // expected-error{{cannot convert value of type '(((String) -> Int)) -> Int' to expected argument type '(((String) throws -> Int)) -> Int'}}
+  subtypeArgument2(x1) // expected-error{{invalid conversion from throwing function of type '(String) throws -> Int' to non-throwing function type '(String) -> Int'}}
   subtypeArgument2(x2)
 }
 
@@ -117,10 +117,10 @@ var c3 : () -> Int = c1 // expected-error{{invalid conversion from throwing func
 var c4 : () -> Int = {() throws -> Int in 0} // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c5 : () -> Int = { try c2() } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c6 : () throws -> Int = { do { _ = try c2() } ; return 0 }
-var c7 : () -> Int = { do { try c2() } ; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
+var c7 : () -> Int = { do { try c2() } ; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c8 : () -> Int = { do { _ = try c2()  } catch _ { var x = 0 } ; return 0 } // expected-warning {{initialization of variable 'x' was never used; consider replacing with assignment to '_' or removing it}}
-var c9 : () -> Int = { do { try c2()  } catch Exception.A { var x = 0 } ; return 0 }// expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
-var c10 : () -> Int = { throw Exception.A; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> _' to non-throwing function type '() -> Int'}}
+var c9 : () -> Int = { do { try c2()  } catch Exception.A { var x = 0 } ; return 0 }// expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
+var c10 : () -> Int = { throw Exception.A; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c11 : () -> Int = { try! c2() }
 var c12 : () -> Int? = { try? c2() }
 

--- a/test/decl/init/throwing.swift
+++ b/test/decl/init/throwing.swift
@@ -16,7 +16,7 @@ class A22108568 {
 
 class B22108568 : A22108568 {
   required init() {
-    try super.init(a: unwrap()) // expected-error {{argument passed to call that takes no arguments}}
+    try super.init(a: unwrap()) // expected-error {{cannot convert value of type 'Int' to expected argument type '()'}}
   }
 }
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -48,7 +48,7 @@ public struct S<A: P> where A.T == S<A> {
 // expected-error@-2 {{generic struct 'S' references itself}}
   func f(a: A.T) {
     g(a: id(t: a))
-    // expected-error@-1 {{cannot convert value of type 'A.T' to expected argument type 'S<_>'}}
+    // expected-error@-1 {{cannot convert value of type 'A.T' to expected argument type 'S<A>'}}
     _ = A.T.self
   }
 

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -35,7 +35,7 @@ func variadic() {
   // expected-error@-1 {{cannot convert value of type '([Int]) -> ()' to specified type '(Int...) -> ()'}}
 
   takesVariadicGeneric({takesIntArray($0)})
-  // expected-error@-1 {{cannot convert value of type 'Array<_>' to expected argument type '[Int]'}}
+  // expected-error@-1 {{cannot convert value of type 'Array<Element>' to expected argument type '[Int]'}}
 
   takesVariadicGeneric({let _: [Int] = $0})
   // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(_...) -> ()'}}

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -145,7 +145,7 @@ func eleven_two() {
 enum Twelve { case Payload(Int) }
 func twelve_helper(_ fn: (Int, Int) -> ()) {}
 func twelve() {
-  twelve_helper { (a, b) in // expected-error {{invalid conversion from throwing function of type '(_, _) throws -> ()' to non-throwing function type '(Int, Int) -> ()'}}
+  twelve_helper { (a, b) in // expected-error {{invalid conversion from throwing function of type '(Int, Int) throws -> ()' to non-throwing function type '(Int, Int) -> ()'}}
     do {
       try thrower()
     } catch Twelve.Payload(a...b) {
@@ -158,7 +158,7 @@ func ==(a: Thirteen, b: Thirteen) -> Bool { return true }
 
 func thirteen_helper(_ fn: (Thirteen) -> ()) {}
 func thirteen() {
-  thirteen_helper { (a) in // expected-error {{invalid conversion from throwing function of type '(_) throws -> ()' to non-throwing function type '(Thirteen) -> ()'}}
+  thirteen_helper { (a) in // expected-error {{invalid conversion from throwing function of type '(Thirteen) throws -> ()' to non-throwing function type '(Thirteen) -> ()'}}
     do {
       try thrower()
     } catch a {

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -105,7 +105,8 @@ func basicSubtyping(
   let _: Derived = baseAndP2 // expected-error {{cannot convert value of type 'Base<Int> & P2' to specified type 'Derived'}}
   let _: Derived & P2 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'Derived & P2'}}
 
-  let _ = Unrelated() as Derived & P2 // expected-error {{value of type 'Unrelated' does not conform to 'Derived & P2' in coercion}}
+  // TODO(diagnostics): Diagnostic regression, better message is `value of type 'Unrelated' does not conform to 'Derived & P2' in coercion`
+  let _ = Unrelated() as Derived & P2 // expected-error {{cannot convert value of type 'Unrelated' to type 'Derived' in coercion}}
   let _ = Unrelated() as? Derived & P2 // expected-warning {{always fails}}
   let _ = baseAndP2 as Unrelated // expected-error {{cannot convert value of type 'Base<Int> & P2' to type 'Unrelated' in coercion}}
   let _ = baseAndP2 as? Unrelated // expected-warning {{always fails}}
@@ -301,8 +302,8 @@ func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
 func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
-// expected-note@-1 2 {{where 'T' = 'Base<String>'}}
-// expected-note@-2   {{where 'T' = 'Base<Int>'}}
+// expected-note@-1 {{where 'T' = 'Base<String>'}}
+// expected-note@-2 2 {{where 'T' = 'Base<Int>'}}
 
 func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
 // expected-note@-1 {{where 'T' = 'Base<String>'}}
@@ -420,9 +421,10 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   conformsToBaseIntAndP2(base)
   // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
+  // TODO(diagnostics): Diagnostic for this problem should mention both `Base<String>` not conforming to `P2`
+  // and invalid generic parameter (Int vs. String)
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}
-  // expected-error@-2 {{argument type 'Base<String>' does not conform to expected type 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2(fakeDerived)
   // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}


### PR DESCRIPTION
Ignore contextual type mismatch to allow solver to make progress
towards solution and diagnose the problem later.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
