### PR TITLE
Fix a Hole in Extension Checking For Non-Nominal Types and Indirectly Nominal Types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1625,6 +1625,11 @@ NOTE(objc_generic_extension_using_type_parameter_here,none,
      "generic parameter used here", ())
 NOTE(objc_generic_extension_using_type_parameter_try_objc,none,
      "add '@objc' to allow uses of 'self' within the function body", ())
+ERROR(invalid_nominal_extension,none,
+      "extension of type %0 must be declared as an extension of %1",
+      (Type, Type))
+NOTE(invalid_nominal_extension_rewrite,none,
+     "did you mean to extend %0 instead?", (Type))
 
 // Protocols
 ERROR(type_does_not_conform,none,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1926,9 +1926,6 @@ public:
 
   void visitExtensionDecl(ExtensionDecl *ED) {
     auto extendedType = ED->getExtendedNominal();
-    // TODO: Sometimes we have an extension that is marked valid but has no
-    //       extended type. Assert, just in case we see it while testing, but
-    //       don't crash. rdar://50401284
     assert(extendedType && "valid extension with no extended type?");
     if (!extendedType || shouldSkipChecking(extendedType))
       return;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3049,29 +3049,35 @@ public:
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {
+    // Produce any diagnostics for the extended type.
+    auto extType = ED->getExtendedType();
+
+    auto nominal = ED->getExtendedNominal();
+    if (nominal == nullptr) {
+      ED->setInvalid();
+      ED->diagnose(diag::non_nominal_extension, extType);
+      return;
+    }
+
     TC.validateExtension(ED);
 
     checkInheritanceClause(ED);
 
-    if (auto nominal = ED->getExtendedNominal()) {
-      TC.validateDecl(nominal);
+    // Check the raw values of an enum, since we might synthesize
+    // RawRepresentable while checking conformances on this extension.
+    if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
+      if (enumDecl->hasRawType())
+        checkEnumRawValues(TC, enumDecl);
+    }
 
-      // Check the raw values of an enum, since we might synthesize
-      // RawRepresentable while checking conformances on this extension.
-      if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
-        if (enumDecl->hasRawType())
-          checkEnumRawValues(TC, enumDecl);
-      }
-
-      // Only generic and protocol types are permitted to have
-      // trailing where clauses.
-      if (auto trailingWhereClause = ED->getTrailingWhereClause()) {
-        if (!ED->getGenericParams() &&
-            !ED->isInvalid()) {
-          ED->diagnose(diag::extension_nongeneric_trailing_where,
-                       nominal->getFullName())
-          .highlight(trailingWhereClause->getSourceRange());
-        }
+    // Only generic and protocol types are permitted to have
+    // trailing where clauses.
+    if (auto trailingWhereClause = ED->getTrailingWhereClause()) {
+      if (!ED->getGenericParams() &&
+          !ED->isInvalid()) {
+        ED->diagnose(diag::extension_nongeneric_trailing_where,
+                      nominal->getFullName())
+        .highlight(trailingWhereClause->getSourceRange());
       }
     }
 
@@ -4371,13 +4377,14 @@ static Type formExtensionInterfaceType(
 /// Check the generic parameters of an extension, recursively handling all of
 /// the parameter lists within the extension.
 static GenericEnvironment *
-checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
+checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext,
                             GenericParamList *genericParams) {
   assert(!ext->getGenericEnvironment());
 
   // Form the interface type of the extension.
   bool mustInferRequirements = false;
   SmallVector<std::pair<Type, Type>, 4> sameTypeReqs;
+  auto type = ext->getExtendedType();
   Type extInterfaceType =
     formExtensionInterfaceType(tc, ext, type, genericParams, sameTypeReqs,
                                mustInferRequirements);
@@ -4488,10 +4495,6 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
 
   DeclValidationRAII IBV(ext);
 
-  auto extendedType = evaluateOrDefault(Context.evaluator,
-                                        ExtendedTypeRequest{ext},
-                                        ErrorType::get(ext->getASTContext()));
-
   if (auto *nominal = ext->getExtendedNominal()) {
     // If this extension was not already bound, it means it is either in an
     // inactive conditional compilation block, or otherwise (incorrectly)
@@ -4504,8 +4507,7 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
     validateDecl(nominal);
 
     if (auto *genericParams = ext->getGenericParams()) {
-      GenericEnvironment *env =
-        checkExtensionGenericParams(*this, ext, extendedType, genericParams);
+      auto *env = checkExtensionGenericParams(*this, ext, genericParams);
       ext->setGenericEnvironment(env);
     }
   }

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -1223,13 +1223,6 @@
       ]
     },
     {
-      key.kind: source.lang.swift.decl.function.method.instance,
-      key.name: "meth()",
-      key.usr: <usr>,
-      key.line: 134,
-      key.column: 8
-    },
-    {
       key.kind: source.lang.swift.decl.class,
       key.name: "CC4",
       key.usr: <usr>,

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -50,14 +50,6 @@ extension K {
   func replacement_finalFunction() {}
 }
 
-extension undeclared { // expected-error{{use of undeclared type 'undeclared'}}
-  @_dynamicReplacement(for: property) // expected-error{{replaced accessor for 'property' could not be found}}
-  var replacement_property: Int { return 2 }
-
-  @_dynamicReplacement(for: func) // expected-error{{replaced function 'func' could not be found}}
-  func func2() -> Int { return 2 }
-}
-
 extension P {
   @_dynamicReplacement(for: v)
   var replacement_v : Int {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -153,3 +153,20 @@ extension DoesNotImposeClassReq_2 where Self : AnyObject {
     set { property = newValue } // Okay
   }
 }
+
+// Reject extension of nominal type via parameterized typealias
+
+struct Nest<Egg> { typealias Contents = Egg }
+struct Tree { 
+  typealias LimbContent = Nest<Int> 
+  typealias BoughPayload = Nest<Nest<Int>>
+}
+
+extension Tree.LimbContent.Contents {
+  // expected-error@-1 {{extension of type 'Tree.LimbContent.Contents' (aka 'Int') must be declared as an extension of 'Int'}}
+  // expected-note@-2 {{did you mean to extend 'Int' instead?}} {{11-36=Int}}
+}
+
+extension Tree.BoughPayload.Contents {
+ // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
+}

--- a/test/decl/nested/type_in_extension.swift
+++ b/test/decl/nested/type_in_extension.swift
@@ -8,12 +8,12 @@ extension G {
   }
 }
 
-extension { // expected-error {{expected type name in extension declaration}}
-  struct S<T> {
+extension G {
+  struct S<T> { // expected-note {{generic type 'S' declared here}}
     func foo(t: T) {}
   }
 
-  class M : S {} // expected-error {{use of undeclared type 'S'}}
+  class M : S {} // expected-error {{reference to generic type 'G<T>.S' requires arguments in <...>}}
 
   protocol P { // expected-error {{protocol 'P' cannot be nested inside another declaration}}
     associatedtype A


### PR DESCRIPTION
Relates to #26967.  We were allowing a narrow class of extensions of trickily-constructed nominal types that involved some kind of indirection through a typealias to slip through our semantic checks.  Diagnose these, and offer an error in the cases where we know we can rewrite the underlying type to a valid nominal type. 

See also rdar://54799560, whose general pattern is reproduced in the added test.