### PR TITLE
 IRGen: Avoid unnecessary swift_getObjectType calls.

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1856,11 +1856,13 @@ void irgen::emitMetatypeOfClassExistential(IRGenFunction &IGF, Explosion &value,
   auto metaTy = metatypeTy.castTo<ExistentialMetatypeType>();
   auto repr = metaTy->getRepresentation();
   assert(repr != MetatypeRepresentation::Thin &&
-         "Class metatypes should have a thin representation");
+         "Class metatypes should not have a thin representation");
   assert((IGF.IGM.ObjCInterop || repr != MetatypeRepresentation::ObjC) &&
          "Class metatypes should not have ObjC representation without runtime");
 
-  auto dynamicType = emitDynamicTypeOfOpaqueHeapObject(IGF, instance, repr);
+  auto dynamicType = emitDynamicTypeOfHeapObject(IGF, instance, repr,
+                                                 existentialTy,
+                                                 /*allow artificial*/ false);
   out.add(dynamicType);
 
   // Get the witness tables.
@@ -1898,8 +1900,10 @@ irgen::emitClassExistentialProjection(IRGenFunction &IGF,
   ArrayRef<llvm::Value*> wtables;
   llvm::Value *value;
   std::tie(wtables, value) = baseTI.getWitnessTablesAndValue(base);
-  auto metadata = emitDynamicTypeOfOpaqueHeapObject(IGF, value,
-                                                MetatypeRepresentation::Thick);
+  auto metadata = emitDynamicTypeOfHeapObject(IGF, value,
+                                              MetatypeRepresentation::Thick,
+                                              baseTy,
+                                              /*allow artificial*/ false);
   IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
                     wtables);
 
