### PR TITLE
New shadowing rule, part 1

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -112,6 +112,10 @@ namespace swift {
 
   enum class KnownProtocolKind : uint8_t;
 
+namespace namelookup {
+  class ImportCache;
+}
+
 namespace syntax {
   class SyntaxArena;
 }
@@ -683,7 +687,9 @@ public:
   /// If there is no Clang module loader, returns a null pointer.
   /// The loader is owned by the AST context.
   ClangModuleLoader *getDWARFModuleLoader() const;
-  
+
+  namelookup::ImportCache &getImportCache() const;
+
   /// Asks every module loader to verify the ASTs it has loaded.
   ///
   /// Does nothing in non-asserts (NDEBUG) builds.

--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -1,0 +1,191 @@
+//===--- ImportCache.h - Caching the import graph ---------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines interfaces for querying the module import graph in an
+// efficient manner.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_IMPORT_CACHE_H
+#define SWIFT_AST_IMPORT_CACHE_H
+
+#include "swift/AST/Module.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/FoldingSet.h"
+
+namespace swift {
+class DeclContext;
+
+namespace namelookup {
+
+/// An object describing a set of modules visible from a DeclContext.
+///
+/// This consists of two arrays of modules; the top-level imports and the
+/// transitive imports.
+///
+/// The top-level imports contains all public imports of the parent module
+/// of 'dc', together with any private imports in the source file containing
+/// 'dc', if there is one.
+///
+/// The transitive imports contains all public imports reachable from the
+/// set of top-level imports.
+///
+/// Both sets only contain unique elements. The top-level imports always
+/// include the parent module of 'dc' explicitly.
+///
+/// The set of transitive imports does not contain any elements found in
+/// the top-level imports.
+///
+/// The Swift standard library module is not included in either set unless
+/// it was explicitly imported (or re-exported).
+class ImportSet final :
+    public llvm::FoldingSetNode,
+    private llvm::TrailingObjects<ImportSet, ModuleDecl::ImportedModule> {
+  friend TrailingObjects;
+  friend ImportCache;
+
+  unsigned NumTopLevelImports;
+  unsigned NumTransitiveImports;
+
+  ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+            ArrayRef<ModuleDecl::ImportedModule> transitiveImports);
+
+  ImportSet(const ImportSet &) = delete;
+  void operator=(const ImportSet &) = delete;
+
+public:
+  void Profile(llvm::FoldingSetNodeID &ID) {
+    Profile(ID, getTopLevelImports());
+  }
+  static void Profile(
+      llvm::FoldingSetNodeID &ID,
+      ArrayRef<ModuleDecl::ImportedModule> topLevelImports);
+
+  size_t numTrailingObjects(OverloadToken<ModuleDecl::ImportedModule>) const {
+    return NumTopLevelImports + NumTransitiveImports;
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getTopLevelImports() const {
+    return {getTrailingObjects<ModuleDecl::ImportedModule>(),
+            NumTopLevelImports};
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getTransitiveImports() const {
+    return {getTrailingObjects<ModuleDecl::ImportedModule>() +
+              NumTopLevelImports,
+            NumTransitiveImports};
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getAllImports() const {
+      return {getTrailingObjects<ModuleDecl::ImportedModule>(),
+              NumTopLevelImports + NumTransitiveImports};
+  }
+};
+
+class alignas(ModuleDecl::ImportedModule) ImportCache {
+  ImportCache(const ImportCache &) = delete;
+  void operator=(const ImportCache &) = delete;
+
+  llvm::FoldingSet<ImportSet> ImportSets;
+  llvm::DenseMap<const DeclContext *, ImportSet *> ImportSetForDC;
+  llvm::DenseMap<std::tuple<const ModuleDecl *,
+                            const DeclContext *>,
+                 ArrayRef<ModuleDecl::AccessPathTy>> VisibilityCache;
+  llvm::DenseMap<std::tuple<const ModuleDecl *,
+                            const ModuleDecl *,
+                            const DeclContext *>,
+                 ArrayRef<ModuleDecl::AccessPathTy>> ShadowCache;
+
+  ModuleDecl::AccessPathTy EmptyAccessPath;
+
+  ArrayRef<ModuleDecl::AccessPathTy> allocateArray(
+      ASTContext &ctx,
+      SmallVectorImpl<ModuleDecl::AccessPathTy> &results);
+
+  ImportSet &getImportSet(ASTContext &ctx,
+                          ArrayRef<ModuleDecl::ImportedModule> topLevelImports);
+
+public:
+  ImportCache() {}
+
+  /// Returns an object descripting all modules transtiively imported
+  /// from 'dc'.
+  ImportSet &getImportSet(const DeclContext *dc);
+
+  /// Returns all access paths into 'mod' that are visible from 'dc',
+  /// including transitively, via re-exports.
+  ArrayRef<ModuleDecl::AccessPathTy>
+  getAllVisibleAccessPaths(const ModuleDecl *mod, const DeclContext *dc);
+
+  bool isImportedBy(const ModuleDecl *mod,
+                    const DeclContext *dc) {
+    return !getAllVisibleAccessPaths(mod, dc).empty();
+  }
+
+  /// Determines if 'mod' is visible from 'dc' as a result of a scoped import.
+  /// Note that if 'mod' was not imported from 'dc' at all, this also returns
+  /// false.
+  bool isScopedImport(const ModuleDecl *mod, DeclBaseName name,
+                      const DeclContext *dc) {
+    auto accessPaths = getAllVisibleAccessPaths(mod, dc);
+    for (auto accessPath : accessPaths) {
+      if (accessPath.empty())
+        continue;
+      if (ModuleDecl::matchesAccessPath(accessPath, name))
+        return true;
+    }
+
+    return false;
+  }
+
+  /// Returns all access paths in 'mod' that are visible from 'dc' if we
+  /// subtract imports of 'other'.
+  ArrayRef<ModuleDecl::AccessPathTy>
+  getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
+                                 const ModuleDecl *other,
+                                 const DeclContext *dc);
+
+  /// Returns 'true' if a declaration named 'name' defined in 'other' shadows
+  /// defined in 'mod', because no access paths can find 'name' in 'mod' from
+  /// 'dc' if we ignore imports of 'other'.
+  bool isShadowedBy(const ModuleDecl *mod,
+                    const ModuleDecl *other,
+                    DeclBaseName name,
+                    const DeclContext *dc) {
+     auto accessPaths = getAllAccessPathsNotShadowedBy(mod, other, dc);
+     return llvm::none_of(accessPaths,
+                          [&](ModuleDecl::AccessPathTy accessPath) {
+                            return ModuleDecl::matchesAccessPath(accessPath, name);
+                          });
+  }
+
+  /// Qualified lookup into types uses a slightly different check that does not
+  /// take access paths into account.
+  bool isShadowedBy(const ModuleDecl *mod,
+                    const ModuleDecl *other,
+                    const DeclContext *dc) {
+    auto accessPaths = getAllAccessPathsNotShadowedBy(mod, other, dc);
+    return accessPaths.empty();
+  }
+
+  /// This is a hack to cope with main file parsing and REPL parsing, where
+  /// we can add ImportDecls after name binding.
+  void clear() {
+    ImportSetForDC.clear();
+  }
+};
+
+}  // namespace namelookup
+
+}  // namespace swift
+
+#endif

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -378,11 +378,11 @@ bool removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls);
 /// other declarations in that set.
 ///
 /// \param decls The set of declarations being considered.
-/// \param curModule The current module.
+/// \param dc The DeclContext from which the lookup was performed.
 ///
 /// \returns true if any shadowed declarations were removed.
 bool removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
-                         const ModuleDecl *curModule);
+                         const DeclContext *dc);
 
 /// Finds decls visible in the given context and feeds them to the given
 /// VisibleDeclConsumer.  If the current DeclContext is nested in a function,

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -175,6 +175,19 @@ FRONTEND_STATISTIC(AST, NumBraceStmtASTScopeExpansions)
 /// Number of ASTScope lookups
 FRONTEND_STATISTIC(AST, NumASTScopeLookups)
 
