### PR TITLE
[IRGen] Fix a missing case of the new bit pattern builder

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1218,7 +1218,7 @@ public:
                                                   getStoredProtocols(), \
                                                   getValueType(), \
                                                   storageTy, \
-                                                  std::move(spareBits), \
+                                                  spareBits.build(), \
                                                   getFixedSize(), \
                                                   getFixedAlignment(), \
                                                   ReferenceCounting::Native, \


### PR DESCRIPTION
This fixes a downstream regression introduced by:
bb2740e540a4679c26d80d9e58d29ef50a38349f

Nothing in Swift proper uses this scenario.