### PR TITLE
[test] Disable misaligned indices test prior to 5.1

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -268,6 +268,14 @@ public func _isStdlibDebugConfiguration() -> Bool {
 #endif
 }
 
+// Return true if the Swift runtime available is at least 5.1
+public func _hasSwift_5_1() -> Bool {
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    return true
+  }
+  return false
+}
+
 @frozen
 public struct LinearCongruentialGenerator: RandomNumberGenerator {
 

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -242,6 +242,9 @@ StringIndexTests.test("String.Index(_:within) / Range<String.Index>(_:in:)") {
 }
 
 StringIndexTests.test("Misaligned") {
+  // Misaligned indices were fixed in 5.1
+  guard _hasSwift_5_1() else { return }
+
   func doIt(_ str: String) {
     let characterIndices = Array(str.indices)
     let scalarIndices = Array(str.unicodeScalars.indices) + [str.endIndex]

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -220,13 +220,6 @@ StringTests.test("Index/Hashable") {
   expectTrue(t.contains(s.startIndex))
 }
 
-var Swift_5_1_Available: Bool {
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-    return true
-  }
-  return false
-}
-
 StringTests.test("ForeignIndexes/Valid") {
   // It is actually unclear what the correct behavior is.  This test is just a
   // change detector.
@@ -247,7 +240,7 @@ StringTests.test("ForeignIndexes/Valid") {
 
     // Scalar alignment fixes and checks were added in 5.1, so we don't get the
     // expected behavior on prior runtimes.
-    guard Swift_5_1_Available else { return }
+    guard _hasSwift_5_1() else { return }
 
     // Donor's second index is scalar-aligned in donor, but not acceptor. This
     // will trigger a stdlib assertion.
@@ -270,7 +263,7 @@ StringTests.test("ForeignIndexes/UnexpectedCrash") {
 
   // Grapheme stride cache under noop scalar alignment was fixed in 5.1, so we
   // get a different answer prior.
-  guard Swift_5_1_Available else { return }
+  guard _hasSwift_5_1() else { return }
 
   // `start` has a cached stride greater than 1, so subscript will trigger an
   // assertion when it makes a multi-grapheme-cluster Character.

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -821,6 +821,9 @@ tests.test("String View Setters") {
 }
 
 tests.test("Scalar alignment") {
+  // Misaligned indices were fixed in 5.1
+  guard _hasSwift_5_1() else { return }
+
   let str = "😀"
   let idx = str.utf8.index(after: str.startIndex)
   let substr = str[idx...]


### PR DESCRIPTION
Misaligned indices were fixed in 5.1, but we should disable the test
when testing back deployment.

Adds a shared helper to StdlibUnittest for the run time check.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

rdar://problem/54754306
rdar://problem/54754302
