### PR TITLE
Add minimal test case for rdar://problem/54580427.

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar54580427.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar54580427.swift
@@ -1,0 +1,23 @@
+// FIXME: This should be linear instead of exponential.
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes --invert-result %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+enum Val {
+  case d([String: Val])
+  case f(Double)
+}
+
+struct X {
+  var x : Float
+}
+
+extension X {
+  func val() -> Val {
+    return Val.d([
+%for i in range(0, N):
+      "x": .f(Double(x)),
+%end
+    ])
+  }
+}


### PR DESCRIPTION
The scale test says the behavior is exponential, but it should be
linear, given that (1) we provide a contextual type outside and
(2) there is precisely 1 type which has the corresponding cases.