### PR TITLE
[AutoDiff] [Sema] Fix a 'EuclideanDifferentiable' derived conformances crasher.

### DIFF
--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -404,13 +404,14 @@ static ValueDecl *deriveEuclideanDifferentiable_differentiableVectorView(
         eucDiffProto->lookupDirect(C.Id_differentiableVectorView).front();
 
     SmallVector<VarDecl *, 8> diffProperties;
-    getStoredPropertiesForDifferentiation(nominal, nominal->getDeclContext(),
-                                          diffProperties);
+    getStoredPropertiesForDifferentiation(nominal, parentDC, diffProperties);
 
     // Create a reference to the memberwise initializer: `TangentVector.init`.
     auto *memberwiseInitDecl =
         context->tangentDecl->getEffectiveMemberwiseInitializer();
     assert(memberwiseInitDecl && "Memberwise initializer must exist");
+    assert(diffProperties.size() ==
+               memberwiseInitDecl->getParameters()->size());
     // `TangentVector`
     auto *tangentTypeExpr =
         TypeExpr::createImplicit(context->tangentContextualType, C);
@@ -425,9 +426,9 @@ static ValueDecl *deriveEuclideanDifferentiable_differentiableVectorView(
     // Create a call:
     //   TangentVector.init(
     //     <property_name_1...>:
-    //        self.differentiableVectorView.<property_name_1>,
+    //        self.<property_name_1>.differentiableVectorView,
     //     <property_name_2...>:
-    //        self.differentiableVectorView.<property_name_2>,
+    //        self.<property_name_2>.differentiableVectorView,
     //     ...
     //   )
     SmallVector<Identifier, 8> argLabels;

--- a/test/Sema/class_differentiable.swift
+++ b/test/Sema/class_differentiable.swift
@@ -139,9 +139,8 @@ extension VectorSpacesEqualSelf : Equatable, AdditiveArithmetic {
 */
 
 // Test generic type with vector space types to `Self`.
-// FIXME(TF-783): Uncomment `EuclideanDifferentiable` conformance once crasher is fixed.
-class GenericVectorSpacesEqualSelf<T> : Differentiable//, EuclideanDifferentiable
-  where T : Differentiable, T == T.TangentVector
+class GenericVectorSpacesEqualSelf<T> : Differentiable, EuclideanDifferentiable
+  where T : EuclideanDifferentiable, T == T.TangentVector
 {
   var w: T
   var b: T


### PR DESCRIPTION
Resolves [TF-783](https://bugs.swift.org/browse/TF-783).