### PR TITLE
[5.1][Diagnostics] Don't crash trying to diagnose missing opaque result type

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2958,10 +2958,10 @@ bool MissingGenericArgumentsFailure::diagnoseForAnchor(
   if (!diagnosed)
     return false;
 
-  if (!hasDecl())
+  auto *DC = getDeclContext();
+  if (!DC)
     return true;
 
-  auto *DC = getDeclContext();
   if (auto *SD = dyn_cast<SubscriptDecl>(DC)) {
     emitDiagnostic(SD, diag::note_call_to_subscript, SD->getFullName());
     return true;
@@ -3011,14 +3011,13 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
     emitDiagnostic(loc, diag::unbound_generic_parameter, GP);
   }
 
-  if (!hasDecl())
+  Type baseTyForNote;
+  auto *DC = getDeclContext();
+  if (!DC)
     return true;
 
   if (!hasLoc(GP))
     return true;
-
-  Type baseTyForNote;
-  auto *DC = getDeclContext();
 
   if (auto *NTD =
           dyn_cast_or_null<NominalTypeDecl>(DC->getSelfNominalTypeDecl())) {
@@ -3039,6 +3038,9 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
   auto &cs = getConstraintSystem();
   auto &TC = getTypeChecker();
   auto *paramDC = getDeclContext();
+
+  if (!paramDC)
+    return;
 
   auto *GTD = dyn_cast<GenericTypeDecl>(paramDC);
   if (!GTD || anchor.is<Expr *>())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2958,6 +2958,9 @@ bool MissingGenericArgumentsFailure::diagnoseForAnchor(
   if (!diagnosed)
     return false;
 
+  if (!hasDecl())
+    return true;
+
   auto *DC = getDeclContext();
   if (auto *SD = dyn_cast<SubscriptDecl>(DC)) {
     emitDiagnostic(SD, diag::note_call_to_subscript, SD->getFullName());
@@ -3007,6 +3010,9 @@ bool MissingGenericArgumentsFailure::diagnoseParameter(
   } else {
     emitDiagnostic(loc, diag::unbound_generic_parameter, GP);
   }
+
+  if (!hasDecl())
+    return true;
 
   if (!hasLoc(GP))
     return true;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1334,10 +1334,10 @@ public:
 
   DeclContext *getDeclContext() const {
     auto *GP = Parameters.front();
-    return GP->getDecl()->getDeclContext();
-  }
+    auto *decl = GP->getDecl();
 
-  bool hasDecl() const { return Parameters.front()->getDecl() != nullptr; }
+    return decl ? decl->getDeclContext() : nullptr;
+  }
 
   bool diagnoseAsError() override;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1337,6 +1337,8 @@ public:
     return GP->getDecl()->getDeclContext();
   }
 
+  bool hasDecl() const { return Parameters.front()->getDecl() != nullptr; }
+
   bool diagnoseAsError() override;
 
   bool diagnoseForAnchor(Anchor anchor,

--- a/validation-test/compiler_crashers_2_fixed/sr11236.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11236.swift
@@ -10,4 +10,3 @@ public func myTri<T: Comparable, U: Comparable> (retval: UnsafeMutablePointer<U>
   retval.initialize(to: trichotomy(x: x, y: y))
 }
 
-print("Hello, World!")

--- a/validation-test/compiler_crashers_2_fixed/sr11236.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11236.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public func trichotomy<T : Comparable>(x: T, y: T) -> some Comparable {
+  if x < y { return -1 } 
+  else if x == y { return 0 }
+  return 1
+}
+
+public func myTri<T: Comparable, U: Comparable> (retval: UnsafeMutablePointer<U>, x: UnsafeMutablePointer<T>, y: UnsafeMutablePointer<T>) {
+  retval.initialize(to: trichotomy(x: x, y: y))
+}
+
+print("Hello, World!")


### PR DESCRIPTION
- **Explanation**:

Avoid a crash when type associated with opaque result 
hasn't been explicitly specified and couldn't be inferred by type checker.

- **Issue**: rdar://problem/52774804

- **Scope**: Constraint solver in diagnostic mode.

- **Risk**: Very Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @xedin 

Resolves: rdar://problem/52774804

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
