### PR TITLE
Assign a SourceLoc to implicit appendInterpolation calls for diagnostics

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1855,11 +1855,11 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
       TokReceiver->registerTokenKindChange(Tok.getLoc(),
                                            tok::string_interpolation_anchor);
 
-      auto callee = new (Context) UnresolvedDotExpr(InterpolationVarRef,
-                                                    /*dotloc=*/BackSlashLoc,
-                                                    appendInterpolation,
-                                                    /*nameloc=*/DeclNameLoc(),
-                                                    /*Implicit=*/true);
+      auto callee = new (Context)
+          UnresolvedDotExpr(InterpolationVarRef,
+                            /*dotloc=*/BackSlashLoc, appendInterpolation,
+                            /*nameloc=*/DeclNameLoc(Segment.Loc),
+                            /*Implicit=*/true);
       auto S = parseExprCallSuffix(makeParserResult(callee), true);
 
       // If we stopped parsing the expression before the expression segment is

--- a/test/Sema/diag_deprecated_string_interpolation.swift
+++ b/test/Sema/diag_deprecated_string_interpolation.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -swift-version 5 -typecheck %s 2>&1 | %FileCheck %s
+
+extension DefaultStringInterpolation {
+    @available(*, deprecated) func appendInterpolation(deprecated: Int) {}
+}
+
+// Make sure diagnostics emitted via string interpolations have a reasonable source location
+
+_ = "\(deprecated: 42)"
+// CHECK: [[@LINE-1]]:7: warning: 'appendInterpolation(deprecated:)' is deprecated
+
+_ = "hello, world\(deprecated: 42)!!!"
+// CHECK: [[@LINE-1]]:19: warning: 'appendInterpolation(deprecated:)' is deprecated
+
+_ = "\(42)\(deprecated: 42)test\(deprecated: 42)"
+// CHECK: [[@LINE-1]]:12: warning: 'appendInterpolation(deprecated:)' is deprecated
+// CHECK: [[@LINE-2]]:33: warning: 'appendInterpolation(deprecated:)' is deprecated
+
+_ = """
+This is a multiline literal with a deprecated interpolation:
+
+\(deprecated: 42)
+"""
+// CHECK: [[@LINE-2]]:2: warning: 'appendInterpolation(deprecated:)' is deprecated


### PR DESCRIPTION
Resolves [SR-10762](https://bugs.swift.org/browse/SR-10762)

I'm a little suspicious of this fix because it seems easier than the comments on that issue indicate, but it seems to work fine in practice so far. If anyone has ideas for additional test cases I'd be happy to add them!