### PR TITLE
Driver: remove COFF from autolink-extract (NFC)

### DIFF
--- a/test/AutolinkExtract/linker-order.ll
+++ b/test/AutolinkExtract/linker-order.ll
@@ -1,28 +1,26 @@
 ; RUN: llc -mtriple armv7--linux-gnueabihf -filetype obj -o - %s | %target-swift-autolink-extract -o - - | %FileCheck %s
-; RUN: llc -mtriple x86_64--windows-gnu -filetype obj -o - %s | %target-swift-autolink-extract -o - - | %FileCheck %s
-; RUN: llc -mtriple x86_64--windows-cygnus -filetype obj -o - %s | %target-swift-autolink-extract -o - - | %FileCheck %s
+
 ; REQUIRES: autolink-extract
 ; REQUIRES: CODEGENERATOR=ARM
-; REQUIRES: CODEGENERATOR=X86
 
 ; Ensure that the options in the object file preserve ordering.  The linker
 ; options are order dependent, and we would accidentally reorder them because we
 ; used a std::set rather than an llvm::SmallSetVector.
 
-@_swift1_autolink_entries_1 = private constant [7 x i8] c"Saleem\00", section ".swift1_autolink_entries", align 8
-@_swift1_autolink_entries_0 = private constant [8 x i8] c"Naureen\00", section ".swift1_autolink_entries", align 8
+@_swift1_autolink_entries_1 = private constant [6 x i8] c"First\00", section ".swift1_autolink_entries", align 8
+@_swift1_autolink_entries_0 = private constant [7 x i8] c"Second\00", section ".swift1_autolink_entries", align 8
 
 @_swift1_autolink_entries_2 = private constant [7 x i8] c"-rpath\00", section ".swift1_autolink_entries", align 8
-@_swift1_autolink_entries_3 = private constant [8 x i8] c"Naureen\00", section ".swift1_autolink_entries", align 8
+@_swift1_autolink_entries_3 = private constant [7 x i8] c"Second\00", section ".swift1_autolink_entries", align 8
 @_swift1_autolink_entries_4 = private constant [7 x i8] c"-rpath\00", section ".swift1_autolink_entries", align 8
-@_swift1_autolink_entries_5 = private constant [7 x i8] c"Saleem\00", section ".swift1_autolink_entries", align 8
+@_swift1_autolink_entries_5 = private constant [6 x i8] c"First\00", section ".swift1_autolink_entries", align 8
 
-; CHECK: Saleem
-; CHECK: Naureen
-
-; CHECK: -rpath
-; CHECK: Naureen
+; CHECK: First
+; CHECK: Second
 
 ; CHECK: -rpath
-; CHECK: Saleem
+; CHECK: Second
+
+; CHECK: -rpath
+; CHECK: First
 

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -31,7 +31,6 @@
 #include "llvm/Option/Option.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ObjectFile.h"
-#include "llvm/Object/COFF.h"
 #include "llvm/Object/ELFObjectFile.h"
 
 using namespace swift;
@@ -138,10 +137,6 @@ static bool extractLinkerFlags(const llvm::object::Binary *Bin,
                                StringRef BinaryFileName,
                                std::vector<std::string> &LinkerFlags) {
   if (auto *ObjectFile = llvm::dyn_cast<llvm::object::ELFObjectFileBase>(Bin)) {
-    extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags);
-    return false;
-  } else if (auto *ObjectFile =
-                 llvm::dyn_cast<llvm::object::COFFObjectFile>(Bin)) {
     extractLinkerFlagsFromObjectFile(ObjectFile, LinkerFlags);
     return false;
   } else if (auto *Archive = llvm::dyn_cast<llvm::object::Archive>(Bin)) {


### PR DESCRIPTION
COFF has not used autolink-extract for autolinking.  It uses the PE/COFF
mechanism instead of `.drectve`.  This removes the dead code.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
