### PR TITLE
[AutoDiff] Remove `CotangentVector`, after deprecation.

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -162,10 +162,6 @@ public protocol Differentiable {
   @available(*, deprecated,
              message: "'AllDifferentiableVariables' is now equal to 'Self' and will be removed")
   typealias AllDifferentiableVariables = Self
-
-  @available(*, deprecated,
-             message: "'CotangentVector' is now equal to 'TangentVector' and will be removed")
-  typealias CotangentVector = TangentVector
 }
 
 public extension Differentiable {


### PR DESCRIPTION
`CotangentVector` was deprecated in apple/swift#24825 and the deprecation was released as part of Swift for TensorFlow v0.4. Now it's time to remove it.