### PR TITLE
SILOptimizer: a new optimization to hoist destroys of memory locations

### DIFF
--- a/include/swift/SIL/MemoryLifetime.h
+++ b/include/swift/SIL/MemoryLifetime.h
@@ -183,6 +183,11 @@ public:
     return &locations[index];
   }
 
+  /// Registers an address projection instruction for a location.
+  void registerProjection(SingleValueInstruction *projection, unsigned locIdx) {
+    addr2LocIdx[projection] = locIdx;
+  }
+
   /// Sets the location bits os \p addr in \p bits, if \p addr is associated
   /// with a location.
   void setBits(Bits &bits, SILValue addr) {
@@ -341,13 +346,29 @@ public:
   /// Calculates the BlockState::exitReachable flags.
   void exitReachableAnalysis();
 
+  using JoinOperation = std::function<void (Bits &dest, const Bits &src)>;
+
   /// Derives the block exit sets from the entry sets by applying the gen and
   /// kill sets.
-  void solveDataflowForward();
+  /// At control flow joins, the \p join operation is applied.
+  void solveForward(JoinOperation join);
+
+  /// Calls solveForward() with a bit-intersection as join operation.
+  void solveForwardWithIntersect();
+
+  /// Calls solveForward() with a bit-union as join operation.
+  void solveForwardWithUnion();
 
   /// Derives the block entry sets from the exit sets by applying the gen and
   /// kill sets.
-  void solveDataflowBackward();
+  /// At control flow joins, the \p join operation is applied.
+  void solveBackward(JoinOperation join);
+
+  /// Calls solveBackward() with a bit-intersection as join operation.
+  void solveBackwardWithIntersect();
+
+  /// Calls solveBackward() with a bit-union as join operation.
+  void solveBackwardWithUnion();
 
   /// Debug dump the MemoryLifetime internals.
   void dump() const;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3240,6 +3240,9 @@ public:
     return LoadOwnershipQualifier(
       SILInstruction::Bits.LoadInst.OwnershipQualifier);
   }
+  void setOwnershipQualifier(LoadOwnershipQualifier qualifier) {
+    SILInstruction::Bits.LoadInst.OwnershipQualifier = unsigned(qualifier);
+  }
 };
 
 // *NOTE* When serializing, we can only represent up to 4 values here. If more
@@ -3278,6 +3281,9 @@ public:
   StoreOwnershipQualifier getOwnershipQualifier() const {
     return StoreOwnershipQualifier(
       SILInstruction::Bits.StoreInst.OwnershipQualifier);
+  }
+  void setOwnershipQualifier(StoreOwnershipQualifier qualifier) {
+    SILInstruction::Bits.StoreInst.OwnershipQualifier = unsigned(qualifier);
   }
 };
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -132,6 +132,8 @@ PASS(DeadObjectElimination, "deadobject-elim",
      "Dead Object Elimination for Classes with Trivial Destruction")
 PASS(DefiniteInitialization, "definite-init",
      "Definite Initialization for Diagnostics")
