### PR TITLE
 [Constraint graph] Make connected components more self-contained.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -96,15 +96,12 @@ void SplitterStep::computeFollowupSteps(
   CG.optimize();
 
   // Compute the connected components of the constraint graph.
-  // FIXME: We're seeding typeVars with TypeVariables so that the
-  // connected-components algorithm only considers those type variables within
-  // our component. There are clearly better ways to do this.
-  std::vector<TypeVariableType *> typeVars(CS.TypeVariables);
-  std::vector<unsigned> components;
-  unsigned numComponents = CG.computeConnectedComponents(typeVars, components);
+  auto components = CG.computeConnectedComponents(CS.TypeVariables);
+  unsigned numComponents =
+      components.size() + CG.getOrphanedConstraints().size();
   if (numComponents < 2) {
     componentSteps.push_back(llvm::make_unique<ComponentStep>(
-        CS, 0, /*single=*/true, &CS.InactiveConstraints, Solutions));
+        CS, 0, &CS.InactiveConstraints, Solutions));
     return;
   }
 
@@ -112,9 +109,18 @@ void SplitterStep::computeFollowupSteps(
   PartialSolutions = std::unique_ptr<SmallVector<Solution, 4>[]>(
       new SmallVector<Solution, 4>[numComponents]);
 
-  for (unsigned i = 0, n = numComponents; i != n; ++i) {
+  // Add components.
+  for (unsigned i : indices(components)) {
     componentSteps.push_back(llvm::make_unique<ComponentStep>(
-        CS, i, /*single=*/false, &Components[i], PartialSolutions[i]));
+        CS, i, &Components[i], std::move(components[i]), PartialSolutions[i]));
+  }
+
+  // Add components for the orphaned constraints.
+  OrphanedConstraints = CG.takeOrphanedConstraints();
+  for (unsigned i : range(components.size(), numComponents)) {
+    auto orphaned = OrphanedConstraints[i - components.size()];
+    componentSteps.push_back(llvm::make_unique<ComponentStep>(
+        CS, i, &Components[i], orphaned, PartialSolutions[i]));
   }
 
   if (isDebugMode()) {
@@ -128,57 +134,6 @@ void SplitterStep::computeFollowupSteps(
     log << "---Connected components---\n";
     CG.printConnectedComponents(CS.TypeVariables, log);
   }
-
-  // Map type variables and constraints into appropriate steps.
-  llvm::DenseMap<TypeVariableType *, unsigned> typeVarComponent;
-  llvm::DenseMap<Constraint *, unsigned> constraintComponent;
-  for (unsigned i = 0, n = typeVars.size(); i != n; ++i) {
-    auto *typeVar = typeVars[i];
-    // Record the component of this type variable.
-    typeVarComponent[typeVar] = components[i];
-
-    for (auto *constraint : CG[typeVar].getConstraints())
-      constraintComponent[constraint] = components[i];
-  }
-
-  // Add the orphaned components to the mapping from constraints to components.
-  unsigned firstOrphanedComponent =
-      numComponents - CG.getOrphanedConstraints().size();
-  {
-    unsigned component = firstOrphanedComponent;
-    for (auto *constraint : CG.getOrphanedConstraints()) {
-      // Register this orphan constraint both as associated with
-      // a given component as a regular constrant, as well as an
-      // "orphan" constraint, so it can be proccessed correctly.
-      constraintComponent[constraint] = component;
-      componentSteps[component]->recordOrphan(constraint);
-      ++component;
-    }
-  }
-
-  for (auto *typeVar : CS.TypeVariables) {
-    auto known = typeVarComponent.find(typeVar);
-    // If current type variable is associated with
-    // a certain component step, record it as being so.
-    if (known != typeVarComponent.end()) {
-      componentSteps[known->second]->record(typeVar);
-      continue;
-    }
-  }
-
-  // Transfer all of the constraints from the work list to
-  // the appropriate component.
-  auto &workList = CS.InactiveConstraints;
-  while (!workList.empty()) {
-    auto *constraint = &workList.front();
-    workList.pop_front();
-    assert(constraintComponent.count(constraint) > 0 && "Missed a constraint");
-    componentSteps[constraintComponent[constraint]]->record(constraint);
-  }
-
-  // Remove all of the orphaned constraints; they'll be re-introduced
-  // by each component independently.
-  OrphanedConstraints = CG.takeOrphanedConstraints();
 
   // Create component ordering based on the information associated
   // with constraints in each step - e.g. number of disjunctions,

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -125,19 +125,11 @@ void SplitterStep::computeFollowupSteps(
 
   // Add components.
   for (unsigned i : indices(components)) {
+    unsigned solutionIndex = components[i].solutionIndex;
     componentSteps.push_back(llvm::make_unique<ComponentStep>(
-        CS, i, &Components[i], std::move(components[i]), PartialSolutions[i]));
+        CS, solutionIndex, &Components[i], std::move(components[i]),
+        PartialSolutions[solutionIndex]));
   }
