### PR TITLE
[AutoDiff] Add 'zeroTangentVector' property to 'Differentiable' protocol.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -159,6 +159,7 @@ IDENTIFIER(AllDifferentiableVariables)
 IDENTIFIER(TangentVector)
 IDENTIFIER(allDifferentiableVariables)
 IDENTIFIER(move)
+IDENTIFIER(zeroTangentVector)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -290,6 +290,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     if (name.isSimpleName(ctx.Id_allDifferentiableVariables))
       return getRequirement(KnownProtocolKind::Differentiable);
 
+    // SWIFT_ENABLE_TENSORFLOW
+    // Differentiable.zeroTangentVector
+    if (name.isSimpleName(ctx.Id_zeroTangentVector))
+      return getRequirement(KnownProtocolKind::Differentiable);
+
     return nullptr;
   }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1982,6 +1982,11 @@ extension Array where Element : Differentiable {
         base[i].move(along: direction.base[i])
       }
     }
+
+    public var zeroTangentVector: TangentVector {
+      TangentVector(Array<Element.TangentVector>(repeating: .zero,
+                                                 count: base.count))
+    }
   }
 }
 
@@ -2092,6 +2097,10 @@ extension Array : Differentiable where Element : Differentiable {
     var view = DifferentiableView(self)
     view.move(along: direction)
     self = view.base
+  }
+
+  public var zeroTangentVector: TangentVector {
+    TangentVector(Array<Element.TangentVector>(repeating: .zero, count: count))
   }
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1911,6 +1911,8 @@ extension ${Self} : Differentiable {
   public mutating func move(along direction: TangentVector) {
     self += direction
   }
+
+  public var zeroTangentVector: TangentVector { .zero }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -200,6 +200,7 @@ extension SIMD${n} : Differentiable
   public func tangentVector(from cotangent: TangentVector) -> TangentVector {
     return cotangent
   }
+  public var zeroTangentVector: TangentVector { .zero }
 }
 
 extension SIMD${n}

--- a/test/Sema/struct_differentiable.swift
+++ b/test/Sema/struct_differentiable.swift
@@ -320,6 +320,7 @@ struct VectorSpaceTypeAlias : AdditiveArithmetic, Differentiable {
   var w: Float
   var b: Float
   typealias TangentVector = Simple
+  var zeroTangentVector: TangentVector { .zero }
 }
 // expected-error @+2 {{type 'VectorSpaceCustomStruct' does not conform to protocol 'Differentiable'}}
 // expected-note @+1 {{do you want to add protocol stubs?}}
@@ -331,6 +332,7 @@ struct VectorSpaceCustomStruct : AdditiveArithmetic, Differentiable {
     var b: Float.TangentVector
     typealias TangentVector = VectorSpaceCustomStruct.TangentVector
   }
+  var zeroTangentVector: TangentVector { .zero }
 }
 
 struct StaticNoDerivative : Differentiable {
@@ -371,14 +373,10 @@ extension NoMemberwiseInitializerExtended: Differentiable
 
 // Test derived conformances in disallowed contexts.
 
-// expected-error @+4 {{type 'OtherFileNonconforming' does not conform to protocol 'Differentiable'}}
-// expected-error @+3 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
-// expected-note @+2 {{do you want to add protocol stubs?}}
-// expected-note @+1 {{do you want to add protocol stubs?}}
+// expected-error @+2 {{type 'OtherFileNonconforming' does not conform to protocol 'Differentiable'}}
+// expected-error @+1 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension OtherFileNonconforming : Differentiable {}
 
-// expected-error @+4 {{type 'GenericOtherFileNonconforming<T>' does not conform to protocol 'Differentiable'}}
-// expected-error @+3 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
-// expected-note @+2 {{do you want to add protocol stubs?}}
-// expected-note @+1 {{do you want to add protocol stubs?}}
+// expected-error @+2 {{type 'GenericOtherFileNonconforming<T>' does not conform to protocol 'Differentiable'}}
+// expected-error @+1 {{implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type}}
 extension GenericOtherFileNonconforming : Differentiable {}


### PR DESCRIPTION
Zero tangent vector is necessary for optimizations on models with an array of parameters, especially for optimizers that iterates over parameters using key paths. The [current implementation](https://github.com/tensorflow/swift-apis/blob/master/Sources/TensorFlow/Optimizers/MomentumBased.swift) of some key-path-based optimizers is wrong in that it won't work with models that contain an array of parameters (tangent vectors like `infinityNorm` are initialized as `.zero`).

An earlier version of these optimizer using the deprecated `AllDifferentiableVariables` property would give the correct results, but would be heavyweight and inefficient because they'd need to 1. add a constraint `TangentVector == AllDifferentiableVariables` to optimizers, and 2. make a copy of all parameters and resetting them to `.zero`. Since we are deprecating `AllDifferentiableVariables`, this is not the right direction.

This problem also means that our `Differentiable` abstraction needs to provide a general mechanism of obtaining a zero tangent vector at a certain instance. Hence we add a `zeroTangentVector` property to the `Differentiable` protocol.

Zero tangent vectors do not have a canonical mathematical definition, but makes sense for `Differentiable` in the standard library because Swift does not have dependent types and thus cannot have a `TangentVector` that depends on a point on a differentiable manifold. Manopt also has an API, `M.zerovec(x)`, that creates a zero tangent vector at a point (see their API doc [here](https://www.manopt.org/tutorial.html)).

Adding `zeroTangentVector` will make it possible to deprecate `AllDifferentiableVariables` completely, because currently some fast.ai notebooks depend on initializing parameter gradients using `AllDifferentiableVariables`.

The new `Differentiable` protocol looks like the following. The [design overview](http://bit.ly/swift-autodiff) has been updated to reflect this change.

```swift
protocol Differentiable {
    /// A type representing the differentiable value’s derivatives.
    /// Mathematically, this is equivalent to the tangent bundle of the
    /// differentiable manifold represented by the differentiable type.
    associatedtype TangentVector: Differentiable & AdditiveArithmetic

    /// Moves `self` along the given direction. In Riemannian geometry,
    /// this is equivalent to exponential map, which moves `self` on the
    /// geodesic surface along the given tangent vector.
    mutating func move(along direction: TangentVector)

    /// A tangent vector such that `move(along: zeroTangentVector)`
    /// will not modify `self`.
    /// - Note: `zeroTangentVector` can be `TangentVector.zero` in most cases,
    ///   but types whose tangent vectors depend on instance properties of
    ///   `self` need to provide a different implementation. For example, an
    ///   array’s zero tangent vector depends on the array’s `count`.
    var zeroTangentVector: TangentVector { get }
}
```

Resolves [TF-708](https://bugs.swift.org/browse/TF-708).