### PR TITLE
Minimized test in compiler_crashers for sr-11232.

### DIFF
--- a/validation-test/compiler_crashers_2/sr11232.swift
+++ b/validation-test/compiler_crashers_2/sr11232.swift
@@ -1,0 +1,26 @@
+// RUN: not --crash %target-swift-emit-silgen %s
+
+protocol Pub {
+  associatedtype Other
+  associatedtype Failure: Error
+}
+
+class AnyPub<Other, Failure: Error> {}
+
+extension Pub {
+  func erase() -> AnyPub<Other, Failure> {
+    return AnyPub<Other, Failure>()
+  }
+}
+
+protocol ObsObj : Pub {
+  associatedtype NeverPub : Pub where Self.NeverPub.Failure == Never
+}
+
+class Subject<Other, Failure: Error> : Pub {}
+
+extension Pub where Other: ObsObj, Other.NeverPub: Subject<Int, Error> {
+  static func f() -> AnyPub<Other.NeverPub.Other, Other.NeverPub.Failure> {
+    return Subject<Other.NeverPub.Other, Other.NeverPub.Failure>().erase()
+  }
+}


### PR DESCRIPTION
(Rebased and squashed and new PR because CI was stuck on the other one.)

Just adds a compiler crasher test. 