### PR TITLE
[Diagnostics] Correctly identify location of requirement failure

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -304,31 +304,12 @@ protected:
     if (isConditional())
       return true;
 
-    auto *anchor = getAnchor();
-    // In the situations like this:
-    //
-    // ```swift
-    // enum E<T: P> { case foo(T) }
-    // let _: E = .foo(...)
-    // ```
-    //
-    // `E` is going to be opened twice. First, when
-    // it's used as a contextual type, and when `E.foo`
-    // is found and its function type is opened.
-    // We still want to record both fixes but should
-    // avoid diagnosing the same problem multiple times.
-    if (isa<UnresolvedMemberExpr>(anchor)) {
-      auto path = getLocator()->getPath();
-      if (path.front().getKind() != ConstraintLocator::UnresolvedMember)
-        return false;
-    }
-
     // For static/initializer calls there is going to be
     // a separate fix, attached to the argument, which is
     // much easier to diagnose.
     // For operator calls we can't currently produce a good
     // diagnostic, so instead let's refer to expression diagnostics.
-    return !(Apply && (isOperator(Apply) || isa<TypeExpr>(anchor)));
+    return !(Apply && isOperator(Apply));
   }
 
   static bool isOperator(const ApplyExpr *apply) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -455,6 +455,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numSavedBindings = cs.solverState->savedBindings.size();
   numConstraintRestrictions = cs.ConstraintRestrictions.size();
   numFixes = cs.Fixes.size();
+  numFixedRequirements = cs.FixedRequirements.size();
   numDisjunctionChoices = cs.DisjunctionChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
@@ -506,6 +507,10 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any opened types.
   truncate(cs.OpenedTypes, numOpenedTypes);
+
+  // Remove any conformances solver had to fix along
+  // the current path.
+  truncate(cs.FixedRequirements, numFixedRequirements);
 
   // Remove any opened existential types.
   truncate(cs.OpenedExistentialTypes, numOpenedExistentialTypes);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -126,33 +126,6 @@ void ConstraintSystem::mergeEquivalenceClasses(TypeVariableType *typeVar1,
   // Merge nodes in the constraint graph.
   CG.mergeNodes(typeVar1, typeVar2);
 
-  // Let's try to de-duplicate any generic requirements
-  // associated with given type variable, if it represents
-  // a generic parameter.
-  if (typeVar1->getImpl().getGenericParameter()) {
-    auto requirements = CG.gatherConstraints(
-        typeVar1, ConstraintGraph::GatheringKind::EquivalenceClass,
-        [](Constraint *constraint) -> bool {
-          if (auto *locator = constraint->getLocator()) {
-            return locator->isLastElement(
-                       ConstraintLocator::TypeParameterRequirement) ||
-                   locator->isLastElement(
-                       ConstraintLocator::ConditionalRequirement);
-          }
-
-          return false;
-        });
-
-    llvm::SmallPtrSet<TypeBase *, 4> existingRequirements;
-    for (auto *req : requirements) {
-      auto constraintTy = req->getSecondType();
-      // If this constraint has already been recorded in the
-      // constraint system, there is no reason to check it twice.
-      if (!existingRequirements.insert(constraintTy.getPointer()).second)
-        retireConstraint(req);
-    }
-  }
-
   if (updateWorkList) {
     addTypeVariableConstraintsToWorkList(typeVar1);
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -126,6 +126,33 @@ void ConstraintSystem::mergeEquivalenceClasses(TypeVariableType *typeVar1,
   // Merge nodes in the constraint graph.
   CG.mergeNodes(typeVar1, typeVar2);
 
+  // Let's try to de-duplicate any generic requirements
+  // associated with given type variable, if it represents
+  // a generic parameter.
+  if (typeVar1->getImpl().getGenericParameter()) {
+    auto requirements = CG.gatherConstraints(
+        typeVar1, ConstraintGraph::GatheringKind::EquivalenceClass,
+        [](Constraint *constraint) -> bool {
+          if (auto *locator = constraint->getLocator()) {
+            return locator->isLastElement(
+                       ConstraintLocator::TypeParameterRequirement) ||
+                   locator->isLastElement(
+                       ConstraintLocator::ConditionalRequirement);
+          }
+
+          return false;
+        });
+
+    llvm::SmallPtrSet<TypeBase *, 4> existingRequirements;
+    for (auto *req : requirements) {
+      auto constraintTy = req->getSecondType();
+      // If this constraint has already been recorded in the
+      // constraint system, there is no reason to check it twice.
+      if (!existingRequirements.insert(constraintTy.getPointer()).second)
+        retireConstraint(req);
+    }
+  }
+
   if (updateWorkList) {
     addTypeVariableConstraintsToWorkList(typeVar1);
   }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -637,8 +637,6 @@ public:
   /// The list of member references which couldn't be resolved,
   /// and had to be assumed based on their use.
   llvm::SmallVector<ConstraintLocator *, 4> MissingMembers;
-  llvm::SmallVector<std::pair<GenericSignature *, unsigned>, 4>
-      FixedRequirements;
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -335,14 +335,14 @@ func testFixIts() {
   _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
   _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
-  _ = ClassAndProtoBound() // expected-error {{referencing initializer 'init()' on 'ClassAndProtoBound' requires that 'X' conform to 'SubProto'}}
+  _ = ClassAndProtoBound() // expected-error {{generic struct 'ClassAndProtoBound' requires that 'X' conform to 'SubProto'}}
 
-  _ = ClassAndProtosBound() 
-  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'NSCopyish'}}
-  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'SubProto'}}
+  _ = ClassAndProtosBound()
+  // expected-error@-1 {{generic struct 'ClassAndProtosBound' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-2 {{generic struct 'ClassAndProtosBound' requires that 'X' conform to 'NSCopyish'}}
   _ = ClassAndProtosBound2()
