### PR TITLE
Adding big-endian support to 5.1 branch

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1495,7 +1495,11 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
     ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> Type;
 
     /// The offset of the tuple element within the tuple.
+#if __APPLE__
     StoredSize Offset;
+#else
+    uint32_t Offset;
+#endif
 
     OpaqueValue *findIn(OpaqueValue *tuple) const {
       return (OpaqueValue*) (((char*) tuple) + Offset);
@@ -1505,6 +1509,9 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
       return Type->getTypeLayout();
     }
   };
+
+  static_assert(sizeof(Element) == sizeof(StoredSize) * 2,
+                "element size should be two words");
 
   Element *getElements() {
     return reinterpret_cast<Element*>(this + 1);

--- a/include/swift/Basic/ByteTreeSerialization.h
+++ b/include/swift/Basic/ByteTreeSerialization.h
@@ -155,7 +155,7 @@ private:
   llvm::BinaryStreamWriter &StreamWriter;
 
   /// The underlying stream of the StreamWriter. We need this reference so that
-  /// we can call \c ExponentialGrowthAppendingBinaryByteStream.writeRaw
+  /// we can call \c ExponentialGrowthAppendingBinaryByteStream.writeInteger
   /// which is more efficient than the generic \c writeBytes of
   /// \c llvm::BinaryStreamWriter since it avoids the arbitrary size memcopy.
   ExponentialGrowthAppendingBinaryByteStream &Stream;
@@ -179,13 +179,10 @@ private:
                  llvm::BinaryStreamWriter &StreamWriter, UserInfoMap &UserInfo)
       : StreamWriter(StreamWriter), Stream(Stream), UserInfo(UserInfo) {}
 
-  /// Write the given value to the ByteTree in the same form in which it is
-  /// represented on the serializing machine.
+  /// Write the given value to the ByteTree in little-endian byte order.
   template <typename T>
-  llvm::Error writeRaw(T Value) {
-    // FIXME: We implicitly inherit the endianess of the serializing machine.
-    // Since we're currently only supporting macOS that's not a problem for now.
-    auto Error = Stream.writeRaw(StreamWriter.getOffset(), Value);
+  llvm::Error writeInteger(T Value) {
+    auto Error = Stream.writeInteger(StreamWriter.getOffset(), Value);
     StreamWriter.setOffset(StreamWriter.getOffset() + sizeof(T));
     return Error;
   }
@@ -205,7 +202,7 @@ private:
     // Set the most significant bit to indicate that the next construct is an
     // object and not a scalar.
     uint32_t ToWrite = NumFields | (1 << 31);
-    auto Error = writeRaw(ToWrite);
+    auto Error = writeInteger(ToWrite);
     (void)Error;
     assert(!Error);
 
@@ -241,7 +238,7 @@ public:
     llvm::BinaryStreamWriter StreamWriter(Stream);
     ByteTreeWriter Writer(Stream, StreamWriter, UserInfo);
 
-    auto Error = Writer.writeRaw(ProtocolVersion);
+    auto Error = Writer.writeInteger(ProtocolVersion);
     (void)Error;
     assert(!Error);
 
@@ -272,7 +269,7 @@ public:
     // bitflag that indicates if the next construct in the tree is an object
     // or a scalar.
     assert((ValueSize & ((uint32_t)1 << 31)) == 0 && "Value size too large");
-    auto SizeError = writeRaw(ValueSize);
+    auto SizeError = writeInteger(ValueSize);
     (void)SizeError;
     assert(!SizeError);
 
@@ -292,11 +289,11 @@ public:
     validateAndIncreaseFieldIndex(Index);
 
     uint32_t ValueSize = sizeof(T);
-    auto SizeError = writeRaw(ValueSize);
+    auto SizeError = writeInteger(ValueSize);
     (void)SizeError;
     assert(!SizeError);
 
-    auto ContentError = writeRaw(Value);
+    auto ContentError = writeInteger(Value);
     (void)ContentError;
     assert(!ContentError);
   }

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -237,6 +237,16 @@ public:
     other.dropData();
   }
 
