### PR TITLE
[Diagnostics][NFCI] Introduce Structured fix-its

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -49,8 +49,7 @@ struct DiagnosticInfo {
     std::string Text;
 
   public:
-    FixIt(CharSourceRange R, StringRef Str)
-        : Range(R), Text(Str) {}
+    FixIt(CharSourceRange R, StringRef Str, ArrayRef<DiagnosticArgument> Args);
 
     CharSourceRange getRange() const { return Range; }
     StringRef getText() const { return Text; }

--- a/include/swift/AST/DiagnosticsAll.def
+++ b/include/swift/AST/DiagnosticsAll.def
@@ -38,6 +38,10 @@
   DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
+#ifndef FIXIT
+#  define FIXIT(ID, Text, Signature)
+#endif
+
 #define DIAG_NO_UNDEF
 
 #include "DiagnosticsCommon.def"
@@ -60,3 +64,4 @@
 #undef WARNING
 #undef ERROR
 #undef REMARK
+#undef FIXIT

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -41,6 +41,10 @@
   DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
+#ifndef FIXIT
+#  define FIXIT(ID, Text, Signature)
+#endif
+
 ERROR(invalid_diagnostic,none,
       "INTERNAL ERROR: this diagnostic should not be produced", ())
 
@@ -166,4 +170,5 @@ NOTE(kind_declname_declared_here,none,
 # undef NOTE
 # undef WARNING
 # undef ERROR
+# undef FIXIT
 #endif

--- a/include/swift/AST/DiagnosticsCommon.h
+++ b/include/swift/AST/DiagnosticsCommon.h
@@ -28,6 +28,8 @@ namespace swift {
   struct Diag;
 
   namespace detail {
+    // These templates are used to help extract the type arguments of the
+    // DIAG/ERROR/WARNING/NOTE/REMARK/FIXIT macros.
     template<typename T>
     struct DiagWithArguments;
     
@@ -35,7 +37,15 @@ namespace swift {
     struct DiagWithArguments<void(ArgTypes...)> {
       typedef Diag<ArgTypes...> type;
     };
-  }
+
+    template <typename T>
+    struct StructuredFixItWithArguments;
+
+    template <typename... ArgTypes>
+    struct StructuredFixItWithArguments<void(ArgTypes...)> {
+      typedef StructuredFixIt<ArgTypes...> type;
+    };
+  } // end namespace detail
 
   enum class StaticSpellingKind : uint8_t;
 
@@ -48,8 +58,10 @@ namespace swift {
   // Declare common diagnostics objects with their appropriate types.
 #define DIAG(KIND,ID,Options,Text,Signature) \
     extern detail::DiagWithArguments<void Signature>::type ID;
+#define FIXIT(ID, Text, Signature) \
+    extern detail::StructuredFixItWithArguments<void Signature>::type ID;
 #include "DiagnosticsCommon.def"
-  }
-}
+  } // end namespace diag
+} // end namespace swift
 
 #endif

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -36,6 +36,10 @@
   DIAG(NOTE,ID,Options,Text,Signature)
 #endif
 
+#ifndef FIXIT
+#  define FIXIT(ID, Text, Signature)
+#endif
+
 //==============================================================================
 // MARK: Lexing and Parsing diagnostics
 //==============================================================================
@@ -1638,4 +1642,5 @@ ERROR(unknown_syntax_entity, PointsToFirstBadToken,
 # undef NOTE
 # undef WARNING
 # undef ERROR
+# undef FIXIT
 #endif

--- a/include/swift/AST/DiagnosticsParse.h
+++ b/include/swift/AST/DiagnosticsParse.h
@@ -25,6 +25,8 @@ namespace swift {
   // Declare common diagnostics objects with their appropriate types.
 #define DIAG(KIND,ID,Options,Text,Signature) \
   extern detail::DiagWithArguments<void Signature>::type ID;
+#define FIXIT(ID,Text,Signature) \
+  extern detail::StructuredFixItWithArguments<void Signature>::type ID;
 #include "DiagnosticsParse.def"
   }
 }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -37,6 +37,10 @@
   DIAG(NOTE,ID,Options,Text,Signature)
 #endif
 
