### PR TITLE
[WIP] SemanticARCOpts: Don't copy let properties of classes.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -298,6 +298,8 @@ public:
     llvm_unreachable("unhandled kind");
   }
 
+  bool isLetAccess(SILFunction *F) const;
+  
   bool isUniquelyIdentified() const {
     switch (getKind()) {
     case Box:

--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -462,15 +462,15 @@ AccessedStorage swift::findAccessedStorageNonNested(SILValue sourceAddr) {
 }
 
 // Return true if the given access is on a 'let' lvalue.
-static bool isLetAccess(const AccessedStorage &storage, SILFunction *F) {
-  if (auto *decl = dyn_cast_or_null<VarDecl>(storage.getDecl()))
+bool AccessedStorage::isLetAccess(SILFunction *F) const {
+  if (auto *decl = dyn_cast_or_null<VarDecl>(getDecl()))
     return decl->isLet();
 
   // It's unclear whether a global will ever be missing it's varDecl, but
   // technically we only preserve it for debug info. So if we don't have a decl,
   // check the flag on SILGlobalVariable, which is guaranteed valid, 
-  if (storage.getKind() == AccessedStorage::Global)
-    return storage.getGlobal()->isLet();
+  if (getKind() == AccessedStorage::Global)
+    return getGlobal()->isLet();
 
   return false;
 }
@@ -560,7 +560,7 @@ bool swift::isPossibleFormalAccessBase(const AccessedStorage &storage,
   // Additional checks that apply to anything that may fall through.
 
   // Immutable values are only accessed for initialization.
-  if (isLetAccess(storage, F))
+  if (storage.isLetAccess(F))
     return false;
 
   return true;

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -38,6 +38,19 @@ case none
 case some(T)
 }
 
+class ClassLet {
+  @_hasStorage let aLet: Klass
+  @_hasStorage var aVar: Klass
+  @_hasStorage let aLetTuple: (Klass, Klass)
+
+  @_hasStorage let anotherLet: ClassLet
+}
+
+class SubclassLet: ClassLet {}
+
+sil_global [let] @a_let_global : $Klass
+sil_global @a_var_global : $Klass
+
 ///////////
 // Tests //
 ///////////
@@ -394,4 +407,275 @@ bb0(%0 : @guaranteed $(Klass, MyInt)):
   %4 = struct_extract %3 : $MyInt, #MyInt.value
   destroy_value %2 : $Klass
   return %4 : $Builtin.Int32
+}
+
+sil [ossa] @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_guaranteed_base
+// CHECK:         ref_element_addr
+// CHECK-NEXT:    load_borrow
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    return
+sil [ossa] @dont_copy_let_properties_with_guaranteed_base : $@convention(thin) (@guaranteed ClassLet) -> () {
+bb0(%x : @guaranteed $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %p = ref_element_addr %x : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_guaranteed_upcast_base
+// CHECK:         ref_element_addr
+// CHECK-NEXT:    load_borrow
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    return
+sil [ossa] @dont_copy_let_properties_with_guaranteed_upcast_base : $@convention(thin) (@guaranteed SubclassLet) -> () {
+bb0(%x : @guaranteed $SubclassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %u = upcast %x : $SubclassLet to $ClassLet
+  %p = ref_element_addr %u : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_global
+// CHECK:         global_addr
+// CHECK-NEXT:    load_borrow
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    return
+sil [ossa] @dont_copy_let_global : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %p = global_addr @a_let_global : $*Klass
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_guaranteed_base_structural
+// CHECK:         ref_element_addr
+// CHECK-NEXT:    tuple_element_addr
+// CHECK-NEXT:    load_borrow
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    return
+sil [ossa] @dont_copy_let_properties_with_guaranteed_base_structural : $@convention(thin) (@guaranteed ClassLet) -> () {
+bb0(%x : @guaranteed $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %p = ref_element_addr %x : $ClassLet, #ClassLet.aLetTuple
+  %q = tuple_element_addr %p : $*(Klass, Klass), 1
+  %v = load [copy] %q : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_copy_var_properties_with_guaranteed_base
+// CHECK:         ref_element_addr
+// CHECK-NEXT:    load [copy]
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    destroy
+// CHECK-NEXT:    return
+sil [ossa] @do_copy_var_properties_with_guaranteed_base : $@convention(thin) (@guaranteed ClassLet) -> () {
+bb0(%x : @guaranteed $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %p = ref_element_addr %x : $ClassLet, #ClassLet.aVar
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_copy_var_global
+// CHECK:         global_addr
+// CHECK-NEXT:    load [copy]
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    destroy
+// CHECK-NEXT:    return
+sil [ossa] @do_copy_var_global : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %p = global_addr @a_var_global : $*Klass
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates
+// CHECK:         [[OUTER:%.*]] = begin_borrow
+// CHECK-NEXT:    ref_element_addr
+// CHECK-NEXT:    [[INNER:%.*]] = load_borrow
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow [[INNER]]
+// CHECK-NEXT:    end_borrow [[OUTER]]
+// CHECK-NEXT:    destroy_value
+sil [ossa] @dont_copy_let_properties_with_borrowed_base_that_dominates : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%x : @owned $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %a = begin_borrow %x : $ClassLet
+  %p = ref_element_addr %a : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  end_borrow %a : $ClassLet
+  destroy_value %x : $ClassLet
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_multi_borrowed_base_that_dominates
+// TODO:         [[OUTER:%.*]] = begin_borrow
+// TODO-NEXT:    ref_element_addr
+// TODO-NEXT:    [[INNER:%.*]] = load_borrow
+// TODO-NEXT:    apply
+// TODO-NEXT:    end_borrow [[INNER]]
+// TODO-NEXT:    end_borrow [[OUTER]]
+// TODO-NEXT:    [[OUTER:%.*]] = begin_borrow
+// TODO-NEXT:    ref_element_addr
+// TODO-NEXT:    [[INNER:%.*]] = load_borrow
+// TODO-NEXT:    apply
+// TODO-NEXT:    end_borrow [[INNER]]
+// TODO-NEXT:    end_borrow [[OUTER]]
+// TODO-NEXT:    destroy_value
+sil [ossa] @dont_copy_let_properties_with_multi_borrowed_base_that_dominates : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%x : @owned $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %a = begin_borrow %x : $ClassLet
+  %p = ref_element_addr %a : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %c = begin_borrow %v : $Klass
+  apply %f(%c) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %c : $Klass
+  destroy_value %v : $Klass
+  end_borrow %a : $ClassLet
+
+  %b = begin_borrow %x : $ClassLet
+  %q = ref_element_addr %b : $ClassLet, #ClassLet.aLet
+  %w = load [copy] %q : $*Klass
+  %d = begin_borrow %w : $Klass
+  apply %f(%d) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %d : $Klass
+  destroy_value %w : $Klass
+  end_borrow %b : $ClassLet
+
+  destroy_value %x : $ClassLet
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_copy_let_properties_with_borrowed_base_that_does_not_dominate
+// CHECK:         begin_borrow
+// CHECK-NEXT:    ref_element_addr
+// CHECK-NEXT:    load [copy]
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    destroy_value
+sil [ossa] @do_copy_let_properties_with_borrowed_base_that_does_not_dominate : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%x : @owned $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %a = begin_borrow %x : $ClassLet
+  %p = ref_element_addr %a : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %b = begin_borrow %v : $Klass
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  // End the lifetime of the base object first...
+  end_borrow %a : $ClassLet
+  destroy_value %x : $ClassLet
+
+  // ...then end the lifetime of the copy.
+  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  end_borrow %b : $Klass
+  destroy_value %v : $Klass
+
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [ossa] @do_or_dont_copy_let_properties_with_multi_borrowed_base_when_it_dominates
+// CHECK:         [[OUTER:%.*]] = begin_borrow
+// TODO-NEXT:    ref_element_addr
+// TODO-NEXT:    [[INNER:%.*]] = load_borrow
+// TODO-NEXT:    apply
+// TODO-NEXT:    end_borrow [[INNER]]
+// TODO-NEXT:    end_borrow [[OUTER]]
+// TODO-NEXT:    begin_borrow
+// TODO-NEXT:    ref_element_addr
+// TODO-NEXT:    load [copy]
+// TODO-NEXT:    apply
+// TODO-NEXT:    end_borrow
+// TODO-NEXT:    destroy_value
+// TODO-NEXT:    apply
+// TODO-NEXT:    destroy_value
+sil [ossa] @do_or_dont_copy_let_properties_with_multi_borrowed_base_when_it_dominates : $@convention(thin) (@owned ClassLet) -> () {
+bb0(%x : @owned $ClassLet):
+  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
+
+  %a = begin_borrow %x : $ClassLet
+  %p = ref_element_addr %a : $ClassLet, #ClassLet.aLet
+  %v = load [copy] %p : $*Klass
+  %c = begin_borrow %v : $Klass
+  apply %f(%c) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %c : $Klass
+  destroy_value %v : $Klass
+  end_borrow %a : $ClassLet
+
+  %b = begin_borrow %x : $ClassLet
+  %q = ref_element_addr %b : $ClassLet, #ClassLet.aLet
+  %w = load [copy] %q : $*Klass
+  %d = begin_borrow %w : $Klass
+  apply %f(%d) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  // End the lifetime of the base object first...
+  end_borrow %b : $ClassLet
+  destroy_value %x : $ClassLet
+
+  // ...then end the lifetime of the copy.
+  apply %f(%d) : $@convention(thin) (@guaranteed Klass) -> ()
+
+  end_borrow %d : $Klass
+  destroy_value %w : $Klass
+
+  return undef : $()
 }


### PR DESCRIPTION
If the lifetime of a value copied out of a let property in a class is dominated by the lifetime
of the base object it was copied from, then we don't need to copy at all, since the value of the
`let` is guaranteed as long as the base object is. rdar://problem/54531607