### PR TITLE
Move lldb commit to latest.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -470,7 +470,7 @@
                 "llvm": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "clang": "ecfead281dab91cee05d78a5699c72cd3c93b08f",
                 "swift": "tensorflow",
-                "lldb": "27b495a4292696b48389ed109b0cf232a125e614",
+                "lldb": "041645695c7f02b23e768369760cef9be136a8d3",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",


### PR DESCRIPTION
This PR moves it to https://github.com/apple/swift-lldb/commit/041645695c7f02b23e768369760cef9be136a8d3

