### PR TITLE
[Diagnostics] Port diagnostic for `CTP_YieldByReference`

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1683,24 +1683,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   if (isUnresolvedOrTypeVarType(exprType) || exprType->isEqual(contextualType))
     return false;
 
-  if (CTP == CTP_YieldByReference) {
-    if (auto contextualLV = contextualType->getAs<LValueType>())
-      contextualType = contextualLV->getObjectType();
-    if (auto exprLV = exprType->getAs<LValueType>()) {
-      diagnose(expr->getLoc(), diag::cannot_yield_wrong_type_by_reference,
-               exprLV->getObjectType(), contextualType);
-    } else if (exprType->isEqual(contextualType)) {
-      diagnose(expr->getLoc(), diag::cannot_yield_rvalue_by_reference_same_type,
-               exprType);
-    } else {
-      diagnose(expr->getLoc(), diag::cannot_yield_rvalue_by_reference, exprType,
-               contextualType);
-    }
-    return true;
-  }
-
-  exprType = exprType->getRValueType();
-
   // Don't attempt fixits if we have an unsolved type variable, since
   // the recovery path's recursion into the type checker via typeCheckCast()
   // will confuse matters.

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -633,6 +633,10 @@ public:
   /// something with doesn't conform to `Error`.
   bool diagnoseThrowsTypeMismatch() const;
 
+  /// Produce a specialized diagnostic if this is an attempt to `yield`
+  /// something of incorrect type.
+  bool diagnoseYieldByReferenceMismatch() const;
+
   /// Attempt to attach any relevant fix-its to already produced diagnostic.
   void tryFixIts(InFlightDiagnostic &diagnostic) const;
 

--- a/test/stmt/yield.swift
+++ b/test/stmt/yield.swift
@@ -25,7 +25,7 @@ struct YieldVariables {
     }
     _modify {
       var x = 0
-      yield &x // expected-error {{cannot yield immutable value of type 'Int' as an inout yield of type 'String'}}
+      yield &x // expected-error {{cannot yield reference to storage of type 'Int' as an inout yield of type 'String'}}
     }
   }
 


### PR DESCRIPTION
Last special case from `FailureDiagnosis::diagnoseContextualConversionError`
has been ported to the new diagnostic framework.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
