### PR TITLE
Add a temporary interface function to migrate swift-apis.

### DIFF
--- a/stdlib/public/CTensorFlow/ctensorflow_init.cpp
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.cpp
@@ -167,4 +167,17 @@ void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
   return tensor;
 }
 
+void TFE_InferShapes_Transition(
+  TFE_Op* op, TF_ShapeAndTypeList* input_shapes,
+  TF_Tensor** input_tensors,
+  TF_ShapeAndTypeList* input_tensor_as_shapes,
+  TF_ShapeAndTypeList** input_resource_shapes_and_types,
+  TF_ShapeAndTypeList** output_shapes,
+  TF_ShapeAndTypeList*** output_resource_shapes_and_types, TF_Status* status) {
+  TFE_InferShapes(op, input_shapes, input_tensors, /* num_tensors*/ 0,
+                  input_tensor_as_shapes, input_resource_shapes_and_types,
+                  output_shapes, output_resource_shapes_and_types, status);
+}
+
+
 }  // extern "C"

--- a/stdlib/public/CTensorFlow/ctensorflow_init.h
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.h
@@ -41,6 +41,10 @@ void *swift_tfc_CreateFloatTensor(int32_t num_dims, int64_t *dims, float *vals,
 void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
                                          TF_Status *status);
 
+struct TF_Tensor;
+struct TF_ShapeAndTypeList;
+struct TFE_Op;
+
 // We removed a redundant argument in the C shape inference API.
 // This interface function lets us migrate swift-apis without breakages.
 // (This is a temporary function and will be removed.)

--- a/stdlib/public/CTensorFlow/ctensorflow_init.h
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.h
@@ -41,6 +41,17 @@ void *swift_tfc_CreateFloatTensor(int32_t num_dims, int64_t *dims, float *vals,
 void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
                                          TF_Status *status);
 
+// We removed a redundant argument in the C shape inference API.
+// This interface function lets us migrate swift-apis without breakages.
+// (This is a temporary function and will be removed.)
+void TFE_InferShapes_Transition(
+  TFE_Op* op, TF_ShapeAndTypeList* input_shapes,
+  TF_Tensor** input_tensors,
+  TF_ShapeAndTypeList* input_tensor_as_shapes,
+  TF_ShapeAndTypeList** input_resource_shapes_and_types,
+  TF_ShapeAndTypeList** output_shapes,
+  TF_ShapeAndTypeList*** output_resource_shapes_and_types, TF_Status* status);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif


### PR DESCRIPTION
We removed a redundant argument from `TFE_InterShapes`  in  https://github.com/tensorflow/tensorflow/commit/6edf8c57c7e7983ae5124fa3bc101ff4e623c237. This PR adds a temporary interface function so that we can migrate swift-apis to the new API without breaking CI in all repos. (This is a temporary function and will be removed in a subsequent PR.)