### PR TITLE
Lazy accessor synthesis for storage in primary files

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4565,10 +4565,9 @@ public:
   bool isSettable(const DeclContext *UseDC,
                   const DeclRefExpr *base = nullptr) const;
 
-  /// Are there any accessors for this declaration, including implicit ones?
-  bool hasAnyAccessors() const {
-    return !getAllAccessors().empty();
-  }
+  /// Does this storage declaration have explicitly-defined accessors
+  /// written in the source?
+  bool hasParsedAccessors() const;
 
   /// Return the ownership of values opaquely read from this storage.
   OpaqueReadOwnership getOpaqueReadOwnership() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4627,12 +4627,20 @@ public:
   /// accessor was not explicitly defined by the user.
   AccessorDecl *getParsedAccessor(AccessorKind kind) const;
 
-  /// Visit all the opaque accessors that this storage is expected to have.
+  /// Visit all parsed accessors.
+  void visitParsedAccessors(llvm::function_ref<void (AccessorDecl*)>) const;
+
+  /// Visit all opaque accessor kinds.
   void visitExpectedOpaqueAccessors(
                             llvm::function_ref<void (AccessorKind)>) const;
 
-  /// Visit all the opaque accessors of this storage declaration.
+  /// Visit all opaque accessors.
   void visitOpaqueAccessors(llvm::function_ref<void (AccessorDecl*)>) const;
