### PR TITLE
[5.1] Runtime: Hook the ObjC runtime with an untrusted demangler.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1741,8 +1741,8 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
         return nullptr;
       }).getMetadata();
   } else {
-    metadata = swift_getTypeByMangledNameInEnvironment(
-      typeStr.data(), typeStr.size(), /* no substitutions */ nullptr, nullptr);
+    metadata = swift_stdlib_getTypeByMangledNameUntrusted(typeStr.data(),
+                                                          typeStr.size());
   }
   if (metadata) {
     auto objcClass =

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -248,6 +248,12 @@ testSuite.test("NotPresent") {
 
   // Swift.Int is not a class type.
   expectNil(NSClassFromString("Si"))
+
+  // Mangled names with byte sequences that look like symbolic references
+  // should not be demangled.
+  expectNil(NSClassFromString("\u{1}badnews"));
+  expectNil(NSClassFromString("$s\u{1}badnews"));
+  expectNil(NSClassFromString("_T\u{1}badnews"));
 }
 
 runAllTests()


### PR DESCRIPTION
Explanation: We don't want objc_getClass and NSClassFromString to be able to feed arbitrary symbolic reference pointers into the Swift runtime.

Scope: Possible security hole if untrusted strings can be fed to NSClassFromString

Issue: rdar://problem/54724618.

Risk: Low

Testing: Swift CI

Reviewed by: @mikeash 
