### PR TITLE
Conditionalize KVOKeyPaths tests that only work with Swift 5.1 (2)

### DIFF
--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -214,7 +214,7 @@ let optionalKeyPathObserver = testObjectForOptionalKeyPath.observe(\.optionalObj
 testObjectForOptionalKeyPath.optionalObject = nil
 testObjectForOptionalKeyPath.optionalObject = "foo"
 
-// CHECK-LABEL: observe keyPath with optional value
-// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
-// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
-// CHECK-NEXT: oldValue = Optional(nil), newValue = Optional(Optional("foo"))
+// CHECK-51-LABEL: observe keyPath with optional value
+// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(Optional("foo"))


### PR DESCRIPTION
This test was added in f34ef5d for a fix in 5.1 and is going to fail in 5.0

rdar://54754307