### PR TITLE
[sil-parser] Fix harmless bug when parsing ossa.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1,4 +1,3 @@
-
 //===--- DiagnosticsParse.def - Diagnostics Text ----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
@@ -485,6 +484,10 @@ ERROR(referenced_value_no_accessor,none,
       "referenced declaration has no %select{getter|setter}0", (unsigned))
 ERROR(expected_sil_value_ownership_kind,none,
       "expected value ownership kind in SIL code", ())
+ERROR(silfunc_and_silarg_have_incompatible_sil_value_ownership,none,
+      "SILFunction and SILArgument have mismatching ValueOwnershipKinds. "
+      "Function type specifies: '@%0'. SIL argument specifies: '@%1'.",
+      (StringRef, StringRef))
 ERROR(expected_sil_colon,none,
       "expected ':' before %0", (StringRef))
 ERROR(expected_sil_tuple_index,none,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -197,6 +197,8 @@ struct ValueOwnershipKind {
           return acc.getValue().merge(x);
         });
   }
+
+  StringRef asString() const;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, ValueOwnershipKind Kind);

--- a/lib/SIL/SILValue.cpp
+++ b/lib/SIL/SILValue.cpp
@@ -188,20 +188,23 @@ ValueOwnershipKind::ValueOwnershipKind(const SILFunction &F, SILType Type,
   }
 }
 
-llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
-                                     ValueOwnershipKind Kind) {
-  switch (Kind) {
+StringRef ValueOwnershipKind::asString() const {
+  switch (Value) {
   case ValueOwnershipKind::Unowned:
-    return os << "unowned";
+    return "unowned";
   case ValueOwnershipKind::Owned:
-    return os << "owned";
+    return "owned";
   case ValueOwnershipKind::Guaranteed:
-    return os << "guaranteed";
+    return "guaranteed";
   case ValueOwnershipKind::Any:
-    return os << "any";
+    return "any";
   }
-
   llvm_unreachable("Unhandled ValueOwnershipKind in switch.");
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     ValueOwnershipKind kind) {
+  return os << kind.asString();
 }
 
 Optional<ValueOwnershipKind>

--- a/test/SIL/Parser/apply_with_conformance.sil
+++ b/test/SIL/Parser/apply_with_conformance.sil
@@ -22,7 +22,7 @@ sil @_TFV4test1S3foofS0_US_1P__FQ_T_ : $@convention(method) <T where T : P> (@in
 // CHECK: call
 // test.bar (test.S, test.X) -> ()
 sil [ossa] @_TF4test3barFTVS_1SVS_1X_T_ : $@convention(thin) (S, X) -> () {
-bb0(%0 : @unowned $S, %1 : @unowned $X):
+bb0(%0 : $S, %1 : $X):
   debug_value %0 : $S  // let s                   // id: %2
   debug_value %1 : $X  // let x                   // id: %3
   // function_ref test.S.foo (test.S)<A : test.P>(A) -> ()

--- a/test/SIL/Parser/ossa_needs_ownership_on_args.sil
+++ b/test/SIL/Parser/ossa_needs_ownership_on_args.sil
@@ -1,0 +1,19 @@
+// RUN: not %sil-opt -verify %s
+
+// Make sure that we error if ossa functions do not parse unless the argument
+// has the proper ownership specifier on it.
+
+import Builtin
+
+sil [ossa] @test1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject): // {{expected-error: SILFunction and SILArgument have mismatching ValueOwnershipKinds. Function type specifies: '@owned'. SIL argument specifies: '@any'.}}
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil [ossa] @test2 : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : @owned $Builtin.Int32): // {{expected-error: SILFunction and SILArgument have mismatching ValueOwnershipKinds. Function type specifies: '@any'. SIL argument specifies: '@owned'.}}
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -52,7 +52,7 @@ class B {
 }
 
 sil [ossa] @test_overloaded_subscript : $@convention(thin) (@guaranteed B, B.Index) -> () {
-bb0(%0 : $B, %1 : $B.Index):
+bb0(%0 : @guaranteed $B, %1 : $B.Index):
   %reader = class_method %0 : $B, #B.subscript!read.1 : (B) -> (B.Index) -> (), $@convention(method) @yield_once (B.Index, @guaranteed B) -> @yields @guaranteed B.Element
   (%element, %token) = begin_apply %reader(%1, %0) : $@convention(method) @yield_once (B.Index, @guaranteed B) -> @yields @guaranteed B.Element
   end_apply %token

--- a/test/SIL/Parser/unmanaged.sil
+++ b/test/SIL/Parser/unmanaged.sil
@@ -16,7 +16,7 @@ bb0(%0 : $*Optional<U>):
 }
 
 sil [ossa] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : @unowned $@sil_unmanaged Optional<C>):
+bb0(%0 : $@sil_unmanaged Optional<C>):
   %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
   unmanaged_retain_value %1 : $Optional<C>
   unmanaged_autorelease_value %1 : $Optional<C>

--- a/test/SIL/Serialization/Inputs/function_param_convention_input.sil
+++ b/test/SIL/Serialization/Inputs/function_param_convention_input.sil
@@ -1,10 +1,18 @@
 
-struct X {}
+sil_stage raw
+
+import Builtin
+
+struct X {
+  let x: Builtin.NativeObject
+}
 
 // Make sure that we can deserialize an apply with various parameter calling
 // conventions.
 sil [serialized] [ossa] @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : @owned $X, %5 : @unowned $X, %6 : @guaranteed $X):
