### PR TITLE
[WIP, Diagnostics] Port CSDiag visitAssignExpr to the new diagnostic framework

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4285,104 +4285,111 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
 }
 
 bool FailureDiagnosis::visitAssignExpr(AssignExpr *assignExpr) {
-  // Diagnose obvious assignments to literals.
-  if (isa<LiteralExpr>(assignExpr->getDest()->getValueProvidingExpr())) {
-    diagnose(assignExpr->getLoc(), diag::cannot_assign_to_literal);
-    return true;
-  }
+  // AssignmentFailure failure(assignExpr, CS, assignExpr->getLoc());
+  // return failure.diagnoseAsError();
 
-  // Situation like `var foo = &bar` didn't get diagnosed early
-  // because originally its parent is a `SequenceExpr` which hasn't
-  // been folded yet, and could represent an operator which accepts
-  // `inout` arguments.
-  if (auto *AddrOf = dyn_cast<InOutExpr>(assignExpr->getSrc())) {
-    diagnose(AddrOf->getLoc(), diag::extraneous_address_of);
-    return true;
-  }
+  // // Diagnose obvious assignments to literals.
+  // if (isa<LiteralExpr>(assignExpr->getDest()->getValueProvidingExpr())) {
+  //   diagnose(assignExpr->getLoc(), diag::cannot_assign_to_literal);
+  //   return true;
+  // }
 
-  if (CS.TC.diagnoseSelfAssignment(assignExpr))
-    return true;
+  // // Situation like `var foo = &bar` didn't get diagnosed early
+  // // because originally its parent is a `SequenceExpr` which hasn't
+  // // been folded yet, and could represent an operator which accepts
+  // // `inout` arguments.
+  // if (auto *AddrOf = dyn_cast<InOutExpr>(assignExpr->getSrc())) {
+  //   diagnose(AddrOf->getLoc(), diag::extraneous_address_of);
+  //   return true;
+  // }
 
-  // Type check the destination first, so we can coerce the source to it.
-  auto destExpr = typeCheckChildIndependently(assignExpr->getDest(),
-                                              TCC_AllowLValue);
-  if (!destExpr) return true;
+  // // Type check the destination first, so we can coerce the source to it.
+  // auto destExpr = typeCheckChildIndependently(assignExpr->getDest(),
+  //                                             TCC_AllowLValue);
+  // if (!destExpr) return true;
 
-  auto destType = CS.getType(destExpr);
-  if (destType->is<UnresolvedType>() || destType->hasTypeVariable()) {
-    // Look closer into why destination has unresolved types since such
-    // means that destination has diagnosable structural problems, and it's
-    // better to diagnose destination (if possible) before moving on to
-    // the source of the assignment.
-    destExpr = typeCheckChildIndependently(
-        destExpr, TCC_AllowLValue | TCC_ForceRecheck, false);
-    if (!destExpr)
-      return true;
+  // auto destType = CS.getType(destExpr);
+  // if (destType->is<UnresolvedType>() || destType->hasTypeVariable()) {
+  //   // Look closer into why destination has unresolved types since such
+  //   // means that destination has diagnosable structural problems, and it's
+  //   // better to diagnose destination (if possible) before moving on to
+  //   // the source of the assignment.
+  //   destExpr = typeCheckChildIndependently(
+  //       destExpr, TCC_AllowLValue | TCC_ForceRecheck, false);
+  //   if (!destExpr)
+  //     return true;
 
-    // If re-checking destination didn't produce diagnostic, let's just type
-    // check the source without contextual information.  If it succeeds, then we
-    // win, but if it fails, we'll have to diagnose this another way.
-    return !typeCheckChildIndependently(assignExpr->getSrc());
-  }
+  //   // If re-checking destination didn't produce diagnostic, let's just type
+  //   // check the source without contextual information.  If it succeeds, then
+  //   we
+  //   // win, but if it fails, we'll have to diagnose this another way.
+  //   return !typeCheckChildIndependently(assignExpr->getSrc());
+  // }
 
-  // If the result type is a non-lvalue, then we are failing because it is
-  // immutable and that's not a great thing to assign to.
-  if (!destType->hasLValueType()) {
-    // If the destination is a subscript, the problem may actually be that we
-    // incorrectly decided on a get-only subscript overload, and we may be able
-    // to come up with a better diagnosis by looking only at subscript candidates
-    // that are set-able.
-    if (auto subscriptExpr = dyn_cast<SubscriptExpr>(destExpr)) {
-      if (diagnoseSubscriptErrors(subscriptExpr, /* inAssignmentDestination = */ true))
-        return true;
-    }
-    // Member ref assignment errors detected elsewhere, so not an assignment issue if found here.
-    // The remaining exception involves mutable pointer conversions which aren't always caught elsewhere.
-    PointerTypeKind ptk;
-    if (!isa<MemberRefExpr>(destExpr) || CS.getType(destExpr)
-                                             ->lookThroughAllOptionalTypes()
-                                             ->getAnyPointerElementType(ptk)) {
-      AssignmentFailure failure(destExpr, CS, assignExpr->getLoc());
-      if (failure.diagnoseAsError())
-        return true;
-    }
-  }
+  // // If the result type is a non-lvalue, then we are failing because it is
+  // // immutable and that's not a great thing to assign to.
+  // if (!destType->hasLValueType()) {
+  //   // If the destination is a subscript, the problem may actually be that we
+  //   // incorrectly decided on a get-only subscript overload, and we may be
+  //   able
+  //   // to come up with a better diagnosis by looking only at subscript
+  //   candidates
+  //   // that are set-able.
+  //   if (auto subscriptExpr = dyn_cast<SubscriptExpr>(destExpr)) {
+  //     if (diagnoseSubscriptErrors(subscriptExpr, /* inAssignmentDestination =
+  //     */ true))
+  //       return true;
+  //   }
+  //   // Member ref assignment errors detected elsewhere, so not an assignment
+  //   issue if found here.
+  //   // The remaining exception involves mutable pointer conversions which
+  //   aren't always caught elsewhere. PointerTypeKind ptk; if
+  //   (!isa<MemberRefExpr>(destExpr) || CS.getType(destExpr)
+  //                                            ->lookThroughAllOptionalTypes()
+  //                                            ->getAnyPointerElementType(ptk))
+  //                                            {
+  //       failure(destExpr, CS, assignExpr->getLoc());
+  //     if (failure.diagnoseAsError())
+  //       return true;
+  //   }
+  // }
 
-  auto *srcExpr = assignExpr->getSrc();
-  auto contextualType = destType->getRValueType();
-  auto contextualTypePurpose = isa<SubscriptExpr>(destExpr)
-                                   ? CTP_SubscriptAssignSource
-                                   : CTP_AssignSource;
-  // Let's try to type-check assignment source expression without using
-  // destination as a contextual type, that allows us to diagnose
-  // contextual problems related to source much easier.
-  //
-  // If source expression requires contextual type to be present,
-  // let's avoid this step because it's always going to fail.
-  {
-    auto *srcExpr = assignExpr->getSrc();
-    ExprTypeSaverAndEraser eraser(srcExpr);
+  // auto *srcExpr = assignExpr->getSrc();
+  // auto contextualType = destType->getRValueType();
+  // auto contextualTypePurpose = isa<SubscriptExpr>(destExpr)
+  //                                  ? CTP_SubscriptAssignSource
+  //                                  : CTP_AssignSource;
+  // // Let's try to type-check assignment source expression without using
+  // // destination as a contextual type, that allows us to diagnose
+  // // contextual problems related to source much easier.
+  // //
+  // // If source expression requires contextual type to be present,
+  // // let's avoid this step because it's always going to fail.
+  // {
+  //   auto *srcExpr = assignExpr->getSrc();
+  //   ExprTypeSaverAndEraser eraser(srcExpr);
 
-    ConcreteDeclRef ref = nullptr;
-    auto type = getTypeOfExpressionWithoutApplying(srcExpr, CS.DC, ref);
+  //   ConcreteDeclRef ref = nullptr;
+  //   auto type = getTypeOfExpressionWithoutApplying(srcExpr, CS.DC, ref);
 
-    if (type && !type->isEqual(contextualType))
-      return diagnoseContextualConversionError(
-          assignExpr->getSrc(), contextualType, contextualTypePurpose);
-  }
+  //   if (type && !type->isEqual(contextualType))
+  //     return diagnoseContextualConversionError(
+  //         assignExpr->getSrc(), contextualType, contextualTypePurpose);
+  // }
 
-  srcExpr = typeCheckChildIndependently(assignExpr->getSrc(), contextualType,
-                                        contextualTypePurpose);
-  if (!srcExpr)
-    return true;
+  // srcExpr = typeCheckChildIndependently(assignExpr->getSrc(), contextualType,
+  //                                       contextualTypePurpose);
+  // if (!srcExpr)
+  //   return true;
 
-  // If we are assigning to _ and have unresolved types on the RHS, then we have
-  // an ambiguity problem.
-  if (isa<DiscardAssignmentExpr>(destExpr->getSemanticsProvidingExpr()) &&
-      CS.getType(srcExpr)->hasUnresolvedType()) {
-    diagnoseAmbiguity(srcExpr);
-    return true;
-  }
+  // // If we are assigning to _ and have unresolved types on the RHS, then we
+  // have
+  // // an ambiguity problem.
+  // if (isa<DiscardAssignmentExpr>(destExpr->getSemanticsProvidingExpr()) &&
+  //     CS.getType(srcExpr)->hasUnresolvedType()) {
+  //   diagnoseAmbiguity(srcExpr);
+  //   return true;
+  // }
 
   return false;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2612,6 +2612,12 @@ ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
   return None;
 }
 
