### PR TITLE
[NameLookup ASTScope] On-by-default.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -246,7 +246,7 @@ namespace swift {
     /// Default is in \c ParseLangArgs
     ///
     /// This is a staging flag; eventually it will be removed.
-    bool EnableASTScopeLookup = false;
+    bool EnableASTScopeLookup = true;
 
     /// Someday, ASTScopeLookup will supplant lookup in the parser
     bool DisableParserLookup = false;

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1750,7 +1750,7 @@ void ASTScopeImpl::reexpand(ScopeCreator &scopeCreator) {
   auto astAncestorScopes = rescueASTAncestorScopesForReuseFromMeOrDescendants();
   disownDescendants(scopeCreator);
   // If the expansion recurses back into the tree for lookup, the ASTAncestor
-  // scopes will have already been rescued and won't be found! HERE
+  // scopes will have already been rescued and won't be found!
   expandAndBeCurrent(scopeCreator);
   replaceASTAncestorScopes(astAncestorScopes);
 }


### PR DESCRIPTION
Turn ASTScope on-by-default for testing and measuring.
If you need to revert, suggest you just set EnableASTScopeLookup to false in LangOptions.h.