### PR TITLE
[oslog][stdlib-private] Refactor and generalize interpolation of Int type in the new os_log APIs so as to extend to other integer types.

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_target_library(swiftOSLogPrototype
 
   OSLog.swift
   OSLogMessage.swift
+  OSLogIntegerTypes.swift
 
   SWIFT_MODULE_DEPENDS_IOS Darwin os
   SWIFT_MODULE_DEPENDS_OSX Darwin os

--- a/stdlib/private/OSLog/OSLogIntegerTypes.swift
+++ b/stdlib/private/OSLog/OSLogIntegerTypes.swift
@@ -1,0 +1,173 @@
+//===----------------- OSLogIntegerTypes.swift ----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file defines extensions for interpolating integer expressions into a
+// OSLogMesage. It defines `appendInterpolation` functions for standard integer
+// types. It also defines extensions for serializing integer types into the
+// argument buffer passed to os_log ABIs.
+//
+// The `appendInterpolation` functions defined in this file accept formatting
+// and privacy options along with the interpolated expression as shown below:
+//
+//         "\(x, format: .hex, privacy: .private\)"
+
+extension OSLogInterpolation {
+
+  /// Define interpolation for expressions of type Int.
+  /// - Parameters:
+  ///  - number: the interpolated expression of type Int, which is autoclosured.
+  ///  - format: a formatting option available for integer types, defined by the
+  ///    enum `IntFormat`.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///    The default is public.
+  @_transparent
+  @_optimize(none)
+  public mutating func appendInterpolation(
+    _ number: @autoclosure @escaping () -> Int,
+    format: IntFormat = .decimal,
+    privacy: Privacy = .public
+  ) {
+    appendInteger(number, format: format, privacy: privacy)
+  }
+
+  /// Define interpolation for expressions of type Int32.
+  /// - Parameters:
+  ///  - number: the interpolated expression of type Int32, which is autoclosured.
+  ///  - format: a formatting option available for integer types, defined by the
+  ///    enum `IntFormat`.
+  ///  - privacy: a privacy qualifier which is either private or public.
+  ///    The default is public.
+  @_transparent
+  @_optimize(none)
+  public mutating func appendInterpolation(
+    _ number: @autoclosure @escaping () -> Int32,
+    format: IntFormat = .decimal,
+    privacy: Privacy = .public
+  ) {
+    appendInteger(number, format: format, privacy: privacy)
+  }
+
+  /// Given an integer, create and append a format specifier for the integer to the
+  /// format string property. Also, append the integer along with necessary headers
+  /// to the OSLogArguments property.
+  @_transparent
+  @_optimize(none)
+  @usableFromInline
+  internal mutating func appendInteger<T>(
+    _ number: @escaping () -> T,
+    format: IntFormat,
+    privacy: Privacy
+  ) where T: FixedWidthInteger {
+    guard argumentCount < maxOSLogArgumentCount else { return }
+
+    let isPrivateArgument = isPrivate(privacy)
+    formatString +=
+      getIntegerFormatSpecifier(
+        T.self,
+        format,
+        isPrivateArgument)
+    addIntHeaders(isPrivateArgument, sizeForEncoding(T.self))
+
+    arguments.append(number)
+    argumentCount += 1
+  }
+
+  /// Update preamble and append argument headers based on the parameters of
+  /// the interpolation.
+  @_transparent
+  @_optimize(none)
+  @usableFromInline
+  internal mutating func addIntHeaders(_ isPrivate: Bool, _ byteCount: Int) {
+    // Append argument header.
+    let argumentHeader = getArgumentHeader(isPrivate: isPrivate, type: .scalar)
+    arguments.append(argumentHeader)
+
+    // Append number of bytes needed to serialize the argument.
+    arguments.append(UInt8(byteCount))
+
+    // Increment total byte size by the number of bytes needed for this
+    // argument, which is the sum of the byte size of the argument and
+    // two bytes needed for the headers.
+    totalBytesForSerializingArguments += byteCount + 2
+
+    preamble = getUpdatedPreamble(isPrivate: isPrivate)
+  }
+
+  /// Construct an os_log format specifier from the given parameters.
+  /// This function must be constant evaluable and all its arguments
+  /// must be known at compile time.
+  @inlinable
+  @_semantics("oslog.interpolation.getFormatSpecifier")
+  @_effects(readonly)
+  @_optimize(none)
+  internal func getIntegerFormatSpecifier<T>(
+    _ integerType: T.Type,
+    _ format: IntFormat,
+    _ isPrivate: Bool
+  ) -> String where T : FixedWidthInteger {
+    var formatSpecifier: String = isPrivate ? "%{private}" : "%{public}"
+
+    // Add a length modifier to the specifier.
+    // TODO: more length modifiers will be added.
+    if (integerType.bitWidth == CLongLong.bitWidth) {
+      formatSpecifier += "ll"
+    }
+
+    // TODO: more format specifiers will be added.
+    switch (format) {
+    case .hex:
+      formatSpecifier += "x"
+    case .octal:
+      formatSpecifier += "o"
+    default:
+      formatSpecifier += integerType.isSigned ? "d" : "u"
+    }
+    return formatSpecifier
+  }
+}
+
+extension OSLogArguments {
+  /// Append an (autoclosured) interpolated expression of integer type, passed to
+  /// `OSLogMessage.appendInterpolation`, to the array of closures tracked
+  /// by this instance.
+  @usableFromInline
+  internal mutating func append<T>(
+    _ value: @escaping () -> T
+  ) where T: FixedWidthInteger {
+    argumentClosures!.append({ $0.serialize(value()) })
+  }
+}
+
+/// Return the number of bytes needed for serializing an integer argument as
+/// specified by os_log. This function must be constant evaluable.
+@inlinable
+@_semantics("oslog.integers.sizeForEncoding")
+@_effects(readonly)
+@_optimize(none)
+internal func sizeForEncoding<T>(
+  _ type: T.Type
+) -> Int where T : FixedWidthInteger  {
+  return type.bitWidth &>> logBitsPerByte
+}
+
+extension OSLogByteBufferBuilder {
+  /// Serialize an integer at the buffer location pointed to by `position`.
+  @usableFromInline
+  internal mutating func serialize<T>(
+    _ value: T
+  ) where T : FixedWidthInteger {
+    let byteCount = sizeForEncoding(T.self)
+    let dest = UnsafeMutableRawBufferPointer(start: position, count: byteCount)
+    withUnsafeBytes(of: value) { dest.copyMemory(from: $0) }
+    position += byteCount
+  }
+}

--- a/stdlib/private/OSLog/OSLogMessage.swift
+++ b/stdlib/private/OSLog/OSLogMessage.swift
@@ -202,68 +202,7 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
     formatString += literal.percentEscapedString
   }
 