+bool AssignmentContextualFailure::diagnoseAsError() {
+  emitDiagnostic(getAnchor()->getLoc(), diag::cannot_convert_assign,
+                 getFromType(), getToType());
+  return true;
+}
+
 bool TupleContextualFailure::diagnoseAsError() {
   auto diagnostic = isNumElementsMismatch()
                         ? diag::tuple_types_not_convertible_nelts
@@ -3950,6 +3956,11 @@ bool MissingContextualConformanceFailure::diagnoseAsError() {
     }
 
     default:
+      // If we're looking at an assignment expression, give a generic cannot
+      // missing conformance diagnostic.
+      if (isa<AssignExpr>(anchor)) {
+        diagnostic = diag::cannot_convert_assign_protocol;
+      }
       break;
     }
   }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -759,6 +759,15 @@ private:
   }
 };
 
+class AssignmentContextualFailure final : public ContextualFailure {
+public:
+  AssignmentContextualFailure(Expr *root, ConstraintSystem &cs, Type fromType,
+                              Type toType, ConstraintLocator *locator)
+      : ContextualFailure(root, cs, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose failures related to conversion between throwing function type
 /// and non-throwing one e.g.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -773,3 +773,16 @@ IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
   return new (cs.getAllocator())
       IgnoreContextualType(cs, resultTy, specifiedTy, locator);
 }
+
+AllowAssignmentMismatch *
+AllowAssignmentMismatch::create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowAssignmentMismatch(cs, lhs, rhs, locator);
+}
+
+bool AllowAssignmentMismatch::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
+  AssignmentContextualFailure failure(root, cs, getFromType(), getToType(),
+                                      getLocator());
+  return failure.diagnose(asNote);
+};

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1312,6 +1312,22 @@ public:
                                       ConstraintLocator *locator);
 };
 
