### PR TITLE
[Constraint solver] Simplify one-way constraints to Equal, not Bind.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4635,7 +4635,8 @@ namespace {
     }
 
     Expr *visitOneWayExpr(OneWayExpr *E) {
-      return E->getSubExpr();
+      auto type = simplifyType(cs.getType(E));
+      return coerceToType(E->getSubExpr(), type, cs.getConstraintLocator(E));
     }
 
     Expr *visitTapExpr(TapExpr *E) {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -633,7 +633,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       }
       break;
 
-    case ConstraintKind::OneWayBind: {
+    case ConstraintKind::OneWayEqual: {
       // Don't produce any bindings if this type variable is on the left-hand
       // side of a one-way binding.
       auto firstType = constraint->getFirstType();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3083,7 +3083,7 @@ namespace {
     Type visitOneWayExpr(OneWayExpr *expr) {
       auto locator = CS.getConstraintLocator(expr);
       auto resultTypeVar = CS.createTypeVariable(locator, 0);
-      CS.addConstraint(ConstraintKind::OneWayBind, resultTypeVar,
+      CS.addConstraint(ConstraintKind::OneWayEqual, resultTypeVar,
                        CS.getType(expr->getSubExpr()), locator);
       return resultTypeVar;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1146,7 +1146,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     llvm_unreachable("Not a conversion");
   }
 
@@ -1209,7 +1209,7 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
   case ConstraintKind::ValueMember:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     return false;
   }
 
@@ -1394,7 +1394,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     llvm_unreachable("Not a relational constraint");
   }
 
@@ -2811,7 +2811,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::ValueMember:
     case ConstraintKind::FunctionInput:
     case ConstraintKind::FunctionResult:
-    case ConstraintKind::OneWayBind:
+    case ConstraintKind::OneWayEqual:
       llvm_unreachable("Not a relational constraint");
     }
   }
@@ -5248,7 +5248,7 @@ ConstraintSystem::simplifyOneWayConstraint(
   }
 
   // Translate this constraint into a one-way binding constraint.
-  return matchTypes(first, secondSimplified, ConstraintKind::Bind, flags,
+  return matchTypes(first, secondSimplified, ConstraintKind::Equal, flags,
                     locator);
 }
 
@@ -7296,7 +7296,7 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
     return simplifyFunctionComponentConstraint(kind, first, second,
                                                subflags, locator);
 
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     return simplifyOneWayConstraint(kind, first, second, subflags, locator);
 
   case ConstraintKind::ValueMember:
@@ -7655,7 +7655,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     // Disjunction constraints are never solved here.
     return SolutionKind::Unsolved;
 
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     return simplifyOneWayConstraint(constraint.getKind(),
                                     constraint.getFirstType(),
                                     constraint.getSecondType(),

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1681,7 +1681,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
       case ConstraintKind::SelfObjectOfProtocol:
       case ConstraintKind::ConformsTo:
       case ConstraintKind::Defaultable:
-      case ConstraintKind::OneWayBind:
+      case ConstraintKind::OneWayEqual:
         break;
       }
     }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -32,7 +32,7 @@ ComponentStep::Scope::Scope(ComponentStep &component)
   TypeVars = std::move(CS.TypeVariables);
 
   for (auto *typeVar : component.TypeVars)
-    CS.TypeVariables.push_back(typeVar);
+    CS.addTypeVariable(typeVar);
 
   auto &workList = CS.InactiveConstraints;
   workList.splice(workList.end(), *component.Constraints);
