### PR TITLE
SIL: Utilities for calculating and verifying memory lifetimes.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -264,7 +264,8 @@ public:
   /// Returns true if \p oper is an argument operand and not the callee
   /// operand.
   bool isArgumentOperand(const Operand &oper) const {
-    return oper.getOperandNumber() >= getOperandIndexOfFirstArgument();
+    return oper.getOperandNumber() >= getOperandIndexOfFirstArgument() &&
+      oper.getOperandNumber() < getOperandIndexOfFirstArgument() + getNumArguments();
   }
 
   /// Return the applied argument index for the given operand.

--- a/include/swift/SIL/MemoryLifetime.h
+++ b/include/swift/SIL/MemoryLifetime.h
@@ -1,0 +1,361 @@
+//===--- MemoryLifetime.h ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file Contains utilities for calculating and verifying memory lifetime.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_MEMORY_LIFETIME_H
+#define SWIFT_SIL_MEMORY_LIFETIME_H
+
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+
+namespace swift {
+
+/// The MemoryLocations utility provides functions to analyze memory locations.
+///
+/// Memory locations are limited to addresses which are guaranteed to
+/// be not aliased, like @in/inout parameters and alloc_stack.
+/// Currently only a certain set of address instructions are supported:
+/// Specifically those instructions which are going to be included when SIL
+/// supports opaque values.
+/// TODO: Support more address instructions, like cast instructions.
+///
+/// The MemoryLocations works well together with MemoryDataflow, which can be
+/// used to calculate global dataflow of location information.
+class MemoryLocations {
+public:
+
+  using Bits = llvm::SmallBitVector;
+
+  /// Represents a not-aliased memory location: either an indirect function
+  /// parameter or an alloc_stack.
+  ///
+  /// Each location has a unique number which is index in the
+  /// MemoryLifetime::locations array and the bit number in the bit sets.
+  ///
+  /// Locations can have sub-locations in case the parent location is a struct
+  /// or tuple with fields/elements. So, each top-level location forms a
+  /// tree-like data structure. Sub-locations are only created lazily, i.e. if
+  /// struct/tuple elements are really accessed with struct/tuple_element_addr.
+  ///
+  /// As most alloc_stack locations only live within a single block, such
+  /// single-block locations are not included in the "regular" data flow
+  /// analysis (to not blow up the bit vectors). They are handled separately
+  /// with a simple single-block data flow analysis, which runs independently
+  /// for each block.
+  struct Location {
+
+    /// The SIL value of the memory location.
+    ///
+    /// For top-level locations this is either a function argument or an
+    /// alloc_stack. For sub-locations it's the struct/tuple_element_addr.
+    /// In case there are multiple struct/tuple_element_addr for a single
+    /// field, this is only one representative instruction out of the set.
+    SILValue representativeValue;
+
+    /// All tracked sub-locations.
+    ///
+    /// If all tracked sub-locations cover the whole memory location, the "self"
+    /// bit is not set. In other words: the "self" bit represents all
+    /// sublocations, which are not explicitly tracked as locations.
+    /// For example:
+    /// \code
+    ///   struct Inner {
+    ///     var a: T
+    ///     var b: T
+    ///   }
+    ///   struct Outer {
+    ///     var x: T
+    ///     var y: Inner
+    ///     var z: T      // not accessed in the analyzed function
+    ///   }
+    /// \endcode
+    ///
+    /// If the analyzed function contains:
+    /// \code
+    ///   %a = alloc_stack $Outer                 // = location 0
+    ///   %ox = struct_element_adr %a, #Outer.x   // = location 1
+    ///   %oy = struct_element_adr %a, #Outer.y   // = location 2
+    ///   %ia = struct_element_adr %oy, #Inner.a  // = location 3
+    ///   %ib = struct_element_adr %oy, #Inner.b  // = location 4
+    /// \endcode
+    ///
+    /// the ``subLocations`` bits are:
+    /// \code
+    ///    location 0 (alloc_stack): [0, 1,   3, 4]
+    ///    location 1 (Outer.x):     [   1        ]
+    ///    location 2 (Outer.y):     [        3, 4]
+    ///    location 3 (Inner.a):     [        3   ]
+    ///    location 4 (Inner.b):     [           4]
+    /// \endcode
+    ///
+    /// Bit 2 is never set because Inner is completly represented by its
+    /// sub-locations 3 and 4. But bit 0 is set in location 0 (the "self" bit),
+    /// because it represents the untracked field ``Outer.z``.
+    Bits subLocations;
+
+    /// The accumulated parent bits, including the "self" bit.
+    ///
+    /// For the example given for ``subLocations``, the ``selfAndParents`` bits
+    /// are:
+    /// \code
+    ///    location 0 (alloc_stack): [0           ]
+    ///    location 1 (Outer.x):     [0, 1        ]
+    ///    location 2 (Outer.y):     [0,   2      ]
+    ///    location 3 (Inner.a):     [0,   2, 3   ]
+    ///    location 4 (Inner.b):     [0,   2,    4]
+    /// \endcode
+    Bits selfAndParents;
+
+    /// The location index of the parent, or -1 if it's a top-level location.
+    ///
+    /// For the example given for ``subLocations``, the ``parentIdx`` indices
+    /// are:
+    /// \code
+    ///    location 0 (alloc_stack): -1
+    ///    location 1 (Outer.x):     0
+    ///    location 2 (Outer.y):     0
+    ///    location 3 (Inner.a):     2
+    ///    location 4 (Inner.b):     2
+    /// \endcode
+    int parentIdx;
+
+    /// Used to decide if a location is completely covered by its sub-locations.
+    ///
+    /// -1 means: not yet initialized.
+    int numFieldsNotCoveredBySubfields = -1;
+
+    Location(SILValue val, unsigned index, int parentIdx = -1);
+  };
+
+private:
+  /// The array of locations.
+  llvm::SmallVector<Location, 64> locations;
+
+  /// Mapping from SIL values (function arguments and alloc_stack) to location
+  /// indices.
+  ///
+  /// In case there are multiple struct/tuple_element_addr for a single
+  /// field, this map contains multiple entries mapping to the same location.
+  llvm::DenseMap<SILValue, unsigned> addr2LocIdx;
+
+  /// Memory locations (e.g. alloc_stack) which live in a single basic block.
+  ///
+  /// Those locations are excluded from the locations to keep the bit sets
+  /// small. They can be handled separately with handleSingleBlockLocations().
+  llvm::SmallVector<SingleValueInstruction *, 16> singleBlockLocations;
+
+public:
+  MemoryLocations() {}
+
+  MemoryLocations(const MemoryLocations &) = delete;
+  MemoryLocations &operator=(const MemoryLocations &) = delete;
+
+  /// Returns the number of collected locations, except single-block locations.
+  unsigned getNumLocations() const { return locations.size(); }
+
+  /// Returns the location index corresponding to a memory address or -1, if
+  /// \p addr is not associated with a location.
+  int getLocationIdx(SILValue addr) const;
+
+  /// Returns the location corresponding to a memory address or null, if
+  /// \p addr is not associated with a location.
+  const Location *getLocation(SILValue addr) const {
+    int locIdx = getLocationIdx(addr);
+    if (locIdx >= 0)
+      return &locations[locIdx];
+    return nullptr;
+  }
+
+  /// Returns the location with a given \p index.
+  const Location *getLocation(unsigned index) const {
+    return &locations[index];
+  }
+
+  /// Sets the location bits os \p addr in \p bits, if \p addr is associated
+  /// with a location.
+  void setBits(Bits &bits, SILValue addr) {
+    if (auto *loc = getLocation(addr))
+      bits |= loc->subLocations;
+  }
+
+  /// Clears the location bits os \p addr in \p bits, if \p addr is associated
+  /// with a location.
+  void clearBits(Bits &bits, SILValue addr) {
+    if (auto *loc = getLocation(addr))
+      bits.reset(loc->subLocations);
+  }
+
+  /// Analyzes all locations in a function.
+  ///
+  /// Single-block locations are not analyzed, but added to singleBlockLocations.
+  void analyzeLocations(SILFunction *function);
+
+  /// Analyze a single top-level location.
+  ///
+  /// If all uses of \p loc are okay, the location and its sub-locations are
+  /// added to the data structures.
+  void analyzeLocation(SILValue loc);
+
+  /// Do a block-local processing for all locations in singleBlockLocations.
+  ///
+  /// First, initializes all locations which are alive in a block and then
+  /// calls \p handlerFunc for the block.
+  void handleSingleBlockLocations(
+                       std::function<void (SILBasicBlock *block)> handlerFunc);
+
+  /// Debug dump the MemoryLifetime internals.
+  void dump() const;
+
+  /// Debug dump a bit set .
+  static void dumpBits(const Bits &bits);
+
+private:
+  /// Clears all datastructures, except singleBlockLocations;
+  void clear();
+
+  // (locationIdx, fieldNr) -> subLocationIdx
+  using SubLocationMap = llvm::DenseMap<std::pair<unsigned, unsigned>, unsigned>;
+
+  /// Helper function called by analyzeLocation to check all uses of the
+  /// location recursively.
+  ///
+  /// The \p subLocationMap is a temporary cache to speed up sub-location lookup.
+  bool analyzeLocationUsesRecursively(SILValue V, unsigned locIdx,
+                                      SmallVectorImpl<SILValue> &collectedVals,
+                                      SubLocationMap &subLocationMap);
+
+  /// Helper function called by analyzeLocation to create a sub-location for
+  /// and address projection and check all of its uses.
+  bool analyzeAddrProjection(
+    SingleValueInstruction *projection, unsigned parentLocIdx,unsigned fieldNr,
+    SmallVectorImpl<SILValue> &collectedVals, SubLocationMap &subLocationMap);
+
+  /// Calculates Location::numFieldsNotCoveredBySubfields
+  void initFieldsCounter(Location &loc);
+
+  /// Only memory locations which store a non-trivial type are considered.
+  bool shouldTrackLocation(SILType type, SILFunction *inFunction) {
+    return !type.isTrivial(*inFunction);
+  }
+};
+
+/// The MemoryDataflow utility calculates global dataflow of memory locations.
+///
+/// The MemoryDataflow works well together with MemoryLocations, which can be
+/// used to analyze locations as input to the dataflow.
+/// TODO: Actuall this utility can be used for any kind of dataflow, not just
+/// for memory locations. Consider renaming it.
+class MemoryDataflow {
+
+public:
+  using Bits = MemoryLocations::Bits;
+
+  /// Basic-block specific information used for dataflow analysis.
+  struct BlockState {
+    /// The backlink to the SILBasicBlock.
+    SILBasicBlock *block;
+
+    /// The bits valid at the entry (i.e. the first instruction) of the block.
+    Bits entrySet;
+
+    /// The bits valid at the exit (i.e. after the terminator) of the block.
+    Bits exitSet;
+
+    /// Generated bits of the block.
+    Bits genSet;
+
+    /// Killed bits of the block.
+    Bits killSet;
+
+    /// True, if this block is reachable from the entry block, i.e. is not an
+    /// unreachable block.
+    ///
+    /// This flag is only computed if entryReachabilityAnalysis is called.
+    bool reachableFromEntry = false;
+
+    /// True, if any function-exit block can be reached from this block, i.e. is
+    /// not a block which eventually ends in an unreachable instruction.
+    ///
+    /// This flag is only computed if exitReachableAnalysis is called.
+    bool exitReachable = false;
+
+    BlockState(SILBasicBlock *block = nullptr) : block(block) { }
+
+    // Utility functions for setting and clearing gen- and kill-bits.
+
+    void genBits(SILValue addr, const MemoryLocations &locs) {
+      if (auto *loc = locs.getLocation(addr)) {
+        killSet.reset(loc->subLocations);
+        genSet |= loc->subLocations;
+      }
+    }
+
+    void killBits(SILValue addr, const MemoryLocations &locs) {
+      if (auto *loc = locs.getLocation(addr)) {
+        genSet.reset(loc->subLocations);
+        killSet |= loc->subLocations;
+      }
+    }
+  };
+
+private:
+  /// All block states.
+  std::vector<BlockState> blockStates;
+
+  /// Getting from SILBasicBlock to BlockState.
+  llvm::DenseMap<SILBasicBlock *, BlockState *> block2State;
+
+public:
+  /// Sets up the BlockState datastructures and associates all basic blocks with
+  /// a state.
+  MemoryDataflow(SILFunction *function, unsigned numLocations);
+
+  MemoryDataflow(const MemoryDataflow &) = delete;
+  MemoryDataflow &operator=(const MemoryDataflow &) = delete;
+
+  using iterator = std::vector<BlockState>::iterator;
+
+  iterator begin() { return blockStates.begin(); }
+  iterator end() { return blockStates.end(); }
+
+  /// Returns the state of a block.
+  BlockState *getState(SILBasicBlock *block) {
+    return block2State[block];
+  }
+
+  /// Calculates the BlockState::reachableFromEntry flags.
+  void entryReachabilityAnalysis();
+
+  /// Calculates the BlockState::exitReachable flags.
+  void exitReachableAnalysis();
+
+  /// Derives the block exit sets from the entry sets by applying the gen and
+  /// kill sets.
+  void solveDataflowForward();
+
+  /// Derives the block entry sets from the exit sets by applying the gen and
+  /// kill sets.
+  void solveDataflowBackward();
+
+  /// Debug dump the MemoryLifetime internals.
+  void dump() const;
+};
+
+/// Verifies the lifetime of memory locations in a function.
+void verifyMemoryLifetime(SILFunction *function);
+
+} // end swift namespace
+
+#endif

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -400,11 +400,12 @@ public:
   //===--------------------------------------------------------------------===//
 
   AllocStackInst *createAllocStack(SILLocation Loc, SILType elementType,
-                                   Optional<SILDebugVariable> Var = None) {
+                                   Optional<SILDebugVariable> Var = None,
+                                   bool hasDynamicLifetime = false) {
     Loc.markAsPrologue();
     return insert(AllocStackInst::create(getSILDebugLocation(Loc), elementType,
                                          getFunction(), C.OpenedArchetypes,
-                                         Var));
+                                         Var, hasDynamicLifetime));
   }
 
   AllocRefInst *createAllocRef(SILLocation Loc, SILType ObjectType,
@@ -439,10 +440,12 @@ public:
   }
 
   AllocBoxInst *createAllocBox(SILLocation Loc, CanSILBoxType BoxType,
-                               Optional<SILDebugVariable> Var = None) {
+                               Optional<SILDebugVariable> Var = None,
+                               bool hasDynamicLifetime = false) {
     Loc.markAsPrologue();
     return insert(AllocBoxInst::create(getSILDebugLocation(Loc), BoxType, *F,
-                                       C.OpenedArchetypes, Var));
+                                       C.OpenedArchetypes, Var,
+                                       hasDynamicLifetime));
   }
 
   AllocExistentialBoxInst *

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3401,8 +3401,7 @@ public:
       return bbi->getOperand();
     if (auto *lbi = dyn_cast<LoadBorrowInst>(v))
       return lbi->getOperand();
