### PR TITLE
[Parser] Add source range test for function types

### DIFF
--- a/test/Parse/function_type_range.swift
+++ b/test/Parse/function_type_range.swift
@@ -1,0 +1,4 @@
+// Ensure that source range for the type does not go past the end of the buffer.
+// RUN: %target-swift-frontend -typecheck %s -parse-stdlib  -dump-ast
+typealias KeyPathComputedArgumentLayoutFn =
+() -> Int


### PR DESCRIPTION
A recent PR (which will be reverted before this one lands) caused the source range of a function type to extend past the end of the source. This PR adds a test to ensure that such a mistake does not sneak back into the compiler.
