### PR TITLE
[SyntaxParse] Fix memory leaks

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4074,7 +4074,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   ParserPosition startPosition = getParserPosition();
   llvm::Optional<SyntaxParsingContext> TmpCtxt;
   TmpCtxt.emplace(SyntaxContext);
-  TmpCtxt->setTransparent();
+  TmpCtxt->setBackTracking();
 
   SourceLoc TypeAliasLoc = consumeToken(tok::kw_typealias);
   SourceLoc EqualLoc;
@@ -4111,13 +4111,13 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   }
 
   if (Flags.contains(PD_InProtocol) && !genericParams && !Tok.is(tok::equal)) {
-    TmpCtxt->setBackTracking();
     TmpCtxt.reset();
     // If we're in a protocol and don't see an '=' this looks like leftover Swift 2
     // code intending to be an associatedtype.
     backtrackToPosition(startPosition);
     return parseDeclAssociatedType(Flags, Attributes);
   }
+  TmpCtxt->setTransparent();
   TmpCtxt.reset();
 
   auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -122,6 +122,7 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
 
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
+    SyntaxParsingContext CCCtxt(SyntaxContext, SyntaxContextKind::Decl);
     consumeToken();
     if (CodeCompletion)
       CodeCompletion->completeAfterPoundDirective();

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -257,20 +257,12 @@ ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
   ParsedRawSyntaxNode EOFToken = Parts.back();
   Parts = Parts.drop_back();
 
-  for (auto RawNode : Parts) {
-    if (RawNode.getKind() != SyntaxKind::CodeBlockItem) {
-      // FIXME: Skip toplevel garbage nodes for now. we shouldn't emit them in
-      // the first place.
-      if (RawNode.isRecorded())
-        getSyntaxCreator().finalizeNode(RawNode.getOpaqueNode());
-      continue;
-    }
-
-    AllTopLevel.push_back(RawNode);
-  }
+  assert(llvm::all_of(Parts, [](const ParsedRawSyntaxNode& node) {
+    return node.getKind() == SyntaxKind::CodeBlockItem;
+  }) && "all top level element must be 'CodeBlockItem'");
 
   auto itemList = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList,
-                                           AllTopLevel);
+                                           Parts);
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
                                   { itemList, EOFToken });
 }

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -17,7 +17,7 @@
                 null,
                 null,
                 {
-                  "id": 1,
+                  "id": 33,
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
@@ -48,7 +48,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 2,
+                  "id": 34,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "x"
@@ -64,11 +64,11 @@
                 },
                 null,
                 {
-                  "id": 34,
+                  "id": 32,
                   "kind": "TypeInitializerClause",
                   "layout": [
                     {
-                      "id": 3,
+                      "id": 1,
                       "tokenKind": {
                         "kind": "equal"
                       },
@@ -82,11 +82,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 33,
+                      "id": 31,
                       "kind": "TupleType",
                       "layout": [
                         {
-                          "id": 20,
+                          "id": 18,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -95,16 +95,16 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 31,
+                          "id": 29,
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
-                              "id": 26,
+                              "id": 24,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 21,
+                                  "id": 19,
                                   "tokenKind": {
                                     "kind": "identifier",
                                     "text": "b"
@@ -115,7 +115,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 22,
+                                  "id": 20,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -129,11 +129,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 24,
+                                  "id": 22,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 23,
+                                      "id": 21,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "Int"
@@ -149,7 +149,7 @@
                                 null,
                                 null,
                                 {
-                                  "id": 25,
+                                  "id": 23,
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
@@ -166,12 +166,12 @@
                               "presence": "Present"
                             },
                             {
-                              "id": 30,
+                              "id": 28,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 27,
+                                  "id": 25,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -181,7 +181,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 22,
+                                  "id": 20,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -195,11 +195,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 29,
+                                  "id": 27,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 28,
+                                      "id": 26,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "String"
@@ -222,7 +222,7 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 32,
+                          "id": 30,
                           "tokenKind": {
                             "kind": "r_paren"
                           },


### PR DESCRIPTION
There were a few places discarding recorded syntax:
- `#<code-complete>` at top-level (this should be parsed as UnknownDecl).
- `typealias` decl with inheritance clause in protocol decl.

(This is not related to GSoC project)