### PR TITLE
[Constraint graph] Having "gathering all mentions" mean "gathering more mentions" 

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -394,7 +394,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
   // Gather the constraints associated with this type variable.
   auto constraints =
       getConstraintGraph().gatherConstraints(
-          typeVar, ConstraintGraph::GatheringKind::EquivalenceClass);
+          typeVar, ConstraintGraph::GatheringKind::PotentialBindings);
 
   PotentialBindings result(typeVar);
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1581,7 +1581,7 @@ void ConstraintSystem::ArgumentInfoCollector::walk(Type argType) {
     visited.insert(rep);
 
     auto constraints = CS.getConstraintGraph().gatherConstraints(
-        rep, ConstraintGraph::GatheringKind::EquivalenceClass);
+        rep, ConstraintGraph::GatheringKind::PotentialBindings);
 
     for (auto *constraint : constraints) {
       switch (constraint->getKind()) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -520,10 +520,12 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
         constraints.push_back(constraint);
     }
 
-    // For any type variable mentioned in a fixed binding, add adjacent
-    // constraints.
-    for (auto adjTypeVar : node.getFixedBindings()) {
-      addAdjacentConstraints(adjTypeVar);
+    if (kind == GatheringKind::PotentialBindings) {
+      // For any type variable mentioned in a fixed binding, add adjacent
+      // constraints.
+      for (auto adjTypeVar : node.getFixedBindings()) {
+        addAdjacentConstraints(adjTypeVar);
+      }
     }
   }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -373,91 +373,6 @@ void ConstraintGraph::unbindTypeVariable(TypeVariableType *typeVar, Type fixed){
   }
 }
 
-llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
-    TypeVariableType *typeVar, GatheringKind kind,
-    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
-  llvm::TinyPtrVector<Constraint *> constraints;
-
-  // Whether we should consider this constraint at all.
-  auto rep = CS.getRepresentative(typeVar);
-  auto shouldConsiderConstraint = [&](Constraint *constraint) {
-    // For a one-way constraint, only consider it when the type variable
-    // is on the right-hand side of the the binding, and the left-hand side of
-    // the binding is one of the type variables currently under consideration.
-    if (constraint->isOneWayConstraint()) {
-      auto lhsTypeVar =
-          constraint->getFirstType()->castTo<TypeVariableType>();
-      if (!CS.isActiveTypeVariable(lhsTypeVar))
-        return false;
-
-      SmallVector<TypeVariableType *, 2> rhsTypeVars;
-      constraint->getSecondType()->getTypeVariables(rhsTypeVars);
-      for (auto rhsTypeVar : rhsTypeVars) {
-        if (CS.getRepresentative(rhsTypeVar) == rep)
-          return true;
-      }
-      return false;
-    }
-
-    return true;
-  };
-
-  auto acceptConstraint = [&](Constraint *constraint) {
-    return shouldConsiderConstraint(constraint) &&
-        acceptConstraintFn(constraint);
-  };
-
-  // Add constraints for the given adjacent type variable.
-  llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
-  llvm::SmallPtrSet<Constraint *, 4> visitedConstraints;
-  auto addAdjacentConstraints = [&](TypeVariableType *adjTypeVar) {
-    auto adjTypeVarsToVisit =
-        (*this)[CS.getRepresentative(adjTypeVar)].getEquivalenceClass();
-    for (auto adjTypeVarEquiv : adjTypeVarsToVisit) {
-      if (!typeVars.insert(adjTypeVarEquiv).second)
-        continue;
-
-      for (auto constraint : (*this)[adjTypeVarEquiv].getConstraints()) {
-        if (!visitedConstraints.insert(constraint).second)
-          continue;
-
-        if (acceptConstraint(constraint))
-          constraints.push_back(constraint);
-      }
-    }
-  };
-
-  auto &reprNode = (*this)[CS.getRepresentative(typeVar)];
-  auto equivClass = reprNode.getEquivalenceClass();
-  for (auto typeVar : equivClass) {
-    auto &node = (*this)[typeVar];
-    for (auto constraint : node.getConstraints()) {
-      if (visitedConstraints.insert(constraint).second &&
-          acceptConstraint(constraint))
-        constraints.push_back(constraint);
-
-      // If we want all mentions, visit type variables within each of our
-      // constraints.
-      if (kind == GatheringKind::AllMentions) {
-        if (!shouldConsiderConstraint(constraint))
-          continue;
-
-        for (auto adjTypeVar : constraint->getTypeVariables()) {
-          addAdjacentConstraints(adjTypeVar);
-        }
-      }
-    }
-
-    // For any type variable mentioned in a fixed binding, add adjacent
-    // constraints.
-    for (auto adjTypeVar : node.getFixedBindings()) {
-      addAdjacentConstraints(adjTypeVar);
-    }
-  }
-
-  return constraints;
-}
-
 #pragma mark Algorithms
 
 /// Perform a depth-first search.
