### PR TITLE
[Gardening] Fix example of SyntaxParsingContext in comment

### DIFF
--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -68,7 +68,7 @@ constexpr size_t SyntaxAlignInBits = 3;
 ///
 /// e.g.
 ///   parseExprParen() {
-///     SyntaxParsingContext LocalCtxt(SyntaxKind::ParenExpr, SyntaxContext);
+///     SyntaxParsingContext LocalCtxt(SyntaxContext, SyntaxKind::ParenExpr);
 ///     consumeToken(tok::l_paren) // In consumeToken(), a RawTokenSyntax is
 ///                                // added to the context.
 ///     parseExpr(); // On returning from parseExpr(), a Expr Syntax node is


### PR DESCRIPTION
## Overview

`SyntaxParsingContext LocalCtxt(SyntaxContext, SyntaxKind::ParenExpr);` is correct, not `SyntaxParsingContext LocalCtxt(SyntaxKind::ParenExpr, SyntaxContext);` according to definition below

```
  SyntaxParsingContext(SyntaxParsingContext *&CtxtHolder, SyntaxKind Kind)
      : SyntaxParsingContext(CtxtHolder) {
    setCreateSyntax(Kind);
  }
```