### PR TITLE
[5.1][Runtime] Fix swift_conformsToProtocol crashing on conformances to unavailable classes.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2333,6 +2333,12 @@ public:
     return TypeRef.getTypeDescriptor(getTypeKind());
   }
 
+  const TargetContextDescriptor<Runtime> **_getTypeDescriptorLocation() const {
+    if (getTypeKind() != TypeReferenceKind::IndirectTypeDescriptor)
+      return nullptr;
+    return TypeRef.IndirectTypeDescriptor.get();
+  }
+
   /// Retrieve the context of a retroactive conformance.
   const TargetContextDescriptor<Runtime> *getRetroactiveContext() const {
     if (!Flags.isRetroactive()) return nullptr;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -145,14 +145,15 @@ ProtocolConformanceDescriptor::getCanonicalTypeMetadata() const {
 
   case TypeReferenceKind::DirectTypeDescriptor:
   case TypeReferenceKind::IndirectTypeDescriptor: {
-    auto anyType = getTypeDescriptor();
-    if (auto type = dyn_cast<TypeContextDescriptor>(anyType)) {
-      if (!type->isGeneric()) {
-        if (auto accessFn = type->getAccessFunction())
-          return accessFn(MetadataState::Abstract).Value;
+    if (auto anyType = getTypeDescriptor()) {
+      if (auto type = dyn_cast<TypeContextDescriptor>(anyType)) {
+        if (!type->isGeneric()) {
+          if (auto accessFn = type->getAccessFunction())
+            return accessFn(MetadataState::Abstract).Value;
+        }
+      } else if (auto protocol = dyn_cast<ProtocolDescriptor>(anyType)) {
+        return _getSimpleProtocolTypeMetadata(protocol);
       }
-    } else if (auto protocol = dyn_cast<ProtocolDescriptor>(anyType)) {
-      return _getSimpleProtocolTypeMetadata(protocol);
     }
 
     return nullptr;

--- a/stdlib/toolchain/Compatibility50/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility50/ProtocolConformance.cpp
@@ -20,9 +20,21 @@
 #include "Overrides.h"
 #include "../../public/runtime/Private.h"
 #include "swift/Basic/Lazy.h"
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
 #include <objc/runtime.h>
 
 using namespace swift;
+
+#if __POINTER_WIDTH__ == 64
+using mach_header_platform = mach_header_64;
+#else
+using mach_header_platform = mach_header;
+#endif
+
+/// The Mach-O section name for the section containing protocol conformances.
+/// This lives within SEG_TEXT.
+constexpr const char ProtocolConformancesSection[] = "__swift5_proto";
 
 // Clone of private function getRootSuperclass. This returns the SwiftObject
 // class in the ABI-stable dylib, regardless of what the local runtime build
@@ -31,6 +43,50 @@ __attribute__((visibility("hidden"), weak))
 const ClassMetadata *swift::getRootSuperclass() {
   auto theClass = SWIFT_LAZY_CONSTANT(objc_getClass("_TtCs12_SwiftObject"));
   return (const ClassMetadata *)theClass;
+}
+
+// A dummy target context descriptor to use in conformance records which point
+// to a NULL descriptor. It doesn't have to be completely valid, just something
+// that code reading conformance descriptors will ignore.
+struct {
+  ContextDescriptorFlags flags;
+  int32_t offset;
+} DummyTargetContextDescriptor = {
+  ContextDescriptorFlags().withKind(ContextDescriptorKind::Extension),
+  0
+};
+
+// Search for any protocol conformance descriptors with a NULL type descriptor
+// and rewrite those to point to the dummy descriptor. This occurs when an
+// extension is used to declare a conformance on a weakly linked type and that
+// type is not present at runtime.
+static void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
+  unsigned long size;
+  const uint8_t *section =
+    getsectiondata(reinterpret_cast<const mach_header_platform *>(mh),
+                   SEG_TEXT, ProtocolConformancesSection,
+                   &size);
+  if (!section)
+    return;
+
+  auto recordsBegin
+    = reinterpret_cast<const ProtocolConformanceRecord*>(section);
+  auto recordsEnd
+    = reinterpret_cast<const ProtocolConformanceRecord*>
+                                          (section + size);
+  for (auto record = recordsBegin; record != recordsEnd; record++) {
+    auto descriptor = record->get();
+    if (auto typePtr = descriptor->_getTypeDescriptorLocation()) {
+      if (*typePtr == nullptr)
+        *typePtr = reinterpret_cast<TargetContextDescriptor<InProcess> *>(
+          &DummyTargetContextDescriptor);
+    }
+  }
+}
+
+// Register the add image callback with dyld.
+static void registerAddImageCallback(void *) {
+  _dyld_register_func_for_add_image(addImageCallback);
 }
 
 // Clone of private helper swift::_swiftoverride_class_getSuperclass
@@ -56,6 +112,10 @@ swift::swift50override_conformsToProtocol(const Metadata *type,
   const ProtocolDescriptor *protocol,
   ConformsToProtocol_t *original_conformsToProtocol)
 {
+  // Register our add image callback if necessary.
+  static OnceToken_t token;
+  SWIFT_ONCE_F(token, registerAddImageCallback, nullptr);
+
   // The implementation of swift_conformsToProtocol in Swift 5.0 would return
   // a false negative answer when asking whether a subclass conforms using
   // a conformance from a superclass. Work around this by walking up the

--- a/test/Interpreter/Inputs/FakeUnavailableSwiftDylib.swift
+++ b/test/Interpreter/Inputs/FakeUnavailableSwiftDylib.swift
@@ -1,0 +1,9 @@
+@available(OSX 1066.0, iOS 1066.0, watchOS 1066.0, tvOS 1066.0, *)
+public protocol UnavailableSwiftProtocol {
+  func someMethod()
+}
+
+@available(OSX 1066.0, iOS 1066.0, watchOS 1066.0, tvOS 1066.0, *)
+public class UnavailableSwiftClass {
+  func someMethod() {}
+}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/26638 to 5.1.

An extension on a class creates a conformance record that's always visible even when that class is not present at runtime. In that case, the type pointer in the conformance record is NULL. The runtime did not like this, and crashed. This fixes it to ignore such records instead.

For back deployment to Swift 5.0, the swiftCompatibility50 library is extended to find conformance records with NULL type pointers and rewrite those pointers to point to a dummy type that will be ignored by the runtime.

rdar://problem/54054895