-    llvm::errs() << "Can not end borrow for value: " << v;
-    llvm_unreachable("standard error assertion");
+    return SILValue();
   }
 
   /// Return the set of guaranteed values that have scopes ended by this

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1370,15 +1370,18 @@ class AllocStackInst final
   friend TrailingObjects;
   friend SILBuilder;
 
+  bool dynamicLifetime = false;
+
   AllocStackInst(SILDebugLocation Loc, SILType elementType,
                  ArrayRef<SILValue> TypeDependentOperands,
                  SILFunction &F,
-                 Optional<SILDebugVariable> Var);
+                 Optional<SILDebugVariable> Var, bool hasDynamicLifetime);
 
   static AllocStackInst *create(SILDebugLocation Loc, SILType elementType,
                                 SILFunction &F,
                                 SILOpenedArchetypesState &OpenedArchetypes,
-                                Optional<SILDebugVariable> Var);
+                                Optional<SILDebugVariable> Var,
+                                bool hasDynamicLifetime);
 
   size_t numTrailingObjects(OverloadToken<Operand>) const {
     return SILInstruction::Bits.AllocStackInst.NumOperands;
@@ -1392,6 +1395,9 @@ public:
       Operands[i].~Operand();
     }
   }
+
+  void setDynamicLifetime() { dynamicLifetime = true; }
+  bool hasDynamicLifetime() const { return dynamicLifetime; }
 
   /// Return the underlying variable declaration associated with this
   /// allocation, or null if this is a temporary allocation.
@@ -1616,19 +1622,25 @@ class AllocBoxInst final
 
   TailAllocatedDebugVariable VarInfo;
 
+  bool dynamicLifetime = false;
+
   AllocBoxInst(SILDebugLocation DebugLoc, CanSILBoxType BoxType,
                ArrayRef<SILValue> TypeDependentOperands, SILFunction &F,
-               Optional<SILDebugVariable> Var);
+               Optional<SILDebugVariable> Var, bool hasDynamicLifetime);
 
   static AllocBoxInst *create(SILDebugLocation Loc, CanSILBoxType boxType,
                               SILFunction &F,
                               SILOpenedArchetypesState &OpenedArchetypes,
-                              Optional<SILDebugVariable> Var);
+                              Optional<SILDebugVariable> Var,
+                              bool hasDynamicLifetime);
 
 public:
   CanSILBoxType getBoxType() const {
     return getType().castTo<SILBoxType>();
   }
