### PR TITLE
AST: Make SubstFlags::UseErrorType the default behavior

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -152,13 +152,13 @@ public:
 
   /// Retrieve the type witness for the given associated type.
   Type getTypeWitness(AssociatedTypeDecl *assocType,
-                      SubstOptions options = None) const;
+                      SubstOptions options=None) const;
 
   /// Retrieve the type witness and type decl (if one exists)
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        SubstOptions options = None) const;
+                        SubstOptions options=None) const;
 
   /// Apply the given function object to each type witness within this
   /// protocol conformance.
@@ -311,13 +311,14 @@ public:
 
   /// Substitute the conforming type and produce a ProtocolConformance that
   /// applies to the substituted type.
-  ProtocolConformance *subst(SubstitutionMap subMap) const;
+  ProtocolConformance *subst(SubstitutionMap subMap,
+                             SubstOptions options=None) const;
 
   /// Substitute the conforming type and produce a ProtocolConformance that
   /// applies to the substituted type.
   ProtocolConformance *subst(TypeSubstitutionFn subs,
                              LookupConformanceFn conformances,
-                             SubstOptions options = None) const;
+                             SubstOptions options=None) const;
 
   void dump() const;
   void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
@@ -589,7 +590,7 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        SubstOptions options = None) const;
+                        SubstOptions options=None) const;
 
   /// Determine whether the protocol conformance has a type witness for the
   /// given associated type.
@@ -714,12 +715,12 @@ public:
 
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        SubstOptions options) const {
+                        SubstOptions options=None) const {
     llvm_unreachable("self-conformances never have associated types");
   }
 
   Type getTypeWitness(AssociatedTypeDecl *assocType,
-                      SubstOptions options) const {
+                      SubstOptions options=None) const {
     llvm_unreachable("self-conformances never have associated types");
   }
 
@@ -860,7 +861,7 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        SubstOptions options = None) const;
+                        SubstOptions options=None) const;
 
   /// Given that the requirement signature of the protocol directly states
   /// that the given dependent type must conform to the given protocol,
@@ -972,7 +973,7 @@ public:
   /// for the given associated type.
   std::pair<Type, TypeDecl *>
   getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
-                        SubstOptions options = None) const {
+                        SubstOptions options=None) const {
     return InheritedConformance->getTypeWitnessAndDecl(assocType, options);
   }
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -102,13 +102,14 @@ public:
   
   /// Apply a substitution to the conforming type.
   ProtocolConformanceRef subst(Type origType,
-                               SubstitutionMap subMap) const;
+                               SubstitutionMap subMap,
+                               SubstOptions options=None) const;
 
   /// Apply a substitution to the conforming type.
   ProtocolConformanceRef subst(Type origType,
                                TypeSubstitutionFn subs,
                                LookupConformanceFn conformances,
-                               SubstOptions options = None) const;
+                               SubstOptions options=None) const;
 
   /// Map contextual types to interface types in the conformance.
   ProtocolConformanceRef mapConformanceOutOfContext() const;

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -94,7 +94,7 @@ public:
   template <typename... Args>
   Optional<Requirement> subst(Args &&... args) const {
     auto newFirst = getFirstType().subst(std::forward<Args>(args)...);
-    if (!newFirst)
+    if (newFirst->hasError())
       return None;
 
     switch (getKind()) {
@@ -102,7 +102,7 @@ public:
     case RequirementKind::Superclass:
     case RequirementKind::SameType: {
       auto newSecond = getSecondType().subst(std::forward<Args>(args)...);
-      if (!newSecond)
+      if (newSecond->hasError())
         return None;
       return Requirement(getKind(), newFirst, newSecond);
     }

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -167,13 +167,14 @@ public:
 
   /// Apply a substitution to all replacement types in the map. Does not
   /// change keys.
-  SubstitutionMap subst(SubstitutionMap subMap) const;
+  SubstitutionMap subst(SubstitutionMap subMap,
+                        SubstOptions options=None) const;
 
   /// Apply a substitution to all replacement types in the map. Does not
   /// change keys.
   SubstitutionMap subst(TypeSubstitutionFn subs,
                         LookupConformanceFn conformances,
-                        SubstOptions options = None) const;
+                        SubstOptions options=None) const;
   
   /// Create a substitution map for a protocol conformance.
   static SubstitutionMap

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -136,19 +136,16 @@ public:
   
 /// Flags that can be passed when substituting into a type.
 enum class SubstFlags {
-  /// If a type cannot be produced because some member type is
-  /// missing, place an 'error' type into the position of the base.
-  UseErrorType = 0x01,
   /// Allow substitutions to recurse into SILFunctionTypes.
   /// Normally, SILType::subst() should be used for lowered
   /// types, however in special cases where the substitution
   /// is just changing between contextual and interface type
   /// representations, using Type::subst() is allowed.
-  AllowLoweredTypes = 0x02,
+  AllowLoweredTypes = 0x01,
   /// Map member types to their desugared witness type.
-  DesugarMemberTypes = 0x04,
+  DesugarMemberTypes = 0x02,
   /// Substitute types involving opaque type archetypes.
-  SubstituteOpaqueArchetypes = 0x08,
+  SubstituteOpaqueArchetypes = 0x04,
 };
 
 /// Options for performing substitutions into a type.
@@ -295,7 +292,7 @@ public:
   ///
   /// \returns the substituted type, or a null type if an error occurred.
   Type subst(SubstitutionMap substitutions,
-             SubstOptions options = None) const;
+             SubstOptions options=None) const;
 
   /// Replace references to substitutable types with new, concrete types and
   /// return the substituted result.
