### PR TITLE
[Diagnostics] Improve the diagnostic for invalid optional pointer conversions for an autoclosure result type.

### DIFF
--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -98,10 +98,6 @@ enum class FixKind : uint8_t {
   /// Swift version 5.
   AutoClosureForwarding,
 
-  /// Allow invalid pointer conversions for autoclosure result types as if the
-  /// pointer type is a function parameter rather than an autoclosure result.
-  AllowAutoClosurePointerConversion,
-
   /// Remove `!` or `?` because base is not an optional type.
   RemoveUnwrap,
 
@@ -627,11 +623,12 @@ public:
                                        ConstraintLocator *locator);
 };
 
+/// Allow invalid pointer conversions for autoclosure result types as if the
+/// pointer type is a function parameter rather than an autoclosure result.
 class AllowAutoClosurePointerConversion final : public ContextualMismatch {
   AllowAutoClosurePointerConversion(ConstraintSystem &cs, Type pointeeType,
                                     Type pointerType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, FixKind::AllowAutoClosurePointerConversion,
-                           pointeeType, pointerType, locator) {}
+      : ContextualMismatch(cs, pointeeType, pointerType, locator) {}
 
 public:
   std::string getName() const override {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3080,10 +3080,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   if (kind >= ConstraintKind::Conversion) {
     // It is never legal to form an autoclosure that results in these
     // implicit conversions to pointer types.
-    bool isAutoClosureArgument = false;
-    if (auto last = locator.last())
-      if (last->getKind() == ConstraintLocator::AutoclosureResult)
-        isAutoClosureArgument = true;
+    bool isAutoClosureArgument = locator.isAutoclosureResult();
 
     // Pointer arguments can be converted from pointer-compatible types.
     if (kind >= ConstraintKind::ArgumentConversion) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3080,7 +3080,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   if (kind >= ConstraintKind::Conversion) {
     // It is never legal to form an autoclosure that results in these
     // implicit conversions to pointer types.
-    bool isAutoClosureArgument = locator.isAutoclosureResult();
+    bool isAutoClosureArgument = locator.isForAutoclosureResult();
 
     // Pointer arguments can be converted from pointer-compatible types.
     if (kind >= ConstraintKind::ArgumentConversion) {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -715,6 +715,21 @@ public:
     return (getSummaryFlags() & ConstraintLocator::IsFunctionConversion);
   }
 
+  bool isAutoclosureResult() const {
+    SmallVector<LocatorPathElt, 4> path;
+    getLocatorParts(path);
+
+    auto last = std::find_if(
+        path.rbegin(), path.rend(), [](LocatorPathElt &elt) -> bool {
+          return elt.getKind() != ConstraintLocator::OptionalPayload;
+        });
+
+    if (last != path.rend())
+      return last->getKind() == ConstraintLocator::AutoclosureResult;
+
+    return false;
+  }
+
   /// Retrieve the base constraint locator, on which this builder's
   /// path is based.
   ConstraintLocator *getBaseLocator() const {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -721,7 +721,8 @@ public:
 
     auto last = std::find_if(
         path.rbegin(), path.rend(), [](LocatorPathElt &elt) -> bool {
-          return elt.getKind() != ConstraintLocator::OptionalPayload;
+          return elt.getKind() != ConstraintLocator::OptionalPayload &&
+                 elt.getKind() != ConstraintLocator::GenericArgument;
         });
 
     if (last != path.rend())

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -715,7 +715,7 @@ public:
     return (getSummaryFlags() & ConstraintLocator::IsFunctionConversion);
   }
 
-  bool isAutoclosureResult() const {
+  bool isForAutoclosureResult() const {
     SmallVector<LocatorPathElt, 4> path;
     getLocatorParts(path);
 

--- a/test/Constraints/invalid_implicit_conversions.swift
+++ b/test/Constraints/invalid_implicit_conversions.swift
@@ -9,7 +9,8 @@ func test(
   _ ptr: UnsafePointer<Int>,
   _ ptrI8: UnsafePointer<Int8>,
   _ ptrU8: UnsafePointer<UInt8>,
-  _ ptrVoid: UnsafePointer<Void> // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
+  _ ptrVoid: UnsafePointer<Void>, // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
+  _ optPtr: UnsafePointer<Int>?
 ) {
   var i: Int = 0
   var a: [Int] = [0]
@@ -23,6 +24,7 @@ func test(
   takesAutoclosure(mutRawPtr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeMutableRawPointer'}}
   takesAutoclosure(mutPtr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeMutablePointer<Int>'}}
   takesAutoclosure(ptr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafePointer<Int>'}}
+  takesAutoclosure(optPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafePointer<Int>?'}}
 
   takesAutoclosure(rawPtr, a) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafeRawPointer, [Int])'}}
   // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}

--- a/test/Constraints/invalid_implicit_conversions.swift
+++ b/test/Constraints/invalid_implicit_conversions.swift
@@ -14,6 +14,7 @@ func test(
 ) {
   var i: Int = 0
   var a: [Int] = [0]
+  var b: [Int]? = [0]
   let s = "string"
 
   takesAutoclosure(rawPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafeRawPointer'}}
@@ -26,17 +27,12 @@ func test(
   takesAutoclosure(ptr, &a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafePointer<Int>'}}
   takesAutoclosure(optPtr, &i) // expected-error {{cannot perform pointer conversion of value of type 'Int' to autoclosure result type 'UnsafePointer<Int>?'}}
 
-  takesAutoclosure(rawPtr, a) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafeRawPointer, [Int])'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
-  takesAutoclosure(ptr, a) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafePointer<Int>, [Int])'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
+  takesAutoclosure(rawPtr, a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeRawPointer'}}
+  takesAutoclosure(ptr, a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafePointer<Int>'}}
+  takesAutoclosure(optPtr, b) // expected-error {{cannot perform pointer conversion of value of type '[Int]?' to autoclosure result type 'UnsafePointer<Int>?'}}
 
-  takesAutoclosure(rawPtr, s) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafeRawPointer, String)'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
-  takesAutoclosure(ptrI8, s) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafePointer<Int8>, String)'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
-  takesAutoclosure(ptrU8, s) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafePointer<UInt8>, String)'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
-  takesAutoclosure(ptrVoid, s) // expected-error {{cannot invoke 'takesAutoclosure' with an argument list of type '(UnsafePointer<Void>, String)'}}
-  // expected-note@-1 {{expected an argument list of type '(T, @autoclosure () throws -> T)'}}
+  takesAutoclosure(rawPtr, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafeRawPointer'}}
+  takesAutoclosure(ptrI8, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafePointer<Int8>'}}
+  takesAutoclosure(ptrU8, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafePointer<UInt8>'}}
+  takesAutoclosure(ptrVoid, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafePointer<Void>'}}
 }


### PR DESCRIPTION
Skip `ConstraintLocator::OptionalPayload` when checking if we're in an autoclosure context for an inout-to-pointer conversion. This lets us apply the `AllowAutoClosurePointerConversion` constraint fix when the pointer is optional.

rdar://problem/53532404
https://bugs.swift.org/browse/SR-11198

