### PR TITLE
[build-script] Propagate libdispatch-cmake-options

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2117,6 +2117,7 @@ for host in "${ALL_HOSTS[@]}"; do
         tmp_product=${product}
         if [[ ${tmp_product} == "libdispatch_static" ]]; then
             tmp_product=libdispatch
+            LIBDISPATCH_STATIC_CMAKE_OPTIONS=${LIBDISPATCH_CMAKE_OPTIONS[@]}
         fi
         if ! [[ $(should_execute_action "${host}-${tmp_product}-build") ]]; then
             continue


### PR DESCRIPTION
PR #25085 [1] enabled building and installing the static variant of the
libdispatch library in build-script-impl. This broke the
`tsan-libdispatch-test` preset [2].

Let's make sure we pass along the options specified in
`libdispatch-cmake-options` when building the static variant.

[1] https://github.com/apple/swift/pull/25085
[2] https://github.com/apple/swift/pull/24330

rdar://problem/49177823