+PASS(DestroyHoisting, "destroy-hoisting",
+     "Hoisting of value destroys")
 PASS(Devirtualizer, "devirtualizer",
      "Indirect Call Devirtualization")
 PASS(DiagnoseInfiniteRecursion, "diagnose-infinite-recursion",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -104,6 +104,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P) {
   P.addClosureLifetimeFixup();
   if (Options.shouldOptimize()) {
     P.addSemanticARCOpts();
+    P.addDestroyHoisting();
   }
   if (!Options.StripOwnershipAfterSerialization)
     P.addOwnershipModelEliminator();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ silopt_register_sources(
   DeadCodeElimination.cpp
   DeadObjectElimination.cpp
   DeadStoreElimination.cpp
+  DestroyHoisting.cpp
   Devirtualizer.cpp
   GenericSpecializer.cpp
   MergeCondFail.cpp

--- a/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
@@ -1,0 +1,731 @@
+//===--- DestroyHoisting.cpp - Hoisting of address destroys ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-destroy-hoisting"
+#include "swift/SIL/MemoryLifetime.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                               DestroyHoisting
+//===----------------------------------------------------------------------===//
+
+/// Hoist destroy_addr instructions up the control flow.
+///
+/// This has two benefits:
+///
+/// * Combine a destroy_addr with a preceeding copy. For example, replace
+///   /code
+///     %v = load [copy] %a
+///     ...
+///     destroy_addr %a
+///   /endcode
+///   with
+///   /code
+///     %v = load [take] %a
+///     ...
+///   /endcode
+
+/// * Shorten the lifetime of memory-values. This can avoid copy-on-write
+///   operations. Specifically, optimize the enum payload in-place modification
+///   pattern:
+///   /code
+///     // inside a mutating enum member function
+///     switch self {
+///       case .A(var cow_container)
+///         cow_container.modify()
+///         self = .A(cow_container)
+///       ...
+///     }
+///   /endcode
+///   DestroyHoisting moves the destroy-part of the self assignment up so that
+///   the cow_container is only single-referenced and will not trigger a copy-
+///   on-write operation when calling modify().
+///
+/// Note that this optimization does _not_ try to split a destroy_addr of a
+/// struct/tuple into destroys of its sub-locations. Also, vice versa, it does
+/// not try to combine multiple destroy_addr of sub-locations into a single
+/// destroy_addr of the aggregate.
+class DestroyHoisting {
+
+  using Bits = MemoryLocations::Bits;
+  using BlockState = MemoryDataflow::BlockState;
+
+  SILFunction *function;
+  MemoryLocations locations;
+
+  /// A cache of generated address projection instructions. The key is the
+  /// location index.
+  llvm::DenseMap<unsigned, SingleValueInstruction *> addressProjections;
+
+  DominanceAnalysis *DA;
+  DominanceInfo *domTree = nullptr;
+  bool madeChanges = false;
+
+  void expandStores(MemoryDataflow &dataFlow);
+
+  void initDataflow(MemoryDataflow &dataFlow);
+
+  void initDataflowInBlock(BlockState &state);
+
+  bool canIgnoreUnreachableBlock(SILBasicBlock *block,
+                                 MemoryDataflow &dataFlow);
+
+  int getDestroyedLoc(SILInstruction *I) {
+    if (auto *DAI = dyn_cast<DestroyAddrInst>(I))
+        return locations.getLocationIdx(DAI->getOperand());
+    return -1;
+  }
+
+  void getUsedLocationsOfAddr(Bits &bits, SILValue addr);
+
+  void getUsedLocationsOfInst(Bits &bits, SILInstruction *Inst);
+
+  void moveDestroys(MemoryDataflow &dataFlow);
+
+  void moveDestroysInBlock(SILBasicBlock *block, Bits &activeDestroys,
+                           SmallVectorImpl<SILInstruction *> &toRemove);
+
+  void insertDestroys(Bits &toInsert, Bits &aliveDestroys,
+                      SmallVectorImpl<SILInstruction *> &removeList,
+                      SILInstruction *afterInst, SILBasicBlock *inBlock);
+
+  void insertDestroy(int locIdx, Bits &insertBits, SILInstruction *atInst);
+
+  bool combineWith(SILInstruction *inst, unsigned locIdx);
+
+  SILValue createAddress(unsigned locIdx, SILBuilder &builder);
+
+  void tailMerging(MemoryDataflow &dataFlow);
+
+  bool tailMergingInBlock(SILBasicBlock *block, MemoryDataflow &dataFlow);
+
+public:
+  DestroyHoisting(SILFunction *function, DominanceAnalysis *DA) :
+    function(function), DA(DA) { }
+
+  bool hoistDestroys();
+};
+
+static bool isExpansionEnabler(SILInstruction *I) {
+  return isa<SwitchEnumInst>(I);
+}
+
+// A pre-pass which expands
+//    store %s to [assign] %a
+// to
+//    destroy_addr %a
+//    store %s to [init] %a
+//
+// This is not a good thing in general. If we would do it unconditionally, it
+// would result in some benchmark regressions. Therefore we only expand stores
+// where we expect that we can move the destroys to or across a switch_enum.
+// This enables the switch-enum optimization (see above).
+// TODO: investigate the benchmark regressions and enable store-expansion more
+//       aggressively.
+void DestroyHoisting::expandStores(MemoryDataflow &dataFlow) {
+  Bits usedLocs(locations.getNumLocations());
+
+  // Initialize the dataflow, which tells us which destroy_addr instructions are
+  // reachable through a switch_enum, without a use of the location in between.
+  // The gen-sets are initialized at all expansion-enabler instructions
+  // (currently only switch_enum instructions).
+  // The kill-sets are initialized with the used locations, because we would not
+  // move a destroy across a use.
+  bool expansionEnablerFound = false;
+  for (BlockState &state : dataFlow) {
+    state.entrySet.reset();
+    state.genSet.reset();
+    state.killSet.reset();
+    state.exitSet.reset();
+    for (SILInstruction &I : *state.block) {
+      if (isExpansionEnabler(&I)) {
+        expansionEnablerFound = true;
+        state.genSet.set();
+        state.killSet.reset();
+      }
+      usedLocs.reset();
+      getUsedLocationsOfInst(usedLocs, &I);
+      state.genSet.reset(usedLocs);
+      state.killSet |= usedLocs;
+    }
+  }
+  if (!expansionEnablerFound)
+    return;
+
+  // Solve the dataflow, which tells us if a destroy_addr is reachable from
+  // a expansion-enabler on _any_ path (therefore "Union" and not "Intersect")
+  // without hitting a use of that location.
+  dataFlow.solveForwardWithUnion();
+
+  Bits activeLocs(locations.getNumLocations());
+  for (BlockState &st : dataFlow) {
+    activeLocs = st.entrySet;
+    for (SILInstruction &I : *st.block) {
+      if (isExpansionEnabler(&I)) {
+        // Set all bits: an expansion-enabler enables expansion for all
+        // locations.
+        activeLocs.set();
+      }
+      if (auto *SI = dyn_cast<StoreInst>(&I)) {
+        if (SI->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
+          int locIdx = locations.getLocationIdx(SI->getDest());
+          if (locIdx >= 0 && activeLocs.test(locIdx)) {
+            // Expand the store.
+            SILBuilder builder(SI);
+            builder.createDestroyAddr(SI->getLoc(), SI->getDest());
+            SI->setOwnershipQualifier(StoreOwnershipQualifier::Init);
+            madeChanges = true;
+          }
+        }
+      }
+      // Clear the bits of used locations.
+      usedLocs.reset();
+      getUsedLocationsOfInst(usedLocs, &I);
+      activeLocs.reset(usedLocs);
+    }
+  }
+}
+
+// Initialize the dataflow for moving destroys up the control flow.
+void DestroyHoisting::initDataflow(MemoryDataflow &dataFlow) {
+  for (BlockState &st : dataFlow) {
+    st.entrySet.set();
+    st.genSet.reset();
+    st.killSet.reset();
+    if (isa<UnreachableInst>(st.block->getTerminator())) {
+      if (canIgnoreUnreachableBlock(st.block, dataFlow)) {
+        st.exitSet.set();
+      } else {
+        st.exitSet.reset();
+      }
+    } else if (st.block->getTerminator()->isFunctionExiting()) {
+      st.exitSet.reset();
+    } else {
+      st.exitSet.set();
+    }
+    initDataflowInBlock(st);
+  }
+}
+
+// Initialize the gen- and kill-sets.
+// It's a backward dataflow problem. A bit <n> in the genSet means: we have seen
+// a destroy_addr of location <n> (when walking backwards).
+// As we are not trying to split or combine destroy_addr instructions, a
+// destroy_addr just sets its "self" bit and not the location's subLocations
+// set (this is different compared to the detaflow in MemoryLifetimeVerifier).
+void DestroyHoisting::initDataflowInBlock(BlockState &state) {
+  Bits usedLocs(state.entrySet.size());
+
+  for (SILInstruction &I : llvm::reverse(*state.block)) {
+    usedLocs.reset();
+    getUsedLocationsOfInst(usedLocs, &I);
+    state.genSet.reset(usedLocs);
+    state.killSet |= usedLocs;
+
+    // For terminators clear the bits in the exit set instead in the genSet,
+    // because we cannot insert destroy_addrs after the terminator in the block.
+    if (isa<TermInst>(&I))
+      state.exitSet.reset(usedLocs);
+
+    int destroyedLoc = getDestroyedLoc(&I);
+    if (destroyedLoc >= 0) {
+      state.killSet.reset(destroyedLoc);
+      state.genSet.set(destroyedLoc);
+    }
+  }
+}
+
+// Handling blocks which eventually end up in an unreachable is surprisingly
+// complicated, because without special treatment it would block destroy-
+// hoisting in the main control flow. Example:
+//
+//   bb1:
+//     cond_br %error_condition, bb2, bb3
+//   bb2:
+//     // some unrelated error processing, which doesn't use any locations
+//     unreachable
+//   bb3:
+//     // continue with main control flow
+//     destroy_addr %some_location
+//
+// We have to initialize the exit-set of bb2 with zeroes. Otherwise we would
+// insert wrong destroys in case there are any location-uses in the unreachable-
+// block (or sub-graph).
+// But having a zero-set at the bb2-entry would block hoisting of the
+// destroy_addr from bb3 into bb1.
+// Therefore we special case the common scenario of a single block with
+// unreachable which does not touch any of our memory locations. We can just
+// ignore those blocks.
+bool DestroyHoisting::canIgnoreUnreachableBlock(SILBasicBlock *block,
+                                                MemoryDataflow &dataFlow) {
+  assert(isa<UnreachableInst>(block->getTerminator()));
+
+  // Is it a single unreachable-block (i.e. it has a single predecessor from
+  // which there is a path to the function exit)?
+  SILBasicBlock *singlePred = block->getSinglePredecessorBlock();
+  if (!singlePred)
+    return false;
+  if (!dataFlow.getState(singlePred)->exitReachable)
+    return false;
+
+  // Check if none of the locations are touched in the unreachable-block.
+  for (SILInstruction &I : *block) {
+    if (isa<EndBorrowInst>(&I))
+      return false;
+    for (Operand &op : I.getAllOperands()) {
+      if (locations.getLocation(op.get()))
+        return false;
+    }
+  }
+  return true;
+}
+
+void DestroyHoisting::getUsedLocationsOfAddr(Bits &bits, SILValue addr) {
+  if (auto *loc = locations.getLocation(addr)) {
+    // destroy_addr locations are "killed" by parent _and_ sublocations. In
+    // other words: a destroy_addr must not be moved across an instruction which
+    // uses the location itself, an aggregate containing the location, or a
+    // sub-field of the location.
+    bits |= loc->selfAndParents;
+    bits |= loc->subLocations;
+  }
+}
+
+// Set all bits of locations which instruction \p I is using. It's including
+// parent and sub-locations (see comment in getUsedLocationsOfAddr).
+void DestroyHoisting::getUsedLocationsOfInst(Bits &bits, SILInstruction *I) {
+  switch (I->getKind()) {
+    case SILInstructionKind::EndBorrowInst:
+      if (auto *LBI = dyn_cast<LoadBorrowInst>(
+                                        cast<EndBorrowInst>(I)->getOperand())) {
+        getUsedLocationsOfAddr(bits, LBI->getOperand());
+      }
+      break;
+    case SILInstructionKind::LoadInst:
+    case SILInstructionKind::StoreInst:
+    case SILInstructionKind::CopyAddrInst:
+    case SILInstructionKind::ApplyInst:
+    case SILInstructionKind::TryApplyInst:
+    case SILInstructionKind::YieldInst:
+      for (Operand &op : I->getAllOperands()) {
+        getUsedLocationsOfAddr(bits, op.get());
+      }
+      break;
+    case SILInstructionKind::DebugValueAddrInst:
+    case SILInstructionKind::DestroyAddrInst:
+      // destroy_addr and debug_value_addr are handled specially.
+      break;
+    default:
+      break;
+  }
+}
+
+static void processRemoveList(SmallVectorImpl<SILInstruction *> &toRemove) {
+  for (SILInstruction *I : toRemove) {
+    I->eraseFromParent();
+  }
+  toRemove.clear();
+}
+
+// Do the actual moving of destroy_addr instructions.
+void DestroyHoisting::moveDestroys(MemoryDataflow &dataFlow) {
+  // Don't eagerly delete destroy_addr instructions, instead put them into this
+  // list. When we are about to "move" a destroy_addr just over some sideeffect-
+  // free instructions, we'll keep it at the current location.
+  llvm::SmallVector<SILInstruction *, 8> toRemove;
+
+  Bits activeDestroys(locations.getNumLocations());
+
+  for (BlockState &state : dataFlow) {
+    SILBasicBlock *block = state.block;
+
+    // Is it an unreachable-block we can ignore?
+    if (isa<UnreachableInst>(block->getTerminator()) && state.exitSet.any())
+      continue;
+
+    // Do the inner-block processing.
+    activeDestroys = state.exitSet;
+    moveDestroysInBlock(block, activeDestroys, toRemove);
+    assert(activeDestroys == state.entrySet);
+
+    if (block->pred_empty()) {
+      // The function entry block: insert all destroys which are still active.
+      insertDestroys(activeDestroys, activeDestroys, toRemove,
+                     nullptr, block);
+    } else if (SILBasicBlock *pred = block->getSinglePredecessorBlock()) {
+      // Insert destroys which are active at the entry of this block, but not
+      // on another successor block of the predecessor.
+      Bits usedLocs = activeDestroys;
+      usedLocs.reset(dataFlow.getState(pred)->exitSet);
+      insertDestroys(usedLocs, activeDestroys,
+                     toRemove, nullptr, block);
+    }
+    // Note that this condition relies on not having critical edges in the CFG.
+    assert(std::all_of(block->getPredecessorBlocks().begin(),
+                       block->getPredecessorBlocks().end(),
+                       [&](SILBasicBlock *P) {
+                         return activeDestroys == dataFlow.getState(P)->exitSet;
+                       }));
+
+    // Delete all destroy_addr and debug_value_addr which are scheduled for
+    // removal.
+    processRemoveList(toRemove);
+  }
+}
+
+void DestroyHoisting::moveDestroysInBlock(
+                                SILBasicBlock *block, Bits &activeDestroys,
+                                SmallVectorImpl<SILInstruction *> &toRemove) {
+  Bits usedLocs(locations.getNumLocations());
+  assert(toRemove.empty());
+
+  for (SILInstruction &I : llvm::reverse(*block)) {
+    usedLocs.reset();
+    getUsedLocationsOfInst(usedLocs, &I);
+    usedLocs &= activeDestroys;
+    insertDestroys(usedLocs, activeDestroys, toRemove, &I, block);
+
+    int destroyedLoc = getDestroyedLoc(&I);
+    if (destroyedLoc >= 0) {
+      activeDestroys.set(destroyedLoc);
+      toRemove.push_back(&I);
+    } else if (auto *DVA = dyn_cast<DebugValueAddrInst>(&I)) {
+      // debug_value_addr does not count as real use of a location. If we are
+      // moving a destroy_addr above a debug_value_addr, just delete that
+      // debug_value_addr.
+      if (auto *dvaLoc = locations.getLocation(DVA->getOperand())) {
+        if (activeDestroys.anyCommon(dvaLoc->subLocations) ||
+            activeDestroys.anyCommon(dvaLoc->selfAndParents))
+          toRemove.push_back(DVA);
+      }
+    } else if (I.mayHaveSideEffects()) {
+      // Delete all destroy_addr and debug_value_addr which are scheduled for
+      // removal.
+      processRemoveList(toRemove);
+    }
+  }
+}
+
+// Insert destroy_addr which are in \p toInsert. Also update \p activeDestroys.
+// But exclude instruction from \p removeList (see below).
+// If \p afterInst is null, insert the destroys at the begin of \p inBlock.
+void DestroyHoisting::insertDestroys(Bits &toInsert, Bits &activeDestroys,
+                          SmallVectorImpl<SILInstruction *> &removeList,
+                          SILInstruction *afterInst, SILBasicBlock *inBlock) {
+  if (toInsert.none())
+    return;
+
+  // The removeList contains destroy_addr (and debug_value_addr) instructions
+  // which we want to delete, but we didn't see any side-effect instructions
+  // since then. There is no value in moving a destroy_addr over side-effect-
+  // free instructions (it could even trigger creating redundant address
+  // projections).
+  // Therefore we remove all such destroy_addr from removeList, i.e. we will
+  // keep them at their original locations and will not move them.
+  Bits keepDestroyedLocs(toInsert.size());
+  auto end = std::remove_if(removeList.begin(), removeList.end(),
+    [&](SILInstruction *I){
+      int destroyedLoc = getDestroyedLoc(I);
+      if (destroyedLoc >= 0 && toInsert.test(destroyedLoc)) {
+        keepDestroyedLocs.set(destroyedLoc);
+        toInsert.reset(destroyedLoc);
+        activeDestroys.reset(destroyedLoc);
+        return true;
+      }
+      if (auto *DVA = dyn_cast<DebugValueAddrInst>(I)) {
+        // Also keep debug_value_addr instructions, located before a
+        // destroy_addr which we won't move.
+        auto *dvaLoc = locations.getLocation(DVA->getOperand());
+        if (dvaLoc && dvaLoc->selfAndParents.anyCommon(keepDestroyedLocs))
+          return true;
+      }
+      return false;
+    });
+  removeList.erase(end, removeList.end());
+
+  if (toInsert.none())
+    return;
+
+  SILInstruction *insertionPoint =
+    (afterInst ? &*std::next(afterInst->getIterator()) : &*inBlock->begin());
+  SILBuilder builder(insertionPoint);
+  SILLocation loc = RegularLocation(insertionPoint->getLoc().getSourceLoc());
+
+  // Insert destroy_addr instructions for all bits in toInsert.
+  for (int locIdx = toInsert.find_first(); locIdx >= 0;
+       locIdx = toInsert.find_next(locIdx)) {
+    if (!combineWith(afterInst, locIdx)) {
+      SILValue addr = createAddress(locIdx, builder);
+      builder.createDestroyAddr(loc, addr);
+    }
+    activeDestroys.reset(locIdx);
+  }
+  madeChanges = true;
+}
+
+// Instead of inserting a destroy_addr, try to combine it with \p inst, in case
+// \p inst is a load [copy] or a non taking copy_addr.
+// We can just convert the load/copy_addr to a taking load/copy_addr.
+bool DestroyHoisting::combineWith(SILInstruction *inst, unsigned locIdx) {
+  if (!inst)
+    return false;
+  switch (inst->getKind()) {
+    case SILInstructionKind::LoadInst: {
+      auto *LI = cast<LoadInst>(inst);
+      int srcIdx = locations.getLocationIdx(LI->getOperand());
+      if (srcIdx == (int)locIdx) {
+        assert(LI->getOwnershipQualifier() == LoadOwnershipQualifier::Copy);
+        LI->setOwnershipQualifier(LoadOwnershipQualifier::Take);
+        return true;
+      }
+      break;
+    }
+    case SILInstructionKind::CopyAddrInst: {
+      auto *CAI = cast<CopyAddrInst>(inst);
+      int srcIdx = locations.getLocationIdx(CAI->getSrc());
+      if (srcIdx == (int)locIdx) {
+        assert(!CAI->isTakeOfSrc());
+        CAI->setIsTakeOfSrc(IsTake);
+        return true;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return false;
+}
+
+// Create an address projection for the sub-location \p locIdx, in case the
+// representativeValue is a begin_access or does not dominate the insertion
+// point of \p builder.
+SILValue DestroyHoisting::createAddress(unsigned locIdx, SILBuilder &builder) {
+  auto *loc = locations.getLocation(locIdx);
+  if (loc->parentIdx < 0)
+    return loc->representativeValue;
+
+  assert(!isa<BeginAccessInst>(loc->representativeValue) &&
+         "only a root location can be a begin_access");
+
+  SingleValueInstruction *&cachedProj = addressProjections[locIdx];
+  if (cachedProj)
+    return cachedProj;
+
+  if (!domTree)
+    domTree = DA->get(function);
+
+  auto *projInst = cast<SingleValueInstruction>(loc->representativeValue);
+  if (domTree->properlyDominates(projInst, &*builder.getInsertionPoint())) {
+    cachedProj = projInst;
+    return projInst;
+  }
+
+  // Recursively create (or get) the address of the parent location.
+  SILValue baseAddr = createAddress(loc->parentIdx, builder);
+
+  // Insert the new projection instruction right below the parent address.
+  // This ensures that it dominates the builder's insertion point.
+  SILBuilder projBuilder(baseAddr->getParentBlock()->begin());
+  if (auto *addrInst = dyn_cast<SingleValueInstruction>(baseAddr))
+    projBuilder.setInsertionPoint(std::next(addrInst->getIterator()));
+  SingleValueInstruction *newProj;
+
+  if (auto *SEA = dyn_cast<StructElementAddrInst>(projInst)) {
+    newProj = projBuilder.createStructElementAddr(SEA->getLoc(), baseAddr,
+                                             SEA->getField(), SEA->getType());
+  } else {
+    auto *TEA = dyn_cast<TupleElementAddrInst>(projInst);
+    newProj = projBuilder.createTupleElementAddr(TEA->getLoc(), baseAddr,
+                                            TEA->getFieldNo(), TEA->getType());
+  }
+  assert(domTree->properlyDominates(newProj, &*builder.getInsertionPoint()) &&
+         "new projection does not dominate insert point");
+  // We need to remember the new projection instruction because in tailMerging
+  // we might call locations.getLocationIdx() on such a new instruction.
+  locations.registerProjection(newProj, locIdx);
+  cachedProj = newProj;
+  return newProj;
+}
+
+// Perform a simple tail merging optimization: at control flow merges, move
+// identical destroy_addr instructions down to the successor block.
+// The hoisting optimization can create such situations, e.g.
+// \code
+//   bb1:
+//     // use of location %a
+//     br bb3
+//   bb2:
+//     br bb3
+//   bb3:
+//     destroy_addr %a  // will be hoisted (duplicated) into bb2 and bb2
+// \endcode
+// This is mainly a code size reduction optimization.
+void DestroyHoisting::tailMerging(MemoryDataflow &dataFlow) {
+
+  // TODO: we could do a worklist algorithm here instead of iterating through
+  // all the function blocks.
+  bool changed = false;
+  do {
+    changed = false;
+    for (SILBasicBlock &block : *function) {
+      changed |= tailMergingInBlock(&block, dataFlow);
+    }
+  } while (changed);
+}
+
+bool DestroyHoisting::tailMergingInBlock(SILBasicBlock *block,
+                                         MemoryDataflow &dataFlow) {
+  if (block->pred_empty() || block->getSinglePredecessorBlock())
+    return false;
+
+  BlockState *state = dataFlow.getState(block);
+
+  // Only if the entry set of the block has some bit sets, it's even possible
+  // that hoisting has moved destroy_addr up to the predecessor blocks.
+  if (state->entrySet.empty())
+    return false;
+
+  Bits canHoist = state->entrySet;
+  Bits destroysInPred(canHoist.size());
+  Bits killedLocs(canHoist.size());
+
+  // Collect all common destroy_addr of the predecessor blocks.
+  for (SILBasicBlock *pred : block->getPredecessorBlocks()) {
+    destroysInPred.reset();
+    killedLocs.reset();
+    for (SILInstruction &I : llvm::reverse(*pred)) {
+      int destroyedLoc = getDestroyedLoc(&I);
+      if (destroyedLoc >= 0 && !killedLocs.test(destroyedLoc))
+        destroysInPred.set(destroyedLoc);
+      getUsedLocationsOfInst(killedLocs, &I);
+      if (!canHoist.test(killedLocs))
+        break;
+    }
+    canHoist &= destroysInPred;
+  }
+  if (canHoist.none())
+    return false;
+
+  // Create the common destroy_addr at the block entry.
+  SILBuilder builder(&*block->begin());
+  SILLocation loc = RegularLocation(block->begin()->getLoc().getSourceLoc());
+  for (int locIdx = canHoist.find_first(); locIdx >= 0;
+       locIdx = canHoist.find_next(locIdx)) {
+    SILValue addr = createAddress(locIdx, builder);
+    builder.createDestroyAddr(loc, addr);
+  }
+
+  // Remove the common destroy_addr from the predecessor blocks.
+  for (SILBasicBlock *pred : block->getPredecessorBlocks()) {
+    destroysInPred = canHoist;
+    SILInstruction *I = pred->getTerminator();
+    while (destroysInPred.any()) {
+      assert(I && "not all destroys fround in predecessor block");
+      SILInstruction *nextI = (I == &pred->front() ?
+                                 nullptr : &*std::prev(I->getIterator()));
+      int destroyedLoc = getDestroyedLoc(I);
+      if (destroyedLoc >= 0 && destroysInPred.test(destroyedLoc)) {
+        destroysInPred.reset(destroyedLoc);
+        I->eraseFromParent();
+      }
+      I = nextI;
+    }
+  }
+  return true;
+}
+
+bool DestroyHoisting::hoistDestroys() {
+  locations.analyzeLocations(function);
+  if (locations.getNumLocations() > 0) {
+    MemoryDataflow dataFlow(function, locations.getNumLocations());
+    dataFlow.exitReachableAnalysis();
+
+    // Step 1: pre-processing: expand store instructions
+    expandStores(dataFlow);
+
+    // Step 2: hoist destroy_addr instructions.
+    // (reuse dataFlow to avoid re-allocating all the data structures)
+    initDataflow(dataFlow);
+    dataFlow.solveBackwardWithIntersect();
+    moveDestroys(dataFlow);
+
+    // Step 3: post-processing: tail merge inserted destroy_addr instructions.
+    tailMerging(dataFlow);
+    addressProjections.clear();
+  }
+
+  // Finally: handle alloc_stack locations within blocks (no need for store-
+  // expansion and tail-merging for such locations).
+  locations.handleSingleBlockLocations([this](SILBasicBlock *block) {
+    llvm::SmallVector<SILInstruction *, 8> toRemove;
+    Bits activeDestroys(locations.getNumLocations());
+    moveDestroysInBlock(block, activeDestroys, toRemove);
+    addressProjections.clear();
+    assert(activeDestroys.none());
+    assert(toRemove.empty());
+  });
+
+  return madeChanges;
+}
+
+//===----------------------------------------------------------------------===//
+//                          DestroyHoistingPass
+//===----------------------------------------------------------------------===//
+
+class DestroyHoistingPass : public SILFunctionTransform {
+public:
+  DestroyHoistingPass() {}
+
+  /// The entry point to the transformation.
+  void run() override {
+    SILFunction *F = getFunction();
+    if (!F->shouldOptimize())
+      return;
+
+    if (!F->hasOwnership())
+      return;
+
+    LLVM_DEBUG(llvm::dbgs() << "*** DestroyHoisting on function: "
+                            << F->getName() << " ***\n");
+
+    bool EdgeChanged = splitAllCriticalEdges(*F, nullptr, nullptr);
+
+    DominanceAnalysis *DA = PM->getAnalysis<DominanceAnalysis>();
+
+    DestroyHoisting CM(F, DA);
+    bool InstChanged = CM.hoistDestroys();
+
+    if (EdgeChanged) {
+      // We split critical edges.
+      invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+      return;
+    }
+    if (InstChanged) {
+      // We moved instructions.
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createDestroyHoisting() {
+  return new DestroyHoistingPass();
+}

--- a/test/SILOptimizer/destroy_hoisting.sil
+++ b/test/SILOptimizer/destroy_hoisting.sil
@@ -1,0 +1,192 @@
+// RUN: %target-sil-opt -destroy-hoisting %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class X {
+}
+
+enum TwoCases {
+  case A(X)
+  case B
+}
+
+struct S {
+  var x: X
+}
+
+struct Outer {
+  var s: S
+  var ox: X
+}
+
+sil @unknown : $@convention(thin) () -> ()
+sil @use_S : $@convention(thin) (@in_guaranteed S) -> ()
+
+// CHECK-LABEL: sil [ossa] @test_simple
+// CHECK:      bb0(%0 : $*S):
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil [ossa] @test_simple : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  br bb1
+bb1:
+  destroy_addr %0 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_move_over_pure_insts
+// CHECK:      bb0(%0 : $*S):
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   return
+sil [ossa] @dont_move_over_pure_insts : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  %r = tuple ()
+  destroy_addr %0 : $*S
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @combine_load
+// CHECK:      bb0(%0 : $*S):
+// CHECK-NEXT:   load [take] %0
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1:
+// CHECK-NEXT:   return
+sil [ossa] @combine_load : $@convention(thin) (@in S) -> @owned S {
+bb0(%0 : $*S):
+  %v = load [copy] %0 : $*S
+  br bb1
+bb1:
+  destroy_addr %0 : $*S
+  return %v : $S
+}
+
+// CHECK-LABEL: sil [ossa] @combine_copy_addr
+// CHECK:      bb0(%0 : $*S, %1 : $*S):
+// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil [ossa] @combine_copy_addr : $@convention(thin) (@in S) -> @out S {
+bb0(%0 : $*S, %1 : $*S):
+  copy_addr %1 to [initialization] %0 : $*S
+  br bb1
+bb1:
+  destroy_addr %1 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @tail_merging
+// CHECK:      bb1:
+// CHECK:        apply
+// CHECK-NEXT:   br bb3
+// CHECK:      bb2:
+// CHECK-NEXT:   br bb3
+// CHECK:      bb3:
+// CHECK-NEXT:   destroy_addr %0
+// CHECK-NEXT:   br bb4
+// CHECK:      bb4:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil [ossa] @tail_merging : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  cond_br undef, bb1, bb2
+bb1:
+  %f = function_ref @use_S : $@convention(thin) (@in_guaranteed S) -> ()
+  %a = apply %f(%0) : $@convention(thin) (@in_guaranteed S) -> ()
+  br bb3
+bb2:
+  br bb3
+bb3:
+  br bb4
+bb4:
+  destroy_addr %0 : $*S
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @store_splitting
+// CHECK:      destroy_addr %0
+// CHECK-NEXT: store %1 to [init] %0
+// CHECK:      return
+sil [ossa] @store_splitting : $@convention(thin) (@inout S, @owned S, @guaranteed TwoCases) -> () {
+bb0(%0 : $*S, %1 : @owned $S, %2 : @guaranteed $TwoCases):
+  switch_enum %2 : $TwoCases, case #TwoCases.A!enumelt: bb1, case #TwoCases.B!enumelt.1: bb2
+
+bb1(%4 : @guaranteed $X):
+  %5 = enum $TwoCases, #TwoCases.B!enumelt
+  store %1 to [assign] %0 : $*S
+  end_borrow %4 : $X
+  br bb3
+
+bb2:
+  destroy_value %1 : $S
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// Check several things: critical edge splitting, handling of sub-locations, complex control flow
+
+// CHECK-LABEL: sil [ossa] @test_complex
+// CHECK:      bb0(%0 : $*Outer, %1 : $*Outer):
+// CHECK:        [[OOX:%[0-9]+]] = struct_element_addr %0 : $*Outer, #Outer.ox
+// CHECK-NEXT:   destroy_addr [[OOX]]
+// CHECK:        [[OS:%[0-9]+]] = struct_element_addr %0 : $*Outer, #Outer.s
+// CHECK:        cond_br undef, bb2, bb1
+// CHECK:      bb1:
+// CHECK-NEXT:   br bb3
+// CHECK:      bb2:
+// CHECK-NEXT:   apply
+// CHECK-NEXT:   br bb3
+// CHECK:      bb3:
+// CHECK-NEXT:   destroy_addr [[OS]]
+// CHECK-NEXT:   br bb4
+// CHECK:      bb4:
+// CHECK:        apply
+// CHECK:        cond_br undef, bb5, bb6
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb4
+// CHECK:      bb6:
+// CHECK-NEXT:   destroy_addr %1
+// CHECK:      br bb7
+// CHECK:      bb7:
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+sil [ossa] @test_complex : $@convention(thin) (@in Outer, @in Outer) -> () {
+bb0(%0 : $*Outer, %1 : $*Outer):
+  %f = function_ref @use_S : $@convention(thin) (@in_guaranteed S) -> ()
+  %2 = struct_element_addr %0 : $*Outer, #Outer.s
+  cond_br undef, bb1, bb2
+bb1:
+  %a1 = apply %f(%2) : $@convention(thin) (@in_guaranteed S) -> ()
+  br bb2
+bb2:
+  br bb3
+bb3:
+  %4 = struct_element_addr %1 : $*Outer, #Outer.s
+  %a2 = apply %f(%4) : $@convention(thin) (@in_guaranteed S) -> ()
+  cond_br undef, bb3, bb4
+bb4:
+  destroy_addr %2 : $*S
+  %3 = struct_element_addr %0 : $*Outer, #Outer.ox
+  destroy_addr %3 : $*X
+  br bb5
+bb5:
+  destroy_addr %1 : $*Outer
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/enum_payload_modification_opt.swift
+++ b/test/SILOptimizer/enum_payload_modification_opt.swift
@@ -1,0 +1,115 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+
+final class Storage {
+  var v : Int
+  init(_ v : Int) {
+    self.v = v
+  }
+}
+
+struct IntBox {
+  var s : Storage
+
+  init(_ x : Int) {
+    s = Storage(x)
+  }
+
+  var value: Int { return s.v }
+
+  mutating func increment(_ delta: Int = 1) {
+    if (!isKnownUniquelyReferenced(&s)) {
+      // We should never see this message
+      print("## copy on write")
+      s = Storage(s.v)
+    }
+    s.v += delta
+  }
+}
+
+enum E: CustomStringConvertible {
+  case value(IntBox)
+  case none
+
+  @inline(never)
+  mutating func simpleIncrement() {
+    switch self {
+    case .value(var i):
+      i.increment()
+      self = .value(i)
+    case .none:
+      break
+    }
+  }
+
+  @inline(never)
+  mutating func incrementWithControlFlow(_ n: Int, _ c: Bool) {
+    switch self {
+    case .value(var i):
+      i.increment()
+      for _ in [0..<n] {
+        print("  loop iter")
+      }
+      if c {
+        i.increment(10)
+        self = .value(i)
+      } else {
+        i.increment(20)
+        self = .value(i)
+      }
+    case .none:
+      break
+    }
+  }
+
+  var description: String {
+    switch self {
+    case .value(let i):
+      return i.s.v.description
+    case .none:
+      return "none"
+    }
+  }
+}
+
+struct ContainingStruct {
+  var e: E = .value(IntBox(27))
+
+  @inline(never)
+  mutating func doSomething() {
+    switch self.e {
+    case .value(var i):
+      i.increment()
+      self.e = .value(i)
+    case .none:
+      break
+    }
+  }
+}
+
+// CHECK:      simpleIncrement start
+print("simpleIncrement start")
+var e1 = E.value(IntBox(27))
+e1.simpleIncrement()
+// CHECK-NEXT: simpleIncrement end: 28
+print("simpleIncrement end: \(e1)")
+
+
+// CHECK-NEXT: incrementWithControlFlow start
+print("incrementWithControlFlow start")
+var e2 = E.value(IntBox(27))
+// CHECK-NEXT:   loop iter
+e2.incrementWithControlFlow(1, true)
+// CHECK-NEXT: incrementWithControlFlow end: 38
+print("incrementWithControlFlow end: \(e2)")
+
+// CHECK-NEXT: ContainingStruct start
+print("ContainingStruct start")
+var s = ContainingStruct()
+s.doSomething()
+// CHECK-NEXT: ContainingStruct end: 28
+print("ContainingStruct end: \(s.e)")
+

--- a/test/SILOptimizer/prespecialize.swift
+++ b/test/SILOptimizer/prespecialize.swift
@@ -14,7 +14,7 @@
 // CHECK: function_ref @$ss16IndexingIteratorV4next7ElementQzSgyFSnySiG_Tg5
 //
 // Look for generic specialization <Swift.Int> of Swift.Array.subscript.getter : (Swift.Int) -> A
-// CHECK: function_ref @$sSn15uncheckedBoundsSnyxGx5lower_x5uppert_tcfCSi_Tg5
+// CHECK: function_ref @$sSayxSicigSi_Tg5
 // CHECK: return
 @inline(never)
 public func test(_ a: inout [Int], size: Int) {

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -102,14 +102,10 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   return %9999 : $()
 }
 
-// Currently not supported
 // CHECK-LABEL: sil @take_from_temp
 // CHECK:      bb0(%0 : $*B, %1 : $*GS<B>):
-// CHECK-NEXT:   alloc_stack
-// CHECK-NEXT:   copy_addr
 // CHECK-NEXT:   struct_element_addr
-// CHECK-NEXT:   copy_addr
-// CHECK-NEXT:   dealloc_stack
+// CHECK-NEXT:   copy_addr [take]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil @take_from_temp : $@convention(thin) <B> (@inout B, @inout GS<B>) -> () {
@@ -416,13 +412,17 @@ bb0(%0 : $*Klass):
   return %9 : $()
 }
 
-// Make sure that we do not optimize this case.
-//
 // CHECK-LABEL: sil @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
-// CHECK: destroy_addr
-// CHECK: destroy_addr
-// CHECK: destroy_addr
-// CHECK: } // end sil function 'non_overlapping_lifetime'
+// CHECK:      bb0([[ARG:%.*]] : $*Klass):
+// CHECK-NEXT:   [[TMP:%.*]] = alloc_stack $Klass
+// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[TMP]]
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK:        apply %{{[0-9]*}}([[TMP]])
+// CHECK-NEXT:   destroy_addr [[TMP]]
+// CHECK-NEXT:   dealloc_stack [[TMP]]
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK-NEXT: } // end sil function 'non_overlapping_lifetime'
 sil @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
   %1a = alloc_stack $Klass

--- a/test/stdlib/DispatchData.swift
+++ b/test/stdlib/DispatchData.swift
@@ -12,384 +12,375 @@ defer { runAllTests() }
 var DispatchAPI = TestSuite("DispatchAPI")
 
 DispatchAPI.test("dispatch_data_t enumeration") {
-	// Ensure we can iterate the empty iterator
-	for _ in DispatchData.empty {
-		_ = 1
-	}
+  // Ensure we can iterate the empty iterator
+  for _ in DispatchData.empty {
+    _ = 1
+  }
 }
 
 DispatchAPI.test("dispatch_data_t deallocator") {
-	let q = DispatchQueue(label: "dealloc queue")
-	var t = 0
+  let q = DispatchQueue(label: "dealloc queue")
+  var t = 0
 
-	do {
-		let size = 1024
-		let p = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
-		let _ = DispatchData(bytesNoCopy: UnsafeBufferPointer(start: p, count: size), deallocator: .custom(q, {
-			t = 1
-			p.deallocate();
-		}))
-	}
+  do {
+    let size = 1024
+    let p = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+    let _ = DispatchData(bytesNoCopy: UnsafeBufferPointer(start: p, count: size), deallocator: .custom(q, {
+      t = 1
+      p.deallocate();
+    }))
+  }
 
-	q.sync {
-		expectEqual(1, t)
-	}
+  q.sync {
+    expectEqual(1, t)
+  }
 }
 
 DispatchAPI.test("DispatchData.copyBytes") {
-	let source1: [UInt8] = [0, 1, 2, 3]
-	let srcPtr1 = UnsafeBufferPointer(start: source1, count: source1.count)
+  let source1: [UInt8] = [0, 1, 2, 3]
+  var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
 
-	var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
-	let destPtr = UnsafeMutableBufferPointer(start: UnsafeMutablePointer(&dest),
-			count: dest.count)
+  var dispatchData = source1.withUnsafeBytes { return DispatchData(bytes: $0) }
 
-	var dispatchData = DispatchData(bytes: srcPtr1)
+  dest.withContiguousMutableStorageIfAvailable { destPtr in
+    // Copy from offset 0
+    var count = dispatchData.copyBytes(to: destPtr, from: 0..<2)
+    expectEqual(count, 2)
+    expectEqual(destPtr[0], 0)
+    expectEqual(destPtr[1], 1)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 0
-	var count = dispatchData.copyBytes(to: destPtr, from: 0..<2)
-	expectEqual(count, 2)
-	expectEqual(destPtr[0], 0)
-	expectEqual(destPtr[1], 1)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 2
+    count = dispatchData.copyBytes(to: destPtr, from: 2..<4)
+    expectEqual(count, 2)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 3)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 2
-	count = dispatchData.copyBytes(to: destPtr, from: 2..<4)
-	expectEqual(count, 2)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 3)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Add two more regions
+    let source2: [UInt8] = [0x10, 0x11, 0x12, 0x13]
+    source2.withUnsafeBytes { dispatchData.append(DispatchData(bytes: $0)) }
 
-	// Add two more regions
-	let source2: [UInt8] = [0x10, 0x11, 0x12, 0x13]
-	let srcPtr2 = UnsafeBufferPointer(start: source2, count: source2.count)
-	dispatchData.append(DispatchData(bytes: srcPtr2))
+    let source3: [UInt8] = [0x14, 0x15, 0x16]
+    source3.withUnsafeBytes { dispatchData.append(DispatchData(bytes: $0)) }
 
-	let source3: [UInt8] = [0x14, 0x15, 0x16]
-	let srcPtr3 = UnsafeBufferPointer(start: source3, count: source3.count)
-	dispatchData.append(DispatchData(bytes: srcPtr3))
+    // Copy from offset 0. Copies across the first two regions
+    count = dispatchData.copyBytes(to: destPtr, from: 0..<6)
+    expectEqual(count, 6)
+    expectEqual(destPtr[0], 0)
+    expectEqual(destPtr[1], 1)
+    expectEqual(destPtr[2], 2)
+    expectEqual(destPtr[3], 3)
+    expectEqual(destPtr[4], 0x10)
+    expectEqual(destPtr[5], 0x11)
 
-	// Copy from offset 0. Copies across the first two regions
-	count = dispatchData.copyBytes(to: destPtr, from: 0..<6)
-	expectEqual(count, 6)
-	expectEqual(destPtr[0], 0)
-	expectEqual(destPtr[1], 1)
-	expectEqual(destPtr[2], 2)
-	expectEqual(destPtr[3], 3)
-	expectEqual(destPtr[4], 0x10)
-	expectEqual(destPtr[5], 0x11)
+    // Copy from offset 2. Copies across the first two regions
+    count = dispatchData.copyBytes(to: destPtr, from: 2..<8)
+    expectEqual(count, 6)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 3)
+    expectEqual(destPtr[2], 0x10)
+    expectEqual(destPtr[3], 0x11)
+    expectEqual(destPtr[4], 0x12)
+    expectEqual(destPtr[5], 0x13)
 
-	// Copy from offset 2. Copies across the first two regions
-	count = dispatchData.copyBytes(to: destPtr, from: 2..<8)
-	expectEqual(count, 6)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 3)
-	expectEqual(destPtr[2], 0x10)
-	expectEqual(destPtr[3], 0x11)
-	expectEqual(destPtr[4], 0x12)
-	expectEqual(destPtr[5], 0x13)
+    // Copy from offset 3. Copies across all three regions
+    count = dispatchData.copyBytes(to: destPtr, from: 3..<9)
+    expectEqual(count, 6)
+    expectEqual(destPtr[0], 3)
+    expectEqual(destPtr[1], 0x10)
+    expectEqual(destPtr[2], 0x11)
+    expectEqual(destPtr[3], 0x12)
+    expectEqual(destPtr[4], 0x13)
+    expectEqual(destPtr[5], 0x14)
 
-	// Copy from offset 3. Copies across all three regions
-	count = dispatchData.copyBytes(to: destPtr, from: 3..<9)
-	expectEqual(count, 6)
-	expectEqual(destPtr[0], 3)
-	expectEqual(destPtr[1], 0x10)
-	expectEqual(destPtr[2], 0x11)
-	expectEqual(destPtr[3], 0x12)
-	expectEqual(destPtr[4], 0x13)
-	expectEqual(destPtr[5], 0x14)
+    // Copy from offset 5. Skips the first region and the first byte of the second
+    count = dispatchData.copyBytes(to: destPtr, from: 5..<11)
+    expectEqual(count, 6)
+    expectEqual(destPtr[0], 0x11)
+    expectEqual(destPtr[1], 0x12)
+    expectEqual(destPtr[2], 0x13)
+    expectEqual(destPtr[3], 0x14)
+    expectEqual(destPtr[4], 0x15)
+    expectEqual(destPtr[5], 0x16)
 
-	// Copy from offset 5. Skips the first region and the first byte of the second
-	count = dispatchData.copyBytes(to: destPtr, from: 5..<11)
-	expectEqual(count, 6)
-	expectEqual(destPtr[0], 0x11)
-	expectEqual(destPtr[1], 0x12)
-	expectEqual(destPtr[2], 0x13)
-	expectEqual(destPtr[3], 0x14)
-	expectEqual(destPtr[4], 0x15)
-	expectEqual(destPtr[5], 0x16)
+    // Copy from offset 8. Skips the first two regions
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    count = dispatchData.copyBytes(to: destPtr, from: 8..<11)
+    expectEqual(count, 3)
+    expectEqual(destPtr[0], 0x14)
+    expectEqual(destPtr[1], 0x15)
+    expectEqual(destPtr[2], 0x16)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 8. Skips the first two regions
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	count = dispatchData.copyBytes(to: destPtr, from: 8..<11)
-	expectEqual(count, 3)
-	expectEqual(destPtr[0], 0x14)
-	expectEqual(destPtr[1], 0x15)
-	expectEqual(destPtr[2], 0x16)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 9. Skips the first two regions and the first byte of the third
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    count = dispatchData.copyBytes(to: destPtr, from: 9..<11)
+    expectEqual(count, 2)
+    expectEqual(destPtr[0], 0x15)
+    expectEqual(destPtr[1], 0x16)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 9. Skips the first two regions and the first byte of the third
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	count = dispatchData.copyBytes(to: destPtr, from: 9..<11)
-	expectEqual(count, 2)
-	expectEqual(destPtr[0], 0x15)
-	expectEqual(destPtr[1], 0x16)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 9, but only 1 byte. Ends before the end of the data
+    destPtr[1] = 0xFF
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    count = dispatchData.copyBytes(to: destPtr, from: 9..<10)
+    expectEqual(count, 1)
+    expectEqual(destPtr[0], 0x15)
+    expectEqual(destPtr[1], 0xFF)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 9, but only 1 byte. Ends before the end of the data
-	destPtr[1] = 0xFF
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	count = dispatchData.copyBytes(to: destPtr, from: 9..<10)
-	expectEqual(count, 1)
-	expectEqual(destPtr[0], 0x15)
-	expectEqual(destPtr[1], 0xFF)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
-
-	// Copy from offset 2, but only 1 byte. This copy is bounded within the 
-	// first region.
-	destPtr[1] = 0xFF
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	count = dispatchData.copyBytes(to: destPtr, from: 2..<3)
-	expectEqual(count, 1)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 0xFF)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 2, but only 1 byte. This copy is bounded within the 
+    // first region.
+    destPtr[1] = 0xFF
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    count = dispatchData.copyBytes(to: destPtr, from: 2..<3)
+    expectEqual(count, 1)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 0xFF)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
+  }
 }
 
 DispatchAPI.test("DispatchData.copyBytesUnsafeRawBufferPointer") {
-	let source1: [UInt8] = [0, 1, 2, 3]
-	let srcPtr1 = UnsafeRawBufferPointer(start: source1, count: source1.count)
+  let source1: [UInt8] = [0, 1, 2, 3]
 
-	var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
-	let destPtr = UnsafeMutableRawBufferPointer(start: UnsafeMutablePointer(&dest),
-			count: dest.count)
-	var dispatchData = DispatchData(bytes: srcPtr1)
+  var dest: [UInt8] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+  var dispatchData = source1.withUnsafeBytes { return DispatchData(bytes: $0) }
 
-	// Copy from offset 0
-	dispatchData.copyBytes(to: destPtr, from: 0..<2)
-	expectEqual(destPtr[0], 0)
-	expectEqual(destPtr[1], 1)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+  dest.withContiguousMutableStorageIfAvailable { destPtr in
+    // Copy from offset 0
+    dispatchData.copyBytes(to: destPtr, from: 0..<2)
+    expectEqual(destPtr[0], 0)
+    expectEqual(destPtr[1], 1)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 2
-	dispatchData.copyBytes(to: destPtr, from: 2..<4)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 3)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 2
+    dispatchData.copyBytes(to: destPtr, from: 2..<4)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 3)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Add two more regions
-	let source2: [UInt8] = [0x10, 0x11, 0x12, 0x13]
-	let srcPtr2 = UnsafeRawBufferPointer(start: source2, count: source2.count)
-	dispatchData.append(DispatchData(bytes: srcPtr2))
+    // Add two more regions
+    let source2: [UInt8] = [0x10, 0x11, 0x12, 0x13]
+    source2.withUnsafeBytes { dispatchData.append(DispatchData(bytes: $0)) }
 
-	let source3: [UInt8] = [0x14, 0x15, 0x16]
-	let srcPtr3 = UnsafeRawBufferPointer(start: source3, count: source3.count)
-	dispatchData.append(DispatchData(bytes: srcPtr3))
+    let source3: [UInt8] = [0x14, 0x15, 0x16]
+    source3.withUnsafeBytes { dispatchData.append(DispatchData(bytes: $0)) }
 
-	// Copy from offset 0. Copies across the first two regions
-	dispatchData.copyBytes(to: destPtr, from: 0..<6)
-	expectEqual(destPtr[0], 0)
-	expectEqual(destPtr[1], 1)
-	expectEqual(destPtr[2], 2)
-	expectEqual(destPtr[3], 3)
-	expectEqual(destPtr[4], 0x10)
-	expectEqual(destPtr[5], 0x11)
+    // Copy from offset 0. Copies across the first two regions
+    dispatchData.copyBytes(to: destPtr, from: 0..<6)
+    expectEqual(destPtr[0], 0)
+    expectEqual(destPtr[1], 1)
+    expectEqual(destPtr[2], 2)
+    expectEqual(destPtr[3], 3)
+    expectEqual(destPtr[4], 0x10)
+    expectEqual(destPtr[5], 0x11)
 
-	// Copy from offset 2. Copies across the first two regions
-	dispatchData.copyBytes(to: destPtr, from: 2..<8)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 3)
-	expectEqual(destPtr[2], 0x10)
-	expectEqual(destPtr[3], 0x11)
-	expectEqual(destPtr[4], 0x12)
-	expectEqual(destPtr[5], 0x13)
+    // Copy from offset 2. Copies across the first two regions
+    dispatchData.copyBytes(to: destPtr, from: 2..<8)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 3)
+    expectEqual(destPtr[2], 0x10)
+    expectEqual(destPtr[3], 0x11)
+    expectEqual(destPtr[4], 0x12)
+    expectEqual(destPtr[5], 0x13)
 
