### PR TITLE
[test] Denineninenineninify behavioral tests added for 5.1

### DIFF
--- a/validation-test/Evolution/Inputs/opaque_archetypes_change_underlying_type.swift
+++ b/validation-test/Evolution/Inputs/opaque_archetypes_change_underlying_type.swift
@@ -19,7 +19,7 @@ public struct Pair : P {
 }
 #endif
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func resilientFunction() -> some P {
 #if BEFORE
   return Int(5)
@@ -28,12 +28,12 @@ public func resilientFunction() -> some P {
 #endif
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func expectedResult() -> Int {
   return resilientFunction().getValue()
 }
 
-@available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func expectedSize() -> Int {
   return MemoryLayout.size(ofValue: resilientFunction())
 }
@@ -42,7 +42,7 @@ public func expectedSize() -> Int {
 public struct Container {
   public init() {}
 
-  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public var property : some P {
     get {
 #if BEFORE
@@ -53,12 +53,12 @@ public struct Container {
     }
   }
 
-  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public func expectedResult() -> Int {
     return property.getValue()
   }
 
-  @available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *)
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public func expectedSize() -> Int {
     return MemoryLayout.size(ofValue: property)
   }

--- a/validation-test/Evolution/test_opaque_archetypes_change_underlying_type.swift
+++ b/validation-test/Evolution/test_opaque_archetypes_change_underlying_type.swift
@@ -7,7 +7,7 @@ import StdlibUnittest
 var OpaqueArchetypes = TestSuite("OpaqueArchetypes")
 
 OpaqueArchetypes.test("test1") {
-  if #available(iOS 9999, macOS 9999, tvOS 9999, watchOS 9999, *) {
+  if #available(macOS 15.0, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
     let o = resilientFunction()
     expectEqual(o.getValue(), expectedResult())
     expectEqual(MemoryLayout.size(ofValue: o), expectedSize())

--- a/validation-test/Reflection/existentials_objc.swift
+++ b/validation-test/Reflection/existentials_objc.swift
@@ -16,7 +16,7 @@ import Foundation
 
 import SwiftReflectionTest
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // Imported class wrapped in AnyObject
 
   // CHECK: Type reference:

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3000,7 +3000,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
-  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  if #available(macOS 15.0, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
     // Identity of empty dictionaries changed in
     // https://github.com/apple/swift/pull/22527
     var d = getBridgedNonverbatimDictionary([:])
@@ -3295,7 +3295,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 }
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+  guard #available(macOS 15.0, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
     // Identity of empty dictionaries changed in
     // https://github.com/apple/swift/pull/22527
     return

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1976,7 +1976,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
-  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  if #available(macOS 15.0, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
     // Identity of empty sets changed in https://github.com/apple/swift/pull/22527
     var s = getBridgedNonverbatimSet([])
     expectTrue(isNativeSet(s))
@@ -2168,7 +2168,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+  guard #available(macOS 15.0, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else {
     // Identity of empty sets changed in https://github.com/apple/swift/pull/22527
     return
   }
@@ -4667,7 +4667,7 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
 }
 
 #if _runtime(_ObjC)
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
   .skip(.custom(
@@ -4690,7 +4690,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
   .skip(.custom(
@@ -4822,7 +4822,7 @@ SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
   .skip(.custom(
@@ -4846,7 +4846,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
   .skip(.custom(
@@ -4871,7 +4871,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
   // https://github.com/apple/swift/pull/23683
   SetTestSuite.test("Upcast.StringEqualityMismatch") {
     // Upcasting from NSString to String keys changes their concept of equality,


### PR DESCRIPTION
Tests that check for stdlib/runtime behavior that changes between Swift 5.0 and the libraries that ship alongside Swift 5.1 need to check for the actual OS versions that contain those libraries.

rdar://problem/54735384