### PR TITLE
[libSyntax] Remove redundant name space for static func call

### DIFF
--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -116,11 +116,11 @@ def make_missing_swift_child(child):
         tok_kind = token.swift_kind() if token else "unknown"
         if not token or not token.text:
             tok_kind += '("")'
-        return 'RawSyntax.missingToken(TokenKind.%s)' % tok_kind
+        return '.missingToken(.%s)' % tok_kind
     else:
         missing_kind = "unknown" if child.syntax_kind == "Syntax" \
                        else child.swift_syntax_kind
-        return 'RawSyntax.missing(SyntaxKind.%s)' % missing_kind
+        return '.missing(.%s)' % missing_kind
 
 
 def create_node_map():


### PR DESCRIPTION
## Overview

Not sure if we have policy for gyb file, but I think that it would be less code to remove redundant name space for static func call in Swift.

## Reference

https://github.com/apple/swift-syntax/pull/141

