### PR TITLE
Remove .swift1_autolink_entries from the final linked binary

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1166,7 +1166,13 @@ void IRGenModule::emitAutolinkInfo() {
     }
     auto EntriesConstant = llvm::ConstantDataArray::getString(
         LLVMContext, EntriesString, /*AddNull=*/false);
-
+    // Mark the swift1_autolink_entries section with the SHF_EXCLUDE attribute
+    // to get the linker to drop it in the final linked binary.
+    // LLVM doesn't provide an interface to specify section attributs in the IR
+    // so we pass the attribute with inline assembly.
+    if (TargetInfo.OutputObjectFormat == llvm::Triple::ELF)
+      Module.appendModuleInlineAsm(".section .swift1_autolink_entries,"
+                                   "\"0x80000000\"");
     auto var =
         new llvm::GlobalVariable(*getModule(), EntriesConstant->getType(), true,
                                  llvm::GlobalValue::PrivateLinkage,

--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -1,0 +1,17 @@
+// RUN: %swiftc_driver -emit-ir %s -o - | %FileCheck %s -check-prefix ELF
+
+// Check that the swift auto link section is available in the object file.
+// RUN: %swiftc_driver -c %s -o %t
+// RUN: llvm-readelf %t -S | %FileCheck %s -check-prefix SECTION
+
+// Checks that the swift auto link section is removed from the final binary.
+// RUN: %swiftc_driver  -emit-executable %s -o %t
+// RUN: llvm-readelf %t -S | %FileCheck %s -check-prefix NOSECTION
+
+// REQUIRES: OS=linux-gnu
+
+print("Hi from Swift!")
+
+// ELF: module asm ".section .swift1_autolink_entries,\220x80000000\22"
+// SECTION: .swift1_autolink_entries
+// NOSECTION-NOT: .swift1_autolink_entries


### PR DESCRIPTION
  Mark the section .swift1_autolink_entries as SHF_EXCLUDE
  so the section will get dropped by the linker after linking the final
  binary.

  This section is used to save the flags needed for auto link and there
  is no reason it should stay in the final linked binary.Mark the
  section .swift1_autolink_entries as SHF_EXCLUDE
  so the section will get dropped by the linker after linking the final
  binary.

  This section is used to save the flags needed for auto link and there
  is no reason it should stay in the final linked binary.

  This solves issue SR-11247