### PR TITLE
Revert "AST: Remove a few utility methods from AbstractStorageDecl"

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4635,6 +4635,16 @@ public:
     return SourceRange();
   }
 
+  /// Retrieve the getter used to access the value of this variable.
+  AccessorDecl *getGetter() const {
+    return getAccessor(AccessorKind::Get);
+  }
+  
+  /// Retrieve the setter used to mutate the value of this variable.
+  AccessorDecl *getSetter() const {
+    return getAccessor(AccessorKind::Set);
+  }
+
   AccessLevel getSetterFormalAccess() const;
 
   AccessScope
@@ -4647,6 +4657,45 @@ public:
   }
 
   void overwriteSetterAccess(AccessLevel accessLevel);
+
+  /// Return the decl for the immutable addressor if it exists.
+  AccessorDecl *getAddressor() const {
+    return getAccessor(AccessorKind::Address);
+  }
+
+  /// Return the decl for the mutable accessor if it exists.
+  AccessorDecl *getMutableAddressor() const {
+    return getAccessor(AccessorKind::MutableAddress);
+  }
+
+  /// Return the appropriate addressor for the given access kind.
+  AccessorDecl *getAddressorForAccess(AccessKind accessKind) const {
+    if (accessKind == AccessKind::Read)
+      return getAddressor();
+    return getMutableAddressor();
+  }
+
+  /// Return the decl for the 'read' coroutine accessor if it exists.
+  AccessorDecl *getReadCoroutine() const {
+    return getAccessor(AccessorKind::Read);
+  }
+
+  /// Return the decl for the 'modify' coroutine accessor if it exists.
+  AccessorDecl *getModifyCoroutine() const {
+    return getAccessor(AccessorKind::Modify);
+  }
+
+  /// Return the decl for the willSet specifier if it exists, this is
+  /// only valid on a declaration with Observing storage.
+  AccessorDecl *getWillSetFunc() const {
+    return getAccessor(AccessorKind::WillSet);
+  }
+
+  /// Return the decl for the didSet specifier if it exists, this is
+  /// only valid on a declaration with Observing storage.
+  AccessorDecl *getDidSetFunc() const {
+    return getAccessor(AccessorKind::DidSet);
+  }
 
   /// Given that this is an Objective-C property or subscript declaration,
   /// produce its getter selector.
