### PR TITLE
[NFC] [AutoDiff] Improve SILGen linear map thunking documentation.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -559,12 +559,7 @@ struct AutoDiffAssociatedFunctionKind {
   explicit AutoDiffAssociatedFunctionKind(StringRef string);
   operator innerty() const { return rawValue; }
   AutoDiffLinearMapKind getLinearMapKind() {
-    switch (*this) {
-    case AutoDiffAssociatedFunctionKind::JVP:
-      return AutoDiffLinearMapKind::Differential;
-    case AutoDiffAssociatedFunctionKind::VJP:
-      return AutoDiffLinearMapKind::Pullback;
-    }
+    return (AutoDiffLinearMapKind::innerty)rawValue;
   }
 };
 

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -531,28 +531,13 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
   return s;
 }
 
-/// The kind of an associated function.
-struct AutoDiffAssociatedFunctionKind {
-  enum innerty : uint8_t {
-     // The Jacobian-vector products function.
-     JVP = 0,
-     // The vector-Jacobian products function.
-     VJP = 1
-  } rawValue;
-
-  AutoDiffAssociatedFunctionKind() = default;
-  AutoDiffAssociatedFunctionKind(innerty rawValue) : rawValue(rawValue) {}
-  explicit AutoDiffAssociatedFunctionKind(StringRef string);
-  operator innerty() const { return rawValue; }
-};
-
 /// The kind of an linear map.
 struct AutoDiffLinearMapKind {
   enum innerty : uint8_t {
-     // The differential function.
-     Differential = 0,
-     // The pullback function.
-     Pullback = 1
+    // The differential function.
+    Differential = 0,
+    // The pullback function.
+    Pullback = 1
   } rawValue;
 
   AutoDiffLinearMapKind() = default;
@@ -560,8 +545,31 @@ struct AutoDiffLinearMapKind {
   operator innerty() const { return rawValue; }
 };
 
-/// In conjunction with the original function decl, identifies an associated
-/// autodiff function.
+/// The kind of an associated function.
+struct AutoDiffAssociatedFunctionKind {
+  enum innerty : uint8_t {
+   // The Jacobian-vector products function.
+   JVP = 0,
+   // The vector-Jacobian products function.
+   VJP = 1
+  } rawValue;
+
+  AutoDiffAssociatedFunctionKind() = default;
+  AutoDiffAssociatedFunctionKind(innerty rawValue) : rawValue(rawValue) {}
+  explicit AutoDiffAssociatedFunctionKind(StringRef string);
+  operator innerty() const { return rawValue; }
+  AutoDiffLinearMapKind getLinearMapKind() {
+    switch (*this) {
+    case AutoDiffAssociatedFunctionKind::JVP:
+      return AutoDiffLinearMapKind::Differential;
+    case AutoDiffAssociatedFunctionKind::VJP:
+      return AutoDiffLinearMapKind::Pullback;
+    }
+  }
+};
+
+/// In conjunction with the original function declaration, identifies an
+/// autodiff associated function.
 ///
 /// Is uniquely allocated within an ASTContext so that it can be hashed and
 /// compared by opaque pointer value.

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -29,7 +29,7 @@ AutoDiffAssociatedFunctionKind::
 AutoDiffAssociatedFunctionKind(StringRef string) {
   Optional<innerty> result =
       llvm::StringSwitch<Optional<innerty>>(string)
-         .Case("jvp", JVP).Case("vjp", VJP);
+          .Case("jvp", JVP).Case("vjp", VJP);
   assert(result && "Invalid string");
   rawValue = *result;
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1788,7 +1788,7 @@ public:
   /// - The last parameter, for differentials.
   /// - The last result, for pullbacks.
   ManagedValue getThunkedAutoDiffLinearMap(
-      ManagedValue linearMap, AutoDiffAssociatedFunctionKind assocFnKind,
+      ManagedValue linearMap, AutoDiffLinearMapKind linearMapKind,
       CanSILFunctionType fromType, CanSILFunctionType toType,
       bool reorderSelf);
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3603,8 +3603,8 @@ SILGenFunction::getThunkedAutoDiffLinearMap(
     auto fromSelfResult = fromConv.getResults().front();
     auto toSelfResult = toConv.getResults().back();
     assert(fromSelfResult.getType() == toSelfResult.getType());
-    // Before: [dir_res_self, dir_res1, ind_res2, ...]
-    //  After: [dir_res1, ind_res2, ..., dir_res_self]
+    // Before: [dir_res_self, dir_res1, dir_res2, ...]
+    //  After: [dir_res1, dir_res2, ..., dir_res_self]
     if (toSelfResult.isFormalDirect() && fromSelfResult.isFormalDirect() &&
         directResults.size() > 1) {
       std::rotate(directResults.begin(), directResults.begin() + 1,


### PR DESCRIPTION
- Add documentation comments clarifying differential/pullback thunk self reordering logic.
- Change `SILGenFunction::getThunkedAutoDiffLinearMap` to use `AutoDiffLinearMapKind`.
- Various gardening.