### PR TITLE
SILGen: Add test to ensure we don't have a vtable entry for synthesized members of a final class

### DIFF
--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -63,6 +63,34 @@ extension Nonfinal: Encodable where T: Encodable {}
 // CHECK-LABEL: // Nonfinal<A>.encode(to:)
 // CHECK-NEXT: sil hidden [ossa] @$s29synthesized_conformance_class8NonfinalCAASERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed Encoder, @guaranteed Nonfinal<T>) -> @error Error {
 
+final class FinalHashableClass : Hashable {
+  static func ==(lhs: FinalHashableClass, rhs: FinalHashableClass) -> Bool {
+    return false
+  }
+
+  func hash(into: inout Hasher) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s29synthesized_conformance_class4doItySiAA18FinalHashableClassCF : $@convention(thin) (@guaranteed FinalHashableClass) -> Int {
+// CHECK: bb0(%0 : @guaranteed $FinalHashableClass):
+// CHECK:   [[FN:%.*]] = function_ref @$s29synthesized_conformance_class18FinalHashableClassC9hashValueSivg : $@convention(method) (@guaranteed FinalHashableClass) -> Int
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]](%0) : $@convention(method) (@guaranteed FinalHashableClass) -> Int
+// CHECK-NEXT: return [[RESULT]] : $Int
+
+func doIt(_ c: FinalHashableClass) -> Int {
+  return c.hashValue
+}
+
+// VTable for FinalHashableClass
+//
+// Note: we should not be emitting a vtable entry for the synthesized
+// FinalHashableClass.hashValue getter!
+
+// CHECK: sil_vtable FinalHashableClass {
+// CHECK-NEXT: #FinalHashableClass.init!allocator.1: (FinalHashableClass.Type) -> () -> FinalHashableClass : @$s29synthesized_conformance_class18FinalHashableClassCACycfC
+// CHECK-NEXT: #FinalHashableClass.deinit!deallocator.1: @$s29synthesized_conformance_class18FinalHashableClassCfD
+// CHECK-NEXT: }
+
 // Witness tables for Final
 
 // CHECK-LABEL: sil_witness_table hidden <T where T : Encodable> Final<T>: Encodable module synthesized_conformance_class {


### PR DESCRIPTION
I believe this was fixed with https://github.com/apple/swift/pull/23932.

5.1 had an inconsistency here because the synthesized declaration was not
marked as final; we would sometimes check if a method itself was final,
other times we would check if both the method and the class were final.

Lucky it worked out so that the emitted vtable entry did not appear to
ever have been used.

Make sure this behavior doesn't change going forward with a test.