### PR TITLE
Refactor declaration attribute checking

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -286,7 +286,7 @@ public:
 protected:
   union { uint64_t OpaqueBits;
 
-  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD_BASE(Decl, bitmax(NumDeclKindBits,8)+1+1+1+1+2+1,
     Kind : bitmax(NumDeclKindBits,8),
 
     /// Whether this declaration is invalid.
@@ -300,10 +300,6 @@ protected:
     ///
     /// Use getClangNode() to retrieve the corresponding Clang AST.
     FromClang : 1,
-
-    /// Whether we've already performed early attribute validation.
-    /// FIXME: This is ugly.
-    EarlyAttrValidation : 1,
 
     /// The validation state of this declaration.
     ValidationState : 2,
@@ -694,7 +690,6 @@ protected:
     Bits.Decl.Invalid = false;
     Bits.Decl.Implicit = false;
     Bits.Decl.FromClang = false;
-    Bits.Decl.EarlyAttrValidation = false;
     Bits.Decl.ValidationState = unsigned(ValidationState::Unchecked);
     Bits.Decl.EscapedFromIfConfig = false;
   }
@@ -836,14 +831,6 @@ public:
   /// Mark this declaration as implicit.
   void setImplicit(bool implicit = true) { Bits.Decl.Implicit = implicit; }
 
-  /// Whether we have already done early attribute validation.
-  bool didEarlyAttrValidation() const { return Bits.Decl.EarlyAttrValidation; }
-
-  /// Set whether we've performed early attribute validation.
-  void setEarlyAttrValidation(bool validated = true) {
-    Bits.Decl.EarlyAttrValidation = validated;
-  }
-  
   /// Get the validation state.
   ValidationState getValidationState() const {
     return ValidationState(Bits.Decl.ValidationState);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -968,12 +968,8 @@ public:
           Overridden->dump(Out);
           abort();
         }
-      }
-      
-      if (D->didEarlyAttrValidation() &&
-          D->getAttrs().hasAttribute<OverrideAttr>()) {
-        if (!D->isInvalid() && D->hasInterfaceType() &&
-            !isa<ClassDecl>(D->getDeclContext()) &&
+
+        if (!isa<ClassDecl>(D->getDeclContext()) &&
             !isa<ProtocolDecl>(D->getDeclContext()) &&
             !isa<ExtensionDecl>(D->getDeclContext())) {
           PrettyStackTraceDecl debugStack("verifying override", D);
@@ -983,7 +979,6 @@ public:
         }
       }
 
-      
       verifyCheckedAlwaysBase(D);
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1490,7 +1490,6 @@ static void addSynthesizedTypealias(NominalTypeDecl *nominal, Identifier name,
                                            name, SourceLoc(),
                                            nullptr, nominal);
   typealias->setUnderlyingType(underlyingType);
-  typealias->setEarlyAttrValidation(true);
   typealias->setAccess(AccessLevel::Public);
   typealias->setValidationToChecked();
   typealias->setImplicit();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1292,7 +1292,6 @@ public:
                                                   true);
     auto D = ::new (DeclPtr) DeclTy(std::forward<Targs>(Args)...);
     D->setClangNode(ClangN);
-    D->setEarlyAttrValidation(true);
     D->setAccess(access);
     if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
       ASD->setSetterAccess(access);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -719,7 +719,6 @@ deriveEquatable_eq(
                      parentDC);
   eqDecl->setImplicit();
   eqDecl->setUserAccessible(false);
-  eqDecl->getAttrs().add(new (C) InfixAttr(/*implicit*/false));
 
   // Add the @_implements(Equatable, ==(_:_:)) attribute
   if (generatedIdentifier != C.Id_EqualsOperator) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MiscDiagnostics.h"
+#include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
@@ -56,15 +57,14 @@ namespace {
     attr->setInvalid();
   }
 
-/// This visits each attribute on a decl early, before the majority of type
-/// checking has been performed for the decl.  The visitor should return true if
+/// This visits each attribute on a decl.  The visitor should return true if
 /// the attribute is invalid and should be marked as such.
-class AttributeEarlyChecker : public AttributeVisitor<AttributeEarlyChecker> {
+class AttributeChecker : public AttributeVisitor<AttributeChecker> {
   TypeChecker &TC;
   Decl *D;
 
 public:
-  AttributeEarlyChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
+  AttributeChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
 
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
@@ -78,59 +78,33 @@ public:
 
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
   IGNORED_ATTR(AlwaysEmitIntoClient)
-  IGNORED_ATTR(Available)
   IGNORED_ATTR(HasInitialValue)
-  IGNORED_ATTR(CDecl)
   IGNORED_ATTR(ClangImporterSynthesizedType)
   IGNORED_ATTR(Convenience)
-  IGNORED_ATTR(DiscardableResult)
-  IGNORED_ATTR(DynamicCallable)
-  IGNORED_ATTR(DynamicMemberLookup)
   IGNORED_ATTR(Effects)
   IGNORED_ATTR(Exported)
-  IGNORED_ATTR(FixedLayout)
   IGNORED_ATTR(ForbidSerializingReference)
-  IGNORED_ATTR(Frozen)
   IGNORED_ATTR(HasStorage)
-  IGNORED_ATTR(ImplementationOnly)
-  IGNORED_ATTR(Implements)
-  IGNORED_ATTR(Infix)
-  IGNORED_ATTR(Inlinable)
   IGNORED_ATTR(Inline)
   IGNORED_ATTR(NonObjC)
-  IGNORED_ATTR(NSApplicationMain)
-  IGNORED_ATTR(NSCopying)
   IGNORED_ATTR(ObjC)
   IGNORED_ATTR(ObjCBridged)
   IGNORED_ATTR(ObjCNonLazyRealization)
   IGNORED_ATTR(ObjCRuntimeName)
-  IGNORED_ATTR(Optimize)
   IGNORED_ATTR(Optional)
-  IGNORED_ATTR(Postfix)
-  IGNORED_ATTR(Prefix)
   IGNORED_ATTR(RawDocComment)
-  IGNORED_ATTR(Required)
   IGNORED_ATTR(RequiresStoredPropertyInits)
   IGNORED_ATTR(RestatedObjCConformance)
-  IGNORED_ATTR(Rethrows)
   IGNORED_ATTR(Semantics)
   IGNORED_ATTR(ShowInInterface)
   IGNORED_ATTR(SILGenName)
-  IGNORED_ATTR(Specialize)
   IGNORED_ATTR(StaticInitializeObjCMetadata)
-  IGNORED_ATTR(SwiftNativeObjCRuntimeBase)
   IGNORED_ATTR(SynthesizedProtocol)
   IGNORED_ATTR(Testable)
-  IGNORED_ATTR(UIApplicationMain)
-  IGNORED_ATTR(UnsafeNoObjCTaggedPointer)
-  IGNORED_ATTR(UsableFromInline)
   IGNORED_ATTR(WeakLinked)
   IGNORED_ATTR(DynamicReplacement)
   IGNORED_ATTR(PrivateImport)
-  IGNORED_ATTR(Custom)
-  IGNORED_ATTR(PropertyWrapper)
   IGNORED_ATTR(DisfavoredOverload)
-  IGNORED_ATTR(FunctionBuilder)
   IGNORED_ATTR(ProjectedValueProperty)
   IGNORED_ATTR(ReferenceOwnership)
 #undef IGNORED_ATTR
@@ -175,32 +149,6 @@ public:
   void visitConsumingAttr(ConsumingAttr *attr) { visitMutationAttr(attr); }
   void visitDynamicAttr(DynamicAttr *attr);
 
-  void visitFinalAttr(FinalAttr *attr) {
-    // Reject combining 'final' with 'open'.
-    if (auto accessAttr = D->getAttrs().getAttribute<AccessControlAttr>()) {
-      if (accessAttr->getAccess() == AccessLevel::Open) {
-        TC.diagnose(attr->getLocation(), diag::open_decl_cannot_be_final,
-                    D->getDescriptiveKind());
-        return;
-      }
-    }
-
-    if (isa<ClassDecl>(D))
-      return;
-
-    // 'final' only makes sense in the context of a class declaration.
-    // Reject it on global functions, protocols, structs, enums, etc.
-    if (!D->getDeclContext()->getSelfClassDecl()) {
-      TC.diagnose(attr->getLocation(), diag::member_cannot_be_final)
-        .fixItRemove(attr->getRange());
-
-      // Remove the attribute so child declarations are not flagged as final
-      // and duplicate the error message.
-      D->getAttrs().removeAttribute(attr);
-      return;
-    }
-  }
-
   void visitIndirectAttr(IndirectAttr *attr) {
     if (auto caseDecl = dyn_cast<EnumElementDecl>(D)) {
       // An indirect case should have a payload.
@@ -221,6 +169,7 @@ public:
     }
   }
 
+  void visitFinalAttr(FinalAttr *attr);
   void visitIBActionAttr(IBActionAttr *attr);
   void visitIBSegueActionAttr(IBSegueActionAttr *attr);
   void visitLazyAttr(LazyAttr *attr);
@@ -236,10 +185,58 @@ public:
   void visitSetterAccessAttr(SetterAccessAttr *attr);
   bool visitAbstractAccessControlAttr(AbstractAccessControlAttr *attr);
   void visitObjCMembersAttr(ObjCMembersAttr *attr);
+
+  void visitAvailableAttr(AvailableAttr *attr);
+
+  void visitCDeclAttr(CDeclAttr *attr);
+
+  void visitDynamicCallableAttr(DynamicCallableAttr *attr);
+
+  void visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr);
+
+  void visitNSCopyingAttr(NSCopyingAttr *attr);
+  void visitRequiredAttr(RequiredAttr *attr);
+  void visitRethrowsAttr(RethrowsAttr *attr);
+
+  void checkApplicationMainAttribute(DeclAttribute *attr,
+                                     Identifier Id_ApplicationDelegate,
+                                     Identifier Id_Kit,
+                                     Identifier Id_ApplicationMain);
+
+  void visitNSApplicationMainAttr(NSApplicationMainAttr *attr);
+  void visitUIApplicationMainAttr(UIApplicationMainAttr *attr);
+
+  void visitUnsafeNoObjCTaggedPointerAttr(UnsafeNoObjCTaggedPointerAttr *attr);
+  void visitSwiftNativeObjCRuntimeBaseAttr(
+                                         SwiftNativeObjCRuntimeBaseAttr *attr);
+
+  void checkOperatorAttribute(DeclAttribute *attr);
+
+  void visitInfixAttr(InfixAttr *attr) { checkOperatorAttribute(attr); }
+  void visitPostfixAttr(PostfixAttr *attr) { checkOperatorAttribute(attr); }
+  void visitPrefixAttr(PrefixAttr *attr) { checkOperatorAttribute(attr); }
+
+  void visitSpecializeAttr(SpecializeAttr *attr);
+
+  void visitFixedLayoutAttr(FixedLayoutAttr *attr);
+  void visitUsableFromInlineAttr(UsableFromInlineAttr *attr);
+  void visitInlinableAttr(InlinableAttr *attr);
+  void visitOptimizeAttr(OptimizeAttr *attr);
+
+  void visitDiscardableResultAttr(DiscardableResultAttr *attr);
+  void visitImplementsAttr(ImplementsAttr *attr);
+
+  void visitFrozenAttr(FrozenAttr *attr);
+
+  void visitCustomAttr(CustomAttr *attr);
+  void visitPropertyWrapperAttr(PropertyWrapperAttr *attr);
+  void visitFunctionBuilderAttr(FunctionBuilderAttr *attr);
+
+  void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
 };
 } // end anonymous namespace
 
