### PR TITLE
ABI checker: exclude unavailable decls from ABI descriptors

### DIFF
--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -130,3 +130,12 @@ public class SwiftObjcClass {
   @objc(ObjCFool:ObjCA:ObjCB:)
   public func foo(a:Int, b:Int, c: Int) {}
 }
+
+@available(iOS 10.2, tvOS 10.3, watchOS 3.4, *)
+@available(macOS, unavailable)
+public class UnavailableOnMac {}
+
+@available(macOS, unavailable)
+extension SwiftObjcClass {
+  public func functionUnavailableOnMac() {}
+}

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1570,9 +1570,9 @@ SDKContext::shouldIgnore(Decl *D, const Decl* Parent) const {
   } else {
     if (D->isPrivateStdlibDecl(false))
       return true;
-    if (AvailableAttr::isUnavailable(D))
-      return true;
   }
+  if (AvailableAttr::isUnavailable(D))
+     return true;
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     switch (getAccessLevel(VD)) {
     case AccessLevel::Internal:


### PR DESCRIPTION
Framework authors usually have different schemes for different deployment
targets. We should exclude platform-unavailable ABIs from the Json file so
developers will only be warned of the breakages that are relevant to the current
scheme.

rdar://54273296
