### PR TITLE
Fix compiler crasher on type alias with a cycle in the constraints

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr11052-typealias.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11052-typealias.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol ProtoA {
+    associatedtype AType1
+}
+
+protocol ProtoB {
+    associatedtype AType2: ProtoA
+    func protoFunc() -> AType2.AType1
+}
+
+extension ProtoB {
+    typealias Alias = AType2.AType1
+}
+
+struct Concrete<AType2: ProtoA>: ProtoB {
+
+    func concreteFunc() -> Alias {
+        fatalError()
+    }
+
+    func protoFunc() -> Alias { // expected-error{{unsupported recursion for reference to type alias 'Alias' of type 'Concrete<AType2>'}}
+        fatalError()
+    }
+}


### PR DESCRIPTION
Fix a compiler crash and display an error when in a cycle on validateDecl and associated type inference. We might be able to break the actual cycle with our work on validateDecl.

rdar://problem/52463696
SR-11052