### PR TITLE
Add -debug-diagnostic-names frontend flag

### DIFF
--- a/docs/DebuggingTheCompiler.rst
+++ b/docs/DebuggingTheCompiler.rst
@@ -86,6 +86,14 @@ diagnostic engine to assert on the first error/warning:
 These allow one to dump a stack trace of where the diagnostic is being emitted
 (if run without a debugger) or drop into the debugger if a debugger is attached.
 
+Finding Diagnostic Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some diagnostics rely heavily on format string arguments, so it can be difficult
+to find their implementation by searching for parts of the emitted message in
+the codebase. To print the corresponding diagnostic name at the end of each
+emitted message, use the ``-Xfrontend -debug-diagnostic-names`` argument.
+
 Debugging the Type Checker
 --------------------------
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -583,6 +583,9 @@ namespace swift {
     /// input being compiled.
     /// May be invalid.
     SourceLoc bufferIndirectlyCausingDiagnostic;
+    
+    /// Print diagnostic names after their messages
+    bool printDiagnosticNames = false;
 
     friend class InFlightDiagnostic;
     friend class DiagnosticTransaction;
@@ -616,6 +619,14 @@ namespace swift {
     void setWarningsAsErrors(bool val) { state.setWarningsAsErrors(val); }
     bool getWarningsAsErrors() const {
       return state.getWarningsAsErrors();
+    }
+
+    /// Whether to print diagnostic names after their messages
+    void setPrintDiagnosticNames(bool val) {
+      printDiagnosticNames = val;
+    }
+    bool getPrintDiagnosticNames() const {
+      return printDiagnosticNames;
     }
 
     void ignoreDiagnostic(DiagID id) {
@@ -826,7 +837,8 @@ namespace swift {
     void emitTentativeDiagnostics();
 
   public:
-    static const char *diagnosticStringFor(const DiagID id);
+    static const char *diagnosticStringFor(const DiagID id,
+                                           bool printDiagnosticName);
 
     /// If there is no clear .dia file for a diagnostic, put it in the one
     /// corresponding to the SourceLoc given here.

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -52,6 +52,9 @@ public:
   /// Treat all warnings as errors
   bool WarningsAsErrors = false;
 
+  // When printing diagnostics, include the diagnostic name at the end
+  bool PrintDiagnosticNames = false;
+
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -306,6 +306,9 @@ def color_diagnostics : Flag<["-"], "color-diagnostics">,
 def no_color_diagnostics : Flag<["-"], "no-color-diagnostics">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Do not print diagnostics in color">;
+def debug_diagnostic_names : Flag<["-"], "debug-diagnostic-names">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
+  HelpText<"Include diagnostic names when printing">;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -233,6 +233,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
                        options::OPT_experimental_dependency_include_intrafile);
   inputArgs.AddLastArg(arguments, options::OPT_package_description_version);
   inputArgs.AddLastArg(arguments, options::OPT_serialize_diagnostics_path);
+  inputArgs.AddLastArg(arguments, options::OPT_debug_diagnostic_names);
   inputArgs.AddLastArg(arguments, options::OPT_enable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_astscope_lookup);
   inputArgs.AddLastArg(arguments, options::OPT_disable_parser_lookup);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -669,6 +669,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.FixitCodeForAllDiagnostics |= Args.hasArg(OPT_fixit_all);
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
   Opts.WarningsAsErrors |= Args.hasArg(OPT_warnings_as_errors);
+  Opts.PrintDiagnosticNames |= Args.hasArg(OPT_debug_diagnostic_names);
 
   assert(!(Opts.WarningsAsErrors && Opts.SuppressWarnings) &&
          "conflicting arguments; should have been caught by driver");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -305,6 +305,9 @@ void CompilerInstance::setUpDiagnosticOptions() {
   if (Invocation.getDiagnosticOptions().WarningsAsErrors) {
     Diagnostics.setWarningsAsErrors(true);
   }
+  if (Invocation.getDiagnosticOptions().PrintDiagnosticNames) {
+    Diagnostics.setPrintDiagnosticNames(true);
+  }
 }
 
 bool CompilerInstance::setUpModuleLoaders() {

--- a/test/Frontend/debug-diagnostic-names.swift
+++ b/test/Frontend/debug-diagnostic-names.swift
@@ -1,0 +1,23 @@
+// RUN: not %target-swift-frontend -debug-diagnostic-names -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK_NAMES
+// RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK_NONAMES
+
+let x =
+// CHECK_NAMES: error: expected initial value after '=' [expected_init_value]{{$}}
+// CHECK_NONAMES: error: expected initial value after '='{{$}}
+
+guard let y = 0 else {}
+// CHECK_NAMES: error: initializer for conditional binding must have Optional type, not 'Int' [condition_optional_element_pattern_not_valid_type]{{$}}
+// CHECK_NONAMES: error: initializer for conditional binding must have Optional type, not 'Int'{{$}}
+
+let z: Double = ""
+// CHECK_NAMES: error: cannot convert value of type 'String' to specified type 'Double' [cannot_convert_initializer_value]{{$}}
+// CHECK_NONAMES: error: cannot convert value of type 'String' to specified type 'Double'{{$}}
+
+func foo() -> Int {
+  return
+  42
+}
+// CHECK_NAMES: warning: expression following 'return' is treated as an argument of the 'return' [unindented_code_after_return]{{$}}
+// CHECK_NAMES: note: indent the expression to silence this warning [indent_expression_to_silence]{{$}}
+// CHECK_NONAMES: warning: expression following 'return' is treated as an argument of the 'return'{{$}}
+// CHECK_NONAMES: note: indent the expression to silence this warning{{$}}


### PR DESCRIPTION
This flag adds diagnostic names to the end of their messages, e.g. `error: cannot convert value of type '[Any]' to specified type '[Int]' [cannot_convert_initializer_value]`. It's intended to be used for debugging purposes when working on the compiler.

Resolves [SR-11239](https://bugs.swift.org/browse/SR-11239)

I ended up calling this `-debug-diagnostic-names` instead of `debug-diagnostic-ids` because 'Diagnostic ID' is kind of an overloaded term within the compiler. I don't feel too strongly either way about the naming though.

cc @brentdax (great idea by the way, I used to rely on a script to map messages back to diags, this is far nicer!)