### PR TITLE
Add syntax for fully qualifying names in shadowed modules

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -51,6 +51,7 @@ TYPE_ATTR(autoclosure)
 TYPE_ATTR(convention)
 TYPE_ATTR(noescape)
 TYPE_ATTR(escaping)
+TYPE_ATTR(qualified)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -136,6 +136,8 @@ public:
     /// This lookup should include results from outside the innermost scope with
     /// results.
     IncludeOuterResults = 0x10,
+    /// Look up only modules visible at this location, not other kinds of names.
+    IncludeOnlyModules = 0x20,
   };
   using Options = OptionSet<Flags>;
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1164,8 +1164,8 @@ public:
   using TypeErrorResult = ParsedSyntaxResult<ParsedUnknownTypeSyntax>;
 
   enum class ParseTypeFlags : uint8_t {
-    HandleCodeCompletion = 1 << 0,
     IsSILFuncDecl = 1 << 1
+    IgnoreCodeCompletion = 1 << 0,
   };
   using ParseTypeOptions = OptionSet<ParseTypeFlags>;
   
@@ -1173,7 +1173,7 @@ public:
 
   TypeASTResult parseType();
   TypeASTResult parseType(Diag<> MessageID,
-                          ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
+                          ParseTypeOptions Flags = {});
   ParserStatus
   parseGenericArgumentsAST(llvm::SmallVectorImpl<TypeRepr *> &ArgsAST,
                            SourceLoc &LAngleLoc, SourceLoc &RAngleLoc);
@@ -1181,16 +1181,16 @@ public:
                                 const TypeAttributes &attrs,
                                 Optional<Scope> &GenericsScope);
   TypeASTResult parseTypeSimpleOrCompositionAST(Diag<> MessageID,
-                                                ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
+                                                ParseTypeOptions Flags = {});
   TypeASTResult parseAnyTypeAST();
 
   ParsedSyntaxResult<ParsedGenericArgumentClauseSyntax>
   parseGenericArgumentClauseSyntax();
 
   TypeResult parseTypeSimple(Diag<> MessageID,
-                             ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
+                             ParseTypeOptions Flags = {});
   TypeResult parseTypeSimpleOrComposition(Diag<> MessageID,
-                                          ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
+                                          ParseTypeOptions Flags = {});
   TypeResult parseTypeIdentifier();
   TypeResult parseAnyType();
   TypeResult parseTypeTupleBody();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1163,11 +1163,17 @@ public:
   using TypeResult = ParsedSyntaxResult<ParsedTypeSyntax>;
   using TypeErrorResult = ParsedSyntaxResult<ParsedUnknownTypeSyntax>;
 
+  enum class ParseTypeFlags : uint8_t {
+    HandleCodeCompletion = 1 << 0,
+    IsSILFuncDecl = 1 << 1
+  };
+  using ParseTypeOptions = OptionSet<ParseTypeFlags>;
+  
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 
   TypeASTResult parseType();
-  TypeASTResult parseType(Diag<> MessageID, bool HandleCodeCompletion = true,
-                          bool IsSILFuncDecl = false);
+  TypeASTResult parseType(Diag<> MessageID,
+                          ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
   ParserStatus
   parseGenericArgumentsAST(llvm::SmallVectorImpl<TypeRepr *> &ArgsAST,
                            SourceLoc &LAngleLoc, SourceLoc &RAngleLoc);
@@ -1175,14 +1181,16 @@ public:
                                 const TypeAttributes &attrs,
                                 Optional<Scope> &GenericsScope);
   TypeASTResult parseTypeSimpleOrCompositionAST(Diag<> MessageID,
-                                                bool HandleCodeCompletion);
+                                                ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
   TypeASTResult parseAnyTypeAST();
 
   ParsedSyntaxResult<ParsedGenericArgumentClauseSyntax>
   parseGenericArgumentClauseSyntax();
 
