### PR TITLE
[ASTDemangler] Demangle other layout constraints

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -32,6 +32,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "llvm/ADT/StringSwitch.h"
 
 using namespace swift;
 
@@ -838,22 +839,45 @@ CanGenericSignature ASTBuilder::demangleGenericSignature(
       break;
     }
     case Demangle::Node::Kind::DependentGenericLayoutRequirement: {
-      // FIXME: Other layout constraints
-      LayoutConstraint constraint;
       auto kindChild = child->getChild(1);
       if (kindChild->getKind() != Demangle::Node::Kind::Identifier)
         return CanGenericSignature();
 
-      if (kindChild->getText() == "C") {
-        auto kind = LayoutConstraintKind::Class;
-        auto layout = LayoutConstraint::getLayoutConstraint(kind, Ctx);
-        builder.addRequirement(
-            Requirement(RequirementKind::Layout, subjectType, layout),
-            source, nullptr);
-        break;
+      auto kind = llvm::StringSwitch<Optional<
+          LayoutConstraintKind>>(kindChild->getText())
+        .Case("U", LayoutConstraintKind::UnknownLayout)
+        .Case("R", LayoutConstraintKind::RefCountedObject)
+        .Case("N", LayoutConstraintKind::NativeRefCountedObject)
+        .Case("C", LayoutConstraintKind::Class)
+        .Case("D", LayoutConstraintKind::NativeClass)
+        .Case("T", LayoutConstraintKind::Trivial)
+        .Cases("E", "e", LayoutConstraintKind::TrivialOfExactSize)
+        .Cases("M", "m", LayoutConstraintKind::TrivialOfAtMostSize)
+        .Default(None);
+
+      if (!kind)
+        return CanGenericSignature();
+
+      LayoutConstraint layout;
+
+      if (kind != LayoutConstraintKind::TrivialOfExactSize &&
+          kind != LayoutConstraintKind::TrivialOfAtMostSize) {
+        layout = LayoutConstraint::getLayoutConstraint(*kind, Ctx);
+      } else {
+        auto size = child->getChild(2)->getIndex();
+        auto alignment = 0;
+
+        if (child->getNumChildren() == 4)
+          alignment = child->getChild(3)->getIndex();
+
+        layout = LayoutConstraint::getLayoutConstraint(*kind, size, alignment,
+                                                       Ctx);
       }
 
-      return CanGenericSignature();
+      builder.addRequirement(
+          Requirement(RequirementKind::Layout, subjectType, layout),
+          source, nullptr);
+      break;
     }
     default:
       return CanGenericSignature();

--- a/test/TypeDecoder/extensions.swift
+++ b/test/TypeDecoder/extensions.swift
@@ -43,3 +43,18 @@ extension Generic where T == Int {
 
 // DEMANGLE-DECL: $s10extensions7GenericVAASiRszlE7Nested2V
 // CHECK-DECL: extensions.(file).Generic extension.Nested2
+
+// Layout Constraints
+// FIXME: When other layout constraints are allowed in source level swift, test
+// that we correctly demangle those as well.
+
+extension Generic where T: AnyObject {
+  struct NestedViaAnyObject {}
+}
+
+// DEMANGLE-TYPE: $s10extensions7GenericVAARlzClE18NestedViaAnyObjectVyx_GD
+// CHECK-TYPE: Generic<τ_0_0>.NestedViaAnyObject
+
+// DEMANGLE-DECL: $s10extensions7GenericVAARlzClE18NestedViaAnyObjectV
+// CHECK-DECL: extensions.(file).Generic extension.NestedViaAnyObject
+


### PR DESCRIPTION
This patch removes a FIXME and demangles all other layout constraints when demangling an extension's generic signature. Testing the other layouts isn't currently possible because they aren't allowed in source level Swift, but I've at least added a Class layout test to ensure that it doesn't break existing functionality. Maybe a flag could be added to enable all layout constraints in the future so we can at least do tests like this?

cc: @jckarter @slavapestov 