-	// Copy from offset 3. Copies across all three regions
-	dispatchData.copyBytes(to: destPtr, from: 3..<9)
-	expectEqual(destPtr[0], 3)
-	expectEqual(destPtr[1], 0x10)
-	expectEqual(destPtr[2], 0x11)
-	expectEqual(destPtr[3], 0x12)
-	expectEqual(destPtr[4], 0x13)
-	expectEqual(destPtr[5], 0x14)
+    // Copy from offset 3. Copies across all three regions
+    dispatchData.copyBytes(to: destPtr, from: 3..<9)
+    expectEqual(destPtr[0], 3)
+    expectEqual(destPtr[1], 0x10)
+    expectEqual(destPtr[2], 0x11)
+    expectEqual(destPtr[3], 0x12)
+    expectEqual(destPtr[4], 0x13)
+    expectEqual(destPtr[5], 0x14)
 
-	// Copy from offset 5. Skips the first region and the first byte of the second
-	dispatchData.copyBytes(to: destPtr, from: 5..<11)
-	expectEqual(destPtr[0], 0x11)
-	expectEqual(destPtr[1], 0x12)
-	expectEqual(destPtr[2], 0x13)
-	expectEqual(destPtr[3], 0x14)
-	expectEqual(destPtr[4], 0x15)
-	expectEqual(destPtr[5], 0x16)
+    // Copy from offset 5. Skips the first region and the first byte of the second
+    dispatchData.copyBytes(to: destPtr, from: 5..<11)
+    expectEqual(destPtr[0], 0x11)
+    expectEqual(destPtr[1], 0x12)
+    expectEqual(destPtr[2], 0x13)
+    expectEqual(destPtr[3], 0x14)
+    expectEqual(destPtr[4], 0x15)
+    expectEqual(destPtr[5], 0x16)
 
