### PR TITLE
[DOCS] Add missing '-parse-as-library' flag in libFuzzerIntegration.rst

### DIFF
--- a/docs/libFuzzerIntegration.rst
+++ b/docs/libFuzzerIntegration.rst
@@ -19,13 +19,13 @@ the ``main`` symbol, such that the fuzzer entry point can be used:
 
 .. code-block:: bash
 
-    % swiftc -sanitize=fuzzer myfile.swift
+    % swiftc -sanitize=fuzzer -parse-as-library myfile.swift
 
 ``libFuzzer`` can be also combined with other sanitizers:
 
 .. code-block:: bash
 
-    % swiftc -sanitize=fuzzer,address myfile.swift
+    % swiftc -sanitize=fuzzer,address -parse-as-library myfile.swift
 
 Finally, we launch the fuzzing process:
 


### PR DESCRIPTION
Add missing ```-parse-as-library``` flag, otherwise the compilation will fail due to ```multiple definition of 'main'``` error.
