### PR TITLE
Added a helper success case for Result<Void, Error> types

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -163,6 +163,14 @@ extension Result where Failure == Swift.Error {
   }
 }
 
+extension Result where Success == Void {
+  /// A success, without passing `Void` explicitly as a the `Success` value.
+  @_transparent
+  public static var success: Result<Success, Failure> {
+    return .success(())
+  }
+}
+
 extension Result: Equatable where Success: Equatable, Failure: Equatable { }
 
 extension Result: Hashable where Success: Hashable, Failure: Hashable { }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -164,7 +164,7 @@ extension Result where Failure == Swift.Error {
 }
 
 extension Result where Success == Void {
-  /// A success, without passing `Void` explicitly as a the `Success` value.
+  /// A success, without passing `Void` explicitly as the `Success` value.
   @_transparent
   public static var success: Result<Success, Failure> {
     return .success(())


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change allows the following:
```diff
func foo(result: (Result<Void, Error>) -> ()) {
+  result(.success)
-  result(.success(()))
}
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
