### PR TITLE
[CMake][SourceKit] SwiftLang should depend on clang-tablegen-targets

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -49,3 +49,5 @@ add_sourcekit_library(SourceKitSwiftLang
       objcarcopts
       profiledata
 )
+
+add_dependencies(SourceKitSwiftLang clang-tablegen-targets)


### PR DESCRIPTION
SwiftLang relies on some clang headers that rely on clang tablegen targets.

cc @compnerd @gottesmm @Rostepher 