### PR TITLE
Add libQuote to apple/swift:tensorflow CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Below is more information about TensorFlow-related build arguments.
     * Default value: None.
 * `tensorflow-swift-apis`: A path to the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) deep learning library repository.
     * Default value: `tensorflow-swift-apis` if the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) repository is cloned. Otherwise, none.
+* `tensorflow-swift`: A path to the [tensorflow/swift](https://github.com/tensorflow/swift) repository.
+    * Default value: `tensorflow-swift` if the [tensorflow/swift](https://github.com/tensorflow/swift) repository is cloned. Otherwise, none.
 
 ### Build systems
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Below is more information about TensorFlow-related build arguments.
     * Default value: None.
 * `tensorflow-swift-apis`: A path to the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) deep learning library repository.
     * Default value: `tensorflow-swift-apis` if the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) repository is cloned. Otherwise, none.
-* `tensorflow-swift`: A path to the [tensorflow/swift](https://github.com/tensorflow/swift) repository.
-    * Default value: `tensorflow-swift` if the [tensorflow/swift](https://github.com/tensorflow/swift) repository is cloned. Otherwise, none.
+* `tensorflow-swift-quote`: A path to the [Quote](https://github.com/tensorflow/swift) library repository.
+    * Default value: `tensorflow-swift-quote` if the [Quote](https://github.com/tensorflow/swift) repository is cloned. Otherwise, none.
 
 ### Build systems
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_TENSORFLOW)
   add_subdirectory(Quote)
 endif()
+# SWIFT_ENABLE_TENSORFLOW END
 
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(Reflection)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -77,6 +77,11 @@ if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_TENSORFLOW)
   add_subdirectory(TensorFlow)
 endif()
 
+# SWIFT_ENABLE_TENSORFLOW
+if(SWIFT_BUILD_STDLIB AND SWIFT_ENABLE_TENSORFLOW)
+  add_subdirectory(Quote)
+endif()
+
 if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(Reflection)
   add_subdirectory(SwiftRemoteMirror)

--- a/stdlib/public/Quote/CMakeLists.txt
+++ b/stdlib/public/Quote/CMakeLists.txt
@@ -18,8 +18,7 @@ if(NOT SWIFT_ENABLE_TENSORFLOW)
   return()
 endif()
 
-find_package(TensorFlow REQUIRED)
-message(STATUS "Building TensorFlow.")
+message(STATUS "Building Quote.")
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
@@ -27,12 +26,12 @@ list(APPEND swift_stdlib_compile_flags "-DCOMPILING_QUOTE_MODULE")
 
 set(SOURCES "")
 
-# Copy tensorflow/swift sources, if they exist.
-if (TENSORFLOW_SWIFT)
-  file(GLOB_RECURSE TENSORFLOW_SWIFT_SOURCES
-    "${TENSORFLOW_SWIFT}/Sources/Quote/*.swift")
-  message(STATUS "Using tensorflow/swift library.")
-  list(APPEND SOURCES "${TENSORFLOW_SWIFT_SOURCES}")
+# Copy Quote sources, if they exist.
+if (TENSORFLOW_SWIFT_QUOTE)
+  file(GLOB_RECURSE TENSORFLOW_SWIFT_QUOTE_SOURCES
+    "${TENSORFLOW_SWIFT_QUOTE}/Sources/Quote/*.swift")
+  message(STATUS "Using Quote library.")
+  list(APPEND SOURCES "${TENSORFLOW_SWIFT_QUOTE_SOURCES}")
 endif()
 
 add_swift_target_library(swiftQuote ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB

--- a/stdlib/public/Quote/CMakeLists.txt
+++ b/stdlib/public/Quote/CMakeLists.txt
@@ -1,0 +1,57 @@
+#===-------------- CMakeLists.txt - Build the Quote library ---------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+#
+# SWIFT_ENABLE_TENSORFLOW
+#
+#===----------------------------------------------------------------------===#
+
+if(NOT SWIFT_ENABLE_TENSORFLOW)
+  return()
+endif()
+
+find_package(TensorFlow REQUIRED)
+message(STATUS "Building TensorFlow.")
+
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
+list(APPEND swift_stdlib_compile_flags "-DCOMPILING_QUOTE_MODULE")
+
+set(SOURCES "")
+
+# Copy tensorflow/swift sources, if they exist.
+if (TENSORFLOW_SWIFT)
+  file(GLOB_RECURSE TENSORFLOW_SWIFT_SOURCES
+    "${TENSORFLOW_SWIFT}/Sources/Quote/*.swift")
+  message(STATUS "Using tensorflow/swift library.")
+  list(APPEND SOURCES "${TENSORFLOW_SWIFT_SOURCES}")
+endif()
+
+add_swift_target_library(swiftQuote ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  "${SOURCES}"
+
+  TARGET_SDKS OSX LINUX
+  PRIVATE_LINK_LIBRARIES "${TF_LIBRARIES}"
+  SWIFT_MODULE_DEPENDS SwiftOnoneSupport
+  SWIFT_MODULE_DEPENDS_IOS Darwin
+  SWIFT_MODULE_DEPENDS_OSX Darwin
+  SWIFT_MODULE_DEPENDS_TVOS Darwin
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_COMPILE_FLAGS "${swift_stdlib_compile_flags}"
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+  INSTALL_IN_COMPONENT stdlib
+  # NOTE: This is a workaround for https://github.com/apple/swift/pull/24382,
+  # which changed the default install_name_dir to `/usr/bin/swift`.
+  DARWIN_INSTALL_NAME_DIR "@rpath")

--- a/stdlib/public/Quote/CMakeLists.txt
+++ b/stdlib/public/Quote/CMakeLists.txt
@@ -18,11 +18,8 @@ if(NOT SWIFT_ENABLE_TENSORFLOW)
   return()
 endif()
 
-message(STATUS "Building Quote.")
-
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
-list(APPEND swift_stdlib_compile_flags "-DCOMPILING_QUOTE_MODULE")
 
 set(SOURCES "")
 
@@ -30,7 +27,6 @@ set(SOURCES "")
 if (TENSORFLOW_SWIFT_QUOTE)
   file(GLOB_RECURSE TENSORFLOW_SWIFT_QUOTE_SOURCES
     "${TENSORFLOW_SWIFT_QUOTE}/Sources/Quote/*.swift")
-  message(STATUS "Using Quote library.")
   list(APPEND SOURCES "${TENSORFLOW_SWIFT_QUOTE_SOURCES}")
 endif()
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -181,6 +181,13 @@ class BuildScriptInvocation(object):
                         "--tensorflow-swift-apis (was '{}')"
                         .format(args.tensorflow_swift_apis))
 
+            if args.tensorflow_swift is not None:
+                if not os.path.isdir(args.tensorflow_swift):
+                    diagnostics.fatal(
+                        "invalid repository specified for "
+                        "--tensorflow-swift (was '{}')"
+                        .format(args.tensorflow_swift))
+
         if args.enable_tensorflow_gpu:
             os.environ['TF_NEED_CUDA'] = '1'
             if '--config=cuda' not in args.tensorflow_bazel_options:

--- a/utils/build-script
+++ b/utils/build-script
@@ -181,12 +181,12 @@ class BuildScriptInvocation(object):
                         "--tensorflow-swift-apis (was '{}')"
                         .format(args.tensorflow_swift_apis))
 
-            if args.tensorflow_swift is not None:
-                if not os.path.isdir(args.tensorflow_swift):
+            if args.tensorflow_swift_quote is not None:
+                if not os.path.isdir(args.tensorflow_swift_quote):
                     diagnostics.fatal(
                         "invalid repository specified for "
-                        "--tensorflow-swift (was '{}')"
-                        .format(args.tensorflow_swift))
+                        "--tensorflow-swift-quote (was '{}')"
+                        .format(args.tensorflow_swift_quote))
 
         if args.enable_tensorflow_gpu:
             os.environ['TF_NEED_CUDA'] = '1'

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -298,7 +298,7 @@ KNOWN_SETTINGS=(
     tensorflow-target-include-dir      ""        "Path to target Tensorflow headers"
     tensorflow-target-lib-dir          ""        "Path to target TensorFlow libraries"
     tensorflow-swift-apis              ""        "Path to TensorFlow deep learning library repository"
-    tensorflow-swift                   ""        "Path to tensorflow/swift repository"
+    tensorflow-swift-quote             ""        "Path to Quote library repository"
 )
 
 # Centralized access point for traced command invocation.
