### PR TITLE
Use backticks instead of single quotes in diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -42,7 +42,7 @@ NOTE(decl_declared_here,none,
 NOTE(kind_declared_here,none,
      "%0 declared here", (DescriptiveDeclKind))
 NOTE(implicit_member_declared_here,none,
-     "%1 '%0' is implicitly declared", (StringRef, StringRef))
+     "%1 `%0` is implicitly declared", (StringRef, StringRef))
 NOTE(extended_type_declared_here,none,
      "extended type declared here", ())
 NOTE(opaque_return_type_declared_here,none,
@@ -88,7 +88,7 @@ ERROR(could_not_find_type_member_corrected,none,
       (Type, DeclName, DeclName))
 
 ERROR(could_not_find_subscript_member_did_you_mean,none,
-      "value of type %0 has no property or method named 'subscript'; "
+      "value of type %0 has no property or method named `subscript`; "
       "did you mean to use the subscript operator?",
       (Type))
 
@@ -4534,7 +4534,7 @@ WARNING(property_wrapper_wrapperValue,none,
         "'projectedValue'; use of 'wrapperValue' is deprecated", ())
 WARNING(property_wrapper_init_initialValue,none,
         "property wrapper's `init(initialValue:)` should be renamed "
-        "to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated",
+        "to `init(wrappedValue:)`; use of `init(initialValue:)` is deprecated",
         ())
 ERROR(property_wrapper_projection_value_missing,none,
       "could not find projection value property %0", (Identifier))

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -310,7 +310,7 @@ enum E21269142 {  // expected-note {{did you mean to specify a raw type on the e
 print(E21269142.Foo.rawValue)  // expected-error {{value of type 'E21269142' has no member 'rawValue'}}
 
 // Check that typo correction does something sensible with synthesized members.
-enum SyntheticMember { // expected-note {{property 'hashValue' is implicitly declared}}
+enum SyntheticMember { // expected-note {{property `hashValue` is implicitly declared}}
   case Foo
 }
 

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -50,8 +50,8 @@ class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform
 // Types which are valid for CodingKey derived conformance should not get that
 // derivation unless they explicitly conform to CodingKey.
 enum X          { case a }
-enum Y : String { case a } // expected-note {{property 'rawValue' is implicitly declared}}
-enum Z : Int    { case a } // expected-note {{property 'rawValue' is implicitly declared}}
+enum Y : String { case a } // expected-note {{property `rawValue` is implicitly declared}}
+enum Z : Int    { case a } // expected-note {{property `rawValue` is implicitly declared}}
 
 let _ = X.a.stringValue // expected-error {{value of type 'X' has no member 'stringValue'}}
 let _ = Y.a.stringValue // expected-error {{value of type 'Y' has no member 'stringValue'}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -332,16 +332,16 @@ struct GenSubscriptFixitTest {
 func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
   _ = s0.subscript("hello")
-  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
 }
 
 func testUnresolvedMemberSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
   _ = s0.subscript
-  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-19=[<#index#>]}}
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-19=[<#index#>]}}
 
   s0.subscript = true
-  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{5-15=[<#index#>]}}
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{5-15=[<#index#>]}}
 }
 
 struct SubscriptTest1 {
@@ -363,17 +363,17 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   if s1["hello"] {}
 
   _ = s1.subscript((true, (5, SubClass())), "hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{52-53=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{52-53=]}}
   _ = s1.subscript((true, (5, baz: SubSubClass())), "hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
   _ = s1.subscript((fo: true, (5, baz: SubClass())), "hello")
   // expected-error@-1 {{cannot convert value of type '(fo: Bool, (Int, baz: SubClass))' to expected argument type '(foo: Bool, bar: (Int, baz: SubClass))'}}
   _ = s1.subscript(SubSubClass())
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
   _ = s1.subscript(ClassConformingToProtocol())
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{47-48=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{47-48=]}}
   _ = s1.subscript(ClassConformingToRefinedProtocol())
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
   _ = s1.subscript(true)
   // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(Bool)'}}
   // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
@@ -381,9 +381,9 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   // expected-error@-1 {{cannot invoke 'subscript' with an argument list of type '(SuperClass)'}}
   // expected-note@-2 {{overloads for 'subscript' exist with these partially matching parameter lists: (Protocol), (String), (SubClass)}}
   _ = s1.subscript("hello")
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}}
   _ = s1.subscript("hello"
-  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named `subscript`; did you mean to use the subscript operator?}}
   // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]
@@ -405,7 +405,7 @@ func testSubscript1(_ s2 : SubscriptTest2) {
   // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: (String, Int), (String, String)}}
 
   _ = s2.subscript("hello", 6)
-  // expected-error@-1 {{value of type 'SubscriptTest2' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest2' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}
   let b = s2[1, "foo"] // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 
   // rdar://problem/27449208
@@ -443,7 +443,7 @@ struct SR2575 {
 }
 
 SR2575().subscript()
-// expected-error@-1 {{value of type 'SR2575' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{20-21=]}}
+// expected-error@-1 {{value of type 'SR2575' has no property or method named `subscript`; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{20-21=]}}
 
 // SR-7890
 

--- a/test/decl/var/property_wrapper_aliases.swift
+++ b/test/decl/var/property_wrapper_aliases.swift
@@ -25,7 +25,7 @@ struct OldWrapper<T> {
 struct OldWrapperWithInit<T> {
   var wrappedValue: T
 
-  init(initialValue: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-8=wrappedValue }}
+  init(initialValue: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to `init(wrappedValue:)`; use of `init(initialValue:)` is deprecated}}{{8-8=wrappedValue }}
     self.wrappedValue = initialValue
   }
 }
@@ -34,7 +34,7 @@ struct OldWrapperWithInit<T> {
 struct OldWrapperWithInit2<T> {
   var wrappedValue: T
 
-  init(initialValue value: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to 'init(wrappedValue:)'; use of 'init(initialValue:)' is deprecated}}{{8-20=wrappedValue}}
+  init(initialValue value: T) { // expected-warning{{property wrapper's `init(initialValue:)` should be renamed to `init(wrappedValue:)`; use of `init(initialValue:)` is deprecated}}{{8-20=wrappedValue}}
     self.wrappedValue = value
   }
 }


### PR DESCRIPTION
Looking through the diagnostics, I noticed some inconsistencies around whether `'`s or `` ` ``s were used in diagnostics. AFAICT there wasn't a pattern to when one was used over the other.

This is an initial PR to convert to backticks. If accepted, I'll follow up with more PRs to convert to backticks. If rejected, I'd be happy to open a PR to remove backticks from existing diagnostics.

I prefer backticks here because:

1. This matches quoting of code in Markdown, which I do often and almost unconsciously at this point
2. Swift itself uses backticks to quote identifiers