### PR TITLE
[Constraint graph] Make connected components more self-contained.

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -96,15 +96,12 @@ void SplitterStep::computeFollowupSteps(
   CG.optimize();
 
   // Compute the connected components of the constraint graph.
-  // FIXME: We're seeding typeVars with TypeVariables so that the
-  // connected-components algorithm only considers those type variables within
-  // our component. There are clearly better ways to do this.
-  std::vector<TypeVariableType *> typeVars(CS.TypeVariables);
-  std::vector<unsigned> components;
-  unsigned numComponents = CG.computeConnectedComponents(typeVars, components);
+  auto components = CG.computeConnectedComponents(CS.TypeVariables);
+  unsigned numComponents =
+      components.size() + CG.getOrphanedConstraints().size();
   if (numComponents < 2) {
     componentSteps.push_back(llvm::make_unique<ComponentStep>(
-        CS, 0, /*single=*/true, &CS.InactiveConstraints, Solutions));
+        CS, 0, &CS.InactiveConstraints, Solutions));
     return;
   }
 
@@ -112,9 +109,18 @@ void SplitterStep::computeFollowupSteps(
   PartialSolutions = std::unique_ptr<SmallVector<Solution, 4>[]>(
       new SmallVector<Solution, 4>[numComponents]);
 
-  for (unsigned i = 0, n = numComponents; i != n; ++i) {
+  // Add components.
+  for (unsigned i : indices(components)) {
     componentSteps.push_back(llvm::make_unique<ComponentStep>(
-        CS, i, /*single=*/false, &Components[i], PartialSolutions[i]));
+        CS, i, &Components[i], std::move(components[i]), PartialSolutions[i]));
+  }
+
+  // Add components for the orphaned constraints.
+  OrphanedConstraints = CG.takeOrphanedConstraints();
+  for (unsigned i : range(components.size(), numComponents)) {
+    auto orphaned = OrphanedConstraints[i - components.size()];
+    componentSteps.push_back(llvm::make_unique<ComponentStep>(
+        CS, i, &Components[i], orphaned, PartialSolutions[i]));
   }
 
   if (isDebugMode()) {
@@ -128,57 +134,6 @@ void SplitterStep::computeFollowupSteps(
     log << "---Connected components---\n";
     CG.printConnectedComponents(CS.TypeVariables, log);
   }
-
-  // Map type variables and constraints into appropriate steps.
-  llvm::DenseMap<TypeVariableType *, unsigned> typeVarComponent;
-  llvm::DenseMap<Constraint *, unsigned> constraintComponent;
-  for (unsigned i = 0, n = typeVars.size(); i != n; ++i) {
-    auto *typeVar = typeVars[i];
-    // Record the component of this type variable.
-    typeVarComponent[typeVar] = components[i];
-
-    for (auto *constraint : CG[typeVar].getConstraints())
-      constraintComponent[constraint] = components[i];
-  }
-
-  // Add the orphaned components to the mapping from constraints to components.
-  unsigned firstOrphanedComponent =
-      numComponents - CG.getOrphanedConstraints().size();
-  {
-    unsigned component = firstOrphanedComponent;
-    for (auto *constraint : CG.getOrphanedConstraints()) {
-      // Register this orphan constraint both as associated with
-      // a given component as a regular constrant, as well as an
-      // "orphan" constraint, so it can be proccessed correctly.
-      constraintComponent[constraint] = component;
-      componentSteps[component]->recordOrphan(constraint);
-      ++component;
-    }
-  }
-
-  for (auto *typeVar : CS.TypeVariables) {
-    auto known = typeVarComponent.find(typeVar);
-    // If current type variable is associated with
-    // a certain component step, record it as being so.
-    if (known != typeVarComponent.end()) {
-      componentSteps[known->second]->record(typeVar);
-      continue;
-    }
-  }
-
-  // Transfer all of the constraints from the work list to
-  // the appropriate component.
-  auto &workList = CS.InactiveConstraints;
-  while (!workList.empty()) {
-    auto *constraint = &workList.front();
-    workList.pop_front();
-    assert(constraintComponent.count(constraint) > 0 && "Missed a constraint");
-    componentSteps[constraintComponent[constraint]]->record(constraint);
-  }
-
-  // Remove all of the orphaned constraints; they'll be re-introduced
-  // by each component independently.
-  OrphanedConstraints = CG.takeOrphanedConstraints();
 
   // Create component ordering based on the information associated
   // with constraints in each step - e.g. number of disjunctions,

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Compiler.h"
 #include <functional>
 #include <utility>
@@ -202,20 +203,30 @@ public:
     return TypeVariables;
   }
 
+  /// Describes a single component, as produced by the connected components
+  /// algorithm.
+  struct Component {
+    /// The type variables in this component.
+    TinyPtrVector<TypeVariableType *> typeVars;
+
+    /// The constraints in this component.
+    TinyPtrVector<Constraint *> constraints;
+
+    /// Whether this component represents an orphaned constraint.
+    bool isOrphanedConstraint() const {
+      return typeVars.empty();
+    }
+  };
+
   /// Compute the connected components of the graph.
   ///
   /// \param typeVars The type variables that should be included in the
   /// set of connected components that are returned.
   ///
-  /// \param components Receives the component numbers for each type variable
-  /// in \c typeVars.
-  ///
-  /// \returns the number of connected components in the graph, which includes
-  /// one component for each of the constraints produced by
-  /// \c getOrphanedConstraints().
-  unsigned computeConnectedComponents(
-             std::vector<TypeVariableType *> &typeVars,
-             std::vector<unsigned> &components);
+  /// \returns the connected components of the graph, where each component
+  /// contains the type variables and constraints specific to that component.
+  SmallVector<Component, 1> computeConnectedComponents(
+             ArrayRef<TypeVariableType *> typeVars);
 
   /// Retrieve the set of "orphaned" constraints, which are known to the
   /// constraint graph but have no type variables to anchor them.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1290,6 +1290,7 @@ private:
     ///
     /// \param constraint The newly generated constraint.
     void addGeneratedConstraint(Constraint *constraint) {
+      assert(constraint && "Null generated constraint?");
       generatedConstraints.push_back(constraint);
     }
 


### PR DESCRIPTION
Have the constraint graph's connected-component implementation be more
self-contained, producing a vector containing each of the actual
components (where each is defined by a list of type variables and a list
of constraints). This simplifies the contract with the client
(SplitterStep) and eliminates a bunch of separate mapping steps to
interpret the results.

It also lets us enrich the Component data structure in the future.