-	// Copy from offset 8. Skips the first two regions
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	dispatchData.copyBytes(to: destPtr, from: 8..<11)
-	expectEqual(destPtr[0], 0x14)
-	expectEqual(destPtr[1], 0x15)
-	expectEqual(destPtr[2], 0x16)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 8. Skips the first two regions
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    dispatchData.copyBytes(to: destPtr, from: 8..<11)
+    expectEqual(destPtr[0], 0x14)
+    expectEqual(destPtr[1], 0x15)
+    expectEqual(destPtr[2], 0x16)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 9. Skips the first two regions and the first byte of the third
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	dispatchData.copyBytes(to: destPtr, from: 9..<11)
-	expectEqual(destPtr[0], 0x15)
-	expectEqual(destPtr[1], 0x16)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 9. Skips the first two regions and the first byte of the third
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    dispatchData.copyBytes(to: destPtr, from: 9..<11)
+    expectEqual(destPtr[0], 0x15)
+    expectEqual(destPtr[1], 0x16)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 9, but only 1 byte. Ends before the end of the data
-	destPtr[1] = 0xFF
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	dispatchData.copyBytes(to: destPtr, from: 9..<10)
-	expectEqual(destPtr[0], 0x15)
-	expectEqual(destPtr[1], 0xFF)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 9, but only 1 byte. Ends before the end of the data
+    destPtr[1] = 0xFF
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    dispatchData.copyBytes(to: destPtr, from: 9..<10)
+    expectEqual(destPtr[0], 0x15)
+    expectEqual(destPtr[1], 0xFF)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
 
