### PR TITLE
IRGen: Peephole metadata requests for opaque types.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2548,6 +2548,10 @@ bool ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
     OpaqueTypeDecl *opaque, ModuleDecl *contextModule,
     ResilienceExpansion contextExpansion) {
   auto namingDecl = opaque->getNamingDecl();
+  
+  // Don't allow replacement if the naming decl is dynamically replaceable.
+  if (namingDecl && namingDecl->isDynamic())
+    return false;
 
   // Allow replacement of opaque result types of inlineable function regardless
   // of resilience and in which context.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2739,6 +2739,12 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(proto)
          && "protocol does not have witness tables?!");
 
+  // Look through any opaque types we're allowed to.
+  if (srcType->hasOpaqueArchetype()) {
+    std::tie(srcType, conformance) =
+      IGF.IGM.substOpaqueTypesWithUnderlyingTypes(srcType, conformance);
+  }
+  
   // If we don't have concrete conformance information, the type must be
   // an archetype and the conformance must be via one of the protocol
   // requirements of the archetype. Look at what's locally bound.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -176,6 +176,8 @@ IRGenModule::getTypeRef(Type type, GenericSignature *genericSig,
 
 std::pair<llvm::Constant *, unsigned>
 IRGenModule::getTypeRef(CanType type, MangledTypeRefRole role) {
+  type = substOpaqueTypesWithUnderlyingTypes(type);
+  
   switch (role) {
   case MangledTypeRefRole::DefaultAssociatedTypeWitness:
   case MangledTypeRefRole::Metadata:
@@ -209,6 +211,9 @@ IRGenModule::emitWitnessTableRefString(CanType type,
                                       ProtocolConformanceRef conformance,
                                       GenericSignature *origGenericSig,
                                       bool shouldSetLowBit) {
+  std::tie(type, conformance)
+    = substOpaqueTypesWithUnderlyingTypes(type, conformance);
+  
   auto origType = type;
   CanGenericSignature genericSig;
   SmallVector<GenericRequirement, 4> requirements;

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1612,7 +1612,7 @@ const TypeInfo *TypeConverter::getTypeEntry(CanType canonicalTy) {
       return it->second;
     }
   }
-  
+
   // If the type is dependent, substitute it into our current context.
   auto contextTy = canonicalTy;
   if (contextTy->hasTypeParameter()) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -820,6 +820,13 @@ public:
   }
 
   clang::CodeGen::CodeGenModule &getClangCGM() const;
+  
+  CanType getRuntimeReifiedType(CanType type);
+  CanType substOpaqueTypesWithUnderlyingTypes(CanType type);
+  SILType substOpaqueTypesWithUnderlyingTypes(SILType type);
+  std::pair<CanType, ProtocolConformanceRef>
+  substOpaqueTypesWithUnderlyingTypes(CanType type,
+                                      ProtocolConformanceRef conformance);
 
   bool isResilient(NominalTypeDecl *decl, ResilienceExpansion expansion);
   bool hasResilientMetadata(ClassDecl *decl, ResilienceExpansion expansion);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -857,7 +857,7 @@ public:
   /// TODO: just make sure that we have a path to them that the debug info
   ///       can follow.
   void bindArchetypes(swift::Type Ty) {
-    auto runtimeTy = getRuntimeReifiedType(IGM, Ty->getCanonicalType());
+    auto runtimeTy = IGM.getRuntimeReifiedType(Ty->getCanonicalType());
     if (!IGM.IRGen.Opts.shouldOptimize() && runtimeTy->hasArchetype())
       runtimeTy.visit([&](CanType t) {
         if (auto archetype = dyn_cast<ArchetypeType>(t))

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -583,10 +583,6 @@ ConstantReference tryEmitConstantTypeMetadataRef(IRGenModule &IGM,
                                                  CanType type,
                                                  SymbolReferenceKind refKind);
 
-/// Get the type as it exists in Swift's runtime type system, removing any
-/// erased generic parameters.
-CanType getRuntimeReifiedType(IRGenModule &IGM, CanType type);
-
 /// Emit a reference to a compile-time constant piece of heap metadata, or
 /// return a null pointer if the type's heap metadata cannot be represented
 /// by a constant.

--- a/test/IRGen/Inputs/opaque_result_type_metadata_external.swift
+++ b/test/IRGen/Inputs/opaque_result_type_metadata_external.swift
@@ -1,0 +1,17 @@
+
+public protocol P {
+  static func stat()
+}
+
+extension Int: P {
+  public static func stat() {}
+}
+
+public func external_opaque() -> some P {
+  return 0
+}
+
+@inlinable
+public func external_inlinable() -> some P {
+  return 0
+}

--- a/test/IRGen/lazy_opaque_result_type.swift
+++ b/test/IRGen/lazy_opaque_result_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -Xllvm -sil-disable-pass=OpaqueArchetypeSpecializer -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -Xllvm -sil-disable-pass=OpaqueArchetypeSpecializer -parse-as-library -module-name=test -O -primary-file %s -emit-ir > %t.ll
 // RUN: %FileCheck %s < %t.ll
 
 protocol P { }

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
+// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
 public protocol O {
   func bar()
@@ -161,12 +161,14 @@ public func useFoo(x: String, y: C) {
 }
 
 // CHECK-LABEL: define {{.*}} @"$s18opaque_result_type6useFoo1x1yySS_AA1CCtF"
-// CHECK: [[CONFORMANCE:%.*]] = call swiftcc i8** @swift_getOpaqueTypeConformance(i8* {{.*}}, %swift.type_descriptor* {{.*}}s18opaque_result_type3baz1zQrx_tAA1PRzAA1QRzlFQOMQ{{.*}}, [[WORD:i32|i64]] 1)
+// CHECK: [[OPAQUE:%.*]] = call {{.*}} @"$s18opaque_result_type3baz1zQrx_tAA1PRzAA1QRzlFQOMg"
+// CHECK: [[CONFORMANCE:%.*]] = call swiftcc i8** @swift_getOpaqueTypeConformance(i8* {{.*}}, %swift.type_descriptor* [[OPAQUE]], [[WORD:i32|i64]] 1)
 // CHECK: [[TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$s18opaque_result_type3baz1zQrx_tAA1PRzAA1QRzlFQOyAA1CCQo_MD")
 // CHECK: call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** [[CONFORMANCE]], %swift.type* [[TYPE]]
 
 // CHECK-LABEL: define {{.*}} @"$sSS18opaque_result_type1PAA1AAaBP_AA1OPWT"
-// CHECK: call swiftcc i8** @swift_getOpaqueTypeConformance(i8* {{.*}}, %swift.type_descriptor* {{.*}}sSS18opaque_result_typeE3pooQryFQOMQ{{.*}}, [[WORD]] 1)
+// CHECK: [[OPAQUE:%.*]] = call {{.*}} @"$sSS18opaque_result_typeE3pooQryFQOMg"
+// CHECK: call swiftcc i8** @swift_getOpaqueTypeConformance(i8* {{.*}}, %swift.type_descriptor* [[OPAQUE]], [[WORD]] 1)
 
 // rdar://problem/49585457
 protocol R {

--- a/test/IRGen/opaque_result_type_availability.swift
+++ b/test/IRGen/opaque_result_type_availability.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -Onone -emit-ir %s | %FileCheck --check-prefix=MAYBE-AVAILABLE %s
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.15 -Onone -emit-ir %s | %FileCheck --check-prefix=ALWAYS-AVAILABLE %s
+// RUN: %target-swift-frontend -enable-implicit-dynamic -target x86_64-apple-macosx10.9 -Onone -emit-ir %s | %FileCheck --check-prefix=MAYBE-AVAILABLE %s
+// RUN: %target-swift-frontend -enable-implicit-dynamic -target x86_64-apple-macosx10.15 -Onone -emit-ir %s | %FileCheck --check-prefix=ALWAYS-AVAILABLE %s
 // REQUIRES: OS=macosx
 
 protocol P {}

--- a/test/IRGen/opaque_result_type_metadata_peephole.swift
+++ b/test/IRGen/opaque_result_type_metadata_peephole.swift
@@ -1,0 +1,73 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -enable-library-evolution -emit-module-path %t/opaque_result_type_metadata_external.swiftmodule %S/Inputs/opaque_result_type_metadata_external.swift
+// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=DEFAULT
+// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=CHECK --check-prefix=IMPLICIT-DYNAMIC
+
+import opaque_result_type_metadata_external
+
+func foo() -> some P {
+  return 0
+}
+
+// The mangled underlying type in foo2 ought to look through foo()'s opaque type
+// CHECK-LABEL: @"$s36opaque_result_type_metadata_peephole4foo2QryFQOMQ" = {{.*}} constant
+// DEFAULT-SAME:            @"symbolic Si"
+// DEFAULT-SAME:            @"get_witness_table S2i36opaque_result_type_metadata_external1PHpyHC
+// IMPLICIT-DYNAMIC-SAME:   @"symbolic _____yQo_ 36opaque_result_type_metadata_peephole3fooQryFQO"
+// IMPLICIT-DYNAMIC-SAME:   @"get_witness_table 36opaque_result_type_metadata_peephole3fooQryFQOyQo_0a1_b1_c1_D9_external1P
+func foo2() -> some P {
+  return foo()
+}
+
+func external_opaque_wrap() -> some P {
+  return external_opaque()
+}
+
+func external_inlinable_wrap() -> some P {
+  return external_inlinable()
+}
+
+func bar<T: P>(x: T) {
+  T.stat()
+}
+
+dynamic func replaceable_opaque() -> some P {
+  return 0
+}
+
+dynamic var replaceable_opaque_var: some P {
+  return 0
+}
+
+// CHECK-LABEL: define {{.*}} @"$s36opaque_result_type_metadata_peephole26testOpaqueMetadataAccessesyyF"
+public func testOpaqueMetadataAccesses() {
+  // We can look through, since it's internal
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: foo())
+  // We can look through, since it's internal
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: foo2())
+  // We can't look through, since it's resilient
+  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %[[EXTERNAL_OPAQUE_METADATA:.*]], i8** %[[EXTERNAL_OPAQUE_PROTO:.*]])
+  bar(x: external_opaque())
+  // We can look through, since it's inlinable
+  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  bar(x: external_inlinable())
+  // We can look through to the wrapped resilient opaque type
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %[[EXTERNAL_OPAQUE_METADATA]], i8** %[[EXTERNAL_OPAQUE_PROTO]])
+  // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: external_opaque_wrap())
+  // We can look all the way through to the inlinable underlying type
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: external_inlinable_wrap())
+
+  // We can't look through since it's dynamically replaceable
+  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: replaceable_opaque())
+  // We can't look through since it's dynamically replaceable
+  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
+  bar(x: replaceable_opaque_var)
+}

--- a/test/Serialization/opaque_cross_file.swift
+++ b/test/Serialization/opaque_cross_file.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -emit-module-path %t/OpaqueCrossFileB.swiftmodule -module-name OpaqueCrossFileB %S/Inputs/OpaqueCrossFileB.swift
+// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -I %t -emit-ir -verify %s | %FileCheck %s
 
 import OpaqueCrossFileB
 


### PR DESCRIPTION
If we're allowed to know at IRGen time what the underlying type of an opaque type is, we can
satisfy references to the opaque type's metadata or protocol witness tables by directly referencing
the underlying type instead.