@@ -310,7 +307,7 @@ public:
   /// \returns the substituted type, or a null type if an error occurred.
   Type subst(TypeSubstitutionFn substitutions,
              LookupConformanceFn conformances,
-             SubstOptions options = None) const;
+             SubstOptions options=None) const;
 
   /// Replace references to substitutable types with error types.
   Type substDependentTypesWithErrorTypes() const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2818,7 +2818,7 @@ public:
       return Param(getType(), Identifier(), getFlags().asParamFlags());
     }
 
-    Yield subst(SubstitutionMap subs, SubstOptions options = None) const {
+    Yield subst(SubstitutionMap subs, SubstOptions options=None) const {
       return Yield(getType().subst(subs, options), getFlags());
     }
 
@@ -2839,7 +2839,7 @@ public:
     CanType getType() const { return CanType(Yield::getType()); }
     CanParam asParam() const { return CanParam::getFromParam(Yield::asParam());}
 
-    CanYield subst(SubstitutionMap subs, SubstOptions options = None) const {
+    CanYield subst(SubstitutionMap subs, SubstOptions options=None) const {
       return CanYield(getType().subst(subs, options)->getCanonicalType(),
                       getFlags());
     }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2227,14 +2227,11 @@ TypeAliasType *TypeAliasType::get(TypeAliasDecl *typealias, Type parent,
     if (parent->hasTypeVariable())
       storedProperties |= RecursiveTypeProperties::HasTypeVariable;
   }
-  auto genericSig = substitutions.getGenericSignature();
-  if (genericSig) {
-    for (Type gp : genericSig->getGenericParams()) {
-      auto substGP = gp.subst(substitutions, SubstFlags::UseErrorType);
-      properties |= substGP->getRecursiveProperties();
-      if (substGP->hasTypeVariable())
-        storedProperties |= RecursiveTypeProperties::HasTypeVariable;
-    }
+
+  for (auto substGP : substitutions.getReplacementTypes()) {
+    properties |= substGP->getRecursiveProperties();
+    if (substGP->hasTypeVariable())
+      storedProperties |= RecursiveTypeProperties::HasTypeVariable;
   }
 
   // Figure out which arena this type will go into.
@@ -2252,6 +2249,7 @@ TypeAliasType *TypeAliasType::get(TypeAliasDecl *typealias, Type parent,
     return result;
 
   // Build a new type.
+  auto *genericSig = typealias->getGenericSignature();
   auto size = totalSizeToAlloc<Type, SubstitutionMap>(parent ? 1 : 0,
                                                       genericSig ? 1 : 0);
   auto mem = ctx.Allocate(size, alignof(TypeAliasType), arena);

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -198,9 +198,6 @@ Type ASTBuilder::createTypeAliasType(GenericTypeDecl *decl, Type parent) {
 
   // FIXME: subst() should build the sugar for us
   declaredType = declaredType.subst(subs);
-  if (!declaredType)
-    return Type();
-
   return TypeAliasType::get(aliasDecl, parent, subs, declaredType);
 }
 
@@ -251,8 +248,7 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
 
   // FIXME: We're not checking that the type satisfies the generic
   // requirements of the signature here.
-  auto substType = origType.subst(subs);
-  return substType;
+  return origType.subst(subs);
 }
 
 Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
@@ -335,9 +331,6 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
 
   // FIXME: subst() should build the sugar for us
   auto declaredType = aliasDecl->getDeclaredInterfaceType().subst(subMap);
-  if (!declaredType)
-    return Type();
-
   return TypeAliasType::get(aliasDecl, parent, subMap, declaredType);
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -672,8 +672,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
           M, cast<ValueDecl>(Current));
       }
 
-      T = T.subst(subMap,
-                  SubstFlags::DesugarMemberTypes | SubstFlags::UseErrorType);
+      T = T.subst(subMap, SubstFlags::DesugarMemberTypes);
     }
 
     printTypeWithOptions(T, options);