+
+  /// Visit all eagerly emitted accessors.
+  ///
+  /// This is the union of the parsed and opaque sets.
+  void visitEmittedAccessors(llvm::function_ref<void (AccessorDecl*)>) const;
 
   void setAccessors(SourceLoc lbraceLoc, ArrayRef<AccessorDecl*> accessors,
                     SourceLoc rbraceLoc);

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -516,8 +516,8 @@ ASTScopeImpl *ScopeCreator::createScopeFor(ASTNode n, ASTScopeImpl *parent) {
 
 void ScopeCreator::addChildrenForAllExplicitAccessors(AbstractStorageDecl *asd,
                                                       ASTScopeImpl *parent) {
-  for (auto accessor : asd->getAllAccessors()) {
-    if (!accessor->isImplicit() && accessor->getStartLoc().isValid()) {
+  asd->visitParsedAccessors([&](AccessorDecl *accessor) {
+    if (accessor->getStartLoc().isValid()) {
       // Accessors are always nested within their abstract storage
       // declaration. The nesting may not be immediate, because subscripts may
       // have intervening scopes for generics.
@@ -526,7 +526,7 @@ void ScopeCreator::addChildrenForAllExplicitAccessors(AbstractStorageDecl *asd,
         ASTVisitorForScopeCreation().visitAbstractFunctionDecl(accessor, parent,
                                                                *this);
     }
-  }
+  });
 }
 
 #pragma mark creation helpers

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2010,6 +2010,13 @@ AccessorDecl *AbstractStorageDecl::getOpaqueAccessor(AccessorKind kind) const {
   return getSynthesizedAccessor(kind);
 }
 
+bool AbstractStorageDecl::hasParsedAccessors() const {
+  for (auto *accessor : getAllAccessors())
+    if (!accessor->isImplicit())
+      return true;
+  return false;
+}
+
 AccessorDecl *AbstractStorageDecl::getParsedAccessor(AccessorKind kind) const {
   auto *accessor = getAccessor(kind);
   if (accessor && !accessor->isImplicit())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2025,6 +2025,22 @@ AccessorDecl *AbstractStorageDecl::getParsedAccessor(AccessorKind kind) const {
   return nullptr;
 }
 
+void AbstractStorageDecl::visitParsedAccessors(
+                        llvm::function_ref<void (AccessorDecl*)> visit) const {
+  for (auto *accessor : getAllAccessors())
+    if (!accessor->isImplicit())
+      visit(accessor);
+}
+
+void AbstractStorageDecl::visitEmittedAccessors(
+                        llvm::function_ref<void (AccessorDecl*)> visit) const {
+  visitParsedAccessors(visit);
+  visitOpaqueAccessors([&](AccessorDecl *accessor) {
+    if (accessor->isImplicit())
+      visit(accessor);
+  });
+}
+
 void AbstractStorageDecl::visitExpectedOpaqueAccessors(
                         llvm::function_ref<void (AccessorKind)> visit) const {
   if (!requiresOpaqueAccessors())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6463,13 +6463,6 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
 
   auto &ctx = dc->getASTContext();
 
-  // FIXME: Remove this once getInterfaceType(), isDesignatedInit() and
-  // anything else that is used below has been request-ified.
-  if (!decl->hasInterfaceType()) {
-    ctx.getLazyResolver()->resolveDeclSignature(
-      const_cast<AbstractFunctionDecl *>(decl));
-  }
-
   // Initializers are not normally inherited, but required initializers can
   // be overridden for invocation from dynamic types, and convenience initializers
   // are conditionally inherited when all designated initializers are available,
@@ -6494,13 +6487,6 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
   if (!base || base->hasClangNode() || base->isObjCDynamic())
     return true;
 
-  // FIXME: Remove this once getInterfaceType(), isDesignatedInit() and
-  // anything else that is used below has been request-ified.
-  if (!base->hasInterfaceType()) {
-    ctx.getLazyResolver()->resolveDeclSignature(
-      const_cast<AbstractFunctionDecl *>(base));
-  }
-
   // As above, convenience initializers are not formally overridable in Swift
   // vtables, although same-named initializers are modeled as overriding for
   // various QoI and objc interop reasons. Even if we "override" a non-required
@@ -6516,6 +6502,17 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
   // at all.
   if (decl->isEffectiveLinkageMoreVisibleThan(base))
     return true;
+
+  // FIXME: Remove this once getInterfaceType() has been request-ified.
+  if (!decl->hasInterfaceType()) {
+    ctx.getLazyResolver()->resolveDeclSignature(
+      const_cast<AbstractFunctionDecl *>(decl));
+  }
+
+  if (!base->hasInterfaceType()) {
+    ctx.getLazyResolver()->resolveDeclSignature(
+      const_cast<AbstractFunctionDecl *>(base));
+  }
 
   // If the method overrides something, we only need a new entry if the
   // override has a more general AST type. However an abstraction

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1618,8 +1618,9 @@ class FindAllSubDecls : public SourceEntityWalker {
       return false;
 
     if (auto ASD = dyn_cast<AbstractStorageDecl>(D)) {
-      auto accessors = ASD->getAllAccessors();
-      Found.insert(accessors.begin(), accessors.end());
+      ASD->visitParsedAccessors([&](AccessorDecl *accessor) {
+        Found.insert(accessor);
+      });
     }
     return true;
   }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1103,15 +1103,13 @@ bool IndexSwiftASTWalker::report(ValueDecl *D) {
     // Even if we don't record a local property we still need to walk its
     // accessor bodies.
     if (auto StoreD = dyn_cast<AbstractStorageDecl>(D)) {
-      for (auto accessor : StoreD->getAllAccessors()) {
-        if (accessor->isImplicit())
-          continue;
+      StoreD->visitParsedAccessors([&](AccessorDecl *accessor) {
+        if (Cancelled)
+          return;
         ManuallyVisitedAccessorStack.push_back(accessor);
         SourceEntityWalker::walk(cast<Decl>(accessor));
         ManuallyVisitedAccessorStack.pop_back();
-        if (Cancelled)
-          return false;
-      }
+      });
     }
   }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1328,15 +1328,15 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
-  for (auto *accessor : vd->getAllAccessors())
+  vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
+  });
 
   tryEmitPropertyDescriptor(vd);
 }
 
 void SILGenModule::visitSubscriptDecl(SubscriptDecl *sd) {
-  for (auto *accessor : sd->getAllAccessors())
-    emitFunction(accessor);
+  llvm_unreachable("top-level subscript?");
 }
 
 bool

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1194,8 +1194,9 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
   // We handle emitting the variable storage when we see the pattern binding.
 
   // Emit the variable's accessors.
-  for (auto *accessor : D->getAllAccessors())
+  D->visitEmittedAccessors([&](AccessorDecl *accessor) {
     SGM.emitFunction(accessor);
+  });
 }
 
 /// Emit literals for the major, minor, and subminor components of the version

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3360,7 +3360,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
             // storage.
             // Properties that are not public don't need property descriptors
             // either.
-            (!baseDecl->hasAnyAccessors() ||
+            (!baseDecl->requiresOpaqueAccessors() ||
              (!getAccessorDeclRef(getRepresentativeAccessorForKeyPath(baseDecl))
                    .isForeign &&
               getAccessorDeclRef(getRepresentativeAccessorForKeyPath(baseDecl))

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1050,9 +1050,9 @@ public:
   }
 
   void visitAccessors(AbstractStorageDecl *asd) {
-    for (auto *accessor : asd->getAllAccessors())
-      if (!accessor->hasForcedStaticDispatch())
-        visitFuncDecl(accessor);
+    asd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+      visitFuncDecl(accessor);
+    });
   }
 };
 
