### PR TITLE
[NFC NameLookup ASTScope] Default LazyASTScopes to true

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -259,7 +259,7 @@ namespace swift {
     bool WarnIfASTScopeLookup = false;
 
     /// Build the ASTScope tree lazily
-    bool LazyASTScopes = false;
+    bool LazyASTScopes = true;
 
     /// Whether to use the import as member inference system
     ///

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -297,7 +297,6 @@ public:
   /// Called from lldb, see rdar://53971116
   void disableASTScopeLookup() {
     LangOpts.EnableASTScopeLookup = false;
-    LangOpts.LazyASTScopes = false;
   }
 
   CodeCompletionCallbacksFactory *getCodeCompletionFactory() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -339,8 +339,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Opts.DisableParserLookup;
   Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
   Opts.WarnIfASTScopeLookup |= Args.hasArg(OPT_warn_if_astscope_lookup);
-  Opts.LazyASTScopes |=
-      Opts.EnableASTScopeLookup && Args.hasArg(OPT_lazy_astscopes);
+  Opts.LazyASTScopes |= Args.hasArg(OPT_lazy_astscopes);
 
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.NamedLazyMemberLoading &= !Args.hasArg(OPT_disable_named_lazy_member_loading);

--- a/test/NameBinding/scope_map_top_level.swift
+++ b/test/NameBinding/scope_map_top_level.swift
@@ -51,10 +51,6 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:                 |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15]
 // CHECK-EXPANDED-NEXT:                 |-ExtensionDeclScope {{.*}}, [17:1 - 19:1]
 // CHECK-EXPANDED-NEXT:                   `-ExtensionBodyScope {{.*}}, [17:15 - 19:1]
-// CHECK-EXPANDED-NEXT:                     `-AbstractFunctionDeclScope {{.*}}, [18:3 - 18:43] 'my_identity()'
-// CHECK-EXPANDED-NEXT:                       `-ParameterListScope {{.*}}, [18:19 - 18:43]
-// CHECK-EXPANDED-NEXT:                         `-MethodBodyScope {{.*}}, [18:29 - 18:43]
-// CHECK-EXPANDED-NEXT:                           `-BraceStmtScope {{.*}}, [18:29 - 18:43]
 // CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                     `-PatternEntryDeclScope {{.*}}, [21:5 - 21:28] entry 0 'i'


### PR DESCRIPTION
The `LazyASTScopes` language option tells the ASTScope system to be lazy. It has no effect unless ASTScope lookup is enabled. Default it to true so that `-enable-astscope-lookup` is all that's needed to try the new system. Since the system is off-by-default, this PR will make no functional change.