### PR TITLE
[silgen] Add SILGen support for emitting copy_unmanaged_value instead…

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -175,19 +175,14 @@ ManagedValue SILGenBuilder::createCopyValue(SILLocation loc,
     SILValue result = createCopy##Name##Value(loc, originalValue.getValue()); \
     return SGF.emitManagedRValueWithCleanup(result); \
   }
-#define UNCHECKED_REF_STORAGE(Name, ...) \
-  ManagedValue \
-  SILGenBuilder::createUnsafeCopy##Name##Value(SILLocation loc, \
-                                               ManagedValue originalValue) { \
-    /* *NOTE* The reason why this is unsafe is that we are converting and */ \
-    /* unconditionally retaining, rather than before converting from */ \
-    /* type->ref checking that our value is not yet uninitialized. */ \
-    auto type = originalValue.getType().getAs<Name##StorageType>(); \
-    SILValue result = create##Name##ToRef( \
-        loc, originalValue.getValue(), \
-        SILType::getPrimitiveObjectType(type.getReferentType())); \
-    result = createCopyValue(loc, result); \
-    return SGF.emitManagedRValueWithCleanup(result); \
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  ManagedValue SILGenBuilder::createCopy##Name##Value(                         \
+      SILLocation loc, ManagedValue originalValue) {                           \
+    /* *NOTE* The reason why this is unsafe is that we are converting and */   \
+    /* unconditionally retaining, rather than before converting from */        \
+    /* type->ref checking that our value is not yet uninitialized. */          \
+    SILValue result = createCopy##Name##Value(loc, originalValue.getValue());  \
+    return SGF.emitManagedRValueWithCleanup(result);                           \
   }
 #include "swift/AST/ReferenceStorage.def"
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -118,9 +118,10 @@ public:
   using SILBuilder::createCopy##Name##Value;                             \
   ManagedValue createCopy##Name##Value(SILLocation loc,                        \
                                        ManagedValue originalValue);
-#define UNCHECKED_REF_STORAGE(Name, ...) \
-  ManagedValue createUnsafeCopy##Name##Value(SILLocation loc, \
-                                             ManagedValue originalValue);
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  using SILBuilder::createCopy##Name##Value;                                   \
+  ManagedValue createCopy##Name##Value(SILLocation loc,                        \
+                                       ManagedValue originalValue);
 #include "swift/AST/ReferenceStorage.def"
 
   ManagedValue createOwnedPhiArgument(SILType type);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3617,15 +3617,12 @@ SILValue SILGenFunction::emitConversionToSemanticRValue(SILLocation loc,
                                                ResilienceExpansion::Maximal)); \
     return B.createCopy##Name##Value(loc, src); \
   }
-#define UNCHECKED_REF_STORAGE(Name, ...) \
-  case ReferenceOwnership::Name: { \
-    /* For static reference storage types, we need to strip the box and */ \
-    /* then do an (unsafe) retain. */ \
-    auto type = storageType.castTo<Name##StorageType>(); \
-    auto result = B.create##Name##ToRef(loc, src, \
-              SILType::getPrimitiveObjectType(type.getReferentType())); \
-    /* SEMANTIC ARC TODO: Does this need a cleanup? */ \
-    return B.createCopyValue(loc, result); \
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  case ReferenceOwnership::Name: {                                             \
+    /* For static reference storage types, we need to strip the box and */     \
+    /* then do an (unsafe) retain. */                                          \
+    auto type = storageType.castTo<Name##StorageType>();                       \
+    return B.createCopy##Name##Value(loc, src);                                \
   }
 #include "swift/AST/ReferenceStorage.def"
   }
@@ -3647,10 +3644,10 @@ ManagedValue SILGenFunction::emitConversionToSemanticRValue(
   case ReferenceOwnership::Name: \
     /* Generate a strong retain and strip the box. */ \
     return B.createCopy##Name##Value(loc, src);
-#define UNCHECKED_REF_STORAGE(Name, ...) \
-  case ReferenceOwnership::Name: \
-    /* Strip the box and then do an (unsafe) retain. */ \
-    return B.createUnsafeCopy##Name##Value(loc, src);
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  case ReferenceOwnership::Name:                                               \
+    /* Strip the box and then do an (unsafe) retain. */                        \
+    return B.createCopy##Name##Value(loc, src);
 #include "swift/AST/ReferenceStorage.def"
   }
   llvm_unreachable("impossible");
