### PR TITLE
[SILOptimizer] Added MandatoryCombiner to passes.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -597,6 +597,7 @@ SILPassPipelinePlan::getSILOptPreparePassPipeline(const SILOptions &Options) {
   }
 
   P.startPipeline("SILOpt Prepare Passes");
+  P.addMandatoryCombine();
   P.addAccessMarkerElimination();
 
   return P;
@@ -653,6 +654,9 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
 SILPassPipelinePlan
 SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
+
+  P.startPipeline("Mandatory Combines");
+  P.addMandatoryCombine();
 
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");


### PR DESCRIPTION
The mandatory combiner is added both to the Onone pass and also to the performance pass.