### PR TITLE
Frontend: add a front-end option to specify module names for which we prefer loading via interfaces

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -76,6 +76,9 @@ public:
   /// binary module has already been built for use by the compiler.
   std::string PrebuiltModuleCachePath;
 
+  /// For these modules, we should prefer using Swift interface when importing them.
+  std::vector<std::string> PreferInterfaceForModules;
+
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
 

--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -132,8 +132,9 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
   explicit ParseableInterfaceModuleLoader(
       ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,
       DependencyTracker *tracker, ModuleLoadingMode loadMode,
+      ArrayRef<std::string> PreferInterfaceForModules,
       bool RemarkOnRebuildFromInterface)
-  : SerializedModuleLoaderBase(ctx, tracker, loadMode),
+  : SerializedModuleLoaderBase(ctx, tracker, loadMode, PreferInterfaceForModules),
   CacheDir(cacheDir), PrebuiltCacheDir(prebuiltCacheDir),
   RemarkOnRebuildFromInterface(RemarkOnRebuildFromInterface)
   {}
@@ -154,10 +155,12 @@ public:
   static std::unique_ptr<ParseableInterfaceModuleLoader>
   create(ASTContext &ctx, StringRef cacheDir, StringRef prebuiltCacheDir,
          DependencyTracker *tracker, ModuleLoadingMode loadMode,
+         ArrayRef<std::string> PreferInterfaceForModules = {},
          bool RemarkOnRebuildFromInterface = false) {
     return std::unique_ptr<ParseableInterfaceModuleLoader>(
       new ParseableInterfaceModuleLoader(ctx, cacheDir, prebuiltCacheDir,
                                          tracker, loadMode,
+                                         PreferInterfaceForModules,
                                          RemarkOnRebuildFromInterface));
   }
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -42,8 +42,10 @@ class SerializedModuleLoaderBase : public ModuleLoader {
 protected:
   ASTContext &Ctx;
   ModuleLoadingMode LoadMode;
+  ArrayRef<std::string> PreferInterfaceForModules;
   SerializedModuleLoaderBase(ASTContext &ctx, DependencyTracker *tracker,
-                             ModuleLoadingMode LoadMode);
+                             ModuleLoadingMode LoadMode,
+                             ArrayRef<std::string> PreferInterfaceForModules = {});
 
   void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
                                              StringRef extension) const;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -373,7 +373,8 @@ bool CompilerInstance::setUpModuleLoaders() {
     StringRef PrebuiltModuleCachePath = FEOpts.PrebuiltModuleCachePath;
     auto PIML = ParseableInterfaceModuleLoader::create(
         *Context, ModuleCachePath, PrebuiltModuleCachePath,
-        getDependencyTracker(), MLM, FEOpts.RemarkOnRebuildFromModuleInterface);
+        getDependencyTracker(), MLM, FEOpts.PreferInterfaceForModules,
+        FEOpts.RemarkOnRebuildFromModuleInterface);
     Context->addModuleLoader(std::move(PIML));
   }
   Context->addModuleLoader(std::move(SML));

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -1435,11 +1435,14 @@ std::error_code ParseableInterfaceModuleLoader::findModuleFilesInDirectory(
   }
 
   // Create an instance of the Impl to do the heavy lifting.
