### PR TITLE
[IRGen] Mix -profile-generate into module hash

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -26,6 +26,7 @@
 // FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
 // split the header upstream so we don't include so much.
 #include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/VersionTuple.h"
 #include <string>
 #include <vector>
@@ -253,15 +254,18 @@ public:
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {}
 
-  // Get a hash of all options which influence the llvm compilation but are not
-  // reflected in the llvm module itself.
-  unsigned getLLVMCodeGenOptionsHash() {
-    unsigned Hash = (unsigned)OptMode;
-    Hash = (Hash << 1) | DisableLLVMOptzns;
-    Hash = (Hash << 1) | DisableSwiftSpecificLLVMOptzns;
-    Hash = (Hash << 1) | GenerateProfile;
-    Hash = (Hash << 1) | Sanitizers.contains(SanitizerKind::Fuzzer);
-    return Hash;
+  /// Appends to \p os an arbitrary string representing all options which
+  /// influence the llvm compilation but are not reflected in the llvm module
+  /// itself.
+  void writeLLVMCodeGenOptionsTo(llvm::raw_ostream &os) {
+    // We put a letter between each value simply to keep them from running into
+    // one another. There might be a vague correspondence between meaning and
+    // letter, but don't sweat it.
+    os << 'O' << (unsigned)OptMode
+       << 'd' << DisableLLVMOptzns
+       << 'D' << DisableSwiftSpecificLLVMOptzns
+       << 'p' << GenerateProfile
+       << 's' << Sanitizers.contains(SanitizerKind::Fuzzer);
   }
 
   /// Should LLVM IR value names be emitted and preserved?

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -265,7 +265,7 @@ public:
        << 'd' << DisableLLVMOptzns
        << 'D' << DisableSwiftSpecificLLVMOptzns
        << 'p' << GenerateProfile
-       << 's' << Sanitizers.contains(SanitizerKind::Fuzzer);
+       << 's' << Sanitizers.toRaw();
   }
 
   /// Should LLVM IR value names be emitted and preserved?

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -259,6 +259,7 @@ public:
     unsigned Hash = (unsigned)OptMode;
     Hash = (Hash << 1) | DisableLLVMOptzns;
     Hash = (Hash << 1) | DisableSwiftSpecificLLVMOptzns;
+    Hash = (Hash << 1) | GenerateProfile;
     return Hash;
   }
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -260,6 +260,7 @@ public:
     Hash = (Hash << 1) | DisableLLVMOptzns;
     Hash = (Hash << 1) | DisableSwiftSpecificLLVMOptzns;
     Hash = (Hash << 1) | GenerateProfile;
+    Hash = (Hash << 1) | Sanitizers.contains(SanitizerKind::Fuzzer);
     return Hash;
   }
 

