### PR TITLE
Enable delayed member parsing

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -829,10 +829,6 @@ public:
   /// \param IDC The context whose member decls should be lazily parsed.
   void parseMembers(IterableDeclContext *IDC);
 
-  /// Use the lazy parsers associated with the context to check whether the decl
-  /// context has been parsed.
-  bool hasUnparsedMembers(const IterableDeclContext *IDC) const;
-
   /// Get the lazy function data for the given generic context.
   ///
   /// \param lazyLoader If non-null, the lazy loader to use when creating the

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -459,6 +459,10 @@ public:
   /// are used.
   ResilienceExpansion getResilienceExpansion() const;
 
+  /// Returns true if this context may possibly contain members visible to
+  /// AnyObject dynamic lookup.
+  bool mayContainMembersAccessedByDynamicLookup() const;
+
   /// Returns true if lookups within this context could affect downstream files.
   ///
   /// \param functionsAreNonCascading If true, functions are considered non-
@@ -724,6 +728,7 @@ public:
     MemberCount = 0;
     HasOperatorDeclarations = 0;
     HasUnparsedMembers = 0;
+    HasNestedClassDeclarations = 0;
   }
 
   /// Determine the kind of iterable context we have.

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -697,7 +697,18 @@ class IterableDeclContext {
   /// detect when a member has been added. A bit would suffice,
   /// but would be more fragile, The scope code could count the members each
   /// time, but I think it's a better trade to just keep a count here.
-  unsigned memberCount = 0;
+  unsigned MemberCount : 29;
+
+  /// Whether parsing the members of this context has been delayed.
+  unsigned HasUnparsedMembers : 1;
+
+  /// Whether delayed parsing detected a possible operator definition
+  /// while skipping the body of this context.
+  unsigned HasOperatorDeclarations : 1;
+
+  /// Whether delayed parsing detect a possible nested class definition
+  /// while skipping the body of this context.
+  unsigned HasNestedClassDeclarations : 1;
 
   template<class A, class B, class C>
   friend struct ::llvm::cast_convert_val;
@@ -709,11 +720,41 @@ class IterableDeclContext {
 
 public:
   IterableDeclContext(IterableDeclContextKind kind)
-    : LastDeclAndKind(nullptr, kind) { }
+    : LastDeclAndKind(nullptr, kind) {
+    MemberCount = 0;
+    HasOperatorDeclarations = 0;
+    HasUnparsedMembers = 0;
+  }
 
   /// Determine the kind of iterable context we have.
   IterableDeclContextKind getIterableContextKind() const {
     return LastDeclAndKind.getInt();
+  }
+
+  bool hasUnparsedMembers() const {
+    return HasUnparsedMembers;
+  }
+
+  void setHasUnparsedMembers() {
+    HasUnparsedMembers = 1;
+  }
+
+  bool maybeHasOperatorDeclarations() const {
+    return HasOperatorDeclarations;
+  }
+
+  void setMaybeHasOperatorDeclarations() {
+    assert(hasUnparsedMembers());
+    HasOperatorDeclarations = 1;
+  }
+
+  bool maybeHasNestedClassDeclarations() const {
+    return HasNestedClassDeclarations;
+  }
+
+  void setMaybeHasNestedClassDeclarations() {
+    assert(hasUnparsedMembers());
+    HasNestedClassDeclarations = 1;
   }
 
   /// Retrieve the set of members in this context.
@@ -728,8 +769,8 @@ public:
   /// is inserted immediately after the hint.
   void addMember(Decl *member, Decl *hint = nullptr);
 
-  /// See \c memberCount
-  unsigned getMemberCount() const { return memberCount; }
+  /// See \c MemberCount
+  unsigned getMemberCount() const { return MemberCount; }
 
   /// Check whether there are lazily-loaded members.
   bool hasLazyMembers() const {

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -374,6 +374,8 @@ class CompilerInstance {
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<SILModule> TheSILModule;
 
+  std::unique_ptr<PersistentParserState> PersistentState;
+
   /// Null if no tracker.
   std::unique_ptr<DependencyTracker> DepTracker;
 
@@ -634,13 +636,11 @@ private:
 
   void parseLibraryFile(unsigned BufferID,
                         const ImplicitImports &implicitImports,
-                        PersistentParserState &PersistentState,
                         DelayedParsingCallbacks *DelayedCB);
 
   /// Return true if had load error
   bool
   parsePartialModulesAndLibraryFiles(const ImplicitImports &implicitImports,
-                                     PersistentParserState &PersistentState,
                                      DelayedParsingCallbacks *DelayedCB);
 
   OptionSet<TypeCheckingFlags> computeTypeCheckingOptions();
@@ -648,7 +648,6 @@ private:
   void forEachFileToTypeCheck(llvm::function_ref<void(SourceFile &)> fn);
 
   void parseAndTypeCheckMainFileUpTo(SourceFile::ASTStage_t LimitStage,
-                                     PersistentParserState &PersistentState,
                                      DelayedParsingCallbacks *DelayedParseCB,
                                      OptionSet<TypeCheckingFlags> TypeCheckOptions);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -887,7 +887,14 @@ public:
 
   void parseDeclListDelayed(IterableDeclContext *IDC);
 
-  bool canDelayMemberDeclParsing();
+  bool parseMemberDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
+                           SourceLoc PosBeforeLB,
+                           Diag<> ErrorDiag,
+                           ParseDeclOptions Options,
+                           IterableDeclContext *IDC);
+
+  bool canDelayMemberDeclParsing(bool &HasOperatorDeclarations,
+                                 bool &HasNestedClassDeclarations);
 
   bool delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
                             SourceLoc PosBeforeLB,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2008,13 +2008,8 @@ LazyContextData *ASTContext::getOrCreateLazyContextData(
   return entry;
 }
 
-bool ASTContext::hasUnparsedMembers(const IterableDeclContext *IDC) const {
-  auto parsers = getImpl().lazyParsers;
-  return std::any_of(parsers.begin(), parsers.end(),
-    [IDC](LazyMemberParser *p) { return p->hasUnparsedMembers(IDC); });
-}
-
 void ASTContext::parseMembers(IterableDeclContext *IDC) {
+  assert(IDC->hasUnparsedMembers());
   for (auto *p: getImpl().lazyParsers) {
     if (p->hasUnparsedMembers(IDC))
       p->parseMembers(IDC);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -748,17 +748,17 @@ public:
     void cleanup(NODE *fn) {                                    \
       popFunction(fn);                                          \
     }
-#define SCOPE_LIKE(NODE)                                        \
-    bool shouldVerify(NODE *fn) {                               \
-      pushScope(fn);                                            \
-      if (fn->hasLazyMembers())                                 \
+#define TYPE_LIKE(NODE)                                         \
+    bool shouldVerify(NODE *dc) {                               \
+      pushScope(dc);                                            \
+      if (dc->hasLazyMembers())                                 \
         return false;                                           \
-      if (fn->getASTContext().hasUnparsedMembers(fn))           \
+      if (dc->hasUnparsedMembers())                             \
         return false;                                           \
-      return shouldVerify(cast<ASTNodeBase<NODE*>::BaseTy>(fn));\
+      return shouldVerify(cast<ASTNodeBase<NODE*>::BaseTy>(dc));\
     }                                                           \
-    void cleanup(NODE *fn) {                                    \
-      popScope(fn);                                             \
+    void cleanup(NODE *dc) {                                    \
+      popScope(dc);                                             \
     }
 
     FUNCTION_LIKE(AbstractClosureExpr)
@@ -767,10 +767,10 @@ public:
     FUNCTION_LIKE(FuncDecl)
     FUNCTION_LIKE(EnumElementDecl)
     FUNCTION_LIKE(SubscriptDecl)
-    SCOPE_LIKE(NominalTypeDecl)
-    SCOPE_LIKE(ExtensionDecl)
+    TYPE_LIKE(NominalTypeDecl)
+    TYPE_LIKE(ExtensionDecl)
 
-#undef SCOPE_LIKE
+#undef TYPE_LIKE
 #undef FUNCTION_LIKE
 
     bool shouldVerify(BraceStmt *BS) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2672,24 +2672,12 @@ bool ValueDecl::canBeAccessedByDynamicLookup() const {
   if (!hasName())
     return false;
 
-  // Dynamic lookup can only find class and protocol members, or extensions of
-  // classes.
-  auto nominalDC = getDeclContext()->getSelfNominalTypeDecl();
-  if (!nominalDC ||
-      (!isa<ClassDecl>(nominalDC) && !isa<ProtocolDecl>(nominalDC)))
-    return false;
-
-  // Dynamic lookup cannot find results within a non-protocol generic context,
-  // because there is no sensible way to infer the generic arguments.
-  if (getDeclContext()->isGenericContext() && !isa<ProtocolDecl>(nominalDC))
+  auto *dc = getDeclContext();
+  if (!dc->mayContainMembersAccessedByDynamicLookup())
     return false;
 
   // Dynamic lookup can find functions, variables, and subscripts.
   if (!isa<FuncDecl>(this) && !isa<VarDecl>(this) && !isa<SubscriptDecl>(this))
-    return false;
-
-  // Dynamic lookup can only find @objc members.
-  if (!isObjC())
     return false;
 
   return true;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -726,7 +726,7 @@ DeclRange IterableDeclContext::getMembers() const {
 void IterableDeclContext::addMember(Decl *member, Decl *Hint) {
   // Add the member to the list of declarations without notification.
   addMemberSilently(member, Hint);
-  ++memberCount;
+  ++MemberCount;
 
   // Notify our parent declaration that we have added the member, which can
   // be used to update the lookup tables.
@@ -794,13 +794,19 @@ void IterableDeclContext::setMemberLoader(LazyMemberLoader *loader,
 }
 
 void IterableDeclContext::loadAllMembers() const {
+  ASTContext &ctx = getASTContext();
+
   // Lazily parse members.
-  getASTContext().parseMembers(const_cast<IterableDeclContext*>(this));
+  if (HasUnparsedMembers) {
+    auto *IDC = const_cast<IterableDeclContext *>(this);
+    ctx.parseMembers(IDC);
+    IDC->HasUnparsedMembers = 0;
+  }
+
   if (!hasLazyMembers())
     return;
 
   // Don't try to load all members re-entrant-ly.
-  ASTContext &ctx = getASTContext();
   auto contextInfo = ctx.getOrCreateLazyIterableContextData(this,
     /*lazyLoader=*/nullptr);
   auto lazyMembers = FirstDeclAndLazyMembers.getInt() & ~LazyMembers::Present;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1025,6 +1025,7 @@ populateLookupTableEntryFromExtensions(ASTContext &ctx,
   if (!ignoreNewExtensions) {
     for (auto e : nominal->getExtensions()) {
       if (e->wasDeserialized() || e->hasClangNode()) {
+        assert(!e->hasUnparsedMembers());
         if (populateLookupTableEntryFromLazyIDCLoader(ctx, table,
                                                       name, e)) {
           return true;
@@ -1054,6 +1055,8 @@ void NominalTypeDecl::prepareLookupTable(bool ignoreNewExtensions) {
   }
 
   if (hasLazyMembers()) {
+    assert(!hasUnparsedMembers());
+
     // Lazy members: if the table needs population, populate the table _only
     // from those members already in the IDC member list_ such as implicits or
     // globals-as-members, then update table entries from the extensions that
@@ -1185,6 +1188,14 @@ TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
       if (!ignoreNewExtensions) {
         for (auto E : getExtensions())
           (void)E->getMembers();
+      }
+    } else {
+      // We still have to parse any unparsed extensions.
+      if (!ignoreNewExtensions) {
+        for (auto *e : getExtensions()) {
+          if (e->hasUnparsedMembers())
+            e->loadAllMembers();
+        }
       }
     }
 

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -72,11 +72,12 @@ void PersistentParserState::delayDecl(DelayedDeclKind Kind,
       ScopeInfo.saveCurrentScope()));
 }
 
-void PersistentParserState::delayDeclList(IterableDeclContext* D,
+void PersistentParserState::delayDeclList(IterableDeclContext *D,
                                           unsigned Flags,
                                           DeclContext *ParentContext,
                                           SourceRange BodyRange,
                                           SourceLoc PreviousLoc) {
+  assert(D->hasUnparsedMembers());
   DelayedDeclListStates[D] = llvm::make_unique<DelayedDeclListState>(Flags,
     ParentContext, BodyRange, PreviousLoc, ScopeInfo.saveCurrentScope());
 }

--- a/validation-test/compiler_crashers_2_fixed/0177-rdar-33093935.swift
+++ b/validation-test/compiler_crashers_2_fixed/0177-rdar-33093935.swift
@@ -10,5 +10,5 @@ extension A {
 }
 
 class B: A {
-  @objc var foo = superclass()?.name // expected-error{{property 'foo' references itself}}
+  @objc var foo = superclass()?.name
 }

--- a/validation-test/compiler_scale/dynamic_lookup.gyb
+++ b/validation-test/compiler_scale/dynamic_lookup.gyb
@@ -1,0 +1,20 @@
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select Sema.IsObjCRequest -Xfrontend=-disable-objc-attr-requires-foundation-module %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+class C${N} {
+  // This is the member we actually have to validate; we only want there
+  // to be one definition:
+% if int(N) == 1:
+  @objc func isObjCMember() {}
+% end
+
+  // Other random @objc and non-@objc members; the test ensures that we're
+  // not touching these:
+  func isAnotherObjCMember() {}
+  func isNonObjCMember() {}
+}
+
+func f${N}(a: AnyObject) {
+  a.isObjCMember!()
+}

--- a/validation-test/compiler_scale/dynamic_lookup_2.swift
+++ b/validation-test/compiler_scale/dynamic_lookup_2.swift
@@ -1,0 +1,19 @@
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed -Xfrontend=-disable-objc-attr-requires-foundation-module %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+// Dynamic member lookup should not force delayed parsing of structs, enums or protocol
+// extensions.
+struct S${N} {}
+enum E${N} {}
+extension Sequence {}
+
+% if int(N) == 1:
+class C {
+    @objc func isObjCMember() {}
+}
+% end
+
+func f${N}(a: AnyObject) {
+  a.isObjCMember!()
+}

--- a/validation-test/compiler_scale/nominal_bodies.gyb
+++ b/validation-test/compiler_scale/nominal_bodies.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --sum-multi --parse --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed %s
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Constructing the global name lookup table would force all delayed type and extension bodies to be parsed. Instead track which ones can contain operators and only visit the members of those. Fixes rdar://problem/53961587.

Another source of overhead was the construction of the AnyObject dispatch table; this process would visit too many members and trigger computation of isObjC() on each one.