### PR TITLE
Fix SR-11159, better checking for enum elements with the same head and different labels

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4731,6 +4731,10 @@ ERROR(empty_switch_stmt,none,
       "'switch' statement body must have at least one 'case' or 'default' "
       "block; do you want to add a default case?",())
 ERROR(non_exhaustive_switch,none, "switch must be exhaustive", ())
+ERROR(enum_element_pattern_assoc_values_using_labels,none,
+      "using label to match to enum, enum element pattern cannot match against mixed labels and variable patterns.",())
+ERROR(enum_element_pattern_assoc_values_using_var_patterns,none,
+      "using variable patterns to match against enum, enum element pattern cannot match against mixed labels and variable patterns.",())
 ERROR(possibly_non_exhaustive_switch,none,
       "the compiler is unable to check that this switch is exhaustive in reasonable time",
       ())

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -513,14 +513,13 @@ public:
   EnumElementPattern(TypeLoc ParentType, SourceLoc DotLoc, DeclNameLoc NameLoc,
                      DeclNameRef Name, EnumElementDecl *Element,
                      Pattern *SubPattern, Optional<bool> Implicit = None)
-    : Pattern(PatternKind::EnumElement),
-      ParentType(ParentType), DotLoc(DotLoc), NameLoc(NameLoc), Name(Name),
-      ElementDeclOrUnresolvedOriginalExpr(Element),
-      SubPattern(SubPattern) {
+      : Pattern(PatternKind::EnumElement), ParentType(ParentType),
+        DotLoc(DotLoc), NameLoc(NameLoc), Name(Name),
+        ElementDeclOrUnresolvedOriginalExpr(Element), SubPattern(SubPattern) {
     if (Implicit.hasValue() && *Implicit)
       setImplicit();
   }
-  
+
   /// Create an unresolved EnumElementPattern for a `.foo` pattern relying on
   /// contextual type.
   EnumElementPattern(SourceLoc DotLoc,

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -374,7 +374,9 @@ namespace {
           // Optimization: If the constructor heads don't match, subspace is
           // impossible.
 
-          if (this->Head != other.Head) {
+          // FIXME: Extraneous warnings for cases with labels
+          if (this->Head.getBaseIdentifier() !=
+              other.Head.getBaseIdentifier()) {
             return false;
           }
 
@@ -557,6 +559,8 @@ namespace {
         PAIRCASE (SpaceKind::Constructor, SpaceKind::Constructor): {
           // Optimization: If the heads of the constructors don't match then
           // the two are disjoint and their difference is the first space.
+
+          // FIXME: Exhuastiveness checking for labelled Enums
           if (this->Head.getBaseIdentifier() !=
               other.Head.getBaseIdentifier()) {
             return *this;

--- a/test/stmt/switch_stmt2.swift
+++ b/test/stmt/switch_stmt2.swift
@@ -150,3 +150,65 @@ func fallthrough_not_last(i: Int) {
     break
   }
 }
+
+// Do not crash
+enum Foo1 
+{
+    case a(x:Int)
+    case a(y:Int)
+}
+
+func Foo1switcher(_ foo:Foo1) {
+    switch foo {
+    case .a(x:):
+      break 
+    case .a(y:):
+      break 
+    case .a(Int): // expected-error {{cannot convert value of type 'Foo1' to expected argument type 'Optional<_>'}}
+      break
+    }
+}
+
+enum Foo2
+{
+    case a(x: Int, y: Int)
+    case a(x: Int)
+}
+
+func Foo2switcher(_ foo:Foo2) {
+    switch foo {
+    case .a(x: let x):
+      print("x: \(x)")
+      break
+    case .a(x: let x, y: let y):
+      print("x: \(x), y: \(y)")
+      break
+    case .a(let x, let z): // expected-error {{missing argument labels 'x:y:' in call}}
+      break
+    case .a(x: let x, let y): // expected-error {{using label to match to enum, enum element pattern cannot match against mixed labels and variable patterns.}}
+      break
+    case .a(let x, y: let y): // expected-error {{using variable patterns to match against enum, enum element pattern cannot match against mixed labels and variable patterns.}}
+      break
+    }
+}
+
+enum Foo3 
+{
+    case a(x: Int)
+    case b(y: Int)
+    case c(Int)
+}
+
+func Foo3switcher(_ foo:Foo3) {
+    switch foo {
+    case .a(y: let y): // expected-error {{tuple pattern element label 'y' must be 'x'}}
+      break
+    case .b(x: let x): // expected-error {{tuple pattern element label 'x' must be 'y'}}
+      break
+    case .c(let v):
+      break
+    }
+}
+
+
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a fix to SR-11159 which was a bug where having two enum elements with different named arguments could cause the compiler to crash in a  switch statement.  I do my best to follow the following [swift evolution proposal ](https://github.com/apple/swift-evolution/blob/master/proposals/0155-normalize-enum-case-representation.md).  There are still a few errors surrounding error messages that I would help from if possible.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11159](https://bugs.swift.org/browse/SR-11159).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->