-  /// Define interpolation for expressions of type Int. This definition enables
-  /// passing a formatting option and a privacy qualifier along with the
-  /// interpolated expression as shown below:
-  ///
-  ///         "\(x, format: .hex, privacy: .private\)"
-  ///
-  /// - Parameters:
-  ///  - number: the interpolated expression of type Int, which is autoclosured.
-  ///  - format: a formatting option available for Int types, defined by the
-  ///    enum `IntFormat`.
-  ///  - privacy: a privacy qualifier which is either private or public.
-  ///    The default is public.
-  @_transparent
-  @_optimize(none)
-  public mutating func appendInterpolation(
-    _ number: @autoclosure @escaping () -> Int,
-    format: IntFormat = .decimal,
-    privacy: Privacy = .public
-  ) {
-    guard argumentCount < maxOSLogArgumentCount else { return }
-
-    addIntHeadersAndFormatSpecifier(
-      format,
-      isPrivate: isPrivate(privacy),
-      bitWidth: Int.bitWidth,
-      isSigned: true)
-    arguments.append(number)
-    argumentCount += 1
-  }
-
-  /// Construct/update format string and headers from the parameters of the
-  /// interpolation.
-  @_transparent
-  @_optimize(none)
-  public mutating func addIntHeadersAndFormatSpecifier(
-    _ format: IntFormat,
-    isPrivate: Bool,
-    bitWidth: Int,
-    isSigned: Bool
-  ) {
-    formatString += getIntegerFormatSpecifier(
-      format,
-      isPrivate: isPrivate,
-      bitWidth: bitWidth,
-      isSigned: isSigned)
-
-    // Append argument header.
-    let argumentHeader =
-      getArgumentHeader(isPrivate: isPrivate, bitWidth: bitWidth, type: .scalar)
-    arguments.append(argumentHeader)
-
-    // Append number of bytes needed to serialize the argument.
-    let argumentByteCount = OSLogSerializationInfo.sizeForEncoding(Int.self)
-    arguments.append(UInt8(argumentByteCount))
-
-    // Increment total byte size by the number of bytes needed for this
-    // argument, which is the sum of the byte size of the argument and
-    // two bytes needed for the headers.
-    totalBytesForSerializingArguments += argumentByteCount + 2
-
-    preamble = getUpdatedPreamble(isPrivate: isPrivate)
-  }
+  /// `appendInterpolation` conformances will be added by extensions to this type.
 
   /// Return true if and only if the parameter is .private.
   /// This function must be constant evaluable.
