### PR TITLE
[Diagnostics] Port tailored contextual diagnostic when thrown type do…

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -629,6 +629,10 @@ public:
   /// or convert an array literal to a dictionary e.g. `let _: [String: Int] = ["A", 0]`
   bool diagnoseConversionToDictionary() const;
 
+  /// Produce a specialized diagnostic if this is an attempt to throw
+  /// something with doesn't conform to `Error`.
+  bool diagnoseThrowsTypeMismatch() const;
+
   /// Attempt to attach any relevant fix-its to already produced diagnostic.
   void tryFixIts(InFlightDiagnostic &diagnostic) const;
 


### PR DESCRIPTION
…esn't conform to `Error`

`throw` statements are type-checked as having contextual `Error`
type to make sure that thrown type conforms to `Error` protocol.
Let's make sure that's correctly handled by new diagnostics framework.

```swift
func foo() throws {
  throw 0 // `Int` doesn't conform to `Error` protocol.
}
```
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
