### PR TITLE
[5.1] [Runtime] Short-circuit search for context descriptor for protocol extensions

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -613,9 +613,14 @@ _findContextDescriptor(Demangle::NodePointer node,
   NodePointer symbolicNode = node;
   if (symbolicNode->getKind() == Node::Kind::Type)
     symbolicNode = symbolicNode->getChild(0);
-  if (symbolicNode->getKind() == Node::Kind::TypeSymbolicReference)
+  if (symbolicNode->getKind() == Node::Kind::TypeSymbolicReference) {
     return cast<TypeContextDescriptor>(
       (const ContextDescriptor *)symbolicNode->getIndex());
+  }
+
+  // Nothing to resolve if have a generic parameter.
+  if (symbolicNode->getKind() == Node::Kind::DependentGenericParamType)
+    return nullptr;
 
   StringRef mangledName =
     Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), Dem);


### PR DESCRIPTION
When looking for a context descriptor for a protocol extension, we
search based on the mangled name--"x", a generic type parameter with
depth and index 0--and are guaranteed to fail because there is no such
concrete type. However, `_findContextDescriptor` will fail very slowly,
spinning through all of the types and conformances in all of the
loaded images. Moreover, negative results aren't cached, so this can
happen repeatedly.

Short-circuit `_findContextDescriptor` when it receives a dependent
generic type parameter type, avoiding the expensive search when it
will find nothing.

Potential fix for rdar://problem/53560010.