@@ -280,7 +219,7 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
     return false
   }
 
-  /// compute a byte-sized argument header consisting of flag and type.
+  /// Compute a byte-sized argument header consisting of flag and type.
   /// Flag and type take up the least and most significant four bits
   /// of the header byte, respectively.
   /// This function should be constant evaluable.
@@ -290,7 +229,6 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
   @_optimize(none)
   internal func getArgumentHeader(
     isPrivate: Bool,
-    bitWidth: Int,
     type: ArgumentType
   ) -> UInt8 {
     let flag: ArgumentFlag = isPrivate ? .privateFlag : .publicFlag
@@ -309,39 +247,6 @@ public struct OSLogInterpolation : StringInterpolationProtocol {
       return preamble | PreambleBitMask.privateBitMask.rawValue
     }
     return preamble
-  }
-
-  /// Construct an os_log format specifier from the given parameters.
-  /// This function must be constant evaluable and all its arguments
-  /// must be known at compile time.
-  @inlinable
-  @_semantics("oslog.interpolation.getFormatSpecifier")
-  @_effects(readonly)
-  @_optimize(none)
-  internal func getIntegerFormatSpecifier(
-    _ format: IntFormat,
-    isPrivate: Bool,
-    bitWidth: Int,
-    isSigned: Bool
-  ) -> String {
-    var formatSpecifier: String = isPrivate ? "%{private}" : "%{public}"
-
-    // Add a length modifier, if needed, to the specifier
-    // TODO: more length modifiers will be added.
-    if (bitWidth == CLongLong.bitWidth) {
-      formatSpecifier += "ll"
-    }
-
-    // TODO: more format specifiers will be added.
-    switch (format) {
-    case .hex:
-      formatSpecifier += "x"
-    case .octal:
-      formatSpecifier += "o"
-    default:
-      formatSpecifier += isSigned ? "d" : "u"
-    }
-    return formatSpecifier
   }
 }
 
@@ -430,35 +335,11 @@ internal struct OSLogArguments {
     argumentClosures!.append({ $0.serialize(header) })
   }
 
-  /// Append an (autoclosured) interpolated expression of type Int, passed to
-  /// `OSLogMessage.appendInterpolation`, to the tracked array of closures.
-  @usableFromInline
-  internal mutating func append(_ value: @escaping () -> Int) {
-    argumentClosures!.append({ $0.serialize(value()) })
-  }
+  /// `append` for other types must be implemented by extensions.
 
   @usableFromInline
   internal func serialize(into bufferBuilder: inout OSLogByteBufferBuilder) {
     argumentClosures?.forEach { $0(&bufferBuilder) }
-  }
-}
-
-/// A struct that provides information regarding the serialization of types
-/// to a byte buffer as specified by the C os_log ABIs.
-@usableFromInline
-internal struct OSLogSerializationInfo {
-  /// Return the number of bytes needed for serializing an UInt8 value.
-  @usableFromInline
-  @_transparent
-  internal static func sizeForEncoding(_ type: UInt8.Type) -> Int {
-    return 1
-  }
-
-  /// Return the number of bytes needed for serializing an Int value.
-  @usableFromInline
-  @_transparent
-  internal static func sizeForEncoding(_ type: Int.Type) -> Int {
-    return Int.bitWidth &>> logBitsPerByte
   }
 }
 