+class AllowAssignmentMismatch : public ContextualMismatch {
+  AllowAssignmentMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
+                          ConstraintLocator *locator)
+      : ContextualMismatch(cs, lhs, rhs, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow mismatched types on lhs and rhs of assignment";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static AllowAssignmentMismatch *create(ConstraintSystem &cs, Type lhs,
+                                         Type rhs, ConstraintLocator *locator);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2769,6 +2769,12 @@ namespace {
       // Handle invalid code.
       if (!expr->getDest() || !expr->getSrc())
         return Type();
+
+      // If this expression is a self assignment, emit a diagnostic then bail
+      // out.
+      if (CS.getTypeChecker().diagnoseSelfAssignment(expr))
+        return nullptr;
+
       Type destTy = genAssignDestType(expr->getDest(), CS);
       CS.addConstraint(ConstraintKind::Conversion, CS.getType(expr->getSrc()), destTy,
                        CS.getConstraintLocator(expr));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2406,6 +2406,10 @@ bool ConstraintSystem::repairFailures(
 
       if (repairViaBridgingCast(*this, lhs, rhs, conversionsOrFixes, locator))
         return true;
+
+      conversionsOrFixes.push_back(AllowAssignmentMismatch::create(
+          *this, lhs, rhs, getConstraintLocator(locator)));
+      return true;
     }
 
     return false;
@@ -4332,11 +4336,10 @@ allFromConditionalConformances(DeclContext *DC, Type baseTy,
 /// If includeInaccessibleMembers is set to true, this burns compile time to
 /// try to identify and classify inaccessible members that may be being
 /// referenced.
-MemberLookupResult ConstraintSystem::
-performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
-                    Type baseTy, FunctionRefKind functionRefKind,
-                    ConstraintLocator *memberLocator,
-                    bool includeInaccessibleMembers) {
+MemberLookupResult ConstraintSystem::performMemberLookup(
+    ConstraintKind constraintKind, DeclName memberName, Type baseTy,
+    FunctionRefKind functionRefKind, ConstraintLocator *memberLocator,
+    bool includeInaccessibleMembers) {
   Type baseObjTy = baseTy->getRValueType();
   Type instanceTy = baseObjTy;
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -56,7 +56,7 @@ func testEquality() {
 
   let x7 : (_ : P1 & P3) -> ()
   let x8 : (_ : P2) -> ()
-  x7 = x8 // expected-error{{cannot assign value of type '(P2) -> ()' to type '(P1 & P3) -> ()'}}
+  x7 = x8 // expected-error{{value of type 'P1 & P3' does not conform to 'P2' in assignment}}
   _ = x7
 }
 


### PR DESCRIPTION
This pull request aims to port all of CSDiag visitAssignExpr to the new diagnostic framework. This is very much a work in progress.

As of now, the PR includes:
- A naive implementation of a port to diagnoseSelfAssignment
- A change to allow MissingConformanceFailures to produce diagnostics in the case of assignment expressions rather than falling back to CSDiag
- The introduction of a new fix, AllowAssignmentMismatch and associated Failure which attempts to catch the majority of non contextual type assignment mismatches.