### PR TITLE
build: dereference variable as appropriate

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2370,7 +2370,7 @@ function(_add_swift_executable_single name)
   # NOTE(compnerd) use the C linker language to invoke `clang` rather than
   # `clang++` as we explicitly link against the C++ runtime.  We were previously
   # actually passing `-nostdlib++` to avoid the C++ runtime linkage.
-  if(SWIFTEXE_SINGLE_SDK STREQUAL ANDROID)
+  if(${SWIFTEXE_SINGLE_SDK} STREQUAL ANDROID)
     set_property(TARGET "${name}" PROPERTY
       LINKER_LANGUAGE "C")
   else()


### PR DESCRIPTION
Certain versions of CMake behave differently with variable expansion.  This may
be evaluated incorrectly in some versions.  Dereference the value explicitly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