@@ -1236,7 +1236,7 @@ PLAYGROUNDSUPPORT_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support"
 # SWIFT_ENABLE_TENSORFLOW
 TENSORFLOW_SOURCE_DIR="${WORKSPACE}/tensorflow"
 TENSORFLOW_SWIFT_APIS_DIR="${WORKSPACE}/tensorflow-swift-apis"
-TENSORFLOW_SWIFT_DIR="${WORKSPACE}/tensorflow-swift"
+TENSORFLOW_SWIFT_QUOTE_DIR="${WORKSPACE}/tensorflow-swift-quote"
 
 if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" && ! -d ${PLAYGROUNDSUPPORT_SOURCE_DIR} ]]; then
     echo "Couldn't find PlaygroundSupport source directory."
@@ -1252,8 +1252,8 @@ if [[ "${ENABLE_TENSORFLOW}" ]]; then
         echo "Invalid TensorFlow high-level APIs repository specified."
         exit 1
     fi
-    if [[ "${TENSORFLOW_SWIFT}" && ! -d "${TENSORFLOW_SWIFT}" ]]; then
-        echo "Invalid tensorflow/swift repository specified."
+    if [[ "${TENSORFLOW_SWIFT_QUOTE}" && ! -d "${TENSORFLOW_SWIFT_QUOTE}" ]]; then
+        echo "Invalid Quote repository specified."
         exit 1
     fi
 fi
