### PR TITLE
[guaranteed-arc-opts] Allow for strong_retain<->release_value and ret…

### DIFF
--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -143,9 +143,9 @@ bool GuaranteedARCOptsVisitor::visitStrongReleaseInst(StrongReleaseInst *SRI) {
     auto *Inst = &*II;
     ++II;
 
-    if (auto *SRA = dyn_cast<StrongRetainInst>(Inst)) {
-      if (SRA->getOperand() == Operand) {
-        SRA->eraseFromParent();
+    if (isa<StrongRetainInst>(Inst) || isa<RetainValueInst>(Inst)) {
+      if (Inst->getOperand(0) == Operand) {
+        Inst->eraseFromParent();
         SRI->eraseFromParent();
         NumInstsEliminated += 2;
         return true;
@@ -198,9 +198,9 @@ bool GuaranteedARCOptsVisitor::visitReleaseValueInst(ReleaseValueInst *RVI) {
     auto *Inst = &*II;
     ++II;
 
-    if (auto *SRA = dyn_cast<RetainValueInst>(Inst)) {
-      if (SRA->getOperand() == Operand) {
-        SRA->eraseFromParent();
+    if (isa<RetainValueInst>(Inst) || isa<StrongRetainInst>(Inst)) {
+      if (Inst->getOperand(0) == Operand) {
+        Inst->eraseFromParent();
         RVI->eraseFromParent();
         NumInstsEliminated += 2;
         return true;

--- a/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
+++ b/test/SILOptimizer/guaranteed_arc_opts_qualified.sil
@@ -158,3 +158,27 @@ bb0(%0 : $C, %1 : $Builtin.Int32):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil @mixed_test_1 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK: } // end sil function 'mixed_test_1'
+sil @mixed_test_1 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  release_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @mixed_test_2 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK: } // end sil function 'mixed_test_2'
+sil @mixed_test_2 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  retain_value %0 : $Builtin.NativeObject
+  strong_release %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…ain_value<->strong_release to be paired.

We are assuming here that retain_value, release_value are always canonicalized
to their strong_* variants as appropriate. That may not always occur. We should
be resilient to such things.
