### PR TITLE
Add a request to lazily parse function bodies.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5594,6 +5594,8 @@ protected:
     SourceRange BodyRange;
   };
 
+  friend class ParseAbstractFunctionBodyRequest;
+
   CaptureInfo Captures;
 
   /// Location of the 'throws' token.

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -48,6 +48,28 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Parse the body of a function, initializer, or deinitializer.
+class ParseAbstractFunctionBodyRequest :
+    public SimpleRequest<ParseAbstractFunctionBodyRequest,
+                         BraceStmt *(AbstractFunctionDecl *),
+                         CacheKind::SeparatelyCached>
+{
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  BraceStmt *evaluate(Evaluator &evaluator, AbstractFunctionDecl *afd) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+  Optional<BraceStmt *> getCachedResult() const;
+  void cacheResult(BraceStmt *value) const;
+};
+
 /// The zone number for the parser.
 #define SWIFT_TYPEID_ZONE Parse
 #define SWIFT_TYPEID_HEADER "swift/AST/ParseTypeIDZone.def"

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -15,3 +15,4 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(Parse, ParseMembersRequest)
+SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest)

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -103,6 +103,13 @@ public:
            rangeContainsTokenLoc(Enclosing, Inner.End);
   }
 
+  /// Returns true if range \p R contains the code-completion location, if any.
+  bool rangeContainsCodeCompletionLoc(SourceRange R) const {
+    return CodeCompletionBufferID
+               ? rangeContainsTokenLoc(R, getCodeCompletionLoc())
+               : false;
+  }
+
   /// Returns the buffer ID for the specified *valid* location.
   ///
   /// Because a valid source location always corresponds to a source buffer,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1124,7 +1124,7 @@ public:
                                        DeclAttributes &Attributes,
                                        bool HasFuncKeyword = true);
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
-  bool parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
+  BraceStmt *parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -109,14 +109,6 @@ public:
   PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
