### PR TITLE
[CS] Look at the fn's rvalue type in getCalleeLocator

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -310,7 +310,12 @@ Type RequirementFailure::getOwnerType() const {
 const GenericContext *RequirementFailure::getGenericContext() const {
   if (auto *genericCtx = AffectedDecl->getAsGenericContext())
     return genericCtx;
-  return AffectedDecl->getDeclContext()->getAsDecl()->getAsGenericContext();
+
+  auto parentDecl = AffectedDecl->getDeclContext()->getAsDecl();
+  if (!parentDecl)
+    return nullptr;
+
+  return parentDecl->getAsGenericContext();
 }
 
 const Requirement &RequirementFailure::getRequirement() const {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -236,6 +236,10 @@ public:
     assert(locator);
     assert(isConditional() || Signature);
     assert(AffectedDecl);
+    assert(getRequirementDC() &&
+           "Couldn't find where the requirement came from?");
+    assert(getGenericContext() &&
+           "Affected decl not within a generic context?");
 
     auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
     assert(reqElt.getRequirementKind() == kind);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -425,7 +425,8 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(Expr *expr) {
     // For an apply of a metatype, we have a short-form constructor. Unlike
     // other locators to callees, these are anchored on the apply expression
     // rather than the function expr.
-    if (simplifyType(getType(fnExpr))->is<AnyMetatypeType>()) {
+    auto fnTy = getFixedTypeRecursive(getType(fnExpr), /*wantRValue*/ true);
+    if (fnTy->is<AnyMetatypeType>()) {
       auto *fnLocator =
           getConstraintLocator(applyExpr, ConstraintLocator::ApplyFunction);
       return getConstraintLocator(fnLocator,

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -714,7 +714,7 @@ protocol Q {
 }
 
 struct SR10694 {
-  init<T : P>(_ x: T) {} // expected-note 2{{where 'T' = 'T'}}
+  init<T : P>(_ x: T) {} // expected-note 3{{where 'T' = 'T'}}
   func bar<T>(_ x: T, _ s: SR10694, _ q: Q) {
     SR10694.self(x) // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
 
@@ -725,6 +725,10 @@ struct SR10694 {
     // expected-error@-1 {{protocol type 'Q' cannot be instantiated}}
 
     type(of: q)(x)  // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
+    // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}
+
+    var srTy = SR10694.self
+    srTy(x) // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
     // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}
   }
 }


### PR DESCRIPTION
Missed this case when implementing https://github.com/apple/swift/pull/24826, we need to look at the function's rvalue type when deciding whether we have a short-form constructor call. I have also added a couple of assertions to `RequirementFailure` that should hopefully make it slightly easier to spot cases where we've resolved to the wrong affected decl. 