### PR TITLE
[CSDiagnostics] Fix a crasher in MissingContextualConformanceFailure

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3943,12 +3943,16 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
 
   Optional<Diag<Type, Type>> diagnostic;
   if (path.empty()) {
-    assert(isa<AssignExpr>(anchor));
-    if (isa<SubscriptExpr>(cast<AssignExpr>(anchor)->getDest())) {
-      diagnostic =
-          getDiagnosticFor(CTP_SubscriptAssignSource, /*forProtocol=*/true);
+    if (getParentExpr() && isa<CallExpr>(getParentExpr())) {
+      diagnostic = getDiagnosticFor(CTP_CallArgument, /*forProtocol=*/true);
     } else {
-      diagnostic = getDiagnosticFor(CTP_AssignSource, /*forProtocol=*/true);
+      assert(isa<AssignExpr>(anchor));
+      if (isa<SubscriptExpr>(cast<AssignExpr>(anchor)->getDest())) {
+        diagnostic =
+            getDiagnosticFor(CTP_SubscriptAssignSource, /*forProtocol=*/true);
+      } else {
+        diagnostic = getDiagnosticFor(CTP_AssignSource, /*forProtocol=*/true);
+      }
     }
   } else {
     const auto &last = path.back();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3943,16 +3943,12 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
 
   Optional<Diag<Type, Type>> diagnostic;
   if (path.empty()) {
-    if (getParentExpr() && isa<CallExpr>(getParentExpr())) {
-      diagnostic = getDiagnosticFor(CTP_CallArgument, /*forProtocol=*/true);
+    assert(isa<AssignExpr>(anchor));
+    if (isa<SubscriptExpr>(cast<AssignExpr>(anchor)->getDest())) {
+      diagnostic =
+          getDiagnosticFor(CTP_SubscriptAssignSource, /*forProtocol=*/true);
     } else {
-      assert(isa<AssignExpr>(anchor));
-      if (isa<SubscriptExpr>(cast<AssignExpr>(anchor)->getDest())) {
-        diagnostic =
-            getDiagnosticFor(CTP_SubscriptAssignSource, /*forProtocol=*/true);
-      } else {
-        diagnostic = getDiagnosticFor(CTP_AssignSource, /*forProtocol=*/true);
-      }
+      diagnostic = getDiagnosticFor(CTP_AssignSource, /*forProtocol=*/true);
     }
   } else {
     const auto &last = path.back();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1926,6 +1926,10 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
             return getTypeMatchFailure(locator);
         }
 
+        if (locator.hasEmptyPath()) {
+          return getTypeMatchFailure(locator);
+        }
+
         auto *fix = MissingConformance::forContextual(
             *this, type1, proto, getConstraintLocator(locator));
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1924,10 +1924,10 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
           // with overloaded declarations.
           if (last->getKind() == ConstraintLocator::ApplyArgToParam)
             return getTypeMatchFailure(locator);
-        }
-
-        if (locator.hasEmptyPath()) {
-          return getTypeMatchFailure(locator);
+        } else { // There are no elements in the path
+          auto *anchor = locator.getAnchor();
+          if (!(anchor && isa<AssignExpr>(anchor)))
+            return getTypeMatchFailure(locator);
         }
 
         auto *fix = MissingConformance::forContextual(

--- a/validation-test/compiler_crashers_2_fixed/sr11394.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11394.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol Foo {}
+func foo(_ bar: Foo) {}
+foo(true ? "a" : "b")


### PR DESCRIPTION
Fix a crasher in `MissingContextualConformanceFailure::diagnoseAsError()`. 

Example:

```swift
protocol Foo {}
func foo(_ bar: Foo) {}
foo(true ? "a" : "b")
```

Here, we have a locator with an empty path, so we assert that the `anchor` points to an `AssignExpr`. However, in this scenario, the anchor points to the two branches of the ternary/if expression (i.e. the two `StringLiteralExpr`s). So, if we have an empty path, return a failure.

Resolves [SR-11394](https://bugs.swift.org/browse/SR-11394).