### PR TITLE
[crash] Explicit type annotation in extension compiler crasher.

### DIFF
--- a/validation-test/compiler_crashers/11269-explicit-type-annotation-in-extension.swift
+++ b/validation-test/compiler_crashers/11269-explicit-type-annotation-in-extension.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+class Foo {}
+
+extension Set where Element: Foo {
+    private func function1() {
+        for foo: Foo in self {
+            print(foo)
+        }
+    }
+}


### PR DESCRIPTION
See https://bugs.swift.org/browse/SR-11269 for more information.