+
+  void setDynamicLifetime() { dynamicLifetime = true; }
+  bool hasDynamicLifetime() const { return dynamicLifetime; }
 
   // Return the type of the memory stored in the alloc_box.
   SILType getAddressType() const {

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 508; // generic opaque return type xref
+const uint16_t SWIFTMODULE_VERSION_MINOR = 509; // [dynamic_lifetime] sil flag
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_host_library(swiftSIL STATIC
   Linker.cpp
   LinearLifetimeChecker.cpp
   LoopInfo.cpp
+  MemoryLifetime.cpp
   Notifications.cpp
   OperandOwnership.cpp
   OptimizationRemark.cpp

--- a/lib/SIL/MemoryLifetime.cpp
+++ b/lib/SIL/MemoryLifetime.cpp
@@ -1,0 +1,912 @@
+//===--- MemoryLifetime.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-memory-lifetime"
+#include "swift/SIL/MemoryLifetime.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/SILModule.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+llvm::cl::opt<bool> DontAbortOnMemoryLifetimeErrors(
+    "dont-abort-on-memory-lifetime-errors",
+    llvm::cl::desc("Don't abort compliation if the memory lifetime checker "
+                   "detects an error."));
+
+namespace swift {
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                            Utility functions
+//===----------------------------------------------------------------------===//
+
+/// Debug dump a location bit vector.
+llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                              const SmallBitVector &bits) {
+  const char *separator = "";
+  OS << '[';
+  for (int idx = bits.find_first(); idx >= 0; idx = bits.find_next(idx)) {
+    OS << separator << idx;
+    separator = ",";
+  }
+  OS << ']';
+  return OS;
+}
+
+/// Enlarge the bitset if needed to set the bit with \p idx.
+static void setBitAndResize(SmallBitVector &bits, unsigned idx) {
+  if (bits.size() <= idx)
+    bits.resize(idx + 1);
+  bits.set(idx);
+}
+
+static bool allUsesInSameBlock(AllocStackInst *ASI) {
+  SILBasicBlock *BB = ASI->getParent();
+  int numDeallocStacks = 0;
+  for (Operand *use : ASI->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (isa<DeallocStackInst>(user)) {
+      ++numDeallocStacks;
+      if (user->getParent() != BB)
+        return false;
+    }
+  }
+  // In case of an unreachable, the dealloc_stack can be missing. In this
+  // case we don't treat it as a single-block location.
+  assert(numDeallocStacks <= 1 &&
+    "A single-block stack location cannot have multiple deallocations");
+  return numDeallocStacks == 1;
+}
+
+} // anonymous namespace
+} // namespace swift
+
+
+//===----------------------------------------------------------------------===//
+//                     MemoryLocations members
+//===----------------------------------------------------------------------===//
+
+MemoryLocations::Location::Location(SILValue val, unsigned index, int parentIdx) :
+      representativeValue(val),
+      parentIdx(parentIdx) {
+  assert(((parentIdx >= 0) ==
+    (isa<StructElementAddrInst>(val) || isa<TupleElementAddrInst>(val))) &&
+    "sub-locations can only be introduced with struct/tuple_element_addr");
+  setBitAndResize(subLocations, index);
+  setBitAndResize(selfAndParents, index);
+}
+
+static SILValue getBaseValue(SILValue addr) {
+  while (true) {
+    switch (addr->getKind()) {
+      case ValueKind::BeginAccessInst:
+        addr = cast<BeginAccessInst>(addr)->getOperand();
+        break;
+      default:
+        return addr;
+    }
+  }
+}
+
+int MemoryLocations::getLocationIdx(SILValue addr) const {
+  auto iter = addr2LocIdx.find(getBaseValue(addr));
+  if (iter == addr2LocIdx.end())
+    return -1;
+  return iter->second;
+}
+
+void MemoryLocations::analyzeLocations(SILFunction *function) {
+  // As we have to limit the set of handled locations to memory, which is
+  // guaranteed to be not aliased, we currently only handle indirect function
+  // arguments and alloc_stack locations.
+  for (SILArgument *arg : function->getArguments()) {
+    SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
+    switch (funcArg->getArgumentConvention()) {
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Constant:
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_Out:
+      analyzeLocation(funcArg);
+      break;
+    default:
+      break;
+    }
+  }
+  for (SILBasicBlock &BB : *function) {
+    for (SILInstruction &I : BB) {
+      auto *ASI = dyn_cast<AllocStackInst>(&I);
+      if (ASI && !ASI->hasDynamicLifetime()) {
+        if (allUsesInSameBlock(ASI)) {
+          singleBlockLocations.push_back(ASI);
+        } else {
+          analyzeLocation(ASI);
+        }
+      }
+    }
+  }
+}
+
+void MemoryLocations::analyzeLocation(SILValue loc) {
+  SILFunction *function = loc->getFunction();
+  assert(function && "cannot analyze a SILValue which is not in a function");
+
+  if (!shouldTrackLocation(loc->getType(), function))
+    return;
+
+  unsigned currentLocIdx = locations.size();
+  locations.push_back(Location(loc, currentLocIdx));
+  SmallVector<SILValue, 8> collectedVals;
+  SubLocationMap subLocationMap;
+  if (!analyzeLocationUsesRecursively(loc, currentLocIdx, collectedVals,
+                                      subLocationMap)) {
+    locations.set_size(currentLocIdx);
+    for (SILValue V : collectedVals) {
+      addr2LocIdx.erase(V);
+    }
+    return;
+  }
+  addr2LocIdx[loc] = currentLocIdx;
+}
+
+void MemoryLocations::handleSingleBlockLocations(
+                       std::function<void (SILBasicBlock *block)> handlerFunc) {
+  SILBasicBlock *currentBlock = nullptr;
+  clear();
+
+  // Walk over all collected single-block locations.
+  for (SingleValueInstruction *SVI : singleBlockLocations) {
+    // Whenever the parent block changes, process the block's locations.
+    if (currentBlock && SVI->getParent() != currentBlock) {
+      handlerFunc(currentBlock);
+      clear();
+    }
+    currentBlock = SVI->getParent();
+    analyzeLocation(SVI);
+  }
+  // Process the last block's locations.
+  if (currentBlock)
+    handlerFunc(currentBlock);
+  clear();
+}
+
+void MemoryLocations::dump() const {
+  unsigned idx = 0;
+  for (const Location &loc : locations) {
+    llvm::dbgs() << "location #" << idx << ": sublocs=" << loc.subLocations
+                 << ", parent=" << loc.parentIdx
+                 << ", parentbits=" << loc.selfAndParents
+                 << ": " << loc.representativeValue;
+    idx++;
+  }
+}
+
+void MemoryLocations::dumpBits(const Bits &bits) {
+  llvm::errs() << bits << '\n';
+}
+
+void MemoryLocations::clear() {
+  locations.clear();
+  addr2LocIdx.clear();
+}
+
+bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx,
+                                    SmallVectorImpl<SILValue> &collectedVals,
+                                    SubLocationMap &subLocationMap) {
+  for (Operand *use : V->getUses()) {
+    SILInstruction *user = use->getUser();
+
+    // We only handle addr-instructions which are planned to be used with
+    // opaque values. We can still consider to support other addr-instructions
+    // like addr-cast instructions. This somehow depends how opaque values will
+    // look like.
+    switch (user->getKind()) {
+      case SILInstructionKind::StructElementAddrInst: {
+        auto SEAI = cast<StructElementAddrInst>(user);
+        if (!analyzeAddrProjection(SEAI, locIdx, SEAI->getFieldNo(),
+                                collectedVals, subLocationMap))
+          return false;
+        break;
+      }
+      case SILInstructionKind::TupleElementAddrInst: {
+        auto *TEAI = cast<TupleElementAddrInst>(user);
+        if (!analyzeAddrProjection(TEAI, locIdx, TEAI->getFieldNo(),
+                                collectedVals, subLocationMap))
+          return false;
+        break;
+      }
+      case SILInstructionKind::BeginAccessInst:
+        if (!analyzeLocationUsesRecursively(cast<BeginAccessInst>(user), locIdx,
+                                            collectedVals, subLocationMap))
+          return false;
+        break;
+      case SILInstructionKind::StoreInst:
+        if (cast<StoreInst>(user)->getOwnershipQualifier() ==
+              StoreOwnershipQualifier::Trivial) {
+          return false;
+        }
+        break;
+      case SILInstructionKind::LoadInst:
+      case SILInstructionKind::EndAccessInst:
+      case SILInstructionKind::LoadBorrowInst:
+      case SILInstructionKind::DestroyAddrInst:
+      case SILInstructionKind::ApplyInst:
+      case SILInstructionKind::TryApplyInst:
+      case SILInstructionKind::DebugValueAddrInst:
+      case SILInstructionKind::CopyAddrInst:
+      case SILInstructionKind::YieldInst:
+      case SILInstructionKind::DeallocStackInst:
+        break;
+      default:
+        return false;
+    }
+  }
+  return true;
+}
+
+bool MemoryLocations::analyzeAddrProjection(
+    SingleValueInstruction *projection, unsigned parentLocIdx,unsigned fieldNr,
+    SmallVectorImpl<SILValue> &collectedVals, SubLocationMap &subLocationMap) {
+
+  if (!shouldTrackLocation(projection->getType(), projection->getFunction()))
+    return true;
+
+  unsigned &subLocIdx = subLocationMap[std::make_pair(parentLocIdx, fieldNr)];
+  if (subLocIdx == 0) {
+    subLocIdx = locations.size();
+    assert(subLocIdx > 0);
+    Location &parentLoc = locations[parentLocIdx];
+
+    locations.push_back(Location(projection, subLocIdx, parentLocIdx));
+
+    locations.back().selfAndParents |= parentLoc.selfAndParents;
+
+    int idx = (int)parentLocIdx;
+    do {
+      Location &loc = locations[idx];
+      setBitAndResize(loc.subLocations, subLocIdx);
+      idx = loc.parentIdx;
+    } while (idx >= 0);
+
+    initFieldsCounter(parentLoc);
+    assert(parentLoc.numFieldsNotCoveredBySubfields >= 1);
+    --parentLoc.numFieldsNotCoveredBySubfields;
+    if (parentLoc.numFieldsNotCoveredBySubfields == 0) {
+      int idx = (int)parentLocIdx;
+      do {
+        Location &loc = locations[idx];
+        loc.subLocations.reset(parentLocIdx);
+        idx = loc.parentIdx;
+      } while (idx >= 0);
+    }
+  }
+
+  if (!analyzeLocationUsesRecursively(projection, subLocIdx, collectedVals,
+                                      subLocationMap)) {
+    return false;
+  }
+  addr2LocIdx[projection] = subLocIdx;
+  collectedVals.push_back(projection);
+  return true;
+}
+
+void MemoryLocations::initFieldsCounter(Location &loc) {
+  if (loc.numFieldsNotCoveredBySubfields >= 0)
+    return;
+
+  loc.numFieldsNotCoveredBySubfields = 0;
+  SILFunction *function = loc.representativeValue->getFunction();
+  SILType ty = loc.representativeValue->getType();
+  if (NominalTypeDecl *decl = ty.getNominalOrBoundGenericNominal()) {
+    if (decl->isResilient(function->getModule().getSwiftModule(),
+                          function->getResilienceExpansion())) {
+      loc.numFieldsNotCoveredBySubfields = INT_MAX;
+      return;
+    }
+    for (VarDecl *field : decl->getStoredProperties()) {
+      SILType fieldTy = ty.getFieldType(field, function->getModule());
+      if (shouldTrackLocation(fieldTy, function))
+        ++loc.numFieldsNotCoveredBySubfields;
+    }
+    return;
+  }
+  auto tupleTy = ty.castTo<TupleType>();
+  for (unsigned idx = 0, end = tupleTy->getNumElements(); idx < end; ++idx) {
+    SILType eltTy = ty.getTupleElementType(idx);
+    if (shouldTrackLocation(eltTy, function))
+      ++loc.numFieldsNotCoveredBySubfields;
+  }
+}
+
+
+//===----------------------------------------------------------------------===//
+//                     MemoryDataflow members
+//===----------------------------------------------------------------------===//
+
+MemoryDataflow::MemoryDataflow(SILFunction *function, unsigned numLocations) {
+  // Resizing is mandatory! Just adding states with push_back would potentially
+  // invalidate previous pointers to states, which are stored in block2State.
+  blockStates.resize(function->size());
+
+  unsigned idx = 0;
+  unsigned numBits = numLocations;
+  for (SILBasicBlock &BB : *function) {
+    BlockState *st = &blockStates[idx++];
+    st->block = &BB;
+    st->entrySet.resize(numBits);
+    st->genSet.resize(numBits);
+    st->killSet.resize(numBits);
+    st->exitSet.resize(numBits);
+    block2State[&BB] = st;
+  }
+}
+
+void MemoryDataflow::entryReachabilityAnalysis() {
+  llvm::SmallVector<BlockState *, 16> workList;
+  BlockState *entryState = &blockStates[0];
+  assert(entryState ==
+         block2State[entryState->block->getParent()->getEntryBlock()]);
+  entryState->reachableFromEntry = true;
+  workList.push_back(entryState);
+
+  while (!workList.empty()) {
+    BlockState *state = workList.pop_back_val();
+    for (SILBasicBlock *succ : state->block->getSuccessorBlocks()) {
+      BlockState *succState = block2State[succ];
+      if (!succState->reachableFromEntry) {
+        succState->reachableFromEntry = true;
+        workList.push_back(succState);
+      }
+    }
+  }
+}
+
+void MemoryDataflow::exitReachableAnalysis() {
+  llvm::SmallVector<BlockState *, 16> workList;
+  for (BlockState &state : blockStates) {
+    if (state.block->getTerminator()->isFunctionExiting()) {
+      state.exitReachable = true;
+      workList.push_back(&state);
+    }
+  }
+  while (!workList.empty()) {
+    BlockState *state = workList.pop_back_val();
+    for (SILBasicBlock *pred : state->block->getPredecessorBlocks()) {
+      BlockState *predState = block2State[pred];
+      if (!predState->exitReachable) {
+        predState->exitReachable = true;
+        workList.push_back(predState);
+      }
+    }
+  }
+}
+
+void MemoryDataflow::solveDataflowForward() {
+  // Pretty standard data flow solving.
+  bool changed = false;
+  bool firstRound = true;
+  do {
+    changed = false;
+    for (BlockState &st : blockStates) {
+      Bits bits = st.entrySet;
+      assert(!bits.empty());
+      for (SILBasicBlock *pred : st.block->getPredecessorBlocks()) {
+        bits &= block2State[pred]->exitSet;
+      }
+      if (firstRound || bits != st.entrySet) {
+        changed = true;
+        st.entrySet = bits;
+        bits |= st.genSet;
+        bits.reset(st.killSet);
+        st.exitSet = bits;
+      }
+    }
+    firstRound = false;
+  } while (changed);
+}
+
+void MemoryDataflow::solveDataflowBackward() {
+  // Pretty standard data flow solving.
+  bool changed = false;
+  bool firstRound = true;
+  do {
+    changed = false;
+    for (BlockState &st : llvm::reverse(blockStates)) {
+      Bits bits = st.exitSet;
+      assert(!bits.empty());
+      for (SILBasicBlock *succ : st.block->getSuccessorBlocks()) {
+        bits &= block2State[succ]->entrySet;
+      }
+      if (firstRound || bits != st.exitSet) {
+        changed = true;
+        st.exitSet = bits;
+        bits |= st.genSet;
+        bits.reset(st.killSet);
+        st.entrySet = bits;
+      }
+    }
+    firstRound = false;
+  } while (changed);
+}
+
+void MemoryDataflow::dump() const {
+  for (const BlockState &st : blockStates) {
+    llvm::dbgs() << "bb" << st.block->getDebugID() << ":\n"
+                 << "    entry: " << st.entrySet << '\n'
+                 << "    gen:   " << st.genSet << '\n'
+                 << "    kill:  " << st.killSet << '\n'
+                 << "    exit:  " << st.exitSet << '\n';
+  }
+}
+
+
+//===----------------------------------------------------------------------===//
+//                          MemoryLifetimeVerifier
+//===----------------------------------------------------------------------===//
+
+/// A utility for verifying memory lifetime.
+///
+/// The MemoryLifetime utility checks the lifetime of memory locations.
+/// This is limited to memory locations which are guaranteed to be not aliased,
+/// like @in or @inout parameters. Also, alloc_stack locations are handled.
+///
+/// In addition to verification, the MemoryLifetime class can be used as utility
+/// (e.g. base class) for optimizations, which need to compute memory lifetime.
+class MemoryLifetimeVerifier {
+
+  using Bits = MemoryLocations::Bits;
+  using BlockState = MemoryDataflow::BlockState;
+
+  SILFunction *function;
+  MemoryLocations locations;
+
+  /// Issue an error if \p condition is false.
+  void require(bool condition, const Twine &complaint,
+                               int locationIdx, SILInstruction *where);
+
+  /// Issue an error if any bit in \p wrongBits is set.
+  void require(const Bits &wrongBits, const Twine &complaint,
+                               SILInstruction *where);
+
+  /// Require that all the subLocation bits of the location, associated with
+  /// \p addr, are clear in \p bits.
+  void requireBitsClear(Bits &bits, SILValue addr, SILInstruction *where);
+
+  /// Require that all the subLocation bits of the location, associated with
+  /// \p addr, are set in \p bits.
+  void requireBitsSet(Bits &bits, SILValue addr, SILInstruction *where);
+
+  /// Handles locations of the predecessor's terminator, which are only valid
+  /// in \p block.
+  /// Example: @out results of try_apply. They are only valid in the
+  /// normal-block, but not in the throw-block.
+  void setBitsOfPredecessor(Bits &bits, SILBasicBlock *block);
+
+  /// Initializes the data flow bits sets in the block states for all blocks.
+  void initDataflow(MemoryDataflow &dataFlow);
+
+  /// Initializes the data flow bits sets in the block state for a single block.
+  void initDataflowInBlock(BlockState &state);
+
+  /// Helper function to set bits for function arguments and returns.
+  void setFuncOperandBits(BlockState &state, Operand &op,
+                          SILArgumentConvention convention,
+                          bool isTryApply);
+
+  /// Perform all checks in the function after the data flow has been computed.
+  void checkFunction(MemoryDataflow &dataFlow);
+
+  /// Check all instructions in \p block, starting with \p bits as entry set.
+  void checkBlock(SILBasicBlock *block, Bits &bits);
+
+  /// Check a function argument against the current live \p bits at the function
+  /// call.
+  void checkFuncArgument(Bits &bits, Operand &argumentOp,
+                          SILArgumentConvention argumentConvention,
+                          SILInstruction *applyInst);
+
+public:
+  MemoryLifetimeVerifier(SILFunction *function) : function(function) {}
+
+  /// The main entry point to verify the lifetime of all memory locations in
+  /// the function.
+  void verify();
+};
+
+
+void MemoryLifetimeVerifier::require(bool condition, const Twine &complaint,
+                                     int locationIdx, SILInstruction *where) {
+  if (condition)
+    return;
+
+  llvm::errs() << "SIL memory lifetime failure in @" << function->getName()
+               << ": " << complaint << '\n';
+  if (locationIdx >= 0) {
+    llvm::errs() << "memory location: "
+                 << locations.getLocation(locationIdx)->representativeValue;
+  }
+  llvm::errs() << "at instruction: " << *where << '\n';
+
+  if (DontAbortOnMemoryLifetimeErrors)
+    return;
+
+  llvm::errs() << "in function:\n";
+  function->print(llvm::errs());
+  abort();
+}
+
+void MemoryLifetimeVerifier::require(const Bits &wrongBits,
+                                const Twine &complaint, SILInstruction *where) {
+  require(wrongBits.none(), complaint, wrongBits.find_first(), where);
+}
+
+void MemoryLifetimeVerifier::requireBitsClear(Bits &bits, SILValue addr,
+                                             SILInstruction *where) {
+  if (auto *loc = locations.getLocation(addr)) {
+    require(bits & loc->subLocations,
+            "memory is initialized, but shouldn't", where);
+  }
+}
+
+void MemoryLifetimeVerifier::requireBitsSet(Bits &bits, SILValue addr,
+                                           SILInstruction *where) {
+  if (auto *loc = locations.getLocation(addr)) {
+    require(~bits & loc->subLocations,
+            "memory is not initialized, but should", where);
+  }
+}
+
+void MemoryLifetimeVerifier::initDataflow(MemoryDataflow &dataFlow) {
+  // Initialize the entry and exit sets to all-bits-set. Except for the function
+  // entry.
+  for (BlockState &st : dataFlow) {
+    if (st.block == function->getEntryBlock()) {
+      st.entrySet.reset();
+      for (SILArgument *arg : function->getArguments()) {
+        SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
+        if (funcArg->getArgumentConvention() !=
+              SILArgumentConvention::Indirect_Out) {
+          locations.setBits(st.entrySet, arg);
+        }
+      }
+    } else {
+      st.entrySet.set();
+    }
+    st.exitSet.set();
+
+    // Anything weired can happen in unreachable blocks. So just ignore them.
+    // Note: while solving the dataflow, unreachable blocks are implicitly
+    // ignored, because their entry/exit sets are all-ones and their gen/kill
+    // sets are all-zeroes.
+    if (st.reachableFromEntry)
+      initDataflowInBlock(st);
+  }
+}
+
+void MemoryLifetimeVerifier::initDataflowInBlock(BlockState &state) {
+  // Initialize the genSet with special cases, like the @out results of an
+  // try_apply in the predecessor block.
+  setBitsOfPredecessor(state.genSet, state.block);
+
+  for (SILInstruction &I : *state.block) {
+    switch (I.getKind()) {
+      case SILInstructionKind::LoadInst: {
+        auto *LI = cast<LoadInst>(&I);
+        switch (LI->getOwnershipQualifier()) {
+          case LoadOwnershipQualifier::Take:
+            state.killBits(LI->getOperand(), locations);
+            break;
+          default:
+            break;
+        }
+        break;
+      }
+      case SILInstructionKind::StoreInst:
+        state.genBits(cast<StoreInst>(&I)->getDest(), locations);
+        break;
+      case SILInstructionKind::CopyAddrInst: {
+        auto *CAI = cast<CopyAddrInst>(&I);
+        if (CAI->isTakeOfSrc())
+          state.killBits(CAI->getSrc(), locations);
+        if (CAI->isInitializationOfDest())
+          state.genBits(CAI->getDest(), locations);
+        break;
+      }
+      case SILInstructionKind::DestroyAddrInst:
+        state.killBits(cast<DestroyAddrInst>(&I)->getOperand(), locations);
+        break;
+      case SILInstructionKind::ApplyInst:
+      case SILInstructionKind::TryApplyInst: {
+        FullApplySite FAS(&I);
+        for (Operand &op : I.getAllOperands()) {
+          if (FAS.isArgumentOperand(op)) {
+            setFuncOperandBits(state, op, FAS.getArgumentConvention(op),
+                              isa<TryApplyInst>(&I));
+          }
+        }
+        break;
+      }
+      case SILInstructionKind::YieldInst: {
+        auto *YI = cast<YieldInst>(&I);
+        for (Operand &op : YI->getAllOperands()) {
+          setFuncOperandBits(state, op, YI->getArgumentConventionForOperand(op),
+                             /*isTryApply=*/ false);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}
+
+void MemoryLifetimeVerifier::setBitsOfPredecessor(Bits &bits,
+                                                  SILBasicBlock *block) {
+  SILBasicBlock *pred = block->getSinglePredecessorBlock();
+  if (!pred)
+    return;
+
+  auto *TAI = dyn_cast<TryApplyInst>(pred->getTerminator());
+
+  // @out results of try_apply are only valid in the normal-block, but not in
+  // the throw-block.
+  if (!TAI || TAI->getNormalBB() != block)
+    return;
+
+  FullApplySite FAS(TAI);
+  for (Operand &op : TAI->getAllOperands()) {
+    if (FAS.isArgumentOperand(op) &&
+        FAS.getArgumentConvention(op) == SILArgumentConvention::Indirect_Out) {
+      locations.setBits(bits, op.get());
+    }
+  }
+}
+
+void MemoryLifetimeVerifier::setFuncOperandBits(BlockState &state, Operand &op,
+                                        SILArgumentConvention convention,
+                                        bool isTryApply) {
+  switch (convention) {
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Constant:
+      state.killBits(op.get(), locations);
+      break;
+    case SILArgumentConvention::Indirect_Out:
+      // try_apply is special, because an @out result is only initialized
+      // in the normal-block, but not in the throw-block.
+      // We handle @out result of try_apply in setBitsOfPredecessor.
+      if (!isTryApply)
+        state.genBits(op.get(), locations);
+      break;
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_InoutAliasable:
+    case SILArgumentConvention::Direct_Owned:
+    case SILArgumentConvention::Direct_Unowned:
+    case SILArgumentConvention::Direct_Deallocating:
+    case SILArgumentConvention::Direct_Guaranteed:
+      break;
+  }
+}
+
+void MemoryLifetimeVerifier::checkFunction(MemoryDataflow &dataFlow) {
+
+  // Collect the bits which we require to be set at function exits.
+  Bits expectedReturnBits(locations.getNumLocations());
+  Bits expectedThrowBits(locations.getNumLocations());
+  for (SILArgument *arg : function->getArguments()) {
+    SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
+    switch (funcArg->getArgumentConvention()) {
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+      locations.setBits(expectedReturnBits, funcArg);
+      locations.setBits(expectedThrowBits, funcArg);
+      break;
+    case SILArgumentConvention::Indirect_Out:
+      locations.setBits(expectedReturnBits, funcArg);
+      break;
+    default:
+      break;
+    }
+  }
+
+  Bits bits(locations.getNumLocations());
+  for (BlockState &st : dataFlow) {
+    if (!st.reachableFromEntry)
+      continue;
+
+    // Check all instructions in the block.
+    bits = st.entrySet;
+    checkBlock(st.block, bits);
+
+    // Check if there is a mismatch in location lifetime at the merge point.
+    for (SILBasicBlock *pred : st.block->getPredecessorBlocks()) {
+      BlockState *predState = dataFlow.getState(pred);
+      if (predState->reachableFromEntry) {
+        require(st.entrySet ^ predState->exitSet,
+          "lifetime mismatch in predecessors", &*st.block->begin());
+      }
+    }
+
+    // Check the bits at function exit.
+    TermInst *term = st.block->getTerminator();
+    assert(bits == st.exitSet || isa<TryApplyInst>(term));
+    switch (term->getKind()) {
+      case SILInstructionKind::ReturnInst:
+      case SILInstructionKind::UnwindInst:
+        require(expectedReturnBits & ~st.exitSet,
+          "indirect argument is not alive at function return", term);
+        require(st.exitSet & ~expectedReturnBits,
+          "memory is initialized at function return but shouldn't", term);
+        break;
+      case SILInstructionKind::ThrowInst:
+        require(expectedThrowBits & ~st.exitSet,
+          "indirect argument is not alive at throw", term);
+        require(st.exitSet & ~expectedThrowBits,
+          "memory is initialized at throw but shouldn't", term);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
+  setBitsOfPredecessor(bits, block);
+
+  for (SILInstruction &I : *block) {
+    switch (I.getKind()) {
+      case SILInstructionKind::LoadInst: {
+        auto *LI = cast<LoadInst>(&I);
+        requireBitsSet(bits, LI->getOperand(), &I);
+        switch (LI->getOwnershipQualifier()) {
+          case LoadOwnershipQualifier::Take:
+            locations.clearBits(bits, LI->getOperand());
+            break;
+          case LoadOwnershipQualifier::Copy:
+          case LoadOwnershipQualifier::Trivial:
+            break;
+          case LoadOwnershipQualifier::Unqualified:
+            llvm_unreachable("unqualified load shouldn't be in ownership SIL");
+        }
+        break;
+      }
+      case SILInstructionKind::StoreInst: {
+        auto *SI = cast<StoreInst>(&I);
+        switch (SI->getOwnershipQualifier()) {
+          case StoreOwnershipQualifier::Init:
+            requireBitsClear(bits, SI->getDest(), &I);
+            locations.setBits(bits, SI->getDest());
+            break;
+          case StoreOwnershipQualifier::Assign:
+            requireBitsSet(bits, SI->getDest(), &I);
+            break;
+          case StoreOwnershipQualifier::Trivial:
+            // A trivial store is either an init or an assign, so we don't
+            // require anything. But we have to set the bits, because in case of
+            // enums a trivial store might assign a non-trivial enum.
+            // Example: store of Optional.none to an Optional<T> where T is not
+            // trivial.
+            locations.setBits(bits, SI->getDest());
+            break;
+          case StoreOwnershipQualifier::Unqualified:
+            llvm_unreachable("unqualified store shouldn't be in ownership SIL");
+        }
+        break;
+      }
+      case SILInstructionKind::CopyAddrInst: {
+        auto *CAI = cast<CopyAddrInst>(&I);
+        requireBitsSet(bits, CAI->getSrc(), &I);
+        if (CAI->isTakeOfSrc())
+          locations.clearBits(bits, CAI->getSrc());
+        if (CAI->isInitializationOfDest()) {
+          requireBitsClear(bits, CAI->getDest(), &I);
+          locations.setBits(bits, CAI->getDest());
+        } else {
+          requireBitsSet(bits, CAI->getDest(), &I);
+        }
+        break;
+      }
+      case SILInstructionKind::DestroyAddrInst: {
+        SILValue opVal = cast<DestroyAddrInst>(&I)->getOperand();
+        requireBitsSet(bits, opVal, &I);
+        locations.clearBits(bits, opVal);
+        break;
+      }
+      case SILInstructionKind::EndBorrowInst: {
+        if (SILValue orig = cast<EndBorrowInst>(&I)->getSingleOriginalValue())
+          requireBitsSet(bits, orig, &I);
+        break;
+      }
+      case SILInstructionKind::ApplyInst:
+      case SILInstructionKind::TryApplyInst: {
+        FullApplySite FAS(&I);
+        for (Operand &op : I.getAllOperands()) {
+          if (FAS.isArgumentOperand(op))
+            checkFuncArgument(bits, op, FAS.getArgumentConvention(op), &I);
+        }
+        break;
+      }
+      case SILInstructionKind::YieldInst: {
+        auto *YI = cast<YieldInst>(&I);
+        for (Operand &op : YI->getAllOperands()) {
+          checkFuncArgument(bits, op, YI->getArgumentConventionForOperand(op),
+                             &I);
+        }
+        break;
+      }
+      case SILInstructionKind::DebugValueAddrInst:
+        requireBitsSet(bits, cast<DebugValueAddrInst>(&I)->getOperand(), &I);
+        break;
+      case SILInstructionKind::DeallocStackInst:
+        requireBitsClear(bits, cast<DeallocStackInst>(&I)->getOperand(), &I);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
+                         SILArgumentConvention argumentConvention,
+                         SILInstruction *applyInst) {
+  switch (argumentConvention) {
+    case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Constant:
+      requireBitsSet(bits, argumentOp.get(), applyInst);
+      locations.clearBits(bits, argumentOp.get());
+      break;
+    case SILArgumentConvention::Indirect_Out:
+      requireBitsClear(bits, argumentOp.get(), applyInst);
+      locations.setBits(bits, argumentOp.get());
+      break;
+    case SILArgumentConvention::Indirect_In_Guaranteed:
+    case SILArgumentConvention::Indirect_Inout:
+    case SILArgumentConvention::Indirect_InoutAliasable:
+      requireBitsSet(bits, argumentOp.get(), applyInst);
+      break;
+    case SILArgumentConvention::Direct_Owned:
+    case SILArgumentConvention::Direct_Unowned:
+    case SILArgumentConvention::Direct_Deallocating:
+    case SILArgumentConvention::Direct_Guaranteed:
+      break;
+  }
+}
+
+void MemoryLifetimeVerifier::verify() {
+  // First step: handle memory locations which (potentially) span multiple
+  // blocks.
+  locations.analyzeLocations(function);
+  if (locations.getNumLocations() > 0) {
+    MemoryDataflow dataFlow(function, locations.getNumLocations());
+    dataFlow.entryReachabilityAnalysis();
+    initDataflow(dataFlow);
+    dataFlow.solveDataflowForward();
+    checkFunction(dataFlow);
+  }
+  // Second step: handle single-block locations.
+  locations.handleSingleBlockLocations([this](SILBasicBlock *block) {
+    Bits bits(locations.getNumLocations());
+    checkBlock(block, bits);
+    assert(bits.none() || DontAbortOnMemoryLifetimeErrors);
+  });
+}
+
+void swift::verifyMemoryLifetime(SILFunction *function) {
+  MemoryLifetimeVerifier verifier(function);
+  verifier.verify();
+}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1019,6 +1019,8 @@ public:
   }
 
   void visitAllocStackInst(AllocStackInst *AVI) {
+    if (AVI->hasDynamicLifetime())
+      *this << "[dynamic_lifetime] ";
     *this << AVI->getElementType();
     printDebugVar(AVI->getVarInfo());
   }
@@ -1052,6 +1054,8 @@ public:
   }
 
   void visitAllocBoxInst(AllocBoxInst *ABI) {
+    if (ABI->hasDynamicLifetime())
+      *this << "[dynamic_lifetime] ";
     *this << ABI->getType();
     printDebugVar(ABI->getVarInfo());
   }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -28,6 +28,7 @@
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/MemoryLifetime.h"
 #include "swift/SIL/PostOrder.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILDebugScope.h"
@@ -4997,6 +4998,11 @@ public:
     // because we build the map of archetypes as we visit the
     // instructions.
     verifyOpenedArchetypes(F);
+
+    if (F->hasOwnership() && F->shouldVerifyOwnership() &&
+        !F->getModule().getASTContext().hadError()) {
+      verifyMemoryLifetime(F);
+    }
   }
 
   void verify() {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -457,7 +457,7 @@ namespace {
 
     void handleStoreUse(unsigned UseID);
     void handleLoadUse(const DIMemoryUse &Use);
-    void handleLoadForTypeOfSelfUse(const DIMemoryUse &Use);
+    void handleLoadForTypeOfSelfUse(DIMemoryUse &Use);
     void handleInOutUse(const DIMemoryUse &Use);
     void handleEscapeUse(const DIMemoryUse &Use);
 
@@ -829,7 +829,7 @@ void LifetimeChecker::handleLoadUse(const DIMemoryUse &Use) {
     return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
 }
 
-void LifetimeChecker::handleLoadForTypeOfSelfUse(const DIMemoryUse &Use) {
+void LifetimeChecker::handleLoadForTypeOfSelfUse(DIMemoryUse &Use) {
   bool IsSuperInitComplete, FailedSelfUse;
   // If the value is not definitively initialized, replace the
   // value_metatype instruction with the metatype argument that was passed into
@@ -869,6 +869,17 @@ void LifetimeChecker::handleLoadForTypeOfSelfUse(const DIMemoryUse &Use) {
           valueMetatype->getType());
     }
     replaceAllSimplifiedUsesAndErase(valueMetatype, metatypeArgument);
+
+    // Dead loads for type-of-self must be removed.
+    // Otherwise it's a violation of memory lifetime.
+    if (isa<LoadBorrowInst>(load)) {
+      assert(load->hasOneUse() && isa<EndBorrowInst>(load->getSingleUse()->getUser()));
+      load->getSingleUse()->getUser()->eraseFromParent();
+    }
+    assert(load->use_empty());
+    load->eraseFromParent();
+    // Clear the Inst pointer just to be sure to avoid use-after-free.
+    Use.Inst = nullptr;
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -803,8 +803,15 @@ void LifetimeChecker::doIt() {
   SILValue ControlVariable;
   if (HasConditionalInitAssign ||
       HasConditionalDestroy ||
-      HasConditionalSelfInitialized)
+      HasConditionalSelfInitialized) {
     ControlVariable = handleConditionalInitAssign();
+    SILValue memAddr = TheMemory.MemoryInst->getOperand();
+    if (auto *ASI = dyn_cast<AllocStackInst>(memAddr)) {
+      ASI->setDynamicLifetime();
+    } else if (auto *ABI = dyn_cast<AllocBoxInst>(memAddr)) {
+      ABI->setDynamicLifetime();
+    }
+  }
   if (!ConditionalDestroys.empty())
     handleConditionalDestroys(ControlVariable);
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -437,7 +437,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
          && "rewriting multi-field box not implemented");
   auto *ASI = Builder.createAllocStack(
       ABI->getLoc(), ABI->getBoxType()->getFieldType(ABI->getModule(), 0),
-      ABI->getVarInfo());
+      ABI->getVarInfo(), ABI->hasDynamicLifetime());
 
   // Transfer a mark_uninitialized if we have one.
   SILValue StackBox = ASI;

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1623,6 +1623,7 @@ SILInstruction *CastOptimizer::optimizeUnconditionalCheckedCastAddrInst(
       Builder.emitStoreValueOperation(Loc, undef, dynamicCast.getDest(),
                                       StoreOwnershipQualifier::Init);
     }
+    Builder.emitDestroyAddr(Loc, Inst->getSrc());
     auto *TrapI = Builder.createBuiltinTrap(Loc);
     eraseInstAction(Inst);
     Builder.setInsertionPoint(std::next(TrapI->getIterator()));

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -395,6 +395,7 @@ namespace sil_block {
   using SILOneTypeLayout = BCRecordLayout<
     SIL_ONE_TYPE,
     SILInstOpCodeField,
+    BCFixed<2>,          // Optional attributes
     TypeIDField,
     SILTypeCategoryField
   >;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -239,7 +239,8 @@ namespace {
 
     void writeConversionLikeInstruction(const SingleValueInstruction *I,
                                         unsigned attrs);
-    void writeOneTypeLayout(SILInstructionKind valueKind, SILType type);
+    void writeOneTypeLayout(SILInstructionKind valueKind,
+                            unsigned attrs, SILType type);
     void writeOneTypeOneOperandLayout(SILInstructionKind valueKind,
                                       unsigned attrs,
                                       SILType type,
@@ -537,10 +538,10 @@ void SILSerializer::handleMethodInst(const MethodInst *MI,
 }
 
 void SILSerializer::writeOneTypeLayout(SILInstructionKind valueKind,
-                                       SILType type) {
+                                       unsigned attrs, SILType type) {
   unsigned abbrCode = SILAbbrCodes[SILOneTypeLayout::Code];
   SILOneTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
-        (unsigned) valueKind,
+        (unsigned) valueKind, attrs,
         S.addTypeRef(type.getASTType()),
         (unsigned)type.getCategory());
 }
@@ -849,7 +850,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::AllocBoxInst: {
     const AllocBoxInst *ABI = cast<AllocBoxInst>(&SI);
-    writeOneTypeLayout(ABI->getKind(), ABI->getType());
+    writeOneTypeLayout(ABI->getKind(), ABI->hasDynamicLifetime() ? 1 : 0,
+                       ABI->getType());
     break;
   }
   case SILInstructionKind::AllocRefInst:
@@ -886,7 +888,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::AllocStackInst: {
     const AllocStackInst *ASI = cast<AllocStackInst>(&SI);
-    writeOneTypeLayout(ASI->getKind(), ASI->getElementType());
+    writeOneTypeLayout(ASI->getKind(), ASI->hasDynamicLifetime() ? 1 : 0,
+                       ASI->getElementType());
     break;
   }
   case SILInstructionKind::ProjectValueBufferInst: {
@@ -1464,7 +1467,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::MetatypeInst: {
     auto &MI = cast<MetatypeInst>(SI);
-    writeOneTypeLayout(MI.getKind(), MI.getType());
+    writeOneTypeLayout(MI.getKind(), 0, MI.getType());
     break;
   }
   case SILInstructionKind::ObjCProtocolInst: {

--- a/test/IRGen/archetype_resilience.sil
+++ b/test/IRGen/archetype_resilience.sil
@@ -23,6 +23,7 @@ sil [ossa] @copyDynamicMultiEnum : $@convention(method) <T, U where T: AnyObject
 bb0(%0 : $*EnumWithClassArchetypeAndDynamicSize<T>):
   %1 = alloc_stack $EnumWithClassArchetypeAndDynamicSize<T> 
   copy_addr %0 to [initialization] %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
+  destroy_addr %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   dealloc_stack %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   %ret = tuple ()
   return %ret : $()

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -56,6 +56,7 @@ sil [ossa] @generic_callee2 : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> 
 bb0(%i : $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <U>):
   %12 = tuple ()
   destroy_value %b : $<τ_0_0> { var τ_0_0 } <U>
+  destroy_addr %i : $*T
   return %12 : $()
 }
 

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1191,6 +1191,18 @@ entry(%0 : $Builtin.Int1):
   return %1 : $()
 }
 
+// CHECK-LABEL: sil @test_dynamic_lifetime_flag : $@convention(thin) () -> ()
+sil @test_dynamic_lifetime_flag : $() -> () {
+bb0:
+  // CHECK: alloc_box [dynamic_lifetime] $<τ_0_0> { var τ_0_0 } <AnyObject>
+  %0 = alloc_box [dynamic_lifetime] $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK: alloc_stack [dynamic_lifetime] $AnyObject
+  %1 = alloc_stack [dynamic_lifetime] $AnyObject
+  dealloc_stack %1 : $*AnyObject
+  %2 = tuple ()
+  return %2 : $()
+}
+
 sil_global @staticProp: $Int
 
 // CHECK-LABEL: sil private @globalinit_func0 : $@convention(thin) () -> () {

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -22,6 +22,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   store_borrow %1 to %3 : $*Builtin.NativeObject
   end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
 
   %4 = tuple()
   return %4 : $()

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -104,6 +104,7 @@ bb0(%0 : $*I, %1 : $*Self):
   %5 = alloc_stack $Self.Assoc                    // users: %6, %8
   %6 = apply %4<I>(%5, %2) : $@convention(witness_method: FooProto) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc
   destroy_addr %2 : $*I                         // id: %7
+  destroy_addr %5 : $*Self.Assoc // id: %8
   dealloc_stack %5 : $*Self.Assoc // id: %8
   dealloc_stack %2 : $*I         // id: %9
   destroy_addr %0 : $*I                           // id: %10

--- a/test/SIL/Parser/ownership_qualified_memopts.sil
+++ b/test/SIL/Parser/ownership_qualified_memopts.sil
@@ -5,20 +5,21 @@ import Builtin
 
 // CHECK-LABEL: sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
-// CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: [[COPY_ARG2:%.*]] = copy_value [[ARG2]]
 // CHECK: store [[COPY_ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
 sil [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
-  %2 = load [take] %0 : $*Builtin.NativeObject
-  %3 = load [copy] %0 : $*Builtin.NativeObject
+  %2 = load [copy] %0 : $*Builtin.NativeObject
+  %3 = load [take] %0 : $*Builtin.NativeObject
   %4 = copy_value %1 : $Builtin.NativeObject
   store %4 to [init] %0 : $*Builtin.NativeObject
   store %1 to [assign] %0 : $*Builtin.NativeObject
   destroy_value %2 : $Builtin.NativeObject
   destroy_value %3 : $Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -25,6 +25,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   store_borrow %1 to %3 : $*Builtin.NativeObject
   end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -23,19 +23,20 @@ bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
 
 // CHECK-LABEL: sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
-// CHECK: [[ARG1_VAL:%.*]] = load [take] [[ARG1]] : $*Builtin.NativeObject
-// CHECK: [[ARG1_VAL_2:%.*]] = load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: [[ARG1_VAL:%.*]] = load [copy] [[ARG1]] : $*Builtin.NativeObject
+// CHECK: [[ARG1_VAL_2:%.*]] = load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG1_VAL]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: destroy_value [[ARG1_VAL_2]]
 // CHECK: } // end sil function 'non_trivial'
 sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
-  %2 = load [take] %0 : $*Builtin.NativeObject
-  %3 = load [copy] %0 : $*Builtin.NativeObject
+  %2 = load [copy] %0 : $*Builtin.NativeObject
+  %3 = load [take] %0 : $*Builtin.NativeObject
   store %2 to [init] %0 : $*Builtin.NativeObject
   store %1 to [assign] %0 : $*Builtin.NativeObject
   destroy_value %3 : $Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -1,0 +1,139 @@
+// RUN: %target-sil-opt -o /dev/null %s
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// A non-trivial type
+class T {
+  init()
+}
+
+struct Inner {
+  var a: T
+  var b: T
+}
+
+struct Outer {
+  var x: T
+  var y: Inner
+  var z: T
+}
+
+sil [ossa] @test_struct : $@convention(thin) (@in Outer) -> @owned T {
+bb0(%0 : $*Outer):
+  %1 = struct_element_addr %0 : $*Outer, #Outer.y
+  %2 = struct_element_addr %0 : $*Outer, #Outer.x
+  %10 = struct_element_addr %0 : $*Outer, #Outer.z
+  %3 = load [copy] %2 : $*T
+  br bb1
+bb1:
+  cond_br undef, bb2, bb6
+bb2:
+  cond_br undef, bb3, bb4
+bb3:
+  %4 = struct_element_addr %1 : $*Inner, #Inner.a
+  %5 = copy_value %3 : $T
+  store %5 to [assign] %4 : $*T
+  br bb5
+bb4:
+  %6 = struct_element_addr %0 : $*Outer, #Outer.y
+  %7 = struct_element_addr %6 : $*Inner, #Inner.b
+  destroy_addr %7 : $*T
+  %8 = copy_value %3 : $T
+  store %8 to [init] %7 : $*T
+  br bb5
+bb5:
+  br bb1
+bb6:
+  destroy_addr %1 : $*Inner
+  destroy_addr %2 : $*T
+  destroy_addr %10 : $*T
+  return %3 : $T
+}
+
+sil [ossa] @test_struct2 : $@convention(thin) (@in Outer, @owned T) -> () {
+bb0(%0 : $*Outer, %1 : $T):
+  %2 = struct_element_addr %0 : $*Outer, #Outer.x
+  store %1 to [assign] %2 : $*T
+  destroy_addr %0 : $*Outer
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil @throwing_func : $@convention(thin) () -> (@out T, @error Error)
+
+sil [ossa] @test_try_apply : $@convention(thin) () -> (@out T, @error Error) {
+bb0(%0 : $*T):
+  %1 = function_ref @throwing_func : $@convention(thin) () -> (@out T, @error Error)
+  try_apply %1(%0) : $@convention(thin) () -> (@out T, @error Error), normal bb1, error bb2
+
+bb1(%2 : $()):
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%4 : @owned $Error):
+  throw %4 : $Error
+
+}
+
+sil [ossa] @test_alloc_stack_simple : $@convention(thin) (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = alloc_stack $T
+  copy_addr %0 to [initialization] %2 : $*T
+  br bb1
+
+bb1:
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_alloc_stack_nested : $@convention(thin) (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %1 = alloc_stack $T
+  copy_addr %0 to [initialization] %1 : $*T
+  %2 = alloc_stack $T
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  cond_br undef, bb1, bb2
+bb1:
+  %3 = alloc_stack $T
+  %4 = alloc_stack $T
+  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [initialization] %4 : $*T
+  destroy_addr %3 : $*T
+  destroy_addr %4 : $*T
+  dealloc_stack %4 : $*T
+  dealloc_stack %3 : $*T
+  br bb3
+bb2:
+  br bb3
+bb3:
+  destroy_addr %1 : $*T
+  dealloc_stack %1 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_unreachable_block : $@convention(thin) (@owned T) -> () {
+bb0(%0 : $T):
+  %2 = alloc_stack $T
+  store %0 to [init] %2 : $*T
+  br bb2
+
+bb1:
+  br bb2
+
+bb2:
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -1,0 +1,132 @@
+// RUN: %target-sil-opt -dont-abort-on-memory-lifetime-errors -o /dev/null %s 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// A non-trivial type
+class T {
+  init()
+}
+
+struct Inner {
+  var a: T
+  var b: T
+}
+
+struct Outer {
+  var x: T
+  var y: Inner
+  var z: T
+}
+
+// CHECK: SIL memory lifetime failure in @test_simple: indirect argument is not alive at function return
+sil [ossa] @test_simple : $@convention(thin) (@inout T) -> @owned T {
+bb0(%0 : $*T):
+  %2 = begin_access [read] [static] %0 : $*T
+  %3 = load [copy] %2 : $*T
+  end_access %2 : $*T
+  br bb1
+bb1:
+  destroy_addr %0 : $*T
+  return %3 : $T
+}
+
+// CHECK: SIL memory lifetime failure in @test_loop: memory is initialized at function return but shouldn't
+sil [ossa] @test_loop : $@convention(thin) (@in T) -> @owned T {
+bb0(%0 : $*T):
+  %2 = begin_access [read] [static] %0 : $*T
+  %3 = load [copy] %2 : $*T
+  end_access %2 : $*T
+  br bb1
+bb1:
+  cond_br undef, bb1, bb2
+bb2:
+  return %3 : $T
+}
+
+// CHECK: SIL memory lifetime failure in @test_merge: lifetime mismatch in predecessors
+sil [ossa] @test_merge : $@convention(thin) (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = alloc_stack $T
+  cond_br undef, bb1, bb2
+
+bb1:
+  copy_addr %0 to [initialization] %2 : $*T
+  br bb3
+bb2:
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  br bb3
+
+bb3:
+  dealloc_stack %2 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK: SIL memory lifetime failure in @test_nesting: memory is initialized at function return but shouldn't
+sil [ossa] @test_nesting : $@convention(thin) (@in Outer) -> () {
+bb0(%0 : $*Outer):
+  %1 = struct_element_addr %0 : $*Outer, #Outer.x
+  %2 = struct_element_addr %0 : $*Outer, #Outer.y
+  destroy_addr %1 : $*T
+  destroy_addr %2 : $*Inner
+  %3 = tuple ()
+  return %3 : $()
+}
+
+sil @throwing_func : $@convention(thin) () -> (@out T, @error Error)
+
+// CHECK: SIL memory lifetime failure in @test_try_apply_return: memory is initialized, but shouldn't
+sil [ossa] @test_try_apply_return : $@convention(thin) () -> ((), @error Error) {
+bb0:
+  %0 = alloc_stack $T
+  %1 = function_ref @throwing_func : $@convention(thin) () -> (@out T, @error Error)
+  try_apply %1(%0) : $@convention(thin) () -> (@out T, @error Error), normal bb1, error bb2
+
+bb1(%2 : $()):
+  dealloc_stack %0 : $*T
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%4 : @owned $Error):
+  dealloc_stack %0 : $*T
+  throw %4 : $Error
+
+}
+
+// CHECK: SIL memory lifetime failure in @test_try_apply_throw: memory is not initialized, but should
+sil [ossa] @test_try_apply_throw : $@convention(thin) () -> ((), @error Error) {
+bb0:
+  %0 = alloc_stack $T
+  %1 = function_ref @throwing_func : $@convention(thin) () -> (@out T, @error Error)
+  try_apply %1(%0) : $@convention(thin) () -> (@out T, @error Error), normal bb1, error bb2
+
+bb1(%2 : $()):
+  destroy_addr %0 : $*T
+  dealloc_stack %0 : $*T
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%4 : @owned $Error):
+  destroy_addr %0 : $*T
+  dealloc_stack %0 : $*T
+  throw %4 : $Error
+
+}
+
+// CHECK: SIL memory lifetime failure in @test_single_block: memory is initialized, but shouldn't
+sil [ossa] @test_single_block : $@convention(thin) (@owned T) -> () {
+bb0(%0 : $T):
+  %2 = alloc_stack $T
+  store %0 to [init] %2 : $*T
+  dealloc_stack %2 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -164,7 +164,7 @@ bb0(%0 : @owned $SomeClass):
   %1 = alloc_box ${ var SomeClass }
   %1a = project_box %1 : ${ var SomeClass }, 0
   store %0 to [init] %1a : $*SomeClass
-  %3 = load [take] %1a : $*SomeClass
+  %3 = load [copy] %1a : $*SomeClass
   destroy_value %1 : ${ var SomeClass }
   return %3 : $SomeClass
 

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -39,6 +39,7 @@ protocol P {}
 
 // CHECK-LABEL: sil @$s22generic_promotable_boxTf2ni_n : $@convention(thin) <T> (@in T, Builtin.Int32) -> Builtin.Int32
 // CHECK:       bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $Builtin.Int32):
+// CHECK-NEXT:    destroy_addr %0
 // CHECK-NEXT:    return [[ARG1]] : $Builtin.Int32
 
 sil [ossa] @generic_promotable_box : $@convention(thin) <T> (@in T, @owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
@@ -46,6 +47,7 @@ entry(%0 : $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <Int>):
   %a = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
   %v = load [trivial] %a : $*Int
   destroy_value %b : $<τ_0_0> { var τ_0_0 } <Int>
+  destroy_addr %0 : $*T
   return %v : $Int
 }
 

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -988,7 +988,7 @@ bb0(%0 : @owned $Array<NSObject>):
   checked_cast_addr_br copy_on_success Array<NSObject> in %1 : $*Array<NSObject> to NSArray in %2 : $*NSArray, bb1, bb2
 
 bb1:
-  destroy_addr %1 : $*Array<NSObject>
+  destroy_addr %2 : $*NSArray
   br bb3
 
 bb2:
@@ -1013,14 +1013,14 @@ bb0(%0 : @owned $Array<NSObject>):
   checked_cast_addr_br take_on_success Array<NSObject> in %1 : $*Array<NSObject> to NSArray in %2 : $*NSArray, bb1, bb2
 
 bb1:
-  destroy_addr %1 : $*Array<NSObject>
+  destroy_addr %2 : $*NSArray
   br bb3
 
 bb2:
+  destroy_addr %1 : $*Array<NSObject>
   br bb3
 
 bb3:
-  destroy_addr %1 : $*Array<NSObject>
   dealloc_stack %2 : $*NSArray
   dealloc_stack %1 : $*Array<NSObject>
   %9999 = tuple()
@@ -1038,14 +1038,13 @@ bb0(%0 : @owned $Array<NSObject>):
   checked_cast_addr_br take_always Array<NSObject> in %1 : $*Array<NSObject> to NSArray in %2 : $*NSArray, bb1, bb2
 
 bb1:
-  destroy_addr %1 : $*Array<NSObject>
+  destroy_addr %2 : $*NSArray
   br bb3
 
 bb2:
   br bb3
 
 bb3:
-  destroy_addr %1 : $*Array<NSObject>
   dealloc_stack %2 : $*NSArray
   dealloc_stack %1 : $*Array<NSObject>
   %9999 = tuple()

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -118,7 +118,7 @@ bb3(%11 : @owned $T):
 //
 // A new copy_value is inserted before the consuming store.
 // CHECK-NEXT:   %3 = copy_value %0 : $T
-// CHECK-NEXT:   store %3 to [init] %1 : $*T
+// CHECK-NEXT:   store %3 to [assign] %1 : $*T
 //
 // The non-consuming use now uses the original value.
 // CHECK-NEXT:   debug_value %0 : $T
@@ -135,7 +135,7 @@ sil [ossa] @testConsume : $@convention(thin) <T> (@in T, @inout T) -> () {
 bb0(%arg : @owned $T, %addr : $*T):
   %copy = copy_value %arg : $T
   debug_value %copy : $T
-  store %copy to [init] %addr : $*T
+  store %copy to [assign] %addr : $*T
   debug_value %arg : $T
   debug_value_addr %addr : $*T
   destroy_value %arg : $T

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -416,7 +416,7 @@ struct ThrowStruct {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers11ThrowStructV27failDuringOrAfterDelegationACSi_tKcfC
 // CHECK:       bb0(%0 : $Int, %1 : $@thin ThrowStruct.Type):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int1
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowStruct
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowStruct
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[INIT_FN:%.*]] = function_ref @$s35definite_init_failable_initializers11ThrowStructV4failACyt_tKcfC
@@ -457,7 +457,7 @@ struct ThrowStruct {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers11ThrowStructV27failBeforeOrAfterDelegationACSi_tKcfC
 // CHECK:       bb0(%0 : $Int, %1 : $@thin ThrowStruct.Type):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int1
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowStruct
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowStruct
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @$s35definite_init_failable_initializers6unwrapyS2iKF
@@ -958,7 +958,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC28failBeforeFullInitialization0h6DuringjK0ACSi_SitKcfc
 // CHECK:       bb0(%0 : $Int, %1 : $Int, %2 : $ThrowDerivedClass):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int1
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         store %2 to [[SELF_BOX]] : $*ThrowDerivedClass
@@ -1028,7 +1028,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC27failAfterFullInitialization0h6DuringjK0ACSi_SitKcfc
 // CHECK:       bb0(%0 : $Int, %1 : $Int, %2 : $ThrowDerivedClass):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int2
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK:         [[ZERO:%.*]] = integer_literal $Builtin.Int2, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         store %2 to [[SELF_BOX]]
@@ -1075,7 +1075,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC28failBeforeFullInitialization0h5AfterjK0ACSi_SitKcfc
 // CHECK:       bb0(%0 : $Int, %1 : $Int, %2 : $ThrowDerivedClass):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int2
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int2, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         store %2 to [[SELF_BOX]]
@@ -1138,7 +1138,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC28failBeforeFullInitialization0h6DuringjK00h5AfterjK0ACSi_S2itKcfc
 // CHECK:       bb0(%0 : $Int, %1 : $Int, %2 : $Int, %3 : $ThrowDerivedClass):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int2
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int2, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         store %3 to [[SELF_BOX]]
@@ -1320,7 +1320,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC27failDuringOrAfterDelegationACSi_tKcfC
 // CHECK:       bb0(%0 : $Int, %1 : $@thick ThrowDerivedClass.Type):
 // CHECK:         [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int1
-// CHECK:         [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK:         [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK:         [[ZERO:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[INIT_FN:%.*]] = function_ref @$s35definite_init_failable_initializers17ThrowDerivedClassCACyKcfC
@@ -1361,7 +1361,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK-LABEL: sil hidden @$s35definite_init_failable_initializers17ThrowDerivedClassC27failBeforeOrAfterDelegationACSi_tKcfC
 // CHECK:       bb0(%0 : $Int, %1 : $@thick ThrowDerivedClass.Type):
 // CHECK-NEXT:    [[BITMAP_BOX:%.*]] = alloc_stack $Builtin.Int1
-// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack $ThrowDerivedClass
+// CHECK-NEXT:    [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ThrowDerivedClass
 // CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK-NEXT:    store [[ZERO]] to [[BITMAP_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @$s35definite_init_failable_initializers6unwrapyS2iKF

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -91,7 +91,7 @@ class Cat : FakeNSObject {
   // CHECK-LABEL: sil hidden @$s40definite_init_failable_initializers_objc3CatC4fail5afterACSgSb_Sbtcfc : $@convention(method) (Bool, Bool, @owned Cat) -> @owned Optional<Cat>
   // CHECK: bb0(%0 : $Bool, %1 : $Bool, %2 : $Cat):
     // CHECK-NEXT: [[HAS_RUN_INIT_BOX:%.+]] = alloc_stack $Builtin.Int1
-    // CHECK-NEXT: [[SELF_BOX:%.+]] = alloc_stack $Cat
+    // CHECK-NEXT: [[SELF_BOX:%.+]] = alloc_stack [dynamic_lifetime] $Cat
     // CHECK:      store %2 to [[SELF_BOX]] : $*Cat
     // CHECK-NEXT: [[COND:%.+]] = struct_extract %0 : $Bool, #Bool._value
     // CHECK-NEXT: cond_br [[COND]], bb1, bb2

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -156,7 +156,7 @@ sil @selfinit_mystruct3 : $@convention(thin) () -> @owned MyStruct3
 sil hidden [ossa] @test_conditional_destroy_delegating_init : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
 // CHECK:  [[CONTROL:%[0-9]+]] = alloc_stack $Builtin.Int1
-// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_stack $MyStruct3
+// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_stack [dynamic_lifetime] $MyStruct3
 
   %2 = alloc_stack $MyStruct3
   %3 = mark_uninitialized [delegatingself] %2 : $*MyStruct3
@@ -209,7 +209,7 @@ sil @selfinit_myclass3 : $@convention(thin) (@owned MyClass3) -> @owned MyClass3
 sil hidden [ossa] @test_conditional_destroy_class_delegating_init : $@convention(thin) (Builtin.Int1, @owned MyClass3) -> () {
 bb0(%0 : $Builtin.Int1, %1 : @owned $MyClass3):
 // CHECK:  [[CONTROL:%[0-9]+]] = alloc_stack $Builtin.Int2
-// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_stack $MyClass3
+// CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_stack [dynamic_lifetime] $MyClass3
 
   %2 = alloc_stack $MyClass3
   %3 = mark_uninitialized [delegatingselfallocated] %2 : $*MyClass3

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -132,7 +132,7 @@ bb0(%0 : $*T, %1 : $*T):
 }
 
 // CHECK-LABEL: sil [ossa] @copy_addr2
-sil [ossa] @copy_addr2 : $@convention(thin) <T> (@in T) -> @out T {
+sil [ossa] @copy_addr2 : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -492,7 +492,7 @@ bb2:
 sil [ossa] @conditionalInitOrAssign : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
   // CHECK: [[CONTROL:%[0-9]+]] = alloc_stack $Builtin.Int1
-  // CHECK: [[CLASSVAL:%[0-9]+]] = alloc_stack $SomeClass
+  // CHECK: [[CLASSVAL:%[0-9]+]] = alloc_stack [dynamic_lifetime] $SomeClass
   // CHECK: integer_literal $Builtin.Int1, 0
   // CHECK: store
   %5 = alloc_stack $SomeClass

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -29,7 +29,7 @@ enum ValueEnum {
   // CHECK-LABEL: sil hidden @$s25definite_init_value_types9ValueEnumO1xACSb_tcfC : $@convention(method) (Bool, @thin ValueEnum.Type) -> @owned ValueEnum
   // CHECK:      bb0(%0 : $Bool, %1 : $@thin ValueEnum.Type):
   // CHECK-NEXT:   [[STATE:%.*]] = alloc_stack $Builtin.Int1
-  // CHECK-NEXT:   [[SELF_BOX:%.*]] = alloc_stack $ValueEnum
+  // CHECK-NEXT:   [[SELF_BOX:%.*]] = alloc_stack [dynamic_lifetime] $ValueEnum
   // CHECK-NEXT:   [[INIT_STATE:%.*]] = integer_literal $Builtin.Int1, 0
   // CHECK-NEXT:   store [[INIT_STATE]] to [[STATE]]
   // CHECK:        [[BOOL:%.*]] = struct_extract %0 : $Bool, #Bool._value

--- a/test/SILOptimizer/devirt_try_apply_ownership.sil
+++ b/test/SILOptimizer/devirt_try_apply_ownership.sil
@@ -212,6 +212,7 @@ bb0(%0 : @owned $Derived1):
   %8 = unchecked_ref_cast %7 : $Base to $Derived1
   %9 = copy_value %8 : $Derived1
   store %8 to [assign] %1 : $*Derived1
+  destroy_addr %1 : $*Derived1
   dealloc_stack %1 : $*Derived1
   return %9 : $Derived1
 }
@@ -294,6 +295,7 @@ bb0(%0 : @owned $Derived2):
   %8 = unchecked_ref_cast %7 : $Base to $Derived2
   %9 = copy_value %8 : $Derived2
   store %8 to [assign] %1 : $*Derived2
+  destroy_addr %1 : $*Derived2
   dealloc_stack %1 : $*Derived2
   return %9 : $Derived2
 }
@@ -400,6 +402,7 @@ bb0(%0 : @owned $CP2):
   %8 = unchecked_ref_cast %7 : $CP1 to $CP2
   %9 = copy_value %8 : $CP2
   store %8 to [assign] %1 : $*CP2
+  destroy_addr %1 : $*CP2
   dealloc_stack %1 : $*CP2
   return %9 : $CP2
 }

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -17,9 +17,9 @@ class C {}
 // CHECK-LABEL: sil @load : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.Int32) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $*Builtin.Int32):
 // CHECK: [[LOAD2:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
+// CHECK: strong_retain [[LOAD2]]
 // CHECK: apply {{%[0-9]+}}([[LOAD2]])
 // CHECK: [[LOAD3:%[0-9]+]] = load [[ARG1]] : $*Builtin.NativeObject
-// CHECK: strong_retain [[LOAD3]]
 // CHECK: apply {{%[0-9]+}}([[LOAD3]])
 // CHECK: [[LOAD4:%[0-9]+]] = load [[ARG2]] : $*Builtin.Int32
 // CHECK: apply {{%[0-9]+}}([[LOAD4]])
@@ -28,10 +28,10 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
   %use_native_object_func = function_ref @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
   %use_int32_func = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
-  %3 = load [take] %0 : $*Builtin.NativeObject
+  %3 = load [copy] %0 : $*Builtin.NativeObject
   apply %use_native_object_func(%3) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 
-  %4 = load [copy] %0 : $*Builtin.NativeObject
+  %4 = load [take] %0 : $*Builtin.NativeObject
   apply %use_native_object_func(%4) : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 
   %5 = load [trivial] %1 : $*Builtin.Int32
@@ -41,7 +41,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> ()
+// CHECK-LABEL: sil @store : $@convention(thin) (Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> @out Builtin.NativeObject {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject, [[ARG3:%[0-9]+]] : $*Builtin.Int32, [[ARG4:%[0-9]+]] : $Builtin.Int32):
 // CHECK: strong_retain [[ARG2]]
 // CHECK: strong_retain [[ARG2]]
@@ -50,7 +50,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.Int32):
 // CHECK: store [[ARG2]] to [[ARG1]] : $*Builtin.NativeObject
 // CHECK: strong_release [[OLDVAL]]
 // CHECK: store [[ARG4]] to [[ARG3]] : $*Builtin.Int32
-sil [ossa] @store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> () {
+sil [ossa] @store : $@convention(thin) (Builtin.NativeObject, @in Builtin.Int32, Builtin.Int32) -> @out Builtin.NativeObject {
 bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject, %2 : $*Builtin.Int32, %3 : $Builtin.Int32):
   %4 = copy_value %1 : $Builtin.NativeObject
   %5 = copy_value %1 : $Builtin.NativeObject
@@ -61,12 +61,12 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject, %2 : $*Bui
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @borrow : $@convention(thin) (@in Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil @borrow : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%[0-9]+]] : $*Builtin.NativeObject):
 // CHECK: [[BORROWED_VALUE:%[0-9]+]] = load [[ARG]] : $*Builtin.NativeObject
 // CHECK: unchecked_ref_cast [[BORROWED_VALUE]]
 // CHECK-NOT: end_borrow
-sil [ossa] @borrow : $@convention(thin) (@in Builtin.NativeObject) -> () {
+sil [ossa] @borrow : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %1 = load_borrow %0 : $*Builtin.NativeObject
   %2 = unchecked_ref_cast %1 : $Builtin.NativeObject to $Builtin.NativeObject

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -242,6 +242,7 @@ bb1:
   br bb3
 
 bb2:
+  destroy_addr %1 : $*Builtin.NativeObject
   br bb3
 
 bb3:
@@ -273,6 +274,7 @@ bb1:
   br bb3
 
 bb2:
+  destroy_addr %1 : $*Builtin.NativeObject
   br bb3
 
 bb3:

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1166,7 +1166,7 @@ bb3:
   br bbEnd(%5 : $Optional<Builtin.NativeObject>)
 
 bb4:
-  destroy_value %3a : $Builtin.NativeObject
+  store %3a to [init] %1 : $*Builtin.NativeObject
   br bb5
 
 bb5:
@@ -1213,7 +1213,7 @@ bb3:
   br bbEnd(%5 : $Optional<Builtin.NativeObject>)
 
 bb4:
-  destroy_value %3a : $Builtin.NativeObject
+  store %3a to [init] %1 : $*Builtin.NativeObject
   br bb5
 
 bb5:
@@ -1255,7 +1255,7 @@ bb3:
   br bbEnd(%5 : $Optional<Builtin.NativeObject>)
 
 bb4:
-  destroy_value %3a : $Builtin.NativeObject
+  store %3a to [init] %1 : $*Builtin.NativeObject
   br bb5
 
 bb5:

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -36,7 +36,7 @@ bb0(%0 : $*SomeClass, %1 : @owned $SomeClass):
 }
 
 // CHECK-LABEL: sil [ossa] @non_box_assign_init
-sil [ossa] @non_box_assign_init : $@convention(thin) (@inout SomeClass, @owned SomeClass) -> () {
+sil [ossa] @non_box_assign_init : $@convention(thin) (@owned SomeClass) -> @out SomeClass {
 bb0(%0 : $*SomeClass, %1 : @owned $SomeClass):
   // Explicitly check that assign [init] is treated as store [init]
   //

--- a/test/SILOptimizer/sil_combine_uncheck.sil
+++ b/test/SILOptimizer/sil_combine_uncheck.sil
@@ -39,6 +39,7 @@ bb0(%0 : $Builtin.Int1):
 // CHECK-LABEL: sil @test_unconditional_checked_cast_addr_fail
 // CHECK: bb0
 // CHECK-NEXT: store undef
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: builtin "int_trap"
 // CHECK: unreachable
 // CHECK: }

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1042,6 +1042,18 @@ entry(%0 : $Builtin.Int1):
   return %1 : $()
 }
 
+// CHECK-LABEL: sil public_external [transparent] [serialized] @test_dynamic_lifetime_flag : $@convention(thin) () -> ()
+sil [transparent] [serialized] @test_dynamic_lifetime_flag : $@convention(thin) () -> () {
+bb0:
+  // CHECK: alloc_box [dynamic_lifetime] $<τ_0_0> { var τ_0_0 } <AnyObject>
+  %0 = alloc_box [dynamic_lifetime] $<τ_0_0> { var τ_0_0 } <AnyObject>
+  // CHECK: alloc_stack [dynamic_lifetime] $AnyObject
+  %1 = alloc_stack [dynamic_lifetime] $AnyObject
+  dealloc_stack %1 : $*AnyObject
+  %2 = tuple ()
+  return %2 : $()
+}
+
 // CHECK-LABEL: sil public_external [transparent] [serialized] @block_storage_type
 sil [transparent] [serialized] @block_storage_type : $@convention(thin) (Int) -> @convention(block) () -> () {
 entry(%0 : $Int):
@@ -1502,6 +1514,7 @@ bb0:
   %119 = function_ref @test_pointer_to_address : $@convention(thin) (Builtin.RawPointer, X) -> ()
   %120 = function_ref @test_bind_memory : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> ()
   %121 = function_ref @cond_fail_test : $@convention(thin) (Builtin.Int1) -> ()
+  %122 = function_ref @test_dynamic_lifetime_flag : $@convention(thin) () -> ()
 
   %124 = function_ref @block_storage_type : $@convention(thin) (Int) -> @convention(block) () -> ()
   %127 = function_ref @bitcasts : $@convention(thin) (@owned Class1) -> @owned (Class2, Int)


### PR DESCRIPTION
In analogy to the ownership verifier, the MemoryLifetimeVerifier checks the lifetime of memory locations.
It's based on MemoryLifetime, which is a general utility for calculating the lifetime of memory locations. It can be used by optimizations, which need to compute memory lifetime.

Memory locations are limited to addresses which are guaranteed to be not aliased, like @in/inout parameters or alloc_stack.
