### PR TITLE
IRGen: Work around runtime bug demangling associated types of opaque types.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1905,6 +1905,19 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
     }
   }
   
+  // The Swift 5.1 runtime fails to demangle associated types of opaque types.
+  auto hasNestedOpaqueArchetype = type.findIf([](CanType sub) -> bool {
+    if (auto archetype = dyn_cast<NestedArchetypeType>(sub)) {
+      if (isa<OpaqueTypeArchetypeType>(archetype->getRoot())) {
+        return true;
+      }
+    }
+    return false;
+  });
+  
+  if (hasNestedOpaqueArchetype)
+    return false;
+  
   return true;
 
 // The visitor below can be used to fine-tune a heuristic to decide whether

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -1,4 +1,7 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
 // REQUIRES: executable_test
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
@@ -38,4 +41,41 @@ if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   print(getPAT(Int.self))
 } else {
   print("i'm getting too old for this sh")
+}
+
+// rdar://problem/54084733
+
+protocol Q {
+  associatedtype A
+  func f() -> A
+}
+struct X: Q {
+  typealias A = Array<Int>
+  func f() -> A {
+    return [1, 2, 3]
+  }
+}
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+dynamic func g() -> some Q {
+  return X()
+}
+
+func h<T: Q>(x: T) -> (T.A?, T.A?) {
+  return (.some(x.f()), .some(x.f()))
+}
+
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  let x = g()
+  // CHECK: {{X()|no really}}
+  print(x)
+  // CHECK: {{[1, 2, 3]|too old}}
+  let y = x.f()
+  print(y)
+  // CHECK: {{[1, 2, 3]|too old}}
+  let z = h(x: x)
+  print(z)
+} else {
+  print("no really")
+  print("i'm getting way too old for this sh")
+  print("way too old")
 }


### PR DESCRIPTION
The Swift 5.1 runtime (and master, for the time being) do not successfully demangle this mangling,
so for the time being, fall back to open-coded metadata access in this case. Workaround for
rdar://problem/54084733.