### PR TITLE
Drop a superfluous NULL write

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6021,13 +6021,8 @@ ParamDecl::getDefaultValueStringRepresentation(
     if (!existing.empty())
       return existing;
 
-    if (!getDefaultValue()) {
-      // TypeChecker::checkDefaultArguments() nulls out the default value
-      // if it fails to type check it. This only seems to happen with an
-      // invalid/incomplete parameter list that contains a parameter with an
-      // unresolved default value.
-      return "<<empty>>";
-    }
+    assert(getDefaultValue()
+           && "Normal default argument with no default expression?!");
     return extractInlinableText(getASTContext().SourceMgr, getDefaultValue(),
                                 scratch);
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1900,8 +1900,6 @@ void TypeChecker::checkDefaultArguments(ParameterList *params,
 
     if (resultTy) {
       param->setDefaultValue(e);
-    } else {
-      param->setDefaultValue(nullptr);
     }
 
     checkInitializerErrorHandling(initContext, e);

--- a/test/SourceKit/CursorInfo/undefined-default-value.swift
+++ b/test/SourceKit/CursorInfo/undefined-default-value.swift
@@ -1,9 +1,0 @@
-enum LogLevel { case error }
-
-func logAsync(level: LogLevel = undefined, messageProducer producer
-
-// RUN: %sourcekitd-test -req=cursor -pos=3:44 %s -- %s | %FileCheck %s
-
-// CHECK: source.lang.swift.decl.function.free (3:6-3:68)
-// CHECK: logAsync(level:messageProducer:)
-// CHECK: LogLevel</Type> = &lt;&lt;empty&gt;&gt


### PR DESCRIPTION
Storing NULL here on failure is brittle and was only necessary when the
typechecker was leaking type variables in expressions.  Now that we're
better about this, it's best to preserve the damaged AST.

<strike>Going to run all the tests to see if this theory is true.</strike>

Hypothesis confirmed.  The invariant that this be non-null has been plumbed and the workaround and its supporting test have been dropped.