@@ -517,6 +432,102 @@ static void depthFirstSearch(
 
   // Walk any type variables related via fixed bindings.
   visitAdjacencies(node.getFixedBindings());
+}
+
+llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
+    TypeVariableType *typeVar, GatheringKind kind,
+    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
+  llvm::TinyPtrVector<Constraint *> constraints;
+
+  // Whether we should consider this constraint at all.
+  auto rep = CS.getRepresentative(typeVar);
+  auto shouldConsiderConstraint = [&](Constraint *constraint) {
+    // For a one-way constraint, only consider it when the type variable
+    // is on the right-hand side of the the binding, and the left-hand side of
+    // the binding is one of the type variables currently under consideration.
+    if (constraint->isOneWayConstraint()) {
+      auto lhsTypeVar =
+          constraint->getFirstType()->castTo<TypeVariableType>();
+      if (!CS.isActiveTypeVariable(lhsTypeVar))
+        return false;
+
+      SmallVector<TypeVariableType *, 2> rhsTypeVars;
+      constraint->getSecondType()->getTypeVariables(rhsTypeVars);
+      for (auto rhsTypeVar : rhsTypeVars) {
+        if (CS.getRepresentative(rhsTypeVar) == rep)
+          return true;
+      }
+      return false;
+    }
+
+    return true;
+  };
+
+  auto acceptConstraint = [&](Constraint *constraint) {
+    return shouldConsiderConstraint(constraint) &&
+        acceptConstraintFn(constraint);
+  };
+
+  if (kind == GatheringKind::AllMentions) {
+    // Perform a depth-first search in the constraint graph to find all of the
+    // constraints that could be affected.
+    SmallPtrSet<TypeVariableType *, 4> typeVariables;
+    llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
+    depthFirstSearch(*this, typeVar,
+                     [&](TypeVariableType *typeVar) {
+                       return typeVariables.insert(typeVar).second;
+                     },
+                     [&](Constraint *constraint) {
+                       if (!shouldConsiderConstraint(constraint))
+                         return false;
+
+                       if (acceptConstraintFn(constraint))
+                         constraints.push_back(constraint);
+
+                       return true;
+                     },
+                     visitedConstraints);
+    return constraints;
+  }
+
+  // Add constraints for the given adjacent type variable.
+  llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
+  llvm::SmallPtrSet<Constraint *, 4> visitedConstraints;
+  auto addAdjacentConstraints = [&](TypeVariableType *adjTypeVar) {
+    auto adjTypeVarsToVisit =
+        (*this)[CS.getRepresentative(adjTypeVar)].getEquivalenceClass();
+    for (auto adjTypeVarEquiv : adjTypeVarsToVisit) {
+      if (!typeVars.insert(adjTypeVarEquiv).second)
+        continue;
+
+      for (auto constraint : (*this)[adjTypeVarEquiv].getConstraints()) {
+        if (!visitedConstraints.insert(constraint).second)
+          continue;
+
+        if (acceptConstraint(constraint))
+          constraints.push_back(constraint);
+      }
+    }
+  };
+
+  auto &reprNode = (*this)[CS.getRepresentative(typeVar)];
+  auto equivClass = reprNode.getEquivalenceClass();
+  for (auto typeVar : equivClass) {
+    auto &node = (*this)[typeVar];
+    for (auto constraint : node.getConstraints()) {
+      if (visitedConstraints.insert(constraint).second &&
+          acceptConstraint(constraint))
+        constraints.push_back(constraint);
+    }
+
+    // For any type variable mentioned in a fixed binding, add adjacent
+    // constraints.
+    for (auto adjTypeVar : node.getFixedBindings()) {
+      addAdjacentConstraints(adjTypeVar);
+    }
+  }
+
+  return constraints;
 }
 
 namespace {

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -181,6 +181,10 @@ public:
     /// Gather constraints associated with all of the variables within the
     /// same equivalence class as the given type variable.
     EquivalenceClass,
+    /// Gather constraints that might be useful for potential bindings,
+    /// which also involves gathering constraints for type variables found
+    /// via fixed bindings.
+    PotentialBindings,
     /// Gather all constraints that mention this type variable or type variables
     /// that it is equivalent to.
     AllMentions,

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -51,3 +51,25 @@ func testFunc() {
   let f = \S.i
   let _: (S) -> Int = f // expected-error {{cannot convert value of type 'KeyPath<S, Int>' to specified type '(S) -> Int'}}
 }
+
+// rdar://problem/54322807
+struct X<T> {
+  init(foo: KeyPath<T, Bool>) { }
+  init(foo: KeyPath<T, Bool?>) { }
+}
+
+struct Wibble {
+  var boolProperty = false
+}
+
+struct Bar {
+  var optWibble: Wibble? = nil
+}
+
+class Foo {
+  var optBar: Bar? = nil
+}
+
+func testFoo<T: Foo>(_: T) {
+  let _: X<T> = .init(foo: \.optBar!.optWibble?.boolProperty)
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
+// RUN: %scale-test --begin 2 --end 15 --step 1 --select NumConstraintScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
When requesting all constraints that mention the given type variable,
use a depth-first search to ensure that we find more mentions, rather
than some subset of them. This is meant to strike a balance that 
fixes rdar://problem/54322807 while not greatly expanding the set
of constraints that are repeatedly visited.