-
-  // Create component ordering based on the information associated
-  // with constraints in each step - e.g. number of disjunctions,
-  // since components are going to be executed in LIFO order, we'd
-  // want to have smaller/faster components at the back of the list.
-  std::sort(componentSteps.begin(), componentSteps.end(),
-            [](const std::unique_ptr<ComponentStep> &lhs,
-               const std::unique_ptr<ComponentStep> &rhs) {
-              return lhs->disjunctionCount() > rhs->disjunctionCount();
-            });
 }
 
 bool SplitterStep::mergePartialSolutions() const {

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -366,24 +366,19 @@ public:
       : SolverStep(cs, solutions), Index(index), IsSingle(false),
         OriginalScore(getCurrentScore()), OriginalBestScore(getBestScore()),
         Constraints(constraints) {
+    if (component.isOrphaned()) {
+      assert(component.constraints.size() == 1);
+      OrphanedConstraint = component.constraints.front();
+    } else {
+      assert(component.typeVars.size() > 0);
+    }
+
     TypeVars = std::move(component.typeVars);
 
     for (auto constraint : component.constraints) {
       constraints->erase(constraint);
       record(constraint);
     }
-  }
-
-  /// Create a component step for an orphaned constraint.
-  ComponentStep(ConstraintSystem &cs, unsigned index,
-                ConstraintList *constraints,
-                Constraint *orphaned,
-                SmallVectorImpl<Solution> &solutions)
-      : SolverStep(cs, solutions), Index(index), IsSingle(false),
-        OriginalScore(getCurrentScore()), OriginalBestScore(getBestScore()),
-        Constraints(constraints), OrphanedConstraint(orphaned) {
-    constraints->erase(orphaned);
-    record(orphaned);
   }
 
 private:
@@ -418,7 +413,8 @@ private:
       getDebugLogger() << "(solving component #" << Index << '\n';
 
     ComponentScope = llvm::make_unique<Scope>(*this);
-    // If this component has oprhaned constraint attached,
+
+    // If this component has orphaned constraint attached,
     // let's return it to the graph.
     CS.CG.setOrphanedConstraint(OrphanedConstraint);
   }

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -341,10 +341,6 @@ class ComponentStep final : public SolverStep {
   /// Constraints "in scope" of this step.
   ConstraintList *Constraints;
 
-  /// Number of disjunction constraints associated with this step,
-  /// used to aid in ordering of the components.
-  unsigned NumDisjunctions = 0;
-
   /// Constraint which doesn't have any free type variables associated
   /// with it, which makes it disconnected in the graph.
   Constraint *OrphanedConstraint = nullptr;
@@ -367,36 +363,23 @@ public:
         OriginalScore(getCurrentScore()), OriginalBestScore(getBestScore()),
         Constraints(constraints) {
     if (component.isOrphaned()) {
-      assert(component.constraints.size() == 1);
-      OrphanedConstraint = component.constraints.front();
+      assert(component.getConstraints().size() == 1);
+      OrphanedConstraint = component.getConstraints().front();
     } else {
       assert(component.typeVars.size() > 0);
     }
 
     TypeVars = std::move(component.typeVars);
 
-    for (auto constraint : component.constraints) {
+    for (auto constraint : component.getConstraints()) {
       constraints->erase(constraint);
-      record(constraint);
+      Constraints->push_back(constraint);
     }
   }
-
-private:
-  /// Record a constraint as associated with this step.
-  void record(Constraint *constraint) {
-    Constraints->push_back(constraint);
-    if (constraint->getKind() == ConstraintKind::Disjunction)
-      ++NumDisjunctions;
-  }
-
-public:
 
   StepResult take(bool prevFailed) override;
 
   StepResult resume(bool prevFailed) override { return finalize(!prevFailed); }
-
-  // The number of disjunction constraints associated with this component.
-  unsigned disjunctionCount() const { return NumDisjunctions; }
 
   void print(llvm::raw_ostream &Out) override {
     Out << "ComponentStep with at #" << Index << '\n';

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -540,6 +540,8 @@ namespace {
 
       // Assign each type variable to its appropriate component.
       SmallVector<Component, 1> components;
+      components.reserve(
+          validComponents.size() + cg.getOrphanedConstraints().size());
       llvm::SmallDenseMap<TypeVariableType *, unsigned> componentIdxMap;
       for (auto typeVar : typeVars) {
         // Find the representative. If we aren't creating a type variable
@@ -575,6 +577,12 @@ namespace {
         auto rep = findRepresentative(typeVar);
         assert(componentIdxMap.count(rep) > 0);
         components[componentIdxMap[rep]].constraints.push_back(&constraint);
+      }
+
+      // Gather orphaned constraints; each gets its own component.
+      for (auto orphaned : cg.getOrphanedConstraints()) {
+        components.push_back({ });
+        components.back().constraints.push_back(orphaned);
       }
 
       return components;
@@ -635,7 +643,6 @@ ConstraintGraph::computeConnectedComponents(
   // Perform connected components via a union-find algorithm on all of the
   // constraints adjacent to these type variables.
   ConnectedComponents cc(*this, typeVars);
-
   return cc.getComponents();
 }
 

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -213,7 +213,7 @@ public:
     TinyPtrVector<Constraint *> constraints;
 
     /// Whether this component represents an orphaned constraint.
-    bool isOrphanedConstraint() const {
+    bool isOrphaned() const {
       return typeVars.empty();
     }
   };

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Compiler.h"
 #include <functional>
 #include <utility>
@@ -202,20 +203,30 @@ public:
     return TypeVariables;
   }
 
+  /// Describes a single component, as produced by the connected components
+  /// algorithm.
+  struct Component {
+    /// The type variables in this component.
+    TinyPtrVector<TypeVariableType *> typeVars;
+
+    /// The constraints in this component.
+    TinyPtrVector<Constraint *> constraints;
+
+    /// Whether this component represents an orphaned constraint.
+    bool isOrphanedConstraint() const {
+      return typeVars.empty();
+    }
+  };
+
   /// Compute the connected components of the graph.
   ///
   /// \param typeVars The type variables that should be included in the
   /// set of connected components that are returned.
   ///
-  /// \param components Receives the component numbers for each type variable
-  /// in \c typeVars.
-  ///
-  /// \returns the number of connected components in the graph, which includes
-  /// one component for each of the constraints produced by
-  /// \c getOrphanedConstraints().
-  unsigned computeConnectedComponents(
-             std::vector<TypeVariableType *> &typeVars,
-             std::vector<unsigned> &components);
+  /// \returns the connected components of the graph, where each component
+  /// contains the type variables and constraints specific to that component.
+  SmallVector<Component, 1> computeConnectedComponents(
+             ArrayRef<TypeVariableType *> typeVars);
 
   /// Retrieve the set of "orphaned" constraints, which are known to the
   /// constraint graph but have no type variables to anchor them.

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -209,13 +209,37 @@ public:
     /// The type variables in this component.
     TinyPtrVector<TypeVariableType *> typeVars;
 
+    /// The original index of this component in the list of components,
+    /// used to provide the index of where the partial solutions will occur.
+    /// FIXME: This is needed due to some ordering dependencies in the
+    /// merging of partial solutions, which appears to also be related
+    /// DisjunctionStep::pruneOverloads() short-circuiting. It should be
+    /// removed.
+    unsigned solutionIndex;
+
+  private:
+    /// The number of disjunctions in this component.
+    unsigned numDisjunctions = 0;
+
     /// The constraints in this component.
     TinyPtrVector<Constraint *> constraints;
+
+  public:
+    Component(unsigned solutionIndex) : solutionIndex(solutionIndex) { }
 
     /// Whether this component represents an orphaned constraint.
     bool isOrphaned() const {
       return typeVars.empty();
     }
+
+    /// Add a constraint.
+    void addConstraint(Constraint *constraint);
+
+    const TinyPtrVector<Constraint *> &getConstraints() const {
+      return constraints;
+    }
+
+    unsigned getNumDisjunctions() const { return numDisjunctions; }
   };
 
   /// Compute the connected components of the graph.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1290,6 +1290,7 @@ private:
     ///
     /// \param constraint The newly generated constraint.
     void addGeneratedConstraint(Constraint *constraint) {
+      assert(constraint && "Null generated constraint?");
       generatedConstraints.push_back(constraint);
     }
 


### PR DESCRIPTION
Have the constraint graph's connected-component implementation be more
self-contained, producing a vector containing each of the actual
components (where each is defined by a list of type variables and a list
of constraints). This simplifies the contract with the client
(SplitterStep) and eliminates a bunch of separate mapping steps to
interpret the results.
