### PR TITLE
Runtime: Hook the ObjC runtime with an untrusted demangler.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1769,8 +1769,8 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
         return nullptr;
       }).getMetadata();
   } else {
-    metadata = swift_getTypeByMangledNameInEnvironment(
-      typeStr.data(), typeStr.size(), /* no substitutions */ nullptr, nullptr);
+    metadata = swift_stdlib_getTypeByMangledNameUntrusted(typeStr.data(),
+                                                          typeStr.size());
   }
   if (metadata) {
     auto objcClass =

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -248,6 +248,12 @@ testSuite.test("NotPresent") {
 
   // Swift.Int is not a class type.
   expectNil(NSClassFromString("Si"))
+
+  // Mangled names with byte sequences that look like symbolic references
+  // should not be demangled.
+  expectNil(NSClassFromString("\u{1}badnews"));
+  expectNil(NSClassFromString("$s\u{1}badnews"));
+  expectNil(NSClassFromString("_T\u{1}badnews"));
 }
 
 runAllTests()


### PR DESCRIPTION
We don't want objc_getClass and NSClassFromString to be able to feed arbitrary symbolic reference pointers into the Swift runtime. Fixes rdar://problem/54724618.