### PR TITLE
More import graph cleanups

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -112,6 +112,10 @@ namespace swift {
 
   enum class KnownProtocolKind : uint8_t;
 
+namespace namelookup {
+  class ImportCache;
+}
+
 namespace syntax {
   class SyntaxArena;
 }
@@ -683,7 +687,9 @@ public:
   /// If there is no Clang module loader, returns a null pointer.
   /// The loader is owned by the AST context.
   ClangModuleLoader *getDWARFModuleLoader() const;
-  
+
+  namelookup::ImportCache &getImportCache() const;
+
   /// Asks every module loader to verify the ASTs it has loaded.
   ///
   /// Does nothing in non-asserts (NDEBUG) builds.

--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -1,0 +1,191 @@
+//===--- ImportCache.h - Caching the import graph ---------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines interfaces for querying the module import graph in an
+// efficient manner.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_IMPORT_CACHE_H
+#define SWIFT_AST_IMPORT_CACHE_H
+
+#include "swift/AST/Module.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/FoldingSet.h"
+
+namespace swift {
+class DeclContext;
+
+namespace namelookup {
+
+/// An object describing a set of modules visible from a DeclContext.
+///
+/// This consists of two arrays of modules; the top-level imports and the
+/// transitive imports.
+///
+/// The top-level imports contains all public imports of the parent module
+/// of 'dc', together with any private imports in the source file containing
+/// 'dc', if there is one.
+///
+/// The transitive imports contains all public imports reachable from the
+/// set of top-level imports.
+///
+/// Both sets only contain unique elements. The top-level imports always
+/// include the parent module of 'dc' explicitly.
+///
+/// The set of transitive imports does not contain any elements found in
+/// the top-level imports.
+///
+/// The Swift standard library module is not included in either set unless
+/// it was explicitly imported (or re-exported).
+class ImportSet final :
+    public llvm::FoldingSetNode,
+    private llvm::TrailingObjects<ImportSet, ModuleDecl::ImportedModule> {
+  friend TrailingObjects;
+  friend ImportCache;
+
+  unsigned NumTopLevelImports;
+  unsigned NumTransitiveImports;
+
+  ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+            ArrayRef<ModuleDecl::ImportedModule> transitiveImports);
+
+  ImportSet(const ImportSet &) = delete;
+  void operator=(const ImportSet &) = delete;
+
+public:
+  void Profile(llvm::FoldingSetNodeID &ID) {
+    Profile(ID, getTopLevelImports());
+  }
+  static void Profile(
+      llvm::FoldingSetNodeID &ID,
+      ArrayRef<ModuleDecl::ImportedModule> topLevelImports);
+
+  size_t numTrailingObjects(OverloadToken<ModuleDecl::ImportedModule>) const {
+    return NumTopLevelImports + NumTransitiveImports;
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getTopLevelImports() const {
+    return {getTrailingObjects<ModuleDecl::ImportedModule>(),
+            NumTopLevelImports};
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getTransitiveImports() const {
+    return {getTrailingObjects<ModuleDecl::ImportedModule>() +
+              NumTopLevelImports,
+            NumTransitiveImports};
+  }
+
+  ArrayRef<ModuleDecl::ImportedModule> getAllImports() const {
+      return {getTrailingObjects<ModuleDecl::ImportedModule>(),
+              NumTopLevelImports + NumTransitiveImports};
+  }
+};
+
+class alignas(ModuleDecl::ImportedModule) ImportCache {
+  ImportCache(const ImportCache &) = delete;
+  void operator=(const ImportCache &) = delete;
+
+  llvm::FoldingSet<ImportSet> ImportSets;
+  llvm::DenseMap<const DeclContext *, ImportSet *> ImportSetForDC;
+  llvm::DenseMap<std::tuple<const ModuleDecl *,
+                            const DeclContext *>,
+                 ArrayRef<ModuleDecl::AccessPathTy>> VisibilityCache;
+  llvm::DenseMap<std::tuple<const ModuleDecl *,
+                            const ModuleDecl *,
+                            const DeclContext *>,
+                 ArrayRef<ModuleDecl::AccessPathTy>> ShadowCache;
+
+  ModuleDecl::AccessPathTy EmptyAccessPath;
+
+  ArrayRef<ModuleDecl::AccessPathTy> allocateArray(
+      ASTContext &ctx,
+      SmallVectorImpl<ModuleDecl::AccessPathTy> &results);
+
+  ImportSet &getImportSet(ASTContext &ctx,
+                          ArrayRef<ModuleDecl::ImportedModule> topLevelImports);
+
+public:
+  ImportCache() {}
+
+  /// Returns an object descripting all modules transtiively imported
+  /// from 'dc'.
+  ImportSet &getImportSet(const DeclContext *dc);
+
+  /// Returns all access paths into 'mod' that are visible from 'dc',
+  /// including transitively, via re-exports.
+  ArrayRef<ModuleDecl::AccessPathTy>
+  getAllVisibleAccessPaths(const ModuleDecl *mod, const DeclContext *dc);
+
+  bool isImportedBy(const ModuleDecl *mod,
+                    const DeclContext *dc) {
+    return !getAllVisibleAccessPaths(mod, dc).empty();
+  }
+
+  /// Determines if 'mod' is visible from 'dc' as a result of a scoped import.
+  /// Note that if 'mod' was not imported from 'dc' at all, this also returns
+  /// false.
+  bool isScopedImport(const ModuleDecl *mod, DeclBaseName name,
+                      const DeclContext *dc) {
+    auto accessPaths = getAllVisibleAccessPaths(mod, dc);
+    for (auto accessPath : accessPaths) {
+      if (accessPath.empty())
+        continue;
+      if (ModuleDecl::matchesAccessPath(accessPath, name))
+        return true;
+    }
+
+    return false;
+  }
+
+  /// Returns all access paths in 'mod' that are visible from 'dc' if we
+  /// subtract imports of 'other'.
+  ArrayRef<ModuleDecl::AccessPathTy>
+  getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
+                                 const ModuleDecl *other,
+                                 const DeclContext *dc);
+
+  /// Returns 'true' if a declaration named 'name' defined in 'other' shadows
+  /// defined in 'mod', because no access paths can find 'name' in 'mod' from
+  /// 'dc' if we ignore imports of 'other'.
+  bool isShadowedBy(const ModuleDecl *mod,
+                    const ModuleDecl *other,
+                    DeclBaseName name,
+                    const DeclContext *dc) {
+     auto accessPaths = getAllAccessPathsNotShadowedBy(mod, other, dc);
+     return llvm::none_of(accessPaths,
+                          [&](ModuleDecl::AccessPathTy accessPath) {
+                            return ModuleDecl::matchesAccessPath(accessPath, name);
+                          });
+  }
+
+  /// Qualified lookup into types uses a slightly different check that does not
+  /// take access paths into account.
+  bool isShadowedBy(const ModuleDecl *mod,
+                    const ModuleDecl *other,
+                    const DeclContext *dc) {
+    auto accessPaths = getAllAccessPathsNotShadowedBy(mod, other, dc);
+    return accessPaths.empty();
+  }
+
+  /// This is a hack to cope with main file parsing and REPL parsing, where
+  /// we can add ImportDecls after name binding.
+  void clear() {
+    ImportSetForDC.clear();
+  }
+};
+
+}  // namespace namelookup
+
+}  // namespace swift
+
+#endif

--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -51,7 +51,7 @@ class ImportSet final :
     public llvm::FoldingSetNode,
     private llvm::TrailingObjects<ImportSet, ModuleDecl::ImportedModule> {
   friend TrailingObjects;
-  friend ImportCache;
+  friend class ImportCache;
 
   unsigned NumTopLevelImports;
   unsigned NumTransitiveImports;
@@ -183,6 +183,8 @@ public:
     ImportSetForDC.clear();
   }
 };
