### PR TITLE
[Constraint graph] Enable one-way constraints in function builders.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -213,7 +213,7 @@ namespace swift {
     unsigned SolverShrinkUnsolvedThreshold = 10;
 
     /// Enable one-way constraints in function builders.
-    bool FunctionBuilderOneWayConstraints = false;
+    bool FunctionBuilderOneWayConstraints = true;
 
     /// Disable the shrink phase of the expression type checker.
     bool SolverDisableShrink = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -408,6 +408,10 @@ def enable_function_builder_one_way_constraints : Flag<["-"],
   "enable-function-builder-one-way-constraints">,
   HelpText<"Enable one-way constraints in the function builder transformation">;
 
+def disable_function_builder_one_way_constraints : Flag<["-"],
+  "disable-function-builder-one-way-constraints">,
+  HelpText<"Disable one-way constraints in the function builder transformation">;
+
 def solver_disable_shrink :
   Flag<["-"], "solver-disable-shrink">,
   HelpText<"Disable the shrink phase of expression type checking">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -441,8 +441,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.getLastArg(OPT_solver_disable_shrink))
     Opts.SolverDisableShrink = true;
-  if (Args.getLastArg(OPT_enable_function_builder_one_way_constraints))
-    Opts.FunctionBuilderOneWayConstraints = true;
+  Opts.FunctionBuilderOneWayConstraints =
+    Args.hasFlag(OPT_enable_function_builder_one_way_constraints,
+                 OPT_disable_function_builder_one_way_constraints,
+                 /*Default=*/true);
 
   if (const Arg *A = Args.getLastArg(OPT_value_recursion_threshold)) {
     unsigned threshold;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1389,7 +1389,9 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
 
   // Update the current DeclContext to be the closure we're about to
   // recurse into.
-  assert(DC == closure->getParent() && "Decl context isn't correct");
+  assert((closure->getParent() == DC ||
+          closure->getParent()->isChildContextOf(DC)) &&
+      "Decl context isn't correct");
   DC = closure;
   return true;
 }

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -276,18 +276,20 @@ struct TagAccepter<Tag> {
 }
 
 func testAcceptColorTagged(b: Bool, i: Int, s: String, d: Double) {
+  // FIXME: When we support buildExpression, drop the "Color" prefix
   // CHECK: Tagged<
   acceptColorTagged {
-    i.tag(.red)
-    s.tag(.green)
-    d.tag(.blue)
+    i.tag(Color.red)
+    s.tag(Color.green)
+    d.tag(Color.blue)
   }
 
+  // FIXME: When we support buildExpression, drop the "Color" prefix
   // CHECK: Tagged<
   TagAccepter<Color>.acceptTagged {
-    i.tag(.red)
-    s.tag(.green)
-    d.tag(.blue)
+    i.tag(Color.red)
+    s.tag(Color.green)
+    d.tag(Color.blue)
   }
 
   // CHECK: Tagged<

--- a/test/IDE/complete_function_builder.swift
+++ b/test/IDE/complete_function_builder.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_TOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_NONTOP | %FileCheck %s -check-prefix=IN_CLOSURE_TOP
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE_COLOR_CONTEXT_DOT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=IN_CLOSURE_COLOR_CONTEXT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=IN_CLOSURE_COLOR_CONTEXT_DOT | %FileCheck %s -check-prefix=IN_CLOSURE_COLOR_CONTEXT_DOT
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_1 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_2 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_3 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_4 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXTUAL_TYPE_5 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_1 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_2 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_3 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_4 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_VALID
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -disable-function-builder-one-way-constraints -code-completion-token=CONTEXTUAL_TYPE_5 | %FileCheck %s -check-prefix=CONTEXTUAL_TYPE_INVALID
 
 struct Tagged<Tag, Entity> {
   let tag: Tag

--- a/test/SourceKit/CursorInfo/function_builder.swift
+++ b/test/SourceKit/CursorInfo/function_builder.swift
@@ -39,7 +39,7 @@ func acceptColorTagged<Result>(@TaggedBuilder<Color> body: (Color) -> Result) {
 func testAcceptColorTagged(i: Int, s: String) {
   acceptColorTagged { color in
     i.tag(color)
-    s.tag(.green)
+    s.tag(Color.green)
   }
 }
 

--- a/test/decl/var/function_builders.swift
+++ b/test/decl/var/function_builders.swift
@@ -24,20 +24,26 @@ var globalWithEmptyImplicitGetter: Int {}
 // expected-error@-1 {{computed property must have accessors specified}}
 // expected-error@-3 {{function builder attribute 'Maker' can only be applied to a variable if it defines a getter}}
 
+// FIXME: extra diagnostics
 @Maker
-var globalWithEmptyExplicitGetter: Int { get {} }  // expected-error {{ype 'Maker' has no member 'buildBlock'}}
+var globalWithEmptyExplicitGetter: Int { get {} }  // expected-error{{type 'Maker' has no member 'buildBlock'}}
+// expected-error@-1 {{cannot convert return expression of type 'Any' to return type 'Int'}}
 
 @Maker
 var globalWithSingleGetter: Int { 0 } // expected-error {{ype 'Maker' has no member 'buildBlock'}}
+// expected-error@-1 {{cannot convert return expression of type 'Any' to return type 'Int'}}
 
 @Maker
 var globalWithMultiGetter: Int { 0; 0 } // expected-error {{ype 'Maker' has no member 'buildBlock'}}
+// expected-error@-1 {{cannot convert return expression of type 'Any' to return type 'Int'}}
 
 @Maker
 func globalFunction() {} // expected-error {{ype 'Maker' has no member 'buildBlock'}}
+// expected-error@-1 {{unexpected non-void return value in void function}}
 
 @Maker
 func globalFunctionWithFunctionParam(fn: () -> ()) {}  // expected-error {{ype 'Maker' has no member 'buildBlock'}}
+// expected-error@-1 {{unexpected non-void return value in void function}}
 
 func makerParam(@Maker
                 fn: () -> ()) {}

--- a/test/multifile/function_builder_multifile.swift
+++ b/test/multifile/function_builder_multifile.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %S/Inputs/function_builder_definition.swift -primary-file %s
 
-func test0() -> (Int, Float, String) {
+func test0() -> (Int, Double, String) {
   return tuplify {
     17
     3.14159

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -310,6 +310,13 @@ EnableSourceImport("enable-source-import", llvm::cl::Hidden,
                    llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+DisableFunctionBuilderOneWayConstraints(
+    "disable-function-builder-one-way-constraints",
+    llvm::cl::desc("Disable one-way constraints in function builders"),
+    llvm::cl::cat(Category),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 SkipDeinit("skip-deinit",
            llvm::cl::desc("Whether to skip printing destructors"),
            llvm::cl::cat(Category),
@@ -3319,6 +3326,8 @@ int main(int argc, char *argv[]) {
     options::ImportObjCHeader;
   InitInvok.getLangOptions().EnableAccessControl =
     !options::DisableAccessControl;
+  InitInvok.getLangOptions().FunctionBuilderOneWayConstraints =
+    !options::DisableFunctionBuilderOneWayConstraints;
   InitInvok.getLangOptions().CodeCompleteInitsInPostfixExpr |=
       options::CodeCompleteInitsInPostfixExpr;
   InitInvok.getLangOptions().CodeCompleteCallPatternHeuristics |=


### PR DESCRIPTION
Enable one-way constraints by default for function builders, finishing
rdar://problem/50150793.
