### PR TITLE
Document that raw `copyMemory` methods handle overlapping memory.

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -375,6 +375,9 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// must be properly aligned for accessing `T`, and `source.count` must be a
   /// multiple of `MemoryLayout<T>.stride`.
   ///
+  /// The memory referenced by `source` may overlap with the memory referenced 
+  /// by this buffer.
+  ///
   /// After calling `copyMemory(from:)`, the first `source.count` bytes of
   /// memory referenced by this buffer are initialized to raw bytes. If the
   /// memory is bound to type `T`, then it contains values of type `T`.

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -966,14 +966,17 @@ public struct UnsafeMutableRawPointer: _Pointer {
   /// must be properly aligned for accessing `T`, and `byteCount` must be a
   /// multiple of `MemoryLayout<T>.stride`.
   ///
-  /// After calling `copyMemory(from:byteCount:)`, the `byteCount` bytes of memory
-  /// referenced by this pointer are initialized to raw bytes. If the memory
-  /// is bound to type `T`, then it contains values of type `T`.
+  /// The memory in the region `source..<(source + byteCount)` may overlap with
+  /// the memory referenced by this pointer.
+  ///
+  /// After calling `copyMemory(from:byteCount:)`, the `byteCount` bytes of 
+  /// memory referenced by this pointer are initialized to raw bytes. If the
+  /// memory is bound to type `T`, then it contains values of type `T`.
   ///
   /// - Parameters:
   ///   - source: A pointer to the memory to copy bytes from. The memory in the
-  ///     region `source..<(source + byteCount)` must be initialized to a trivial
-  ///     type.
+  ///     region `source..<(source + byteCount)` must be initialized to a
+  ///     trivial type.
   ///   - byteCount: The number of bytes to copy. `byteCount` must not be negative.
   @inlinable
   public func copyMemory(from source: UnsafeRawPointer, byteCount: Int) {


### PR DESCRIPTION
Resolves [SR-11329](https://bugs.swift.org/browse/SR-11329).
