### PR TITLE
[SyntaxParse] Don't parse postfix if faield to parse type identifier

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -209,11 +209,9 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
   }
 
   // '.Type', '.Protocol', '?', '!', and '[]' still leave us with type-simple.
-  while (Result->isSuccess() || !Result->getUnknownNodes().empty()) {
-    auto PrevType = Result->isSuccess()
-                        ? Result->getResult()
-                        : ParsedSyntaxRecorder::makeUnknownType(
-                              Result->getUnknownNodes(), *SyntaxContext);
+  while (Result->isSuccess()) {
+    auto PrevType = Result->getResult();
+
     if ((Tok.is(tok::period) || Tok.is(tok::period_prefix)) &&
         (peekToken().isContextualKeyword("Type") ||
          peekToken().isContextualKeyword("Protocol"))) {
@@ -236,9 +234,6 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
         continue;
       }
     }
-    if (!Result->isSuccess())
-      Result =
-          makeParsedResult<ParsedTypeSyntax>({PrevType}, Result->getStatus());
     break;
   }
 

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -400,6 +400,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT | %FileCheck %s -check-prefix=UNBOUND_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNBOUND_DOT_2 | %FileCheck %s -check-prefix=UNBOUND_DOT_2
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERICARG_OPTIONAL | %FileCheck %s -check-prefix=GENERICARG_OPTIONAL
+
 //===--- Helper types that are used in this test
 
 struct FooStruct {
@@ -1129,3 +1131,6 @@ func testUnbound2(x: OuterStruct<Int>.Inner.#^UNBOUND_DOT_2^#) {}
 // UNBOUND_DOT_2: Begin completions
 // UNBOUND_DOT_2-DAG: Keyword/None:                       Type[#OuterStruct<Int>.Inner.Type#]; name=Type
 // UNBOUND_DOT_2: End completions
+
+func testGenericArgForOptional() -> Set<#^GENERICARG_OPTIONAL^#>? {}
+// GENERICARG_OPTIONAL: Begin completions


### PR DESCRIPTION
Fixes crashing regression in code-completion.