### PR TITLE
Revert "Add a request to lazily parse function bodies."

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5594,8 +5594,6 @@ protected:
     SourceRange BodyRange;
   };
 
-  friend class ParseAbstractFunctionBodyRequest;
-
   CaptureInfo Captures;
 
   /// Location of the 'throws' token.

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -48,28 +48,6 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Parse the body of a function, initializer, or deinitializer.
-class ParseAbstractFunctionBodyRequest :
-    public SimpleRequest<ParseAbstractFunctionBodyRequest,
-                         BraceStmt *(AbstractFunctionDecl *),
-                         CacheKind::SeparatelyCached>
-{
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  BraceStmt *evaluate(Evaluator &evaluator, AbstractFunctionDecl *afd) const;
-
-public:
-  // Caching
-  bool isCached() const { return true; }
-  Optional<BraceStmt *> getCachedResult() const;
-  void cacheResult(BraceStmt *value) const;
-};
-
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse
 #define SWIFT_TYPEID_HEADER "swift/AST/ParseTypeIDZone.def"

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -15,4 +15,3 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(Parse, ParseMembersRequest)
-SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1124,7 +1124,7 @@ public:
                                        DeclAttributes &Attributes,
                                        bool HasFuncKeyword = true);
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
-  BraceStmt *parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
+  bool parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -109,6 +109,14 @@ public:
   PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
