### PR TITLE
Faster module name lookup

### DIFF
--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -53,10 +53,12 @@ class ImportSet final :
   friend TrailingObjects;
   friend ImportCache;
 
-  unsigned NumTopLevelImports;
+  unsigned HasHeaderImportModule : 1;
+  unsigned NumTopLevelImports : 31;
   unsigned NumTransitiveImports;
 
-  ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+  ImportSet(bool hasHeaderImportModule,
+            ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
             ArrayRef<ModuleDecl::ImportedModule> transitiveImports);
 
   ImportSet(const ImportSet &) = delete;
@@ -72,6 +74,13 @@ public:
 
   size_t numTrailingObjects(OverloadToken<ModuleDecl::ImportedModule>) const {
     return NumTopLevelImports + NumTransitiveImports;
+  }
+
+  /// This is a bit of a hack to make module name lookup work properly.
+  /// If our import set includes the ClangImporter's special header import
+  /// module, we have to check it first, before any other imported module.
+  bool hasHeaderImportModule() const {
+    return HasHeaderImportModule;
   }
 
   ArrayRef<ModuleDecl::ImportedModule> getTopLevelImports() const {

--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -51,7 +51,7 @@ class ImportSet final :
     public llvm::FoldingSetNode,
     private llvm::TrailingObjects<ImportSet, ModuleDecl::ImportedModule> {
   friend TrailingObjects;
-  friend ImportCache;
+  friend class ImportCache;
 
   unsigned HasHeaderImportModule : 1;
   unsigned NumTopLevelImports : 31;
@@ -192,6 +192,8 @@ public:
     ImportSetForDC.clear();
   }
 };
+
+ArrayRef<ModuleDecl::ImportedModule> getAllImports(const DeclContext *dc);
 
 }  // namespace namelookup
 

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -35,9 +35,6 @@ enum class ResolutionKind {
   /// If non-overloadable decls are returned, this indicates ambiguous lookup.
   Overloadable,
 
-  /// Lookup should match a single decl.
-  Exact,
-
   /// Lookup should match a single decl that declares a type.
   TypesOnly
 };

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -59,16 +59,6 @@ void lookupInModule(const DeclContext *moduleOrFile,
                     NLKind lookupKind, ResolutionKind resolutionKind,
                     const DeclContext *moduleScopeContext);
 
-template <typename Fn>
-void forAllVisibleModules(const DeclContext *DC, const Fn &fn) {
-  DeclContext *moduleScope = DC->getModuleScopeContext();
-  if (auto file = dyn_cast<FileUnit>(moduleScope))
-    file->forAllVisibleModules(fn);
-  else
-    cast<ModuleDecl>(moduleScope)
-        ->forAllVisibleModules(ModuleDecl::AccessPathTy(), fn);
-}
-
 /// Performs a qualified lookup into the given module and, if necessary, its
 /// reexports, observing proper shadowing rules.
 void

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -23,9 +23,11 @@
 using namespace swift;
 using namespace namelookup;
 
-ImportSet::ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+ImportSet::ImportSet(bool hasHeaderImportModule,
+                     ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
                      ArrayRef<ModuleDecl::ImportedModule> transitiveImports)
