### PR TITLE
[ownership] Re-architect ownership pipeline so that we do not strip o…

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -231,10 +231,13 @@ PASS(OpaqueArchetypeSpecializer, "opaque-archetype-specializer",
 PASS(Outliner, "outliner",
      "Function Outlining Optimization")
 PASS(OwnershipModelEliminator, "ownership-model-eliminator",
-     "Eliminate Ownership Annotation of SIL")
-PASS(NonTransparentFunctionOwnershipModelEliminator,
-     "non-transparent-func-ownership-model-eliminator",
-     "Eliminate Ownership Annotations from non-transparent SIL Functions")
+     "Lower all SIL functions in ossa into their non-ossa variant")
+PASS(LocalOwnershipModelEliminator,
+     "local-ownership-model-eliminator",
+     "OME for non-serialized SIL Functions (including transparent).")
+PASS(LocalNonTransparentOwnershipModelEliminator,
+     "local-nontransparent-ownership-model-eliminator",
+     "OME for non-transparent, non-serialized SIL Functions")
 PASS(RCIdentityDumper, "rc-id-dumper",
      "Print Reference Count Identities")
 PASS(PerfInliner, "inline",

--- a/test/SILOptimizer/ome_non_transparent.sil
+++ b/test/SILOptimizer/ome_non_transparent.sil
@@ -1,10 +1,12 @@
-// RUN: %target-sil-opt -non-transparent-func-ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -local-nontransparent-ownership-model-eliminator %s | %FileCheck %s
+// RUN: %target-sil-opt -local-ownership-model-eliminator %s | %FileCheck --check-prefix=CHECK-LOCAL %s
 
 sil_stage raw
 
 import Builtin
 
 // CHECK-LABEL: sil [transparent] [ossa] @foo : $@convention(thin) () -> () {
+// CHECK-LOCAL-LABEL: sil [transparent] @foo : $@convention(thin) () -> () {
 sil [transparent] [ossa] @foo : $@convention(thin) () -> () {
 bb0:
   %9999 = tuple()
@@ -12,7 +14,24 @@ bb0:
 }
 
 // CHECK-LABEL: sil @bar : $@convention(thin) () -> () {
+// CHECK-LOCAL-LABEL: sil @bar : $@convention(thin) () -> () {
 sil [ossa] @bar : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil public_external [transparent] [ossa] @foo_pe : $@convention(thin) () -> () {
+// CHECK-LOCAL-LABEL: sil public_external [transparent] [ossa] @foo_pe : $@convention(thin) () -> () {
+sil public_external [transparent] [ossa] @foo_pe : $@convention(thin) () -> () {
+bb0:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil public_external [ossa] @bar_pe : $@convention(thin) () -> () {
+// CHECK-LOCAL-LABEL: sil public_external [ossa] @bar_pe : $@convention(thin) () -> () {
+sil public_external [ossa] @bar_pe : $@convention(thin) () -> () {
 bb0:
   %9999 = tuple()
   return %9999 : $()

--- a/test/SILOptimizer/ome_strip_deserialize.sil
+++ b/test/SILOptimizer/ome_strip_deserialize.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -module-name OMEStripDeserializationInput %S/Inputs/ome_strip_deserialize_input.sil -emit-module -o %t/OMEStripDeserializationInput.swiftmodule
-// RUN: %target-sil-opt -non-transparent-func-ownership-model-eliminator -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -local-nontransparent-ownership-model-eliminator -performance-linker -I %t %s | %FileCheck %s
 // RUN: %target-sil-opt -ownership-model-eliminator -performance-linker -I %t %s | %FileCheck --check-prefix=CHECK-STRIP-ALL %s
 
 sil_stage canonical
@@ -10,7 +10,7 @@ import OMEStripDeserializationInput
 // Make sure that we properly set the deserialization call back for stripping
 // ownership SIL.
 
-// CHECK-LABEL: sil public_external [serialized] @bar : $@convention(thin) () -> ()
+// CHECK-LABEL: sil public_external [serialized] [ossa] @bar : $@convention(thin) () -> ()
 // CHECK: } // end sil function 'bar'
 
 // CHECK-STRIP-ALL-LABEL: sil public_external [serialized] @bar : $@convention(thin) () -> ()


### PR DESCRIPTION
…ssa from external functions.

Specifically, previously the plan was as follows:

```
-Onone:

* Run Diagnostic Passes.
* Serialize.
* Lower ownership.
* IRGen

-O:

* Run Diagnostic Passes
* Lower Ownership from all but transparent functions and register a
  deserialization notification to ensure any further non-transparent functions
  we linked in were stripped as well.
* Run Performance Passes Before Serialization.
* Serialize.
* Lower ownership from all functions and register a notification to ensure all
  further functions that are linked in are lowered on link.
* Run rest of performance passes.
* IRGen.
```

There is a problem with this setup though: what happens if we lower ownership
from a function, dce it, and then reload the function. Our declaration and new
definition will be inconsistent! After some thought, I realized that it really
did not make sense to just hide such inconsistency since the model in SIL is
that once ownership is removed, it can not be added back.

This commit works around this problem by creating 3 different styles of
ownership model eliminator, each varying what it will eliminate. Specifically:

1. Eliminate all + everything deserialized.
2. Eliminate non-external. Leave deserialized things alone.
3. Eliminate non-transparent, non-external only. Leave deserialized things alone.

We change the scheme such that we only lower external functions once we know we
will never DCE/relink any functions.

```
-Onone:

* Run Diagnostic Passes.
* Serialize.
* (1).
* IRGen

-O:

* Run Diagnostic Passes
* (2).
* Run Performance Passes Before Serialization.
* Serialize.
* (3).
* Run rest of performance passes.
* (1).
* IRGen.
```

When the option is disabled, we always lower ownership for local functions right
before mandatory inlining in the diagnostic passes, in the same place we used to
run an instance of (1). This is safe to do since if all functions before they
are serialized have ownership lowered, all serialized SIL should only have
lowered ownership implying we can never deserialize a function with ownership
not lowered, the previous state of the world. ☐.