-void AttributeEarlyChecker::visitTransparentAttr(TransparentAttr *attr) {
+void AttributeChecker::visitTransparentAttr(TransparentAttr *attr) {
   DeclContext *Ctx = D->getDeclContext();
   // Protocol declarations cannot be transparent.
   if (isa<ProtocolDecl>(Ctx))
@@ -262,7 +259,7 @@ void AttributeEarlyChecker::visitTransparentAttr(TransparentAttr *attr) {
   }
 }
 
-void AttributeEarlyChecker::visitMutationAttr(DeclAttribute *attr) {
+void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
   FuncDecl *FD = cast<FuncDecl>(D);
 
   SelfAccessKind attrModifier;
@@ -326,7 +323,7 @@ void AttributeEarlyChecker::visitMutationAttr(DeclAttribute *attr) {
     diagnoseAndRemoveAttr(attr, diag::static_functions_not_mutating);
 }
 
-void AttributeEarlyChecker::visitDynamicAttr(DynamicAttr *attr) {
+void AttributeChecker::visitDynamicAttr(DynamicAttr *attr) {
   // Members cannot be both dynamic and @_transparent.
   if (D->getAttrs().hasAttribute<TransparentAttr>())
     diagnoseAndRemoveAttr(attr, diag::dynamic_with_transparent);
@@ -336,23 +333,150 @@ void AttributeEarlyChecker::visitDynamicAttr(DynamicAttr *attr) {
                           diag::dynamic_and_library_evolution_not_supported);
 }
 
-void AttributeEarlyChecker::visitIBActionAttr(IBActionAttr *attr) {
+static bool
+validateIBActionSignature(TypeChecker &TC, DeclAttribute *attr, const FuncDecl *FD,
+                          unsigned minParameters, unsigned maxParameters,
+                          bool hasVoidResult = true) {
+  bool valid = true;
+
+  auto arity = FD->getParameters()->size();
+  auto resultType = FD->getResultInterfaceType();
+
+  if (arity < minParameters || arity > maxParameters) {
+    auto diagID = diag::invalid_ibaction_argument_count;
+    if (minParameters == maxParameters)
+      diagID = diag::invalid_ibaction_argument_count_exact;
+    else if (minParameters == 0)
+      diagID = diag::invalid_ibaction_argument_count_max;
+    TC.diagnose(FD, diagID, attr->getAttrName(), minParameters, maxParameters);
+    valid = false;
+  }
+
+  if (resultType->isVoid() != hasVoidResult) {
+    TC.diagnose(FD, diag::invalid_ibaction_result, attr->getAttrName(),
+                hasVoidResult);
+    valid = false;
+  }
+
+  // We don't need to check here that parameter or return types are
+  // ObjC-representable; IsObjCRequest will validate that.
+
+  if (!valid)
+    attr->setInvalid();
+  return valid;
+}
+
+static bool isiOS(TypeChecker &TC) {
+  return TC.getLangOpts().Target.isiOS();
+}
+
+static bool iswatchOS(TypeChecker &TC) {
+  return TC.getLangOpts().Target.isWatchOS();
+}
+
+static bool isRelaxedIBAction(TypeChecker &TC) {
+  return isiOS(TC) || iswatchOS(TC);
+}
+
+void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
+  // Only instance methods can be IBActions.
+  const FuncDecl *FD = cast<FuncDecl>(D);
+  if (!FD->isPotentialIBActionTarget()) {
+    diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl,
+                          attr->getAttrName());
+    return;
+  }
+
+  if (isRelaxedIBAction(TC))
+    // iOS, tvOS, and watchOS allow 0-2 parameters to an @IBAction method.
+    validateIBActionSignature(TC, attr, FD, /*minParams=*/0, /*maxParams=*/2);
+  else
+    // macOS allows 1 parameter to an @IBAction method.
+    validateIBActionSignature(TC, attr, FD, /*minParams=*/1, /*maxParams=*/1);
+}
+
+void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
   // Only instance methods can be IBActions.
   const FuncDecl *FD = cast<FuncDecl>(D);
   if (!FD->isPotentialIBActionTarget())
     diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl,
                           attr->getAttrName());
+
+  if (!validateIBActionSignature(TC, attr, FD,
+                                 /*minParams=*/1, /*maxParams=*/3,
+                                 /*hasVoidResult=*/false))
+    return;
+
+  // If the IBSegueAction method's selector belongs to one of the ObjC method
+  // families (like -newDocumentSegue: or -copyScreen), it would return the
+  // object at +1, but the caller would expect it to be +0 and would therefore
+  // leak it.
+  //
+  // To prevent that, diagnose if the selector belongs to one of the method
+  // families and suggest that the user change the Swift name or Obj-C selector.
+  auto currentSelector = FD->getObjCSelector();
+
+  SmallString<32> prefix("make");
+
+  switch (currentSelector.getSelectorFamily()) {
+  case ObjCSelectorFamily::None:
+    // No error--exit early.
+    return;
+
+  case ObjCSelectorFamily::Alloc:
+  case ObjCSelectorFamily::Init:
+  case ObjCSelectorFamily::New:
+    // Fix-it will replace the "alloc"/"init"/"new" in the selector with "make".
+    break;
+
+  case ObjCSelectorFamily::Copy:
+    // Fix-it will replace the "copy" in the selector with "makeCopy".
+    prefix += "Copy";
+    break;
+
+  case ObjCSelectorFamily::MutableCopy:
+    // Fix-it will replace the "mutable" in the selector with "makeMutable".
+    prefix += "Mutable";
+    break;
+  }
+
+  // Emit the actual error.
+  TC.diagnose(FD, diag::ibsegueaction_objc_method_family,
+              attr->getAttrName(), currentSelector);
+
+  // The rest of this is just fix-it generation.
+
+  /// Replaces the first word of \c oldName with the prefix, where "word" is a
+  /// sequence of lowercase characters.
+  auto replacingPrefix = [&](Identifier oldName) -> Identifier {
+    SmallString<32> scratch = prefix;
+    scratch += oldName.str().drop_while(clang::isLowercase);
+    return TC.Context.getIdentifier(scratch);
+  };
+
+  // Suggest changing the Swift name of the method, unless there is already an
+  // explicit selector.
+  if (!FD->getAttrs().hasAttribute<ObjCAttr>() ||
+      !FD->getAttrs().getAttribute<ObjCAttr>()->hasName()) {
+    auto newSwiftBaseName = replacingPrefix(FD->getBaseName().getIdentifier());
+    auto argumentNames = FD->getFullName().getArgumentNames();
+    DeclName newSwiftName(TC.Context, newSwiftBaseName, argumentNames);
+
+    auto diag = TC.diagnose(FD, diag::fixit_rename_in_swift, newSwiftName);
+    fixDeclarationName(diag, FD, newSwiftName);
+  }
+
+  // Suggest changing just the selector to one with a different first piece.
+  auto oldPieces = currentSelector.getSelectorPieces();
+  SmallVector<Identifier, 4> newPieces(oldPieces.begin(), oldPieces.end());
+  newPieces[0] = replacingPrefix(newPieces[0]);
+  ObjCSelector newSelector(TC.Context, currentSelector.getNumArgs(), newPieces);
+
+  auto diag = TC.diagnose(FD, diag::fixit_rename_in_objc, newSelector);
+  fixDeclarationObjCName(diag, FD, currentSelector, newSelector);
 }
 