+#ifndef FIXIT
+#  define FIXIT(ID, Text, Signature)
+#endif
+
 NOTE(decl_declared_here,none,
      "%0 declared here", (DeclName))
 NOTE(kind_declared_here,none,
@@ -145,6 +149,8 @@ ERROR(could_not_use_member_on_existential,none,
       "member %1 cannot be used on value of protocol type %0; use a generic"
       " constraint instead",
       (Type, DeclName))
+FIXIT(replace_with_type,"%0",(Type))
+FIXIT(insert_type_qualification,"%0.",(Type))
 
 ERROR(candidate_inaccessible,none,
       "%0 is inaccessible due to "
@@ -297,6 +303,9 @@ ERROR(cannot_infer_closure_type,none,
 ERROR(cannot_infer_closure_result_type,none,
       "unable to infer complex closure return type; "
       "add explicit type to disambiguate", ())
+FIXIT(insert_closure_return_type,
+      "%select{| () }1-> %0 %select{|in }1",
+      (Type, bool))
 
 ERROR(incorrect_explicit_closure_result,none,
       "declared closure result %0 is incompatible with contextual type %1",
@@ -343,6 +352,9 @@ ERROR(cannot_convert_thrown_type,none,
 ERROR(cannot_throw_error_code,none,
       "thrown error code type %0 does not conform to 'Error'; construct an %1 "
       "instance", (Type, Type))
+
+FIXIT(insert_type_coercion,
+      " %select{as!|as}0 %1",(bool, Type))
 
 ERROR(bad_yield_count,none,
       "expected %0 yield value(s)", (unsigned))
@@ -4178,6 +4190,9 @@ NOTE(availability_guard_with_version_check, none,
 
 NOTE(availability_add_attribute, none,
      "add @available attribute to enclosing %0", (DescriptiveDeclKind))
+FIXIT(insert_available_attr,
+      "@available(%0 %1, *)\n%2",
+      (StringRef, StringRef, StringRef))
 
 ERROR(availability_accessor_only_version_newer, none,
       "%select{getter|setter}0 for %1 is only available in %2 %3"
@@ -4595,4 +4610,5 @@ ERROR(function_builder_arguments, none,
 # undef NOTE
 # undef WARNING
 # undef ERROR
+# undef FIXIT
 #endif

--- a/include/swift/AST/DiagnosticsSema.h
+++ b/include/swift/AST/DiagnosticsSema.h
@@ -35,6 +35,8 @@ namespace swift {
   // Declare common diagnostics objects with their appropriate types.
 #define DIAG(KIND,ID,Options,Text,Signature) \
     extern detail::DiagWithArguments<void Signature>::type ID;
+#define FIXIT(ID,Text,Signature) \
+    extern detail::StructuredFixItWithArguments<void Signature>::type ID;
 #include "DiagnosticsSema.def"
   }
 }

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -29,6 +29,15 @@ using namespace swift;
 
 DiagnosticConsumer::~DiagnosticConsumer() = default;
 
+DiagnosticInfo::FixIt::FixIt(CharSourceRange R, StringRef Str,
+                             ArrayRef<DiagnosticArgument> Args) : Range(R) {
+  // FIXME: Defer text formatting to later in the pipeline.
+  llvm::raw_string_ostream OS(Text);
+  DiagnosticEngine::formatDiagnosticText(OS, Str, Args,
+                                         DiagnosticFormatOptions::
+                                         formatForFixIts());
+}
+
 llvm::SMLoc DiagnosticConsumer::getRawLoc(SourceLoc loc) {
   return loc.Value;
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -108,6 +108,13 @@ static constexpr const char *const debugDiagnosticStrings[] = {
     "<not a diagnostic>",
 };
 
+static constexpr const char *const fixItStrings[] = {
+#define DIAG(KIND, ID, Options, Text, Signature)
+#define FIXIT(ID, Text, Signature) Text,
+#include "swift/AST/DiagnosticsAll.def"
+    "<not a fix-it>",
+};
+
 DiagnosticState::DiagnosticState() {
   // Initialize our per-diagnostic state to default
   perDiagnosticBehavior.resize(LocalDiagID::NumDiags, Behavior::Unspecified);
@@ -162,10 +169,11 @@ InFlightDiagnostic &InFlightDiagnostic::highlightChars(SourceLoc Start,
 /// Add an insertion fix-it to the currently-active diagnostic.  The
 /// text is inserted immediately *after* the token specified.
 ///
-InFlightDiagnostic &InFlightDiagnostic::fixItInsertAfter(SourceLoc L,
-                                                         StringRef Str) {
+InFlightDiagnostic &
+InFlightDiagnostic::fixItInsertAfter(SourceLoc L, StringRef FormatString,
+                                     ArrayRef<DiagnosticArgument> Args) {
   L = Lexer::getLocForEndOfToken(Engine->SourceMgr, L);
-  return fixItInsert(L, Str);
+  return fixItInsert(L, FormatString, Args);
 }
 
 /// Add a token-based removal fix-it to the currently-active
@@ -189,10 +197,20 @@ InFlightDiagnostic &InFlightDiagnostic::fixItRemove(SourceRange R) {
     charRange = CharSourceRange(charRange.getStart(),
                                 charRange.getByteLength()+1);
   }
-  Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(charRange, {}));
+  Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(charRange, {}, {}));
   return *this;
 }
 
+InFlightDiagnostic &
+InFlightDiagnostic::fixItReplace(SourceRange R, StringRef FormatString,
+                                 ArrayRef<DiagnosticArgument> Args) {
+  auto &SM = Engine->SourceMgr;
+  auto charRange = toCharSourceRange(SM, R);
+
+  Engine->getActiveDiagnostic().addFixIt(
+      Diagnostic::FixIt(charRange, FormatString, Args));
+  return *this;
+}
 
 InFlightDiagnostic &InFlightDiagnostic::fixItReplace(SourceRange R,
                                                      StringRef Str) {
@@ -207,6 +225,7 @@ InFlightDiagnostic &InFlightDiagnostic::fixItReplace(SourceRange R,
 
   // If we're replacing with something that wants spaces around it, do a bit of
   // extra work so that we don't suggest extra spaces.
+  // FIXME: This could probably be applied to structured fix-its as well.
   if (Str.back() == ' ') {
     if (isspace(extractCharAfter(SM, charRange.getEnd())))
       Str = Str.drop_back();
@@ -215,18 +234,19 @@ InFlightDiagnostic &InFlightDiagnostic::fixItReplace(SourceRange R,
     if (isspace(extractCharBefore(SM, charRange.getStart())))
       Str = Str.drop_front();
   }
-
-  Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(charRange, Str));
-  return *this;
+  
+  return fixItReplace(R, "%0", {Str});
 }
 
-InFlightDiagnostic &InFlightDiagnostic::fixItReplaceChars(SourceLoc Start,
-                                                          SourceLoc End,
-                                                          StringRef Str) {
+InFlightDiagnostic &
+InFlightDiagnostic::fixItReplaceChars(SourceLoc Start, SourceLoc End,
+                                      StringRef FormatString,
+                                      ArrayRef<DiagnosticArgument> Args) {
   assert(IsActive && "Cannot modify an inactive diagnostic");
   if (Engine && Start.isValid())
-    Engine->getActiveDiagnostic().addFixIt(Diagnostic::FixIt(
-        toCharSourceRange(Engine->SourceMgr, Start, End), Str));
+    Engine->getActiveDiagnostic().addFixIt(
+        Diagnostic::FixIt(toCharSourceRange(Engine->SourceMgr, Start, End),
+                          FormatString, Args));
   return *this;
 }
 
@@ -242,10 +262,10 @@ InFlightDiagnostic &InFlightDiagnostic::fixItExchange(SourceRange R1,
   auto text1 = SM.extractText(charRange1);
   auto text2 = SM.extractText(charRange2);
 
-  Engine->getActiveDiagnostic()
-    .addFixIt(Diagnostic::FixIt(charRange1, text2));
-  Engine->getActiveDiagnostic()
-    .addFixIt(Diagnostic::FixIt(charRange2, text1));
+  Engine->getActiveDiagnostic().addFixIt(
+      Diagnostic::FixIt(charRange1, "%0", {text2}));
+  Engine->getActiveDiagnostic().addFixIt(
+      Diagnostic::FixIt(charRange2, "%0", {text1}));
   return *this;
 }
 
@@ -921,6 +941,10 @@ const char *DiagnosticEngine::diagnosticStringFor(const DiagID id,
     return debugDiagnosticStrings[(unsigned)id];
   }
   return diagnosticStrings[(unsigned)id];
+}
+
+const char *InFlightDiagnostic::fixItStringFor(const FixItID id) {
+  return fixItStrings[(unsigned)id];
 }
 
 void DiagnosticEngine::setBufferIndirectlyCausingDiagnosticToInput(

--- a/lib/AST/DiagnosticList.cpp
+++ b/lib/AST/DiagnosticList.cpp
@@ -24,12 +24,20 @@ enum class swift::DiagID : uint32_t {
 static_assert(static_cast<uint32_t>(swift::DiagID::invalid_diagnostic) == 0,
               "0 is not the invalid diagnostic ID");
 
+enum class swift::FixItID : uint32_t {
+#define DIAG(KIND, ID, Options, Text, Signature)
+#define FIXIT(ID, Text, Signature) ID,
+#include "swift/AST/DiagnosticsAll.def"
+};
+
 // Define all of the diagnostic objects and initialize them with their 
 // diagnostic IDs.
 namespace swift {
   namespace diag {
 #define DIAG(KIND,ID,Options,Text,Signature) \
     detail::DiagWithArguments<void Signature>::type ID = { DiagID::ID };
+#define FIXIT(ID, Text, Signature) \
+    detail::StructuredFixItWithArguments<void Signature>::type ID = {FixItID::ID};
 #include "swift/AST/DiagnosticsAll.def"
   } // end namespace diag
 } // end namespace swift

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6121,14 +6121,13 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
     // If we found a type, presuppose it was the intended result and insert a
     // fixit hint.
     if (resultType && !isUnresolvedOrTypeVarType(resultType)) {
-      std::string resultTypeStr = resultType->getString();
-      
       // If there is a location for an 'in' token, then the argument list was
       // specified somehow but no return type was.  Insert a "-> ReturnType "
       // before the in token.
       if (closure->getInLoc().isValid()) {
         diagnose(closure->getLoc(), diag::cannot_infer_closure_result_type)
-          .fixItInsert(closure->getInLoc(), "-> " + resultTypeStr + " ");
+            .fixItInsert(closure->getInLoc(), diag::insert_closure_return_type,
+                         resultType, /*argListSpecified*/ false);
         return true;
       }
       
@@ -6138,9 +6137,10 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       //
       // As such, we insert " () -> ReturnType in " right after the '{' that
       // starts the closure body.
-      auto insertString = " () -> " + resultTypeStr + " " + "in ";
       diagnose(closure->getLoc(), diag::cannot_infer_closure_result_type)
-        .fixItInsertAfter(closure->getBody()->getLBraceLoc(), insertString);
+          .fixItInsertAfter(closure->getBody()->getLBraceLoc(),
+                            diag::insert_closure_return_type, resultType,
+                            /*argListSpecified*/ true);
       return true;
     }
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2413,17 +2413,13 @@ bool ContextualFailure::tryTypeCoercionFixIt(
   if (Kind != CheckedCastKind::Unresolved) {
     auto *anchor = getAnchor();
 
-    SmallString<32> buffer;
-    llvm::raw_svector_ostream OS(buffer);
     bool canUseAs = Kind == CheckedCastKind::Coercion ||
                     Kind == CheckedCastKind::BridgingCoercion;
     if (bothOptional && canUseAs)
       toType = OptionalType::get(toType);
-    toType->print(OS);
-    diagnostic.fixItInsert(
-        Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
-                                   anchor->getEndLoc()),
-        (llvm::Twine(canUseAs ? " as " : " as! ") + OS.str()).str());
+    diagnostic.fixItInsert(Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
+                                                      anchor->getEndLoc()),
+                           diag::insert_type_coercion, canUseAs, toType);
     return true;
   }
 
@@ -3270,12 +3266,13 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
 
     // Fall back to a fix-it with a full type qualifier
     if (auto *NTD = Member->getDeclContext()->getSelfNominalTypeDecl()) {
-      auto typeName = NTD->getSelfInterfaceType()->getString();
+      auto type = NTD->getSelfInterfaceType();
       if (auto *SE = dyn_cast<SubscriptExpr>(getRawAnchor())) {
         auto *baseExpr = SE->getBase();
-        Diag->fixItReplace(baseExpr->getSourceRange(), typeName);
+        Diag->fixItReplace(baseExpr->getSourceRange(), diag::replace_with_type,
+                           type);
       } else {
-        Diag->fixItInsert(loc, typeName + ".");
+        Diag->fixItInsert(loc, diag::insert_type_qualification, type);
       }
     }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1180,20 +1180,14 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
 
   StringRef OriginalIndent =
       Lexer::getIndentationForLine(TC.Context.SourceMgr, InsertLoc);
-
-  std::string AttrText;
-  {
-    llvm::raw_string_ostream Out(AttrText);
-
-    PlatformKind Target = targetPlatform(TC.getLangOpts());
-    Out << "@available(" << platformString(Target) << " "
-        << RequiredRange.getLowerEndpoint().getAsString() << ", *)\n"
-        << OriginalIndent;
-  }
+  PlatformKind Target = targetPlatform(TC.getLangOpts());
 
   TC.diagnose(D, diag::availability_add_attribute,
               KindForDiagnostic)
-      .fixItInsert(InsertLoc, AttrText);
+      .fixItInsert(InsertLoc, diag::insert_available_attr,
+                   platformString(Target),
+                   RequiredRange.getLowerEndpoint().getAsString(),
+                   OriginalIndent);
 }
 
 /// In the special case of being in an existing, nontrivial type refinement


### PR DESCRIPTION
These are defined with macros like errors/warnings/notes, and make use of format strings and diagnostic arguments. The intent is to leverage diagnostic arguments in the future to disambiguate ambiguously spelled types.

Ported a few miscellaneous fix-its to the new system.

Some of the rationale for this change is explained [here](https://forums.swift.org/t/structured-fix-its-and-diagnostic-arguments/27645). This change alone isn't enough to fix e.g. [SR-8668](https://bugs.swift.org/browse/SR-8668), but it's a first step towards being able to handle that kind of situation better.

If this seems like a good direction to take, the next steps I had in mind are roughly:
- Move the formatting of fix-it arguments into the DiagnosticConsumers (Didn't want to do that as part of this PR and end up with a huge diff, it'll likely require moving DiagnosticArgument out of the DiagnosticEngine header)
- Port more fix-its over to using format strings (This really only makes sense for the more complicated fix-its)
- Maybe allow attaching an optional DeclContext to a diagnostic which can be used to determine if types need qualification when formatted

cc @jrose-apple (this builds on some of the argument formatting changes to diags from a few weeks back)
cc @xedin (this may eventually affect many fix-its produced during type checking)