### PR TITLE
Update checkout for tensorflow.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -484,7 +484,7 @@
                 "icu": "release-61-1",
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
-                "tensorflow": "c6719f20911f8aa6b6d9cded1c0f7761cb9c69a0",
+                "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
                 "tensorflow-swift-apis": "3629ddc49b706df89f89fa3e92e495e6e3f42332",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a"


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/commit/7c7d924821a8b1b20433c2f3f484bbd409873a84

Resolves macOS toolchain error, fixed by https://github.com/tensorflow/tensorflow/pull/31512.
```
$ ./swift/utils/build-toolchain-tensorflow --pkg
...
error: cannot parse the debug map for './/Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-08-23-a.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/Swift/macosx/x86_64/modulemaps/CTensorFlow/c_api_eager.h-e': The file was not recognized as a valid object file
error: cannot parse the debug map for './/Library/Developer/Toolchains/swift-tensorflow-DEVELOPMENT-2019-08-23-a.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/Swift/macosx/x86_64/modulemaps/CTensorFlow/c_api_eager.h': The file was not recognized as a valid object file
```