### PR TITLE
Share SIL TypeConverters between SILModules in batch mode

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4193,10 +4193,6 @@ public:
   SILLayout *getLayout() const { return Layout; }
   SubstitutionMap getSubstitutions() const { return Substitutions; }
 
-  // In SILType.h:
-  CanType getFieldLoweredType(SILModule &M, unsigned index) const;
-  SILType getFieldType(SILModule &M, unsigned index) const;
-
   // TODO: SILBoxTypes should be explicitly constructed in terms of specific
   // layouts. As a staging mechanism, we expose the old single-boxed-type
   // interface.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -55,6 +55,10 @@ class SerializedModuleLoader;
 class MemoryBufferSerializedModuleLoader;
 class SILModule;
 
+namespace Lowering {
+class TypeConverter;
+}
+
 /// The abstract configuration of the compiler, including:
 ///   - options for all stages of translation,
 ///   - information about the build environment,
@@ -372,6 +376,7 @@ class CompilerInstance {
   SourceManager SourceMgr;
   DiagnosticEngine Diagnostics{SourceMgr};
   std::unique_ptr<ASTContext> Context;
+  std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
   std::unique_ptr<SILModule> TheSILModule;
 
   std::unique_ptr<PersistentParserState> PersistentState;
@@ -422,8 +427,6 @@ class CompilerInstance {
 
   bool isWholeModuleCompilation() { return PrimaryBufferIDs.empty(); }
 
-  void createSILModule();
-
 public:
   // Out of line to avoid having to import SILModule.h.
   CompilerInstance();
@@ -447,6 +450,10 @@ public:
 
   SILOptions &getSILOptions() { return Invocation.getSILOptions(); }
   const SILOptions &getSILOptions() const { return Invocation.getSILOptions(); }
+
+  Lowering::TypeConverter &getSILTypes();
+
+  void createSILModule();
 
   void addDiagnosticConsumer(DiagnosticConsumer *DC) {
     Diagnostics.addConsumer(*DC);

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -292,30 +292,7 @@ public:
   ///
   /// WARNING: This is not a constant time operation because it is implemented
   /// in terms of getVarDecl, which requests all BaseType's stored properties.
-  SILType getType(SILType BaseType, SILModule &M) const {
-    assert(isValid());
-    switch (getKind()) {
-    case ProjectionKind::Struct:
-    case ProjectionKind::Class:
-      return BaseType.getFieldType(getVarDecl(BaseType), M);
-    case ProjectionKind::Enum:
-      return BaseType.getEnumElementType(getEnumElementDecl(BaseType), M);
-    case ProjectionKind::Box:
-      return BaseType.castTo<SILBoxType>()->getFieldType(M, getIndex());
-    case ProjectionKind::Tuple:
-      return BaseType.getTupleElementType(getIndex());
-    case ProjectionKind::Upcast:
-    case ProjectionKind::RefCast:
-    case ProjectionKind::BitwiseCast:
-    case ProjectionKind::TailElems:
-      return getCastType(BaseType);
-    case ProjectionKind::Index:
-      // Index types do not change the underlying type.
-      return BaseType;
-    }
-
-    llvm_unreachable("Unhandled ProjectionKind in switch.");
-  }
+  SILType getType(SILType BaseType, SILModule &M) const;
 
   VarDecl *getVarDecl(SILType BaseType) const {
     assert(isValid());

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1746,13 +1746,7 @@ public:
         getSILDebugLocation(Loc), valueType, operand));
   }
   ProjectBoxInst *createProjectBox(SILLocation Loc, SILValue boxOperand,
-                                   unsigned index) {
-    auto boxTy = boxOperand->getType().castTo<SILBoxType>();
-    auto fieldTy = boxTy->getFieldType(getModule(), index);
-
-    return insert(new (getModule()) ProjectBoxInst(
-        getSILDebugLocation(Loc), boxOperand, index, fieldTy));
-  }
+                                   unsigned index);
   ProjectExistentialBoxInst *createProjectExistentialBox(SILLocation Loc,
                                                          SILType valueTy,
                                                          SILValue boxOperand) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2089,7 +2089,7 @@ visitOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *Inst) {
   remapOpenedType(cast<OpenedArchetypeType>(openedType));
 
   if (!Inst->getOperand()->getType().canUseExistentialRepresentation(
-          Inst->getModule(), ExistentialRepresentation::Class)) {
+          ExistentialRepresentation::Class)) {
     getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
     recordClonedInstruction(Inst, getBuilder().createOpenExistentialMetatype(
                                       getOpLocation(Inst->getLoc()),

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1643,9 +1643,7 @@ public:
   bool hasDynamicLifetime() const { return dynamicLifetime; }
 
   // Return the type of the memory stored in the alloc_box.
-  SILType getAddressType() const {
-    return getBoxType()->getFieldType(getModule(), 0).getAddressType();
-  }
+  SILType getAddressType() const;
 
   /// Return the underlying variable declaration associated with this
   /// allocation, or null if this is a temporary allocation.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -260,7 +260,8 @@ private:
 
   // Intentionally marked private so that we need to use 'constructSIL()'
   // to construct a SILModule.
-  SILModule(ModuleDecl *M, SILOptions &Options, const DeclContext *associatedDC,
+  SILModule(ModuleDecl *M, Lowering::TypeConverter &TC,
+            SILOptions &Options, const DeclContext *associatedDC,
             bool wholeModule);
 
   SILModule(const SILModule&) = delete;
@@ -313,7 +314,7 @@ public:
   void serialize();
 
   /// This converts Swift types to SILTypes.
-  mutable Lowering::TypeConverter Types;
+  Lowering::TypeConverter &Types;
 
   /// Invalidate cached entries in SIL Loader.
   void invalidateSILLoaderCaches();
@@ -340,12 +341,14 @@ public:
   /// If a source file is provided, SIL will only be emitted for decls in that
   /// source file.
   static std::unique_ptr<SILModule>
-  constructSIL(ModuleDecl *M, SILOptions &Options, FileUnit *sf = nullptr);
+  constructSIL(ModuleDecl *M, Lowering::TypeConverter &TC,
+               SILOptions &Options, FileUnit *sf = nullptr);
 
   /// Create and return an empty SIL module that we can
   /// later parse SIL bodies directly into, without converting from an AST.
   static std::unique_ptr<SILModule>
-  createEmptyModule(ModuleDecl *M, SILOptions &Options,
+  createEmptyModule(ModuleDecl *M, Lowering::TypeConverter &TC,
+                    SILOptions &Options,
                     bool WholeModule = false);
 
   /// Get the Swift module associated with this SIL module.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -35,6 +35,7 @@ namespace swift {
   class ForeignErrorConvention;
   enum IsInitialization_t : bool;
   enum IsTake_t : bool;
+  class ModuleDecl;
   class SILBuilder;
   class SILLocation;
   class SILModule;
@@ -712,10 +713,10 @@ class TypeConverter {
                               const TypeLowering *lowering);
 
 public:
-  SILModule &M;
+  ModuleDecl &M;
   ASTContext &Context;
 
-  TypeConverter(SILModule &m);
+  TypeConverter(ModuleDecl &m);
   ~TypeConverter();
   TypeConverter(TypeConverter const &) = delete;
   TypeConverter &operator=(TypeConverter const &) = delete;
@@ -803,7 +804,8 @@ public:
   }
 
   SILType getLoweredLoadableType(Type t,
-                                 ResilienceExpansion forExpansion) {
+                                 ResilienceExpansion forExpansion,
+                                 SILModule &M) {
     const TypeLowering &ti = getTypeLowering(t, forExpansion);
     assert(
         (ti.isLoadable() || !SILModuleConventions(M).useLoweredAddresses()) &&

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -69,6 +69,10 @@ namespace swift {
   class UnifiedStatsReporter;
   enum class SourceFileKind;
 
+  namespace Lowering {
+    class TypeConverter;
+  }
+
   /// Used to optionally maintain SIL parsing context for the parser.
   ///
   /// When not parsing SIL, this has no overhead.
@@ -254,11 +258,13 @@ namespace swift {
   /// The module must contain source files. The optimizer will assume that the
   /// SIL of all files in the module is present in the SILModule.
   std::unique_ptr<SILModule>
-  performSILGeneration(ModuleDecl *M, SILOptions &options);
+  performSILGeneration(ModuleDecl *M, Lowering::TypeConverter &TC,
+                       SILOptions &options);
 
   /// Turn a source file into SIL IR.
   std::unique_ptr<SILModule>
-  performSILGeneration(FileUnit &SF, SILOptions &options);
+  performSILGeneration(FileUnit &SF, Lowering::TypeConverter &TC,
+                       SILOptions &options);
 
   using ModuleOrSourceFile = PointerUnion<ModuleDecl *, SourceFile *>;
 

--- a/lib/Frontend/ParseableInterfaceModuleLoader.cpp
+++ b/lib/Frontend/ParseableInterfaceModuleLoader.cpp
@@ -592,7 +592,8 @@ public:
 
       SILOptions &SILOpts = subInvocation.getSILOptions();
       auto Mod = SubInstance.getMainModule();
-      auto SILMod = performSILGeneration(Mod, SILOpts);
+      auto &TC = SubInstance.getSILTypes();
+      auto SILMod = performSILGeneration(Mod, TC, SILOpts);
       if (!SILMod) {
         LLVM_DEBUG(llvm::dbgs() << "SILGen did not produce a module\n");
         SubError = true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -917,7 +917,7 @@ generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
   if (!opts.InputsAndOutputs.hasPrimaryInputs()) {
     // If there are no primary inputs the compiler is in WMO mode and builds one
     // SILModule for the entire module.
-    auto SM = performSILGeneration(mod, SILOpts);
+    auto SM = performSILGeneration(mod, Instance.getSILTypes(), SILOpts);
     std::deque<PostSILGenInputs> PSGIs;
     const PrimarySpecificPaths PSPs =
         Instance.getPrimarySpecificPathsForWholeModuleOptimizationMode();
@@ -930,7 +930,7 @@ generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
   // once for each such input.
   std::deque<PostSILGenInputs> PSGIs;
   for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
-    auto SM = performSILGeneration(*PrimaryFile, SILOpts);
+    auto SM = performSILGeneration(*PrimaryFile, Instance.getSILTypes(), SILOpts);
     const PrimarySpecificPaths PSPs =
         Instance.getPrimarySpecificPathsForSourceFile(*PrimaryFile);
     PSGIs.push_back(PostSILGenInputs{std::move(SM), true, PrimaryFile, PSPs});
@@ -944,7 +944,7 @@ generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
       if (Invocation.getFrontendOptions().InputsAndOutputs.isInputPrimary(
               SASTF->getFilename())) {
         assert(PSGIs.empty() && "Can only handle one primary AST input");
-        auto SM = performSILGeneration(*SASTF, SILOpts);
+        auto SM = performSILGeneration(*SASTF, Instance.getSILTypes(), SILOpts);
         const PrimarySpecificPaths &PSPs =
             Instance.getPrimarySpecificPathsForPrimary(SASTF->getFilename());
         PSGIs.push_back(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -82,7 +82,6 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Target/TargetMachine.h"
 
-#include <deque>
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -648,13 +647,6 @@ createOptRecordFile(StringRef Filename, DiagnosticEngine &DE) {
   return File;
 }
 
-struct PostSILGenInputs {
-  std::unique_ptr<SILModule> TheSILModule;
-  bool ASTGuaranteedToCorrespondToSIL;
-  ModuleOrSourceFile ModuleOrPrimarySourceFile;
-  PrimarySpecificPaths PSPs;
-};
-
 static bool precompileBridgingHeader(CompilerInvocation &Invocation,
                                      CompilerInstance &Instance) {
   auto clangImporter = static_cast<ClangImporter *>(
@@ -896,15 +888,27 @@ static bool writeTBDIfNeeded(CompilerInvocation &Invocation,
   return writeTBD(Instance.getMainModule(), TBDPath, tbdOpts);
 }
 
-static std::deque<PostSILGenInputs>
-generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
+static bool performCompileStepsPostSILGen(
+    CompilerInstance &Instance, CompilerInvocation &Invocation,
+    std::unique_ptr<SILModule> SM, bool astGuaranteedToCorrespondToSIL,
+    ModuleOrSourceFile MSF, const PrimarySpecificPaths &PSPs,
+    bool moduleIsPublic, int &ReturnValue, FrontendObserver *observer,
+    UnifiedStatsReporter *Stats);
+
+static bool
+performCompileStepsPostSema(CompilerInvocation &Invocation,
+                            CompilerInstance &Instance,
+                            bool moduleIsPublic, int &ReturnValue,
+                            FrontendObserver *observer,
+                            UnifiedStatsReporter *Stats) {
   auto mod = Instance.getMainModule();
   if (auto SM = Instance.takeSILModule()) {
-    std::deque<PostSILGenInputs> PSGIs;
     const PrimarySpecificPaths PSPs =
         Instance.getPrimarySpecificPathsForAtMostOnePrimary();
-    PSGIs.push_back(PostSILGenInputs{std::move(SM), false, mod, PSPs});
-    return PSGIs;
+    return performCompileStepsPostSILGen(Instance, Invocation, std::move(SM),
+                                         /*ASTGuaranteedToCorrespondToSIL=*/false,
+                                         mod, PSPs, moduleIsPublic,
+                                         ReturnValue, observer, Stats);
   }
 
   SILOptions &SILOpts = Invocation.getSILOptions();
@@ -918,40 +922,51 @@ generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
     // If there are no primary inputs the compiler is in WMO mode and builds one
     // SILModule for the entire module.
     auto SM = performSILGeneration(mod, Instance.getSILTypes(), SILOpts);
-    std::deque<PostSILGenInputs> PSGIs;
     const PrimarySpecificPaths PSPs =
         Instance.getPrimarySpecificPathsForWholeModuleOptimizationMode();
-    PSGIs.push_back(PostSILGenInputs{
-        std::move(SM), llvm::none_of(mod->getFiles(), fileIsSIB), mod, PSPs});
-    return PSGIs;
+    bool astGuaranteedToCorrespondToSIL =
+        llvm::none_of(mod->getFiles(), fileIsSIB);
+    return performCompileStepsPostSILGen(Instance, Invocation, std::move(SM),
+                                         astGuaranteedToCorrespondToSIL,
+                                         mod, PSPs, moduleIsPublic,
+                                         ReturnValue, observer, Stats);
   }
   // If there are primary source files, build a separate SILModule for
   // each source file, and run the remaining SILOpt-Serialize-IRGen-LLVM
   // once for each such input.
-  std::deque<PostSILGenInputs> PSGIs;
-  for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
-    auto SM = performSILGeneration(*PrimaryFile, Instance.getSILTypes(), SILOpts);
-    const PrimarySpecificPaths PSPs =
-        Instance.getPrimarySpecificPathsForSourceFile(*PrimaryFile);
-    PSGIs.push_back(PostSILGenInputs{std::move(SM), true, PrimaryFile, PSPs});
+  if (!Instance.getPrimarySourceFiles().empty()) {
+    bool result = false;
+    for (auto *PrimaryFile : Instance.getPrimarySourceFiles()) {
+      auto SM = performSILGeneration(*PrimaryFile, Instance.getSILTypes(), SILOpts);
+      const PrimarySpecificPaths PSPs =
+          Instance.getPrimarySpecificPathsForSourceFile(*PrimaryFile);
+      result |= performCompileStepsPostSILGen(Instance, Invocation, std::move(SM),
+                                              /*ASTGuaranteedToCorrespondToSIL*/true,
+                                              PrimaryFile, PSPs, moduleIsPublic,
+                                              ReturnValue, observer, Stats);
+    }
+
+    return result;
   }
-  if (!PSGIs.empty())
-    return PSGIs;
+
   // If there are primary inputs but no primary _source files_, there might be
   // a primary serialized input.
+  bool result = false;
   for (FileUnit *fileUnit : mod->getFiles()) {
     if (auto SASTF = dyn_cast<SerializedASTFile>(fileUnit))
       if (Invocation.getFrontendOptions().InputsAndOutputs.isInputPrimary(
               SASTF->getFilename())) {
-        assert(PSGIs.empty() && "Can only handle one primary AST input");
         auto SM = performSILGeneration(*SASTF, Instance.getSILTypes(), SILOpts);
         const PrimarySpecificPaths &PSPs =
             Instance.getPrimarySpecificPathsForPrimary(SASTF->getFilename());
-        PSGIs.push_back(
-            PostSILGenInputs{std::move(SM), !fileIsSIB(SASTF), mod, PSPs});
+        result |= performCompileStepsPostSILGen(Instance, Invocation, std::move(SM),
+                                                !fileIsSIB(SASTF),
+                                                mod, PSPs, moduleIsPublic,
+                                                ReturnValue, observer, Stats);
       }
   }
-  return PSGIs;
+
+  return result;
 }
 
 /// Emits index data for all primary inputs, or the main module.
@@ -1001,13 +1016,6 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
 
   return hadAnyError;
 }
-
-static bool performCompileStepsPostSILGen(
-    CompilerInstance &Instance, CompilerInvocation &Invocation,
-    std::unique_ptr<SILModule> SM, bool astGuaranteedToCorrespondToSIL,
-    ModuleOrSourceFile MSF, const PrimarySpecificPaths &PSPs,
-    bool moduleIsPublic, int &ReturnValue, FrontendObserver *observer,
-    UnifiedStatsReporter *Stats);
 
 /// Performs the compile requested by the user.
 /// \param Instance Will be reset after performIRGeneration when the verifier
@@ -1125,21 +1133,8 @@ static bool performCompile(CompilerInstance &Instance,
   assert(FrontendOptions::doesActionGenerateSIL(Action) &&
          "All actions not requiring SILGen must have been handled!");
 
-  std::deque<PostSILGenInputs> PSGIs = generateSILModules(Invocation, Instance);
-
-  while (!PSGIs.empty()) {
-    auto PSGI = std::move(PSGIs.front());
-    PSGIs.pop_front();
-    if (performCompileStepsPostSILGen(Instance, Invocation,
-                                      std::move(PSGI.TheSILModule),
-                                      PSGI.ASTGuaranteedToCorrespondToSIL,
-                                      PSGI.ModuleOrPrimarySourceFile,
-                                      PSGI.PSPs,
-                                      moduleIsPublic,
-                                      ReturnValue, observer, Stats))
-      return true;
-  }
-  return false;
+  return performCompileStepsPostSema(Invocation, Instance, moduleIsPublic,
+                                     ReturnValue, observer, Stats);
 }
 
 /// Get the main source file's private discriminator and attach it to

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1562,7 +1562,7 @@ ContainedAddress irgen::emitBoxedExistentialProjection(IRGenFunction &IGF,
                                               CanType projectedType) {
   // TODO: Non-ErrorType boxed existentials.
   assert(baseTy.canUseExistentialRepresentation(
-           IGF.getSILModule(), ExistentialRepresentation::Boxed, Type()));
+           ExistentialRepresentation::Boxed, Type()));
   
   // Get the reference to the existential box.
   llvm::Value *box = base.claimNext();
@@ -1616,7 +1616,7 @@ OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
                                 ArrayRef<ProtocolConformanceRef> conformances) {
   // TODO: Non-Error boxed existentials.
   assert(destType.canUseExistentialRepresentation(
-           IGF.getSILModule(), ExistentialRepresentation::Boxed, Type()));
+           ExistentialRepresentation::Boxed, Type()));
 
   auto &destTI = IGF.getTypeInfo(destType).as<ErrorExistentialTypeInfo>();
   auto srcMetadata = IGF.emitTypeMetadataRef(formalSrcType);
@@ -1656,7 +1656,7 @@ void irgen::emitBoxedExistentialContainerDeallocation(IRGenFunction &IGF,
                                                       CanType valueType) {
   // TODO: Non-Error boxed existentials.
   assert(containerType.canUseExistentialRepresentation(
-           IGF.getSILModule(), ExistentialRepresentation::Boxed, Type()));
+           ExistentialRepresentation::Boxed, Type()));
 
   auto box = container.claimNext();
   auto srcMetadata = IGF.emitTypeMetadataRef(valueType);
@@ -1803,7 +1803,7 @@ void irgen::emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,
                                            SILType type, Explosion &out) {
   // TODO: Non-Error boxed existentials.
   assert(type.canUseExistentialRepresentation(
-           IGF.getSILModule(), ExistentialRepresentation::Boxed, Type()));
+           ExistentialRepresentation::Boxed, Type()));
 
   // Get the reference to the existential box.
   llvm::Value *box = value.claimNext();

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/SIL/SILModule.h"
 
 #include "ConstantBuilder.h"
 #include "Explosion.h"
@@ -1527,7 +1528,7 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   assert(T->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
   auto &eltTI = IGM.getTypeInfoForLowered(
-    T->getFieldLoweredType(IGM.getSILModule(), 0));
+    getSILBoxFieldLoweredType(T, IGM.getSILModule().Types, 0));
   if (!eltTI.isFixedSize()) {
     if (!NonFixedBoxTI)
       NonFixedBoxTI = new NonFixedBoxTypeInfo(IGM);
@@ -1575,7 +1576,8 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // Produce a tailored box metadata for the type.
   assert(T->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
-  return new FixedBoxTypeInfo(IGM, T->getFieldType(IGM.getSILModule(), 0));
+  return new FixedBoxTypeInfo(IGM,
+      getSILBoxFieldType(T, IGM.getSILModule().Types, 0));
 }
 
 OwnedAddress
@@ -1586,8 +1588,8 @@ irgen::emitAllocateBox(IRGenFunction &IGF, CanSILBoxType boxType,
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
   return boxTI.allocate(IGF,
-                      boxType->getFieldType(IGF.IGM.getSILModule(), 0), env,
-                      name);
+                  getSILBoxFieldType(boxType, IGF.IGM.getSILModule().Types, 0),
+                        env, name);
 }
 
 void irgen::emitDeallocateBox(IRGenFunction &IGF,
@@ -1597,7 +1599,7 @@ void irgen::emitDeallocateBox(IRGenFunction &IGF,
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
   return boxTI.deallocate(IGF, box,
-                          boxType->getFieldType(IGF.IGM.getSILModule(), 0));
+                 getSILBoxFieldType(boxType, IGF.IGM.getSILModule().Types, 0));
 }
 
 Address irgen::emitProjectBox(IRGenFunction &IGF,
@@ -1607,7 +1609,7 @@ Address irgen::emitProjectBox(IRGenFunction &IGF,
   assert(boxType->getLayout()->getFields().size() == 1
          && "multi-field boxes not implemented yet");
   return boxTI.project(IGF, box,
-                       boxType->getFieldType(IGF.IGM.getSILModule(), 0));
+                 getSILBoxFieldType(boxType, IGF.IGM.getSILModule().Types, 0));
 }
 
 Address irgen::emitAllocateExistentialBoxInBuffer(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2036,7 +2036,7 @@ void IRGenSILFunction::visitExistentialMetatypeInst(
   SILValue op = i->getOperand();
   SILType opType = op->getType();
 
-  switch (opType.getPreferredExistentialRepresentation(IGM.getSILModule())) {
+  switch (opType.getPreferredExistentialRepresentation()) {
   case ExistentialRepresentation::Metatype: {
     Explosion existential = getLoweredExplosion(op);
     emitMetatypeOfMetatype(*this, existential, opType, result);
@@ -4188,8 +4188,8 @@ void IRGenSILFunction::visitDeallocBoxInst(swift::DeallocBoxInst *i) {
 void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   assert(i->getBoxType()->getLayout()->getFields().size() == 1
          && "multi field boxes not implemented yet");
-  const TypeInfo &type = getTypeInfo(i->getBoxType()
-                                      ->getFieldType(IGM.getSILModule(), 0));
+  const TypeInfo &type = getTypeInfo(
+      getSILBoxFieldType(i->getBoxType(), IGM.getSILModule().Types, 0));
 
   // Derive name from SIL location.
   bool IsAnonymous = false;
@@ -4224,7 +4224,7 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
 
   assert(i->getBoxType()->getLayout()->getFields().size() == 1 &&
          "box for a local variable should only have one field");
-  auto SILTy = i->getBoxType()->getFieldType(IGM.getSILModule(), 0);
+  auto SILTy = getSILBoxFieldType(i->getBoxType(), IGM.getSILModule().Types, 0);
   auto RealType = SILTy.getASTType();
   auto DbgTy = DebugTypeInfo::getLocalVariable(Decl, RealType, type);
 

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -874,7 +874,8 @@ private:
     if (!CI.getASTContext().hadError()) {
       // We don't want anything to get stripped, so pretend we're doing a
       // non-whole-module generation.
-      sil = performSILGeneration(*M->getFiles().front(), CI.getSILOptions());
+      sil = performSILGeneration(*M->getFiles().front(), CI.getSILTypes(),
+                                 CI.getSILOptions());
       runSILDiagnosticPasses(*sil);
       runSILOwnershipEliminatorPass(*sil);
       runSILLoweringPasses(*sil);

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -61,6 +61,7 @@ namespace {
 struct IRGenContext {
   IRGenOptions IROpts;
   SILOptions SILOpts;
+  Lowering::TypeConverter TC;
   std::unique_ptr<SILModule> SILMod;
   llvm::LLVMContext LLVMContext;
   irgen::IRGenerator IRGen;
@@ -69,7 +70,8 @@ struct IRGenContext {
 private:
   IRGenContext(ASTContext &ctx, ModuleDecl *module)
     : IROpts(createIRGenOptions()),
-      SILMod(SILModule::createEmptyModule(module, SILOpts)),
+      TC(*module),
+      SILMod(SILModule::createEmptyModule(module, TC, SILOpts)),
       IRGen(IROpts, *SILMod),
       IGM(IRGen, IRGen.createTargetMachine(), LLVMContext) {}
 

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -212,7 +212,7 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
   }
 
   auto foreignRepresentation =
-    t->getForeignRepresentableIn(ForeignLanguage::ObjectiveC, M.TheSwiftModule);
+    t->getForeignRepresentableIn(ForeignLanguage::ObjectiveC, &M);
   switch (foreignRepresentation.first) {
   case ForeignRepresentableKind::None:
   case ForeignRepresentableKind::Trivial:

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -172,6 +172,37 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
   }
 }
 
+/// Apply this projection to \p BaseType and return the relevant subfield's
+/// SILType if BaseField has less subtypes than projection's offset.
+///
+/// WARNING: This is not a constant time operation because it is implemented
+/// in terms of getVarDecl, which requests all BaseType's stored properties.
+SILType Projection::getType(SILType BaseType, SILModule &M) const {
+  assert(isValid());
+  switch (getKind()) {
+  case ProjectionKind::Struct:
+  case ProjectionKind::Class:
+    return BaseType.getFieldType(getVarDecl(BaseType), M);
+  case ProjectionKind::Enum:
+    return BaseType.getEnumElementType(getEnumElementDecl(BaseType), M);
+  case ProjectionKind::Box:
+    return getSILBoxFieldType(BaseType.castTo<SILBoxType>(),
+                              M.Types, getIndex());
+  case ProjectionKind::Tuple:
+    return BaseType.getTupleElementType(getIndex());
+  case ProjectionKind::Upcast:
+  case ProjectionKind::RefCast:
+  case ProjectionKind::BitwiseCast:
+  case ProjectionKind::TailElems:
+    return getCastType(BaseType);
+  case ProjectionKind::Index:
+    // Index types do not change the underlying type.
+    return BaseType;
+  }
+
+  llvm_unreachable("Unhandled ProjectionKind in switch.");
+}
+
 NullablePtr<SingleValueInstruction>
 Projection::createObjectProjection(SILBuilder &B, SILLocation Loc,
                                    SILValue Base) const {
@@ -306,7 +337,7 @@ void Projection::getFirstLevelProjections(SILType Ty, SILModule &Mod,
                  assert(X.getMostDerivedType(Mod) == Ty);
                  X.append(P);
                  assert(X.getMostDerivedType(Mod)
-                        == Box->getFieldType(Mod, field));
+                        == getSILBoxFieldType(Box, Mod.Types, field));
                  X.verify(Mod););
       (void)Box;
       Out.push_back(P);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -96,6 +96,16 @@ SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
   return SILType::getPrimitiveObjectType(appliedFnType);
 }
 
+ProjectBoxInst *SILBuilder::createProjectBox(SILLocation Loc,
+                                             SILValue boxOperand,
+                                             unsigned index) {
+  auto boxTy = boxOperand->getType().castTo<SILBoxType>();
+  auto fieldTy = getSILBoxFieldType(boxTy, getModule().Types, index);
+
+  return insert(new (getModule()) ProjectBoxInst(
+      getSILDebugLocation(Loc), boxOperand, index, fieldTy));
+}
+
 // If legal, create an unchecked_ref_cast from the given operand and result
 // type, otherwise return null.
 SingleValueInstruction *

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -253,7 +253,8 @@ SILType SILFunction::getLoweredType(Type t) const {
 }
 
 SILType SILFunction::getLoweredLoadableType(Type t) const {
-  return getModule().Types.getLoweredLoadableType(t, getResilienceExpansion());
+  auto &M = getModule();
+  return M.Types.getLoweredLoadableType(t, getResilienceExpansion(), M);
 }
 
 const TypeLowering &SILFunction::getTypeLowering(SILType type) const {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -284,6 +284,10 @@ AllocBoxInst *AllocBoxInst::create(SILDebugLocation Loc,
                                   hasDynamicLifetime);
 }
 
+SILType AllocBoxInst::getAddressType() const {
+  return getSILBoxFieldType(getBoxType(), getModule().Types, 0).getAddressType();
+}
+
 VarDecl *AllocBoxInst::getDecl() const {
   return getLoc().getAsASTNode<VarDecl>();
 }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -93,7 +93,7 @@ SILModule::SILModule(ModuleDecl *SwiftModule, SILOptions &Options,
                      const DeclContext *associatedDC, bool wholeModule)
     : TheSwiftModule(SwiftModule), AssociatedDeclContext(associatedDC),
       Stage(SILStage::Raw), wholeModule(wholeModule), Options(Options),
-      serialized(false), SerializeSILAction(), Types(*this) {
+      serialized(false), SerializeSILAction(), Types(*SwiftModule) {
   // We always add the base SILModule serialization callback.
   std::unique_ptr<DeserializationNotificationHandler> callback(
       new SILModule::SerializationCallback());

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -89,11 +89,13 @@ class SILModule::SerializationCallback final
   }
 };
 
-SILModule::SILModule(ModuleDecl *SwiftModule, SILOptions &Options,
-                     const DeclContext *associatedDC, bool wholeModule)
-    : TheSwiftModule(SwiftModule), AssociatedDeclContext(associatedDC),
+SILModule::SILModule(ModuleDecl *SwiftModule, TypeConverter &TC,
+                     SILOptions &Options, const DeclContext *associatedDC,
+                     bool wholeModule)
+    : TheSwiftModule(SwiftModule),
+      AssociatedDeclContext(associatedDC),
       Stage(SILStage::Raw), wholeModule(wholeModule), Options(Options),
-      serialized(false), SerializeSILAction(), Types(*SwiftModule) {
+      serialized(false), SerializeSILAction(), Types(TC) {
   // We always add the base SILModule serialization callback.
   std::unique_ptr<DeserializationNotificationHandler> callback(
       new SILModule::SerializationCallback());
@@ -118,10 +120,10 @@ SILModule::~SILModule() {
 }
 
 std::unique_ptr<SILModule>
-SILModule::createEmptyModule(ModuleDecl *M, SILOptions &Options,
+SILModule::createEmptyModule(ModuleDecl *M, TypeConverter &TC, SILOptions &Options,
                              bool WholeModule) {
   return std::unique_ptr<SILModule>(
-      new SILModule(M, Options, M, WholeModule));
+      new SILModule(M, TC, Options, M, WholeModule));
 }
 
 ASTContext &SILModule::getASTContext() const {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2295,8 +2295,8 @@ public:
             "project_box operand should be a value");
     auto boxTy = I->getOperand()->getType().getAs<SILBoxType>();
     require(boxTy, "project_box operand should be a @box type");
-    require(I->getType() == boxTy->getFieldType(F.getModule(),
-                                                I->getFieldIndex()),
+    require(I->getType() == getSILBoxFieldType(boxTy, F.getModule().Types,
+                                               I->getFieldIndex()),
             "project_box result should be address of boxed type");
 
     // If we have a mark_uninitialized as a user, the mark_uninitialized must be
@@ -2316,7 +2316,7 @@ public:
     require(operandType.isObject(),
             "project_existential_box operand must not be address");
 
-    require(operandType.canUseExistentialRepresentation(F.getModule(),
+    require(operandType.canUseExistentialRepresentation(
                                               ExistentialRepresentation::Boxed),
             "project_existential_box operand must be boxed existential");
 
@@ -2581,7 +2581,8 @@ public:
             "result of alloc_box must be an object");
     for (unsigned field : indices(AI->getBoxType()->getLayout()->getFields())) {
       verifyOpenedArchetype(AI,
-                   AI->getBoxType()->getFieldLoweredType(F.getModule(), field));
+        getSILBoxFieldLoweredType(AI->getBoxType(), F.getModule().Types,
+                                  field));
     }
 
     // An alloc_box with a mark_uninitialized user can not have any other users.
@@ -3056,7 +3057,7 @@ public:
     SILType operandType = OEI->getOperand()->getType();
     require(operandType.isAddress(),
             "open_existential_addr must be applied to address");
-    require(operandType.canUseExistentialRepresentation(F.getModule(),
+    require(operandType.canUseExistentialRepresentation(
                                         ExistentialRepresentation::Opaque),
            "open_existential_addr must be applied to opaque existential");
 
@@ -3087,7 +3088,7 @@ public:
     require(operandType.isObject(),
             "open_existential_ref operand must not be address");
 
-    require(operandType.canUseExistentialRepresentation(F.getModule(),
+    require(operandType.canUseExistentialRepresentation(
                                               ExistentialRepresentation::Class),
             "open_existential_ref operand must be class existential");
 
@@ -3109,7 +3110,7 @@ public:
     require(operandType.isObject(),
             "open_existential_box operand must not be address");
 
-    require(operandType.canUseExistentialRepresentation(F.getModule(),
+    require(operandType.canUseExistentialRepresentation(
                                               ExistentialRepresentation::Boxed),
             "open_existential_box operand must be boxed existential");
 
@@ -3131,7 +3132,7 @@ public:
     require(operandType.isObject(),
             "open_existential_box operand must not be address");
 
-    require(operandType.canUseExistentialRepresentation(F.getModule(),
+    require(operandType.canUseExistentialRepresentation(
                                               ExistentialRepresentation::Boxed),
             "open_existential_box operand must be boxed existential");
 
@@ -3199,7 +3200,7 @@ public:
     require(!operandType.isAddress(),
             "open_existential_value must not be applied to address");
     require(operandType.canUseExistentialRepresentation(
-                F.getModule(), ExistentialRepresentation::Opaque),
+                ExistentialRepresentation::Opaque),
             "open_existential_value must be applied to opaque existential");
 
     require(!OEI->getType().isAddress(),
@@ -3217,7 +3218,7 @@ public:
     SILType exType = AEBI->getExistentialType();
     require(exType.isObject(),
             "alloc_existential_box #0 result should be a value");
-    require(exType.canUseExistentialRepresentation(F.getModule(),
+    require(exType.canUseExistentialRepresentation(
                                              ExistentialRepresentation::Boxed,
                                              AEBI->getFormalConcreteType()),
             "alloc_existential_box must be used with a boxed existential "
@@ -3233,7 +3234,7 @@ public:
     SILType exType = AEI->getOperand()->getType();
     require(exType.isAddress(),
             "init_existential_addr must be applied to an address");
-    require(exType.canUseExistentialRepresentation(F.getModule(),
+    require(exType.canUseExistentialRepresentation(
                                        ExistentialRepresentation::Opaque,
                                        AEI->getFormalConcreteType()),
             "init_existential_addr must be used with an opaque "
@@ -3292,7 +3293,7 @@ public:
     SILType concreteType = IEI->getOperand()->getType();
     require(concreteType.getASTType()->isBridgeableObjectType(),
             "init_existential_ref operand must be a class instance");
-    require(IEI->getType().canUseExistentialRepresentation(F.getModule(),
+    require(IEI->getType().canUseExistentialRepresentation(
                                      ExistentialRepresentation::Class,
                                      IEI->getFormalConcreteType()),
             "init_existential_ref must be used with a class existential type");
@@ -3324,7 +3325,7 @@ public:
     require(exType.isAddress(),
             "deinit_existential_addr must be applied to an address");
     require(exType.canUseExistentialRepresentation(
-                F.getModule(), ExistentialRepresentation::Opaque),
+                ExistentialRepresentation::Opaque),
             "deinit_existential_addr must be applied to an opaque existential");
   }
 
@@ -3334,7 +3335,7 @@ public:
             "deinit_existential_value must not be applied to an address");
     require(
         exType.canUseExistentialRepresentation(
-            F.getModule(), ExistentialRepresentation::Opaque),
+            ExistentialRepresentation::Opaque),
         "deinit_existential_value must be applied to an opaque existential");
   }
   
@@ -3342,7 +3343,7 @@ public:
     SILType exType = DEBI->getOperand()->getType();
     require(exType.isObject(),
             "dealloc_existential_box must be applied to a value");
-    require(exType.canUseExistentialRepresentation(F.getModule(),
+    require(exType.canUseExistentialRepresentation(
                                        ExistentialRepresentation::Boxed),
             "dealloc_existential_box must be applied to a boxed "
             "existential");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -99,7 +99,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
   // by value.  If it is address-only, then we can't load it, so capture it
   // by its address (like a var) instead.
   if (!var->supportsMutation() &&
-      (!SILModuleConventions(M).useLoweredAddresses() ||
+      (Context.LangOpts.EnableSILOpaqueValues ||
        !getTypeLowering(var->getType(), expansion).isAddressOnly()))
     return CaptureKind::Constant;
 
@@ -128,7 +128,7 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
 using RecursiveProperties = TypeLowering::RecursiveProperties;
 
 static RecursiveProperties
-classifyType(CanType type, SILModule &M, CanGenericSignature sig,
+classifyType(CanType type, TypeConverter &TC, CanGenericSignature sig,
              ResilienceExpansion expansion);
 
 namespace {
@@ -138,12 +138,12 @@ namespace {
   class TypeClassifierBase : public CanTypeVisitor<Impl, RetTy> {
     Impl &asImpl() { return *static_cast<Impl*>(this); }
   protected:
-    SILModule &M;
+    TypeConverter &TC;
     CanGenericSignature Sig;
     ResilienceExpansion Expansion;
-    TypeClassifierBase(SILModule &M, CanGenericSignature Sig,
+    TypeClassifierBase(TypeConverter &TC, CanGenericSignature Sig,
                        ResilienceExpansion Expansion)
-      : M(M), Sig(Sig), Expansion(Expansion) {}
+      : TC(TC), Sig(Sig), Expansion(Expansion) {}
 
   public:
     // The subclass should implement:
@@ -247,7 +247,7 @@ namespace {
     CanGenericSignature getGenericSignature() {
       if (Sig)
         return Sig;
-      return M.Types.getCurGenericContext();
+      return TC.getCurGenericContext();
     }
 
     RetTy visitAbstractTypeParamType(CanType type) {
@@ -293,8 +293,7 @@ namespace {
           return getConcreteReferenceStorageReferent(bound->getCanonicalType());
         }
 
-        auto &ctx = M.getASTContext();
-        return ctx.TheUnknownObjectType;
+        return TC.Context.TheUnknownObjectType;
       }
 
       return type;
@@ -324,8 +323,7 @@ namespace {
     RetTy visit##Name##StorageType(Can##Name##StorageType type) { \
       auto referentType = type->getReferentType(); \
       auto concreteType = getConcreteReferenceStorageReferent(referentType); \
-      auto &ctx = M.getASTContext(); \
-      if (Name##StorageType::get(concreteType, ctx) \
+      if (Name##StorageType::get(concreteType, TC.Context) \
             ->isLoadable(Expansion)) { \
         return asImpl().visitLoadable##Name##StorageType(type); \
       } else { \
@@ -363,7 +361,7 @@ namespace {
 
     RetTy visitExistentialType(CanType type) {
       switch (SILType::getPrimitiveObjectType(type)
-                .getPreferredExistentialRepresentation(M)) {
+                .getPreferredExistentialRepresentation()) {
       case ExistentialRepresentation::None:
         llvm_unreachable("not an existential type?!");
       // Opaque existentials are address-only.
@@ -410,7 +408,7 @@ namespace {
     RetTy visitTupleType(CanTupleType type) {
       RecursiveProperties props;
       for (auto eltType : type.getElementTypes()) {
-        props.addSubobject(classifyType(eltType, M, Sig, Expansion));
+        props.addSubobject(classifyType(eltType, TC, Sig, Expansion));
       }
       return asImpl().handleAggregateByProperties(type, props);
     }
@@ -447,9 +445,9 @@ namespace {
   class TypeClassifier :
       public TypeClassifierBase<TypeClassifier, RecursiveProperties> {
   public:
-    TypeClassifier(SILModule &M, CanGenericSignature Sig,
+    TypeClassifier(TypeConverter &TC, CanGenericSignature Sig,
                    ResilienceExpansion Expansion)
-        : TypeClassifierBase(M, Sig, Expansion) {}
+        : TypeClassifierBase(TC, Sig, Expansion) {}
 
     RecursiveProperties handle(CanType type, RecursiveProperties properties) {
       return properties;
@@ -465,21 +463,21 @@ namespace {
 
       // Consult the type lowering.
       type = getSubstitutedTypeForTypeLowering(type);
-      auto &lowering = M.Types.getTypeLowering(type, Expansion);
+      auto &lowering = TC.getTypeLowering(type, Expansion);
       return handleClassificationFromLowering(type, lowering);
     }
 
     RecursiveProperties visitAnyStructType(CanType type, StructDecl *D) {
       // Consult the type lowering.
       type = getSubstitutedTypeForTypeLowering(type);
-      auto &lowering = M.Types.getTypeLowering(type, Expansion);
+      auto &lowering = TC.getTypeLowering(type, Expansion);
       return handleClassificationFromLowering(type, lowering);
     }
 
   private:
     CanType getSubstitutedTypeForTypeLowering(CanType type) {
       // If we're using a generic signature different from
-      // M.Types.getCurGenericContext(), we have to map the
+      // TC.getCurGenericContext(), we have to map the
       // type into context before asking for a type lowering
       // because the rest of type lowering doesn't have a generic
       // signature plumbed through.
@@ -500,19 +498,19 @@ namespace {
   };
 } // end anonymous namespace
 
-static RecursiveProperties classifyType(CanType type, SILModule &M,
+static RecursiveProperties classifyType(CanType type, TypeConverter &tc,
                                         CanGenericSignature sig,
                                         ResilienceExpansion expansion) {
-  return TypeClassifier(M, sig, expansion).visit(type);
+  return TypeClassifier(tc, sig, expansion).visit(type);
 }
 
 /// True if the type, or the referenced type of an address
 /// type, is address-only.  For example, it could be a resilient struct or
 /// something of unknown size.
-bool SILType::isAddressOnly(CanType type, SILModule &M,
+bool SILType::isAddressOnly(CanType type, TypeConverter &tc,
                             CanGenericSignature sig,
                             ResilienceExpansion expansion) {
-  return classifyType(type, M, sig, expansion).isAddressOnly();
+  return classifyType(type, tc, sig, expansion).isAddressOnly();
 }
 
 namespace {
@@ -708,7 +706,7 @@ namespace {
     mutable ArrayRef<Child> Children = {};
     
   protected:
-    virtual void lowerChildren(SILModule &M, SmallVectorImpl<Child> &children)
+    virtual void lowerChildren(TypeConverter &TC, SmallVectorImpl<Child> &children)
       const = 0;
     
   public:
@@ -722,12 +720,12 @@ namespace {
     virtual SILValue rebuildAggregate(SILBuilder &B, SILLocation loc,
                                       ArrayRef<SILValue> values) const = 0;
 
-    ArrayRef<Child> getChildren(SILModule &M) const {
+    ArrayRef<Child> getChildren(TypeConverter &TC) const {
       if (Children.data() == nullptr) {
         SmallVector<Child, 4> children;
-        lowerChildren(M, children);
+        lowerChildren(TC, children);
         auto isDependent = IsDependent_t(getLoweredType().hasTypeParameter());
-        auto buf = operator new(sizeof(Child) * children.size(), M.Types,
+        auto buf = operator new(sizeof(Child) * children.size(), TC,
                                 isDependent);
         memcpy(buf, children.data(), sizeof(Child) * children.size());
         Children = {reinterpret_cast<Child*>(buf), children.size()};
@@ -739,7 +737,7 @@ namespace {
     void forEachNonTrivialChild(SILBuilder &B, SILLocation loc,
                                 SILValue aggValue,
                                 const T &operation) const {
-      for (auto &child : getChildren(B.getModule())) {
+      for (auto &child : getChildren(B.getModule().Types)) {
         auto &childLowering = child.getLowering();
         // Skip trivial children.
         if (childLowering.isTrivial())
@@ -780,7 +778,7 @@ namespace {
       }
 
       llvm::SmallVector<SILValue, 8> loweredChildValues;
-      for (auto &child : getChildren(B.getModule())) {
+      for (auto &child : getChildren(B.getModule().Types)) {
         auto &childLowering = child.getLowering();
         SILValue childValue = asImpl().emitRValueProject(B, loc, aggValue,
                                                          child.getIndex(),
@@ -848,7 +846,7 @@ namespace {
     }
   
   private:
-    void lowerChildren(SILModule &M, SmallVectorImpl<Child> &children)
+    void lowerChildren(TypeConverter &TC, SmallVectorImpl<Child> &children)
     const override {
       // The children are just the elements of the lowered tuple.
       auto silTy = getLoweredType();
@@ -857,7 +855,7 @@ namespace {
       unsigned index = 0;
       for (auto elt : tupleTy.getElementTypes()) {
         auto silElt = SILType::getPrimitiveType(elt, silTy.getCategory());
-        auto &eltTL = M.Types.getTypeLowering(silElt, getResilienceExpansion());
+        auto &eltTL = TC.getTypeLowering(silElt, getResilienceExpansion());
         children.push_back(Child{index, eltTL});
         ++index;
       }
@@ -885,15 +883,15 @@ namespace {
     }
         
   private:
-    void lowerChildren(SILModule &M, SmallVectorImpl<Child> &children)
+    void lowerChildren(TypeConverter &TC, SmallVectorImpl<Child> &children)
     const override {
       auto silTy = getLoweredType();
       auto structDecl = silTy.getStructOrBoundGenericStruct();
       assert(structDecl);
       
       for (auto prop : structDecl->getStoredProperties()) {
-        SILType propTy = silTy.getFieldType(prop, M);
-        auto &propTL = M.Types.getTypeLowering(propTy, getResilienceExpansion());
+        SILType propTy = silTy.getFieldType(prop, TC);
+        auto &propTL = TC.getTypeLowering(propTy, getResilienceExpansion());
         children.push_back(Child{prop, propTL});
       }
     }
@@ -1166,13 +1164,11 @@ namespace {
   class LowerType
     : public TypeClassifierBase<LowerType, TypeLowering *>
   {
-    TypeConverter &TC;
     IsDependent_t Dependent;
   public:
     LowerType(TypeConverter &TC, CanGenericSignature Sig,
               ResilienceExpansion Expansion, IsDependent_t Dependent)
-      : TypeClassifierBase(TC.M, Sig, Expansion),
-        TC(TC), Dependent(Dependent) {}
+      : TypeClassifierBase(TC, Sig, Expansion), Dependent(Dependent) {}
 
     TypeLowering *handleTrivial(CanType type) {
       return handleTrivial(type, RecursiveProperties::forTrivial());
@@ -1192,7 +1188,7 @@ namespace {
 
     TypeLowering *handleAddressOnly(CanType type,
                                     RecursiveProperties properties) {
-      if (SILModuleConventions(M).useLoweredAddresses()) {
+      if (!TC.Context.LangOpts.EnableSILOpaqueValues) {
         auto silType = SILType::getPrimitiveAddressType(type);
         return new (TC, Dependent) AddressOnlyTypeLowering(silType, properties,
                                                            Expansion);
@@ -1241,7 +1237,7 @@ namespace {
       if (D->isResilient()) {
         // If the type is resilient and defined in our module, make a note of
         // that, since our lowering now depends on the resilience expansion.
-        bool sameModule = (D->getModuleContext() == M.getSwiftModule());
+        bool sameModule = (D->getModuleContext() == &TC.M);
         if (sameModule)
           properties.addSubobject(RecursiveProperties::forResilient());
 
@@ -1266,20 +1262,19 @@ namespace {
       if (handleResilience(structType, D, properties))
         return handleAddressOnly(structType, properties);
 
-      auto subMap = structType->getContextSubstitutionMap(
-          M.getSwiftModule(), D);
+      auto subMap = structType->getContextSubstitutionMap(&TC.M, D);
 
       // Classify the type according to its stored properties.
       for (auto field : D->getStoredProperties()) {
         // FIXME: Remove this once getInterfaceType() is a request.
         if (!field->hasInterfaceType())
-          M.getASTContext().getLazyResolver()->resolveDeclSignature(field);
+          TC.Context.getLazyResolver()->resolveDeclSignature(field);
 
         auto substFieldType =
           field->getInterfaceType().subst(subMap)->getCanonicalType();
 
         properties.addSubobject(classifyType(substFieldType->getCanonicalType(),
-                                             M, Sig, Expansion));
+                                             TC, Sig, Expansion));
       }
 
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
@@ -1304,8 +1299,7 @@ namespace {
                                                             Expansion);
       }
 
-      auto subMap = enumType->getContextSubstitutionMap(
-          M.getSwiftModule(), D);
+      auto subMap = enumType->getContextSubstitutionMap(&TC.M, D);
 
       // Accumulate the properties of all direct payloads.
       for (auto elt : D->getAllElements()) {
@@ -1321,12 +1315,12 @@ namespace {
 
         // FIXME: Remove this once getInterfaceType() is a request.
         if (!elt->hasInterfaceType())
-          M.getASTContext().getLazyResolver()->resolveDeclSignature(elt);
+          TC.Context.getLazyResolver()->resolveDeclSignature(elt);
 
         auto substEltType =
           elt->getArgumentInterfaceType().subst(subMap)->getCanonicalType();
         
-        properties.addSubobject(classifyType(substEltType, M, Sig, Expansion));
+        properties.addSubobject(classifyType(substEltType, TC, Sig, Expansion));
       }
 
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
@@ -1348,7 +1342,7 @@ namespace {
   };
 } // end anonymous namespace
 
-TypeConverter::TypeConverter(SILModule &m)
+TypeConverter::TypeConverter(ModuleDecl &m)
   : M(m), Context(m.getASTContext()) {
 }
 
@@ -1586,7 +1580,7 @@ CanType TypeConverter::computeLoweredRValueType(AbstractionPattern origType,
       }
     }
 
-    return getNativeSILFunctionType(M, origType, substFnType);
+    return getNativeSILFunctionType(*this, origType, substFnType);
   }
 
   // Ignore dynamic self types.
@@ -2566,7 +2560,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
          ->getCanonicalType());
   }
   assert(contextBoxTy->getLayout()->getFields().size() == 1
-         && contextBoxTy->getFieldType(M, 0).getASTType()
+         && getSILBoxFieldType(contextBoxTy, *this, 0).getASTType()
              == loweredContextType
          && "box field type doesn't match capture!");
 #endif
@@ -2610,7 +2604,7 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
 
   // FIXME: Remove this once getInterfaceType() is a request.
   if (!elt->hasInterfaceType())
-    C.getLazyResolver()->resolveDeclSignature(elt);
+    Context.getLazyResolver()->resolveDeclSignature(elt);
 
   auto boxSignature = getEffectiveGenericSignature(enumDecl);
 
@@ -2635,22 +2629,22 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
 
   // Instantiate the layout with enum's substitution list.
   auto subMap = boundEnum->getContextSubstitutionMap(
-      M.getSwiftModule(), enumDecl, enumDecl->getGenericEnvironment());
+      &M, enumDecl, enumDecl->getGenericEnvironment());
 
   auto boxTy = SILBoxType::get(C, layout, subMap);
   return boxTy;
 }
 
-static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
+static void countNumberOfInnerFields(unsigned &fieldsCount, TypeConverter &TC,
                                      SILType Ty, ResilienceExpansion expansion) {
   if (auto *structDecl = Ty.getStructOrBoundGenericStruct()) {
-    assert(!structDecl->isResilient(Module.getSwiftModule(), expansion) &&
+    assert(!structDecl->isResilient(&TC.M, expansion) &&
            " FSO should not be trying to explode resilient (ie address-only) "
            "types at all");
     for (auto *prop : structDecl->getStoredProperties()) {
-      SILType propTy = Ty.getFieldType(prop, Module);
+      SILType propTy = Ty.getFieldType(prop, TC);
       unsigned fieldsCountBefore = fieldsCount;
-      countNumberOfInnerFields(fieldsCount, Module, propTy, expansion);
+      countNumberOfInnerFields(fieldsCount, TC, propTy, expansion);
       if (fieldsCount == fieldsCountBefore) {
         // size of Struct(BigStructType) == size of BigStructType()
         // prevent counting its size as BigStructType()+1
@@ -2662,7 +2656,7 @@ static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
   if (auto tupleTy = Ty.getAs<TupleType>()) {
     for (auto elt : tupleTy.getElementTypes()) {
       auto silElt = SILType::getPrimitiveObjectType(elt);
-      countNumberOfInnerFields(fieldsCount, Module, silElt, expansion);
+      countNumberOfInnerFields(fieldsCount, TC, silElt, expansion);
     }
     return;
   }
@@ -2670,7 +2664,7 @@ static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
     if (enumDecl->isIndirect()) {
       return;
     }
-    assert(!enumDecl->isResilient(Module.getSwiftModule(), expansion) &&
+    assert(!enumDecl->isResilient(&TC.M, expansion) &&
            " FSO should not be trying to explode resilient (ie address-only) "
            "types at all");
     unsigned fieldsCountBefore = fieldsCount;
@@ -2683,16 +2677,16 @@ static void countNumberOfInnerFields(unsigned &fieldsCount, SILModule &Module,
         continue;
 
       if (!elt->hasInterfaceType())
-        enumDecl->getASTContext().getLazyResolver()->resolveDeclSignature(elt);
+        TC.Context.getLazyResolver()->resolveDeclSignature(elt);
 
       // Although one might assume enums have a fields count of 1
       // Which holds true for current uses of this code
       // (we shouldn't expand enums)
       // Number of fields > 1 as "future proof" for this heuristic:
       // In case it is used by a pass that tries to explode enums.
-      auto payloadTy = Ty.getEnumElementType(elt, Module);
+      auto payloadTy = Ty.getEnumElementType(elt, TC);
       fieldsCount = 0;
-      countNumberOfInnerFields(fieldsCount, Module, payloadTy, expansion);
+      countNumberOfInnerFields(fieldsCount, TC, payloadTy, expansion);
       if (fieldsCount > maxEnumCount) {
         maxEnumCount = fieldsCount;
       }
@@ -2710,7 +2704,7 @@ unsigned TypeConverter::countNumberOfFields(SILType Ty,
     return std::max(Iter->second, 1U);
   }
   unsigned fieldsCount = 0;
-  countNumberOfInnerFields(fieldsCount, M, Ty, expansion);
+  countNumberOfInnerFields(fieldsCount, *this, Ty, expansion);
   TypeFields[key] = fieldsCount;
   return std::max(fieldsCount, 1U);
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1662,7 +1662,8 @@ void SILGenModule::emitSourceFile(SourceFile *sf) {
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<SILModule>
-SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF) {
+SILModule::constructSIL(ModuleDecl *mod, TypeConverter &tc,
+                        SILOptions &options, FileUnit *SF) {
   SharedTimer timer("SILGen");
   const DeclContext *DC;
   if (SF) {
@@ -1672,7 +1673,7 @@ SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF) {
   }
 
   std::unique_ptr<SILModule> M(
-      new SILModule(mod, options, DC, /*wholeModule*/ SF == nullptr));
+      new SILModule(mod, tc, options, DC, /*wholeModule*/ SF == nullptr));
   SILGenModule SGM(*M, mod);
 
   if (SF) {
@@ -1721,11 +1722,13 @@ SILModule::constructSIL(ModuleDecl *mod, SILOptions &options, FileUnit *SF) {
 }
 
 std::unique_ptr<SILModule>
-swift::performSILGeneration(ModuleDecl *mod, SILOptions &options) {
-  return SILModule::constructSIL(mod, options, nullptr);
+swift::performSILGeneration(ModuleDecl *mod, Lowering::TypeConverter &tc,
+                            SILOptions &options) {
+  return SILModule::constructSIL(mod, tc, options, nullptr);
 }
 
 std::unique_ptr<SILModule>
-swift::performSILGeneration(FileUnit &sf, SILOptions &options) {
-  return SILModule::constructSIL(sf.getParentModule(), options, &sf);
+swift::performSILGeneration(FileUnit &sf, Lowering::TypeConverter &tc,
+                            SILOptions &options) {
+  return SILModule::constructSIL(sf.getParentModule(), tc, options, &sf);
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5424,7 +5424,7 @@ AccessorBaseArgPreparer::AccessorBaseArgPreparer(SILGenFunction &SGF,
 
 ArgumentSource AccessorBaseArgPreparer::prepare() {
   // If the base is a boxed existential, we will open it later.
-  if (baseLoweredType.getPreferredExistentialRepresentation(SGF.SGM.M) ==
+  if (baseLoweredType.getPreferredExistentialRepresentation() ==
       ExistentialRepresentation::Boxed) {
     assert(!baseLoweredType.isAddress() &&
            "boxed existential should not be an address");

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -763,7 +763,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
   }
 
   switch (existentialTL.getLoweredType().getObjectType()
-            .getPreferredExistentialRepresentation(SGM.M, concreteFormalType)) {
+            .getPreferredExistentialRepresentation(concreteFormalType)) {
   case ExistentialRepresentation::None:
     llvm_unreachable("not an existential type");
   case ExistentialRepresentation::Metatype: {
@@ -932,7 +932,7 @@ SILGenFunction::emitOpenExistential(
   assert(isInFormalEvaluationScope());
 
   SILType existentialType = existentialValue.getType();
-  switch (existentialType.getPreferredExistentialRepresentation(SGM.M)) {
+  switch (existentialType.getPreferredExistentialRepresentation()) {
   case ExistentialRepresentation::Opaque: {
     // With CoW existentials we can't consume the boxed value inside of
     // the existential. (We could only do so after a uniqueness check on

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -850,13 +850,13 @@ namespace {
       assert(base.getType().isExistentialType() &&
              "base for open existential component must be an existential");
       assert((base.getType().isAddress() ||
-              base.getType().getPreferredExistentialRepresentation(SGF.SGM.M) ==
+              base.getType().getPreferredExistentialRepresentation() ==
                   ExistentialRepresentation::Boxed) &&
              "base value of open-existential component was not an address or a "
              "boxed existential?");
       SILValue addr;
 
-      auto rep = base.getType().getPreferredExistentialRepresentation(SGF.SGM.M);
+      auto rep = base.getType().getPreferredExistentialRepresentation();
       switch (rep) {
       case ExistentialRepresentation::Opaque:
         addr = SGF.B.createOpenExistentialAddr(
@@ -922,14 +922,14 @@ namespace {
              "base for open existential component must be an existential");
       ManagedValue ref;
       if (refType.is<ExistentialMetatypeType>()) {
-        assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
+        assert(refType.getPreferredExistentialRepresentation()
                  == ExistentialRepresentation::Metatype);
         ref = ManagedValue::forUnmanaged(
                 SGF.B.createOpenExistentialMetatype(loc,
                                                     result.getUnmanagedValue(),
                                                     getTypeOfRValue()));
       } else {
-        assert(refType.getPreferredExistentialRepresentation(SGF.SGM.M)
+        assert(refType.getPreferredExistentialRepresentation()
                  == ExistentialRepresentation::Class);
         ref = SGF.B.createOpenExistentialRef(loc, result, getTypeOfRValue());
       }
@@ -4188,7 +4188,7 @@ SILGenFunction::emitOpenExistentialLValue(SILLocation loc,
 
   // Open up the existential.
   auto rep = lv.getTypeOfRValue()
-    .getPreferredExistentialRepresentation(SGM.M);
+    .getPreferredExistentialRepresentation();
   switch (rep) {
   case ExistentialRepresentation::Opaque:
   case ExistentialRepresentation::Boxed: {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -648,7 +648,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   // Lower the witness thunk type with the requirement's abstraction level.
   auto witnessSILFnType = getNativeSILFunctionType(
-      M, AbstractionPattern(reqtOrigTy), reqtSubstTy,
+      M.Types, AbstractionPattern(reqtOrigTy), reqtSubstTy,
       requirement, witnessRef, witnessSubsForTypeLowering, conformance);
 
   // Mangle the name of the witness thunk.

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -152,8 +152,7 @@ bool ExistentialSpecializer::canSpecializeExistentialArgsInFunction(
       continue;
 
     auto ExistentialRepr =
-        CalleeArg->getType().getPreferredExistentialRepresentation(
-            F->getModule());
+        CalleeArg->getType().getPreferredExistentialRepresentation();
     if (ExistentialRepr != ExistentialRepresentation::Opaque &&
           ExistentialRepr != ExistentialRepresentation::Class)
       continue;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -174,7 +174,7 @@ void ExistentialSpecializerCloner::cloneArguments(
     ArrayRef<ProtocolConformanceRef> Conformances =
         Ctx.AllocateCopy(NewConformances);
     auto ExistentialRepr =
-        ArgDesc.Arg->getType().getPreferredExistentialRepresentation(M);
+        ArgDesc.Arg->getType().getPreferredExistentialRepresentation();
     auto &EAD = ExistentialArgDescriptor[ArgDesc.Index];
     switch (ExistentialRepr) {
     case ExistentialRepresentation::Opaque: {
@@ -434,7 +434,7 @@ void ExistentialTransform::populateThunkBody() {
       auto OpenedSILType = NewF->getLoweredType(OpenedType);
       SILValue archetypeValue;
       auto ExistentialRepr =
-          ArgDesc.Arg->getType().getPreferredExistentialRepresentation(M);
+          ArgDesc.Arg->getType().getPreferredExistentialRepresentation();
       switch (ExistentialRepr) {
       case ExistentialRepresentation::Opaque: {
         archetypeValue = Builder.createOpenExistentialAddr(

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -367,7 +367,7 @@ computeNewArgInterfaceTypes(SILFunction *F, IndicesSet &PromotableIndices,
     auto paramBoxTy = paramTy.castTo<SILBoxType>();
     assert(paramBoxTy->getLayout()->getFields().size() == 1
            && "promoting compound box not implemented yet");
-    auto paramBoxedTy = paramBoxTy->getFieldType(F->getModule(), 0);
+    auto paramBoxedTy = getSILBoxFieldType(paramBoxTy, Types, 0);
     auto &paramTL = Types.getTypeLowering(paramBoxedTy, expansion);
     ParameterConvention convention;
     if (paramTL.isAddressOnly()) {
@@ -479,7 +479,8 @@ ClosureCloner::populateCloned() {
     auto BoxTy = (*I)->getType().castTo<SILBoxType>();
     assert(BoxTy->getLayout()->getFields().size() == 1 &&
            "promoting compound box not implemented");
-    auto BoxedTy = BoxTy->getFieldType(Cloned->getModule(), 0).getObjectType();
+    auto BoxedTy = getSILBoxFieldType(BoxTy, Cloned->getModule().Types, 0)
+      .getObjectType();
     SILValue MappedValue =
         ClonedEntryBB->createFunctionArgument(BoxedTy, (*I)->getDecl());
 
@@ -997,7 +998,7 @@ bool isPartialApplyNonEscapingUser(Operand *CurrentOp, PartialApplyInst *PAI,
   auto BoxTy = BoxArg->getType().castTo<SILBoxType>();
   assert(BoxTy->getLayout()->getFields().size() == 1 &&
          "promoting compound box not implemented yet");
-  if (BoxTy->getFieldType(M, 0).isAddressOnly(*F)) {
+  if (getSILBoxFieldType(BoxTy, M.Types, 0).isAddressOnly(*F)) {
     LLVM_DEBUG(llvm::dbgs() << "        FAIL! Box is an address only "
                                "argument!\n");
     return false;

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -34,7 +34,7 @@ PMOMemoryObjectInfo::PMOMemoryObjectInfo(AllocationInst *allocation)
   if (auto *abi = dyn_cast<AllocBoxInst>(MemoryInst)) {
     assert(abi->getBoxType()->getLayout()->getFields().size() == 1 &&
            "analyzing multi-field boxes not implemented");
-    MemorySILType = abi->getBoxType()->getFieldType(module, 0);
+    MemorySILType = getSILBoxFieldType(abi->getBoxType(), module.Types, 0);
   } else {
     MemorySILType = cast<AllocStackInst>(MemoryInst)->getElementType();
   }

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1434,7 +1434,7 @@ static SILType getMemoryType(AllocationInst *memory) {
   if (auto *abi = dyn_cast<AllocBoxInst>(memory)) {
     assert(abi->getBoxType()->getLayout()->getFields().size() == 1 &&
            "optimizing multi-field boxes not implemented");
-    return abi->getBoxType()->getFieldType(abi->getModule(), 0);
+    return getSILBoxFieldType(abi->getBoxType(), abi->getModule().Types, 0);
   }
 
   assert(isa<AllocStackInst>(memory));

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1532,7 +1532,7 @@ static bool optimizeStaticallyKnownProtocolConformance(
         Ctx.AllocateCopy(NewConformances);
 
     auto ExistentialRepr =
-        Dest->getType().getPreferredExistentialRepresentation(Mod, SourceType);
+        Dest->getType().getPreferredExistentialRepresentation(SourceType);
 
     switch (ExistentialRepr) {
     default:

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1000,7 +1000,8 @@ ASTUnitRef ASTProducer::createASTUnit(
 
     if (auto SF = CompIns.getPrimarySourceFile()) {
       SILOptions SILOpts = Invocation.getSILOptions();
-      std::unique_ptr<SILModule> SILMod = performSILGeneration(*SF, SILOpts);
+      auto &TC = CompIns.getSILTypes();
+      std::unique_ptr<SILModule> SILMod = performSILGeneration(*SF, TC, SILOpts);
       runSILDiagnosticPasses(*SILMod);
     }
   }

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -24,6 +24,7 @@
 #include "swift/Option/Options.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/TypeLowering.h"
 #include "swift/Subsystems.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Bitcode/BitstreamReader.h"
@@ -177,7 +178,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
                          true);
   ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
   SILOptions SILOpts;
-  std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, SILOpts);
+  std::unique_ptr<Lowering::TypeConverter> TC(new Lowering::TypeConverter(*M));
+  std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, *TC, SILOpts);
   createSwiftModuleObjectFile(*SM, (*ErrOrBuf)->getBuffer(),
                               Invocation.getOutputFilename());
   return 0;

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -277,8 +277,7 @@ int main(int argc, char **argv) {
   if (Invocation.hasSerializedAST()) {
     assert(!CI.hasSILModule() &&
            "performSema() should not create a SILModule.");
-    CI.setSILModule(
-        SILModule::createEmptyModule(CI.getMainModule(), CI.getSILOptions()));
+    CI.createSILModule();
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -189,8 +189,7 @@ int main(int argc, char **argv) {
   if (Invocation.hasSerializedAST()) {
     assert(!CI.hasSILModule() &&
            "performSema() should not create a SILModule.");
-    CI.setSILModule(SILModule::createEmptyModule(
-        CI.getMainModule(), CI.getSILOptions(), PerformWMO));
+    CI.createSILModule();
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -191,8 +191,7 @@ int main(int argc, char **argv) {
   if (Invocation.hasSerializedAST()) {
     assert(!CI.hasSILModule() &&
            "performSema() should not create a SILModule.");
-    CI.setSILModule(
-        SILModule::createEmptyModule(CI.getMainModule(), CI.getSILOptions()));
+    CI.createSILModule();
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -389,8 +389,7 @@ int main(int argc, char **argv) {
   if (Invocation.hasSerializedAST()) {
     assert(!CI.hasSILModule() &&
            "performSema() should not create a SILModule.");
-    CI.setSILModule(SILModule::createEmptyModule(
-        CI.getMainModule(), CI.getSILOptions(), PerformWMO));
+    CI.createSILModule();
     std::unique_ptr<SerializedSILLoader> SL = SerializedSILLoader::create(
         CI.getASTContext(), CI.getSILModule(), nullptr);
 


### PR DESCRIPTION
Batch mode compiles a single AST ModuleDecl but creates a new SILModule for each translation unit emitted by SILGen/IRGen. This SILModule had a lot of cached state that did not depend on the translation unit and was being re-created for each source file.

This PR decouples the TypeConverter from the SILModule, making it only depend on the ModuleDecl instead, and refactors the frontend to share a single instance across all SILModules it creates.