### PR TITLE
[Build System: build-script-impl] Ignore swift-api-dump.py and swift_build_sdk_interfaces.py when running dsymutil on executables and shared libraries.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3880,8 +3880,7 @@ for host in "${ALL_HOSTS[@]}"; do
             # Exclude shell scripts and static archives.
             (cd "${INSTALL_SYMROOT}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
-               grep -v crashlog.py | \
-               grep -v symbolication.py | \
+               grep -v '.py$' | \
                grep -v '.a$' | \
                xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
 


### PR DESCRIPTION
Related to #26644.