-	// Copy from offset 2, but only 1 byte. This copy is bounded within the 
-	// first region.
-	destPtr[1] = 0xFF
-	destPtr[2] = 0xFF
-	destPtr[3] = 0xFF
-	destPtr[4] = 0xFF
-	destPtr[5] = 0xFF
-	dispatchData.copyBytes(to: destPtr, from: 2..<3)
-	expectEqual(destPtr[0], 2)
-	expectEqual(destPtr[1], 0xFF)
-	expectEqual(destPtr[2], 0xFF)
-	expectEqual(destPtr[3], 0xFF)
-	expectEqual(destPtr[4], 0xFF)
-	expectEqual(destPtr[5], 0xFF)
+    // Copy from offset 2, but only 1 byte. This copy is bounded within the 
+    // first region.
+    destPtr[1] = 0xFF
+    destPtr[2] = 0xFF
+    destPtr[3] = 0xFF
+    destPtr[4] = 0xFF
+    destPtr[5] = 0xFF
+    dispatchData.copyBytes(to: destPtr, from: 2..<3)
+    expectEqual(destPtr[0], 2)
+    expectEqual(destPtr[1], 0xFF)
+    expectEqual(destPtr[2], 0xFF)
+    expectEqual(destPtr[3], 0xFF)
+    expectEqual(destPtr[4], 0xFF)
+    expectEqual(destPtr[5], 0xFF)
+  }
 }
 
 DispatchAPI.test("DispatchData.buffers") {
-	let bytes = [UInt8(0), UInt8(1), UInt8(2), UInt8(2)]
-	var ptr = UnsafeBufferPointer<UInt8>(start: bytes, count: bytes.count)
-	var data = DispatchData(bytes: ptr)
-	expectEqual(bytes.count, data.count)
-	for i in 0..<data.count {
-		expectEqual(data[i], bytes[i])
-	}
+  let bytes = [UInt8(0), UInt8(1), UInt8(2), UInt8(2)]
+  var ptr = UnsafeBufferPointer<UInt8>(start: bytes, count: bytes.count)
+  var data = DispatchData(bytes: ptr)
+  expectEqual(bytes.count, data.count)
+  for i in 0..<data.count {
+    expectEqual(data[i], bytes[i])
+  }
 
-	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
-	expectEqual(bytes.count, data.count)
-	for i in 0..<data.count {
-		expectEqual(data[i], bytes[i])
-	}
+  data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+  expectEqual(bytes.count, data.count)
+  for i in 0..<data.count {
+    expectEqual(data[i], bytes[i])
+  }
 
-	ptr = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
-	data = DispatchData(bytes: ptr)
-	expectEqual(data.count, 0)
+  ptr = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+  data = DispatchData(bytes: ptr)
+  expectEqual(data.count, 0)
 
-	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
-	expectEqual(data.count, 0)
+  data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+  expectEqual(data.count, 0)
 }
 
 DispatchAPI.test("DispatchData.bufferUnsafeRawBufferPointer") {
-	let bytes = [UInt8(0), UInt8(1), UInt8(2), UInt8(2)]
-	var ptr = UnsafeRawBufferPointer(start: bytes, count: bytes.count)
-	var data = DispatchData(bytes: ptr)
-	expectEqual(bytes.count, data.count)
-	for i in 0..<data.count {
-		expectEqual(data[i], bytes[i])
-	}
+  let bytes = [UInt8(0), UInt8(1), UInt8(2), UInt8(2)]
+  var ptr = UnsafeRawBufferPointer(start: bytes, count: bytes.count)
+  var data = DispatchData(bytes: ptr)
+  expectEqual(bytes.count, data.count)
+  for i in 0..<data.count {
+    expectEqual(data[i], bytes[i])
+  }
 
-	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
-	expectEqual(bytes.count, data.count)
-	for i in 0..<data.count {
-		expectEqual(data[i], bytes[i])
-	}
+  data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+  expectEqual(bytes.count, data.count)
+  for i in 0..<data.count {
+    expectEqual(data[i], bytes[i])
+  }
 
-	ptr = UnsafeRawBufferPointer(start: nil, count: 0)
-	data = DispatchData(bytes: ptr)
-	expectEqual(data.count, 0)
+  ptr = UnsafeRawBufferPointer(start: nil, count: 0)
+  data = DispatchData(bytes: ptr)
+  expectEqual(data.count, 0)
 
-	data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
-	expectEqual(data.count, 0)
+  data = DispatchData(bytesNoCopy: ptr, deallocator: .custom(nil, {}))
+  expectEqual(data.count, 0)
 }
 
 DispatchAPI.test("DispatchData.enumerateBytes") {
-	let count = 240
-	var bytes = [UInt8]()
-	for i in 0..<count {
-		bytes.append(UInt8(i))
-	}
-	let ptr = UnsafeRawBufferPointer(start: bytes, count: bytes.count)
-	let data = DispatchData(bytes: ptr)
+  let count = 240
+  var bytes = [UInt8]()
+  for i in 0..<count {
+    bytes.append(UInt8(i))
+  }
+  let data = bytes.withUnsafeBytes { return DispatchData(bytes: $0) }
 
-	var nextIndex = 0
+  var nextIndex = 0
 #if swift(>=4.2)
-	data.enumerateBytes({ ptr, offset, stop in
-		for i in 0..<ptr.count {
-			expectEqual(ptr[i + offset], UInt8(i + offset))
-		}
-		nextIndex = offset + ptr.count
-	})
+  data.enumerateBytes({ ptr, offset, stop in
+    for i in 0..<ptr.count {
+      expectEqual(ptr[i + offset], UInt8(i + offset))
+    }
+    nextIndex = offset + ptr.count
+  })
 #else
-	data.enumerateBytes(block: { ptr, offset, stop in
-		for i in 0..<ptr.count {
-			expectEqual(ptr[i + offset], UInt8(i + offset))
-		}
-		nextIndex = offset + ptr.count
-	})
+  data.enumerateBytes(block: { ptr, offset, stop in
+    for i in 0..<ptr.count {
+      expectEqual(ptr[i + offset], UInt8(i + offset))
+    }
+    nextIndex = offset + ptr.count
+  })
 #endif
-	expectEqual(nextIndex, data.count)
+  expectEqual(nextIndex, data.count)
 }
 
 DispatchAPI.test("DispatchData.enumerateBytesTrailingClosure") {
-	let count = 240
-	var bytes = [UInt8]()
-	for i in 0..<count {
-		bytes.append(UInt8(i))
-	}
-	let ptr = UnsafeRawBufferPointer(start: bytes, count: bytes.count)
-	let data = DispatchData(bytes: ptr)
+  let count = 240
+  var bytes = [UInt8]()
+  for i in 0..<count {
+    bytes.append(UInt8(i))
+  }
+  let data = bytes.withUnsafeBytes { return DispatchData(bytes: $0) }
 
-	var nextIndex = 0
-	data.enumerateBytes() { ptr, offset, stop in
-		for i in 0..<ptr.count {
-			expectEqual(ptr[i + offset], UInt8(i + offset))
-		}
-		nextIndex = offset + ptr.count
-	}
-	expectEqual(nextIndex, data.count)
+  var nextIndex = 0
+  data.enumerateBytes() { ptr, offset, stop in
+    for i in 0..<ptr.count {
+      expectEqual(ptr[i + offset], UInt8(i + offset))
+    }
+    nextIndex = offset + ptr.count
+  }
+  expectEqual(nextIndex, data.count)
 }


### PR DESCRIPTION
DestroyHoisting moves destroys of memory locations up the control flow as far as possible.
Beside destroy_addr, also "store [assign]" is considered a destroy, because is is equivalent to an destroy_addr + a "store [init]".
The main purpose of this optimization is to minimize copy-on-write operations for arrays, etc. Especially if such COW containers  are used as enum payloads and modified in-place. E.g.

```
switch e {
  case .A(var arr):
    arr.append(x)
    self = .A(arr)
...
```

In such a case DestroyHoisting can move the destroy of the self-assignment up before the switch and thus let the array buffer only be single-referenced at the time of the append.

When we have ownership SIL throughout the pass pipeline this optimization will replace the current destroy hoisting optimization in CopyForwarding.
For now, this optimization only runs in the mandatory pipeline (but not for -Onone) where we already have ownership SIL.

https://bugs.swift.org/browse/SR-10605
rdar://problem/50463362