### PR TITLE
Fix memory leak when using -enable-astscope-lookup 

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -168,7 +168,9 @@ public:
 
   ScopeCreator(SourceFile *SF)
       : ctx(SF->getASTContext()),
-        sourceFileScope(new (ctx) ASTSourceFileScope(SF, this)) {}
+        sourceFileScope(new (ctx) ASTSourceFileScope(SF, this)) {
+    ctx.addDestructorCleanup(scopedNodes);
+  }
 
   ScopeCreator(const ScopeCreator &) = delete;  // ensure no copies
   ScopeCreator(const ScopeCreator &&) = delete; // ensure no moves
@@ -660,8 +662,6 @@ public:
 
   // Make vanilla new illegal for ASTScopes.
   void *operator new(size_t bytes) = delete;
-  // Need this because have virtual destructors
-  void operator delete(void *data) {}
 
   // Only allow allocation of scopes using the allocator of a particular source
   // file.


### PR DESCRIPTION
ASTScopes are disabled by default, but when enabled there is a memory leak. This PR stops the leak.
Fixes https://bugs.swift.org/browse/SR-11368.