### PR TITLE
Bugfix for crasher SR-11269.

### DIFF
--- a/test/Profiler/pgo_foreach.swift
+++ b/test/Profiler/pgo_foreach.swift
@@ -42,7 +42,7 @@ public func guessForEach1(x: Int32) -> Int32 {
 // IR-OPT-LABEL: define swiftcc i32 @$s9pgo_foreach10guessWhiles5Int32VAD1x_tF
 
 public func guessForEach2(x: Int32) -> Int32 {
-  // SIL: switch_enum {{.*}} : $Optional<(key: String, value: Int32)>, case #Optional.some!enumelt.1: {{.*}} !case_count(168), case #Optional.none!enumelt: {{.*}} !case_count(42)
+  // SIL: switch_enum {{.*}} : $Optional<(String, Int32)>, case #Optional.some!enumelt.1: {{.*}} !case_count(168), case #Optional.none!enumelt: {{.*}} !case_count(42)
 
   var ret : Int32 = 0
   let names = ["John" : Int32(1), "Paul" : Int32(2), "George" : Int32(3), "Ringo" : Int32(x)]

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -592,3 +592,14 @@ func unusedArgPattern(_ xx: [Int]) {
     loopBodyEnd()
   }
 }
+
+// Test for SR-11269. Make sure that the sil contains the needed upcast.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s7foreach25genericFuncWithConversion4listySayxG_tAA1CCRbzlF
+// CHECK: bb2([[ITER_VAL:%.*]] : @owned $T):
+// CHECK:   [[ITER_VAL_UPCAST:%.*]] = upcast [[ITER_VAL]] : $T to $C
+func genericFuncWithConversion<T: C>(list : [T]) {
+  for item: C in list {
+    print(item)
+  }
+}


### PR DESCRIPTION
Fix for: https://bugs.swift.org/browse/SR-11269.

The lesser used else branch was not evaluating the auto-conversion code that shows up under getConvertElementExpr(). Consolidate this logic under buildElementRValue which gets called in both paths.