+
+ArrayRef<ModuleDecl::ImportedModule> getAllImports(const DeclContext *dc);
 
 }  // namespace namelookup
 

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -61,16 +61,6 @@ void lookupInModule(const DeclContext *moduleOrFile,
                     NLKind lookupKind, ResolutionKind resolutionKind,
                     const DeclContext *moduleScopeContext);
 
-template <typename Fn>
-void forAllVisibleModules(const DeclContext *DC, const Fn &fn) {
-  DeclContext *moduleScope = DC->getModuleScopeContext();
-  if (auto file = dyn_cast<FileUnit>(moduleScope))
-    file->forAllVisibleModules(fn);
-  else
-    cast<ModuleDecl>(moduleScope)
-        ->forAllVisibleModules(ModuleDecl::AccessPathTy(), fn);
-}
-
 /// Performs a qualified lookup into the given module and, if necessary, its
 /// reexports, observing proper shadowing rules.
 void

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -35,9 +35,6 @@ enum class ResolutionKind {
   /// If non-overloadable decls are returned, this indicates ambiguous lookup.
   Overloadable,
 
-  /// Lookup should match a single decl.
-  Exact,
-
   /// Lookup should match a single decl that declares a type.
   TypesOnly
 };

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -42,10 +42,14 @@ enum class ResolutionKind {
   TypesOnly
 };
 
-/// Performs a lookup into the given module and, if necessary, its
-/// reexports, observing proper shadowing rules.
+/// Performs a lookup into the given module and it's imports.
 ///
-/// \param module The module that will contain the name.
+/// If 'moduleOrFile' is a ModuleDecl, we search the module and it's
+/// public imports. If 'moduleOrFile' is a SourceFile, we search the
+/// file's parent module, the module's public imports, and the source
+/// file's private imports.
+///
+/// \param moduleOrFile The module or file unit whose imports to search.
 /// \param accessPath The import scope on \p module.
 /// \param name The name to look up.
 /// \param[out] decls Any found decls will be added to this vector.
@@ -54,12 +58,11 @@ enum class ResolutionKind {
 /// \param moduleScopeContext The top-level context from which the lookup is
 ///        being performed, for checking access. This must be either a
 ///        FileUnit or a Module.
-/// \param extraImports Private imports to include in this search.
-void lookupInModule(ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
+void lookupInModule(const DeclContext *moduleOrFile,
+                    ModuleDecl::AccessPathTy accessPath,
                     DeclName name, SmallVectorImpl<ValueDecl *> &decls,
                     NLKind lookupKind, ResolutionKind resolutionKind,
-                    const DeclContext *moduleScopeContext,
-                    ArrayRef<ModuleDecl::ImportedModule> extraImports = {});
+                    const DeclContext *moduleScopeContext);
 
 template <typename Fn>
 void forAllVisibleModules(const DeclContext *DC, const Fn &fn) {
@@ -74,12 +77,12 @@ void forAllVisibleModules(const DeclContext *DC, const Fn &fn) {
 /// Performs a qualified lookup into the given module and, if necessary, its
 /// reexports, observing proper shadowing rules.
 void
-lookupVisibleDeclsInModule(ModuleDecl *M, ModuleDecl::AccessPathTy accessPath,
+lookupVisibleDeclsInModule(const DeclContext *moduleOrFile,
+                           ModuleDecl::AccessPathTy accessPath,
                            SmallVectorImpl<ValueDecl *> &decls,
                            NLKind lookupKind,
                            ResolutionKind resolutionKind,
-                           const DeclContext *moduleScopeContext,
-                           ArrayRef<ModuleDecl::ImportedModule> extraImports = {});
+                           const DeclContext *moduleScopeContext);
 
 } // end namespace namelookup
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -378,11 +378,11 @@ bool removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls);
 /// other declarations in that set.
 ///
 /// \param decls The set of declarations being considered.
-/// \param curModule The current module.
+/// \param dc The DeclContext from which the lookup was performed.
 ///
 /// \returns true if any shadowed declarations were removed.
 bool removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
-                         const ModuleDecl *curModule);
+                         const DeclContext *dc);
 
 /// Finds decls visible in the given context and feeds them to the given
 /// VisibleDeclConsumer.  If the current DeclContext is nested in a function,

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -175,6 +175,19 @@ FRONTEND_STATISTIC(AST, NumBraceStmtASTScopeExpansions)
 /// Number of ASTScope lookups
 FRONTEND_STATISTIC(AST, NumASTScopeLookups)
 
+/// Number of lookups of the cached import graph for a module or
+/// source file.
+FRONTEND_STATISTIC(AST, ImportSetFoldHit)
+FRONTEND_STATISTIC(AST, ImportSetFoldMiss)
+
+FRONTEND_STATISTIC(AST, ImportSetCacheHit)
+FRONTEND_STATISTIC(AST, ImportSetCacheMiss)
+
+FRONTEND_STATISTIC(AST, ModuleVisibilityCacheHit)
+FRONTEND_STATISTIC(AST, ModuleVisibilityCacheMiss)
+
+FRONTEND_STATISTIC(AST, ModuleShadowCacheHit)
+FRONTEND_STATISTIC(AST, ModuleShadowCacheMiss)
 
 /// Number of full function bodies parsed.
 FRONTEND_STATISTIC(Parse, NumFunctionsParsed)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericSignatureBuilder.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleLoader.h"
@@ -251,6 +252,9 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   /// The various module loaders that import external modules into this
   /// ASTContext.
   SmallVector<std::unique_ptr<swift::ModuleLoader>, 4> ModuleLoaders;
+
+  /// Singleton used to cache the import graph.
+  swift::namelookup::ImportCache TheImportCache;
 
   /// The module loader used to load Clang modules.
   ClangModuleLoader *TheClangModuleLoader = nullptr;