@@ -2627,14 +2627,14 @@ for host in "${ALL_HOSTS[@]}"; do
                         )
                     fi
 
-                    # Handle tensorflow/swift repository.
-                    if [[ ! "${TENSORFLOW_SWIFT}" && -d "${TENSORFLOW_SWIFT_DIR}" ]] ; then
-                        TENSORFLOW_SWIFT="${TENSORFLOW_SWIFT_DIR}"
+                    # Handle Quote repository.
+                    if [[ ! "${TENSORFLOW_SWIFT_QUOTE}" && -d "${TENSORFLOW_SWIFT_QUOTE_DIR}" ]] ; then
+                        TENSORFLOW_SWIFT_QUOTE="${TENSORFLOW_SWIFT_QUOTE_DIR}"
                     fi
-                    if [[ "${TENSORFLOW_SWIFT}" ]] ; then
+                    if [[ "${TENSORFLOW_SWIFT_QUOTE}" ]] ; then
                         cmake_options=(
                             "${cmake_options[@]}"
-                            -DTENSORFLOW_SWIFT:PATH="${TENSORFLOW_SWIFT}"
+                            -DTENSORFLOW_SWIFT_QUOTE:PATH="${TENSORFLOW_SWIFT_QUOTE}"
                         )
                     fi
                 fi

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -298,6 +298,7 @@ KNOWN_SETTINGS=(
     tensorflow-target-include-dir      ""        "Path to target Tensorflow headers"
     tensorflow-target-lib-dir          ""        "Path to target TensorFlow libraries"
     tensorflow-swift-apis              ""        "Path to TensorFlow deep learning library repository"
+    tensorflow-swift                   ""        "Path to tensorflow/swift repository"
 )
 
 # Centralized access point for traced command invocation.
@@ -1235,6 +1236,7 @@ PLAYGROUNDSUPPORT_SOURCE_DIR="${WORKSPACE}/swift-xcode-playground-support"
 # SWIFT_ENABLE_TENSORFLOW
 TENSORFLOW_SOURCE_DIR="${WORKSPACE}/tensorflow"
 TENSORFLOW_SWIFT_APIS_DIR="${WORKSPACE}/tensorflow-swift-apis"
+TENSORFLOW_SWIFT_DIR="${WORKSPACE}/tensorflow-swift"
 
 if [[ ! "${SKIP_BUILD_PLAYGROUNDSUPPORT}" && ! -d ${PLAYGROUNDSUPPORT_SOURCE_DIR} ]]; then
     echo "Couldn't find PlaygroundSupport source directory."
@@ -1248,6 +1250,10 @@ if [[ "${ENABLE_TENSORFLOW}" ]]; then
     fi
     if [[ "${TENSORFLOW_SWIFT_APIS}" && ! -d "${TENSORFLOW_SWIFT_APIS}" ]]; then
         echo "Invalid TensorFlow high-level APIs repository specified."
+        exit 1
+    fi
+    if [[ "${TENSORFLOW_SWIFT}" && ! -d "${TENSORFLOW_SWIFT}" ]]; then
+        echo "Invalid tensorflow/swift repository specified."
         exit 1
     fi
 fi
@@ -2618,6 +2624,17 @@ for host in "${ALL_HOSTS[@]}"; do
                         cmake_options=(
                             "${cmake_options[@]}"
                             -DTENSORFLOW_SWIFT_APIS:PATH="${TENSORFLOW_SWIFT_APIS}"
+                        )
+                    fi
+
+                    # Handle tensorflow/swift repository.
+                    if [[ ! "${TENSORFLOW_SWIFT}" && -d "${TENSORFLOW_SWIFT_DIR}" ]] ; then
+                        TENSORFLOW_SWIFT="${TENSORFLOW_SWIFT_DIR}"
+                    fi
+                    if [[ "${TENSORFLOW_SWIFT}" ]] ; then
+                        cmake_options=(
+                            "${cmake_options[@]}"
+                            -DTENSORFLOW_SWIFT:PATH="${TENSORFLOW_SWIFT}"
                         )
                     fi
                 fi

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1063,6 +1063,9 @@ def create_argument_parser():
     option('--tensorflow-swift-apis', store_path,
            default=None,
            help='Path to a TensorFlow deep learning library repository.')
