### PR TITLE
Advance swift apis 

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -456,7 +456,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
                 "tensorflow": "c6719f20911f8aa6b6d9cded1c0f7761cb9c69a0",
-                "tensorflow-swift-apis": "8258171504d505c3fef99641213eeea2d1ba67fa",
+                "tensorflow-swift-apis": "3629ddc49b706df89f89fa3e92e495e6e3f42332",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-05-a"
             }


### PR DESCRIPTION
Moves swift-apis commit to https://github.com/tensorflow/swift-apis/commit/3629ddc49b706df89f89fa3e92e495e6e3f42332, which contains some fixes for https://github.com/fastai/fastai_dev/pull/150 