@@ -1182,9 +1182,9 @@ public:
   }
 
   void visitAccessors(AbstractStorageDecl *asd) {
-    for (auto *accessor : asd->getAllAccessors())
-      if (!accessor->hasForcedStaticDispatch())
-        visitFuncDecl(accessor);
+    asd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+      visitFuncDecl(accessor);
+    });
   }
 };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4039,7 +4039,6 @@ namespace {
         method = func;
       } else if (auto var = dyn_cast<VarDecl>(foundDecl)) {
         // Properties.
-        addExpectedOpaqueAccessorsToStorage(var);
 
         // If this isn't a property on a type, complain.
         if (!var->getDeclContext()->isTypeContext()) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1293,13 +1293,6 @@ SynthesizeAccessorRequest::evaluate(Evaluator &evaluator,
   }
 }
 
-void swift::addExpectedOpaqueAccessorsToStorage(AbstractStorageDecl *storage) {
-  storage->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
-    // Force synthesis if necessary.
-    (void) storage->getSynthesizedAccessor(kind);
-  });
-}
-
 /// Synthesize the body of a setter which just delegates to a mutable
 /// addressor.
 static std::pair<BraceStmt *, bool>
@@ -1717,7 +1710,6 @@ static VarDecl *synthesizePropertyWrapperStorageWrapperProperty(
     property->setImplInfo(StorageImplInfo::getMutableComputed());
   else
     property->setImplInfo(StorageImplInfo::getImmutableComputed());
-  addExpectedOpaqueAccessorsToStorage(property);
 
   var->getAttrs().add(
       new (ctx) ProjectedValuePropertyAttr(name, SourceLoc(), SourceRange(),

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -45,9 +45,6 @@ class ObjCReason;
 // Implemented in TypeCheckerOverride.cpp
 bool checkOverrides(ValueDecl *decl);
 
-// These are implemented in CodeSynthesis.cpp.
-void addExpectedOpaqueAccessorsToStorage(AbstractStorageDecl *storage);
-
 /// Describes the kind of implicit constructor that will be
 /// generated.
 enum class ImplicitConstructorKind {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -181,7 +181,7 @@ private:
     // when we process the accessor, we can use this TRC as the
     // parent.
     if (auto *StorageDecl = dyn_cast<AbstractStorageDecl>(D)) {
-      if (StorageDecl->hasAnyAccessors()) {
+      if (StorageDecl->hasParsedAccessors()) {
         StorageContexts[StorageDecl] = NewTRC;
       }
     }
@@ -230,7 +230,7 @@ private:
       // locations and have callers of that method provide appropriate source
       // locations.
       SourceLoc BracesEnd = storageDecl->getBracesRange().End;
-      if (storageDecl->hasAnyAccessors() && BracesEnd.isValid()) {
+      if (storageDecl->hasParsedAccessors() && BracesEnd.isValid()) {
         return SourceRange(storageDecl->getStartLoc(),
                            BracesEnd);
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2528,12 +2528,8 @@ public:
     // Compute these requests in case they emit diagnostics.
     (void) VD->isGetterMutating();
     (void) VD->isSetterMutating();
-
-    // Retrieve the backing property of a wrapped property.
     (void) VD->getPropertyWrapperBackingProperty();
-
-    // Set up accessors, also lowering lazy and @NSManaged properties.
-    addExpectedOpaqueAccessorsToStorage(VD);
+    (void) VD->getImplInfo();
 
     // Add the '@_hasStorage' attribute if this property is stored.
     if (VD->hasStorage() && !VD->getAttrs().hasAttribute<HasStorageAttr>())
@@ -2542,9 +2538,8 @@ public:
     // Reject cases where this is a variable that has storage but it isn't
     // allowed.
     if (VD->hasStorage()) {
-      // Stored properties in protocols are diagnosed in
-      // addExpectedOpaqueAccessorsToStorage(), to ensure they run when a
-      // protocol requirement is validated but not type checked.
+      // Note: Stored properties in protocols are diagnosed in
+      // finishProtocolStorageImplInfo().
 
       // Enums and extensions cannot have stored instance properties.
       // Static stored properties are allowed, with restrictions
@@ -2614,8 +2609,6 @@ public:
     }
 
     TC.checkDeclAttributes(VD);
-
-    addExpectedOpaqueAccessorsToStorage(VD);
 
     if (VD->getDeclContext()->getSelfClassDecl()) {
       checkDynamicSelfType(VD, VD->getValueInterfaceType());
@@ -2861,8 +2854,7 @@ public:
     // Compute these requests in case they emit diagnostics.
     (void) SD->isGetterMutating();
     (void) SD->isSetterMutating();
-
-    addExpectedOpaqueAccessorsToStorage(SD);
+    (void) SD->getImplInfo();
 
     if (SD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
       TC.checkDynamicReplacementAttribute(SD);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2658,8 +2658,9 @@ public:
       TC.checkDynamicReplacementAttribute(VD);
 
     // Now check all the accessors.
-    for (auto *accessor : VD->getAllAccessors())
+    VD->visitEmittedAccessors([&](AccessorDecl *accessor) {
       visit(accessor);
+    });
   }
 
   void visitBoundVars(Pattern *P) {
@@ -2880,8 +2881,9 @@ public:
     }
 
     // Now check all the accessors.
-    for (auto *accessor : SD->getAllAccessors())
+    SD->visitEmittedAccessors([&](AccessorDecl *accessor) {
       visit(accessor);
+    });
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1879,8 +1879,6 @@ OverriddenDeclsRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     SmallVector<OverrideMatch, 2> matches;
     for (auto overridden : overridingASD->getOverriddenDecls()) {
       auto baseASD = cast<AbstractStorageDecl>(overridden);
-      addExpectedOpaqueAccessorsToStorage(baseASD);
-
       auto kind = accessor->getAccessorKind();
 
       // If the base doesn't consider this an opaque accessor,

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -280,9 +280,9 @@ void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
   }
 
   // Explicitly look at each accessor here: see visitAccessorDecl.
-  for (auto accessor : ASD->getAllAccessors()) {
+  ASD->visitEmittedAccessors([&](AccessorDecl *accessor) {
     visitFuncDecl(accessor);
-  }
+  });
 }
 
 void TBDGenVisitor::visitVarDecl(VarDecl *VD) {

--- a/test/IRGen/Inputs/vtable_multi_file_helper.swift
+++ b/test/IRGen/Inputs/vtable_multi_file_helper.swift
@@ -9,7 +9,7 @@ class SillySequence : Sequence, IteratorProtocol {
   var storedProperty: Int = 0
 
   func makeIterator() -> SillySequence {
-    return sel
+    return self
   }
 
   func next() -> Int? {
@@ -21,4 +21,8 @@ class Holder {
   func getSillySequence() -> SillySequence {
     return SillySequence()
   }
+}
+
+class Base {
+  func method() {}
 }

--- a/test/IRGen/vtable_multi_file.swift
+++ b/test/IRGen/vtable_multi_file.swift
@@ -2,6 +2,12 @@
 
 // REQUIRES: CPU=x86_64
 
+// CHECK-LABEL: @"$s17vtable_multi_file7DerivedCMf" = internal global
+// CHECK-SAME: @"$s17vtable_multi_file4BaseC6methodyyF"
+class Derived : Base {
+  func another() {}
+}
+
 func markUsed<T>(_ t: T) {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s17vtable_multi_file36baseClassVtablesIncludeImplicitInitsyyF"() {{.*}} {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -845,7 +845,7 @@ class infer_instanceVar1 {
   }
 
   var observingAccessorsVar1: Int {
-  // CHECK: @objc @_hasStorage var observingAccessorsVar1: Int {
+  // CHECK: @_hasStorage @objc var observingAccessorsVar1: Int {
     willSet {}
     // CHECK-NEXT: {{^}} @objc get
     didSet {}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/26461. It introduces new methods on AbstractStorageDecl for visiting accessors in a deterministic way, intended to replace getAllAccessors():

- visitParsedAccessors() - visits parsed accessors only
- visitEmittedAccessors() - visits parsed and opaque accessors

This facilitates the removal of `addExpectedOpaqueAccessorsToStorage()`.