### PR TITLE
IRGen: Add addLoweredTypeRef API and use it for capture and

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1457,7 +1457,9 @@ public:
     }
 
     auto boxDescriptor = IGF.IGM.getAddrOfBoxDescriptor(
-        boxedInterfaceType.getASTType());
+        boxedInterfaceType,
+        env ? env->getGenericSignature()->getCanonicalSignature()
+            : CanGenericSignature());
     llvm::Value *allocation = IGF.emitUnmanagedAlloc(layout, name,
                                                      boxDescriptor);
     Address rawAddr = project(IGF, allocation, boxedType);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -823,7 +823,7 @@ public:
   
   CanType getRuntimeReifiedType(CanType type);
   CanType substOpaqueTypesWithUnderlyingTypes(CanType type);
-  SILType substOpaqueTypesWithUnderlyingTypes(SILType type);
+  SILType substOpaqueTypesWithUnderlyingTypes(SILType type, CanGenericSignature genericSig);
   std::pair<CanType, ProtocolConformanceRef>
   substOpaqueTypesWithUnderlyingTypes(CanType type,
                                       ProtocolConformanceRef conformance);
@@ -1071,7 +1071,11 @@ public:
   
   std::pair<llvm::Constant *, unsigned>
   getTypeRef(CanType type, MangledTypeRefRole role);
-  
+
+  std::pair<llvm::Constant *, unsigned>
+  getLoweredTypeRef(SILType loweredType, CanGenericSignature genericSig,
+                    MangledTypeRefRole role);
+
   llvm::Constant *emitWitnessTableRefString(CanType type,
                                             ProtocolConformanceRef conformance,
                                             GenericSignature *genericSig,
@@ -1109,7 +1113,8 @@ public:
                                              CanSILFunctionType substCalleeType,
                                              SubstitutionMap subs,
                                              const HeapLayout &layout);
-  llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
+  llvm::Constant *getAddrOfBoxDescriptor(SILType boxedType,
+                                         CanGenericSignature genericSig);
 
   /// Produce an associated type witness that refers to the given type.
   llvm::Constant *getAssociatedTypeWitness(Type type, bool inProtocolContext);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -526,14 +526,14 @@ CanType IRGenModule::substOpaqueTypesWithUnderlyingTypes(CanType type) {
   return type;
 }
 
-SILType IRGenModule::substOpaqueTypesWithUnderlyingTypes(SILType type) {
+SILType IRGenModule::substOpaqueTypesWithUnderlyingTypes(
+    SILType type, CanGenericSignature genericSig) {
   // Substitute away opaque types whose underlying types we're allowed to
   // assume are constant.
   if (type.getASTType()->hasOpaqueArchetype()) {
     ReplaceOpaqueTypesWithUnderlyingTypes replacer(getSwiftModule(),
                                                   ResilienceExpansion::Maximal);
-    type = type.subst(getSILModule(), replacer, replacer,
-                      CanGenericSignature(),
+    type = type.subst(getSILModule(), replacer, replacer, genericSig,
                       /*substitute opaque*/ true);
   }
 

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -37,7 +37,8 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
 
   // Substitute opaque types if allowed.
   auto origType = type;
-  type = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(type);
+  type =
+      IGF.IGM.substOpaqueTypesWithUnderlyingTypes(type, CanGenericSignature());
 
   auto formalType = type.getASTType();
   auto &ti = IGF.IGM.getTypeInfoForLowered(formalType);

--- a/test/IRGen/opaque_result_type_substitution.swift
+++ b/test/IRGen/opaque_result_type_substitution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -primary-file %s | %FileCheck %s
 
 protocol E {}
 
@@ -67,3 +67,54 @@ public func test2<S : Hashable, T, V>(_ s: S, _ t: T, _ v: V) {
 // CHECK:  [[PAIR_OPAQUE:%.*]] = call swiftcc %swift.metadata_response @"$s31opaque_result_type_substitution4PairVMa"({{.*}}, %swift.type* [[MD]], %swift.type* [[MD]])
 // CHECK:  [[MD2:%.*]] = extractvalue %swift.metadata_response [[PAIR_OPAQUE]], 0
 // CHECK:  call {{.*}}* @"$s31opaque_result_type_substitution4PairVyAC6foobarQryFQOyxq__Qo_AEGr0_lWOh"({{.*}}, %swift.type* {{.*}}, %swift.type* [[MD2]])
+
+public protocol Thing { }
+
+public struct Thingy : Thing {}
+
+public protocol KeyProto {
+  associatedtype Value
+}
+
+extension KeyProto {
+  public static func transform3<T : Thing>(
+    _ transform: @escaping (A<Self>) -> T)
+  -> some Thing {
+      return Thingy()
+  }
+}
+
+public struct A<Key : KeyProto> {}
+
+extension A {
+  public func transform2<T>(_ transform: @escaping (Key.Value) -> T) -> Thingy {
+    return Thingy()
+  }
+}
+
+struct AKey : KeyProto {
+  typealias Value = Int
+}
+
+extension Thing {
+  public func transform<K>(key _: K.Type = K.self, transform: @escaping (inout K) -> Void) -> some Thing {
+    return Thingy()
+  }
+}
+
+struct OutterThing<Content : Thing> : Thing {
+  let content: Content
+
+  init(_ c: Content) {
+    self.content = c
+  }
+
+  var body: some Thing {
+    return AKey.transform3 { y in
+      y.transform2 { i in
+       self.content.transform(
+         key: Thingy.self) { value in }
+      }
+    }
+  }
+}


### PR DESCRIPTION
 box descriptors

We want to substitute opaque result types in addTypeRef but when we pass
SILFunctionTypes this would fail because AST type substitution does not
support lowered SIL types.

Instead add addLoweredTypeRef which substitutes based on SILTypes.

rdar://54529445