### PR TITLE
[ClangImporter][IRGen] Handle SVE builtin types

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -263,7 +263,7 @@ static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
     const ObjectFile *O = dyn_cast<ObjectFile>(BinaryFile);
     if (!O) {
       auto Universal = cast<MachOUniversalBinary>(BinaryFile);
-      ObjectOwner = unwrap(Universal->getObjectForArch(Arch));
+      ObjectOwner = unwrap(Universal->getMachOObjectForArch(Arch));
       O = ObjectOwner.get();
     }
 

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -112,10 +112,10 @@ static bool needToRelocate(SectionRef S) {
       "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
       "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
     };
-    StringRef Name;
-    if (auto EC = S.getName(Name))
-      reportError(EC);
-    return ELFSectionsList.count(Name);
+    auto NameOrErr = S.getName();
+    if (!NameOrErr)
+      reportError(errorToErrorCode(NameOrErr.takeError()));
+    return ELFSectionsList.count(*NameOrErr);
   }
 
   return true;


### PR DESCRIPTION
Clang r368413 introduced the SVE builtin types; update various switch
statements to handle them. This assumes that the types should not be
mapped into Swift, similar to the OpenCL types.