### PR TITLE
[ownership] When creating a new function declaration for deserializat…

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -566,11 +566,13 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
         linkage == SILLinkage::PublicNonABI) {
       fn->setLinkage(SILLinkage::SharedExternal);
     }
+
     if (fn->isDynamicallyReplaceable() != isDynamic) {
       LLVM_DEBUG(llvm::dbgs() << "SILFunction type mismatch.\n");
       MF->error();
       return nullptr;
     }
+
   } else {
     // Otherwise, create a new function.
     SILSerializationFunctionBuilder builder(SILMod);
@@ -595,7 +597,8 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     for (auto ID : SemanticsIDs) {
       fn->addSemanticsAttr(MF->getIdentifierText(ID));
     }
-
+    if (!hasQualifiedOwnership)
+      fn->setOwnershipEliminated();
     if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), fn);
   }
   // Mark this function as deserialized. This avoids rerunning diagnostic
@@ -664,15 +667,15 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     return fn;
   }
 
-  if (!hasQualifiedOwnership)
-    fn->setOwnershipEliminated();
-
   NumDeserializedFunc++;
 
   assert(!(fn->getGenericEnvironment() && !fn->empty())
          && "function already has context generic params?!");
   if (genericEnv)
     fn->setGenericEnvironment(genericEnv);
+  if (!hasQualifiedOwnership) {
+    fn->setOwnershipEliminated();
+  }
 
   scratch.clear();
   kind = SILCursor.readRecord(entry.ID, scratch);


### PR DESCRIPTION
…ion, set the ownership eliminated flag.

I found this issue by inspection. I do not think it is actually possible to hit
this bug today since:

1. To hit the bug one would need to link in a definition of a function when we
do not have a pre-existing function. If we create the declaration first, then we
set the flag correctly when we deserialize the body of the function.

2. We today always set a callback on functions when we link in the body and
always strip ownership/set that flag. So we /should/ always set it correctly.

That being said, it is better to match what was actually serialized as close as
possible.
