### PR TITLE
[Diagnostics] Lift all restrictions from `invalid generic arguments` …

### DIFF
--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -29,7 +29,9 @@ func foo6(a : A) {
 
 func foo7(b : [B]) {}
 func foo8(a : [A]) {
-  foo7(b : a) // expected-error {{cannot convert value of type '[A]' to expected argument type '[B]'}} {{13-13= as! [B]}}
+  // TODO(diagnostics): Since `A` and `B` are related it would make sense to suggest forced downcast.
+  foo7(b : a) // expected-error {{cannot convert value of type '[A]' to expected argument type '[B]'}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('A' and 'B') are expected to be equal}}
 }
 
 protocol P1 {}

--- a/test/expr/cast/array_bridge.swift
+++ b/test/expr/cast/array_bridge.swift
@@ -39,6 +39,7 @@ var b: [B] = []
 a = b as [A]
 
 b = a // expected-error {{cannot assign value of type '[A]' to type '[B]'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('A' and 'B') are expected to be equal}}
 
 var aa: [[A]] = []
 var bb: [[B]] = []
@@ -76,6 +77,7 @@ var f: [F] = []
 
 e = f as [E]
 f = e // expected-error {{cannot assign value of type '[E]' to type '[F]'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('E' and 'F') are expected to be equal}}
 
 class G {
   var x = 0
@@ -126,3 +128,4 @@ var i: [I] = []
 
 aoa = i as [AnyObject]
 i = aoa // expected-error {{cannot assign value of type '[AnyObject]' to type '[I]'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('AnyObject' and 'I') are expected to be equal}}

--- a/test/expr/cast/array_coerce.swift
+++ b/test/expr/cast/array_coerce.swift
@@ -17,6 +17,7 @@ var da: Array<D> = [d1]
 
 ca = da
 da = ca // expected-error{{cannot assign value of type 'Array<C>' to type 'Array<D>'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
 
 var caa = [ca]
 var daa = [da]
@@ -29,6 +30,7 @@ var das: [D] = [d1]
 
 cas = das
 das = cas // expected-error{{cannot assign value of type '[C]' to type '[D]'}}
+// expected-note@-1 {{arguments to generic parameter 'Element' ('C' and 'D') are expected to be equal}}
 
 // ArraySlice<T>
 var cs = ca[0...0]

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -34,8 +34,10 @@ func variadic() {
   let _: (Int...) -> () = {takesIntArray($0)}
   // expected-error@-1 {{cannot convert value of type '([Int]) -> ()' to specified type '(Int...) -> ()'}}
 
+  // TODO(diagnostics): This requires special handling - variadic vs. array
   takesVariadicGeneric({takesIntArray($0)})
   // expected-error@-1 {{cannot convert value of type 'Array<Element>' to expected argument type '[Int]'}}
+  // expected-note@-2 {{arguments to generic parameter 'Element' ('Element' and 'Int') are expected to be equal}}
 
   takesVariadicGeneric({let _: [Int] = $0})
   // expected-error@-1 {{cannot convert value of type '(_) -> ()' to expected argument type '(_...) -> ()'}}

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -4,7 +4,7 @@ protocol P1 {
   typealias DependentInConcreteConformance = Self
 }
 
-class Base<T> : P1 {
+class Base<T> : P1 { // expected-note {{arguments to generic parameter 'T' ('String' and 'Int') are expected to be equal}}
   typealias DependentClass = T
 
   required init(classInit: ()) {}
@@ -302,11 +302,11 @@ func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
 func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
-// expected-note@-1 {{where 'T' = 'Base<String>'}}
-// expected-note@-2 2 {{where 'T' = 'Base<Int>'}}
+// expected-note@-1 {{where 'T' = 'FakeDerived'}}
+// expected-note@-2 {{where 'T' = 'Base<Int>'}}
 
 func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
-// expected-note@-1 {{where 'T' = 'Base<String>'}}
+// expected-note@-1 {{where 'T' = 'FakeDerived'}}
 // expected-note@-2 {{where 'T' = 'Base<Int>'}}
 
 class FakeDerived : Base<String>, P2 {
@@ -421,16 +421,15 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   conformsToBaseIntAndP2(base)
   // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
-  // TODO(diagnostics): Diagnostic for this problem should mention both `Base<String>` not conforming to `P2`
-  // and invalid generic parameter (Int vs. String)
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
+  // expected-error@-2 {{cannot convert value of type 'Base<String>' to expected argument type 'Base<Int>'}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'FakeDerived' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<String>' inherit from 'Base<Int>'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'FakeDerived' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2(p2Archetype)
   // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}


### PR DESCRIPTION
…fix expect to optional types

This helps us to better diagnose failures related to generic
requirements like `T == [Int]` as well as protocol compositions,
which require deep equality check.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
