### PR TITLE
Use a better hash seed when doing string hashing in the compiler

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -52,7 +52,13 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 516; // encode GenericSignature and GenericEnvironment together
+const uint16_t SWIFTMODULE_VERSION_MINOR = 517; // better string hash seed
+
+/// A standard hash seed used for all string hashes in a serialized module.
+///
+/// This is the same as the default used by llvm::djbHash, just provided
+/// explicitly here to note that it's part of the format.
+const uint32_t SWIFTMODULE_HASH_SEED = 5381;
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1090,8 +1090,7 @@ namespace {
     }
 
     hash_value_type ComputeHash(key_type_ref key) {
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second, 0);
+      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -1340,8 +1339,7 @@ namespace {
     }
 
     hash_value_type ComputeHash(internal_key_type key) {
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second, 0);
+      return static_cast<unsigned>(key.first) + llvm::djbHash(key.second);
     }
 
     static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -97,7 +97,6 @@ struct RawValueKey {
   // FIXME: doesn't accommodate >64-bit or signed raw integer or float values.
   union {
     StringRef stringValue;
-    uint32_t charValue;
     IntValueTy intValue;
     FloatValueTy floatValue;
   };
@@ -181,8 +180,7 @@ public:
       return DenseMapInfo<uint64_t>::getHashValue(k.intValue.v0) &
              DenseMapInfo<uint64_t>::getHashValue(k.intValue.v1);
     case RawValueKey::Kind::String:
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(k.stringValue, 0);
+      return DenseMapInfo<StringRef>::getHashValue(k.stringValue);
     case RawValueKey::Kind::Empty:
     case RawValueKey::Kind::Tombstone:
       return 0;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -103,8 +103,7 @@ public:
   external_key_type GetExternalKey(internal_key_type ID) { return ID; }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/Serialization/DocFormat.h
+++ b/lib/Serialization/DocFormat.h
@@ -69,6 +69,15 @@ const uint16_t SWIFTDOC_VERSION_MAJOR = 1;
 /// adhering to the 80-column limit for this line.
 const uint16_t SWIFTDOC_VERSION_MINOR = 1; // Last change: skipping 0 for testing purposes
 
+/// The hash seed used for the string hashes in a Swift 5.1 swiftdoc file.
+///
+/// 0 is not a good seed for llvm::djbHash, but swiftdoc files use a stable
+/// format, so we can't change the hash seed without a version bump. Any new
+/// hashed strings should use a new stable hash seed constant. (No such constant
+/// has been defined at the time this doc comment was last updated because there
+/// are no other strings to hash.)
+const uint32_t SWIFTDOC_HASH_SEED_5_1 = 0;
+
 /// The record types within the comment block.
 ///
 /// Be very careful when changing this block; it must remain

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -972,8 +972,7 @@ public:
 
   hash_value_type ComputeHash(internal_key_type key) {
     assert(!key.empty());
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTDOC_HASH_SEED_5_1);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -391,8 +391,7 @@ public:
 
   hash_value_type ComputeHash(internal_key_type key) {
     if (key.first == DeclBaseName::Kind::Normal) {
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key.second, 0);
+      return llvm::djbHash(key.second, SWIFTMODULE_HASH_SEED);
     } else {
       return (hash_value_type)key.first;
     }
@@ -454,8 +453,7 @@ public:
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
@@ -515,8 +513,7 @@ public:
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
@@ -551,8 +548,7 @@ public:
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {
@@ -607,8 +603,7 @@ public:
 
   hash_value_type ComputeHash(internal_key_type key) {
     if (key.first == DeclBaseName::Kind::Normal) {
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key.second, 0);
+      return llvm::djbHash(key.second, SWIFTMODULE_HASH_SEED);
     } else {
       return (hash_value_type)key.first;
     }
@@ -782,8 +777,7 @@ public:
   }
 
   hash_value_type ComputeHash(internal_key_type key) {
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
   }
 
   static bool EqualKey(internal_key_type lhs, internal_key_type rhs) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -102,8 +102,8 @@ namespace {
       switch (key.getKind()) {
         case DeclBaseName::Kind::Normal:
           assert(!key.empty());
-          // FIXME: DJB seed=0, audit whether the default seed could be used.
-          return llvm::djbHash(key.getIdentifier().str(), 0);
+          return llvm::djbHash(key.getIdentifier().str(),
+                               SWIFTMODULE_HASH_SEED);
         case DeclBaseName::Kind::Subscript:
           return static_cast<uint8_t>(DeclNameKind::Subscript);
         case DeclBaseName::Kind::Constructor:
@@ -179,8 +179,7 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       assert(!key.empty());
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key.str(), 0);
+      return llvm::djbHash(key.str(), SWIFTMODULE_HASH_SEED);
     }
 
     int32_t getNameDataForBase(const NominalTypeDecl *nominal,
@@ -244,8 +243,7 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       assert(!key.empty());
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key, 0);
+      return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -286,8 +284,7 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       assert(!key.empty());
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key.str(), 0);
+      return llvm::djbHash(key.str(), SWIFTMODULE_HASH_SEED);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -332,8 +329,7 @@ namespace {
       switch (key.getKind()) {
       case DeclBaseName::Kind::Normal:
         assert(!key.empty());
-        // FIXME: DJB seed=0, audit whether the default seed could be used.
-        return llvm::djbHash(key.getIdentifier().str(), 0);
+        return llvm::djbHash(key.getIdentifier().str(), SWIFTMODULE_HASH_SEED);
       case DeclBaseName::Kind::Subscript:
         return static_cast<uint8_t>(DeclNameKind::Subscript);
       case DeclBaseName::Kind::Constructor:
@@ -4402,8 +4398,7 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       llvm::SmallString<32> scratch;
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key.getString(scratch), 0);
+      return llvm::djbHash(key.getString(scratch), SWIFTMODULE_HASH_SEED);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -197,8 +197,7 @@ public:
 
   hash_value_type ComputeHash(key_type_ref key) {
     assert(!key.empty());
-    // FIXME: DJB seed=0, audit whether the default seed could be used.
-    return llvm::djbHash(key, 0);
+    return llvm::djbHash(key, SWIFTDOC_HASH_SEED_5_1);
   }
 
   std::pair<unsigned, unsigned>

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -109,8 +109,7 @@ namespace {
 
     hash_value_type ComputeHash(key_type_ref key) {
       assert(!key.empty());
-      // FIXME: DJB seed=0, audit whether the default seed could be used.
-      return llvm::djbHash(key, 0);
+      return llvm::djbHash(key, SWIFTMODULE_HASH_SEED);
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-swift-frontend -emit-module %t/partial.a.swiftmodule %t/partial.b.swiftmodule -module-name test -enable-library-evolution -sil-merge-partial-modules -disable-diagnostic-passes -disable-sil-perf-optzns -o %t/test.swiftmodule
 
-// RUN: %target-sil-opt %t/test.swiftmodule -disable-sil-linking > %t/dump.sil
+// RUN: %target-sil-opt %t/test.swiftmodule -disable-sil-linking -emit-sorted-sil > %t/dump.sil
 // RUN: %FileCheck %s < %t/dump.sil
 // RUN: %FileCheck %s --check-prefix=NEGATIVE < %t/dump.sil
 
@@ -40,28 +40,30 @@ public class CircleManager : ShapeManager {
   public override func manage() {}
 }
 
-// FIXME: Why is the definition order totally random?
-
-// CHECK-LABEL: sil [canonical] @$s4test17versionedFunctionyyF : $@convention(thin) () -> ()
-
-// CHECK-LABEL: sil [canonical] @$s4test9RectangleV4areaSfvg : $@convention(method) (Rectangle) -> Float
-
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$s4test9RectangleVAA5ShapeA2aDP4drawyyFTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> () {
-// CHECK: function_ref @$s4test14publicFunctionyyF
-// CHECK: }
-
 // CHECK-LABEL: sil [canonical] @$s4test14publicFunctionyyF : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$s4test9RectangleVAA5ShapeA2aDP4areaSfvgTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> Float {
-// CHECK: function_ref @$s4test9RectangleV4areaSfvg
+// CHECK-LABEL: sil [serialized] [canonical] @$s4test17inlinableFunctionyyF : $@convention(thin) () -> () {
+// CHECK: function_ref @$s4test17inlinableFunctionyyFyycfU_
 // CHECK: }
 
 // CHECK-LABEL: sil shared [serialized] [canonical] @$s4test17inlinableFunctionyyFyycfU_ : $@convention(thin) () -> () {
 // CHECK: function_ref @$s4test17versionedFunctionyyF
 // CHECK: }
 
-// CHECK-LABEL: sil [serialized] [canonical] @$s4test17inlinableFunctionyyF : $@convention(thin) () -> () {
-// CHECK: function_ref @$s4test17inlinableFunctionyyFyycfU_
+// CHECK-LABEL: sil [canonical] @$s4test17versionedFunctionyyF : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [canonical] @$s4test9RectangleV4areaSfvg : $@convention(method) (Rectangle) -> Float
+
+// CHECK-LABEL: sil [serialized] [canonical] @$s4test9RectangleV4drawyyF : $@convention(method) (Rectangle) -> () {
+// CHECK: function_ref @$s4test14publicFunctionyyF
+// CHECK: }
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$s4test9RectangleVAA5ShapeA2aDP4areaSfvgTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> Float {
+// CHECK: function_ref @$s4test9RectangleV4areaSfvg
+// CHECK: }
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$s4test9RectangleVAA5ShapeA2aDP4drawyyFTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> () {
+// CHECK: function_ref @$s4test9RectangleV4drawyyF
 // CHECK: }
 
 // CHECK-LABEL: sil_witness_table [serialized] Rectangle: Shape module test {

--- a/test/SIL/Serialization/Recovery/function.sil
+++ b/test/SIL/Serialization/Recovery/function.sil
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil %s -emit-sib -o %t/Library.sib -module-name Library -I %S/Inputs/good-modules -parse-stdlib
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules | %FileCheck %s
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY %s
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY-NEGATIVE %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules -emit-sorted-sil | %FileCheck -check-prefix=CHECK-RECOVERY %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules -emit-sorted-sil | %FileCheck -check-prefix=CHECK-RECOVERY-NEGATIVE %s
 
 // CHECK-LABEL: sil_stage raw
 // CHECK-RECOVERY-LABEL: sil_stage raw

--- a/test/SIL/Serialization/assignattr.sil
+++ b/test/SIL/Serialization/assignattr.sil
@@ -2,21 +2,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name assignattr
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name assignattr
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name assignattr | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name assignattr -emit-sorted-sil | %FileCheck %s
 
 sil_stage raw
 
 import Builtin
-
-// CHECK-LABEL: sil [serialized] [ossa] @trivial_assign : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
-// CHECK: assign [[ARG2]] to [init] [[ARG1]] : $*Builtin.Int32
-sil [serialized] [ossa] @trivial_assign : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
-  assign %1 to [init] %0 : $*Builtin.Int32
-  %2 = tuple()
-  return %2 : $()
-}
 
 // CHECK-LABEL: sil [serialized] [ossa] @non_trivial_assign : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
@@ -30,4 +20,14 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   assign %1 to [reinit] %0 : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @trivial_assign : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: assign [[ARG2]] to [init] [[ARG1]] : $*Builtin.Int32
+sil [serialized] [ossa] @trivial_assign : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  assign %1 to [init] %0 : $*Builtin.Int32
+  %2 = tuple()
+  return %2 : $()
 }

--- a/test/SIL/Serialization/boxes.sil
+++ b/test/SIL/Serialization/boxes.sil
@@ -2,7 +2,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name boxes
 // RUN: %target-sil-opt %t/tmp.sib -emit-sib -o %t/tmp.2.sib -module-name boxes
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name boxes | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name boxes -emit-sorted-sil | %FileCheck %s
+
+// Keep this file in sorted order by using alphabetical prefixes on the SIL functions.
 
 sil_stage canonical
 
@@ -15,8 +17,8 @@ struct Q: P {}
 
 // TODO: Transform boxes by transforming their arguments, not as single-field,
 // so that they work as parameters in generic SIL functions.
-// CHECK-LABEL: sil hidden [serialized] [ossa] @box_type_parsing : $@convention(thin) (
-sil hidden [serialized] [ossa] @box_type_parsing : $@convention(thin) (
+// CHECK-LABEL: sil hidden [serialized] [ossa] @AA_box_type_parsing : $@convention(thin) (
+sil hidden [serialized] [ossa] @AA_box_type_parsing : $@convention(thin) (
   // CHECK: <τ_0_0> { var τ_0_0 } <F>,
   <B>{ var B }<F>,
   // CHECK: <τ_0_0 where τ_0_0 : P> { let τ_0_0 } <G>,
@@ -37,8 +39,8 @@ entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @u
   unreachable
 }
 
-// CHECK-LABEL: sil hidden [serialized] [ossa] @box_type_parsing_in_generic_function : $@convention(thin) <F, G where G : P> (
-sil hidden [serialized] [ossa] @box_type_parsing_in_generic_function : $@convention(thin) <F, G: P> (
+// CHECK-LABEL: sil hidden [serialized] [ossa] @BB_box_type_parsing_in_generic_function : $@convention(thin) <F, G where G : P> (
+sil hidden [serialized] [ossa] @BB_box_type_parsing_in_generic_function : $@convention(thin) <F, G: P> (
   // CHECK: <τ_0_0> { var τ_0_0 } <F>,
   <B>{ var B }<F>,
   // CHECK: <τ_0_0 where τ_0_0 : P> { let τ_0_0 } <G>,
@@ -59,8 +61,8 @@ entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @u
   unreachable
 }
 
-// CHECK-LABEL: sil hidden [serialized] [ossa] @same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (
-sil hidden [serialized] [ossa] @same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (
+// CHECK-LABEL: sil hidden [serialized] [ossa] @CC_same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (
+sil hidden [serialized] [ossa] @CC_same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (
   // CHECK: <τ_0_0> { var τ_0_0 } <Int>,
   <A> { var A } <Int>,
   // CHECK: <τ_0_0> { var τ_0_0 } <String>
@@ -71,8 +73,8 @@ entry(%0 : @unowned $<A> { var A } <Int>, %1 : @unowned $<A> { var A } <String>)
   unreachable
 }
 
-// CHECK-LABEL: sil hidden [serialized] [ossa] @same_generic_param_name_in_outer_scope : $@convention(thin) <A> (
-sil hidden [serialized] [ossa] @same_generic_param_name_in_outer_scope : $@convention(thin) <A> (
+// CHECK-LABEL: sil hidden [serialized] [ossa] @DD_same_generic_param_name_in_outer_scope : $@convention(thin) <A> (
+sil hidden [serialized] [ossa] @DD_same_generic_param_name_in_outer_scope : $@convention(thin) <A> (
   // CHECK: <τ_0_0> { var τ_0_0 } <A>
   <A> { var A } <A>
 // CHECK: ) -> ()
@@ -81,14 +83,14 @@ entry(%0 : @unowned $<B> { var B } <A>):
   unreachable
 }
 
-// CHECK-LABEL: sil hidden [serialized] [ossa] @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <τ_0_0> { let τ_0_0 } <Int>) -> ()
-sil hidden [serialized ] [ossa] @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> () {
+// CHECK-LABEL: sil hidden [serialized] [ossa] @EE_box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <τ_0_0> { let τ_0_0 } <Int>) -> ()
+sil hidden [serialized ] [ossa] @EE_box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> () {
 entry(%0 : @owned ${ var Int }, %1 : @guaranteed $<T> { let T } <Int>):
   unreachable
 }
 
-// CHECK-LABEL: sil hidden [serialized] [ossa] @address_of_box
-sil hidden [serialized] [ossa] @address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> () {
+// CHECK-LABEL: sil hidden [serialized] [ossa] @FF_address_of_box
+sil hidden [serialized] [ossa] @FF_address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> () {
 // CHECK: %0 : $*{ var Int }, %1 : $*<τ_0_0> { let τ_0_0 } <Int>
 entry(%0 : $*{ var Int }, %1 : $*<T> { let T } <Int>):
   unreachable
@@ -96,11 +98,11 @@ entry(%0 : $*{ var Int }, %1 : $*<T> { let T } <Int>):
 
 sil [serialized] @serialize_all : $@convention(thin) () -> () {
 entry:
-  %0 = function_ref @box_type_parsing : $@convention(thin) (<B>{ var B }<F>, <C: P>{ let C }<G>, <D: P>{ var D }<Q>, { let Int }, { var Int, let String }, {}, <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>) -> ()
-  %1 = function_ref @box_type_parsing_in_generic_function : $@convention(thin) <F, G: P> (<B>{ var B }<F>, <C: P>{ let C }<G>, <D: P>{ var D }<Q>, { let Int }, { var Int, let String }, {}, <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>) -> ()
-  %2 = function_ref @same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (<A> { var A } <Int>, <A> { var A } <String>) -> ()
-  %3 = function_ref @same_generic_param_name_in_outer_scope : $@convention(thin) <A> (<A> { var A } <A>) -> ()
-  %4 = function_ref @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> ()
-  %5 = function_ref @address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> ()
+  %0 = function_ref @AA_box_type_parsing : $@convention(thin) (<B>{ var B }<F>, <C: P>{ let C }<G>, <D: P>{ var D }<Q>, { let Int }, { var Int, let String }, {}, <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>) -> ()
+  %1 = function_ref @BB_box_type_parsing_in_generic_function : $@convention(thin) <F, G: P> (<B>{ var B }<F>, <C: P>{ let C }<G>, <D: P>{ var D }<Q>, { let Int }, { var Int, let String }, {}, <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>) -> ()
+  %2 = function_ref @CC_same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (<A> { var A } <Int>, <A> { var A } <String>) -> ()
+  %3 = function_ref @DD_same_generic_param_name_in_outer_scope : $@convention(thin) <A> (<A> { var A } <A>) -> ()
+  %4 = function_ref @EE_box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> ()
+  %5 = function_ref @FF_address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> ()
   unreachable
 }

--- a/test/SIL/Serialization/copy_value_destroy_value.sil
+++ b/test/SIL/Serialization/copy_value_destroy_value.sil
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name copydestroy_value
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name copydestroy_value
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name copydestroy_value | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name copydestroy_value -emit-sorted-sil | %FileCheck %s
 
 sil_stage canonical
 
@@ -21,12 +21,12 @@ bb0(%0 : @owned $@sil_unowned Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @test : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+// CHECK-LABEL: sil [serialized] [ossa] @test_copy_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[ARG1:%[0-9]+]] : @owned $Builtin.NativeObject):
 // CHECK: [[COPY_VALUE_RESULT:%[0-9]+]] = copy_value [[ARG1]] : $Builtin.NativeObject
 // CHECK: destroy_value [[ARG1]]
 // CHECK: return [[COPY_VALUE_RESULT]]
-sil [serialized] [ossa] @test : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+sil [serialized] [ossa] @test_copy_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject

--- a/test/SIL/Serialization/dynamically_replaceable.sil
+++ b/test/SIL/Serialization/dynamically_replaceable.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -o %t/tmp.swiftmodule
-// RUN: %target-sil-opt %t/tmp.swiftmodule -disable-sil-linking | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.swiftmodule -disable-sil-linking -emit-sorted-sil | %FileCheck %s
 
 
 // CHECK-DAG-LABEL: sil [serialized] [dynamically_replacable] [canonical] @test_dynamically_replaceable

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -1,9 +1,10 @@
-
 // First parse this and then emit a *.sib. Then read in the *.sib, then recreate
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name keypaths
 // RUN: %target-sil-opt %t/tmp.sib -emit-sib -o %t/tmp.2.sib -module-name keypaths
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name keypaths | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name keypaths -emit-sorted-sil | %FileCheck %s
+
+// Keep this file in sorted order by using alphabetical prefixes on the SIL functions.
 
 sil_stage canonical
 
@@ -62,8 +63,8 @@ public struct GenT<A, B> {
   public let z: (e0: External<A>, e1: External<B>)
 }
 
-// CHECK-LABEL: sil shared [serialized] @stored_properties
-sil shared [serialized] @stored_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @AA_stored_properties
+sil shared [serialized] @AA_stored_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
   %a = keypath $WritableKeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
@@ -77,8 +78,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @stored_properties_generic
-sil shared [serialized] @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @BB_stored_properties_generic
+sil shared [serialized] @BB_stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where {{.*}}> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; stored_property #Gen.x : $τ_0_0) <D, E, F>
   %a = keypath $WritableKeyPath<Gen<D,E,F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; stored_property #Gen.x : $G) <D, E, F>
@@ -88,8 +89,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @tuple_elements
-sil shared [serialized] @tuple_elements : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @CC_tuple_elements
+sil shared [serialized] @CC_tuple_elements : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
   %a = keypath $WritableKeyPath<T, Int>, (root $T; stored_property #T.x : $(Int, Int); tuple_element #0 : $Int)
@@ -103,8 +104,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @tuple_generic
-sil shared [serialized] @tuple_generic : $@convention(thin) <T, U> () -> () {
+// CHECK-LABEL: sil shared [serialized] @DD_tuple_generic
+sil shared [serialized] @DD_tuple_generic : $@convention(thin) <T, U> () -> () {
 entry:
   // CHECK: keypath $WritableKeyPath<(T, U), T>, <τ_0_0, τ_0_1> (root $(τ_0_0, τ_0_1); tuple_element #0 : $τ_0_0) <T, U>
   %a = keypath $WritableKeyPath<(T, U), T>, <τ_0_0, τ_0_1> (root $(τ_0_0, τ_0_1); tuple_element #0 : $τ_0_0) <T, U>
@@ -145,8 +146,8 @@ sil @set_gen_int_subs : $@convention(thin) <A: Hashable, B: Hashable, C: Hashabl
 sil @gen_subs_eq : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
 sil @gen_subs_hash : $@convention(thin) <A: Hashable, B: Hashable, C: Hashable> (UnsafeRawPointer) -> Int
 
-// CHECK-LABEL: sil shared [serialized] @computed_properties
-sil shared [serialized] @computed_properties : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @EE_computed_properties
+sil shared [serialized] @EE_computed_properties : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
   %a = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int : $@convention(thin) (@in_guaranteed S) -> @out Int)
@@ -163,8 +164,8 @@ entry:
 sil @get_gen_a : $@convention(thin) <X1: P, Y1: Q, Z1: R> (@in_guaranteed Gen<X1, Y1, Z1>) -> @out X1
 sil @set_gen_a : $@convention(thin) <X2: P, Y2: Q, Z2: R> (@in_guaranteed X2, @in_guaranteed Gen<X2, Y2, Z2>) -> ()
 
-// CHECK-LABEL: sil shared [serialized] @computed_properties_generic
-sil shared [serialized] @computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @FF_computed_properties_generic
+sil shared [serialized] @FF_computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $KeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; settable_property $τ_0_0, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> @out τ_0_0, setter @set_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed τ_0_0, @in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> ()) <D, E, F>
   %a = keypath $KeyPath<Gen<D, E, F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; settable_property $G, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <X3: P, Y3: Q, Z3: R> (@in_guaranteed Gen<X3, Y3, Z3>) -> @out X3, setter @set_gen_a : $@convention(thin) <X4: P, Y4: Q, Z4: R> (@in_guaranteed X4, @in_guaranteed Gen<X4, Y4, Z4>) -> ()) <D, E, F>
@@ -172,8 +173,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @optional
-sil shared [serialized] @optional : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] @GG_optional
+sil shared [serialized] @GG_optional : $@convention(thin) () -> () {
 entry:
   // CHECK: keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
   %a = keypath $KeyPath<Optional<Int>, Optional<Int>>, (root $Optional<Int>; optional_chain : $Int; optional_wrap : $Optional<Int>)
@@ -183,8 +184,8 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @indexes
-sil shared [serialized] @indexes : $@convention(thin) (S, C) -> () {
+// CHECK-LABEL: sil shared [serialized] @HH_indexes
+sil shared [serialized] @HH_indexes : $@convention(thin) (S, C) -> () {
 // CHECK: bb0([[S:%.*]] : $S, [[C:%.*]] : $C):
 entry(%s : $S, %c : $C):
   // CHECK: keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) ([[S]], [[C]])
@@ -202,8 +203,8 @@ entry(%s : $S, %c : $C):
   return undef : $()
 }
 
-// CHECK-LABEL: sil shared [serialized] @external
-sil shared [serialized] @external : $@convention(thin) <D: P, E: Q, F: R> () -> () {
+// CHECK-LABEL: sil shared [serialized] @II_external
+sil shared [serialized] @II_external : $@convention(thin) <D: P, E: Q, F: R> () -> () {
 entry:
   // CHECK: keypath $KeyPath<Gen<D, E, F>, D>, <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (root $Gen<τ_0_0, τ_0_1, τ_0_2>; settable_property $τ_0_0, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> @out τ_0_0, setter @set_gen_a : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P, τ_0_1 : Q, τ_0_2 : R> (@in_guaranteed τ_0_0, @in_guaranteed Gen<τ_0_0, τ_0_1, τ_0_2>) -> (), external #Gen.x<τ_0_0, τ_0_1, τ_0_2>) <D, E, F>
   %a = keypath $KeyPath<Gen<D, E, F>, D>, <G: P, H: Q, I: R> (root $Gen<G, H, I>; settable_property $G, id @id_a : $@convention(thin) () -> (), getter @get_gen_a : $@convention(thin) <X3: P, Y3: Q, Z3: R> (@in_guaranteed Gen<X3, Y3, Z3>) -> @out X3, setter @set_gen_a : $@convention(thin) <X4: P, Y4: Q, Z4: R> (@in_guaranteed X4, @in_guaranteed Gen<X4, Y4, Z4>) -> (), external #Gen.x<G, H, I>) <D, E, F>
@@ -213,15 +214,15 @@ entry:
 
 sil [serialized] @serialize_all : $@convention(thin) () -> () {
 entry:
-  %0 = function_ref @stored_properties : $@convention(thin) () -> ()
-  %1 = function_ref @stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
-  %2 = function_ref @tuple_elements : $@convention(thin) () -> ()
-  %3 = function_ref @tuple_generic : $@convention(thin) <T, U> () -> ()
-  %4 = function_ref @computed_properties : $@convention(thin) () -> ()
-  %5 = function_ref @computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
-  %6 = function_ref @optional : $@convention(thin) () -> ()
-  %7 = function_ref @indexes : $@convention(thin) (S, C) -> ()
-  %8 = function_ref @external : $@convention(thin) <D: P, E: Q, F: R> () -> ()
+  %0 = function_ref @AA_stored_properties : $@convention(thin) () -> ()
+  %1 = function_ref @BB_stored_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
+  %2 = function_ref @CC_tuple_elements : $@convention(thin) () -> ()
+  %3 = function_ref @DD_tuple_generic : $@convention(thin) <T, U> () -> ()
+  %4 = function_ref @EE_computed_properties : $@convention(thin) () -> ()
+  %5 = function_ref @FF_computed_properties_generic : $@convention(thin) <D: P, E: Q, F: R> () -> ()
+  %6 = function_ref @GG_optional : $@convention(thin) () -> ()
+  %7 = function_ref @HH_indexes : $@convention(thin) (S, C) -> ()
+  %8 = function_ref @II_external : $@convention(thin) <D: P, E: Q, F: R> () -> ()
 
   unreachable
 }

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -2,24 +2,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name ownership_qualified_memopts
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name ownership_qualified_memopts
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name ownership_qualified_memopts | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name ownership_qualified_memopts -emit-sorted-sil | %FileCheck %s
 
 sil_stage canonical
 
 import Builtin
 
-
-// CHECK-LABEL: sil [serialized] [ossa] @trivial_args : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
-// CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
-// CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
-sil [serialized] [ossa] @trivial_args : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
-  load [trivial] %0 : $*Builtin.Int32
-  store %1 to [trivial] %0 : $*Builtin.Int32
-  %2 = tuple()
-  return %2 : $()
-}
 
 // CHECK-LABEL: sil [serialized] [ossa] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @owned $Builtin.NativeObject):
@@ -39,4 +27,16 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   destroy_addr %0 : $*Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @trivial_args : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
+// CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
+sil [serialized] [ossa] @trivial_args : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+  load [trivial] %0 : $*Builtin.Int32
+  store %1 to [trivial] %0 : $*Builtin.Int32
+  %2 = tuple()
+  return %2 : $()
 }

--- a/test/Serialization/always_inline.swift
+++ b/test/Serialization/always_inline.swift
@@ -2,15 +2,15 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_always_inline.swift
 // RUN: llvm-bcanalyzer %t/def_always_inline.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sib -I %t %s -o %t/always_inline.sib
-// RUN: %target-sil-opt -performance-linker %t/always_inline.sib -I %t | %FileCheck %s -check-prefix=SIL
+// RUN: %target-sil-opt -performance-linker %t/always_inline.sib -I %t -emit-sorted-sil | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 
 import def_always_inline
 
-// SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$s17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
-
 // SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$s17def_always_inline16testAlwaysInline1xS2b_tF : $@convention(thin) (Bool) -> Bool {
+
+// SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$s17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
 
 // SIL-LABEL: sil @main
 // SIL: [[RAW:%.+]] = global_addr @$s13always_inline3rawSbvp : $*Bool

--- a/test/Serialization/early-serialization.swift
+++ b/test/Serialization/early-serialization.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -O -module-name Swift -module-link-name swiftCore -parse-as-library -parse-stdlib -emit-module %s -o %t/Swift.swiftmodule
-// RUN: %target-sil-opt -enable-sil-verify-all %t/Swift.swiftmodule -o - | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %t/Swift.swiftmodule -emit-sorted-sil -o - | %FileCheck %s
 
 // Test that early serialization works as expected:
 // - it happens before the performance inlining and thus preserves @_semantics functions
@@ -10,18 +10,6 @@
 public struct Int {
   @inlinable
   public init() {}
-}
-
-// Check that a specialized version of a function is produced
-// CHECK: sil shared [serializable] [_semantics "array.get_capacity"] [canonical] @$sSa12_getCapacitySiyFSi_Tgq5 : $@convention(method) (Array<Int>) -> Int
-
-// Check that a call of a @_semantics function was not inlined if early-serialization is enabled.
-// CHECK: sil [serialized] [canonical] @$ss28userOfSemanticsAnnotatedFuncySiSaySiGF
-// CHECK: function_ref
-// CHECK: apply
-@inlinable
-public func userOfSemanticsAnnotatedFunc(_ a: Array<Int>) -> Int {
-  return a._getCapacity()
 }
 
 @frozen
@@ -37,4 +25,16 @@ public struct Array<T> {
   internal func _getCapacity() -> Int {
     return Int()
   }
+}
+
+// Check that a specialized version of a function is produced
+// CHECK: sil shared [serializable] [_semantics "array.get_capacity"] [canonical] @$sSa12_getCapacitySiyFSi_Tgq5 : $@convention(method) (Array<Int>) -> Int
+
+// Check that a call of a @_semantics function was not inlined if early-serialization is enabled.
+// CHECK: sil [serialized] [canonical] @$ss28userOfSemanticsAnnotatedFuncySiSaySiGF
+// CHECK: function_ref
+// CHECK: apply
+@inlinable
+public func userOfSemanticsAnnotatedFunc(_ a: Array<Int>) -> Int {
+  return a._getCapacity()
 }

--- a/test/Serialization/noinline.swift
+++ b/test/Serialization/noinline.swift
@@ -2,15 +2,15 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_noinline.swift
 // RUN: llvm-bcanalyzer %t/def_noinline.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-sib -I %t %s -o %t/noinline.sib
-// RUN: %target-sil-opt -performance-linker %t/noinline.sib -I %t | %FileCheck %s -check-prefix=SIL
+// RUN: %target-sil-opt -performance-linker %t/noinline.sib -I %t -emit-sorted-sil | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 
 import def_noinline
 
-// SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$s12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {
-
 // SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$s12def_noinline12testNoinline1xS2b_tF : $@convention(thin) (Bool) -> Bool {
+
+// SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$s12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {
 
 // SIL-LABEL: sil @main
 // SIL: [[RAW:%.+]] = global_addr @$s8noinline3rawSbvp : $*Bool

--- a/test/sil-opt/sil-opt.swift
+++ b/test/sil-opt/sil-opt.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -module-link-name swiftCore -O -parse-as-library -parse-stdlib -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -module-name="Swift" | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -O -parse-as-library -parse-stdlib -emit-sib -o - | %target-sil-opt -enable-sil-verify-all -module-name="Swift" | %FileCheck %s -check-prefix=SIB-CHECK
+// RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -module-link-name swiftCore -O -parse-as-library -parse-stdlib -emit-module -emit-module-path - -o /dev/null | %target-sil-opt -enable-sil-verify-all -module-name="Swift" -emit-sorted-sil | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -module-name Swift -g -O -parse-as-library -parse-stdlib -emit-sib -o - | %target-sil-opt -enable-sil-verify-all -module-name="Swift" -emit-sorted-sil | %FileCheck %s -check-prefix=SIB-CHECK
 
 // CHECK: import Builtin
 // CHECK: import Swift
@@ -11,13 +11,6 @@
 // CHECK-NEXT:  @inlinable init
 // CHECK-NEXT: }
 
-// CHECK: sil{{.*}} @unknown : $@convention(thin) () -> ()
-
-// CHECK-LABEL: sil [serialized] [canonical] @$ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
-// CHECK: bb0
-// CHECK-NEXT: struct $X ()
-// CHECK-NEXT: return
-
 // CHECK-LABEL: sil [serialized] [canonical] @$ss1XV4testyyF : $@convention(method) (X) -> ()
 // CHECK: bb0
 // CHECK-NEXT: function_ref
@@ -25,6 +18,13 @@
 // CHECK-NEXT: apply
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
+
+// CHECK-LABEL: sil [serialized] [canonical] @$ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
+// CHECK: bb0
+// CHECK-NEXT: struct $X ()
+// CHECK-NEXT: return
+
+// CHECK-LABEL: sil{{.*}} @unknown : $@convention(thin) () -> ()
 
 
 // SIB-CHECK: import Builtin
@@ -37,13 +37,6 @@
 // SIB-CHECK-NEXT:  init
 // SIB-CHECK-NEXT: }
 
-// SIB-CHECK: sil [canonical] @unknown : $@convention(thin) () -> ()
-
-// SIB-CHECK-LABEL: sil [serialized] [canonical] @$ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
-// SIB-CHECK: bb0
-// SIB-CHECK-NEXT: struct $X ()
-// SIB-CHECK-NEXT: return
-
 // SIB-CHECK-LABEL: sil [serialized] [canonical] @$ss1XV4testyyF : $@convention(method) (X) -> ()
 // SIB-CHECK: bb0
 // SIB-CHECK-NEXT: function_ref
@@ -51,6 +44,13 @@
 // SIB-CHECK-NEXT: apply
 // SIB-CHECK-NEXT: tuple
 // SIB-CHECK-NEXT: return
+
+// SIB-CHECK-LABEL: sil [serialized] [canonical] @$ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
+// SIB-CHECK: bb0
+// SIB-CHECK-NEXT: struct $X ()
+// SIB-CHECK-NEXT: return
+
+// SIB-CHECK-LABEL: sil [canonical] @unknown : $@convention(thin) () -> ()
 
 @_silgen_name("unknown")
 public func unknown() -> ()


### PR DESCRIPTION
- Remove explicit seeds from string hashes that are compiler-version-dependent already.

- Comment that we can't change the seed for swiftdoc files (@nkcsgexi).

- Switch to a "better" explicit seed for serialization lookup tables. This last one changed the order of SIL entity deserialization (as @adrian-prantl noticed in the original #14890), but we shouldn't have been relying on that anyway (@gottesmm). It's actually rather scary that that was matching source order at the time.