### PR TITLE
[Diagnostics] Improve the diagnostic for invalid pointer conversion for an autoclosure result type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1133,6 +1133,10 @@ ERROR(c_function_pointer_from_generic_function,none,
       "function", ())
 ERROR(invalid_autoclosure_forwarding,none,
       "add () to forward @autoclosure parameter", ())
+ERROR(invalid_autoclosure_pointer_conversion,none,
+      "cannot perform pointer conversion of value of type %0 to autoclosure "
+      "result type %1",
+      (Type, Type))
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Declarations

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1978,6 +1978,14 @@ bool AutoClosureForwardingFailure::diagnoseAsError() {
   return true;
 }
 
+bool AutoClosurePointerConversionFailure::diagnoseAsError() {
+  auto *anchor = getAnchor();
+  auto diagnostic = diag::invalid_autoclosure_pointer_conversion;
+  emitDiagnostic(anchor->getLoc(), diagnostic, PointeeType, PointerType)
+      .highlight(anchor->getSourceRange());
+  return true;
+}
+
 bool NonOptionalUnwrapFailure::diagnoseAsError() {
   auto *anchor = getAnchor();
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1981,7 +1981,7 @@ bool AutoClosureForwardingFailure::diagnoseAsError() {
 bool AutoClosurePointerConversionFailure::diagnoseAsError() {
   auto *anchor = getAnchor();
   auto diagnostic = diag::invalid_autoclosure_pointer_conversion;
-  emitDiagnostic(anchor->getLoc(), diagnostic, PointeeType, PointerType)
+  emitDiagnostic(anchor->getLoc(), diagnostic, getFromType(), getToType())
       .highlight(anchor->getSourceRange());
   return true;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -785,16 +785,12 @@ public:
 /// var i = 0
 /// foo(&i) // Invalid conversion to UnsafePointer
 /// \endcode
-class AutoClosurePointerConversionFailure final : public FailureDiagnostic {
-  Type PointeeType;
-  Type PointerType;
-
+class AutoClosurePointerConversionFailure final : public ContextualFailure {
 public:
   AutoClosurePointerConversionFailure(Expr *root, ConstraintSystem &cs,
                                       Type pointeeType, Type pointerType,
                                       ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), PointeeType(pointeeType),
-        PointerType(pointerType) {}
+      : ContextualFailure(root, cs, pointeeType, pointerType, locator) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -777,6 +777,28 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose invalid pointer conversions for an autoclosure result type.
+///
+/// \code
+/// func foo(_ x: @autoclosure () -> UnsafePointer<Int>) {}
+///
+/// var i = 0
+/// foo(&i) // Invalid conversion to UnsafePointer
+/// \endcode
+class AutoClosurePointerConversionFailure final : public FailureDiagnostic {
+  Type PointeeType;
+  Type PointerType;
+
+public:
+  AutoClosurePointerConversionFailure(Expr *root, ConstraintSystem &cs,
+                                      Type pointeeType, Type pointerType,
+                                      ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator), PointeeType(pointeeType),
+        PointerType(pointerType) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose situations when there was an attempt to unwrap entity
 /// of non-optional type e.g.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -269,6 +269,20 @@ AutoClosureForwarding *AutoClosureForwarding::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AutoClosureForwarding(cs, locator);
 }
 
+bool AllowAutoClosurePointerConversion::diagnose(Expr *root, bool asNote) const {
+  auto failure = AutoClosurePointerConversionFailure(root, getConstraintSystem(),
+      PointeeType, PointerType, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowAutoClosurePointerConversion *
+AllowAutoClosurePointerConversion::create(ConstraintSystem &cs, Type pointeeType,
+                                          Type pointerType,
+                                          ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowAutoClosurePointerConversion(cs, pointeeType, pointerType, locator);
+}
+
 bool RemoveUnwrap::diagnose(Expr *root, bool asNote) const {
   auto failure = NonOptionalUnwrapFailure(root, getConstraintSystem(), BaseType,
                                           getLocator());

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -271,7 +271,7 @@ AutoClosureForwarding *AutoClosureForwarding::create(ConstraintSystem &cs,
 
 bool AllowAutoClosurePointerConversion::diagnose(Expr *root, bool asNote) const {
   auto failure = AutoClosurePointerConversionFailure(root, getConstraintSystem(),
-      PointeeType, PointerType, getLocator());
+      getFromType(), getToType(), getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -625,14 +625,11 @@ public:
                                        ConstraintLocator *locator);
 };
 
-class AllowAutoClosurePointerConversion final : public ConstraintFix {
-  Type PointeeType;
-  Type PointerType;
-
+class AllowAutoClosurePointerConversion final : public ContextualMismatch {
   AllowAutoClosurePointerConversion(ConstraintSystem &cs, Type pointeeType,
                                     Type pointerType, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AllowAutoClosurePointerConversion, locator),
-        PointeeType(pointeeType), PointerType(pointerType) {}
+      : ContextualMismatch(cs, FixKind::AllowAutoClosurePointerConversion,
+                           pointeeType, pointerType, locator) {}
 
 public:
   std::string getName() const override {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -98,6 +98,10 @@ enum class FixKind : uint8_t {
   /// Swift version 5.
   AutoClosureForwarding,
 
+  /// Allow invalid pointer conversions for autoclosure result types as if the
+  /// pointer type is a function parameter rather than an autoclosure result.
+  AllowAutoClosurePointerConversion,
+
   /// Remove `!` or `?` because base is not an optional type.
   RemoveUnwrap,
 
@@ -619,6 +623,28 @@ public:
 
   static AutoClosureForwarding *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
+};
+
+class AllowAutoClosurePointerConversion final : public ConstraintFix {
+  Type PointeeType;
+  Type PointerType;
+
+  AllowAutoClosurePointerConversion(ConstraintSystem &cs, Type pointeeType,
+                                    Type pointerType, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowAutoClosurePointerConversion, locator),
+        PointeeType(pointeeType), PointerType(pointerType) {}
+
+public:
+  std::string getName() const override {
+    return "allow pointer conversion for autoclosure result type";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static AllowAutoClosurePointerConversion *create(ConstraintSystem &cs,
+                                                   Type pointeeType,
+                                                   Type pointerType,
+                                                   ConstraintLocator *locator);
 };
 
 class RemoveUnwrap final : public ConstraintFix {

--- a/test/Constraints/invalid_implicit_conversions.swift
+++ b/test/Constraints/invalid_implicit_conversions.swift
@@ -15,14 +15,14 @@ func test(
   var a: [Int] = [0]
   let s = "string"
 
-  takesAutoclosure(rawPtr, &i) // expected-error {{'&' used with non-inout argument of type 'Int'}}
-  takesAutoclosure(mutRawPtr, &i) // expected-error {{'&' used with non-inout argument of type 'Int'}}
-  takesAutoclosure(mutPtr, &i) // expected-error {{'&' used with non-inout argument of type 'Int'}}
-  takesAutoclosure(ptr, &i) // expected-error {{'&' used with non-inout argument of type 'Int'}}
-  takesAutoclosure(rawPtr, &a) // expected-error {{'&' used with non-inout argument of type '[Int]'}}
-  takesAutoclosure(mutRawPtr, &a) // expected-error {{'&' used with non-inout argument of type '[Int]'}}
-  takesAutoclosure(mutPtr, &a) // expected-error {{'&' used with non-inout argument of type '[Int]'}}
-  takesAutoclosure(ptr, &a) // expected-error {{'&' used with non-inout argument of type '[Int]'}}
+  takesAutoclosure(rawPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafeRawPointer'}}
+  takesAutoclosure(mutRawPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafeMutableRawPointer'}}
+  takesAutoclosure(mutPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafeMutablePointer<Int>'}}
+  takesAutoclosure(ptr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafePointer<Int>'}}
+  takesAutoclosure(rawPtr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeRawPointer'}}
+  takesAutoclosure(mutRawPtr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeMutableRawPointer'}}
+  takesAutoclosure(mutPtr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeMutablePointer<Int>'}}
+  takesAutoclosure(ptr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafePointer<Int>'}}
 
   takesAutoclosure(rawPtr, a) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafeRawPointer, [Int])'}}
   // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}


### PR DESCRIPTION
Add constraint fix `AllowAutoClosurePointerConversion` and corresponding diagnostic `AutoClosurePointerConversionFailure`. When we discover that we're trying to do an inout-to-pointer conversion for an autoclosure result in `matchTypes`, add the constraint fix, which tries to do the conversion as if the pointer type is a regular function argument.