### PR TITLE
[semantic-arc-opts] Convert a piece of code to be an assert.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -100,10 +100,13 @@ static bool isConsumed(
       return true;
     }
     case UseLifetimeConstraint::MustBeLive:
-      // Ok, this constraint can take something owned as live. Lets
-      // see if it can also take something that is guaranteed. If it
-      // can not, then we bail.
-      map.canAcceptKind(ValueOwnershipKind::Guaranteed);
+      // Ok, this constraint can take something owned as live. Assert that it
+      // can also accept something that is guaranteed. Any non-consuming use of
+      // an owned value should be able to take a guaranteed parameter as well
+      // (modulo bugs). We assert to catch these.
+      assert(map.canAcceptKind(ValueOwnershipKind::Guaranteed) &&
+             "Any non-consuming use of an owned value should be able to take a "
+             "guaranteed value");
       continue;
     }
   }


### PR DESCRIPTION
Ignoring bugs, any owned value that is used in a read only manner should be able
to be borrowed and used in such a place as well.

Originally this code (before refactoring) would assert, so we were checking that
this could not happen in our asserts builds. Due to refactoring the assert was
lost. This changes the code to have the assert again, this time explicitly
instead of inside the method.
