### PR TITLE
Some preliminary cleanups related to setInterfaceType()

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3916,6 +3916,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         auto newValueParam = valueParams->get(0);
         newValueParam->setInterfaceType(valueIfaceTy);
         newValueParam->getTypeLoc().setType(valueIfaceTy);
+        accessor->getBodyResultTypeLoc().setType(TupleType::getEmpty(Context));
         break;
       }
 
@@ -3932,6 +3933,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // If we add yield types to the function type, we'll need to update this.
       case AccessorKind::Read:
       case AccessorKind::Modify:
+        accessor->getBodyResultTypeLoc().setType(TupleType::getEmpty(Context));
         break;
       }
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -241,7 +241,7 @@ static void bindExtensionToNominal(ExtensionDecl *ext,
   nominal->addExtension(ext);
 }
 
-static void bindExtensions(SourceFile &SF, TypeChecker &TC) {
+static void bindExtensions(SourceFile &SF) {
   // Utility function to try and resolve the extended type without diagnosing.
   // If we succeed, we go ahead and bind the extension. Otherwise, return false.
   auto tryBindExtension = [&](ExtensionDecl *ext) -> bool {
@@ -413,7 +413,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
     // Resolve extensions. This has to occur first during type checking,
     // because the extensions need to be wired into the AST for name lookup
     // to work.
-    bindExtensions(SF, TC);
+    bindExtensions(SF);
 
     // Look for bridging functions. This only matters when
     // -enable-source-import is provided.


### PR DESCRIPTION
I'd like to add an assertion to setInterfaceType() that prevents it from being called multiple times on the same ValueDecl. There is still a fair bit of work remaining before we can do that, but some of the simpler changes can be peeled off and tested now.