### PR TITLE
Revert "ASTVerifier: make sure isFinal and FinalAttr are in sync"

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2362,14 +2362,6 @@ public:
         }
       }
 
-      if (VD->isFinal() != VD->getAttrs().hasAttribute<FinalAttr>()) {
-        Out << "decl should be final iff it has FinalAttr, but isFinal() = "
-            << VD->isFinal() << " and hasAttribute<FinalAttr>() = "
-            << VD->getAttrs().hasAttribute<FinalAttr>() << "\n";
-        VD->dump(Out);
-        abort();
-      }
-
       verifyCheckedBase(VD);
     }
 


### PR DESCRIPTION
Reverts apple/swift#26740. It's not testing what I thought it was testing, and it fails on Windows.