### PR TITLE
[AutoDiff] Deprecate `Differentiable.AllDifferentiableVariables`.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -155,9 +155,7 @@ IDENTIFIER(by)
 IDENTIFIER(scale)
 IDENTIFIER(x)
 // Differentiable
-IDENTIFIER(AllDifferentiableVariables)
 IDENTIFIER(TangentVector)
-IDENTIFIER(allDifferentiableVariables)
 IDENTIFIER(move)
 
 // Kinds of layout constraints

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -386,6 +386,10 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
   SmallVector<VarDecl *, 8> diffProperties;
   getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
 
+  // Add ad-hoc implicit conformances for `TangentVector`.
+  // TODO(TF-632): Remove this implicit conformance logic when synthesized
+  // member types can be extended.
+
   // `TangentVector` struct can derive `PointwiseMultiplicative` if the
   // `TangentVector` types of all stored properties conform to
   // `PointwiseMultiplicative`.

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -83,10 +83,11 @@ static StructDecl *convertToStructDecl(ValueDecl *v) {
       typeDecl->getDeclaredInterfaceType()->getAnyNominal());
 }
 
-// Get the `Differentiable` protocol associated type for the given `VarDecl`.
+// Get the `Differentiable` protocol `TangentVector` associated type for the
+// given `VarDecl`.
 // TODO: Generalize and move function to shared place for use with other derived
 // conformances.
