### PR TITLE
[OwnershipVerifier] Dump instruction in context when verifying operand ownership.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -672,7 +672,8 @@ void SILInstruction::verifyOperandOwnership() const {
                       "with the operand's operand ownership kind map.\n";
       llvm::errs() << "Value: " << opValue;
       llvm::errs() << "Value Ownership Kind: " << valueOwnershipKind << "\n";
-      llvm::errs() << "Instruction: " << *this;
+      llvm::errs() << "Instruction:\n";
+      printInContext(llvm::errs());
       llvm::errs() << "Operand Ownership Kind Map: " << operandOwnershipKindMap;
     }
 


### PR DESCRIPTION
When there's an operand ownership verification error, dump the instruction in context like SILVerifier so that things are easier to debug.

Before:
```console
Value Ownership Kind: guaranteed
Instruction:   store %0 to [init] %2 : $*Vector             // id: %3
```

After:
```console
Value Ownership Kind: guaranteed
Instruction:
  %0 = argument of bb0 : $Vector                 // user: %3
    %2 = alloc_stack $Vector                     // user: %3
->   store %0 to [init] %2 : $*Vector             // id: %3
```