### PR TITLE
[CodeCompletion] Fix a crash in collectPossibleCalleesByQualifiedLookup

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -289,6 +289,8 @@ static void collectPossibleCalleesByQualifiedLookup(
     if (!VD->hasInterfaceType())
       continue;
     Type declaredMemberType = VD->getInterfaceType();
+    if (!declaredMemberType->is<AnyFunctionType>())
+      continue;
     if (VD->getDeclContext()->isTypeContext()) {
       if (isa<FuncDecl>(VD)) {
         if (!isOnMetaType && VD->isStatic())

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -368,3 +368,13 @@ func test_41071587(x: Any) {
   }
 }
 // RDAR_41071587: Begin completions
+
+// rdar://problem/54215016
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_54215016 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_54215016
+struct test_54215016 {
+  func genericError<Value>()
+  func test() {
+    genericError(#^RDAR_54215016^#)
+// RDAR_54215016: Begin completions
+  }
+}


### PR DESCRIPTION
We cannot assume that `FuncDecl`/`ConstructorDecl`/`SubscriptDecl`s have `AnyFunctionType` interface type or null type. They may have `ErrorType`s.

rdar://problem/54215016