+  copy_addr [take] %1 to [initialization] %0 : $*X
+  destroy_value %4 : $X
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/Recovery/function.sil
+++ b/test/SIL/Serialization/Recovery/function.sil
@@ -13,7 +13,7 @@ import Types
 // CHECK-LABEL: sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
 // CHECK-RECOVERY-NEGATIVE-NOT: sil [ossa] @missingParam
 sil [ossa] @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
-entry(%arg : @unowned $SoonToBeMissing):
+entry(%arg : $SoonToBeMissing):
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/unmanaged.sil
+++ b/test/SIL/Serialization/unmanaged.sil
@@ -16,7 +16,7 @@ class C {}
 // CHECK: unmanaged_autorelease_value [[REF]]
 // CHECK: unmanaged_release_value [[REF]]
 sil [serialized] [ossa] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : @unowned $@sil_unmanaged Optional<C>):
+bb0(%0 : $@sil_unmanaged Optional<C>):
   %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
   unmanaged_retain_value %1 : $Optional<C>
   unmanaged_autorelease_value %1 : $Optional<C>

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -56,7 +56,7 @@ bb6:
 }
 
 sil [ossa] @test_struct2 : $@convention(thin) (@in Outer, @owned T) -> () {
-bb0(%0 : $*Outer, %1 : $T):
+bb0(%0 : $*Outer, %1 : @owned $T):
   %2 = struct_element_addr %0 : $*Outer, #Outer.x
   store %1 to [assign] %2 : $*T
   destroy_addr %0 : $*Outer
@@ -122,7 +122,7 @@ bb3:
 }
 
 sil [ossa] @test_unreachable_block : $@convention(thin) (@owned T) -> () {
-bb0(%0 : $T):
+bb0(%0 : @owned $T):
   %2 = alloc_stack $T
   store %0 to [init] %2 : $*T
   br bb2

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -122,7 +122,7 @@ bb2(%4 : @owned $Error):
 
 // CHECK: SIL memory lifetime failure in @test_single_block: memory is initialized, but shouldn't
 sil [ossa] @test_single_block : $@convention(thin) (@owned T) -> () {
-bb0(%0 : $T):
+bb0(%0 : @owned $T):
   %2 = alloc_stack $T
   store %0 to [init] %2 : $*T
   dealloc_stack %2 : $*T

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1037,7 +1037,7 @@ bb3:
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'deinit_access'
 sil [ossa] @deinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
-bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
+bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
   %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
   copy_addr %2 to [initialization] %5 : $*T
@@ -1076,7 +1076,7 @@ bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'nodeinit_access'
 sil [ossa] @nodeinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
-bb0(%0 : @owned $*T, %1 : @owned $*T, %2 : @owned $*T):
+bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
   %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
   copy_addr %2 to [initialization] %5 : $*T

--- a/test/SILOptimizer/devirtualize_ownership.sil
+++ b/test/SILOptimizer/devirtualize_ownership.sil
@@ -99,7 +99,7 @@ bb0(%0 : @guaranteed $Node):
 
 // CHECK-LABEL: sil private [transparent] [noinline] [ossa] @transparent_target
 sil private [transparent] [noinline] [ossa] @transparent_target : $@convention(method) (@guaranteed Node) -> Int {
-bb0(%0 : @owned $Node):
+bb0(%0 : @guaranteed $Node):
   %2 = ref_element_addr %0 : $Node, #Node.index
   %3 = load [trivial] %2 : $*Int
   // CHECK: return

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -486,7 +486,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK-NEXT: return
 // CHECK: } // end sil function 'test_recursive_nativeobject_baz'
 sil [transparent] [ossa] @test_recursive_nativeobject_baz : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   return %0 : $Builtin.NativeObject
 }
 

--- a/test/SILOptimizer/opaque_values_mandatory.sil
+++ b/test/SILOptimizer/opaque_values_mandatory.sil
@@ -13,7 +13,7 @@ typealias Int = Builtin.Int64
 // CHECK: return %0 : $T
 // CHECK-LABEL: } // end sil function 'f010_diagnose_identity'
 sil hidden [ossa] @f010_diagnose_identity : $@convention(thin) <T> (@in T) -> @out T {
-bb0(%0 : $T):
+bb0(%0 : @owned $T):
   %c = copy_value %0 : $T
   destroy_value %0 : $T
   return %c : $T
@@ -31,7 +31,7 @@ bb0(%0 : $T):
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f020_assign_inout'
 sil hidden [ossa] @f020_assign_inout : $@convention(thin) <T> (@inout T, @in T) -> () {
-bb0(%0 : $*T, %1 : $T):
+bb0(%0 : $*T, %1 : @owned $T):
   %2 = copy_value %1 : $T
   assign %2 to %0 : $*T
   destroy_value %1 : $T

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -158,7 +158,7 @@ struct X3 {
 // CHECK: end_access [[ACCESS]] : $*X3
 // CHECK-LABEL: } // end sil function 'testStoreNontrivial'
 sil private [ossa] @testStoreNontrivial : $@convention(thin) (@inout X3, @guaranteed AnyObject) -> () {
-bb0(%0 : $*X3, %1 : $AnyObject):
+bb0(%0 : $*X3, %1 : @guaranteed $AnyObject):
   %4 = copy_value %1 : $AnyObject
   %5 = begin_access [modify] [unknown] %0 : $*X3
   %6 = struct_element_addr %5 : $*X3, #X3.x2


### PR DESCRIPTION
Specifically, we were preferring the always correct ownership kind specified by
the FunctionType and ignoring what we parsed from the argument. This PR changes
ossa to give a nice error when this is detected and fixes the places where this
tests were written incorrectly.
