### PR TITLE
[IDE][Sema] Fix code completion unreachable/hang in TypeBase::getContextSubtitutions

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3494,7 +3494,9 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
       continue;
     }
 
-    llvm_unreachable("Bad base type");
+    // Assert and break to avoid hanging if we get an unexpected baseTy.
+    assert(0 && "Bad base type");
+    break;
   }
 
   while (n > 0) {

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -397,6 +397,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_ARGS_LOCAL_RETURN | %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOL_DOT_1 | %FileCheck %s -check-prefix=PROTOCOL_DOT_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT | %FileCheck %s -check-prefix=UNBOUND_DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT_2 | %FileCheck %s -check-prefix=UNBOUND_DOT_2
 
 //===--- Helper types that are used in this test
 
@@ -1093,3 +1095,37 @@ func testProtocol() {
 // PROTOCOL_DOT_1-DAG: Keyword/None:                       Type[#FooProtocol.Type#]; name=Type
 // PROTOCOL_DOT_1: End completions
 }
+
+//===---
+//===--- Test we can complete unbound generic types
+//===---
+
+public final class Task<Success> {
+  public enum Inner {
+    public typealias Failure = Int
+    case success(Success)
+    case failure(Failure)
+  }
+}
+extension Task.Inner {
+  public init(left error: Failure) {
+    fatalError()
+  }
+}
+extension Task.Inner.#^UNBOUND_DOT^# {}
+func testUnbound(x: Task.Inner.#^UNBOUND_DOT^#) {}
+// UNBOUND_DOT: Begin completions
+// UNBOUND_DOT-DAG: Decl[TypeAlias]/CurrNominal:        Failure[#Int#]; name=Failure
+// UNBOUND_DOT-DAG: Keyword/None:                       Type[#Task.Inner.Type#]; name=Type
+// UNBOUND_DOT: End completions
+
+
+protocol MyProtocol {}
+struct OuterStruct<U>  {
+  class Inner<V>: MyProtocol {}
+}
+
+func testUnbound2(x: OuterStruct<Int>.Inner.#^UNBOUND_DOT_2^#) {}
+// UNBOUND_DOT_2: Begin completions
+// UNBOUND_DOT_2-DAG: Keyword/None:                       Type[#OuterStruct<Int>.Inner.Type#]; name=Type
+// UNBOUND_DOT_2: End completions


### PR DESCRIPTION
There are paths from code completion giving it an `UnboundGenericType`, which it doesn't expect.

This patch:
1) Updates the code completion paths to not attempt substitution on `UnboundGenericType`s
2) Updates `getContextSubstitutions` to assert and break out of the loop when given an unhandled type to avoid hanging release builds if a similar bug occurs in future.

Resolves rdar://problem/53959978