### PR TITLE
Update checkout for swift-apis.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -448,7 +448,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "tensorflow": "fee0b38d6a2ce3e480c8b6643efe466b889036fa",
-                "tensorflow-swift-apis": "12ad18d705e3dc7137ba4dba9d5d0d2b8cc39f27",
+                "tensorflow-swift-apis": "085217d35c02e07214f3ac99aab2ed0507cfc803",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-07-28-a"
             }


### PR DESCRIPTION
https://github.com/tensorflow/swift-apis/commit/085217d35c02e07214f3ac99aab2ed0507cfc803
`AllDifferentiableVariables` is deprecated.