### PR TITLE
[Serialization] Remove "delayed actions" support

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -87,45 +87,10 @@ class ModuleFile
   /// A callback to be invoked every time a type was deserialized.
   std::function<void(Type)> DeserializedTypeCallback;
 
-  /// The number of entities that are currently being deserialized.
-  unsigned NumCurrentDeserializingEntities = 0;
-
   /// Is this module file actually a .sib file? .sib files are serialized SIL at
   /// arbitrary granularity and arbitrary stage; unlike serialized Swift
   /// modules, which are assumed to contain canonical SIL for an entire module.
   bool IsSIB = false;
-
-  /// RAII class to be used when deserializing an entity.
-  class DeserializingEntityRAII {
-    ModuleFile &MF;
-
-  public:
-    DeserializingEntityRAII(ModuleFile &mf)
-        : MF(mf.getModuleFileForDelayedActions()) {
-      ++MF.NumCurrentDeserializingEntities;
-    }
-    ~DeserializingEntityRAII() {
-      assert(MF.NumCurrentDeserializingEntities > 0 &&
-             "Imbalanced currently-deserializing count?");
-      if (MF.NumCurrentDeserializingEntities == 1) {
-        MF.finishPendingActions();
-      }
-
-      --MF.NumCurrentDeserializingEntities;
-    }
-  };
-  friend class DeserializingEntityRAII;
-
-  /// Picks a specific ModuleFile instance to serve as the "delayer" for the
-  /// entire module.
-  ///
-  /// This is usually \c this, but when there are partial swiftmodules all
-  /// loaded for the same module it may be different.
-  ModuleFile &getModuleFileForDelayedActions();
-
-  /// Finish any pending actions that were waiting for the topmost entity to
-  /// be deserialized.
-  void finishPendingActions();
 
 public:
   /// Represents another module that has been imported as a dependency.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -143,14 +143,9 @@ static void skipRecord(llvm::BitstreamCursor &cursor, unsigned recordKind) {
   auto next = cursor.advance(AF_DontPopBlockAtEnd);
   assert(next.Kind == llvm::BitstreamEntry::Record);
 
-#if NDEBUG
-  cursor.skipRecord(next.ID);
-#else
-  SmallVector<uint64_t, 64> scratch;
-  StringRef blobData;
-  unsigned kind = cursor.readRecord(next.ID, scratch, &blobData);
+  unsigned kind = cursor.skipRecord(next.ID);
   assert(kind == recordKind);
-#endif
+  (void)kind;
 }
 
 void ModuleFile::fatal(llvm::Error error) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -57,12 +57,12 @@ StringRef swift::getNameOfModule(const ModuleFile *MF) {
 }
 
 namespace {
-  struct OffsetAndKind {
+  struct DeclAndOffset {
     const Decl *D;
     uint64_t offset;
   };
 
-  static raw_ostream &operator<<(raw_ostream &os, OffsetAndKind &&pair) {
+  static raw_ostream &operator<<(raw_ostream &os, DeclAndOffset &&pair) {
     return os << Decl::getKindName(pair.D->getKind())
               << "Decl @ " << pair.offset;
   }
@@ -97,13 +97,13 @@ namespace {
         os << "While deserializing ";
 
         if (auto VD = dyn_cast<ValueDecl>(DeclOrOffset.get())) {
-          os << "'" << VD->getBaseName() << "' (" << OffsetAndKind{VD, offset}
+          os << "'" << VD->getBaseName() << "' (" << DeclAndOffset{VD, offset}
              << ")";
         } else if (auto ED = dyn_cast<ExtensionDecl>(DeclOrOffset.get())) {
           os << "extension of '" << ED->getExtendedType() << "' ("
-             << OffsetAndKind{ED, offset} << ")";
+             << DeclAndOffset{ED, offset} << ")";
         } else {
-          os << OffsetAndKind{DeclOrOffset.get(), offset};
+          os << DeclAndOffset{DeclOrOffset.get(), offset};
         }
       }
       os << " in '" << getNameOfModule(MF) << "'\n";


### PR DESCRIPTION
Previously, cycle-breaking logic would delay certain actions until all re-entrant deserialization was complete for a particular module. That hasn't been used in a while, though, now that the AST itself supports more laziness, so let's take it out.

No functionality change; this really was unused. PR also contains some other minor cleanups in deserialization.
