### PR TITLE
[IRGen] Fix undefined behaviour when emitting metadata.

### DIFF
--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -663,7 +663,7 @@ private:
   llvm::Value *LocalSelf = nullptr;
   /// If set, the dynamic Self type is assumed to be equivalent to this exact class.
   CanType LocalSelfType;
-  bool LocalSelfIsExact;
+  bool LocalSelfIsExact = false;
   LocalSelfKind SelfKind;
 };
 


### PR DESCRIPTION
MetadataRequest.cpp:2383:7: runtime error: load of value 40,
which is not a valid value for type 'bool'.