### PR TITLE
[Diagnostics] Treat type requirement failures associated with `Self` …

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -182,8 +182,7 @@ func r22162441(_ lines: [String]) {
 
 func testMap() {
   let a = 42
-  [1,a].map { $0 + 1.0 } // expected-error {{binary operator '+' cannot be applied to operands of type 'Any' and 'Double'}}
-  // expected-note @-1 {{expected an argument list of type '(Double, Double)'}}
+  [1,a].map { $0 + 1.0 } // expected-error {{cannot convert value of type 'Int' to expected element type 'Double'}}
 }
 
 // <rdar://problem/22414757> "UnresolvedDot" "in wrong phase" assertion from verifier


### PR DESCRIPTION
…= `Any` as unrelated

This helps us to filter out cases like operator overloads where
`Self` type comes from e.g. default for collection element -
`[1, "hello"].map { $0 + 1 }`. Main problem here is that
collection type couldn't be determined without unification to
`Any` and `+` failing for all numeric overloads is just a consequence.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