-  TypeResult parseTypeSimple(Diag<> MessageID, bool HandleCodeCompletion);
-  TypeResult parseTypeSimpleOrComposition(Diag<> MessageID, bool HandleCodeCompletion);
+  TypeResult parseTypeSimple(Diag<> MessageID,
+                             ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
+  TypeResult parseTypeSimpleOrComposition(Diag<> MessageID,
+                                          ParseTypeOptions Flags = ParseTypeFlags::HandleCodeCompletion);
   TypeResult parseTypeIdentifier();
   TypeResult parseAnyType();
   TypeResult parseTypeTupleBody();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1164,14 +1164,15 @@ public:
   using TypeErrorResult = ParsedSyntaxResult<ParsedUnknownTypeSyntax>;
 
   enum class ParseTypeFlags : uint8_t {
-    IsSILFuncDecl = 1 << 1
     IgnoreCodeCompletion = 1 << 0,
+    IsSILFuncDecl = 1 << 1,
+    Minimal = 1 << 2
   };
   using ParseTypeOptions = OptionSet<ParseTypeFlags>;
   
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);
 
-  TypeASTResult parseType();
+  TypeASTResult parseType(ParseTypeOptions Flags = {});
   TypeASTResult parseType(Diag<> MessageID,
                           ParseTypeOptions Flags = {});
   ParserStatus
@@ -1191,7 +1192,7 @@ public:
                              ParseTypeOptions Flags = {});
   TypeResult parseTypeSimpleOrComposition(Diag<> MessageID,
                                           ParseTypeOptions Flags = {});
-  TypeResult parseTypeIdentifier();
+  TypeResult parseTypeIdentifier(ParseTypeOptions Flags = {});
   TypeResult parseAnyType();
   TypeResult parseTypeTupleBody();
   TypeResult parseTypeCollection();

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -311,6 +311,9 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
     Printer << " ";
   }
