### PR TITLE
[Diagnostics] Extend generic argument mismatch to cover [T] to Unsafe…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -611,7 +611,15 @@ Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
 }
 
 void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
-  auto genericTypeDecl = getActual()->getCanonicalType()->getAnyGeneric();
+  auto *locator = getLocator();
+  // Since there could be implicit conversions assoicated with argument
+  // to parameter conversions, let's use parameter type as a source of
+  // generic parameter information.
+  auto paramSourceTy =
+      locator->isLastElement(ConstraintLocator::ApplyArgToParam) ? getRequired()
+                                                                 : getActual();
+
+  auto genericTypeDecl = paramSourceTy->getAnyGeneric();
   auto param = genericTypeDecl->getGenericParams()->getParams()[position];
 
   auto lhs = resolveType(getActual()->getGenericArgs()[position])

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -54,7 +54,8 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
   var ii: [Int] = [0, 1, 2]
   var ff: [Float] = [0, 1, 2]
   takesMutablePointer(&ii)
-  takesMutablePointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
+  takesMutablePointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Float' and 'Int') are expected to be equal}}
   takesMutablePointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int>${diag_suffix}'}}
   takesMutablePointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>${diag_suffix}'}}
 
@@ -152,9 +153,11 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   var ii: [Int] = [0, 1, 2]
   var ff: [Float] = [0, 1, 2]
   takesConstPointer(&ii)
-  takesConstPointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
+  takesConstPointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Float' and 'Int') are expected to be equal}}
   takesConstPointer(ii)
-  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>${diag_suffix}'}}
+  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Float' and 'Int') are expected to be equal}}
   takesConstPointer([0, 1, 2])
   // <rdar://problem/22308330> QoI: CSDiags doesn't handle array -> pointer impl conversions well
   takesConstPointer([0.0, 1.0, 2.0])
@@ -338,7 +341,8 @@ func f23202128() {
   UMP(&pipe)  // expected-error {{cannot pass immutable value as inout argument: 'pipe' is a 'let' constant}}
 
   var pipe2: [Int] = [0, 0]
-  UMP(&pipe2) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Int32'}}
+  UMP(&pipe2) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int32>'}}
+  // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int' and 'Int32') are expected to be equal}}
 
 
   UP(pipe)    // ok


### PR DESCRIPTION
…*Pointer<T> conversions

Example:

```swift
func foo(_ x: UnsafePointer<Int>) {}
var arr: [Float] = [0, 1, 2]
foo(&arr) // Cannot convert [Float] to UnsafePointer<Int> because of Float vs. Int
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
