### PR TITLE
[5.1] ABI/API checker: avoid printing fully qualified names in generic signature

### DIFF
--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -193,3 +193,5 @@ public class Zoo {
     return Cat()
   }
 }
+
+public func returnFunctionTypeOwnershipChange() -> (C1) -> () { return { _ in } }

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -200,3 +200,5 @@ public class Zoo {
     return Dog()
   }
 }
+
+public func returnFunctionTypeOwnershipChange() -> (__owned C1) -> () { return { _ in } }

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -44,6 +44,7 @@ cake: Func Somestruct2.foo1(_:) has parameter 0 type change from C3 to C1
 cake: Func Zoo.getCurrentAnimalInlinable() has return type change from Cat to Dog
 cake: Func ownershipChange(_:_:) has parameter 0 changing from InOut to Default
 cake: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
+cake: Func returnFunctionTypeOwnershipChange() has return type change from (C1) -> () to (__owned C1) -> ()
 cake: Var Zoo.current has declared type change from Cat to Dog
 
 /* Decl Attribute changes */

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -1,7 +1,7 @@
 
 /* Generic Signature Changes */
 cake: Func P1.P1Constraint() has generic signature change from <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> to <τ_0_0 where τ_0_0 : P1>
-cake: Protocol P3 has generic signature change from <τ_0_0 : cake.P1, τ_0_0 : cake.P2> to <τ_0_0 : cake.P1, τ_0_0 : cake.P4>
+cake: Protocol P3 has generic signature change from <τ_0_0 : P1, τ_0_0 : P2> to <τ_0_0 : P1, τ_0_0 : P4>
 
 /* RawRepresentable Changes */
 

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -1,7 +1,7 @@
 
 /* Generic Signature Changes */
 cake: Func P1.P1Constraint() has generic signature change from <Self where Self : P1, Self : P2> to <Self where Self : P1>
-cake: Protocol P3 has generic signature change from <Self : cake.P1, Self : cake.P2> to <Self : cake.P1, Self : cake.P4>
+cake: Protocol P3 has generic signature change from <Self : P1, Self : P2> to <Self : P1, Self : P4>
 
 /* RawRepresentable Changes */
 

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -59,7 +59,7 @@
       "declKind": "Protocol",
       "usr": "s:4cake2P3P",
       "moduleName": "cake",
