### PR TITLE
[ownership] Skip functions with ownership in LICM.

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -764,6 +764,11 @@ public:
 
   void run() override {
     SILFunction *F = getFunction();
+
+    // If our function has ownership, skip it.
+    if (F->hasOwnership())
+      return;
+
     SILLoopAnalysis *LA = PM->getAnalysis<SILLoopAnalysis>();
     SILLoopInfo *LoopInfo = LA->get(F);
 


### PR DESCRIPTION
Thought I could get away with this. But now that I am going to not be stripping ownership from functions in other modules, we are covering more of the code base I think. So makes sense to just turn it off.