### PR TITLE
IRGen: Use known value witnesses in generic metadata patterns.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2358,7 +2358,8 @@ template <class Impl, class DeclType>
     }
 
     void addValueWitnessTable() {
-      auto table = asImpl().emitValueWitnessTable();
+      ConstantReference table =
+                              asImpl().emitValueWitnessTable(/*relative*/ true);
       B.addRelativeAddress(table);
     }
   
@@ -3455,13 +3456,13 @@ namespace {
       B.add(emitNominalTypeDescriptor());
     }
 
-    llvm::Constant *emitValueWitnessTable() {
+    ConstantReference emitValueWitnessTable(bool relativeReference) {
       auto type = this->Target->getDeclaredType()->getCanonicalType();
-      return irgen::emitValueWitnessTable(IGM, type, false);
+      return irgen::emitValueWitnessTable(IGM, type, false, relativeReference);
     }
 
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable());
+      B.add(emitValueWitnessTable(false).getValue());
     }
 
     void addFieldOffset(VarDecl *var) {
@@ -3517,10 +3518,9 @@ namespace {
     }
   };
   
-  /// Emit a value witness table for a fixed-layout generic type, or a null
-  /// placeholder if the value witness table is dependent on generic parameters.
-  /// Returns nullptr if the value witness table is dependent.
-  static llvm::Constant *
+  /// Emit a value witness table for a fixed-layout generic type, or a template
+  /// if the value witness table is dependent on generic parameters.
+  static ConstantReference
   getValueWitnessTableForGenericValueType(IRGenModule &IGM,
                                           NominalTypeDecl *decl,
                                           bool &dependent) {
@@ -3528,7 +3528,8 @@ namespace {
       = decl->getDeclaredType()->getCanonicalType();
     
     dependent = hasDependentValueWitnessTable(IGM, unboundType);
-    return emitValueWitnessTable(IGM, unboundType, dependent);
+    return emitValueWitnessTable(IGM, unboundType, dependent,
+                                 /*relative reference*/ true);
   }
   
   /// A builder for metadata templates.
@@ -3564,7 +3565,8 @@ namespace {
       return StructContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
-    llvm::Constant *emitValueWitnessTable() {
+    ConstantReference emitValueWitnessTable(bool relativeReference) {
+      assert(relativeReference && "should only relative reference");
       return getValueWitnessTableForGenericValueType(IGM, Target,
                                                      HasDependentVWT);
     }
@@ -3697,13 +3699,13 @@ namespace {
       B.addInt(IGM.MetadataKindTy, unsigned(getMetadataKind(Target)));
     }
 
-    llvm::Constant *emitValueWitnessTable() {
+    ConstantReference emitValueWitnessTable(bool relativeReference) {
       auto type = Target->getDeclaredType()->getCanonicalType();
-      return irgen::emitValueWitnessTable(IGM, type, false);
+      return irgen::emitValueWitnessTable(IGM, type, false, relativeReference);
     }
 
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable());
+      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
     }
 
     llvm::Constant *emitNominalTypeDescriptor() {
@@ -3798,7 +3800,8 @@ namespace {
       return EnumContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
     }
 
-    llvm::Constant *emitValueWitnessTable() {
+    ConstantReference emitValueWitnessTable(bool relativeReference) {
+      assert(relativeReference && "should only relative reference");
       return getValueWitnessTableForGenericValueType(IGM, Target,
                                                      HasDependentVWT);
     }
@@ -4054,7 +4057,7 @@ namespace {
     }
 
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable());
+      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
     }
 
     void flagUnfilledFieldOffset() {
@@ -4081,7 +4084,7 @@ namespace {
     }
 
     void addValueWitnessTable() {
-      B.add(emitValueWitnessTable());
+      B.add(emitValueWitnessTable(/*relative*/ false).getValue());
     }
     
     void addPayloadSize() const {

--- a/lib/IRGen/GenValueWitness.h
+++ b/lib/IRGen/GenValueWitness.h
@@ -31,6 +31,7 @@ namespace swift {
 namespace irgen {
   class ConstantStructBuilder;
   class IRGenModule;
+  class ConstantReference;
 
   /// True if a type has a generic-parameter-dependent value witness table.
   /// Currently, this is true if the size and/or alignment of the type is
@@ -42,8 +43,9 @@ namespace irgen {
   /// \param isPattern - true if the table just serves as an instantiation
   ///   pattern and does not need to be modifiable in-place (if the type
   ///   does not have static layout for some reason)
-  llvm::Constant *emitValueWitnessTable(IRGenModule &IGM, CanType type,
-                                        bool isPattern);
+  ConstantReference emitValueWitnessTable(IRGenModule &IGM, CanType type,
+                                          bool isPattern,
+                                          bool relativeReference);
 }
 }
 

--- a/test/IRGen/generic_metadata_fixed_known_vwtable.swift
+++ b/test/IRGen/generic_metadata_fixed_known_vwtable.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// CHECK-LABEL: @"$s36generic_metadata_fixed_known_vwtable6StroctVMP" =
+// CHECK-SAME:    $sytWV
+struct Stroct<T> {}
+
+// CHECK-LABEL: @"$s36generic_metadata_fixed_known_vwtable4EnomOMP" =
+// CHECK-SAME:    $sytWV
+enum Enom<T> {}


### PR DESCRIPTION
We were unnecessarily conservative here; generic metadata patterns support indirectable references
to value witness tables exported by the standard library, so if we have a fixed-layout generic
type that matches a known value witness table layout, use that instead of generating a new
value witness table.