### PR TITLE
Replace last uses of llvm::index_sequence_{,for}

### DIFF
--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -195,7 +195,7 @@ class SimpleRequest<Derived, Output(Inputs...), Caching> {
 
   template<size_t ...Indices>
   llvm::Expected<Output>
-  callDerived(Evaluator &evaluator, llvm::index_sequence<Indices...>) const {
+  callDerived(Evaluator &evaluator, std::index_sequence<Indices...>) const {
     static_assert(sizeof...(Indices) > 0, "Subclass must define evaluate()");
     return asDerived().evaluate(evaluator, std::get<Indices>(storage)...);
   }
@@ -217,7 +217,7 @@ public:
   static llvm::Expected<OutputType>
   evaluateRequest(const Derived &request, Evaluator &evaluator) {
     return request.callDerived(evaluator,
-                               llvm::index_sequence_for<Inputs...>());
+                               std::index_sequence_for<Inputs...>());
   }
 
   /// Retrieve the nearest source location to which this request applies.

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -310,7 +310,7 @@ namespace detail {
 struct GetOperandsFunctor {
   template <size_t... Idx>
   std::array<SILValue, sizeof...(Idx)>
-  operator()(SILInstruction *i, llvm::index_sequence<Idx...> seq) const {
+  operator()(SILInstruction *i, std::index_sequence<Idx...> seq) const {
     return {i->getOperand(Idx)...};
   }
 };
@@ -327,15 +327,15 @@ template <typename... MatcherTys> struct MatcherFunctor {
   template <size_t... Idx>
   std::array<bool, sizeof...(MatcherTys)>
   matchHelper(const std::array<SILValue, sizeof...(MatcherTys)> &operands,
-              llvm::index_sequence<Idx...> seq) {
+              std::index_sequence<Idx...> seq) {
     return {individual(std::get<Idx>(matchers), std::get<Idx>(operands))...};
   }
 
   bool match(SILInstruction *i) {
     std::array<SILValue, sizeof...(MatcherTys)> operands =
-        GetOperandsFunctor{}(i, llvm::index_sequence_for<MatcherTys...>{});
+        GetOperandsFunctor{}(i, std::index_sequence_for<MatcherTys...>{});
     auto tmpResult =
-        matchHelper(operands, llvm::index_sequence_for<MatcherTys...>{});
+        matchHelper(operands, std::index_sequence_for<MatcherTys...>{});
     for (unsigned i : indices(tmpResult)) {
       if (!tmpResult[i])
         return false;


### PR DESCRIPTION
After the next merge, swift will fail to compile because of a few straggling uses of llvm::index_sequence and llvm::index_sequence_for. Let's replace them with those available in c++.