### PR TITLE
[Typechecker] Check for generic signature when matching overrides

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4398,6 +4398,7 @@ GenericSignature *
 ASTContext::getOverrideGenericSignature(const ValueDecl *base,
                                         const ValueDecl *derived) {
   auto baseGenericCtx = base->getAsGenericContext();
+  auto derivedGenericCtx = derived->getAsGenericContext();
   auto &ctx = base->getASTContext();
 
   if (!baseGenericCtx) {
@@ -4418,6 +4419,10 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   }
 
   if (derivedClass->getSuperclass().isNull()) {
+    return nullptr;
+  }
+
+  if (!derivedGenericCtx || !derivedGenericCtx->isGeneric()) {
     return nullptr;
   }
 
@@ -4449,12 +4454,8 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   GenericSignatureBuilder builder(ctx);
   builder.addGenericSignature(derivedClass->getGenericSignature());
 
-  if (auto derivedGenericCtx = derived->getAsGenericContext()) {
-    if (derivedGenericCtx->isGeneric()) {
-      for (auto param : *derivedGenericCtx->getGenericParams()) {
-        builder.addGenericParameter(param);
-      }
-    }
+  for (auto param : *derivedGenericCtx->getGenericParams()) {
+    builder.addGenericParameter(param);
   }
 
   auto source =

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -170,14 +170,14 @@ bool swift::isOverrideBasedOnType(ValueDecl *decl, Type declTy,
   if (declIUOAttr != parentDeclIUOAttr)
     return false;
 
-  auto parentGenericCtx = parentDecl->getAsGenericContext();
   auto declGenericCtx = decl->getAsGenericContext();
+  auto &ctx = decl->getASTContext();
+  auto sig = ctx.getOverrideGenericSignature(parentDecl, decl);
 
-  if (parentGenericCtx && declGenericCtx) {
-    if (parentGenericCtx->getGenericSignature()->getCanonicalSignature() !=
-        declGenericCtx->getGenericSignature()->getCanonicalSignature()) {
-      return false;
-    }
+  if (sig && declGenericCtx &&
+      declGenericCtx->getGenericSignature()->getCanonicalSignature() !=
+          sig->getCanonicalSignature()) {
+    return false;
   }
 
   // If this is a constructor, let's compare only parameter types.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -170,6 +170,12 @@ bool swift::isOverrideBasedOnType(ValueDecl *decl, Type declTy,
   if (declIUOAttr != parentDeclIUOAttr)
     return false;
 
+  // If the generic signatures don't match, then return false because we don't
+  // want to complain if an overridden method matches multiple superclass
+  // methods which differ in generic signature.
+  //
+  // We can still succeed with a subtype match later in
+  // OverrideMatcher::match().
   auto declGenericCtx = decl->getAsGenericContext();
   auto &ctx = decl->getASTContext();
   auto sig = ctx.getOverrideGenericSignature(parentDecl, decl);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -170,6 +170,16 @@ bool swift::isOverrideBasedOnType(ValueDecl *decl, Type declTy,
   if (declIUOAttr != parentDeclIUOAttr)
     return false;
 
+  auto parentGenericCtx = parentDecl->getAsGenericContext();
+  auto declGenericCtx = decl->getAsGenericContext();
+
+  if (parentGenericCtx && declGenericCtx) {
+    if (parentGenericCtx->getGenericSignature()->getCanonicalSignature() !=
+        declGenericCtx->getGenericSignature()->getCanonicalSignature()) {
+      return false;
+    }
+  }
+
   // If this is a constructor, let's compare only parameter types.
   if (isa<ConstructorDecl>(decl)) {
     // Within a protocol context, check for a failability mismatch.

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -606,6 +606,23 @@ class SR_10198_Base {
 }
 
 class SR_10198_Derived: SR_10198_Base {
-  override func a<T>(_ val: T) -> String { return super.a(val) }
-  override func a<T: Equatable>(_ val: T) -> String { return super.a(val) }
+  override func a<T>(_ val: T) -> String { return super.a(val) } // okay
+  override func a<T: Equatable>(_ val: T) -> String { return super.a(val) } // okay
 }
+
+protocol SR_10198_Base_P {
+  associatedtype Bar
+}
+
+struct SR_10198_Base_S: SR_10198_Base_P {
+  typealias Bar = Int
+}
+
+class SR_10198_Base_1 {
+  init<F: SR_10198_Base_P>(_ arg: F) where F.Bar == Int {}
+}
+
+class SR_10198_Derived_1: SR_10198_Base_1 {
+  init(_ arg1: Int) { super.init(SR_10198_Base_S()) } // okay, doesn't crash
+}
+

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -597,3 +597,15 @@ class SR_4206_Derived<C: SR_4206_Container> : SR_4206_Base<C.Key> {
   typealias Key = C.Key
   override func foo(forKey key: Key) throws {} // Okay, no generic signature mismatch
 }
+
+// SR-10198
+
+class SR_10198_Base {
+  func a<T>(_ val: T) -> String { return "not equatable" }
+  func a<T: Equatable>(_ val: T) -> String { return "equatable" }
+}
+
+class SR_10198_Derived: SR_10198_Base {
+  override func a<T>(_ val: T) -> String { return super.a(val) }
+  override func a<T: Equatable>(_ val: T) -> String { return super.a(val) }
+}


### PR DESCRIPTION
At the moment, we trigger an error for the following code:

```swift
class Base {
  func a<T>(_ val: T) -> String { return "not equatable" }
  func a<T: Equatable>(_ val: T) -> String { return "equatable" }
}

class Derived: Base {
  // error: cannot override more than one superclass declaration
  override func a<T>(_ val: T) -> String { return super.a(val) }
  override func a<T: Equatable>(_ val: T) -> String { return super.a(val) }
}
```

even though the overrides are valid because they have different generic signatures. This PR adds a check to `isOverrideBasedOnType()` to ensure we also take into consideration the generic signature of the overridden and base declarations. This means we can ignore the other declaration and not include it in the match.

Resolves [SR-10198](https://bugs.swift.org/browse/SR-10198)
Resolves rdar://problem/49339618