### PR TITLE
[AutoDiff] Fix correctness and a leak in array literal differentiation.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4883,7 +4883,7 @@ public:
     } else {
       setAdjointValue(origExit, origResult, makeConcreteAdjointValue(seed));
       LLVM_DEBUG(getADDebugStream()
-                 << "Assigned seed " << seed
+                 << "Assigned seed " << *seed
                  << " as the adjoint of original result " << origResult);
     }
 
@@ -5206,9 +5206,9 @@ public:
   }
 
   AllocStackInst *
-  emitDifferentiableViewSubscript(ApplyInst *ai, SILType eltType,
-                                  SILValue adjointArray, SILValue fnRef,
-                                  CanGenericSignature genericSig, int index) {
+  emitArrayTangentSubscript(ApplyInst *ai, SILType eltType,
+                            SILValue adjointArray, SILValue fnRef,
+                            CanGenericSignature genericSig, int index) {
     auto &ctx = builder.getASTContext();
     auto astType = eltType.getASTType();
     auto literal = builder.createIntegerLiteral(
@@ -5233,19 +5233,25 @@ public:
     return subscriptBuffer;
   }
 
-  void
-  accumulateDifferentiableViewSubscriptDirect(ApplyInst *ai, SILType eltType,
-                                              StoreInst *si,
-                                              AllocStackInst *subscriptBuffer) {
+  void accumulateArrayTangentSubscriptDirect(ApplyInst *ai, SILType eltType,
+                                             StoreInst *si,
+                                             AllocStackInst *subscriptBuffer) {
     auto newAdjValue = builder.emitLoadValueOperation(
         ai->getLoc(), subscriptBuffer, LoadOwnershipQualifier::Take);
-    addAdjointValue(si->getParent(), si->getSrc(),
+    recordTemporary(newAdjValue);
+    SILValue src = si->getSrc();
+    // When the store's source is a `copy_value`, the `copy_value` is part of
+    // array literal initialization. In this case, add the adjoint to the source
+    // of the copy directly.
+    if (auto *cvi = dyn_cast<CopyValueInst>(src))
+      src = cvi->getOperand();
+    addAdjointValue(si->getParent(), src,
                     makeConcreteAdjointValue(newAdjValue), si->getLoc());
     blockTemporaries[ai->getParent()].push_back(newAdjValue);
     builder.createDeallocStack(ai->getLoc(), subscriptBuffer);
   }
 
-  void accumulateDifferentiableViewSubscriptIndirect(
+  void accumulateArrayTangentSubscriptIndirect(
       ApplyInst *ai, CopyAddrInst *cai, AllocStackInst *subscriptBuffer) {
     addToAdjointBuffer(cai->getParent(), cai->getSrc(), subscriptBuffer,
                        cai->getLoc());
@@ -5296,15 +5302,15 @@ public:
           auto inst = use->getUser();
           if (auto si = dyn_cast<StoreInst>(inst)) {
             auto tanType = getRemappedTangentType(si->getSrc()->getType());
-            auto subscriptBuffer = emitDifferentiableViewSubscript(
+            auto subscriptBuffer = emitArrayTangentSubscript(
                 ai, tanType, adjointArray, fnRef, genericSig, 0);
-            accumulateDifferentiableViewSubscriptDirect(
+            accumulateArrayTangentSubscriptDirect(
                 ai, tanType, si, subscriptBuffer);
           } else if (auto cai = dyn_cast<CopyAddrInst>(inst)) {
             auto tanType = getRemappedTangentType(cai->getSrc()->getType());
-            auto subscriptBuffer = emitDifferentiableViewSubscript(
+            auto subscriptBuffer = emitArrayTangentSubscript(
                 ai, tanType, adjointArray, fnRef, genericSig, 0);
-            accumulateDifferentiableViewSubscriptIndirect(
+            accumulateArrayTangentSubscriptIndirect(
                 ai, cai, subscriptBuffer);
           } else if (auto iai = dyn_cast<IndexAddrInst>(inst)) {
             for (auto use : iai->getUses()) {
@@ -5312,19 +5318,19 @@ public:
                 auto literal = dyn_cast<IntegerLiteralInst>(iai->getIndex());
                 auto tanType = getRemappedTangentType(
                     si->getSrc()->getType());
-                auto subscriptBuffer = emitDifferentiableViewSubscript(
+                auto subscriptBuffer = emitArrayTangentSubscript(
                     ai, tanType, adjointArray, fnRef,
                     genericSig, literal->getValue().getLimitedValue());
-                accumulateDifferentiableViewSubscriptDirect(
+                accumulateArrayTangentSubscriptDirect(
                     ai, tanType, si, subscriptBuffer);
               } else if (auto cai = dyn_cast<CopyAddrInst>(use->getUser())) {
                 auto literal = dyn_cast<IntegerLiteralInst>(iai->getIndex());
                 auto tanType = getRemappedTangentType(
                     cai->getSrc()->getType());
-                auto subscriptBuffer = emitDifferentiableViewSubscript(
+                auto subscriptBuffer = emitArrayTangentSubscript(
                     ai, tanType, adjointArray, fnRef,
                     genericSig, literal->getValue().getLimitedValue());
-                accumulateDifferentiableViewSubscriptIndirect(
+                accumulateArrayTangentSubscriptIndirect(
                     ai, cai, subscriptBuffer);
               }
             }
@@ -5788,15 +5794,11 @@ public:
 
   /// Handle `copy_value` instruction.
   ///   Original: y = copy_value x
-  ///    Adjoint: adj[x] = copy_value adj[y]
+  ///    Adjoint: adj[x] += adj[y]
   void visitCopyValueInst(CopyValueInst *cvi) {
     auto *bb = cvi->getParent();
     auto adj = getAdjointValue(bb, cvi);
-    auto adjVal = materializeAdjoint(adj, cvi->getLoc());
-    auto adjValCopy = builder.emitCopyValueOperation(cvi->getLoc(), adjVal);
-    recordTemporary(adjValCopy);
-    addAdjointValue(bb, cvi->getOperand(), makeConcreteAdjointValue(adjValCopy),
-                    cvi->getLoc());
+    addAdjointValue(bb, cvi->getOperand(), adj, cvi->getLoc());
   }
 
   /// Handle `begin_borrow` instruction.

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -1,12 +1,13 @@
 // RUN: %target-run-simple-swift
 
 import StdlibUnittest
+import DifferentiationUnittest
 
-var ArrayAutodiffTests = TestSuite("ArrayAutodiff")
+var ArrayAutoDiffTests = TestSuite("ArrayAutoDiff")
 
 typealias FloatArrayGrad = Array<Float>.TangentVector
 
-ArrayAutodiffTests.test("ArrayIdentity") {
+ArrayAutoDiffTests.test("ArrayIdentity") {
   func arrayIdentity(_ x: [Float]) -> [Float] {
     return x
   }
@@ -17,7 +18,7 @@ ArrayAutodiffTests.test("ArrayIdentity") {
     backprop(FloatArrayGrad([1, 2, 3, 4])))
 }
 
-ArrayAutodiffTests.test("ArraySubscript") {
+ArrayAutoDiffTests.test("ArraySubscript") {
   func sumFirstThree(_ array: [Float]) -> Float {
     return array[0] + array[1] + array[2]
   }
@@ -27,19 +28,19 @@ ArrayAutodiffTests.test("ArraySubscript") {
     gradient(at: [2, 3, 4, 5, 6, 7], in: sumFirstThree))
 }
 
-ArrayAutodiffTests.test("ArrayLiteral") {
-  func twoElementLiteral(_ x: Float, _ y: Float) -> [Float] {
+ArrayAutoDiffTests.test("ArrayLiteral") {
+  func twoElementLiteral(_ x: Tracked<Float>, _ y: Tracked<Float>) -> [Tracked<Float>] {
     return [x, y]
   }
 
-  let (gradX, gradY) = pullback(at: Float(1), Float(1), in: twoElementLiteral)(
-    Array<Float>.DifferentiableView([Float(1), Float(2)]))
+  let (gradX, gradY) = pullback(at: Tracked<Float>(1), Tracked<Float>(1), in: twoElementLiteral)(
+    Array<Tracked<Float>>.DifferentiableView([Tracked<Float>(1), Tracked<Float>(2)]))
 
-  expectEqual(gradX, Float(1))
-  expectEqual(gradY, Float(2))
+  expectEqual(Tracked<Float>(1), gradX)
+  expectEqual(Tracked<Float>(2), gradY)
 }
 
-ArrayAutodiffTests.test("ArrayLiteralIndirect") {
+ArrayAutoDiffTests.test("ArrayLiteralIndirect") {
   func twoElementLiteralIndirect<T: Differentiable & AdditiveArithmetic>(_ x: T, _ y: T) -> [T] {
     return [x, y]
   }
@@ -51,11 +52,11 @@ ArrayAutodiffTests.test("ArrayLiteralIndirect") {
   let (gradX, gradY) = pullback(at: Float(1), Float(1), in: twoElementLiteralIndirectWrapper)(
     Array<Float>.DifferentiableView([Float(1), Float(2)]))
 
-  expectEqual(gradX, Float(1))
-  expectEqual(gradY, Float(2))
+  expectEqual(Float(1), gradX)
+  expectEqual(Float(2), gradY)
 }
 
-ArrayAutodiffTests.test("ArrayConcat") {
+ArrayAutoDiffTests.test("ArrayConcat") {
   struct TwoArrays : Differentiable {
     var a: [Float]
     var b: [Float]
@@ -89,7 +90,7 @@ ArrayAutodiffTests.test("ArrayConcat") {
       in: sumFirstThreeConcatted))
 }
 
-ArrayAutodiffTests.test("Array.DifferentiableView.init") {
+ArrayAutoDiffTests.test("Array.DifferentiableView.init") {
   @differentiable
   func constructView(_ x: [Float]) -> Array<Float>.DifferentiableView {
     return Array<Float>.DifferentiableView(x)
@@ -101,7 +102,7 @@ ArrayAutodiffTests.test("Array.DifferentiableView.init") {
     backprop(FloatArrayGrad([1, 2, 3, 4])))
 }
 
-ArrayAutodiffTests.test("Array.DifferentiableView.base") {
+ArrayAutoDiffTests.test("Array.DifferentiableView.base") {
   @differentiable
   func accessBase(_ x: Array<Float>.DifferentiableView) -> [Float] {
     return x.base
@@ -115,7 +116,7 @@ ArrayAutodiffTests.test("Array.DifferentiableView.base") {
     backprop(FloatArrayGrad([1, 2, 3, 4])))
 }
 
-ArrayAutodiffTests.test("Array.DifferentiableView : KeyPathIterable") {
+ArrayAutoDiffTests.test("Array.DifferentiableView : KeyPathIterable") {
   struct Container : KeyPathIterable {
     let a: Array<Float>.DifferentiableView
   }

--- a/test/AutoDiff/leakchecking.swift
+++ b/test/AutoDiff/leakchecking.swift
@@ -604,4 +604,13 @@ LeakCheckingTests.testWithLeakChecking("ControlFlowWithSwitchEnumWithPayload") {
   expectEqual((-2674, 2), Tracked<Float>(-1337).valueWithGradient(in: { x in enum_notactive2(.b(4, 5), x) }))
 }
 
+LeakCheckingTests.testWithLeakChecking("ArrayLiteralInitialization") {
+  func concat(_ x: [Tracked<Float>]) -> Tracked<Float> { return x[0] }
+  func foo(_ x: Tracked<Float>) -> Float {
+    let y = x + x
+    return concat([x, y]).value
+  }
+  expectEqual(Tracked<Float>(1), gradient(at: .zero, in: foo))
+}
+
 runAllTests()


### PR DESCRIPTION
* When differentiating an array literal initialization, the result from loading must be destroyed. Use `PullbackEmitter::recordTemporary` to record the value for cleanup. This resolves [TF-706](https://bugs.swift.org/browse/TF-706).

* Array literal differentiation produced zero derivatives for values of non-trivial loadable types in OSSA. This was because we added adjoint values to the `store [init]`'s source operand while the source operand came from a `copy_value`, while this `copy_value` is part of the array literal initialization. This patch fixes this by detecting `copy_value`s before adding an adjoint.