### PR TITLE
AST: Fix memory corruption in TypeAliasType::get()

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2249,7 +2249,7 @@ TypeAliasType *TypeAliasType::get(TypeAliasDecl *typealias, Type parent,
     return result;
 
   // Build a new type.
-  auto *genericSig = typealias->getGenericSignature();
+  auto *genericSig = substitutions.getGenericSignature();
   auto size = totalSizeToAlloc<Type, SubstitutionMap>(parent ? 1 : 0,
                                                       genericSig ? 1 : 0);
   auto mem = ctx.Allocate(size, alignof(TypeAliasType), arena);


### PR DESCRIPTION
The type alias might not have a generic signature set yet, so we have to
use the generic signature in the substitution map.

Yay for un-request-ified decl checking!

Caught by ASAN - <rdar://problem/54637931>.