@@ -484,12 +365,5 @@ internal struct OSLogByteBufferBuilder {
     position += 1
   }
 
-  /// Serialize an Int at the buffer location pointed to by `position`.
-  @usableFromInline
-  internal mutating func serialize(_ value: Int) {
-    let byteCount = OSLogSerializationInfo.sizeForEncoding(Int.self)
-    let dest = UnsafeMutableRawBufferPointer(start: position, count: byteCount)
-    withUnsafeBytes(of: value) { dest.copyMemory(from: $0) }
-    position += byteCount
-  }
+  /// `serialize` for other other types must be implemented by extensions.
 }

--- a/test/SILOptimizer/OSLogPrototypeCompileTest.swift
+++ b/test/SILOptimizer/OSLogPrototypeCompileTest.swift
@@ -262,5 +262,37 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
     // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 48
   }
+
+  // CHECK-LABEL: @$s25OSLogPrototypeCompileTest22testInt32InterpolationL_1hy0aB06LoggerV_tF
+  func testInt32Interpolation(h: Logger) {
+    h.log("32-bit integer value: \(Int32.min)")
+
+    // Check if there is a call to _os_log_impl with a literal format string.
+
+    // CHECK-DAG: [[OS_LOG_IMPL:%[0-9]+]] = function_ref @_os_log_impl : $@convention(c)
+    // CHECK-DAG: apply [[OS_LOG_IMPL]]({{%.*}}, {{%.*}}, {{%.*}}, [[CHARPTR:%[0-9]+]], {{%.*}}, {{%.*}})
+    // CHECK-DAG: [[CHARPTR]] = struct $UnsafePointer<Int8> ([[LIT:%[0-9]+]] : $Builtin.RawPointer)
+    // CHECK-DAG: [[LIT]] = string_literal utf8 "32-bit integer value: %{public}d"
+
+    // Check if the size of the argument buffer is a constant.
+
+    // CHECK-DAG: [[ALLOCATE:%[0-9]+]] = function_ref @$sSp8allocate8capacitySpyxGSi_tFZ
+    // CHECK-DAG: apply [[ALLOCATE]]<UInt8>([[BUFFERSIZE:%[0-9]+]], {{%.*}})
+    // CHECK-DAG: [[BUFFERSIZE]] = struct $Int ([[BUFFERSIZELIT:%[0-9]+]]
+    // CHECK-64-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int64, 8
+    // CHECK-32-DAG: [[BUFFERSIZELIT]] = integer_literal $Builtin.Int32, 8
+
+    // Check whether the header bytes: premable and argument count are constants.
+
+    // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype0A17ByteBufferBuilderV9serializeyys5UInt8VF
+    // CHECK-DAG: apply [[SERIALIZE]]([[PREAMBLE:%[0-9]+]], {{%.*}})
+    // CHECK-DAG: [[PREAMBLE]] =  struct $UInt8 ([[PREAMBLELIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[PREAMBLELIT]] = integer_literal $Builtin.Int8, 0
+
+    // CHECK-DAG: [[SERIALIZE:%[0-9]+]] = function_ref @$s14OSLogPrototype0A17ByteBufferBuilderV9serializeyys5UInt8VF
+    // CHECK-DAG: apply [[SERIALIZE]]([[ARGCOUNT:%[0-9]+]], {{%.*}})
+    // CHECK-DAG: [[ARGCOUNT]] =  struct $UInt8 ([[ARGCOUNTLIT:%[0-9]+]] : $Builtin.Int8)
+    // CHECK-DAG: [[ARGCOUNTLIT]] = integer_literal $Builtin.Int8, 1
+  }
 }
 


### PR DESCRIPTION
* Moved `OSLogInterpolation.appendInterpolation` method and related helper functions for `Int` to a new file `OSLogIntegerTypes.swift`. 

* Generalized the helper functions so that they can accept any integer type. 

* Used this to add support for Int32. Support for other integer types will be implemented similar to Int32. 