-void AttributeEarlyChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
-  // Only instance methods can be IBActions.
-  const FuncDecl *FD = cast<FuncDecl>(D);
-  if (!FD->isPotentialIBActionTarget())
-    diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl,
-                          attr->getAttrName());
-}
-
-void AttributeEarlyChecker::visitIBDesignableAttr(IBDesignableAttr *attr) {
+void AttributeChecker::visitIBDesignableAttr(IBDesignableAttr *attr) {
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
     if (auto nominalDecl = ED->getExtendedNominal()) {
       if (!isa<ClassDecl>(nominalDecl))
@@ -361,7 +485,7 @@ void AttributeEarlyChecker::visitIBDesignableAttr(IBDesignableAttr *attr) {
   }
 }
 
-void AttributeEarlyChecker::visitIBInspectableAttr(IBInspectableAttr *attr) {
+void AttributeChecker::visitIBInspectableAttr(IBInspectableAttr *attr) {
   // Only instance properties can be 'IBInspectable'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
@@ -369,7 +493,7 @@ void AttributeEarlyChecker::visitIBInspectableAttr(IBInspectableAttr *attr) {
                                  attr->getAttrName());
 }
 
-void AttributeEarlyChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
+void AttributeChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
   // Only instance properties can be 'GKInspectable'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
@@ -419,7 +543,7 @@ isAcceptableOutletType(Type type, bool &isArray, TypeChecker &TC) {
 }
 
 
-void AttributeEarlyChecker::visitIBOutletAttr(IBOutletAttr *attr) {
+void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
   // Only instance properties can be 'IBOutlet'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
@@ -479,7 +603,7 @@ void AttributeEarlyChecker::visitIBOutletAttr(IBOutletAttr *attr) {
   }
 }
 
-void AttributeEarlyChecker::visitNSManagedAttr(NSManagedAttr *attr) {
+void AttributeChecker::visitNSManagedAttr(NSManagedAttr *attr) {
   // @NSManaged only applies to instance methods and properties within a class.
   if (cast<ValueDecl>(D)->isStatic() ||
       !D->getDeclContext()->getSelfClassDecl()) {
@@ -503,28 +627,32 @@ void AttributeEarlyChecker::visitNSManagedAttr(NSManagedAttr *attr) {
 
 }
 
-void AttributeEarlyChecker::
+void AttributeChecker::
 visitLLDBDebuggerFunctionAttr(LLDBDebuggerFunctionAttr *attr) {
   // This is only legal when debugger support is on.
   if (!D->getASTContext().LangOpts.DebuggerSupport)
     diagnoseAndRemoveAttr(attr, diag::attr_for_debugger_support_only);
 }
 
-void AttributeEarlyChecker::visitOverrideAttr(OverrideAttr *attr) {
+void AttributeChecker::visitOverrideAttr(OverrideAttr *attr) {
   if (!isa<ClassDecl>(D->getDeclContext()) &&
       !isa<ProtocolDecl>(D->getDeclContext()) &&
       !isa<ExtensionDecl>(D->getDeclContext()))
     diagnoseAndRemoveAttr(attr, diag::override_nonclass_decl);
 }
 
-void AttributeEarlyChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
+void AttributeChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
+  if (auto overrideAttr = D->getAttrs().getAttribute<OverrideAttr>())
+    diagnoseAndRemoveAttr(overrideAttr, diag::nonoverride_and_override_attr);
+
   if (!isa<ClassDecl>(D->getDeclContext()) &&
       !isa<ProtocolDecl>(D->getDeclContext()) &&
-      !isa<ExtensionDecl>(D->getDeclContext()))
+      !isa<ExtensionDecl>(D->getDeclContext())) {
     diagnoseAndRemoveAttr(attr, diag::nonoverride_wrong_decl_context);
+  }
 }
 
-void AttributeEarlyChecker::visitLazyAttr(LazyAttr *attr) {
+void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
   // lazy may only be used on properties.
   auto *VD = cast<VarDecl>(D);
 
@@ -547,7 +675,7 @@ void AttributeEarlyChecker::visitLazyAttr(LazyAttr *attr) {
   }
 }
 
-bool AttributeEarlyChecker::visitAbstractAccessControlAttr(
+bool AttributeChecker::visitAbstractAccessControlAttr(
     AbstractAccessControlAttr *attr) {
   // Access control attr may only be used on value decls and extensions.
   if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D)) {
@@ -579,11 +707,85 @@ bool AttributeEarlyChecker::visitAbstractAccessControlAttr(
   return false;
 }
 
-void AttributeEarlyChecker::visitAccessControlAttr(AccessControlAttr *attr) {
+void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
   visitAbstractAccessControlAttr(attr);
+
+  if (auto extension = dyn_cast<ExtensionDecl>(D)) {
+    if (attr->getAccess() == AccessLevel::Open) {
+      TC.diagnose(attr->getLocation(), diag::access_control_extension_open)
+        .fixItReplace(attr->getRange(), "public");
+      attr->setInvalid();
+      return;
+    }
+
+    NominalTypeDecl *nominal = extension->getExtendedNominal();
+
+    // Extension is ill-formed; suppress the attribute.
+    if (!nominal) {
+      attr->setInvalid();
+      return;
+    }
+
+    AccessLevel typeAccess = nominal->getFormalAccess();
+    if (attr->getAccess() > typeAccess) {
+      TC.diagnose(attr->getLocation(), diag::access_control_extension_more,
+                  typeAccess,
+                  nominal->getDescriptiveKind(),
+                  attr->getAccess())
+        .fixItRemove(attr->getRange());
+      attr->setInvalid();
+      return;
+    }
+
+  } else if (auto extension = dyn_cast<ExtensionDecl>(D->getDeclContext())) {
+    AccessLevel maxAccess = extension->getMaxAccessLevel();
+    if (std::min(attr->getAccess(), AccessLevel::Public) > maxAccess) {
+      // FIXME: It would be nice to say what part of the requirements actually
+      // end up being problematic.
+      auto diag =
+          TC.diagnose(attr->getLocation(),
+                      diag::access_control_ext_requirement_member_more,
+                      attr->getAccess(),
+                      D->getDescriptiveKind(),
+                      maxAccess);
+      swift::fixItAccess(diag, cast<ValueDecl>(D), maxAccess);
+      return;
+    }
+
+    if (auto extAttr =
+        extension->getAttrs().getAttribute<AccessControlAttr>()) {
+      AccessLevel defaultAccess = extension->getDefaultAccessLevel();
+      if (attr->getAccess() > defaultAccess) {
+        auto diag = TC.diagnose(attr->getLocation(),
+                                diag::access_control_ext_member_more,
+                                attr->getAccess(),
+                                extAttr->getAccess());
+        // Don't try to fix this one; it's just a warning, and fixing it can
+        // lead to diagnostic fights between this and "declaration must be at
+        // least this accessible" checking for overrides and protocol
+        // requirements.
+      } else if (attr->getAccess() == defaultAccess) {
+        TC.diagnose(attr->getLocation(),
+                    diag::access_control_ext_member_redundant,
+                    attr->getAccess(),
+                    D->getDescriptiveKind(),
+                    extAttr->getAccess())
+          .fixItRemove(attr->getRange());
+      }
+    }
+  }
+
+  if (attr->getAccess() == AccessLevel::Open) {
+    if (!isa<ClassDecl>(D) && !D->isPotentiallyOverridable() &&
+        !attr->isInvalid()) {
+      TC.diagnose(attr->getLocation(), diag::access_control_open_bad_decl)
+        .fixItReplace(attr->getRange(), "public");
+      attr->setInvalid();
+    }
+  }
 }
 
-void AttributeEarlyChecker::visitSetterAccessAttr(
+void AttributeChecker::visitSetterAccessAttr(
     SetterAccessAttr *attr) {
   auto storage = dyn_cast<AbstractStorageDecl>(D);
   if (!storage)
@@ -611,15 +813,44 @@ void AttributeEarlyChecker::visitSetterAccessAttr(
     diagnoseAndRemoveAttr(attr, diag::access_control_setter_read_only,
                           attr->getAccess(), storageKind);
   }
+
+  auto getterAccess = cast<ValueDecl>(D)->getFormalAccess();
+  if (attr->getAccess() > getterAccess) {
+    // This must stay in sync with diag::access_control_setter_more.
+    enum {
+      SK_Variable = 0,
+      SK_Property,
+      SK_Subscript
+    } storageKind;
+    if (isa<SubscriptDecl>(D))
+      storageKind = SK_Subscript;
+    else if (D->getDeclContext()->isTypeContext())
+      storageKind = SK_Property;
+    else
+      storageKind = SK_Variable;
+    TC.diagnose(attr->getLocation(), diag::access_control_setter_more,
+                getterAccess, storageKind, attr->getAccess());
+    attr->setInvalid();
+    return;
+
+  } else if (attr->getAccess() == getterAccess) {
+    TC.diagnose(attr->getLocation(),
+                diag::access_control_setter_redundant,
+                attr->getAccess(),
+                D->getDescriptiveKind(),
+                getterAccess)
+      .fixItRemove(attr->getRange());
+    return;
+  }
 }
 
-void AttributeEarlyChecker::visitObjCMembersAttr(ObjCMembersAttr *attr) {
+void AttributeChecker::visitObjCMembersAttr(ObjCMembersAttr *attr) {
   if (!isa<ClassDecl>(D))
     diagnoseAndRemoveAttr(attr, diag::objcmembers_attribute_nonclass);
 }
 
-void TypeChecker::checkDeclAttributesEarly(Decl *D) {
-  AttributeEarlyChecker Checker(*this, D);
+void TypeChecker::checkDeclAttributes(Decl *D) {
+  AttributeChecker Checker(*this, D);
   for (auto attr : D->getAttrs()) {
     if (!attr->isValid()) continue;
 
@@ -664,147 +895,6 @@ void TypeChecker::checkDeclAttributesEarly(Decl *D) {
     else
       Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr);
   }
-}
-
-namespace {
-class AttributeChecker : public AttributeVisitor<AttributeChecker> {
-  TypeChecker &TC;
-  Decl *D;
-
-  /// This emits a diagnostic with a fixit to remove the attribute.
-  template<typename ...ArgTypes>
-  void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
-    ::diagnoseAndRemoveAttr(TC, D, attr, std::forward<ArgTypes>(Args)...);
-  }
-
-public:
-  AttributeChecker(TypeChecker &TC, Decl *D) : TC(TC), D(D) {}
-
-  /// Deleting this ensures that all attributes are covered by the visitor
-  /// below.
-  void visitDeclAttribute(DeclAttribute *A) = delete;
-
-#define IGNORED_ATTR(CLASS)                                              \
-    void visit##CLASS##Attr(CLASS##Attr *) {}
-
-    IGNORED_ATTR(Alignment)
-    IGNORED_ATTR(AlwaysEmitIntoClient)
-    IGNORED_ATTR(Borrowed)
-    IGNORED_ATTR(HasInitialValue)
-    IGNORED_ATTR(ClangImporterSynthesizedType)
-    IGNORED_ATTR(Consuming)
-    IGNORED_ATTR(Convenience)
-    IGNORED_ATTR(Dynamic)
-    IGNORED_ATTR(DynamicReplacement)
-    IGNORED_ATTR(Effects)
-    IGNORED_ATTR(Exported)
-    IGNORED_ATTR(ForbidSerializingReference)
-    IGNORED_ATTR(GKInspectable)
-    IGNORED_ATTR(HasStorage)
-    IGNORED_ATTR(IBDesignable)
-    IGNORED_ATTR(IBInspectable)
-    IGNORED_ATTR(IBOutlet) // checked early.
-    IGNORED_ATTR(Indirect)
-    IGNORED_ATTR(Inline)
-    IGNORED_ATTR(Lazy)      // checked early.
-    IGNORED_ATTR(LLDBDebuggerFunction)
-    IGNORED_ATTR(Mutating)
-    IGNORED_ATTR(NonMutating)
-    IGNORED_ATTR(NonObjC)
-    IGNORED_ATTR(NSManaged) // checked early.
-    IGNORED_ATTR(ObjC)
-    IGNORED_ATTR(ObjCBridged)
-    IGNORED_ATTR(ObjCMembers)
-    IGNORED_ATTR(ObjCNonLazyRealization)
-    IGNORED_ATTR(ObjCRuntimeName)
-    IGNORED_ATTR(Optional)
-    IGNORED_ATTR(Override)
-    IGNORED_ATTR(PrivateImport)
-    IGNORED_ATTR(RawDocComment)
-    IGNORED_ATTR(ReferenceOwnership)
-    IGNORED_ATTR(RequiresStoredPropertyInits)
-    IGNORED_ATTR(RestatedObjCConformance)
-    IGNORED_ATTR(Semantics)
-    IGNORED_ATTR(ShowInInterface)
-    IGNORED_ATTR(SILGenName)
-    IGNORED_ATTR(StaticInitializeObjCMetadata)
-    IGNORED_ATTR(SynthesizedProtocol)
-    IGNORED_ATTR(Testable)
-    IGNORED_ATTR(Transparent)
-    IGNORED_ATTR(WarnUnqualifiedAccess)
-    IGNORED_ATTR(WeakLinked)
-    IGNORED_ATTR(DisfavoredOverload)
-    IGNORED_ATTR(ProjectedValueProperty)
-#undef IGNORED_ATTR
-
-  void visitAvailableAttr(AvailableAttr *attr);
-  
-  void visitCDeclAttr(CDeclAttr *attr);
-
-  void visitDynamicCallableAttr(DynamicCallableAttr *attr);
-
-  void visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr);
-  
-  void visitFinalAttr(FinalAttr *attr);
-  void visitIBActionAttr(IBActionAttr *attr);
-  void visitIBSegueActionAttr(IBSegueActionAttr *attr);
-  void visitNSCopyingAttr(NSCopyingAttr *attr);
-  void visitRequiredAttr(RequiredAttr *attr);
-  void visitRethrowsAttr(RethrowsAttr *attr);
-
-  void visitAccessControlAttr(AccessControlAttr *attr);
-  void visitSetterAccessAttr(SetterAccessAttr *attr);
-
-  void checkApplicationMainAttribute(DeclAttribute *attr,
-                                     Identifier Id_ApplicationDelegate,
-                                     Identifier Id_Kit,
-                                     Identifier Id_ApplicationMain);
-  
-  void visitNSApplicationMainAttr(NSApplicationMainAttr *attr);
-  void visitUIApplicationMainAttr(UIApplicationMainAttr *attr);
-
-  void visitUnsafeNoObjCTaggedPointerAttr(UnsafeNoObjCTaggedPointerAttr *attr);
-  void visitSwiftNativeObjCRuntimeBaseAttr(
-                                         SwiftNativeObjCRuntimeBaseAttr *attr);
-
-  void checkOperatorAttribute(DeclAttribute *attr);
-
-  void visitInfixAttr(InfixAttr *attr) { checkOperatorAttribute(attr); }
-  void visitPostfixAttr(PostfixAttr *attr) { checkOperatorAttribute(attr); }
-  void visitPrefixAttr(PrefixAttr *attr) { checkOperatorAttribute(attr); }
-
-  void visitSpecializeAttr(SpecializeAttr *attr);
-
-  void visitFixedLayoutAttr(FixedLayoutAttr *attr);
-  void visitUsableFromInlineAttr(UsableFromInlineAttr *attr);
-  void visitInlinableAttr(InlinableAttr *attr);
-  void visitOptimizeAttr(OptimizeAttr *attr);
-
-  void visitDiscardableResultAttr(DiscardableResultAttr *attr);
-  void visitImplementsAttr(ImplementsAttr *attr);
-
-  void visitFrozenAttr(FrozenAttr *attr);
-
-  void visitNonOverrideAttr(NonOverrideAttr *attr);
-  void visitCustomAttr(CustomAttr *attr);
-  void visitPropertyWrapperAttr(PropertyWrapperAttr *attr);
-  void visitFunctionBuilderAttr(FunctionBuilderAttr *attr);
-
-  void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
-};
-} // end anonymous namespace
-
-
-static bool isiOS(TypeChecker &TC) {
-  return TC.getLangOpts().Target.isiOS();
-}
-
-static bool iswatchOS(TypeChecker &TC) {
-  return TC.getLangOpts().Target.isWatchOS();
-}
-
-static bool isRelaxedIBAction(TypeChecker &TC) {
-  return isiOS(TC) || iswatchOS(TC);
 }
 
 /// Returns true if the given method is an valid implementation of a
@@ -1002,126 +1092,6 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   }
 }
 
-static bool
-validateIBActionSignature(TypeChecker &TC, DeclAttribute *attr, FuncDecl *FD,
-                          unsigned minParameters, unsigned maxParameters,
-                          bool hasVoidResult = true) {
-  bool valid = true;
-
-  auto arity = FD->getParameters()->size();
-  auto resultType = FD->getResultInterfaceType();
-
-  if (arity < minParameters || arity > maxParameters) {
-    auto diagID = diag::invalid_ibaction_argument_count;
-    if (minParameters == maxParameters)
-      diagID = diag::invalid_ibaction_argument_count_exact;
-    else if (minParameters == 0)
-      diagID = diag::invalid_ibaction_argument_count_max;
-    TC.diagnose(FD, diagID, attr->getAttrName(), minParameters, maxParameters);
-    valid = false;
-  }
-
-  if (resultType->isVoid() != hasVoidResult) {
-    TC.diagnose(FD, diag::invalid_ibaction_result, attr->getAttrName(),
-                hasVoidResult);
-    valid = false;
-  }
-
-  // We don't need to check here that parameter or return types are
-  // ObjC-representable; IsObjCRequest will validate that.
-
-  if (!valid)
-    attr->setInvalid();
-  return valid;
-}
-
-void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
-  auto *FD = cast<FuncDecl>(D);
-
-  if (isRelaxedIBAction(TC))
-    // iOS, tvOS, and watchOS allow 0-2 parameters to an @IBAction method.
-    validateIBActionSignature(TC, attr, FD, /*minParams=*/0, /*maxParams=*/2);
-  else
-    // macOS allows 1 parameter to an @IBAction method.
-    validateIBActionSignature(TC, attr, FD, /*minParams=*/1, /*maxParams=*/1);
-}
-
-void AttributeChecker::visitIBSegueActionAttr(IBSegueActionAttr *attr) {
-  auto *FD = cast<FuncDecl>(D);
-  if (!validateIBActionSignature(TC, attr, FD,
-                                 /*minParams=*/1, /*maxParams=*/3,
-                                 /*hasVoidResult=*/false))
-    return;
-
-  // If the IBSegueAction method's selector belongs to one of the ObjC method
-  // families (like -newDocumentSegue: or -copyScreen), it would return the
-  // object at +1, but the caller would expect it to be +0 and would therefore
-  // leak it.
-  //
-  // To prevent that, diagnose if the selector belongs to one of the method
-  // families and suggest that the user change the Swift name or Obj-C selector.
-  auto currentSelector = FD->getObjCSelector();
-
-  SmallString<32> prefix("make");
-
-  switch (currentSelector.getSelectorFamily()) {
-  case ObjCSelectorFamily::None:
-    // No error--exit early.
-    return;
-
-  case ObjCSelectorFamily::Alloc:
-  case ObjCSelectorFamily::Init:
-  case ObjCSelectorFamily::New:
-    // Fix-it will replace the "alloc"/"init"/"new" in the selector with "make".
-    break;
-
-  case ObjCSelectorFamily::Copy:
-    // Fix-it will replace the "copy" in the selector with "makeCopy".
-    prefix += "Copy";
-    break;
-
-  case ObjCSelectorFamily::MutableCopy:
-    // Fix-it will replace the "mutable" in the selector with "makeMutable".
-    prefix += "Mutable";
-    break;
-  }
-
-  // Emit the actual error.
-  TC.diagnose(FD, diag::ibsegueaction_objc_method_family,
-              attr->getAttrName(), currentSelector);
-
-  // The rest of this is just fix-it generation.
-
-  /// Replaces the first word of \c oldName with the prefix, where "word" is a
-  /// sequence of lowercase characters.
-  auto replacingPrefix = [&](Identifier oldName) -> Identifier {
-    SmallString<32> scratch = prefix;
-    scratch += oldName.str().drop_while(clang::isLowercase);
-    return TC.Context.getIdentifier(scratch);
-  };
-
-  // Suggest changing the Swift name of the method, unless there is already an
-  // explicit selector.
-  if (!FD->getAttrs().hasAttribute<ObjCAttr>() ||
-      !FD->getAttrs().getAttribute<ObjCAttr>()->hasName()) {
-    auto newSwiftBaseName = replacingPrefix(FD->getBaseName().getIdentifier());
-    auto argumentNames = FD->getFullName().getArgumentNames();
-    DeclName newSwiftName(TC.Context, newSwiftBaseName, argumentNames);
-
-    auto diag = TC.diagnose(FD, diag::fixit_rename_in_swift, newSwiftName);
-    fixDeclarationName(diag, FD, newSwiftName);
-  }
-
-  // Suggest changing just the selector to one with a different first piece.
-  auto oldPieces = currentSelector.getSelectorPieces();
-  SmallVector<Identifier, 4> newPieces(oldPieces.begin(), oldPieces.end());
-  newPieces[0] = replacingPrefix(newPieces[0]);
-  ObjCSelector newSelector(TC.Context, currentSelector.getNumArgs(), newPieces);
-
-  auto diag = TC.diagnose(FD, diag::fixit_rename_in_objc, newSelector);
-  fixDeclarationObjCName(diag, FD, currentSelector, newSelector);
-}
-
 /// Get the innermost enclosing declaration for a declaration.
 static Decl *getEnclosingDeclForDecl(Decl *D) {
   // If the declaration is an accessor, treat its storage declaration
@@ -1232,9 +1202,29 @@ void AttributeChecker::visitSwiftNativeObjCRuntimeBaseAttr(
 }
 
 void AttributeChecker::visitFinalAttr(FinalAttr *attr) {
-  // final on classes marks all members with final.
+  // Reject combining 'final' with 'open'.
+  if (auto accessAttr = D->getAttrs().getAttribute<AccessControlAttr>()) {
+    if (accessAttr->getAccess() == AccessLevel::Open) {
+      TC.diagnose(attr->getLocation(), diag::open_decl_cannot_be_final,
+                  D->getDescriptiveKind());
+      return;
+    }
+  }
+
   if (isa<ClassDecl>(D))
     return;
+
+  // 'final' only makes sense in the context of a class declaration.
+  // Reject it on global functions, protocols, structs, enums, etc.
+  if (!D->getDeclContext()->getSelfClassDecl()) {
+    TC.diagnose(attr->getLocation(), diag::member_cannot_be_final)
+      .fixItRemove(attr->getRange());
+
+    // Remove the attribute so child declarations are not flagged as final
+    // and duplicate the error message.
+    D->getAttrs().removeAttribute(attr);
+    return;
+  }
 
   // We currently only support final on var/let, func and subscript
   // declarations.
@@ -1551,114 +1541,6 @@ void AttributeChecker::visitRethrowsAttr(RethrowsAttr *attr) {
 
   TC.diagnose(attr->getLocation(), diag::rethrows_without_throwing_parameter);
   attr->setInvalid();
-}
-
-void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
-  if (auto extension = dyn_cast<ExtensionDecl>(D)) {
-    if (attr->getAccess() == AccessLevel::Open) {
-      TC.diagnose(attr->getLocation(), diag::access_control_extension_open)
-        .fixItReplace(attr->getRange(), "public");
-      attr->setInvalid();
-      return;
-    }
-
-    NominalTypeDecl *nominal = extension->getExtendedNominal();
-
-    // Extension is ill-formed; suppress the attribute.
-    if (!nominal) {
-      attr->setInvalid();
-      return;
-    }
-
-    AccessLevel typeAccess = nominal->getFormalAccess();
-    if (attr->getAccess() > typeAccess) {
-      TC.diagnose(attr->getLocation(), diag::access_control_extension_more,
-                  typeAccess,
-                  nominal->getDescriptiveKind(),
-                  attr->getAccess())
-        .fixItRemove(attr->getRange());
-      attr->setInvalid();
-      return;
-    }
-
-  } else if (auto extension = dyn_cast<ExtensionDecl>(D->getDeclContext())) {
-    AccessLevel maxAccess = extension->getMaxAccessLevel();
-    if (std::min(attr->getAccess(), AccessLevel::Public) > maxAccess) {
-      // FIXME: It would be nice to say what part of the requirements actually
-      // end up being problematic.
-      auto diag =
-          TC.diagnose(attr->getLocation(),
-                      diag::access_control_ext_requirement_member_more,
-                      attr->getAccess(),
-                      D->getDescriptiveKind(),
-                      maxAccess);
-      swift::fixItAccess(diag, cast<ValueDecl>(D), maxAccess);
-      return;
-    }
-
-    if (auto extAttr =
-        extension->getAttrs().getAttribute<AccessControlAttr>()) {
-      AccessLevel defaultAccess = extension->getDefaultAccessLevel();
-      if (attr->getAccess() > defaultAccess) {
-        auto diag = TC.diagnose(attr->getLocation(),
-                                diag::access_control_ext_member_more,
-                                attr->getAccess(),
-                                extAttr->getAccess());
-        // Don't try to fix this one; it's just a warning, and fixing it can
-        // lead to diagnostic fights between this and "declaration must be at
-        // least this accessible" checking for overrides and protocol
-        // requirements.
-      } else if (attr->getAccess() == defaultAccess) {
-        TC.diagnose(attr->getLocation(),
-                    diag::access_control_ext_member_redundant,
-                    attr->getAccess(),
-                    D->getDescriptiveKind(),
-                    extAttr->getAccess())
-          .fixItRemove(attr->getRange());
-      }
-    }
-  }
-
-  if (attr->getAccess() == AccessLevel::Open) {
-    if (!isa<ClassDecl>(D) && !D->isPotentiallyOverridable() &&
-        !attr->isInvalid()) {
-      TC.diagnose(attr->getLocation(), diag::access_control_open_bad_decl)
-        .fixItReplace(attr->getRange(), "public");
-      attr->setInvalid();
-    }
-  }
-}
-
-void
-AttributeChecker::visitSetterAccessAttr(SetterAccessAttr *attr) {
-  auto getterAccess = cast<ValueDecl>(D)->getFormalAccess();
-  if (attr->getAccess() > getterAccess) {
-    // This must stay in sync with diag::access_control_setter_more.
-    enum {
-      SK_Variable = 0,
-      SK_Property,
-      SK_Subscript
-    } storageKind;
-    if (isa<SubscriptDecl>(D))
-      storageKind = SK_Subscript;
-    else if (D->getDeclContext()->isTypeContext())
-      storageKind = SK_Property;
-    else
-      storageKind = SK_Variable;
-    TC.diagnose(attr->getLocation(), diag::access_control_setter_more,
-                getterAccess, storageKind, attr->getAccess());
-    attr->setInvalid();
-    return;
-
-  } else if (attr->getAccess() == getterAccess) {
-    TC.diagnose(attr->getLocation(),
-                diag::access_control_setter_redundant,
-                attr->getAccess(),
-                D->getDescriptiveKind(),
-                getterAccess)
-      .fixItRemove(attr->getRange());
-    return;
-  }
 }
 
 /// Collect all used generic parameter types from a given type.
@@ -2438,12 +2320,6 @@ void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
   }
 }
 
-void AttributeChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
-  if (auto overrideAttr = D->getAttrs().getAttribute<OverrideAttr>()) {
-    diagnoseAndRemoveAttr(overrideAttr, diag::nonoverride_and_override_attr);
-  }
-}
-
 void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   auto dc = D->getInnermostDeclContext();
 
@@ -2622,17 +2498,7 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
 
 void TypeChecker::checkParameterAttributes(ParameterList *params) {
   for (auto param: *params) {
-    checkDeclAttributesEarly(param);
     checkDeclAttributes(param);
-  }
-}
-
-void TypeChecker::checkDeclAttributes(Decl *D) {
-  AttributeChecker Checker(*this, D);
-
-  for (auto attr : D->getAttrs()) {
-    if (attr->isValid())
-      Checker.visit(attr);
   }
 }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -16,6 +16,7 @@
 
 #include "TypeCheckAvailability.h"
 #include "TypeChecker.h"
+#include "TypeCheckObjC.h"
 #include "MiscDiagnostics.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Initializer.h"

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -496,7 +496,7 @@ static void checkGenericParams(GenericParamList *genericParams,
     return;
 
   for (auto gp : *genericParams) {
-    tc.checkDeclAttributesEarly(gp);
+    tc.checkDeclAttributes(gp);
     checkInheritanceClause(gp);
   }
 
@@ -1766,7 +1766,6 @@ lookupPrecedenceGroupPrimitive(DeclContext *dc, Identifier name,
 }
 
 void TypeChecker::validateDecl(PrecedenceGroupDecl *PGD) {
-  checkDeclAttributesEarly(PGD);
   checkDeclAttributes(PGD);
 
   if (PGD->isInvalid() || PGD->hasValidationStarted())
@@ -1882,7 +1881,6 @@ static bool checkDesignatedTypes(OperatorDecl *OD,
 /// reference to its precedence group and the transitive validity of that
 /// group.
 void TypeChecker::validateDecl(OperatorDecl *OD) {
-  checkDeclAttributesEarly(OD);
   checkDeclAttributes(OD);
 
   auto IOD = dyn_cast<InfixOperatorDecl>(OD);
@@ -2128,7 +2126,6 @@ public:
   }
   
   void visitImportDecl(ImportDecl *ID) {
-    TC.checkDeclAttributesEarly(ID);
     TC.checkDeclAttributes(ID);
   }
 
@@ -2222,7 +2219,6 @@ public:
       }
     }
 
-    TC.checkDeclAttributesEarly(VD);
     TC.checkDeclAttributes(VD);
     validateAttributes(TC, VD);
 
@@ -2287,7 +2283,7 @@ public:
     // Check all the pattern/init pairs in the PBD.
     validatePatternBindingEntries(TC, PBD);
 
-    TC.checkDeclAttributesEarly(PBD);
+    TC.checkDeclAttributes(PBD);
 
     for (unsigned i = 0, e = PBD->getNumPatternEntries(); i != e; ++i) {
       // Type check each VarDecl that this PatternBinding handles.
@@ -2456,7 +2452,6 @@ public:
       TC.checkProtocolSelfRequirements(SD);
     }
 
-    TC.checkDeclAttributesEarly(SD);
     TC.checkDeclAttributes(SD);
     validateAttributes(TC, SD);
 
@@ -2502,7 +2497,6 @@ public:
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
-    TC.checkDeclAttributesEarly(TAD);
 
     TC.validateDecl(TAD);
     TC.checkDeclAttributes(TAD);
@@ -2511,8 +2505,6 @@ public:
   }
   
   void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
-    TC.checkDeclAttributesEarly(OTD);
-    
     TC.validateDecl(OTD);
     TC.checkDeclAttributes(OTD);
     
@@ -2520,8 +2512,6 @@ public:
   }
   
   void visitAssociatedTypeDecl(AssociatedTypeDecl *AT) {
-    TC.checkDeclAttributesEarly(AT);
-
     TC.validateDecl(AT);
     TC.checkDeclAttributes(AT);
 
@@ -2623,7 +2613,6 @@ public:
     for (Decl *member : ED->getMembers())
       visit(member);
 
-    TC.checkDeclAttributesEarly(ED);
     TC.checkDeclAttributes(ED);
     validateAttributes(TC, ED);
 
@@ -2659,7 +2648,6 @@ public:
 
     TC.checkPatternBindingCaptures(SD);
 
-    TC.checkDeclAttributesEarly(SD);
     TC.checkDeclAttributes(SD);
     validateAttributes(TC, SD);
 
@@ -2904,7 +2892,6 @@ public:
       }
     }
 
