### PR TITLE
[DO NOT MERGE][stdlib] Keep Dictionary storage at least 25% full when possible

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -444,7 +444,9 @@ public struct Dictionary<Key: Hashable, Value> {
   ///   reallocating its storage buffer.
   public // FIXME(reserveCapacity): Should be inlinable
   init(minimumCapacity: Int) {
-    _variant = _Variant(native: _NativeDictionary(capacity: minimumCapacity))
+    var native = _NativeDictionary<Key, Value>()
+    native.reserveCapacity(minimumCapacity, isUnique: false)
+    _variant = _Variant(native: native)
   }
 
   /// Creates a new dictionary from the key-value pairs in the given sequence.

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -380,7 +380,9 @@ extension _DictionaryStorage {
     capacity: Int,
     move: Bool
   ) -> _DictionaryStorage {
-    let scale = _HashTable.scale(forCapacity: capacity)
+    let scale = max(
+      original._reservedScale,
+      _HashTable.scale(forCapacity: capacity))
     return allocate(scale: scale, age: nil, seed: nil)
   }
 

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -113,8 +113,13 @@ extension Dictionary._Variant {
 #if _runtime(_ObjC)
     guard isNative else {
       let cocoa = asCocoa
-      let capacity = Swift.max(cocoa.count, capacity)
-      self = .init(native: _NativeDictionary(cocoa, capacity: capacity))
+      var native = _NativeDictionary<Key, Value>(
+        cocoa,
+        capacity: Swift.max(cocoa.count, capacity))
+      if capacity > 0 {
+        native.reserveCapacity(capacity, isUnique: true)
+      }
+      self = .init(native: native)
       return
     }
 #endif

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -55,7 +55,7 @@ internal struct _HashTable {
 }
 
 extension _HashTable {
-  /// The inverse of the maximum hash table load factor.
+  /// The maximum hash table load factor.
   private static var maxLoadFactor: Double {
     @inline(__always) get { return 3 / 4 }
   }
@@ -63,6 +63,19 @@ extension _HashTable {
   internal static func capacity(forScale scale: Int8) -> Int {
     let bucketCount = (1 as Int) &<< scale
     return Int(Double(bucketCount) * maxLoadFactor)
+  }
+
+  internal static func minimumCapacity(forScale scale: Int8) -> Int {
+    // For scales less than 4, set no minimum.
+    if scale < 4 { return 0 }
+    // Otherwise, set a minimum load factor of 25% plus one. (The plus one is
+    // necessary to ensure we don't shrink down by two scales after a removal,
+    // ending up with a table at full capacity. It's better to jump down a
+    // single step, so that the resulting table is half full and it won't get
+    // immediately resized again if an insertion follows the removal that
+    // triggered the shrinking.)
+    let capacity = (1 as Int) &<< (scale - 2)
+    return capacity + 1
   }
 
   internal static func scale(forCapacity capacity: Int) -> Int8 {


### PR DESCRIPTION
This is an experimental implementation of shrinking Dictionary storage after removals.

It isn't clear this is worth doing, and the bulk of the actual work towards landing it would be in benchmarking and adding test coverage, which is not at all done. However, the implementation is an interesting exercise in library evolution. 

It's *almost* possible to make this feature deploy back to earlier OSes -- except Set/Dictionary doesn't record the reserved capacity in 5.0 & 5.1, and that arguably rules out shrinking. (We'd also have to make the minimum load factor part of the ABI, but that's less of an issue.)

rdar://problem/18114559