### PR TITLE
Lazy accessor synthesis for storage in secondary files

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4592,6 +4592,23 @@ public:
   /// with caution.
   AccessorDecl *getSynthesizedAccessor(AccessorKind kind) const;
 
+  /// Return an accessor part of the set of opaque accessors dictated by the
+  /// requirements of the ABI.
+  ///
+  /// This will synthesize the accessor if one is required but not specified
+  /// in source; for example, most of the time a mutable property is required
+  /// to have a 'modify' accessor, but if the property was only written with
+  /// 'get' and 'set' accessors, 'modify' will be synthesized to call 'get'
+  /// followed by 'set'.
+  ///
+  /// If the accessor is not needed for ABI reasons, this returns nullptr.
+  /// To ensure an accessor is always returned, use getSynthesizedAccessor().
+  AccessorDecl *getOpaqueAccessor(AccessorKind kind) const;
+
+  /// Return an accessor that was written in source. Returns null if the
+  /// accessor was not explicitly defined by the user.
+  AccessorDecl *getParsedAccessor(AccessorKind kind) const;
+
   /// Visit all the opaque accessors that this storage is expected to have.
   void visitExpectedOpaqueAccessors(
                             llvm::function_ref<void (AccessorKind)>) const;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1804,7 +1804,7 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
   if ((PrintAbstract || isGetSetImpl()) &&
       !Options.PrintGetSetOnRWProperties &&
       !Options.FunctionDefinitions &&
-      !ASD->getAccessor(AccessorKind::Get)->isMutating() &&
+      !ASD->isGetterMutating() &&
       !ASD->getAccessor(AccessorKind::Set)->isExplicitNonMutating()) {
     return;
   }

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -161,8 +161,7 @@ static bool isStoredWithPrivateSetter(VarDecl *VD) {
     return false;
 
   if (VD->isLet() ||
-      (VD->getAccessor(AccessorKind::Set) &&
-       !VD->getAccessor(AccessorKind::Set)->isImplicit()))
+      VD->getParsedAccessor(AccessorKind::Set))
     return false;
 
   return true;

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -114,7 +114,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
       return {BaseName, ObjCSelector()};
     return {VAD->getObjCPropertyName(), ObjCSelector()};
   } else if (auto *SD = dyn_cast<SubscriptDecl>(VD)) {
-    return getObjCNameForSwiftDecl(SD->getAccessor(AccessorKind::Get),
+    return getObjCNameForSwiftDecl(SD->getParsedAccessor(AccessorKind::Get),
                                    PreferredName);
   } else if (auto *EL = dyn_cast<EnumElementDecl>(VD)) {
     SmallString<64> Buffer;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2556,7 +2556,7 @@ bool ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
       return true;
     }
   } else if (auto *asd = dyn_cast<AbstractStorageDecl>(namingDecl)) {
-    auto *getter = asd->getAccessor(AccessorKind::Get);
+    auto *getter = asd->getOpaqueAccessor(AccessorKind::Get);
     if (getter &&
         getter->getResilienceExpansion() == ResilienceExpansion::Minimal) {
       return true;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3628,13 +3628,13 @@ namespace {
       case ImportedAccessorKind::PropertyGetter: {
         auto property = getImplicitProperty(importedName, decl);
         if (!property) return nullptr;
-        return property->getAccessor(AccessorKind::Get);
+        return property->getParsedAccessor(AccessorKind::Get);
       }
 
       case ImportedAccessorKind::PropertySetter:
         auto property = getImplicitProperty(importedName, decl);
         if (!property) return nullptr;
-        return property->getAccessor(AccessorKind::Set);
+        return property->getParsedAccessor(AccessorKind::Set);
       }
 
       return importFunctionDecl(decl, importedName, correctSwiftName, None);
@@ -5010,8 +5010,8 @@ namespace {
       // Only record overrides of class members.
       if (overridden) {
         result->setOverriddenDecl(overridden);
-        getter->setOverriddenDecl(overridden->getAccessor(AccessorKind::Get));
-        if (auto parentSetter = overridden->getAccessor(AccessorKind::Set))
+        getter->setOverriddenDecl(overridden->getParsedAccessor(AccessorKind::Get));
+        if (auto parentSetter = overridden->getParsedAccessor(AccessorKind::Set))
           if (setter)
             setter->setOverriddenDecl(parentSetter);
       }
@@ -6516,10 +6516,10 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
 
     // The index types match. This is an override, so mark it as such.
     subscript->setOverriddenDecl(parentSub);
-    auto getterThunk = subscript->getAccessor(AccessorKind::Get);
-    getterThunk->setOverriddenDecl(parentSub->getAccessor(AccessorKind::Get));
-    if (auto parentSetter = parentSub->getAccessor(AccessorKind::Set)) {
-      if (auto setterThunk = subscript->getAccessor(AccessorKind::Set))
+    auto getterThunk = subscript->getParsedAccessor(AccessorKind::Get);
+    getterThunk->setOverriddenDecl(parentSub->getParsedAccessor(AccessorKind::Get));
+    if (auto parentSetter = parentSub->getParsedAccessor(AccessorKind::Set)) {
+      if (auto setterThunk = subscript->getParsedAccessor(AccessorKind::Set))
         setterThunk->setOverriddenDecl(parentSetter);
     }
 
@@ -8397,10 +8397,8 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   func->computeType();
   func->setAccess(getOverridableAccessLevel(dc));
   func->setValidationToChecked();
-  func->setImplicit();
   func->setIsObjC(false);
   func->setIsDynamic(false);
-  func->setIsTransparent(false);
 
   func->setBodySynthesizer(synthesizeConstantGetterBody,
                            ConstantGetterBodyContextData(valueExpr, convertKind)

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -268,9 +268,8 @@ public:
         //   return 0; <- No indentation added because of the getter.
         // }
         if (auto VD = dyn_cast_or_null<VarDecl>(Cursor->getAsDecl())) {
-          if (auto Getter = VD->getAccessor(AccessorKind::Get)) {
-            if (!Getter->isImplicit() &&
-                Getter->getAccessorKeywordLoc().isInvalid()) {
+          if (auto Getter = VD->getParsedAccessor(AccessorKind::Get)) {
+            if (Getter->getAccessorKeywordLoc().isInvalid()) {
               LineAndColumn = ParentLineAndColumn;
               continue;
             }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1793,7 +1793,7 @@ namespace {
         }
 
         // Don't emit descriptors for properties without accessors.
-        auto getter = var->getAccessor(AccessorKind::Get);
+        auto getter = var->getOpaqueAccessor(AccessorKind::Get);
         if (!getter)
           return;
 
@@ -1804,7 +1804,7 @@ namespace {
         auto &methods = getMethodList(var);
         methods.push_back(getter);
 
-        if (auto setter = var->getAccessor(AccessorKind::Set))
+        if (auto setter = var->getOpaqueAccessor(AccessorKind::Set))
           methods.push_back(setter);
       }
     }
@@ -2030,13 +2030,13 @@ namespace {
     void visitSubscriptDecl(SubscriptDecl *subscript) {
       if (!requiresObjCSubscriptDescriptor(IGM, subscript)) return;
 
-      auto getter = subscript->getAccessor(AccessorKind::Get);
+      auto getter = subscript->getOpaqueAccessor(AccessorKind::Get);
       if (!getter) return;
 
       auto &methods = getMethodList(subscript);
       methods.push_back(getter);
 
-      if (auto setter = subscript->getAccessor(AccessorKind::Set))
+      if (auto setter = subscript->getOpaqueAccessor(AccessorKind::Set))
         methods.push_back(setter);
     }
   };

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -567,7 +567,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     // property itself (for instance, with a private/internal property whose
     // accessor is @inlinable or @usableFromInline)
     auto getterDecl = cast<AbstractStorageDecl>(getDecl())
-      ->getAccessor(AccessorKind::Get);
+      ->getOpaqueAccessor(AccessorKind::Get);
     return getSILLinkage(getDeclLinkage(getterDecl), forDefinition);
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1062,14 +1062,10 @@ bool IndexSwiftASTWalker::report(ValueDecl *D) {
   if (startEntityDecl(D)) {
     // Pass accessors.
     if (auto StoreD = dyn_cast<AbstractStorageDecl>(D)) {
-      auto isNullOrImplicit = [](const Decl *D) -> bool {
-        return !D || D->isImplicit();
-      };
-
       bool usedPseudoAccessors = false;
       if (isa<VarDecl>(D) &&
-          isNullOrImplicit(StoreD->getAccessor(AccessorKind::Get)) &&
-          isNullOrImplicit(StoreD->getAccessor(AccessorKind::Set))) {
+          !StoreD->getParsedAccessor(AccessorKind::Get) &&
+          !StoreD->getParsedAccessor(AccessorKind::Set)) {
         usedPseudoAccessors = true;
         auto VarD = cast<VarDecl>(D);
         // No actual getter or setter, pass 'pseudo' accessors.

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1447,7 +1447,7 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
         size_t destI = 0;
         for (size_t srcI = 0, e = values.size(); srcI != e; ++srcI) {
           if (auto storage = dyn_cast<AbstractStorageDecl>(values[srcI]))
-            if (auto accessor = storage->getAccessor(*accessorKind))
+            if (auto accessor = storage->getOpaqueAccessor(*accessorKind))
               values[destI++] = accessor;
         }
         values.resize(destI);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1256,23 +1256,25 @@ private:
 
     printAvailability(VD);
 
+    auto *getter = VD->getOpaqueAccessor(AccessorKind::Get);
+    auto *setter = VD->getOpaqueAccessor(AccessorKind::Set);
+
     os << ";";
     if (VD->isStatic()) {
       os << ")\n";
       // Older Clangs don't support class properties, so print the accessors as
       // well. This is harmless.
-      printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Get), true);
+      printAbstractFunctionAsMethod(getter, true);
       if (isSettable) {
-        auto *setter = VD->getAccessor(AccessorKind::Set);
         assert(setter && "settable ObjC property missing setter decl");
         printAbstractFunctionAsMethod(setter, true);
       }
     } else {
       os << "\n";
       if (looksLikeInitMethod(VD->getObjCGetterSelector()))
-        printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Get), false);
+        printAbstractFunctionAsMethod(getter, false);
       if (isSettable && looksLikeInitMethod(VD->getObjCSetterSelector()))
-        printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Set), false);
+        printAbstractFunctionAsMethod(setter, false);
     }
   }
 
@@ -1287,9 +1289,10 @@ private:
       isNSUIntegerSubscript = isNSUInteger(indexParam->getType());
     }
 
-    printAbstractFunctionAsMethod(SD->getAccessor(AccessorKind::Get), false,
+    auto *getter = SD->getOpaqueAccessor(AccessorKind::Get);
+    printAbstractFunctionAsMethod(getter, false,
                                   isNSUIntegerSubscript);
-    if (auto setter = SD->getAccessor(AccessorKind::Set))
+    if (auto *setter = SD->getOpaqueAccessor(AccessorKind::Set))
       printAbstractFunctionAsMethod(setter, false, isNSUIntegerSubscript);
   }
 

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -213,9 +213,10 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
   if (isa<ProtocolDecl>(getDeclContext()))
     return false;
   
-  // Any property that's potentially resilient should have accessors
-  // synthesized.
-  if (!getAccessor(AccessorKind::Get))
+  // FIXME: We should support properties and subscripts with '_read' accessors;
+  // 'get' is not part of the opaque accessor set there.
+  auto *getter = getOpaqueAccessor(AccessorKind::Get);
+  if (!getter)
     return false;
 
   // If the getter is mutating, we cannot form a keypath to it at all.
@@ -231,8 +232,7 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
   // then we still do.
 
   // Check the linkage of the declaration.
-  auto getter = SILDeclRef(getAccessor(AccessorKind::Get));
-  auto getterLinkage = getter.getLinkage(ForDefinition);
+  auto getterLinkage = SILDeclRef(getter).getLinkage(ForDefinition);
   
   switch (getterLinkage) {
   case SILLinkage::Public:

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2184,7 +2184,8 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
       // of its accessors.
       if (auto capturedVar = dyn_cast<VarDecl>(capture.getDecl())) {
         auto collectAccessorCaptures = [&](AccessorKind kind) {
-          collectFunctionCaptures(capturedVar->getAccessor(kind));
+          if (auto *accessor = capturedVar->getParsedAccessor(kind))
+            collectFunctionCaptures(accessor);
         };
 
         if (!capture.isDirect()) {
@@ -2212,6 +2213,9 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
           case WriteImplKind::Stored:
             break;
           case WriteImplKind::StoredWithObservers:
+            collectAccessorCaptures(AccessorKind::WillSet);
+            collectAccessorCaptures(AccessorKind::DidSet);
+            break;
           case WriteImplKind::Set:
             collectAccessorCaptures(AccessorKind::Set);
             break;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5811,7 +5811,7 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
   // Create the branch.
   FuncDecl *memberFunc;
   if (auto *VD = dyn_cast<VarDecl>(e->getMember().getDecl())) {
-    memberFunc = VD->getAccessor(AccessorKind::Get);
+    memberFunc = VD->getOpaqueAccessor(AccessorKind::Get);
     memberMethodTy = FunctionType::get({}, memberMethodTy);
   } else
     memberFunc = cast<FuncDecl>(e->getMember().getDecl());
@@ -5920,7 +5920,7 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
 
   // Create the branch.
   auto subscriptDecl = cast<SubscriptDecl>(e->getMember().getDecl());
-  auto member = SILDeclRef(subscriptDecl->getAccessor(AccessorKind::Get),
+  auto member = SILDeclRef(subscriptDecl->getOpaqueAccessor(AccessorKind::Get),
                            SILDeclRef::Kind::Func)
     .asForeign();
   B.createDynamicMethodBranch(e, base, member, hasMemberBB, noMemberBB);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2604,9 +2604,9 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
 static AccessorDecl *
 getRepresentativeAccessorForKeyPath(AbstractStorageDecl *storage) {
   if (storage->requiresOpaqueGetter())
-    return storage->getAccessor(AccessorKind::Get);
+    return storage->getOpaqueAccessor(AccessorKind::Get);
   assert(storage->requiresOpaqueReadCoroutine());
-  return storage->getAccessor(AccessorKind::Read);
+  return storage->getOpaqueAccessor(AccessorKind::Read);
 }
 
 static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
@@ -2755,7 +2755,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   // back to the declaration whose setter introduced the witness table
   // entry.
   if (isa<ProtocolDecl>(property->getDeclContext())) {
-    auto setter = property->getAccessor(AccessorKind::Set);
+    auto setter = property->getOpaqueAccessor(AccessorKind::Set);
     if (!SILDeclRef::requiresNewWitnessTableEntry(setter)) {
       // Find the setter that does have a witness table entry.
       auto wtableSetter =

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1307,11 +1307,10 @@ namespace {
           // If we have a nonmutating setter on a value type, the call
           // captures all of 'self' and we cannot rewrite an assignment
           // into an initialization.
-          auto setter = VD->getAccessor(AccessorKind::Set);
-          if (setter->isNonMutating() &&
-              setter->getDeclContext()->getSelfNominalTypeDecl() &&
-              setter->isInstanceMember() &&
-              !setter->getDeclContext()->getDeclaredInterfaceType()
+          if (!VD->isSetterMutating() &&
+              VD->getDeclContext()->getSelfNominalTypeDecl() &&
+              VD->isInstanceMember() &&
+              !VD->getDeclContext()->getDeclaredInterfaceType()
                   ->hasReferenceSemantics()) {
             return false;
           }
@@ -2485,7 +2484,7 @@ namespace {
 
     void emitUsingAccessor(AccessorKind accessorKind, bool isDirect) {
       auto accessor =
-        SGF.SGM.getAccessorDeclRef(Storage->getAccessor(accessorKind));
+        SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
       case AccessorKind::Get:
@@ -2915,7 +2914,7 @@ static SGFAccessKind getBaseAccessKind(SILGenModule &SGM,
 
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor: {
-    auto accessor = member->getAccessor(strategy.getAccessor());
+    auto accessor = member->getOpaqueAccessor(strategy.getAccessor());
     return getBaseAccessKindForAccessor(SGM, accessor, baseFormalType);
   }
     
@@ -2968,10 +2967,10 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   // dynamic replacement directly call the implementation.
   if (isContextRead && isOnSelfParameter && strategy.hasAccessor() &&
       strategy.getAccessor() == AccessorKind::Get &&
-      var->getAccessor(AccessorKind::Read)) {
+      var->getOpaqueAccessor(AccessorKind::Read)) {
     bool isObjC = false;
     auto readAccessor =
-        SGF.SGM.getAccessorDeclRef(var->getAccessor(AccessorKind::Read));
+        SGF.SGM.getAccessorDeclRef(var->getOpaqueAccessor(AccessorKind::Read));
     if (isCallToReplacedInDynamicReplacement(
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;
@@ -3139,10 +3138,10 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   // dynamic replacement directly call the implementation.
   if (isContextRead && isOnSelfParameter && strategy.hasAccessor() &&
       strategy.getAccessor() == AccessorKind::Get &&
-      decl->getAccessor(AccessorKind::Read)) {
+      decl->getOpaqueAccessor(AccessorKind::Read)) {
     bool isObjC = false;
     auto readAccessor =
-        SGF.SGM.getAccessorDeclRef(decl->getAccessor(AccessorKind::Read));
+        SGF.SGM.getAccessorDeclRef(decl->getOpaqueAccessor(AccessorKind::Read));
     if (isCallToReplacedInDynamicReplacement(
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -358,10 +358,11 @@ public:
       return asDerived().addMissingMethod(requirementRef);
 
     auto witnessStorage = cast<AbstractStorageDecl>(witness.getDecl());
-    auto witnessAccessor =
-      witnessStorage->getAccessor(reqAccessor->getAccessorKind());
-    if (!witnessAccessor)
+    if (reqAccessor->isSetter() && !witnessStorage->supportsMutation())
       return asDerived().addMissingMethod(requirementRef);
+
+    auto witnessAccessor =
+      witnessStorage->getSynthesizedAccessor(reqAccessor->getAccessorKind());
 
     return addMethodImplementation(requirementRef,
                                    SILDeclRef(witnessAccessor,
@@ -1120,8 +1121,8 @@ public:
 
       if (hasDidSetOrWillSetDynamicReplacement &&
           isa<ExtensionDecl>(storage->getDeclContext()) &&
-          fd != storage->getAccessor(AccessorKind::WillSet) &&
-          fd != storage->getAccessor(AccessorKind::DidSet))
+          fd != storage->getParsedAccessor(AccessorKind::WillSet) &&
+          fd != storage->getParsedAccessor(AccessorKind::DidSet))
         return;
     }
     SGM.emitFunction(fd);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4085,12 +4085,12 @@ namespace {
           // The property is non-settable, so add "getter:".
           primaryDiag.fixItInsert(modifierLoc, "getter: ");
           E->overrideObjCSelectorKind(ObjCSelectorExpr::Getter, modifierLoc);
-          method = var->getAccessor(AccessorKind::Get);
+          method = var->getOpaqueAccessor(AccessorKind::Get);
           break;
         }
 
         case ObjCSelectorExpr::Getter:
-          method = var->getAccessor(AccessorKind::Get);
+          method = var->getOpaqueAccessor(AccessorKind::Get);
           break;
 
         case ObjCSelectorExpr::Setter:
@@ -4111,7 +4111,7 @@ namespace {
             return E;
           }
 
-          method = var->getAccessor(AccessorKind::Set);
+          method = var->getOpaqueAccessor(AccessorKind::Set);
           break;
         }
       } else {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1320,22 +1320,6 @@ synthesizeModifyCoroutineSetterBody(AccessorDecl *setter, ASTContext &ctx) {
                                                 setter->getStorage(), ctx);
 }
 
-/// The specified AbstractStorageDecl was just found to satisfy a
-/// protocol property requirement.  Ensure that it has the full
-/// complement of accessors.
-void TypeChecker::synthesizeWitnessAccessorsForStorage(
-                                             AbstractStorageDecl *requirement,
-                                             AbstractStorageDecl *storage) {
-  // Make sure the protocol requirement itself has the right accessors.
-  // FIXME: This should be a request kicked off by SILGen.
-  DeclsToFinalize.insert(requirement);
-
-  requirement->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
-    // Force synthesis if necessary.
-    (void) storage->getSynthesizedAccessor(kind);
-  });
-}
-
 /// Given a VarDecl with a willSet: and/or didSet: specifier, synthesize the
 /// setter which calls them.
 static std::pair<BraceStmt *, bool>

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -165,8 +165,6 @@ static void finishImplicitAccessor(AccessorDecl *accessor,
 
 static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
                                            ASTContext &ctx) {
-  assert(!storage->getAccessor(AccessorKind::Get));
-
   SourceLoc loc = storage->getLoc();
 
   GenericEnvironment *genericEnvironmentOfLazyAccessor = nullptr;
@@ -244,7 +242,6 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
 static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
                                            ASTContext &ctx,
                                            AccessorDecl *getter = nullptr) {
-  assert(!storage->getAccessor(AccessorKind::Set));
   assert(storage->supportsMutation());
 
   SourceLoc loc = storage->getLoc();
@@ -370,8 +367,8 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
       // FIXME: This should be folded into the WriteImplKind below.
       if (auto var = dyn_cast<VarDecl>(storage)) {
         if (var->hasAttachedPropertyWrapper()) {
-          if (var->getAccessor(AccessorKind::DidSet) ||
-              var->getAccessor(AccessorKind::WillSet))
+          if (var->getParsedAccessor(AccessorKind::DidSet) ||
+              var->getParsedAccessor(AccessorKind::WillSet))
             return false;
 
           break;
@@ -463,11 +460,11 @@ createCoroutineAccessorPrototype(AbstractStorageDecl *storage,
   // the storage (and its getters/setters if it has them).
   SmallVector<const Decl *, 2> asAvailableAs;
   asAvailableAs.push_back(storage);
-  if (FuncDecl *getter = storage->getAccessor(AccessorKind::Get)) {
+  if (FuncDecl *getter = storage->getParsedAccessor(AccessorKind::Get)) {
     asAvailableAs.push_back(getter);
   }
   if (kind == AccessorKind::Modify) {
-    if (FuncDecl *setter = storage->getAccessor(AccessorKind::Set)) {
+    if (FuncDecl *setter = storage->getParsedAccessor(AccessorKind::Set)) {
       asAvailableAs.push_back(setter);
     }
   }
@@ -1148,7 +1145,7 @@ synthesizeInheritedGetterBody(AccessorDecl *getter, ASTContext &ctx) {
 /// Synthesize the body of a getter which just delegates to an addressor.
 static std::pair<BraceStmt *, bool>
 synthesizeAddressedGetterBody(AccessorDecl *getter, ASTContext &ctx) {
-  assert(getter->getStorage()->getAccessor(AccessorKind::Address));
+  assert(getter->getStorage()->getParsedAccessor(AccessorKind::Address));
 
   // This should call the addressor.
   return synthesizeTrivialGetterBody(getter, TargetImpl::Implementation, ctx);
@@ -1158,7 +1155,7 @@ synthesizeAddressedGetterBody(AccessorDecl *getter, ASTContext &ctx) {
 /// coroutine accessor.
 static std::pair<BraceStmt *, bool>
 synthesizeReadCoroutineGetterBody(AccessorDecl *getter, ASTContext &ctx) {
-  assert(getter->getStorage()->getAccessor(AccessorKind::Read));
+  assert(getter->getStorage()->getParsedAccessor(AccessorKind::Read));
 
   // This should call the read coroutine.
   return synthesizeTrivialGetterBody(getter, TargetImpl::Implementation, ctx);
@@ -1399,7 +1396,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
   // TODO: check the body of didSet to only do this load (which may call the
   // superclass getter) if didSet takes an argument.
   VarDecl *OldValue = nullptr;
-  if (VD->getAccessor(AccessorKind::DidSet)) {
+  if (VD->getParsedAccessor(AccessorKind::DidSet)) {
     Expr *OldValueExpr
       = buildStorageReference(Set, VD, target, /*isLValue=*/true, Ctx);
     OldValueExpr = new (Ctx) LoadExpr(OldValueExpr, VD->getType());
@@ -1416,7 +1413,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
     SetterBody.push_back(OldValue);
   }
 
-  if (auto willSet = VD->getAccessor(AccessorKind::WillSet))
+  if (auto willSet = VD->getParsedAccessor(AccessorKind::WillSet))
     callObserver(willSet, ValueDecl);
   
   // Create an assignment into the storage or call to superclass setter.
@@ -1425,7 +1422,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
   createPropertyStoreOrCallSuperclassSetter(Set, ValueDRE, VD, target,
                                             SetterBody, Ctx);
 
-  if (auto didSet = VD->getAccessor(AccessorKind::DidSet))
+  if (auto didSet = VD->getParsedAccessor(AccessorKind::DidSet))
     callObserver(didSet, OldValue);
 
   return { BraceStmt::create(Ctx, Loc, SetterBody, Loc, true),
@@ -1792,11 +1789,9 @@ PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
   unsigned numWrappers = var->getAttachedPropertyWrappers().size();
   if (numWrappers < 1)
     return None;
-  if (var->getAccessor(AccessorKind::Get) &&
-      !var->getAccessor(AccessorKind::Get)->isImplicit())
+  if (var->getParsedAccessor(AccessorKind::Get))
     return None;
-  if (var->getAccessor(AccessorKind::Set) &&
-      !var->getAccessor(AccessorKind::Set)->isImplicit())
+  if (var->getParsedAccessor(AccessorKind::Set))
     return None;
 
   // Start with the traits from the outermost wrapper.
@@ -2076,7 +2071,7 @@ static void finishPropertyWrapperImplInfo(VarDecl *var,
   }
 
   bool wrapperSetterIsUsable = false;
-  if (var->getAccessor(AccessorKind::Set)) {
+  if (var->getParsedAccessor(AccessorKind::Set)) {
     wrapperSetterIsUsable = true;
   } else if (parentSF && parentSF->Kind != SourceFileKind::Interface
              && !var->isLet()) {
@@ -2153,11 +2148,6 @@ static void finishStorageImplInfo(AbstractStorageDecl *storage,
     finishProtocolStorageImplInfo(storage, info);
 }
 
-static bool hasParsedAccessor(AbstractStorageDecl *storage, AccessorKind kind) {
-  auto *accessor = storage->getAccessor(kind);
-  return (accessor && !accessor->isImplicit());
-}
-
 /// Gets the storage info of the provided storage decl if it has the
 /// @_hasStorage attribute and it's not in SIL mode.
 ///
@@ -2179,8 +2169,8 @@ static StorageImplInfo classifyWithHasStorageAttr(VarDecl *var) {
   WriteImplKind writeImpl;
   ReadWriteImplKind readWriteImpl;
 
-  if (hasParsedAccessor(var, AccessorKind::Get) &&
-      hasParsedAccessor(var, AccessorKind::Set)) {
+  if (var->getParsedAccessor(AccessorKind::Get) &&
+      var->getParsedAccessor(AccessorKind::Set)) {
     // If we see `@_hasStorage var x: T { get set }`, then our property has
     // willSet/didSet observers.
     writeImpl = var->getAttrs().hasAttribute<OverrideAttr>() ?
@@ -2222,25 +2212,27 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       auto *SF = storage->getDeclContext()->getParentSourceFile();
       if (SF && SF->Kind == SourceFileKind::SIL)
         return StorageImplInfo::getSimpleStored(
-          StorageIsMutable_t(hasParsedAccessor(var, AccessorKind::Set)));
+          var->getParsedAccessor(AccessorKind::Set)
+          ? StorageIsMutable
+          : StorageIsNotMutable);
 
       return classifyWithHasStorageAttr(var);
     }
   }
 
-  bool hasWillSet = hasParsedAccessor(storage, AccessorKind::WillSet);
-  bool hasDidSet = hasParsedAccessor(storage, AccessorKind::DidSet);
-  bool hasSetter = hasParsedAccessor(storage, AccessorKind::Set);
-  bool hasModify = hasParsedAccessor(storage, AccessorKind::Modify);
-  bool hasMutableAddress = hasParsedAccessor(storage, AccessorKind::MutableAddress);
+  bool hasWillSet = storage->getParsedAccessor(AccessorKind::WillSet);
+  bool hasDidSet = storage->getParsedAccessor(AccessorKind::DidSet);
+  bool hasSetter = storage->getParsedAccessor(AccessorKind::Set);
+  bool hasModify = storage->getParsedAccessor(AccessorKind::Modify);
+  bool hasMutableAddress = storage->getParsedAccessor(AccessorKind::MutableAddress);
 
   // 'get', 'read', and a non-mutable addressor are all exclusive.
   ReadImplKind readImpl;
-  if (hasParsedAccessor(storage, AccessorKind::Get)) {
+  if (storage->getParsedAccessor(AccessorKind::Get)) {
     readImpl = ReadImplKind::Get;
-  } else if (hasParsedAccessor(storage, AccessorKind::Read)) {
+  } else if (storage->getParsedAccessor(AccessorKind::Read)) {
     readImpl = ReadImplKind::Read;
-  } else if (hasParsedAccessor(storage, AccessorKind::Address)) {
+  } else if (storage->getParsedAccessor(AccessorKind::Address)) {
     readImpl = ReadImplKind::Address;
 
   // If there's a writing accessor of any sort, there must also be a
@@ -2349,7 +2341,7 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   // But we might need to create opaque accessors for them.
   if (auto sourceFile = dc->getParentSourceFile()) {
     if (sourceFile->Kind == SourceFileKind::SIL) {
-      if (!var->getAccessor(AccessorKind::Get))
+      if (!var->getParsedAccessor(AccessorKind::Get))
         return false;
     }
   }
@@ -2451,8 +2443,8 @@ synthesizeSetterBody(AccessorDecl *setter, ASTContext &ctx) {
     }
 
     if (var->hasAttachedPropertyWrapper()) {
-      if (var->getAccessor(AccessorKind::WillSet) ||
-          var->getAccessor(AccessorKind::DidSet)) {
+      if (var->getParsedAccessor(AccessorKind::WillSet) ||
+          var->getParsedAccessor(AccessorKind::DidSet)) {
         return synthesizeObservedSetterBody(setter, TargetImpl::Wrapper, ctx);
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2499,8 +2499,8 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       decl = func;
     } else if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
       decl = storage;
-      auto getter = storage->getAccessor(AccessorKind::Get);
-      if (!getter || getter->isImplicit() || !getter->hasBody()) {
+      auto getter = storage->getParsedAccessor(AccessorKind::Get);
+      if (!getter || !getter->hasBody()) {
         TC.diagnose(attr->getLocation(),
                     diag::function_builder_attribute_on_storage_without_getter,
                     nominal->getFullName(),
@@ -2836,8 +2836,8 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     // exclusivity checking.
     // If there is a didSet or willSet function we allow dynamic replacement.
     if (VD->hasStorage() &&
-        !VD->getAccessor(AccessorKind::DidSet) &&
-        !VD->getAccessor(AccessorKind::WillSet))
+        !VD->getParsedAccessor(AccessorKind::DidSet) &&
+        !VD->getParsedAccessor(AccessorKind::WillSet))
       return;
     // Don't add dynamic to local variables.
     if (VD->getDeclContext()->isLocalContext())

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2519,31 +2519,31 @@ private:
     if (!D)
       return;
 
-    if (!D->hasAnyAccessors()) {
+    if (!D->requiresOpaqueAccessors()) {
       return;
     }
-    
+
     // Check availability of accessor functions.
     // TODO: if we're talking about an inlineable storage declaration,
     // this probably needs to be refined to not assume that the accesses are
     // specifically using the getter/setter.
     switch (AccessContext) {
     case MemberAccessContext::Getter:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Get),
+      diagAccessorAvailability(D->getOpaqueAccessor(AccessorKind::Get),
                                ReferenceRange, ReferenceDC, None);
       break;
 
     case MemberAccessContext::Setter:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Set),
+      diagAccessorAvailability(D->getOpaqueAccessor(AccessorKind::Set),
                                ReferenceRange, ReferenceDC, None);
       break;
 
     case MemberAccessContext::InOut:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Get),
+      diagAccessorAvailability(D->getOpaqueAccessor(AccessorKind::Get),
                                ReferenceRange, ReferenceDC,
                                DeclAvailabilityFlag::ForInout);
 
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Set),
+      diagAccessorAvailability(D->getOpaqueAccessor(AccessorKind::Set),
                                ReferenceRange, ReferenceDC,
                                DeclAvailabilityFlag::ForInout);
       break;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4628,10 +4628,10 @@ static void finalizeType(TypeChecker &TC, NominalTypeDecl *nominal) {
     // affects vtable layout.
     TC.addImplicitConstructors(CD);
     CD->addImplicitDestructor();
-  }
 
-  // Force lowering of stored properties.
-  (void) nominal->getStoredProperties();
+    // Force lowering of stored properties.
+    (void) nominal->getStoredProperties();
+  }
 
   if (isa<ClassDecl>(nominal) || isa<ProtocolDecl>(nominal)) {
     for (auto *D : nominal->getMembers()) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -809,8 +809,8 @@ static void requestLayoutForMetadataSources(TypeChecker &tc, Type type) {
     // parameter is of dependent type then the body of a function with said
     // parameter could potentially require the generic type's layout to
     // recover them.
-    if (auto *nominalDecl = type->getAnyNominal()) {
-      tc.requestNominalLayout(nominalDecl);
+    if (auto *classDecl = type->getClassOrBoundGenericClass()) {
+      tc.requestClassLayout(classDecl);
     }
   });
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3693,11 +3693,6 @@ void ConformanceChecker::resolveValueWitnesses() {
       auto witness = Conformance->getWitness(requirement).getDecl();
       if (!witness) return;
 
-      // Make sure that we finalize the witness, so we can emit this
-      // witness table.
-      if (isa<AbstractStorageDecl>(witness))
-        TC.DeclsToFinalize.insert(witness);
-
       // Objective-C checking for @objc requirements.
       if (requirement->isObjC() &&
           requirement->getFullName() == witness->getFullName() &&

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -238,15 +238,17 @@ static bool checkObjCWitnessSelector(TypeChecker &tc, ValueDecl *req,
   // FIXME: Check property names!
 
   // Check the getter.
-  if (auto reqGetter = reqStorage->getAccessor(AccessorKind::Get)) {
-    auto *witnessGetter = witnessStorage->getAccessor(AccessorKind::Get);
+  if (auto reqGetter = reqStorage->getParsedAccessor(AccessorKind::Get)) {
+    auto *witnessGetter =
+      witnessStorage->getSynthesizedAccessor(AccessorKind::Get);
     if (checkObjCWitnessSelector(tc, reqGetter, witnessGetter))
       return true;
   }
 
   // Check the setter.
-  if (auto reqSetter = reqStorage->getAccessor(AccessorKind::Set)) {
-    auto *witnessSetter = witnessStorage->getAccessor(AccessorKind::Set);
+  if (auto reqSetter = reqStorage->getParsedAccessor(AccessorKind::Set)) {
+    auto *witnessSetter =
+      witnessStorage->getSynthesizedAccessor(AccessorKind::Set);
     if (checkObjCWitnessSelector(tc, reqSetter, witnessSetter))
       return true;
   }
@@ -264,48 +266,40 @@ static ParameterList *getParameterList(ValueDecl *value) {
 
 // Find a standin declaration to place the diagnostic at for the
 // given accessor kind.
-static ValueDecl *getStandinForAccessor(AbstractStorageDecl *witnessStorage,
+static ValueDecl *getStandinForAccessor(AbstractStorageDecl *witness,
                                         AccessorKind requirementKind) {
-  auto getExplicitAccessor = [&](AccessorKind kind) -> AccessorDecl* {
-    if (auto accessor = witnessStorage->getAccessor(kind)) {
-      if (!accessor->isImplicit())
-        return accessor;
-    }
-    return nullptr;
-  };
-
   // If the storage actually explicitly provides that accessor, great.
-  if (auto accessor = getExplicitAccessor(requirementKind))
+  if (auto accessor = witness->getParsedAccessor(requirementKind))
     return accessor;
 
   // If it didn't, check to see if it provides something else that corresponds
   // to the requirement.
   switch (requirementKind) {
   case AccessorKind::Get:
-    if (auto read = getExplicitAccessor(AccessorKind::Read))
+    if (auto read = witness->getParsedAccessor(AccessorKind::Read))
       return read;
-    if (auto addressor = getExplicitAccessor(AccessorKind::Address))
+    if (auto addressor = witness->getParsedAccessor(AccessorKind::Address))
       return addressor;
     break;
 
   case AccessorKind::Read:
-    if (auto getter = getExplicitAccessor(AccessorKind::Get))
+    if (auto getter = witness->getParsedAccessor(AccessorKind::Get))
       return getter;
-    if (auto addressor = getExplicitAccessor(AccessorKind::Address))
+    if (auto addressor = witness->getParsedAccessor(AccessorKind::Address))
       return addressor;
     break;
 
   case AccessorKind::Modify:
-    if (auto setter = getExplicitAccessor(AccessorKind::Set))
+    if (auto setter = witness->getParsedAccessor(AccessorKind::Set))
       return setter;
-    if (auto addressor = getExplicitAccessor(AccessorKind::MutableAddress))
+    if (auto addressor = witness->getParsedAccessor(AccessorKind::MutableAddress))
       return addressor;
     break;
 
   case AccessorKind::Set:
-    if (auto modify = getExplicitAccessor(AccessorKind::Modify))
+    if (auto modify = witness->getParsedAccessor(AccessorKind::Modify))
       return modify;
-    if (auto addressor = getExplicitAccessor(AccessorKind::MutableAddress))
+    if (auto addressor = witness->getParsedAccessor(AccessorKind::MutableAddress))
       return addressor;
     break;
 
@@ -317,7 +311,7 @@ static ValueDecl *getStandinForAccessor(AbstractStorageDecl *witnessStorage,
   }
 
   // Otherwise, just diagnose starting at the storage declaration itself.
-  return witnessStorage;
+  return witness;
 }
 
 RequirementMatch
@@ -5040,9 +5034,9 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, funcReq);
         } else {
           auto storageReq = cast<AbstractStorageDecl>(req);
-          if (auto getter = storageReq->getAccessor(AccessorKind::Get))
+          if (auto getter = storageReq->getParsedAccessor(AccessorKind::Get))
             sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, getter);
-          if (auto setter = storageReq->getAccessor(AccessorKind::Set))
+          if (auto setter = storageReq->getParsedAccessor(AccessorKind::Set))
             sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, setter);
         }
       }
@@ -5151,7 +5145,7 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
             auto *storageReq = dyn_cast<AbstractStorageDecl>(req);
             if (!storageReq)
               continue;
-            req = storageReq->getAccessor(*accessorKind);
+            req = storageReq->getOpaqueAccessor(*accessorKind);
             if (!req)
               continue;
           }
@@ -5169,10 +5163,10 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
         auto *storageFound = dyn_cast_or_null<AbstractStorageDecl>(found);
         if (!storageReq || !storageFound)
           continue;
-        req = storageReq->getAccessor(*accessorKind);
+        req = storageReq->getOpaqueAccessor(*accessorKind);
         if (!req)
           continue;
-        found = storageFound->getAccessor(*accessorKind);
+        found = storageFound->getOpaqueAccessor(*accessorKind);
       }
 
       // Determine whether the witness for this conformance is in fact

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2208,12 +2208,6 @@ void ConformanceChecker::recordWitness(ValueDecl *requirement,
   // Record this witness in the conformance.
   auto witness = match.getWitness(TC.Context);
   Conformance->setWitness(requirement, witness);
-
-  // Synthesize accessors for the protocol witness table to use.
-  if (auto storage = dyn_cast<AbstractStorageDecl>(witness.getDecl()))
-    TC.synthesizeWitnessAccessorsForStorage(
-                                        cast<AbstractStorageDecl>(requirement),
-                                        storage);
 }
 
 void ConformanceChecker::recordOptionalWitness(ValueDecl *requirement) {
@@ -5337,12 +5331,6 @@ void DefaultWitnessChecker::recordWitness(
                                   const RequirementMatch &match) {
   Proto->setDefaultWitness(requirement,
                            match.getWitness(TC.Context));
-
-  // Synthesize accessors for the protocol witness table to use.
-  if (auto storage = dyn_cast<AbstractStorageDecl>(match.Witness))
-    TC.synthesizeWitnessAccessorsForStorage(
-                                        cast<AbstractStorageDecl>(requirement),
-                                        storage);
 }
 
 void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -556,7 +556,7 @@ public:
   /// The list of declarations that we've done at least partial validation
   /// of during type-checking, but which will need to be finalized before
   /// we can hand them off to SILGen etc.
-  llvm::SetVector<ValueDecl *> DeclsToFinalize;
+  llvm::SetVector<ClassDecl *> DeclsToFinalize;
 
   /// Track the index of the next declaration that needs to be finalized,
   /// from the \c DeclsToFinalize set.
@@ -810,7 +810,7 @@ public:
 
   /// Request that the given class needs to have all members validated
   /// after everything in the translation unit has been processed.
-  void requestNominalLayout(NominalTypeDecl *nominalDecl);
+  void requestClassLayout(ClassDecl *classDecl);
 
   /// Request that the superclass of the given class, if any, needs to have
   /// all members validated after everything in the translation unit has
@@ -819,7 +819,7 @@ public:
 
   /// Perform final validation of a declaration after everything in the
   /// translation unit has been processed.
-  void finalizeDecl(ValueDecl *D);
+  void finalizeDecl(ClassDecl *CD);
 
   /// Resolve a reference to the given type declaration within a particular
   /// context.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1172,12 +1172,6 @@ public:
   /// target.
   void synthesizeMemberForLookup(NominalTypeDecl *target, DeclName member);
 
-  /// The specified AbstractStorageDecl \c storage was just found to satisfy
-  /// the protocol property \c requirement.  Ensure that it has the full
-  /// complement of accessors.
-  void synthesizeWitnessAccessorsForStorage(AbstractStorageDecl *requirement,
-                                            AbstractStorageDecl *storage);
-
   /// Pre-check the expression, validating any types that occur in the
   /// expression and folding sequence expressions.
   bool preCheckExpression(Expr *&expr, DeclContext *dc);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4891,15 +4891,6 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
 
       orderedTopLevelDecls.push_back(addDeclRef(D));
 
-      // If this is a global variable, force the accessors to be
-      // serialized.
-      if (auto VD = dyn_cast<VarDecl>(D)) {
-        if (auto *getter = VD->getAccessor(swift::AccessorKind::Get))
-          addDeclRef(getter);
-        if (auto *setter = VD->getAccessor(swift::AccessorKind::Set))
-          addDeclRef(setter);
-      }
-
       // If this nominal type has associated top-level decls for a
       // derived conformance (for example, ==), force them to be
       // serialized.

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -159,8 +159,8 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
             auto witnessStorage = cast<AbstractStorageDecl>(witnessDecl);
             storage->visitOpaqueAccessors([&](AccessorDecl *reqtAccessor) {
               auto witnessAccessor =
-                witnessStorage->getAccessor(reqtAccessor->getAccessorKind());
-              assert(witnessAccessor && "no corresponding witness accessor?");
+                witnessStorage->getSynthesizedAccessor(
+                  reqtAccessor->getAccessorKind());
               addSymbolIfNecessary(reqtAccessor, witnessAccessor);
             });
           }

--- a/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
@@ -6,3 +6,4 @@ Struct _GlobalRuntimeFunctionCountersState is a new API without @available attri
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
 Struct _RuntimeFunctionCounters is a new API without @available attribute
 Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
+Accessor Slice.subscript(_:).Read() has been removed

--- a/test/multifile/Inputs/inlinable-other.swift
+++ b/test/multifile/Inputs/inlinable-other.swift
@@ -1,0 +1,4 @@
+public struct OtherStruct {
+  public internal(set) static var staticProp = 123
+  // expected-note@-1 {{setter for 'staticProp' is not '@usableFromInline' or public}}
+}

--- a/test/multifile/Inputs/protocol-conformance-let-other.swift
+++ b/test/multifile/Inputs/protocol-conformance-let-other.swift
@@ -1,4 +1,3 @@
 public protocol P {
   let x: Int
-  // expected-error@-1 {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
 }

--- a/test/multifile/Inputs/protocol-conformance-objc-other.swift
+++ b/test/multifile/Inputs/protocol-conformance-objc-other.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public class Pony {
+  public var hindEnd: Int = 0
+}

--- a/test/multifile/inlinable.swift
+++ b/test/multifile/inlinable.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -typecheck -verify %s %S/Inputs/inlinable-other.swift
+
+@frozen public struct HasInitExpr {
+  public var hasInlinableInit = mutatingFunc(&OtherStruct.staticProp)
+  // expected-warning@-1 {{setter for 'staticProp' is internal and should not be referenced from a property initializer in a '@frozen' type}}
+}
+
+public func mutatingFunc(_: inout Int) -> Int {
+  return 0
+}

--- a/test/multifile/protocol-conformance-objc.swift
+++ b/test/multifile/protocol-conformance-objc.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -sdk %sdk -emit-ir -primary-file %s %S/Inputs/protocol-conformance-objc-other.swift -module-name test
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol Horse {
+  var hindEnd: Int { get set }
+}
+
+extension Pony : Horse {}
+


### PR DESCRIPTION
We now have three methods on AbstractStorageDecl that will eventually replace `getAccessor()`:

- `getParsedAccessor()` -- returns an accessor explicitly written in source; otherwise always returns nullptr.
- `getOpaqueAccessor()` -- if the accessor kind is part of the ABI of the storage, or if it was parsed, returns the accessor. Returns nullptr if the accessor was not parsed and is not part of the opaque ABI set. The accessor is synthesized if necessary. It's possible for an accessor to be parsed, but not part of the ABI; an example is `AccessorKind::WillSet` or `AccessorKind::DidSet`. For convenience this method returns an accessor in this case also. An example of an accessor that is neither parsed or part of the ABI is `AccessorKind::Read` on a computed property that only has a getter. In this case, this method will return nullptr.
- `getSynthesizedAccessor()` -- returns an accessor, always synthesizing one if necessary. This should only be used when, eg, emitting protocol witnesses, which can sometimes require accessors not part of the storage's ABI (for example, an `@objc dynamic` property does not usually have an `AccessorKind::Modify`, but if it witnesses a mutable protocol requirement, we synthesize one). Note that if `getSynthesizedAccessor()` returns an accessor not part of the opaque ABI accessor set, the generated accessor will be emitted with shared linkage.

Using the above three operations, we can now trigger lazy accessor synthesis from various stages of the pipeline, eliminating some logic found in Sema's `finalizeDecl()` for forcing accessor synthesis for declarations in secondary files.

We still force synthesis of accessors in primary files, and in a couple of other random places. These need a little bit more refactoring to eliminate, because we still call `getAccessor()`, `getAllAccessors()` and `hasAnyAccessors()` on declarations in primary files.

As for `finalizeDecl()`, it's still used to add some implicit members to ClassDecls, and not much else. The `TypeChecker::DeclsToFinalize` list now only ever contains ClassDecls. This is also going away soon, in favor of a request to get the "vtable members" of a class.