### PR TITLE
[patternmatch] Add InstructionOperand_match to support for matching a…

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -862,6 +862,17 @@ Iterator removeAdjacentIf(const Iterator first, const Iterator last,
   return insertionPoint;
 }
 
+namespace detail {
+template <bool...> struct bool_pack;
+} // namespace detail
+
+template <bool... b>
+using all_true =
+    std::is_same<detail::bool_pack<b..., true>, detail::bool_pack<true, b...>>;
+
+/// traits class for checking whether Ts consists only of compound types.
+template <class... Ts>
+using are_all_compound = all_true<std::is_compound<Ts>::value...>;
 
 } // end namespace swift
 

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -458,7 +458,7 @@ static CondFailInst *hasCondFailUse(SILValue V) {
 /// a cond_fail on the second result.
 static CondFailInst *isOverflowChecked(BuiltinInst *AI) {
   for (auto *Op : AI->getUses()) {
-    if (!match(Op->getUser(), m_TupleExtractInst(m_ValueBase(), 1)))
+    if (!match(Op->getUser(), m_TupleExtractOperation(m_ValueBase(), 1)))
       continue;
 
     TupleExtractInst *TEI = cast<TupleExtractInst>(Op->getUser());
@@ -474,11 +474,10 @@ static bool isSignedLessEqual(SILValue Start, SILValue End, SILBasicBlock &BB) {
   // If we have an inclusive range "low...up" the loop exit count will be
   // "up + 1" but the overflow check is on "up".
   SILValue PreInclusiveEnd;
-  if (!match(
-          End,
-          m_TupleExtractInst(m_ApplyInst(BuiltinValueKind::SAddOver,
-                                         m_SILValue(PreInclusiveEnd), m_One()),
-                             0)))
+  if (!match(End, m_TupleExtractOperation(
+                      m_ApplyInst(BuiltinValueKind::SAddOver,
+                                  m_SILValue(PreInclusiveEnd), m_One()),
+                      0)))
     PreInclusiveEnd = SILValue();
 
   bool IsPreInclusiveEndLEQ = false;
@@ -811,11 +810,11 @@ private:
     // Look for a compare of induction variable + 1.
     // TODO: obviously we need to handle many more patterns.
     if (!match(Cond, m_ApplyInst(BuiltinValueKind::ICMP_EQ,
-                                 m_TupleExtractInst(m_Specific(Inc), 0),
+                                 m_TupleExtractOperation(m_Specific(Inc), 0),
                                  m_SILValue(End))) &&
         !match(Cond,
                m_ApplyInst(BuiltinValueKind::ICMP_EQ, m_SILValue(End),
-                           m_TupleExtractInst(m_Specific(Inc), 0)))) {
+                           m_TupleExtractOperation(m_Specific(Inc), 0)))) {
       LLVM_DEBUG(llvm::dbgs() << " found no exit condition\n");
       return nullptr;
     }
@@ -1075,7 +1074,7 @@ static bool isComparisonKnownFalse(BuiltinInst *Builtin,
   // Iteration count + 1 < 0 (start)
   // Iteration count + 1 == 0 (start)
   auto MatchIndVarHeader = m_Specific(IndVar.HeaderVal);
-  auto MatchIncrementIndVar = m_TupleExtractInst(
+  auto MatchIncrementIndVar = m_TupleExtractOperation(
       m_ApplyInst(BuiltinValueKind::SAddOver, MatchIndVarHeader, m_One()), 0);
   auto MatchIndVarStart = m_Specific(IndVar.Start);
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -135,10 +135,10 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
 
   SILValue RecNext = Cmp->getArguments()[0];
   SILPhiArgument *RecArg;
-  if (!match(RecNext,
-             m_TupleExtractInst(m_ApplyInst(BuiltinValueKind::SAddOver,
-                                            m_SILPhiArgument(RecArg), m_One()),
-                                0)))
+  if (!match(RecNext, m_TupleExtractOperation(
+                          m_ApplyInst(BuiltinValueKind::SAddOver,
+                                      m_SILPhiArgument(RecArg), m_One()),
+                          0)))
     return None;
 
   if (RecArg->getParent() != Header)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -263,29 +263,27 @@ matchSizeOfMultiplication(SILValue I, MetatypeInst *RequiredType,
 
   SILValue Dist;
   MetatypeInst *StrideType;
-  if (match(
-          Res->getOperand(1),
-          m_ApplyInst(
-              BuiltinValueKind::TruncOrBitCast,
-              m_TupleExtractInst(
-                  m_ApplyInst(
-                      BuiltinValueKind::SMulOver, m_SILValue(Dist),
-                      m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                  m_ApplyInst(BuiltinValueKind::Strideof,
-                                              m_MetatypeInst(StrideType)))),
-                  0))) ||
-      match(
-          Res->getOperand(1),
-          m_ApplyInst(
-              BuiltinValueKind::TruncOrBitCast,
-              m_TupleExtractInst(
-                  m_ApplyInst(
-                      BuiltinValueKind::SMulOver,
-                      m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
-                                  m_ApplyInst(BuiltinValueKind::Strideof,
-                                              m_MetatypeInst(StrideType))),
-                      m_SILValue(Dist)),
-                  0)))) {
+  if (match(Res->getOperand(1),
+            m_ApplyInst(
+                BuiltinValueKind::TruncOrBitCast,
+                m_TupleExtractOperation(
+                    m_ApplyInst(
+                        BuiltinValueKind::SMulOver, m_SILValue(Dist),
+                        m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
+                                    m_ApplyInst(BuiltinValueKind::Strideof,
+                                                m_MetatypeInst(StrideType)))),
+                    0))) ||
+      match(Res->getOperand(1),
+            m_ApplyInst(
+                BuiltinValueKind::TruncOrBitCast,
+                m_TupleExtractOperation(
+                    m_ApplyInst(
+                        BuiltinValueKind::SMulOver,
+                        m_ApplyInst(BuiltinValueKind::ZExtOrBitCast,
+                                    m_ApplyInst(BuiltinValueKind::Strideof,
+                                                m_MetatypeInst(StrideType))),
+                        m_SILValue(Dist)),
+                    0)))) {
     if (StrideType != RequiredType)
       return nullptr;
     TruncOrBitCast = cast<BuiltinInst>(Res->getOperand(1));

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -113,9 +113,9 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
           m_IndexRawPointerInst(IndexRawPtr))) {
     SILValue Ptr = IndexRawPtr->getOperand(0);
     SILValue TruncOrBitCast = IndexRawPtr->getOperand(1);
-    if (match(TruncOrBitCast,
-              m_ApplyInst(BuiltinValueKind::TruncOrBitCast,
-                          m_TupleExtractInst(m_BuiltinInst(StrideMul), 0)))) {
+    if (match(TruncOrBitCast, m_ApplyInst(BuiltinValueKind::TruncOrBitCast,
+                                          m_TupleExtractOperation(
+                                              m_BuiltinInst(StrideMul), 0)))) {
       if (match(StrideMul,
                 m_ApplyInst(
                     BuiltinValueKind::SMulOver, m_SILValue(Distance),
@@ -166,9 +166,9 @@ visitPointerToAddressInst(PointerToAddressInst *PTAI) {
   //
   BuiltinInst *Bytes;
   if (match(PTAI->getOperand(),
-            m_IndexRawPointerInst(m_ValueBase(),
-                                  m_TupleExtractInst(m_BuiltinInst(Bytes),
-                                                     0)))) {
+            m_IndexRawPointerInst(
+                m_ValueBase(),
+                m_TupleExtractOperation(m_BuiltinInst(Bytes), 0)))) {
     if (match(Bytes, m_ApplyInst(BuiltinValueKind::SMulOver, m_ValueBase(),
                                  m_ApplyInst(BuiltinValueKind::Strideof,
                                              m_MetatypeInst(Metatype)),


### PR DESCRIPTION
…gainst instructions with misc number of operands.

NOTE:

1. To test this I changed UnaryOp_match to use this under the hood.

2. These types of m_##ID##Inst matchers now will only accept compound types and
I added a static assert to verify that this mistake doesn't happen. We
previously had matchers that would take an int or the like to match tuple
extract patterns. I converted those to use TupleExtractOperation that also
properly handles destructures.
