### PR TITLE
Revert "[Sema] Setter has incorrect mutating-ness inside class-constrained protocol extension"

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1964,17 +1964,8 @@ void TypeChecker::validateDecl(OperatorDecl *OD) {
 }
 
 bool swift::doesContextHaveValueSemantics(DeclContext *dc) {
-  if (Type contextTy = dc->getDeclaredInterfaceType()) {
-    // If the decl context is an extension, then it could be imposing a class
-    // constraint (ex: where Self: SomeClass). Make sure we include that
-    // in our check as well.
-    auto extensionRequiresClass = false;
-    if (auto ED = dyn_cast<ExtensionDecl>(dc)) {
-      extensionRequiresClass =
-          ED->getGenericSignature()->requiresClass(ED->getSelfInterfaceType());
-    }
-    return !contextTy->hasReferenceSemantics() && !extensionRequiresClass;
-  }
+  if (Type contextTy = dc->getDeclaredInterfaceType())
+    return !contextTy->hasReferenceSemantics();
   return false;
 }
 

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -124,23 +124,3 @@ struct WrapperContext {
     static let propUsingMember = originalValue
   }
 }
-
-// SR-11298
-
-protocol SR_11298_P {}
-
-class SR_11298_C: SR_11298_P {
-  var property: String = ""
-}
-
-// Self: SR_11298_C requirement constrains this extension to SR_11298C and its subclasses.
-// Since this implies a class constraint, the setter should be implicitly nonmutating.
-extension SR_11298_P where Self: SR_11298_C {
-  var wrappingProperty: String {
-    get { return property }
-    set { property = newValue }
-  }
-}
-
-let instance = SR_11298_C()
-instance.wrappingProperty = "" // Okay


### PR DESCRIPTION
Reverts apple/swift#26669. Needs more discussion—it's more source-breaking than it seemed at first.