### PR TITLE
Use `sccache` (if available) for building a tensorflow toolchain.

### DIFF
--- a/utils/build-toolchain-tensorflow
+++ b/utils/build-toolchain-tensorflow
@@ -148,6 +148,8 @@ if [ ${INSTALLER_PACKAGE} ]; then
 fi
 
 ./utils/build-script ${DRY_RUN} --preset="${SWIFT_PACKAGE}" \
+        --cmake-c-launcher=`which sccache` \
+        --cmake-cxx-launcher=`which sccache` \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \


### PR DESCRIPTION
Having an `sccache` can speed up the building of toolchains. If the `sccache` command is not found, it gracefully degenerates to normal compilation. 