### PR TITLE
disable sized deallocation for SyntaxData

### DIFF
--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -133,6 +133,10 @@ class SyntaxData final
   }
 
 public:
+  /// Disable sized deallocation for SyntaxData, because it has tail-allocated
+  /// data.
+  void operator delete(void *p) { ::operator delete(p); }
+
   /// Get the node immediately before this current node that does contain a
   /// non-missing token. Return nullptr if we cannot find such node.
   RC<SyntaxData> getPreviousNode() const;


### PR DESCRIPTION
This is the same change for the same reason as https://github.com/apple/swift/pull/24628, for SyntaxData.