### PR TITLE
[CMake] Add missing dependencies for swift-lldb unified build support

### DIFF
--- a/include/swift/Syntax/CMakeLists.txt
+++ b/include/swift/Syntax/CMakeLists.txt
@@ -17,3 +17,7 @@ add_gyb_target(swift-syntax-generated-headers
     "${generated_include_sources}")
 set_property(TARGET swift-syntax-generated-headers
     PROPERTY FOLDER "Miscellaneous")
+
+if(TARGET clang)
+  add_dependencies(swift-syntax-generated-headers clang)
+endif()

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -53,4 +53,8 @@ if(SWIFT_INCLUDE_TOOLS)
     set(CMAKE_C_COMPILER ${CURRENT_CMAKE_C_COMPILER})
     set(CMAKE_CXX_COMPILER ${CURRENT_CMAKE_CXX_COMPILER})
   endif()
+
+  if(TARGET clang)
+    add_dependencies(swiftReflection clang)
+  endif()
 endif()

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -35,6 +35,7 @@ add_swift_tool_symlink(swift-format swift editor-integration)
 # If building as part of clang, make sure the headers are installed.
 if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swift clang-resource-headers)
+  add_dependencies(swift swift-syntax-generated-headers)
 endif()
 
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_EXECUTABLE_SUFFIX}"


### PR DESCRIPTION
I am not very familiar with the swift codebase. If there are better ways to achieve this, please speak up. This is required for swift-lldb https://github.com/apple/swift-lldb/pull/1847