### PR TITLE
[5.1] [Runtime] Add caching based on ABI name to _findContextDescriptor.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -613,9 +613,14 @@ _findContextDescriptor(Demangle::NodePointer node,
   NodePointer symbolicNode = node;
   if (symbolicNode->getKind() == Node::Kind::Type)
     symbolicNode = symbolicNode->getChild(0);
-  if (symbolicNode->getKind() == Node::Kind::TypeSymbolicReference)
+  if (symbolicNode->getKind() == Node::Kind::TypeSymbolicReference) {
     return cast<TypeContextDescriptor>(
       (const ContextDescriptor *)symbolicNode->getIndex());
+  }
+
+  // Nothing to resolve if have a generic parameter.
+  if (symbolicNode->getKind() == Node::Kind::DependentGenericParamType)
+    return nullptr;
 
   StringRef mangledName =
     Demangle::mangleNode(node, ExpandResolvedSymbolicReferences(Dem), Dem);

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -196,10 +196,8 @@ namespace {
   };
 } // end anonymous namespace
 
-namespace {
-  inline llvm::hash_code llvm::hash_value(StringRef S) {
-    return hash_combine_range(S.begin(), S.end());
-  }
+inline llvm::hash_code llvm::hash_value(StringRef S) {
+  return hash_combine_range(S.begin(), S.end());
 }
 
 struct TypeMetadataPrivateState {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -245,6 +245,7 @@ static void _forEachTypeMetadataSectionAfter(
     for (auto *section = begin; section != end; section++) {
       f(section->Begin, section->End);
     }
+    *start = snapshot.Count;
   }
 }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -196,8 +196,10 @@ namespace {
   };
 } // end anonymous namespace
 
-llvm::hash_code llvm::hash_value(StringRef S) {
-  return hash_combine_range(S.begin(), S.end());
+namespace {
+  inline llvm::hash_code llvm::hash_value(StringRef S) {
+    return hash_combine_range(S.begin(), S.end());
+  }
 }
 
 struct TypeMetadataPrivateState {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -249,6 +249,19 @@ public:
   const ContextDescriptor *
   _searchConformancesByMangledTypeName(Demangle::NodePointer node);
 
+  /// Iterate over protocol conformance sections starting from the given index.
+  /// The index is updated to the current number of protocol sections. Passing
+  /// the same index to the next call will iterate over any sections that were
+  /// added after the previous call.
+  ///
+  /// Takes a function to call for each section found. The two parameters are
+  /// the start and end of the section.
+  void
+  _forEachProtocolConformanceSectionAfter(
+    size_t *start, 
+    const std::function<void(const ProtocolConformanceRecord *,
+                             const ProtocolConformanceRecord *)> &f);
+
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                       Demangle::Demangler &Dem);
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -634,6 +634,21 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
   return nullptr;
 }
 
+void
+swift::_forEachProtocolConformanceSectionAfter(
+  size_t *start, 
+  const std::function<void(const ProtocolConformanceRecord *,
+                           const ProtocolConformanceRecord *)> &f) {
+  auto snapshot = Conformances.get().SectionsToScan.snapshot();
+  if (snapshot.Count > *start) {
+    auto *begin = snapshot.begin() + *start;
+    auto *end = snapshot.end();
+    for (auto *section = begin; section != end; section++) {
+      f(section->Begin, section->End);
+    }
+  }
+}
+
 bool swift::_checkGenericRequirements(
                       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
                       SmallVectorImpl<const void *> &extraArguments,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -646,6 +646,7 @@ swift::_forEachProtocolConformanceSectionAfter(
     for (auto *section = begin; section != end; section++) {
       f(section->Begin, section->End);
     }
+    *start = snapshot.Count;
   }
 }
 


### PR DESCRIPTION
This is a one-to-many cache that's more speculative than the cache mapping mangled names to context descriptors. Entries found in the cache need to be verified for a match before they can be returned. However, this allows scanning conformance records up front and building up the cache in one scan rather than performing an expensive scan of all conformance records every time the mangled name cache misses.

rdar://problem/53560010