### PR TITLE
Revert "[CS] Don't crash when default argument is magic literal and types don't match"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -361,9 +361,6 @@ ERROR(cannot_convert_default_arg_value,none,
       (Type,Type))
 ERROR(cannot_convert_default_arg_value_protocol,none,
       "default argument value of type %0 does not conform to %1", (Type,Type))
-ERROR(default_argument_literal_cannot_convert, none,
-      "cannot call %0 %1 because default argument of type %2 cannot be "
-      "converted to type %3", (DescriptiveDeclKind, DeclName, Type, Type))
 ERROR(cannot_convert_default_arg_value_nil,none,
       "nil default argument value cannot be converted to type %0", (Type))
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3417,21 +3417,6 @@ bool MissingArgumentsFailure::diagnoseTrailingClosure(ClosureExpr *closure) {
   return true;
 }
 
-bool DefaultArgumentTypeMismatch::diagnoseAsError() {
-  auto choice = getChoiceFor(getRawAnchor());
-  if (!choice.hasValue())
-    return false;
-
-  auto declName = choice.getValue().choice.getName();
-  auto declKind = choice.getValue().choice.getDecl()->getDescriptiveKind();
-
-  emitDiagnostic(getAnchor()->getLoc(),
-                 diag::default_argument_literal_cannot_convert, declKind,
-                 declName, FromType, ToType);
-
-  return true;
-}
-
 bool ClosureParamDestructuringFailure::diagnoseAsError() {
   auto *closure = cast<ClosureExpr>(getAnchor());
   auto params = closure->getParameters();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1210,21 +1210,6 @@ private:
   bool diagnoseTrailingClosure(ClosureExpr *closure);
 };
 
-class DefaultArgumentTypeMismatch final : public FailureDiagnostic {
-  using Param = AnyFunctionType::Param;
-
-  Type FromType;
-  Type ToType;
-
-public:
-  DefaultArgumentTypeMismatch(Expr *root, ConstraintSystem &cs, Type fromType,
-                              Type toType, ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), FromType(fromType),
-        ToType(toType) {}
-
-  bool diagnoseAsError() override;
-};
-
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {
   using ParamBinding = SmallVector<unsigned, 1>;
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -482,21 +482,6 @@ bool AddMissingArguments::diagnose(Expr *root, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
-IgnoreDefaultArgumentTypeMismatch *
-IgnoreDefaultArgumentTypeMismatch::create(ConstraintSystem &cs, Type fromType,
-                                          Type toType,
-                                          ConstraintLocator *locator) {
-  return new (cs.getAllocator())
-      IgnoreDefaultArgumentTypeMismatch(cs, fromType, toType, locator);
-}
-
-bool IgnoreDefaultArgumentTypeMismatch::diagnose(Expr *root,
-                                                 bool asNote) const {
-  DefaultArgumentTypeMismatch failure(root, getConstraintSystem(), FromType,
-                                      ToType, getLocator());
-  return failure.diagnose(asNote);
-}
-
 AddMissingArguments *
 AddMissingArguments::create(ConstraintSystem &cs, FunctionType *funcType,
                             llvm::ArrayRef<Param> synthesizedArgs,

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -189,9 +189,6 @@ enum class FixKind : uint8_t {
   /// when base is an r-value type.
   AllowMutatingMemberOnRValueBase,
 
-  /// Fix the type of the default argument
-  DefaultArgumentTypeMismatch,
-  
   /// Allow a single tuple parameter to be matched with N arguments
   /// by forming all of the given arguments into a single tuple.
   AllowTupleSplatForSingleParameter,
@@ -1021,27 +1018,6 @@ private:
   MutableArrayRef<Param> getSynthesizedArgumentsBuf() {
     return {getTrailingObjects<Param>(), NumSynthesized};
   }
-};
-
-class IgnoreDefaultArgumentTypeMismatch final : public ConstraintFix {
-  Type FromType;
-  Type ToType;
-
-  IgnoreDefaultArgumentTypeMismatch(ConstraintSystem &cs, Type fromType,
-                                    Type toType, ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::DefaultArgumentTypeMismatch, locator),
-        FromType(fromType), ToType(toType) {}
-
-public:
-  std::string getName() const override {
-    return "ignore default argument type mismatch";
-  }
-
-  bool diagnose(Expr *root, bool asNote = false) const override;
-
-  static IgnoreDefaultArgumentTypeMismatch *create(ConstraintSystem &cs,
-                                                   Type fromType, Type toType,
-                                                   ConstraintLocator *locator);
 };
 
 class MoveOutOfOrderArgument final : public ConstraintFix {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -53,7 +53,6 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
     case ApplyArgument:
     case ApplyFunction:
     case FunctionArgument:
-    case DefaultArgument:
     case FunctionResult:
     case OptionalPayload:
     case Member:
@@ -275,10 +274,6 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
 
     case FunctionArgument:
       out << "function argument";
-      break;
-
-    case DefaultArgument:
-      out << "default argument";
       break;
 
     case FunctionResult:

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -65,8 +65,6 @@ public:
     GenericParameter,
     /// The argument type of a function.
     FunctionArgument,
-    /// The default argument type of a function.
-    DefaultArgument,
     /// The result type of a function.
     FunctionResult,
     /// A tuple element referenced by position.
@@ -149,7 +147,6 @@ public:
     case ApplyFunction:
     case GenericParameter:
     case FunctionArgument:
-    case DefaultArgument:
     case FunctionResult:
     case OptionalPayload:
     case Member:
@@ -247,7 +244,6 @@ public:
       return 0;
 
     case FunctionArgument:
-    case DefaultArgument:
     case FunctionResult:
       return IsFunctionConversion;
     }

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -168,12 +168,3 @@ let fooThing5 = Foo(a: 0, d: 1, h: nil) // expected-error {{missing argument for
 // Here b = false and g = nil, but we're checking that f doesn't get a default value
 let fooThing6 = Foo(a: 0, d: 1, e: 2, h: nil) // expected-error {{missing argument for parameter 'f' in call}}
                                               // expected-note@-29 {{'init(a:b:d:e:f:g:h:)' declared here}}
-
-// SR-11074
-
-func sr_11074(x: Int) {}
-func sr_11074(line: String = #line) {} // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
-sr_11074() // expected-error {{cannot call global function 'sr_11074(line:)' because default argument of type 'Int' cannot be converted to type 'String'}}
-
-class SR_11074_C { init(line: String = #line) {} } // expected-error {{default argument value of type 'Int' cannot be converted to type 'String'}}
-let _ = SR_11074_C() // expected-error {{cannot call initializer 'init(line:)' because default argument of type 'Int' cannot be converted to type 'String'}}

--- a/validation-test/compiler_crashers_2_fixed/sr11074.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11074.swift
@@ -1,5 +1,0 @@
-// RUN: not %target-swift-frontend -typecheck %s
-
-func foo(x: Int) {}
-func foo(line: String = #line) {}
-foo()


### PR DESCRIPTION
Reverts apple/swift#26074, as it causes a regression with generic type resolution. 

See [SR-11223](https://bugs.swift.org/browse/SR-11223)