### PR TITLE
[Typechecker] Relax existential to concrete type cast check for non-final classes

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4298,7 +4298,11 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //     print("Caught bar error")
     //   }
     // }
-    if (fromExistential) {
+    //
+    // Note: we relax the restriction if the type we're casting to is a class
+    // because it's possible that we might have a subclass that conforms to
+    // the protocol.
+    if (fromExistential && !toType->hasReferenceSemantics()) {
       if (auto NTD = toType->getAnyNominal()) {
         if (!isa<ProtocolDecl>(NTD)) {
           auto protocolDecl =

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4304,15 +4304,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     // that conforms to the protocol.
     if (fromExistential && !toExistential) {
       if (auto NTD = toType->getAnyNominal()) {
-        bool shouldContinue = true;
-
-        // If we have a non-final class, then don't check
-        if (toType->is<ClassType>() && !NTD->isFinal()) {
-          shouldContinue = false;
-        }
-
-        // Otherwise, check the cast.
-        if (shouldContinue) {
+        if (!toType->is<ClassType>() || NTD->isFinal()) {
           auto protocolDecl =
               dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal());
           if (protocolDecl &&

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -55,7 +55,7 @@ case is B,
      is D,
      is S:
   ()
-case is E: // expected-warning {{cast from 'P' to unrelated type 'E' always fails}}
+case is E:
   ()
 default:
   ()
@@ -69,7 +69,7 @@ case let d as D:
   d.d()
 case let s as S:
   s.s()
-case let e as E: // expected-warning {{cast from 'P' to unrelated type 'E' always fails}}
+case let e as E:
   e.e()
 default:
   ()

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -209,7 +209,7 @@ class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {}
 func sr_6400_4() {
   do {
     throw SR_6400_E.castError
-  } catch let error as SR_6400_A { // expected-warning {{cast from 'Error' to unrelated type 'SR_6400_A' always fails}} // expected-warning {{immutable value 'error' was never used; consider replacing with '_' or removing it}}
+  } catch let error as SR_6400_A { // expected-warning {{immutable value 'error' was never used; consider replacing with '_' or removing it}}
     print("Foo")
   } catch {
     print("Bar")
@@ -223,3 +223,17 @@ func sr_6400_4() {
     print("Bar")
   }
 }
+
+// SR-11402
+
+protocol SR_11402_P {}
+class SR_11402_Superclass {}
+class SR_11402_Subclass: SR_11402_Superclass, SR_11402_P {}
+
+func sr_11402_func(_ x: SR_11402_P) {
+  if let y = x as? SR_11402_Superclass { // Okay
+    print(y)
+  }
+}
+
+sr_11402_func(SR_11402_Subclass())

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -209,16 +209,16 @@ class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {}
 func sr_6400_4() {
   do {
     throw SR_6400_E.castError
-  } catch let error as SR_6400_A { // expected-warning {{immutable value 'error' was never used; consider replacing with '_' or removing it}}
-    print("Foo")
+  } catch let error as SR_6400_A { // Okay
+    print(error)
   } catch {
     print("Bar")
   }
   
   do {
     throw SR_6400_E.castError
-  } catch let error as SR_6400_B { // expected-warning {{immutable value 'error' was never used; consider replacing with '_' or removing it}}
-    print("Foo")
+  } catch let error as SR_6400_B { // Okay
+    print(error)
   } catch {
     print("Bar")
   }
@@ -230,10 +230,16 @@ protocol SR_11402_P {}
 class SR_11402_Superclass {}
 class SR_11402_Subclass: SR_11402_Superclass, SR_11402_P {}
 
-func sr_11402_func(_ x: SR_11402_P) {
+func sr_11402_func1(_ x: SR_11402_P) {
   if let y = x as? SR_11402_Superclass { // Okay
     print(y)
   }
 }
 
-sr_11402_func(SR_11402_Subclass())
+final class SR_11402_Final {}
+
+func sr_11402_func2(_ x: SR_11402_P) {
+  if let y = x as? SR_11402_Final { // expected-error {{cast from 'SR_11402_P' to unrelated type 'SR_11402_Final' always fails}}
+    print(y)
+  }
+}

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -239,7 +239,7 @@ func sr_11402_func1(_ x: SR_11402_P) {
 final class SR_11402_Final {}
 
 func sr_11402_func2(_ x: SR_11402_P) {
-  if let y = x as? SR_11402_Final { // expected-error {{cast from 'SR_11402_P' to unrelated type 'SR_11402_Final' always fails}}
+  if let y = x as? SR_11402_Final { // expected-warning {{cast from 'SR_11402_P' to unrelated type 'SR_11402_Final' always fails}}
     print(y)
   }
 }


### PR DESCRIPTION
Relax existential to concrete type cast check for classes, otherwise we have emit a warning for the code below:

```swift
protocol MyProtocol {}
class Superclass {} // Superclass does not conform to MyProtocol
class Subclass: Superclass, MyProtocol {} // Subclass conforms to MyProtocol

func f(_ x: MyProtocol) { // Expects existential of type MyProtocol
  if let y = x as? Superclass { // Superclass is 'unrelated', but cast still succeeds
    print(y)
  }
}

f(Subclass())
```

Resolves [SR-11402](https://bugs.swift.org/browse/SR-11402).
