### PR TITLE
[semantic-arc-opts] Fix a thinko.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -369,7 +369,7 @@ static bool isWrittenTo(SILFunction &f, SILValue value) {
   // conservative and assume that the value is written to.
   const auto &storage = findAccessedStorageNonNested(value);
   if (!storage)
-    return false;
+    return true;
 
   // Then see if we ever write to this address in a flow insensitive
   // way (ignoring stores that are obviously the only initializer to

--- a/test/SILOptimizer/semantic-arc-opts-canonical.sil
+++ b/test/SILOptimizer/semantic-arc-opts-canonical.sil
@@ -1,6 +1,6 @@
 // RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts %s | %FileCheck %s
 
-sil_stage raw
+sil_stage canonical
 
 import Builtin
 
@@ -37,6 +37,8 @@ enum FakeOptional<T> {
 case none
 case some(T)
 }
+
+sil @fakeoptional_guaranteed_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 
 ///////////
 // Tests //
@@ -394,4 +396,41 @@ bb0(%0 : @guaranteed $(Klass, MyInt)):
   %4 = struct_extract %3 : $MyInt, #MyInt.value
   destroy_value %2 : $Klass
   return %4 : $Builtin.Int32
+}
+
+// Make sure that we do not optimize this case.
+//
+// CHECK-LABEL: sil [ossa] @handle_phi_address_nodes : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: load [copy]
+// CHECK: } // end sil function 'handle_phi_address_nodes'
+sil [ossa] @handle_phi_address_nodes : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt.1, %0 : $Klass
+  %2 = copy_value %1 : $FakeOptional<Klass>
+  %3 = copy_value %1 : $FakeOptional<Klass>
+
+  %4 = alloc_stack $FakeOptional<Klass>
+  store %2 to [init] %4 : $*FakeOptional<Klass>
+  %5 = alloc_stack $FakeOptional<Klass>
+  store %3 to [init] %5 : $*FakeOptional<Klass>
+
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%4 : $*FakeOptional<Klass>)
+
+bb2:
+  br bb3(%5 : $*FakeOptional<Klass>)
+
+bb3(%6 : $*FakeOptional<Klass>):
+  %7 = load [copy] %6 : $*FakeOptional<Klass>
+  %8 = function_ref @fakeoptional_guaranteed_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+  apply %8(%7) : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+  destroy_value %7 : $FakeOptional<Klass>
+  destroy_addr %5 : $*FakeOptional<Klass>
+  dealloc_stack %5 : $*FakeOptional<Klass>
+  destroy_addr %4 : $*FakeOptional<Klass>
+  dealloc_stack %4 : $*FakeOptional<Klass>
+  %9999 = tuple()
+  return %9999 : $()
 }


### PR DESCRIPTION
This can only affect us in code where we use address phi arguments (which can
never happen in raw sil where this runs today).

I am going to be moving it later once I finish bringing up lowering ownership
after diagnostics.
