### PR TITLE
Linux: Build CMake if the checked out version is newer than the installed version.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1042,6 +1042,13 @@ def main_normal():
     if args.cmake is not None:
         toolchain.cmake = args.cmake
 
+    cmake = CMake(args=args, toolchain=toolchain)
+    # Check the CMake version is sufficient on Linux and build from source if not.
+    cmake_path = cmake.check_cmake_version(SWIFT_SOURCE_ROOT, SWIFT_BUILD_ROOT)
+    if cmake_path is not None:
+        toolchain.cmake = cmake_path
+        args.cmake = cmake_path
+
     # Preprocess the arguments to apply defaults.
     BuildScriptInvocation.apply_default_arguments(toolchain, args)
 


### PR DESCRIPTION
For Linux only, if the checked out CMake repository is a newer version than the installed CMake version, build and use CMake from source.

This does not affect macOS build  or set any minimum required CMake version in CMakeLists.txt