@@ -1492,6 +1496,10 @@ void ASTContext::verifyAllLoadedModules() const {
     assert(!M->getFiles().empty() || M->failedToLoad());
   }
 #endif
+}
+
+swift::namelookup::ImportCache &ASTContext::getImportCache() const {
+  return getImpl().TheImportCache;
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -50,6 +50,7 @@ add_swift_host_library(swiftAST STATIC
   GenericSignature.cpp
   GenericSignatureBuilder.cpp
   Identifier.cpp
+  ImportCache.cpp
   InlinableText.cpp
   LayoutConstraint.cpp
   Module.cpp

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -1,0 +1,280 @@
+//===--- ImportCache.cpp - Caching the import graph -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines interfaces for querying the module import graph in an
+// efficient manner.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/DenseSet.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/ImportCache.h"
+#include "swift/AST/Module.h"
+
+using namespace swift;
+using namespace namelookup;
+
+ImportSet::ImportSet(ArrayRef<ModuleDecl::ImportedModule> topLevelImports,
+                     ArrayRef<ModuleDecl::ImportedModule> transitiveImports)
+  : NumTopLevelImports(topLevelImports.size()),
+    NumTransitiveImports(transitiveImports.size()) {
+  auto buffer = getTrailingObjects<ModuleDecl::ImportedModule>();
+  std::uninitialized_copy(topLevelImports.begin(), topLevelImports.end(),
+                          buffer);
+  std::uninitialized_copy(transitiveImports.begin(), transitiveImports.end(),
+                          buffer + topLevelImports.size());
+
+#ifndef NDEBUG
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 8> unique;
+  for (auto import : topLevelImports) {
+    auto result = unique.insert(import).second;
+    assert(result && "Duplicate imports in import set");
+  }
+  for (auto import : transitiveImports) {
+    auto result = unique.insert(import).second;
+    assert(result && "Duplicate imports in import set");
+  }
+#endif
+}
+
+void ImportSet::Profile(
+    llvm::FoldingSetNodeID &ID,
+    ArrayRef<ModuleDecl::ImportedModule> topLevelImports) {
+  ID.AddInteger(topLevelImports.size());
+  for (auto import : topLevelImports) {
+    ID.AddInteger(import.first.size());
+    for (auto accessPathElt : import.first) {
+      ID.AddPointer(accessPathElt.first.getAsOpaquePointer());
+    }
+    ID.AddPointer(import.second);
+  }
+}
+
+static void collectExports(ModuleDecl::ImportedModule next,
+                           SmallVectorImpl<ModuleDecl::ImportedModule> &stack) {
+  SmallVector<ModuleDecl::ImportedModule, 4> exports;
+  next.second->getImportedModulesForLookup(exports);
+  for (auto exported : exports) {
+    if (next.first.empty())
+      stack.push_back(exported);
+    else if (exported.first.empty()) {
+      exported.first = next.first;
+      stack.push_back(exported);
+    } else if (ModuleDecl::isSameAccessPath(next.first, exported.first)) {
+      stack.push_back(exported);
+    }
+  }
+}
+
+ImportSet &
+ImportCache::getImportSet(ASTContext &ctx,
+                          ArrayRef<ModuleDecl::ImportedModule> imports) {
+  SmallVector<ModuleDecl::ImportedModule, 4> topLevelImports;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> transitiveImports;
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 32> visited;
+
+  for (auto next : imports) {
+    if (!visited.insert(next).second)
+      continue;
+
+    topLevelImports.push_back(next);
+  }
+
+  void *InsertPos = nullptr;
+
+  llvm::FoldingSetNodeID ID;
+  ImportSet::Profile(ID, topLevelImports);
+
+  if (ImportSet *result = ImportSets.FindNodeOrInsertPos(ID, InsertPos)) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ImportSetFoldHit++;
+    return *result;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ImportSetFoldMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> stack;
+  for (auto next : topLevelImports) {
+    collectExports(next, stack);
+  }
+
+  while (!stack.empty()) {
+    auto next = stack.pop_back_val();
+
+    if (!visited.insert(next).second)
+      continue;
+
+    transitiveImports.push_back(next);
+    collectExports(next, stack);
+  }
+
+  // Find the insert position again, in case the above traversal invalidated
+  // the folding set via re-entrant calls to getImportSet() from
+  // getImportedModulesForLookup().
+  if (ImportSet *result = ImportSets.FindNodeOrInsertPos(ID, InsertPos))
+    return *result;
+
+  void *mem = ctx.Allocate(
+    sizeof(ImportSet) +
+    sizeof(ModuleDecl::ImportedModule) * topLevelImports.size() +
+    sizeof(ModuleDecl::ImportedModule) * transitiveImports.size(),
+    alignof(ImportSet), AllocationArena::Permanent);
+
+  auto *result = new (mem) ImportSet(topLevelImports, transitiveImports);
+  ImportSets.InsertNode(result, InsertPos);
+
+  return *result;
+}
+
+ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto *file = dyn_cast<FileUnit>(dc);
+  auto *mod = dc->getParentModule();
+  if (!file)
+    dc = mod;
+
+  auto &ctx = mod->getASTContext();
+
+  auto found = ImportSetForDC.find(dc);
+  if (found != ImportSetForDC.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ImportSetCacheHit++;
+    return *found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ImportSetCacheMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> imports;
+  imports.emplace_back(ModuleDecl::AccessPathTy(), mod);
+
+  if (file) {
+    ModuleDecl::ImportFilter importFilter;
+    importFilter |= ModuleDecl::ImportFilterKind::Private;
+    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    file->getImportedModules(imports, importFilter);
+  }
+
+  auto &result = getImportSet(ctx, imports);
+  ImportSetForDC[dc] = &result;
+
+  return result;
+}
+
+ArrayRef<ModuleDecl::AccessPathTy> ImportCache::allocateArray(
+    ASTContext &ctx,
+    SmallVectorImpl<ModuleDecl::AccessPathTy> &results) {
+  if (results.empty())
+    return ArrayRef<ModuleDecl::AccessPathTy>();
+  else if (results.size() == 1 && results[0].empty())
+    return {&EmptyAccessPath, 1};
+  else
+    return ctx.AllocateCopy(results);
+}
+
+ArrayRef<ModuleDecl::AccessPathTy>
+ImportCache::getAllVisibleAccessPaths(const ModuleDecl *mod,
+                                      const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto &ctx = mod->getASTContext();
+
+  auto key = std::make_pair(mod, dc);
+  auto found = VisibilityCache.find(key);
+  if (found != VisibilityCache.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ModuleVisibilityCacheHit++;
+    return found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ModuleVisibilityCacheMiss++;
+
+  SmallVector<ModuleDecl::AccessPathTy, 1> accessPaths;
+  for (auto next : getImportSet(dc).getAllImports()) {
+    // If we found 'mod', record the access path.
+    if (next.second == mod) {
+      // Make sure the list of access paths is unique.
+      if (!llvm::is_contained(accessPaths, next.first))
+        accessPaths.push_back(next.first);
+    }
+  }
+
+  auto result = allocateArray(ctx, accessPaths);
+  VisibilityCache[key] = result;
+  return result;
+}
+
+ArrayRef<ModuleDecl::AccessPathTy>
+ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
+                                            const ModuleDecl *other,
+                                            const DeclContext *dc) {
+  dc = dc->getModuleScopeContext();
+  auto *currentMod = dc->getParentModule();
+  auto &ctx = currentMod->getASTContext();
+
+  // Fast path.
+  if (currentMod == other)
+    return ArrayRef<ModuleDecl::AccessPathTy>();
+
+  auto key = std::make_tuple(mod, other, dc);
+  auto found = ShadowCache.find(key);
+  if (found != ShadowCache.end()) {
+    if (ctx.Stats)
+      ctx.Stats->getFrontendCounters().ModuleShadowCacheHit++;
+    return found->second;
+  }
+
+  if (ctx.Stats)
+    ctx.Stats->getFrontendCounters().ModuleShadowCacheMiss++;
+
+  SmallVector<ModuleDecl::ImportedModule, 4> stack;
+  llvm::SmallDenseSet<ModuleDecl::ImportedModule, 32> visited;
+
+  stack.emplace_back(ModuleDecl::AccessPathTy(), currentMod);
+
+  if (auto *file = dyn_cast<FileUnit>(dc)) {
+    ModuleDecl::ImportFilter importFilter;
+    importFilter |= ModuleDecl::ImportFilterKind::Private;
+    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    file->getImportedModules(stack, importFilter);
+  }
+
+  SmallVector<ModuleDecl::AccessPathTy, 4> accessPaths;
+
+  while (!stack.empty()) {
+    auto next = stack.pop_back_val();
+
+    // Don't visit a module more than once.
+    if (!visited.insert(next).second)
+      continue;
+
+    // Don't visit the 'other' module's re-exports.
+    if (next.second == other)
+      continue;
+
+    // If we found 'mod' via some access path, remember the access
+    // path.
+    if (next.second == mod) {
+      // Make sure the list of access paths is unique.
+      if (!llvm::is_contained(accessPaths, next.first))
+        accessPaths.push_back(next.first);
+    }
+
+    collectExports(next, stack);
+  }
+
+  auto result = allocateArray(ctx, accessPaths);
+  ShadowCache[key] = result;
+  return result;
+};

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -278,3 +278,9 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
   ShadowCache[key] = result;
   return result;
 };
+
+ArrayRef<ModuleDecl::ImportedModule>
+swift::namelookup::getAllImports(const DeclContext *dc) {
+  return dc->getASTContext().getImportCache().getImportSet(dc)
+    .getAllImports();
+}

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/ModuleLoader.h"
@@ -1642,6 +1643,8 @@ bool SourceFile::isImportedImplementationOnly(const ModuleDecl *module) const {
 }
 
 void ModuleDecl::clearLookupCache() {
+  getASTContext().getImportCache().clear();
+
   if (!Cache)
     return;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1431,32 +1431,6 @@ forAllImportedModules(const ModuleDecl *topLevel,
   return true;
 }
 
-bool
-ModuleDecl::forAllVisibleModules(AccessPathTy thisPath,
-                                 llvm::function_ref<bool(ImportedModule)> fn) const {
-  return forAllImportedModules<true>(this, thisPath, fn);
-}
-
-bool FileUnit::forAllVisibleModules(
-    llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn) const {
-  if (!getParentModule()->forAllVisibleModules(ModuleDecl::AccessPathTy(), fn))
-    return false;
-
-  if (auto SF = dyn_cast<SourceFile>(this)) {
-    // Handle privately visible modules as well.
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    SmallVector<ModuleDecl::ImportedModule, 4> imports;
-    SF->getImportedModules(imports, importFilter);
-    for (auto importPair : imports)
-      if (!importPair.second->forAllVisibleModules(importPair.first, fn))
-        return false;
-  }
-
-  return true;
-}
-
 void ModuleDecl::collectLinkLibraries(LinkLibraryCallback callback) const {
   // FIXME: The proper way to do this depends on the decls used.
   FORWARD(collectLinkLibraries, (callback));

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -12,7 +12,7 @@
 
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/LazyResolver.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/NameLookup.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -23,19 +23,11 @@ namespace {
 
 /// Encapsulates the work done for a recursive qualified lookup into a module.
 ///
-/// The \p LookupStrategy handles the non-recursive part of the lookup, as well
-/// as how to combine results from across modules (e.g. handling shadowing). It
+/// The \p LookupStrategy handles the non-recursive part of the lookup. It
 /// must be a subclass of ModuleNameLookup.
 template <typename LookupStrategy>
 class ModuleNameLookup {
-  /// The usable results of a lookup in a particular module may differ based on
-  /// where the lookup is happening.
-  using ModuleLookupCacheKey = std::pair<ModuleDecl::ImportedModule,
-                                         const DeclContext * /*lookupScope*/>;
-  using ModuleLookupCache = llvm::SmallDenseMap<ModuleLookupCacheKey,
-                                                TinyPtrVector<ValueDecl *>, 32>;
-
-  ModuleLookupCache cache;
+  ASTContext &ctx;
   const ResolutionKind resolutionKind;
   const bool respectAccessControl;
 
@@ -46,43 +38,10 @@ class ModuleNameLookup {
     return static_cast<LookupStrategy *>(this);
   }
 
-  /// After finding decls by name lookup, filter based on the given
-  /// resolution kind and add them to \p results.
-  ///
-  /// \returns true if lookup is (locally) complete and does not need to recurse
-  /// further.
-  bool recordImportDecls(
-      SmallVectorImpl<ValueDecl *> &results,
-      ArrayRef<ValueDecl *> newDecls);
-
-  /// Given a list of imports and an access path to limit by, perform a lookup
-  /// into each of them and record the results in \p decls, filtering based on
-  /// the given resolution kind.
-  void collectLookupResultsFromImports(
-      SmallVectorImpl<ValueDecl *> &decls,
-      ArrayRef<ModuleDecl::ImportedModule> imports,
-      ModuleDecl::AccessPathTy accessPath,
-      const DeclContext *moduleScopeContext);
-
-  /// Performs a qualified lookup into the given module and, if necessary, its
-  /// reexports. The lookup into \p module itself will not check or update the
-  /// lookup cache.
-  ///
-  /// The results are appended to \p decls.
-  ///
-  /// \returns The slice of \p decls that includes the newly-found
-  /// declarations.
-  ///
-  /// \see lookupInModule
-  ArrayRef<ValueDecl *> lookupInModuleUncached(
-      SmallVectorImpl<ValueDecl *> &decls,
-      ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-      const DeclContext *moduleScopeContext,
-      ArrayRef<ModuleDecl::ImportedModule> extraImports);
-
 public:
   ModuleNameLookup(ASTContext &ctx, ResolutionKind resolutionKind)
-      : resolutionKind(resolutionKind),
+      : ctx(ctx),
+        resolutionKind(resolutionKind),
         respectAccessControl(!ctx.isAccessControlDisabled()) {}
 
   /// Performs a qualified lookup into the given module and, if necessary, its
@@ -90,9 +49,9 @@ public:
   ///
   /// The results are appended to \p decls.
   void lookupInModule(SmallVectorImpl<ValueDecl *> &decls,
-                      ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-                      const DeclContext *moduleScopeContext,
-                      ArrayRef<ModuleDecl::ImportedModule> extraImports = {});
+                      const DeclContext *moduleOrFile,
+                      ModuleDecl::AccessPathTy accessPath,
+                      const DeclContext *moduleScopeContext);
 };
 
 
@@ -101,7 +60,6 @@ public:
 class LookupByName : public ModuleNameLookup<LookupByName> {
   using Super = ModuleNameLookup<LookupByName>;
   friend Super;
-  friend class LookupVisibleDecls;
 
   const DeclName name;
   const NLKind lookupKind;
@@ -156,141 +114,97 @@ private:
 } // end anonymous namespace
 
 template <typename LookupStrategy>
-bool ModuleNameLookup<LookupStrategy>::recordImportDecls(
-    SmallVectorImpl<ValueDecl *> &results,
-    ArrayRef<ValueDecl *> newDecls) {
-
-  results.append(newDecls.begin(), newDecls.end());
-
-  if (resolutionKind == ResolutionKind::Overloadable) {
-    // If we only found top-level functions, keep looking, since we may
-    // find additional overloads.
-    if (llvm::all_of(newDecls,
-                     [](ValueDecl *VD) { return isa<FuncDecl>(VD); }))
-      return false;
-  }
-
-  return !newDecls.empty() && getDerived()->canReturnEarly();
-}
-
-template <typename LookupStrategy>
-void ModuleNameLookup<LookupStrategy>::collectLookupResultsFromImports(
+void ModuleNameLookup<LookupStrategy>::lookupInModule(
     SmallVectorImpl<ValueDecl *> &decls,
-    ArrayRef<ModuleDecl::ImportedModule> reexports,
+    const DeclContext *moduleOrFile,
     ModuleDecl::AccessPathTy accessPath,
     const DeclContext *moduleScopeContext) {
+  assert(moduleOrFile->isModuleScopeContext());
 
-  SmallVector<ValueDecl *, 8> localDecls;
-  for (auto next : reexports) {
-    // Filter any whole-module imports, and skip specific-decl imports if the
-    // import path doesn't match exactly.
-    ModuleDecl::AccessPathTy combinedAccessPath;
-    if (accessPath.empty()) {
-      combinedAccessPath = next.first;
-    } else if (!next.first.empty() &&
-               !ModuleDecl::isSameAccessPath(next.first, accessPath)) {
-      // If we ever allow importing non-top-level decls, it's possible the
-      // rule above isn't what we want.
-      assert(next.first.size() == 1 && "import of non-top-level decl");
-      continue;
-    } else {
-      combinedAccessPath = accessPath;
-    }
-
-    lookupInModule(localDecls, next.second, combinedAccessPath,
-                   moduleScopeContext);
-  }
-
-  (void) recordImportDecls(decls, localDecls);
-}
-
-template <typename LookupStrategy>
-ArrayRef<ValueDecl *> ModuleNameLookup<LookupStrategy>::lookupInModuleUncached(
-    SmallVectorImpl<ValueDecl *> &decls,
-    ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-    const DeclContext *moduleScopeContext,
-    ArrayRef<ModuleDecl::ImportedModule> extraImports) {
-
-  // Do the lookup.
-  SmallVector<ValueDecl *, 4> localDecls;
-  getDerived()->doLocalLookup(module, accessPath, localDecls);
-
-  llvm::erase_if(localDecls, [=](ValueDecl *VD) {
-    if (resolutionKind == ResolutionKind::TypesOnly && !isa<TypeDecl>(VD))
-      return true;
-    if (respectAccessControl && !VD->isAccessibleFrom(moduleScopeContext))
-      return true;
-    return false;
-  });
-
-  // Record the decls by overload signature.
   const size_t initialCount = decls.size();
-  const bool canReturnEarly = recordImportDecls(decls, localDecls);
+  size_t currentCount = decls.size();
+
+  auto updateNewDecls = [&](const DeclContext *moduleScopeContext) {
+    if (decls.size() == currentCount)
+      return;
+
+    auto newEnd = std::remove_if(
+      decls.begin() + currentCount, decls.end(),
+      [&](ValueDecl *VD) {
+        if (resolutionKind == ResolutionKind::TypesOnly && !isa<TypeDecl>(VD))
+          return true;
+        if (respectAccessControl && !VD->isAccessibleFrom(moduleScopeContext))
+          return true;
+        return false;
+      });
+    decls.erase(newEnd, decls.end());
+
+    currentCount = decls.size();
+  };
+
+  // Do the lookup into the current module.
+  auto *module = moduleOrFile->getParentModule();
+  getDerived()->doLocalLookup(module, accessPath, decls);
+  updateNewDecls(moduleScopeContext);
+
+  bool canReturnEarly = (initialCount != decls.size() &&
+                         getDerived()->canReturnEarly());
+  if (canReturnEarly &&
+      resolutionKind == ResolutionKind::Overloadable) {
+    // If we only found top-level functions, keep looking, since we may
+    // find additional overloads.
+    if (std::find_if(decls.begin() + initialCount, decls.end(),
+                     [](ValueDecl *VD) { return !isa<FuncDecl>(VD); })
+        == decls.end())
+      canReturnEarly = false;
+  }
 
   // If needed, search for decls in re-exported modules as well.
   if (!canReturnEarly) {
-    SmallVector<ModuleDecl::ImportedModule, 8> reexports;
-    module->getImportedModulesForLookup(reexports);
-    assert(llvm::none_of(reexports,
-                         [module](ModuleDecl::ImportedModule import) -> bool {
-                           return import.second == nullptr || import.second == module;
-                         }));
-    reexports.append(extraImports.begin(), extraImports.end());
+    auto &imports = ctx.getImportCache().getImportSet(moduleOrFile);
 
-    // Special treatment based on the use site only applies to immediate
-    // imports of the top-level module.
-    // FIXME: It ought to apply to anything re-exported by those immediate
-    // imports as well, since re-exports are supposed to be treated like part of
-    // the module they're re-exported from.
-    const DeclContext *moduleScopeContextForReexports = moduleScopeContext;
-    if (moduleScopeContext && moduleScopeContext->getParentModule() != module)
-      moduleScopeContextForReexports = nullptr;
+    auto visitImport = [&](ModuleDecl::ImportedModule import,
+                           const DeclContext *moduleScopeContext) {
+      if (import.first.empty())
+        import.first = accessPath;
+      else if (!accessPath.empty() &&
+               !ModuleDecl::isSameAccessPath(import.first, accessPath))
+        return;
 
-    collectLookupResultsFromImports(decls, reexports, accessPath,
-                                    moduleScopeContextForReexports);
+      getDerived()->doLocalLookup(import.second, import.first, decls);
+      updateNewDecls(moduleScopeContext);
+    };
+
+    // FIXME: If we don't visit transitive imports first, a couple of
+    // bridging header tests fail because looking something up in a
+    // "normal" Clang module before looking up in the bridging header
+    // module can fail. Investigate why.
+    for (auto import : imports.getTransitiveImports()) {
+      visitImport(import, nullptr);
+    }
+
+    for (auto import : imports.getTopLevelImports()) {
+      // A module appears in its own top-level import list; since we checked
+      // it already, skip it.
+      if (import.second == module)
+        continue;
+
+      visitImport(import, moduleScopeContext);
+    }
   }
 
+  // Nothing more to do if we don't have ambiguous results.
+  if (decls.size() - initialCount <= 1)
+    return;
+
   // Remove duplicated declarations, which can happen when the same module is
-  // imported indirectly through two intermediate modules.
+  // imported with multiple access paths.
   llvm::SmallPtrSet<ValueDecl *, 4> knownDecls;
   decls.erase(std::remove_if(decls.begin() + initialCount, decls.end(),
                              [&](ValueDecl *d) -> bool {
                                return !knownDecls.insert(d).second;
                              }),
               decls.end());
-
-  return llvm::makeArrayRef(decls).slice(initialCount);
-}
-
-template <typename LookupStrategy>
-void ModuleNameLookup<LookupStrategy>::lookupInModule(
-    SmallVectorImpl<ValueDecl *> &decls,
-    ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
-    const DeclContext *moduleScopeContext,
-    ArrayRef<ModuleDecl::ImportedModule> extraImports) {
-  assert(module);
-  assert(llvm::none_of(extraImports,
-                       [](ModuleDecl::ImportedModule import) -> bool {
-    return import.second == nullptr;
-  }));
-
-  const ModuleDecl::ImportedModule import{accessPath, module};
-  const ModuleLookupCacheKey cacheKey{import, moduleScopeContext};
-
-  {
-    // Explicitly scope the cache lookup here, because the iterator won't be
-    // valid after we do all the work to populate the cache.
-    const auto iter = cache.find(cacheKey);
-    if (iter != cache.end()) {
-      decls.append(iter->second.begin(), iter->second.end());
-      return;
-    }
-  }
-
-  const ArrayRef<ValueDecl *> lookupResults =
-      lookupInModuleUncached(decls, module, accessPath, moduleScopeContext,
-                             extraImports);
-  cache.try_emplace(cacheKey, lookupResults);
 }
 
 void namelookup::lookupInModule(const DeclContext *moduleOrFile,
@@ -302,26 +216,16 @@ void namelookup::lookupInModule(const DeclContext *moduleOrFile,
                                 const DeclContext *moduleScopeContext) {
   assert(moduleScopeContext->isModuleScopeContext());
 
-  auto *startModule = moduleOrFile->getParentModule();
-  auto &ctx = startModule->getASTContext();
+  auto &ctx = moduleOrFile->getASTContext();
   auto *stats = ctx.Stats;
   if (stats)
     stats->getFrontendCounters().NumLookupInModule++;
 
   FrontendStatsTracer tracer(stats, "lookup-in-module");
 
-  // Add private imports to the extra search list.
-  SmallVector<ModuleDecl::ImportedModule, 8> extraImports;
-  if (auto *file = dyn_cast<FileUnit>(moduleOrFile)) {
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    file->getImportedModules(extraImports, importFilter);
-  }
-
   LookupByName lookup(ctx, resolutionKind, name, lookupKind);
-  lookup.lookupInModule(decls, startModule, topAccessPath, moduleScopeContext,
-                        extraImports);
+  lookup.lookupInModule(decls, moduleOrFile, topAccessPath,
+                        moduleScopeContext);
 }
 
 void namelookup::lookupVisibleDeclsInModule(
@@ -332,21 +236,8 @@ void namelookup::lookupVisibleDeclsInModule(
     ResolutionKind resolutionKind,
     const DeclContext *moduleScopeContext) {
   assert(moduleScopeContext->isModuleScopeContext());
-
-  auto *startModule = moduleOrFile->getParentModule();
-  auto &ctx = startModule->getASTContext();
-
-  // Add private imports to the extra search list.
-  SmallVector<ModuleDecl::ImportedModule, 8> extraImports;
-  if (auto *file = dyn_cast<FileUnit>(moduleOrFile)) {
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    file->getImportedModules(extraImports, importFilter);
-  }
-
+  auto &ctx = moduleOrFile->getASTContext();
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
-  lookup.lookupInModule(decls, startModule, accessPath, moduleScopeContext,
-                        extraImports);
+  lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext);
 }
 

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -180,10 +180,7 @@ void ModuleNameLookup<LookupStrategy>::collectLookupResultsFromImports(
     ModuleDecl::AccessPathTy accessPath,
     const DeclContext *moduleScopeContext) {
 
-  // Prefer scoped imports (those importing a specific name from a module, like
-  // `import func Swift.max`) to whole-module imports.
-  SmallVector<ValueDecl *, 8> unscopedValues;
-  SmallVector<ValueDecl *, 8> scopedValues;
+  SmallVector<ValueDecl *, 8> localDecls;
   for (auto next : reexports) {
     // Filter any whole-module imports, and skip specific-decl imports if the
     // import path doesn't match exactly.
@@ -200,16 +197,11 @@ void ModuleNameLookup<LookupStrategy>::collectLookupResultsFromImports(
       combinedAccessPath = accessPath;
     }
 
-    auto &resultSet = next.first.empty() ? unscopedValues : scopedValues;
-    lookupInModule(resultSet, next.second, combinedAccessPath,
+    lookupInModule(localDecls, next.second, combinedAccessPath,
                    moduleScopeContext);
   }
 
-  // Add the results from scoped imports, then the results from unscoped
-  // imports if needed.
-  const bool canReturnEarly = recordImportDecls(decls, scopedValues);
-  if (!canReturnEarly)
-    (void)recordImportDecls(decls, unscopedValues);
+  (void) recordImportDecls(decls, localDecls);
 }
 
 template <typename LookupStrategy>

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -190,7 +190,6 @@ static void recordShadowedDeclsAfterSignatureMatch(
   for (unsigned firstIdx : indices(decls)) {
     auto firstDecl = decls[firstIdx];
     auto firstModule = firstDecl->getModuleContext();
-    auto firstSig = firstDecl->getOverloadSignature();
     for (unsigned secondIdx : range(firstIdx + 1, decls.size())) {
       // Determine whether one module takes precedence over another.
       auto secondDecl = decls[secondIdx];
@@ -203,6 +202,7 @@ static void recordShadowedDeclsAfterSignatureMatch(
       // used the null type.
       if (!ctx.isSwiftVersionAtLeast(5)) {
         auto secondSig = secondDecl->getOverloadSignature();
+        auto firstSig = firstDecl->getOverloadSignature();
         if (firstSig.IsVariable && secondSig.IsVariable)
           if (firstSig.InExtensionOfGenericType !=
               secondSig.InExtensionOfGenericType)

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1644,12 +1644,6 @@ bool DeclContext::lookupQualified(ModuleDecl *module, DeclName member,
     }
   }
 
-  llvm::SmallPtrSet<ValueDecl *, 4> knownDecls;
-  decls.erase(std::remove_if(decls.begin(), decls.end(),
-                             [&](ValueDecl *vd) -> bool {
-    return !knownDecls.insert(vd).second;
-  }), decls.end());
-
   pruneLookupResultSet(this, options, decls);
 
   if (auto *debugClient = this->getParentModule()->getDebugClient()) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1706,9 +1706,9 @@ bool DeclContext::lookupAnyObject(DeclName member, NLOptions options,
 
   // Collect all of the visible declarations.
   SmallVector<ValueDecl *, 4> allDecls;
-  forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(this)) {
     import.second->lookupClassMember(import.first, member, allDecls);
-  });
+  }
 
   // For each declaration whose context is not something we've
   // already visited above, add it to the list of declarations.
@@ -1750,9 +1750,9 @@ void DeclContext::lookupAllObjCMethods(
        ObjCSelector selector,
        SmallVectorImpl<AbstractFunctionDecl *> &results) const {
   // Collect all of the methods with this selector.
-  forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(this)) {
     import.second->lookupObjCMethods(selector, results);
-  });
+  }
 
   // Filter out duplicates.
   llvm::SmallPtrSet<AbstractFunctionDecl *, 8> visited;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -206,6 +206,17 @@ static void recordShadowedDeclsAfterSignatureMatch(
       if (firstModule != secondModule &&
           firstDecl->getDeclContext()->isModuleScopeContext() &&
           secondDecl->getDeclContext()->isModuleScopeContext()) {
+        // First, scoped imports shadow unscoped imports.
+        bool firstScoped = imports.isScopedImport(firstModule, name, dc);
+        bool secondScoped = imports.isScopedImport(secondModule, name, dc);
+        if (!firstScoped && secondScoped) {
+          shadowed.insert(firstDecl);
+          break;
+        } else if (firstScoped && !secondScoped) {
+          shadowed.insert(secondDecl);
+          continue;
+        }
+
         // Now check if one module shadows the other.
         if (imports.isShadowedBy(firstModule, secondModule, name, dc)) {
           shadowed.insert(firstDecl);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -963,21 +963,12 @@ void UnqualifiedLookupFactory::recordDependencyOnTopLevelName(
 }
 
 void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
-  // Add private imports to the extra search list.
-  SmallVector<ModuleDecl::ImportedModule, 8> extraImports;
-  if (auto FU = dyn_cast<FileUnit>(dc)) {
-    ModuleDecl::ImportFilter importFilter;
-    importFilter |= ModuleDecl::ImportFilterKind::Private;
-    importFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    FU->getImportedModules(extraImports, importFilter);
-  }
-
   using namespace namelookup;
   SmallVector<ValueDecl *, 8> CurModuleResults;
   auto resolutionKind = isOriginallyTypeLookup ? ResolutionKind::TypesOnly
                                                : ResolutionKind::Overloadable;
-  lookupInModule(&M, {}, Name, CurModuleResults, NLKind::UnqualifiedLookup,
-                 resolutionKind, dc, extraImports);
+  lookupInModule(dc, {}, Name, CurModuleResults, NLKind::UnqualifiedLookup,
+                 resolutionKind, dc);
 
   // Always perform name shadowing for type lookup.
   if (options.contains(Flags::TypeLookup)) {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -980,7 +980,7 @@ void UnqualifiedLookupFactory::addImportedResults(DeclContext *const dc) {
 
   // Always perform name shadowing for type lookup.
   if (options.contains(Flags::TypeLookup)) {
-    removeShadowedDecls(CurModuleResults, &M);
+    removeShadowedDecls(CurModuleResults, dc);
   }
 
   for (auto VD : CurModuleResults) {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleNameLookup.h"
@@ -1021,17 +1022,14 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   if (!desiredModule && Name == Ctx.TheBuiltinModule->getName())
     desiredModule = Ctx.TheBuiltinModule;
   if (desiredModule) {
-    forAllVisibleModules(
-        dc, [&](const ModuleDecl::ImportedModule &import) -> bool {
-          if (import.second == desiredModule) {
-            Results.push_back(LookupResultEntry(import.second));
+    // Make sure the desired module is actually visible from the current
+    // context.
+    if (Ctx.getImportCache().isImportedBy(desiredModule, dc)) {
+      Results.push_back(LookupResultEntry(desiredModule));
 #ifndef NDEBUG
-            addedResult(Results.back());
+      addedResult(Results.back());
 #endif
-            return false;
-          }
-          return true;
-        });
+    }
   }
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/LinkLibrary.h"
 #include "swift/AST/Module.h"
@@ -1684,7 +1685,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
       // FIXME: This forces the creation of wrapper modules for all imports as
       // well, and may do unnecessary work.
       cacheEntry.setInt(true);
-      result->forAllVisibleModules({}, [&](ModuleDecl::ImportedModule import) {});
+      (void) namelookup::getAllImports(result);
     }
   } else {
     // Build the representation of the Clang module in Swift.
@@ -1704,7 +1705,7 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     // Force load overlays for all imported modules.
     // FIXME: This forces the creation of wrapper modules for all imports as
     // well, and may do unnecessary work.
-    result->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {});
+    (void) namelookup::getAllImports(result);
   }
 
   if (clangModule->isSubModule()) {

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImporterImpl.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Module.h"
 
 using namespace swift;
@@ -118,7 +119,7 @@ ModuleDecl *ClangImporter::Implementation::loadModuleDWARF(
   decl->addFile(*wrapperUnit);
 
   // Force load overlay modules for all imported modules.
-  decl->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {});
+  (void) namelookup::getAllImports(decl);
 
   // Register the module with the ASTContext so it is available for lookups.
   ModuleDecl *&loaded = SwiftContext.LoadedModules[name];

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -226,7 +226,7 @@ static void doGlobalExtensionLookup(Type BaseType,
   }
 
   // Handle shadowing.
-  removeShadowedDecls(FoundDecls, CurrDC->getParentModule());
+  removeShadowedDecls(FoundDecls, CurrDC);
 }
 
 /// Enumerate immediate members of the type \c LookupType and its

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/GenericSignatureBuilder.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ModuleNameLookup.h"
@@ -364,10 +365,9 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
 
   DynamicLookupConsumer ConsumerWrapper(Consumer, LS, CurrDC);
 
-  CurrDC->getParentSourceFile()->forAllVisibleModules(
-      [&](ModuleDecl::ImportedModule Import) {
-        Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
-      });
+  for (auto Import : namelookup::getAllImports(CurrDC)) {
+    Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
+  }
 }
 
 namespace {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/StringExtras.h"
@@ -1795,10 +1796,12 @@ void swift::diagnoseAttrsRequiringFoundation(SourceFile &SF) {
       return;
   }
 
-  SF.forAllVisibleModules([&](ModuleDecl::ImportedModule import) {
-    if (import.second->getName() == Ctx.Id_Foundation)
+  for (auto import : namelookup::getAllImports(&SF)) {
+    if (import.second->getName() == Ctx.Id_Foundation) {
       ImportsFoundationModule = true;
-  });
+      break;
+    }
+  }
 
   if (ImportsFoundationModule)
     return;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -97,8 +97,8 @@ namespace {
       removeOverriddenDecls(FoundOuterDecls);
 
       // Remove any shadowed declarations from the found-declarations set.
-      removeShadowedDecls(FoundDecls, DC->getParentModule());
-      removeShadowedDecls(FoundOuterDecls, DC->getParentModule());
+      removeShadowedDecls(FoundDecls, DC);
+      removeShadowedDecls(FoundOuterDecls, DC);
 
       // Filter out those results that have been removed from the
       // found-declarations set.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/NameLookup.h"
@@ -249,7 +250,7 @@ static void bindExtensions(SourceFile &SF) {
 
   // FIXME: The current source file needs to be handled specially, because of
   // private extensions.
-  SF.forAllVisibleModules([&](ModuleDecl::ImportedModule import) {
+  for (auto import : namelookup::getAllImports(&SF)) {
     // FIXME: Respect the access path?
     for (auto file : import.second->getFiles()) {
       auto SF = dyn_cast<SourceFile>(file);
@@ -262,7 +263,7 @@ static void bindExtensions(SourceFile &SF) {
             worklist.push_back(ED);
       }
     }
-  });
+  }
 
   // Phase 2 - repeatedly go through the worklist and attempt to bind each
   // extension there, removing it from the worklist if we succeed.

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -28,10 +28,8 @@
 #if canImport(CoreGraphics)
   let square = CGRect(x: 100, y: 100, width: 100, height: 100)
   // expected-error@-1 {{use of unresolved identifier 'CGRect'}}
-  // expected-note@-2 {{'square' declared here}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
-  // expected-error@-1 {{ambiguous use of 'square'}}
 #endif
 
 #if canImport(MixedWithHeader)

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -37,7 +37,7 @@ localVar(42)  // expected-error {{cannot call value of non-function type 'Bool'}
 var _ : localVar // should still work
 
 _ = scopedVar // no-warning
-scopedVar(42) // expected-error {{cannot call value of non-function type 'Int'}}
+scopedVar(42)
 
 var _ : Bool = scopedFunction(true)
 var _ : Int  = scopedFunction(42)

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -2,7 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_intFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_boolFunctions.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify
+// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s -I %t -sdk "" -verify -swift-version 5
 
 // RUN: not %target-swift-frontend -dump-ast %s -I %t -sdk "" > %t.astdump
 // RUN: %FileCheck %s < %t.astdump
@@ -14,15 +15,15 @@ import var overload_vars.scopedVar
 import func overload_boolFunctions.scopedFunction
 
 struct LocalType {}
-func something(_ obj: LocalType) -> LocalType { return obj } // expected-note {{found this candidate}}
-func something(_ a: Int, _ b: Int, _ c: Int) -> () {} // expected-note {{found this candidate}}
+func something(_ obj: LocalType) -> LocalType { return obj }
+func something(_ a: Int, _ b: Int, _ c: Int) -> () {}
 
 var _ : Bool = something(true)
 var _ : Int = something(1)
 var _ : (Int, Int) = something(1, 2)
 var _ : LocalType = something(LocalType())
 var _ : () = something(1, 2, 3)
-something = 42 // expected-error {{ambiguous reference to member 'something'}}
+something = 42
 
 let ambValue = ambiguousWithVar // no-warning - var preferred
 let ambValueChecked: Int = ambValue
@@ -40,7 +41,7 @@ scopedVar(42) // expected-error {{cannot call value of non-function type 'Int'}}
 
 var _ : Bool = scopedFunction(true)
 var _ : Int  = scopedFunction(42)
-scopedFunction = 42 // expected-error {{ambiguous reference to member 'scopedFunction'}}
+scopedFunction = 42
 
 // FIXME: Should be an error -- a type name and a function cannot overload.
 var _ : Int = TypeNameWins(42)

--- a/test/NameBinding/import-resolution.swift
+++ b/test/NameBinding/import-resolution.swift
@@ -32,8 +32,8 @@ letters.asdf.A // expected-error{{module 'letters' has no member named 'asdf'}}
 var uA : A // expected-error {{'A' is ambiguous for type lookup in this context}}
 var uB : B = abcde.B()
 var uC : C // expected-error {{'C' is ambiguous for type lookup in this context}}
-var uD : D // expected-error {{'D' is ambiguous for type lookup in this context}}
-var uE : E // expected-error {{'E' is ambiguous for type lookup in this context}}
+var uD : D = asdf.D()
+var uE : E = aeiou.E()
 var uF : F = letters.F()
 
 var qA1 : abcde.A // okay

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -14,13 +14,14 @@
 #include "ModuleAPIDiff.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ImportCache.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/RawComment.h"
 #include "swift/AST/USRGeneration.h"
@@ -2665,7 +2666,7 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
     }
 
     SmallVector<ModuleDecl::ImportedModule, 16> scratch;
-    M->forAllVisibleModules({}, [&](const ModuleDecl::ImportedModule &next) {
+    for (auto next : namelookup::getAllImports(M)) {
       llvm::outs() << next.second->getName();
       if (next.second->isClangModule())
         llvm::outs() << " (Clang)";
@@ -2684,7 +2685,7 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
           llvm::outs() << " (Clang)";
         llvm::outs() << "\n";
       }
-    });
+    }
   }
 
   return ExitCode;


### PR DESCRIPTION
Builds on https://github.com/apple/swift/pull/26865. Completely eliminates the various forms of forAllVisibleModules() in favor of usage of the ImportCache.