### PR TITLE
 [Serialization] Teach serialization to get a generic signature from opaque types

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 507; // exact_self_class sil attr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 508; // generic opaque return type xref
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1719,6 +1719,8 @@ giveUpFastPath:
         currentSig = fn->getGenericSignature();
       } else if (auto subscript = dyn_cast<SubscriptDecl>(base)) {
         currentSig = subscript->getGenericSignature();
+      } else if (auto opaque = dyn_cast<OpaqueTypeDecl>(base)) {
+        currentSig = opaque->getGenericSignature();
       }
 
       if (!currentSig) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1731,6 +1731,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
   case DeclContextKind::GenericTypeDecl: {
     auto generic = cast<GenericTypeDecl>(DC);
 
+    writeCrossReference(DC->getParent(), pathLen + 1);
+
     // Opaque return types are unnamed and need a special xref.
     if (auto opaque = dyn_cast<OpaqueTypeDecl>(generic)) {
       if (!opaque->hasName()) {
@@ -1744,8 +1746,6 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     }
       
     assert(generic->hasName());
-    
-    writeCrossReference(DC->getParent(), pathLen + 1);
 
     abbrCode = DeclTypeAbbrCodes[XRefTypePathPieceLayout::Code];
 

--- a/test/Serialization/Inputs/xref-opaque-generic-type/best-protocol.swift
+++ b/test/Serialization/Inputs/xref-opaque-generic-type/best-protocol.swift
@@ -1,0 +1,16 @@
+public protocol BestProtocol {}
+public protocol GoodProtocol {
+  associatedtype A
+}
+
+public struct BestStruct: BestProtocol {
+  public init() {}
+}
+
+extension BestProtocol {
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public func _bestValue<X: GoodProtocol>(_ x: X.Type, _ a: X.A) -> some BestProtocol {
+    return BestStruct()
+  }
+}
+

--- a/test/Serialization/Inputs/xref-opaque-generic-type/output.json
+++ b/test/Serialization/Inputs/xref-opaque-generic-type/output.json
@@ -1,0 +1,8 @@
+{
+  "./best-protocol.swift": {
+    "swiftmodule": "./best-protocol.swiftmodule"
+  },
+  "./xref-opaque-generic-type.swift": {
+    "swiftmodule": "./xref-opaque-generic-type.swiftmodule"
+  }
+}

--- a/test/Serialization/xref-generic-opaque-type.swift
+++ b/test/Serialization/xref-generic-opaque-type.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/xref-opaque-generic-type/* %t/.
+// RUN: cp %s %t/xref-generic-opaque-type.swift
+// RUN: cd %t
+// RUN: %target-swiftc_driver -emit-module -incremental %t/best-protocol.swift %t/xref-generic-opaque-type.swift -module-name A -output-file-map %t/output.json
+
+@usableFromInline
+struct GoodStruct: GoodProtocol {
+  @usableFromInline
+  typealias A = Int
+}
+
+extension BestProtocol {
+  @inlinable
+  @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+  public func bestValue(_ x: Int) -> some BestProtocol {
+    return _bestValue(GoodStruct.self, x)
+  }
+}


### PR DESCRIPTION
Previously, if we had an XREF to an opaque type, we would fail trying to
get the generic signature from that type.

Fixes rdar://53958358