### PR TITLE
[memaccess] Change AccessedStorage::hasIdenticalBase() to use accesso…

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -232,11 +232,11 @@ public:
     case Yield:
     case Nested:
     case Unidentified:
-      return value == other.value;
+      return getValue() == other.getValue();
     case Global:
-      return global == other.global;
+      return getGlobal() == other.getGlobal();
     case Class:
-      return value == other.value
+      return getObject() == other.getObject()
              && getElementIndex() == other.getElementIndex();
     }
     llvm_unreachable("covered switch");


### PR DESCRIPTION
…rs to access state instead of accessing state directly.

Currently this is the only place in the code base where AccessedStorage's
underlying value is not accessed via an accessor (an invariant of
AccessedStorage). Despite breaking that invariant, the code today is technically
correct, but with some changes that @jckarter is working on will break this code
since we want to look through the begin_borrow on a class in the accessor
instead of in the AccessedStorage's constructor. So accessing the value directly
in that case will return the begin_borrow instead of the operand of the
begin_borrow like the accessor would.