-  void delayFunctionBodyParsing(AbstractFunctionDecl *AFD,
-                                SourceRange BodyRange,
-                                SourceLoc PreviousLoc);
-  std::unique_ptr<FunctionBodyState>
-  takeFunctionBodyState(AbstractFunctionDecl *AFD);
-
-  bool hasFunctionBodyState(AbstractFunctionDecl *AFD);
-
   void delayDecl(DelayedDeclKind Kind, unsigned Flags,
                  DeclContext *ParentContext,
                  SourceRange BodyRange, SourceLoc PreviousLoc);

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -24,22 +24,20 @@ class ModuleDecl;
 class SourceLoader : public ModuleLoader {
 private:
   ASTContext &Ctx;
-  bool SkipBodies;
   bool EnableLibraryEvolution;
 
   explicit SourceLoader(ASTContext &ctx,
-                        bool skipBodies,
                         bool enableResilience,
                         DependencyTracker *tracker)
     : ModuleLoader(tracker), Ctx(ctx),
-      SkipBodies(skipBodies), EnableLibraryEvolution(enableResilience) {}
+      EnableLibraryEvolution(enableResilience) {}
 
 public:
   static std::unique_ptr<SourceLoader>
-  create(ASTContext &ctx, bool skipBodies, bool enableResilience,
+  create(ASTContext &ctx, bool enableResilience,
          DependencyTracker *tracker = nullptr) {
     return std::unique_ptr<SourceLoader>{
-      new SourceLoader(ctx, skipBodies, enableResilience, tracker)
+      new SourceLoader(ctx, enableResilience, tracker)
     };
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -118,9 +118,13 @@ PrintOptions PrintOptions::printParseableInterfaceFile(bool preferTypeRepr) {
 
   result.FunctionBody = [](const ValueDecl *decl, ASTPrinter &printer) {
     auto AFD = dyn_cast<AbstractFunctionDecl>(decl);
-    if (!AFD || !AFD->hasInlinableBodyText()) return;
+    if (!AFD)
+      return;
     if (AFD->getResilienceExpansion() != ResilienceExpansion::Minimal)
       return;
+    if (!AFD->hasInlinableBodyText())
+      return;
+
     SmallString<128> scratch;
     printer << " " << AFD->getInlinableBodyText(scratch);
   };

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1272,7 +1272,7 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
   // Create scope for the body.
   // We create body scopes when there is no body for source kit to complete
   // erroneous code in bodies. But don't let compiler synthesize one.
-  if (decl->getBody(false) && decl->getBodySourceRange().isValid()) {
+  if (decl->getBodySourceRange().isValid() && decl->getBody(false)) {
     if (AbstractFunctionBodyScope::isAMethod(decl))
       scopeCreator.constructExpandAndInsertUncheckable<MethodBodyScope>(leaf,
                                                                         decl);
@@ -1771,10 +1771,10 @@ bool IterableTypeScope::isBodyCurrent() const {
 }
 
 void AbstractFunctionBodyScope::beCurrent() {
-  bodyWhenLastExpanded = decl->getBody();
+  bodyWhenLastExpanded = decl->getBody(false);
 }
 bool AbstractFunctionBodyScope::isCurrent() const {
-  return bodyWhenLastExpanded == decl->getBody();
+  return bodyWhenLastExpanded == decl->getBody(false);
   ;
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -663,7 +663,7 @@ void UnqualifiedLookupFactory::lookupNamesIntroducedByFunctionDecl(
   const bool isCascadingUse =
       AFD->isCascadingContextForLookup(false) &&
       (isCascadingUseArg.getValueOr(
-          Loc.isInvalid() || !AFD->getBody() ||
+          Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
           !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc)));
 
   if (AFD->getDeclContext()->isTypeContext())
@@ -814,7 +814,9 @@ void UnqualifiedLookupFactory::lookForLocalVariablesIn(
   // FIXME: when we can parse and typecheck the function body partially
   // for code completion, AFD->getBody() check can be removed.
 
-  if (Loc.isInvalid() || !AFD->getBody()) {
+  if (Loc.isInvalid() || AFD->getBodySourceRange().isInvalid() ||
+      !SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc) ||
+      !AFD->getBody()) {
     return;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -315,12 +315,9 @@ void CompilerInstance::setUpDiagnosticOptions() {
 
 bool CompilerInstance::setUpModuleLoaders() {
   if (hasSourceImport()) {
-    bool immediate = FrontendOptions::isActionImmediate(
-        Invocation.getFrontendOptions().RequestedAction);
     bool enableLibraryEvolution =
       Invocation.getFrontendOptions().EnableLibraryEvolution;
     Context->addModuleLoader(SourceLoader::create(*Context,
-                                                  !immediate,
                                                   enableLibraryEvolution,
                                                   getDependencyTracker()));
   }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -138,6 +138,9 @@ public:
 
 private:
   void parseFunctionBody(AbstractFunctionDecl *AFD) {
+    // FIXME: This duplicates the evaluation of
+    // ParseAbstractFunctionBodyRequest, but installs a code completion
+    // factory.
     assert(AFD->getBodyKind() == FuncDecl::BodyKind::Unparsed);
 
     SourceFile &SF = *AFD->getDeclContext()->getParentSourceFile();
@@ -152,8 +155,8 @@ private:
           CodeCompletionFactory->createCodeCompletionCallbacks(TheParser));
       TheParser.setCodeCompletionCallbacks(CodeCompletion.get());
     }
-    if (ParserState.hasFunctionBodyState(AFD))
-      TheParser.parseAbstractFunctionBodyDelayed(AFD);
+    auto body = TheParser.parseAbstractFunctionBodyDelayed(AFD);
+    AFD->setBodyParsed(body);
 
     if (CodeCompletion)
       CodeCompletion->doneParsing();

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -25,31 +25,6 @@ PersistentParserState::PersistentParserState() { }
 
 PersistentParserState::~PersistentParserState() { }
 
-void PersistentParserState::delayFunctionBodyParsing(AbstractFunctionDecl *AFD,
-                                                     SourceRange BodyRange,
-                                                     SourceLoc PreviousLoc) {
-  std::unique_ptr<FunctionBodyState> State;
-  State.reset(new FunctionBodyState(BodyRange, PreviousLoc,
-                                    ScopeInfo.saveCurrentScope()));
-  assert(DelayedFunctionBodies.find(AFD) == DelayedFunctionBodies.end() &&
-         "Already recorded state for this body");
-  DelayedFunctionBodies[AFD] = std::move(State);
-}
-
-std::unique_ptr<PersistentParserState::FunctionBodyState>
-PersistentParserState::takeFunctionBodyState(AbstractFunctionDecl *AFD) {
-  assert(AFD->getBodyKind() == AbstractFunctionDecl::BodyKind::Unparsed);
-  DelayedFunctionBodiesTy::iterator I = DelayedFunctionBodies.find(AFD);
-  assert(I != DelayedFunctionBodies.end() && "State should be saved");
-  std::unique_ptr<FunctionBodyState> State = std::move(I->second);
-  DelayedFunctionBodies.erase(I);
-  return State;
-}
-
-bool PersistentParserState::hasFunctionBodyState(AbstractFunctionDecl *AFD) {
-  return DelayedFunctionBodies.find(AFD) != DelayedFunctionBodies.end();
-}
-
 void PersistentParserState::delayDecl(DelayedDeclKind Kind,
                                       unsigned Flags,
                                       DeclContext *ParentContext,

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1054,7 +1054,10 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       // for us, but it can't do the right thing inside local types.
       // FIXME: when we can parse and typecheck the function body partially for
       // code completion, AFD->getBody() check can be removed.
-      if (Loc.isValid() && AFD->getBody()) {
+      if (Loc.isValid() &&
+          AFD->getSourceRange().isValid() &&
+          SM.rangeContainsTokenLoc(AFD->getSourceRange(), Loc) &&
+          AFD->getBody()) {
         namelookup::FindLocalVal(SM, Loc, Consumer).visit(AFD->getBody());
       }
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -152,9 +152,6 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   assert(done && "Parser returned early?");
   (void)done;
 
-  if (SkipBodies)
-    performDelayedParsing(importMod, persistentState, nullptr);
-
   // FIXME: Support recursive definitions in immediate modes by making type
   // checking even lazier.
   if (SkipBodies)

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -56,20 +56,6 @@ static FileOrError findModule(ASTContext &ctx, StringRef moduleID,
   return make_error_code(std::errc::no_such_file_or_directory);
 }
 
-namespace {
-
-/// Don't parse any function bodies except those that are transparent.
-class SkipNonTransparentFunctions : public DelayedParsingCallbacks {
-  bool shouldDelayFunctionBodyParsing(Parser &TheParser,
-                                      AbstractFunctionDecl *AFD,
-                                      const DeclAttributes &Attrs,
-                                      SourceRange BodyRange) override {
-    return Attrs.hasAttribute<TransparentAttr>();
-  }
-};
-
-} // unnamed namespace
-
 void SourceLoader::collectVisibleTopLevelModuleNames(
     SmallVectorImpl<Identifier> &names) const {
   // TODO: Implement?
@@ -145,20 +131,11 @@ ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
   importMod->addFile(*importFile);
 
   bool done;
-  PersistentParserState persistentState;
-  SkipNonTransparentFunctions delayCallbacks;
-  parseIntoSourceFile(*importFile, bufferID, &done, nullptr, &persistentState,
-                      SkipBodies ? &delayCallbacks : nullptr);
+  parseIntoSourceFile(*importFile, bufferID, &done, nullptr, nullptr, nullptr);
   assert(done && "Parser returned early?");
   (void)done;
 
-  // FIXME: Support recursive definitions in immediate modes by making type
-  // checking even lazier.
-  if (SkipBodies)
-    performNameBinding(*importFile);
-  else
-    performTypeChecking(*importFile, persistentState.getTopLevelContext(),
-                        None);
+  performNameBinding(*importFile);
   importMod->setHasResolvedImports();
   return importMod;
 }


### PR DESCRIPTION
Rework the lazy function body parsing mechanism to use the
request-evaluator, so that asking for the body of a function will
initiate parsing. Clean up a number of callers to
`AbstractFunctionDecl::getBody()` that don't actually need the body, so
we don't perform unnecessary parsing.

This change does not delay parsing of function bodies in the general
case; rather, it sets up the infrastructure to always delay parsing of
function bodies.