### PR TITLE
[SyntaxParse] use parseGenericArgumentClauseSyntax()

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1094,6 +1094,8 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       } else {
         if (!Backtracking)
           diagnose(Tok, diag::expected_parameter_colon);
+        NameLoc = SourceLoc();
+        SecondNameLoc = SourceLoc();
       }
     } else if (InOut) {
       // If we don't have labels, 'inout' is not a obsoleted use.

--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -5,13 +5,19 @@ class C {
   typealias Inner: Foo = Int
 
   typealias Alias1 = [Generic<Int
-  typealias Alias2 = () -> (a b: [Generic<Int
+
 
   // Implict accessor with attribute at the top of its body.
   var x: Int {
     @objc
     func f() {}
   }
+}
+do {
+  typealias Alias2 = () -> (a b: [Generic<Int
+}
+do {
+  typealias Alias3 = (a b C, 
 }
 
 // Orphan '}' at top level

--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -4,7 +4,8 @@ class C {
   // Erroneous typealias decl.
   typealias Inner: Foo = Int
 
-  typealias Inner: Foo2 = [Generic<Int
+  typealias Alias1 = [Generic<Int
+  typealias Alias2 = () -> (a b: [Generic<Int
 
   // Implict accessor with attribute at the top of its body.
   var x: Int {


### PR DESCRIPTION
To parse generic arguments for types. There's no reason to use AST version of it.