### PR TITLE
[Serialization] Remove several unnecessary bits of helper logic

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -193,7 +193,7 @@ public:
 
     /// This is a convenience function that writes the entire name, in forward
     /// order, to \p out.
-    void printForward(raw_ostream &out) const;
+    void printForward(raw_ostream &out, StringRef delim = ".") const;
   };
 
 private:

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1200,11 +1200,12 @@ ModuleDecl::ReverseFullNameIterator::operator++() {
 }
 
 void
-ModuleDecl::ReverseFullNameIterator::printForward(raw_ostream &out) const {
+ModuleDecl::ReverseFullNameIterator::printForward(raw_ostream &out,
+                                                  StringRef delim) const {
   SmallVector<StringRef, 8> elements(*this, {});
   swift::interleave(swift::reversed(elements),
                     [&out](StringRef next) { out << next; },
-                    [&out] { out << '.'; });
+                    [&out, delim] { out << delim; });
 }
 
 void

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2814,13 +2814,6 @@ public:
     for (auto Attr : D->getAttrs())
       writeDeclAttribute(Attr);
 
-    if (auto VD = dyn_cast<ValueDecl>(D)) {
-      // Hack: synthesize a 'final' attribute if finality was inferred.
-      if (VD->isFinal() && !D->getAttrs().hasAttribute<FinalAttr>())
-        writeDeclAttribute(
-            new (D->getASTContext()) FinalAttr(/*Implicit=*/false));
-    }
-
     if (auto *value = dyn_cast<ValueDecl>(D))
       writeDiscriminatorsIfNeeded(value);
 


### PR DESCRIPTION
Several commits that simplify Serialization in mostly trivial ways, mainly by removing Serialization's ad-hoc copy of an existing helper function. No intended functionality change.