### PR TITLE
[ownership] When deserializing a SILFunction, match the ownership of …

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -318,6 +318,12 @@ private:
          SILFunction *InsertBefore = nullptr,
          const SILDebugScope *DebugScope = nullptr);
 
+  /// Set has ownership to the given value. True means that the function has
+  /// ownership, false means it does not.
+  ///
+  /// Only for use by FunctionBuilders!
+  void setHasOwnership(bool newValue) { HasOwnership = newValue; }
+
 public:
   ~SILFunction();
 
@@ -444,9 +450,7 @@ public:
 
   /// Sets the HasOwnership flag to false. This signals to SIL that no
   /// ownership instructions should be in this function any more.
-  void setOwnershipEliminated() {
-    HasOwnership = false;
-  }
+  void setOwnershipEliminated() { setHasOwnership(false); }
 
   /// Returns true if this function was deserialized from canonical
   /// SIL. (.swiftmodule files contain canonical SIL; .sib files may be 'raw'

--- a/include/swift/SIL/SILFunctionBuilder.h
+++ b/include/swift/SIL/SILFunctionBuilder.h
@@ -106,7 +106,15 @@ class SILFunctionBuilder {
 
   void addFunctionAttributes(SILFunction *F, DeclAttributes &Attrs,
                              SILModule &M, SILDeclRef constant = SILDeclRef());
+
+  /// We do not expose this to everyone, instead we allow for our users to opt
+  /// into this if they need to. Please do not do this in general! We only want
+  /// to use this when deserializing a function body.
+  static void setHasOwnership(SILFunction *F, bool newValue) {
+    F->setHasOwnership(newValue);
+  }
 };
+
 } // namespace swift
 
 #endif

--- a/lib/Serialization/SILSerializationFunctionBuilder.h
+++ b/lib/Serialization/SILSerializationFunctionBuilder.h
@@ -33,6 +33,10 @@ public:
         IsNotSerialized, IsNotDynamic, ProfileCounter(), IsNotThunk,
         SubclassScope::NotApplicable);
   }
+
+  void setHasOwnership(SILFunction *f, bool newValue) {
+    builder.setHasOwnership(f, newValue);
+  }
 };
 
 } // namespace swift


### PR DESCRIPTION
…the deserialized function.

Ownership is truly a property not of a declaration, but of a function body. So
it makes sense to just match what we deserialize.

This also helps us to avoid mismatches if we lower ownership from a function,
delete it, and then relink it.

I also used this as an opportunity to clean up where we set that flag in
deserialization to only happen in one place for both declarations/definitions.