### PR TITLE
[android] Link against math library for Bionic.

### DIFF
--- a/stdlib/public/Platform/bionic.modulemap.gyb
+++ b/stdlib/public/Platform/bionic.modulemap.gyb
@@ -83,6 +83,7 @@ module SwiftGlibc [system] {
       export *
     }
     module math {
+      link "m"
       header "${GLIBC_INCLUDE_PATH}/math.h"
       export *
     }


### PR DESCRIPTION
The Bionic modulemap was missing the autolinking information against
libm, so using the module math functions might have hit undefined
symbols (it was happening in TestDecimal in Foundation for me). The line
is present in the Linux glibc.modulemap, but was not there for Android
Bionic modulemap.
