### PR TITLE
SILOptimizer: fix a crash in DestructorAnalysis

### DIFF
--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -14,6 +14,8 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/Support/Debug.h"
 
@@ -71,10 +73,15 @@ bool DestructorAnalysis::isSafeType(CanType Ty) {
       return cacheResult(Ty, true);
 
     // Check the stored properties.
-    for (auto SP : Struct->getStoredProperties())
+    for (auto SP : Struct->getStoredProperties()) {
+      // FIXME: Remove this once getInterfaceType() is a request.
+      if (!SP->hasInterfaceType()) {
+        ASTContext &Ctx = Mod->getSwiftModule()->getASTContext();
+        Ctx.getLazyResolver()->resolveDeclSignature(SP);
+      }
       if (!isSafeType(SP->getInterfaceType()->getCanonicalType()))
         return cacheResult(Ty, false);
-
+    }
     return cacheResult(Ty, true);
   }
 


### PR DESCRIPTION
The interface type of a stored property is computed lazily.

Unfortunately I could not come up with an isolated test case.

rdar://problem/53956331
