### PR TITLE
[AppKit] Fix incorrect rawValue for NSEvent.SpecialKey.deleteForward

### DIFF
--- a/stdlib/public/Darwin/AppKit/NSEvent.swift
+++ b/stdlib/public/Darwin/AppKit/NSEvent.swift
@@ -116,7 +116,7 @@ extension NSEvent.SpecialKey {
     static public let f34 = NSEvent.SpecialKey(rawValue: 0xF725)
     static public let f35 = NSEvent.SpecialKey(rawValue: 0xF726)
     static public let insert = NSEvent.SpecialKey(rawValue: 0xF727)
-    static public let deleteForward = NSEvent.SpecialKey(rawValue: 0xF7028)
+    static public let deleteForward = NSEvent.SpecialKey(rawValue: 0xF728)
     static public let home = NSEvent.SpecialKey(rawValue: 0xF729)
     static public let begin = NSEvent.SpecialKey(rawValue: 0xF72A)
     static public let end = NSEvent.SpecialKey(rawValue: 0xF72B)


### PR DESCRIPTION
Update the rawValue to match [NSDeleteFunctionKey](https://developer.apple.com/documentation/appkit/1535851-function-key_unicodes/nsdeletefunctionkey?language=objc).

The [NSEvent.SpecialKey.deleteForward](https://developer.apple.com/documentation/appkit/nsevent/specialkey/3019379-deleteforward) rawValue is currently `0xF7028`. This appears to be a typo, as the [relevant AppKit docs](https://developer.apple.com/documentation/appkit/1535851-function-key_unicodes/nsdeletefunctionkey?language=objc) say it should be `0xF728`.

I noticed this when using a switch to handle NSEvent `specialKey` values, and testing the forward delete key. My case for .deleteForward was skipped, and the specialKey rawValue of the actual event was `0xF728`.
