### PR TITLE
Move hash_code implementation for StringRef into LLVMSupport

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -3,6 +3,7 @@
 if(SWIFT_BUILD_DYNAMIC_STDLIB)
   add_swift_target_library(swiftRemoteMirror
                            SHARED DONT_EMBED_BITCODE NOSWIFTRT
+                           ../runtime/LLVMSupport.cpp
                            SwiftRemoteMirror.cpp
                            LINK_LIBRARIES
                              swiftReflection

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -196,10 +196,6 @@ namespace {
   };
 } // end anonymous namespace
 
-inline llvm::hash_code llvm::hash_value(StringRef S) {
-  return hash_combine_range(S.begin(), S.end());
-}
-
 struct TypeMetadataPrivateState {
   ConcurrentMap<NominalTypeDescriptorCacheEntry> NominalCache;
   ConcurrentReadableArray<TypeMetadataSection> SectionsToScan;

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -134,16 +134,3 @@ void swift::_swift_instantiateInertHeapObject(void *address,
                                               const HeapMetadata *metadata) {
   ::new (address) HeapObject{metadata};
 }
-
-namespace llvm { namespace hashing { namespace detail {
-  // An extern variable expected by LLVM's hashing templates. We don't link any
-  // LLVM libs into the runtime, so define it as a weak symbol.
-  //
-  // Systems that compile this code into a dynamic library will do so with
-  // hidden visibility, making this all internal to the dynamic library.
-  // Systems that statically link the Swift runtime into applications (e.g. on
-  // Linux) need this to handle the case when the app already uses LLVM.
-  uint64_t LLVM_ATTRIBUTE_WEAK fixed_seed_override = 0;
-} // namespace detail
-} // namespace hashing
-} // namespace llvm


### PR DESCRIPTION
Since SwiftRuntimeTests uses MetadataLookup.cpp and links against
LLVMSupport for gtest, in a debug build on Windows, defining the
hash_code implementation creates multiple symbol conflicts. Moving the
definition to LLVMSupport which is not used by SwiftRuntimeTests to
avoid this.