@@ -3702,15 +3699,12 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &SGF,
     } \
     ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name) \
   }
-#define UNCHECKED_REF_STORAGE(Name, ...) \
-  case ReferenceOwnership::Name: { \
-    /* For static reference storage types, we need to strip the box. */ \
-    auto type = storageType.castTo<Name##StorageType>(); \
-    auto value = SGF.B.createLoad(loc, src, LoadOwnershipQualifier::Trivial); \
-    auto result = SGF.B.create##Name##ToRef(loc, value, \
-            SILType::getPrimitiveObjectType(type.getReferentType())); \
-    /* SEMANTIC ARC TODO: Does this need a cleanup? */ \
-    return SGF.B.createCopyValue(loc, result); \
+#define UNCHECKED_REF_STORAGE(Name, ...)                                       \
+  case ReferenceOwnership::Name: {                                             \
+    /* For static reference storage types, we need to strip the box. */        \
+    auto type = storageType.castTo<Name##StorageType>();                       \
+    auto value = SGF.B.createLoad(loc, src, LoadOwnershipQualifier::Trivial);  \
+    return SGF.B.createCopy##Name##Value(loc, value);                          \
   }
 #include "swift/AST/ReferenceStorage.def"
 #undef ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE_HELPER

--- a/test/SILGen/unmanaged.swift
+++ b/test/SILGen/unmanaged.swift
@@ -39,8 +39,7 @@ func get(holder holder: inout Holder) -> C {
 // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [static] [[ADDR]] : $*Holder
 // CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = load [[T0]] : $*@sil_unmanaged C
-// CHECK-NEXT:   [[T2:%.*]] = unmanaged_to_ref [[T1]]
-// CHECK-NEXT:   strong_retain [[T2]]
+// CHECK-NEXT:   [[T2:%.*]] = copy_unmanaged_value [[T1]]
 // CHECK-NEXT:   end_access [[READ]] : $*Holder
 // CHECK-NEXT:   return [[T2]]
 
@@ -52,6 +51,5 @@ func project(fn fn: () -> Holder) -> C {
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: [[T0:%.*]] = apply [[FN]]()
 // CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
-// CHECK-NEXT: [[T2:%.*]] = unmanaged_to_ref [[T1]]
-// CHECK-NEXT: strong_retain [[T2]]
+// CHECK-NEXT: [[T2:%.*]] = copy_unmanaged_value [[T1]]
 // CHECK-NEXT: return [[T2]]

--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -50,10 +50,9 @@ func get(holder holder: inout Holder) -> C {
 // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [unknown] [[ADDR]] : $*Holder
 // CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = load [trivial] [[T0]] : $*@sil_unmanaged C
-// CHECK-NEXT:   [[T2:%.*]] = unmanaged_to_ref [[T1]]
-// CHECK-NEXT:   [[T2_COPY:%.*]] = copy_value [[T2]]
+// CHECK-NEXT:   [[T2:%.*]] = copy_unmanaged_value [[T1]]
 // CHECK-NEXT:   end_access [[READ]] : $*Holder
-// CHECK-NEXT:   return [[T2_COPY]]
+// CHECK-NEXT:   return [[T2]]
 
 func project(fn fn: () -> Holder) -> C {
   return fn().value
@@ -63,7 +62,6 @@ func project(fn fn: () -> Holder) -> C {
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: [[T0:%.*]] = apply [[FN]]()
 // CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
-// CHECK-NEXT: [[T2:%.*]] = unmanaged_to_ref [[T1]]
-// CHECK-NEXT: [[COPIED_T2:%.*]] = copy_value [[T2]]
+// CHECK-NEXT: [[T2:%.*]] = copy_unmanaged_value [[T1]]
 // CHECK-NOT: destroy_value [[BORROWED_FN_COPY]]
-// CHECK-NEXT: return [[COPIED_T2]]
+// CHECK-NEXT: return [[T2]]


### PR DESCRIPTION
… of unmanaged_to_ref + strong_retain.

This will ensure that the optimizer never eliminates the strong_retain. This
operation is meant to be unmanaged, we should respect the user's choice here
even in optimized builds.