+
+  if (hasAttr(TAK_qualified))
+    Printer.printSimpleAttr("@qualified") << " ";
 }
 
 IdentTypeRepr *IdentTypeRepr::create(ASTContext &C,

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -476,6 +476,12 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
 #endif
   SharedTimer timer("UnqualifiedLookupFactory performUnqualifiedLookup");
 
+  if (options.contains(UnqualifiedLookup::Flags::IncludeOnlyModules)) {
+    lookForAModuleWithTheGivenName(DC);
+    recordCompletionOfAScope();
+    return;
+  }
+
   const Optional<bool> initialIsCascadingUse = getInitialIsCascadingUse();
 
   ContextAndUnresolvedIsCascadingUse contextAndIsCascadingUse{

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -411,9 +411,13 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     }
     if (isType) {
       ParserResult<TypeRepr> ty = parseType();
-      if (ty.isNonNull())
-        return makeParserResult(
-            new (Context) TypeExpr(TypeLoc(ty.get(), Type())));
+      if (ty.isNonNull()) {
+        auto E = new (Context) TypeExpr(TypeLoc(ty.get(), Type()));
+        ParserResult<Expr> Result = makeParserResult(static_cast<Expr*>(E));
+        if (Tok.isFollowingLParen())
+          Result = parseExprCallSuffix(Result, false);
+        return Result;
+      }
       checkForInputIncomplete();
       return nullptr;
     }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -337,7 +337,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       }
 
       if (isBareType && paramContext == ParameterContextKind::EnumElement) {
-        auto type = parseType(diag::expected_parameter_type, {});
+        auto type = parseType(diag::expected_parameter_type,
+                              ParseTypeFlags::IgnoreCodeCompletion);
         status |= type;
         param.Type = type.getPtrOrNull();
         param.FirstName = Identifier();
@@ -348,7 +349,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // Otherwise, if this is a bare type, then the user forgot to name the
         // parameter, e.g. "func foo(Int) {}"
         SourceLoc typeStartLoc = Tok.getLoc();
-        auto type = parseType(diag::expected_parameter_type, {});
+        auto type = parseType(diag::expected_parameter_type,
+                              ParseTypeFlags::IgnoreCodeCompletion);
         status |= type;
         param.Type = type.getPtrOrNull();
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -337,7 +337,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       }
 
       if (isBareType && paramContext == ParameterContextKind::EnumElement) {
-        auto type = parseType(diag::expected_parameter_type, false);
+        auto type = parseType(diag::expected_parameter_type, {});
         status |= type;
         param.Type = type.getPtrOrNull();
         param.FirstName = Identifier();
@@ -348,7 +348,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // Otherwise, if this is a bare type, then the user forgot to name the
         // parameter, e.g. "func foo(Int) {}"
         SourceLoc typeStartLoc = Tok.getLoc();
-        auto type = parseType(diag::expected_parameter_type, false);
+        auto type = parseType(diag::expected_parameter_type, {});
         status |= type;
         param.Type = type.getPtrOrNull();
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -174,7 +174,7 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
     Result = parseTypeTupleBody();
     break;
   case tok::code_complete: {
-    if (!Flags.contains(ParseTypeFlags::HandleCodeCompletion))
+    if (Flags.contains(ParseTypeFlags::IgnoreCodeCompletion))
       break;
     if (CodeCompletion)
       CodeCompletion->completeTypeSimpleBeginning();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -168,7 +168,7 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
   case tok::kw_Self:
   case tok::kw_Any:
   case tok::identifier:
-    Result = parseTypeIdentifier();
+    Result = parseTypeIdentifier(Flags);
     break;
   case tok::l_paren:
     Result = parseTypeTupleBody();
@@ -240,8 +240,8 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
   return *Result;
 }
 
-Parser::TypeASTResult Parser::parseType() {
-  return parseType(diag::expected_type);
+Parser::TypeASTResult Parser::parseType(ParseTypeOptions Flags) {
+  return parseType(diag::expected_type, Flags);
 }
 
 Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
@@ -613,7 +613,7 @@ Parser::parseGenericArgumentsAST(SmallVectorImpl<TypeRepr *> &ArgsAST,
 ///   type-identifier:
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///
-Parser::TypeResult Parser::parseTypeIdentifier() {
+Parser::TypeResult Parser::parseTypeIdentifier(Parser::ParseTypeOptions Flags) {
   if (Tok.isNot(tok::identifier) && Tok.isNot(tok::kw_Self)) {
     // is this the 'Any' type
     if (Tok.is(tok::kw_Any))
@@ -701,6 +701,8 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
       }
       if (!peekToken().isContextualKeyword("Type") &&
           !peekToken().isContextualKeyword("Protocol")) {
+        if (Flags.contains(ParseTypeFlags::Minimal))
+          break;
         Period = consumeTokenSyntax();
         continue;
       }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1272,7 +1272,7 @@ bool SILParser::parseSILType(SILType &Result,
     attrs.convention = "thin";
   }
 
-  Parser::ParseTypeOptions Flags = Parser::ParseTypeFlags::HandleCodeCompletion;
+  Parser::ParseTypeOptions Flags;
   if (IsFuncDecl)
     Flags |= Parser::ParseTypeFlags::IsSILFuncDecl;
   ParserResult<TypeRepr> TyR = P.parseType(diag::expected_sil_type, Flags);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1272,9 +1272,10 @@ bool SILParser::parseSILType(SILType &Result,
     attrs.convention = "thin";
   }
 
-  ParserResult<TypeRepr> TyR = P.parseType(diag::expected_sil_type,
-                                           /*handleCodeCompletion*/ true,
-                                           /*isSILFuncDecl*/ IsFuncDecl);
+  Parser::ParseTypeOptions Flags = Parser::ParseTypeFlags::HandleCodeCompletion;
+  if (IsFuncDecl)
+    Flags |= Parser::ParseTypeFlags::IsSILFuncDecl;
+  ParserResult<TypeRepr> TyR = P.parseType(diag::expected_sil_type, Flags);
 
   if (TyR.isNull())
     return true;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -260,6 +260,8 @@ convertToUnqualifiedLookupOptions(NameLookupOptions options) {
     newOptions |= UnqualifiedLookup::Flags::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IncludeOuterResults))
     newOptions |= UnqualifiedLookup::Flags::IncludeOuterResults;
+  if (options.contains(NameLookupFlags::IncludeOnlyModules))
+    newOptions |= UnqualifiedLookup::Flags::IncludeOnlyModules;
 
   return newOptions;
 }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -66,6 +66,9 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Whether we should not produce diagnostics if the type is invalid.
   SilenceErrors = 1 << 10,
+
+  /// Whether the name is known to be fully qualified.
+  FullyQualified = 1 << 11,
 };
 
 /// Type resolution contexts that require special handling.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -312,6 +312,9 @@ enum class NameLookupFlags {
   IncludeOuterResults = 0x20,
   /// Whether to consider synonyms declared through @_implements().
   IncludeAttributeImplements = 0x40,
+  /// Whether to only look up modules visible at this location, not other kinds
+  /// of visible names.
+  IncludeOnlyModules = 0x80,
 };
 
 /// A set of options that control name lookup.

--- a/test/attr/attr_qualified.swift
+++ b/test/attr/attr_qualified.swift
@@ -14,4 +14,4 @@ func uglyInit() -> Int { (@qualified Swift.Int)(bitPattern: 0) } // no-error
 
 func badRef() { Swift.print("hello") } // expected-error {{type 'Swift' has no member 'print'}}
 func goodRef() { @qualified Swift.print("hello") } // no-error
-func uglyRef() { (@qualified Swift).print("hello") } // no-error
+func uglyRef() { (@qualified Swift.print)("hello") } // no-error

--- a/test/attr/attr_qualified.swift
+++ b/test/attr/attr_qualified.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+class Swift {
+  struct Nested {}
+}
+
+func badType() -> Swift.Int { 0 } // expected-error {{'Int' is not a member type of 'Swift'}}
+func goodType() -> @qualified Swift.Int { 0 } // no-error
+func uglyType() -> @qualified Swift.Array<Swift.Nested> { [] } // no-error
+
+func badInit() -> Int { Swift.Int(bitPattern: 0) } // expected-error {{type 'Swift' has no member 'Int'}}
+func goodInit() -> Int { @qualified Swift.Int(bitPattern: 0) } // no-error
+func uglyInit() -> Int { (@qualified Swift.Int)(bitPattern: 0) } // no-error
+
+func badRef() { Swift.print("hello") } // expected-error {{type 'Swift' has no member 'print'}}
+func goodRef() { @qualified Swift.print("hello") } // no-error
+func uglyRef() { (@qualified Swift).print("hello") } // no-error


### PR DESCRIPTION
This PR allows you to write `@qualified ModuleName.TypeName` to access the indicated type reliably, even if `ModuleName` has the same name as a type in scope. It's meant to be used with modules like XCTest, where the `XCTest.XCTest` class shadows the module itself, preventing you from fully qualifying the name of any declaration in the module.

Caveats abound:

* We don't know if we actually want this feature yet. If we do, it'll certainly require an evolution proposal.
* We definitely don't know if this is the syntax we'll want for it—a type attribute is merely the easiest thing to implement.
* ~~This PR includes some basic tests of the feature, but not all of them pass yet. In particular, `@qualified` is currently too greedy in expression context, and making it less so might require a little refactoring.~~
* This PR also currently makes `-verify-syntax-tree` unhappy.
* The unqualified lookup changes are probably unnecessary and/or poorly implemented.

Fixes [SR-898](https://bugs.swift.org/browse/SR-898).