### PR TITLE
Return nil on applying() failure instead of crashing

### DIFF
--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -54,7 +54,7 @@ extension CollectionDifference {
 }
 
 // Error type allows the use of throw to unroll state on application failure
-fileprivate enum _ApplicationError : Error { case failed }
+private enum _ApplicationError : Error { case failed }
 
 extension RangeReplaceableCollection {
   /// Applies the given difference to this collection.

--- a/test/stdlib/Diffing.swift
+++ b/test/stdlib/Diffing.swift
@@ -629,6 +629,68 @@ if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
               }}}}}}
   }
 
+  suite.test("Fast applicator error condition") {
+    let bear = "bear"
+    let bird = "bird"
+    let bat = "bat"
+
+    let diff = bird.difference(from: bear)
+
+    expectEqual(nil, bat.applying(diff))
+  }
+
+  suite.test("Fast applicator boundary condition remove last element") {
+    let base = [1, 2, 3]
+
+    expectEqual([1, 2], base.applying(CollectionDifference<Int>([.remove(offset: base.count - 1, element: 3, associatedWith: nil)])!))
+  }
+
+  suite.test("Fast applicator boundary condition append element") {
+    let base = [1, 2, 3]
+
+    expectEqual([1, 2, 3, 4], base.applying(CollectionDifference<Int>([.insert(offset: base.count, element: 4, associatedWith: nil)])!))
+  }
+
+  suite.test("Fast applicator error boundary condition remove at endIndex") {
+    let base = [1, 2, 3]
+
+    expectEqual(nil, base.applying(CollectionDifference<Int>([.remove(offset: base.count, element: 4, associatedWith: nil)])!))
+  }
+
+  suite.test("Fast applicator error boundary condition insert beyond end") {
+    let base = [1, 2, 3]
+
+    expectEqual(nil, base.applying(CollectionDifference<Int>([.insert(offset: base.count + 1, element: 5, associatedWith: nil)])!))
+  }
+
+  suite.test("Fast applicator boundary condition replace tail") {
+    let base = [1, 2, 3]
+
+    expectEqual([1, 2, 4], base.applying(CollectionDifference<Int>([
+      .remove(offset: base.count - 1, element: 3, associatedWith: nil),
+      .insert(offset: base.count - 1, element: 4, associatedWith: nil)
+    ])!))
+  }
+
+  suite.test("Fast applicator error boundary condition insert beyond end after tail removal") {
+    let base = [1, 2, 3]
+
+    expectEqual(nil, base.applying(CollectionDifference<Int>([
+      .remove(offset: base.count - 1, element: 3, associatedWith: nil),
+      .insert(offset: base.count, element: 4, associatedWith: nil)
+    ])!))
+
+  }
+
+  suite.test("Fast applicator error boundary condition insert beyond end after non-tail removal") {
+    let base = [1, 2, 3]
+
+    expectEqual(nil, base.applying(CollectionDifference<Int>([
+      .remove(offset: base.count - 2, element: 2, associatedWith: nil),
+      .insert(offset: base.count, element: 4, associatedWith: nil)
+    ])!))
+  }
+
   suite.test("Fast applicator fuzzer") {
     func makeArray() -> [Int] {
       var arr = [Int]()


### PR DESCRIPTION
The application of a diff onto an invalid base state is supposed to cause `nil` to be returned from `applying()`, but instead it just crashes with an index out of bounds error.

Oops.

Generally speaking maintaining consistent diff and base states is the programmer's responsibility, but not crashing on invalid application is necessary for diffs to be useful as a boundary type for passing between modules so someone else's bug doesn't turn into anyone else's crash.

This PR includes exhaustive coverage of the boundary between application success and failure as well as fixes for the failing tests, including the test from the original report.

Resolves &lt;rdar://problem/53663769&gt;