### PR TITLE
[Typechecker]Check for non-associativity at end of chain of right-assoc operators.

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -522,8 +522,17 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
       // If we've drained the entire sequence, we're done.
       if (S.empty()) return LHS;
 
-      // Otherwise, start all over with our new LHS.
-      return foldSequence(TC, DC, LHS, S, precedenceBound);
+      // Otherwise, we have to check that this next operator actually
+      // associates.
+      if ((op2 = getNextOperator()) && op2.precedence) {
+        associativity =
+            TC.Context.associateInfixOperators(op1.precedence, op2.precedence);
+        RHS = S[1];
+      }
+
+      // If so, start all over with our new LHS.
+      if (associativity != Associativity::None)
+        return foldSequence(TC, DC, LHS, S, precedenceBound);
     }
 
     // If we ended up here, it's because we're either:

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -416,7 +416,7 @@ namespace {
       if (!group) return false;
       if (storedGroup == group) return !GroupAndIsStrict.getInt();
       return TC.Context.associateInfixOperators(group, storedGroup)
-               == Associativity::Left;
+               != Associativity::Right;
     }
   };
 } // end anonymous namespace
@@ -522,17 +522,8 @@ static Expr *foldSequence(TypeChecker &TC, DeclContext *DC,
       // If we've drained the entire sequence, we're done.
       if (S.empty()) return LHS;
 
-      // Otherwise, we have to check that this next operator actually
-      // associates.
-      if ((op2 = getNextOperator()) && op2.precedence) {
-        associativity =
-            TC.Context.associateInfixOperators(op1.precedence, op2.precedence);
-        RHS = S[1];
-      }
-
-      // If so, start all over with our new LHS.
-      if (associativity != Associativity::None)
-        return foldSequence(TC, DC, LHS, S, precedenceBound);
+      // Otherwise, start all over with our new LHS.
+      return foldSequence(TC, DC, LHS, S, precedenceBound);
     }
 
     // If we ended up here, it's because we're either:

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -237,3 +237,21 @@ func sr10843() {
   (^^^)(s, s)
   _ = (==)(0, 0)
 }
+
+// SR-10970
+precedencegroup PowerPrecedence {
+  lowerThan: BitwiseShiftPrecedence
+  higherThan: AdditionPrecedence
+  associativity: right
+}
+infix operator ^^ : PowerPrecedence
+
+extension Int {
+  static func ^^ (lhs: Int, rhs: Int) -> Int {
+    var result = 1
+    for _ in 1...rhs { result *= lhs }
+    return result
+  }
+}
+
+_ = 1 ^^ 2 ^^ 3 * 4 // expected-error {{adjacent operators are in unordered precedence groups 'PowerPrecedence' and 'MultiplicationPrecedence'}}


### PR DESCRIPTION

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-10970](https://bugs.swift.org/browse/SR-10970).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
