### PR TITLE
[semantic-arc-opts] Change semantic arc opts to use a SmallBlotSetVec…

### DIFF
--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -125,6 +125,15 @@ public:
     return true;
   }
 
+  /// Return the last element of the blot map vector. Will be None if blotted.
+  Optional<ValueT> pop_back_val() {
+    auto result = Vector.pop_back_val();
+    if (!result)
+      return result;
+    Map.erase(*result);
+    return result;
+  }
+
   /// Attempt to lookup the index of \p V. Returns None upon failure and the
   /// value on success.
   Optional<unsigned> getIndex(const ValueT &V) {


### PR DESCRIPTION
…tor instead of a SmallSetVector.

Blotting is a trick with Map/Set vectors that involves one assigning None to the
vector at the index mapped to an entry instead of deleting the entry itself from
the vector. This ensures that we do not need to move elements of the vector down
when erasing elements from the worklist.