+  void delayFunctionBodyParsing(AbstractFunctionDecl *AFD,
+                                SourceRange BodyRange,
+                                SourceLoc PreviousLoc);
+  std::unique_ptr<FunctionBodyState>
+  takeFunctionBodyState(AbstractFunctionDecl *AFD);
+
+  bool hasFunctionBodyState(AbstractFunctionDecl *AFD);
+
   void delayDecl(DelayedDeclKind Kind, unsigned Flags,
                  DeclContext *ParentContext,
                  SourceRange BodyRange, SourceLoc PreviousLoc);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -118,13 +118,9 @@ PrintOptions PrintOptions::printParseableInterfaceFile(bool preferTypeRepr) {
 
   result.FunctionBody = [](const ValueDecl *decl, ASTPrinter &printer) {
     auto AFD = dyn_cast<AbstractFunctionDecl>(decl);
-    if (!AFD)
-      return;
+    if (!AFD || !AFD->hasInlinableBodyText()) return;
     if (AFD->getResilienceExpansion() != ResilienceExpansion::Minimal)
       return;
-    if (!AFD->hasInlinableBodyText())
-      return;
-
     SmallString<128> scratch;
     printer << " " << AFD->getInlinableBodyText(scratch);
   };

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1272,7 +1272,7 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
   // Create scope for the body.
   // We create body scopes when there is no body for source kit to complete
   // erroneous code in bodies. But don't let compiler synthesize one.
-  if (decl->getBodySourceRange().isValid() && decl->getBody(false)) {
+  if (decl->getBody(false) && decl->getBodySourceRange().isValid()) {
     if (AbstractFunctionBodyScope::isAMethod(decl))
       scopeCreator.constructExpandAndInsertUncheckable<MethodBodyScope>(leaf,
                                                                         decl);
@@ -1771,10 +1771,10 @@ bool IterableTypeScope::isBodyCurrent() const {
 }
 
 void AbstractFunctionBodyScope::beCurrent() {
-  bodyWhenLastExpanded = decl->getBody(false);
+  bodyWhenLastExpanded = decl->getBody();
 }
 bool AbstractFunctionBodyScope::isCurrent() const {
-  return bodyWhenLastExpanded == decl->getBody(false);
+  return bodyWhenLastExpanded == decl->getBody();
   ;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -33,7 +33,6 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
-#include "swift/AST/ParseRequests.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -6308,22 +6307,37 @@ bool AbstractFunctionDecl::argumentNameIsAPIByDefault() const {
 }
 
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
-  if ((getBodyKind() == BodyKind::Synthesize ||
-       getBodyKind() == BodyKind::Unparsed) &&
-      !canSynthesize)
+  switch (getBodyKind()) {
+  case BodyKind::Deserialized:
+  case BodyKind::MemberwiseInitializer:
+  case BodyKind::None:
+  case BodyKind::Skipped:
     return nullptr;
 
-  ASTContext &ctx = getASTContext();
+  case BodyKind::Parsed:
+  case BodyKind::TypeChecked:
+    return Body;
 
-  // Don't allow getBody() to trigger parsing of an unparsed body containing the
-  // code completion location.
-  if (getBodyKind() == BodyKind::Unparsed &&
-      ctx.SourceMgr.rangeContainsCodeCompletionLoc(getBodySourceRange())) {
+  case BodyKind::Unparsed:
+    // FIXME: Go parse now!
     return nullptr;
+
+  case BodyKind::Synthesize: {
+    if (!canSynthesize)
+      return nullptr;
+
+    const_cast<AbstractFunctionDecl *>(this)->setBodyKind(BodyKind::None);
+    BraceStmt *body;
+    bool isTypeChecked;
+
+    auto mutableThis = const_cast<AbstractFunctionDecl *>(this);
+    std::tie(body, isTypeChecked) = (Synthesizer.Fn)(
+        mutableThis, Synthesizer.Context);
+    mutableThis->setBody(
+        body, isTypeChecked ? BodyKind::TypeChecked : BodyKind::Parsed);
+    return body;
   }
-
-  auto mutableThis = const_cast<AbstractFunctionDecl *>(this);
-  return evaluateOrDefault(ctx.evaluator, ParseAbstractFunctionBodyRequest{mutableThis}, nullptr);
+  }
 }
 
 SourceRange AbstractFunctionDecl::getBodySourceRange() const {
@@ -6790,15 +6804,11 @@ bool AbstractFunctionDecl::hasInlinableBodyText() const {
   switch (getBodyKind()) {
   case BodyKind::Deserialized:
     return true;
-
-  case BodyKind::Unparsed:
   case BodyKind::Parsed:
   case BodyKind::TypeChecked:
-    if (auto body = getBody())
-      return !body->isImplicit();
-    return false;
-
+    return getBody() && !getBody()->isImplicit();
   case BodyKind::None:
+  case BodyKind::Unparsed:
   case BodyKind::Synthesize:
   case BodyKind::Skipped:
   case BodyKind::MemberwiseInitializer:
@@ -7665,50 +7675,4 @@ SourceLoc swift::extractNearestSourceLoc(const Decl *decl) {
     return loc;
 
   return extractNearestSourceLoc(decl->getDeclContext());
-}
-
-Optional<BraceStmt *>
-ParseAbstractFunctionBodyRequest::getCachedResult() const {
-  using BodyKind = AbstractFunctionDecl::BodyKind;
-  auto afd = std::get<0>(getStorage());
-  switch (afd->getBodyKind()) {
-  case BodyKind::Deserialized:
-  case BodyKind::MemberwiseInitializer:
-  case BodyKind::None:
-  case BodyKind::Skipped:
-    return nullptr;
-
-  case BodyKind::TypeChecked:
-  case BodyKind::Parsed:
-    return afd->Body;
-
-  case BodyKind::Synthesize:
-  case BodyKind::Unparsed:
-    return None;
-  }
-}
-
-void ParseAbstractFunctionBodyRequest::cacheResult(BraceStmt *value) const {
-  using BodyKind = AbstractFunctionDecl::BodyKind;
-  auto afd = std::get<0>(getStorage());
-  switch (afd->getBodyKind()) {
-  case BodyKind::Deserialized:
-  case BodyKind::MemberwiseInitializer:
-  case BodyKind::None:
-  case BodyKind::Skipped:
-    // The body is always empty, so don't cache anything.
-    assert(value == nullptr);
-    return;
-
-  case BodyKind::Parsed:
-  case BodyKind::TypeChecked:
-    afd->Body = value;
-    return;
-
-  case BodyKind::Synthesize:
-  case BodyKind::Unparsed:
-    llvm_unreachable("evaluate() did not set the body kind");
-    return;
-  }
-
 }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -663,7 +663,7 @@ void UnqualifiedLookupFactory::lookupNamesIntroducedByFunctionDecl(
   const bool isCascadingUse =
       AFD->isCascadingContextForLookup(false) &&
       (isCascadingUseArg.getValueOr(
-          Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
+          Loc.isInvalid() || !AFD->getBody() ||
           !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc)));
 
   if (AFD->getDeclContext()->isTypeContext())
@@ -814,9 +814,7 @@ void UnqualifiedLookupFactory::lookForLocalVariablesIn(
   // FIXME: when we can parse and typecheck the function body partially
   // for code completion, AFD->getBody() check can be removed.
 
-  if (Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
-      !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc) ||
-      !AFD->getBody()) {
+  if (Loc.isInvalid() || !AFD->getBody()) {
     return;
   }
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -48,50 +48,6 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
       llvm::makeArrayRef(parser.parseDeclListDelayed(idc)));
 }
 
-BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
-    Evaluator &evaluator, AbstractFunctionDecl *afd) const {
-  using BodyKind = AbstractFunctionDecl::BodyKind;
-
-  switch (afd->getBodyKind()) {
-  case BodyKind::Deserialized:
-  case BodyKind::MemberwiseInitializer:
-  case BodyKind::None:
-  case BodyKind::Skipped:
-    return nullptr;
-
-  case BodyKind::TypeChecked:
-  case BodyKind::Parsed:
-    return afd->Body;
-
-  case BodyKind::Synthesize: {
-    BraceStmt *body;
-    bool isTypeChecked;
-
-    std::tie(body, isTypeChecked) = (afd->Synthesizer.Fn)(
-        afd, afd->Synthesizer.Context);
-    afd->setBodyKind(isTypeChecked ? BodyKind::TypeChecked : BodyKind::Parsed);
-    return body;
-  }
-
-  case BodyKind::Unparsed: {
-    // FIXME: It should be fine to delay body parsing of local functions, so
-    // the DelayBodyParsing should go away entirely
-    // FIXME: How do we configure code completion?
-    SourceFile &sf = *afd->getDeclContext()->getParentSourceFile();
-    SourceManager &sourceMgr = sf.getASTContext().SourceMgr;
-    unsigned bufferID = sourceMgr.findBufferContainingLoc(afd->getLoc());
-    Parser parser(bufferID, sf, nullptr, nullptr, nullptr,
-                 /*DelayBodyParsing=*/false);
-    parser.SyntaxContext->setDiscard();
-    auto body = parser.parseAbstractFunctionBodyDelayed(afd);
-    afd->setBodyKind(BodyKind::Parsed);
-    return body;
-  }
-  }
-
-}
-
-
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *parseRequestFunctions[] = {
 #define SWIFT_REQUEST(Zone, Name)                      \

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -138,9 +138,6 @@ public:
 
 private:
   void parseFunctionBody(AbstractFunctionDecl *AFD) {
-    // FIXME: This duplicates the evaluation of
-    // ParseAbstractFunctionBodyRequest, but installs a code completion
-    // factory.
     assert(AFD->getBodyKind() == FuncDecl::BodyKind::Unparsed);
 
     SourceFile &SF = *AFD->getDeclContext()->getParentSourceFile();
@@ -155,8 +152,8 @@ private:
           CodeCompletionFactory->createCodeCompletionCallbacks(TheParser));
       TheParser.setCodeCompletionCallbacks(CodeCompletion.get());
     }
-    auto body = TheParser.parseAbstractFunctionBodyDelayed(AFD);
-    AFD->setBodyParsed(body);
+    if (ParserState.hasFunctionBodyState(AFD))
+      TheParser.parseAbstractFunctionBodyDelayed(AFD);
 
     if (CodeCompletion)
       CodeCompletion->doneParsing();

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -25,6 +25,31 @@ PersistentParserState::PersistentParserState() { }
 
 PersistentParserState::~PersistentParserState() { }
 
+void PersistentParserState::delayFunctionBodyParsing(AbstractFunctionDecl *AFD,
+                                                     SourceRange BodyRange,
+                                                     SourceLoc PreviousLoc) {
+  std::unique_ptr<FunctionBodyState> State;
+  State.reset(new FunctionBodyState(BodyRange, PreviousLoc,
+                                    ScopeInfo.saveCurrentScope()));
+  assert(DelayedFunctionBodies.find(AFD) == DelayedFunctionBodies.end() &&
+         "Already recorded state for this body");
+  DelayedFunctionBodies[AFD] = std::move(State);
+}
+
+std::unique_ptr<PersistentParserState::FunctionBodyState>
+PersistentParserState::takeFunctionBodyState(AbstractFunctionDecl *AFD) {
+  assert(AFD->getBodyKind() == AbstractFunctionDecl::BodyKind::Unparsed);
+  DelayedFunctionBodiesTy::iterator I = DelayedFunctionBodies.find(AFD);
+  assert(I != DelayedFunctionBodies.end() && "State should be saved");
+  std::unique_ptr<FunctionBodyState> State = std::move(I->second);
+  DelayedFunctionBodies.erase(I);
+  return State;
+}
+
+bool PersistentParserState::hasFunctionBodyState(AbstractFunctionDecl *AFD) {
+  return DelayedFunctionBodies.find(AFD) != DelayedFunctionBodies.end();
+}
+
 void PersistentParserState::delayDecl(DelayedDeclKind Kind,
                                       unsigned Flags,
                                       DeclContext *ParentContext,

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1054,10 +1054,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       // for us, but it can't do the right thing inside local types.
       // FIXME: when we can parse and typecheck the function body partially for
       // code completion, AFD->getBody() check can be removed.
-      if (Loc.isValid() &&
-          AFD->getSourceRange().isValid() &&
-          SM.rangeContainsTokenLoc(AFD->getSourceRange(), Loc) &&
-          AFD->getBody()) {
+      if (Loc.isValid() && AFD->getBody()) {
         namelookup::FindLocalVal(SM, Loc, Consumer).visit(AFD->getBody());
       }
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -152,6 +152,9 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   assert(done && "Parser returned early?");
   (void)done;
 
+  if (SkipBodies)
+    performDelayedParsing(importMod, persistentState, nullptr);
+
   // FIXME: Support recursive definitions in immediate modes by making type
   // checking even lazier.
   if (SkipBodies)


### PR DESCRIPTION
Reverts apple/swift#26972

It broke all CI bots because of a compiler error