+/// Number of lookups of the cached import graph for a module or
+/// source file.
+FRONTEND_STATISTIC(AST, ImportSetFoldHit)
+FRONTEND_STATISTIC(AST, ImportSetFoldMiss)
+
+FRONTEND_STATISTIC(AST, ImportSetCacheHit)
+FRONTEND_STATISTIC(AST, ImportSetCacheMiss)
+
+FRONTEND_STATISTIC(AST, ModuleVisibilityCacheHit)
+FRONTEND_STATISTIC(AST, ModuleVisibilityCacheMiss)
+
+FRONTEND_STATISTIC(AST, ModuleShadowCacheHit)
+FRONTEND_STATISTIC(AST, ModuleShadowCacheMiss)
 
 /// Number of full function bodies parsed.
 FRONTEND_STATISTIC(Parse, NumFunctionsParsed)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericSignatureBuilder.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleLoader.h"
@@ -251,6 +252,9 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   /// The various module loaders that import external modules into this
   /// ASTContext.
   SmallVector<std::unique_ptr<swift::ModuleLoader>, 4> ModuleLoaders;
+
+  /// Singleton used to cache the import graph.
+  swift::namelookup::ImportCache TheImportCache;
 
   /// The module loader used to load Clang modules.
   ClangModuleLoader *TheClangModuleLoader = nullptr;
