### PR TITLE
[ConstraintSystem] Introduce a notion of a "hole"

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2834,18 +2834,6 @@ bool MissingMemberFailure::diagnoseAsError() {
   if (!anchor || !baseExpr)
     return false;
 
-  if (auto *typeVar = getBaseType()->getAs<TypeVariableType>()) {
-    auto &CS = getConstraintSystem();
-    auto *memberLoc = typeVar->getImpl().getLocator();
-    // Don't try to diagnose anything besides first missing
-    // member in the chain. e.g. `x.foo().bar()` let's make
-    // sure to diagnose only `foo()` as missing because we
-    // don't really know much about what `bar()` is supposed
-    // to be.
-    if (CS.MissingMembers.count(memberLoc))
-      return false;
-  }
-
   auto baseType = resolveType(getBaseType())->getWithoutSpecifierType();
 
   DeclNameLoc nameLoc(anchor->getStartLoc());

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -125,12 +125,6 @@ Solution ConstraintSystem::finalize() {
   }
   solution.Fixes.append(Fixes.begin() + firstFixIndex, Fixes.end());
 
-  // Remember all of the missing member references encountered,
-  // that helps diagnostics to avoid emitting error for each
-  // member in the chain.
-  for (auto *member : MissingMembers)
-    solution.MissingMembers.push_back(member);
-
   // Remember all the disjunction choices we made.
   for (auto &choice : DisjunctionChoices) {
     // We shouldn't ever register disjunction choices multiple times,
@@ -267,10 +261,6 @@ void ConstraintSystem::applySolution(const Solution &solution) {
     
   // Register any fixes produced along this path.
   Fixes.append(solution.Fixes.begin(), solution.Fixes.end());
-
-  // Register any missing members encountered along this path.
-  MissingMembers.insert(solution.MissingMembers.begin(),
-                        solution.MissingMembers.end());
 }
 
 /// Restore the type variable bindings to what they were before
@@ -460,7 +450,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
   numCheckedConformances = cs.CheckedConformances.size();
-  numMissingMembers = cs.MissingMembers.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
   numBuilderTransformedClosures = cs.builderTransformedClosures.size();
@@ -528,9 +517,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any conformances checked along the current path.
   truncate(cs.CheckedConformances, numCheckedConformances);
-
-  // Remove any missing members found along the current path.
-  truncate(cs.MissingMembers, numMissingMembers);
 
   /// Remove any builder transformed closures.
   truncate(cs.builderTransformedClosures, numBuilderTransformedClosures);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -452,6 +452,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numSavedBindings = cs.solverState->savedBindings.size();
   numConstraintRestrictions = cs.ConstraintRestrictions.size();
   numFixes = cs.Fixes.size();
+  numHoles = cs.Holes.size();
   numFixedRequirements = cs.FixedRequirements.size();
   numDisjunctionChoices = cs.DisjunctionChoices.size();
   numOpenedTypes = cs.OpenedTypes.size();
@@ -499,6 +500,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any fixes.
   truncate(cs.Fixes, numFixes);
+
+  // Remove any holes encountered along the current path.
+  truncate(cs.Holes, numHoles);
 
   // Remove any disjunction choices.
   truncate(cs.DisjunctionChoices, numDisjunctionChoices);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -634,9 +634,6 @@ public:
   /// The list of fixes that need to be applied to the initial expression
   /// to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;
-  /// The list of member references which couldn't be resolved,
-  /// and had to be assumed based on their use.
-  llvm::SmallVector<ConstraintLocator *, 4> MissingMembers;
 
   /// The set of disjunction choices used to arrive at this solution,
   /// which informs constraint application.
@@ -1102,9 +1099,6 @@ private:
   /// an inference failure e.g. missing member, ambiguous generic
   /// parameter which hasn't been explicitly specified.
   llvm::SmallSetVector<ConstraintLocator *, 4> Holes;
-
-  /// The set of type variables representing types of missing members.
-  llvm::SmallSetVector<ConstraintLocator *, 4> MissingMembers;
 
   /// The set of remembered disjunction choices used to reach
   /// the current constraint system.
@@ -1661,8 +1655,6 @@ public:
 
     unsigned numCheckedConformances;
 
-    unsigned numMissingMembers;
-
     unsigned numDisabledConstraints;
 
     unsigned numFavoredConstraints;
@@ -2045,9 +2037,7 @@ public:
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix);
 
-  void recordHole(TypeVariableType *typeVar) {
-    Holes.insert(typeVar->getImpl().getLocator());
-  }
+  void recordHole(TypeVariableType *typeVar);
 
   bool isHole(TypeVariableType *typeVar) const {
     return isHoleAt(typeVar->getImpl().getLocator());

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1095,6 +1095,14 @@ private:
 
   /// The set of fixes applied to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;
+
+  /// The set of "holes" in the constraint system encountered
+  /// along the current path identified by locator. A "hole" is
+  /// a type variable which type couldn't be determined due to
+  /// an inference failure e.g. missing member, ambiguous generic
+  /// parameter which hasn't been explicitly specified.
+  llvm::SmallSetVector<ConstraintLocator *, 4> Holes;
+
   /// The set of type variables representing types of missing members.
   llvm::SmallSetVector<ConstraintLocator *, 4> MissingMembers;
 
@@ -1631,6 +1639,9 @@ public:
     /// The length of \c Fixes.
     unsigned numFixes;
 
+    /// The length of \c Holes.
+    unsigned numHoles;
+
     /// The length of \c FixedRequirements.
     unsigned numFixedRequirements;
 
@@ -2033,6 +2044,18 @@ public:
   /// Log and record the application of the fix. Return true iff any
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix);
+
+  void recordHole(TypeVariableType *typeVar) {
+    Holes.insert(typeVar->getImpl().getLocator());
+  }
+
+  bool isHole(TypeVariableType *typeVar) const {
+    return isHoleAt(typeVar->getImpl().getLocator());
+  }
+
+  bool isHoleAt(ConstraintLocator *locator) const {
+    return bool(Holes.count(locator));
+  }
 
   /// Determine whether constraint system already has a fix recorded
   /// for a particular location.

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -94,8 +94,6 @@ class sr7440_Genre {
     return sr7440_Genre.fetch(genreID: iTunesGenre.genreID, name: iTunesGenre.name)
 // expected-error@-1 {{value of type 'sr7440_ITunesGenre' has no member 'genreID'; did you mean 'genre'?}}
 // expected-error@-2 {{cannot convert return expression of type '()' to return type 'sr7440_Genre'}}
-// expected-error@-3 {{protocol type 'Any' cannot conform to 'BinaryInteger' because only concrete types can conform to protocols}}
-// TODO(diagnostics): Last diagnostic should not be recorded but to be able to correctly handle it we need a notion of a "hole" in constraint system.
   }
 }
 

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -59,6 +59,7 @@ class Outer3 // expected-error {{circular reference}}
 protocol Initable {
   init()
   // expected-note@-1 {{protocol requires initializer 'init()' with type '()'; do you want to add a stub?}}
+  // expected-note@-2 {{did you mean 'init'?}}
 }
 
 protocol Shape : Circle {}

--- a/test/decl/protocol/special/coding/class_codable_default_initializer.swift
+++ b/test/decl/protocol/special/coding/class_codable_default_initializer.swift
@@ -7,7 +7,7 @@ class NoInitializers { // expected-error {{class 'NoInitializers' has no initial
 
   func foo() {
     // The class should not receive a default constructor.
-    let _ = NoInitializers.init() // expected-error {{type 'NoInitializers' has no member 'init'}}
+    let _ = NoInitializers.init() // expected-error {{'NoInitializers' cannot be constructed because it has no accessible initializers}}
   }
 }
 


### PR DESCRIPTION
A "hole" is a type variable which type couldn't be determined
due to an inference failure e.g. missing member, ambiguous generic
parameter which hasn't been explicitly specified.

It is used to propagate information about failures and avoid
recording fixes which are a consequence of earlier failures e.g.

```swift
func foo<T: BinaryInteger>(_: T) {}

struct S {}

 foo(S.bar) // Actual failure here is that `S` doesn't have a member
            // `bar` but a consequence of that failure is that generic
            // parameter `T` doesn't conform to `BinaryInteger`.
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
