### PR TITLE
Advance commit ids of tensorflow and swift-apis.

### DIFF
--- a/stdlib/public/CTensorFlow/ctensorflow_init.cpp
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.cpp
@@ -167,17 +167,4 @@ void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
   return tensor;
 }
 
-void TFE_InferShapes_Transition(
-  TFE_Op* op, TF_ShapeAndTypeList* input_shapes,
-  TF_Tensor** input_tensors,
-  TF_ShapeAndTypeList* input_tensor_as_shapes,
-  TF_ShapeAndTypeList** input_resource_shapes_and_types,
-  TF_ShapeAndTypeList** output_shapes,
-  TF_ShapeAndTypeList*** output_resource_shapes_and_types, TF_Status* status) {
-  TFE_InferShapes(op, input_shapes, input_tensors, /* num_tensors*/ 0,
-                  input_tensor_as_shapes, input_resource_shapes_and_types,
-                  output_shapes, output_resource_shapes_and_types, status);
-}
-
-
 }  // extern "C"

--- a/stdlib/public/CTensorFlow/ctensorflow_init.h
+++ b/stdlib/public/CTensorFlow/ctensorflow_init.h
@@ -41,21 +41,6 @@ void *swift_tfc_CreateFloatTensor(int32_t num_dims, int64_t *dims, float *vals,
 void *swift_tfc_CreateScalarStringTensor(char *val, int32_t valLen,
                                          TF_Status *status);
 
-struct TF_Tensor;
-struct TF_ShapeAndTypeList;
-struct TFE_Op;
-
-// We removed a redundant argument in the C shape inference API.
-// This interface function lets us migrate swift-apis without breakages.
-// (This is a temporary function and will be removed.)
-void TFE_InferShapes_Transition(
-  TFE_Op* op, TF_ShapeAndTypeList* input_shapes,
-  TF_Tensor** input_tensors,
-  TF_ShapeAndTypeList* input_tensor_as_shapes,
-  TF_ShapeAndTypeList** input_resource_shapes_and_types,
-  TF_ShapeAndTypeList** output_shapes,
-  TF_ShapeAndTypeList*** output_resource_shapes_and_types, TF_Status* status);
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -455,8 +455,8 @@
                 "icu": "release-61-1",
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
-                "tensorflow": "fee0b38d6a2ce3e480c8b6643efe466b889036fa",
-                "tensorflow-swift-apis": "085217d35c02e07214f3ac99aab2ed0507cfc803",
+                "tensorflow": "c6719f20911f8aa6b6d9cded1c0f7761cb9c69a0",
+                "tensorflow-swift-apis": "8258171504d505c3fef99641213eeea2d1ba67fa",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a"
             }


### PR DESCRIPTION
this also cleans up the temporary `TFE_InferShapes_Transition` API.