### PR TITLE
[Sema] Fix protocol refinement access control message

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1833,16 +1833,16 @@ ERROR(protocol_access,none,
       "|private or fileprivate}4 because %select{it refines|its 'where' clause uses}2"
       "|%select{in this context|fileprivate|internal|public|%error}1 "
       "%select{protocol cannot refine|protocol's 'where' clause cannot use}2}0 "
-      "%select{a private|a fileprivate|an internal|%error|%error}3 protocol",
-      (bool, AccessLevel, bool, AccessLevel, bool))
+      "%select{a private|a fileprivate|an internal|%error|%error}3 %5",
+      (bool, AccessLevel, bool, AccessLevel, bool, DescriptiveDeclKind))
 WARNING(protocol_access_warn,none,
         "%select{protocol should be declared "
         "%select{private|fileprivate|internal|%error|%error}1 because "
         "%select{it refines|its 'where' clause uses}2"
         "|%select{in this context|fileprivate|internal|public|%error}1 "
         "%select{protocol should not refine|protocol's 'where' clause should not use}2}0 "
-        "%select{a private|a fileprivate|an internal|%error|%error}3 protocol",
-        (bool, AccessLevel, bool, AccessLevel, bool))
+        "%select{a private|a fileprivate|an internal|%error|%error}3 %5",
+        (bool, AccessLevel, bool, AccessLevel, bool, DescriptiveDeclKind))
 ERROR(protocol_usable_from_inline,none,
       "protocol %select{refined|used}0 by '@usableFromInline' protocol "
       "must be '@usableForInline' or public", (bool))

