### PR TITLE
[Diagnostics] [Typechecker] Emit fix-its for witness mismatches

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2116,10 +2116,11 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     auto witness = match.Witness;
     auto diag =
         diags.diagnose(witness, diag::protocol_witness_settable_conflict);
-    auto VD = cast<VarDecl>(witness);
-    if (VD->hasStorage()) {
-      auto PBD = VD->getParentPatternBinding();
-      diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));
+    if (auto VD = dyn_cast<VarDecl>(witness)) {
+      if (VD->hasStorage()) {
+        auto PBD = VD->getParentPatternBinding();
+        diag.fixItReplace(PBD->getStartLoc(), getTokenText(tok::kw_var));
+      }
     }
     break;
   }
@@ -2166,7 +2167,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
   case MatchKind::RethrowsConflict: {
     auto witness = match.Witness;
     auto diag =
-        diags.diagnose(match.Witness, diag::protocol_witness_rethrows_conflict);
+        diags.diagnose(witness, diag::protocol_witness_rethrows_conflict);
     auto FD = cast<FuncDecl>(witness);
     diag.fixItReplace(FD->getThrowsLoc(), getTokenText(tok::kw_rethrows));
     break;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2072,10 +2072,9 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
                    (unsigned)match.MissingRequirement->getKind());
     break;
 
-  case MatchKind::ThrowsConflict: {
+  case MatchKind::ThrowsConflict:
     diags.diagnose(match.Witness, diag::protocol_witness_throws_conflict);
     break;
-  }
 
   case MatchKind::OptionalityConflict: {
     auto &adjustments = match.OptionalAdjustments;
@@ -2146,24 +2145,20 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     }
     break;
   }
