### PR TITLE
[ConstraintSystem] Activate delayed key path dynamic member references

### DIFF
--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -328,3 +328,42 @@ func rdar52779809(_ ref1: Ref<S>, _ ref2: Ref<Q>) {
   // CHECK: function_ref @$s29keypath_dynamic_member_lookup3RefV0B6Memberqd__s7KeyPathCyxqd__G_tcluig
   _ = ref2.bar // Ok
 }
+
+func make_sure_delayed_keypath_dynamic_member_works() {
+  @propertyWrapper @dynamicMemberLookup
+  struct Wrapper<T> {
+    var storage: T? = nil
+
+    var wrappedValue: T {
+      get { storage! }
+    }
+
+    var projectedValue: Wrapper<T> { self }
+
+    init() { }
+
+    init(wrappedValue: T) {
+      storage = wrappedValue
+    }
+
+    subscript<Property>(dynamicMember keyPath: KeyPath<T, Property>) -> Wrapper<Property> {
+      get { .init() }
+    }
+  }
+
+  struct Field {
+    @Wrapper var v: Bool = true
+  }
+
+  struct Arr {
+    var fields: [Field] = []
+  }
+
+  struct Test {
+    @Wrapper var data: Arr
+
+    func test(_ index: Int) {
+      let _ = self.$data.fields[index].v.wrappedValue
+    }
+  }
+}


### PR DESCRIPTION
Since key path dynamic member depends on information from
`applicable function` constraint associated with invocation
it can't be eagerly solved during constraint generation
phase, so it has to be delayed until actual solving starts.

Subscripts used to always have at least one choice - `keypath application`,
which along with actual valid choices always formed a disjunction.
That is no longer the case since `keypath application` is added
only when it makes sense, which means delayed dynamic member
constraint has to be added to "active" list to get re-attempted.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
