### PR TITLE
[NameLookup, ASTScope] Fix typo in ASTScope tree creation

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1788,7 +1788,7 @@ void PatternEntryDeclScope::beCurrent() {
   unsigned varCount = 0;
   getPatternEntry().getPattern()->forEachVariable(
       [&](VarDecl *) { ++varCount; });
-  varCountWhenLastExpanded = 0;
+  varCountWhenLastExpanded = varCount;
 }
 bool PatternEntryDeclScope::isCurrent() const {
   if (initWhenLastExpanded != getPatternEntry().getOriginalInit())


### PR DESCRIPTION
Since ASTScope lookup is currently disabled-by-default, this fix won't affect anything unless `-enable-astscope-lookup` is passed in. This PR fixes a typo in PatternEntryDeclScope::beCurrent that caused needless rebuilding of scopes, and could potentially create problems.