-      "genericSig": "<τ_0_0 : cake.P1, τ_0_0 : cake.P2>",
+      "genericSig": "<τ_0_0 : P1, τ_0_0 : P2>",
       "conformances": [
         {
           "kind": "Conformance",
@@ -1238,7 +1238,7 @@
       "declKind": "Protocol",
       "usr": "s:4cake4PSubP",
       "moduleName": "cake",
-      "genericSig": "<τ_0_0 : cake.PSuper>",
+      "genericSig": "<τ_0_0 : PSuper>",
       "conformances": [
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -59,7 +59,7 @@
       "declKind": "Protocol",
       "usr": "s:4cake2P3P",
       "moduleName": "cake",
-      "genericSig": "<Self : cake.P1, Self : cake.P2>",
+      "genericSig": "<Self : P1, Self : P2>",
       "conformances": [
         {
           "kind": "Conformance",
@@ -1137,7 +1137,7 @@
       "declKind": "Protocol",
       "usr": "s:4cake4PSubP",
       "moduleName": "cake",
-      "genericSig": "<Self : cake.PSuper>",
+      "genericSig": "<Self : PSuper>",
       "conformances": [
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
@@ -1,1 +1,1 @@
-
+Func BidirectionalCollection.difference(from:by:) has parameter 1 type change from (τ_0_0.Element, τ_1_0.Element) -> Bool to (τ_1_0.Element, τ_0_0.Element) -> Bool

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1088,6 +1088,10 @@ StringRef printGenericSignature(SDKContext &Ctx, ArrayRef<Requirement> AllReqs) 
     return StringRef();
   OS << "<";
   bool First = true;
+  PrintOptions Opts = PrintOptions::printInterface();
+  // We always print unqualifed type names to avoid false positives introduced
+  // by the heuristics working differently.
+  Opts.FullyQualifiedTypesIfAmbiguous = false;
   for (auto Req: AllReqs) {
     if (!First) {
       OS << ", ";
@@ -1095,9 +1099,9 @@ StringRef printGenericSignature(SDKContext &Ctx, ArrayRef<Requirement> AllReqs) 
       First = false;
     }
     if (Ctx.checkingABI())
-      getCanonicalRequirement(Req).print(OS, PrintOptions::printInterface());
+      getCanonicalRequirement(Req).print(OS, Opts);
     else
-      Req.print(OS, PrintOptions::printInterface());
+      Req.print(OS, Opts);
   }
   OS << ">";
   return Ctx.buffer(OS.str());

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -2077,7 +2077,7 @@ swift::ide::api::getSDKNodeRoot(SDKContext &SDKCtx,
     if (Opts.Verbose)
       llvm::errs() << "Loading module: " << Name << "...\n";
     auto *M = Ctx.getModuleByName(Name);
-    if (!M) {
+    if (!M || M->failedToLoad()) {
       llvm::errs() << "Failed to load module: " << Name << '\n';
       if (Opts.AbortOnModuleLoadFailure)
         return nullptr;

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -794,8 +794,14 @@ static bool isSDKNodeEqual(SDKContext &Ctx, const SDKNode &L, const SDKNode &R) 
         return false;
       if (Left->getPrintedName() == Right->getPrintedName())
         return true;
-      return Left->getName() == Right->getName() &&
-        Left->hasSameChildren(*Right);
+      if (Ctx.checkingABI()) {
+        // For abi checking where we don't have sugar types at all, the printed
+        // name difference is enough to indicate these two types differ.
+        return false;
+      } else {
+        return Left->getName() == Right->getName() &&
+          Left->hasSameChildren(*Right);
+      }
     }
 
     case SDKNodeKind::DeclFunction: {

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -927,7 +927,7 @@ void swift::ide::api::SDKNodeType::diagnose(SDKNode *Right) {
 }
 
 void swift::ide::api::SDKNodeTypeFunc::diagnose(SDKNode *Right) {
-  SDKNode::diagnose(Right);
+  SDKNodeType::diagnose(Right);
   auto *RT = dyn_cast<SDKNodeTypeFunc>(Right);
   if (!RT || !shouldDiagnoseType(this))
     return;

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2145,7 +2145,7 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
   // Find member hoist changes to help refine diagnostics.
   findTypeMemberDiffs(LeftModule, RightModule, Ctx.getTypeMemberDiffs());
   DiagnosisEmitter::diagnosis(LeftModule, RightModule, Ctx);
-  return 0;
+  return options::CompilerStyleDiags && Ctx.getDiags().hadAnyError() ? 1 : 0;
 }
 
 static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
@@ -2167,7 +2167,7 @@ static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
   RightCollector.deSerialize(RightPath);
   diagnoseModuleChange(Ctx, LeftCollector.getSDKRoot(), RightCollector.getSDKRoot(),
                        OutputPath, std::move(ProtocolReqWhitelist));
-  return 0;
+  return options::CompilerStyleDiags && Ctx.getDiags().hadAnyError() ? 1 : 0;
 }
 
 static void populateAliasChanges(NodeMap &AliasMap, DiffVector &AllItems,

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -73,10 +73,10 @@ def get_api_digester_path(tool_path):
 class DumpConfig:
     def __init__(self, tool_path, platform):
         target_map = {
-            'iphoneos': 'arm64-apple-ios10.0',
-            'macosx': 'x86_64-apple-macosx10.11',
-            'appletvos': 'arm64-apple-tvos10.0',
-            'watchos': 'armv7k-apple-watchos3.0',
+            'iphoneos': 'arm64-apple-ios13.0',
+            'macosx': 'x86_64-apple-macosx10.15',
+            'appletvos': 'arm64-apple-tvos13.0',
+            'watchos': 'armv7k-apple-watchos6.0',
         }
         self.tool_path = get_api_digester_path(tool_path)
         self.platform = platform
@@ -149,8 +149,8 @@ A convenient wrapper for swift-api-digester.
         the output file of the module baseline should end with .json
         ''')
 
-    basic_group.add_argument('--swift-version', default='4', help='''
-        Swift version to use; default is 4
+    basic_group.add_argument('--swift-version', default='5', help='''
+        Swift version to use; default is 5
         ''')
 
     basic_group.add_argument('--module', default=None, help='''


### PR DESCRIPTION
The heuristics to decide whether fully qualified type names should be printed may
work differently when generating the baseline and when importing from just built
frameworks. This patch makes it consistent so that such false positives won't happen.

rdar://54276347