### PR TITLE
Weak/unowned property validation cleanup

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -374,7 +374,8 @@ private:
 class CanType : public Type {
   bool isActuallyCanonicalOrNull() const;
 
-  static bool isReferenceTypeImpl(CanType type, bool functionsCount);
+  static bool isReferenceTypeImpl(CanType type, GenericSignature *sig,
+                                  bool functionsCount);
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
@@ -408,8 +409,26 @@ public:
   // Provide a few optimized accessors that are really type-class queries.
 
   /// Do values of this type have reference semantics?
+  ///
+  /// This includes isAnyClassReferenceType(), as well as function types.
   bool hasReferenceSemantics() const {
-    return isReferenceTypeImpl(*this, /*functions count*/ true);
+    return isReferenceTypeImpl(*this,
+                               /*signature*/ nullptr,
+                               /*functions count*/ true);
+  }
+
+  /// Are variables of this type permitted to have
+  /// ownership attributes?
+  ///
+  /// This includes:
+  ///   - class types, generic or not
+  ///   - archetypes with class or class protocol bounds
+  ///   - existentials with class or class protocol bounds
+  /// But not:
+  ///   - function types
+  bool allowsOwnership(GenericSignature *sig) const {
+    return isReferenceTypeImpl(*this, sig,
+                               /*functions count*/ false);
   }
 
   /// Are values of this type essentially just class references,
@@ -419,10 +438,13 @@ public:
   ///   - a class type
   ///   - a bound generic class type
   ///   - a class-bounded archetype type
+  ///   - a class-bounded type parameter
   ///   - a class-bounded existential type
   ///   - a dynamic Self type
   bool isAnyClassReferenceType() const {
-    return isReferenceTypeImpl(*this, /*functions count*/ false);
+    return isReferenceTypeImpl(*this,
+                               /*signature*/ nullptr,
+                               /*functions count*/ false);
   }
 
   /// Is this type existential?

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -541,7 +541,7 @@ public:
   
   /// allowsOwnership() - Are variables of this type permitted to have
   /// ownership attributes?
-  bool allowsOwnership();  
+  bool allowsOwnership(GenericSignature *sig=nullptr);
 
   /// Determine whether this type involves a type variable.
   bool hasTypeVariable() const {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -251,12 +251,6 @@ static void validatePatternBindingEntry(TypeChecker &tc,
                                                    ? Property : GlobalVariable);
     }
   }
-
-  // If we have any type-adjusting attributes, apply them here.
-  assert(binding->getPattern(entryNumber)->hasType() && "Type missing?");
-  if (auto var = binding->getSingleVar()) {
-    tc.checkTypeModifyingDeclAttributes(var);
-  }
 }
 
 /// Validate the entries in the given pattern binding declaration.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -989,9 +989,9 @@ public:
   void checkParameterAttributes(ParameterList *params);
   void checkDynamicReplacementAttribute(ValueDecl *D);
   static ValueDecl *findReplacedDynamicFunction(const ValueDecl *d);
-  void checkTypeModifyingDeclAttributes(VarDecl *var);
 
-  void checkReferenceOwnershipAttr(VarDecl *D, ReferenceOwnershipAttr *attr);
+  Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,
+                                   ReferenceOwnershipAttr *attr);
 
   /// Check the default arguments that occur within this value decl.
   void checkDefaultArguments(ParameterList *params, ValueDecl *VD);


### PR DESCRIPTION
Don't change the interface type from checkDeclAttributes() -- instead, return the modified type from TypeChecker::checkReferenceOwnershipAttr(), which will make it easier to request-ify in the future.

Note that TypeChecker::checkReferenceOwnershipAttr() is still in TypeCheckAttr.cpp, which no longer makes sense. I'm going to move it to it's final home once I land some more refactorings in this area.