### PR TITLE
Move ClangImporter::loadModuleClang() into ClangImporter::Implementation

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -93,8 +93,6 @@ private:
                 DependencyTracker *tracker,
                 std::unique_ptr<DWARFImporterDelegate> dwarfImporterDelegate);
 
-  ModuleDecl *loadModuleClang(SourceLoc importLoc,
-                              ArrayRef<std::pair<Identifier, SourceLoc>> path);
 public:
   /// Create a new Clang importer that can import a suitable Clang
   /// module into the given ASTContext.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -610,7 +610,11 @@ private:
   llvm::DenseMap<Identifier, LoadedFile *> DWARFModuleUnits;
 
 public:
-  /// "Import" a module from debug info. Because debug info types are read on
+  /// Load a module using the clang::CompilerInstance.
+  ModuleDecl *loadModuleClang(SourceLoc importLoc,
+                              ArrayRef<std::pair<Identifier, SourceLoc>> path);
+  
+  /// "Load" a module from debug info. Because debug info types are read on
   /// demand, this doesn't really do any work.
   ModuleDecl *loadModuleDWARF(SourceLoc importLoc,
                               ArrayRef<std::pair<Identifier, SourceLoc>> path);


### PR DESCRIPTION
Move ClangImporter::loadModuleClang() into ClangImporter::Implementation so it forms an obvious contrast with loadModuleDWARF(). Also document the difference between the two calls.
