### PR TITLE
[Sema] Setter has incorrect mutating-ness inside class-constrained protocol extension

### DIFF
--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -124,3 +124,23 @@ struct WrapperContext {
     static let propUsingMember = originalValue
   }
 }
+
+// SR-11298
+
+protocol SR_11298_P {}
+
+class SR_11298_C: SR_11298_P {
+  var property: String = ""
+}
+
+// Self: SR_11298_C requirement constrains this extension to SR_11298C and its subclasses.
+// Since this implies a class constraint, the setter should be implicitly nonmutating.
+extension SR_11298_P where Self: SR_11298_C {
+  var wrappingProperty: String {
+    get { return property }
+    set { property = newValue }
+  }
+}
+
+let instance = SR_11298_C()
+instance.wrappingProperty = "" // Okay


### PR DESCRIPTION
If we have a class-constrained protocol extension, where the protocol does not impose a class requirement, then the setter is incorrectly inferred to be mutating by default.

Resolves [SR-11298](https://bugs.swift.org/browse/SR-11298).