### PR TITLE
[Source Tooling] Refactoring action to convert if statement to switch

### DIFF
--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -70,6 +70,8 @@ RANGE_REFACTORING(ConvertIfLetExprToGuardExpr, "Convert To Guard Expression", co
 
 RANGE_REFACTORING(ConvertGuardExprToIfLetExpr, "Convert To IfLet Expression", convert.to.iflet.expr)
 
+RANGE_REFACTORING(ConvertToSwitchStmt, "Convert To Switch Statement", convert.switch.stmt)
+
 // These internal refactorings are designed to be helpful for working on
 // the compiler/standard library, etc., but are likely to be just confusing and
 // noise for general development.

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L19-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L19-3.swift.expected
@@ -1,0 +1,40 @@
+enum E {
+  case case1
+  case case2
+  case case3
+}
+
+func someFunc(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  switch e {
+case .case1:
+print("first string")
+    print("second string")
+default:
+print("default")
+}
+}
+
+func withoutElse(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  } else if e == .case3 {
+    print("case3")
+  }
+}
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L28-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L28-3.swift.expected
@@ -1,0 +1,40 @@
+enum E {
+  case case1
+  case case2
+  case case3
+}
+
+func someFunc(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .case1 {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  switch e {
+case .case1:
+print("case1")
+case .case2:
+print("case2")
+case .case3:
+print("case3")
+}
+}
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L8-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/basic/L8-3.swift.expected
@@ -1,0 +1,39 @@
+enum E {
+  case case1
+  case case2
+  case case3
+}
+
+func someFunc(e: E) {
+  switch e {
+case .case1:
+print("case1")
+case .case2:
+print("case2")
+default:
+print("default")
+}
+}
+
+func twoStringBody(e: E) {
+  if e == .case1 {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  } else if e == .case3 {
+    print("case3")
+  }
+}
+
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/basic.swift
+++ b/test/refactoring/ConvertToSwitchStmt/basic.swift
@@ -1,0 +1,46 @@
+enum E {
+  case case1
+  case case2
+  case case3
+}
+
+func someFunc(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  }
+  else {
+    print("default")
+  }
+}
+
+func twoStringBody(e: E) {
+  if e == .case1 {
+    print("first string")
+    print("second string")
+  } else {
+    print("default")
+  }
+}
+
+func withoutElse(e: E) {
+  if e == .case1 {
+    print("case1")
+  } else if e == .case2 {
+    print("case2")
+  } else if e == .case3 {
+    print("case3")
+  }
+}
+
+// RUN: rm -rf %t.result && mkdir -p %t.result
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=8:3 -end-pos=15:4 > %t.result/L8-3.swift
+// RUN: diff -u %S/Outputs/basic/L8-3.swift.expected %t.result/L8-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=19:3 -end-pos=24:4 > %t.result/L19-3.swift
+// RUN: diff -u %S/Outputs/basic/L19-3.swift.expected %t.result/L19-3.swift
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=28:3 -end-pos=34:4 > %t.result/L28-3.swift
+// RUN: diff -u %S/Outputs/basic/L28-3.swift.expected %t.result/L28-3.swift

--- a/test/refactoring/RefactoringKind/basic.swift
+++ b/test/refactoring/RefactoringKind/basic.swift
@@ -275,6 +275,23 @@ func testConvertToIfLetExpr(idxOpt: Int?) {
   print(idx)
 }
 
+func testConvertToSwitchStmt(e: E) {
+  if e == .e1 {
+    print("e1")
+  } else if e == .e2 {
+    print("e2")
+  }
+  else {
+    print("default")
+  }
+
+  let x = "some other type"
+  if e == .e1 {
+    print("e1")
+  } else if x == "some value" {
+    print("x")
+  }
+}
 
 // RUN: %refactor -source-filename %s -pos=2:1 -end-pos=5:13 | %FileCheck %s -check-prefix=CHECK1
 // RUN: %refactor -source-filename %s -pos=3:1 -end-pos=5:13 | %FileCheck %s -check-prefix=CHECK1
@@ -373,6 +390,9 @@ func testConvertToIfLetExpr(idxOpt: Int?) {
 
 // RUN: %refactor -source-filename %s -pos=272:3 -end-pos=275:13 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-IFLET-EXPRESSION
 
+// RUN: %refactor -source-filename %s -pos=279:3 -end-pos=286:4 | %FileCheck %s -check-prefix=CHECK-CONVERT-TO-SWITCH-STATEMENT
+// RUN: %refactor -pos=289:3 -end-pos=293:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-EXTRCT-METHOD
+
 // CHECK1: Action begins
 // CHECK1-NEXT: Extract Method
 // CHECK1-NEXT: Action ends
@@ -423,3 +443,5 @@ func testConvertToIfLetExpr(idxOpt: Int?) {
 // CHECK-CONVERT-TO-GUARD-EXPRESSION: Convert To Guard Expression
 
 // CHECK-CONVERT-TO-IFLET-EXPRESSION: Convert To IfLet Expression
+
+// CHECK-CONVERT-TO-SWITCH-STATEMENT: Convert To Switch Statement

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -71,7 +71,8 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
                       "trailingclosure", "Perform trailing closure refactoring"),
            clEnumValN(RefactoringKind::ReplaceBodiesWithFatalError,
                       "replace-bodies-with-fatalError", "Perform trailing closure refactoring"),
-           clEnumValN(RefactoringKind::MemberwiseInitLocalRefactoring, "memberwise-init", "Generate member wise initializer")));
+           clEnumValN(RefactoringKind::MemberwiseInitLocalRefactoring, "memberwise-init", "Generate member wise initializer"),
+           clEnumValN(RefactoringKind::ConvertToSwitchStmt, "convert-to-switch-stmt", "Perform convert to switch statement")));
 
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
Implement action to convert if statements from:
  ```
var e = E.case1
  if e == .case1 {}
  else if e == .case2 {}
  else {}
```
to
```
  var e = E.case1
  switch e {
  case .case1: break
  case .case2: break
  default: break
  }
```

Resolves [SR-5740](https://bugs.swift.org/browse/SR-5740).

@nkcsgexi 