@@ -1492,6 +1496,10 @@ void ASTContext::verifyAllLoadedModules() const {
     assert(!M->getFiles().empty() || M->failedToLoad());
   }
 #endif
+}
+
+swift::namelookup::ImportCache &ASTContext::getImportCache() const {
+  return getImpl().TheImportCache;
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -50,6 +50,7 @@ add_swift_host_library(swiftAST STATIC
   GenericSignature.cpp
   GenericSignatureBuilder.cpp
   Identifier.cpp
+  ImportCache.cpp
   InlinableText.cpp
   LayoutConstraint.cpp
   Module.cpp

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -1,0 +1,280 @@
+//===--- ImportCache.cpp - Caching the import graph -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines interfaces for querying the module import graph in an
+// efficient manner.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/DenseSet.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ImportCache.h"
+#include "swift/AST/Module.h"
+
+using namespace swift;
+using namespace namelookup;
+
+ImportSet::ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+                     ArrayRef<ModuleDecl::ImportedModule> transitiveImports)
+  : NumTopLevelImports(topLevelImports.size()),
+    NumTransitiveImports(transitiveImports.size()) {
+  auto buffer = getTrailingObjects<ModuleDecl::ImportedModule>();
+  std::uninitialized_copy(topLevelImports.begin(), topLevelImports.end(),
+                          buffer);
+  std::uninitialized_copy(transitiveImports.begin(), transitiveImports.end(),
+                          buffer + topLevelImports.size());
+
+#ifndef NDEBUG
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 8> unique;
+  for (auto import : topLevelImports) {
+    auto result = unique.insert(import).second;
+    assert(result && "Duplicate imports in import set");
+  }
+  for (auto import : transitiveImports) {
+    auto result = unique.insert(import).second;
+    assert(result && "Duplicate imports in import set");
+  }
+#endif
+}
+
+void ImportSet::Profile(
+    llvm::FoldingSetNodeID &ID,
+    ArrayRef<ModuleDecl::ImportedModule> topLevelImports) {
+  ID.AddInteger(topLevelImports.size());
+  for (auto import : topLevelImports) {
+    ID.AddInteger(import.first.size());
+    for (auto accessPathElt : import.first) {
+      ID.AddPointer(accessPathElt.first.getAsOpaquePointer());
+    }
+    ID.AddPointer(import.second);
+  }
+}
+
+static void collectExports(ModuleDecl::ImportedModule next,
+                           SmallVectorImpl<ModuleDecl::ImportedModule> &stack) {
+  SmallVector<ModuleDecl::ImportedModule, 4> exports;
+  next.second->getImportedModulesForLookup(exports);
+  for (auto exported : exports) {
+    if (next.first.empty())
+      stack.push_back(exported);
+    else if (exported.first.empty()) {
+      exported.first = next.first;
+      stack.push_back(exported);
+    } else if (ModuleDecl::isSameAccessPath(next.first, exported.first)) {
+      stack.push_back(exported);
+    }
+  }
+}
+
+ImportSet &
+ImportCache::getImportSet(ASTContext &ctx,
+                          ArrayRef<ModuleDecl::ImportedModule> imports) {
+  SmallVector<ModuleDecl::ImportedModule, 4> topLevelImports;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> transitiveImports;
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 32> visited;
+
+  for (auto next : imports) {
+    if (!visited.insert(next).second)
+      continue;
+
+    topLevelImports.push_back(next);
+  }
+
+  void *InsertPos = nullptr;
+
+  llvm::FoldingSetNodeID ID;
+  ImportSet::Profile(ID, topLevelImports);
+
+  if (ImportSet *result = ImportSets.FindNodeOrInsertPos(ID, InsertPos)) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ImportSetFoldHit++;
+    return *result;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ImportSetFoldMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> stack;
+  for (auto next : topLevelImports) {
+    collectExports(next, stack);
+  }
+
+  while (!stack.empty()) {
+    auto next = stack.pop_back_val();
+
+    if (!visited.insert(next).second)
+      continue;
+
+    transitiveImports.push_back(next);
+    collectExports(next, stack);
+  }
+
+  // Find the insert position again, in case the above traversal invalidated
+  // the folding set via re-entrant calls to getImportSet() from
+  // getImportedModulesForLookup().
+  if (ImportSet *result = ImportSets.FindNodeOrInsertPos(ID, InsertPos))
+    return *result;
+
+  void *mem = ctx.Allocate(
+    sizeof(ImportSet) +
+    sizeof(ModuleDecl::ImportedModule) * topLevelImports.size() +
+    sizeof(ModuleDecl::ImportedModule) * transitiveImports.size(),
+    alignof(ImportSet), AllocationArena::Permanent);
+
+  auto *result = new (mem) ImportSet(topLevelImports, transitiveImports);
+  ImportSets.InsertNode(result, InsertPos);
+
+  return *result;
+}
+
+ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto *file = dyn_cast<FileUnit>(dc);
+  auto *mod = dc->getParentModule();
+  if (!file)
+    dc = mod;
+
+  auto &ctx = mod->getASTContext();
+
+  auto found = ImportSetForDC.find(dc);
+  if (found != ImportSetForDC.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ImportSetCacheHit++;
+    return *found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ImportSetCacheMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> imports;
+  imports.emplace_back(ModuleDecl::AccessPathTy(), mod);
+
+  if (file) {
+    ModuleDecl::ImportFilter importFilter;
+    importFilter |= ModuleDecl::ImportFilterKind::Private;
+    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    file->getImportedModules(imports, importFilter);
+  }
+
+  auto &result = getImportSet(ctx, imports);
+  ImportSetForDC[dc] = &result;
+
+  return result;
+}
+
+ArrayRef<ModuleDecl::AccessPathTy> ImportCache::allocateArray(
+    ASTContext &ctx,
+    SmallVectorImpl<ModuleDecl::AccessPathTy> &results) {
+  if (results.empty())
+    return ArrayRef<ModuleDecl::AccessPathTy>();
+  else if (results.size() == 1 && results[0].empty())
+    return {&EmptyAccessPath, 1};
+  else
+    return ctx.AllocateCopy(results);
+}
+
+ArrayRef<ModuleDecl::AccessPathTy>
+ImportCache::getAllVisibleAccessPaths(const ModuleDecl *mod,
+                                      const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto &ctx = mod->getASTContext();
+
+  auto key = std::make_pair(mod, dc);
+  auto found = VisibilityCache.find(key);
+  if (found != VisibilityCache.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ModuleVisibilityCacheHit++;
+    return found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ModuleVisibilityCacheMiss++;
+
+  SmallVector<ModuleDecl::AccessPathTy, 1> accessPaths;
+  for (auto next : getImportSet(dc).getAllImports()) {
+    // If we found 'mod', record the access path.
+    if (next.second == mod) {
+      // Make sure the list of access paths is unique.
+      if (!llvm::is_contained(accessPaths, next.first))
+        accessPaths.push_back(next.first);
+    }
+  }
+
+  auto result = allocateArray(ctx, accessPaths);
+  VisibilityCache[key] = result;
+  return result;
+}
+
+ArrayRef<ModuleDecl::AccessPathTy>
+ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
+                                            const ModuleDecl *other,
+                                            const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto *currentMod = dc->getParentModule();
+  auto &ctx = currentMod->getASTContext();
+
+  // Fast path.
+  if (currentMod == other)
+    return ArrayRef<ModuleDecl::AccessPathTy>();
+
+  auto key = std::make_tuple(mod, other, dc);
+  auto found = ShadowCache.find(key);
+  if (found != ShadowCache.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ModuleShadowCacheHit++;
+    return found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ModuleShadowCacheMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> stack;
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 32> visited;
+
+  stack.emplace_back(ModuleDecl::AccessPathTy(), currentMod);
+
+  if (auto *file = dyn_cast<FileUnit>(dc)) {
+    ModuleDecl::ImportFilter importFilter;
+    importFilter |= ModuleDecl::ImportFilterKind::Private;
+    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    file->getImportedModules(stack, importFilter);
+  }
+
+  SmallVector<ModuleDecl::AccessPathTy, 4> accessPaths;
+
+  while (!stack.empty()) {
+    auto next = stack.pop_back_val();
+
+    // Don't visit a module more than once.
+    if (!visited.insert(next).second)
+      continue;
+
+    // Don't visit the 'other' module's re-exports.
+    if (next.second == other)
+      continue;
+
+    // If we found 'mod' via some access path, remember the access
+    // path.
+    if (next.second == mod) {
+      // Make sure the list of access paths is unique.
+      if (!llvm::is_contained(accessPaths, next.first))
+        accessPaths.push_back(next.first);
+    }
+
+    collectExports(next, stack);
+  }
+
+  auto result = allocateArray(ctx, accessPaths);
+  ShadowCache[key] = result;
+  return result;
+};

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/ModuleLoader.h"
@@ -1642,6 +1643,8 @@ bool SourceFile::isImportedImplementationOnly(const ModuleDecl *module) const {
 }
 
 void ModuleDecl::clearLookupCache() {
+  getASTContext().getImportCache().clear();
+
   if (!Cache)
     return;
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -190,7 +190,6 @@ static void recordShadowedDeclsAfterSignatureMatch(
   for (unsigned firstIdx : indices(decls)) {
     auto firstDecl = decls[firstIdx];
     auto firstModule = firstDecl->getModuleContext();
-    auto firstSig = firstDecl->getOverloadSignature();
     for (unsigned secondIdx : range(firstIdx + 1, decls.size())) {
       // Determine whether one module takes precedence over another.
       auto secondDecl = decls[secondIdx];
@@ -203,6 +202,7 @@ static void recordShadowedDeclsAfterSignatureMatch(
       // used the null type.
       if (!ctx.isSwiftVersionAtLeast(5)) {
         auto secondSig = secondDecl->getOverloadSignature();
+        auto firstSig = firstDecl->getOverloadSignature();
         if (firstSig.IsVariable && secondSig.IsVariable)
           if (firstSig.InExtensionOfGenericType !=
               secondSig.InExtensionOfGenericType)

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1644,12 +1644,6 @@ bool DeclContext::lookupQualified(ModuleDecl *module, DeclName member,
     }
   }
 
-  llvm::SmallPtrSet<ValueDecl *, 4> knownDecls;
-  decls.erase(std::remove_if(decls.begin(), decls.end(),
-                             [&](ValueDecl *vd) -> bool {
-    return !knownDecls.insert(vd).second;
-  }), decls.end());
-
   pruneLookupResultSet(this, options, decls);
 
   if (auto *debugClient = this->getParentModule()->getDebugClient()) {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -980,7 +980,7 @@ void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
 
   // Always perform name shadowing for type lookup.
   if (options.contains(Flags::TypeLookup)) {
-    removeShadowedDecls(CurModuleResults, &M);
+    removeShadowedDecls(CurModuleResults, dc);
   }
 
   for (auto VD : CurModuleResults) {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleNameLookup.h"
@@ -1021,17 +1022,14 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   if (!desiredModule && Name == Ctx.TheBuiltinModule->getName())
     desiredModule = Ctx.TheBuiltinModule;
   if (desiredModule) {
-    forAllVisibleModules(
-        dc, [&](const ModuleDecl::ImportedModule &import) -> bool {
-          if (import.second == desiredModule) {
-            Results.push_back(LookupResultEntry(import.second));
+    // Make sure the desired module is actually visible from the current
+    // context.
+    if (Ctx.getImportCache().isImportedBy(desiredModule, dc)) {
+      Results.push_back(LookupResultEntry(desiredModule));
 #ifndef NDEBUG
-            addedResult(Results.back());
+      addedResult(Results.back());
 #endif
-            return false;
-          }
-          return true;
-        });
+    }
   }
 }
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -226,7 +226,7 @@ static void doGlobalExtensionLookup(Type BaseType,
   }
 
   // Handle shadowing.
-  removeShadowedDecls(FoundDecls, CurrDC->getParentModule());
+  removeShadowedDecls(FoundDecls, CurrDC);
 }
 
 /// Enumerate immediate members of the type \c LookupType and its

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -97,8 +97,8 @@ namespace {
       removeOverriddenDecls(FoundOuterDecls);
 
       // Remove any shadowed declarations from the found-declarations set.
-      removeShadowedDecls(FoundDecls, DC->getParentModule());
-      removeShadowedDecls(FoundOuterDecls, DC->getParentModule());
+      removeShadowedDecls(FoundDecls, DC);
+      removeShadowedDecls(FoundOuterDecls, DC);
 
       // Filter out those results that have been removed from the
       // found-declarations set.


### PR DESCRIPTION
Module name lookup has its own set of shadowing rules based on the import graph. If a module A imports a module B, and module B imports module C, then when referenced from A, top-level declarations in B would shadow those in C. This shadowing behaves differently depending on the declaration kind:

1) types and variables shadow all symbols with the same name that appear subsequently in the import graph traversal
2) top-level functions shadow all top level functions with the same exact type only

I would like to replace module name lookup shadowing with the shadowing rules used for qualified lookup since this enables some optimizations to be implemented in module name lookup which are currently difficult to do.

As a first step toward this goal, this PR re-implements the module name lookup shadowing rule inside the normal `removeShadowedDecls()` path. This is done by introducing a new ImportCache utility class, which caches the results of various queries against the module import graph.