### PR TITLE
Simplify lazy member parsing

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -69,7 +69,6 @@ namespace swift {
   class LazyGenericContextData;
   class LazyIterableDeclContextData;
   class LazyMemberLoader;
-  class LazyMemberParser;
   class LazyResolver;
   class PatternBindingDecl;
   class PatternBindingInitializer;
@@ -425,12 +424,6 @@ private:
   void setLazyResolver(LazyResolver *resolver);
 
 public:
-  /// Add a lazy parser for resolving members later.
-  void addLazyParser(LazyMemberParser *parser);
-
-  /// Remove a lazy parser.
-  void removeLazyParser(LazyMemberParser *parser);
-
   /// getIdentifier - Return the uniqued and AST-Context-owned version of the
   /// specified string.
   Identifier getIdentifier(StringRef Str) const;
@@ -821,12 +814,6 @@ public:
   /// across all calls for the same \p func.
   LazyContextData *getOrCreateLazyContextData(const DeclContext *decl,
                                               LazyMemberLoader *lazyLoader);
-
-  /// Use the lazy parsers associated with the context to populate the members
-  /// of the given decl context.
-  ///
-  /// \param IDC The context whose member decls should be lazily parsed.
-  std::vector<Decl *> parseMembers(IterableDeclContext *IDC);
 
   /// Get the lazy function data for the given generic context.
   ///

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -51,7 +51,6 @@ namespace swift {
   class GenericParamList;
   class LazyResolver;
   class LazyMemberLoader;
-  class LazyMemberParser;
   class GenericSignature;
   class GenericTypeParamDecl;
   class GenericTypeParamType;

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -85,21 +85,6 @@ public:
   LazyMemberLoader *loader;
 };
 
-/// A class that can lazily parse members for an iterable decl context.
-class LazyMemberParser {
-public:
-  virtual ~LazyMemberParser() = default;
-
-  /// Retrieves the parsed members for the given decl context \p IDC.
-  virtual std::vector<Decl *> parseMembers(IterableDeclContext *IDC) = 0;
-
-  /// Return whether the iterable decl context needs parsing.
-  virtual bool hasUnparsedMembers(const IterableDeclContext *IDC) = 0;
-
-  /// Parse all delayed decl list members.
-  virtual void parseAllDelayedDeclLists() = 0;
-};
-
 /// Context data for generic contexts.
 class LazyGenericContextData : public LazyContextData {
 public:

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -982,8 +982,6 @@ public:
                                  bool &HasNestedClassDeclarations);
 
   bool delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
-                            SourceLoc PosBeforeLB,
-                            ParseDeclOptions Options,
                             IterableDeclContext *IDC);
 
   ParserResult<TypeDecl> parseDeclTypeAlias(ParseDeclOptions Flags,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -976,7 +976,6 @@ public:
   bool parseMemberDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
                            SourceLoc PosBeforeLB,
                            Diag<> ErrorDiag,
-                           ParseDeclOptions Options,
                            IterableDeclContext *IDC);
 
   bool canDelayMemberDeclParsing(bool &HasOperatorDeclarations,

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -26,11 +26,9 @@
 
 namespace swift {
   class AbstractFunctionDecl;
-  class LazyMemberParser;
-  class ASTContext;
 
 /// Parser state persistent across multiple parses.
-class PersistentParserState: public LazyMemberParser {
+class PersistentParserState {
 public:
   struct ParserPos {
     SourceLoc Loc;
@@ -84,34 +82,11 @@ public:
     {}
   };
 
-  class DelayedDeclListState {
-    friend class PersistentParserState;
-    friend class Parser;
-    unsigned Flags;
-    DeclContext *ParentContext;
-    ParserPos BodyPos;
-    SourceLoc BodyEnd;
-    SavedScope Scope;
-
-    SavedScope takeScope() {
-      return std::move(Scope);
-    }
-
-  public:
-    DelayedDeclListState(unsigned Flags,
-                     DeclContext *ParentContext, SourceRange BodyRange,
-                     SourceLoc PreviousLoc, SavedScope &&Scope)
-    : Flags(Flags), ParentContext(ParentContext), BodyPos{BodyRange.Start, PreviousLoc},
-      BodyEnd(BodyRange.End), Scope(std::move(Scope))
-    {}
-  };
-
   bool InPoundLineEnvironment = false;
   // FIXME: When condition evaluation moves to a later phase, remove this bit
   // and adjust the client call 'performParseOnly'.
   bool PerformConditionEvaluation = true;
 private:
-  ASTContext &Ctx;
   ScopeInfo ScopeInfo;
   using DelayedFunctionBodiesTy =
       llvm::DenseMap<AbstractFunctionDecl *,
@@ -123,15 +98,14 @@ private:
 
   std::unique_ptr<DelayedDeclState> CodeCompletionDelayedDeclState;
 
-  llvm::DenseMap<IterableDeclContext *, std::unique_ptr<DelayedDeclListState>>
-    DelayedDeclListStates;
+  std::vector<IterableDeclContext *> DelayedDeclLists;
 
   /// The local context for all top-level code.
   TopLevelContext TopLevelCode;
 
 public:
   swift::ScopeInfo &getScopeInfo() { return ScopeInfo; }
-  PersistentParserState(ASTContext &Ctx);
+  PersistentParserState();
   ~PersistentParserState();
 
   void delayFunctionBodyParsing(AbstractFunctionDecl *AFD,
@@ -146,14 +120,10 @@ public:
                  DeclContext *ParentContext,
                  SourceRange BodyRange, SourceLoc PreviousLoc);
 
-  void delayDeclList(IterableDeclContext *D, unsigned Flags,
-                     DeclContext *ParentContext,
-                     SourceRange BodyRange, SourceLoc PreviousLoc);
+  void delayDeclList(IterableDeclContext *D);
 
   void delayTopLevel(TopLevelCodeDecl *TLCD, SourceRange BodyRange,
                      SourceLoc PreviousLoc);
-
-  std::vector<Decl *> parseMembers(IterableDeclContext *IDC) override;
 
   bool hasDelayedDecl() {
     return CodeCompletionDelayedDeclState.get() != nullptr;
@@ -171,14 +141,7 @@ public:
     return std::move(CodeCompletionDelayedDeclState);
   }
 
-  std::unique_ptr<DelayedDeclListState>
-    takeDelayedDeclListState(IterableDeclContext *IDC);
-
-  bool hasUnparsedMembers(const IterableDeclContext *IDC) override {
-    return DelayedDeclListStates.find(IDC) != DelayedDeclListStates.end();
-  }
-
-  void parseAllDelayedDeclLists() override;
+  void parseAllDelayedDeclLists();
 
   TopLevelContext &getTopLevelContext() {
     return TopLevelCode;

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -106,6 +106,7 @@ private:
 public:
   swift::ScopeInfo &getScopeInfo() { return ScopeInfo; }
   PersistentParserState();
+  PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
   void delayFunctionBodyParsing(AbstractFunctionDecl *AFD,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -782,7 +782,7 @@ void CompilerInstance::parseAndCheckTypesUpTo(
   std::unique_ptr<DelayedParsingCallbacks> DelayedCB{
       computeDelayedParsingCallback()};
 
-  PersistentState = llvm::make_unique<PersistentParserState>(getASTContext());
+  PersistentState = llvm::make_unique<PersistentParserState>();
 
   bool hadLoadError = parsePartialModulesAndLibraryFiles(
       implicitImports, DelayedCB.get());
@@ -1053,7 +1053,7 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals,
                                   MainBufferID);
   }
 
-  PersistentState = llvm::make_unique<PersistentParserState>(getASTContext());
+  PersistentState = llvm::make_unique<PersistentParserState>();
 
   SWIFT_DEFER {
     if (ParseDelayedBodyOnEnd)

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -207,7 +207,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   // Parse, typecheck and temporarily insert the incomplete code into the AST.
   const unsigned OriginalDeclCount = SF.Decls.size();
 
-  PersistentParserState PersistentState(Ctx);
+  PersistentParserState PersistentState;
   std::unique_ptr<DelayedParsingCallbacks> DelayedCB(
       new CodeCompleteDelayedCallbacks(Ctx.SourceMgr.getCodeCompletionLoc()));
   bool Done;

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -964,7 +964,7 @@ public:
       IRGenOpts(),
       SILOpts(),
       Input(*this),
-      PersistentState(CI.getASTContext())
+      PersistentState()
   {
     ASTContext &Ctx = CI.getASTContext();
     Ctx.LangOpts.EnableAccessControl = false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3186,12 +3186,71 @@ Parser::parseDecl(ParseDeclOptions Flags,
   return DeclResult;
 }
 
+/// Determine the declaration parsing options to use when parsing the members
+/// of the given context.
+static Parser::ParseDeclOptions getMemberParseDeclOptions(
+                                                    IterableDeclContext *idc) {
+  using ParseDeclOptions = Parser::ParseDeclOptions;
+
+  auto decl = idc->getDecl();
+  switch (decl->getKind()) {
+  case DeclKind::Extension:
+    return ParseDeclOptions(
+        Parser::PD_HasContainerType | Parser::PD_InExtension);
+  case DeclKind::Enum:
+    return ParseDeclOptions(
+        Parser::PD_HasContainerType | Parser::PD_AllowEnumElement |
+        Parser::PD_InEnum);
+
+  case DeclKind::Protocol:
+    return ParseDeclOptions(
+        Parser::PD_HasContainerType | Parser::PD_DisallowInit |
+        Parser::PD_InProtocol);
+
+  case DeclKind::Class:
+    return ParseDeclOptions(
+        Parser::PD_HasContainerType | Parser::PD_AllowDestructor |
+        Parser::PD_InClass);
+
+  case DeclKind::Struct:
+    return ParseDeclOptions(Parser::PD_HasContainerType | Parser::PD_InStruct);
+
+  default:
+    llvm_unreachable("Bad iterable decl context kinds.");
+  }
+}
+
+static ScopeKind getMemberParseScopeKind(IterableDeclContext *idc) {
+  auto decl = idc->getDecl();
+  switch (decl->getKind()) {
+  case DeclKind::Extension: return ScopeKind::Extension;
+  case DeclKind::Enum: return ScopeKind::EnumBody;
+  case DeclKind::Protocol: return ScopeKind::ProtocolBody;
+  case DeclKind::Class: return ScopeKind::ClassBody;
+  case DeclKind::Struct: return ScopeKind::StructBody;
+
+  default:
+    llvm_unreachable("Bad iterable decl context kinds.");
+  }
+}
+
 std::vector<Decl *> Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
   auto DelayedState = State->takeDelayedDeclListState(IDC);
   assert(DelayedState.get() && "should have delayed state");
+  (void)DelayedState;
 
-  auto BeginParserPosition = getParserPosition(DelayedState->BodyPos);
-  auto EndLexerState = L->getStateForEndOfTokenLoc(DelayedState->BodyEnd);
+  Decl *D = const_cast<Decl*>(IDC->getDecl());
+  DeclContext *DC = cast<DeclContext>(D);
+  SourceRange BodyRange;
+  if (auto ext = dyn_cast<ExtensionDecl>(IDC)) {
+    BodyRange = ext->getBraces();
+  } else {
+    auto *ntd = cast<NominalTypeDecl>(IDC);
+    BodyRange = ntd->getBraces();
+  }
+
+  auto BeginParserPosition = getParserPosition({BodyRange.Start,BodyRange.End});
+  auto EndLexerState = L->getStateForEndOfTokenLoc(BodyRange.End);
 
   // ParserPositionRAII needs a primed parser to restore to.
   if (Tok.is(tok::NUM_TOKENS))
@@ -3209,11 +3268,16 @@ std::vector<Decl *> Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
   // Rewind to the beginning of the decl.
   restoreParserPosition(BeginParserPosition);
 
-  // Re-enter the lexical scope.
-  Scope S(this, DelayedState->takeScope());
-  ContextChange CC(*this, DelayedState->ParentContext);
-  Decl *D = const_cast<Decl*>(IDC->getDecl());
+  // Re-enter the lexical scope. The top-level scope is needed because
+  // delayed parsing of members happens with a fresh parser, where there is
+  // no context.
+  Scope TopLevelScope(this, ScopeKind::TopLevel);
+
+  Scope S(this, getMemberParseScopeKind(IDC));
+  ContextChange CC(*this, DC);
   SourceLoc LBLoc = consumeToken(tok::l_brace);
+  (void)LBLoc;
+  assert(LBLoc == BodyRange.Start);
   SourceLoc RBLoc;
   Diag<> Id;
   switch (D->getKind()) {
@@ -3226,21 +3290,8 @@ std::vector<Decl *> Parser::parseDeclListDelayed(IterableDeclContext *IDC) {
     llvm_unreachable("Bad iterable decl context kinds.");
   }
   bool hadError = false;
-  std::vector<Decl *> decls;
-  if (auto *ext = dyn_cast<ExtensionDecl>(D)) {
-    decls = parseDeclList(ext->getBraces().Start, RBLoc, Id,
-                          ParseDeclOptions(DelayedState->Flags),
-                          ext, hadError);
-    ext->setBraces({LBLoc, RBLoc});
-  } else {
-    auto *ntd = cast<NominalTypeDecl>(D);
-    decls = parseDeclList(ntd->getBraces().Start, RBLoc, Id,
-                          ParseDeclOptions(DelayedState->Flags),
-                          ntd, hadError);
-    ntd->setBraces({LBLoc, RBLoc});
-  }
-
-  return decls;
+  ParseDeclOptions Options = getMemberParseDeclOptions(IDC);
+  return parseDeclList(LBLoc, RBLoc, Id, Options, IDC, hadError);
 }
 
 void Parser::parseDeclDelayed() {
@@ -3657,10 +3708,10 @@ ParserStatus Parser::parseDeclItem(bool &PreviousHadSemi,
 bool Parser::parseMemberDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
                                  SourceLoc PosBeforeLB,
                                  Diag<> ErrorDiag,
-                                 ParseDeclOptions Options,
                                  IterableDeclContext *IDC) {
   bool HasOperatorDeclarations;
   bool HasNestedClassDeclarations;
+  ParseDeclOptions Options = getMemberParseDeclOptions(IDC);
 
   if (canDelayMemberDeclParsing(HasOperatorDeclarations,
                                 HasNestedClassDeclarations)) {
@@ -3834,11 +3885,10 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   } else {
     ContextChange CC(*this, ext);
     Scope S(this, ScopeKind::Extension);
-    ParseDeclOptions Options(PD_HasContainerType | PD_InExtension);
 
     if (parseMemberDeclList(LBLoc, RBLoc, PosBeforeLB,
                             diag::expected_rbrace_extension,
-                            Options, ext))
+                            ext))
       status.setIsParseError();
 
     // Don't propagate the code completion bit from members: we cannot help
@@ -5759,11 +5809,10 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
     Status.setIsParseError();
   } else {
     Scope S(this, ScopeKind::EnumBody);
-    ParseDeclOptions Options(PD_HasContainerType | PD_AllowEnumElement | PD_InEnum);
 
     if (parseMemberDeclList(LBLoc, RBLoc, PosBeforeLB,
                             diag::expected_rbrace_enum,
-                            Options, ED))
+                            ED))
       Status.setIsParseError();
   }
 
@@ -6046,11 +6095,10 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
   } else {
     // Parse the body.
     Scope S(this, ScopeKind::StructBody);
-    ParseDeclOptions Options(PD_HasContainerType | PD_InStruct);
 
     if (parseMemberDeclList(LBLoc, RBLoc, PosBeforeLB,
                             diag::expected_rbrace_struct,
-                            Options, SD))
+                            SD))
       Status.setIsParseError();
   }
 
@@ -6160,12 +6208,10 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   } else {
     // Parse the body.
     Scope S(this, ScopeKind::ClassBody);
-    ParseDeclOptions Options(PD_HasContainerType | PD_AllowDestructor |
-                             PD_InClass);
 
     if (parseMemberDeclList(LBLoc, RBLoc, PosBeforeLB,
                             diag::expected_rbrace_class,
-                            Options, CD))
+                            CD))
       Status.setIsParseError();
   }
 
