### PR TITLE
 [Experiment] Turn on one-way constraints within function builders by default

### DIFF
--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -166,6 +166,11 @@ FRONTEND_STATISTIC(Sema, NumLeafScopes)
 /// This is a measure of complexity of the contraction algorithm.
 FRONTEND_STATISTIC(Sema, NumConstraintsConsideredForEdgeContraction)
 
+/// Number of constraint-solving scopes created in the typechecker, while
+/// solving expression type constraints. A rough proxy for "how much work the
+/// expression typechecker did".
+FRONTEND_STATISTIC(Sema, NumCyclicOneWayComponentsCollapsed)
+
 /// Number of declarations that were deserialized. A rough proxy for the amount
 /// of material loaded from other modules.
 FRONTEND_STATISTIC(Sema, NumDeclsDeserialized)

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -440,8 +440,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.getLastArg(OPT_solver_disable_shrink))
     Opts.SolverDisableShrink = true;
-  if (Args.getLastArg(OPT_enable_function_builder_one_way_constraints))
-    Opts.FunctionBuilderOneWayConstraints = true;
+
+  // EXPERIMENTAL: Turn on by default
+  Opts.FunctionBuilderOneWayConstraints = true;
 
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -723,6 +723,26 @@ namespace {
     }
 
   private:
+    /// Perform the union of two type variables in a union-find data structure
+    /// used for connected components.
+    ///
+    /// \returns true if the two components were separate and have now been
+    /// joined, \c false if they were already in the same set.
+    bool unionSets(TypeVariableType *typeVar1, TypeVariableType *typeVar2) {
+      auto rep1 = findRepresentative(typeVar1);
+      auto rep2 = findRepresentative(typeVar2);
+      if (rep1 == rep2)
+        return false;
+
+      // Reparent the type variable with the higher ID. The actual choice doesn't
+      // matter, but this makes debugging easier.
+      if (rep1->getID() < rep2->getID())
+        representatives[rep2] = rep1;
+      else
+        representatives[rep1] = rep2;
+      return true;
+    }
+
     /// Perform the connected components algorithm, skipping one-way
     /// constraints.
     ///
@@ -773,24 +793,24 @@ namespace {
         vector.push_back(typeVar);
     }
 
