### PR TITLE
ReflectionContext: Keep read range properly-aligned.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -193,6 +193,11 @@ public:
       }
       RangeStart = std::min(RangeStart, (uint64_t)S->addr + Slide);
       RangeEnd = std::max(RangeEnd, (uint64_t)(S->addr + S->size + Slide));
+      // Keep the range rounded to 8 byte alignment on both ends so we don't
+      // introduce misaligned pointers mapping between local and remote
+      // address space.
+      RangeStart = RangeStart & ~7;
+      RangeEnd = RangeEnd + 7 & ~7;      
     }
  
     if (RangeStart == UINT64_MAX && RangeEnd == UINT64_MAX)

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -7,9 +7,6 @@
 // FIXME: Should not require objc_interop -- please put Objective-C-specific
 // testcases in functions_objc.swift
 
-// rdar://54556791
-// UNSUPPORTED: CPU=armv7k
-
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 


### PR DESCRIPTION
If a Mach-O image got emitted in just the wrong way, the range of `__TEXT,__swift*` sections to
read could end up starting at an unaligned address (because things like type refs have only one
byte alignment), and this would cause the reflection context to read an unaligned chunk of the
remote memory, causing alignment errors when addresses are mapped to the local copy. Keep the ranges at least 8-byte-aligned to stave off the alignment issues we might run into with any metadata structures, which are generally at most pointer aligned. Fixes rdar://problem/54556791