### PR TITLE
[master-next] Revert to use of getOrInsertFunction api.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2198,11 +2198,13 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
   }
 
   // Get or create a shared helper function to do the instantiation.
-  auto *instantiationFnTy = llvm::FunctionType::get(IGF.IGM.TypeMetadataPtrTy,
-                                                    {cache->getType()}, false);
-  auto instantiationFn = llvm::Function::Create(
-      instantiationFnTy, llvm::Function::ExternalLinkage,
-      "__swift_instantiateConcreteTypeFromMangledName", IGM.getModule());
+  auto instantiationFn = cast<llvm::Function>(
+      IGM.getModule()
+          ->getOrInsertFunction(
+              "__swift_instantiateConcreteTypeFromMangledName",
+              IGF.IGM.TypeMetadataPtrTy, cache->getType())
+          .getCallee()
+          ->stripPointerCasts());
   if (instantiationFn->empty()) {
     ApplyIRLinkage(IRLinkage::InternalLinkOnceODR)
       .to(instantiationFn);


### PR DESCRIPTION
We really want to get the function if it already exists not create new
ones.