### PR TITLE
Don't crash when asking IsIUO on an incorrectly-SwiftName-d ClangImporter decl.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3413,8 +3413,10 @@ IsImplicitlyUnwrappedOptionalRequest::evaluate(Evaluator &evaluator,
       }
 
       // If the parameter is not the 'newValue' parameter to a setter, it
-      // must be a subscript index parameter.
-      auto *subscript = cast<SubscriptDecl>(storage);
+      // must be a subscript index parameter (or we have an invalid AST).
+      auto *subscript = dyn_cast<SubscriptDecl>(storage);
+      if (!subscript)
+        return false;
       auto *subscriptParams = subscript->getIndices();
 
       auto where = llvm::find_if(*accessorParams,


### PR DESCRIPTION
Sometimes the importer creates property decls with nonsensical types in response to nonsensical
SwiftName attributes on Clang types. Don't crash in IsIUORequest when this happens and a property accessor happens to have an unexpected param decl.