--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -56,6 +56,26 @@ namespace swift {
   std::error_code moveFileIfDifferent(const llvm::Twine &source,
                                       const llvm::Twine &destination);
 
+  enum class FileDifference : uint8_t {
+    /// The source and destination paths refer to the exact same file.
+    IdenticalFile,
+    /// The source and destination paths refer to separate files with identical
+    /// contents.
+    SameContents,
+    /// The source and destination paths refer to separate files with different
+    /// contents.
+    DifferentContents
+  };
+
+  /// Compares the files at \p source and \p destination to determine if they
+  /// are the exact same files, different files with the same contents, or
+  /// different files with different contents. If \p allowDestinationErrors is
+  /// set, file system errors relating to the \p destination file return a
+  /// \c DifferentFile result, rather than an error.
+  llvm::ErrorOr<FileDifference>
+  areFilesDifferent(const llvm::Twine &source, const llvm::Twine &destination,
+                    bool allowDestinationErrors);
+
   namespace vfs {
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
     getFileOrSTDIN(llvm::vfs::FileSystem &FS,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -431,7 +431,7 @@ template<typename ...ArgTypes>
 void
 diagnoseSync(DiagnosticEngine *Diags, llvm::sys::Mutex *DiagMutex,
              SourceLoc Loc, Diag<ArgTypes...> ID,
-         typename swift::detail::PassArgument<ArgTypes>::type... Args) {
+             typename swift::detail::PassArgument<ArgTypes>::type... Args) {
   if (!Diags)
     return;
   if (DiagMutex)
@@ -453,6 +453,18 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
                         const version::Version &effectiveLanguageVersion,
                         StringRef OutputFilename,
                         UnifiedStatsReporter *Stats) {
+#ifndef NDEBUG
+  // To check that we only skip generating code when it would have no effect, in
+  // assertion builds we still generate the code, but write it into a temporary
+  // file that we compare to the original file.
+
+  /// The OutputFilename originally passed to us, if we are generating code for
+  /// an assertion. Empty if not.
+  StringRef OriginalOutputFilename = "";
+  /// Scratch buffer for temporary file's name.
+  SmallString<64> AssertScratch;
+#endif
+
   if (Opts.UseIncrementalLLVMCodeGen && HashGlobal) {
     // Check if we can skip the llvm part of the compilation if we have an
     // existing object file which was generated from the same llvm IR.
@@ -474,7 +486,24 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
         !Opts.PrintInlineTree &&
         !needsRecompile(OutputFilename, HashData, HashGlobal, DiagMutex)) {
       // The llvm IR did not change. We don't need to re-create the object file.
+#ifdef NDEBUG
       return false;
+#else
+      // ...but we're in an asserts build, so we want to check that assumption.
+      auto AssertSuffix = llvm::sys::path::filename(OutputFilename);
+
+      auto EC = llvm::sys::fs::createTemporaryFile("assert", AssertSuffix,
+                                                   AssertScratch);
+      if (EC) {
+        diagnoseSync(Diags, DiagMutex,
+                     SourceLoc(), diag::error_opening_output,
+                     AssertScratch, EC.message());
+        return true;
+      }
+
+      OriginalOutputFilename = OutputFilename;
+      OutputFilename = AssertScratch;
+#endif
     }
 
     // Store the hash in the global variable so that it is written into the
@@ -561,6 +590,44 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
     if (DiagMutex)
       DiagMutex->unlock();
   }
+
+#ifndef NDEBUG
+  if (!OriginalOutputFilename.empty()) {
+    // We're done changing the file; make sure it's saved before we compare.
+    RawOS->close();
+
+    auto result =
+        swift::areFilesDifferent(OutputFilename, OriginalOutputFilename,
+                                 /*allowDestinationErrors=*/false);
+
+    if (!result)
+      // File system error.
+      llvm::report_fatal_error(
+          Twine("Error comparing files: ") + result.getError().message()
+      );
+
+    switch (*result) {
+    case FileDifference::DifferentContents:
+      llvm::report_fatal_error(
+          "Swift skipped an LLVM compile that would have changed output; pass "
+          "-Xfrontend -disable-incremental-llvm-codegen to work around this bug"
+      );
+      // Note for future debuggers: If you see this error, either you changed
+      // LLVM and need to clean your build folder to rebuild everything with it,
+      // or IRGenOptions::getLLVMCodeGenOptionsHash() doesn't account for a flag
+      // that changed LLVM's output between this compile and the previous one.
+
+    case FileDifference::SameContents:
+      // Removing the file is best-effort.
+      (void)llvm::sys::fs::remove(OutputFilename);
+      break;
+
+    case FileDifference::IdenticalFile:
+      llvm_unreachable("one of these should be a temporary file");
+    }
+  }
+#endif
+
   return false;
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -349,7 +349,7 @@ static void getHashOfModule(MD5::MD5Result &Result, IRGenOptions &Opts,
 
   // Add all options which influence the llvm compilation but are not yet
   // reflected in the llvm module itself.
-  HashStream << Opts.getLLVMCodeGenOptionsHash();
+  Opts.writeLLVMCodeGenOptionsTo(HashStream);
 
   HashStream.final(Result);
 }
@@ -614,7 +614,7 @@ bool swift::performLLVM(IRGenOptions &Opts, DiagnosticEngine *Diags,
       );
       // Note for future debuggers: If you see this error, either you changed
       // LLVM and need to clean your build folder to rebuild everything with it,
-      // or IRGenOptions::getLLVMCodeGenOptionsHash() doesn't account for a flag
+      // or IRGenOptions::writeLLVMCodeGenOptionsTo() doesn't account for a flag
       // that changed LLVM's output between this compile and the previous one.
 
     case FileDifference::SameContents:

--- a/test/IRGen/Inputs/empty.swift
+++ b/test/IRGen/Inputs/empty.swift
@@ -1,0 +1,1 @@
+// This space intentionally left blank.

--- a/test/IRGen/Inputs/empty.swift
+++ b/test/IRGen/Inputs/empty.swift
@@ -1,1 +1,0 @@
-// This space intentionally left blank.

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -41,6 +41,16 @@
 // CHECK-LABEL: empty file with profiling
 // CHECK: empty.o: prev MD5=[[EMPTY_MD5]] recompiling
 
+// RUN: echo "empty file" >>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: echo "empty file with fuzzer" >>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -sanitize=fuzzer 2>>%t/log
+
+// CHECK-LABEL: empty file
+// CHECK: empty.o: MD5=[[EMPTY_MD5_2:[0-9a-f]+]]
+// CHECK-LABEL: empty file with fuzzer
+// CHECK: empty.o: prev MD5=[[EMPTY_MD5_2]] recompiling
+
 // Test with multiple output files
 
 // RUN: echo "multi-threaded initial" >>%t/log

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -31,6 +31,15 @@
 // CHECK: test.o: MD5=[[TEST3_MD5:[0-9a-f]+]]
 // CHECK: test.o: prev MD5=[[TEST2_MD5]] recompiling
 
+// RUN: echo "empty file" >>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: echo "empty file with profiling" >>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -profile-generate 2>>%t/log
+
+// CHECK-LABEL: empty file
+// CHECK: empty.o: MD5=[[EMPTY_MD5:[0-9a-f]+]]
+// CHECK-LABEL: empty file with profiling
+// CHECK: empty.o: prev MD5=[[EMPTY_MD5]] recompiling
 
 // Test with multiple output files
 

--- a/test/IRGen/module_hash.swift
+++ b/test/IRGen/module_hash.swift
@@ -32,9 +32,9 @@
 // CHECK: test.o: prev MD5=[[TEST2_MD5]] recompiling
 
 // RUN: echo "empty file" >>%t/log
-// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/../Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
 // RUN: echo "empty file with profiling" >>%t/log
-// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -profile-generate 2>>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/../Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -profile-generate 2>>%t/log
 
 // CHECK-LABEL: empty file
 // CHECK: empty.o: MD5=[[EMPTY_MD5:[0-9a-f]+]]
@@ -42,9 +42,9 @@
 // CHECK: empty.o: prev MD5=[[EMPTY_MD5]] recompiling
 
 // RUN: echo "empty file" >>%t/log
-// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/../Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen 2>>%t/log
 // RUN: echo "empty file with fuzzer" >>%t/log
-// RUN: %target-swift-frontend -c -primary-file %S/Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -sanitize=fuzzer 2>>%t/log
+// RUN: %target-swift-frontend -c -primary-file %S/../Inputs/empty.swift -module-name=empty -o %t/empty.o -Xllvm -debug-only=irgen -sanitize=fuzzer 2>>%t/log
 
 // CHECK-LABEL: empty file
 // CHECK: empty.o: MD5=[[EMPTY_MD5_2:[0-9a-f]+]]


### PR DESCRIPTION
When rebuilding a .o file, we hash the IR generated by IRGen and compare it to a hash embedded in the .o file. If they match, we simply skip asking LLVM to optimize and generate code. Certain flags that control our LLVM configuration are mixed into the hash, but the -profile-generate flag was not one of them. This usually wouldn’t matter because profiling would insert additional code into the IR, but in edge cases like empty files or files containing only protocol declarations, it could cause linker errors when profiling was turned off.

This change adds the `GenerateProfile` flag into the IR hash, ensuring that we always recompile, even if the IR was identical.

Fixes rdar://problem/54126622.