--- a/test/Compatibility/accessibility_where.swift
+++ b/test/Compatibility/accessibility_where.swift
@@ -9,14 +9,14 @@ public protocol BaseProtocol {
 }
 
 public protocol PublicProtocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-warning@-1 {{public protocol's 'where' clause should not use a private protocol}}
+  // expected-warning@-1 {{public protocol's 'where' clause should not use a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-warning@-1 {{associated type in a public protocol uses a private type in its requirement}}
 }
 
 public protocol PublicProtocol2 : BaseProtocol where T == InternalStruct {
-  // expected-warning@-1 {{public protocol's 'where' clause should not use an internal protocol}}
+  // expected-warning@-1 {{public protocol's 'where' clause should not use an internal struct}}
 
   associatedtype X : BaseProtocol where X.T == InternalStruct
   // expected-warning@-1 {{associated type in a public protocol uses an internal type in its requirement}}
@@ -27,7 +27,7 @@ public protocol PublicProtocol3 : BaseProtocol where T == PublicStruct {
 }
 
 internal protocol InternalProtocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-warning@-1 {{internal protocol's 'where' clause should not use a private protocol}}
+  // expected-warning@-1 {{internal protocol's 'where' clause should not use a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-warning@-1 {{associated type in an internal protocol uses a private type in its requirement}}
@@ -42,7 +42,7 @@ internal protocol InternalProtocol3 : BaseProtocol where T == PublicStruct {
 }
 
 protocol Protocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-warning@-1 {{protocol should be declared fileprivate because its 'where' clause uses a private protocol}}
+  // expected-warning@-1 {{protocol should be declared fileprivate because its 'where' clause uses a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-warning@-1 {{associated type in an internal protocol uses a private type in its requirement}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -435,6 +435,15 @@ public protocol PublicRefinesInternal : InternalProto {} // expected-error {{pub
 public protocol PublicRefinesPI : PrivateProto, InternalProto {} // expected-error {{public protocol cannot refine a private protocol}}
 public protocol PublicRefinesIP : InternalProto, PrivateProto {} // expected-error {{public protocol cannot refine a private protocol}}
 
+private typealias PrivateTypeAlias = PublicProto; // expected-note {{type declared here}}
+private typealias PrivateCompoundTypeAlias = PublicProto & AnyObject // expected-note {{type declared here}}
+
+protocol DefaultRefinesPrivateClass: PrivateClass {} // expected-error {{protocol must be declared private or fileprivate because it refines a private class}}
+public protocol PublicRefinesPrivateClass: PrivateClass {} // expected-error {{public protocol cannot refine a private class}}
+public protocol PublicRefinesPrivateTypeAlias: PrivateTypeAlias {} // expected-error {{public protocol cannot refine a private type alias}}
+public protocol PublicRefinesPrivateCompoundTypeAlias: PrivateCompoundTypeAlias {} // expected-error {{public protocol cannot refine a private type alias}}
+
+
 
 // expected-note@+1 * {{type declared here}}
 private typealias PrivateInt = Int

--- a/test/Sema/accessibility_where.swift
+++ b/test/Sema/accessibility_where.swift
@@ -1,22 +1,26 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
-private struct PrivateStruct {} // expected-note 6{{type declared here}}
+private struct PrivateStruct {} // expected-note 8{{type declared here}}
 internal struct InternalStruct {} // expected-note 2{{type declared here}}
 public struct PublicStruct {}
+private class PrivateClass {} // expected-note 4{{type declared here}}
 
 public protocol BaseProtocol {
   associatedtype T
 }
 
+public protocol BaseProtocol2 {}
+private typealias PrivateTypeAlias = BaseProtocol2 // expected-note 2{{type declared here}}
+
 public protocol PublicProtocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-error@-1 {{public protocol's 'where' clause cannot use a private protocol}}
+  // expected-error@-1 {{public protocol's 'where' clause cannot use a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-error@-1 {{associated type in a public protocol uses a private type in its requirement}}
 }
 
 public protocol PublicProtocol2 : BaseProtocol where T == InternalStruct {
-  // expected-error@-1 {{public protocol's 'where' clause cannot use an internal protocol}}
+  // expected-error@-1 {{public protocol's 'where' clause cannot use an internal struct}}
 
   associatedtype X : BaseProtocol where X.T == InternalStruct
   // expected-error@-1 {{associated type in a public protocol uses an internal type in its requirement}}
@@ -27,7 +31,7 @@ public protocol PublicProtocol3 : BaseProtocol where T == PublicStruct {
 }
 
 internal protocol InternalProtocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-error@-1 {{internal protocol's 'where' clause cannot use a private protocol}}
+  // expected-error@-1 {{internal protocol's 'where' clause cannot use a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
@@ -42,7 +46,7 @@ internal protocol InternalProtocol3 : BaseProtocol where T == PublicStruct {
 }
 
 protocol Protocol1 : BaseProtocol where T == PrivateStruct {
-  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private protocol}}
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private struct}}
 
   associatedtype X : BaseProtocol where X.T == PrivateStruct
   // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
@@ -54,4 +58,32 @@ protocol Protocol2 : BaseProtocol where T == InternalStruct {
 
 protocol Protocol3 : BaseProtocol where T == PublicStruct {
   associatedtype X : BaseProtocol where X.T == PublicStruct
+}
+
+protocol Protocol4 : BaseProtocol where T == PrivateClass {
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private class}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateClass
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+protocol Protocol5 : BaseProtocol where T == PrivateTypeAlias {
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private type alias}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateTypeAlias
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+protocol Protocol6 : BaseProtocol where T == (PrivateClass, AnyObject) {
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private type}}
+
+  associatedtype X : BaseProtocol where X.T == (PrivateClass, AnyObject)
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+protocol Protocol7 : BaseProtocol where T == (PrivateStruct) -> Void {
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private type}}
+
+  associatedtype X : BaseProtocol where X.T == (PrivateStruct) -> Void
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
 }


### PR DESCRIPTION
Previously, the protocol refinement access control error would always assume a protocol was being refined/used in a where clause. Change it to instead refer to the appropriate declaration kind.

Resolves [SR-9195](https://bugs.swift.org/browse/SR-9195)

cc @slavapestov 