### PR TITLE
[stdlib] AutoreleasingUnsafeMutablePointer: eliminate questionable pointer use

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -154,6 +154,14 @@ public func expectFailure(
   _anyExpectFailed.orAndFetch(startAnyExpectFailed)
 }
 
+/// An opaque function that ignores its argument and returns nothing.
+public func noop<T>(_ value: T) {}
+
+/// An opaque function that simply returns its argument.
+public func identity<T>(_ value: T) -> T {
+  return value
+}
+
 public func identity(_ element: OpaqueValue<Int>) -> OpaqueValue<Int> {
   return element
 }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -336,7 +336,10 @@ public func _getBridgedNonVerbatimObjectiveCType<T>(_: T.Type) -> Any.Type?
 
 // -- Pointer argument bridging
 
-/// A mutable pointer-to-ObjC-pointer argument.
+/// A mutable pointer addressing an Objective-C reference that doesn't own its
+/// target.
+///
+/// `Pointee` must be a class type or `Optional<C>` where `C` is a class.
 ///
 /// This type has implicit conversions to allow passing any of the following
 /// to a C or ObjC API:
@@ -368,13 +371,17 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     self._rawValue = _rawValue
   }
 
-  /// Access the `Pointee` instance referenced by `self`.
+  /// Retrieve or set the `Pointee` instance referenced by `self`.
+  ///
+  /// `AutoreleasingUnsafeMutablePointer` is assumed to reference a value with
+  /// `__autoreleasing` ownership semantics, like `NSFoo **` declarations in
+  /// ARC. Setting the pointee autoreleases the new value before trivially
+  /// storing it in the referenced memory.
   ///
   /// - Precondition: the pointee has been initialized with an instance of type
   ///   `Pointee`.
   @inlinable
   public var pointee: Pointee {
-    /// Retrieve the value the pointer points to.
     @_transparent get {
       // The memory addressed by this pointer contains a non-owning reference,
       // therefore we *must not* point an `UnsafePointer<AnyObject>` to
@@ -392,12 +399,6 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
         to: Pointee.self)
     }
 
-    /// Set the value the pointer points to, copying over the previous value.
-    ///
-    /// AutoreleasingUnsafeMutablePointers are assumed to reference a
-    /// value with __autoreleasing ownership semantics, like 'NSFoo**'
-    /// in ARC. This autoreleases the argument before trivially
-    /// storing it to the referenced memory.
     @_transparent nonmutating set {
       // Autorelease the object reference.
       let object = unsafeBitCast(newValue, to: Optional<AnyObject>.self)

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -392,8 +392,8 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
       // an extra twist, `Pointee` is allowed (but not required) to be an
       // optional type, so we actually need to load it as an optional, and
       // explicitly handle the nil case.
-      let unmanaged = UnsafeRawPointer(_rawValue)
-        .load(as: Optional<Unmanaged<AnyObject>>.self)
+      let unmanaged =
+        UnsafePointer<Optional<Unmanaged<AnyObject>>>(_rawValue).pointee
       return unsafeBitCast(
         unmanaged?.takeUnretainedValue(),
         to: Pointee.self)
@@ -413,9 +413,8 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
       } else {
         unmanaged = nil
       }
-      UnsafeMutableRawPointer(_rawValue).storeBytes(
-        of: unmanaged,
-        as: Optional<Unmanaged<AnyObject>>.self)
+      UnsafeMutablePointer<Optional<Unmanaged<AnyObject>>>(_rawValue).pointee =
+        unmanaged
     }
   }
 

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -394,14 +394,14 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
       // explicitly handle the nil case.
       let unmanaged =
         UnsafePointer<Optional<Unmanaged<AnyObject>>>(_rawValue).pointee
