### PR TITLE
ABI/API checker: populate several lazily computed attributes to nodes

### DIFF
--- a/test/api-digester/Outputs/Cake-binary-vs-interface.txt
+++ b/test/api-digester/Outputs/Cake-binary-vs-interface.txt
@@ -1,2 +1,11 @@
-// We shouldn't see this. rdar://54797231
-cake: Class C4 is now with @objc
+cake: Func FrozenKind.__derived_enum_equals(_:_:) has been removed
+cake: Accessor GlobalLetChangedToVar.Get() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Get() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Modify() is a new API without @available attribute
+cake: Accessor GlobalVarChangedToLet.Set() is a new API without @available attribute
+cake: Enum FrozenKind is now with @frozen
+cake: Enum IceKind is now with @frozen
+cake: Func FrozenKind.==(_:_:) is a new API without @available attribute
+cake: Var C1.CIIns1 is no longer a stored property
+cake: Var C1.CIIns2 is no longer a stored property
+cake: Var RemoveSetters.Value is no longer a stored property

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1823,5 +1823,5 @@
       ]
     }
   ],
-  "json_format_version": 4
+  "json_format_version": 5
 }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1674,5 +1674,5 @@
       ]
     }
   ],
-  "json_format_version": 4
+  "json_format_version": 5
 }

--- a/test/api-digester/Outputs/clang-module-dump.txt
+++ b/test/api-digester/Outputs/clang-module-dump.txt
@@ -33,7 +33,8 @@
           "protocolReq": true,
           "objc_name": "anotherFunctionFromProt",
           "declAttributes": [
-            "ObjC"
+            "ObjC",
+            "Dynamic"
           ],
           "reqNewWitnessTableEntry": true,
           "funcSelfKind": "NonMutating"
@@ -44,7 +45,8 @@
       "moduleName": "Foo",
       "objc_name": "AnotherObjcProt",
       "declAttributes": [
-        "ObjC"
+        "ObjC",
+        "Dynamic"
       ]
     },
     {
@@ -76,7 +78,8 @@
           "isOpen": true,
           "objc_name": "someFunction",
           "declAttributes": [
-            "ObjC"
+            "ObjC",
+            "Dynamic"
           ],
           "funcSelfKind": "NonMutating"
         },
@@ -100,7 +103,8 @@
           "objc_name": "init",
           "declAttributes": [
             "Override",
-            "ObjC"
+            "ObjC",
+            "Dynamic"
           ]
         }
       ],
@@ -110,7 +114,8 @@
       "isOpen": true,
       "objc_name": "ClangInterface",
       "declAttributes": [
-        "ObjC"
+        "ObjC",
+        "Dynamic"
       ],
       "superclassUsr": "c:objc(cs)NSObject",
       "superclassNames": [
@@ -161,7 +166,8 @@
           "protocolReq": true,
           "objc_name": "someFunctionFromProt",
           "declAttributes": [
-            "ObjC"
+            "ObjC",
+            "Dynamic"
           ],
           "reqNewWitnessTableEntry": true,
           "funcSelfKind": "NonMutating"
@@ -172,9 +178,10 @@
       "moduleName": "Foo",
       "objc_name": "ObjcProt",
       "declAttributes": [
-        "ObjC"
+        "ObjC",
+        "Dynamic"
       ]
     }
   ],
-  "json_format_version": 4
+  "json_format_version": 5
 }

--- a/test/api-digester/Outputs/empty-baseline.json
+++ b/test/api-digester/Outputs/empty-baseline.json
@@ -2,5 +2,5 @@
   "kind": "Root",
   "name": "TopLevel",
   "printedName": "TopLevel",
-  "json_format_version": 4
+  "json_format_version": 5
 }

--- a/test/api-digester/compare-dump-binary-vs-interface.swift
+++ b/test/api-digester/compare-dump-binary-vs-interface.swift
@@ -3,11 +3,17 @@
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
 
