### PR TITLE
[DNM] See If Diagnosing Non-Prima Fascie Nominal Extensions Breaks Stuff

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4508,6 +4508,20 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
         checkExtensionGenericParams(*this, ext, extendedType, genericParams);
       ext->setGenericEnvironment(env);
     }
+  } else if (auto extType = ext->getExtendedType()) {
+    if (!ext->isInvalid()) {
+      // If we've got here, then we have some kind of extension of a prima
+      // fascie non-nominal type.  This can come up when we're projecting
+      // typealiases out of bound generic types.
+      //
+      // struct Array<T> { typealias Indices = Range<Int> }
+      // extension Array.Indices.Bound {}
+      //
+      // FIXME: This diagnostic is bogus, but will do for testing.
+      ext->setInvalid();
+      ext->getASTContext().Diags.diagnose(ext,
+                                          diag::non_nominal_extension, extType);
+    }
   }
 }
 


### PR DESCRIPTION
⚠️ Do Not Merge This ⚠️ 

The AST has two separate things you can reach for when asking the question "which type am I extending here?".  The first question is "give me the nominal type decl that I'm extending", which will succeed if type resolution is able to pick out a nominal type and only a nominal type.  The second question is "which capital-T `Type` am I extending" which will go through semantic resolution and may succeed in cases where the previous query failed - see also rdar://54799560

I'm going to measure if restricting this has impact on the source compat suite.