### PR TITLE
Debug Info: Record -gmodules breadcrumbs for PCH debug info.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1601,15 +1601,19 @@ private:
       auto Idx = ClangDecl->getOwningModuleID();
       auto SubModuleDesc = Reader.getSourceDescriptor(Idx);
       auto TopLevelModuleDesc = getClangModule(*TypeDecl->getModuleContext());
-      if (SubModuleDesc && TopLevelModuleDesc) {
-        // Describe the submodule, but substitute the cached ASTFile from
-        // the toplevel module. The ASTFile pointer in SubModule may be
-        // dangling and cant be trusted.
-        Scope = getOrCreateModule({SubModuleDesc->getModuleName(),
-                                   SubModuleDesc->getPath(),
-                                   TopLevelModuleDesc->getASTFile(),
-                                   TopLevelModuleDesc->getSignature()},
-                                  SubModuleDesc->getModuleOrNull());
+      if (SubModuleDesc) {
+        if (TopLevelModuleDesc)
+          // Describe the submodule, but substitute the cached ASTFile from
+          // the toplevel module. The ASTFile pointer in SubModule may be
+          // dangling and cant be trusted.
+          Scope = getOrCreateModule({SubModuleDesc->getModuleName(),
+                                     SubModuleDesc->getPath(),
+                                     TopLevelModuleDesc->getASTFile(),
+                                     TopLevelModuleDesc->getSignature()},
+                                    SubModuleDesc->getModuleOrNull());
+        else if (SubModuleDesc->getModuleOrNull() == nullptr)
+          // This is (bridging header) PCH.
+          Scope = getOrCreateModule(*SubModuleDesc, nullptr);
       }
     }
     if (!Scope)

--- a/test/DebugInfo/BridgingHeaderPCH-Type.swift
+++ b/test/DebugInfo/BridgingHeaderPCH-Type.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend \
+// RUN:   -emit-pch %S/Inputs/BridgingHeader.h -o %t.pch
+// RUN: %target-swift-frontend \
+// RUN:   -import-objc-header %t.pch -emit-ir -g %s -o - | %FileCheck %s
+
+// CHECK: !DIModule(scope: null, name: "BridgingHeader.h",
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}}splitDebugFilename:
+// CHECK-SAME:           dwoId:
+
+public let p = Point(x: 1, y: 2)

--- a/test/DebugInfo/Inputs/BridgingHeader.h
+++ b/test/DebugInfo/Inputs/BridgingHeader.h
@@ -1,0 +1,3 @@
+struct Point {
+  int x, y;
+};


### PR DESCRIPTION
Produce a DWO-style skeleton CU pointing to the PCH containing the
Clang debug info for types imported from a PCH. This allows
DWARFIMporterDelegate to find the type definitions there.

<rdar://problem/49233932>