-      return unsafeBitCast(
+      return _unsafeReferenceCast(
         unmanaged?.takeUnretainedValue(),
         to: Pointee.self)
     }
 
     @_transparent nonmutating set {
       // Autorelease the object reference.
-      let object = unsafeBitCast(newValue, to: Optional<AnyObject>.self)
+      let object = _unsafeReferenceCast(newValue, to: Optional<AnyObject>.self)
       Builtin.retain(object)
       Builtin.autorelease(object)
 

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -89,7 +89,7 @@ public struct Unmanaged<Instance: AnyObject> {
   /// and you know that you're not responsible for releasing the result.
   ///
   /// - Returns: The object referenced by this `Unmanaged` instance.
-  @inlinable // unsafe-performance
+  @_transparent // unsafe-performance
   public func takeUnretainedValue() -> Instance {
     return _value
   }
@@ -101,7 +101,7 @@ public struct Unmanaged<Instance: AnyObject> {
   /// and you know that you're responsible for releasing the result.
   ///
   /// - Returns: The object referenced by this `Unmanaged` instance.
-  @inlinable // unsafe-performance
+  @_transparent // unsafe-performance
   public func takeRetainedValue() -> Instance {
     let result = _value
     release()

--- a/test/stdlib/AutoreleasingUnsafeMutablePointer.swift
+++ b/test/stdlib/AutoreleasingUnsafeMutablePointer.swift
@@ -1,0 +1,186 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import ObjectiveC // for autoreleasepool
+
+var suite = TestSuite("AutoreleasingUnsafeMutablePointer")
+
+/// Call `body` passing it an AutoreleasingUnsafeMutablePointer whose pointee
+/// has the specified value, allocated in a temporary buffer.
+func withAUMP<Pointee: AnyObject>(
+  as type: Pointee.Type = Pointee.self,
+  initialValue: Optional<Unmanaged<Pointee>> = nil,
+  _ body: (AutoreleasingUnsafeMutablePointer<Optional<Pointee>>) -> Void
+) {
+  let p =
+    UnsafeMutablePointer<Optional<Unmanaged<Pointee>>>.allocate(capacity: 1)
+  p.initialize(to: initialValue)
+  body(AutoreleasingUnsafeMutablePointer(p))
+  p.deallocate()
+}
+
+/// Call `body` passing it an AutoreleasingUnsafeMutablePointer whose pointee
+/// has the specified value, allocated in a temporary buffer.
+func withAUMP<Pointee: AnyObject>(
+  initialValues: [Unmanaged<Pointee>?],
+  _ body: (AutoreleasingUnsafeMutablePointer<Optional<Pointee>>) -> Void
+) {
+  let p = UnsafeMutablePointer<Optional<Unmanaged<Pointee>>>.allocate(
+    capacity: initialValues.count
+  )
+  for i in 0 ..< initialValues.count {
+    (p + i).initialize(to: initialValues[i])
+  }
+
+  let aump = AutoreleasingUnsafeMutablePointer<Optional<Pointee>>(p)
+  body(aump)
+  p.deallocate()
+}
+
+suite.test("helper calls its closure exactly once") {
+  // `withAUMP` is expected to call its closure exactly once, with an argument
+  // pointing to a nil value.
+  var runCount = 0
+  withAUMP(as: LifetimeTracked.self) { p in
+    runCount += 1
+    expectNil(p.pointee)
+  }
+  expectEqual(runCount, 1)
+}
+
+suite.test("init doesn't autorelease") {
+  let originalInstances = LifetimeTracked.instances
+  let unmanaged = Unmanaged.passRetained(LifetimeTracked(42))
+  expectEqual(LifetimeTracked.instances, originalInstances + 1)
+
+  withAUMP(initialValue: unmanaged) { p in noop(p) }
+
+  // Releasing the original reference should immediately deallocate the
+  // object.
+  expectEqual(LifetimeTracked.instances, originalInstances + 1)
+  unmanaged.release()
+  expectEqual(LifetimeTracked.instances, originalInstances)
+}
+
+suite.test("getter initially returns the initial value") {
+  withAUMP(as: LifetimeTracked.self) { p in
+    expectNil(p.pointee)
+  }
+
+  let unmanaged = Unmanaged.passRetained(LifetimeTracked(42))
+  withAUMP(initialValue: unmanaged) { p in
+    expectTrue(p.pointee === unmanaged.takeUnretainedValue())
+  }
+  unmanaged.release()
+}
+
+suite.test("pointee getter returns the last value set") {
+  autoreleasepool {
+    withAUMP(as: LifetimeTracked.self) { p in
+      expectNil(p.pointee)
+      let object = LifetimeTracked(23)
+      p.pointee = object
+      expectTrue(p.pointee === object)
+      let other = LifetimeTracked(42)
+      p.pointee = other
+      expectTrue(p.pointee === other)
+      p.pointee = nil
+      expectNil(p.pointee)
+    }
+  }
+}
+
+suite.test("pointee getter doesn't autorelease") {
+  let originalInstances = LifetimeTracked.instances
+  autoreleasepool {
+    let unmanaged = Unmanaged.passRetained(LifetimeTracked(42))
+    expectEqual(LifetimeTracked.instances, originalInstances + 1)
+
+    withAUMP(initialValue: unmanaged) { p in
+      expectTrue(p.pointee === unmanaged.takeUnretainedValue())
+    }
+    // Releasing the original reference should immediately deallocate the
+    // object.
+    expectEqual(LifetimeTracked.instances, originalInstances + 1)
+    unmanaged.release()
+    expectEqual(LifetimeTracked.instances, originalInstances)
+  }
+}
+
+suite.test("pointee setter autoreleases the new value") {
+  let originalInstances = LifetimeTracked.instances
+  autoreleasepool {
+    withAUMP(as: LifetimeTracked.self) { p in
+      let object = LifetimeTracked(42)
+      // There is one more instance now.
+      expectEqual(LifetimeTracked.instances, originalInstances + 1)
+      p.pointee = object
+    }
+    // The strong reference to `object` is gone, but the autoreleasepool
+    // is still holding onto it.
+    expectEqual(LifetimeTracked.instances, originalInstances + 1)
+  }
+  // Draining the pool deallocates the instance.
+  expectEqual(LifetimeTracked.instances, originalInstances)
+}
+
+suite.test("AutoreleasingUnsafeMutablePointer doesn't retain its value") {
+  let originalInstances = LifetimeTracked.instances
+  withAUMP(as: LifetimeTracked.self) { p in
+    autoreleasepool {
+      let object = LifetimeTracked(42)
+      p.pointee = object
+      expectEqual(LifetimeTracked.instances, originalInstances + 1)
+    }
+    // Draining the pool deallocates the instance, even though
+    // the autoreleasing pointer still points to it.
+    // This is okay as long as the pointer isn't dereferenced.
+    expectEqual(LifetimeTracked.instances, originalInstances)
+  }
+  expectEqual(LifetimeTracked.instances, originalInstances)
+}
+
+suite.test("subscript[0] is the same as pointee.getter") {
+  withAUMP(as: LifetimeTracked.self) { p in
+    expectNil(p[0])
+  }
+
+  let unmanaged = Unmanaged.passRetained(LifetimeTracked(42))
+  withAUMP(initialValue: unmanaged) { p in
+    expectTrue(p[0] === unmanaged.takeUnretainedValue())
+  }
+  unmanaged.release()
+}
+
+
+suite.test("subscript and advanced(by:) works") {
+  let originalInstances = LifetimeTracked.instances
+  let count = 100
+
+  var refs = 0
+  let values: [Unmanaged<LifetimeTracked>?] = (0 ..< count).map { i in
+    if i % 10 == 0 {
+      refs += 1
+      return Unmanaged.passRetained(LifetimeTracked(i))
+    } else {
+      return nil
+    }
+  }
+
+  withAUMP(initialValues: values) { p in
+    for i in 0 ..< count {
+      expectTrue(p[i] === values[i]?.takeUnretainedValue())
+      expectTrue(p.advanced(by: i).pointee === values[i]?.takeUnretainedValue())
+    }
+  }
+
+  expectEqual(LifetimeTracked.instances, originalInstances + refs)
+  for unmanaged in values {
+    unmanaged?.release()
+  }
+  expectEqual(LifetimeTracked.instances, originalInstances)
+}
+
+runAllTests()


### PR DESCRIPTION
`AutoreleasingUnsafeMutablePointer` is pointing to a +0 reference, but in its `pointee` property’s getter/setter implementations, it is loading the pointer into regular `Unsafe[Mutable]Pointer`s. Those are assuming that the addressed memory contains a +1 reference, which can mislead the compiler into doing optimizations that aren’t valid.

Change the getter/setter implementations so that they use `UnsafeRawPointer` and load/store `Unmanaged` values instead. As long as `Unmanaged.passUnretained(_:)` and `Unmanaged.takeUnretainedValue()` do the right thing, then `AutoreleasingUnsafeMutablePointer` won’t have issues, either. (This boils down to ensuring that loading a strong reference out of an `unmanaged(unsafe)` value works correctly.)