+// The goal of this test to make sure flag -use-interface-for-module works.
+// We first build .swiftinterface with -enable-library-evolution
+// Secondly, we We first build .swiftmodule without -enable-library-evolution
+// Using swift-api-digester to load via .swiftinterface and .swiftmodule should
+// always give us some difference.
+
 // Generate .swiftinterface file for module cake
 // RUN: %target-swift-frontend -typecheck -emit-parseable-module-interface-path %t.mod1/cake.swiftinterface %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 
 // Generate .swiftmodule file for module cake
-// RUN: %target-swift-frontend -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library  -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module -o %t.mod1/cake.swiftmodule %S/Inputs/cake_baseline/cake.swift -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -parse-as-library  -disable-objc-attr-requires-foundation-module -module-cache-path %t.module-cache
 
 // Dump Json file for cake ABI via .swiftmodule file
 // RUN: %api-digester -dump-sdk -module cake -o - -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod1 -I %S/Inputs/APINotesLeft -abi > %t.dump1.json

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1278,6 +1278,24 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Type Ty, TypeInitInfo Info) :
   }
 }
 
+static std::vector<DeclAttrKind> collectDeclAttributes(Decl *D) {
+  std::vector<DeclAttrKind> Results;
+  for (auto *Attr: D->getAttrs())
+    Results.push_back(Attr->getKind());
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+#define HANDLE(COND, KIND_NAME)                                                                   \
+    if (VD->COND && !llvm::is_contained(Results, DeclAttrKind::KIND_NAME))                        \
+      Results.emplace_back(DeclAttrKind::KIND_NAME);
+    // These attributes may be semantically applicable to the current decl but absent from
+    // the actual AST. Populting them to the nodes ensure we don't have false positives.
+    HANDLE(isObjC(), DAK_ObjC)
+    HANDLE(isFinal(), DAK_Final)
+    HANDLE(isDynamic(), DAK_Dynamic)
+#undef HANDLE
+  }
+  return Results;
+}
+
 SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D):
       Ctx(Ctx), DKind(D->getKind()),
       Location(calculateLocation(Ctx, D)),
@@ -1294,22 +1312,8 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, Decl *D):
       ObjCName(Ctx.getObjcName(D)),
       IsImplicit(D->isImplicit()),
       IsDeprecated(D->getAttrs().getDeprecated(D->getASTContext())),
-      IsABIPlaceholder(isABIPlaceholderRecursive(D)) {
-
-  // Force some attributes that are lazily computed.
-  // FIXME: we should use these AST predicates directly instead of looking at
-  // the attributes rdar://50217247.
-  if (auto *VD = dyn_cast<ValueDecl>(D)) {
-    (void) VD->isObjC();
-    (void) VD->isFinal();
-    (void) VD->isDynamic();
-  }
-
-  // Capture all attributes.
-  auto AllAttrs = D->getAttrs();
-  std::transform(AllAttrs.begin(), AllAttrs.end(), std::back_inserter(DeclAttrs),
-                 [](DeclAttribute *attr) { return attr->getKind(); });
-}
+      IsABIPlaceholder(isABIPlaceholderRecursive(D)),
+      DeclAttrs(collectDeclAttributes(D)) {}
 
 SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, OperatorDecl *OD):
     SDKNodeInitInfo(Ctx, cast<Decl>(OD)) {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.h
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.h
@@ -62,7 +62,7 @@ namespace api {
 ///
 /// When the json format changes in a way that requires version-specific handling, this number should be incremented.
 /// This ensures we could have backward compatibility so that version changes in the format won't stop the checker from working.
-const uint8_t DIGESTER_JSON_VERSION = 4; // Add objc_name field
+const uint8_t DIGESTER_JSON_VERSION = 5; // Populate ObjC, Dynamic and Final to attribute list
 const uint8_t DIGESTER_JSON_DEFAULT_VERSION = 0; // Use this version number for files before we have a version number in json.
 
 class SDKNode;


### PR DESCRIPTION
ABI/API checker should check semantic differences of two modules.
Adhering too strictly to the actual ASTs could yield false positives. This
patch populates ObjC, Dynamic and Final to the attribute list if AST
APIs say so.

rdar://50217247