### PR TITLE
[AutoDiff] Temporarily disable non-varied result warning.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -4594,12 +4594,13 @@ public:
                attr->getIndices().parameters->getNumIndices());
     auto origParamArgs = original->getArgumentsWithoutIndirectResults();
 
-    // Check if result is not varied.
+    // TODO(TF-788): Re-enable non-varied result warning.
+    /*
+    // Emit a warning and fixit if original result is not varied, because it
+    // will always have a zero derivative.
     SmallVector<SILValue, 8> origFormalResults;
     collectAllFormalResultsInTypeOrder(*original, origFormalResults);
     auto origResult = origFormalResults[getIndices().source];
-    // Emit warning if original result is not varied, because it will always
-    // have a zero derivative.
     if (!activityInfo.isVaried(origResult, getIndices().parameters)) {
       // Emit fixit if original result has a valid source location.
       auto startLoc = origResult.getLoc().getStartSourceLoc();
@@ -4610,6 +4611,7 @@ public:
             .fixItInsertAfter(endLoc, ")");
       }
     }
+    */
 
     auto *diffEntry = getDifferential().getEntryBlock();
     diffBuilder.setInsertionPoint(
@@ -5624,8 +5626,10 @@ public:
     SmallVector<SILValue, 8> origFormalResults;
     collectAllFormalResultsInTypeOrder(original, origFormalResults);
     auto origResult = origFormalResults[getIndices().source];
-    // Emit warning if original result is not varied, because it will always
-    // have a zero derivative.
+    // TODO(TF-788): Re-enable non-varied result warning.
+    /*
+    // Emit a warning and fixit if original result is not varied, because it
+    // will always have a zero derivative.
     if (!getActivityInfo().isVaried(origResult, getIndices().parameters)) {
       // Emit fixit if original result has a valid source location.
       auto startLoc = origResult.getLoc().getStartSourceLoc();
@@ -5636,6 +5640,7 @@ public:
             .fixItInsertAfter(endLoc, ")");
       }
     }
+    */
     builder.setInsertionPoint(
         pullbackEntry, getNextFunctionLocalAllocationInsertionPoint());
     if (seed->getType().isAddress()) {

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -50,11 +50,13 @@ _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s -> Float in
   return tmp.x
 }
 _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) { s in
-  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}} {{13-13=)}}
+  // TODO(TF-788): Re-enable non-varied result warning.
+  // xpected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}} {{13-13=)}}
   return s.y
 }
 _ = gradient(at: NoDerivativeProperty(x: 1, y: 1)) {
-  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{3-3=withoutDerivative(at:}} {{7-7=)}}
+  // TODO(TF-788): Re-enable non-varied result warning.
+  // xpected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{3-3=withoutDerivative(at:}} {{7-7=)}}
   $0.y
 }
 
@@ -295,8 +297,18 @@ func one() -> Float {
 }
 @differentiable
 func nonVariedResult(_ x: Float) -> Float {
-  // expected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}} {{15-15=)}}
+  // TODO(TF-788): Re-enable non-varied result warning.
+  // xpected-warning @+1 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}} {{15-15=)}}
   return one()
+}
+
+// Check that `withoutDerivative(at:)` silences the warning.
+
+struct TF_775: Differentiable {
+  @differentiable(wrt: (self))
+  func nonVariedResult(_ input: Float) -> Float {
+    withoutDerivative(at: input)
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/AutoDiff/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/forward_mode_diagnostics.swift
@@ -80,7 +80,8 @@ func one() -> Float {
 }
 @differentiable
 func nonVariedResult(_ x: Float) -> Float {
-  // expected-warning @+1 2 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}}
+  // TODO(TF-788): Re-enable non-varied result warning.
+  // xpected-warning @+1 2 {{result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?}} {{10-10=withoutDerivative(at:}}
   return one()
 }
 


### PR DESCRIPTION
Previously, a warning and fixit was generated for differentiable functions
with non-varied results.

```swift
@differentiable
func nonVariedResult(_ x: Float) -> Float {
  .zero
}
```

```
tf-775.swift:3:3: warning: result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?
  .zero
  ^
  withoutDerivative(at: )
```

---

However, [TF-775](https://bugs.swift.org/browse/TF-775) exposes that the fixit does not work and the warning is unsilenceable.

```swift
@differentiable
func nonVariedResult(_ x: Float) -> Float {
  withoutDerivative(at: .zero)
}
```

```
tf-775.swift:3:3: warning: result does not depend on differentiation arguments and will always have a zero derivative; do you want to use 'withoutDerivative(at:)'?
  withoutDerivative(at: .zero)
  ^
  withoutDerivative(at:       )
```

---

This patch temporarily disables the warning, as a robust fix requires non-trivial activity analysis changes. A lack of warning is better than an unsilenceable false positive.

[TF-788](https://bugs.swift.org/browse/TF-788) tracks re-enabling the warning.
Add regression test to ensure that unsilenceable warnings will not happen again.