### PR TITLE
SimplifyCFG: fix a bug in switch_enum -> select_enum conversion

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3156,6 +3156,11 @@ getSwitchEnumPred(SILBasicBlock *BB, SILBasicBlock *PostBB,
 
   // Check if BB is reachable from multiple enum cases. This means that there is
   // a single-branch block for each enum case which branch to BB.
+  // Usually in this case BB has no arguments. If there are any arguments, bail,
+  // because the argument may be used by other instructions.
+  if (BB->getNumArguments() != 0)
+    return nullptr;
+
   SILBasicBlock *CommonPredPredBB = nullptr;
   for (auto PredBB : BB->getPredecessorBlocks()) {
     TermInst *PredTerm = PredBB->getTerminator();

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -411,6 +411,47 @@ bb4(%20 : $Builtin.Int32):                         // Preds: bb1 bb2 bb3
   return %21 : $Int32
 }
 
+enum TwoCases {
+  case A
+  case B
+}
+
+struct S {
+  var x: Builtin.Int32
+}
+
+sil @useSandInt :  $@convention(thin) (S, Builtin.Int32) -> ()
+
+// CHECK-LABEL: sil @dont_opt_switch_enum_with_arg_bb
+sil @dont_opt_switch_enum_with_arg_bb : $@convention(thin) (TwoCases, S, S) -> Builtin.Int32 {
+bb0(%0 : $TwoCases, %1 : $S, %2 : $S):
+  %3 = integer_literal $Builtin.Int32, 3
+  %4 = integer_literal $Builtin.Int32, 4
+  // CHECK: switch_enum
+  switch_enum %0 : $TwoCases, case #TwoCases.A!enumelt: bb1, case #TwoCases.B!enumelt.1: bb2
+
+bb1:
+  br bb3(%1 : $S)
+
+bb2:
+  br bb3(%2 : $S)
+
+bb3(%10 : $S):
+  br bb4(%3 : $Builtin.Int32)
+
+bb4(%20 : $Builtin.Int32):
+  %11 = function_ref @useSandInt :  $@convention(thin) (S, Builtin.Int32) -> ()
+  %12 = apply %11(%10, %20) : $@convention(thin) (S, Builtin.Int32) -> ()
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb4(%4 : $Builtin.Int32)
+
+bb6:
+  // CHECK: return
+  return %20 : $Builtin.Int32
+}
+
 enum E {
   case Nope, Yup(Builtin.Int1)
 }


### PR DESCRIPTION
This bug is > 3 years old. Looks like we didn't hit this SIL code pattern so far.

https://bugs.swift.org/browse/SR-11263
rdar://problem/54312894
