### PR TITLE
[SyntaxParse] Don't discard 'typealias' without identifier

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4104,8 +4104,10 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   Status |= parseIdentifierDeclName(*this, Id, IdLoc, "typealias",
                                     tok::colon, tok::equal);
-  if (Status.isError())
+  if (Status.isError()) {
+    TmpCtxt->setTransparent();
     return nullptr;
+  }
     
   DebuggerContextChange DCC(*this, Id, DeclKind::TypeAlias);
 

--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -22,6 +22,9 @@ do {
 do {
   typealias Alias3 = () -> @objc func
 }
+do {
+  typealias
+}
 
 // Orphan '}' at top level
 }


### PR DESCRIPTION
Fixes round trip issue introduced by #26937 