### PR TITLE
Adjust for svn r368826

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -383,8 +383,13 @@ static bool needsRecompile(StringRef OutputFilename, ArrayRef<uint8_t> HashData,
 
   // Search for the section which holds the hash.
   for (auto &Section : ObjectFile->sections()) {
-    StringRef SectionName;
-    Section.getName(SectionName);
+    llvm::Expected<StringRef> SectionNameOrErr = Section.getName();
+    if (!SectionNameOrErr) {
+      llvm::consumeError(SectionNameOrErr.takeError());
+      continue;
+    }
+
+    StringRef SectionName = *SectionNameOrErr;
     if (SectionName == HashSectionName) {
       llvm::Expected<llvm::StringRef> SectionData = Section.getContents();
       if (!SectionData) {

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -114,8 +114,12 @@ extractLinkerFlagsFromObjectFile(const llvm::object::ObjectFile *ObjectFile,
                                  CompilerInstance &Instance) {
   // Search for the section we hold autolink entries in
   for (auto &Section : ObjectFile->sections()) {
-    llvm::StringRef SectionName;
-    Section.getName(SectionName);
+    llvm::Expected<llvm::StringRef> SectionNameOrErr = Section.getName();
+    if (!SectionNameOrErr) {
+      llvm::consumeError(SectionNameOrErr.takeError());
+      continue;
+    }
+    llvm::StringRef SectionName = *SectionNameOrErr;
     if (SectionName == ".swift1_autolink_entries") {
       llvm::Expected<llvm::StringRef> SectionData = Section.getContents();
       if (!SectionData) {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -167,8 +167,12 @@ collectASTModules(llvm::cl::list<std::string> &InputNames,
     }
 
     for (auto &Section : Obj->sections()) {
-      llvm::StringRef Name;
-      Section.getName(Name);
+      llvm::Expected<llvm::StringRef> NameOrErr = Section.getName();
+      if (!NameOrErr) {
+        llvm::consumeError(NameOrErr.takeError());
+        continue;
+      }
+      llvm::StringRef Name = *NameOrErr;
       if ((MachO && Name == swift::MachOASTSectionName) ||
           (ELF && Name == swift::ELFASTSectionName) ||
           (COFF && Name == swift::COFFASTSectionName)) {

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -112,10 +112,12 @@ static bool needToRelocate(SectionRef S) {
       "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
       "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
     };
-    StringRef Name;
-    if (auto EC = S.getName(Name))
-      reportError(EC);
-    return ELFSectionsList.count(Name);
+    llvm::Expected<llvm::StringRef> NameOrErr = S.getName();
+    if (!NameOrErr) {
+      reportError(errorToErrorCode(NameOrErr.takeError()));
+      return false;
+    }
+    return ELFSectionsList.count(*NameOrErr);
   }
 
   return true;


### PR DESCRIPTION
LLVM svn r368826 changed the SectionRef::getName() interface to return an
Expected<StringRef> instead of filling out one that is passed to it.
Adjust accordingly.

cc @compnerd @shahmishal 