+  /// Create a new ClusteredBitVector from the provided APInt,
+  /// with a size of 0 if the optional does not have a value.
+  ClusteredBitVector(const llvm::Optional<APInt> &bits)
+    : Bits(bits) {}
+
+  /// Create a new ClusteredBitVector from the provided APInt,
+  /// with a size of 0 if the optional does not have a value.
+  ClusteredBitVector(llvm::Optional<APInt> &&bits)
+    : Bits(std::move(bits)) {}
+
   ClusteredBitVector &operator=(const ClusteredBitVector &other) {
     // Do something with our current out-of-line storage.
     if (hasOutOfLineData()) {

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -11,15 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the ClusteredBitVector class, a bitset data
-// structure appropriate for situations meeting two criteria:
-//
-//   - Many vectors are no larger than a particular constant size, and
-//     such vectors should be stored as compactly as possible.  This
-//     constant size should be at least as large as any reasonable
-//     target's pointer size in bits (i.e. at least 64).
-//
-//   - Most vectors have no bits set, and those that do tend to have
-//     them set in coherent ranges.
+// structure.
 //
 // For example, this would be reasonable to use to describe the
 // unoccupied bits in a memory layout.
@@ -30,212 +22,44 @@
 //
 // Primary observers:
 //   - testing a specific bit
-//   - searching for set bits from the start
+//   - converting to llvm::APInt
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_CLUSTEREDBITVECTOR_H
 #define SWIFT_BASIC_CLUSTEREDBITVECTOR_H
 
-#include "swift/Basic/LLVM.h"
-#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Optional.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/MathExtras.h"
-#include <algorithm>
 #include <cassert>
-#include <climits>
-#include <cstdlib>
-#include <type_traits>
-
-namespace llvm {
-  class APInt;
-}
 
 namespace swift {
 
-/// A vector of bits.  This data structure is optimized to store an
-/// empty vector of any size without doing any allocation.
+/// A vector of bits.
 class ClusteredBitVector {
-  using ChunkType = uint64_t;
-  static_assert(std::is_unsigned<ChunkType>::value, "ChunkType must be unsigned");
-  enum {
-    ChunkSizeInBits = sizeof(ChunkType) * CHAR_BIT
-  };
-  static_assert(sizeof(ChunkType) >= sizeof(ChunkType*),
-                "ChunkType must be large enough to store a pointer");
+  using APInt = llvm::APInt;
 
-  /// Return the number of chunks required to store a vector of the
-  /// given number of bits.
-  static size_t getNumChunksForBits(size_t value) { 
-    return (value + ChunkSizeInBits - 1) / ChunkSizeInBits;
-  }
+  /// Represents the bit vector as an integer.
+  /// The least-significant bit of the integer corresponds to the bit
+  /// at index 0. If the optional does not have a value then the bit
+  /// vector has a length of 0 bits.
+  llvm::Optional<APInt> Bits;
 
-  /// Either:
-  ///   - a uint64_t * with at least enough storage for
-  ///     getNumChunksForBits(LengthInBits) or
-  ///   - inline storage for a single chunk
-  /// as determined by HasOutOfLineData.
-  ///
-  /// 1) When using out-of-line storage:
-  ///
-  /// Suppose chunk size = 8, length = 13, capacity = 24.
-  ///
-  ///   11010101 00011010 101010010
-  ///   ~~~~~~~~  ^ ~~~~~        ^
-  ///     data    |  data        |
-  ///             |              +---- bits in other chunks
-  ///    high bits in last chunk         are uninitialized
-  ///      are guaranteed zero
-  /// 
-  /// The capacity (in bits) is stored at index -1.
-  ///
-  /// 2) When using inline storage:
-  ///
-  ///  a) LengthInBits >= ChunkSizeInBits.  In this case, Data must be 0.
-  ///     All bits are considered to be zero in this case.
-  ///
-  ///  b) 0 == LengthInBits.  In this case, Data must be 0.
-  ///
-  ///  c) 0 < LengthInBits < ChunkSizeInBits.  In this case, Data contains
-  ///     a single chunk, with its unused high bits zeroed like in the
-  ///     out-of-line case.
-  ///
-  /// Therefore, an efficient way to test whether all bits are zero:
-  /// Data != 0.  (isInlineAndAllClear())  Not *guaranteed* to find
-  /// something, but still efficient.
-  ChunkType Data;
-  
-  size_t LengthInBits : sizeof(size_t) * CHAR_BIT - 1;
-  size_t HasOutOfLineData : 1;
+  /// Copy constructor from APInt.
+  ClusteredBitVector(const APInt &bits) : Bits(bits) {}
 
-  /// Is this vector using out-of-line storage?
-  bool hasOutOfLineData() const { return HasOutOfLineData; }
-
-  /// Return true if this vector is not using out-of-line storage and
-  /// does not have any bits set.  This is a special-case representation
-  /// where the capacity can be smaller than the length.
-  ///
-  /// This is a necessary condition for hasSufficientChunkStorage(),
-  /// and it's quicker to test, so a lot of routines in this class
-  /// that need to work on chunk data in the general case test this
-  /// first.
-  bool isInlineAndAllClear() const {
-    assert(!hasOutOfLineData() || Data != 0);
-    return Data == 0;
-  }
-
-  /// Return true if this vector is not in the special case where the
-  /// capacity is smaller than the length.  If this is true, then
-  /// it's safe to call routines like getChunks().
-  bool hasSufficientChunkStorage() const {
-    return !(isInlineAndAllClear() && LengthInBits > ChunkSizeInBits);
-  }
-
-  /// Return the number of chunks required in order to store the full
-  /// length (not capacity) of this bit vector.  This may be greater
-  /// than the capacity in exactly one case, (2a), i.e.
-  /// !hasSufficientChunkStorage().
-  size_t getLengthInChunks() const {
-    return getNumChunksForBits(LengthInBits);
-  }
-
-  /// Return the current capacity of this bit vector, in bits.  This
-  /// is a relatively important operation because it's needed on every
-  /// append.
-  size_t getCapacityInBits() const {
-    return hasOutOfLineData() ? getOutOfLineCapacityInBits() : ChunkSizeInBits;
-  }
-
-  /// Return the current capacity of this bit vector, in chunks.
-  size_t getCapacityInChunks() const {
-    return getCapacityInBits() / ChunkSizeInBits;
-  }
-
-  /// Return the current capacity of this bit vector, in bits, given
-  /// that it's using out-of-line storage.
-  size_t getOutOfLineCapacityInBits() const {
-    assert(hasOutOfLineData());
-    return (size_t) getOutOfLineChunksPtr()[-1];
-  }
-
-  /// Return the current capacity of this bit vector, in chunks, given
-  /// that it's using out-of-line storage.
-  size_t getOutOfLineCapacityInChunks() const {
-    return getOutOfLineCapacityInBits() / ChunkSizeInBits;
-  }
-
-  /// Return a pointer to the data storage of this bit vector.
-  ChunkType *getChunksPtr() {
-    assert(hasSufficientChunkStorage());
-    return hasOutOfLineData() ? getOutOfLineChunksPtr() : &Data;
-  }
-  const ChunkType *getChunksPtr() const {
-    assert(hasSufficientChunkStorage());
-    return hasOutOfLineData() ? getOutOfLineChunksPtr() : &Data;
-  }
-
-  MutableArrayRef<ChunkType> getChunks() {
-    assert(hasSufficientChunkStorage());
-    return { getChunksPtr(), getLengthInChunks() };
-  }
-  ArrayRef<ChunkType> getChunks() const {
-    assert(hasSufficientChunkStorage());
-    return { getChunksPtr(), getLengthInChunks() };
-  }
-
-  MutableArrayRef<ChunkType> getOutOfLineChunks() {
-    return { getOutOfLineChunksPtr(), getLengthInChunks() };
-  }
-  ArrayRef<ChunkType> getOutOfLineChunks() const {
-    return { getOutOfLineChunksPtr(), getLengthInChunks() };
-  }
-
-  /// Return a pointer to the data storage of this bit vector, given
-  /// that it's using out-of-line storage.
-  ChunkType *getOutOfLineChunksPtr() {
-    assert(hasOutOfLineData());
-    return reinterpret_cast<ChunkType*>(Data);
-  }
-  const ChunkType *getOutOfLineChunksPtr() const {
-    assert(hasOutOfLineData());
-    return reinterpret_cast<const ChunkType*>(Data);
-  }
-
+  /// Move constructor from APInt.
+  ClusteredBitVector(APInt &&bits) : Bits(std::move(bits)) {}
 public:
   /// Create a new bit vector of zero length.  This does not perform
   /// any allocations.
-  ClusteredBitVector() : Data(0), LengthInBits(0), HasOutOfLineData(0) {}
-
-  /// Return a constant bit-vector of the given size.
-  static ClusteredBitVector getConstant(size_t numBits, bool value) {
-    ClusteredBitVector result;
-    if (value) {
-      result.reserve(numBits);
-      result.appendSetBits(numBits);
-    } else {
-      result.appendClearBits(numBits);
-    }
-    return result;
-  }
+  ClusteredBitVector() = default;
 
   ClusteredBitVector(const ClusteredBitVector &other)
-    : Data(other.Data),
-      LengthInBits(other.LengthInBits),
-      HasOutOfLineData(other.HasOutOfLineData) {
-    if (hasOutOfLineData()) {
-      makeIndependentCopy();
-    }
-  }
+    : Bits(other.Bits) {}
 
   ClusteredBitVector(ClusteredBitVector &&other)
-    : Data(other.Data),
-      LengthInBits(other.LengthInBits),
-      HasOutOfLineData(other.HasOutOfLineData) {
-    other.dropData();
-  }
+    : Bits(std::move(other.Bits)) {}
 
   /// Create a new ClusteredBitVector from the provided APInt,
   /// with a size of 0 if the optional does not have a value.
@@ -248,159 +72,61 @@ public:
     : Bits(std::move(bits)) {}
 
   ClusteredBitVector &operator=(const ClusteredBitVector &other) {
-    // Do something with our current out-of-line storage.
-    if (hasOutOfLineData()) {
-      // Copy into our current storage if its capacity is adequate.
-      auto otherLengthInChunks = other.getLengthInChunks();
-      if (otherLengthInChunks <= getOutOfLineCapacityInChunks()) {
-        LengthInBits = other.LengthInBits;
-        if (other.isInlineAndAllClear()) {
-          memset(getOutOfLineChunksPtr(), 0,
-                 otherLengthInChunks * sizeof(ChunkType));
-        } else {
-          memcpy(getOutOfLineChunksPtr(), other.getChunksPtr(),
-                 otherLengthInChunks * sizeof(ChunkType));
-        }
-        return *this;
-      }
-
-      // Otherwise, destroy our current storage.
-      destroy();
-    }
-
-    Data = other.Data;
-    LengthInBits = other.LengthInBits;
-    HasOutOfLineData = other.HasOutOfLineData;
-    if (HasOutOfLineData) {
-      makeIndependentCopy();
-    }
-
+    this->Bits = other.Bits;
     return *this;
   }
 
   ClusteredBitVector &operator=(ClusteredBitVector &&other) {
-    // Just drop our current out-of-line storage.
-    if (hasOutOfLineData()) {
-      destroy();
-    }
-
-    Data = other.Data;
-    LengthInBits = other.LengthInBits;
-    HasOutOfLineData = other.HasOutOfLineData;
-    other.dropData();
+    this->Bits = std::move(other.Bits);
     return *this;
   }
 
-  ~ClusteredBitVector() {
-    if (hasOutOfLineData()) {
-      destroy();
-    }
-  }
+  ~ClusteredBitVector() = default;
 
   /// Return true if this vector is zero-length (*not* if it does not
   /// contain any set bits).
   bool empty() const {
-    return LengthInBits == 0;
+    return !Bits.hasValue();
   }
 
   /// Return the length of this bit-vector.
   size_t size() const {
-    return LengthInBits;
-  }
-
-  /// Reserve space for an extra N bits.  This may unnecessarily force
-  /// the vector to use an out-of-line representation.
-  void reserveExtra(size_t numBits) {
-    auto requiredBits = LengthInBits + numBits;
-    if (requiredBits > getCapacityInBits()) {
-      auto requiredChunks = getNumChunksForBits(requiredBits);
-      auto chunkCount = getCapacityInChunks();
-      assert(requiredChunks > chunkCount);
-      do {
-        // Growth curve: 1 (inline) -> 3 -> 7 -> 15 -> 31 -> ...
-        // This is a particularly nice sequence because we store the
-        // capacity in the chunk at index -1, so the actual allocation
-        // size is a power of 2.
-        chunkCount = chunkCount * 2 + 1;
-      } while (requiredChunks > chunkCount);
-
-      reallocate(chunkCount);
-    }
-    // Postcondition: hasSufficientChunkStorage().
-  }
-
-  /// Reserve space for a total of N bits.  This may unnecessarily
-  /// force the vector to use an out-of-line representation.
-  void reserve(size_t requiredSize) {
-    if (requiredSize > getCapacityInBits()) {
-      reallocate(getNumChunksForBits(requiredSize));
-    }
-    // Postcondition: hasSufficientChunkStorage().
+    return Bits ? Bits.getValue().getBitWidth() : 0;
   }
 
   /// Append the bits from the given vector to this one.
   void append(const ClusteredBitVector &other) {
     // Nothing to do if the other vector is empty.
-    if (other.empty()) return;
-
-    // Special case: don't allocate space for zero bits.
-    if (isInlineAndAllClear() && other.isInlineAndAllClear()) {
-      LengthInBits += other.LengthInBits;
+    if (!other.Bits) {
       return;
     }
-
-    // Okay, one or the other of these is using out-of-line storage.
-    // Assume that bits might be set.
-    reserveExtra(other.size());
-
-    if (other.isInlineAndAllClear()) {
-      appendConstantBitsReserved(other.size(), 0);
-    } else {
-      appendReserved(other.size(), other.getChunksPtr());
-    }
-  }
-
-  /// Append the bits from the given vector to this one.
-  void append(ClusteredBitVector &&other) {
-    // If this vector is empty, just move the other.
-    if (empty()) {
-      *this = std::move(other);
+    if (!Bits) {
+      Bits = other.Bits;
       return;
     }
-
-    // Otherwise, use copy-append.
-    append(other);
+    APInt &v = Bits.getValue();
+    unsigned w = v.getBitWidth();
+    v = v.zext(w + other.Bits.getValue().getBitWidth());
+    v.insertBits(other.Bits.getValue(), w);
+    return;
   }
 
   /// Add the low N bits from the given value to the vector.
   void add(size_t numBits, uint64_t value) {
-    assert(numBits <= 64);
-    if (numBits == 0) return;
-
-    if (value == 0 && isInlineAndAllClear()) {
-      LengthInBits += numBits;
-      return;
-    }
-
-    reserveExtra(numBits);
-    static_assert(sizeof(value) <= sizeof(ChunkType),
-                  "chunk too small for this, break 'value' up into "
-                  "multiple parts");
-    const ChunkType chunks[] = { value };
-    appendReserved(numBits, chunks);
+    append(fromAPInt(APInt(numBits, value)));
   }
 
   /// Append a number of clear bits to this vector.
   void appendClearBits(size_t numBits) {
-    if (numBits == 0) return;
-
-    if (isInlineAndAllClear()) {
-      LengthInBits += numBits;
+    if (numBits == 0) {
       return;
     }
-
-    reserveExtra(numBits);
-    appendConstantBitsReserved(numBits, 0);
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v = v.zext(v.getBitWidth() + numBits);
+      return;
+    }
+    Bits = APInt::getNullValue(numBits);
   }
 
   /// Extend the vector out to the given length with clear bits.
@@ -409,12 +135,20 @@ public:
     appendClearBits(newSize - size());
   }
 
-
   /// Append a number of set bits to this vector.
   void appendSetBits(size_t numBits) {
-    if (numBits == 0) return;
-    reserveExtra(numBits);
-    appendConstantBitsReserved(numBits, 1);
+    if (numBits == 0) {
+      return;
+    }
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      unsigned w = v.getBitWidth();
+      v = v.zext(w + numBits);
+      v.setBitsFrom(w);
+      return;
+    }
+    Bits = APInt::getAllOnesValue(numBits);
+    return;
   }
 
   /// Extend the vector out to the given length with set bits.
@@ -426,31 +160,15 @@ public:
   /// Test whether a particular bit is set.
   bool operator[](size_t i) const {
     assert(i < size());
-    if (isInlineAndAllClear()) return false;
-    return getChunks()[i / ChunkSizeInBits]
-             & (ChunkType(1) << (i % ChunkSizeInBits));
+    return Bits.getValue()[i];
   }
 
   /// Intersect a bit-vector of the same size into this vector.
   ClusteredBitVector &operator&=(const ClusteredBitVector &other) {
     assert(size() == other.size());
-
-    // If this vector is all-clear, this is a no-op.
-    if (isInlineAndAllClear())
-      return *this;
-
-    // If the other vector is all-clear, we need to wipe this one.
-    if (other.isInlineAndAllClear()) {
-      for (auto &chunk : getChunks())
-        chunk = 0;
-      return *this;
-    }
-
-    // Otherwise, &= the chunks pairwise.
-    auto chunks = getChunks();
-    auto oi = other.getChunksPtr();
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i, ++oi) {
-      *i &= *oi;
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v &= other.Bits.getValue();
     }
     return *this;
   }
@@ -458,21 +176,9 @@ public:
   /// Union a bit-vector of the same size into this vector.
   ClusteredBitVector &operator|=(const ClusteredBitVector &other) {
     assert(size() == other.size());
-
-    // If the other vector is all-clear, this is a no-op.
-    if (other.isInlineAndAllClear())
-      return *this;
-
-    // If this vector is all-clear, we just copy the other.
-    if (isInlineAndAllClear()) {
-      return (*this = other);
-    }
-
-    // Otherwise, |= the chunks pairwise.
-    auto chunks = getChunks();
-    auto oi = other.getChunksPtr();
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i, ++oi) {
-      *i |= *oi;
+    if (Bits) {
+      APInt &v = Bits.getValue();
+      v |= other.Bits.getValue();
     }
     return *this;
   }
@@ -480,66 +186,41 @@ public:
   /// Set bit i.
   void setBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    getChunks()[i / ChunkSizeInBits] |= (ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().setBit(i);
   }
 
   /// Clear bit i.
   void clearBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) return;
-    getChunksPtr()[i / ChunkSizeInBits] &= ~(ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().clearBit(i);
   }
 
   /// Toggle bit i.
   void flipBit(size_t i) {
     assert(i < size());
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    getChunksPtr()[i / ChunkSizeInBits] ^= (ChunkType(1) << (i % ChunkSizeInBits));
+    Bits.getValue().flipBit(i);
   }
 
   /// Toggle all the bits in this vector.
   void flipAll() {
-    if (empty()) return;
-    if (isInlineAndAllClear()) {
-      reserve(LengthInBits);
-    }
-    for (auto &chunk : getChunks()) {
-      chunk = ~chunk;
-    }
-    if (auto tailBits = size() % ChunkSizeInBits) {
-      getChunks().back() &= ((ChunkType(1) << tailBits) - 1);
+    if (Bits) {
+      Bits.getValue().flipAllBits();
     }
   }
 
-  /// Set the length of this vector to zero, but do not release any capacity.
+  /// Set the length of this vector to zero.
   void clear() {
-    LengthInBits = 0;
-    if (!hasOutOfLineData())
-      Data = 0;
+    Bits.reset();
   }
 
   /// Count the number of set bits in this vector.
   size_t count() const {
-    if (isInlineAndAllClear()) return 0;
-    size_t count = 0;
-    for (ChunkType chunk : getChunks()) {
-      count += llvm::countPopulation(chunk);
-    }
-    return count;
+    return Bits ? Bits.getValue().countPopulation() : 0;
   }
 
   /// Determine if there are any bits set in this vector.
   bool any() const {
-    if (isInlineAndAllClear()) return false;
-    for (ChunkType chunk : getChunks()) {
-      if (chunk) return true;
-    }
-    return false;
+    return Bits && Bits.getValue() != 0;
   }
 
   /// Determine if there are no bits set in this vector.
@@ -551,16 +232,13 @@ public:
 
   friend bool operator==(const ClusteredBitVector &lhs,
                          const ClusteredBitVector &rhs) {
-    if (lhs.size() != rhs.size())
+    if (lhs.size() != rhs.size()) {
       return false;
-    if (lhs.empty())
-      return true;
-
-    if (!lhs.hasOutOfLineData() && !rhs.hasOutOfLineData()) {
-      return lhs.Data == rhs.Data;
-    } else {
-      return equalsSlowCase(lhs, rhs);
     }
+    if (lhs.size() == 0) {
+      return true;
+    }
+    return lhs.Bits.getValue() == rhs.Bits.getValue();
   }
   friend bool operator!=(const ClusteredBitVector &lhs,
                          const ClusteredBitVector &rhs) {
@@ -569,73 +247,36 @@ public:
 
   /// Return this bit-vector as an APInt, with low indices becoming
   /// the least significant bits of the number.
-  llvm::APInt asAPInt() const;
+  APInt asAPInt() const {
+    // Return 1-bit wide zero APInt for a 0-bit vector.
+    return Bits ? Bits.getValue() : APInt();
+  }
 
   /// Construct a bit-vector from an APInt.
-  static ClusteredBitVector fromAPInt(const llvm::APInt &value);
+  static ClusteredBitVector fromAPInt(const APInt &value) {
+    return ClusteredBitVector(value);
+  }
+
+  /// Construct a bit-vector from an APInt.
+  static ClusteredBitVector fromAPInt(APInt &&value) {
+    return ClusteredBitVector(std::move(value));
+  }
+
+  /// Return a constant bit-vector of the given size.
+  static ClusteredBitVector getConstant(size_t numBits, bool value) {
+    if (numBits == 0) {
+      return ClusteredBitVector();
+    }
+    auto vec = APInt::getNullValue(numBits);
+    if (value) {
+      vec.flipAllBits();
+    }
+    return ClusteredBitVector(vec);
+  }
 
   /// Pretty-print the vector.
   void print(llvm::raw_ostream &out) const;
   void dump() const;
-
-private:
-  /// Make this object store an independent copy of the out of line
-  /// data it currently stores, simply overwriting the current pointer
-  /// without deleting it.
-  void makeIndependentCopy() {
-    assert(hasOutOfLineData());
-    auto lengthToCopy = getLengthInChunks();
-    allocateAndCopyFrom(getOutOfLineChunksPtr(), lengthToCopy, lengthToCopy);
-  }
-
-  /// Reallocate this vector, copying the current data into the new space.
-  void reallocate(size_t newCapacityInChunks);
-
-  ChunkType *allocate(size_t newCapacityInChunks) {
-    assert(HasOutOfLineData && "bit should already be set");
-    ChunkType *newData = new ChunkType[newCapacityInChunks + 1] + 1;
-    newData[-1] = newCapacityInChunks * ChunkSizeInBits;
-    Data = reinterpret_cast<ChunkType>(newData);
-    assert(!isInlineAndAllClear());
-    assert(getCapacityInChunks() == newCapacityInChunks);
-    return newData;
-  }
-
-  void allocateAndCopyFrom(const ChunkType *oldData,
-                           size_t newCapacityInChunks,
-                           size_t numChunksToCopy) {
-    auto newData = allocate(newCapacityInChunks);
-    memcpy(newData, oldData, numChunksToCopy * sizeof(ChunkType));
-  }
-
-  /// Drop references to the current data.
-  void dropData() {
-    LengthInBits = 0;
-    HasOutOfLineData = false;
-    Data = 0;
-  }
-
-  /// Destroy the out of line data currently stored in this object.
-  void destroy() {
-    assert(hasOutOfLineData());
-    delete[] (getOutOfLineChunksPtr() - 1);
-  }
-
-  /// Append a certain number of constant bits to this vector, given
-  /// that it's known to contain enough capacity for them.
-  void appendConstantBitsReserved(size_t numBits, bool addOnes);
-
-  /// Append bits from the given array to this vector.
-  void appendReserved(size_t numBits, const ChunkType *nextChunk);
-
-  /// Append bits to this vector, given that it's known to contain
-  /// enough capacity for them all.
-  void appendReserved(size_t numBits,
-                llvm::function_ref<ChunkType(size_t numBitsWanted)> generator);
-
-  /// The slow case of equality-checking.
-  static bool equalsSlowCase(const ClusteredBitVector &lhs,
-                             const ClusteredBitVector &rhs);
 };
 
 } // end namespace swift

--- a/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
+++ b/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
@@ -33,13 +33,10 @@ class ExponentialGrowthAppendingBinaryByteStream
   /// The buffer holding the data.
   SmallVector<uint8_t, 0> Data;
 
-  llvm::support::endianness Endian;
+  /// Data in the stream is always encoded in little-endian byte order.
+  const llvm::support::endianness Endian = llvm::support::endianness::little;
 public:
-  ExponentialGrowthAppendingBinaryByteStream()
-      : ExponentialGrowthAppendingBinaryByteStream(
-            llvm::support::endianness::little) {}
-  ExponentialGrowthAppendingBinaryByteStream(llvm::support::endianness Endian)
-      : Endian(Endian) {}
+  ExponentialGrowthAppendingBinaryByteStream() = default;
 
   void reserve(size_t Size);
 
@@ -57,16 +54,11 @@ public:
 
   llvm::Error writeBytes(uint32_t Offset, ArrayRef<uint8_t> Buffer) override;
 
-  /// This is an optimized version of \c writeBytes that assumes we know the
-  /// size of \p Value at compile time (which in particular holds for integers).
-  /// It does so by exposing the memcpy to the optimizer along with the size 
-  /// of the value being assigned; the compiler can then optimize the memcpy
-  /// into a fixed set of instructions.
-  /// This assumes that the endianess of this steam is the same as the native
-  /// endianess on the executing machine. No endianess transformations are
-  /// performed.
+  /// This is an optimized version of \c writeBytes specifically for integers.
+  /// Integers are written in little-endian byte order.
   template<typename T>
-  llvm::Error writeRaw(uint32_t Offset, T Value) {
+  llvm::Error writeInteger(uint32_t Offset, T Value) {
+    static_assert(std::is_integral<T>::value, "Integer required.");
     if (auto Error = checkOffsetForWrite(Offset, sizeof(T))) {
       return Error;
     }
@@ -77,7 +69,8 @@ public:
       Data.resize(RequiredSize);
     }
 
-    ::memcpy(Data.data() + Offset, &Value, sizeof Value);
+    llvm::support::endian::write<T, llvm::support::unaligned>(
+      Data.data() + Offset, Value, Endian);
 
     return llvm::Error::success();
   }

--- a/lib/Basic/ClusteredBitVector.cpp
+++ b/lib/Basic/ClusteredBitVector.cpp
@@ -16,192 +16,9 @@
 
 #include "swift/Basic/ClusteredBitVector.h"
 
-#include "llvm/ADT/APInt.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
-
-ClusteredBitVector ClusteredBitVector::fromAPInt(const llvm::APInt &bits) {
-  // This is not a very efficient algorithm.
-  ClusteredBitVector result;
-  for (unsigned i = 0, e = bits.getBitWidth(); i != e; ++i) {
-    if (bits[i]) {
-      result.appendSetBits(1);
-    } else {
-      result.appendClearBits(1);
-    }
-  }
-  return result;
-}
-
-llvm::APInt ClusteredBitVector::asAPInt() const {
-  if (size() == 0) {
-    // APInt doesn't like zero-bit values.
-    return llvm::APInt(1, 0);
-  }
-
-  if (isInlineAndAllClear()) {
-    return llvm::APInt(size(), 0);
-  } else {
-    // This assumes that the chunk size is the same as APInt's.
-    // TODO: it'd be nice to be able to do this without copying.
-    return llvm::APInt(size(), getChunks());
-  }
-}
-
-void ClusteredBitVector::reallocate(size_t newCapacityInChunks) {
-  // If we already have out-of-line storage, the padding invariants
-  // will still apply, and we just need to copy the old data into
-  // the new allocation.
-  if (hasOutOfLineData()) {
-    auto oldData = getOutOfLineChunksPtr();
-    allocateAndCopyFrom(oldData, newCapacityInChunks, getLengthInChunks());
-    delete[] (oldData - 1);
-    return;
-  }
-
-  // Otherwise, we might need to establish the invariants.  If we
-  // were in inline-and-all-clear mode, the vector might logically
-  // be much longer than a single chunk, but all-zero.
-  HasOutOfLineData = true;
-  auto oldDataValue = Data;
-  auto newData = allocate(newCapacityInChunks);
-
-  // All of these cases initialize 'length' chunks in newData.
-  switch (auto length = getLengthInChunks()) {
-  case 0:
-    break;
-  case 1:
-    newData[0] = oldDataValue;
-    break;
-  default:
-    assert(oldDataValue == 0 && "not previously in inline-and-all-clear?");
-    memset(newData, 0, length * sizeof(ChunkType));
-    break;
-  }
-}
-
-void ClusteredBitVector::appendReserved(size_t numBits,
-                llvm::function_ref<ChunkType(size_t numBitsWanted)> generator) {
-  assert(LengthInBits + numBits <= getCapacityInBits());
-  assert(numBits > 0);
-
-  auto getMoreBits =
-    [&](size_t numBitsWanted) -> ChunkType {
-    auto result = generator(numBitsWanted);
-    assert((numBitsWanted == ChunkSizeInBits ||
-            result <= (ChunkType(1) << numBitsWanted)) &&
-           "generator returned out-of-range value!");
-    return result;
-  };
-
-  // Check whether the current end of the vector is a clean multiple
-  // of the chunk size.
-  auto offset = LengthInBits % ChunkSizeInBits;
-  ChunkType *nextChunk = &getChunksPtr()[LengthInBits / ChunkSizeInBits];
-
-  // Now we can go ahead and add in the right number of extra bits.
-  LengthInBits += numBits;
-
-  // If not, we need to combine the generator result with that last chunk.
-  if (offset) {
-    auto claimedBits = std::min(numBits, size_t(ChunkSizeInBits - offset));
-
-    // The extra bits in data[chunkIndex] are guaranteed to be zero.
-    *nextChunk++ |= (getMoreBits(claimedBits) << offset);
-    
-    numBits -= claimedBits;
-    if (numBits == 0) return;
-  }
-
-  // For the rest, just generator chunks one at a time.
-  do {
-    auto claimedBits = std::min(numBits, size_t(ChunkSizeInBits));
-    *nextChunk++ = getMoreBits(claimedBits);
-    numBits -= claimedBits;
-  } while (numBits);
-}
-
-void ClusteredBitVector::appendConstantBitsReserved(size_t numBits,
-                                                    bool addOnes) {
-  assert(LengthInBits + numBits <= getCapacityInBits());
-  assert(numBits > 0);
-
-  ChunkType pattern = (addOnes ? ~ChunkType(0) : ChunkType(0));
-  appendReserved(numBits, [=](size_t numBitsWanted) -> ChunkType {
-    return (pattern >> (ChunkSizeInBits - numBitsWanted));
-  });
-}
-
-void ClusteredBitVector::appendReserved(size_t numBits,
-                                        const ChunkType *nextChunk) {
-  // This is easy if we're not currently at an offset.
-  // (Note that this special case generator relies on the exact
-  // implementation of the main appendReserved routine.)
-  auto offset = LengthInBits % ChunkSizeInBits;
-  if (!offset) {
-    appendReserved(numBits, [&](size_t numBitsWanted) -> ChunkType {
-      return *nextChunk++;
-    });
-    return;
-  }
-
-  // But if we are, we need to be constantly mixing values.
-  ChunkType prevChunk = 0;
-  size_t bitsRemaining = 0;
-  appendReserved(numBits, [&](size_t numBitsWanted) -> ChunkType {
-    auto resultMask = (numBitsWanted == ChunkSizeInBits
-                         ? ~ChunkType(0)
-                         : ((ChunkType(1) << numBitsWanted) - 1));
-
-    // If we can resolve the desired bits out of the current chunk,
-    // all the better.
-    if (numBitsWanted <= bitsRemaining) {
-      assert(numBitsWanted != ChunkSizeInBits);
-      auto result = prevChunk & resultMask;
-      bitsRemaining -= numBitsWanted;
-      prevChunk >>= numBitsWanted;
-      return result;
-    }
-
-    // |-- bitsRemaining --|-------- ChunkSizeInBits --------|
-    // |     prevChunk     |             nextChunk           |
-    // |------ numBitsWanted ------|----- bitsRemaining' ----|
-    //                             |        prevChunk'       |
-
-    auto newChunk = *nextChunk++;
-    auto result = (prevChunk | (newChunk << bitsRemaining)) & resultMask;
-    prevChunk = newChunk >> (numBitsWanted - bitsRemaining);
-    bitsRemaining = ChunkSizeInBits + bitsRemaining - numBitsWanted;
-    return result;
-  });
-}
-
-bool ClusteredBitVector::equalsSlowCase(const ClusteredBitVector &lhs,
-                                        const ClusteredBitVector &rhs) {
-  assert(lhs.size() == rhs.size());
-  assert(!lhs.empty() && !rhs.empty());
-  assert(lhs.hasOutOfLineData() || rhs.hasOutOfLineData());
-
-  if (!lhs.hasOutOfLineData()) {
-    assert(lhs.Data == 0 || lhs.getLengthInChunks() == 1);
-    for (auto chunk : rhs.getOutOfLineChunks())
-      if (chunk != lhs.Data)
-        return false;
-    return true;
-  } else if (!rhs.hasOutOfLineData()) {
-    assert(rhs.Data == 0 || rhs.getLengthInChunks() == 1);
-    for (auto chunk : lhs.getOutOfLineChunks())
-      if (chunk != rhs.Data)
-        return false;
-    return true;
-  } else {
-    auto lhsChunks = lhs.getOutOfLineChunks();
-    auto rhsChunks = rhs.getOutOfLineChunks();
-    assert(lhsChunks.size() == rhsChunks.size());
-    return lhsChunks == rhsChunks;
-  }
-}
 
 void ClusteredBitVector::dump() const {
   print(llvm::errs());
@@ -210,8 +27,12 @@ void ClusteredBitVector::dump() const {
 /// Pretty-print the vector.
 void ClusteredBitVector::print(llvm::raw_ostream &out) const {
   // Print in 8 clusters of 8 bits per row.
+  if (!Bits) {
+    return;
+  }
+  auto &v = Bits.getValue();
   for (size_t i = 0, e = size(); ; ) {
-    out << ((*this)[i++] ? '1' : '0');
+    out << (v[i++] ? '1' : '0');
     if (i == e) {
       return;
     } else if ((i & 64) == 0) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -706,7 +706,7 @@ addCommonInvocationArguments(std::vector<std::string> &invocationArgStrs,
       invocationArgStrs.push_back("-mcpu=cyclone");
     }
   } else if (triple.getArch() == llvm::Triple::systemz) {
-    invocationArgStrs.push_back("-march=z196");
+    invocationArgStrs.push_back("-march=z13");
   }
 
   if (!importerOpts.Optimization.empty()) {

--- a/lib/IRGen/BitPatternBuilder.h
+++ b/lib/IRGen/BitPatternBuilder.h
@@ -1,0 +1,170 @@
+//===--- BitPatternBuilder.h - Create masks for composite types -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "swift/Basic/ClusteredBitVector.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+namespace irgen {
+
+/// BitPatternBuilder is a class to help with the construction of
+/// bit masks for composite types. The class should be constructed
+/// using the byte order of the target platform. Elements added
+/// to the class must mask an entire element in a composite type.
+/// These elements must be byte aligned. For example, if you want
+/// to add a 64-bit integer to the bit pattern with the low 32
+/// bits set to 1 and the high 32 bits set to 0 then you must create
+/// a 64-bit APInt and append it in its entirety rather than calling
+/// the appendSetBits and appendClearBits helper functions which
+/// would not be portable across architectures using different byte
+/// orders.
+///
+/// Example construction of a mask for a struct:
+///
+///   // Type T that we are generating a mask for:
+///   struct T {
+///     uint8_t a;
+///     uint8_t b;
+///     uint16_t c;
+///   };
+///
+///   // Code to generate the mask:
+///   auto mask = BitPatternBuilder(isLittleEndian());
+///   mask.appendSetBits(8);             // mask T.a with 0xff
+///   mask.appendClearBits(8);           // mask T.b with 0x00
+///   mask.append(APInt(16, 0x1177ULL)); // mask T.c with 0x1177
+///
+///   // Little-endian result:
+///   mask.build(); // 0x117700ff [ ff 00 77 11 ]
+///
+///   // Big-endian result:
+///   mask.build(); // 0xff001177 [ ff 00 11 77 ]
+///
+class BitPatternBuilder {
+  using APInt = llvm::APInt;
+
+  // An array of masks that, when combined, will form the mask for a
+  // composite value. Generally these correspond to elements in a
+  // struct (or class, tuple etc.).
+  llvm::SmallVector<APInt, 8> Elements;
+
+  // Little-endian byte order implies that elements should be
+  // appended to the most significant bit. If this flag is false
+  // then elements should be appended to the least signficant
+  // bit (big-endian byte order).
+  bool LittleEndian;
+
+  // The combined size of the elements added so far in bits.
+  unsigned Size = 0;
+public:
+  /// Create a new BitPatternBuilder with either a little-endian
+  /// (true) or big-endian (false) byte order.
+  BitPatternBuilder(bool littleEndian) : LittleEndian(littleEndian) {}
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(const APInt &value) {
+    assert(value.getBitWidth() % 8 == 0);
+    Size += value.getBitWidth();
+    Elements.push_back(value);
+  }
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(APInt &&value) {
+    assert(value.getBitWidth() % 8 == 0);
+    Size += value.getBitWidth();
+    Elements.push_back(std::move(value));
+  }
+
+  /// Append the given mask to the bit pattern. The mask should mask
+  /// an entire element type and be byte aligned.
+  void append(const ClusteredBitVector &value) {
+    assert(value.size() % 8 == 0);
+    if (!value.empty()) {
+      Size += value.size();
+      Elements.push_back(value.asAPInt());
+    }
+  }
+
+  /// Append the given number of set (1) bits to the bit pattern. The
+  /// number of bits must be a multiple of 8 and mask a whole number
+  /// of element types.
+  void appendSetBits(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    if (numBits) {
+      Size += numBits;
+      Elements.push_back(APInt::getAllOnesValue(numBits));
+    }
+  }
+
+  /// Append the given number of clear (0) bits to the bit pattern. The
+  /// number of bits must be a multiple of 8 and mask a whole number
+  /// of element types.
+  void appendClearBits(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    if (numBits) {
+      Size += numBits;
+      Elements.push_back(APInt::getNullValue(numBits));
+    }
+  }
+
+  /// Append set (1) bits to the bit pattern until it reaches the
+  /// given size in bits. The total number of bits must be a
+  /// multiple of 8.
+  void padWithSetBitsTo(unsigned totalSizeInBits) {
+    assert(totalSizeInBits % 8 == 0);
+    assert(totalSizeInBits >= Size);
+    appendSetBits(totalSizeInBits - Size);
+  }
+
+  /// Append clear (0) bits to the bit pattern until it reaches the
+  /// given size in bits. The total number of bits must be a
+  /// multiple of 8.
+  void padWithClearBitsTo(unsigned totalSizeInBits) {
+    assert(totalSizeInBits % 8 == 0);
+    assert(totalSizeInBits >= Size);
+    appendClearBits(totalSizeInBits - Size);
+  }
+
+  /// Build the complete mask for the composite type. If the mask has a
+  /// length of 0 then the optional will not contain a value. Otherwise
+  /// the option will contain a value that is the combined length of
+  /// the elements appended to the builder. The mask represents is an
+  /// integer in the target byte order.
+  llvm::Optional<APInt> build() const {
+    if (Size == 0) {
+      return llvm::Optional<APInt>();
+    }
+    auto result = APInt::getNullValue(Size);
+    unsigned offset = 0;
+    for (const auto &e : Elements) {
+      unsigned index = offset;
+      if (!LittleEndian) {
+        index = Size - offset - e.getBitWidth();
+      }
+      result.insertBits(e, index);
+      offset += e.getBitWidth();
+    }
+    assert(offset == Size);
+    return result;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+

--- a/lib/IRGen/BitPatternReader.h
+++ b/lib/IRGen/BitPatternReader.h
@@ -1,0 +1,82 @@
+//===--- BitPatternReader.h - Split bit patterns into chunks. -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "swift/Basic/ClusteredBitVector.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/Optional.h"
+
+namespace swift {
+namespace irgen {
+
+/// BitPatternReader allows an APInt to be read from in chunks.
+/// Chunks may be read starting from either the least significant bit
+/// (little-endian) or the most significant bit (big-endian).
+///
+/// This is useful when interpreting an APInt as a multi-byte mask
+/// that needs to be applied to a value with a composite type.
+///
+/// Example:
+///
+///   // big-endian
+///   auto x = BitPatternReader(APInt(32, 0x1234), false);
+///   x.read(16) // 0x12
+///   x.read(8)  // 0x3
+///   x.read(8)  // 0x4
+///
+///   // little-endian
+///   auto y = BitPatternReader(APInt(32, 0x1234), true);
+///   y.read(16) // 0x34
+///   y.read(8)  // 0x2
+///   y.read(8)  // 0x1
+///
+class BitPatternReader {
+  using APInt = llvm::APInt;
+
+  const APInt Value;
+  const bool LittleEndian;
+  unsigned Offset = 0;
+public:
+  /// If the reader is in little-endian mode then bits will be read
+  /// from the least significant to the most significant. Otherwise
+  /// they will be read from the most significant to the least
+  /// significant.
+  BitPatternReader(const APInt &value, bool littleEndian) :
+      Value(value),
+      LittleEndian(littleEndian) {}
+
+  /// Read the given number of bits from the unread part of the
+  /// underlying value and adjust the remaining value as appropriate.
+  APInt read(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    assert(Value.getBitWidth() >= Offset + numBits);
+    unsigned offset = Offset;
+    if (!LittleEndian) {
+      offset = Value.getBitWidth() - offset - numBits;
+    }
+    Offset += numBits;
+    return Value.extractBits(numBits, offset);
+  }
+
+  // Skip the number of bits provided.
+  void skip(unsigned numBits) {
+    assert(numBits % 8 == 0);
+    assert(Value.getBitWidth() >= Offset + numBits);
+    Offset += numBits;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -373,137 +373,10 @@ void EnumPayload::store(IRGenFunction &IGF, Address address) const {
   }
 }
 
-namespace {
-struct ult {
-  bool operator()(const APInt &a, const APInt &b) const {
-    return a.ult(b);
-  }
-};
-} // end anonymous namespace
-
-static void emitSubSwitch(IRGenFunction &IGF,
-                    MutableArrayRef<EnumPayload::LazyValue> values,
-                    APInt mask,
-                    MutableArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
-                    SwitchDefaultDest dflt) {
-recur:
-  assert(!values.empty() && "didn't exit out when exhausting all values?!");
-  
-  assert(!cases.empty() && "switching with no cases?!");
-  
-  auto &DL = IGF.IGM.DataLayout;
-  auto &pv = values.front();
-  values = values.slice(1);
-  auto payloadTy = getPayloadType(pv);
-  unsigned size = DL.getTypeSizeInBits(payloadTy);
-  
-  // Grab a chunk of the mask.
-  auto maskPiece = mask.zextOrTrunc(size);
-  mask = mask.lshr(size);
-  
-  // If the piece is zero, this doesn't affect the switch. We can just move
-  // forward and recur.
-  if (maskPiece == 0) {
-    for (auto &casePair : cases)
-      casePair.first = casePair.first.lshr(size);
-    goto recur;
-  }
-  
-  // Force the value we will test.
-  auto v = forcePayloadValue(pv);
-  auto payloadIntTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), size);
-  
-  // Need to coerce to integer for 'icmp eq' if it's not already an integer
-  // or pointer. (Switching or masking will also require a cast to integer.)
-  if (!isa<llvm::IntegerType>(v->getType())
-      && !isa<llvm::PointerType>(v->getType()))
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-  
-  // Apply the mask if it's interesting.
-  if (!maskPiece.isAllOnesValue()) {
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-    auto maskConstant = llvm::ConstantInt::get(payloadIntTy, maskPiece);
-    v = IGF.Builder.CreateAnd(v, maskConstant);
-  }
-  
-  // Gather the values we will switch over for this payload chunk.
-  // FIXME: std::map is lame. Should hash APInts.
-  std::map<APInt, SmallVector<std::pair<APInt, llvm::BasicBlock*>, 2>, ult>
-    subCases;
-  
-  for (auto casePair : cases) {
-    // Grab a chunk of the value.
-    auto valuePiece = casePair.first.zextOrTrunc(size);
-    // Index the case according to this chunk.
-    subCases[valuePiece].push_back({std::move(casePair.first).lshr(size),
-                                    casePair.second});
-  }
-  
-  bool needsAdditionalCases = !values.empty() && mask != 0;
-  SmallVector<std::pair<llvm::BasicBlock *, decltype(cases)>, 2> recursiveCases;
-  
-  auto blockForCases
-    = [&](MutableArrayRef<std::pair<APInt, llvm::BasicBlock*>> cases)
-        -> llvm::BasicBlock *
-    {
-      // If we need to recur, emit a new block.
-      if (needsAdditionalCases) {
-        auto newBB = IGF.createBasicBlock("");
-        recursiveCases.push_back({newBB, cases});
-        return newBB;
-      }
-      // Otherwise, we can jump directly to the ultimate destination.
-      assert(cases.size() == 1 && "more than one case for final destination?!");
-      return cases.front().second;
-    };
-  
-  // If there's only one case, do a cond_br.
-  if (subCases.size() == 1) {
-    auto &subCase = *subCases.begin();
-    llvm::BasicBlock *block = blockForCases(subCase.second);
-    // If the default case is unreachable, we don't need to conditionally
-    // branch.
-    if (dflt.getInt()) {
-      IGF.Builder.CreateBr(block);
-      goto next;
-    }
-  
-    auto &valuePiece = subCase.first;
-    llvm::Value *valueConstant = llvm::ConstantInt::get(payloadIntTy,
-                                                        valuePiece);
-    valueConstant = IGF.Builder.CreateBitOrPointerCast(valueConstant,
-                                                       v->getType());
-    auto cmp = IGF.Builder.CreateICmpEQ(v, valueConstant);
-    IGF.Builder.CreateCondBr(cmp, block, dflt.getPointer());
-    goto next;
-  }
-  
-  // Otherwise, do a switch.
-  {
-    v = IGF.Builder.CreateBitOrPointerCast(v, payloadIntTy);
-    auto swi = IGF.Builder.CreateSwitch(v, dflt.getPointer(), subCases.size());
-    
-    for (auto &subCase : subCases) {
-      auto &valuePiece = subCase.first;
-      auto valueConstant = llvm::ConstantInt::get(IGF.IGM.getLLVMContext(),
-                                                  valuePiece);
-
-      swi->addCase(valueConstant, blockForCases(subCase.second));
-    }
-  }
-  
-next:
-  // Emit the recursive cases.
-  for (auto &recursive : recursiveCases) {
-    IGF.Builder.emitBlock(recursive.first);
-    emitSubSwitch(IGF, values, mask, recursive.second, dflt);
-  }
-}
-
 void EnumPayload::emitSwitch(IRGenFunction &IGF,
-                           APInt mask,
-                           ArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
-                           SwitchDefaultDest dflt) const {
+                             const APInt &mask,
+                             ArrayRef<std::pair<APInt, llvm::BasicBlock *>> cases,
+                             SwitchDefaultDest dflt) const {
   // If there's only one case to test, do a simple compare and branch.
   if (cases.size() == 1) {
     // If the default case is unreachable, don't bother branching at all.
@@ -517,12 +390,16 @@ void EnumPayload::emitSwitch(IRGenFunction &IGF,
     return;
   }
 
-  // Otherwise, break down the decision tree.
-  SmallVector<std::pair<APInt, llvm::BasicBlock*>, 4> mutableCases
-    (cases.begin(), cases.end());
-  
-  emitSubSwitch(IGF, PayloadValues, mask, mutableCases, dflt);
-  
+  // Otherwise emit a switch statement.
+  auto &context = IGF.IGM.getLLVMContext();
+  unsigned numBits = mask.countPopulation();
+  auto target = emitGatherSpareBits(IGF, SpareBitVector::fromAPInt(mask),
+                                    0, numBits);
+  auto swi = IGF.Builder.CreateSwitch(target, dflt.getPointer(), cases.size());
+  for (auto &c : cases) {
+    auto value = llvm::ConstantInt::get(context, gatherBits(mask, c.first));
+    swi->addCase(value, c.second);
+  }
   assert(IGF.Builder.hasPostTerminatorIP());
 }
 

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -10,10 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "BitPatternReader.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
 #include "GenEnum.h"
 #include "IRGenModule.h"
+
+#include <algorithm>
 #include <map>
 
 using namespace swift;
@@ -37,6 +40,23 @@ static llvm::Type *getPayloadType(EnumPayload::LazyValue value) {
   return value.dyn_cast<llvm::Value *>()->getType();
 }
 
+// Clear bits starting from the most significant until the number
+// of set bits in the value is less than or equal to numSetBits.
+//
+// For example: getLowestNSetBits(0x11111100, 2) = 0x00001100
+static llvm::APInt getLowestNSetBits(llvm::APInt value,
+                                     unsigned numSetBits) {
+  // TODO: optimize
+  for (unsigned i = 0; i < value.getBitWidth(); ++i) {
+    if (numSetBits == 0) {
+      value.clearBit(i);
+    } else if (value[i]) {
+      numSetBits -= 1;
+    }
+  }
+  return value;
+}
+
 EnumPayload EnumPayload::zero(IRGenModule &IGM, EnumPayloadSchema schema) {
   // We don't need to create any values yet; they can be filled in when
   // real values are inserted.
@@ -48,18 +68,19 @@ EnumPayload EnumPayload::zero(IRGenModule &IGM, EnumPayloadSchema schema) {
 }
 
 EnumPayload EnumPayload::fromBitPattern(IRGenModule &IGM,
-                                        APInt bitPattern,
+                                        const APInt &bitPattern,
                                         EnumPayloadSchema schema) {
+  auto maskReader = BitPatternReader(bitPattern, IGM.Triple.isLittleEndian());
+
   EnumPayload result;
-  
   schema.forEachType(IGM, [&](llvm::Type *type) {
     unsigned bitSize = IGM.DataLayout.getTypeSizeInBits(type);
 
     llvm::IntegerType *intTy
       = llvm::IntegerType::get(IGM.getLLVMContext(), bitSize);
-    
+
     // Take some bits off of the bottom of the pattern.
-    auto bits = bitPattern.zextOrTrunc(bitSize);
+    auto bits = maskReader.read(bitSize);
     auto val = llvm::ConstantInt::get(intTy, bits);
     if (val->getType() != type) {
       if (type->isPointerTy())
@@ -67,164 +88,68 @@ EnumPayload EnumPayload::fromBitPattern(IRGenModule &IGM,
       else
         val = llvm::ConstantExpr::getBitCast(val, type);
     }
-    
+
     result.PayloadValues.push_back(val);
-    
-    // Shift the remaining bits down.
-    bitPattern = bitPattern.lshr(bitSize);
   });
-    
+
   return result;
 }
 
-// Fn: void(LazyValue &payloadValue, unsigned payloadBitWidth,
-//          unsigned payloadValueOffset, unsigned valueBitWidth,
-//          unsigned valueOffset)
-template<typename Fn>
-static void withValueInPayload(IRGenFunction &IGF,
-                               const EnumPayload &payload,
-                               llvm::Type *valueType,
-                               int numBitsUsedInValue,
+/// Create a mask for an element with the given type at the provided
+/// offset into the payload. The offset and size are in bits but
+/// must be a multiple of 8 (i.e. byte aligned).
+static APInt createElementMask(const llvm::DataLayout &DL,
+                               llvm::Type *type,
                                unsigned payloadOffset,
-                               Fn &&f) {
-  auto &DataLayout = IGF.IGM.DataLayout;
-  int valueTypeBitWidth = DataLayout.getTypeSizeInBits(valueType);
-  int valueBitWidth =
-      numBitsUsedInValue < 0 ? valueTypeBitWidth : numBitsUsedInValue;
-  assert(numBitsUsedInValue <= valueTypeBitWidth);
+                               unsigned payloadSizeInBits) {
+  // Create a mask for the bytes that make up the stored element
+  // by zero extending the element's mask to its storage size.
+  // This makes the mask valid regardless of endianness.
+  auto elSize = DL.getTypeSizeInBits(type);
+  auto elStoreSize = DL.getTypeStoreSizeInBits(type);
+  auto elMask = APInt::getLowBitsSet(elStoreSize, elSize);
 
-  // Find the elements we need to touch.
-  // TODO: Linear search through the payload elements is lame.
-  MutableArrayRef<EnumPayload::LazyValue> payloads = payload.PayloadValues;
-  llvm::Type *payloadType;
-  int payloadBitWidth;
-  int valueOffset = 0, payloadValueOffset = payloadOffset;
-  for (;;) {
-    payloadType = getPayloadType(payloads.front());
-    payloadBitWidth = IGF.IGM.DataLayout.getTypeSizeInBits(payloadType);
-    
-    // Does this element overlap the area we need to touch?
-    if (payloadValueOffset < payloadBitWidth) {
-      // See how much of the value we can fit here.
-      int valueChunkWidth = payloadBitWidth - payloadValueOffset;
-      valueChunkWidth = std::min(valueChunkWidth, valueBitWidth - valueOffset);
-    
-      f(payloads.front(),
-        payloadBitWidth, payloadValueOffset,
-        valueTypeBitWidth, valueOffset);
-      
-      // If we used the entire value, we're done.
-      valueOffset += valueChunkWidth;
-      if (valueOffset >= valueBitWidth)
-        return;
-    }
-    
-    payloadValueOffset = std::max(payloadValueOffset - payloadBitWidth, 0);
-    payloads = payloads.slice(1);
+  // Pad the valueMask so that it can be applied to the entire
+  // payload.
+  auto mask = APInt::getNullValue(payloadSizeInBits);
+  auto offset = payloadOffset;
+  if (DL.isBigEndian()) {
+    offset = payloadSizeInBits - payloadOffset - elStoreSize;
   }
+  mask.insertBits(elMask, offset);
+  return mask;
 }
 
 void EnumPayload::insertValue(IRGenFunction &IGF, llvm::Value *value,
-                              unsigned payloadOffset,
-                              int numBitsUsedInValue) {
-  withValueInPayload(IGF, *this, value->getType(), numBitsUsedInValue, payloadOffset,
-    [&](LazyValue &payloadValue,
-        unsigned payloadBitWidth,
-        unsigned payloadValueOffset,
-        unsigned valueBitWidth,
-        unsigned valueOffset) {
-      auto payloadType = getPayloadType(payloadValue);
-      // See if the value matches the payload type exactly. In this case we
-      // don't need to do any work to use the value.
-      if (payloadValueOffset == 0 && valueOffset == 0) {
-        if (value->getType() == payloadType) {
-          payloadValue = value;
-          return;
-        }
-        // If only the width matches exactly, we can still do a bitcast.
-        if (payloadBitWidth == valueBitWidth) {
-          auto bitcast = IGF.Builder.CreateBitOrPointerCast(value, payloadType);
-          payloadValue = bitcast;
-          return;
-        }
-      }
-      
-      // Select out the chunk of the value to merge with the existing payload.
-      llvm::Value *subvalue = value;
-      
-      auto valueIntTy =
-        llvm::IntegerType::get(IGF.IGM.getLLVMContext(), valueBitWidth);
-      auto payloadIntTy =
-        llvm::IntegerType::get(IGF.IGM.getLLVMContext(), payloadBitWidth);
-      auto payloadTy = getPayloadType(payloadValue);
-      subvalue = IGF.Builder.CreateBitOrPointerCast(subvalue, valueIntTy);
-      if (valueOffset > 0)
-        subvalue = IGF.Builder.CreateLShr(subvalue,
-                               llvm::ConstantInt::get(valueIntTy, valueOffset));
-      subvalue = IGF.Builder.CreateZExtOrTrunc(subvalue, payloadIntTy);
-      if (IGF.IGM.Triple.isLittleEndian()) {
-        if (payloadValueOffset > 0)
-          subvalue = IGF.Builder.CreateShl(subvalue,
-                        llvm::ConstantInt::get(payloadIntTy, payloadValueOffset));
-      } else {
-        if ((valueBitWidth == 32 || valueBitWidth == 16 || valueBitWidth == 8 || valueBitWidth == 1) &&
-            payloadBitWidth > (payloadValueOffset + valueBitWidth)) {
-          unsigned shiftBitWidth = valueBitWidth;
-          if (valueBitWidth == 1) {
-            shiftBitWidth = 8;
-          }
-          subvalue = IGF.Builder.CreateShl(subvalue,
-            llvm::ConstantInt::get(payloadIntTy, (payloadBitWidth - shiftBitWidth) - payloadValueOffset));
-        }
-      }
+                              unsigned payloadOffset) {
+  auto &DL = IGF.IGM.DataLayout;
 
-      // If there hasn't yet been a value stored here, we can use the adjusted
-      // value directly.
-      if (payloadValue.is<llvm::Type *>()) {
-        payloadValue = IGF.Builder.CreateBitOrPointerCast(subvalue, payloadTy);
-      }
-      // Otherwise, bitwise-or it in, brazenly assuming there are zeroes
-      // underneath.
-      else {
-        // TODO: This creates a bunch of bitcasting noise for non-integer
-        // payload fields.
-        auto lastValue = payloadValue.get<llvm::Value *>();
-        lastValue = IGF.Builder.CreateBitOrPointerCast(lastValue, payloadIntTy);
-        lastValue = IGF.Builder.CreateOr(lastValue, subvalue);
-        payloadValue = IGF.Builder.CreateBitOrPointerCast(lastValue, payloadTy);
-      }
-    });
+  // Create a mask for the value we are going to insert.
+  auto type = value->getType();
+  auto payloadSize = getAllocSizeInBits(DL);
+  auto mask = createElementMask(DL, type, payloadOffset, payloadSize);
+
+  // Scatter the value into the payload.
+  emitScatterBits(IGF, mask, value);
 }
 
 llvm::Value *EnumPayload::extractValue(IRGenFunction &IGF, llvm::Type *type,
                                        unsigned payloadOffset) const {
   auto &DL = IGF.IGM.DataLayout;
-  auto &C = IGF.IGM.getLLVMContext();
 
-  // Create a mask for the bytes that make up the stored value by
-  // by zero extending the value mask to its storage size.
-  // This makes the mask valid regardless of endianness.
-  auto valueSize = DL.getTypeSizeInBits(type);
-  auto valueMask = APInt::getLowBitsSet(DL.getTypeStoreSizeInBits(type),
-                                        valueSize);
-
-  // Pad the valueMask so that it can be applied to the entire
-  // payload.
-  auto payloadMask = APInt::getNullValue(getAllocSizeInBits(DL));
-  payloadMask.insertBits(valueMask, payloadOffset);
+  // Create a mask for the value we are going to extract.
+  auto payloadSize = getAllocSizeInBits(DL);
+  auto mask = createElementMask(DL, type, payloadOffset, payloadSize);
 
   // Convert the payload mask into a SpareBitVector.
   // TODO: make emitGatherSpareBits take an APInt and delete.
-  auto mask = SpareBitVector::fromAPInt(std::move(payloadMask));
+  auto bits = SpareBitVector::fromAPInt(std::move(mask));
 
   // Gather the value from the payload.
-  auto value = emitGatherSpareBits(IGF, mask, 0, valueSize);
+  auto valueSize = DL.getTypeSizeInBits(type);
+  auto value = emitGatherSpareBits(IGF, bits, 0, valueSize);
 
   // Convert the integer value to the required type.
-  if (DL.getTypeSizeInBits(value->getType()) > valueSize) {
-    auto intTy = llvm::IntegerType::get(C, valueSize);
-    value = IGF.Builder.CreateTrunc(value, intTy);
-  }
   if (value->getType() != type) {
     value = IGF.Builder.CreateBitOrPointerCast(value, type);
   }
@@ -361,20 +286,22 @@ void EnumPayload::emitSwitch(IRGenFunction &IGF,
   }
 
   // Otherwise emit a switch statement.
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &C = IGF.IGM.getLLVMContext();
   unsigned numBits = mask.countPopulation();
   auto target = emitGatherSpareBits(IGF, SpareBitVector::fromAPInt(mask),
                                     0, numBits);
   auto swi = IGF.Builder.CreateSwitch(target, dflt.getPointer(), cases.size());
   for (auto &c : cases) {
-    auto value = llvm::ConstantInt::get(context, gatherBits(mask, c.first));
+    auto value = llvm::ConstantInt::get(C, gatherBits(mask, c.first));
     swi->addCase(value, c.second);
   }
   assert(IGF.Builder.hasPostTerminatorIP());
 }
 
 llvm::Value *
-EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
+EnumPayload::emitCompare(IRGenFunction &IGF,
+                         const APInt &mask,
+                         const APInt &value) const {
   // Succeed trivially for an empty payload, or if the payload is masked
   // out completely.
   if (PayloadValues.empty() || mask == 0)
@@ -382,20 +309,20 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
 
   assert((~mask & value) == 0
          && "value has masked out bits set?!");
-  
+
   auto &DL = IGF.IGM.DataLayout;
+  auto valueReader = BitPatternReader(value, DL.isLittleEndian());
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   llvm::Value *condition = nullptr;
   for (auto &pv : PayloadValues) {
     auto v = forcePayloadValue(pv);
     unsigned size = DL.getTypeSizeInBits(v->getType());
 
     // Break off a piece of the mask and value.
-    auto maskPiece = mask.zextOrTrunc(size);
-    auto valuePiece = value.zextOrTrunc(size);
-    
-    mask = mask.lshr(size);
-    value = value.lshr(size);
-    
+    auto maskPiece = maskReader.read(size);
+    auto valuePiece = valueReader.read(size);
+
     // If this piece is zero, it doesn't affect the comparison.
     if (maskPiece == 0)
       continue;
@@ -432,19 +359,20 @@ EnumPayload::emitCompare(IRGenFunction &IGF, APInt mask, APInt value) const {
 }
 
 void
-EnumPayload::emitApplyAndMask(IRGenFunction &IGF, APInt mask) {
+EnumPayload::emitApplyAndMask(IRGenFunction &IGF, const APInt &mask) {
   // Early exit if the mask has no effect.
   if (mask.isAllOnesValue())
     return;
 
   auto &DL = IGF.IGM.DataLayout;
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   for (auto &pv : PayloadValues) {
     auto payloadTy = getPayloadType(pv);
     unsigned size = DL.getTypeSizeInBits(payloadTy);
 
-    // Break off a chunk of the mask.
-    auto maskPiece = mask.zextOrTrunc(size);
-    mask = mask.lshr(size);
+    // Read a chunk of the mask.
+    auto maskPiece = maskReader.read(size);
     
     // If this piece is all ones, it has no effect.
     if (maskPiece.isAllOnesValue())
@@ -473,19 +401,20 @@ EnumPayload::emitApplyAndMask(IRGenFunction &IGF, APInt mask) {
 }
 
 void
-EnumPayload::emitApplyOrMask(IRGenFunction &IGF, APInt mask) {
+EnumPayload::emitApplyOrMask(IRGenFunction &IGF, const APInt &mask) {
   // Early exit if the mask has no effect.
   if (mask == 0)
     return;
 
   auto &DL = IGF.IGM.DataLayout;
+  auto maskReader = BitPatternReader(mask, DL.isLittleEndian());
+
   for (auto &pv : PayloadValues) {
     auto payloadTy = getPayloadType(pv);
     unsigned size = DL.getTypeSizeInBits(payloadTy);
 
-    // Break off a chunk of the mask.
-    auto maskPiece = mask.zextOrTrunc(size);
-    mask = mask.lshr(size);
+    // Read a chunk of the mask.
+    auto maskPiece = maskReader.read(size);
 
     // If this piece is zero, it has no effect.
     if (maskPiece == 0)
@@ -543,57 +472,119 @@ EnumPayload::emitApplyOrMask(IRGenFunction &IGF,
   }
 }
 
+void EnumPayload::emitScatterBits(IRGenFunction &IGF,
+                                  const APInt &mask,
+                                  llvm::Value *value) {
+  auto &DL = IGF.IGM.DataLayout;
+  auto &B = IGF.Builder;
+
+  unsigned valueBits = DL.getTypeSizeInBits(value->getType());
+  auto totalBits = std::min(valueBits, mask.countPopulation());
+  auto maskReader = BitPatternReader(getLowestNSetBits(mask, totalBits),
+                                     DL.isLittleEndian());
+  auto usedBits = 0u;
+  for (auto &pv : PayloadValues) {
+    auto partType = getPayloadType(pv);
+    auto partSize = DL.getTypeSizeInBits(partType);
+    auto partMask = maskReader.read(partSize);
+
+    // Skip this element if there are no set bits in the mask.
+    if (partMask == 0) {
+      continue;
+    }
+
+    // Calculate the number of bits we are going to scatter.
+    auto partCount = partMask.countPopulation();
+
+    // Scatter bits from the source into the bits specified by the mask.
+    auto offset = usedBits;
+    if (DL.isBigEndian()) {
+      offset = totalBits - partCount - usedBits;
+    }
+    auto partValue = irgen::emitScatterBits(IGF, partMask, value, offset);
+
+    // If necessary OR with the existing value.
+    if (auto existingValue = pv.dyn_cast<llvm::Value*>()) {
+      if (partType != partValue->getType()) {
+        existingValue = B.CreateBitOrPointerCast(existingValue,
+                                                 partValue->getType());
+      }
+      partValue = B.CreateOr(partValue, existingValue);
+    }
+
+    // Convert the integer result to the target type.
+    if (partType != partValue->getType()) {
+      partValue = B.CreateBitOrPointerCast(partValue, partType);
+    }
+
+    // Update this payload element.
+    pv = partValue;
+
+    // Update our position in the source integer.
+    usedBits += partCount;
+    if (usedBits >= totalBits) {
+      break;
+    }
+  }
+}
+
 llvm::Value *
 EnumPayload::emitGatherSpareBits(IRGenFunction &IGF,
                                  const SpareBitVector &spareBits,
                                  unsigned firstBitOffset,
-                                 unsigned bitWidth) const {
+                                 unsigned resultBitWidth) const {
   auto &DL = IGF.IGM.DataLayout;
-  unsigned payloadOffset = 0;
+  auto &C = IGF.IGM.getLLVMContext();
+
+  auto mask = getLowestNSetBits(spareBits.asAPInt(),
+                                resultBitWidth - firstBitOffset);
+  auto bitWidth = mask.countPopulation();
+  auto spareBitReader = BitPatternReader(std::move(mask),
+                                         DL.isLittleEndian());
+  auto usedBits = firstBitOffset;
+
   llvm::Value *spareBitValue = nullptr;
-  auto destTy = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), bitWidth);
   for (auto &pv : PayloadValues) {
     // If this value is zero, it has nothing to add to the spare bits.
     auto v = pv.dyn_cast<llvm::Value*>();
     if (!v) {
-      payloadOffset += DL.getTypeSizeInBits(pv.get<llvm::Type*>());
+      spareBitReader.skip(DL.getTypeSizeInBits(pv.get<llvm::Type*>()));
       continue;
     }
-    
-    unsigned size = DL.getTypeSizeInBits(v->getType());
+
     // Slice the spare bit vector.
-    // FIXME: this is inefficient.
-    auto spareBitsPart = SpareBitVector::getConstant(size, false);
-    unsigned numBitsInPart = 0;
-    for (unsigned i = 0; i < size; ++i)
-      if (spareBits[payloadOffset + i]) {
-        spareBitsPart.setBit(i);
-        ++numBitsInPart;
-      }
-    
-    payloadOffset += size;
-    
+    unsigned size = DL.getTypeSizeInBits(v->getType());
+    auto spareBitsPart = spareBitReader.read(size);
+    unsigned numBitsInPart = spareBitsPart.countPopulation();
+
     // If there were no spare bits in this part, it has nothing to add.
     if (numBitsInPart == 0)
       continue;
-    
-    if (firstBitOffset >= bitWidth)
+
+    if (usedBits >= bitWidth)
       break;
 
+    unsigned offset = usedBits;
+    if (DL.isBigEndian()) {
+      offset = bitWidth - usedBits - numBitsInPart;
+    }
     // Get the spare bits from this part.
-    auto bits = irgen::emitGatherBits(IGF, spareBitsPart.asAPInt(),
-                                      v, firstBitOffset, bitWidth);
-    firstBitOffset += numBitsInPart;
-    
+    auto bits = irgen::emitGatherBits(IGF, spareBitsPart,
+                                      v, offset, resultBitWidth);
+    usedBits += numBitsInPart;
+
     // Accumulate it into the full set.
-    if (!spareBitValue)
-      spareBitValue = bits;
-    else
-      spareBitValue = IGF.Builder.CreateOr(spareBitValue, bits);
+    if (spareBitValue) {
+      bits = IGF.Builder.CreateOr(spareBitValue, bits);
+    }
+    spareBitValue = bits;
   }
-  if (!spareBitValue)
-    return llvm::ConstantInt::get(destTy, 0);
-  return spareBitValue;
+  auto destTy = llvm::IntegerType::get(C, resultBitWidth);
+  if (spareBitValue) {
+    assert(spareBitValue->getType() == destTy);
+    return spareBitValue;
+  }
+  return llvm::ConstantInt::get(destTy, 0);
 }
 
 unsigned EnumPayload::getAllocSizeInBits(const llvm::DataLayout &DL) const {

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -95,9 +95,9 @@ public:
 
   /// Generate an enum payload containing the given bit pattern.
   static EnumPayload fromBitPattern(IRGenModule &IGM,
-                                    APInt bitPattern,
+                                    const APInt &bitPattern,
                                     EnumPayloadSchema schema);
-  
+
   /// Insert a value into the enum payload.
   ///
   /// The current payload value at the given offset is assumed to be zero.
@@ -105,8 +105,7 @@ public:
   /// that need storing in \p value otherwise the full bit-width of \p value
   /// will be stored.
   void insertValue(IRGenFunction &IGF,
-                   llvm::Value *value, unsigned bitOffset,
-                   int numBitsUsedInValue = -1);
+                   llvm::Value *value, unsigned bitOffset);
   
   /// Extract a value from the enum payload.
   llvm::Value *extractValue(IRGenFunction &IGF,
@@ -147,18 +146,25 @@ public:
   
   /// Emit an equality comparison operation that payload & mask == value.
   llvm::Value *emitCompare(IRGenFunction &IGF,
-                           APInt mask,
-                           APInt value) const;
+                           const APInt &mask,
+                           const APInt &value) const;
   
   /// Apply an AND mask to the payload.
-  void emitApplyAndMask(IRGenFunction &IGF, APInt mask);
+  void emitApplyAndMask(IRGenFunction &IGF, const APInt &mask);
   
   /// Apply an OR mask to the payload.
-  void emitApplyOrMask(IRGenFunction &IGF, APInt mask);
+  void emitApplyOrMask(IRGenFunction &IGF, const APInt &mask);
   
   /// Apply an OR mask to the payload.
   void emitApplyOrMask(IRGenFunction &IGF, EnumPayload mask);
-  
+
+  /// Scatter the bits in value to the bit positions indicated by the
+  /// mask. The new bits are added using OR, so an emitApplyAndMask
+  /// call should be used first if existing bits need to be cleared.
+  void emitScatterBits(IRGenFunction &IGF,
+                       const APInt &mask,
+                       llvm::Value *value);
+
   /// Gather bits from an enum payload based on a spare bit mask.
   llvm::Value *emitGatherSpareBits(IRGenFunction &IGF,
                                    const SpareBitVector &spareBits,

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -26,54 +26,38 @@ namespace swift {
 namespace irgen {
   
 /// A description of how to represent an enum payload as a value.
-/// A payload can either use a generic word-chunked representation, or attempt
-/// to follow the explosion schema of one of its payload types.
+/// A payload can either use a generic word-chunked representation,
+/// or attempt to follow the explosion schema of one of its payload
+/// types.
+/// TODO: the current code only ever uses the generic word-chunked
+/// representation, it might be better if it used an appropriate
+/// explosion schema instead.
 class EnumPayloadSchema {
-  using BitSizeTy = llvm::PointerEmbeddedInt<unsigned, 31>;
-
-  const llvm::PointerUnion<ExplosionSchema *, BitSizeTy> Value;
-
+  // A size in bits less than 0 indicates that the payload size is
+  // dynamic.
+  const int64_t BitSize;
 public:
-  EnumPayloadSchema() : Value((ExplosionSchema *)nullptr) {}
+  /// Create a new schema with a dynamic size.
+  EnumPayloadSchema() : BitSize(-1) {}
 
-  explicit operator bool() {
-    return Value.getOpaqueValue() != nullptr;
-  }
-
+  /// Create a new schema with the given fixed size in bits.
   explicit EnumPayloadSchema(unsigned bits)
-    : Value(BitSizeTy(bits)) {}
+    : BitSize(static_cast<int64_t>(bits)) {}
 
-  EnumPayloadSchema(ExplosionSchema &s)
-    : Value(&s) {}
+  /// Report whether the schema has a fixed size.
+  explicit operator bool() const {
+    return BitSize >= 0;
+  }
 
-  static EnumPayloadSchema withBitSize(unsigned bits) {
-    return EnumPayloadSchema(bits);
-  }
-  
-  ExplosionSchema *getSchema() const {
-    return Value.dyn_cast<ExplosionSchema*>();
-  }
-  
   /// Invoke a functor for each element type in the schema.
   template<typename TypeFn /* void(llvm::Type *schemaType) */>
   void forEachType(IRGenModule &IGM, TypeFn &&fn) const {
-    // Follow an explosion schema if we have one.
-    if (auto *explosion = Value.dyn_cast<ExplosionSchema *>()) {
-      for (auto &element : *explosion) {
-        auto type = element.getScalarType();
-        assert(IGM.DataLayout.getTypeSizeInBits(type)
-                 == IGM.DataLayout.getTypeAllocSizeInBits(type)
-               && "enum payload schema elements should use full alloc size");
-        (void) type;
-        fn(element.getScalarType());
-      }
-      return;
-    }
-    
-    // Otherwise, chunk into pointer-sized integer values by default.
-    unsigned bitSize = Value.get<BitSizeTy>();
-    unsigned pointerSize = IGM.getPointerSize().getValueInBits();
-    
+    assert(BitSize >= 0 && "payload size must not be dynamic");
+
+    // Chunk into pointer-sized integer values.
+    int64_t bitSize = BitSize;
+    int64_t pointerSize = IGM.getPointerSize().getValueInBits();
+
     while (bitSize >= pointerSize) {
       fn(IGM.SizeTy);
       bitSize -= pointerSize;

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -164,6 +164,10 @@ public:
                                    const SpareBitVector &spareBits,
                                    unsigned firstBitOffset,
                                    unsigned bitWidth) const;
+private:
+  /// Calculate the total number of bits this payload requires.
+  /// This will always be a multiple of 8.
+  unsigned getAllocSizeInBits(const llvm::DataLayout &DL) const;
 };
   
 }

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -141,7 +141,7 @@ public:
   /// Emit a switch over specific bit patterns for the payload.
   /// The value will be tested as if AND-ed against the given mask.
   void emitSwitch(IRGenFunction &IGF,
-                  APInt mask,
+                  const APInt &mask,
                   ArrayRef<std::pair<APInt, llvm::BasicBlock*>> cases,
                   SwitchDefaultDest dflt) const;
   

--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -29,9 +29,8 @@ static unsigned getNumLowObjCReservedBits(const IRGenModule &IGM) {
     return 0;
 
   // Get the index of the first non-reserved bit.
-  SpareBitVector ObjCMask = IGM.TargetInfo.ObjCPointerReservedBits;
-  ObjCMask.flipAll();
-  return ObjCMask.enumerateSetBits().findNext().getValue();
+  auto &mask = IGM.TargetInfo.ObjCPointerReservedBits;
+  return mask.asAPInt().countTrailingOnes();
 }
 
 /*****************************************************************************/

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -213,10 +213,11 @@ public:
   ///   SpareBitVector spareBits;
   ///   for (EnumElementDecl *elt : u->getAllElements())
   ///     getFragileTypeInfo(elt->getArgumentType())
-  ///       .applyFixedSpareBitsMask(spareBits);
+  ///       .applyFixedSpareBitsMask(IGM, spareBits);
   ///
   /// and end up with a spare bits mask for the entire enum.
-  void applyFixedSpareBitsMask(SpareBitVector &mask) const;
+  void applyFixedSpareBitsMask(const IRGenModule &IGM,
+                               SpareBitVector &mask) const;
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -213,19 +213,10 @@ public:
   ///   SpareBitVector spareBits;
   ///   for (EnumElementDecl *elt : u->getAllElements())
   ///     getFragileTypeInfo(elt->getArgumentType())
-  ///       .applyFixedSpareBitsMask(spareBits, 0);
+  ///       .applyFixedSpareBitsMask(spareBits);
   ///
   /// and end up with a spare bits mask for the entire enum.
   void applyFixedSpareBitsMask(SpareBitVector &mask) const;
-  
-  /// Applies a fixed spare bits mask to the given BitVector,
-  /// clearing any bits used by valid representations of the type.
-  ///
-  /// If the bitvector is empty or smaller than this type, it is grown and
-  /// filled with bits direct from the spare bits mask. If the bitvector is
-  /// larger than this type, the trailing bits are untouched.
-  static void applyFixedSpareBitsMask(SpareBitVector &mask,
-                                      const SpareBitVector &spareBits);
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1334,11 +1334,6 @@ namespace {
         PayloadBitCount = ~0u;
       }
     }
-    
-    ~PayloadEnumImplStrategyBase() override {
-      if (auto schema = PayloadSchema.getSchema())
-        delete schema;
-    }
 
     void getSchema(ExplosionSchema &schema) const override {
       if (TIK < Loadable) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6931,6 +6931,24 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
   return result;
 }
 
+/// Pack masked bits into the low bits of an integer value.
+llvm::APInt irgen::gatherBits(const llvm::APInt &mask,
+                              const llvm::APInt &value) {
+  assert(mask.getBitWidth() == value.getBitWidth());
+  llvm::APInt result = llvm::APInt(mask.countPopulation(), 0);
+  unsigned j = 0;
+  for (unsigned i = 0; i < mask.getBitWidth(); ++i) {
+    if (!mask[i]) {
+      continue;
+    }
+    if (value[i]) {
+      result.setBit(j);
+    }
+    ++j;
+  }
+  return result;
+}
+
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 llvm::APInt irgen::scatterBits(const llvm::APInt &mask, unsigned value) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6801,62 +6801,141 @@ void irgen::emitStoreEnumTagToAddress(IRGenFunction &IGF,
     .storeTag(IGF, enumTy, enumAddr, theCase);
 }
 
-/// Scatter spare bits from the low bits of an integer value.
-llvm::Value *irgen::emitScatterSpareBits(IRGenFunction &IGF,
-                                         const SpareBitVector &spareBitMask,
-                                         llvm::Value *packedBits,
-                                         unsigned packedLowBit) {
-  auto destTy
-    = llvm::IntegerType::get(IGF.IGM.getLLVMContext(), spareBitMask.size());
-  llvm::Value *result = nullptr;
-  unsigned usedBits = packedLowBit;
+/// Extract the rightmost run of contiguous set bits from the
+/// provided integer or zero if there are no set bits in the
+/// provided integer. For example:
+///
+///   rightmostMask(0x0f0f_0f0f) = 0x0000_000f
+///   rightmostMask(0xf0f0_f0f0) = 0x0000_00f0
+///   rightmostMask(0xffff_ff10) = 0x0000_0010
+///   rightmostMask(0xffff_ff80) = 0xffff_ff80
+///   rightmostMask(0x0000_0000) = 0x0000_0000
+///
+static inline llvm::APInt rightmostMask(const llvm::APInt& mask) {
+  if (mask.isShiftedMask()) {
+    return mask;
+  }
+  // This formula is derived from the formula to "turn off the
+  // rightmost contiguous string of 1's" in Chapter 2-1 of
+  // Hacker's Delight (Second Edition) by Henry S. Warren and
+  // attributed to Luther Woodrum.
+  llvm::APInt result = -mask;
+  result &= mask; // isolate rightmost set bit
+  result += mask; // clear rightmost contiguous set bits
+  result &= mask; // mask out carry bit leftover from add
+  result ^= mask; // extract desired bits
+  return result;
+}
 
-  // Expand the packed bits to the destination type.
-  packedBits = IGF.Builder.CreateZExtOrTrunc(packedBits, destTy);
+/// Pack masked bits into the low bits of an integer value.
+/// Equivalent to a parallel bit extract instruction (PEXT),
+/// although we don't currently emit PEXT directly.
+llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
+                                   llvm::APInt mask,
+                                   llvm::Value *source,
+                                   unsigned resultLowBit,
+                                   unsigned resultBitWidth) {
+  auto &builder = IGF.Builder;
+  auto &context = IGF.IGM.getLLVMContext();
+  assert(mask.getBitWidth() == source->getType()->getIntegerBitWidth()
+    && "source and mask must have same width");
 
-  auto spareBitEnumeration = spareBitMask.enumerateSetBits();
-  for (auto nextSpareBit = spareBitEnumeration.findNext();
-       nextSpareBit.hasValue();
-       nextSpareBit = spareBitEnumeration.findNext()) {
-    unsigned u = nextSpareBit.getValue(), startBit = u;
-    assert(u >= usedBits - packedLowBit
-           && "used more bits than we've processed?!");
-
-    // Shift the selected bits into place.
-    llvm::Value *newBits;
-    if (u > usedBits)
-      newBits = IGF.Builder.CreateShl(packedBits, u - usedBits);
-    else if (u < usedBits)
-      newBits = IGF.Builder.CreateLShr(packedBits, usedBits - u);
-    else
-      newBits = packedBits;
-
-    // See how many consecutive bits we have.
-    unsigned numBits = 1;
-    ++u;
-    for (unsigned e = spareBitMask.size(); u < e && spareBitMask[u]; ++u) {
-      ++numBits;
-      auto nextBit = spareBitEnumeration.findNext(); (void) nextBit;
-      assert(nextBit.hasValue());
-    }
-
-    // Mask out the selected bits.
-    auto val = APInt::getAllOnesValue(numBits);
-    if (numBits < spareBitMask.size())
-      val = val.zext(spareBitMask.size());
-    val = val.shl(startBit);
-    auto mask = llvm::ConstantInt::get(IGF.IGM.getLLVMContext(), val);
-    newBits = IGF.Builder.CreateAnd(newBits, mask);
-
-    // Accumulate the result.
-    if (result)
-      result = IGF.Builder.CreateOr(result, newBits);
-    else
-      result = newBits;
-
-    usedBits += numBits;
+  // The source and mask need to be at least as wide as the result so
+  // that bits can be shifted into the correct position.
+  auto destTy = llvm::IntegerType::get(context, resultBitWidth);
+  if (mask.getBitWidth() < resultBitWidth) {
+    source = builder.CreateZExt(source, destTy);
+    mask = mask.zext(resultBitWidth);
   }
 
+  // Shift each set of contiguous set bits into position and
+  // accumulate them into the result.
+  int64_t usedBits = resultLowBit;
+  llvm::Value *result = nullptr;
+  while (mask != 0) {
+    // Isolate the rightmost run of contiguous set bits.
+    // Example: 0b0011_01101_1100 -> 0b0000_0001_1100
+    llvm::APInt partMask = rightmostMask(mask);
+
+    // Update the bits we need to mask next.
+    mask ^= partMask;
+
+    // Shift the selected bits into position.
+    llvm::Value *part = source;
+    int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
+    if (offset > 0) {
+      uint64_t shift = uint64_t(offset);
+      part = builder.CreateLShr(part, shift);
+      partMask.lshrInPlace(shift);
+    } else if (offset < 0) {
+      uint64_t shift = uint64_t(-offset);
+      part = builder.CreateShl(part, shift);
+      partMask <<= shift;
+    }
+
+    // Truncate the output to the result size.
+    if (partMask.getBitWidth() > resultBitWidth) {
+      partMask = partMask.trunc(resultBitWidth);
+      part = builder.CreateTrunc(part, destTy);
+    }
+
+    // Mask out selected bits.
+    part = builder.CreateAnd(part, partMask);
+
+    // Accumulate the result.
+    result = result ? builder.CreateOr(result, part) : part;
+
+    // Update the offset and remaining mask.
+    usedBits += partMask.countPopulation();
+  }
+  return result;
+}
+
+/// Unpack bits from the low bits of an integer value and
+/// move them to the bit positions indicated by the mask.
+/// Equivalent to a parallel bit deposit instruction (PDEP),
+/// although we don't currently emit PDEP directly.
+llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
+                                    llvm::APInt mask,
+                                    llvm::Value *source,
+                                    unsigned packedLowBit) {
+  auto &builder = IGF.Builder;
+  auto &context = IGF.IGM.getLLVMContext();
+
+  // Expand the packed bits to the destination type.
+  auto destTy = llvm::IntegerType::get(context, mask.getBitWidth());
+  source = builder.CreateZExtOrTrunc(source, destTy);
+
+  // Shift each set of contiguous set bits into position and
+  // accumulate them into the result.
+  int64_t usedBits = packedLowBit;
+  llvm::Value *result = nullptr;
+  while (mask != 0) {
+    // Isolate the rightmost run of contiguous set bits.
+    // Example: 0b0011_01101_1100 -> 0b0000_0001_1100
+    llvm::APInt partMask = rightmostMask(mask);
+
+    // Update the bits we need to mask next.
+    mask ^= partMask;
+
+    // Shift the selected bits into position.
+    llvm::Value *part = source;
+    int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
+    if (offset > 0) {
+      part = builder.CreateShl(part, uint64_t(offset));
+    } else if (offset < 0) {
+      part = builder.CreateLShr(part, uint64_t(-offset));
+    }
+
+    // Mask out selected bits.
+    part = builder.CreateAnd(part, partMask);
+
+    // Accumulate the result.
+    result = result ? builder.CreateOr(result, part) : part;
+
+    // Update the offset and remaining mask.
+    usedBits += partMask.countPopulation();
+  }
   return result;
 }
 
@@ -6923,8 +7002,8 @@ EnumPayload irgen::interleaveSpareBits(IRGenFunction &IGF,
         payloadValue = IGF.Builder.CreateLShr(payloadValue,
                        llvm::ConstantInt::get(IGF.IGM.Int32Ty, usedBits));
       }
-      payloadValue = emitScatterSpareBits(IGF, spareBitsChunk,
-                                          payloadValue, 0);
+      payloadValue = emitScatterBits(IGF, spareBitsChunk.asAPInt(),
+                                     payloadValue, 0);
       if (payloadValue->getType() != type) {
         if (type->isPointerTy())
           payloadValue = IGF.Builder.CreateIntToPtr(payloadValue, type);

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -4227,12 +4227,12 @@ namespace {
       } else if (!CommonSpareBits.empty()) {
         // Otherwise the payload is just the index.
         payload = EnumPayload::zero(IGM, PayloadSchema);
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-        // Code produced above are of type IGM.Int32Ty
-        // However, payload is IGM.SizeTy in 64bit
-        if (numCaseBits >= 64)
-          tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
-#endif
+        if (!IGF.IGM.Triple.isLittleEndian()) {
+          if (IGF.IGM.Triple.isArch64Bit() && numCaseBits >= 64) {
+            // Need to set the full 64-bit chunk on big-endian systems.
+            tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
+          }
+	}
         // We know we won't use more than numCaseBits from tagIndex's value:
         // We made sure of this in the logic above.
         payload.insertValue(IGF, tagIndex, 0,

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -115,6 +115,7 @@
 #include "llvm/Support/Compiler.h"
 #include "clang/CodeGen/SwiftCallingConv.h"
 
+#include "BitPatternBuilder.h"
 #include "GenDecl.h"
 #include "GenMeta.h"
 #include "GenProto.h"
@@ -140,17 +141,6 @@ static llvm::Constant *emitEnumLayoutFlags(IRGenModule &IGM, bool isVWTMutable){
   if (isVWTMutable) flags |= EnumLayoutFlags::IsVWTMutable;
 
   return IGM.getSize(Size(uintptr_t(flags)));
-}
-
-static SpareBitVector
-getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
-  if (startBit == 0) {
-    return SpareBitVector::fromAPInt(bits);
-  }
-  SpareBitVector result;
-  result.appendClearBits(startBit);
-  result.append(SpareBitVector::fromAPInt(bits));
-  return result;
 }
 
 static IsABIAccessible_t
@@ -981,10 +971,9 @@ namespace {
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
-      auto bits
-        = getBitVectorFromAPInt(getDiscriminatorIdxConst(theCase)->getValue());
-      bits.extendWithClearBits(cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits());
-      return bits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
+      auto val = getDiscriminatorIdxConst(theCase)->getValue();
+      return ClusteredBitVector::fromAPInt(val.zextOrSelf(size.getValueInBits()));
     }
 
     ClusteredBitVector
@@ -3189,90 +3178,64 @@ namespace {
         return APInt::getAllOnesValue(totalSize);
       auto baseMask =
         getFixedPayloadTypeInfo().getFixedExtraInhabitantMask(IGM);
-      
-      if (baseMask.getBitWidth() < totalSize)
-        baseMask = baseMask.zext(totalSize)
-         | APInt::getHighBitsSet(totalSize, totalSize - baseMask.getBitWidth());
-      
-      return baseMask;
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      mask.append(baseMask);
+      mask.padWithSetBitsTo(totalSize);
+      return mask.build().getValue();
     }
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
       APInt payloadPart, extraPart;
       std::tie(payloadPart, extraPart) = getNoPayloadCaseValue(theCase);
-      ClusteredBitVector bits;
-
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
       if (PayloadBitCount > 0)
-        bits = getBitVectorFromAPInt(payloadPart);
+        value.append(payloadPart);
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount > 0) {
-        ClusteredBitVector extraBits = getBitVectorFromAPInt(extraPart,
-                                                             bits.size());
-        bits.extendWithClearBits(totalSize);
-        extraBits.extendWithClearBits(totalSize);
-        bits |= extraBits;
-      } else {
-        assert(totalSize == bits.size());
+        auto paddedWidth = size.getValueInBits() - PayloadBitCount;
+        value.append(extraPart.zextOrSelf(paddedWidth));
       }
-      return bits;
+      return value.build();
     }
 
     ClusteredBitVector
     getBitMaskForNoPayloadElements() const override {
       // Use the extra inhabitants mask from the payload.
       auto &payloadTI = getFixedPayloadTypeInfo();
-      APInt extraInhabitantsMaskInt;
 
-      // If we used extra inhabitants from the payload, then we can use the
-      // payload's mask to find the bits we need to test.
-      auto extraDiscriminatorBits = (~APInt(8, 0));
-      if (payloadTI.getFixedSize().getValueInBits() != 0)
-        extraDiscriminatorBits =
-          extraDiscriminatorBits.zextOrTrunc(
-              payloadTI.getFixedSize().getValueInBits());
-      if (getNumExtraInhabitantTagValues() > 0) {
-        extraInhabitantsMaskInt = payloadTI.getFixedExtraInhabitantMask(IGM);
-        // If we have more no-payload cases than extra inhabitants, also
-        // mask in up to four bytes for discriminators we generate using
-        // extra tag bits.
-        if (ExtraTagBitCount > 0) {
-          extraInhabitantsMaskInt |= extraDiscriminatorBits;
-        }
-      } else {
-        // If we only use extra tag bits, then we need that extra tag plus
-        // up to four bytes of discriminator.
-        extraInhabitantsMaskInt = extraDiscriminatorBits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      if (Size payloadSize = payloadTI.getFixedSize()) {
+        auto payloadMask = APInt::getNullValue(payloadSize.getValueInBits());
+        if (getNumExtraInhabitantTagValues() > 0)
+          payloadMask |= payloadTI.getFixedExtraInhabitantMask(IGM);
+        if (ExtraTagBitCount > 0)
+          payloadMask |= 0xffffffffULL;
+        mask.append(std::move(payloadMask));
       }
-      auto extraInhabitantsMask
-        = getBitVectorFromAPInt(extraInhabitantsMaskInt);
-      
-      // Extend to include the extra tag bits, which are always significant.
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-      extraInhabitantsMask.extendWithSetBits(totalSize);
-      return extraInhabitantsMask;
+      if (ExtraTagBitCount > 0) {
+        mask.padWithSetBitsTo(size.getValueInBits());
+      }
+      return mask.build();
     }
 
     ClusteredBitVector getTagBitsForPayloads() const override {
       // We only have tag bits if we spilled extra bits.
-      ClusteredBitVector result;
-      unsigned payloadSize
-        = getFixedPayloadTypeInfo().getFixedSize().getValueInBits();
-      result.appendClearBits(payloadSize);
+      auto tagBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      Size payloadSize = getFixedPayloadTypeInfo().getFixedSize();
+      tagBits.appendClearBits(payloadSize.getValueInBits());
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-
+      Size totalSize = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount) {
-        result.appendSetBits(ExtraTagBitCount);
-        result.extendWithClearBits(totalSize);
+        Size extraTagSize = totalSize - payloadSize;
+        tagBits.append(APInt(extraTagSize.getValueInBits(),
+                             (1U << ExtraTagBitCount) - 1));
       } else {
         assert(payloadSize == totalSize);
       }
-      return result;
+      return tagBits.build();
     }
   };
 
@@ -3604,18 +3567,14 @@ namespace {
     EnumPayload getEmptyCasePayload(IRGenFunction &IGF,
                                     llvm::Value *tag,
                                     llvm::Value *tagIndex) const {
-      SpareBitVector commonSpareBits = CommonSpareBits;
-      commonSpareBits.flipAll();
-
-      EnumPayload result = interleaveSpareBits(IGF, PayloadSchema,
-                                               commonSpareBits, tagIndex);
-      result.emitApplyOrMask(IGF,
-                             interleaveSpareBits(IGF, PayloadSchema,
-                                                 PayloadTagBits, tag));
-
+      auto result = EnumPayload::zero(IGF.IGM, PayloadSchema);
+      if (!CommonSpareBits.empty())
+        result.emitScatterBits(IGF, ~CommonSpareBits.asAPInt(), tagIndex);
+      if (!PayloadTagBits.empty())
+        result.emitScatterBits(IGF, PayloadTagBits.asAPInt(), tag);
       return result;
     }
-    
+
     struct DestructuredLoadableEnum {
       EnumPayload payload;
       llvm::Value *extraTagBits;
@@ -4226,17 +4185,10 @@ namespace {
         payload = getEmptyCasePayload(IGF, tag, tagIndex);
       } else if (!CommonSpareBits.empty()) {
         // Otherwise the payload is just the index.
+        auto mask = APInt::getLowBitsSet(CommonSpareBits.size(),
+                                         std::min(32U, numCaseBits));
         payload = EnumPayload::zero(IGM, PayloadSchema);
-        if (!IGF.IGM.Triple.isLittleEndian()) {
-          if (IGF.IGM.Triple.isArch64Bit() && numCaseBits >= 64) {
-            // Need to set the full 64-bit chunk on big-endian systems.
-            tagIndex = IGF.Builder.CreateZExt(tagIndex, IGM.SizeTy);
-          }
-	}
-        // We know we won't use more than numCaseBits from tagIndex's value:
-        // We made sure of this in the logic above.
-        payload.insertValue(IGF, tagIndex, 0,
-                            numCaseBits >= 32 ? -1 : numCaseBits);
+        payload.emitScatterBits(IGF, mask, tagIndex);
       }
 
       // If the tag bits do not fit in the spare bits, the remaining tag bits
@@ -4858,10 +4810,7 @@ namespace {
         payload.emitApplyAndMask(IGF, spareBitMask);
 
         // Store the tag into the spare bits.
-        payload.emitApplyOrMask(IGF,
-                                interleaveSpareBits(IGF, PayloadSchema,
-                                                    PayloadTagBits,
-                                                    spareTagBits));
+        payload.emitScatterBits(IGF, PayloadTagBits.asAPInt(), spareTagBits);
 
         // Store the payload back.
         payload.store(IGF, payloadAddr);
@@ -5218,8 +5167,8 @@ namespace {
       if (CommonSpareBits.count()) {
         // Factor the index value into parts to scatter into the payload and
         // to store in the extra tag bits, if any.
-        EnumPayload payload =
-          interleaveSpareBits(IGF, PayloadSchema, CommonSpareBits, indexValue);
+        auto payload = EnumPayload::zero(IGM, PayloadSchema);
+        payload.emitScatterBits(IGF, CommonSpareBits.asAPInt(), indexValue);
         payload.store(IGF, projectPayload(IGF, dest));
         if (getExtraTagBitCountForExtraInhabitants() > 0) {
           auto tagBits = IGF.Builder.CreateLShr(indexValue,
@@ -5274,11 +5223,10 @@ namespace {
       auto tagBits = CommonSpareBits.asAPInt();
       auto fixedTI = cast<FixedTypeInfo>(TI);
       if (getExtraTagBitCountForExtraInhabitants() > 0) {
-        auto bitSize = fixedTI->getFixedSize().getValueInBits();
-        tagBits = tagBits.zext(bitSize);
-        auto extraTagMask = APInt::getAllOnesValue(bitSize)
-          .shl(CommonSpareBits.size());
-        tagBits |= extraTagMask;
+        auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+        mask.append(CommonSpareBits);
+        mask.padWithSetBitsTo(fixedTI->getFixedSize().getValueInBits());
+        tagBits = mask.build().getValue();
       }
       return tagBits;
     }
@@ -5323,30 +5271,28 @@ namespace {
       auto extraTagMask = getExtraTagBitCountForExtraInhabitants() >= 32
         ? ~0u : (1 << getExtraTagBitCountForExtraInhabitants()) - 1;
 
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
       if (auto payloadBitCount = CommonSpareBits.count()) {
         auto payloadTagMask = payloadBitCount >= 32
           ? ~0u : (1 << payloadBitCount) - 1;
         auto payloadPart = mask & payloadTagMask;
-        auto payloadBits = scatterBits(CommonSpareBits.asAPInt().zextOrTrunc(bits),
+        auto payloadBits = scatterBits(CommonSpareBits.asAPInt(),
                                        payloadPart);
+        value.append(payloadBits);
         if (getExtraTagBitCountForExtraInhabitants() > 0) {
-          auto extraBits = APInt(bits,
-                                 (mask >> payloadBitCount) & extraTagMask)
-            .shl(CommonSpareBits.size());
-          payloadBits |= extraBits;
+          value.append(APInt(bits - CommonSpareBits.size(),
+                             (mask >> payloadBitCount) & extraTagMask));
         }
-        return payloadBits;
       } else {
-        auto value = APInt(bits, mask & extraTagMask);
-        return value.shl(CommonSpareBits.size());
+        value.appendClearBits(CommonSpareBits.size());
+        value.append(APInt(bits - CommonSpareBits.size(), mask & extraTagMask));
       }
+      return value.build().getValue();
     }
 
     ClusteredBitVector
     getBitPatternForNoPayloadElement(EnumElementDecl *theCase) const override {
       assert(TIK >= Fixed);
-
-      APInt payloadPart, extraPart;
 
       auto emptyI = std::find_if(ElementsWithNoPayload.begin(),
                                  ElementsWithNoPayload.end(),
@@ -5355,24 +5301,19 @@ namespace {
 
       unsigned index = emptyI - ElementsWithNoPayload.begin();
 
+      APInt payloadPart, extraPart;
       std::tie(payloadPart, extraPart) = getNoPayloadCaseValue(index);
-      ClusteredBitVector bits;
+      auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      if (PayloadBitCount > 0)
+        value.append(payloadPart);
 
-      if (!CommonSpareBits.empty())
-        bits = getBitVectorFromAPInt(payloadPart);
-
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
       if (ExtraTagBitCount > 0) {
-        ClusteredBitVector extraBits =
-          getBitVectorFromAPInt(extraPart, bits.size());
-        bits.extendWithClearBits(totalSize);
-        extraBits.extendWithClearBits(totalSize);
-        bits |= extraBits;
-      } else {
-        assert(totalSize == bits.size());
+        auto paddedWidth = size.getValueInBits() - PayloadBitCount;
+        auto extraPadded = extraPart.zextOrSelf(paddedWidth);
+        value.append(std::move(extraPadded));
       }
-      return bits;
+      return value.build();
     }
 
     ClusteredBitVector
@@ -5388,19 +5329,22 @@ namespace {
 
     ClusteredBitVector getTagBitsForPayloads() const override {
       assert(TIK >= Fixed);
-      
-      ClusteredBitVector result = PayloadTagBits;
+      Size size = cast<FixedTypeInfo>(TI)->getFixedSize();
 
-      unsigned totalSize
-        = cast<FixedTypeInfo>(TI)->getFixedSize().getValueInBits();
-
-      if (ExtraTagBitCount) {
-        result.appendSetBits(ExtraTagBitCount);
-        result.extendWithClearBits(totalSize);
-      } else {
-        assert(PayloadTagBits.size() == totalSize);
+      if (ExtraTagBitCount == 0) {
+        assert(PayloadTagBits.size() == size.getValueInBits());
+        return PayloadTagBits;
       }
-      return result;
+
+      // Build a mask containing the tag bits for the payload and those
+      // spilled into the extra tag.
+      auto tagBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      tagBits.append(PayloadTagBits);
+
+      // Set tag bits in extra tag to 1.
+      unsigned extraTagSize = size.getValueInBits() - PayloadTagBits.size();
+      tagBits.append(APInt(extraTagSize, (1U << ExtraTagBitCount) - 1U));
+      return tagBits.build();
     }
   };
 
@@ -6268,16 +6212,15 @@ NoPayloadEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
   // Unused tag bits in the physical size can be used as spare bits.
   // TODO: We can use all values greater than the largest discriminator as
   // extra inhabitants, not just those made available by spare bits.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(usedTagBits);
-  spareBits.extendWithSetBits(tagSize.getValueInBits());
+  auto spareBits = SpareBitVector::fromAPInt(
+      APInt::getBitsSetFrom(tagSize.getValueInBits(), usedTagBits));
 
   Alignment alignment(tagSize.getValue());
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/true, alignment);
 
   return registerEnumTypeInfo(new LoadableEnumTypeInfo(*this,
-                                   enumTy, tagSize, std::move(spareBits),
-                                   alignment, IsPOD, AlwaysFixedSize));
+                              enumTy, tagSize, std::move(spareBits),
+                              alignment, IsPOD, AlwaysFixedSize));
 }
 
 TypeInfo *
@@ -6376,18 +6319,19 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeFixedLayout(
   // sets to be able to reason about how many spare bits from the payload type
   // we can forward. If we spilled tag bits, however, we can offer the unused
   // bits we have in that byte.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(payloadTI.getFixedSize().getValueInBits());
-  if (ExtraTagBitCount > 0) {
-    spareBits.appendClearBits(ExtraTagBitCount);
-    spareBits.appendSetBits(extraTagByteCount * 8 - ExtraTagBitCount);
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+  if (auto size = payloadTI.getFixedSize().getValueInBits()) {
+    spareBits.appendClearBits(size);
   }
-  
+  if (ExtraTagBitCount > 0) {
+    auto paddedSize = extraTagByteCount * 8;
+    spareBits.append(APInt::getBitsSetFrom(paddedSize, ExtraTagBitCount));
+  }
   auto alignment = payloadTI.getFixedAlignment();
   applyLayoutAttributes(TC.IGM, theEnum, /*fixed*/true, alignment);
 
   getFixedEnumTypeInfo(
-      enumTy, Size(sizeWithTag), std::move(spareBits), alignment,
+      enumTy, Size(sizeWithTag), spareBits.build(), alignment,
       payloadTI.isPOD(ResilienceExpansion::Maximal),
       payloadTI.isBitwiseTakable(ResilienceExpansion::Maximal));
   if (TIK >= Loadable && CopyDestroyKind == Normal) {
@@ -6473,8 +6417,11 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
     // if the type is layout-dependent. (Even when the runtime does, it will
     // likely only track a subset of the spare bits.)
     if (!AllowFixedLayoutOptimizations || TIK < Loadable) {
-      if (CommonSpareBits.size() < payloadBits)
+      if (CommonSpareBits.size() < payloadBits) {
+        // All bits are zero so we don't have to worry about endianness.
+        assert(CommonSpareBits.none());
         CommonSpareBits.extendWithClearBits(payloadBits);
+      }
       continue;
     }
 
@@ -6486,7 +6433,7 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
     // they can contain Obj-C tagged pointers. To handle this case
     // correctly, we get spare bits from the unsubstituted type.
     auto &fixedOrigTI = cast<FixedTypeInfo>(*elt.origTI);
-    fixedOrigTI.applyFixedSpareBitsMask(CommonSpareBits);
+    fixedOrigTI.applyFixedSpareBitsMask(IGM, CommonSpareBits);
   }
 
   unsigned commonSpareBitCount = CommonSpareBits.count();
@@ -6537,12 +6484,19 @@ MultiPayloadEnumImplStrategy::completeFixedLayout(TypeConverter &TC,
   if (numTagBits >= commonSpareBitCount) {
     PayloadTagBits = CommonSpareBits;
 
+    auto builder = BitPatternBuilder(IGM.Triple.isLittleEndian());
     // We're using all of the common spare bits as tag bits, so none
     // of them are spare; nor are the extra tag bits.
-    spareBits.appendClearBits(CommonSpareBits.size() + ExtraTagBitCount);
+    builder.appendClearBits(CommonSpareBits.size());
 
     // The remaining bits in the extra tag bytes are spare.
-    spareBits.appendSetBits(extraTagByteCount * 8 - ExtraTagBitCount);
+    if (ExtraTagBitCount) {
+      builder.append(APInt::getBitsSetFrom(extraTagByteCount * 8,
+                                           ExtraTagBitCount));
+    }
+
+    // Set the spare bit mask.
+    spareBits = builder.build();
 
   // Otherwise, we need to construct a new bitset that doesn't
   // include the bits we aren't using.
@@ -6689,7 +6643,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
                llvm::dbgs() << ":\n";);
 
     SpareBitVector spareBits;
-    fixedTI->applyFixedSpareBitsMask(spareBits);
+    fixedTI->applyFixedSpareBitsMask(IGM, spareBits);
 
     auto bitMask = strategy->getBitMaskForNoPayloadElements();
     assert(bitMask.size() == fixedTI->getFixedSize().getValueInBits());
@@ -6827,16 +6781,16 @@ llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
                                    llvm::Value *source,
                                    unsigned resultLowBit,
                                    unsigned resultBitWidth) {
-  auto &builder = IGF.Builder;
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &B = IGF.Builder;
+  auto &C = IGF.IGM.getLLVMContext();
   assert(mask.getBitWidth() == source->getType()->getIntegerBitWidth()
     && "source and mask must have same width");
 
   // The source and mask need to be at least as wide as the result so
   // that bits can be shifted into the correct position.
-  auto destTy = llvm::IntegerType::get(context, resultBitWidth);
+  auto destTy = llvm::IntegerType::get(C, resultBitWidth);
   if (mask.getBitWidth() < resultBitWidth) {
-    source = builder.CreateZExt(source, destTy);
+    source = B.CreateZExt(source, destTy);
     mask = mask.zext(resultBitWidth);
   }
 
@@ -6857,25 +6811,25 @@ llvm::Value *irgen::emitGatherBits(IRGenFunction &IGF,
     int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
     if (offset > 0) {
       uint64_t shift = uint64_t(offset);
-      part = builder.CreateLShr(part, shift);
+      part = B.CreateLShr(part, shift);
       partMask.lshrInPlace(shift);
     } else if (offset < 0) {
       uint64_t shift = uint64_t(-offset);
-      part = builder.CreateShl(part, shift);
+      part = B.CreateShl(part, shift);
       partMask <<= shift;
     }
 
     // Truncate the output to the result size.
     if (partMask.getBitWidth() > resultBitWidth) {
       partMask = partMask.trunc(resultBitWidth);
-      part = builder.CreateTrunc(part, destTy);
+      part = B.CreateTrunc(part, destTy);
     }
 
     // Mask out selected bits.
-    part = builder.CreateAnd(part, partMask);
+    part = B.CreateAnd(part, partMask);
 
     // Accumulate the result.
-    result = result ? builder.CreateOr(result, part) : part;
+    result = result ? B.CreateOr(result, part) : part;
 
     // Update the offset and remaining mask.
     usedBits += partMask.countPopulation();
@@ -6891,16 +6845,43 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
                                     llvm::APInt mask,
                                     llvm::Value *source,
                                     unsigned packedLowBit) {
-  auto &builder = IGF.Builder;
-  auto &context = IGF.IGM.getLLVMContext();
+  auto &DL = IGF.IGM.DataLayout;
+  auto &B = IGF.Builder;
+  auto &C = IGF.IGM.getLLVMContext();
 
-  // Expand the packed bits to the destination type.
-  auto destTy = llvm::IntegerType::get(context, mask.getBitWidth());
-  source = builder.CreateZExtOrTrunc(source, destTy);
+  // Expand or contract the packed bits to the destination type.
+  auto bitSize = mask.getBitWidth();
+  auto sourceTy = dyn_cast<llvm::IntegerType>(source->getType());
+  if (!sourceTy) {
+    auto numBits = DL.getTypeSizeInBits(source->getType());
+    sourceTy = llvm::IntegerType::get(C, numBits);
+    source = B.CreateBitOrPointerCast(source, sourceTy);
+  }
+  assert(packedLowBit < sourceTy->getBitWidth() &&
+      "packedLowBit out of range");
+
+  auto destTy = llvm::IntegerType::get(C, bitSize);
+  auto usedBits = int64_t(packedLowBit);
+  if (usedBits > 0 && sourceTy->getBitWidth() > bitSize) {
+    // Need to shift before truncation if the packed value is wider
+    // than the mask.
+    source = B.CreateLShr(source, uint64_t(usedBits));
+    usedBits = 0;
+  }
+  if (sourceTy->getBitWidth() != bitSize) {
+    source = B.CreateZExtOrTrunc(source, destTy);
+  }
+
+  // No need to AND with the mask if the whole source can just be
+  // shifted into place.
+  // TODO: could do more to avoid inserting unnecessary ANDs. For
+  // example we could take into account the packedLowBit.
+  auto unknownBits = std::min(sourceTy->getBitWidth(), bitSize);
+  bool needMask = !(mask.isShiftedMask() &&
+                    mask.countPopulation() >= unknownBits);
 
   // Shift each set of contiguous set bits into position and
   // accumulate them into the result.
-  int64_t usedBits = packedLowBit;
   llvm::Value *result = nullptr;
   while (mask != 0) {
     // Isolate the rightmost run of contiguous set bits.
@@ -6914,16 +6895,18 @@ llvm::Value *irgen::emitScatterBits(IRGenFunction &IGF,
     llvm::Value *part = source;
     int64_t offset = int64_t(partMask.countTrailingZeros()) - usedBits;
     if (offset > 0) {
-      part = builder.CreateShl(part, uint64_t(offset));
+      part = B.CreateShl(part, uint64_t(offset));
     } else if (offset < 0) {
-      part = builder.CreateLShr(part, uint64_t(-offset));
+      part = B.CreateLShr(part, uint64_t(-offset));
     }
 
     // Mask out selected bits.
-    part = builder.CreateAnd(part, partMask);
+    if (needMask) {
+      part = B.CreateAnd(part, partMask);
+    }
 
     // Accumulate the result.
-    result = result ? builder.CreateOr(result, part) : part;
+    result = result ? B.CreateOr(result, part) : part;
 
     // Update the offset and remaining mask.
     usedBits += partMask.countPopulation();
@@ -6962,54 +6945,6 @@ llvm::APInt irgen::scatterBits(const llvm::APInt &mask, unsigned value) {
     }
     value >>= 1;
   }
-  return result;
-}
-
-/// A version of the above where the tag value is dynamic.
-EnumPayload irgen::interleaveSpareBits(IRGenFunction &IGF,
-                                       const EnumPayloadSchema &schema,
-                                       const SpareBitVector &spareBitVector,
-                                       llvm::Value *value) {
-  EnumPayload result;
-  APInt spareBits = spareBitVector.asAPInt();
-
-  unsigned usedBits = 0;
-
-  auto &DL = IGF.IGM.DataLayout;
-  schema.forEachType(IGF.IGM, [&](llvm::Type *type) {
-    unsigned bitSize = DL.getTypeSizeInBits(type);
-
-    // Take some bits off of the bottom of the pattern.
-    auto spareBitsChunk = SpareBitVector::fromAPInt(
-        spareBits.zextOrTrunc(bitSize));
-
-    if (usedBits >= 32 || spareBitsChunk.count() == 0) {
-      result.PayloadValues.push_back(type);
-    } else {
-      llvm::Value *payloadValue = value;
-      if (usedBits > 0) {
-        payloadValue = IGF.Builder.CreateLShr(payloadValue,
-                       llvm::ConstantInt::get(IGF.IGM.Int32Ty, usedBits));
-      }
-      payloadValue = emitScatterBits(IGF, spareBitsChunk.asAPInt(),
-                                     payloadValue, 0);
-      if (payloadValue->getType() != type) {
-        if (type->isPointerTy())
-          payloadValue = IGF.Builder.CreateIntToPtr(payloadValue, type);
-        else
-          payloadValue = IGF.Builder.CreateBitCast(payloadValue, type);
-      }
-
-      result.PayloadValues.push_back(payloadValue);
-    }
-    
-    // Shift the remaining bits down.
-    spareBits = spareBits.lshr(bitSize);
-
-    // Consume bits from the input value.
-    usedBits += spareBitsChunk.count();
-  });
-
   return result;
 }
 

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -90,12 +90,6 @@ void emitStoreEnumTagToAddress(IRGenFunction &IGF,
                                 SILType enumTy,
                                 Address enumAddr,
                                 EnumElementDecl *theCase);
-  
-/// Unpack bits from value and scatter them into the masked bits.
-EnumPayload interleaveSpareBits(IRGenFunction &IGF,
-                                const EnumPayloadSchema &schema,
-                                const SpareBitVector &spareBitVector,
-                                llvm::Value *value);
 
 /// Pack masked bits into the low bits of an integer value.
 /// Equivalent to a parallel bit extract instruction (PEXT),

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -91,13 +91,7 @@ void emitStoreEnumTagToAddress(IRGenFunction &IGF,
                                 Address enumAddr,
                                 EnumElementDecl *theCase);
   
-/// Interleave the occupiedValue and spareValue bits, taking a bit from one
-/// or the other at each position based on the spareBits mask.
-APInt
-interleaveSpareBits(IRGenModule &IGM, const SpareBitVector &spareBits,
-                    unsigned bits, unsigned spareValue, unsigned occupiedValue);
-
-/// A version of the above where the tag value is dynamic.
+/// Unpack bits from value and scatter them into the masked bits.
 EnumPayload interleaveSpareBits(IRGenFunction &IGF,
                                 const EnumPayloadSchema &schema,
                                 const SpareBitVector &spareBitVector,
@@ -111,6 +105,7 @@ llvm::Value *emitGatherBits(IRGenFunction &IGF,
                             llvm::Value *source,
                             unsigned resultLowBit,
                             unsigned resultBitWidth);
+
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 /// Equivalent to a parallel bit deposit instruction (PDEP),
@@ -119,6 +114,10 @@ llvm::Value *emitScatterBits(IRGenFunction &IGF,
                              llvm::APInt mask,
                              llvm::Value *packedBits,
                              unsigned packedLowBit);
+
+/// Unpack bits from the low bits of an integer value and
+/// move them to the bit positions indicated by the mask.
+llvm::APInt scatterBits(const llvm::APInt &mask, unsigned value);
   
 /// An implementation strategy for an enum, which handles how the enum is
 /// laid out and how to perform TypeInfo operations on values of the enum.

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -106,6 +106,10 @@ llvm::Value *emitGatherBits(IRGenFunction &IGF,
                             unsigned resultLowBit,
                             unsigned resultBitWidth);
 
+/// Pack masked bits into the low bits of an integer value.
+llvm::APInt gatherBits(const llvm::APInt &mask,
+                       const llvm::APInt &value);
+
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 /// Equivalent to a parallel bit deposit instruction (PDEP),
@@ -118,7 +122,7 @@ llvm::Value *emitScatterBits(IRGenFunction &IGF,
 /// Unpack bits from the low bits of an integer value and
 /// move them to the bit positions indicated by the mask.
 llvm::APInt scatterBits(const llvm::APInt &mask, unsigned value);
-  
+
 /// An implementation strategy for an enum, which handles how the enum is
 /// laid out and how to perform TypeInfo operations on values of the enum.
 class EnumImplStrategy {

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -103,17 +103,22 @@ EnumPayload interleaveSpareBits(IRGenFunction &IGF,
                                 const SpareBitVector &spareBitVector,
                                 llvm::Value *value);
 
-/// Gather spare bits into the low bits of a smaller integer value.
-llvm::Value *emitGatherSpareBits(IRGenFunction &IGF,
-                                 const SpareBitVector &spareBitMask,
-                                 llvm::Value *spareBits,
-                                 unsigned resultLowBit,
-                                 unsigned resultBitWidth);
-/// Scatter spare bits from the low bits of a smaller integer value.
-llvm::Value *emitScatterSpareBits(IRGenFunction &IGF,
-                                  const SpareBitVector &spareBitMask,
-                                  llvm::Value *packedBits,
-                                  unsigned packedLowBit);
+/// Pack masked bits into the low bits of an integer value.
+/// Equivalent to a parallel bit extract instruction (PEXT),
+/// although we don't currently emit PEXT directly.
+llvm::Value *emitGatherBits(IRGenFunction &IGF,
+                            llvm::APInt mask,
+                            llvm::Value *source,
+                            unsigned resultLowBit,
+                            unsigned resultBitWidth);
+/// Unpack bits from the low bits of an integer value and
+/// move them to the bit positions indicated by the mask.
+/// Equivalent to a parallel bit deposit instruction (PDEP),
+/// although we don't currently emit PDEP directly.
+llvm::Value *emitScatterBits(IRGenFunction &IGF,
+                             llvm::APInt mask,
+                             llvm::Value *packedBits,
+                             unsigned packedLowBit);
   
 /// An implementation strategy for an enum, which handles how the enum is
 /// laid out and how to perform TypeInfo operations on values of the enum.

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -30,6 +30,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "BitPatternBuilder.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
@@ -583,8 +584,11 @@ namespace {
                               .getFixedExtraInhabitantMask(IGM);
 
       // Zext out to the size of the existential.
-      bits = bits.zextOrTrunc(asDerived().getFixedSize().getValueInBits());
-      return bits;
+      auto totalSize = asDerived().getFixedSize().getValueInBits();
+      auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+      mask.append(bits);
+      mask.padWithClearBitsTo(totalSize);
+      return mask.build().getValue();
     }
   };
 
@@ -649,8 +653,10 @@ namespace {
                                                      ReferenceOwnership::Name, \
                                                      Refcounting); \
         /* Zext out to the size of the existential. */ \
-        bits = bits.zextOrTrunc(getFixedSize().getValueInBits()); \
-        return bits; \
+        auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian()); \
+        mask.append(bits); \
+        mask.padWithClearBitsTo(getFixedSize().getValueInBits()); \
+        return mask.build().getValue(); \
       } else { \
         return Super::getFixedExtraInhabitantMask(IGM); \
       } \
@@ -922,10 +928,11 @@ public:
     return getHeapObjectFixedExtraInhabitantValue(IGM, bits, index, offset);
   }
   APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
-    auto mask = APInt::getAllOnesValue(IGM.getPointerSize().getValueInBits());
-    mask = mask.zext(getFixedSize().getValueInBits());
-    mask = mask.shl(getLayout().getMetadataRefOffset(IGM).getValueInBits());
-    return mask;
+    auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    mask.appendClearBits(getLayout().getMetadataRefOffset(IGM).getValueInBits());
+    mask.appendSetBits(IGM.getPointerSize().getValueInBits());
+    mask.padWithClearBitsTo(getFixedSize().getValueInBits());
+    return mask.build().getValue();
   }
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                        Address src, SILType T,
@@ -1135,17 +1142,20 @@ public:
   const TypeInfo * \
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
-                                                     ReferenceOwnership::Name, \
-                                                     Refcounting); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
+                                                   ReferenceOwnership::Name, \
+                                                   Refcounting); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     return AddressOnly##Name##ClassExistentialTypeInfo::create( \
                                                  getStoredProtocols(), \
                                                  storageTy, \
-                                                 std::move(spareBits), \
+                                                 spareBits.build(), \
                                                  getFixedSize(), \
                                                  getFixedAlignment(), \
                                                  Refcounting, \
@@ -1157,18 +1167,21 @@ public:
   const TypeInfo * \
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
-                                                     ReferenceOwnership::Name, \
-                                                     Refcounting); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
+                                                   ReferenceOwnership::Name, \
+                                                   Refcounting); \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     if (TC.IGM.isLoadableReferenceAddressOnly(Refcounting)) { \
       return AddressOnly##Name##ClassExistentialTypeInfo::create( \
                                                    getStoredProtocols(), \
                                                    storageTy, \
-                                                   std::move(spareBits), \
+                                                   spareBits.build(), \
                                                    getFixedSize(), \
                                                    getFixedAlignment(), \
                                                    Refcounting, \
@@ -1178,7 +1191,7 @@ public:
                                                    getStoredProtocols(), \
                                                    getValueType(), \
                                                    storageTy, \
-                                                   std::move(spareBits), \
+                                                   spareBits.build(), \
                                                    getFixedSize(), \
                                                    getFixedAlignment(), \
                                                    Refcounting, \
@@ -1191,11 +1204,14 @@ public:
   create##Name##StorageType(TypeConverter &TC, \
                             bool isOptional) const override { \
     assert(Refcounting == ReferenceCounting::Native); \
-    auto spareBits = TC.IGM.getReferenceStorageSpareBits( \
+    auto ref = TC.IGM.getReferenceStorageSpareBits( \
                                                    ReferenceOwnership::Name, \
                                                    ReferenceCounting::Native); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
+    spareBits.append(ref); \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
       spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
+    } \
     auto storageTy = buildReferenceStorageType(TC.IGM, \
                               TC.IGM.Name##ReferencePtrTy->getElementType()); \
     return Loadable##Name##ClassExistentialTypeInfo::create( \
@@ -1414,7 +1430,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     Alignment align = IGM.getPointerAlignment();
     Size size = classFields.size() * IGM.getPointerSize();
 
-    SpareBitVector spareBits;
+    auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
 
     // The class pointer is an unknown heap object, so it may be a tagged
     // pointer, if the platform has those.
@@ -1430,9 +1446,8 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     for (unsigned i = 1, e = classFields.size(); i < e; ++i) {
       spareBits.append(IGM.getWitnessTablePtrSpareBits());
     }
-
     return ClassExistentialTypeInfo::create(protosWithWitnessTables, type,
-                                            size, std::move(spareBits), align,
+                                            size, spareBits.build(), align,
                                             refcounting);
   }
 
@@ -1446,23 +1461,11 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
   Size size = opaque.getSize(IGM);
   // There are spare bits in the metadata pointer and witness table pointers
   // consistent with a native object reference.
-  SpareBitVector spareBits;
-  spareBits.appendClearBits(size.getValueInBits());
-  /* TODO: There are spare bits we could theoretically use in the type metadata
-     and witness table pointers, but opaque existentials are currently address-
-     only, and we can't soundly take advantage of spare bits for in-memory
-     representations.
-   
-  auto metadataOffset = opaque.getMetadataRefOffset(IGM);
-  spareBits.appendClearBits(metadataOffset.getValueInBits());
-  auto typeSpareBits = IGM.getHeapObjectSpareBits();
-  spareBits.append(typeSpareBits);
-  auto witnessSpareBits =
-    IGM.getWitnessTablePtrSpareBits();
-  for (unsigned i = 0, e = protosWithWitnessTables.size(); i < e; ++i)
-    spareBits.append(witnessSpareBits);
-  assert(spareBits.size() == size.getValueInBits());
-   */
+  // TODO: There are spare bits we could theoretically use in the type metadata
+  // and witness table pointers, but opaque existentials are currently address-
+  // only, and we can't soundly take advantage of spare bits for in-memory
+  // representations.
+  auto spareBits = SpareBitVector::getConstant(size.getValueInBits(), false);
   return OpaqueExistentialTypeInfo::create(protosWithWitnessTables, type, size,
                                            std::move(spareBits),
                                            align);
@@ -1491,12 +1494,12 @@ TypeConverter::convertExistentialMetatypeType(ExistentialMetatypeType *T) {
   SmallVector<const ProtocolDecl *, 4> protosWithWitnessTables;
   SmallVector<llvm::Type*, 4> fields;
 
-  SpareBitVector spareBits;
-
   assert(T->getRepresentation() != MetatypeRepresentation::Thin &&
          "existential metatypes cannot have thin representation");
   auto &baseTI = cast<LoadableTypeInfo>(getMetatypeTypeInfo(T->getRepresentation()));
   fields.push_back(baseTI.getStorageType());
+
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
   spareBits.append(baseTI.getSpareBits());
 
   for (auto protoTy : layout.getProtocols()) {
@@ -1517,7 +1520,7 @@ TypeConverter::convertExistentialMetatypeType(ExistentialMetatypeType *T) {
   Alignment align = IGM.getPointerAlignment();
 
   return ExistentialMetatypeTypeInfo::create(protosWithWitnessTables, type,
-                                             size, std::move(spareBits), align,
+                                             size, spareBits.build(), align,
                                              baseTI);
 }
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1218,7 +1218,7 @@ public:
                                                   getStoredProtocols(), \
                                                   getValueType(), \
                                                   storageTy, \
-                                                  std::move(spareBits), \
+                                                  spareBits.build(), \
                                                   getFixedSize(), \
                                                   getFixedAlignment(), \
                                                   ReferenceCounting::Native, \

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_IRGEN_GENRECORD_H
 #define SWIFT_IRGEN_GENRECORD_H
 
+#include "BitPatternBuilder.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "Explosion.h"
@@ -598,27 +599,32 @@ public:
     // inhabitants.
     auto &field = *asImpl().getFixedExtraInhabitantProvidingField(IGM);
     auto &fieldTI = cast<FixedTypeInfo>(field.getTypeInfo());
-    APInt fieldValue = fieldTI.getFixedExtraInhabitantValue(IGM, bits, index);
-    return fieldValue.shl(field.getFixedByteOffset().getValueInBits());
+    auto fieldSize = fieldTI.getFixedExtraInhabitantMask(IGM).getBitWidth();
+
+    auto value = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    value.appendClearBits(field.getFixedByteOffset().getValueInBits());
+    value.append(fieldTI.getFixedExtraInhabitantValue(IGM, fieldSize, index));
+    value.padWithClearBitsTo(bits);
+    return value.build().getValue();
   }
 
   APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
     auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM);
     if (!field)
       return APInt();
-    
+
     const FixedTypeInfo &fieldTI
       = cast<FixedTypeInfo>(field->getTypeInfo());
     auto targetSize = asImpl().getFixedSize().getValueInBits();
-    
+
     if (fieldTI.isKnownEmpty(ResilienceExpansion::Maximal))
       return APInt(targetSize, 0);
-    
-    APInt fieldMask = fieldTI.getFixedExtraInhabitantMask(IGM);
-    if (targetSize > fieldMask.getBitWidth())
-      fieldMask = fieldMask.zext(targetSize);
-    fieldMask = fieldMask.shl(field->getFixedByteOffset().getValueInBits());
-    return fieldMask;
+
+    auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    mask.appendClearBits(field->getFixedByteOffset().getValueInBits());
+    mask.append(fieldTI.getFixedExtraInhabitantMask(IGM));
+    mask.padWithClearBitsTo(targetSize);
+    return mask.build().getValue();
   }
 
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -626,7 +626,6 @@ public:
       TotalStride(Size(ClangLayout.getSize().getQuantity())),
       TotalAlignment(IGM.getCappedAlignment(
                                        Alignment(ClangLayout.getAlignment()))) {
-    SpareBits.reserve(TotalStride.getValue() * 8);
   }
 
   void collectRecordFields() {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -328,7 +328,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   // Gather the occupied bits.
   auto OccupiedBits = SpareBits;
   OccupiedBits.flipAll();
-  llvm::Value *idx = emitGatherSpareBits(IGF, OccupiedBits, val, 0, 31);
+  llvm::Value *idx = emitGatherBits(IGF, OccupiedBits.asAPInt(), val, 0, 31);
   
   // See if spare bits fit into the 31 bits of the index.
   unsigned numSpareBits = SpareBits.count();
@@ -336,7 +336,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   if (numOccupiedBits < 31) {
     // Gather the spare bits.
     llvm::Value *spareIdx
-      = emitGatherSpareBits(IGF, SpareBits, val, numOccupiedBits, 31);
+      = emitGatherBits(IGF, SpareBits.asAPInt(), val, numOccupiedBits, 31);
     // Unbias by subtracting one.
 
     uint64_t shifted = static_cast<uint64_t>(1) << numOccupiedBits;
@@ -830,13 +830,13 @@ FixedTypeInfo::storeSpareBitExtraInhabitant(IRGenFunction &IGF,
   }
   
   // Scatter the occupied bits.
-  auto OccupiedBits = SpareBits;
-  OccupiedBits.flipAll();
-  llvm::Value *occupied = emitScatterSpareBits(IGF, OccupiedBits,
-                                               occupiedIndex, 0);
+  auto OccupiedBits = ~SpareBits.asAPInt();
+  llvm::Value *occupied = emitScatterBits(IGF, OccupiedBits,
+                                          occupiedIndex, 0);
   
   // Scatter the spare bits.
-  llvm::Value *spare = emitScatterSpareBits(IGF, SpareBits, spareIndex, 0);
+  llvm::Value *spare = emitScatterBits(IGF, SpareBits.asAPInt(),
+                                       spareIndex, 0);
   
   // Combine the values and store to the destination.
   llvm::Value *inhabitant = IGF.Builder.CreateOr(occupied, spare);

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -294,7 +294,10 @@ FixedTypeInfo::getSpareBitFixedExtraInhabitantValue(IRGenModule &IGM,
     spareIndex = (index >> occupiedBitCount) + 1;
   }
 
-  return interleaveSpareBits(IGM, SpareBits, bits, spareIndex, occupiedIndex);
+  APInt mask = SpareBits.asAPInt().zextOrTrunc(bits);
+  APInt v = scatterBits(mask, spareIndex);
+  v |= scatterBits(~mask, occupiedIndex);
+  return v;
 }
 
 llvm::Value *

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -254,26 +254,21 @@ unsigned FixedTypeInfo::getSpareBitExtraInhabitantCount() const {
                   unsigned(ValueWitnessFlags::MaxNumExtraInhabitants));
 }
 
-void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask,
-                                            const SpareBitVector &spareBits) {
+void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask) const {
   // If the mask is no longer than the stored spare bits, we can just
   // apply the stored spare bits.
-  if (mask.size() <= spareBits.size()) {
+  if (mask.size() <= SpareBits.size()) {
     // Grow the mask out if necessary; the tail padding is all spare bits.
-    mask.extendWithSetBits(spareBits.size());
-    mask &= spareBits;
+    mask.extendWithSetBits(SpareBits.size());
+    mask &= SpareBits;
+    return;
+  }
 
   // Otherwise, we have to grow out the stored spare bits before we
   // can intersect.
-  } else {
-    auto paddedSpareBits = spareBits;
-    paddedSpareBits.extendWithSetBits(mask.size());
-    mask &= paddedSpareBits;
-  }
-}
-
-void FixedTypeInfo::applyFixedSpareBitsMask(SpareBitVector &mask) const {
-  return applyFixedSpareBitsMask(mask, SpareBits);
+  auto paddedSpareBits = SpareBits;
+  paddedSpareBits.extendWithSetBits(mask.size());
+  mask &= paddedSpareBits;
 }
 
 APInt

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -266,7 +266,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   // A tuple type metadata record has a couple extra fields.
   auto tupleElementTy = createStructType(*this, "swift.tuple_element_type", {
     TypeMetadataPtrTy,      // Metadata *Type;
-    SizeTy                  // size_t Offset;
+    Int32Ty                 // int32_t Offset;
   });
   TupleTypeMetadataPtrTy = createStructPointerType(*this, "swift.tuple_type", {
     TypeMetadataStructTy,   // (base)

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 
+#include "BitPatternBuilder.h"
 #include "FixedTypeInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
@@ -363,24 +364,9 @@ void StructLayoutBuilder::setAsBodyOfStruct(llvm::StructType *type) const {
 
 /// Return the spare bit mask of the structure built so far.
 SpareBitVector StructLayoutBuilder::getSpareBits() const {
-  // Calculate the size up front to reduce possible allocations.
-  unsigned numBits = 0;
-  for (auto &v : CurSpareBits) {
-    numBits += v.size();
+  auto spareBits = BitPatternBuilder(IGM.Triple.isLittleEndian());
+  for (const auto &v : CurSpareBits) {
+    spareBits.append(v);
   }
-  if (numBits == 0) {
-    return SpareBitVector();
-  }
-  // Assemble the spare bit mask.
-  auto mask = llvm::APInt::getNullValue(numBits);
-  unsigned offset = 0;
-  for (auto &v : CurSpareBits) {
-    if (v.size() == 0) {
-      continue;
-    }
-    mask.insertBits(v.asAPInt(), offset);
-    offset += v.size();
-  }
-  assert(offset == numBits);
-  return SpareBitVector::fromAPInt(std::move(mask));
+  return spareBits.build();
 }

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -78,7 +78,7 @@ StructLayout::StructLayout(IRGenModule &IGM,
   } else {
     MinimumAlign = builder.getAlignment();
     MinimumSize = builder.getSize();
-    SpareBits = std::move(builder.getSpareBits());
+    SpareBits = builder.getSpareBits();
     IsFixedLayout = builder.isFixedLayout();
     IsKnownPOD = builder.isPOD();
     IsKnownBitwiseTakable = builder.isBitwiseTakable();
@@ -263,9 +263,11 @@ void StructLayoutBuilder::addFixedSizeElement(ElementLayout &elt) {
     if (isFixedLayout()) {
       auto paddingTy = llvm::ArrayType::get(IGM.Int8Ty, paddingRequired);
       StructFields.push_back(paddingTy);
-      
+
       // The padding can be used as spare bits by enum layout.
-      CurSpareBits.appendSetBits(Size(paddingRequired).getValueInBits());
+      auto numBits = Size(paddingRequired).getValueInBits();
+      auto mask = llvm::APInt::getAllOnesValue(numBits);
+      CurSpareBits.push_back(SpareBitVector::fromAPInt(mask));
     }
   }
 
@@ -318,7 +320,7 @@ void StructLayoutBuilder::addElementAtFixedOffset(ElementLayout &elt) {
   StructFields.push_back(elt.getType().getStorageType());
   
   // Carry over the spare bits from the element.
-  CurSpareBits.append(eltTI.getSpareBits());
+  CurSpareBits.push_back(eltTI.getSpareBits());
 }
 
 /// Add an element at a non-fixed offset to the aggregate.
@@ -326,7 +328,7 @@ void StructLayoutBuilder::addElementAtNonFixedOffset(ElementLayout &elt) {
   assert(!isFixedLayout());
   elt.completeNonFixed(elt.getType().isPOD(ResilienceExpansion::Maximal),
                        NextNonFixedOffsetIndex);
-  CurSpareBits.clear();
+  CurSpareBits = SmallVector<SpareBitVector, 8>(); // clear spare bits
 }
 
 /// Add a non-fixed-size element to the aggregate at offset zero.
@@ -335,7 +337,7 @@ void StructLayoutBuilder::addNonFixedSizeElementAtOffsetZero(ElementLayout &elt)
   assert(!isa<FixedTypeInfo>(elt.getType()));
   assert(CurSize.isZero());
   elt.completeInitialNonFixedSize(elt.getType().isPOD(ResilienceExpansion::Maximal));
-  CurSpareBits.clear();
+  CurSpareBits = SmallVector<SpareBitVector, 8>(); // clear spare bits
 }
 
 /// Produce the current fields as an anonymous structure.
@@ -357,4 +359,28 @@ void StructLayoutBuilder::setAsBodyOfStruct(llvm::StructType *type) const {
           || IGM.DataLayout.getStructLayout(type)->getSizeInBytes()
             == CurSize.getValue())
          && "LLVM size of fixed struct type does not match StructLayout size");
+}
+
+/// Return the spare bit mask of the structure built so far.
+SpareBitVector StructLayoutBuilder::getSpareBits() const {
+  // Calculate the size up front to reduce possible allocations.
+  unsigned numBits = 0;
+  for (auto &v : CurSpareBits) {
+    numBits += v.size();
+  }
+  if (numBits == 0) {
+    return SpareBitVector();
+  }
+  // Assemble the spare bit mask.
+  auto mask = llvm::APInt::getNullValue(numBits);
+  unsigned offset = 0;
+  for (auto &v : CurSpareBits) {
+    if (v.size() == 0) {
+      continue;
+    }
+    mask.insertBits(v.asAPInt(), offset);
+    offset += v.size();
+  }
+  assert(offset == numBits);
+  return SpareBitVector::fromAPInt(std::move(mask));
 }

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -239,7 +239,7 @@ protected:
   Size CurSize = Size(0);
 private:
   Alignment CurAlignment = Alignment(1);
-  SpareBitVector CurSpareBits;
+  SmallVector<SpareBitVector, 8> CurSpareBits;
   unsigned NextNonFixedOffsetIndex = 0;
   bool IsFixedLayout = true;
   IsPOD_t IsKnownPOD = IsPOD;
@@ -300,12 +300,9 @@ public:
 
   /// Return the alignment of the structure built so far.
   Alignment getAlignment() const { return CurAlignment; }
-  
-  /// Return the spare bit mask of the structure built so far.
-  const SpareBitVector &getSpareBits() const { return CurSpareBits; }
 
   /// Return the spare bit mask of the structure built so far.
-  SpareBitVector &getSpareBits() { return CurSpareBits; }
+  SpareBitVector getSpareBits() const;
 
   /// Build the current elements as a new anonymous struct type.
   llvm::StructType *getAsAnonStruct() const;

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -115,7 +115,7 @@ IRGenTypeVerifierFunction::emit(ArrayRef<CanType> formalTypes) {
         auto fixedXIOpaque = Builder.CreateBitCast(fixedXIBuf,
                                                        IGM.OpaquePtrTy);
         auto xiMask = fixedTI->getFixedExtraInhabitantMask(IGM);
-        auto xiSchema = EnumPayloadSchema::withBitSize(xiMask.getBitWidth());
+        auto xiSchema = EnumPayloadSchema(xiMask.getBitWidth());
 
         auto maxXiCount = std::min(xiCount, 256u);
         auto numCases = llvm::ConstantInt::get(IGM.Int32Ty, maxXiCount);

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2507,7 +2507,7 @@ internal enum KeyPathPatternStoredOffset {
   case inline(UInt32)
   case outOfLine(UInt32)
   case unresolvedFieldOffset(UInt32)
-  case unresolvedIndirectOffset(UnsafePointer<UInt32>)
+  case unresolvedIndirectOffset(UnsafePointer<UInt>)
 }
 internal struct KeyPathPatternComputedArguments {
   var getLayout: KeyPathComputedArgumentLayoutFn
@@ -2602,7 +2602,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
                                 as: Int32.self)
       let ptr = _resolveRelativeIndirectableAddress(base, relativeOffset)
       offset = .unresolvedIndirectOffset(
-                                       ptr.assumingMemoryBound(to: UInt32.self))
+                                       ptr.assumingMemoryBound(to: UInt.self))
     default:
       offset = .inline(header.storedOffsetPayload)
     }
@@ -3151,7 +3151,8 @@ internal struct InstantiateKeyPathBuffer : KeyPathPatternVisitor {
       case .unresolvedIndirectOffset(let pointerToOffset):
         // Look up offset in the indirectly-referenced variable we have a
         // pointer.
-        let offset = UInt32(pointerToOffset.pointee)
+        assert(pointerToOffset.pointee <= UInt32.max)
+        let offset = UInt32(truncatingIfNeeded: pointerToOffset.pointee)
         let header = RawKeyPathComponent.Header(storedWithOutOfLineOffset: kind,
                                                 mutable: mutable)
         pushDest(header)

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -233,74 +233,39 @@ static MultiPayloadLayout getMultiPayloadLayout(const EnumMetadata *enumType) {
 static void storeMultiPayloadTag(OpaqueValue *value,
                                  MultiPayloadLayout layout,
                                  unsigned tag) {
-  auto tagBytes = reinterpret_cast<char *>(value) + layout.payloadSize;
-#if defined(__BIG_ENDIAN__)
-  small_memcpy(tagBytes,
-               reinterpret_cast<char *>(&tag) + 4 - layout.numTagBytes,
-               layout.numTagBytes);
-#else
-  small_memcpy(tagBytes, &tag, layout.numTagBytes);
-#endif
+  auto tagBytes = reinterpret_cast<uint8_t *>(value) + layout.payloadSize;
+  storeEnumElement(tagBytes, tag, layout.numTagBytes);
 }
 
 static void storeMultiPayloadValue(OpaqueValue *value,
                                    MultiPayloadLayout layout,
                                    unsigned payloadValue) {
-  auto bytes = reinterpret_cast<char *>(value);
-#if defined(__BIG_ENDIAN__)
-  unsigned numPayloadValueBytes =
-      std::min(layout.payloadSize, sizeof(payloadValue));
-  memcpy(bytes + sizeof(OpaqueValue *) - numPayloadValueBytes,
-         reinterpret_cast<char *>(&payloadValue) + 4 - numPayloadValueBytes,
-         numPayloadValueBytes);
-  if (layout.payloadSize > sizeof(payloadValue) &&
-      layout.payloadSize > sizeof(OpaqueValue *)) {
-    memset(bytes, 0,
-           sizeof(OpaqueValue *) - numPayloadValueBytes);
-    memset(bytes + sizeof(OpaqueValue *), 0,
-           layout.payloadSize - sizeof(OpaqueValue *));
-  }
-#else
-  memcpy(bytes, &payloadValue,
-         std::min(layout.payloadSize, sizeof(payloadValue)));
-
-  // If the payload is larger than the value, zero out the rest.
-  if (layout.payloadSize > sizeof(payloadValue))
-    memset(bytes + sizeof(payloadValue), 0,
-           layout.payloadSize - sizeof(payloadValue));
-#endif
+  auto bytes = reinterpret_cast<uint8_t *>(value);
+  storeEnumElement(bytes, payloadValue, layout.payloadSize);
 }
 
 static unsigned loadMultiPayloadTag(const OpaqueValue *value,
                                     MultiPayloadLayout layout,
                                     unsigned baseValue = 0) {
-  auto tagBytes = reinterpret_cast<const char *>(value) + layout.payloadSize;
+  auto tagBytes = reinterpret_cast<const uint8_t *>(value) +
+                  layout.payloadSize;
+  auto tag = loadEnumElement(tagBytes, layout.numTagBytes);
 
-  unsigned tag = baseValue;
-#if defined(__BIG_ENDIAN__)
-  small_memcpy(reinterpret_cast<char *>(&tag) + 4 - layout.numTagBytes,
-               tagBytes, layout.numTagBytes);
-#else
-  small_memcpy(&tag, tagBytes, layout.numTagBytes);
-#endif
+  // The maximum number of extra tag bytes is 4.
+  // Note: return early to avoid shifting baseValue by 32 which is
+  // undefined behaviour.
+  if (layout.numTagBytes == 4) {
+    return tag;
+  }
 
-  return tag;
+  // Replace out-of-range bytes with the base value.
+  return tag | (baseValue & (~0u << (layout.numTagBytes * 8)));
 }
 
 static unsigned loadMultiPayloadValue(const OpaqueValue *value,
                                       MultiPayloadLayout layout) {
-  auto bytes = reinterpret_cast<const char *>(value);
-  unsigned payloadValue = 0;
-#if defined(__BIG_ENDIAN__)
-  unsigned numPayloadValueBytes =
-      std::min(layout.payloadSize, sizeof(payloadValue));
-  memcpy(reinterpret_cast<char *>(&payloadValue) + 4 - numPayloadValueBytes,
-         bytes + sizeof(OpaqueValue *) - numPayloadValueBytes, numPayloadValueBytes);
-#else
-  memcpy(&payloadValue, bytes,
-         std::min(layout.payloadSize, sizeof(payloadValue)));
-#endif
-  return payloadValue;
+  auto bytes = reinterpret_cast<const uint8_t *>(value);
+  return loadEnumElement(bytes, layout.payloadSize);
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -170,14 +170,14 @@ inline void storeEnumTagSinglePayloadImpl(
 
     // Store into the value.
 #if defined(__BIG_ENDIAN__)
-  unsigned numPayloadTagBytes = std::min(size_t(4), payloadSize);
-  if (numPayloadTagBytes)
-    small_memcpy(valueAddr,
-                 reinterpret_cast<uint8_t *>(&payloadIndex) + 4 -
-                     numPayloadTagBytes,
-                 numPayloadTagBytes, true);
-  if (payloadSize > 4)
-	    memset(valueAddr + 4, 0, payloadSize - 4);
+  uint64_t payloadIndexBuf = static_cast<uint64_t>(payloadIndex);
+  if (payloadSize >= 8) {
+    memcpy(valueAddr, &payloadIndexBuf, 8);
+    memset(valueAddr + 8, 0, payloadSize - 8);
+  } else if (payloadSize > 0) {
+    payloadIndexBuf <<= (8 - payloadSize) * 8;
+    memcpy(valueAddr, &payloadIndexBuf, payloadSize);
+  }
   if (numExtraTagBytes)
     small_memcpy(extraTagBitAddr,
                  reinterpret_cast<uint8_t *>(&extraTagIndex) + 4 -

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -21,45 +21,85 @@
 
 namespace swift {
 
-/// This is a small and fast implementation of memcpy with a constant count. It
-/// should be a performance win for small constant values where the function
-/// can be inlined, the loop unrolled and the memory accesses merged.
-template <unsigned count> static void small_memcpy(void *dest, const void *src) {
-  uint8_t *d8 = (uint8_t*)dest;
-  const uint8_t *s8 = (const uint8_t*)src;
-  for (unsigned i = 0; i < count; i++) {
-    *d8++ = *s8++;
+/// Store the given 4-byte unsigned integer value into the variable-
+/// length destination buffer. The value will be zero extended or
+/// truncated to fit in the buffer.
+static inline void storeEnumElement(uint8_t *dst,
+                                    uint32_t value,
+                                    size_t size) {
+  // Note: we use fixed size memcpys to encourage the compiler to
+  // optimize them into unaligned stores.
+  switch (size) {
+  case 0:
+    return;
+  case 1:
+    dst[0] = uint8_t(value);
+    return;
+  case 2:
+#if defined(__BIG_ENDIAN__)
+    value <<= 16;
+#endif
+    memcpy(dst, &value, 2);
+    return;
+  case 3:
+#if defined(__BIG_ENDIAN__)
+    value <<= 8;
+#endif
+    memcpy(dst, &value, 3);
+    return;
+  case 4:
+    memcpy(dst, &value, 4);
+    return;
   }
+  // Store value into first word of destination. Set the rest of the
+  // destination to zero.
+  // NOTE: this is likely to change on big-endian systems.
+#if defined(__BIG_ENDIAN__) && defined(__LP64__)
+  memset(&dst[0], 0, size);
+  memcpy(&dst[std::min(size - 4, size_t(4))], &value, 4);
+#else
+  memcpy(&dst[0], &value, 4);
+  memset(&dst[4], 0, size - 4);
+#endif
 }
 
-static inline void small_memcpy(void *dest, const void *src, unsigned count,
-                                bool countMaybeThree = false) {
-  // This is specialization of the memcpy line below with
-  // specialization for values of 1, 2 and 4.
-  // memcpy(dst, src, count)
-  if (count == 1) {
-    small_memcpy<1>(dest, src);
-  } else if (count == 2) {
-    small_memcpy<2>(dest, src);
-  } else if (countMaybeThree && count == 3) {
-    small_memcpy<3>(dest, src);
-  } else if (count == 4) {
-    small_memcpy<4>(dest, src);
-  } else {
-    swift::crash("Tagbyte values should be 1, 2 or 4.");
+/// Load a 4-byte unsigned integer value from the variable-length
+/// source buffer. The value will be zero-extended or truncated to fit
+/// into the returned value.
+static inline uint32_t loadEnumElement(const uint8_t *src,
+                                       size_t size) {
+  // Note: we use fixed size memcpys to encourage the compiler to
+  // optimize them into unaligned loads.
+  uint32_t result = 0;
+  switch (size) {
+  case 0:
+    return 0;
+  case 1:
+    return uint32_t(src[0]);
+  case 2:
+    memcpy(&result, src, 2);
+#if defined(__BIG_ENDIAN__)
+    result >>= 16;
+#endif
+    return result;
+  case 3:
+    memcpy(&result, src, 3);
+#if defined(__BIG_ENDIAN__)
+    result >>= 8;
+#endif
+    return result;
+  case 4:
+    memcpy(&result, src, 4);
+    return result;
   }
-}
-
-static inline void small_memset(void *dest, uint8_t value, unsigned count) {
-  if (count == 1) {
-    memset(dest, value, 1);
-  } else if (count == 2) {
-    memset(dest, value, 2);
-  } else if (count == 4) {
-    memset(dest, value, 4);
-  } else {
-    swift::crash("Tagbyte values should be 1, 2 or 4.");
-  }
+  // Load value from the first word of the source.
+  // NOTE: this is likely to change on big-endian systems.
+#if defined(__BIG_ENDIAN__) && defined(__LP64__)
+  memcpy(&result, &src[std::min(size - 4, size_t(4))], 4);
+#else
+  memcpy(&result, &src[0], 4);
+#endif
+  return result;
 }
 
 inline unsigned getEnumTagSinglePayloadImpl(
@@ -71,18 +111,12 @@ inline unsigned getEnumTagSinglePayloadImpl(
   if (emptyCases > payloadNumExtraInhabitants) {
     auto *valueAddr = reinterpret_cast<const uint8_t *>(enumAddr);
     auto *extraTagBitAddr = valueAddr + payloadSize;
-    unsigned extraTagBits = 0;
     unsigned numBytes =
         getEnumTagCounts(payloadSize,
                          emptyCases - payloadNumExtraInhabitants,
                          1 /*payload case*/).numTagBytes;
 
-#if defined(__BIG_ENDIAN__)
-    small_memcpy(reinterpret_cast<uint8_t *>(&extraTagBits) + 4 - numBytes,
-                 extraTagBitAddr, numBytes);
-#else
-    small_memcpy(&extraTagBits, extraTagBitAddr, numBytes);
-#endif
+    unsigned extraTagBits = loadEnumElement(extraTagBitAddr, numBytes);
 
     // If the extra tag bits are zero, we have a valid payload or
     // extra inhabitant (checked below). If nonzero, form the case index from
@@ -90,24 +124,7 @@ inline unsigned getEnumTagSinglePayloadImpl(
     if (extraTagBits > 0) {
       unsigned caseIndexFromExtraTagBits =
           payloadSize >= 4 ? 0 : (extraTagBits - 1U) << (payloadSize * 8U);
-
-#if defined(__BIG_ENDIAN__)
-      // On BE high order bytes contain the index
-      unsigned long caseIndexFromValue = 0;
-      unsigned numPayloadTagBytes = std::min(size_t(8), payloadSize);
-      if (numPayloadTagBytes)
-        memcpy(reinterpret_cast<uint8_t *>(&caseIndexFromValue) + 8 -
-               numPayloadTagBytes,
-               valueAddr, numPayloadTagBytes);
-#else
-      // In practice we should need no more than four bytes from the payload
-      // area.
-      unsigned caseIndexFromValue = 0;
-      unsigned numPayloadTagBytes = std::min(size_t(4), payloadSize);
-      if (numPayloadTagBytes)
-        small_memcpy(&caseIndexFromValue, valueAddr,
-                     numPayloadTagBytes, true);
-#endif
+      unsigned caseIndexFromValue = loadEnumElement(valueAddr, payloadSize);
       unsigned noPayloadIndex =
           (caseIndexFromExtraTagBits | caseIndexFromValue) +
           payloadNumExtraInhabitants;
@@ -143,7 +160,7 @@ inline void storeEnumTagSinglePayloadImpl(
   // if any.
   if (whichCase <= payloadNumExtraInhabitants) {
     if (numExtraTagBytes != 0)
-      small_memset(extraTagBitAddr, 0, numExtraTagBytes);
+      storeEnumElement(extraTagBitAddr, 0, numExtraTagBytes);
 
     // If this is the payload case, we're done.
     if (whichCase == 0)
@@ -169,29 +186,10 @@ inline void storeEnumTagSinglePayloadImpl(
   }
 
     // Store into the value.
-#if defined(__BIG_ENDIAN__)
-  uint64_t payloadIndexBuf = static_cast<uint64_t>(payloadIndex);
-  if (payloadSize >= 8) {
-    memcpy(valueAddr, &payloadIndexBuf, 8);
-    memset(valueAddr + 8, 0, payloadSize - 8);
-  } else if (payloadSize > 0) {
-    payloadIndexBuf <<= (8 - payloadSize) * 8;
-    memcpy(valueAddr, &payloadIndexBuf, payloadSize);
-  }
+  if (payloadSize)
+    storeEnumElement(valueAddr, payloadIndex, payloadSize);
   if (numExtraTagBytes)
-    small_memcpy(extraTagBitAddr,
-                 reinterpret_cast<uint8_t *>(&extraTagIndex) + 4 -
-                     numExtraTagBytes,
-                 numExtraTagBytes);
-#else
-  unsigned numPayloadTagBytes = std::min(size_t(4), payloadSize);
-  if (numPayloadTagBytes)
-    small_memcpy(valueAddr, &payloadIndex, numPayloadTagBytes, true);
-  if (payloadSize > 4)
-    memset(valueAddr + 4, 0, payloadSize - 4);
-  if (numExtraTagBytes)
-    small_memcpy(extraTagBitAddr, &extraTagIndex, numExtraTagBytes);
-#endif
+    storeEnumElement(extraTagBitAddr, extraTagIndex, numExtraTagBytes);
 }
 
 } /* end namespace swift */

--- a/stdlib/public/runtime/EnumImpl.h
+++ b/stdlib/public/runtime/EnumImpl.h
@@ -51,12 +51,10 @@ static inline void storeEnumElement(uint8_t *dst,
     memcpy(dst, &value, 4);
     return;
   }
-  // Store value into first word of destination. Set the rest of the
-  // destination to zero.
-  // NOTE: this is likely to change on big-endian systems.
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-  memset(&dst[0], 0, size);
-  memcpy(&dst[std::min(size - 4, size_t(4))], &value, 4);
+  // Store zero extended value in the destination.
+#if defined(__BIG_ENDIAN__)
+  memset(&dst[0], 0, size - 4);
+  memcpy(&dst[size - 4], &value, 4);
 #else
   memcpy(&dst[0], &value, 4);
   memset(&dst[4], 0, size - 4);
@@ -92,10 +90,9 @@ static inline uint32_t loadEnumElement(const uint8_t *src,
     memcpy(&result, src, 4);
     return result;
   }
-  // Load value from the first word of the source.
-  // NOTE: this is likely to change on big-endian systems.
-#if defined(__BIG_ENDIAN__) && defined(__LP64__)
-  memcpy(&result, &src[std::min(size - 4, size_t(4))], 4);
+  // Load value by truncating the source to 4 bytes.
+#if defined(__BIG_ENDIAN__)
+  memcpy(&result, &src[size - 4], 4);
 #else
   memcpy(&result, &src[0], 4);
 #endif

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Support/PointerLikeTypeTraits.h"
 #include <algorithm>
 #include <cctype>
+#include <cinttypes>
 #include <condition_variable>
 #include <new>
 #include <unordered_set>
@@ -3898,10 +3899,15 @@ void _swift_debug_verifyTypeLayoutAttribute(Metadata *type,
                                             size_t size,
                                             const char *description) {
   auto presentValue = [&](const void *value) {
-    if (size < sizeof(long long)) {
-      long long intValue = 0;
-      memcpy(&intValue, value, size);
-      fprintf(stderr, "%lld (%#llx)\n                  ", intValue, intValue);
+    if (size <= sizeof(uint64_t)) {
+      uint64_t intValue = 0;
+      auto ptr = reinterpret_cast<uint8_t *>(&intValue);
+#if defined(__BIG_ENDIAN__)
+      ptr += sizeof(uint64_t) - size;
+#endif
+      memcpy(ptr, value, size);
+      fprintf(stderr, "%" PRIu64 " (%#" PRIx64 ")\n", intValue, intValue);
+      fprintf(stderr, "                  ");
     }
     auto bytes = reinterpret_cast<const uint8_t *>(value);
     for (unsigned i = 0; i < size; ++i) {

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2516,10 +2516,9 @@ entry(%x : $Int32):
   %c = tuple (%b : $Optional<()>, %x : $Int32)
   // CHECK-64: [[INT_ZEXT:%.*]] = zext i32 %0 to i64
   // CHECK-64: [[INT_SHL:%.*]] = shl i64 [[INT_ZEXT]], 32
-  // CHECK-64: [[COMBINE:%.*]] = or i64 0, [[INT_SHL]]
   %d = enum $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt.1, %c : $(Optional<()>, Int32)
-  // CHECK-64: [[BIT:%.*]] = trunc i64 [[COMBINE]] to i1
-  // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[COMBINE]], 32
+  // CHECK-64: [[BIT:%.*]] = trunc i64 [[INT_SHL]] to i1
+  // CHECK-64: [[INT_SHR:%.*]] = lshr i64 [[INT_SHL]], 32
   // CHECK-64: [[INT:%.*]] = trunc i64 [[INT_SHR]] to i32
   %e = unchecked_enum_data %d : $Optional<(Optional<()>, Int32)>, #Optional.some!enumelt.1
   return %d : $Optional<(Optional<()>, Int32)>

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -882,23 +882,12 @@ enum SinglePayloadSpareBit {
 sil @single_payload_spare_bit_switch : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
-// CHECK-64:  switch i64 %0, label %[[X_DEST:[0-9]+]] [
+// CHECK:  switch i64 %{{[0-9]+}}, label %[[X_DEST:[0-9]+]] [
 // --              0x8000_0000_0000_0000
-// CHECK-64:    i64 -9223372036854775808, label %[[Y_DEST:[0-9]+]]
+// CHECK:    i64 -9223372036854775808, label %[[Y_DEST:[0-9]+]]
 // --              0x8000_0000_0000_0001
-// CHECK-64:    i64 -9223372036854775807, label %[[Z_DEST:[0-9]+]]
-// CHECK-64:  ]
-
-// CHECK-32:  switch i32 %0, label %[[X_DEST:[0-9]+]] [
-// CHECK-32:    i32 0, label %[[Y_HIGH:[0-9]+]]
-// CHECK-32:    i32 1, label %[[Z_HIGH:[0-9]+]]
-// CHECK-32:  ]
-// CHECK-32: ; <label>:[[Y_HIGH]]
-// CHECK-32:  [[IS_Y:%.*]] = icmp eq i32 %1, -2147483648
-// CHECK-32:  br i1 [[IS_Y]], label %[[Y_DEST:[0-9]+]], label %[[X_DEST]]
-// CHECK-32: ; <label>:[[Z_HIGH]]
-// CHECK-32:  [[IS_Z:%.*]] = icmp eq i32 %1, -2147483648
-// CHECK-32:  br i1 [[IS_Z]], label %[[Z_DEST:[0-9]+]], label %[[X_DEST]]
+// CHECK:    i64 -9223372036854775807, label %[[Z_DEST:[0-9]+]]
+// CHECK:  ]
   switch_enum %u : $SinglePayloadSpareBit, case #SinglePayloadSpareBit.x!enumelt.1: x_dest, case #SinglePayloadSpareBit.y!enumelt: y_dest, case #SinglePayloadSpareBit.z!enumelt: z_dest
 
 // CHECK: ; <label>:[[X_DEST]]

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -581,7 +581,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = and i64 [[SPARE_TAG_TMP2]], -4611686018427387904
 
 //   -- Apply the new spare bits
-// CHECK-NEXT: [[SECOND_NEW:%.*]] = or i64 [[SECOND_PROJ]], [[SPARE_TAG_TMP]]
+// CHECK-NEXT: [[SECOND_NEW:%.*]] = or i64 [[SPARE_TAG_TMP]], [[SECOND_PROJ]]
 
 //   -- Store the payload back
 // CHECK-NEXT: [[PAYLOAD:%.*]] = bitcast %T20enum_value_semantics31MultiPayloadNontrivialSpareBitsO* [[SELF]] to { i64, i64 }*
@@ -647,7 +647,7 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[SPARE_TAG_TMP:%.*]] = shl i64 [[SPARE_TAG_TMP2]], 63
 //                                                                -- 0x8000000000000000
 // CHECK-NEXT: [[SPARE_TAG:%.*]] = and i64 [[SPARE_TAG_TMP:%.*]], -9223372036854775808
-// CHECK-NEXT: [[PAYLOAD_NEW:%.*]] = or i64 [[PAYLOAD_PROJ]], [[SPARE_TAG]]
+// CHECK-NEXT: [[PAYLOAD_NEW:%.*]] = or i64 [[SPARE_TAG]], [[PAYLOAD_PROJ]]
 
 //   -- Store the payload
 // CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = bitcast %T20enum_value_semantics029MultiPayloadSpareBitsAndExtraG0O* %0 to i64*

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -9,7 +9,7 @@
 // CHECK: [[TYPE:%swift.type]] = type {
 // CHECK: [[OPAQUE:%swift.opaque]] = type opaque
 // CHECK: [[TUPLE_TYPE:%swift.tuple_type]] = type { [[TYPE]], i64, i8*, [0 x %swift.tuple_element_type] }
-// CHECK: %swift.tuple_element_type = type { [[TYPE]]*, i64 }
+// CHECK: %swift.tuple_element_type = type { [[TYPE]]*, i32 }
 
 func dup<T>(_ x: T) -> (T, T) { var x = x; return (x,x) }
 // CHECK:    define hidden swiftcc void @"$s14generic_tuples3dupyx_xtxlF"(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -58,7 +58,7 @@ entry(%x : $float3):
 // armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
 // powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
-// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -38,5 +38,5 @@
 // WATCHSIMULATOR64_CPU: "-target-cpu" "core2"
 
 // RUN: not %swift -typecheck -target s390x-unknown-linux-gnu -Xcc -### %s 2>&1 | %FileCheck -check-prefix=S390X_CPU %s
-// S390X_CPU: "-target-cpu" "z196"
+// S390X_CPU: "-target-cpu" "z13"
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2657,8 +2657,7 @@ void serializeSyntaxTreeAsByteTree(
     ResponseBuilder::Dictionary &Dict) {
   auto StartClock = clock();
   // Serialize the syntax tree as a ByteTree
-  swift::ExponentialGrowthAppendingBinaryByteStream Stream(
-      llvm::support::endianness::little);
+  auto Stream = swift::ExponentialGrowthAppendingBinaryByteStream();
   Stream.reserve(32 * 1024);
   std::map<void *, void *> UserInfo;
   UserInfo[swift::byteTree::UserInfoKeyReusedNodeIds] = &ReusedNodeIds;

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -735,8 +735,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
         return EXIT_FAILURE;
       }
 
-      swift::ExponentialGrowthAppendingBinaryByteStream Stream(
-          llvm::support::endianness::little);
+      auto Stream = ExponentialGrowthAppendingBinaryByteStream();
       Stream.reserve(32 * 1024);
       std::map<void *, void *> UserInfo;
       UserInfo[swift::byteTree::UserInfoKeyReusedNodeIds] = &ReusedNodeIds;

--- a/unittests/Basic/ClusteredBitVectorTest.cpp
+++ b/unittests/Basic/ClusteredBitVectorTest.cpp
@@ -131,28 +131,6 @@ template <class T> struct ComparableOptional {
   }
 };
 
-TEST(ClusteredBitVector, Enumeration) {
-  ClusteredBitVector temp;
-  temp.appendClearBits(256);
-  temp.setBit(64);
-  temp.setBit(40);
-  temp.setBit(39);
-  temp.setBit(63);
-  temp.setBit(201);
-
-  using Opt = ComparableOptional<size_t>;
-
-  auto enumerator = temp.enumerateSetBits();
-  EXPECT_EQ(Opt(39), enumerator.findNext());
-  EXPECT_EQ(Opt(40), enumerator.findNext());
-  EXPECT_EQ(Opt(63), enumerator.findNext());
-  EXPECT_EQ(Opt(64), enumerator.findNext());
-  EXPECT_EQ(Opt(201), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-  EXPECT_EQ(Opt(), enumerator.findNext());
-}
-
 TEST(ClusteredBitVector, SetClearBit) {
   ClusteredBitVector vec;
   vec.appendClearBits(64);

--- a/unittests/Basic/ClusteredBitVectorTest.cpp
+++ b/unittests/Basic/ClusteredBitVectorTest.cpp
@@ -115,22 +115,6 @@ TEST(ClusteredBitVector, AssignAfterGrowth) {
   EXPECT_EQ(false, vec[64]);
 }
 
-/// define == on llvm::Optional, you jerks
-template <class T> struct ComparableOptional {
-  Optional<T> Value;
-  ComparableOptional(const T &value) : Value(value) {}
-  ComparableOptional() : Value() {}
-
-  bool operator==(const Optional<T> &other) const {
-    if (Value.hasValue()) {
-      return other.hasValue()
-          && Value.getValue() == other.getValue();
-    } else {
-      return !other.hasValue();
-    }
-  }
-};
-
 TEST(ClusteredBitVector, SetClearBit) {
   ClusteredBitVector vec;
   vec.appendClearBits(64);

--- a/unittests/Basic/ExponentialGrowthAppendingBinaryByteStreamTests.cpp
+++ b/unittests/Basic/ExponentialGrowthAppendingBinaryByteStreamTests.cpp
@@ -18,7 +18,6 @@
 #include "gtest/gtest.h"
 
 using namespace llvm;
-using namespace llvm::support;
 using namespace swift;
 
 class ExponentialGrowthAppendingBinaryByteStreamTest : public testing::Test {};
@@ -27,7 +26,7 @@ class ExponentialGrowthAppendingBinaryByteStreamTest : public testing::Test {};
 // unittests/BinaryStreamTests.cpp in the LLVM project
 TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, ReadAndWrite) {
   StringRef Strings[] = {"1", "2", "3", "4"};
-  ExponentialGrowthAppendingBinaryByteStream Stream(support::little);
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
   BinaryStreamWriter Writer(Stream);
   BinaryStreamReader Reader(Stream);
@@ -76,7 +75,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, ReadAndWrite) {
 }
 
 TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteAtInvalidOffset) {
-  ExponentialGrowthAppendingBinaryByteStream Stream(llvm::support::little);
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
   EXPECT_EQ(0U, Stream.getLength());
 
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't', 'T', 'e', 's', 't'};
@@ -97,7 +96,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteAtInvalidOffset) {
 TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, InitialSizeZero) {
   // Test that the stream also works with an initial size of 0, which doesn't
   // grow when doubled.
-  ExponentialGrowthAppendingBinaryByteStream Stream(llvm::support::little);
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't'};
   auto Test = makeArrayRef(InputData).take_front(4);
@@ -106,7 +105,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, InitialSizeZero) {
 }
 
 TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, GrowMultipleSteps) {
-  ExponentialGrowthAppendingBinaryByteStream Stream(llvm::support::little);
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
   // Test that the buffer can grow multiple steps at once, e.g. 1 -> 2 -> 4
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't'};
@@ -116,7 +115,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, GrowMultipleSteps) {
 }
 
 TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteIntoMiddle) {
-  ExponentialGrowthAppendingBinaryByteStream Stream(llvm::support::little);
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
   // Test that the stream resizes correctly if we write into its middle
   std::vector<uint8_t> InitialData = {'T', 'e', 's', 't'};
@@ -143,16 +142,16 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteIntoMiddle) {
   EXPECT_EQ(6u, Stream.getLength());
 }
 
-TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteRaw) {
-  ExponentialGrowthAppendingBinaryByteStream Stream(llvm::support::little);
+TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteInteger) {
+  auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
-  // Test the writeRaw method
+  // Test the writeInteger method
   std::vector<uint8_t> InitialData = {'H', 'e', 'l', 'l', 'o'};
   auto InitialDataRef = makeArrayRef(InitialData);
   EXPECT_THAT_ERROR(Stream.writeBytes(0, InitialDataRef), Succeeded());
   EXPECT_EQ(InitialDataRef, Stream.data());
 
-  EXPECT_THAT_ERROR(Stream.writeRaw(5, (uint8_t)' '), Succeeded());
+  EXPECT_THAT_ERROR(Stream.writeInteger(5, (uint8_t)' '), Succeeded());
   std::vector<uint8_t> AfterFirstInsert = {'H', 'e', 'l', 'l', 'o', ' '};
   auto AfterFirstInsertRef = makeArrayRef(AfterFirstInsert);
   EXPECT_EQ(AfterFirstInsertRef, Stream.data());
@@ -162,7 +161,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteRaw) {
                       'o' << 8 |
                       'r' << 16 |
                       'l' << 24;
-  EXPECT_THAT_ERROR(Stream.writeRaw(6, ToInsert), Succeeded());
+  EXPECT_THAT_ERROR(Stream.writeInteger(6, ToInsert), Succeeded());
   std::vector<uint8_t> AfterSecondInsert = {'H', 'e', 'l', 'l', 'o', ' ',
                                             'w', 'o', 'r', 'l'};
   auto AfterSecondInsertRef = makeArrayRef(AfterSecondInsert);

--- a/utils/test-clustered-bit-vector/generator.cpp
+++ b/utils/test-clustered-bit-vector/generator.cpp
@@ -175,26 +175,6 @@ static void run() {
     // Validate that everything's still okay.
     for (auto i = 0; i != NV; ++i) {
       checkConsistency("cbvs[" + Twine(i) + "]", cbvs[i], vecs[i], 1);
-
-      auto enumerator = cbvs[i].enumerateSetBits();
-      auto nextIndex = enumerator.findNext();
-      for (unsigned j = 0, je = cbvs[i].size(); j != je; ++j) {
-        assert((!nextIndex || nextIndex.getValue() >= j) && "going in reverse?");
-        if (cbvs[i][j]) {
-          if (!nextIndex || nextIndex.getValue() != j) {
-            llvm::outs() << "  cbvs[" << i << "][" << j
-                         << "] is set but was not found by enumerator\n";
-            abort();
-          }
-          nextIndex = enumerator.findNext();
-        } else {
-          if (nextIndex && nextIndex.getValue() == j) {
-            llvm::outs() << "  cbvs[" << i << "][" << j
-                         << "] is not set but was found by enumerator\n";
-            abort();
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
These are a bunch of backporting commits to 5.1 branch to add big-endian support. All the commits have already been merged in the master branch. These commits resolve the enum issue mentioned in https://forums.swift.org/t/fixing-enums-on-big-endian-systems/21730 and some other test failures seen on big-endian platforms, i.e., s390x. 