+  auto ModuleName = ModuleID.first.str();
   ParseableInterfaceModuleLoaderImpl Impl(
-                Ctx, ModPath, InPath, ModuleID.first.str(),
+                Ctx, ModPath, InPath, ModuleName,
                 CacheDir, PrebuiltCacheDir, ModuleID.second,
                 RemarkOnRebuildFromInterface, dependencyTracker,
-                LoadMode);
+                llvm::is_contained(PreferInterfaceForModules,
+                                   ModuleName)?
+                  ModuleLoadingMode::PreferParseable : LoadMode);
 
   // Ask the impl to find us a module that we can load or give us an error
   // telling us that we couldn't load it.

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -104,8 +104,10 @@ Optional<bool> forEachModuleSearchPath(
 
 // Defined out-of-line so that we can see ~ModuleFile.
 SerializedModuleLoaderBase::SerializedModuleLoaderBase(
-    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode)
-    : ModuleLoader(tracker), Ctx(ctx), LoadMode(loadMode) {}
+    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
+    ArrayRef<std::string> PreferInterfaceForModules)
+    : ModuleLoader(tracker), Ctx(ctx), LoadMode(loadMode),
+      PreferInterfaceForModules(PreferInterfaceForModules) {}
 
 SerializedModuleLoaderBase::~SerializedModuleLoaderBase() = default;
 SerializedModuleLoader::~SerializedModuleLoader() = default;

--- a/test/api-digester/Outputs/Cake-interface-vs-binary.txt
+++ b/test/api-digester/Outputs/Cake-interface-vs-binary.txt
@@ -1,0 +1,12 @@
+cake: Func FrozenKind.__derived_enum_equals(_:_:) has been removed
+cake: Accessor GlobalLetChangedToVar.Get() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Get() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Modify() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Set() is a new API without @available attribute
+cake: Class C4 is now with @objc
+cake: Enum FrozenKind is now with @frozen
+cake: Enum IceKind is now with @frozen
+cake: Func FrozenKind.==(_:_:) is a new API without @available attribute
+cake: Var C1.CIIns1 is no longer a stored property
+cake: Var C1.CIIns2 is no longer a stored property
+cake: Var RemoveSetters.Value is no longer a stored property

--- a/test/api-digester/compare-dump-interface-vs-binary.swift
+++ b/test/api-digester/compare-dump-interface-vs-binary.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t.mod1)
+// RUN: %empty-directory(%t.mod2)
+// RUN: %empty-directory(%t.sdk)
+// RUN: %empty-directory(%t.module-cache)
+
+// Generate .swiftinterface file for module cake
+// RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+
+// Generate .swiftmodule file for module cake
+// RUN: %target-swift-frontend -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library  -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
+
+// Dump Json file for cake ABI via .swiftmodule file
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi > %t.dump1.json
+
+// Dump Json file for cake ABI via .swiftinteface file
+// RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi -use-interface-for-module cake > %t.dump2.json
+
+// Compare two Json files and we should see some differences.
+// RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json -abi -o %t.result
+
+// RUN: %clang -E -P -x c %S/Outputs/Cake-interface-vs-binary.txt -o - | sed '/^\s*$/d' > %t.expected
+// RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
+// RUN: diff -u %t.expected %t.result.tmp

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -229,6 +229,11 @@ static llvm::cl::opt<bool>
 Migrator("migrator",
          llvm::cl::desc("Dump Json suitable for generating migration script"),
          llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
+PreferInterfaceForModules("use-interface-for-module", llvm::cl::ZeroOrMore,
+                          llvm::cl::desc("Prefer loading these modules via interface"),
+                          llvm::cl::cat(Category));
 } // namespace options
 
 namespace {
@@ -2430,6 +2435,9 @@ static int prepareForDump(const char *Main,
   }
   for (auto M : options::ModuleNames) {
     Modules.insert(M);
+  }
+  for (auto M: options::PreferInterfaceForModules) {
+    InitInvok.getFrontendOptions().PreferInterfaceForModules.push_back(M);
   }
   if (Modules.empty()) {
     llvm::errs() << "Need to specify -include-all or -module <name>\n";


### PR DESCRIPTION
ABI checker imports Swift frameworks by using Swift interfaces for various
reasons. The existing way of controlling preferred importing mechanism is by
setting an environment variable (SWIFT_FORCE_MODULE_LOADING), which may lead
to performance issues because the stdlib could also be loaded in this way.

This patch adds a new front-end option to specify module names for
which we prefer importing via Swift interface. The option currently is only
accessible via swift-api-digester.

rdar://54559888
