### PR TITLE
Mark implicit_tupling_untupling_codegen as executable. [NFC]

### DIFF
--- a/test/Compatibility/implicit_tupling_untupling_codegen.swift
+++ b/test/Compatibility/implicit_tupling_untupling_codegen.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 
+// REQUIRES: executable_test
+
 // Even though we test that type-checking and exhaustiveness checking work fine
 // in the presence of implicit tupling/untupling in exhaustive_switch.swift,
 // make sure that the "patched" patterns do not lead to incorrect codegen.


### PR DESCRIPTION
Test was broken in Android CI because the CI cannot execute executable
tests, and need to be skip using this tag.

/cc @varungandhi-apple 