@@ -6255,13 +6301,9 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
       Status.setIsParseError();
     } else {
       // Parse the members.
-      ParseDeclOptions Options(PD_HasContainerType |
-                               PD_DisallowInit |
-                               PD_InProtocol);
-
       if (parseMemberDeclList(LBraceLoc, RBraceLoc, PosBeforeLB,
                               diag::expected_rbrace_protocol,
-                              Options, Proto))
+                              Proto))
         Status.setIsParseError();
     }
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -36,7 +36,6 @@ ArrayRef<Decl *>
 ParseMembersRequest::evaluate(Evaluator &evaluator,
                               IterableDeclContext *idc) const {
   SourceFile &sf = *idc->getDecl()->getDeclContext()->getParentSourceFile();
-  assert(sf.Kind != SourceFileKind::SIL && "cannot delay parsing SIL");
   unsigned bufferID = *sf.getBufferID();
 
   // Lexer diaganostics have been emitted during skipping, so we disable lexer's

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -529,7 +529,7 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
     Generator(SF.getASTContext(), &State) {
   State = PersistentState;
   if (!State) {
-    OwnedState.reset(new PersistentParserState(Context));
+    OwnedState.reset(new PersistentParserState());
     State = OwnedState.get();
   }
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -145,7 +145,7 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   importMod->addFile(*importFile);
 
   bool done;
-  PersistentParserState persistentState(Ctx);
+  PersistentParserState persistentState;
   SkipNonTransparentFunctions delayCallbacks;
   parseIntoSourceFile(*importFile, bufferID, &done, nullptr, &persistentState,
                       SkipBodies ? &delayCallbacks : nullptr);


### PR DESCRIPTION
Lazy parsing for the members of nominal types and extensions depends
only on information already present in
`IterableDeclContext`. Eliminate the use of PersistentParserState as
an intermediary and have the member-parsing request construct a new
`Parser` instance itself to handle parsing. Make this possible even
for ill-formed nominal types/extensions to simplify the code path.

Eliminate `LazyMemberParser` and all of its uses, because it was only
present for lazy member parsing, which no longer needs it.