+    option('--tensorflow-swift', store_path,
+           default=None,
+           help='Path to a tensorflow/swift repository.')
     option('--tensorflow-bazel-options', append,
            type=argparse.ShellSplitType(),
            default=[],

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1063,9 +1063,9 @@ def create_argument_parser():
     option('--tensorflow-swift-apis', store_path,
            default=None,
            help='Path to a TensorFlow deep learning library repository.')
-    option('--tensorflow-swift', store_path,
+    option('--tensorflow-swift-quote', store_path,
            default=None,
-           help='Path to a tensorflow/swift repository.')
+           help='Path to a Quote repository.')
     option('--tensorflow-bazel-options', append,
            type=argparse.ShellSplitType(),
            default=[],

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -217,7 +217,7 @@ EXPECTED_DEFAULTS = {
     'tensorflow_target_lib_dir': None,
     'tensorflow_target_include_dir': None,
     'tensorflow_swift_apis': None,
-    'tensorflow_swift': None,
+    'tensorflow_swift_quote': None,
     'host_bazel': None,
     'tensorflow_bazel_options': [],
 }
@@ -619,7 +619,7 @@ EXPECTED_OPTIONS = [
     PathOption('--tensorflow-target-lib-dir'),
     PathOption('--tensorflow-target-include-dir'),
     PathOption('--tensorflow-swift-apis'),
-    PathOption('--tensorflow-swift'),
+    PathOption('--tensorflow-swift-quote'),
     PathOption('--host-bazel'),
     AppendOption('--tensorflow-bazel-options'),
 ]

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -217,6 +217,7 @@ EXPECTED_DEFAULTS = {
     'tensorflow_target_lib_dir': None,
     'tensorflow_target_include_dir': None,
     'tensorflow_swift_apis': None,
+    'tensorflow_swift': None,
     'host_bazel': None,
     'tensorflow_bazel_options': [],
 }
@@ -618,6 +619,7 @@ EXPECTED_OPTIONS = [
     PathOption('--tensorflow-target-lib-dir'),
     PathOption('--tensorflow-target-include-dir'),
     PathOption('--tensorflow-swift-apis'),
+    PathOption('--tensorflow-swift'),
     PathOption('--host-bazel'),
     AppendOption('--tensorflow-bazel-options'),
 ]

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -38,7 +38,7 @@
             "remote": { "id": "tensorflow/tensorflow" } },
         "tensorflow-swift-apis": {
             "remote": { "id": "tensorflow/swift-apis" } },
-        "tensorflow-swift": {
+        "tensorflow-swift-quote": {
             "remote": { "id": "tensorflow/swift" } },
         "icu": {
             "remote": { "id": "unicode-org/icu" },
@@ -488,7 +488,7 @@
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "tensorflow": "c6719f20911f8aa6b6d9cded1c0f7761cb9c69a0",
                 "tensorflow-swift-apis": "3629ddc49b706df89f89fa3e92e495e6e3f42332",
-                "tensorflow-swift": "03a61b10adfff4d08c23ed487b0a0a786932a07d",
+                "tensorflow-swift-quote": "03a61b10adfff4d08c23ed487b0a0a786932a07d",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a"
             }

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -38,6 +38,8 @@
             "remote": { "id": "tensorflow/tensorflow" } },
         "tensorflow-swift-apis": {
             "remote": { "id": "tensorflow/swift-apis" } },
+        "tensorflow-swift": {
+            "remote": { "id": "tensorflow/swift" } },
         "icu": {
             "remote": { "id": "unicode-org/icu" },
             "platforms": [ "Linux" ]
@@ -486,6 +488,7 @@
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "tensorflow": "c6719f20911f8aa6b6d9cded1c0f7761cb9c69a0",
                 "tensorflow-swift-apis": "3629ddc49b706df89f89fa3e92e495e6e3f42332",
+                "tensorflow-swift": "03a61b10adfff4d08c23ed487b0a0a786932a07d",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a"
             }


### PR DESCRIPTION
Now that libQuote has been opensourced at https://github.com/tensorflow/swift, it would be good to get it into CI to make sure we don't break quoting as we keep on merging with the recent master.