### PR TITLE
ASTVerifier: make sure isFinal and FinalAttr are in sync

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2367,6 +2367,14 @@ public:
         }
       }
 
+      if (VD->isFinal() != VD->getAttrs().hasAttribute<FinalAttr>()) {
+        Out << "decl should be final iff it has FinalAttr, but isFinal() = "
+            << VD->isFinal() << " and hasAttribute<FinalAttr>() = "
+            << VD->getAttrs().hasAttribute<FinalAttr>() << "\n";
+        VD->dump(Out);
+        abort();
+      }
+
       verifyCheckedBase(VD);
     }
 


### PR DESCRIPTION
Serialization is currently working around them *not* having been in sync in the past, but they are now, and we might as well start depending on it (see #26735).