### PR TITLE
[5.1][Diagnostics] Don't crash when gathering info about property wrapper …

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3564,6 +3564,14 @@ SubstitutionMap TypeBase::getMemberSubstitutionMap(
 
 Type TypeBase::getTypeOfMember(ModuleDecl *module, const ValueDecl *member,
                                Type memberType) {
+  if (is<ErrorType>())
+    return ErrorType::get(getASTContext());
+
+  if (auto *lvalue = getAs<LValueType>()) {
+    auto objectTy = lvalue->getObjectType();
+    return objectTy->getTypeOfMember(module, member, memberType);
+  }
+
   // If no member type was provided, use the member's type.
   if (!memberType)
     memberType = member->getInterfaceType();

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1164,3 +1164,19 @@ struct SR_11381_W<T> {
 struct SR_11381_S {
   @SR_11381_W var foo: Int = nil // expected-error {{'nil' requires a contextual type}}
 }
+
+// rdar://problem/54184846 - crash while trying to retrieve wrapper info on l-value base type
+func test_missing_method_with_lvalue_base() {
+  @propertyWrapper
+  struct Ref<T> {
+    var wrappedValue: T
+  }
+
+  struct S<T> where T: RandomAccessCollection, T.Element: Equatable {
+    @Ref var v: T.Element
+
+    init(items: T, v: Ref<T.Element>) {
+      self.v.binding = v // expected-error {{value of type 'T.Element' has no member 'binding'}}
+    }
+  }
+}


### PR DESCRIPTION
…in l-value base

- **Explanation**:

Make `TypeBase::getTypeOfMember` more resilient to base type
being either an l-value (which we can look through), or an
error type - in such can it would return immediately.

- **Issue**: rdar://problem/54184846

- **Scope**: Constraint solver in diagnostic mode.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @DougGregor

Resolves: rdar://problem/54184846
(cherry picked from commit c67cf88b7dbb86600d91c68265c07844ccb445e9)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