-static Type getAssociatedType(VarDecl *decl, DeclContext *DC, Identifier id) {
+static Type getTangentVectorType(VarDecl *decl, DeclContext *DC) {
   auto &C = decl->getASTContext();
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   if (!decl->hasInterfaceType())
@@ -96,13 +97,14 @@ static Type getAssociatedType(VarDecl *decl, DeclContext *DC, Identifier id) {
                                               None);
   if (!conf)
     return nullptr;
-  Type assocType = conf->getTypeWitnessByName(varType, id);
-  return assocType;
+  Type tangentType = conf->getTypeWitnessByName(varType, C.Id_TangentVector);
+  return tangentType;
 }
 
-// Get the `Differentiable` protocol associated struct for the given nominal
-// `DeclContext`. Asserts that the associated struct type exists.
-static StructDecl *getAssociatedStructDecl(DeclContext *DC, Identifier id) {
+// Get the `Differentiable` protocol associated `TangentVector` struct for the
+// given nominal `DeclContext`. Asserts that the `TangentVector` struct type
+// exists.
+static StructDecl *getTangentVectorStructDecl(DeclContext *DC) {
   assert(DC->getSelfNominalTypeDecl() && "Must be a nominal `DeclContext`");
   auto &C = DC->getASTContext();
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
@@ -110,8 +112,9 @@ static StructDecl *getAssociatedStructDecl(DeclContext *DC, Identifier id) {
   auto conf = TypeChecker::conformsToProtocol(DC->getSelfTypeInContext(),
                                               diffableProto, DC, None);
   assert(conf && "Nominal must conform to `Differentiable`");
-  Type assocType = conf->getTypeWitnessByName(DC->getSelfTypeInContext(), id);
-  assert(assocType && "`Differentiable` protocol associated type not found");
+  auto assocType = conf->getTypeWitnessByName(
+      DC->getSelfTypeInContext(), C.Id_TangentVector);
+  assert(assocType && "`Differentiable.TangentVector` type not found");
   auto *structDecl = dyn_cast<StructDecl>(assocType->getAnyNominal());
   assert(structDecl && "Associated type must be a struct type");
   return structDecl;
@@ -127,17 +130,13 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
   auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
   auto *addArithProto = C.getProtocol(KnownProtocolKind::AdditiveArithmetic);
 
-  // Nominal type must not customize `TangentVector` or
-  // `AllDifferentiableVariables` to anything other than `Self`.
-  // Otherwise, synthesis is semantically unsupported.
+  // Nominal type must not customize `TangentVector` to anything other than
+  // `Self`. Otherwise, synthesis is semantically unsupported.
   auto tangentDecls = nominal->lookupDirect(C.Id_TangentVector);
-  auto allDiffableVarsDecls =
-      nominal->lookupDirect(C.Id_AllDifferentiableVariables);
   auto nominalTypeInContext =
       DC->mapTypeIntoContext(nominal->getDeclaredInterfaceType());
 
-  auto isValidAssocTypeCandidate =
-      [&](ValueDecl *v, bool checkAdditiveArithmetic = false) -> StructDecl * {
+  auto isValidAssocTypeCandidate = [&](ValueDecl *v) -> StructDecl * {
     // Valid candidate must be a struct or a typealias to a struct.
     auto *structDecl = convertToStructDecl(v);
     if (!structDecl)
@@ -153,10 +152,8 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
         TypeChecker::conformsToProtocol(structDecl->getDeclaredInterfaceType(),
                                         diffableProto, DC, None))
       return structDecl;
-    // 3. Equal nominal (and conform to `AdditiveArithmetic` if flag is true).
+    // 3. Equal nominal and conform to `AdditiveArithmetic`.
     if (structDecl == nominal) {
-      if (!checkAdditiveArithmetic)
-        return structDecl;
       // Check conformance to `AdditiveArithmetic`.
       if (TypeChecker::conformsToProtocol(nominalTypeInContext, addArithProto,
                                           DC, None))
@@ -167,26 +164,17 @@ bool DerivedConformance::canDeriveDifferentiable(NominalTypeDecl *nominal,
   };
 
   auto invalidTangentDecls = llvm::partition(tangentDecls, [&](ValueDecl *v) {
-    return isValidAssocTypeCandidate(v, /*checkAdditiveArithmetic*/ true);
+    return isValidAssocTypeCandidate(v);
   });
-  auto invalidAllDiffableVarsDecls =
-      llvm::partition(allDiffableVarsDecls, isValidAssocTypeCandidate);
 
   auto validTangentDeclCount =
       std::distance(tangentDecls.begin(), invalidTangentDecls);
   auto invalidTangentDeclCount =
       std::distance(invalidTangentDecls, tangentDecls.end());
-  auto validAllDiffableVarsDeclCount =
-      std::distance(allDiffableVarsDecls.begin(), invalidAllDiffableVarsDecls);
-  auto invalidAllDiffableVarsDeclCount =
-      std::distance(invalidAllDiffableVarsDecls, allDiffableVarsDecls.end());
 
-  // There cannot be any invalid associated types. There can be at most one
-  // valid associated type.
-  if (invalidTangentDeclCount != 0 ||
-      invalidAllDiffableVarsDeclCount != 0 ||
-      validTangentDeclCount > 1 ||
-      validAllDiffableVarsDeclCount > 1)
+  // There cannot be any invalid `TangentVector` types.
+  // There can be at most one valid `TangentVector` type.
+  if (invalidTangentDeclCount != 0 || validTangentDeclCount > 1)
     return false;
 
   // All stored properties not marked with `@noDerivative`:
@@ -346,7 +334,7 @@ static ValueDecl *deriveDifferentiable_move(DerivedConformance &derived) {
   auto &C = derived.TC.Context;
   auto *parentDC = derived.getConformanceContext();
 
-  auto *tangentDecl = getAssociatedStructDecl(parentDC, C.Id_TangentVector);
+  auto *tangentDecl = getTangentVectorStructDecl(parentDC);
   auto tangentType = tangentDecl->getDeclaredInterfaceType();
 
   return deriveDifferentiable_method(
@@ -355,210 +343,23 @@ static ValueDecl *deriveDifferentiable_move(DerivedConformance &derived) {
       {deriveBodyDifferentiable_move, nullptr});
 }
 
-// Return the underlying `allDifferentiableVariables` of a VarDecl `x`.
-// If `x` conforms to `Differentiable`, return `allDifferentiableVariables`.
-// Otherwise, return `x`.
-static ValueDecl *getUnderlyingAllDiffableVariables(DeclContext *DC,
-                                                    VarDecl *varDecl) {
-  auto *module = DC->getParentModule();
-  auto &C = module->getASTContext();
-  auto *diffableProto = C.getProtocol(KnownProtocolKind::Differentiable);
-  auto *allDiffableVarsReq =
-      getProtocolRequirement(diffableProto, C.Id_allDifferentiableVariables);
-  if (!varDecl->hasInterfaceType())
-    C.getLazyResolver()->resolveDeclSignature(varDecl);
-  auto varType = DC->mapTypeIntoContext(varDecl->getValueInterfaceType());
-  auto confRef = module->lookupConformance(varType, diffableProto);
-  if (!confRef)
-    return varDecl;
-  // Use protocol requirement as a default for abstract conformances.
-  // If conformance is concrete, get concrete witness declaration instead.
-  ValueDecl *allDiffableVarsDecl = allDiffableVarsReq;
-  if (confRef->isConcrete())
-    allDiffableVarsDecl = confRef->getConcrete()->getWitnessDecl(
-        allDiffableVarsReq);
-  return allDiffableVarsDecl;
-}
-
-// Synthesize getter body for `allDifferentiableVariables` computed property.
-static std::pair<BraceStmt *, bool>
-derivedBody_allDifferentiableVariablesGetter(AbstractFunctionDecl *getterDecl,
-                                             void *) {
-  auto *parentDC = getterDecl->getParent();
-  auto *nominal = parentDC->getSelfNominalTypeDecl();
-  auto &C = nominal->getASTContext();
-
-  auto *allDiffableVarsStruct =
-      getAssociatedStructDecl(parentDC, C.Id_AllDifferentiableVariables);
-  auto *allDiffableVarsInitDecl =
-      allDiffableVarsStruct->getEffectiveMemberwiseInitializer();
-  assert(allDiffableVarsInitDecl &&
-         "'AllDifferentiableVariables' memberwise initializer not found");
-
-  auto *selfDecl = getterDecl->getImplicitSelfDecl();
-  auto *selfDRE =
-      new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
-
-  auto *initDRE = new (C) DeclRefExpr(allDiffableVarsInitDecl, DeclNameLoc(),
-                                      /*Implicit*/ true);
-  initDRE->setFunctionRefKind(FunctionRefKind::SingleApply);
-
-  auto allDiffableVarsType = parentDC->mapTypeIntoContext(
-      allDiffableVarsStruct->getDeclaredInterfaceType());
-  Expr *baseExpr = TypeExpr::createImplicit(allDiffableVarsType, C);
-  auto *initExpr = new (C) ConstructorRefCallExpr(initDRE, baseExpr);
-  initExpr->setThrows(false);
-  initExpr->setImplicit();
-
-  SmallVector<Expr *, 2> members;
-  SmallVector<Identifier, 2> memberNames;
-
-  llvm::DenseMap<Identifier, VarDecl *> diffPropertyMap;
-  SmallVector<VarDecl *, 8> diffProperties;
-  getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
-  for (auto *member : diffProperties)
-    diffPropertyMap[member->getName()] = member;
-
-  for (auto initParam : *allDiffableVarsInitDecl->getParameters()) {
-    auto member = diffPropertyMap[initParam->getName()];
-    Expr *memberExpr = new (C) MemberRefExpr(selfDRE, SourceLoc(), member,
-                                             DeclNameLoc(), /*Implicit*/ true);
-    member->setInterfaceType(member->getValueInterfaceType());
-    auto *memberAllDiffableVarsDecl =
-        getUnderlyingAllDiffableVariables(parentDC, member);
-    if (member != memberAllDiffableVarsDecl) {
-      memberExpr = new (C) MemberRefExpr(memberExpr, SourceLoc(),
-                                         memberAllDiffableVarsDecl,
-                                         DeclNameLoc(), /*Implicit*/ true);
-    }
-    members.push_back(memberExpr);
-    memberNames.push_back(member->getName());
-  }
-  Expr *callExpr = CallExpr::createImplicit(C, initExpr, members, memberNames);
-
-  ASTNode returnStmt = new (C) ReturnStmt(SourceLoc(), callExpr, true);
-  auto *braceStmt =
-      BraceStmt::create(C, SourceLoc(), returnStmt, SourceLoc(), true);
-  return std::pair<BraceStmt *, bool>(braceStmt, false);
-}
-
-// Synthesize setter body for `allDifferentiableVariables` computed property.
-static std::pair<BraceStmt *, bool>
-derivedBody_allDifferentiableVariablesSetter(AbstractFunctionDecl *setterDecl,
-                                             void *) {
-  auto *parentDC = setterDecl->getParent();
-  auto *nominal = parentDC->getSelfNominalTypeDecl();
-  auto &C = nominal->getASTContext();
-
-  auto *selfDecl = setterDecl->getImplicitSelfDecl();
-  Expr *selfDRE =
-      new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit*/ true);
-
-  auto *allDiffableVarsStruct =
-      getAssociatedStructDecl(parentDC, C.Id_AllDifferentiableVariables);
-  auto *newValueDecl = setterDecl->getParameters()->get(0);
-  Expr *newValueDRE =
-      new (C) DeclRefExpr(newValueDecl, DeclNameLoc(), /*Implicit*/ true);
-
-  // Map `AllDifferentiableVariables` struct members to their names for
-  // efficient lookup.
-  llvm::DenseMap<Identifier, VarDecl *> diffPropertyMap;
-  for (auto *member : allDiffableVarsStruct->getStoredProperties())
-    diffPropertyMap[member->getName()] = member;
-
-  SmallVector<ASTNode, 2> assignExprs;
-  SmallVector<VarDecl *, 8> diffProperties;
-  getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
-  for (auto *member : diffProperties) {
-    // Skip immutable members.
-    if (member->isLet())
-      continue;
-    // Create lhs: either `self.x` or `self.x.allDifferentiableVariables`.
-    auto *lhsAllDiffableVars =
-         getUnderlyingAllDiffableVariables(parentDC, member);
-    Expr *lhs;
-    if (member == lhsAllDiffableVars) {
-      lhs = new (C) MemberRefExpr(selfDRE, SourceLoc(), member, DeclNameLoc(),
-                                  /*Implicit*/ true);
-    } else {
-      auto *paramDRE = new (C) MemberRefExpr(selfDRE, SourceLoc(), member,
-                                             DeclNameLoc(), /*Implicit*/ true);
-      lhs = new (C) MemberRefExpr(paramDRE, SourceLoc(), lhsAllDiffableVars,
-                                  DeclNameLoc(), /*Implicit*/ true);
-    }
-    // Create rhs: `newValue.x`.
-    auto *rhs = new (C) MemberRefExpr(newValueDRE, SourceLoc(),
-                                      diffPropertyMap[member->getName()],
-                                      DeclNameLoc(), /*Implicit*/ true);
-    // Create assign expression.
-    auto *assignExpr = new (C) AssignExpr(lhs, SourceLoc(), rhs,
-                                          /*Implicit*/ true);
-    assignExprs.push_back(assignExpr);
-  }
-
-  auto *braceStmt =
-      BraceStmt::create(C, SourceLoc(), assignExprs, SourceLoc(), true);
-  return std::pair<BraceStmt *, bool>(braceStmt, false);
-}
-
-// Synthesize `allDifferentiableVariables` computed property declaration.
-static ValueDecl *
-deriveDifferentiable_allDifferentiableVariables(DerivedConformance &derived) {
-  auto *parentDC = derived.getConformanceContext();
-  auto &TC = derived.TC;
-  auto &C = TC.Context;
-
-  // Get `AllDifferentiableVariables` struct.
-  auto *allDiffableVarsStruct =
-      getAssociatedStructDecl(parentDC, C.Id_AllDifferentiableVariables);
-
-  auto returnInterfaceTy = allDiffableVarsStruct->getDeclaredInterfaceType();
-  auto returnTy = parentDC->mapTypeIntoContext(returnInterfaceTy);
-
-  VarDecl *allDiffableVarsDecl;
-  PatternBindingDecl *pbDecl;
-  std::tie(allDiffableVarsDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_allDifferentiableVariables, returnInterfaceTy, returnTy,
-      /*isStatic*/ false, /*isFinal*/ true);
-
-  AccessorDecl *getterDecl;
-  AccessorDecl *setterDecl;
-  std::tie(getterDecl, setterDecl) =
-      derived.addGetterAndSetterToMutableDerivedProperty(allDiffableVarsDecl,
-                                                         returnTy);
-  getterDecl->setBodySynthesizer(&derivedBody_allDifferentiableVariablesGetter);
-  setterDecl->setBodySynthesizer(&derivedBody_allDifferentiableVariablesSetter);
-  derived.addMembersToConformanceContext(
-      {getterDecl, setterDecl, allDiffableVarsDecl, pbDecl});
-
-  addExpectedOpaqueAccessorsToStorage(allDiffableVarsDecl, C);
-  triggerAccessorSynthesis(TC, allDiffableVarsDecl);
-
-  return allDiffableVarsDecl;
-}
-
-// Return associated `TangentVector` or `AllDifferentiableVariables` struct for
-// a nominal type, if it exists.
-// If not, synthesize the struct. Also return a Boolean value that indicates
-// whether synthesis occurred.
-static std::pair<StructDecl *, bool>
-getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
-                                      Identifier id) {
+// Return associated `TangentVector` struct for a nominal type, if it exists.
+// If not, synthesize the struct.
+static StructDecl *
+getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
   auto &TC = derived.TC;
   auto *parentDC = derived.getConformanceContext();
   auto *nominal = derived.Nominal;
   auto &C = nominal->getASTContext();
 
-  assert(id == C.Id_TangentVector || id == C.Id_AllDifferentiableVariables);
-
   // If the associated struct already exists, return it.
-  auto lookup = nominal->lookupDirect(id);
+  auto lookup = nominal->lookupDirect(C.Id_TangentVector);
   assert(lookup.size() < 2 &&
-         "Expected at most one associated type named member");
+         "Expected at most one associated type named `TangentVector`");
   if (lookup.size() == 1) {
     auto *structDecl = convertToStructDecl(lookup.front());
     assert(structDecl && "Expected lookup result to be a struct");
-    return {structDecl, false};
+    return structDecl;
   }
 
   // Otherwise, synthesize a new struct. The struct must conform to
@@ -578,48 +379,38 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   auto kpIterableType = TypeLoc::withoutLoc(kpIterableProto->getDeclaredType());
 
   SmallVector<TypeLoc, 4> inherited{diffableType};
+  // `TangentVector` must conform to `AdditiveArithmetic`.
+  inherited.push_back(addArithType);
 
   // Cache original members and their associated types for later use.
   SmallVector<VarDecl *, 8> diffProperties;
   getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
 
-  // If the associated type is `TangentVector`, make it also conform to
-  // `AdditiveArithmetic`.
-  if (id == C.Id_TangentVector)
-    inherited.push_back(addArithType);
-
-  // Associated struct can derive `AdditiveArithmetic` if the associated types
-  // of all stored properties conform to `AdditiveArithmetic`.
-  bool canDeriveAdditiveArithmetic =
-      llvm::all_of(diffProperties, [&](VarDecl *vd) {
-        return TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
-                                     addArithProto, parentDC, None);
-      });
-
-  // Associated struct can derive `PointwiseMultiplicative` if the associated
-  // types of all stored properties conform to `PointwiseMultiplicative`.
+  // `TangentVector` struct can derive `PointwiseMultiplicative` if the
+  // `TangentVector` types of all stored properties conform to
+  // `PointwiseMultiplicative`.
   bool canDerivePointwiseMultiplicative =
       llvm::all_of(diffProperties, [&](VarDecl *vd) {
-        return TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
+        return TC.conformsToProtocol(getTangentVectorType(vd, parentDC),
                                      pointMulProto, parentDC, None);
       });
 
-  // Associated struct can derive `ElementaryFunctions` if the associated types
-  // of all stored properties conform to `ElementaryFunctions`.
+  // `TangentVector` struct can derive `ElementaryFunctions` if the
+  // `TangentVector` types of all stored properties conform to
+  // `ElementaryFunctions`.
   bool canDeriveElementaryFunctions =
       llvm::all_of(diffProperties, [&](VarDecl *vd) {
-        return TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
+        return TC.conformsToProtocol(getTangentVectorType(vd, parentDC),
                                      mathProto, parentDC, None);
       });
 
-  // Associated struct can derive `VectorProtocol` if the associated types of
-  // all members conform to `VectorProtocol` and share the same
+  // `TangentVector` struct can derive `VectorProtocol` if the `TangentVector`
+  // types of all members conform to `VectorProtocol` and share the same
   // `VectorSpaceScalar` type.
   Type sameScalarType;
-  bool canDeriveVectorProtocol =
-      canDeriveAdditiveArithmetic && !diffProperties.empty() &&
+  bool canDeriveVectorProtocol = !diffProperties.empty() &&
       llvm::all_of(diffProperties, [&](VarDecl *vd) {
-        auto conf = TC.conformsToProtocol(getAssociatedType(vd, parentDC, id),
+        auto conf = TC.conformsToProtocol(getTangentVectorType(vd, parentDC),
                                           vectorProto, nominal, None);
         if (!conf)
           return false;
@@ -632,49 +423,47 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
         return scalarType->isEqual(sameScalarType);
       });
 
-  // If the associated struct is `AllDifferentiableVariables`, conform it to:
-  // - `AdditiveArithmetic`, if all members of the parent conform to
-  //   `AdditiveArithmetic`.
-  // - `KeyPathIterable`, if the parent conforms to to `KeyPathIterable`.
-  if (id == C.Id_AllDifferentiableVariables) {
-    if (canDeriveAdditiveArithmetic)
-      inherited.push_back(addArithType);
-    if (TC.conformsToProtocol(nominal->getDeclaredInterfaceType(),
-                              kpIterableProto, parentDC,
-                              None))
-      inherited.push_back(kpIterableType);
-  }
-  // If all members conform to `PointwiseMultiplicative`, make the associated
-  // struct conform to `PointwiseMultiplicative`.
+  // `TangentVector` struct should derive `KeyPathIterable` if the parent struct
+  // conforms to `KeyPathIterable`.
+  bool shouldDeriveKeyPathIterable =
+      TC.conformsToProtocol(nominal->getDeclaredInterfaceType(),
+                            kpIterableProto, parentDC, None).hasValue();
+
+  // If all members conform to `PointwiseMultiplicative`, make the
+  // `TangentVector` struct conform to `PointwiseMultiplicative`.
   if (canDerivePointwiseMultiplicative)
     inherited.push_back(pointMulType);
-  // If all members conform to `ElementaryFunctions`, make the associated struct
-  // conform to `ElementaryFunctions`.
+  // If all members conform to `ElementaryFunctions`, make the `TangentVector`
+  // struct conform to `ElementaryFunctions`.
   if (canDeriveElementaryFunctions)
     inherited.push_back(mathType);
   // If all members also conform to `VectorProtocol` with the same `Scalar`
-  // type, make the associated struct conform to `VectorProtocol` instead of
-  // just `AdditiveArithmetic`.
+  // type, make the `TangentVector` struct conform to `VectorProtocol`.
   if (canDeriveVectorProtocol)
     inherited.push_back(vectorType);
+  // If parent type conforms to `KeyPathIterable`, make the `TangentVector`
+  // struct conform to `KeyPathIterable`.
+  if (shouldDeriveKeyPathIterable)
+    inherited.push_back(kpIterableType);
 
-  auto *structDecl = new (C) StructDecl(SourceLoc(), id, SourceLoc(),
-                                        /*Inherited*/ C.AllocateCopy(inherited),
-                                        /*GenericParams*/ {}, parentDC);
+  auto *structDecl =
+      new (C) StructDecl(SourceLoc(), C.Id_TangentVector, SourceLoc(),
+                         /*Inherited*/ C.AllocateCopy(inherited),
+                         /*GenericParams*/ {}, parentDC);
   structDecl->setImplicit();
   structDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
 
-  // Add members to associated struct.
+  // Add members to `TangentVector` struct.
   for (auto *member : diffProperties) {
-    // Add this member's corresponding associated type to the parent's
-    // associated struct.
+    // Add this member's corresponding `TangentVector` type to the parent's
+    // `TangentVector` struct.
     auto *newMember = new (C) VarDecl(
         member->isStatic(), member->getIntroducer(), member->isCaptureList(),
         /*NameLoc*/ SourceLoc(), member->getName(), structDecl);
     // NOTE: `newMember` is not marked as implicit here, because that affects
     // memberwise initializer synthesis.
 
-    auto memberAssocType = getAssociatedType(member, parentDC, id);
+    auto memberAssocType = getTangentVectorType(member, parentDC);
     auto memberAssocInterfaceType = memberAssocType->hasArchetype()
                                         ? memberAssocType->mapTypeOutOfContext()
                                         : memberAssocType;
@@ -700,7 +489,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     C.addSynthesizedDecl(newMember);
     C.addSynthesizedDecl(memberBinding);
 
-    // Now that this member is in the associated type, it should be marked
+    // Now that this member is in the `TangentVector` type, it should be marked
     // `@differentiable` so that the differentiation transform will synthesize
     // associated functions for it. We only add this to public stored
     // properties, because their access outside the module will go through a
@@ -736,8 +525,8 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
     }
   }
 
-  // If nominal type has `@_fixed_layout` attribute, mark associated struct as
-  // `@_fixed_layout` as well.
+  // If nominal type has `@_fixed_layout` attribute, mark `TangentVector` struct
+  // as `@_fixed_layout` as well.
   if (nominal->getAttrs().hasAttribute<FixedLayoutAttr>())
     structDecl->addFixedLayoutAttr();
 
@@ -756,7 +545,7 @@ getOrSynthesizeSingleAssociatedStruct(DerivedConformance &derived,
   derived.addMembersToConformanceContext({structDecl});
   C.addSynthesizedDecl(structDecl);
 
-  return {structDecl, true};
+  return structDecl;
 }
 
 // Add a typealias declaration with the given name and underlying target
@@ -845,83 +634,41 @@ static void checkAndDiagnoseImplicitNoDerivative(TypeChecker &TC,
   }
 }
 
-// Get or synthesize all associated struct types: `TangentVector`,
-// and `AllDifferentiableVariables`.
-// Return the type corresponding to the given identifier.
+// Get or synthesize `TangentVector` struct type.
 static Type
-getOrSynthesizeAssociatedStructType(DerivedConformance &derived,
-                                    Identifier id) {
+getOrSynthesizeTangentVectorStructType(DerivedConformance &derived) {
   auto &TC = derived.TC;
   auto *parentDC = derived.getConformanceContext();
   auto *nominal = derived.Nominal;
   auto &C = nominal->getASTContext();
 
-  // Get or synthesize `AllDifferentiableVariables` and `TangentVector` structs
-  // at once. Synthesizing all three structs at once is necessary in order to
-  // correctly set their mutually recursive associated types.
-  auto allDiffableVarsStructSynthesis =
-      getOrSynthesizeSingleAssociatedStruct(derived,
-                                            C.Id_AllDifferentiableVariables);
-  auto *allDiffableVarsStruct = allDiffableVarsStructSynthesis.first;
-  if (!allDiffableVarsStruct)
-    return nullptr;
-  bool freshlySynthesized = allDiffableVarsStructSynthesis.second;
-
-  auto tangentStructSynthesis =
-      getOrSynthesizeSingleAssociatedStruct(derived, C.Id_TangentVector);
-  auto *tangentStruct = tangentStructSynthesis.first;
+  // Get or synthesize `TangentVector` struct.
+  auto *tangentStruct =
+      getOrSynthesizeTangentVectorStruct(derived, C.Id_TangentVector);
   if (!tangentStruct)
     return nullptr;
-  freshlySynthesized |= tangentStructSynthesis.second;
-
-  // When all structs are freshly synthesized, we check emit warnings for
-  // implicit `@noDerivative` members. Checking for fresh synthesis is necessary
-  // because `getOrSynthesizeAssociatedStructType` will be called multiple times
-  // during synthesis.
-  if (freshlySynthesized)
-    checkAndDiagnoseImplicitNoDerivative(TC, nominal, parentDC);
-
-  // Add associated typealiases for structs.
+  // Check and emit warnings for implicit `@noDerivative` members.
+  checkAndDiagnoseImplicitNoDerivative(TC, nominal, parentDC);
+  // Add `TangentVector` typealias for `TangentVector` struct.
   addAssociatedTypeAliasDecl(C.Id_TangentVector,
                              tangentStruct, tangentStruct, TC);
-  addAssociatedTypeAliasDecl(C.Id_TangentVector,
-                             allDiffableVarsStruct, tangentStruct, TC);
-
-  addAssociatedTypeAliasDecl(C.Id_AllDifferentiableVariables,
-                             allDiffableVarsStruct, allDiffableVarsStruct, TC);
-  addAssociatedTypeAliasDecl(C.Id_AllDifferentiableVariables,
-                             tangentStruct, tangentStruct, TC);
-
-  TC.validateDecl(allDiffableVarsStruct);
   TC.validateDecl(tangentStruct);
 
-  // Sanity checks for synthesized structs.
+  // Sanity checks for synthesized struct.
   assert(DerivedConformance::canDeriveAdditiveArithmetic(tangentStruct,
                                                          parentDC) &&
          "Should be able to derive `AdditiveArithmetic`");
-  assert(DerivedConformance::canDeriveDifferentiable(
-      tangentStruct, parentDC) && "Should be able to derive `Differentiable`");
-  assert(DerivedConformance::canDeriveDifferentiable(
-      allDiffableVarsStruct, parentDC) &&
-          "Should be able to derive `Differentiable`");
+  assert(DerivedConformance::canDeriveDifferentiable(tangentStruct, parentDC) &&
+         "Should be able to derive `Differentiable`");
 
-  // Return the requested associated struct type.
-  StructDecl *requestedStructDecl = nullptr;
-  if (id == C.Id_TangentVector)
-    requestedStructDecl = tangentStruct;
-  else if (id == C.Id_AllDifferentiableVariables)
-    requestedStructDecl = allDiffableVarsStruct;
-  else
-    llvm_unreachable("Unknown `Differentiable` associated type identifier");
+  // Return the `TangentVector` struct type.
   return parentDC->mapTypeIntoContext(
-      requestedStructDecl->getDeclaredInterfaceType());
+      tangentStruct->getDeclaredInterfaceType());
 }
 
-// Synthesize an associated struct type (`TangentVector` or
-// `AllDifferentiableVariables`).
+// Synthesize the `TangentVector` struct type.
 static Type
-deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
-                                      Identifier id) {
+deriveDifferentiable_TangentVectorStruct(DerivedConformance &derived) {
   auto &TC = derived.TC;
   auto *parentDC = derived.getConformanceContext();
   auto *nominal = derived.Nominal;
@@ -931,14 +678,14 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
   SmallVector<VarDecl *, 16> diffProperties;
   getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
 
-  // If any member has an invalid associated type, return nullptr.
+  // If any member has an invalid `TangentVector` type, return nullptr.
   for (auto *member : diffProperties)
-    if (!getAssociatedType(member, parentDC, id))
+    if (!getTangentVectorType(member, parentDC))
       return nullptr;
 
   // Prevent re-synthesis during repeated calls.
   // FIXME: Investigate why this is necessary to prevent duplicate synthesis.
-  auto lookup = nominal->lookupDirect(id);
+  auto lookup = nominal->lookupDirect(C.Id_TangentVector);
   if (lookup.size() == 1)
     if (auto *structDecl = convertToStructDecl(lookup.front()))
       if (structDecl->isImplicit())
@@ -953,13 +700,11 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
   // Check conditions for returning `Self`.
   // - `Self` is not a class type.
   // - No `@noDerivative` stored properties exist.
-  // - All stored properties must have specified associated type equal to
-  //   `Self`.
-  // - If associated type is `TangentVector`, parent type must also conform to
-  //   `AdditiveArithmetic`.
+  // - All stored properties must have `TangentVector` type equal to `Self`.
+  // - Parent type must also conform to `AdditiveArithmetic`.
   bool allMembersAssocTypeEqualsSelf =
       llvm::all_of(diffProperties, [&](VarDecl *member) {
-        auto memberAssocType = getAssociatedType(member, parentDC, id);
+        auto memberAssocType = getTangentVectorType(member, parentDC);
         return member->getType()->isEqual(memberAssocType);
       });
 
@@ -970,11 +715,11 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
 
   // Return `Self` if conditions are met.
   if (!hasNoDerivativeStoredProp && !nominal->getSelfClassDecl() &&
-      (id == C.Id_AllDifferentiableVariables ||
-       (allMembersAssocTypeEqualsSelf && nominalConformsToAddArith))) {
+      allMembersAssocTypeEqualsSelf && nominalConformsToAddArith) {
     auto selfType = parentDC->getSelfTypeInContext();
-    auto *aliasDecl = new (C) TypeAliasDecl(SourceLoc(), SourceLoc(), id,
-                                            SourceLoc(), {}, parentDC);
+    auto *aliasDecl =
+        new (C) TypeAliasDecl(SourceLoc(), SourceLoc(), C.Id_TangentVector,
+                              SourceLoc(), {}, parentDC);
     aliasDecl->setUnderlyingType(selfType);
     aliasDecl->setImplicit();
     aliasDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
@@ -985,46 +730,8 @@ deriveDifferentiable_AssociatedStruct(DerivedConformance &derived,
     return selfType;
   }
 
-  // Otherwise, check if all stored properties have all `Differentiable`
-  // protocol associated types equal to each other:
-  // `TangentVector == AllDifferentiableVariables`.
-  bool allMembersAssocTypesEqualsSelf =
-      llvm::all_of(diffProperties, [&](VarDecl *member) {
-        auto tangentType =
-            getAssociatedType(member, parentDC, C.Id_TangentVector);
-        auto allDiffableVarsType =
-            getAssociatedType(member, parentDC, C.Id_AllDifferentiableVariables);
-        return tangentType->isEqual(allDiffableVarsType);
-      });
-
-  // If all stored properties (excluding ones with `@noDerivative`) have all
-  // `Differentiable` protocol associated types equal to `Self`, then get or
-  // synthesize `AllDifferentiableVariables` struct and let `TangentVector`
-  // alias to it.
-  if (allMembersAssocTypesEqualsSelf) {
-    auto allDiffableVarsStructSynthesis = getOrSynthesizeSingleAssociatedStruct(
-        derived, C.Id_AllDifferentiableVariables);
-    auto *allDiffableVarsStruct = allDiffableVarsStructSynthesis.first;
-    auto freshlySynthesized = allDiffableVarsStructSynthesis.second;
-    // When the struct is freshly synthesized, we check emit warnings for
-    // implicit `@noDerivative` members. Checking for fresh synthesis is
-    // necessary because this code path will be executed called multiple times
-    // during synthesis.
-    if (freshlySynthesized)
-      checkAndDiagnoseImplicitNoDerivative(TC, nominal, parentDC);
-    addAssociatedTypeAliasDecl(C.Id_AllDifferentiableVariables,
-        allDiffableVarsStruct, allDiffableVarsStruct, TC);
-    addAssociatedTypeAliasDecl(C.Id_TangentVector,
-        allDiffableVarsStruct, allDiffableVarsStruct, TC);
-    addAssociatedTypeAliasDecl(C.Id_TangentVector,
-        parentDC, allDiffableVarsStruct, TC);
-    TC.validateDecl(allDiffableVarsStruct);
-    return parentDC->mapTypeIntoContext(
-        allDiffableVarsStruct->getDeclaredInterfaceType());
-  }
-
-  // Otherwise, get or synthesize associated struct type.
-  return getOrSynthesizeAssociatedStructType(derived, id);
+  // Otherwise, get or synthesize `TangentVector` struct type.
+  return getOrSynthesizeTangentVectorStructType(derived);
 }
 
 ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
@@ -1033,8 +740,6 @@ ValueDecl *DerivedConformance::deriveDifferentiable(ValueDecl *requirement) {
     return nullptr;
   if (requirement->getBaseName() == TC.Context.Id_move)
     return deriveDifferentiable_move(*this);
-  if (requirement->getBaseName() == TC.Context.Id_allDifferentiableVariables)
-    return deriveDifferentiable_allDifferentiableVariables(*this);
   TC.diagnose(requirement->getLoc(), diag::broken_differentiable_requirement);
   return nullptr;
 }
@@ -1044,11 +749,7 @@ Type DerivedConformance::deriveDifferentiable(AssociatedTypeDecl *requirement) {
   if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
   if (requirement->getBaseName() == TC.Context.Id_TangentVector)
-    return deriveDifferentiable_AssociatedStruct(
-        *this, TC.Context.Id_TangentVector);
-  if (requirement->getBaseName() == TC.Context.Id_AllDifferentiableVariables)
-    return deriveDifferentiable_AssociatedStruct(
-        *this, TC.Context.Id_AllDifferentiableVariables);
+    return deriveDifferentiable_TangentVectorStruct(*this);
   TC.diagnose(requirement->getLoc(), diag::broken_differentiable_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -285,11 +285,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     if (name.isSimpleName(ctx.Id_typeList))
       return getRequirement(KnownProtocolKind::TensorGroup);
 
-    // SWIFT_ENABLE_TENSORFLOW
-    // Differentiable.allDifferentiableVariables
-    if (name.isSimpleName(ctx.Id_allDifferentiableVariables))
-      return getRequirement(KnownProtocolKind::Differentiable);
-
     return nullptr;
   }
 
@@ -454,9 +449,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
     // SWIFT_ENABLE_TENSORFLOW
     // Differentiable.TangentVector
-    // Differentiable.AllDifferentiableVariables
-    if (name.isSimpleName(ctx.Id_TangentVector) ||
-        name.isSimpleName(ctx.Id_AllDifferentiableVariables))
+    if (name.isSimpleName(ctx.Id_TangentVector))
       return getRequirement(KnownProtocolKind::Differentiable);
 
     // SWIFT_ENABLE_TENSORFLOW

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -65,20 +65,12 @@ public struct Tracked<T> {
   }
   private var handle: Box
 
-  @differentiable(
-    vjp: _vjpInit
-    where T : Differentiable, T == T.AllDifferentiableVariables,
-          T == T.TangentVector
-  )
+  @differentiable(vjp: _vjpInit where T : Differentiable, T == T.TangentVector)
   public init(_ value: T) {
     self.handle = Box(value)
   }
 
-  @differentiable(
-    vjp: _vjpValue
-    where T : Differentiable, T == T.AllDifferentiableVariables,
-          T == T.TangentVector
-  )
+  @differentiable(vjp: _vjpValue where T : Differentiable, T == T.TangentVector)
   public var value: T {
     get { handle.value }
     set { handle.value = newValue }
@@ -174,17 +166,11 @@ extension Tracked : Strideable where T : Strideable, T.Stride == T.Stride.Magnit
 }
 
 // For now, `T` must be restricted to trivial types (like `Float` or `Tensor`).
-extension Tracked : Differentiable
-  where T : Differentiable, T == T.AllDifferentiableVariables,
-        T == T.TangentVector
-{
-  public typealias AllDifferentiableVariables = Tracked<T.AllDifferentiableVariables>
+extension Tracked : Differentiable where T : Differentiable, T == T.TangentVector {
   public typealias TangentVector = Tracked<T.TangentVector>
 }
 
-extension Tracked where T : Differentiable, T == T.AllDifferentiableVariables,
-                        T == T.TangentVector
-{
+extension Tracked where T : Differentiable, T == T.TangentVector {
   @usableFromInline
   internal static func _vjpInit(_ value: T)
       -> (value: Self, pullback: (Self.TangentVector) -> (T.TangentVector)) {
@@ -197,9 +183,7 @@ extension Tracked where T : Differentiable, T == T.AllDifferentiableVariables,
   }
 }
 
-extension Tracked where T : Differentiable, T == T.AllDifferentiableVariables,
-                        T == T.TangentVector
-{
+extension Tracked where T : Differentiable, T == T.TangentVector {
   @usableFromInline
   @differentiating(+)
   internal static func _vjpAdd(lhs: Self, rhs: Self)
@@ -216,7 +200,7 @@ extension Tracked where T : Differentiable, T == T.AllDifferentiableVariables,
 }
 
 extension Tracked where T : Differentiable & SignedNumeric, T == T.Magnitude,
-                        T == T.AllDifferentiableVariables, T == T.TangentVector {
+                        T == T.TangentVector {
   @usableFromInline
   @differentiating(*)
   internal static func _vjpMultiply(lhs: Self, rhs: Self)
@@ -225,8 +209,7 @@ extension Tracked where T : Differentiable & SignedNumeric, T == T.Magnitude,
   }
 }
 
-extension Tracked where T : Differentiable & FloatingPoint,
-                        T == T.AllDifferentiableVariables, T == T.TangentVector {
+extension Tracked where T : Differentiable & FloatingPoint, T == T.TangentVector {
   @usableFromInline
   @differentiating(/)
   internal static func _vjpDivide(lhs: Self, rhs: Self)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1952,26 +1952,6 @@ extension Array where Element : Differentiable {
 
     public typealias TangentVector =
       Array<Element.TangentVector>.DifferentiableView
-    public typealias AllDifferentiableVariables =
-      Array<Element.AllDifferentiableVariables>.DifferentiableView
-
-    public var allDifferentiableVariables: AllDifferentiableVariables {
-      get {
-        return AllDifferentiableVariables(
-          base.map { $0.allDifferentiableVariables })
-      }
-      set {
-        precondition(
-          base.count == newValue.base.count,
-          "cannot set Array.DifferentiableView.AllDifferentiableVariables " +
-            "with count \(base.count) to " +
-            "Array.DifferentiableView.AllDifferentiableVariables with " +
-            "different count \(newValue.base.count)")
-        for i in base.indices {
-          base[i].allDifferentiableVariables = newValue.base[i]
-        }
-      }
-    }
 
     public mutating func move(along direction: TangentVector) {
       precondition(
@@ -2066,27 +2046,13 @@ extension Array.DifferentiableView : AdditiveArithmetic
 /// Makes `Array` differentiable as the product manifold of `Element`
 /// multiplied with itself `count` times.
 extension Array : Differentiable where Element : Differentiable {
-  // In an ideal world, `TangentVector`, `TangentVector`, and
-  // `AllDifferentiableVariables` would all be `Array`s. Unfortunately, we
-  // can't conform `Array` to `AdditiveArithmetic` for `TangentVector` and
-  // `TangentVector`, because `Array` already has a static `+` method with
-  // different semantics from `AdditiveArithmetic` `+`. So we use
+  // In an ideal world, `TangentVector` would be `[Element.TangentVector]`.
+  // Unfortunately, we cannot conform `Array` to `AdditiveArithmetic` for
+  // `TangentVector` because `Array` already has a static `+` method with
+  // different semantics from `AdditiveArithmetic.+`. So we use
   // `Array.DifferentiableView` for all these associated types.
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
-  public typealias AllDifferentiableVariables =
-    Array<Element.AllDifferentiableVariables>.DifferentiableView
-
-  public var allDifferentiableVariables: AllDifferentiableVariables {
-    get {
-      return DifferentiableView(self).allDifferentiableVariables
-    }
-    set {
-      var view = DifferentiableView(self)
-      view.allDifferentiableVariables = newValue
-      self = view.base
-    }
-  }
 
   public mutating func move(along direction: TangentVector) {
     var view = DifferentiableView(self)

--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -721,7 +721,6 @@ internal protocol _AnyDerivativeBox {
   func _subtracting(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox
 
   // `Differentiable` requirements.
-  var _allDifferentiableVariables: _AnyDerivativeBox { get }
   mutating func _move(along direction: _AnyDerivativeBox)
 
   /// The underlying base value, type-erased to `Any`.
@@ -818,10 +817,6 @@ internal struct _ConcreteDerivativeBox<T> : _AnyDerivativeBox
   }
 
   // `Differentiable` requirements.
-
-  var _allDifferentiableVariables: _AnyDerivativeBox {
-    return _ConcreteDerivativeBox(_base.allDifferentiableVariables)
-  }
 
   mutating func _move(along direction: _AnyDerivativeBox) {
     if direction._isOpaqueZero() {

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1906,7 +1906,6 @@ extension ${Self} : VectorProtocol {
 
 extension ${Self} : Differentiable {
   public typealias TangentVector = ${Self}
-  public typealias AllDifferentiableVariables = ${Self}
 
   public mutating func move(along direction: TangentVector) {
     self += direction

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -196,10 +196,6 @@ extension SIMD${n} : Differentiable
   where Scalar : Differentiable & BinaryFloatingPoint,
         Scalar.TangentVector : BinaryFloatingPoint {
   public typealias TangentVector = SIMD${n}
-  public typealias AllDifferentiableVariables = SIMD${n}
-  public func tangentVector(from cotangent: TangentVector) -> TangentVector {
-    return cotangent
-  }
 }
 
 extension SIMD${n}

--- a/test/AutoDiff/control_flow.swift
+++ b/test/AutoDiff/control_flow.swift
@@ -492,9 +492,9 @@ ControlFlowTests.test("Enums") {
       return input * w1
     }
   }
-  expectEqual((Dense.AllDifferentiableVariables(w1: 10), 20),
+  expectEqual((Dense.TangentVector(w1: 10), 20),
               Dense(w1: 4, w2: 5).gradient(at: 2, in: { dense, x in dense(x) }))
-  expectEqual((Dense.AllDifferentiableVariables(w1: 2), 4),
+  expectEqual((Dense.TangentVector(w1: 2), 4),
               Dense(w1: 4, w2: nil).gradient(at: 2, in: { dense, x in dense(x) }))
 
   indirect enum Indirect {

--- a/test/AutoDiff/derived_conformances.swift
+++ b/test/AutoDiff/derived_conformances.swift
@@ -26,8 +26,6 @@ DerivedConformanceTests.test("MemberwiseInitializers") {
     @noDerivative let constant2 = Double(1)
     var x = Float(1)
   }
-  expectEqual(HasNoDerivativeConstant.AllDifferentiableVariables(x: 0),
-              HasNoDerivativeConstant.AllDifferentiableVariables.zero)
   expectEqual(HasNoDerivativeConstant.TangentVector(x: 0),
               HasNoDerivativeConstant.TangentVector.zero)
 }

--- a/test/AutoDiff/derived_differentiable.swift
+++ b/test/AutoDiff/derived_differentiable.swift
@@ -12,10 +12,8 @@ public struct Foo : Differentiable {
 // CHECK-AST:   @differentiable
 // CHECK-AST:   public var a: Float
 // CHECK-AST:   internal init(a: Float)
-// CHECK-AST:   public struct AllDifferentiableVariables
-// CHECK-AST:     public typealias AllDifferentiableVariables = Foo.AllDifferentiableVariables
-// CHECK-AST:     public typealias TangentVector = Foo.AllDifferentiableVariables
-// CHECK-AST:   public typealias TangentVector = Foo.AllDifferentiableVariables
+// CHECK-AST:   public struct TangentVector
+// CHECK-AST:     public typealias TangentVector = Foo.TangentVector
 
 // CHECK-SILGEN-LABEL: // Foo.a.getter
 // CHECK-SILGEN-NEXT: sil [transparent] [serialized] [differentiable source 0 wrt 0] [ossa] @$s22derived_differentiable3FooV1aSfvg : $@convention(method) (Foo) -> Float
@@ -33,7 +31,6 @@ let _: @differentiable (AdditiveTangentIsSelf) -> Float = { x in
 // CHECK-AST:         internal var dummy: PointwiseMultiplicativeDummy
 // CHECK-AST:         internal init(a: Float, dummy: PointwiseMultiplicativeDummy)
 // CHECK-AST:         internal typealias TangentVector = AdditiveTangentIsSelf
-// CHECK-AST:         internal typealias AllDifferentiableVariables = AdditiveTangentIsSelf
 
 struct TestNoDerivative : Differentiable {
   var w: Float
@@ -44,10 +41,8 @@ struct TestNoDerivative : Differentiable {
 // CHECK-AST:         var w: Float
 // CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
 // CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
-// CHECK-AST:         internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, ElementaryFunctions, VectorProtocol
-// CHECK-AST:           internal typealias AllDifferentiableVariables = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:           internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
-// CHECK-AST:         internal typealias TangentVector = TestNoDerivative.AllDifferentiableVariables
+// CHECK-AST:         internal struct TangentVector : Differentiable, AdditiveArithmetic, ElementaryFunctions, VectorProtocol
+// CHECK-AST:           internal typealias TangentVector = TestNoDerivative.TangentVector
 
 struct TestPointwiseMultiplicative : Differentiable {
   var w: PointwiseMultiplicativeDummy
@@ -58,10 +53,8 @@ struct TestPointwiseMultiplicative : Differentiable {
 // CHECK-AST:         var w: PointwiseMultiplicativeDummy
 // CHECK-AST:         @noDerivative internal var technicallyDifferentiable: PointwiseMultiplicativeDummy
 // CHECK-AST:         internal init(w: PointwiseMultiplicativeDummy, technicallyDifferentiable: PointwiseMultiplicativeDummy)
-// CHECK-AST:         internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, PointwiseMultiplicative
-// CHECK-AST:           internal typealias AllDifferentiableVariables = TestPointwiseMultiplicative.AllDifferentiableVariables
-// CHECK-AST:           internal typealias TangentVector = TestPointwiseMultiplicative.AllDifferentiableVariables
-// CHECK-AST:         internal typealias TangentVector = TestPointwiseMultiplicative.AllDifferentiableVariables
+// CHECK-AST:         internal struct TangentVector : Differentiable, AdditiveArithmetic, PointwiseMultiplicative
+// CHECK-AST:           internal typealias TangentVector = TestPointwiseMultiplicative.TangentVector
 
 
 struct TestKeyPathIterable : Differentiable, KeyPathIterable {
@@ -73,10 +66,8 @@ struct TestKeyPathIterable : Differentiable, KeyPathIterable {
 // CHECK-AST:         var w: Float
 // CHECK-AST:         @noDerivative internal var technicallyDifferentiable: Float
 // CHECK-AST:         internal init(w: Float, technicallyDifferentiable: Float)
-// CHECK-AST:         internal struct AllDifferentiableVariables : Differentiable, AdditiveArithmetic, KeyPathIterable, ElementaryFunctions, VectorProtocol
-// CHECK-AST:           internal typealias AllDifferentiableVariables = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:           internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
-// CHECK-AST:         internal typealias TangentVector = TestKeyPathIterable.AllDifferentiableVariables
+// CHECK-AST:         internal struct TangentVector : Differentiable, AdditiveArithmetic, ElementaryFunctions, VectorProtocol, KeyPathIterable
+// CHECK-AST:           internal typealias TangentVector = TestKeyPathIterable.TangentVector
 
 struct GenericTanMember<T : Differentiable> : Differentiable, AdditiveArithmetic {
   var x: T.TangentVector
@@ -86,7 +77,6 @@ struct GenericTanMember<T : Differentiable> : Differentiable, AdditiveArithmetic
 // CHECK-AST:   internal var x: T.TangentVector
 // CHECK-AST:   internal init(x: T.TangentVector)
 // CHECK-AST:   internal typealias TangentVector = GenericTanMember<T>
-// CHECK-AST:   internal typealias AllDifferentiableVariables = GenericTanMember<T>
 // CHECK-AST:   internal static var zero: GenericTanMember<T> { get }
 // CHECK-AST:   internal static func + (lhs: GenericTanMember<T>, rhs: GenericTanMember<T>) -> GenericTanMember<T>
 // CHECK-AST:   internal static func - (lhs: GenericTanMember<T>, rhs: GenericTanMember<T>) -> GenericTanMember<T>

--- a/test/AutoDiff/e2e_differentiable_property.swift
+++ b/test/AutoDiff/e2e_differentiable_property.swift
@@ -137,7 +137,7 @@ E2EDifferentiablePropertyTests.test("computed property") {
   let actualGrad = gradient(at: TF_544(value: 2.4)) { x in
     return x.computed * x.computed
   }
-  let expectedGrad = TF_544.AllDifferentiableVariables(value: 4.8)
+  let expectedGrad = TF_544.TangentVector(value: 4.8)
   expectEqual(expectedGrad, actualGrad)
 }
 

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -141,7 +141,6 @@ func TF_508() {
 struct TF_523_Struct : Differentiable & AdditiveArithmetic {
   var a: Float = 1
   typealias TangentVector = TF_523_Struct
-  typealias AllDifferentiableVariables = TF_523_Struct
 }
 
 @differentiable
@@ -180,7 +179,6 @@ struct TF_546<T: FloatingPoint>: AdditiveArithmetic {
 }
 extension TF_546: Differentiable where T: Differentiable {
   typealias TangentVector = TF_546
-  typealias AllDifferentiableVariables = TF_546
 }
 extension TF_546 where T: Differentiable, T == T.TangentVector {
   static func _vjpInit(real: T, imaginary: T) -> (TF_546, (TF_546) -> (T, T)) {
@@ -248,7 +246,7 @@ public func TF_688<Scalar: Differentiable>(
 }
 
 // TF-697: Test generic requirements of generated AD associated function.
-protocol TF_697_Module: Differentiable where AllDifferentiableVariables == TangentVector {
+protocol TF_697_Module: Differentiable {
     associatedtype Input
     associatedtype Output: Differentiable
 

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -25,8 +25,7 @@ struct FloatPair : Differentiable & AdditiveArithmetic {
 }
 
 struct Pair<T : Differentiable, U : Differentiable> : Differentiable
-  where T == T.AllDifferentiableVariables, T == T.TangentVector,
-        U == U.AllDifferentiableVariables, U == U.TangentVector
+  where T == T.TangentVector, U == U.TangentVector
 {
   var first: Tracked<T>
   var second: Tracked<U>
@@ -495,9 +494,9 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithIfInMethod") {
       return input * w1
     }
   }
-  expectEqual((Dense.AllDifferentiableVariables(w1: 10), 20),
+  expectEqual((Dense.TangentVector(w1: 10), 20),
               Dense(w1: 4, w2: 5).gradient(at: 2, in: { dense, x in dense(x) }))
-  expectEqual((Dense.AllDifferentiableVariables(w1: 2), 4),
+  expectEqual((Dense.TangentVector(w1: 2), 4),
               Dense(w1: 4, w2: nil).gradient(at: 2, in: { dense, x in dense(x) }))
 }
 

--- a/test/AutoDiff/vtable_sil.swift
+++ b/test/AutoDiff/vtable_sil.swift
@@ -7,7 +7,7 @@
 
 class Super : Differentiable {
   var base: Float
-  // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
+  // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.
   var _nontrivial: [Float] = []
 
   // TODO(TF-654): Uncomment attribute when differentiation supports class initializers.
@@ -99,7 +99,7 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil5SuperCyS2f_Sftcig
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil5SuperCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk
-// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s10vtable_sil5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.TangentVector) -> () : @$s10vtable_sil5SuperC4move5alongyAC13TangentVectorV_tF
 // CHECK-NEXT:   #Super.deinit!deallocator.1: @$s10vtable_sil5SuperCfD
 // CHECK-NEXT: }
 
@@ -120,7 +120,7 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [override]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [override]
-// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s10vtable_sil5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF [inherited]
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.TangentVector) -> () : @$s10vtable_sil5SuperC4move5alongyAC13TangentVectorV_tF [inherited]
 // CHECK-NEXT:   #Sub.f!1.jvp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_1_vtable_entry_thunk
 // CHECK-NEXT:   #Sub.f!1.vjp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_1_vtable_entry_thunk
 // CHECK-NEXT:   #Sub.deinit!deallocator.1: @$s10vtable_sil3SubCfD
@@ -143,7 +143,7 @@ class SubSub : Sub {}
 // CHECK-NEXT:   #Super.subscript!getter.1: (Super) -> (Float, Float) -> Float : @$s10vtable_sil3SubCyS2f_Sftcig [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.jvp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__jvp_src_0_wrt_0_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Super.subscript!getter.1.vjp.1.SUU: (Super) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubCyS2f_Sftcig__vjp_src_0_wrt_0_vtable_entry_thunk [inherited]
-// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.AllDifferentiableVariables) -> () : @$s10vtable_sil5SuperC4move5alongyAC26AllDifferentiableVariablesV_tF [inherited]
+// CHECK-NEXT:   #Super.move!1: (Super) -> (Super.TangentVector) -> () : @$s10vtable_sil5SuperC4move5alongyAC13TangentVectorV_tF [inherited]
 // CHECK-NEXT:   #Sub.f!1.jvp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__jvp_src_0_wrt_0_1_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #Sub.f!1.vjp.1.SSU: (Sub) -> (Float, Float) -> Float : @AD__$s10vtable_sil3SubC1fyS2f_SftF__vjp_src_0_wrt_0_1_vtable_entry_thunk [inherited]
 // CHECK-NEXT:   #SubSub.deinit!deallocator.1: @$s10vtable_sil03SubC0CfD

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -448,7 +448,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "tensorflow": "fee0b38d6a2ce3e480c8b6643efe466b889036fa",
-                "tensorflow-swift-apis": "211491271e59000057ccecf18a7b6a20420a7647",
+                "tensorflow-swift-apis": "bcdc695f9af67686117ace02a8e80195ee7f77e6",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a"
             }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -448,7 +448,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "tensorflow": "fee0b38d6a2ce3e480c8b6643efe466b889036fa",
-                "tensorflow-swift-apis": "bcdc695f9af67686117ace02a8e80195ee7f77e6",
+                "tensorflow-swift-apis": "12ad18d705e3dc7137ba4dba9d5d0d2b8cc39f27",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a"
             }


### PR DESCRIPTION
Deprecate the `AllDifferentiableVariables` associated type of the
`Differentiable` protocol.

`AllDifferentiableVariables` is not essential for differentiable
programming and was added as a workaround to enable key-path-based
machine learning optimizers: let parameters and gradients have the same type
(`AllDifferentiableVariables == TangentVector`) to enable joint key-path
iteration.

It is possible to implement key-path-based machine learning optimizers
via other means (do key-path-based operations on `TangentVector`, then
call `Differentiable.move(along:)` to perform update), so
`AllDifferentiableVariables` is no longer necessary.

---

Simplified `Differentiable` protocol:
```swift
/// A type that mathematically represents a differentiable manifold whose
/// tangent spaces are finite-dimensional.
public protocol Differentiable {
  /// A type representing a differentiable value’s derivatives.
  /// Mathematically, this is equivalent to the tangent bundle of the
  /// differentiable manifold represented by the differentiable type.
  associatedtype TangentVector: Differentiable & AdditiveArithmetic
    where TangentVector.TangentVector == TangentVector

  /// Moves `self` along the given direction. In Riemannian geometry,
  /// this is equivalent to exponential map, which moves `self` on the
  /// geodesic surface along the given tangent vector.
  mutating func move(along direction: TangentVector)
}
```

Resolves [TF-707](https://bugs.swift.org/projects/TF/issues/TF-707).