### PR TITLE
SR-10597 KeyPath dynamic member lookup

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -82,7 +82,7 @@ ERROR(could_not_find_value_member_corrected,none,
       "value of type %0 has no member %1; did you mean %2?",
       (Type, DeclName, DeclName))
 ERROR(could_not_find_value_dynamic_member_corrected,none,
-      "neither the value type %0 and dynamic key path subscript of type %1 has a member %2; did you mean %3?",
+      "value of type %0 has no dynamic member %2 using key path from root type %1; did you mean %3?",
       (Type, Type, DeclName, DeclName))
 
 ERROR(could_not_find_type_member,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -82,7 +82,7 @@ ERROR(could_not_find_value_member_corrected,none,
       "value of type %0 has no member %1; did you mean %2?",
       (Type, DeclName, DeclName))
 ERROR(could_not_find_value_dynamic_member_corrected,none,
-      "value of type %0 and dynamic keyPath of type %1 has no member %2; did you mean %3?",
+      "neither the value type %0 and dynamic key path subscript of type %1 has a member %2; did you mean %3?",
       (Type,Type, DeclName, DeclName))
 
 ERROR(could_not_find_type_member,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -84,6 +84,9 @@ ERROR(could_not_find_value_member_corrected,none,
 ERROR(could_not_find_value_dynamic_member_corrected,none,
       "value of type %0 has no dynamic member %2 using key path from root type %1; did you mean %3?",
       (Type, Type, DeclName, DeclName))
+ERROR(could_not_find_value_dynamic_member,none,
+      "value of type %0 has no dynamic member %2 using key path from root type %1",
+      (Type, Type, DeclName))
 
 ERROR(could_not_find_type_member,none,
       "type %0 has no member %1", (Type, DeclName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -81,6 +81,10 @@ ERROR(could_not_find_value_member,none,
 ERROR(could_not_find_value_member_corrected,none,
       "value of type %0 has no member %1; did you mean %2?",
       (Type, DeclName, DeclName))
+ERROR(could_not_find_value_dynamic_member_corrected,none,
+      "value of type %0 and dynamic keyPath of type %1 has no member %2; did you mean %3?",
+      (Type,Type, DeclName, DeclName))
+
 ERROR(could_not_find_type_member,none,
       "type %0 has no member %1", (Type, DeclName))
 ERROR(could_not_find_type_member_corrected,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -83,7 +83,7 @@ ERROR(could_not_find_value_member_corrected,none,
       (Type, DeclName, DeclName))
 ERROR(could_not_find_value_dynamic_member_corrected,none,
       "neither the value type %0 and dynamic key path subscript of type %1 has a member %2; did you mean %3?",
-      (Type,Type, DeclName, DeclName))
+      (Type, Type, DeclName, DeclName))
 
 ERROR(could_not_find_type_member,none,
       "type %0 has no member %1", (Type, DeclName))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2323,7 +2323,7 @@ bool MissingMemberFailure::diagnoseAsError() {
             diag::could_not_find_value_dynamic_member,
             baseExprType, baseType, getName());
         diagnostic.highlight(baseExpr->getSourceRange())
-        .highlight(nameLoc.getSourceRange());
+            .highlight(nameLoc.getSourceRange());
       }
     } else {
       if (auto correction = corrections.claimUniqueCorrection()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2319,7 +2319,6 @@ bool MissingMemberFailure::diagnoseAsError() {
         diagnostic.highlight(baseExpr->getSourceRange())
             .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);
-        
       } else {
         auto diagnostic = emitDiagnostic(
             anchor->getLoc(),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2312,20 +2312,20 @@ bool MissingMemberFailure::diagnoseAsError() {
     if (auto correction = corrections.claimUniqueCorrection()) {
       if (getLocator()->isForKeyPathDynamicMemberLookup()) {
         auto diagnostic = emitDiagnostic(
-                                         anchor->getLoc(),
-                                         diag::could_not_find_value_dynamic_member_corrected,
-                                         baseExprType, baseType, getName(),
-                                         correction->CorrectedName);
+            anchor->getLoc(),
+            diag::could_not_find_value_dynamic_member_corrected,
+            baseExprType, baseType, getName(),
+            correction->CorrectedName);
         diagnostic.highlight(baseExpr->getSourceRange())
         .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);
         
       } else {
         auto diagnostic = emitDiagnostic(
-                                         anchor->getLoc(),
-                                         diag::could_not_find_value_member_corrected,
-                                         baseType, getName(),
-                                         correction->CorrectedName);
+            anchor->getLoc(),
+            diag::could_not_find_value_member_corrected,
+            baseType, getName(),
+            correction->CorrectedName);
         diagnostic.highlight(baseExpr->getSourceRange())
         .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2237,8 +2237,8 @@ bool MissingMemberFailure::diagnoseAsError() {
   auto tryTypoCorrection = [&] {
     TC.performTypoCorrection(getDC(), DeclRefKind::Ordinary, baseType,
                              defaultMemberLookupOptions, corrections);
-    // If isForKeyPathDynamicMemberLookup we are including the
-    // typo corrections to the wrapper type too.
+    // If locator points to the member found via key path dynamic member lookup,
+    // emit typo corrections for the wrapper type too.
     if (getLocator()->isForKeyPathDynamicMemberLookup()) {
       TC.performTypoCorrection(getDC(), DeclRefKind::Ordinary,
                                baseExprType, defaultMemberLookupOptions,
@@ -2317,7 +2317,7 @@ bool MissingMemberFailure::diagnoseAsError() {
                                          baseExprType, baseType, getName(),
                                          correction->CorrectedName);
         diagnostic.highlight(baseExpr->getSourceRange())
-        .highlight(nameLoc.getSourceRange());
+            .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);
         
       } else {
@@ -2327,7 +2327,7 @@ bool MissingMemberFailure::diagnoseAsError() {
                                          baseType, getName(),
                                          correction->CorrectedName);
         diagnostic.highlight(baseExpr->getSourceRange())
-        .highlight(nameLoc.getSourceRange());
+            .highlight(nameLoc.getSourceRange());
         correction->addFixits(diagnostic);
       }
     } else {

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -704,7 +704,7 @@ struct SR10597_W<T> {
   var wooo: SR10597 { SR10597() } // expected-note {{declared here}}
 }
 
-_ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{value of type 'SR10597_W<SR10597>' and dynamic keyPath of type 'SR10597' has no member 'wooooo'; did you mean 'wooo'?}}
+_ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{neither the value type 'SR10597_W<SR10597>' and dynamic key path subscript of type 'SR10597' has a member 'wooooo'; did you mean 'wooo'?}}
 
 final class SR10597_1 {
     var woo: Int? // expected-note 2 {{'woo' declared here}}
@@ -719,4 +719,4 @@ struct SR10597_1_W<T> {
   }
 }
 
-_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' and dynamic keyPath of type 'SR10597_1' has no member 'wooo'; did you mean 'woo'?}}
+_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{neither the value type 'SR10597_1_W<SR10597_1>' and dynamic key path subscript of type 'SR10597_1' has a member 'wooo'; did you mean 'woo'?}}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -688,3 +688,35 @@ func invalid_refs_through_dynamic_lookup() {
     _ = lens.baz("hello")  // expected-error {{dynamic key path member lookup cannot refer to static method 'baz'}}
   }
 }
+
+// SR-10597
+
+final class SR10597 {
+}
+
+@dynamicMemberLookup
+struct SR10597_W<T> {
+  var obj: T
+  init(_ obj: T) { self.obj = obj }
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> U {
+    return obj[keyPath: member]
+  }
+  var wooo: SR10597 { SR10597() } // expected-note {{declared here}}
+}
+
+_ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{value of type 'SR10597_W<SR10597>' and dynamic keyPath of type 'SR10597' has no member 'wooooo'; did you mean 'wooo'?}}
+
+final class SR10597_1 {
+    var woo: Int? // expected-note 2 {{'woo' declared here}}
+}
+
+@dynamicMemberLookup
+struct SR10597_1_W<T> {
+  var obj: T
+  init(_ obj: T) { self.obj = obj }
+  subscript<U>(dynamicMember member: KeyPath<T, U>) -> U {
+    return obj[keyPath: member]
+  }
+}
+
+_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' and dynamic keyPath of type 'SR10597_1' has no member 'wooo'; did you mean 'woo'?}}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -704,7 +704,7 @@ struct SR10597_W<T> {
   var wooo: SR10597 { SR10597() } // expected-note {{declared here}}
 }
 
-_ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{neither the value type 'SR10597_W<SR10597>' and dynamic key path subscript of type 'SR10597' has a member 'wooooo'; did you mean 'wooo'?}}
+_ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{value of type 'SR10597_W<SR10597>' has no dynamic member 'wooooo' using key path from root type 'SR10597'; did you mean 'wooo'?}}
 
 final class SR10597_1 {
     var woo: Int? // expected-note 2 {{'woo' declared here}}
@@ -719,4 +719,4 @@ struct SR10597_1_W<T> {
   }
 }
 
-_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{neither the value type 'SR10597_1_W<SR10597_1>' and dynamic key path subscript of type 'SR10597_1' has a member 'wooo'; did you mean 'woo'?}}
+_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' has no dynamic member 'wooooo' using key path from root type 'SR10597_1'; did you mean 'woo'?}}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -705,6 +705,7 @@ struct SR10597_W<T> {
 }
 
 _ = SR10597_W<SR10597>(SR10597()).wooooo // expected-error {{value of type 'SR10597_W<SR10597>' has no dynamic member 'wooooo' using key path from root type 'SR10597'; did you mean 'wooo'?}}
