### PR TITLE
[test] Add a quick test for NSEvent.SpecialKey.deleteForward’s rawValue

### DIFF
--- a/test/stdlib/NSEvent.swift
+++ b/test/stdlib/NSEvent.swift
@@ -16,6 +16,13 @@ func testSpecialKey(_ specialKey: NSEvent.SpecialKey, rawValue: Int) {
 
 NSEventTests.test("NSEvent.specialKey") {
     testSpecialKey(NSEvent.SpecialKey.upArrow, rawValue: 0xF700)
+
+    if #available(macOS 9999, *) {
+        // NSEvent.SpecialKey.deleteForward used to have the wrong rawValue in
+        // macOS 10.15 and below. See https://github.com/apple/swift/pull/26853
+        // (rdar://54725550).
+        testSpecialKey(NSEvent.SpecialKey.deleteForward, rawValue: 0xF728)
+    }
 }
 
 runAllTests()


### PR DESCRIPTION
This is a followup to #26853, dropping in a quick test for the correct rawValue.

rdar://54725550