### PR TITLE
DWARFImporter: Allow filtering type lookups by containing module.

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -87,7 +87,9 @@ public:
   virtual ~DWARFImporterDelegate() = default;
   /// Perform a qualified lookup of a Clang type with this name.
   /// \param kind  Only return results with this type kind.
+  /// \param inModule only return results from this module.
   virtual void lookupValue(StringRef name, llvm::Optional<ClangTypeKind> kind,
+                           StringRef inModule,
                            SmallVectorImpl<clang::Decl *> &results) {}
   /// vtable anchor.
   virtual void anchor();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1325,8 +1325,9 @@ public:
 
   /// Look for namespace-scope values with the given name using the
   /// DWARFImporterDelegate.
+  /// \param inModule only return results from this module.
   void lookupValueDWARF(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                        NLKind lookupKind,
+                        NLKind lookupKind, Identifier inModule,
                         SmallVectorImpl<ValueDecl *> &results);
 
   /// Look for top-level scope types with a name and kind using the


### PR DESCRIPTION
There is a bit of a problem with this in the current form. LLDB knows about submodules and would really like to have a fully qualified module::submodule::type decl context for the lookup. I may need to add a variant of LLDB's FindTypes that returns each type with its declContext so I can filter the results after the search instead.