### PR TITLE
Revert "[AST] Paren'd reference to an IUO function crashes the compiler in SILGen"

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2272,17 +2272,6 @@ namespace {
       auto *choiceLocator = cs.getConstraintLocator(locator.withPathElement(
           ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice));
 
-      // We won't have a disjunction choice if we have an IUO function call
-      // wrapped in parens (i.e. '(s.foo)()'), because we only create a
-      // single constraint to bind to an optional type. So, we can just return
-      // false here as there's no need to force unwrap.
-      if (!solution.DisjunctionChoices.count(choiceLocator)) {
-        auto type = choice.getDecl()->getInterfaceType();
-        assert((type && type->is<AnyFunctionType>()) &&
-               "expected a function type");
-        return false;
-      }
-
       return solution.getDisjunctionChoice(choiceLocator);
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2190,34 +2190,9 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
                                               openedFullType,
                                               refType};
 
-  // If we have something like '(s.foo)()', where 's.foo()' returns an IUO,
-  // then we need to only create a single constraint that binds the
-  // type to an optional.
-  auto isIUOCallWrappedInParens = [&]() {
-    auto decl = choice.getDecl();
-    auto type = decl ? decl->getInterfaceType() : nullptr;
-    if (!type || !type->is<AnyFunctionType>())
-      return false;
-
-    auto expr = locator->getAnchor();
-    if (!expr)
-      return false;
-
-    if (isa<CallExpr>(expr)) {
-      return false;
-    }
-
-    auto parentExpr = getParentExpr(expr);
-    if (parentExpr && isa<ParenExpr>(parentExpr))
-      return true;
-
-    return false;
-  };
-
   // In some cases we already created the appropriate bind constraints.
   if (!bindConstraintCreated) {
-    if (choice.isImplicitlyUnwrappedValueOrReturnValue() &&
-        !isIUOCallWrappedInParens()) {
+    if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
       // Build the disjunction to attempt binding both T? and T (or
       // function returning T? and function returning T).
       buildDisjunctionForImplicitlyUnwrappedOptional(boundType, refType,

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -223,26 +223,3 @@ var y: Int = 2
 
 let r = sr6988(x: x, y: y)
 let _: Int = r
-
-// SR-10492
-
-struct SR_10492_S {
-  func foo() -> Int! { return 0 }
-}
-
-let sr_10492_s = SR_10492_S()
-let sr_10492_int1: Int = (sr_10492_s.foo)() // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
-// expected-note@-1 {{coalesce}}{{44-44= ?? <#default value#>}}
-// expected-note@-2 {{force-unwrap}}{{44-44=!}}
-let sr_10492_int2: Int? = (sr_10492_s.foo)() // Okay
-
-
-class SR_10492_C1 {
-  init!() {}
-}
-
-class SR_10492_C2 {
-  init(_ foo: SR_10492_C1) {}
-}
-
-let bar = SR_10492_C2(SR_10492_C1()) // Okay

--- a/validation-test/compiler_crashers_2_fixed/sr10492.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr10492.swift
@@ -1,8 +1,0 @@
-// RUN: not %target-swift-frontend -emit-silgen %s
-
-struct S {
-  func foo() -> Int! { return 0 }
-}
-
-let s = S()
-let x: Int = (s.foo)()


### PR DESCRIPTION
Reverts apple/swift#26831

As @hamishknight mentioned in the original PR, I breaks some valid code.