+_ = SR10597_W<SR10597>(SR10597()).bla // expected-error {{value of type 'SR10597_W<SR10597>' has no dynamic member 'bla' using key path from root type 'SR10597'}}
 
 final class SR10597_1 {
     var woo: Int? // expected-note 2 {{'woo' declared here}}
@@ -720,3 +721,4 @@ struct SR10597_1_W<T> {
 }
 
 _ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' has no dynamic member 'wooo' using key path from root type 'SR10597_1'; did you mean 'woo'?}}
+_ = SR10597_1_W<SR10597_1>(SR10597_1()).bla // expected-error {{value of type 'SR10597_1_W<SR10597_1>' has no dynamic member 'bla' using key path from root type 'SR10597_1'}}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -719,4 +719,4 @@ struct SR10597_1_W<T> {
   }
 }
 
-_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' has no dynamic member 'wooooo' using key path from root type 'SR10597_1'; did you mean 'woo'?}}
+_ = SR10597_1_W<SR10597_1>(SR10597_1()).wooo // expected-error {{value of type 'SR10597_1_W<SR10597_1>' has no dynamic member 'wooo' using key path from root type 'SR10597_1'; did you mean 'woo'?}}


### PR DESCRIPTION
Resolves [SR-10597](https://bugs.swift.org/browse/SR-10597).
Both types were added as corrections so two tests added one for a correction in each type :))

cc @xedin 