### PR TITLE
Add basic SIMD benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -147,6 +147,7 @@ set(SWIFT_BENCH_MODULES
     single-source/RemoveWhere
     single-source/ReversedCollections
     single-source/RomanNumbers
+    single-source/SIMDInt
     single-source/SequenceAlgos
     single-source/SetTests
     single-source/SevenBoom

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -96,6 +96,7 @@ public func run_SIMD4Int32Shr(N: Int) {
   blackHole(a)
 }
 
+// The wrapped sum of these integers is expected to be 1000
 let bulkSumInts = Array(repeating: SIMD4<Int32>(1, 2, 3, 4), count: 100)
 
 @inline(never)
@@ -103,6 +104,6 @@ public func run_SIMD4Int32BulkSum(N: Int) {
   for _ in 0..<N {
     let ints = identity(bulkSumInts)
     let sum = ints.reduce(SIMD4<Int32>(), &+).wrappedSum()
-    blackHole(sum)
+    CheckResults(sum == 1000)
   }
 }

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -1,0 +1,71 @@
+//===--- SIMDInt.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let SIMDInt = [
+  BenchmarkInfo(name: "SIMDIntAdd", runFunction: run_SIMDIntAdd, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntSub", runFunction: run_SIMDIntSub, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntMul", runFunction: run_SIMDIntMul, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntDiv", runFunction: run_SIMDIntDiv, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntRem", runFunction: run_SIMDIntRem, tags: [.validation, .api]),
+]
+
+@inline(never)
+public func run_SIMDIntAdd(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a &+ b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntSub(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a &- b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntMul(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a &* b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntDiv(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a / b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntRem(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a % b
+  }
+  blackHole(a)
+}

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -15,19 +15,19 @@ import TestsUtils
 let t: [BenchmarkCategory] = [.validation, .api, .simd]
 
 public let SIMDInt = [
-  BenchmarkInfo(name: "SIMDIntAdd",     runFunction: run_SIMDIntAdd,     tags: t),
-  BenchmarkInfo(name: "SIMDIntSub",     runFunction: run_SIMDIntSub,     tags: t),
-  BenchmarkInfo(name: "SIMDIntMul",     runFunction: run_SIMDIntMul,     tags: t),
-  BenchmarkInfo(name: "SIMDIntDiv",     runFunction: run_SIMDIntDiv,     tags: t),
-  BenchmarkInfo(name: "SIMDIntRem",     runFunction: run_SIMDIntRem,     tags: t),
-  BenchmarkInfo(name: "SIMDIntShl",     runFunction: run_SIMDIntShl,     tags: t),
-  BenchmarkInfo(name: "SIMDIntShr",     runFunction: run_SIMDIntShr,     tags: t),
-  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: t,
+  BenchmarkInfo(name: "SIMD4Int32.add",     runFunction: run_SIMD4Int32Add,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.sub",     runFunction: run_SIMD4Int32Sub,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.mul",     runFunction: run_SIMD4Int32Mul,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.div",     runFunction: run_SIMD4Int32Div,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.rem",     runFunction: run_SIMD4Int32Rem,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.shl",     runFunction: run_SIMD4Int32Shl,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.shr",     runFunction: run_SIMD4Int32Shr,     tags: t),
+  BenchmarkInfo(name: "SIMD4Int32.bulkSum", runFunction: run_SIMD4Int32BulkSum, tags: t,
                 setUpFunction: { blackHole(bulkSumInts) }),
 ]
 
 @inline(never)
-public func run_SIMDIntAdd(N: Int) {
+public func run_SIMD4Int32Add(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -37,7 +37,7 @@ public func run_SIMDIntAdd(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntSub(N: Int) {
+public func run_SIMD4Int32Sub(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -47,7 +47,7 @@ public func run_SIMDIntSub(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntMul(N: Int) {
+public func run_SIMD4Int32Mul(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -57,7 +57,7 @@ public func run_SIMDIntMul(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntDiv(N: Int) {
+public func run_SIMD4Int32Div(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -67,7 +67,7 @@ public func run_SIMDIntDiv(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntRem(N: Int) {
+public func run_SIMD4Int32Rem(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -77,7 +77,7 @@ public func run_SIMDIntRem(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntShl(N: Int) {
+public func run_SIMD4Int32Shl(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -87,7 +87,7 @@ public func run_SIMDIntShl(N: Int) {
 }
 
 @inline(never)
-public func run_SIMDIntShr(N: Int) {
+public func run_SIMD4Int32Shr(N: Int) {
   var a = identity(SIMD4<Int32>(1, 2, 3, 4))
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
@@ -99,7 +99,7 @@ public func run_SIMDIntShr(N: Int) {
 let bulkSumInts = Array(repeating: SIMD4<Int32>(1, 2, 3, 4), count: 100)
 
 @inline(never)
-public func run_SIMDIntBulkSum(N: Int) {
+public func run_SIMD4Int32BulkSum(N: Int) {
   for _ in 0..<N {
     let ints = identity(bulkSumInts)
     let sum = ints.reduce(SIMD4<Int32>(), &+).wrappedSum()

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -18,6 +18,8 @@ public let SIMDInt = [
   BenchmarkInfo(name: "SIMDIntMul", runFunction: run_SIMDIntMul, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntDiv", runFunction: run_SIMDIntDiv, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntRem", runFunction: run_SIMDIntRem, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntShl", runFunction: run_SIMDIntShl, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntShr", runFunction: run_SIMDIntShr, tags: [.validation, .api]),
 ]
 
 @inline(never)
@@ -66,6 +68,26 @@ public func run_SIMDIntRem(N: Int) {
   let b = identity(SIMD4<Int32>(5, 6, 7, 8))
   for _ in 0..<N {
     a = a % b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntShl(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a &<< b
+  }
+  blackHole(a)
+}
+
+@inline(never)
+public func run_SIMDIntShr(N: Int) {
+  var a = identity(SIMD4<Int32>(1, 2, 3, 4))
+  let b = identity(SIMD4<Int32>(5, 6, 7, 8))
+  for _ in 0..<N {
+    a = a &>> b
   }
   blackHole(a)
 }

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -22,7 +22,8 @@ public let SIMDInt = [
   BenchmarkInfo(name: "SIMDIntRem",     runFunction: run_SIMDIntRem,     tags: t),
   BenchmarkInfo(name: "SIMDIntShl",     runFunction: run_SIMDIntShl,     tags: t),
   BenchmarkInfo(name: "SIMDIntShr",     runFunction: run_SIMDIntShr,     tags: t),
-  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: t),
+  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: t,
+                setUpFunction: { blackHole(bulkSumInts) }),
 ]
 
 @inline(never)

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -20,6 +20,7 @@ public let SIMDInt = [
   BenchmarkInfo(name: "SIMDIntRem", runFunction: run_SIMDIntRem, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntShl", runFunction: run_SIMDIntShl, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntShr", runFunction: run_SIMDIntShr, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDBulkSum, tags: [.validation, .api]),
 ]
 
 @inline(never)
@@ -90,4 +91,15 @@ public func run_SIMDIntShr(N: Int) {
     a = a &>> b
   }
   blackHole(a)
+}
+
+let bulkSumInts = Array(repeating: SIMD4<Int32>(1, 2, 3, 4), count: 100)
+
+@inline(never)
+public func run_SIMDIntBulkSum(N: Int) {
+  for _ in 0..<N {
+    let ints = identity(bulkSumInts)
+    let sum = ints.reduce(SIMD4<Int32>(), &+).wrappedSum()
+    blackHole(sum)
+  }
 }

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -20,7 +20,7 @@ public let SIMDInt = [
   BenchmarkInfo(name: "SIMDIntRem", runFunction: run_SIMDIntRem, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntShl", runFunction: run_SIMDIntShl, tags: [.validation, .api]),
   BenchmarkInfo(name: "SIMDIntShr", runFunction: run_SIMDIntShr, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDBulkSum, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: [.validation, .api]),
 ]
 
 @inline(never)

--- a/benchmark/single-source/SIMDInt.swift
+++ b/benchmark/single-source/SIMDInt.swift
@@ -12,15 +12,17 @@
 
 import TestsUtils
 
+let t: [BenchmarkCategory] = [.validation, .api, .simd]
+
 public let SIMDInt = [
-  BenchmarkInfo(name: "SIMDIntAdd", runFunction: run_SIMDIntAdd, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntSub", runFunction: run_SIMDIntSub, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntMul", runFunction: run_SIMDIntMul, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntDiv", runFunction: run_SIMDIntDiv, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntRem", runFunction: run_SIMDIntRem, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntShl", runFunction: run_SIMDIntShl, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntShr", runFunction: run_SIMDIntShr, tags: [.validation, .api]),
-  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: [.validation, .api]),
+  BenchmarkInfo(name: "SIMDIntAdd",     runFunction: run_SIMDIntAdd,     tags: t),
+  BenchmarkInfo(name: "SIMDIntSub",     runFunction: run_SIMDIntSub,     tags: t),
+  BenchmarkInfo(name: "SIMDIntMul",     runFunction: run_SIMDIntMul,     tags: t),
+  BenchmarkInfo(name: "SIMDIntDiv",     runFunction: run_SIMDIntDiv,     tags: t),
+  BenchmarkInfo(name: "SIMDIntRem",     runFunction: run_SIMDIntRem,     tags: t),
+  BenchmarkInfo(name: "SIMDIntShl",     runFunction: run_SIMDIntShl,     tags: t),
+  BenchmarkInfo(name: "SIMDIntShr",     runFunction: run_SIMDIntShr,     tags: t),
+  BenchmarkInfo(name: "SIMDIntBulkSum", runFunction: run_SIMDIntBulkSum, tags: t),
 ]
 
 @inline(never)

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -69,6 +69,10 @@ public enum BenchmarkCategory : String {
   // significant optimization.
   case cpubench
 
+  // SIMD benchmarks that reflect the performance of using Swift's SIMD types
+  // from the standard library directly.
+  case simd
+
   // Explicit skip marker
   case skip
 }

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -142,6 +142,7 @@ import ReduceInto
 import RemoveWhere
 import ReversedCollections
 import RomanNumbers
+import SIMDInt
 import SequenceAlgos
 import SetTests
 import SevenBoom
@@ -322,6 +323,7 @@ registerBenchmark(ReduceInto)
 registerBenchmark(RemoveWhere)
 registerBenchmark(ReversedCollections)
 registerBenchmark(RomanNumbers)
+registerBenchmark(SIMDInt)
 registerBenchmark(SequenceAlgos)
 registerBenchmark(SetTests)
 registerBenchmark(SevenBoom)


### PR DESCRIPTION
Add benchmarks for SIMD operations to `benchmark/single-source/` that should show off the performance of using Swift's `SIMD` types (namely `SIMD4` here).

I'm open to suggestions on better test cases.