### PR TITLE
Fix property wrappers with tuples.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2342,8 +2342,8 @@ assign_by_wrapper
   assign_by_wrapper %0 : $S to %1 : $*T, init %2 : $F, set %3 : $G
   // $S can be a value or address type
   // $T must be the type of a property wrapper.
-  // $F must be a function type, taking $S as a single argument and returning $T
-  // $G must be a function type, taking $S as a single argument and with not return value
+  // $F must be a function type, taking $S as a single argument (or multiple arguments in case of a tuple) and returning $T
+  // $G must be a function type, taking $S as a single argument (or multiple arguments in case of a tuple) and without a return value
 
 Similar to the ``assign`` instruction, but the assignment is done via a
 delegate.

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1961,6 +1961,34 @@ public:
             "Store operand type and dest type mismatch");
   }
 
+  // Usually the assign_by_wrapper initializer or setter has a single argument
+  // (the value). But in case of a tuple, the initializer/setter expect the
+  // tuple elements as separate arguments.
+  void checkAssignByWrapperArgsRecursively(SILType ty,
+                               SILFunctionConventions &conv, unsigned &argIdx) {
+    if (auto tupleTy = ty.getAs<TupleType>()) {
+      for (Type et : tupleTy->getElementTypes()) {
+        SILType elTy = SILType::getPrimitiveType(CanType(et), ty.getCategory());
+        checkAssignByWrapperArgsRecursively(elTy, conv, argIdx);
+      }
+      return;
+    }
+    require(argIdx < conv.getNumSILArguments(),
+            "initializer or setter has too few arguments");
+    SILType argTy = conv.getSILArgumentType(argIdx++);
+    if (ty.isAddress() && argTy.isObject())
+      ty = ty.getObjectType();
+    require(ty == argTy,
+            "wrong argument type of initializer or setter");
+  }
+
+  void checkAssignByWrapperArgs(SILType ty, SILFunctionConventions &conv) {
+    unsigned argIdx = conv.getSILArgIndexOfFirstParam();
+    checkAssignByWrapperArgsRecursively(ty, conv, argIdx);
+    require(argIdx == conv.getNumSILArguments(),
+            "initializer or setter has too many arguments");
+  }
+
   void checkAssignByWrapperInst(AssignByWrapperInst *AI) {
     SILValue Src = AI->getSrc(), Dest = AI->getDest();
     require(AI->getModule().getStage() == SILStage::Raw,
@@ -1970,11 +1998,7 @@ public:
     SILValue initFn = AI->getInitializer();
     CanSILFunctionType initTy = initFn->getType().castTo<SILFunctionType>();
     SILFunctionConventions initConv(initTy, AI->getModule());
-    unsigned firstArgIdx = initConv.getSILArgIndexOfFirstParam();
-    require(initConv.getNumSILArguments() == firstArgIdx + 1,
-            "init function has wrong number of arguments");
-    require(Src->getType() == initConv.getSILArgumentType(firstArgIdx),
-            "wrong argument type of init function");
+    checkAssignByWrapperArgs(Src->getType(), initConv);
     switch (initConv.getNumIndirectSILResults()) {
       case 0:
         require(initConv.getNumDirectSILResults() == 1,
@@ -1998,10 +2022,7 @@ public:
     SILFunctionConventions setterConv(setterTy, AI->getModule());
     require(setterConv.getNumIndirectSILResults() == 0,
             "set function has indirect results");
-    require(setterConv.getNumSILArguments() == 1,
-            "init function has wrong number of arguments");
-    require(Src->getType() == setterConv.getSILArgumentType(0),
-            "wrong argument type of init function");
+    checkAssignByWrapperArgs(Src->getType(), setterConv);
   }
 
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \

--- a/test/SILOptimizer/property_wrappers_and_tuples.swift
+++ b/test/SILOptimizer/property_wrappers_and_tuples.swift
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift %s -module-name=a -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+@propertyWrapper struct D<Value> {
+    var wrappedValue: Value {
+      didSet {
+        print("set: \(wrappedValue)")
+      }
+    }
+
+    init(wrappedValue: Value) {
+      self.wrappedValue = wrappedValue
+      print("init: \(wrappedValue)")
+    }
+
+}
+
+struct S<T> {
+    @D var a: (Int,Int)
+    @D var b: (T,T)
+    @D var c: (Int,(Int, Bool))
+    @D var d: (T,Int)
+    @D var e: (Int,(T, Bool))
+
+    init(_ t: T) {
+        // CHECK: init: (27, 28)
+        a = (27, 28)
+        // CHECK: init: (a.X, a.X)
+        b = (t, t)
+        // CHECK: init: (27, (28, true))
+        c = (27, (28, true))
+        // CHECK: init: (a.X, 27)
+        d = (t, 27)
+        // CHECK: init: (27, (a.X, true))
+        e = (27, (t, true))
+        // CHECK: set: (27, 28)
+        a = (27, 28)
+        // CHECK: set: (a.X, a.X)
+        b = (t, t)
+        // CHECK: set: (27, (28, true))
+        c = (27, (28, true))
+        // CHECK: set: (a.X, 27)
+        d = (t, 27)
+        // CHECK: set: (27, (a.X, true))
+        e = (27, (t, true))
+    }
+
+}
+
+class X {
+
+
+  static var numInstances = 0
+
+  init() {
+    X.numInstances += 1
+  }
+
+  deinit {
+    X.numInstances -= 1
+  }
+}
+
+func test() {
+  _ = S(X())
+}
+
+test()
+
+// CHECK: num instances of X: 0
+print("num instances of X: \(X.numInstances)")


### PR DESCRIPTION
In case of a tuple as value type, the initializer and setter takes the tuple elements as separate arguments. This was just not handled in the assign_by_wrapper instruction lowering.

rdar://problem/53866473
