### PR TITLE
[ModuleInterface] Don't print property wrapper storage vars

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -143,6 +143,16 @@ PrintOptions PrintOptions::printParseableInterfaceFile(bool preferTypeRepr) {
         }
       }
 
+      // Skip printing the synthesized storage vars for property wrappers.
+      if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+        // Property wrappers are limited to single-var pattern bindings.
+        if (auto *VD = PBD->getSingleVar()) {
+          if (VD->getOriginalWrappedProperty(
+                  PropertyWrapperSynthesizedPropertyKind::Backing))
+            return false;
+        }
+      }
+
       // Skip extensions that extend things we wouldn't print.
       if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
         if (!shouldPrint(ED->getExtendedNominal(), options))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1485,7 +1485,7 @@ SourceRange PatternBindingEntry::getSourceRange(bool omitAccessors) const {
 bool PatternBindingEntry::hasInitStringRepresentation() const {
   if (InitContextAndIsText.getInt())
     return !InitStringRepresentation.empty();
-  return getInit() && getInit()->getSourceRange().isValid();
+  return getOriginalInit() && getOriginalInit()->getSourceRange().isValid();
 }
 
 StringRef PatternBindingEntry::getInitStringRepresentation(

--- a/test/ParseableInterface/property_wrappers.swift
+++ b/test/ParseableInterface/property_wrappers.swift
@@ -62,3 +62,17 @@ public struct HasWrappers {
   // CHECK-NEXT: }  
   @WrapperWithInitialValue(alternate: false) public var z
 }
+
+// CHECK: @frozen public struct FrozenWithWrappers {
+@frozen
+public struct FrozenWithWrappers {
+  // CHECK: @TestResilient.Wrapper public var val: Swift.Int {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: set
+  // CHECK-NEXT: }
+  @Wrapper public var val: Int
+
+  // CHECK-NOT: var _val
+
+// CHECK-NEXT: }
+}

--- a/test/ParseableInterface/property_wrappers_layout.swift
+++ b/test/ParseableInterface/property_wrappers_layout.swift
@@ -1,0 +1,13 @@
+// NOTE: This file has a dependency on test/ParseableInterface/property_wrappers.swift
+//       It ensures that we properly synthesize the hidden _val backing property
+//       even if we omit it in the module interface.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %S/property_wrappers.swift -emit-module-interface-path %t/PropertyWrappers.swiftinterface -module-name PropertyWrappers -enable-library-evolution
+// RUN: %target-swift-frontend -emit-sil %t/PropertyWrappers.swiftinterface -module-name PropertyWrappers -enable-library-evolution -o %t/layout.sil
+// RUN: %FileCheck %s < %t/layout.sil
+
+// CHECK: @frozen public struct FrozenWithWrappers {
+// CHECK-NEXT: @Wrapper public var val: Int { get set }
+// CHECK-NEXT: @_hasStorage var _val: Wrapper<Int> { get set }
+// CHECK-NEXT: }


### PR DESCRIPTION
Previously, we would print the backing `_val` property for a given
property with a wrapper. This ended up printing incorrect output or
crashing when printing the initializer for these properties, because the
initializer consists of wholly-constructed calls to
`MyWrapper.init(wrappedValue:)`. We don't need these storage vars, so just
omit them.

Fixes rdar://53555890 and rdar://53468607