@@ -2237,8 +2241,10 @@ Address irgen::emitOpaqueBoxedExistentialProjection(
         IGF.getTypeInfo(existentialTy).as<ClassExistentialTypeInfo>();
     auto valueAddr = baseTI.projectValue(IGF, base);
     auto value = IGF.Builder.CreateLoad(valueAddr);
-    auto metadata = emitDynamicTypeOfOpaqueHeapObject(IGF, value,
-                                                MetatypeRepresentation::Thick);
+    auto metadata = emitDynamicTypeOfHeapObject(IGF, value,
+                                                MetatypeRepresentation::Thick,
+                                                existentialTy,
+                                                /*allow artificial*/ false);
 
     // If we are projecting into an opened archetype, capture the
     // witness tables.

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1717,8 +1717,10 @@ llvm::Value *IRGenFunction::getLocalSelfMetadata() {
     SelfKind = SwiftMetatype;
     break;
   case ObjectReference:
-    LocalSelf = emitDynamicTypeOfOpaqueHeapObject(*this, LocalSelf,
-                                                 MetatypeRepresentation::Thick);
+    LocalSelf = emitDynamicTypeOfHeapObject(*this, LocalSelf,
+                                MetatypeRepresentation::Thick,
+                                SILType::getPrimitiveObjectType(LocalSelfType),
+                                /*allow artificial*/ false);
     SelfKind = SwiftMetatype;
     break;
   }
@@ -1839,9 +1841,25 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
 
 /// Given an opaque class instance pointer, produce the type metadata reference
 /// as a %type*.
-llvm::Value *irgen::emitDynamicTypeOfOpaqueHeapObject(IRGenFunction &IGF,
+///
+/// You should only use this if you have an untyped object pointer with absolutely no type information.
+/// Generally, it's better to use \c emitDynamicTypeOfHeapObject, which will
+/// use the most efficient possible access pattern to get the dynamic type based on
+/// the static type information.
+static llvm::Value *emitDynamicTypeOfOpaqueHeapObject(IRGenFunction &IGF,
                                                   llvm::Value *object,
                                                   MetatypeRepresentation repr) {
+  if (!IGF.IGM.ObjCInterop) {
+    // Without objc interop, getting the dynamic type of an object is always
+    // just a load of the isa pointer.
+
+    assert(repr == MetatypeRepresentation::Thick
+           && "objc metatypes should not occur without objc interop, "
+              "and thin metadata should not be requested here");
+    return emitLoadOfHeapMetadataRef(IGF, object, IsaEncoding::Pointer,
+                                     /*suppressCast*/ false);
+  }
+  
   object = IGF.Builder.CreateBitCast(object, IGF.IGM.ObjCPtrTy);
   llvm::CallInst *metadata;
   

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -140,12 +140,6 @@ emitAllocateExistentialBoxInBuffer(IRGenFunction &IGF, SILType boxedType,
                                    Address destBuffer, GenericEnvironment *env,
                                    const llvm::Twine &name, bool isOutlined);
 
-/// Given an opaque class instance pointer, produce the type
-/// metadata reference as a %type*.
-llvm::Value *emitDynamicTypeOfOpaqueHeapObject(IRGenFunction &IGF,
-                                               llvm::Value *object,
-                                               MetatypeRepresentation rep);
-
 /// Given a heap-object instance, with some heap-object type,
 /// produce a reference to its type metadata.
 llvm::Value *emitDynamicTypeOfHeapObject(IRGenFunction &IGF,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2255,14 +2255,16 @@ unsigned IRGenModule::getBuiltinIntegerWidth(BuiltinIntegerWidth w) {
   llvm_unreachable("impossible width value");
 }
 
-void IRGenFunction::setLocalSelfMetadata(CanType exactSelfClass,
+void IRGenFunction::setLocalSelfMetadata(CanType selfClass,
+                                         bool isExactSelfClass,
                                          llvm::Value *value,
                                          IRGenFunction::LocalSelfKind kind) {
   assert(!LocalSelf && "already have local self metadata");
   LocalSelf = value;
-  assert((!exactSelfClass || exactSelfClass->getClassOrBoundGenericClass())
+  assert(selfClass->getClassOrBoundGenericClass()
          && "self type not a class?");
-  ExactSelfType = exactSelfClass;
+  LocalSelfIsExact = isExactSelfClass;
+  LocalSelfType = selfClass;
   SelfKind = kind;
 }
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -644,7 +644,7 @@ public:
   };
 
   llvm::Value *getLocalSelfMetadata();
-  void setLocalSelfMetadata(CanType selfBaseTy,
+  void setLocalSelfMetadata(CanType selfBaseTy, bool selfIsExact,
                             llvm::Value *value, LocalSelfKind kind);
 
 private:
@@ -662,7 +662,8 @@ private:
   /// The value that satisfies metadata lookups for dynamic Self.
   llvm::Value *LocalSelf = nullptr;
   /// If set, the dynamic Self type is assumed to be equivalent to this exact class.
-  CanType ExactSelfType;
+  CanType LocalSelfType;
+  bool LocalSelfIsExact;
   LocalSelfKind SelfKind;
 };
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1610,12 +1610,10 @@ static void emitLocalSelfMetadata(IRGenSILFunction &IGF) {
   // Specify the exact Self type if we know it, either because the class
   // is final, or because the function we're emitting is a method with the
   // [exact_self_class] attribute set on it during the SIL pipeline.
-  CanType exactSelfTy;
-  if (selfTy->getClassOrBoundGenericClass()->isFinal()
-      || IGF.CurSILFn->isExactSelfClass())
-    exactSelfTy = selfTy;
+  bool isExact = selfTy->getClassOrBoundGenericClass()->isFinal()
+    || IGF.CurSILFn->isExactSelfClass();
 
-  IGF.setLocalSelfMetadata(exactSelfTy, value, selfKind);
+  IGF.setLocalSelfMetadata(selfTy, isExact, value, selfKind);
 }
 
 /// Emit the definition for the given SIL constant.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2380,7 +2380,7 @@ IRGenFunction::emitTypeMetadataRef(CanType type,
 
   // If we're asking for the metadata of the type that dynamic Self is known
   // to be equal to, we can just use the self metadata.
-  if (ExactSelfType == type) {
+  if (LocalSelfIsExact && LocalSelfType == type) {
     return MetadataResponse::forComplete(getLocalSelfMetadata());
   }
   

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -37,8 +37,8 @@ class C {
     return id(nil)
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A12SelfArgumentACXDSgyF"(%T21dynamic_self_metadata1CC* swiftself)
-  // CHECK: [[CAST1:%.+]] = bitcast %T21dynamic_self_metadata1CC* %0 to [[METATYPE:%.+]]
-  // CHECK: [[TYPE1:%.+]] = call %swift.type* @swift_getObjectType([[METATYPE]] [[CAST1]])
+  // CHECK: [[GEP1:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[TYPE1:%.+]] = load {{.*}} [[GEP1]]
   // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, %swift.type* [[TYPE1]])
   // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
   // CHECK: call swiftcc void @"$s21dynamic_self_metadata2idyxxlF"({{.*}}, %swift.type* [[TYPE2]])
@@ -48,8 +48,8 @@ class C {
     return nil
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A18SelfConformingTypeACXDSgyF"(%T21dynamic_self_metadata1CC* swiftself)
-  // CHECK: [[SELF:%.*]] = bitcast %T21dynamic_self_metadata1CC* %0 to %objc_object*
-  // CHECK: [[SELF_TYPE:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* [[SELF]])
+  // CHECK: [[SELF_GEP:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} [[SELF_GEP]]
   // CHECK: [[METADATA_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s21dynamic_self_metadata1GVMa"(i64 0, %swift.type* [[SELF_TYPE]])
   // CHECK: [[METADATA:%.*]] =  extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
   // CHECK: call i8** @swift_getWitnessTable(%swift.protocol_conformance_descriptor* bitcast ({{.*}} @"$s21dynamic_self_metadata1GVyxGAA1PAAMc" to %swift.protocol_conformance_descriptor*), %swift.type* [[METADATA]], i8*** undef)

--- a/test/IRGen/exact_self_class_metadata_peephole.swift
+++ b/test/IRGen/exact_self_class_metadata_peephole.swift
@@ -62,7 +62,8 @@ final private class FinalPrivateNonfinalSubclass<U>: PrivateNonfinal<U, String, 
   // CHECK-LABEL: define {{.*}}FinalPrivateNonfinalSubclass{{.*}}burts
   @inline(never)
   final func burts() {
-    // CHECK: [[TYPE:%.*]] = call {{.*}} @swift_getObjectType
+    // CHECK: [[TYPE_GEP:%.*]] = getelementptr {{.*}} %0
+    // CHECK: [[TYPE:%.*]] = load {{.*}} [[TYPE_GEP]]
     // CHECK: call {{.*}} @useMetadata(%swift.type* [[TYPE]], %swift.type* [[TYPE]])
     useMetadata(FinalPrivateNonfinalSubclass<U>.self)
     // CHECK: [[INSTANTIATED_TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}}FinalPrivateNonfinalSubclass
@@ -80,7 +81,8 @@ final private class PrivateFinal<T, U, V> {
 
   // CHECK-LABEL: define {{.*}}PrivateFinal{{.*}}butts
   func butts() {
-    // CHECK: [[TYPE:%.*]] = call {{.*}} @swift_getObjectType
+    // CHECK: [[TYPE_GEP:%.*]] = getelementptr {{.*}} %0
+    // CHECK: [[TYPE:%.*]] = load {{.*}} [[TYPE_GEP]]
     // CHECK: call {{.*}} @useMetadata(%swift.type* [[TYPE]], %swift.type* [[TYPE]])
     useMetadata(PrivateFinal<T, U, V>.self)
     // CHECK: [[INSTANTIATED_TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}}PrivateFinal

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -99,9 +99,9 @@ public class D {
 }
 
 // CHECK: define void @testDynamicSelfMetatype(i8*, i8*)
-// CHECK:   [[C:%.*]] = bitcast i8* %0 to %T27objc_generic_class_metadata1DC*
-// CHECK:   [[O:%.*]] = bitcast %T27objc_generic_class_metadata1DC* [[C]] to %objc_object*
-// CHECK:   call %swift.type* @swift_getObjectType(%objc_object* [[O]]
+// CHECK:   [[T0:%.*]] = bitcast {{.*}} %0
+// CHECK:   [[T1:%.*]] = bitcast {{.*}} [[T0]]
+// CHECK:   [[TYPE:%.*]] = load {{.*}} [[T1]]
 sil @testDynamicSelfMetatype : $@convention(objc_method) (@owned D) -> () {
 bb0(%0 : $D):
   %1 = metatype $@thick @dynamic_self D.Type

--- a/test/IRGen/object_type.swift
+++ b/test/IRGen/object_type.swift
@@ -4,6 +4,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
+// REQUIRES: objc_interop
 
 // Check if the runtime function swift_getObjectType is not readnone and
 // therefore not re-scheduled with release-calls, which would lead to a crash

--- a/test/IRGen/protocol_accessor_multifile.swift
+++ b/test/IRGen/protocol_accessor_multifile.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/protocol_accessor_multifile_other.swift > %t.ll
-// RUN: %FileCheck %s < %t.ll
+// RUN: %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-runtime < %t.ll
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.ll
 
 // CHECK: @"$s27protocol_accessor_multifile5ProtoMp" = external{{( dllimport)?}} global
@@ -28,7 +28,8 @@ class GenericContext<T: Proto> {
 // CHECK-LABEL: define{{.*}} void @"$s27protocol_accessor_multifile19useClassExistentialyyF"()
 func useClassExistential() {
   let g = getClassExistential()
-  // CHECK: [[G_TYPE:%.+]] = call %swift.type* @swift_getObjectType({{%.+}} {{%.+}})
+  // CHECK-objc: [[G_TYPE:%.+]] = call %swift.type* @swift_getObjectType({{%.+}} {{%.+}})
+  // CHECK-native: [[G_TYPE:%.+]] = load %swift.type*
   // CHECK: call swiftcc void {{%.+}}(i{{32|64}} 1, {{%.+}} {{%.+}}, %swift.type* [[G_TYPE]], i8** {{%.+}})
   g?.baseProp = 1
   // CHECK: ret void


### PR DESCRIPTION
In too many places, we were calling into `emitDynamicTypeOfOpaqueHeapObject` even when we had
more specific type information about the heap object we were querying. Replace all calls with
`emitDynamicTypeOfHeapObject`, which uses the best available access path and completely avoids
runtime calls for pure Swift classes and heap objects. When targeting non-ObjC-interop platforms,
we also know we never need to call `swift_getObjectType`, so avoid doing so altogether.