### PR TITLE
Add frontend flag `-warn-if-astscope-lookup` with test

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -261,8 +261,12 @@ namespace swift {
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;
 
-    /// Sound we compare to ASTScope-based resolution for debugging?
+    /// Should  we compare to ASTScope-based resolution for debugging?
     bool CompareToASTScopeLookup = false;
+
+    /// Since some tests fail if the warning is output, use a flag to decide
+    /// whether it is. The warning is useful for testing.
+    bool WarnIfASTScopeLookup = false;
 
     /// Whether to use the import as member inference system
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -124,6 +124,9 @@ def disable_target_os_checking :
   
 def compare_to_astscope_lookup : Flag<["-"], "compare-to-astscope-lookup">,
   HelpText<"Compare legacy to ASTScope-based unqualified name lookup (for debugging)">;
+  
+def warn_if_astscope_lookup : Flag<["-"], "warn-if-astscope-lookup">,
+  HelpText<"Print a warning if ASTScope lookup is used">;
 
 def print_clang_stats : Flag<["-"], "print-clang-stats">,
   HelpText<"Print Clang importer statistics">;

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -486,7 +486,7 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
   const bool compareToASTScopes = Ctx.LangOpts.CompareToASTScopeLookup;
   if (useASTScopesForExperimentalLookup() && !compareToASTScopes) {
     static bool haveWarned = false;
-    if (!haveWarned) {
+    if (!haveWarned && Ctx.LangOpts.WarnIfASTScopeLookup) {
       haveWarned = true;
       llvm::errs() << "WARNING: TRYING Scope exclusively\n";
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -338,6 +338,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    options::OPT_disable_astscope_lookup, Opts.EnableASTScopeLookup) ||
       Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
+  Opts.WarnIfASTScopeLookup |= Args.hasArg(OPT_warn_if_astscope_lookup);
 
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.NamedLazyMemberLoading &= !Args.hasArg(OPT_disable_named_lazy_member_loading);

--- a/test/NameBinding/warn-if-astscope.swift
+++ b/test/NameBinding/warn-if-astscope.swift
@@ -1,0 +1,13 @@
+// Verify the action of -warn-if-astscope-lookup
+//
+// RUN: not %target-swift-frontend -typecheck %s -enable-astscope-lookup 2>&1 |  %FileCheck %s --check-prefix=CHECK-NO-WARN
+// RUN: not %target-swift-frontend -typecheck %s -disable-astscope-lookup 2>&1 | %FileCheck %s --check-prefix=CHECK-NO-WARN
+// RUN: not %target-swift-frontend -typecheck %s -enable-astscope-lookup -warn-if-astscope-lookup 2>&1 | %FileCheck %s --check-prefix=CHECK-WARN
+// RUN: not %target-swift-frontend -typecheck %s -disable-astscope-lookup -warn-if-astscope-lookup 2>&1 | %FileCheck %s --check-prefix=CHECK-NO-WARN
+
+func foo() -> Int {
+  return bar() // create an error so the input to fileCheck isn't empty
+}
+
+// CHECK-NO-WARN-NOT: WARNING: TRYING Scope exclusively
+// CHECK-WARN: WARNING: TRYING Scope exclusively


### PR DESCRIPTION
For testing, it is important to know if ASTScope lookup is being used. However, the warning on stderr I had causes the swiftpr tests to fail. This flag enables the warning as a debug aid.