### PR TITLE
[Constraint graph] Associate all constraints with components.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -164,12 +164,6 @@ void SplitterStep::computeFollowupSteps(
       componentSteps[known->second]->record(typeVar);
       continue;
     }
-
-    // Otherwise, associate it with all of the component steps,
-    // expect for components with orphaned constraints, they are
-    // not supposed to have any type variables.
-    for (unsigned i = 0; i != firstOrphanedComponent; ++i)
-      componentSteps[i]->record(typeVar);
   }
 
   // Transfer all of the constraints from the work list to

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -123,10 +123,10 @@ void SplitterStep::computeFollowupSteps(
     CG.verify();
 
     log << "---Constraint graph---\n";
-    CG.print(log);
+    CG.print(CS.TypeVariables, log);
 
     log << "---Connected components---\n";
-    CG.printConnectedComponents(log);
+    CG.printConnectedComponents(CS.TypeVariables, log);
   }
 
   // Map type variables and constraints into appropriate steps.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -172,6 +172,7 @@ void SplitterStep::computeFollowupSteps(
   while (!workList.empty()) {
     auto *constraint = &workList.front();
     workList.pop_front();
+    assert(constraintComponent.count(constraint) > 0 && "Missed a constraint");
     componentSteps[constraintComponent[constraint]]->record(constraint);
   }
 

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -246,13 +246,15 @@ public:
   }
 
   /// Print the graph.
-  void print(llvm::raw_ostream &out);
+  void print(ArrayRef<TypeVariableType *> typeVars, llvm::raw_ostream &out);
+  void dump(llvm::raw_ostream &out);
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");
 
   /// Print the connected components of the graph.
-  void printConnectedComponents(llvm::raw_ostream &out);
+  void printConnectedComponents(ArrayRef<TypeVariableType *> typeVars,
+                                llvm::raw_ostream &out);
 
   LLVM_ATTRIBUTE_DEPRECATED(void dumpConnectedComponents() LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");


### PR DESCRIPTION
The connected components computation was not forming components when all of
the type variables in a component were already bound. Any remaining
constraints involving those type variables would then arbitrarily end up
in component 0, due to the the default-construction behavior of a map’s
operator[] with missing keys, artificially increasing the size of that
component with (typically) additional disjunctions.

Ensure that all constraints get into a component, creating one to hold
the a constraint even when all of the type variables are already bound.
Then, assert the invariant that every constraint is associated with a
component.

In time, we should probably eliminate this notion of disjunctions that
remain even when the type variable has been bound. For now, strengthen the
invariant to at least ensure that they get solved in isolation.