### PR TITLE
[5.1] Sema: Compare canonical bound signatures when comparing opaque type archetypes for dynamic replacement

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2363,7 +2363,8 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   if (matchMode.contains(TypeMatchFlags::AllowCompatibleOpaqueTypeArchetypes))
     if (auto opaque1 = t1->getAs<OpaqueTypeArchetypeType>())
       if (auto opaque2 = t2->getAs<OpaqueTypeArchetypeType>())
-        return opaque1->getBoundSignature() == opaque2->getBoundSignature() &&
+        return opaque1->getBoundSignature()->getCanonicalSignature() ==
+                   opaque2->getBoundSignature()->getCanonicalSignature() &&
                opaque1->getInterfaceType()->getCanonicalType()->matches(
                    opaque2->getInterfaceType()->getCanonicalType(), matchMode);
 

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify -enable-opaque-result-types %s
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify -enable-opaque-result-types %s -swift-version 5
 
 protocol P {
   func paul()

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -473,3 +473,16 @@ func invoke_52528543<T: P_52528543, U: P_52528543>(x: T, y: U) {
   var xab = f_52528543(x: x2)
   xab = f_52528543(x: y2) // expected-error{{cannot assign}}
 }
+
+protocol Proto {}
+
+struct I : Proto {}
+
+dynamic func foo<S>(_ s: S) -> some Proto {
+  return I()
+}
+
+@_dynamicReplacement(for: foo)
+func foo_repl<S>(_ s: S) -> some Proto {
+ return   I()
+}


### PR DESCRIPTION
Explanation: Dynamic replacement of generic functions that return an
opaque type fails resulting in a crash

Origination: Introduction of dynamic replacement of some types.

Risk: Low risk change replaces one line

Reviewed by: Doug G.

Testing: Tested as part of the Swift regression tests

master PR: https://github.com/apple/swift/pull/26564

rdar://53610474