### PR TITLE
[C++ Interop] Fix method mangling.

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -684,10 +684,10 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
             std::string s(1, '\01');
             s += asmLabel->getLabel();
             return s;
-          } else if (namedClangDecl->hasAttr<clang::OverloadableAttr>()) {
+          } else if (namedClangDecl->hasAttr<clang::OverloadableAttr>() ||
+                     getDecl()->getASTContext().LangOpts.EnableCXXInterop) {
             std::string storage;
             llvm::raw_string_ostream SS(storage);
-            // FIXME: When we can import C++, use Clang's mangler all the time.
             mangleClangDecl(SS, namedClangDecl, getDecl()->getASTContext());
             return SS.str();
           }

--- a/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
+++ b/test/ClangImporter/Inputs/custom-modules/cxx_interop.h
@@ -29,3 +29,8 @@ class Methods {
 
   static int SimpleStaticMethod(int);
 };
+
+class Methods2 {
+public:
+  int SimpleMethod(int);
+};

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -50,3 +50,12 @@ func basicMethodsConst(a: UnsafeMutablePointer<Methods>) -> Int32 {
 func basicMethodsStatic() -> Int32 {
   return Methods.SimpleStaticMethod(5)
 }
+
+// CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir12basicMethods1as5Int32VSpySo8Methods2VG_tF"(i8*)
+// CHECK: [[THIS_PTR1:%.*]] = bitcast i8* %0 to %TSo8Methods2V*
+// CHECK: [[THIS_PTR2:%.*]] = bitcast %TSo8Methods2V* [[THIS_PTR1]] to %class.Methods2*
+// CHECK: [[RESULT:%.*]] = call i32 @{{_ZN8Methods212SimpleMethodEi|"\?SimpleMethod@Methods2@@QEAAHH@Z"}}(%class.Methods2* [[THIS_PTR2]], i32 4)
+// CHECK: ret i32 [[RESULT]]
+func basicMethods(a: UnsafeMutablePointer<Methods2>) -> Int32 {
+  return a.pointee.SimpleMethod(4)
+}


### PR DESCRIPTION
Multiple methods with the same name were colliding at the sil level. This was causing a compiler crasher.