### PR TITLE
[Typechecker][QoI] Calls with unexpected trailing closures weren't getting passed on to ArgumentMatcher

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3299,16 +3299,20 @@ public:
     if (tuple)
       arg = tuple->getElement(argIdx);
 
-    auto &param = Parameters[paramIdx];
-    TC.diagnose(arg->getLoc(), diag::trailing_closure_bad_param,
-                param.getPlainType())
-      .highlight(arg->getSourceRange());
+    if (argIdx >= Parameters.size()) {
+      TC.diagnose(arg->getLoc(), diag::extra_trailing_closure_in_call)
+          .highlight(arg->getSourceRange());
+    } else {
+      auto &param = Parameters[paramIdx];
+      TC.diagnose(arg->getLoc(), diag::trailing_closure_bad_param,
+                  param.getPlainType())
+          .highlight(arg->getSourceRange());
 
-    auto candidate = CandidateInfo[0];
-    if (candidate.getDecl())
-      TC.diagnose(candidate.getDecl(), diag::decl_declared_here,
-                  candidate.getDecl()->getFullName());
-
+      auto candidate = CandidateInfo[0];
+      if (candidate.getDecl())
+        TC.diagnose(candidate.getDecl(), diag::decl_declared_here,
+                    candidate.getDecl()->getFullName());
+    }
     Diagnosed = true;
 
     return true;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -308,7 +308,7 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
       return true;
     }
     bool trailingClosureMismatch(unsigned paramIdx, unsigned argIdx) override {
-      result = CC_ArgumentMismatch;
+      result = CC_ArgumentCountMismatch;
       return true;
     }
   } listener;

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -213,10 +213,8 @@ func rdar_45535925() {
 // rdar://problem/50668864
 func rdar_50668864() {
   struct Foo {
-    init(anchors: [Int]) {
-      // TODO: This would be improved when argument conversions are diagnosed via new diagnostic framework,
-      // actual problem here is that `[Int]` cannot be converted to function type represented by a closure.
-      self = .init { _ in [] } // expected-error {{type of expression is ambiguous without more context}}
+    init(anchors: [Int]) { // expected-note {{'init(anchors:)' declared here}}
+      self = .init { _ in [] } // expected-error {{trailing closure passed to parameter of type '[Int]' that does not accept a closure}}
     }
   }
 }

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -34,9 +34,8 @@ trailingClosureSingle1 { 1 } // expected-error {{missing argument for parameter 
 trailingClosureSingle1() { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{24-24=x: <#Int#>}}
 
 func trailingClosureSingle2(x: () -> Int, y: Int) {} // expected-note * {{here}}
-// FIXME: Bad diagnostics.
-trailingClosureSingle2 { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: () -> Int, y: Int)'}}
-trailingClosureSingle2() { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: () -> Int, y: Int)'}}
+trailingClosureSingle2 { 1 } // expected-error {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+trailingClosureSingle2() { 1 } // expected-error {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
 
 func trailingClosureMulti1(x: Int, y: Int, z: () -> Int) {} // expected-note * {{here}}
 trailingClosureMulti1(y: 1) { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{23-23=x: <#Int#>, }}
@@ -44,11 +43,9 @@ trailingClosureMulti1(x: 1) { 1 } // expected-error {{missing argument for param
 trailingClosureMulti1(x: 1, y: 1) // expected-error {{missing argument for parameter 'z' in call}} {{33-33=, z: <#() -> Int#>}}
 
 func trailingClosureMulti2(x: Int, y: () -> Int, z: Int) {} // expected-note * {{here}}
-trailingClosureMulti2 { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int, z: Int)'}}
-// FIXME: Bad diagnostics.
-trailingClosureMulti2() { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int, z: Int)'}}
-trailingClosureMulti2(x: 1) { 1 } // expected-error {{cannot invoke 'trailingClosureMulti2' with an argument list of type '(x: Int, @escaping () -> Int)'}}
-// expected-note@-1{{expected an argument list of type '(x: Int, y: () -> Int, z: Int)'}}
+trailingClosureMulti2 { 1 } // expected-error {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+trailingClosureMulti2() { 1 } // expected-error {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
+trailingClosureMulti2(x: 1) { 1 } // expected-error {{trailing closure passed to parameter of type 'Int' that does not accept a closure}}
 
 func param2Func(x: Int, y: Int) {} // expected-note * {{here}}
 param2Func(x: 1) // expected-error {{missing argument for parameter 'y' in call}} {{16-16=, y: <#Int#>}}

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -132,8 +132,7 @@ func rdar17965209_test() {
 func limitXY(_ xy:Int, toGamut gamut: [Int]) {}
 let someInt = 0
 let intArray = [someInt]
-limitXY(someInt, toGamut: intArray) {}  // expected-error{{cannot invoke 'limitXY' with an argument list of type '(Int, toGamut: [Int], @escaping () -> ())'}}
-// expected-note@-1{{expected an argument list of type '(Int, toGamut: [Int])'}}
+limitXY(someInt, toGamut: intArray) {}  // expected-error{{extra trailing closure passed in call}}
 
 // <rdar://problem/23036383> QoI: Invalid trailing closures in stmt-conditions produce lowsy diagnostics
 func retBool(x: () -> Int) -> Bool {}


### PR DESCRIPTION
Unexpected trailing closures to a call were being treated as "too far" in closeness to be worth trying to `matchCallArguments` to diagnose the problem, thus causing some diagnostic code to be skipped and ending up with worse generic diagnoses instead. 

Someone with access to Radar might want to check if this fixes rdar://problem/50668864 and rdar://problem/17965209 as suggested in the test comments here.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10000](https://bugs.swift.org/browse/SR-10000).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
