### PR TITLE
Sema: The synthesized hashValue getter for a final class should be final [5.1]

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1135,6 +1135,13 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   hashValueDecl->copyFormalAccessFrom(derived.Nominal,
                                       /*sourceIsParentContext*/ true);
 
+  if (auto *classDecl = dyn_cast<ClassDecl>(parentDC)) {
+    if (classDecl->isFinal()) {
+      getterDecl->getAttrs().add(new (C) FinalAttr(IsImplicit));
+      hashValueDecl->getAttrs().add(new (C) FinalAttr(IsImplicit));
+    }
+  }
+
   Pattern *hashValuePat = new (C) NamedPattern(hashValueDecl, /*implicit*/true);
   hashValuePat->setType(intType);
   hashValuePat = TypedPattern::createImplicit(C, hashValuePat, intType);

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -63,6 +63,34 @@ extension Nonfinal: Encodable where T: Encodable {}
 // CHECK-LABEL: // Nonfinal<A>.encode(to:)
 // CHECK-NEXT: sil hidden [ossa] @$s29synthesized_conformance_class8NonfinalCAASERzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed Encoder, @guaranteed Nonfinal<T>) -> @error Error {
 
+final class FinalHashableClass : Hashable {
+  static func ==(lhs: FinalHashableClass, rhs: FinalHashableClass) -> Bool {
+    return false
+  }
+
+  func hash(into: inout Hasher) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s29synthesized_conformance_class4doItySiAA18FinalHashableClassCF : $@convention(thin) (@guaranteed FinalHashableClass) -> Int {
+// CHECK: bb0(%0 : @guaranteed $FinalHashableClass):
+// CHECK:   [[FN:%.*]] = function_ref @$s29synthesized_conformance_class18FinalHashableClassC9hashValueSivg : $@convention(method) (@guaranteed FinalHashableClass) -> Int
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]](%0) : $@convention(method) (@guaranteed FinalHashableClass) -> Int
+// CHECK-NEXT: return [[RESULT]] : $Int
+
+func doIt(_ c: FinalHashableClass) -> Int {
+  return c.hashValue
+}
+
+// VTable for FinalHashableClass
+//
+// Note: we should not be emitting a vtable entry for the synthesized
+// FinalHashableClass.hashValue getter!
+
+// CHECK: sil_vtable FinalHashableClass {
+// CHECK-NEXT: #FinalHashableClass.init!allocator.1: (FinalHashableClass.Type) -> () -> FinalHashableClass : @$s29synthesized_conformance_class18FinalHashableClassCACycfC
+// CHECK-NEXT: #FinalHashableClass.deinit!deallocator.1: @$s29synthesized_conformance_class18FinalHashableClassCfD
+// CHECK-NEXT: }
+
 // Witness tables for Final
 
 // CHECK-LABEL: sil_witness_table hidden <T where T : Encodable> Final<T>: Encodable module synthesized_conformance_class {


### PR DESCRIPTION
If the class is final but the declaration is not, we still dispatch to it
statically but end up emitting a dispatch thunk and method descriptor.

This was fixed on master when IsFinalRequest was introduced, but it needs
a separate fix for the 5.1 branch.