### PR TITLE
[Diagnostics] Port contextual mismatches involving `nil` to new frame…

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1677,73 +1677,29 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     return failure.diagnose();
   }
 
-  // Try to find the contextual type in a variety of ways.  If the constraint
-  // system had a contextual type specified, we use it - it will have a purpose
-  // indicator which allows us to give a very "to the point" diagnostic.
-  Diag<Type> nilDiag;
-  std::function<void(void)> nilFollowup;
+  // If we don't have a type for the expression, then we cannot use it in
+  // conversion constraint diagnostic generation.  If the types match, then it
+  // must not be the contextual type that is the problem.
+  if (isUnresolvedOrTypeVarType(exprType) || exprType->isEqual(contextualType))
+    return false;
 
   // If this is conversion failure due to a return statement with an argument
   // that cannot be coerced to the result type of the function, emit a
   // specific error.
-  switch (CTP) {
-  case CTP_Unused:
-  case CTP_CannotFail:
-    llvm_unreachable("These contextual type purposes cannot fail with a "
-                     "conversion type specified!");
-  case CTP_CalleeResult:
-    llvm_unreachable("CTP_CalleeResult does not actually install a "
-                     "contextual type");
-  case CTP_Initialization:
-    nilDiag = diag::cannot_convert_initializer_value_nil;
-    nilFollowup = [this] {
-      TypeRepr *patternTR = CS.getContextualTypeLoc().getTypeRepr();
-      if (!patternTR)
-        return;
-      auto diag = diagnose(patternTR->getLoc(), diag::note_make_optional,
-                           OptionalType::get(CS.getContextualType()));
-      if (patternTR->isSimple()) {
-        diag.fixItInsertAfter(patternTR->getEndLoc(), "?");
-      } else {
-        diag.fixItInsert(patternTR->getStartLoc(), "(");
-        diag.fixItInsertAfter(patternTR->getEndLoc(), ")?");
-      }
-    };
-    break;
-  case CTP_ReturnSingleExpr:
-  case CTP_ReturnStmt:
-    // Special case the "conversion to void" case.
-    if (contextualType->isVoid()) {
-      diagnose(expr->getLoc(), diag::cannot_return_value_from_void_func)
-        .highlight(expr->getSourceRange());
-      return true;
-    }
-
-    nilDiag = diag::cannot_convert_to_return_type_nil;
-    break;
-  case CTP_ThrowStmt: {
-    if (isa<NilLiteralExpr>(expr->getValueProvidingExpr())) {
-      diagnose(expr->getLoc(), diag::cannot_throw_nil);
-      return true;
-    }
-
-    if (isUnresolvedOrTypeVarType(exprType) ||
-        exprType->isEqual(contextualType))
-      return false;
-
+  if (CTP == CTP_ThrowStmt) {
     // If we tried to throw the error code of an error type, suggest object
     // construction.
     auto &TC = CS.getTypeChecker();
     if (auto errorCodeProtocol =
             TC.Context.getProtocol(KnownProtocolKind::ErrorCodeProtocol)) {
-      if (auto conformance =
-            TypeChecker::conformsToProtocol(CS.getType(expr), errorCodeProtocol, CS.DC,
-                                            ConformanceCheckFlags::InExpression)) {
+      if (auto conformance = TypeChecker::conformsToProtocol(
+              CS.getType(expr), errorCodeProtocol, CS.DC,
+              ConformanceCheckFlags::InExpression)) {
         Type errorCodeType = CS.getType(expr);
         Type errorType =
-          conformance->getTypeWitnessByName(errorCodeType,
-                                            TC.Context.Id_ErrorType)
-            ->getCanonicalType();
+            conformance
+                ->getTypeWitnessByName(errorCodeType, TC.Context.Id_ErrorType)
+                ->getCanonicalType();
         if (errorType) {
           auto diag = diagnose(expr->getLoc(), diag::cannot_throw_error_code,
                                errorCodeType, errorType);
@@ -1760,18 +1716,11 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
     // if this ever expands, this should be a specific form like () is for
     // return.
     diagnose(expr->getLoc(), diag::cannot_convert_thrown_type, exprType)
-      .highlight(expr->getSourceRange());
+        .highlight(expr->getSourceRange());
     return true;
   }
 
-  case CTP_EnumCaseRawValue:
-    nilDiag = diag::cannot_convert_raw_initializer_value_nil;
-    break;
-  case CTP_DefaultParameter:
-    nilDiag = diag::cannot_convert_default_arg_value_nil;
-    break;
-
-  case CTP_YieldByReference:
+  if (CTP == CTP_YieldByReference) {
     if (auto contextualLV = contextualType->getAs<LValueType>())
       contextualType = contextualLV->getObjectType();
     if (auto exprLV = exprType->getAs<LValueType>()) {
@@ -1781,58 +1730,10 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
       diagnose(expr->getLoc(), diag::cannot_yield_rvalue_by_reference_same_type,
                exprType);
     } else {
-      diagnose(expr->getLoc(), diag::cannot_yield_rvalue_by_reference,
-               exprType, contextualType);
+      diagnose(expr->getLoc(), diag::cannot_yield_rvalue_by_reference, exprType,
+               contextualType);
     }
     return true;
-  case CTP_YieldByValue:
-    nilDiag = diag::cannot_convert_yield_value_nil;
-    break;
-  case CTP_CallArgument:
-    nilDiag = diag::cannot_convert_argument_value_nil;
-    break;
-  case CTP_ClosureResult:
-    nilDiag = diag::cannot_convert_closure_result_nil;
-    break;
-  case CTP_ArrayElement:
-    nilDiag = diag::cannot_convert_array_element_nil;
-    break;
-  case CTP_DictionaryKey:
-    nilDiag = diag::cannot_convert_dict_key_nil;
-    break;
-  case CTP_DictionaryValue:
-    nilDiag = diag::cannot_convert_dict_value_nil;
-    break;
-  case CTP_CoerceOperand:
-    nilDiag = diag::cannot_convert_coerce_nil;
-    break;
-  case CTP_AssignSource:
-    nilDiag = diag::cannot_convert_assign_nil;
-    break;
-  case CTP_SubscriptAssignSource:
-    nilDiag = diag::cannot_convert_subscript_assign_nil;
-    break;
-  }
-
-  // If we're diagnostic an issue with 'nil', produce a specific diagnostic,
-  // instead of uttering ExpressibleByNilLiteral.
-  if (isa<NilLiteralExpr>(expr->getValueProvidingExpr())) {
-    // If the source type is some kind of optional, the contextual conversion
-    // to 'nil' didn't fail, something else did.
-    if (contextualType->getOptionalObjectType())
-      return false;
-    diagnose(expr->getLoc(), nilDiag, contextualType);
-    if (nilFollowup)
-      nilFollowup();
-    return true;
-  }
-  
-  // If we don't have a type for the expression, then we cannot use it in
-  // conversion constraint diagnostic generation.  If the types match, then it
-  // must not be the contextual type that is the problem.
-  if (isUnresolvedOrTypeVarType(exprType) ||
-      exprType->isEqual(contextualType)) {
-    return false;
   }
 
   exprType = exprType->getRValueType();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1841,6 +1841,18 @@ bool ContextualFailure::diagnoseAsError() {
   auto *anchor = getAnchor();
   auto path = getLocator()->getPath();
 
+  if (CTP == CTP_ReturnSingleExpr || CTP == CTP_ReturnStmt) {
+    // Special case the "conversion to void".
+    if (getToType()->isVoid()) {
+      emitDiagnostic(anchor->getLoc(), diag::cannot_return_value_from_void_func)
+          .highlight(anchor->getSourceRange());
+      return true;
+    }
+  }
+
+  if (diagnoseConversionToNil())
+    return true;
+
   assert(!path.empty());
 
   if (diagnoseMissingFunctionCall())
@@ -1886,6 +1898,159 @@ bool ContextualFailure::diagnoseAsError() {
   diag.highlight(anchor->getSourceRange());
 
   (void)tryFixIts(diag);
+  return true;
+}
+
+static Optional<Diag<Type>>
+getContextualNilDiagnostic(ContextualTypePurpose CTP) {
+  switch (CTP) {
+  case CTP_Unused:
+  case CTP_CannotFail:
+    llvm_unreachable("These contextual type purposes cannot fail with a "
+                     "conversion type specified!");
+  case CTP_CalleeResult:
+    llvm_unreachable("CTP_CalleeResult does not actually install a "
+                     "contextual type");
+  case CTP_Initialization:
+    return diag::cannot_convert_initializer_value_nil;
+
+  case CTP_ReturnSingleExpr:
+  case CTP_ReturnStmt:
+    return diag::cannot_convert_to_return_type_nil;
+
+  case CTP_ThrowStmt:
+  case CTP_YieldByReference:
+    return None;
+
+  case CTP_EnumCaseRawValue:
+    return diag::cannot_convert_raw_initializer_value_nil;
+  case CTP_DefaultParameter:
+    return diag::cannot_convert_default_arg_value_nil;
+  case CTP_YieldByValue:
+    return diag::cannot_convert_yield_value_nil;
+  case CTP_CallArgument:
+    return diag::cannot_convert_argument_value_nil;
+  case CTP_ClosureResult:
+    return diag::cannot_convert_closure_result_nil;
+  case CTP_ArrayElement:
+    return diag::cannot_convert_array_element_nil;
+  case CTP_DictionaryKey:
+    return diag::cannot_convert_dict_key_nil;
+  case CTP_DictionaryValue:
+    return diag::cannot_convert_dict_value_nil;
+  case CTP_CoerceOperand:
+    return diag::cannot_convert_coerce_nil;
+  case CTP_AssignSource:
+    return diag::cannot_convert_assign_nil;
+  case CTP_SubscriptAssignSource:
+    return diag::cannot_convert_subscript_assign_nil;
+  }
+}
+
+bool ContextualFailure::diagnoseConversionToNil() const {
+  auto *anchor = getAnchor();
+
+  if (!isa<NilLiteralExpr>(anchor))
+    return false;
+
+  auto &cs = getConstraintSystem();
+  auto *locator = getLocator();
+
+  Optional<ContextualTypePurpose> CTP;
+  // Easy case were failure has been identified as contextual already.
+  if (locator->isLastElement(ConstraintLocator::ContextualType)) {
+    CTP = getContextualTypePurpose();
+  } else {
+    // Here we need to figure out where where `nil` is located.
+    // It could be e.g. an argument to a subscript/call, assignment
+    // source like `s[0] = nil` or an array element like `[nil]` or
+    // `[nil: 42]` as a sub-expression to a larger one.
+    auto *parentExpr = findParentExpr(anchor);
+
+    // Looks like it's something similar to `let _ = nil`.
+    if (!parentExpr) {
+      emitDiagnostic(anchor->getLoc(), diag::unresolved_nil_literal);
+      return true;
+    }
+
+    // Two choices here - whether it's a regular assignment
+    // e.g. `let _: S = nil` or a subscript one e.g. `s[0] = nil`.
+    if (auto *AE = dyn_cast<AssignExpr>(parentExpr)) {
+      CTP = isa<SubscriptExpr>(AE->getDest()) ? CTP_SubscriptAssignSource
+                                              : CTP_AssignSource;
+    } else if (isa<ArrayExpr>(parentExpr)) {
+      CTP = CTP_ArrayElement;
+    } else if (isa<ClosureExpr>(parentExpr)) {
+      CTP = CTP_ClosureResult;
+    } else if (isa<ParenExpr>(parentExpr) || isa<TupleExpr>(parentExpr)) {
+      auto *enclosingExpr = findParentExpr(parentExpr);
+
+      if (!enclosingExpr) {
+        // If there is no enclosing expression it's something like
+        // `(nil)` or `(a: nil)` which can't be inferred without a
+        // contextual type.
+        emitDiagnostic(anchor->getLoc(), diag::unresolved_nil_literal);
+        return true;
+      }
+
+      if (auto *TE = dyn_cast<TupleExpr>(parentExpr)) {
+        // In case of dictionary e.g. `[42: nil]` we need to figure
+        // out whether nil is a "key" or a "value".
+        if (auto *DE = dyn_cast<DictionaryExpr>(enclosingExpr)) {
+          assert(TE->getNumElements() == 2);
+          CTP = TE->getElement(0) == anchor ? CTP_DictionaryKey
+                                            : CTP_DictionaryValue;
+        } else {
+          // Can't initialize one of the tuple elements with `nil`.
+          CTP = CTP_Initialization;
+        }
+      }
+
+      // `nil` is passed as an argument to a parameter which doesn't
+      // expect it e.g. `foo(a: nil)` or `s[x: nil]`.
+      if (isa<ApplyExpr>(enclosingExpr) || isa<SubscriptExpr>(enclosingExpr))
+        CTP = CTP_CallArgument;
+    } else if (auto *CE = dyn_cast<CoerceExpr>(parentExpr)) {
+      // `nil` is passed as a left-hand side of the coercion
+      // operator e.g. `nil as Foo`
+      CTP = CTP_CoerceOperand;
+    } else {
+      // Otherwise let's produce a generic `nil` conversion diagnostic.
+      emitDiagnostic(anchor->getLoc(), diag::cannot_use_nil_with_this_type,
+                     getToType());
+      return true;
+    }
+  }
+
+  if (!CTP)
+    return false;
+
+  if (CTP == CTP_ThrowStmt) {
+    emitDiagnostic(anchor->getLoc(), diag::cannot_throw_nil);
+    return true;
+  }
+
+  auto diagnostic = getContextualNilDiagnostic(*CTP);
+  if (!diagnostic)
+    return false;
+
+  emitDiagnostic(anchor->getLoc(), *diagnostic, getToType());
+
+  if (CTP == CTP_Initialization) {
+    auto *patternTR = cs.getContextualTypeLoc().getTypeRepr();
+    if (!patternTR)
+      return true;
+
+    auto diag = emitDiagnostic(patternTR->getLoc(), diag::note_make_optional,
+                               OptionalType::get(getToType()));
+    if (patternTR->isSimple()) {
+      diag.fixItInsertAfter(patternTR->getEndLoc(), "?");
+    } else {
+      diag.fixItInsert(patternTR->getStartLoc(), "(");
+      diag.fixItInsertAfter(patternTR->getEndLoc(), ")?");
+    }
+  }
+
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -615,6 +615,9 @@ public:
 
   bool diagnoseAsError() override;
 
+  /// If we're trying to convert something to `nil`.
+  bool diagnoseConversionToNil() const;
+
   // If we're trying to convert something of type "() -> T" to T,
   // then we probably meant to call the value.
   bool diagnoseMissingFunctionCall() const;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3777,11 +3777,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     return result;
   }
 
-  // Let's not try to fix missing conformance for Void
-  // and Never because that doesn't really make sense.
-  if (type->isVoid() || type->isUninhabited())
-    return SolutionKind::Error;
-
   auto protocolTy = protocol->getDeclaredType();
   // If this conformance has been fixed already, let's just consider this done.
   if (hasFixedRequirement(type, RequirementKind::Conformance, protocolTy))
@@ -3793,6 +3788,27 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   {
     SmallVector<LocatorPathElt, 4> path;
     auto *anchor = locator.getLocatorParts(path);
+
+    // If this is a `nil` literal, it would be a contextual failure.
+    if (auto *Nil = dyn_cast_or_null<NilLiteralExpr>(anchor)) {
+      auto *fixLocator = getConstraintLocator(
+          getContextualType(Nil)
+              ? locator.withPathElement(LocatorPathElt::ContextualType())
+              : locator);
+
+      // Here the roles are reversed - `nil` is something we are trying to
+      // convert to `type` by making sure that it conforms to a specific
+      // protocol.
+      auto *fix =
+          ContextualMismatch::create(*this, protocolTy, type, fixLocator);
+
+      return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+    }
+
+    // Let's not try to fix missing conformance for Void
+    // or Never because that doesn't really make sense.
+    if (type->isVoid() || type->isUninhabited())
+      return SolutionKind::Error;
 
     if (path.empty())
       return SolutionKind::Error;

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -184,8 +184,8 @@ func keyedSubscripting(_ b: B, idx: A, a: A) {
   dict[NSString()] = a
   let value = dict[NSString()]
 
-  dict[nil] = a // expected-error {{ambiguous subscript with base type 'NSMutableDictionary' and index type '_'}}
-  let q = dict[nil]  // expected-error {{ambiguous subscript}}
+  dict[nil] = a // expected-error {{'nil' is not compatible with expected argument type 'NSCopying'}}
+  let q = dict[nil]  // expected-error {{'nil' is not compatible with expected argument type 'NSCopying'}}
   _ = q
 }
 

--- a/test/Constraints/add_with_nil.swift
+++ b/test/Constraints/add_with_nil.swift
@@ -2,5 +2,5 @@
 
 func test(_ x: Int) -> Int {
   return x + nil
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-1 {{'nil' is not compatible with expected argument type 'Int'}}
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -504,6 +504,7 @@ func test(_ a : B) {
   B.f1(nil)              // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
   a.function(42, a: nil) // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
   a.function(42, nil)    // expected-error {{missing argument label 'a:' in call}}
+  // expected-error@-1 {{'nil' is not compatible with expected argument type 'AOpts'}}
   a.f2(nil)              // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
 
   func foo1(_ arg: Bool) -> Int {return nil}
@@ -833,8 +834,9 @@ struct rdar27891805 {
 }
 
 try rdar27891805(contentsOfURL: nil, usedEncoding: nil)
-// expected-error@-1 {{argument labels '(contentsOfURL:, usedEncoding:)' do not match any available overloads}}
-// expected-note@-2 {{overloads for 'rdar27891805' exist with these partially matching parameter lists: (contentsOf: String, encoding: String), (contentsOf: String, usedEncoding: inout String)}}
+// expected-error@-1 {{incorrect argument labels in call (have 'contentsOfURL:usedEncoding:', expected 'contentsOf:encoding:')}}
+// expected-error@-2 {{'nil' is not compatible with expected argument type 'String'}}
+// expected-error@-3 {{'nil' is not compatible with expected argument type 'String'}}
 
 // Make sure RawRepresentable fix-its don't crash in the presence of type variables
 class NSCache<K, V> {
@@ -1002,7 +1004,7 @@ func SR_6272_c() {
 struct SR_6272_D: ExpressibleByIntegerLiteral {
   typealias IntegerLiteralType = Int
   init(integerLiteral: Int) {}
-  static func +(lhs: SR_6272_D, rhs: Int) -> Float { return 42.0 } // expected-note {{found this candidate}}
+  static func +(lhs: SR_6272_D, rhs: Int) -> Float { return 42.0 }
 }
 
 func SR_6272_d() {
@@ -1196,7 +1198,7 @@ func rdar17170728() {
 
   let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{ambiguous use of operator '+'}}
+    // expected-error@-1 {{'nil' cannot be used in context expecting type 'Bool'}}
   }
 }
 

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -23,15 +23,15 @@ useDictStringInt(["Hello" : 1, "World" : 2.5])
 useDictStringInt([4.5 : 2])
 // expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt([nil : 2])
-// expected-error@-1 {{'nil' is not compatible with expected dictionary key type 'String'}}
+// expected-error@-1 {{'nil' is not compatible with expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt([7 : 1, "World" : 2])
 // expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 useDictStringInt(["Hello" : nil])
-// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'Int'}}
+// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'DictStringInt.Value' (aka 'Int')}}
 
 typealias FuncBoolToInt = (Bool) -> Int
 let dict1: MyDictionary<String, FuncBoolToInt> = ["Hello": nil]
-// expected-error@-1 {{'nil' is not compatible with expected dictionary value type '(Bool) -> Int'}}
+// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'FuncBoolToInt' (aka '(Bool) -> Int')}}
 
 // Generic dictionary literals.
 useDict(["Hello" : 1])

--- a/test/Constraints/rdar45511837.swift
+++ b/test/Constraints/rdar45511837.swift
@@ -18,6 +18,7 @@ class Foo<Bar: NSObject> {
 
   lazy var foo: () -> Void = {
     // TODO: improve diagnostic message
-    _ = self.foobar + nil // expected-error {{'Foo<Bar>' requires that 'Bar' inherit from 'NSObject'}}
+    _ = self.foobar + nil // expected-error {{'Bar' is not convertible to 'String'; did you mean to use 'as!' to force downcast?}}
+    // expected-error@-1 {{'nil' is not compatible with expected argument type 'String'}}
   }
 }


### PR DESCRIPTION
…work

Detect and diagnose contextual failures originating in an attempt
to convert `nil` to some other non-optional type e.g.

```swift
let _: Int = nil // can't initialize `Int` with `nil`

func foo() -> Int {
  return nil // can't return `nil` from `foo`
}

_ = 1 + nil // there is no `+` overload which accepts `Int` and optional
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
