### PR TITLE
Sr 11159 space engine

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -23,8 +23,10 @@
 #include "swift/Basic/APIntMap.h"
 #include <llvm/ADT/APFloat.h>
 
-#include <numeric>
 #include <forward_list>
+#include <iterator>
+#include <numeric>
+#include <utility>
 
 using namespace swift;
 
@@ -115,7 +117,7 @@ namespace {
 
       // In type space, we reuse HEAD to help us print meaningful name, e.g.,
       // tuple element name in fixits.
-      Identifier Head;
+      DeclName Head;
       std::forward_list<Space> Spaces;
 
       size_t computeSize(TypeChecker &TC, const DeclContext *DC,
@@ -170,19 +172,18 @@ namespace {
         llvm_unreachable("unhandled kind");
       }
 
-      explicit Space(Type T, Identifier NameForPrinting)
-        : Kind(SpaceKind::Type), TypeAndVal(T),
-          Head(NameForPrinting), Spaces({}){}
+      explicit Space(Type T, DeclName NameForPrinting)
+          : Kind(SpaceKind::Type), TypeAndVal(T), Head(NameForPrinting),
+            Spaces({}) {}
       explicit Space(UnknownCase_t, bool allowedButNotRequired)
         : Kind(SpaceKind::UnknownCase),
           TypeAndVal(Type(), allowedButNotRequired), Head(Identifier()),
           Spaces({}) {}
-      explicit Space(Type T, Identifier H, ArrayRef<Space> SP)
-        : Kind(SpaceKind::Constructor), TypeAndVal(T), Head(H),
-          Spaces(SP.begin(), SP.end()) {}
-      explicit Space(Type T, Identifier H, std::forward_list<Space> SP)
-        : Kind(SpaceKind::Constructor), TypeAndVal(T), Head(H),
-          Spaces(SP) {}
+      explicit Space(Type T, DeclName H, ArrayRef<Space> SP)
+          : Kind(SpaceKind::Constructor), TypeAndVal(T), Head(H),
+            Spaces(SP.begin(), SP.end()) {}
+      explicit Space(Type T, DeclName H, std::forward_list<Space> SP)
+          : Kind(SpaceKind::Constructor), TypeAndVal(T), Head(H), Spaces(SP) {}
       explicit Space(ArrayRef<Space> SP)
         : Kind(SpaceKind::Disjunct), TypeAndVal(Type()),
           Head(Identifier()), Spaces(SP.begin(), SP.end()) {}
@@ -194,7 +195,7 @@ namespace {
         : Kind(SpaceKind::Empty), TypeAndVal(Type()), Head(Identifier()),
           Spaces({}) {}
 
-      static Space forType(Type T, Identifier NameForPrinting) {
+      static Space forType(Type T, DeclName NameForPrinting) {
         if (T->isStructurallyUninhabited())
           return Space();
         return Space(T, NameForPrinting);
@@ -202,7 +203,7 @@ namespace {
       static Space forUnknown(bool allowedButNotRequired) {
         return Space(UnknownCase, allowedButNotRequired);
       }
-      static Space forConstructor(Type T, Identifier H, ArrayRef<Space> SP) {
+      static Space forConstructor(Type T, DeclName H, ArrayRef<Space> SP) {
         if (llvm::any_of(SP, std::mem_fn(&Space::isEmpty))) {
           // A constructor with an unconstructible parameter can never actually
           // be used.
@@ -210,7 +211,7 @@ namespace {
         }
         return Space(T, H, SP);
       }
-      static Space forConstructor(Type T, Identifier H,
+      static Space forConstructor(Type T, DeclName H,
                                   std::forward_list<Space> SP) {
         // No need to filter SP here; this is only used to copy other
         // Constructor spaces.
@@ -263,7 +264,7 @@ namespace {
         return TypeAndVal.getPointer();
       }
 
-      Identifier getHead() const {
+      DeclName getHead() const {
         assert(getKind() == SpaceKind::Constructor
                && "Wrong kind of space tried to access head");
         return Head;
@@ -272,7 +273,7 @@ namespace {
       Identifier getPrintingName() const {
         assert(getKind() == SpaceKind::Type
                && "Wrong kind of space tried to access printing name");
-        return Head;
+        return Head.getBaseIdentifier();
       }
 
       const std::forward_list<Space> &getSpaces() const {
@@ -333,7 +334,7 @@ namespace {
             return this->isSubspace(or2Space, TC, DC);
           }
 
-          return true;
+          return false;
         }
         PAIRCASE (SpaceKind::Type, SpaceKind::Disjunct): {
           // (_ : Ty1) <= (S1 | ... | Sn) iff (S1 <= S) || ... || (Sn <= S)
@@ -372,10 +373,11 @@ namespace {
         PAIRCASE (SpaceKind::Constructor, SpaceKind::Constructor): {
           // Optimization: If the constructor heads don't match, subspace is
           // impossible.
+
           if (this->Head != other.Head) {
             return false;
           }
-          
+
           // Special Case: Short-circuit comparisons with payload-less
           // constructors.
           if (other.getSpaces().empty()) {
@@ -557,7 +559,8 @@ namespace {
         PAIRCASE (SpaceKind::Constructor, SpaceKind::Constructor): {
           // Optimization: If the heads of the constructors don't match then
           // the two are disjoint and their difference is the first space.
-          if (this->Head != other.Head) {
+          if (this->Head.getBaseIdentifier() !=
+              other.Head.getBaseIdentifier()) {
             return *this;
           }
 
@@ -696,19 +699,40 @@ namespace {
           buffer << (getBoolValue() ? "true" : "false");
           break;
         case SpaceKind::Constructor: {
-          if (!Head.empty()) {
+          if (!Head.getBaseIdentifier().empty()) {
             buffer << ".";
-            buffer << Head.str();
+            buffer << Head.getBaseIdentifier().str();
           }
 
           if (Spaces.empty()) {
             return;
           }
 
+          auto args = Head.getArgumentNames().begin();
+          auto argEnd = Head.getArgumentNames().end();
+
+          // FIXME: Clean up code for performance
           buffer << "(";
-          interleave(Spaces, [&](const Space &param) {
-            param.show(buffer, forDisplay);
-          }, [&buffer]() { buffer << ", "; });
+          llvm::SmallVector<std::pair<Identifier, Space>, 4> labelSpaces;
+          for (auto param : Spaces) {
+            if (args != argEnd) {
+              labelSpaces.push_back(
+                  std::pair<Identifier, Space>(*args, param));
+              args++;
+            } else
+              labelSpaces.push_back(
+                  std::pair<Identifier, Space>(Identifier(), param));
+          }
+          interleave(
+              labelSpaces,
+              [&](const std::pair<Identifier, Space> &param) {
+                if (!param.first.empty()) {
+                  buffer << param.first;
+                  buffer << ": ";
+                }
+                param.second.show(buffer, forDisplay);
+              },
+              [&buffer]() { buffer << ", "; });
           buffer << ")";
         }
           break;
@@ -806,7 +830,7 @@ namespace {
                     Space::forType(TTy->getUnderlyingType(), Identifier()));
               }
             }
-            return Space::forConstructor(tp, eed->getName(),
+            return Space::forConstructor(tp, eed->getFullName(),
                                          constElemSpaces);
           });
 
@@ -967,7 +991,6 @@ namespace {
             return;
 
           Space projection = projectPattern(TC, caseItem.getPattern());
-
           bool isRedundant = !projection.isEmpty() &&
                              llvm::any_of(spaces, [&](const Space &handled) {
             return projection.isSubspace(handled, TC, DC);
@@ -1420,8 +1443,8 @@ namespace {
         auto subSpace = projectPattern(TC, OSP->getSubPattern());
         // To match patterns like (_, _, ...)?, we must rewrite the underlying
         // tuple pattern to .some(_, _, ...) first.
-        if (subSpace.getKind() == SpaceKind::Constructor
-            && subSpace.getHead().empty()) {
+        if (subSpace.getKind() == SpaceKind::Constructor &&
+            subSpace.getHead().getBaseIdentifier().empty()) {
           return Space::forConstructor(item->getType(), name,
                                        std::move(subSpace.getSpaces()));
         }

--- a/test/FixCode/fixits-switch.swift.result
+++ b/test/FixCode/fixits-switch.swift.result
@@ -55,19 +55,19 @@ func foo4(_ e : E2) -> Int {
   switch e {
   case .e2:
     return 1
-  case .e1(let a, let s):
+  case .e1(a: let a, s: let s):
 <#code#>
-case .e3(let a):
+case .e3(a: let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(let a, _):
+case .e6(a: let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(let a, _, _):
+case .e8(a: let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>
@@ -93,19 +93,19 @@ func foo6(_ e : E2) -> Int {
   switch e {
   case let .e1(x, y):
     return x + y
-  case .e2(let a):
+  case .e2(a: let a):
 <#code#>
-case .e3(let a):
+case .e3(a: let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(let a, _):
+case .e6(a: let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(let a, _, _):
+case .e8(a: let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>
@@ -117,17 +117,17 @@ func foo7(_ e : E2) -> Int {
   case .e2(1): return 0
   case .e1: return 0
   case .e3: return 0
-  case .e2(let a):
+  case .e2(a: let a):
 <#code#>
 case .e4(_):
 <#code#>
 case .e5(_, _):
 <#code#>
-case .e6(let a, _):
+case .e6(a: let a, _):
 <#code#>
 case .e7:
 <#code#>
-case .e8(let a, _, _):
+case .e8(a: let a, _, _):
 <#code#>
 case .e9(_, _, _):
 <#code#>

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1196,13 +1196,13 @@ enum Z {
 
 func sr11160_extra() {
   switch Z.z1(a: 1) { // expected-error {{switch must be exhaustive}}
-                      // expected-note@-1 {{add missing case: '.z1(let a)'}}
+                      // expected-note@-1 {{add missing case: '.z1(a: let a)'}}
   case .z2(_, _): ()
   case .z3(_): ()
   }
 
   switch Z.z1(a: 1) { // expected-error {{switch must be exhaustive}}
-                      // expected-note@-1 {{add missing case: '.z2(let a, let b)'}}
+                      // expected-note@-1 {{add missing case: '.z2(a: let a, b: let b)'}}
   case .z1(_): ()
   case .z3(_): ()
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Split off of #26741 to separate Enum changes and Space Engine changes, related to #26741

Changes Identifiers to DeclNames so that in checking elements the associated values are taken into account.  Other exhaustiveness and redundancy to compare these associated values are taken to make sure the correct message is shown. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11159](https://bugs.swift.org/browse/SR-11159).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
