### PR TITLE
These tests require __swift_debug_verifyTypeLayoutAttribute which is …

### DIFF
--- a/test/Interpreter/multi_payload_extra_inhabitant.swift
+++ b/test/Interpreter/multi_payload_extra_inhabitant.swift
@@ -7,6 +7,7 @@
 // REQUIRES: swift_stdlib_asserts
 
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 // CHECK-NOT: Type verification
 

--- a/test/Interpreter/struct_extra_inhabitants.swift
+++ b/test/Interpreter/struct_extra_inhabitants.swift
@@ -11,6 +11,7 @@
 // REQUIRES: swift_stdlib_asserts
 
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
 
 // CHECK-NOT: Type verification
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1233,6 +1233,7 @@ if 'remote_run_host' in lit_config.params:
     if 'use_os_stdlib' not in lit_config.params:
         remote_run_lib_path = remote_lib_dir
     else:
+        config.available_features.add('use_os_stdlib')
         os_stdlib_path = ''
         if run_vendor == 'apple':
             #If we get swift-in-the-OS for non-Apple platforms, add a condition here


### PR DESCRIPTION
…not ABI or available on OS stdlibs

  Interpreter/multi_payload_extra_inhabitant.swift
  Interpreter/struct_extra_inhabitants.swift

Mark the test as unsupported when running the tests with the OS' stdlib.

rdar://54749176