### PR TITLE
SILGen: Emit bb args for shared loadable case bindings that come after address-only ones.

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2341,7 +2341,7 @@ void PatternMatchEmission::initSharedCaseBlockDest(CaseStmt *caseBlock,
     // We don't pass address-only values in basic block arguments.
     SILType ty = SGF.getLoweredType(vd->getType());
     if (ty.isAddressOnly(SGF.F))
-      return;
+      continue;
     block->createPhiArgument(ty, ValueOwnershipKind::Owned, vd);
   }
 }

--- a/test/SILGen/switch_mixed_address_only_loadable.swift
+++ b/test/SILGen/switch_mixed_address_only_loadable.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen %s
+
+// rdar://problem/53956564
+
+func foo<T>(x: Int, y: T, z: Int) {
+  switch (x, y, z) {
+  case (let xx, let yy, let zz), (let xx, let yy, let zz):
+    _ = xx
+    _ = yy
+    _ = zz
+    break
+  }
+}


### PR DESCRIPTION
Looks like a think-o; even if we see an address-only binding in a shared pattern block, we still
expect bb args in the lowered basic block for anything that comes after it. rdar://problem/53956564