### PR TITLE
API/ABI checker: diagnose members in removed extensions rather than extensions themselves

### DIFF
--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -6,7 +6,6 @@ cake: Protocol P3 has generic signature change from <τ_0_0 : cake.P1, τ_0_0 : 
 /* RawRepresentable Changes */
 
 /* Removed Decls */
-Swift: Extension Int has been removed
 cake: Accessor GlobalVarChangedToLet.Modify() has been removed
 cake: Accessor GlobalVarChangedToLet.Set() has been removed
 cake: Accessor RemoveSetters.Value.Modify() has been removed
@@ -18,6 +17,7 @@ cake: AssociatedType RequiementChanges.removedType has been removed
 cake: Class C3 has been removed
 cake: Constructor Somestruct2.init(_:) has been removed
 cake: Func C4.foo() has been removed
+cake: Func Int.IntEnhancer() has been removed
 cake: Func RequiementChanges.removedFunc() has been removed
 cake: Var RequiementChanges.removedVar has been removed
 

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -6,13 +6,13 @@ cake: Protocol P3 has generic signature change from <Self : cake.P1, Self : cake
 /* RawRepresentable Changes */
 
 /* Removed Decls */
-Swift: Extension Int has been removed
 cake: Accessor GlobalVarChangedToLet.Set() has been removed
 cake: Accessor RemoveSetters.Value.Set() has been removed
 cake: Accessor RemoveSetters.subscript(_:).Set() has been removed
 cake: AssociatedType RequiementChanges.removedType has been removed
 cake: Constructor Somestruct2.init(_:) has been removed
 cake: Func C4.foo() has been removed
+cake: Func Int.IntEnhancer() has been removed
 cake: Func RequiementChanges.removedFunc() has been removed
 cake: Var RequiementChanges.removedVar has been removed
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -510,6 +510,7 @@ public:
   ArrayRef<SDKNode*> getConformances() const { return Conformances; }
   NodeVector getConformances() { return Conformances; }
   bool isExternal() const { return IsExternal; }
+  bool isExtension() const { return isExternal(); }
   StringRef getSuperClassName() const {
     return SuperclassNames.empty() ? StringRef() : SuperclassNames.front();
   };


### PR DESCRIPTION
"Extension A has been removed" isn't very informative, we should emit diagnostics for
each members in the extension.