### PR TITLE
[AST] Be lenient with PatternBindingIntializer without PatBindingDecl

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1366,9 +1366,11 @@ ParamDecl *PatternBindingInitializer::getImplicitSelfDecl() {
 }
 
 VarDecl *PatternBindingInitializer::getInitializedLazyVar() const {
-  if (auto var = getBinding()->getSingleVar()) {
-    if (var->getAttrs().hasAttribute<LazyAttr>())
-      return var;
+  if (auto binding = getBinding()) {
+    if (auto var = binding->getSingleVar()) {
+      if (var->getAttrs().hasAttribute<LazyAttr>())
+        return var;
+    }
   }
   return nullptr;
 }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -598,18 +598,17 @@ void UnqualifiedLookupFactory::lookupInModuleScopeContext(
 
 void UnqualifiedLookupFactory::lookupNamesIntroducedByPatternBindingInitializer(
     PatternBindingInitializer *PBI, Optional<bool> isCascadingUse) {
-  assert(PBI->getBinding());
   // Lazy variable initializer contexts have a 'self' parameter for
   // instance member lookup.
   if (auto *selfParam = PBI->getImplicitSelfDecl())
     lookupNamesIntroducedByLazyVariableInitializer(PBI, selfParam,
                                                    isCascadingUse);
-  else if (PBI->getBinding()->getDeclContext()->isTypeContext())
+  else if (PBI->getParent()->isTypeContext())
     lookupNamesIntroducedByInitializerOfStoredPropertyOfAType(PBI,
                                                               isCascadingUse);
   else
     lookupNamesIntroducedByInitializerOfGlobalOrLocal(PBI, isCascadingUse);
-  }
+}
 
   void UnqualifiedLookupFactory::lookupNamesIntroducedByLazyVariableInitializer(
       PatternBindingInitializer *PBI, ParamDecl *selfParam,

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AFTER_PAREN | %FileCheck %s -check-prefix=AFTER_PAREN
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_NODOT | %FileCheck %s -check-prefix=ARG_MyEnum_NODOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_DOT | %FileCheck %s -check-prefix=ARG_MyEnum_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_NOBINDING | %FileCheck %s -check-prefix=ARG_MyEnum_NOBINDING
 
 enum MyEnum {
   case east, west
@@ -38,4 +39,9 @@ struct TestStruct {
 // ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific:     west[#MyEnum#]; name=west
 // ARG_MyEnum_DOT: End completions
 
+ @MyStruct(arg1: MyEnum.#^ARG_MyEnum_NOBINDING^#)
+// ARG_MyEnum_NOBINDING: Begin completions
+// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: east[#MyEnum#];
+// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: west[#MyEnum#];
+// ARG_MyEnum_NOBINDING: End completions
 }


### PR DESCRIPTION
`PatternBindingInitializer` may not be attached to any `PatternBindingDecl`. e.g.

```swift
struct S {
    @CustomAttr(something)
}
```

In this case `DeclContext` for `something` is `PatternBindingInitializer`, but it doesn't have `PatternBindingDecl` because it's not written yet.

Fixes a crash in code-completion.

rdar://problem/53034550
