### PR TITLE
Parse: repair build after #26981

### DIFF
--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -80,8 +80,8 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
     SourceFile &sf = *afd->getDeclContext()->getParentSourceFile();
     SourceManager &sourceMgr = sf.getASTContext().SourceMgr;
     unsigned bufferID = sourceMgr.findBufferContainingLoc(afd->getLoc());
-    Parser parser(bufferID, sf, nullptr, nullptr, nullptr,
-                 /*DelayBodyParsing=*/false);
+    Parser parser(bufferID, sf, static_cast<SILParserTUStateBase *>(nullptr),
+                  nullptr, nullptr, /*DelayBodyParsing=*/false);
     parser.SyntaxContext->setDiscard();
     auto body = parser.parseAbstractFunctionBodyDelayed(afd);
     afd->setBodyKind(BodyKind::Parsed);


### PR DESCRIPTION
The build on Windows has been failing due to the ambiguous constructor
overload:

```
lib\Parse\ParseRequests.cpp(83): error C2666: 'swift::Parser::Parser': 2 overloads have similar conversions
include\swift\Parse\Parser.h(412): note: could be 'swift::Parser::Parser(std::unique_ptr<swift::Lexer,std::default_delete<_Ty>>,swift::SourceFile &,swift::SILParserTUStateBase *,swift::PersistentParserState *,std::shared_ptr<swift::SyntaxParseActions>,bool)'
        with
        [
            _Ty=swift::Lexer
        ]
include\swift\Parse\Parser.h(408): note: or       'swift::Parser::Parser(unsigned int,swift::SourceFile &,swift::SILParserTUStateBase *,swift::PersistentParserState *,std::shared_ptr<swift::SyntaxParseActions>,bool)'
include\swift\Parse\Parser.h(403): note: or       'swift::Parser::Parser(unsigned int,swift::SourceFile &,swift::DiagnosticEngine *,swift::SILParserTUStateBase *,swift::PersistentParserState *,std::shared_ptr<swift::SyntaxParseActions>,bool)'
lib\Parse\ParseRequests.cpp(84): note: while trying to match the argument list '(unsigned int, swift::SourceFile, nullptr, nullptr, nullptr, bool)'
```

Since the `SILParserTUStateBase` version is a delegating constructor,
use the `DiagnosticEngine` variant.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
