### PR TITLE
[Parser, NameLookup, ASTScope] Parser changes for lazy ASTScopes

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -926,10 +926,12 @@ public:
   void setBody(BraceStmt * b) { Body = b; }
 
   SourceLoc getLoc() const { return SubExpr ? SubExpr->getLoc() : SourceLoc(); }
-
-  SourceRange getSourceRange() const {
-    return SubExpr ? SubExpr->getSourceRange() : SourceRange();
+  
+  SourceLoc getStartLoc() const {
+    return SubExpr ? SubExpr->getStartLoc() : SourceLoc();
   }
+
+  SourceLoc getEndLoc() const;
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Tap;
@@ -1027,6 +1029,8 @@ public:
     // token, so the range should be (Start == End).
     return Loc;
   }
+  
+  /// Could also be computed by relexing.
   SourceLoc getTrailingQuoteLoc() const {
     return TrailingQuoteLoc;
   }

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -813,9 +813,16 @@ public:
                           SourceLoc OtherLoc);
 
   /// Returns the proper location for a missing right brace, parenthesis, etc.
-  SourceLoc getConfabulatedMatchingTokenLoc() const;
-  
-  SourceLoc getErrorOrMissingLocForLazyASTScopes() const;
+  SourceLoc getLocForMissingMatchingToken() const;
+
+  /// When encountering an error or a missing matching token (e.g. '}') return
+  /// its location. This value should be right at the end of the last token in
+  /// the ASTNode being parsed so that it nests within any enclosing nodes, and,
+  /// for ASTScope lookups, it does not preceed any identifiers to be looked up.
+  /// The latter case obtaines when the parsing an interpolated string literal
+  /// because there may be identifiers to be looked up and they must precede the
+  /// location of a missing close brace.
+  SourceLoc getErrorOrMissingLoc() const;
 
   /// Parse a comma separated list of some elements.
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -571,7 +571,7 @@ public:
 
   /// Retrieve the location just past the end of the previous
   /// source location.
-  SourceLoc getEndOfPreviousLoc();
+  SourceLoc getEndOfPreviousLoc() const;
 
   /// If the current token is the specified kind, consume it and
   /// return true.  Otherwise, return false without consuming it.
@@ -811,6 +811,11 @@ public:
   /// error diagnostic,  a note at the specified note location, and return the location of the previous token.
   bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
                           SourceLoc OtherLoc);
+
+  /// Returns the proper location for a missing right brace, parenthesis, etc.
+  SourceLoc getConfabulatedMatchingTokenLoc() const;
+  
+  SourceLoc getErrorOrMissingLocForLazyASTScopes() const;
 
   /// Parse a comma separated list of some elements.
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
@@ -1067,6 +1072,9 @@ public:
   parseDeclPrecedenceGroup(ParseDeclOptions flags, DeclAttributes &attributes);
 
   ParserResult<TypeRepr> parseDeclResultType(Diag<> MessageID);
+
+  /// Get the location for a type error.
+  SourceLoc getTypeErrorLoc() const;
 
   //===--------------------------------------------------------------------===//
   // Type Parsing

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -815,13 +815,14 @@ public:
   /// Returns the proper location for a missing right brace, parenthesis, etc.
   SourceLoc getLocForMissingMatchingToken() const;
 
-  /// When encountering an error or a missing matching token (e.g. '}') return
-  /// its location. This value should be right at the end of the last token in
+  /// When encountering an error or a missing matching token (e.g. '}'), return
+  /// the location to use for it. This value should be at the last token in
   /// the ASTNode being parsed so that it nests within any enclosing nodes, and,
   /// for ASTScope lookups, it does not preceed any identifiers to be looked up.
-  /// The latter case obtaines when the parsing an interpolated string literal
-  /// because there may be identifiers to be looked up and they must precede the
-  /// location of a missing close brace.
+  /// However, the latter case does not hold when  parsing an interpolated
+  /// string literal because there may be identifiers to be looked up in the
+  /// literal and their locations will not precede the location of a missing
+  /// close brace.
   SourceLoc getErrorOrMissingLoc() const;
 
   /// Parse a comma separated list of some elements.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3654,7 +3654,9 @@ public:
         if (D->isImplicit())
           return;
         // FIXME: This is not working well for decl parents.