@@ -1447,10 +1446,12 @@ void PrintAST::printSingleDepthOfGenericSignature(
         second = req.getSecondType();
 
       if (!subMap.empty()) {
-        if (Type subFirst = substParam(first))
+        Type subFirst = substParam(first);
+        if (!subFirst->hasError())
           first = subFirst;
         if (second) {
-          if (Type subSecond = substParam(second))
+          Type subSecond = substParam(second);
+          if (!subSecond->hasError())
             second = subSecond;
           if (!(first->is<ArchetypeType>() || first->isTypeParameter()) &&
               !(second->is<ArchetypeType>() || second->isTypeParameter()))

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -180,8 +180,7 @@ Type GenericEnvironment::mapTypeIntoContext(
 
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
                            lookupConformance,
-                           (SubstFlags::AllowLoweredTypes|
-                            SubstFlags::UseErrorType));
+                           SubstFlags::AllowLoweredTypes);
   assert((!result->hasTypeParameter() || result->hasError()) &&
          "not fully substituted");
   return result;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3817,7 +3817,7 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
     subMap = SubstitutionMap::getProtocolSubstitutions(
         proto, parentType, ProtocolConformanceRef(proto));
 
-    type = type.subst(subMap, SubstFlags::UseErrorType);
+    type = type.subst(subMap);
   } else {
     // Substitute in the superclass type.
     auto parentPA = basePA->getEquivalenceClassIfPresent();
@@ -3827,7 +3827,7 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
 
     subMap = parentType->getMemberSubstitutionMap(parentDecl->getParentModule(),
                                                   concreteDecl);
-    type = type.subst(subMap, SubstFlags::UseErrorType);
+    type = type.subst(subMap);
   }
 
   // If we had a typealias, form a sugared type.
@@ -5187,7 +5187,7 @@ GenericSignatureBuilder::addRequirement(const Requirement &req,
   // Local substitution for types in the requirement.
   auto subst = [&](Type t) {
     if (subMap)
-      return t.subst(*subMap, SubstFlags::UseErrorType);
+      return t.subst(*subMap);
 
     return t;
   };

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1351,7 +1351,7 @@ SmallVector<Type, 2> TypeAliasType::getInnermostGenericArgs() const {
   result.reserve(numMyGenericParams);
   unsigned startIndex = numAllGenericParams - numMyGenericParams;
   for (auto gp : genericSig->getGenericParams().slice(startIndex)) {
-    result.push_back(Type(gp).subst(subMap, SubstFlags::UseErrorType));
+    result.push_back(Type(gp).subst(subMap));
   }
   return result;
 }
@@ -2953,9 +2953,8 @@ Type ProtocolCompositionType::get(const ASTContext &C,
 
 FunctionType *
 GenericFunctionType::substGenericArgs(SubstitutionMap subs) {
-  auto substFn = Type(this).subst(subs)->castTo<AnyFunctionType>();
-  return FunctionType::get(substFn->getParams(),
-                           substFn->getResult(), getExtInfo());
+  return substGenericArgs(
+    [=](Type t) { return t.subst(subs); });
 }
 
 FunctionType *GenericFunctionType::substGenericArgs(
@@ -2996,9 +2995,6 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
   // Produce a failed result.
   auto failed = [&]() -> Type {
-    if (!options.contains(SubstFlags::UseErrorType))
-      return Type();
-
     Type baseType = ErrorType::get(substBase ? substBase : origBase);
     if (assocType)
       return DependentMemberType::get(baseType, assocType);
@@ -3056,7 +3052,7 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
     // Retrieve the type witness.
     auto witness =
       conformance->getConcrete()->getTypeWitness(assocType, options);
-    if (!witness)
+    if (!witness || witness->hasError())
       return failed();
 
     // This is a hacky feature allowing code completion to migrate to
@@ -3302,17 +3298,11 @@ static Type substType(Type derivedType,
     }
 
     // If we failed to substitute a generic type parameter, give up.
-    if (isa<GenericTypeParamType>(substOrig)) {
-      if (options.contains(SubstFlags::UseErrorType))
-        return ErrorType::get(type);
-      return Type();
-    }
+    if (isa<GenericTypeParamType>(substOrig))
+      return ErrorType::get(type);
 
-    if (auto primaryArchetype = dyn_cast<PrimaryArchetypeType>(substOrig)) {
-      if (options.contains(SubstFlags::UseErrorType))
-        return ErrorType::get(type);
-      return Type();
-    }
+    if (auto primaryArchetype = dyn_cast<PrimaryArchetypeType>(substOrig))
+      return ErrorType::get(type);
 
     // Opened existentials cannot be substituted in this manner,
     // but if they appear in the original type this is not an
@@ -3359,8 +3349,7 @@ Type Type::substDependentTypesWithErrorTypes() const {
   return substType(*this,
                    [](SubstitutableType *t) -> Type { return Type(); },
                    MakeAbstractConformanceForGenericType(),
-                   (SubstFlags::AllowLoweredTypes |
-                    SubstFlags::UseErrorType));
+                   SubstFlags::AllowLoweredTypes);
 }
 
 const DependentMemberType *TypeBase::findUnresolvedDependentMemberType() {
@@ -3601,7 +3590,7 @@ Type TypeBase::getTypeOfMember(ModuleDecl *module, const ValueDecl *member,
 
   // Perform the substitution.
   auto substitutions = getMemberSubstitutionMap(module, member);
-  return memberType.subst(substitutions, SubstFlags::UseErrorType);
+  return memberType.subst(substitutions);
 }
 
 Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
@@ -3616,7 +3605,7 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
                                    genericMemberType->getExtInfo());
   }
 
-  auto type = memberType.subst(subs, SubstFlags::UseErrorType);
+  auto type = memberType.subst(subs);
   if (baseDecl->getDeclContext()->getSelfProtocolDecl())
     return type;
 
@@ -3984,25 +3973,19 @@ case TypeKind::Id:
     }
 
     auto subMap = alias->getSubstitutionMap();
-    if (auto genericSig = subMap.getGenericSignature()) {
-      for (Type gp : genericSig->getGenericParams()) {
-        Type oldReplacementType = gp.subst(subMap);
-        if (!oldReplacementType)
-          return newUnderlyingType;
+    for (Type oldReplacementType : subMap.getReplacementTypes()) {
+      if (oldReplacementType->hasTypeParameter() ||
+          oldReplacementType->hasArchetype())
+        return newUnderlyingType;
 
-        if (oldReplacementType->hasTypeParameter() ||
-            oldReplacementType->hasArchetype())
-          return newUnderlyingType;
+      Type newReplacementType = oldReplacementType.transformRec(fn);
+      if (!newReplacementType)
+        return newUnderlyingType;
 
-        Type newReplacementType = oldReplacementType.transformRec(fn);
-        if (!newReplacementType)
-          return newUnderlyingType;
-
-        // If anything changed with the replacement type, we lose the sugar.
-        // FIXME: This is really unfortunate.
-        if (!newReplacementType->isEqual(oldReplacementType))
-          return newUnderlyingType;
-      }
+      // If anything changed with the replacement type, we lose the sugar.
+      // FIXME: This is really unfortunate.
+      if (!newReplacementType->isEqual(oldReplacementType))
+        return newUnderlyingType;
     }
 
     if (oldUnderlyingType.getPointer() == newUnderlyingType.getPointer())

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2086,9 +2086,7 @@ public:
 
         // Pass in DesugarMemberTypes so that we see the actual
         // concrete type witnesses instead of type alias types.
-        T = T.subst(Subs,
-                    (SubstFlags::DesugarMemberTypes |
-                     SubstFlags::UseErrorType));
+        T = T.subst(Subs, SubstFlags::DesugarMemberTypes);
       }
     }
 
@@ -4147,7 +4145,7 @@ public:
     // type.
     auto substMap = currTy->getMemberSubstitutionMap(
         CurrDeclContext->getParentModule(), VD);
-    ResultT = ResultT.subst(substMap, SubstFlags::UseErrorType);
+    ResultT = ResultT.subst(substMap);
     if (!ResultT || !ResultT->is<DependentMemberType>())
       // If resolved print it.
       return nullptr;

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -313,7 +313,7 @@ static void collectPossibleCalleesByQualifiedLookup(
     auto subs = baseTy->getMetatypeInstanceType()->getMemberSubstitutionMap(
         DC.getParentModule(), VD,
         VD->getInnermostDeclContext()->getGenericEnvironmentOfContext());
-    auto fnType = declaredMemberType.subst(subs, SubstFlags::UseErrorType);
+    auto fnType = declaredMemberType.subst(subs);
     if (!fnType)
       continue;
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -314,7 +314,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
           First = First.subst(subMap);
           Second = Second.subst(subMap);
 
-          if (!First || !Second) {
+          if (First->hasError() || Second->hasError()) {
             // Substitution with interface type bases can only fail
             // if a concrete type fails to conform to a protocol.
             // In this case, just give up on the extension altogether.

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1398,7 +1398,6 @@ private:
     Type objcType = ProtocolConformanceRef(conformance).getTypeWitnessByName(
                                            nominal->getDeclaredType(),
                                            ctx.Id_ObjectiveCType);
-    if (!objcType) return nullptr;
 
     // Dig out the Objective-C class.
     return objcType->getClassOrBoundGenericClass();

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -225,7 +225,6 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     Type bridgedTy =
       ProtocolConformanceRef(conformance).getTypeWitnessByName(
         t, M.getASTContext().Id_ObjectiveCType);
-    assert(bridgedTy && "Missing _ObjectiveCType witness?");
     if (purpose == BridgedTypePurpose::ForResult && clangTy)
       bridgedTy = OptionalType::get(bridgedTy);
     return bridgedTy;

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1276,9 +1276,7 @@ namespace {
           M.getASTContext().getLazyResolver()->resolveDeclSignature(field);
 
         auto substFieldType =
-          field->getInterfaceType()
-            .subst(subMap, SubstFlags::UseErrorType)
-            ->getCanonicalType();
+          field->getInterfaceType().subst(subMap)->getCanonicalType();
 
         properties.addSubobject(classifyType(substFieldType->getCanonicalType(),
                                              M, Sig, Expansion));
@@ -1326,9 +1324,7 @@ namespace {
           M.getASTContext().getLazyResolver()->resolveDeclSignature(elt);
 
         auto substEltType =
-          elt->getArgumentInterfaceType()
-            .subst(subMap, SubstFlags::UseErrorType)
-            ->getCanonicalType();
+          elt->getArgumentInterfaceType().subst(subMap)->getCanonicalType();
         
         properties.addSubobject(classifyType(substEltType, M, Sig, Expansion));
       }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -103,7 +103,6 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF,
   if (!objcTypeReq) return None;
 
   Type objcType = conformance->getTypeWitness(objcTypeReq);
-  assert(objcType);
 
   // Create a reference to the witness.
   SILDeclRef witnessConstant(witness);
@@ -192,7 +191,6 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
 
   // Retrieve the _ObjectiveCType witness.
   auto objcType = conformance->getTypeWitness(objcTypeRequirement);
-  assert(objcType);
 
   // Create a reference to the witness.
   SILDeclRef witnessConstant(witness.getDecl());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3441,8 +3441,8 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
   lv.add<ValueComponent>(base, None, baseTypeData,
                          /*isRValue=*/!base.isLValue());
 
-  auto substFormalType = ivar->getInterfaceType().subst(subMap)
-    ->getCanonicalType().getReferenceStorageReferent();
+  auto substFormalType = ivar->getValueInterfaceType().subst(subMap)
+    ->getCanonicalType();
 
   lv.addMemberVarComponent(*this, loc, ivar, subMap, options, /*super*/ false,
                            accessKind, strategy, substFormalType);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6793,7 +6793,7 @@ Expr *ExprRewriter::convertLiteralInPlace(Expr *literal,
     // Extract the literal type.
     Type builtinLiteralType =
         conformance->getTypeWitnessByName(type, literalType);
-    if (!builtinLiteralType)
+    if (builtinLiteralType->hasError())
       return nullptr;
 
     // Perform the builtin conversion.

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -548,8 +548,7 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
   subs = SubstitutionMap::getOverrideSubstitutions(superclassCtor, fn, subs);
   ConcreteDeclRef ctorRef(superclassCtor, subs);
 
-  auto type = superclassCtor->getInitializerInterfaceType()
-      .subst(subs, SubstFlags::UseErrorType);
+  auto type = superclassCtor->getInitializerInterfaceType().subst(subs);
   auto *ctorRefExpr =
       new (ctx) OtherConstructorDeclRefExpr(ctorRef, DeclNameLoc(),
                                             IsImplicit, type);
@@ -665,7 +664,7 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     auto *bodyParam = bodyParams->get(idx);
 
     auto paramTy = superclassParam->getInterfaceType();
-    auto substTy = paramTy.subst(subMap, SubstFlags::UseErrorType);
+    auto substTy = paramTy.subst(subMap);
 
     bodyParam->setInterfaceType(substTy);
     bodyParam->getTypeLoc() = TypeLoc::withoutLoc(substTy);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -576,8 +576,7 @@ static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
             // because the requirements might look like `T: P, T.U: Q`, where
             // U is an associated type of protocol P.
             return type.subst(QuerySubstitutionMap{contextSubMap},
-                              LookUpConformanceInSubstitutionMap(subMap),
-                              SubstFlags::UseErrorType);
+                              LookUpConformanceInSubstitutionMap(subMap));
           });
     }
   }
@@ -2254,8 +2253,7 @@ Type simplifyTypeImpl(ConstraintSystem &cs, Type type, Fn getFixedTypeFn) {
         auto subs = SubstitutionMap::getProtocolSubstitutions(
           proto, lookupBaseType, *conformance);
         auto result = assocType->getDeclaredInterfaceType().subst(subs);
-
-        if (result && !result->hasError())
+        if (!result->hasError())
           return result;
       }
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -798,7 +798,8 @@ public:
     auto FoundSignatureType = VD->getOverloadSignatureType();
     if (FoundSignatureType && shouldSubst) {
       auto subs = BaseTy->getMemberSubstitutionMap(M, VD);
-      if (auto CT = FoundSignatureType.subst(subs))
+      auto CT = FoundSignatureType.subst(subs);
+      if (!CT->hasError())
         FoundSignatureType = CT->getCanonicalType();
     }
 
@@ -816,7 +817,8 @@ public:
       if (OtherSignatureType && shouldSubst) {
         auto ActualBaseTy = getBaseTypeForMember(M, OtherVD, BaseTy);
         auto subs = ActualBaseTy->getMemberSubstitutionMap(M, OtherVD);
-        if (auto CT = OtherSignatureType.subst(subs))
+        auto CT = OtherSignatureType.subst(subs);
+        if (!CT->hasError())
           OtherSignatureType = CT->getCanonicalType();
       }
 
@@ -968,7 +970,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
     auto subs =
         baseType->getMemberSubstitutionMap(dc->getParentModule(), subscript);
     auto memberType = rootType.subst(subs);
-    if (!memberType || !memberType->mayHaveMembers())
+    if (!memberType->mayHaveMembers())
       continue;
 
     KeyPathDynamicMemberConsumer::SubscriptChange sub(consumer, subscript,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -629,10 +629,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
         return;
 
       auto subMap = DRE->getDeclRef().getSubstitutions();
-      auto fromTy =
-        Type(GenericTypeParamType::get(0, 0, TC.Context)).subst(subMap);
-      auto toTy =
-        Type(GenericTypeParamType::get(0, 1, TC.Context)).subst(subMap);
+      auto fromTy = subMap.getReplacementTypes()[0];
+      auto toTy = subMap.getReplacementTypes()[1];
 
       // Warn about `unsafeBitCast` formulations that are undefined behavior
       // or have better-defined alternative APIs that can be used instead.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -229,11 +229,8 @@ public:
     if (!D->getDeclContext()->isLocalContext()) {
       if (!ObjC || !D->isObjC() || isa<ConstructorDecl>(D)) {
         if (auto subMap = DRE->getDeclRef().getSubstitutions()) {
-          auto genericSig = subMap.getGenericSignature();
-          for (auto gp : genericSig->getGenericParams()) {
-            if (auto type = Type(gp).subst(subMap)) {
-              checkType(type, DRE->getLoc());
-            }
+          for (auto type : subMap.getReplacementTypes()) {
+            checkType(type, DRE->getLoc());
           }
         }
       }

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -255,8 +255,7 @@ bool CircularityChecker::expandStruct(CanType type, StructDecl *S,
         continue;
     }
 
-    auto fieldType =field->getInterfaceType().subst(
-      subMap, SubstFlags::UseErrorType);
+    auto fieldType =field->getInterfaceType().subst(subMap);
     if (addMember(type, field, fieldType, depth))
       return true;
   }
@@ -293,8 +292,7 @@ bool CircularityChecker::expandEnum(CanType type, EnumDecl *E,
         continue;
     }
 
-    auto eltType = elt->getArgumentInterfaceType().subst(
-      subMap, SubstFlags::UseErrorType);
+    auto eltType = elt->getArgumentInterfaceType().subst(subMap);
     if (addMember(type, elt, eltType, depth))
       return true;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -752,7 +752,7 @@ swift::matchWitness(TypeChecker &tc,
 
       // If substitution failed, skip the requirement. This only occurs in
       // invalid code.
-      if (!replacedInReq || replacedInReq->hasError())
+      if (replacedInReq->hasError())
         continue;
 
       if (reqGenericEnv) {
@@ -1814,8 +1814,7 @@ static Type getRequirementTypeForDisplay(ModuleDecl *module,
 
                         return Type(dependentType);
                       },
-                      LookUpConformanceInModule(module),
-                      SubstFlags::UseErrorType);
+                      LookUpConformanceInModule(module));
   };
 
   if (auto fnTy = type->getAs<AnyFunctionType>()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -355,7 +355,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
       // witness completely.
       if (!allUnresolved.count(result.first)) {
         auto existingWitness =
-        conformance->getTypeWitness(result.first);
+          conformance->getTypeWitness(result.first);
         existingWitness = dc->mapTypeIntoContext(existingWitness);
 
         // If the deduced type contains an irreducible
@@ -547,8 +547,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
 
   ModuleDecl *module = conformance->getDeclContext()->getParentModule();
   auto resultType = type.subst(QueryTypeSubstitutionMap{substitutions},
-                               LookUpConformanceInModule(module),
-                               SubstFlags::UseErrorType);
+                               LookUpConformanceInModule(module));
   if (!resultType->hasError()) return resultType;
 
   // Map error types with original types *back* to the original, dependent type.
@@ -867,7 +866,7 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
                           QueryTypeSubstitutionMap{substitutions},
                           LookUpConformanceInModule(dc->getParentModule()));
 
-  if (!defaultType)
+  if (defaultType->hasError())
     return Type();
 
   if (auto failed = checkTypeWitness(tc, dc, proto, assocType, defaultType)) {
@@ -962,9 +961,9 @@ Type AssociatedTypeInference::substCurrentTypeWitnesses(Type type) {
       SWIFT_DEFER { recursionCheck.erase(assocType); };
 
       // Try to substitute into the base type.
-      if (Type result = depMemTy->substBaseType(dc->getParentModule(), baseTy)){
+      Type result = depMemTy->substBaseType(dc->getParentModule(), baseTy);
+      if (!result->hasError())
         return result;
-      }
 
       // If that failed, check whether it's because of the conformance we're
       // evaluating.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -773,7 +773,7 @@ public:
 
       iteratorTy = conformance->getTypeWitnessByName(sequenceType,
                                                      TC.Context.Id_Iterator);
-      if (!iteratorTy)
+      if (iteratorTy->hasError())
         return nullptr;
 
       auto witness = conformance->getWitnessByName(
@@ -838,7 +838,7 @@ public:
 
     Type elementTy = genConformance->getTypeWitnessByName(iteratorTy,
                                                         TC.Context.Id_Element);
-    if (!elementTy)
+    if (elementTy->hasError())
       return nullptr;
 
     auto *varRef =

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -610,8 +610,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
       ConcreteDeclRef memberRef(underlyingVar, subs);
       auto *memberRefExpr = new (ctx) MemberRefExpr(
           result, SourceLoc(), memberRef, DeclNameLoc(), /*Implicit=*/true);
-      auto type = underlyingVar->getValueInterfaceType()
-          .subst(subs, SubstFlags::UseErrorType);
+      auto type = underlyingVar->getValueInterfaceType().subst(subs);
       if (isLValue)
         type = LValueType::get(type);
       memberRefExpr->setType(type);
@@ -716,8 +715,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
     assert(target != TargetImpl::Super);
     auto *storageDRE = new (ctx) DeclRefExpr(storage, DeclNameLoc(),
                                              /*IsImplicit=*/true, semantics);
-    auto type = storage->getValueInterfaceType()
-        .subst(subs, SubstFlags::UseErrorType);
+    auto type = storage->getValueInterfaceType().subst(subs);
     if (isLValue)
       type = LValueType::get(type);
     storageDRE->setType(type);
@@ -752,8 +750,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
 
   Expr *lookupExpr;
   ConcreteDeclRef memberRef(storage, subs);
-  auto type = storage->getValueInterfaceType()
-      .subst(subs, SubstFlags::UseErrorType);
+  auto type = storage->getValueInterfaceType().subst(subs);
   if (isMemberLValue)
     type = LValueType::get(type);
 
@@ -761,8 +758,7 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   // that accepts the enclosing self along with key paths, form that subscript
   // operation now.
   if (enclosingSelfAccess) {
-    Type storageType = storage->getValueInterfaceType()
-        .subst(subs, SubstFlags::UseErrorType);
+    Type storageType = storage->getValueInterfaceType().subst(subs);
     // Metatype instance for the wrapper type itself.
     TypeExpr *wrapperMetatype = TypeExpr::createImplicit(storageType, ctx);
 
@@ -1396,8 +1392,7 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
 
   auto callObserver = [&](AccessorDecl *observer, VarDecl *arg) {
     ConcreteDeclRef ref(observer, subs);
-    auto type = observer->getInterfaceType()
-                  .subst(subs, SubstFlags::UseErrorType);
+    auto type = observer->getInterfaceType().subst(subs);
     Expr *Callee = new (Ctx) DeclRefExpr(ref, DeclNameLoc(), /*imp*/true);
     Callee->setType(type);
     auto *ValueDRE = new (Ctx) DeclRefExpr(arg, DeclNameLoc(), /*imp*/true);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4626,9 +4626,7 @@ public:
     if (alias &&
         alias->getAttrs().isUnavailable(ctx) &&
         alias->isCompatibilityAlias()) {
-      underlyingType = alias->getUnderlyingTypeLoc().getType().subst(subMap);
-      assert(underlyingType);
-      return underlyingType;
+      return alias->getUnderlyingTypeLoc().getType().subst(subMap);
     }
 
     auto parentType = parentTypeOrError.get();

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -873,9 +873,7 @@ void SwiftLangSupport::printMemberDeclDescription(const swift::ValueDecl *VD,
     if (usePlaceholder)
       OS << "<#T##";
 
-    if (auto substitutedTy = paramTy.subst(substMap))
-      paramTy = substitutedTy;
-
+    paramTy = paramTy.subst(substMap);
     if (paramTy->hasError() && param->getTypeLoc().hasLocation()) {
       // Fallback to 'TypeRepr' printing.
       param->getTypeLoc().getTypeRepr()->print(OS);


### PR DESCRIPTION
We've fixed a number of bugs recently where callers did not expect
to get a null Type out of subst(). This occurs particularly often
in SourceKit, where the input AST is often invalid and the types
resulting from substitution are mostly used for display.

Let's fix all these potential problems in one fell swoop by changing
subst() to always return a Type, possibly one containing ErrorTypes.

Only a couple of places depended on the old behavior, and they were
easy enough to change from checking for a null Type to checking if
the result responds with true to hasError().

Also while we're at it, simplify a few call sites of subst().