### PR TITLE
Skip module trace emission if we encountered errors when compiling.

### DIFF
--- a/test/Driver/Inputs/IllformedModule.swiftmodule
+++ b/test/Driver/Inputs/IllformedModule.swiftmodule
@@ -1,0 +1,1 @@
+// Placeholder text so that nobody accidentally deletes this when deleting empty files.

--- a/test/Driver/loaded_module_trace_skip.swift
+++ b/test/Driver/loaded_module_trace_skip.swift
@@ -1,5 +1,5 @@
+// rdar://problem/54860311.
 // RUN: not %target-typecheck-verify-swift -emit-loaded-module-trace -o %t/mytrace -I %S/Inputs 2>&1 | %FileCheck %s
-// XFAIL: *
 
 import IllformedModule
 // CHECK: unexpected error produced: malformed compiled module

--- a/test/Driver/loaded_module_trace_skip.swift
+++ b/test/Driver/loaded_module_trace_skip.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-typecheck-verify-swift -emit-loaded-module-trace -o %t/mytrace -I %S/Inputs 2>&1 | %FileCheck %s
+// XFAIL: *
+
+import IllformedModule
+// CHECK: unexpected error produced: malformed compiled module


### PR DESCRIPTION
Otherwise, we end up having empty module names, which lead to a crash later on (in compilers with assertions disabled).

Fixes rdar://problem/54860311.