### PR TITLE
[Coverage] Drop records for functions DCE'd after builtin lowering

### DIFF
--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -73,9 +73,6 @@ private:
   // Tail-allocated expression list.
   MutableArrayRef<llvm::coverage::CounterExpression> Expressions;
 
-  // Whether the coverage mapping's name data is in the profile symbol table.
-  bool HasSymtabEntry;
-
   // Disallow copying into temporary objects.
   SILCoverageMap(const SILCoverageMap &other) = delete;
   SILCoverageMap &operator=(const SILCoverageMap &) = delete;
@@ -111,14 +108,6 @@ public:
   ArrayRef<llvm::coverage::CounterExpression> getExpressions() const {
     return Expressions;
   }
-
-  /// Check whether this coverage mapping can reference its name data within
-  /// the profile symbol table.
-  bool hasSymtabEntry() const { return HasSymtabEntry; }
-
-  /// Guarantee that this coverage mapping can reference its name data within
-  /// the profile symbol table.
-  void setSymtabEntryGuaranteed() { HasSymtabEntry = true; }
 
   void printCounter(llvm::raw_ostream &OS, llvm::coverage::Counter C) const;
 

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -256,15 +256,6 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     replacement.add(NameGEP);
     replacement.add(args.claimAll());
     args = std::move(replacement);
-
-    if (Opts.EmitProfileCoverageMapping) {
-      // Update the associated coverage mapping: it's now safe to emit, because
-      // a symtab entry for this function is guaranteed (r://39146527).
-      auto &coverageMaps = SILMod.getCoverageMaps();
-      auto CovMapIt = coverageMaps.find(PGOFuncName);
-      if (CovMapIt != coverageMaps.end())
-        CovMapIt->second->setSymtabEntryGuaranteed();
-    }
   }
 
   if (IID != llvm::Intrinsic::not_intrinsic) {

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -50,8 +50,7 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   return CM;
 }
 
-SILCoverageMap::SILCoverageMap(uint64_t Hash)
-    : Hash(Hash), HasSymtabEntry(false) {}
+SILCoverageMap::SILCoverageMap(uint64_t Hash) : Hash(Hash) {}
 
 SILCoverageMap::~SILCoverageMap() {}
 

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -1079,6 +1079,9 @@ void SILProfiler::assignRegionCounters() {
       CurrentFuncName, getEquivalentPGOLinkage(CurrentFuncLinkage),
       CurrentFileName);
 
+  assert((!CurrentFuncName.empty() && !PGOFuncName.empty()) &&
+         "Expected covered region to be named");
+
   LLVM_DEBUG(llvm::dbgs() << "Assigning counters to: " << CurrentFuncName
                           << "\n");
   Root.walk(Mapper);

--- a/test/Profiler/coverage_dead_code_elim.swift
+++ b/test/Profiler/coverage_dead_code_elim.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping  -O -whole-module-optimization -emit-ir -o - | %FileCheck %s
+
+// CHECK-NOT: llvm_coverage_mapping = internal constant
+
+func foo() {}


### PR DESCRIPTION
A function may be eliminated as dead code after initial builtin lowering
occurs. When this happens, an entry in the profile symbol table for the
function is not guaranteed. Its coverage record should be dropped.

rdar://42564768