-  case MatchKind::MutatingConflict: {
+  case MatchKind::MutatingConflict:
     diags.diagnose(match.Witness,
                    diag::protocol_witness_mutation_modifier_conflict,
                    SelfAccessKind::Mutating);
     break;
-  }
-  case MatchKind::NonMutatingConflict: {
-    diags.diagnose(match.Witness,
-                   diag::protocol_witness_mutation_modifier_conflict,
-                   SelfAccessKind::NonMutating);
+  case MatchKind::NonMutatingConflict:
+    // Don't bother about this, because a non-mutating witness can satisfy
+    // a mutating requirement.
     break;
-  }
-  case MatchKind::ConsumingConflict: {
+  case MatchKind::ConsumingConflict:
     diags.diagnose(match.Witness,
                    diag::protocol_witness_mutation_modifier_conflict,
                    SelfAccessKind::Consuming);
     break;
-  }
   case MatchKind::RethrowsConflict: {
     auto witness = match.Witness;
     auto diag =

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2129,6 +2129,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     auto diag = diags.diagnose(
         witness, diag::protocol_witness_prefix_postfix_conflict, false,
         witness->getAttrs().hasAttribute<PostfixAttr>() ? 2 : 0);
+    // We already emit a fix-it when we're missing the attribute, so only
+    // emit a fix-it if the attribute is there, but is not correct.
     if (auto attr = witness->getAttrs().getAttribute<PostfixAttr>()) {
       diag.fixItReplace(attr->getLocation(), "prefix");
     }
@@ -2140,6 +2142,8 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     auto diag = diags.diagnose(
         witness, diag::protocol_witness_prefix_postfix_conflict, true,
         witness->getAttrs().hasAttribute<PrefixAttr>() ? 1 : 0);
+    // We already emit a fix-it when we're missing the attribute, so only
+    // emit a fix-it if the attribute is there, but is not correct.
     if (auto attr = witness->getAttrs().getAttribute<PrefixAttr>()) {
       diag.fixItReplace(attr->getLocation(), "postfix");
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2106,8 +2106,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
       }
       diag.fixItRemove(loc);
     } else {
-      diag.fixItInsert(witness->getAttributeInsertionLoc(true),
-                       getTokenText(tok::kw_static));
+      diag.fixItInsert(witness->getAttributeInsertionLoc(true), "static ");
     }
     break;
   }

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -16,7 +16,7 @@ protocol Foo {
 
 struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
   let bar1: Int // expected-note {{candidate is not settable, but protocol requires it}}{{3-6=var}}
-  var bar2: Int // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static}}
+  var bar2: Int // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static }}
   static var bar3: Int = 1 // expected-note {{candidate operates on a type, not an instance as required}}{{3-10=}}
   static postfix func ^^^(value: ConformsToFoo) -> Int { return 0 } // expected-error {{operator implementation without matching operator declaration}}
   // expected-note@-1 {{candidate is postfix, not prefix as required}}{{10-17=prefix}}
@@ -24,7 +24,7 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
   // expected-note@-1 {{candidate is prefix, not postfix as required}}{{10-16=postfix}}
   func bar4(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
   var bar5: Int { return 0 } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
-  subscript(_ pos: Int) -> Int { return 0 } // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static}}
+  subscript(_ pos: Int) -> Int { return 0 } // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static }}
 }
 
 protocol Foo1 {

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -9,9 +9,7 @@ protocol Foo {
   var bar3: Int { get set } // expected-note {{protocol requires property 'bar3' with type 'Int'; do you want to add a stub?}}
   static prefix func ^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
   static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
-  func bar4() // expected-note {{protocol requires function 'bar4()' with type '() -> ()'; do you want to add a stub?}}
-  func bar5(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar5(closure:)' with type '(() throws -> Int) throws -> ()'; do you want to add a stub?}}
-  func bar6() // expected-note {{protocol requires function 'bar6()' with type '() -> ()'; do you want to add a stub?}}
+  func bar4(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar4(closure:)' with type '(() throws -> Int) throws -> ()'; do you want to add a stub?}}
 }
 
 struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
@@ -22,7 +20,5 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
   // expected-note@-1 {{candidate is postfix, not prefix as required}}{{10-17=prefix}}
   static prefix func ^^^^(value: ConformsToFoo) -> Int { return 0 } // expected-error {{operator implementation without matching operator declaration}}
   // expected-note@-1 {{candidate is prefix, not postfix as required}}{{10-16=postfix}}
-  mutating func bar4() {} // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}{{3-12=}}
-  func bar5(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
-  func bar6() throws {} // expected-note {{candidate throws, but protocol does not allow it}}{{15-22=}}
+  func bar4(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
 }

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -11,6 +11,7 @@ protocol Foo {
   static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
   func bar4(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar4(closure:)' with type '(() throws -> Int) throws -> ()'; do you want to add a stub?}}
   var bar5: Int { get set } // expected-note {{protocol requires property 'bar5' with type 'Int'; do you want to add a stub?}}
+  static subscript(_ pos: Int) -> Int { get } // expected-note {{protocol requires subscript with type '(Int) -> Int'; do you want to add a stub?}}
 }
 
 struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
@@ -23,4 +24,5 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
   // expected-note@-1 {{candidate is prefix, not postfix as required}}{{10-16=postfix}}
   func bar4(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
   var bar5: Int { return 0 } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
+  subscript(_ pos: Int) -> Int { return 0 } // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static}}
 }

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -26,3 +26,11 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
   var bar5: Int { return 0 } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
   subscript(_ pos: Int) -> Int { return 0 } // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static}}
 }
+
+protocol Foo1 {
+  subscript(value: Bool) -> Bool { get set } // expected-note {{protocol requires subscript with type '(Bool) -> Bool'; do you want to add a stub?}}
+}
+
+struct ConformsToFoo1: Foo1 { // expected-error {{type 'ConformsToFoo1' does not conform to protocol 'Foo1'}}
+  subscript(value: Bool) -> Bool { return false } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
+}

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -10,6 +10,7 @@ protocol Foo {
   static prefix func ^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
   static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
   func bar4(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar4(closure:)' with type '(() throws -> Int) throws -> ()'; do you want to add a stub?}}
+  var bar5: Int { get set } // expected-note {{protocol requires property 'bar5' with type 'Int'; do you want to add a stub?}}
 }
 
 struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
@@ -21,4 +22,5 @@ struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not co
   static prefix func ^^^^(value: ConformsToFoo) -> Int { return 0 } // expected-error {{operator implementation without matching operator declaration}}
   // expected-note@-1 {{candidate is prefix, not postfix as required}}{{10-16=postfix}}
   func bar4(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
+  var bar5: Int { return 0 } // expected-note {{candidate is not settable, but protocol requires it}}{{none}}
 }

--- a/test/decl/protocol/req/witness_fix_its.swift
+++ b/test/decl/protocol/req/witness_fix_its.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+prefix operator ^^^
+postfix operator ^^^^
+
+protocol Foo {
+  var bar1: Int { get set } // expected-note {{protocol requires property 'bar1' with type 'Int'; do you want to add a stub?}}
+  static var bar2: Int { get set } // expected-note {{protocol requires property 'bar2' with type 'Int'; do you want to add a stub?}}
+  var bar3: Int { get set } // expected-note {{protocol requires property 'bar3' with type 'Int'; do you want to add a stub?}}
+  static prefix func ^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
+  static postfix func ^^^^(value: Self) -> Int // expected-note {{protocol requires function '^^^^' with type '(ConformsToFoo) -> Int'; do you want to add a stub?}}
+  func bar4() // expected-note {{protocol requires function 'bar4()' with type '() -> ()'; do you want to add a stub?}}
+  func bar5(closure: () throws -> Int) rethrows // expected-note {{protocol requires function 'bar5(closure:)' with type '(() throws -> Int) throws -> ()'; do you want to add a stub?}}
+  func bar6() // expected-note {{protocol requires function 'bar6()' with type '() -> ()'; do you want to add a stub?}}
+}
+
+struct ConformsToFoo: Foo { // expected-error {{type 'ConformsToFoo' does not conform to protocol 'Foo'}}
+  let bar1: Int // expected-note {{candidate is not settable, but protocol requires it}}{{3-6=var}}
+  var bar2: Int // expected-note {{candidate operates on an instance, not a type as required}}{{3-3=static}}
+  static var bar3: Int = 1 // expected-note {{candidate operates on a type, not an instance as required}}{{3-10=}}
+  static postfix func ^^^(value: ConformsToFoo) -> Int { return 0 } // expected-error {{operator implementation without matching operator declaration}}
+  // expected-note@-1 {{candidate is postfix, not prefix as required}}{{10-17=prefix}}
+  static prefix func ^^^^(value: ConformsToFoo) -> Int { return 0 } // expected-error {{operator implementation without matching operator declaration}}
+  // expected-note@-1 {{candidate is prefix, not postfix as required}}{{10-16=postfix}}
+  mutating func bar4() {} // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}{{3-12=}}
+  func bar5(closure: () throws -> Int) throws {} // expected-note {{candidate is not 'rethrows', but protocol requires it}}{{40-46=rethrows}}
+  func bar6() throws {} // expected-note {{candidate throws, but protocol does not allow it}}{{15-22=}}
+}


### PR DESCRIPTION
Saw a couple of FIXMEs, so I decided to address them and then also add fix-its for the rest of the cases.

This PR adds fix-its for when the witness does not match the requirements.

1. I didn't add a fix-it for the `@nonobjc` case because the attribute's location does not look correct when I pass it to `fixItReplace` (i.e. the replaced range does not look correct).
2. I couldn't reproduce two diagnostics - one for `nonmutating` and one for `__consuming`.