@@ -7062,11 +7111,11 @@ inline bool AbstractStorageDecl::isSettable(const DeclContext *UseDC,
 inline void
 AbstractStorageDecl::overwriteSetterAccess(AccessLevel accessLevel) {
   Accessors.setInt(accessLevel);
-  if (auto setter = getAccessor(AccessorKind::Set))
+  if (auto setter = getSetter())
     setter->overwriteAccess(accessLevel);
-  if (auto modify = getAccessor(AccessorKind::Modify))
+  if (auto modify = getModifyCoroutine())
     modify->overwriteAccess(accessLevel);
-  if (auto mutableAddressor = getAccessor(AccessorKind::MutableAddress))
+  if (auto mutableAddressor = getMutableAddressor())
     mutableAddressor->overwriteAccess(accessLevel);
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -856,7 +856,7 @@ void SubscriptDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
   auto *leaf =
       scopeCreator.createGenericParamScopes(sub, sub->getGenericParams(), this);
   auto *params = scopeCreator.createSubtree<AbstractFunctionParamsScope>(
-      leaf, sub->getIndices(), sub->getAccessor(AccessorKind::Get));
+      leaf, sub->getIndices(), sub->getGetter());
   scopeCreator.addChildrenForAllExplicitAccessors(sub, params);
 }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2390,50 +2390,50 @@ public:
     void verifyChecked(AbstractStorageDecl *ASD) {
       if (ASD->hasAccess() && ASD->isSettable(nullptr)) {
         auto setterAccess = ASD->getSetterFormalAccess();
-        auto *setter = ASD->getAccessor(AccessorKind::Set);
-        if (setter && setter->getFormalAccess() != setterAccess) {
+        if (ASD->getSetter() &&
+            ASD->getSetter()->getFormalAccess() != setterAccess) {
           Out << "AbstractStorageDecl's setter access is out of sync"
                  " with the access actually on the setter\n";
           abort();
         }
       }
 
-      if (auto getter = ASD->getAccessor(AccessorKind::Get)) {
+      if (auto getter = ASD->getGetter()) {
         if (getter->isMutating() != ASD->isGetterMutating()) {
           Out << "AbstractStorageDecl::isGetterMutating is out of sync"
                  " with whether the getter is actually mutating\n";
           abort();
         }
       }
-      if (auto setter = ASD->getAccessor(AccessorKind::Set)) {
+      if (auto setter = ASD->getSetter()) {
         if (setter->isMutating() != ASD->isSetterMutating()) {
           Out << "AbstractStorageDecl::isSetterMutating is out of sync"
                  " with whether the setter is actually mutating\n";
           abort();
         }
       }
-      if (auto addressor = ASD->getAccessor(AccessorKind::Address)) {
+      if (auto addressor = ASD->getAddressor()) {
         if (addressor->isMutating() != ASD->isGetterMutating()) {
           Out << "AbstractStorageDecl::isGetterMutating is out of sync"
                  " with whether immutable addressor is mutating";
           abort();
         }
       }
-      if (auto reader = ASD->getAccessor(AccessorKind::Read)) {
+      if (auto reader = ASD->getReadCoroutine()) {
         if (reader->isMutating() != ASD->isGetterMutating()) {
           Out << "AbstractStorageDecl::isGetterMutating is out of sync"
                  " with whether read accessor is mutating";
           abort();
         }
       }
-      if (auto addressor = ASD->getAccessor(AccessorKind::MutableAddress)) {
+      if (auto addressor = ASD->getMutableAddressor()) {
         if (addressor->isMutating() != ASD->isSetterMutating()) {
           Out << "AbstractStorageDecl::isSetterMutating is out of sync"
                  " with whether mutable addressor is mutating";
           abort();
         }
       }
-      if (auto modifier = ASD->getAccessor(AccessorKind::Modify)) {
+      if (auto modifier = ASD->getModifyCoroutine()) {
         if (modifier->isMutating() !=
             (ASD->isSetterMutating() || ASD->isGetterMutating())) {
           Out << "AbstractStorageDecl::isSetterMutating is out of sync"
@@ -2475,7 +2475,7 @@ public:
       if (!var->getDeclContext()->contextHasLazyGenericEnvironment()) {
         typeForAccessors =
             var->getDeclContext()->mapTypeIntoContext(typeForAccessors);
-        if (const FuncDecl *getter = var->getAccessor(AccessorKind::Get)) {
+        if (const FuncDecl *getter = var->getGetter()) {
           if (getter->getParameters()->size() != 0) {
             Out << "property getter has parameters\n";
             abort();
@@ -2496,7 +2496,7 @@ public:
         }
       }
 
-      if (const FuncDecl *setter = var->getAccessor(AccessorKind::Set)) {
+      if (const FuncDecl *setter = var->getSetter()) {
         if (setter->hasInterfaceType()) {
           if (!setter->getResultInterfaceType()->isVoid()) {
             Out << "property setter has non-Void result type\n";

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -161,8 +161,8 @@ static bool isStoredWithPrivateSetter(VarDecl *VD) {
     return false;
 
   if (VD->isLet() ||
-      (VD->getAccessor(AccessorKind::Set) &&
-       !VD->getAccessor(AccessorKind::Set)->isImplicit()))
+      (VD->getSetter() &&
+       !VD->getSetter()->isImplicit()))
     return false;
 
   return true;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4651,9 +4651,9 @@ bool AbstractStorageDecl::hasPrivateAccessor() const {
 }
 
 bool AbstractStorageDecl::hasDidSetOrWillSetDynamicReplacement() const {
-  if (auto *func = getAccessor(AccessorKind::DidSet))
+  if (auto *func = getDidSetFunc())
     return func->getAttrs().hasAttribute<DynamicReplacementAttr>();
-  if (auto *func = getAccessor(AccessorKind::WillSet))
+  if (auto *func = getWillSetFunc())
     return func->getAttrs().hasAttribute<DynamicReplacementAttr>();
   return false;
 }
@@ -4809,8 +4809,8 @@ AbstractStorageDecl::getSetterFormalAccessScope(const DeclContext *useDC,
 void AbstractStorageDecl::setComputedSetter(AccessorDecl *setter) {
   assert(getImplInfo().getReadImpl() == ReadImplKind::Get);
   assert(!getImplInfo().supportsMutation());
-  assert(getAccessor(AccessorKind::Get) && "invariant check: missing getter");
-  assert(!getAccessor(AccessorKind::Set) && "already has a setter");
+  assert(getGetter() && "invariant check: missing getter");
+  assert(!getSetter() && "already has a setter");
   assert(hasClangNode() && "should only be used for ObjC properties");
   assert(setter && "should not be called for readonly properties");
   assert(setter->getAccessorKind() == AccessorKind::Set);
@@ -4855,7 +4855,7 @@ getNameFromObjcAttribute(const ObjCAttr *attr, DeclName preferredName) {
 ObjCSelector
 AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
   // If the getter has an @objc attribute with a name, use that.
-  if (auto getter = getAccessor(AccessorKind::Get)) {
+  if (auto getter = getGetter()) {
       if (auto name = getNameFromObjcAttribute(getter->getAttrs().
           getAttribute<ObjCAttr>(), preferredName))
         return *name;
@@ -4885,7 +4885,7 @@ AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
 ObjCSelector
 AbstractStorageDecl::getObjCSetterSelector(Identifier preferredName) const {
   // If the setter has an @objc attribute with a name, use that.
-  auto setter = getAccessor(AccessorKind::Set);
+  auto setter = getSetter();
   auto objcAttr = setter ? setter->getAttrs().getAttribute<ObjCAttr>()
                          : nullptr;
   if (auto name = getNameFromObjcAttribute(objcAttr, DeclName(preferredName))) {

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -114,8 +114,7 @@ getObjCNameForSwiftDecl(const ValueDecl *VD, DeclName PreferredName){
       return {BaseName, ObjCSelector()};
     return {VAD->getObjCPropertyName(), ObjCSelector()};
   } else if (auto *SD = dyn_cast<SubscriptDecl>(VD)) {
-    return getObjCNameForSwiftDecl(SD->getAccessor(AccessorKind::Get),
-                                   PreferredName);
+    return getObjCNameForSwiftDecl(SD->getGetter(), PreferredName);
   } else if (auto *EL = dyn_cast<EnumElementDecl>(VD)) {
     SmallString<64> Buffer;
     {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2556,7 +2556,7 @@ bool ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
       return true;
     }
   } else if (auto *asd = dyn_cast<AbstractStorageDecl>(namingDecl)) {
-    auto *getter = asd->getAccessor(AccessorKind::Get);
+    auto *getter = asd->getGetter();
     if (getter &&
         getter->getResilienceExpansion() == ResilienceExpansion::Minimal) {
       return true;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3628,13 +3628,13 @@ namespace {
       case ImportedAccessorKind::PropertyGetter: {
         auto property = getImplicitProperty(importedName, decl);
         if (!property) return nullptr;
-        return property->getAccessor(AccessorKind::Get);
+        return property->getGetter();
       }
 
       case ImportedAccessorKind::PropertySetter:
         auto property = getImplicitProperty(importedName, decl);
         if (!property) return nullptr;
-        return property->getAccessor(AccessorKind::Set);
+        return property->getSetter();
       }
 
       return importFunctionDecl(decl, importedName, correctSwiftName, None);
@@ -5010,8 +5010,8 @@ namespace {
       // Only record overrides of class members.
       if (overridden) {
         result->setOverriddenDecl(overridden);
-        getter->setOverriddenDecl(overridden->getAccessor(AccessorKind::Get));
-        if (auto parentSetter = overridden->getAccessor(AccessorKind::Set))
+        getter->setOverriddenDecl(overridden->getGetter());
+        if (auto parentSetter = overridden->getSetter())
           if (setter)
             setter->setOverriddenDecl(parentSetter);
       }
@@ -6516,10 +6516,10 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
 
     // The index types match. This is an override, so mark it as such.
     subscript->setOverriddenDecl(parentSub);
-    auto getterThunk = subscript->getAccessor(AccessorKind::Get);
-    getterThunk->setOverriddenDecl(parentSub->getAccessor(AccessorKind::Get));
-    if (auto parentSetter = parentSub->getAccessor(AccessorKind::Set)) {
-      if (auto setterThunk = subscript->getAccessor(AccessorKind::Set))
+    auto getterThunk = subscript->getGetter();
+    getterThunk->setOverriddenDecl(parentSub->getGetter());
+    if (auto parentSetter = parentSub->getSetter()) {
+      if (auto setterThunk = subscript->getSetter())
         setterThunk->setOverriddenDecl(parentSetter);
     }
 

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -268,7 +268,7 @@ public:
         //   return 0; <- No indentation added because of the getter.
         // }
         if (auto VD = dyn_cast_or_null<VarDecl>(Cursor->getAsDecl())) {
-          if (auto Getter = VD->getAccessor(AccessorKind::Get)) {
+          if (auto Getter = VD->getGetter()) {
             if (!Getter->isImplicit() &&
                 Getter->getAccessorKeywordLoc().isInvalid()) {
               LineAndColumn = ParentLineAndColumn;

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1793,7 +1793,7 @@ namespace {
         }
 
         // Don't emit descriptors for properties without accessors.
-        auto getter = var->getAccessor(AccessorKind::Get);
+        auto getter = var->getGetter();
         if (!getter)
           return;
 
@@ -1804,7 +1804,7 @@ namespace {
         auto &methods = getMethodList(var);
         methods.push_back(getter);
 
-        if (auto setter = var->getAccessor(AccessorKind::Set))
+        if (auto setter = var->getSetter())
           methods.push_back(setter);
       }
     }
@@ -2030,13 +2030,13 @@ namespace {
     void visitSubscriptDecl(SubscriptDecl *subscript) {
       if (!requiresObjCSubscriptDescriptor(IGM, subscript)) return;
 
-      auto getter = subscript->getAccessor(AccessorKind::Get);
+      auto getter = subscript->getGetter();
       if (!getter) return;
 
       auto &methods = getMethodList(subscript);
       methods.push_back(getter);
 
-      if (auto setter = subscript->getAccessor(AccessorKind::Set))
+      if (auto setter = subscript->getSetter())
         methods.push_back(setter);
     }
   };

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -566,8 +566,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     // Return the linkage of the getter, which may be more permissive than the
     // property itself (for instance, with a private/internal property whose
     // accessor is @inlinable or @usableFromInline)
-    auto getterDecl = cast<AbstractStorageDecl>(getDecl())
-      ->getAccessor(AccessorKind::Get);
+    auto getterDecl = cast<AbstractStorageDecl>(getDecl())->getGetter();
     return getSILLinkage(getDeclLinkage(getterDecl), forDefinition);
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1067,9 +1067,8 @@ bool IndexSwiftASTWalker::report(ValueDecl *D) {
       };
 
       bool usedPseudoAccessors = false;
-      if (isa<VarDecl>(D) &&
-          isNullOrImplicit(StoreD->getAccessor(AccessorKind::Get)) &&
-          isNullOrImplicit(StoreD->getAccessor(AccessorKind::Set))) {
+      if (isa<VarDecl>(D) && isNullOrImplicit(StoreD->getGetter()) &&
+          isNullOrImplicit(StoreD->getSetter())) {
         usedPseudoAccessors = true;
         auto VarD = cast<VarDecl>(D);
         // No actual getter or setter, pass 'pseudo' accessors.

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1261,18 +1261,17 @@ private:
       os << ")\n";
       // Older Clangs don't support class properties, so print the accessors as
       // well. This is harmless.
-      printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Get), true);
+      printAbstractFunctionAsMethod(VD->getGetter(), true);
       if (isSettable) {
-        auto *setter = VD->getAccessor(AccessorKind::Set);
-        assert(setter && "settable ObjC property missing setter decl");
-        printAbstractFunctionAsMethod(setter, true);
+        assert(VD->getSetter() && "settable ObjC property missing setter decl");
+        printAbstractFunctionAsMethod(VD->getSetter(), true);
       }
     } else {
       os << "\n";
       if (looksLikeInitMethod(VD->getObjCGetterSelector()))
-        printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Get), false);
+        printAbstractFunctionAsMethod(VD->getGetter(), false);
       if (isSettable && looksLikeInitMethod(VD->getObjCSetterSelector()))
-        printAbstractFunctionAsMethod(VD->getAccessor(AccessorKind::Set), false);
+        printAbstractFunctionAsMethod(VD->getSetter(), false);
     }
   }
 
@@ -1287,9 +1286,8 @@ private:
       isNSUIntegerSubscript = isNSUInteger(indexParam->getType());
     }
 
-    printAbstractFunctionAsMethod(SD->getAccessor(AccessorKind::Get), false,
-                                  isNSUIntegerSubscript);
-    if (auto setter = SD->getAccessor(AccessorKind::Set))
+    printAbstractFunctionAsMethod(SD->getGetter(), false, isNSUIntegerSubscript);
+    if (auto setter = SD->getSetter())
       printAbstractFunctionAsMethod(setter, false, isNSUIntegerSubscript);
   }
 

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -215,7 +215,7 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
   
   // Any property that's potentially resilient should have accessors
   // synthesized.
-  if (!getAccessor(AccessorKind::Get))
+  if (!getGetter())
     return false;
 
   // If the getter is mutating, we cannot form a keypath to it at all.
@@ -231,7 +231,7 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
   // then we still do.
 
   // Check the linkage of the declaration.
-  auto getter = SILDeclRef(getAccessor(AccessorKind::Get));
+  auto getter = SILDeclRef(getGetter());
   auto getterLinkage = getter.getLinkage(ForDefinition);
   
   switch (getterLinkage) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2183,10 +2183,6 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
       // If the capture is of a computed property, grab the transitive captures
       // of its accessors.
       if (auto capturedVar = dyn_cast<VarDecl>(capture.getDecl())) {
-        auto collectAccessorCaptures = [&](AccessorKind kind) {
-          collectFunctionCaptures(capturedVar->getAccessor(kind));
-        };
-
         if (!capture.isDirect()) {
           auto impl = capturedVar->getImplInfo();
 
@@ -2195,13 +2191,13 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
             // Will capture storage later.
             break;
           case ReadImplKind::Address:
-            collectAccessorCaptures(AccessorKind::Address);
+            collectFunctionCaptures(capturedVar->getAddressor());
             break;
           case ReadImplKind::Get:
-            collectAccessorCaptures(AccessorKind::Get);
+            collectFunctionCaptures(capturedVar->getGetter());
             break;
           case ReadImplKind::Read:
-            collectAccessorCaptures(AccessorKind::Read);
+            collectFunctionCaptures(capturedVar->getReadCoroutine());
             break;
           case ReadImplKind::Inherited:
             llvm_unreachable("inherited local variable?");
@@ -2213,13 +2209,13 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
             break;
           case WriteImplKind::StoredWithObservers:
           case WriteImplKind::Set:
-            collectAccessorCaptures(AccessorKind::Set);
+            collectFunctionCaptures(capturedVar->getSetter());
             break;
           case WriteImplKind::MutableAddress:
-            collectAccessorCaptures(AccessorKind::MutableAddress);
+            collectFunctionCaptures(capturedVar->getMutableAddressor());
             break;
           case WriteImplKind::Modify:
-            collectAccessorCaptures(AccessorKind::Modify);
+            collectFunctionCaptures(capturedVar->getModifyCoroutine());
             break;
           case WriteImplKind::InheritedWithObservers:
             llvm_unreachable("inherited local variable");
@@ -2233,10 +2229,10 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
             // We've already processed the read and write operations.
             break;
           case ReadWriteImplKind::MutableAddress:
-            collectAccessorCaptures(AccessorKind::MutableAddress);
+            collectFunctionCaptures(capturedVar->getMutableAddressor());
             break;
           case ReadWriteImplKind::Modify:
-            collectAccessorCaptures(AccessorKind::Modify);
+            collectFunctionCaptures(capturedVar->getModifyCoroutine());
             break;
           }
         }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5811,7 +5811,7 @@ RValue SILGenFunction::emitDynamicMemberRefExpr(DynamicMemberRefExpr *e,
   // Create the branch.
   FuncDecl *memberFunc;
   if (auto *VD = dyn_cast<VarDecl>(e->getMember().getDecl())) {
-    memberFunc = VD->getAccessor(AccessorKind::Get);
+    memberFunc = VD->getGetter();
     memberMethodTy = FunctionType::get({}, memberMethodTy);
   } else
     memberFunc = cast<FuncDecl>(e->getMember().getDecl());
@@ -5920,7 +5920,7 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
 
   // Create the branch.
   auto subscriptDecl = cast<SubscriptDecl>(e->getMember().getDecl());
-  auto member = SILDeclRef(subscriptDecl->getAccessor(AccessorKind::Get),
+  auto member = SILDeclRef(subscriptDecl->getGetter(),
                            SILDeclRef::Kind::Func)
     .asForeign();
   B.createDynamicMethodBranch(e, base, member, hasMemberBB, noMemberBB);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2604,9 +2604,9 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
 static AccessorDecl *
 getRepresentativeAccessorForKeyPath(AbstractStorageDecl *storage) {
   if (storage->requiresOpaqueGetter())
-    return storage->getAccessor(AccessorKind::Get);
+    return storage->getGetter();
   assert(storage->requiresOpaqueReadCoroutine());
-  return storage->getAccessor(AccessorKind::Read);
+  return storage->getReadCoroutine();
 }
 
 static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
@@ -2755,7 +2755,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   // back to the declaration whose setter introduced the witness table
   // entry.
   if (isa<ProtocolDecl>(property->getDeclContext())) {
-    auto setter = property->getAccessor(AccessorKind::Set);
+    auto setter = property->getSetter();
     if (!SILDeclRef::requiresNewWitnessTableEntry(setter)) {
       // Find the setter that does have a witness table entry.
       auto wtableSetter =

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1307,7 +1307,7 @@ namespace {
           // If we have a nonmutating setter on a value type, the call
           // captures all of 'self' and we cannot rewrite an assignment
           // into an initialization.
-          auto setter = VD->getAccessor(AccessorKind::Set);
+          auto setter = VD->getSetter();
           if (setter->isNonMutating() &&
               setter->getDeclContext()->getSelfNominalTypeDecl() &&
               setter->isInstanceMember() &&

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1120,8 +1120,7 @@ public:
 
       if (hasDidSetOrWillSetDynamicReplacement &&
           isa<ExtensionDecl>(storage->getDeclContext()) &&
-          fd != storage->getAccessor(AccessorKind::WillSet) &&
-          fd != storage->getAccessor(AccessorKind::DidSet))
+          fd != storage->getDidSetFunc() && fd != storage->getWillSetFunc())
         return;
     }
     SGM.emitFunction(fd);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4085,12 +4085,12 @@ namespace {
           // The property is non-settable, so add "getter:".
           primaryDiag.fixItInsert(modifierLoc, "getter: ");
           E->overrideObjCSelectorKind(ObjCSelectorExpr::Getter, modifierLoc);
-          method = var->getAccessor(AccessorKind::Get);
+          method = var->getGetter();
           break;
         }
 
         case ObjCSelectorExpr::Getter:
-          method = var->getAccessor(AccessorKind::Get);
+          method = var->getGetter();
           break;
 
         case ObjCSelectorExpr::Setter:
@@ -4111,7 +4111,7 @@ namespace {
             return E;
           }
 
-          method = var->getAccessor(AccessorKind::Set);
+          method = var->getSetter();
           break;
         }
       } else {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3987,7 +3987,7 @@ void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
     VD->overwriteAccess(desiredAccess);
 
     if (auto *ASD = dyn_cast<AbstractStorageDecl>(VD)) {
-      if (auto *getter = ASD->getAccessor(AccessorKind::Get))
+      if (auto *getter = ASD->getGetter())
         getter->overwriteAccess(desiredAccess);
 
       if (auto *setterAttr = attrs.getAttribute<SetterAccessAttr>()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2499,7 +2499,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
       decl = func;
     } else if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
       decl = storage;
-      auto getter = storage->getAccessor(AccessorKind::Get);
+      auto getter = storage->getGetter();
       if (!getter || getter->isImplicit() || !getter->hasBody()) {
         TC.diagnose(attr->getLocation(),
                     diag::function_builder_attribute_on_storage_without_getter,
@@ -2835,9 +2835,7 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
     // Don't turn stored into computed properties. This could conflict with
     // exclusivity checking.
     // If there is a didSet or willSet function we allow dynamic replacement.
-    if (VD->hasStorage() &&
-        !VD->getAccessor(AccessorKind::DidSet) &&
-        !VD->getAccessor(AccessorKind::WillSet))
+    if (VD->hasStorage() && !VD->getDidSetFunc() && !VD->getWillSetFunc())
       return;
     // Don't add dynamic to local variables.
     if (VD->getDeclContext()->isLocalContext())

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2529,22 +2529,20 @@ private:
     // specifically using the getter/setter.
     switch (AccessContext) {
     case MemberAccessContext::Getter:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Get),
-                               ReferenceRange, ReferenceDC, None);
+      diagAccessorAvailability(D->getGetter(), ReferenceRange, ReferenceDC,
+                               None);
       break;
 
     case MemberAccessContext::Setter:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Set),
-                               ReferenceRange, ReferenceDC, None);
+      diagAccessorAvailability(D->getSetter(), ReferenceRange, ReferenceDC,
+                               None);
       break;
 
     case MemberAccessContext::InOut:
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Get),
-                               ReferenceRange, ReferenceDC,
+      diagAccessorAvailability(D->getGetter(), ReferenceRange, ReferenceDC,
                                DeclAvailabilityFlag::ForInout);
 
-      diagAccessorAvailability(D->getAccessor(AccessorKind::Set),
-                               ReferenceRange, ReferenceDC,
+      diagAccessorAvailability(D->getSetter(), ReferenceRange, ReferenceDC,
                                DeclAvailabilityFlag::ForInout);
       break;
     }

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -259,7 +259,7 @@ public:
           if (auto lazyVar = init->getInitializedLazyVar()) {
             // If we have a getter with a body, we're already re-parented
             // everything so pretend we're inside the getter.
-            if (auto getter = lazyVar->getAccessor(AccessorKind::Get)) {
+            if (auto getter = lazyVar->getGetter()) {
               if (getter->getBody(/*canSynthesize=*/false)) {
                 TmpDC = getter;
                 continue;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1041,7 +1041,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     // Otherwise, if this is a subscript, validate that covariance is ok.
     // If the parent is non-mutable, it's okay to be covariant.
     auto parentSubscript = cast<SubscriptDecl>(baseDecl);
-    if (parentSubscript->getAccessor(AccessorKind::Set)) {
+    if (parentSubscript->getSetter()) {
       diags.diagnose(subscript, diag::override_mutable_covariant_subscript,
                      declTy, baseTy);
       diags.diagnose(baseDecl, diag::subscript_override_here);
@@ -1088,7 +1088,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
           IsSilentDifference = true;
 
     // The overridden property must not be mutable.
-    if (cast<AbstractStorageDecl>(baseDecl)->getAccessor(AccessorKind::Set) &&
+    if (cast<AbstractStorageDecl>(baseDecl)->getSetter() &&
         !IsSilentDifference) {
       diags.diagnose(property, diag::override_mutable_covariant_property,
                   property->getName(), parentPropertyTy, propertyTy);
@@ -1557,8 +1557,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     // Make sure that the overriding property doesn't have storage.
     if ((overrideASD->hasStorage() ||
          overrideASD->getAttrs().hasAttribute<LazyAttr>()) &&
-        !(overrideASD->getAccessor(AccessorKind::WillSet) ||
-          overrideASD->getAccessor(AccessorKind::DidSet))) {
+        !(overrideASD->getWillSetFunc() || overrideASD->getDidSetFunc())) {
       bool downgradeToWarning = false;
       if (!ctx.isSwiftVersionAtLeast(5) &&
           overrideASD->getAttrs().hasAttribute<LazyAttr>()) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -37,7 +37,7 @@ extractEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
                    const VarDecl *constant) {
   diagnoseExplicitUnavailability(constant, UseLoc, DC, nullptr);
 
-  const FuncDecl *getter = constant->getAccessor(AccessorKind::Get);
+  const FuncDecl *getter = constant->getGetter();
   if (!getter)
     return nullptr;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -238,16 +238,14 @@ static bool checkObjCWitnessSelector(TypeChecker &tc, ValueDecl *req,
   // FIXME: Check property names!
 
   // Check the getter.
-  if (auto reqGetter = reqStorage->getAccessor(AccessorKind::Get)) {
-    auto *witnessGetter = witnessStorage->getAccessor(AccessorKind::Get);
-    if (checkObjCWitnessSelector(tc, reqGetter, witnessGetter))
+  if (auto reqGetter = reqStorage->getGetter()) {
+    if (checkObjCWitnessSelector(tc, reqGetter, witnessStorage->getGetter()))
       return true;
   }
 
   // Check the setter.
-  if (auto reqSetter = reqStorage->getAccessor(AccessorKind::Set)) {
-    auto *witnessSetter = witnessStorage->getAccessor(AccessorKind::Set);
-    if (checkObjCWitnessSelector(tc, reqSetter, witnessSetter))
+  if (auto reqSetter = reqStorage->getSetter()) {
+    if (checkObjCWitnessSelector(tc, reqSetter, witnessStorage->getSetter()))
       return true;
   }
 
@@ -5040,9 +5038,9 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
           sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, funcReq);
         } else {
           auto storageReq = cast<AbstractStorageDecl>(req);
-          if (auto getter = storageReq->getAccessor(AccessorKind::Get))
+          if (auto getter = storageReq->getGetter())
             sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, getter);
-          if (auto setter = storageReq->getAccessor(AccessorKind::Set))
+          if (auto setter = storageReq->getSetter())
             sf->ObjCUnsatisfiedOptReqs.emplace_back(dc, setter);
         }
       }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4894,10 +4894,10 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       // If this is a global variable, force the accessors to be
       // serialized.
       if (auto VD = dyn_cast<VarDecl>(D)) {
-        if (auto *getter = VD->getAccessor(swift::AccessorKind::Get))
-          addDeclRef(getter);
-        if (auto *setter = VD->getAccessor(swift::AccessorKind::Set))
-          addDeclRef(setter);
+        if (VD->getGetter())
+          addDeclRef(VD->getGetter());
+        if (VD->getSetter())
+          addDeclRef(VD->getSetter());
       }
 
       // If this nominal type has associated top-level decls for a


### PR DESCRIPTION
Reverts apple/swift#26456

Using to test whether reverting this change fixes failure source compatibility suite.