### PR TITLE
cmake: symlink framework ABI baseline data to the build directory

### DIFF
--- a/utils/api_checker/CMakeLists.txt
+++ b/utils/api_checker/CMakeLists.txt
@@ -1,9 +1,29 @@
+set(framework "FrameworkABIBaseline")
 swift_install_in_component(FILES "swift-api-checker.py"
                            DESTINATION "bin"
                            COMPONENT toolchain-tools)
 swift_install_in_component(DIRECTORY "sdk-module-lists"
                            DESTINATION "bin"
                            COMPONENT toolchain-tools)
-swift_install_in_component(DIRECTORY "FrameworkABIBaseline"
+swift_install_in_component(DIRECTORY "${framework}"
                            DESTINATION "lib/swift"
                            COMPONENT toolchain-tools)
+
+# Add symlink of FrameworkABIBaseline to the build dir. This ensures we can
+# find the baseline data from the same relative path as if we are running the
+# checker from the toolchain.
+set(SWIFTLIB_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift")
+set(dest "${SWIFTLIB_DIR}/${framework}")
+set(source "${CMAKE_CURRENT_SOURCE_DIR}/${framework}")
+
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(CMAKE_SYMLINK_COMMAND copy)
+else()
+    set(CMAKE_SYMLINK_COMMAND create_symlink)
+endif()
+add_custom_command(OUTPUT "${dest}"
+                   DEPENDS "${source}"
+                   COMMAND "${CMAKE_COMMAND}" "-E" "${CMAKE_SYMLINK_COMMAND}" "${source}" "${dest}")
+add_custom_target("symlink_abi_checker_data" ALL
+                  DEPENDS "${dest}"
+                  COMMENT "Symlinking ABI checker baseline data to ${dest}")


### PR DESCRIPTION
When running the ABI checker from the build artifact, the executable
should be able to find baselines in the same relative paths as if
it's running from a toolchain.