### PR TITLE
[AST] Handle getSuperclassForDecl() returning an ErrorType in more places

### DIFF
--- a/test/IDE/complete_name_lookup.swift
+++ b/test/IDE/complete_name_lookup.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FOO_OBJECT_DOT_1 | %FileCheck %s -check-prefix=FOO_OBJECT_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BAR_OBJECT_DOT_1 | %FileCheck %s -check-prefix=BAR_OBJECT_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CATCHSEQUENCE_DOT | %FileCheck %s -check-prefix=CATCHSEQUENCE_DOT
 
 protocol FooBaseProtocol {
   var instanceProperty: Int { get }
@@ -35,3 +36,21 @@ func test(a: BarStruct) {
   a.#^BAR_OBJECT_DOT_1^#
 }
 
+protocol ObservableConvertibleType {
+    associatedtype T
+}
+class Observable<T> : ObservableConvertibleType {}
+class CatchSequence<S: Sequence>: Observable<S.Element.T> where S.Element: ObservableConvertibleType {}
+
+extension ObservableConvertibleType {
+    static func catchError() -> Observable<T> {
+        return CatchSequence.#^CATCHSEQUENCE_DOT^#
+    }
+}
+// CATCHSEQUENCE_DOT: Begin completions
+// CATCHSEQUENCE_DOT-DAG: Keyword[self]/CurrNominal:          self[#CatchSequence<_>.Type#]; name=self
+// CATCHSEQUENCE_DOT-DAG: Keyword/CurrNominal:                Type[#CatchSequence<_>.Type#]; name=Type
+// CATCHSEQUENCE_DOT-DAG: Decl[Constructor]/CurrNominal:      init()[#CatchSequence<_>#]; name=init()
+// CATCHSEQUENCE_DOT-DAG: Decl[StaticMethod]/Super:           catchError()[#Observable<CatchSequence<_>.T>#]; name=catchError()
+// CATCHSEQUENCE_DOT-DAG: Decl[TypeAlias]/Super:              T[#T#]; name=T
+// CATCHSEQUENCE_DOT: End completions


### PR DESCRIPTION
~~We already were at some call sites, but weren't in `ModuleDecl::lookupConformance()` or `TypeBase::getContextSubstitutions()`. Code completion was hitting both of these cases.~~

Slava fixed the root cause of this in https://github.com/apple/swift/pull/26776. This is now just adding a regression test.

Resolves rdar://problem/54145042