### PR TITLE
Update for Removal of DisableFPElim

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -896,13 +896,7 @@ bool swift::irgen::shouldRemoveTargetFeature(StringRef feature) {
 
 void IRGenModule::setHasFramePointer(llvm::AttrBuilder &Attrs,
                                      bool HasFramePointer) {
-  if (HasFramePointer) {
-    Attrs.addAttribute("no-frame-pointer-elim", "true");
-    Attrs.addAttribute("no-frame-pointer-elim-non-leaf");
-  } else {
-    Attrs.addAttribute("no-frame-pointer-elim", "false");
-    Attrs.removeAttribute("no-frame-pointer-elim-non-leaf");
-  }
+  Attrs.addAttribute("frame-pointer", HasFramePointer ? "all" : "none");
 }
 
 void IRGenModule::setHasFramePointer(llvm::Function *F,


### PR DESCRIPTION
DisableFPElim was removed from CGO in cfe r366645. This change fixes the
build for master-next.

This reimplements @plotfi patch https://github.com/apple/swift/pull/26263 which I believe may have been lost in a merge.