@@ -92,7 +92,7 @@ void SplitterStep::computeFollowupSteps(
   CG.optimize();
 
   // Compute the connected components of the constraint graph.
-  auto components = CG.computeConnectedComponents(CS.TypeVariables);
+  auto components = CG.computeConnectedComponents(CS.getTypeVariables());
   unsigned numComponents = components.size();
   if (numComponents < 2) {
     steps.push_back(llvm::make_unique<ComponentStep>(
@@ -106,10 +106,10 @@ void SplitterStep::computeFollowupSteps(
     CG.verify();
 
     log << "---Constraint graph---\n";
-    CG.print(CS.TypeVariables, log);
+    CG.print(CS.getTypeVariables(), log);
 
     log << "---Connected components---\n";
-    CG.printConnectedComponents(CS.TypeVariables, log);
+    CG.printConnectedComponents(CS.getTypeVariables(), log);
   }
 
   // Take the orphaned constraints, because they'll go into a component now.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -312,7 +312,7 @@ StepResult ComponentStep::take(bool prevFailed) {
     // Activate all of the one-way constraints.
     SmallVector<Constraint *, 4> oneWayConstraints;
     for (auto &constraint : CS.InactiveConstraints) {
-      if (constraint.getKind() == ConstraintKind::OneWayBind)
+      if (constraint.isOneWayConstraint())
         oneWayConstraints.push_back(&constraint);
     }
     for (auto constraint : oneWayConstraints) {

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -342,7 +342,7 @@ class ComponentStep final : public SolverStep {
     ConstraintSystem &CS;
     ConstraintSystem::SolverScope *SolverScope;
 
-    std::vector<TypeVariableType *> TypeVars;
+    SetVector<TypeVariableType *> TypeVars;
     ConstraintSystem::SolverScope *PrevPartialScope = nullptr;
 
     // The component this scope is associated with.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -66,7 +66,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -135,7 +135,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -239,7 +239,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::BindOverload:
@@ -312,7 +312,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::DynamicTypeOf: Out << " dynamicType type of "; break;
   case ConstraintKind::EscapableFunctionOf: Out << " @escaping type of "; break;
   case ConstraintKind::OpenedExistentialOf: Out << " opened archetype of "; break;
-  case ConstraintKind::OneWayBind: Out << " one-way bind to "; break;
+  case ConstraintKind::OneWayEqual: Out << " one-way bind to "; break;
   case ConstraintKind::KeyPath:
       Out << " key path from ";
       getSecondType()->print(Out);
@@ -521,7 +521,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
-  case ConstraintKind::OneWayBind:
+  case ConstraintKind::OneWayEqual:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -150,11 +150,11 @@ enum class ConstraintKind : char {
   /// The first type is a type that's a candidate to be the underlying type of
   /// the second opaque archetype.
   OpaqueUnderlyingType,
-  /// The first type will be bound to the second type, but only when the
+  /// The first type will be equal to the second type, but only when the
   /// second type has been fully determined (and mapped down to a concrete
-  /// type). At that point, this constraint will be treated like a `Bind`
+  /// type). At that point, this constraint will be treated like an `Equal`
   /// constraint.
-  OneWayBind,
+  OneWayEqual,
 };
 
 /// Classification of the different kinds of constraints.
@@ -495,7 +495,7 @@ public:
     case ConstraintKind::BindOverload:
     case ConstraintKind::OptionalObject:
     case ConstraintKind::OpaqueUnderlyingType:
-    case ConstraintKind::OneWayBind:
+    case ConstraintKind::OneWayEqual:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:
@@ -608,6 +608,11 @@ public:
   /// Determine if this constraint represents explicit conversion,
   /// e.g. coercion constraint "as X" which forms a disjunction.
   bool isExplicitConversion() const;
+
+  /// Whether this is a one-way constraint.
+  bool isOneWayConstraint() const {
+    return Kind == ConstraintKind::OneWayEqual;
+  }
 
   /// Retrieve the overload choice for an overload-binding constraint.
   OverloadChoice getOverloadChoice() const {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -384,7 +384,7 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
     // For a one-way constraint, only consider it when the type variable
     // is on the right-hand side of the the binding, and the left-hand side of
     // the binding is one of the type variables currently under consideration.
-    if (constraint->getKind() == ConstraintKind::OneWayBind) {
+    if (constraint->isOneWayConstraint()) {
       auto lhsTypeVar =
           constraint->getFirstType()->castTo<TypeVariableType>();
       if (!CS.isActiveTypeVariable(lhsTypeVar))
@@ -633,7 +633,7 @@ namespace {
           continue;
 
         TypeVariableType *typeVar;
-        if (constraint.getKind() == ConstraintKind::OneWayBind) {
+        if (constraint.isOneWayConstraint()) {
           // For one-way constraints, associate the constraint with the
           // left-hand type variable.
           typeVar = constraint.getFirstType()->castTo<TypeVariableType>();
@@ -780,7 +780,7 @@ namespace {
             },
             [&](Constraint *constraint) {
               // Record and skip one-way constraints.
-              if (constraint->getKind() == ConstraintKind::OneWayBind) {
+              if (constraint->isOneWayConstraint()) {
                 oneWayConstraints.push_back(constraint);
                 return false;
               }

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -337,7 +337,7 @@ private:
   ConstraintSystem &CS;
 
   /// The type variables in this graph, in stable order.
-  SmallVector<TypeVariableType *, 4> TypeVariables;
+  std::vector<TypeVariableType *> TypeVariables;
 
   /// Constraints that are "orphaned" because they contain no type variables.
   SmallVector<Constraint *, 4> OrphanedConstraints;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -107,7 +107,7 @@ bool ConstraintSystem::hasFreeTypeVariables() {
 }
 
 void ConstraintSystem::addTypeVariable(TypeVariableType *typeVar) {
-  TypeVariables.push_back(typeVar);
+  TypeVariables.insert(typeVar);
   
   // Notify the constraint graph.
   (void)CG[typeVar];

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1055,7 +1055,7 @@ private:
   /// solution it represents.
   Score CurrentScore;
 
-  std::vector<TypeVariableType *> TypeVariables;
+  llvm::SetVector<TypeVariableType *> TypeVariables;
 
   /// Maps expressions to types for choosing a favored overload
   /// type in a disjunction constraint.
@@ -1766,9 +1766,15 @@ public:
 
   /// Retrieve the set of active type variables.
   ArrayRef<TypeVariableType *> getTypeVariables() const {
-    return TypeVariables;
+    return TypeVariables.getArrayRef();
   }
-  
+
+  /// Whether the given type variable is active in the constraint system at
+  /// the moment.
+  bool isActiveTypeVariable(TypeVariableType *typeVar) const {
+    return TypeVariables.count(typeVar) > 0;
+  }
+
   TypeBase* getFavoredType(Expr *E) {
     assert(E != nullptr);
     return this->FavoredTypes[E];

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3664,7 +3664,7 @@ void ConstraintSystem::print(raw_ostream &out) {
   }
 
   out << "Type Variables:\n";
-  for (auto tv : TypeVariables) {
+  for (auto tv : getTypeVariables()) {
     out.indent(2);
     tv->getImpl().print(out);
     if (tv->getImpl().canBindToLValue())

--- a/test/Constraints/function_builder_one_way.swift
+++ b/test/Constraints/function_builder_one_way.swift
@@ -1,3 +1,4 @@
+// RUN: %target-typecheck-verify-swift -enable-function-builder-one-way-constraints
 // RUN: %target-typecheck-verify-swift -debug-constraints -enable-function-builder-one-way-constraints > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
@@ -49,23 +50,23 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 
 // CHECK: ---Connected components---
 // CHECK-NEXT: 0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T69 depends on 1
-// CHECK-NEXT: 1: $T9 $T11 $T13 $T16 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5, 6
-// CHECK-NEXT: 6: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 7, 10
-// CHECK-NEXT: 10: $T48 $T54 $T55 $T56 depends on 11
-// CHECK-NEXT: 11: $T49 $T50 $T51 $T52 $T53
-// CHECK-NEXT: 7: $T33 $T35 $T39 $T40 $T41 $T42 depends on 8, 9
-// CHECK-NEXT: 9: $T36 $T37 $T38
-// CHECK-NEXT: 8: $T34
-// CHECK-NEXT: 5: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
-// CHECK-NEXT: 4: $T14 $T15
-// CHECK-NEXT: 3: $T12
+// CHECK-NEXT: 1: $T9 $T11 $T16 $T30 $T62 $T63 $T64 $T65 $T66 $T67 $T68 depends on 2, 3, 4, 5
+// CHECK-NEXT: 5: $T32 $T43 $T44 $T45 $T46 $T47 $T57 $T58 $T59 $T60 $T61 depends on 6, 9
+// CHECK-NEXT: 9: $T48 $T54 $T55 $T56 depends on 10
+// CHECK-NEXT: 10: $T49 $T50 $T51 $T52 $T53
+// CHECK-NEXT: 6: $T33 $T35 $T39 $T40 $T41 $T42 depends on 7, 8
+// CHECK-NEXT: 8: $T36 $T37 $T38
+// CHECK-NEXT: 7: $T34
+// CHECK-NEXT: 4: $T17 $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27 $T28 $T29
+// CHECK-NEXT: 3: $T14 $T15
 // CHECK-NEXT: 2: $T10
 let names = ["Alice", "Bob", "Charlie"]
 let b = true
+var number = 17
 print(
   tuplify(names) { name in
     17
-    3.14159
+    number
     "Hello, \(name)"
     tuplify(["a", "b"]) { value in
       value.first!
@@ -74,6 +75,6 @@ print(
       2.71828
       ["if", "stmt"]
     } else {
-      [1, 2, 3, 4]
+      [1, 2, 3, 17]
     }
   })


### PR DESCRIPTION
One-way constraint expressions, which are the only things that
introduce one-way constraints at this point, want to look through
lvalue types to produce values. Rename OneWayBind to OneWayEqual, map
it down to an Equal constraint when it is simplified (to drop
lvalue-ness), and apply that coercion during constraint application.

Part of rdar://problem/50150793.