-  : NumTopLevelImports(topLevelImports.size()),
+  : HasHeaderImportModule(hasHeaderImportModule),
+    NumTopLevelImports(topLevelImports.size()),
     NumTransitiveImports(transitiveImports.size()) {
   auto buffer = getTrailingObjects<ModuleDecl::ImportedModule>();
   std::uninitialized_copy(topLevelImports.begin(), topLevelImports.end(),
@@ -78,6 +80,11 @@ static void collectExports(ModuleDecl::ImportedModule next,
 ImportSet &
 ImportCache::getImportSet(ASTContext &ctx,
                           ArrayRef<ModuleDecl::ImportedModule> imports) {
+  bool hasHeaderImportModule = false;
+  ModuleDecl *headerImportModule = nullptr;
+  if (auto *loader = ctx.getClangModuleLoader())
+    headerImportModule = loader->getImportedHeaderModule();
+
   SmallVector<ModuleDecl::ImportedModule, 4> topLevelImports;
 
   SmallVector<ModuleDecl::ImportedModule, 4> transitiveImports;
@@ -88,6 +95,8 @@ ImportCache::getImportSet(ASTContext &ctx,
       continue;
 
     topLevelImports.push_back(next);
+    if (next.second == headerImportModule)
+      hasHeaderImportModule = true;
   }
 
   void *InsertPos = nullptr;
@@ -116,6 +125,9 @@ ImportCache::getImportSet(ASTContext &ctx,
       continue;
 
     transitiveImports.push_back(next);
+    if (next.second == headerImportModule)
+      hasHeaderImportModule = true;
+
     collectExports(next, stack);
   }
 
@@ -131,7 +143,9 @@ ImportCache::getImportSet(ASTContext &ctx,
     sizeof(ModuleDecl::ImportedModule) * transitiveImports.size(),
     alignof(ImportSet), AllocationArena::Permanent);
 
-  auto *result = new (mem) ImportSet(topLevelImports, transitiveImports);
+  auto *result = new (mem) ImportSet(hasHeaderImportModule,
+                                     topLevelImports,
+                                     transitiveImports);
   ImportSets.InsertNode(result, InsertPos);
 
   return *result;

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -292,3 +292,9 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
   ShadowCache[key] = result;
   return result;
 };
+
+ArrayRef<ModuleDecl::ImportedModule>
+swift::namelookup::getAllImports(const DeclContext *dc) {
+  return dc->getASTContext().getImportCache().getImportSet(dc)
+    .getAllImports();
+}

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1431,32 +1431,6 @@ forAllImportedModules(const ModuleDecl *topLevel,
   return true;
 }
 
-bool
-ModuleDecl::forAllVisibleModules(AccessPathTy thisPath,
-                                 llvm::function_ref<bool(ImportedModule)> fn) const {
-  return forAllImportedModules<true>(this, thisPath, fn);
-}
-
-bool FileUnit::forAllVisibleModules(
-    llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn) const {
-  if (!getParentModule()->forAllVisibleModules(ModuleDecl::AccessPathTy(), fn))
-    return false;
-
-  if (auto SF = dyn_cast<SourceFile>(this)) {
-    // Handle privately visible modules as well.
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    SmallVector<ModuleDecl::ImportedModule, 4> imports;
-    SF->getImportedModules(imports, importFilter);
-    for (auto importPair : imports)
-      if (!importPair.second->forAllVisibleModules(importPair.first, fn))
-        return false;
-  }
-
-  return true;
-}
-
 void ModuleDecl::collectLinkLibraries(LinkLibraryCallback callback) const {
   // FIXME: The proper way to do this depends on the decls used.
   FORWARD(collectLinkLibraries, (callback));

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -12,49 +12,22 @@
 
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/LazyResolver.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/NameLookup.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 using namespace namelookup;
 
-/// Returns true if this particular ValueDecl is overloadable.
-static bool isOverloadable(const ValueDecl *VD) {
-  // FIXME: This is very suspect; it doesn't really match how the rest of the
-  // compiler works anymore. (With extensions imported from different modules,
-  // properties can have the same base names as methods.) How do we want
-  // cross-module shadowing to work?
-  return isa<FuncDecl>(VD) ||
-         isa<ConstructorDecl>(VD) ||
-         isa<SubscriptDecl>(VD);
-}
-
 namespace {
 
 /// Encapsulates the work done for a recursive qualified lookup into a module.
 ///
-/// The \p LookupStrategy handles the non-recursive part of the lookup, as well
-/// as how to combine results from across modules (e.g. handling shadowing). It
+/// The \p LookupStrategy handles the non-recursive part of the lookup. It
 /// must be a subclass of ModuleNameLookup.
 template <typename LookupStrategy>
 class ModuleNameLookup {
-  /// An alias for the LookupStrategy subclass's nested OverloadSetTy whose
-  /// resolution can be delayed until after the subclass type is
-  /// considered "complete".
-  template <bool CRTPWorkaround>
-  using OverloadSetTy =
-      typename std::enable_if<CRTPWorkaround,
-                              LookupStrategy>::type::OverloadSetTy;
-
-  /// The usable results of a lookup in a particular module may differ based on
-  /// where the lookup is happening.
-  using ModuleLookupCacheKey = std::pair<ModuleDecl::ImportedModule,
-                                         const DeclContext * /*lookupScope*/>;
-  using ModuleLookupCache = llvm::SmallDenseMap<ModuleLookupCacheKey,
-                                                TinyPtrVector<ValueDecl *>, 32>;
-
-  ModuleLookupCache cache;
+  ASTContext &ctx;
   const ResolutionKind resolutionKind;
   const bool respectAccessControl;
 
@@ -65,59 +38,20 @@ class ModuleNameLookup {
     return static_cast<LookupStrategy *>(this);
   }
 
-  /// After finding decls by name lookup, filter based on the given
-  /// resolution kind and existing overload set and add them to \p results.
-  ///
-  /// \p overloads is updated based on the new declarations.
-  ///
-  /// \returns true if lookup is (locally) complete and does not need to recurse
-  /// further.
-  template <bool CRTPWorkaround = true>
-  bool recordImportDecls(
-      SmallVectorImpl<ValueDecl *> &results,
-      ArrayRef<ValueDecl *> newDecls,
-      OverloadSetTy<CRTPWorkaround> &overloads);
-
-  /// Given a list of imports and an access path to limit by, perform a lookup
-  /// into each of them and record the results in \p decls, filtering based on
-  /// the given resolution kind and existing overload set.
-  template <bool CRTPWorkaround = true>
-  void collectLookupResultsFromImports(
-      SmallVectorImpl<ValueDecl *> &decls,
-      ArrayRef<ModuleDecl::ImportedModule> imports,
-      ModuleDecl::AccessPathTy accessPath,
-      const DeclContext *moduleScopeContext,
-      OverloadSetTy<CRTPWorkaround> &overloads);
-
-  /// Performs a qualified lookup into the given module and, if necessary, its
-  /// reexports, observing proper shadowing rules. The lookup into \p module
-  /// itself will not check or update the lookup cache.
-  ///
-  /// The results are appended to \p decls.
-  ///
-  /// \returns The slice of \p decls that includes the newly-found
-  /// declarations.
-  ///
-  /// \see lookupInModule
-  ArrayRef<ValueDecl *> lookupInModuleUncached(
-      SmallVectorImpl<ValueDecl *> &decls,
-      ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-      const DeclContext *moduleScopeContext,
-      ArrayRef<ModuleDecl::ImportedModule> extraImports);
-
 public:
   ModuleNameLookup(ASTContext &ctx, ResolutionKind resolutionKind)
-      : resolutionKind(resolutionKind),
+      : ctx(ctx),
+        resolutionKind(resolutionKind),
         respectAccessControl(!ctx.isAccessControlDisabled()) {}
 
   /// Performs a qualified lookup into the given module and, if necessary, its
-  /// reexports, observing proper shadowing rules.
+  /// reexports.
   ///
   /// The results are appended to \p decls.
   void lookupInModule(SmallVectorImpl<ValueDecl *> &decls,
-                      ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-                      const DeclContext *moduleScopeContext,
-                      ArrayRef<ModuleDecl::ImportedModule> extraImports = {});
+                      const DeclContext *moduleOrFile,
+                      ModuleDecl::AccessPathTy accessPath,
+                      const DeclContext *moduleScopeContext);
 };
 
 
@@ -126,7 +60,6 @@ public:
 class LookupByName : public ModuleNameLookup<LookupByName> {
   using Super = ModuleNameLookup<LookupByName>;
   friend Super;
-  friend class LookupVisibleDecls;
 
   const DeclName name;
   const NLKind lookupKind;
@@ -138,40 +71,6 @@ public:
       lookupKind(lookupKind) {}
 
 private:
-  class SortCanType {
-  public:
-    bool operator()(CanType lhs, CanType rhs) const {
-      return std::less<TypeBase *>()(lhs.getPointer(), rhs.getPointer());
-    }
-  };
-
-  using OverloadSetTy = llvm::SmallSet<CanType, 4, SortCanType>;
-
-  /// Does \p VD conflict with the \p overloads we've already seen?
-  static bool isValidOverload(const OverloadSetTy &overloads,
-                              const ValueDecl *VD) {
-    if (!isOverloadable(VD))
-      return overloads.empty();
-    return !overloads.count(VD->getInterfaceType()->getCanonicalType());
-  }
-
-  /// Updates \p overloads with the types of the given decls.
-  ///
-  /// \returns true if all of the given decls are overloadable, false if not.
-  static bool updateOverloadSet(OverloadSetTy &overloads,
-                                ArrayRef<ValueDecl *> decls) {
-    for (auto result : decls) {
-      if (!isOverloadable(result))
-        return false;
-      if (!result->hasInterfaceType())
-        continue;
-      // FIXME: This relies on the interface type including argument labels.
-      // FIXME: ...and it doesn't handle different generic requirements.
-      overloads.insert(result->getInterfaceType()->getCanonicalType());
-    }
-    return true;
-  }
-
   /// Returns whether it's okay to stop recursively searching imports, given 
   /// that we found something non-overloadable.
   static bool canReturnEarly() {
@@ -199,45 +98,6 @@ public:
       lookupKind(lookupKind) {}
 
 private:
-  using OverloadSetEntry =
-      std::pair<ResolutionKind, LookupByName::OverloadSetTy>;
-  using OverloadSetTy = llvm::DenseMap<DeclBaseName, OverloadSetEntry>;
-  static_assert(ResolutionKind() == ResolutionKind::Overloadable,
-                "Entries in NamedCanTypeSet should be overloadable initially");
-
-  /// Does \p VD conflict with the \p overloads we've already seen?
-  static bool isValidOverload(OverloadSetTy &overloads, const ValueDecl *VD) {
-    // Note: 'overloads' is not const because it's cheaper to create the empty
-    // set value under this name once and check it repeatedly.
-    const OverloadSetEntry &entry = overloads[VD->getBaseName()];
-    if (entry.first != ResolutionKind::Overloadable)
-      return false;
-    return LookupByName::isValidOverload(entry.second, VD);
-  }
-
-  /// Updates \p overloads with the types of the given decls.
-  ///
-  /// \returns true, since there can always be more overloadable decls.
-  static bool updateOverloadSet(OverloadSetTy &overloads,
-                                ArrayRef<ValueDecl *> decls) {
-    for (auto result : decls) {
-      OverloadSetEntry &entry = overloads[result->getBaseName()];
-      if (!isOverloadable(result)) {
-        entry.first = ResolutionKind::Exact;
-        entry.second.clear();
-        continue;
-      }
-
-      if (!result->hasInterfaceType())
-        continue;
-
-      // FIXME: This relies on the interface type including argument labels.
-      // FIXME: ...and it doesn't handle different generic requirements.
-      entry.second.insert(result->getInterfaceType()->getCanonicalType());
-    }
-    return true;
-  }
-
   /// Returns whether it's okay to stop recursively searching imports, given
   /// that we found something non-overloadable.
   static bool canReturnEarly() {
@@ -254,194 +114,114 @@ private:
 } // end anonymous namespace
 
 template <typename LookupStrategy>
-template <bool CRTPWorkaround>
-bool ModuleNameLookup<LookupStrategy>::recordImportDecls(
-    SmallVectorImpl<ValueDecl *> &results,
-    ArrayRef<ValueDecl *> newDecls,
-    OverloadSetTy<CRTPWorkaround> &overloads) {
-
-  static_assert(
-      std::is_same<decltype(overloads),
-                   typename LookupStrategy::OverloadSetTy &>::value,
-      "Template params should be inferred.");
-
-  const size_t originalSize = results.size();
-
-  switch (resolutionKind) {
-  case ResolutionKind::Overloadable: {
-    // Add new decls if they provide a new overload. Note that the new decls
-    // may be ambiguous with respect to each other, just not any decls already
-    // in the overload set.
-    llvm::copy_if(newDecls, std::back_inserter(results),
-                  [&](ValueDecl *result) -> bool {
-      if (!result->hasInterfaceType()) {
-        if (auto *typeResolver = result->getASTContext().getLazyResolver()) {
-          typeResolver->resolveDeclSignature(result);
-          if (result->isInvalid())
-            return true;
-        } else {
-          return true;
-        }
-      }
-      return getDerived()->isValidOverload(overloads, result);
-    });
-
-    // Update the overload set.
-    bool stillOverloadable = getDerived()->updateOverloadSet(overloads,
-                                                             newDecls);
-    if (stillOverloadable)
-      return false;
-    break;
-  }
-
-  case ResolutionKind::Exact:
-    // Add all decls. If they're ambiguous, they're ambiguous; if we got to this
-    // point, the caller hasn't found anything that shadows these decls.
-    results.append(newDecls.begin(), newDecls.end());
-    break;
-
-  case ResolutionKind::TypesOnly:
-    // Add type decls only. If they're ambiguous, they're ambiguous; if we got
-    // to this point, the caller hasn't found anything that shadows these decls.
-    llvm::copy_if(newDecls, std::back_inserter(results),
-                  [](const ValueDecl *VD) { return isa<TypeDecl>(VD); });
-    break;
-  }
-
-  return results.size() != originalSize && getDerived()->canReturnEarly();
-}
-
-template <typename LookupStrategy>
-template <bool CRTPWorkaround>
-void ModuleNameLookup<LookupStrategy>::collectLookupResultsFromImports(
+void ModuleNameLookup<LookupStrategy>::lookupInModule(
     SmallVectorImpl<ValueDecl *> &decls,
-    ArrayRef<ModuleDecl::ImportedModule> reexports,
+    const DeclContext *moduleOrFile,
     ModuleDecl::AccessPathTy accessPath,
-    const DeclContext *moduleScopeContext,
-    OverloadSetTy<CRTPWorkaround> &overloads) {
+    const DeclContext *moduleScopeContext) {
+  assert(moduleOrFile->isModuleScopeContext());
 
-  static_assert(
-      std::is_same<decltype(overloads),
-                   typename LookupStrategy::OverloadSetTy &>::value,
-      "Template params should be inferred.");
-
-  // Prefer scoped imports (those importing a specific name from a module, like
-  // `import func Swift.max`) to whole-module imports.
-  SmallVector<ValueDecl *, 8> unscopedValues;
-  SmallVector<ValueDecl *, 8> scopedValues;
-  for (auto next : reexports) {
-    // Filter any whole-module imports, and skip specific-decl imports if the
-    // import path doesn't match exactly.
-    ModuleDecl::AccessPathTy combinedAccessPath;
-    if (accessPath.empty()) {
-      combinedAccessPath = next.first;
-    } else if (!next.first.empty() &&
-               !ModuleDecl::isSameAccessPath(next.first, accessPath)) {
-      // If we ever allow importing non-top-level decls, it's possible the
-      // rule above isn't what we want.
-      assert(next.first.size() == 1 && "import of non-top-level decl");
-      continue;
-    } else {
-      combinedAccessPath = accessPath;
-    }
-
-    auto &resultSet = next.first.empty() ? unscopedValues : scopedValues;
-    lookupInModule(resultSet, next.second, combinedAccessPath,
-                   moduleScopeContext);
-  }
-
-  // Add the results from scoped imports, then the results from unscoped
-  // imports if needed.
-  const bool canReturnEarly = recordImportDecls(decls, scopedValues, overloads);
-  if (!canReturnEarly)
-    (void)recordImportDecls(decls, unscopedValues, overloads);
-}
-
-template <typename LookupStrategy>
-ArrayRef<ValueDecl *> ModuleNameLookup<LookupStrategy>::lookupInModuleUncached(
-    SmallVectorImpl<ValueDecl *> &decls,
-    ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-    const DeclContext *moduleScopeContext,
-    ArrayRef<ModuleDecl::ImportedModule> extraImports) {
-
-  // Do the lookup.
-  SmallVector<ValueDecl *, 4> localDecls;
-  getDerived()->doLocalLookup(module, accessPath, localDecls);
-  if (respectAccessControl) {
-    llvm::erase_if(localDecls, [=](ValueDecl *VD) {
-      return !VD->isAccessibleFrom(moduleScopeContext);
-    });
-  }
-
-  // Record the decls by overload signature.
   const size_t initialCount = decls.size();
-  typename LookupStrategy::OverloadSetTy overloads;
-  const bool canReturnEarly = recordImportDecls(decls, localDecls, overloads);
+  size_t currentCount = decls.size();
+
+  auto updateNewDecls = [&](const DeclContext *moduleScopeContext) {
+    if (decls.size() == currentCount)
+      return;
+
+    auto newEnd = std::remove_if(
+      decls.begin() + currentCount, decls.end(),
+      [&](ValueDecl *VD) {
+        if (resolutionKind == ResolutionKind::TypesOnly && !isa<TypeDecl>(VD))
+          return true;
+        if (respectAccessControl && !VD->isAccessibleFrom(moduleScopeContext))
+          return true;
+        return false;
+      });
+    decls.erase(newEnd, decls.end());
+
+    currentCount = decls.size();
+  };
+
+  // Do the lookup into the current module.
+  auto *module = moduleOrFile->getParentModule();
+  getDerived()->doLocalLookup(module, accessPath, decls);
+  updateNewDecls(moduleScopeContext);
+
+  bool canReturnEarly = (initialCount != decls.size() &&
+                         getDerived()->canReturnEarly());
+  if (canReturnEarly &&
+      resolutionKind == ResolutionKind::Overloadable) {
+    // If we only found top-level functions, keep looking, since we may
+    // find additional overloads.
+    if (std::find_if(decls.begin() + initialCount, decls.end(),
+                     [](ValueDecl *VD) { return !isa<FuncDecl>(VD); })
+        == decls.end())
+      canReturnEarly = false;
+  }
 
   // If needed, search for decls in re-exported modules as well.
   if (!canReturnEarly) {
-    SmallVector<ModuleDecl::ImportedModule, 8> reexports;
-    module->getImportedModulesForLookup(reexports);
-    assert(llvm::none_of(reexports,
-                         [module](ModuleDecl::ImportedModule import) -> bool {
-                           return import.second == nullptr || import.second == module;
-                         }));
-    reexports.append(extraImports.begin(), extraImports.end());
+    auto &imports = ctx.getImportCache().getImportSet(moduleOrFile);
 
-    // Special treatment based on the use site only applies to immediate
-    // imports of the top-level module.
-    // FIXME: It ought to apply to anything re-exported by those immediate
-    // imports as well, since re-exports are supposed to be treated like part of
-    // the module they're re-exported from.
-    const DeclContext *moduleScopeContextForReexports = moduleScopeContext;
-    if (moduleScopeContext && moduleScopeContext->getParentModule() != module)
-      moduleScopeContextForReexports = nullptr;
+    auto visitImport = [&](ModuleDecl::ImportedModule import,
+                           const DeclContext *moduleScopeContext) {
+      if (import.first.empty())
+        import.first = accessPath;
+      else if (!accessPath.empty() &&
+               !ModuleDecl::isSameAccessPath(import.first, accessPath))
+        return;
 
-    collectLookupResultsFromImports(decls, reexports, accessPath,
-                                    moduleScopeContextForReexports, overloads);
+      getDerived()->doLocalLookup(import.second, import.first, decls);
+      updateNewDecls(moduleScopeContext);
+    };
+
+    // If the ClangImporter's special header import module appears in the
+    // import set, we must visit it first.
+    ModuleDecl *headerImportModule = nullptr;
+    if (imports.hasHeaderImportModule()) {
+      if (auto *loader = ctx.getClangModuleLoader()) {
+        headerImportModule = loader->getImportedHeaderModule();
+        if (headerImportModule) {
+          ModuleDecl::ImportedModule import({}, headerImportModule);
+          visitImport(import, nullptr);
+        }
+      }
+    }
+
+    for (auto import : imports.getTopLevelImports()) {
+      // A module appears in its own top-level import list; since we checked
+      // it already, skip it.
+      if (import.second == module)
+        continue;
+
+      // Skip the special import set module; we've already visited it.
+      if (import.second == headerImportModule)
+        continue;
+
+      visitImport(import, moduleScopeContext);
+    }
+
+    for (auto import : imports.getTransitiveImports()) {
+      // Skip the special import set module; we've already visited it.
+      if (import.second == headerImportModule)
+        continue;
+
+      visitImport(import, nullptr);
+    }
   }
 
+  // Nothing more to do if we don't have ambiguous results.
+  if (decls.size() - initialCount <= 1)
+    return;
+
   // Remove duplicated declarations, which can happen when the same module is
-  // imported indirectly through two intermediate modules.
+  // imported with multiple access paths.
   llvm::SmallPtrSet<ValueDecl *, 4> knownDecls;
   decls.erase(std::remove_if(decls.begin() + initialCount, decls.end(),
                              [&](ValueDecl *d) -> bool {
                                return !knownDecls.insert(d).second;
                              }),
               decls.end());
-
-  return llvm::makeArrayRef(decls).slice(initialCount);
-}
-
-template <typename LookupStrategy>
-void ModuleNameLookup<LookupStrategy>::lookupInModule(
-    SmallVectorImpl<ValueDecl *> &decls,
-    ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-    const DeclContext *moduleScopeContext,
-    ArrayRef<ModuleDecl::ImportedModule> extraImports) {
-  assert(module);
-  assert(llvm::none_of(extraImports,
-                       [](ModuleDecl::ImportedModule import) -> bool {
-    return import.second == nullptr;
-  }));
-
-  const ModuleDecl::ImportedModule import{accessPath, module};
-  const ModuleLookupCacheKey cacheKey{import, moduleScopeContext};
-
-  {
-    // Explicitly scope the cache lookup here, because the iterator won't be
-    // valid after we do all the work to populate the cache.
-    const auto iter = cache.find(cacheKey);
-    if (iter != cache.end()) {
-      decls.append(iter->second.begin(), iter->second.end());
-      return;
-    }
-  }
-
-  const ArrayRef<ValueDecl *> lookupResults =
-      lookupInModuleUncached(decls, module, accessPath, moduleScopeContext,
-                             extraImports);
-  cache.try_emplace(cacheKey, lookupResults);
 }
 
 void namelookup::lookupInModule(const DeclContext *moduleOrFile,
@@ -452,26 +232,15 @@ void namelookup::lookupInModule(const DeclContext *moduleOrFile,
                                 const DeclContext *moduleScopeContext) {
   assert(moduleScopeContext->isModuleScopeContext());
 
-  auto *startModule = moduleOrFile->getParentModule();
-  auto &ctx = startModule->getASTContext();
+  auto &ctx = moduleOrFile->getASTContext();
   auto *stats = ctx.Stats;
   if (stats)
     stats->getFrontendCounters().NumLookupInModule++;
 
   FrontendStatsTracer tracer(stats, "lookup-in-module");
 
-  // Add private imports to the extra search list.
-  SmallVector<ModuleDecl::ImportedModule, 8> extraImports;
-  if (auto *file = dyn_cast<FileUnit>(moduleOrFile)) {
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    file->getImportedModules(extraImports, importFilter);
-  }
-
   LookupByName lookup(ctx, resolutionKind, name, lookupKind);
-  lookup.lookupInModule(decls, startModule, {}, moduleScopeContext,
-                        extraImports);
+  lookup.lookupInModule(decls, moduleOrFile, {}, moduleScopeContext);
 }
 
 void namelookup::lookupVisibleDeclsInModule(
@@ -482,21 +251,8 @@ void namelookup::lookupVisibleDeclsInModule(
     ResolutionKind resolutionKind,
     const DeclContext *moduleScopeContext) {
   assert(moduleScopeContext->isModuleScopeContext());
-
-  auto *startModule = moduleOrFile->getParentModule();
-  auto &ctx = startModule->getASTContext();
-
-  // Add private imports to the extra search list.
-  SmallVector<ModuleDecl::ImportedModule, 8> extraImports;
-  if (auto *file = dyn_cast<FileUnit>(moduleOrFile)) {
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    file->getImportedModules(extraImports, importFilter);
-  }
-
+  auto &ctx = moduleOrFile->getASTContext();
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
-  lookup.lookupInModule(decls, startModule, accessPath, moduleScopeContext,
-                        extraImports);
+  lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext);
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1706,9 +1706,9 @@ bool DeclContext::lookupAnyObject(DeclName member, NLOptions options,
 
   // Collect all of the visible declarations.
   SmallVector<ValueDecl *, 4> allDecls;
-  forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(this)) {
     import.second->lookupClassMember(import.first, member, allDecls);
-  });
+  }
 
   // For each declaration whose context is not something we've
   // already visited above, add it to the list of declarations.
@@ -1750,9 +1750,9 @@ void DeclContext::lookupAllObjCMethods(
        ObjCSelector selector,
        SmallVectorImpl<AbstractFunctionDecl *> &results) const {
   // Collect all of the methods with this selector.
-  forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(this)) {
     import.second->lookupObjCMethods(selector, results);
-  });
+  }
 
   // Filter out duplicates.
   llvm::SmallPtrSet<AbstractFunctionDecl *, 8> visited;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/Module.h"
@@ -1684,7 +1685,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
       // FIXME: This forces the creation of wrapper modules for all imports as
       // well, and may do unnecessary work.
       cacheEntry.setInt(true);
-      result->forAllVisibleModules({}, [&](ModuleDecl::ImportedModule import) {});
+      (void) namelookup::getAllImports(result);
     }
   } else {
     // Build the representation of the Clang module in Swift.
@@ -1704,7 +1705,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     // Force load overlays for all imported modules.
     // FIXME: This forces the creation of wrapper modules for all imports as
     // well, and may do unnecessary work.
-    result->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {});
+    (void) namelookup::getAllImports(result);
   }
 
   if (clangModule->isSubModule()) {

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImporterImpl.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Module.h"
 
 using namespace swift;
@@ -118,7 +119,7 @@ ModuleDecl *ClangImporter::Implementation::loadModuleDWARF(
   decl->addFile(*wrapperUnit);
 
   // Force load overlay modules for all imported modules.
-  decl->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {});
+  (void) namelookup::getAllImports(decl);
 
   // Register the module with the ASTContext so it is available for lookups.
   ModuleDecl *&loaded = SwiftContext.LoadedModules[name];

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericSignatureBuilder.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleNameLookup.h"
@@ -364,10 +365,9 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
 
   DynamicLookupConsumer ConsumerWrapper(Consumer, LS, CurrDC);
 
-  CurrDC->getParentSourceFile()->forAllVisibleModules(
-      [&](ModuleDecl::ImportedModule Import) {
-        Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
-      });
+  for (auto Import : namelookup::getAllImports(CurrDC)) {
+    Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
+  }
 }
 
 namespace {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/StringExtras.h"
@@ -1795,10 +1796,12 @@ void swift::diagnoseAttrsRequiringFoundation(SourceFile &SF) {
       return;
   }
 
-  SF.forAllVisibleModules([&](ModuleDecl::ImportedModule import) {
-    if (import.second->getName() == Ctx.Id_Foundation)
+  for (auto import : namelookup::getAllImports(&SF)) {
+    if (import.second->getName() == Ctx.Id_Foundation) {
       ImportsFoundationModule = true;
-  });
+      break;
+    }
+  }
 
   if (ImportsFoundationModule)
     return;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/NameLookup.h"
@@ -249,7 +250,7 @@ static void bindExtensions(SourceFile &SF) {
 
   // FIXME: The current source file needs to be handled specially, because of
   // private extensions.
-  SF.forAllVisibleModules([&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(&SF)) {
     // FIXME: Respect the access path?
     for (auto file : import.second->getFiles()) {
       auto SF = dyn_cast<SourceFile>(file);
@@ -262,7 +263,7 @@ static void bindExtensions(SourceFile &SF) {
             worklist.push_back(ED);
       }
     }
-  });
+  }
 
   // Phase 2 - repeatedly go through the worklist and attempt to bind each
   // extension there, removing it from the worklist if we succeed.

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -28,10 +28,8 @@
 #if canImport(CoreGraphics)
   let square = CGRect(x: 100, y: 100, width: 100, height: 100)
   // expected-error@-1 {{use of unresolved identifier 'CGRect'}}
-  // expected-note@-2 {{'square' declared here}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
-  // expected-error@-1 {{ambiguous use of 'square'}}
 #endif
 
 #if canImport(MixedWithHeader)

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -2,7 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_intFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_boolFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify
+// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify -swift-version 5
 
 // RUN: not %target-swift-frontend -dump-ast %s -I %t -sdk "" > %t.astdump
 // RUN: %FileCheck %s < %t.astdump
@@ -14,15 +15,15 @@ import var overload_vars.scopedVar
 import func overload_boolFunctions.scopedFunction
 
 struct LocalType {}
-func something(_ obj: LocalType) -> LocalType { return obj } // expected-note {{found this candidate}}
-func something(_ a: Int, _ b: Int, _ c: Int) -> () {} // expected-note {{found this candidate}}
+func something(_ obj: LocalType) -> LocalType { return obj }
+func something(_ a: Int, _ b: Int, _ c: Int) -> () {}
 
 var _ : Bool = something(true)
 var _ : Int = something(1)
 var _ : (Int, Int) = something(1, 2)
 var _ : LocalType = something(LocalType())
 var _ : () = something(1, 2, 3)
-something = 42 // expected-error {{ambiguous reference to member 'something'}}
+something = 42
 
 let ambValue = ambiguousWithVar // no-warning - var preferred
 let ambValueChecked: Int = ambValue
@@ -36,11 +37,11 @@ localVar(42)  // expected-error {{cannot call value of non-function type 'Bool'}
 var _ : localVar // should still work
 
 _ = scopedVar // no-warning
-scopedVar(42) // expected-error {{cannot call value of non-function type 'Int'}}
+scopedVar(42)
 
 var _ : Bool = scopedFunction(true)
 var _ : Int  = scopedFunction(42)
-scopedFunction = 42 // expected-error {{ambiguous reference to member 'scopedFunction'}}
+scopedFunction = 42
 
 // FIXME: Should be an error -- a type name and a function cannot overload.
 var _ : Int = TypeNameWins(42)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -14,13 +14,14 @@
 #include "ModuleAPIDiff.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/USRGeneration.h"
@@ -2665,7 +2666,7 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
     }
 
     SmallVector<ModuleDecl::ImportedModule, 16> scratch;
-    M->forAllVisibleModules({}, [&](const ModuleDecl::ImportedModule &next) {
+    for (auto next : namelookup::getAllImports(M)) {
       llvm::outs() << next.second->getName();
       if (next.second->isClangModule())
         llvm::outs() << " (Clang)";
@@ -2684,7 +2685,7 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
           llvm::outs() << " (Clang)";
         llvm::outs() << "\n";
       }
-    });
+    }
   }
 
   return ExitCode;


### PR DESCRIPTION
Builds on https://github.com/apple/swift/pull/26864 by replacing lookupInModule() with a much simpler implementation that walks a cached traversal of the import graph.