### PR TITLE
[IRGen] Adjust for LLVM r352827

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1729,6 +1729,7 @@ emitGenericTypeMetadataAccessFunction(IRGenFunction &IGF,
                 IGM.Int8PtrTy, // arg 1
                 IGM.Int8PtrTy, // arg 2
                 IGM.TypeContextDescriptorPtrTy) // type context descriptor
+        .getCallee()
         ->stripPointerCasts());
 
     if (thunkFn->empty()) {


### PR DESCRIPTION
getOrInsertFunction returns a FunctonCallee after LLVM r352827, so we
need to call getCallee to get the actual Value.