-  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'NSCopyish'}}
-  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-1 {{generic struct 'ClassAndProtosBound2' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-2 {{generic struct 'ClassAndProtosBound2' requires that 'X' conform to 'NSCopyish'}}
 
   _ = Pair()
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
@@ -631,7 +631,7 @@ func rdar40537858() {
   }
 
   var arr: [S] = []
-  _ = List(arr, id: \.id) // expected-error {{referencing initializer 'init(_:id:)' on 'List' requires that 'S.Id' conform to 'Hashable'}}
+  _ = List(arr, id: \.id) // expected-error {{generic struct 'List' requires that 'S.Id' conform to 'Hashable'}}
 
   enum E<T: P> { // expected-note 2 {{where 'T' = 'S'}}
     case foo(T)
@@ -639,8 +639,8 @@ func rdar40537858() {
   }
 
   var s = S(id: S.Id())
-  let _: E = .foo(s)   // expected-error {{enum case 'foo' requires that 'S' conform to 'P'}}
-  let _: E = .bar([s]) // expected-error {{enum case 'bar' requires that 'S' conform to 'P'}}
+  let _: E = .foo(s)   // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
+  let _: E = .bar([s]) // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
 }
 
 // https://bugs.swift.org/browse/SR-8934
@@ -797,4 +797,21 @@ struct R_51413254 {
   mutating func test(_ anyDict: Any) throws {
     self.str = try anyDict ==> Key("a") // Ok
   }
+}
+
+func test_correct_identification_of_requirement_source() {
+  struct X<T: P> { // expected-note {{where 'T' = 'Int'}}
+    init<U: P>(_: T, _: U) {} // expected-note {{where 'U' = 'Int'}}
+  }
+
+  struct A : P {
+    static func foo(_ arg: A) -> A {
+      return A()
+    }
+  }
+
+  _ = X(17, A())
+  // expected-error@-1 {{generic struct 'X' requires that 'Int' conform to 'P'}}
+  _ = X(A(), 17)
+  // expected-error@-1 {{initializer 'init(_:_:)' requires that 'Int' conform to 'P'}}
 }

--- a/test/Constraints/rdar44569159.swift
+++ b/test/Constraints/rdar44569159.swift
@@ -6,13 +6,12 @@ struct S<V> where V: P { // expected-note {{where 'V' = 'Double'}}
 }
 
 struct A {
-  subscript<T>(_ v: S<T>) -> A { // expected-note {{where 'T' = 'Double'}}
+  subscript<T>(_ v: S<T>) -> A {
     fatalError()
   }
 }
 
 func foo(_ v: Double) {
   _ = A()[S(value: v)]
-// expected-error@-1 {{subscript 'subscript(_:)' requires that 'Double' conform to 'P'}}
-// expected-error@-2 {{referencing initializer 'init(value:)' on 'S' requires that 'Double' conform to 'P'}}
+ // expected-error@-1 {{generic struct 'S' requires that 'Double' conform to 'P'}}
 }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -94,6 +94,8 @@ class sr7440_Genre {
     return sr7440_Genre.fetch(genreID: iTunesGenre.genreID, name: iTunesGenre.name)
 // expected-error@-1 {{value of type 'sr7440_ITunesGenre' has no member 'genreID'; did you mean 'genre'?}}
 // expected-error@-2 {{cannot convert return expression of type '()' to return type 'sr7440_Genre'}}
+// expected-error@-3 {{protocol type 'Any' cannot conform to 'BinaryInteger' because only concrete types can conform to protocols}}
+// TODO(diagnostics): Last diagnostic should not be recorded but to be able to correctly handle it we need a notion of a "hole" in constraint system.
   }
 }
 

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -405,7 +405,7 @@ func test() {
   // expected-error@-1 {{generic parameter 'A' could not be inferred}}
   _ = Claws.Fangs<NotADog>()
   // expected-error@-1 {{generic parameter 'A' could not be inferred}}
-  // expected-error@-2 {{referencing initializer 'init()' on 'Claws.Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
+  // expected-error@-2 {{generic struct 'Fangs' requires that 'NotADog' conform to 'ExpressibleByDogLiteral'}}
   // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}} {{12-12=<<#A: ExpressibleByCatLiteral#>>}}
 }
 

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -4,9 +4,10 @@
 // to diagnose other errors in adjacent exprs.
 
 struct P<T: K> { }
+// expected-note@-1 {{arguments to generic parameter 'T' ('String' and '_') are expected to be equal}}
 
 struct S {
-    init<B>(_ a: P<B>) { // expected-note {{where 'B' = 'String'}}
+    init<B>(_ a: P<B>) {
         fatalError()
     }
 }
@@ -17,7 +18,7 @@ func + <Object>(lhs: KeyPath<A, Object>, rhs: String) -> P<Object> {
     fatalError()
 }
 
-// expected-error@+1{{}}
+// expected-error@+1{{type 'String' does not conform to protocol 'K'}}
 func + (lhs: KeyPath<A, String>, rhs: String) -> P<String> {
     fatalError()
 }
@@ -27,7 +28,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{initializer 'init(_:)' requires that 'String' conform to 'K'}}
+    static let j = S(\A.id + "id") // expected-error {{cannot convert value of type 'P<String>' to expected argument type 'P<_>'}}
 }
 
 // SR-5034


### PR DESCRIPTION
Previously in situations like:

```swift
protocol P {}

struct S<T: P> {
  var value: T
}

_ = S(value: 42)
```

Diagnostic has reported a problem as related to "reference" to `init`
but the failing generic type requirement belongs to `S`, so a
better diagnostic in such case should mention `generic struct S`.

In order to do that we need to first de-duplicate generic type requirement 
checking since constraint system would record generic parameter multiple
times: 1. While resolving `S` and 2. When determining a type of constructor member.

And afterwards add special logic to `RequirementFailure` to determine where
generic signature came from.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
