### PR TITLE
Add method disableASTScopeLookup for lldb

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -291,6 +291,12 @@ public:
 
   void setCodeCompletionFactory(CodeCompletionCallbacksFactory *Factory) {
     CodeCompletionFactory = Factory;
+    disableASTScopeLookup();
+  }
+  
+  /// Called from lldb, see rdar://53971116
+  void disableASTScopeLookup() {
+    LangOpts.EnableASTScopeLookup = false;
   }
 
   CodeCompletionCallbacksFactory *getCodeCompletionFactory() const {


### PR DESCRIPTION
<!-- What's in this pull request? -->
For now, lldb cannot work with ASTScope, see rdar://53971116.
Also see https://github.com/apple/swift-lldb/pull/1849.
Add a hook for lldb to call to disable ASTScope lookup.