-    TC.checkDeclAttributesEarly(CD);
     TC.checkDeclAttributes(CD);
     validateAttributes(TC, CD);
 
@@ -2947,7 +2934,6 @@ public:
     for (auto Member : PD->getMembers())
       visit(Member);
 
-    TC.checkDeclAttributesEarly(PD);
     TC.checkDeclAttributes(PD);
     validateAttributes(TC, PD);
 
@@ -3049,7 +3035,6 @@ public:
     checkAccessControl(TC, FD);
 
     TC.checkParameterAttributes(FD->getParameters());
-    TC.checkDeclAttributesEarly(FD);
     TC.checkDeclAttributes(FD);
     validateAttributes(TC, FD);
 
@@ -3095,7 +3080,6 @@ public:
   void visitEnumElementDecl(EnumElementDecl *EED) {
     TC.validateDecl(EED);
 
-    TC.checkDeclAttributesEarly(EED);
     TC.checkDeclAttributes(EED);
     validateAttributes(TC, EED);
 
@@ -3136,8 +3120,6 @@ public:
 
     checkGenericParams(ED->getGenericParams(), ED, TC);
 
-    TC.checkDeclAttributesEarly(ED);
-
     for (Decl *Member : ED->getMembers())
       visit(Member);
 
@@ -3158,7 +3140,6 @@ public:
   void visitIfConfigDecl(IfConfigDecl *ICD) {
     // The active members of the #if block will be type checked along with
     // their enclosing declaration.
-    TC.checkDeclAttributesEarly(ICD);
     TC.checkDeclAttributes(ICD);
   }
 
@@ -3183,7 +3164,6 @@ public:
       TC.checkProtocolSelfRequirements(CD);
     }
 
