### PR TITLE
Basic: convert descriptors to `FILE *`

### DIFF
--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -214,14 +214,14 @@ swift::areFilesDifferent(const llvm::Twine &source,
   // The two files match in size, so we have to compare the bytes to determine
   // if they're the same.
   std::error_code sourceRegionErr;
-  fs::mapped_file_region sourceRegion(sourceFile.fd,
+  fs::mapped_file_region sourceRegion(fs::convertFDToNativeFile(sourceFile.fd),
                                       fs::mapped_file_region::readonly,
                                       size, 0, sourceRegionErr);
   if (sourceRegionErr)
     return sourceRegionErr;
 
   std::error_code destRegionErr;
-  fs::mapped_file_region destRegion(destFile.fd,
+  fs::mapped_file_region destRegion(fs::convertFDToNativeFile(destFile.fd),
                                     fs::mapped_file_region::readonly,
                                     size, 0, destRegionErr);
 


### PR DESCRIPTION
Ensure that convert the file descriptor to `FILE *` when passing the parameter
to `fs::mapped_file_region`'s constructor which takes a `FILE *`.  Repairs the
build for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
