### PR TITLE
Add Quote to update-checkout-config.json

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -38,6 +38,8 @@
             "remote": { "id": "tensorflow/tensorflow" } },
         "tensorflow-swift-apis": {
             "remote": { "id": "tensorflow/swift-apis" } },
+        "tensorflow-swift-quote": {
+            "remote": { "id": "tensorflow/swift" } },
         "icu": {
             "remote": { "id": "unicode-org/icu" },
             "platforms": [ "Linux" ]
@@ -486,6 +488,7 @@
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
                 "tensorflow-swift-apis": "74a9bd2f7332a117bb159653bec865a00e9d3745",
+                "tensorflow-swift-quote": "03a61b10adfff4d08c23ed487b0a0a786932a07d",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a"
             }


### PR DESCRIPTION
Recently, we've given up on https://github.com/apple/swift/pull/26708 which was trying to include Quote in the apple/swift:tensorflow build.

However, we still need a little bit of that PR in order to keep track of which version of Quote the quoting logic in the compiler depends on.

It is somewhat awkward to clone Quote during the build and then not use it afterwards, but that's the best that our current infrastructure allows us.