### PR TITLE
 [tensorflow-merge] fix differentiable attribute typechecking

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3189,6 +3189,9 @@ static bool checkTransposingParameters(
 
 // SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
+  if (attr->isImplicit())
+    return;
+
   auto &ctx = TC.Context;
   auto lookupConformance =
       LookUpConformanceInModule(D->getDeclContext()->getParentModule());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3189,6 +3189,9 @@ static bool checkTransposingParameters(
 
 // SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
+  // Skip checking implicit differentiable attributes, because they do not
+  // contain the WhereClause, and these checks assume that the WhereClause is
+  // available.
   if (attr->isImplicit())
     return;
 

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -43,9 +43,9 @@ func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
 struct ComputedPropertyDupeAttributes<T : Differentiable> : Differentiable {
   var value: T
 
-  @differentiable // expected-error {{duplicate '@differentiable' attribute with same parameters}}
+  @differentiable // expected-note {{other attribute declared here}}
   var computed1: T {
-    @differentiable // expected-note {{other attribute declared here}}
+    @differentiable // expected-error {{duplicate '@differentiable' attribute with same parameters}}
     get { value }
     set { value = newValue }
   }


### PR DESCRIPTION
`visitDifferentiableAttr` creates an implicit `@differentiable` on getters. This implicit attr has `Requirements` resolved, and has `WhereClause = nullptr`. Then it gets visited by `visitDifferentiableAttr`, which assumes that the where clause is in `WhereClause`. Therefore, `visitDifferentiableAttr` thinks that it's an attribute without a where clause, and it gets confused.

This PR fixes this by avoiding typechecking implicit differentiable attrs.

Also I fixed a related test where the error and note got swapped for some reason. (Still a few AutoDiff tests failing for me).