### PR TITLE
IRGen: Fix crash if the type of a class stored property hasn't been validated yet

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -22,7 +22,6 @@
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/IRGenOptions.h"
-#include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -298,9 +297,6 @@ namespace {
                                   SILType classType,
                                   bool superclass) {
       for (VarDecl *var : theClass->getStoredProperties()) {
-        if (!var->hasInterfaceType())
-          IGM.Context.getLazyResolver()->resolveDeclSignature(var);
-
         SILType type = classType.getFieldType(var, IGM.getSILModule());
 
         // Lower the field type.

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -107,6 +107,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/LazyResolver.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/IR/Function.h"
@@ -5777,6 +5778,9 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
       elementsWithPayload.push_back({elt, nativeTI, nativeTI});
       continue;
     }
+
+    if (!elt->hasInterfaceType())
+      TC.IGM.Context.getLazyResolver()->resolveDeclSignature(elt);
 
     // Compute whether this gives us an apparent payload or dynamic layout.
     // Note that we do *not* apply substitutions from a bound generic instance

--- a/test/multifile/class-layout/final-stored-property/Inputs/library.swift
+++ b/test/multifile/class-layout/final-stored-property/Inputs/library.swift
@@ -1,4 +1,28 @@
-final class Burger {
-  let onions: Bool = true
-  let cheeseSlices: Int = 0
+public struct InnerStruct {
+  let field: Int = 0
+
+  public init() {}
+}
+
+public enum InnerEnum {
+  case field(Int)
+}
+
+public struct OuterStruct {
+  let first: InnerStruct = InnerStruct()
+  let second: InnerEnum = InnerEnum.field(0)
+
+  public init() {}
+}
+
+public final class Burger {
+  public let onions: Bool = true
+  public let complex: OuterStruct = OuterStruct()
+  public let cheeseSlices: Int = 0
+}
+
+@_fixed_layout
+public final class Burrito {
+  public let filling: OuterStruct = OuterStruct()
+  public let cilantro: Int = 0
 }

--- a/test/multifile/class-layout/final-stored-property/main.swift
+++ b/test/multifile/class-layout/final-stored-property/main.swift
@@ -1,6 +1,13 @@
 // RUN: %target-build-swift %S/Inputs/library.swift %S/main.swift
 // RUN: %target-build-swift -whole-module-optimization %S/Inputs/library.swift %S/main.swift
+// RUN: %target-build-swift -enable-library-evolution %S/Inputs/library.swift %S/main.swift
+// RUN: %target-build-swift -enable-library-evolution -whole-module-optimization %S/Inputs/library.swift %S/main.swift
 
 func meltCheese(_ burger: Burger) -> Int {
   return burger.cheeseSlices
+}
+
+@inlinable
+func bestBurrito(_ burrito: Burrito) -> Int {
+  return burrito.cilantro
 }


### PR DESCRIPTION
This is a regression from recent changes to make finalizeDecl() do
less work. All these resolveDeclSignature() calls will hopefully go
away soon, once validateDecl() is refactored into a getInterfaceType()
request.