### PR TITLE
Revert "[semantic-arc-opts] Teach load [copy] -> load_borrow about forwarding…"

### DIFF
--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -437,28 +437,6 @@ bb0(%x : @guaranteed $ClassLet):
   return undef : $()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_guaranteed_base_and_forwarding_uses :
-// CHECK:         ref_element_addr
-// CHECK-NEXT:    load_borrow
-// CHECK-NEXT:    unchecked_ref_cast
-// CHECK-NEXT:    apply
-// CHECK-NEXT:    end_borrow
-// CHECK-NEXT:    return
-// CHECK: } // end sil function 'dont_copy_let_properties_with_guaranteed_base_and_forwarding_uses'
-sil [ossa] @dont_copy_let_properties_with_guaranteed_base_and_forwarding_uses : $@convention(thin) (@guaranteed ClassLet) -> () {
-bb0(%x : @guaranteed $ClassLet):
-  %f = function_ref @black_hole : $@convention(thin) (@guaranteed Klass) -> ()
-
-  %p = ref_element_addr %x : $ClassLet, #ClassLet.aLet
-  %v = load [copy] %p : $*Klass
-  %c = unchecked_ref_cast %v : $Klass to $Klass
-  %b = begin_borrow %c : $Klass
-  apply %f(%b) : $@convention(thin) (@guaranteed Klass) -> ()
-  end_borrow %b : $Klass
-  destroy_value %c : $Klass
-  return undef : $()
-}
-
 // CHECK-LABEL: sil [ossa] @dont_copy_let_properties_with_guaranteed_upcast_base
 // CHECK:         ref_element_addr
 // CHECK-NEXT:    load_borrow


### PR DESCRIPTION
Reverts apple/swift#26956

This is the only change since https://ci.swift.org/job/swift-master-source-compat-suite/ is failing with a SILVerifier error, e.g. https://ci.swift.org/job/swift-master-source-compat-suite/4045/artifact/swift-source-compat-suite/FAIL_Lark_4.2_BuildSwiftPackage.log:
```
Function: '$s13CodeGenerator13ServiceMethodV8syncCall2atSaySSGAA11IndentationV_tF'
Found over consume?!
Value:   %5 = load_borrow %4 : $*(element: QualifiedName, type: SwiftTypeClass) // users: %6, %10, %24
User:   end_borrow %5 : $(element: QualifiedName, type: SwiftTypeClass) // id: %10
```