-        return;
+        // But it must work when using lazy ASTScopes for IterableDeclContexts
+        if (!Ctx.LangOpts.LazyASTScopes || !isa<IterableDeclContext>(D))
+          return;
       } else if (Stmt *S = Parent.getAsStmt()) {
         Enclosing = S->getSourceRange();
         if (S->isImplicit())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3655,7 +3655,7 @@ public:
           return;
         // FIXME: This is not working well for decl parents.
         // But it must work when using lazy ASTScopes for IterableDeclContexts
-        if (!Ctx.LangOpts.LazyASTScopes || !isa<IterableDeclContext>(D))
+        if (!isa<IterableDeclContext>(D))
           return;
       } else if (Stmt *S = Parent.getAsStmt()) {
         Enclosing = S->getSourceRange();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2228,13 +2228,7 @@ VarDecl * TapExpr::getVar() const {
 }
 
 SourceLoc TapExpr::getEndLoc() const {
-  // Before LazyASTScopes, was:
-  // return SubExpr ? SubExpr->getSourceRange() : SourceRange();
-
   // Include the body in the range, assuming the body follows the SubExpr.
-  // ASTScopes needs the body in the range in order to do lookups into the
-  // expressions in interpolated strings.
-
   // Also, be (perhaps overly) defensive about null pointers & invalid
   // locations.
   if (auto *const b = getBody()) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3434,7 +3434,7 @@ ParserResult<Expr> Parser::parseExprCollection() {
   if (Status.isError()) {
     // If we've already got errors, don't emit missing RightK diagnostics.
     RSquareLoc = Tok.is(tok::r_square) ? consumeToken()
-                                       : getConfabulatedMatchingTokenLoc();
+                                       : getLocForMissingMatchingToken();
   } else if (parseMatchingToken(tok::r_square, RSquareLoc,
                                 diag::expected_rsquare_array_expr,
                                 LSquareLoc)) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1913,6 +1913,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
 
   // The start location of the entire string literal.
   SourceLoc Loc = Tok.getLoc();
+  SourceLoc EndLoc = Loc.getAdvancedLoc(Tok.getLength());
 
   StringRef OpenDelimiterStr, OpenQuoteStr, CloseQuoteStr, CloseDelimiterStr;
   unsigned DelimiterLength = Tok.getCustomDelimiterLen();
@@ -2032,9 +2033,7 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     Status = parseStringSegments(Segments, EntireTok, InterpolationVar, 
                                  Stmts, LiteralCapacity, InterpolationCount);
 
-    // At this point, PreviousLoc points to the last token parsed within
-    // the body, so use that for the brace statement location.
-    auto Body = BraceStmt::create(Context, Loc, Stmts, PreviousLoc,
+    auto Body = BraceStmt::create(Context, Loc, Stmts, EndLoc,
                                   /*implicit=*/false);
     AppendingExpr = new (Context) TapExpr(nullptr, Body);
   }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -542,10 +542,8 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
 }
 
 SourceLoc Parser::getTypeErrorLoc() const {
-  /// LazyASTScopes require that the ends of types, etc. which are at the end of
-  /// \c IterableTypeContext \c Decls, such as \c StructDecl not be beyond the
-  /// end of the enclosing \c Decl.
-  return Context.LangOpts.LazyASTScopes ? getErrorOrMissingLocForLazyASTScopes() : Tok.getLoc();
+  // Use the same location as a missing close brace, etc.
+  return getErrorOrMissingLoc();
 }
 
 ParserStatus Parser::parseGenericArguments(SmallVectorImpl<TypeRepr *> &Args,

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -520,7 +520,8 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
     auto diag = diagnose(Tok, diag::extra_rbracket);
     diag.fixItInsert(result.get()->getStartLoc(), getTokenText(tok::l_square));
     consumeToken();
-    return makeParserErrorResult(new (Context) ErrorTypeRepr(Tok.getLoc()));
+    return makeParserErrorResult(new (Context)
+                                     ErrorTypeRepr(getTypeErrorLoc()));
   } else if (!result.isParseError() && Tok.is(tok::colon)) {
     auto colonTok = consumeToken();
     auto secondType = parseType(diag::expected_dictionary_value_type);
@@ -534,9 +535,17 @@ ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
         diag.fixItInsertAfter(secondType.get()->getEndLoc(), getTokenText(tok::r_square));
       }
     }
-    return makeParserErrorResult(new (Context) ErrorTypeRepr(Tok.getLoc()));
+    return makeParserErrorResult(new (Context)
+                                     ErrorTypeRepr(getTypeErrorLoc()));
   }
   return result;
+}
+
+SourceLoc Parser::getTypeErrorLoc() const {
+  /// LazyASTScopes require that the ends of types, etc. which are at the end of
+  /// \c IterableTypeContext \c Decls, such as \c StructDecl not be beyond the
+  /// end of the enclosing \c Decl.
+  return Context.LangOpts.LazyASTScopes ? getErrorOrMissingLocForLazyASTScopes() : Tok.getLoc();
 }
 
 ParserStatus Parser::parseGenericArguments(SmallVectorImpl<TypeRepr *> &Args,


### PR DESCRIPTION
<!-- What's in this pull request? -->
- Factors locations for missing close braces (etc.) and error into two functions: 'getConfabulatedMatchingTokenLoc' and `getErrorOrMissingLocForLazyASTScopes`.
- Also takes `AppendingExpr` into account when computing the end location of  a`TapExpr`.
- Adds a check in ASTVerifier for the end locations.
- Moves the fictional closing brace in the synthesized expression for an `InterpolatedStringLiteralExpr` back one character so it coincides with the closing quote, in order to avoid a nesting violation.
- Leaves the `PreviousTokenLoc` pointing to the start of an `InterpolatedStringLiteralExpr` instead of somewhere in the middle, and uses that to locate a missing closing brace at the close quote.