-    TC.checkDeclAttributesEarly(CD);
     TC.checkDeclAttributes(CD);
     validateAttributes(TC, CD);
     TC.checkParameterAttributes(CD->getParameters());
@@ -3303,7 +3283,6 @@ public:
   void visitDestructorDecl(DestructorDecl *DD) {
     TC.validateDecl(DD);
 
-    TC.checkDeclAttributesEarly(DD);
     TC.checkDeclAttributes(DD);
     validateAttributes(TC, DD);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2260,9 +2260,6 @@ public:
       }
     }
 
-    if (VD->getAttrs().hasAttribute<DynamicReplacementAttr>())
-      TC.checkDynamicReplacementAttribute(VD);
-
     // Now check all the accessors.
     VD->visitEmittedAccessors([&](AccessorDecl *accessor) {
       visit(accessor);
@@ -2468,10 +2465,6 @@ public:
     (void) SD->isGetterMutating();
     (void) SD->isSetterMutating();
     (void) SD->getImplInfo();
-
-    if (SD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
-      TC.checkDynamicReplacementAttribute(SD);
-    }
 
     TC.checkParameterAttributes(SD->getIndices());
     TC.checkDefaultArguments(SD->getIndices(), SD);
@@ -3051,10 +3044,6 @@ public:
       TC.definedFunctions.push_back(FD);
     }
 
-    if (FD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
-      TC.checkDynamicReplacementAttribute(FD);
-    }
-
     checkExplicitAvailability(FD);
 
     if (FD->getDeclContext()->getSelfClassDecl())
@@ -3260,10 +3249,6 @@ public:
       TC.typeCheckAbstractFunctionBody(CD);
     } else {
       TC.definedFunctions.push_back(CD);
-    }
-
-    if (CD->getAttrs().hasAttribute<DynamicReplacementAttr>()) {
-      TC.checkDynamicReplacementAttribute(CD);
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2159,24 +2159,9 @@ public:
     // Reject cases where this is a variable that has storage but it isn't
     // allowed.
     if (VD->hasStorage()) {
-      // Note: Stored properties in protocols are diagnosed in
-      // finishProtocolStorageImplInfo().
+      // Note: Stored properties in protocols, enums, etc are diagnosed in
+      // finishStorageImplInfo().
 
-      // Enums and extensions cannot have stored instance properties.
-      // Static stored properties are allowed, with restrictions
-      // enforced below.
-      if (isa<EnumDecl>(VD->getDeclContext()) &&
-          !VD->isStatic() && !VD->isInvalid()) {
-        // Enums can only have computed properties.
-        TC.diagnose(VD->getLoc(), diag::enum_stored_property);
-        VD->markInvalid();
-      } else if (isa<ExtensionDecl>(VD->getDeclContext()) &&
-                 !VD->isStatic() && !VD->isInvalid() &&
-                 !VD->getAttrs().getAttribute<DynamicReplacementAttr>()) {
-        TC.diagnose(VD->getLoc(), diag::extension_stored_property);
-        VD->markInvalid();
-      }
-      
       // We haven't implemented type-level storage in some contexts.
       if (VD->isStatic()) {
         auto PBD = VD->getParentPatternBinding();
@@ -2197,13 +2182,9 @@ public:
 
         auto DC = VD->getDeclContext();
 
-        // Non-stored properties are fine.
-        if (!PBD->hasStorage()) {
-          // do nothing
-
         // Stored type variables in a generic context need to logically
         // occur once per instantiation, which we don't yet handle.
-        } else if (DC->getExtendedProtocolDecl()) {
+        if (DC->getExtendedProtocolDecl()) {
           unimplementedStatic(ProtocolExtensions);
         } else if (DC->isGenericContext()
                && !DC->getGenericSignatureOfContext()->areAllParamsConcrete()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4153,14 +4153,15 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
             (typealias->getGenericParams() ?
              TypeResolverContext::GenericTypeAliasDecl :
              TypeResolverContext::TypeAliasDecl));
-          if (validateType(typealias->getUnderlyingTypeLoc(),
+          auto &underlyingTL = typealias->getUnderlyingTypeLoc();
+          if (underlyingTL.isNull() ||
+              validateType(underlyingTL,
                            TypeResolution::forStructural(typealias), options)) {
             typealias->setInvalid();
-            typealias->getUnderlyingTypeLoc().setInvalidType(Context);
+            underlyingTL.setInvalidType(Context);
           }
 
-          typealias->setUnderlyingType(
-                                  typealias->getUnderlyingTypeLoc().getType());
+          typealias->setUnderlyingType(underlyingTL.getType());
 
           // Note that this doesn't set the generic environment of the alias yet,
           // because we haven't built one for the protocol.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1851,7 +1851,7 @@ std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
   return { 4, func->getFullName() };
 }
 
-bool swift::fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
+bool swift::fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
                                DeclName targetName) {
   if (decl->isImplicit()) return false;
   if (decl->getFullName() == targetName) return false;
@@ -1919,7 +1919,7 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
   return false;
 }
 
-bool swift::fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
+bool swift::fixDeclarationObjCName(InFlightDiagnostic &diag, const ValueDecl *decl,
                                    Optional<ObjCSelector> nameOpt,
                                    Optional<ObjCSelector> targetNameOpt,
                                    bool ignoreImpliedName) {

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -28,6 +28,7 @@ class SubscriptDecl;
 class TypeChecker;
 class ValueDecl;
 class VarDecl;
+class InFlightDiagnostic;
 
 using llvm::Optional;
 
@@ -138,6 +139,26 @@ bool canBeRepresentedInObjC(const ValueDecl *decl);
 ///
 /// NOTE: This is only here to support the --enable-source-import hack.
 void checkBridgedFunctions(ASTContext &ctx);
+
+/// Attach Fix-Its to the given diagnostic that updates the name of the
+/// given declaration to the desired target name.
+///
+/// \returns false if the name could not be fixed.
+bool fixDeclarationName(InFlightDiagnostic &diag, const ValueDecl *decl,
+                        DeclName targetName);
+
+/// Fix the Objective-C name of the given declaration to match the provided
+/// Objective-C selector.
+///
+/// \param ignoreImpliedName When true, ignore the implied name of the
+/// given declaration, because it no longer applies.
+///
+/// For properties, the selector should be a zero-parameter selector of the
+/// given property's name.
+bool fixDeclarationObjCName(InFlightDiagnostic &diag, const ValueDecl *decl,
+                            Optional<ObjCSelector> nameOpt,
+                            Optional<ObjCSelector> targetNameOpt,
+                            bool ignoreImpliedName = false);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -796,8 +796,6 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL,
   bool hadError = false;
   
   for (auto param : *PL) {
-    checkDeclAttributesEarly(param);
-
     auto typeRepr = param->getTypeLoc().getTypeRepr();
     if (!typeRepr &&
         param->hasInterfaceType()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -20,6 +20,7 @@
 #include "MiscDiagnostics.h"
 #include "TypeAccessScopeChecker.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckObjC.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Basic/Statistic.h"

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -983,7 +983,6 @@ public:
 
   void typeCheckDecl(Decl *D);
 
-  void checkDeclAttributesEarly(Decl *D);
   static void addImplicitDynamicAttribute(Decl *D);
   void checkDeclAttributes(Decl *D);
   void checkParameterAttributes(ParameterList *params);
@@ -2111,26 +2110,6 @@ bool diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf);
 /// DiagnosticsSema.def.
 std::pair<unsigned, DeclName> getObjCMethodDiagInfo(
                                 AbstractFunctionDecl *method);
-
-/// Attach Fix-Its to the given diagnostic that updates the name of the
-/// given declaration to the desired target name.
-///
-/// \returns false if the name could not be fixed.
-bool fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
-                        DeclName targetName);
-
-/// Fix the Objective-C name of the given declaration to match the provided
-/// Objective-C selector.
-///
-/// \param ignoreImpliedName When true, ignore the implied name of the
-/// given declaration, because it no longer applies.
-///
-/// For properties, the selector should be a zero-parameter selector of the
-/// given property's name.
-bool fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
-                            Optional<ObjCSelector> nameOpt,
-                            Optional<ObjCSelector> targetNameOpt,
-                            bool ignoreImpliedName = false);
 
 bool areGenericRequirementsSatisfied(const DeclContext *DC,
                                      const GenericSignature *sig,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -986,7 +986,6 @@ public:
   static void addImplicitDynamicAttribute(Decl *D);
   void checkDeclAttributes(Decl *D);
   void checkParameterAttributes(ParameterList *params);
-  void checkDynamicReplacementAttribute(ValueDecl *D);
   static ValueDecl *findReplacedDynamicFunction(const ValueDecl *d);
 
   Type checkReferenceOwnershipAttr(VarDecl *D, Type interfaceType,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2270,9 +2270,7 @@ template <typename T, typename ...Args>
 T *ModuleFile::createDecl(Args &&... args) {
   // Note that this method is not used for all decl kinds.
   static_assert(std::is_base_of<Decl, T>::value, "not a Decl");
-  T *result = new (getContext()) T(std::forward<Args>(args)...);
-  result->setEarlyAttrValidation(true);
-  return result;
+  return new (getContext()) T(std::forward<Args>(args)...);
 }
 
 static const uint64_t lazyConformanceContextDataPositionMask = 0xFFFFFFFFFFFF;
@@ -3132,7 +3130,6 @@ public:
 
       fn = accessor;
     }
-    fn->setEarlyAttrValidation();
     declOrOffset = fn;
 
     MF.configureGenericEnvironment(fn, genericEnvID);
@@ -3301,7 +3298,6 @@ public:
       PatternBindingDecl::createDeserialized(ctx, SourceLoc(),
                                              StaticSpelling.getValue(),
                                              SourceLoc(), patterns.size(), dc);
-    binding->setEarlyAttrValidation(true);
     declOrOffset = binding;
 
     binding->setStatic(isStatic);
@@ -3912,7 +3908,6 @@ public:
 
     auto extension = ExtensionDecl::create(ctx, SourceLoc(), TypeLoc(), { },
                                            DC, nullptr);
-    extension->setEarlyAttrValidation();
     declOrOffset = extension;
 
     // Generic parameter lists are written from outermost to innermost.

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -239,7 +239,7 @@ class ThisDerived1 : ThisBase1 {
 
     self.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisDerived1'}}
     self.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisDerived1'}}
-    self.baseExtStaticVar = 42
+    self.baseExtStaticVar = 42 // expected-error {{instance member 'baseExtStaticVar' cannot be used on type 'ThisDerived1'}}
     self.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisDerived1'}}
     self.baseExtStaticFunc0()
 
@@ -264,7 +264,7 @@ class ThisDerived1 : ThisBase1 {
 
     self.derivedExtProp = 42 // expected-error {{member 'derivedExtProp' cannot be used on type 'ThisDerived1'}}
     self.derivedExtFunc0() // expected-error {{instance member 'derivedExtFunc0' cannot be used on type 'ThisDerived1'}}
-    self.derivedExtStaticVar = 42
+    self.derivedExtStaticVar = 42 // expected-error {{instance member 'derivedExtStaticVar' cannot be used on type 'ThisDerived1'}}
     self.derivedExtStaticProp = 42 // expected-error {{member 'derivedExtStaticProp' cannot be used on type 'ThisDerived1'}}
     self.derivedExtStaticFunc0()
 
@@ -305,7 +305,7 @@ class ThisDerived1 : ThisBase1 {
 
     super.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisBase1'}}
     super.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisBase1'}}
-    super.baseExtStaticVar = 42 
+    super.baseExtStaticVar = 42 // expected-error {{instance member 'baseExtStaticVar' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticFunc0()
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -35,25 +35,25 @@ protocol Protocol_Class2 : class {}
 class FáncyName {}
 @objc (FancyName) extension FáncyName {}
 
-@objc  
-var subject_globalVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+var subject_globalVar: Int
 
 var subject_getterSetter: Int {
-  @objc 
-  get { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  get {
     return 0
   }
-  @objc
-  set {  // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  set {
   }
 }
 
 var subject_global_observingAccessorsVar1: Int = 0 {
-  @objc 
-  willSet { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  willSet {
   }
-  @objc 
-  didSet { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  didSet {
   }
 }
 
@@ -85,11 +85,11 @@ class subject_getterSetter1 {
   }
 
   var observingAccessorsVar1: Int = 0 {
-    @objc
-    willSet { // expected-error {{observing accessors are not allowed to be marked @objc}} {{5-10=}}
+    @objc // expected-error {{observing accessors are not allowed to be marked @objc}} {{5-11=}}
+    willSet {
     }
-    @objc
-    didSet { // expected-error {{observing accessors are not allowed to be marked @objc}} {{5-10=}}
+    @objc // expected-error {{observing accessors are not allowed to be marked @objc}} {{5-11=}}
+    didSet {
     }
   }
 }
@@ -102,25 +102,25 @@ class subject_staticVar1 {
   class var staticVar2: Int { return 42 }
 }
 
-@objc
-func subject_freeFunc() { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-6=}}
-  @objc
-  var subject_localVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+func subject_freeFunc() {
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  var subject_localVar: Int
   // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}
 
-  @objc
-  func subject_nestedFreeFunc() { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  func subject_nestedFreeFunc() {
   }
 }
 
-@objc
-func subject_genericFunc<T>(t: T) { // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-6=}}
-  @objc
-  var subject_localVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+func subject_genericFunc<T>(t: T) {
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  var subject_localVar: Int
   // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}
 
-  @objc
-  func subject_instanceFunc() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  func subject_instanceFunc() {}
 }
 
 func subject_funcParam(a: @objc Int) { // expected-error {{attribute can only be applied to declarations, not types}} {{1-1=@objc }} {{27-33=}}
@@ -128,26 +128,26 @@ func subject_funcParam(a: @objc Int) { // expected-error {{attribute can only be
 
 @objc // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_struct {
-  @objc
-  var subject_instanceVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  var subject_instanceVar: Int
 
-  @objc
-  init() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  init() {}
 
-  @objc
-  func subject_instanceFunc() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  func subject_instanceFunc() {}
 }
 
 @objc   // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_genericStruct<T> {
-  @objc
-  var subject_instanceVar: Int // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  var subject_instanceVar: Int
 
-  @objc
-  init() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  init() {}
 
-  @objc
-  func subject_instanceFunc() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  func subject_instanceFunc() {}
 }
 
 @objc
@@ -210,8 +210,8 @@ enum subject_enum: Int {
   @objc(subject_enumElement2)
   case subject_enumElement2
 
-  @objc(subject_enumElement3)
-  case subject_enumElement3, subject_enumElement4 // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-30=}}
+  @objc(subject_enumElement3) // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
+  case subject_enumElement3, subject_enumElement4
 
   @objc   // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
@@ -219,16 +219,16 @@ enum subject_enum: Int {
   @nonobjc // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
   case subject_enumElement7
 
-  @objc   
-  init() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  init() {}
 
-  @objc
-  func subject_instanceFunc() {} // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-8=}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  func subject_instanceFunc() {}
 }
 
 enum subject_enum2 {
-  @objc(subject_enum2Element1)
-  case subject_enumElement1 // expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-31=}}
+  @objc(subject_enum2Element1) // expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-32=}}
+  case subject_enumElement1
 }
 
 @objc
@@ -256,14 +256,14 @@ protocol subject_protocol5 : Protocol_Class1 {} // expected-error {{@objc protoc
 protocol subject_protocol6 : Protocol_ObjC1 {}
 
 protocol subject_containerProtocol1 {
-  @objc
-  var subject_instanceVar: Int { get } // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  var subject_instanceVar: Int { get }
 
-  @objc
-  func subject_instanceFunc() // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  func subject_instanceFunc()
 
-  @objc
-  static func subject_staticFunc() // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  static func subject_staticFunc()
 }
 
 @objc

--- a/validation-test/compiler_crashers_2_fixed/0205-rdar54321473.swift
+++ b/validation-test/compiler_crashers_2_fixed/0205-rdar54321473.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+class A {
+  var member: B
+
+protocol B {
+  typealias Elem = Undefined<Int, <#placeholder#>
+
+typealias C = Undefined<Int


### PR DESCRIPTION
This PR combines checkDeclAttributesEearly(), checkDeclAttributes() and validateAttributes() into a single visitor, and only performs the checks on declarations in primary files.

Also fix <rdar://problem/54321473>, <rdar://problem/54471229>, and <https://bugs.swift.org/browse/SR-11322> while I'm here.