### PR TITLE
Add now-fixed test case for rdar://problem/54028336.

### DIFF
--- a/test/decl/protocol/special/coding/Inputs/property_wrappers_codable_multifile_other.swift
+++ b/test/decl/protocol/special/coding/Inputs/property_wrappers_codable_multifile_other.swift
@@ -1,0 +1,10 @@
+@propertyWrapper
+struct Printed<Value: Codable>: Codable {
+    var wrappedValue: Value {
+        didSet { print(wrappedValue) }
+    }
+}
+
+struct Foo: Codable {
+    @Printed var bar: Bool = false
+}

--- a/test/decl/protocol/special/coding/property_wrappers_codable_multifile.swift
+++ b/test/decl/protocol/special/coding/property_wrappers_codable_multifile.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -c -primary-file %s %S/Inputs/property_wrappers_codable_multifile_other.swift
+
+func test(_ value: Foo = Foo()) {
+  let _: Codable = value
+}


### PR DESCRIPTION
This test case was triggering "does not conform to Codable"
diagnostics due to multi-file ordering issues.