-    /// Build the directed graph of one-way constraints among components.
-    void buildOneWayConstraintGraph(ArrayRef<Constraint *> oneWayConstraints)  {
-      /// Retrieve the set of representatives for the type variables that
-      /// occur within the given type.
-      auto getRepresentativesInType = [&](Type type) {
-        TinyPtrVector<TypeVariableType *> results;
+    /// Retrieve the (uniqued) set of type variable representations that occur
+    /// within the given type.
+    TinyPtrVector<TypeVariableType *>
+    getRepresentativesInType(Type type) const {
+      TinyPtrVector<TypeVariableType *> results;
 
-        SmallVector<TypeVariableType *, 2> typeVars;
-        type->getTypeVariables(typeVars);
-        for (auto typeVar : typeVars) {
-          auto rep = findRepresentative(typeVar);
-          insertIfUnique(results, rep);
-        }
+      SmallVector<TypeVariableType *, 2> typeVars;
+      type->getTypeVariables(typeVars);
+      for (auto typeVar : typeVars) {
+        auto rep = findRepresentative(typeVar);
+        insertIfUnique(results, rep);
+      }
 
-        return results;
-      };
+      return results;
+    }
 
-      // Add all of the one-way constraint edges to the digraph.
+    /// Add all of the one-way constraints to the one-way digraph
+    void addOneWayConstraintEdges(ArrayRef<Constraint *> oneWayConstraints) {
       for (auto constraint : oneWayConstraints) {
         auto lhsTypeReps =
             getRepresentativesInType(constraint->getFirstType());
@@ -803,14 +823,56 @@ namespace {
         // be solved before the left-hand type variables.
         for (auto lhsTypeRep : lhsTypeReps) {
           for (auto rhsTypeRep : rhsTypeReps) {
+            if (lhsTypeRep == rhsTypeRep)
+              break;
+
             insertIfUnique(oneWayDigraph[rhsTypeRep].outAdjacencies,lhsTypeRep);
             insertIfUnique(oneWayDigraph[lhsTypeRep].inAdjacencies,rhsTypeRep);
           }
         }
       }
+    }
 
-      // Minimize the in-adjacencies.
-      removeIndirectOneWayInAdjacencies();
+    using TypeVariablePair = std::pair<TypeVariableType *, TypeVariableType *>;
+
+    /// Build the directed graph of one-way constraints among components.
+    void buildOneWayConstraintGraph(ArrayRef<Constraint *> oneWayConstraints) {
+      auto &cs = cg.getConstraintSystem();
+      auto &ctx = cs.getASTContext();
+      bool contractedCycle = false;
+      do {
+        // Construct the one-way digraph from scratch.
+        oneWayDigraph.clear();
+        addOneWayConstraintEdges(oneWayConstraints);
+
+        // Minimize the in-adjacencies, detecting cycles along the way.
+        SmallVector<TypeVariablePair, 4> cycleEdges;
+        removeIndirectOneWayInAdjacencies(cycleEdges);
+
+        // For any contractions we need to perform due to cycles, perform a
+        // union the connected components based on the type variable pairs.
+        contractedCycle = false;
+        for (const auto &edge : cycleEdges) {
+          if (unionSets(edge.first, edge.second)) {
+            if (ctx.LangOpts.DebugConstraintSolver) {
+              auto &log = ctx.TypeCheckerDebug->getStream();
+              if (cs.solverState)
+                log.indent(cs.solverState->depth * 2);
+
+              log << "Collapsing one-way components for $T"
+                  << edge.first->getID() << " and $T" << edge.second->getID()
+                  << " due to cycle.\n";
+            }
+
+            if (ctx.Stats) {
+              ctx.Stats->getFrontendCounters()
+                  .NumCyclicOneWayComponentsCollapsed++;
+            }
+
+            contractedCycle = true;
+          }
+        }
+      } while (contractedCycle);
     }
 
     /// Perform a depth-first search to produce a from the given type variable,
@@ -845,14 +907,17 @@ namespace {
     /// Minimize the incoming adjacencies for one of the nodes in the one-way
     /// directed graph by eliminating any in-adjacencies that can also be
     /// found indirectly.
-    void removeIndirectOneWayInAdjacencies(TypeVariableType *typeVar,
-                                           OneWayComponent &component) {
+    void removeIndirectOneWayInAdjacencies(
+        TypeVariableType *typeVar,
+        OneWayComponent &component,
+        SmallVectorImpl<TypeVariablePair> &cycleEdges) {
       // Perform a depth-first search from each of the in adjacencies to
       // this type variable, traversing each of the one-way edges backwards
       // to find all of the components whose type variables must be
       // bound before this component can be solved.
       SmallPtrSet<TypeVariableType *, 4> visited;
       SmallPtrSet<TypeVariableType *, 4> indirectlyReachable;
+      SmallVector<TypeVariableType *, 4> currentPath;
       for (auto inAdj : component.inAdjacencies) {
         postorderDepthFirstSearchRec(
             inAdj,
@@ -866,9 +931,30 @@ namespace {
               return oneWayComponent->second.inAdjacencies;
             },
             [&](TypeVariableType *typeVar) {
-              return visited.insert(typeVar).second;
+              // If we haven't seen this type variable yet, add it to the
+              // path.
+              if (visited.insert(typeVar).second) {
+                currentPath.push_back(typeVar);
+                return true;
+              }
+
+              // Add edges between this type variable and every other type
+              // variable in the path.
+              for (auto otherTypeVar : reversed(currentPath)) {
+                // When we run into our own type variable, we're done.
+                if (otherTypeVar == typeVar)
+                  break;
+
+                cycleEdges.push_back({typeVar, otherTypeVar});
+              }
+
+              return false;
             },
             [&](TypeVariableType *dependsOn) {
+              // Remove this type variable from the path.
+              assert(currentPath.back() == dependsOn);
+              currentPath.pop_back();
+
               // Don't record dependency on ourselves.
               if (dependsOn == inAdj)
                 return;
@@ -891,11 +977,12 @@ namespace {
     /// Minimize the incoming adjacencies for all of the nodes in the one-way
     /// directed graph by eliminating any in-adjacencies that can also be
     /// found indirectly.
-    void removeIndirectOneWayInAdjacencies()  {
+    void removeIndirectOneWayInAdjacencies(
+        SmallVectorImpl<TypeVariablePair> &cycleEdges)  {
       for (auto &oneWayEntry : oneWayDigraph) {
         auto typeVar = oneWayEntry.first;
         auto &component = oneWayEntry.second;
-        removeIndirectOneWayInAdjacencies(typeVar, component);
+        removeIndirectOneWayInAdjacencies(typeVar, component, cycleEdges);
       }
     }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1211,6 +1211,8 @@ void ConstraintGraph::printConnectedComponents(
 }
 
 void ConstraintGraph::dumpConnectedComponents() {
+  llvm::SaveAndRestore<bool>
+    debug(CS.getASTContext().LangOpts.DebugConstraintSolver, true);
   printConnectedComponents(CS.TypeVariables, llvm::dbgs());
 }
 

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -8,6 +8,10 @@ enum Either<T,U> {
 
 @_functionBuilder
 struct TupleBuilder {
+  static func buildBlock<T1>(_ t1: T1) -> T1 {
+    return t1
+  }
+
   static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
     return (t1, t2)
   }
@@ -44,16 +48,18 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 }
 
 // CHECK: ---Connected components---
-// CHECK-NEXT:  0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T61 depends on 1
-// CHECK-NEXT:  1: $T9 $T11 $T13 $T16 $T30 $T54 $T55 $T56 $T57 $T58 $T59 $T60 depends on 2, 3, 4, 5, 6
-// CHECK-NEXT:  6: $T31 $T32 $T34 $T35 $T36 $T47 $T48 $T49 $T50 $T51 $T52 $T53 depends on 7
-// CHECK-NEXT:  7: $T37 $T39 $T43 $T44 $T45 $T46 depends on 8, 9
-// CHECK-NEXT:  9: $T40 $T41 $T42
-// CHECK-NEXT:  8: $T38
-// CHECK-NEXT:  5: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
-// CHECK-NEXT:  4: $T14 $T15
-// CHECK-NEXT:  3: $T12
-// CHECK-NEXT:  2: $T10
+// CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T69 depends on 1
+// CHECK-NEXT: 1: $T9 $T11 $T13 $T16 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5, 6
+// CHECK-NEXT: 6: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 7, 10
+// CHECK-NEXT: 10: $T48 $T54 $T55 $T56 depends on 11
+// CHECK-NEXT: 11: $T49 $T50 $T51 $T52 $T53
+// CHECK-NEXT: 7: $T33 $T35 $T39 $T40 $T41 $T42 depends on 8, 9
+// CHECK-NEXT: 9: $T36 $T37 $T38
+// CHECK-NEXT: 8: $T34
+// CHECK-NEXT: 5: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
+// CHECK-NEXT: 4: $T14 $T15
+// CHECK-NEXT: 3: $T12
+// CHECK-NEXT: 2: $T10
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
 print(
@@ -67,5 +73,7 @@ print(
     if b {
       2.71828
       ["if", "stmt"]
+    } else {
+      [1, 2, 3, 4]
     }
   })


### PR DESCRIPTION
An experiment in turning on one-way constraints by default for function builders. This is not to be merged as-is. The functionality changes we want are in https://github.com/apple/swift/pull/26654