### PR TITLE
ABI checker: report any printed name changes for type nodes

### DIFF
--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -193,3 +193,5 @@ public class Zoo {
     return Cat()
   }
 }
+
+public func returnFunctionTypeOwnershipChange() -> (C1) -> () { return { _ in } }

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -200,3 +200,5 @@ public class Zoo {
     return Dog()
   }
 }
+
+public func returnFunctionTypeOwnershipChange() -> (__owned C1) -> () { return { _ in } }

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -44,6 +44,7 @@ cake: Func Somestruct2.foo1(_:) has parameter 0 type change from C3 to C1
 cake: Func Zoo.getCurrentAnimalInlinable() has return type change from Cat to Dog
 cake: Func ownershipChange(_:_:) has parameter 0 changing from InOut to Default
 cake: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
+cake: Func returnFunctionTypeOwnershipChange() has return type change from (C1) -> () to (__owned C1) -> ()
 cake: Var Zoo.current has declared type change from Cat to Dog
 
 /* Decl Attribute changes */

--- a/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
@@ -1,0 +1,1 @@
+Func BidirectionalCollection.difference(from:by:) has parameter 1 type change from (τ_0_0.Element, τ_1_0.Element) -> Bool to (τ_1_0.Element, τ_0_0.Element) -> Bool

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -796,8 +796,14 @@ static bool isSDKNodeEqual(SDKContext &Ctx, const SDKNode &L, const SDKNode &R) 
         return false;
       if (Left->getPrintedName() == Right->getPrintedName())
         return true;
-      return Left->getName() == Right->getName() &&
-        Left->hasSameChildren(*Right);
+      if (Ctx.checkingABI()) {
+        // For abi checking where we don't have sugar types at all, the printed
+        // name difference is enough to indicate these two types differ.
+        return false;
+      } else {
+        return Left->getName() == Right->getName() &&
+          Left->hasSameChildren(*Right);
+      }
     }
 
     case SDKNodeKind::DeclFunction: {

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -927,7 +927,7 @@ void swift::ide::api::SDKNodeType::diagnose(SDKNode *Right) {
 }
 
 void swift::ide::api::SDKNodeTypeFunc::diagnose(SDKNode *Right) {
-  SDKNode::diagnose(Right);
+  SDKNodeType::diagnose(Right);
   auto *RT = dyn_cast<SDKNodeTypeFunc>(Right);
   if (!RT || !shouldDiagnoseType(this))
     return;


### PR DESCRIPTION
Under ABI checking mode where we don't have sugar types, any printed name
changes of type nodes worth raising an alert.

rdar://45567621
