### PR TITLE
[5.1] [Constraint solver] Cope with circular inheritance.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1554,11 +1554,18 @@ ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
 
   auto classDecl2 = type2->getClassOrBoundGenericClass();
+  SmallPtrSet<ClassDecl *, 4> superclasses1;
   for (auto super1 = type1->getSuperclass();
        super1;
        super1 = super1->getSuperclass()) {
-    if (super1->getClassOrBoundGenericClass() != classDecl2)
+    auto superclass1 = super1->getClassOrBoundGenericClass();
+    if (superclass1 != classDecl2) {
+      // Break if we have circular inheritance.
+      if (superclass1 && !superclasses1.insert(superclass1).second)
+        break;
+
       continue;
+    }
 
     return matchTypes(super1, type2, ConstraintKind::Bind,
                       subflags, locator);

--- a/test/decl/class/circular_inheritance_2.swift
+++ b/test/decl/class/circular_inheritance_2.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://problem/54296278 - infinite loop
+class Foo {}
+class Bar: Bar {} // expected-error{{'Bar' inherits from itself}}
+func foo(_ o: AnyObject) -> Foo? {
+    return o as? Bar // expected-error{{cannot convert return expression of type 'Bar?' to return type 'Foo?'}}
+}


### PR DESCRIPTION
This loop in the constraint solver won't terminate when given
ill-formed code involving circular inheritance. Make it
terminate. Fixes rdar://problem/54296278.
