### PR TITLE
[test] Remove redirection stderr->out that corrupted output.

### DIFF
--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -dump-parse %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -dump-parse %s | %FileCheck %s
 // RUN: not %target-swift-frontend -dump-ast %s | %FileCheck %s -check-prefix=CHECK-AST
 
 // CHECK-LABEL: (func_decl{{.*}}"foo(_:)"


### PR DESCRIPTION
The RUN line was redirecting stderr to stdout, but nothing in the test
was checking for the stderr output.

However, the last line of stderr was an empty newline, which was printed
(in my machine) in the middle of the dump from the AST, breaking the
test.

If we ever need to check the stderr, it should be redirected to a file,
and the file should be passed to FileCheck independently, to avoid
concurrent uses of the output buffer.

A similar change was performed in 39d396313152a1c026df0938a224552518bbc5e0 to the second line of the test.

/cc @akyrtzi 