### PR TITLE
Remove BuiltinMath funcs for Float80/Android

### DIFF
--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -62,7 +62,7 @@ def TypedUnaryIntrinsicFunctions():
 // Note these have a corresponding LLVM intrinsic
 % for T, CT, bits, ufunc in TypedUnaryIntrinsicFunctions():
 %  if bits == 80:
-#if !os(Windows) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %  end
 @_transparent
 public func _${ufunc}(_ x: ${T}) -> ${T} {


### PR DESCRIPTION
These were previously removed in SE-0246, so they weren't modified when Float80 was removed elsewhere on Android. Reverting SE-0246 on master triggers an Android break.