### PR TITLE
Basic: normalise android triples when loading modules

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -328,6 +328,16 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
     return llvm::Triple(newArch, newVendor, newOS, *newEnvironment);
   }
 
+  // android - drop the API level.  That is not pertinent to the module; the API
+  // availability is handled by the clang importer.
+  if (triple.isAndroid()) {
+    StringRef environment =
+        llvm::Triple::getEnvironmentTypeName(triple.getEnvironment());
+
+    return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+                        triple.getOSName(), environment);
+  }
+
   // Other platforms get no normalization.
   return triple;
 }

--- a/test/Serialization/android-modules.swift
+++ b/test/Serialization/android-modules.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift_driver_plain --driver-mode=swiftc -target aarch64-unknown-linux-android -c %s -parse-stdlib -module-name Swift -emit-module -emit-module-path %t/Swift.swiftmodule
+// RUN: %swift_driver_plain --driver-mode=swiftc -O -target aarch64-unknown-linux-android21 -c %s -I %t
+


### PR DESCRIPTION
The android API level can be ignored when loading the module.  The API
level controls the NDK APIs which are available and is equivalent to the
SDK version for Darwin.  This allows us to keep the API level in the
triple which future versions of Android's toolchain does.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
