### PR TITLE
[ownership] Rename the local helper macro NO_OPERAND_INST -> SHOULD_N…

### DIFF
--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -106,40 +106,38 @@ public:
 
 } // end anonymous namespace
 
-/// Implementation for instructions without operands. These should never be
-/// visited.
-#define NO_OPERAND_INST(INST)                                                  \
+/// Implementation for instructions that we should never visit since they are
+/// not valid in ossa or do not have operands. Since we should never visit
+/// these, we just assert.
+#define SHOULD_NEVER_VISIT_INST(INST)                                          \
   OperandOwnershipKindMap OperandOwnershipKindClassifier::visit##INST##Inst(   \
       INST##Inst *i) {                                                         \
-    assert(i->getNumOperands() == 0 &&                                         \
-           "Expected instruction without operands?!");                         \
-    llvm_unreachable("Instruction without operand can not be compatible with " \
-                     "any def's OwnershipValueKind");                          \
+    llvm_unreachable("Visited instruction that should never be visited?!");    \
   }
-NO_OPERAND_INST(AllocBox)
-NO_OPERAND_INST(AllocExistentialBox)
-NO_OPERAND_INST(AllocGlobal)
-NO_OPERAND_INST(AllocStack)
-NO_OPERAND_INST(FloatLiteral)
-NO_OPERAND_INST(FunctionRef)
-NO_OPERAND_INST(DynamicFunctionRef)
-NO_OPERAND_INST(PreviousDynamicFunctionRef)
-NO_OPERAND_INST(GlobalAddr)
-NO_OPERAND_INST(GlobalValue)
-NO_OPERAND_INST(IntegerLiteral)
-NO_OPERAND_INST(Metatype)
-NO_OPERAND_INST(ObjCProtocol)
-NO_OPERAND_INST(RetainValue)
-NO_OPERAND_INST(RetainValueAddr)
-NO_OPERAND_INST(StringLiteral)
-NO_OPERAND_INST(StrongRetain)
-NO_OPERAND_INST(Unreachable)
-NO_OPERAND_INST(Unwind)
+SHOULD_NEVER_VISIT_INST(AllocBox)
+SHOULD_NEVER_VISIT_INST(AllocExistentialBox)
+SHOULD_NEVER_VISIT_INST(AllocGlobal)
+SHOULD_NEVER_VISIT_INST(AllocStack)
+SHOULD_NEVER_VISIT_INST(FloatLiteral)
+SHOULD_NEVER_VISIT_INST(FunctionRef)
+SHOULD_NEVER_VISIT_INST(DynamicFunctionRef)
+SHOULD_NEVER_VISIT_INST(PreviousDynamicFunctionRef)
+SHOULD_NEVER_VISIT_INST(GlobalAddr)
+SHOULD_NEVER_VISIT_INST(GlobalValue)
+SHOULD_NEVER_VISIT_INST(IntegerLiteral)
+SHOULD_NEVER_VISIT_INST(Metatype)
+SHOULD_NEVER_VISIT_INST(ObjCProtocol)
+SHOULD_NEVER_VISIT_INST(RetainValue)
+SHOULD_NEVER_VISIT_INST(RetainValueAddr)
+SHOULD_NEVER_VISIT_INST(StringLiteral)
+SHOULD_NEVER_VISIT_INST(StrongRetain)
+SHOULD_NEVER_VISIT_INST(Unreachable)
+SHOULD_NEVER_VISIT_INST(Unwind)
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
-  NO_OPERAND_INST(StrongRetain##Name)                                          \
-  NO_OPERAND_INST(Name##Retain)
+  SHOULD_NEVER_VISIT_INST(StrongRetain##Name)                                  \
+  SHOULD_NEVER_VISIT_INST(Name##Retain)
 #include "swift/AST/ReferenceStorage.def"
-#undef NO_OPERAND_INST
+#undef SHOULD_NEVER_VISIT_INST
 
 /// Instructions whose arguments are always compatible with one convention.
 #define CONSTANT_OWNERSHIP_INST(OWNERSHIP, USE_LIFETIME_CONSTRAINT, INST)      \


### PR DESCRIPTION
…EVER_VISIT_INST

This is being used for this expanded purpose as evidenced us creating visitors
for instructions that should never be visited using this macro.
