### PR TITLE
[Diagnostics] Allow column specification in verify mode

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -565,12 +565,14 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
 
       llvm::SMFixIt fixIt(llvm::SMRange{StartLoc, EndLoc}, I->getMessage());
       addError(expected.MessageRange.begin(), "incorrect message found", fixIt);
-    } else {
+    } else if (I->getColumnNo() + 1 != (int)*expected.ColumnNo) {
       // The difference must be only in the column
       addError(expected.MessageRange.begin(),
                llvm::formatv("message found at column {0} but was expected to "
                              "appear at column {1}",
                              I->getColumnNo() + 1, *expected.ColumnNo));
+    } else {
+      llvm_unreachable("unhandled difference from expected diagnostic");
     }
     CapturedDiagnostics.erase(I);
     ExpectedDiagnostics.erase(ExpectedDiagnostics.begin()+i);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -18,6 +18,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Lexer.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -52,7 +53,8 @@ namespace {
     // This is the message string with escapes expanded.
     std::string MessageStr;
     unsigned LineNo = ~0U;
-    
+    Optional<unsigned> ColumnNo;
+
     std::vector<ExpectedFixIt> Fixits;
 
     ExpectedDiagnosticInfo(const char *ExpectedStart,
@@ -125,6 +127,12 @@ DiagnosticVerifier::findDiagnostic(const ExpectedDiagnosticInfo &Expected,
     // Verify the file and line of the diagnostic.
     if (I->getLineNo() != (int)Expected.LineNo ||
         I->getFilename() != BufferName)
+      continue;
+
+    // If a specific column was expected, verify it. Add one to the captured
+    // index so expected column numbers correspond to printed output.
+    if (Expected.ColumnNo.hasValue() &&
+        I->getColumnNo() + 1 != (int)*Expected.ColumnNo)
       continue;
 
     // Verify the classification and string.
@@ -262,10 +270,14 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
       continue;
     }
 
+    ExpectedDiagnosticInfo Expected(DiagnosticLoc, ExpectedClassification);
     int LineOffset = 0;
+
     if (TextStartIdx > 0 && MatchStart[0] == '@') {
-      if (MatchStart[1] != '+' && MatchStart[1] != '-') {
-        addError(MatchStart.data(), "expected '+'/'-' for line offset");
+      if (MatchStart[1] != '+' && MatchStart[1] != '-' &&
+          MatchStart[1] != ':') {
+        addError(MatchStart.data(),
+                 "expected '+'/'-' for line offset, or ':' for column");
         continue;
       }
       StringRef Offs;
@@ -285,13 +297,27 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
         TextStartIdx = 0;
       }
 
-      if (Offs.getAsInteger(10, LineOffset)) {
-        addError(MatchStart.data(), "expected line offset before '{{'");
-        continue;
+      size_t ColonIndex = Offs.find(':');
+      // Check whether a line offset was provided
+      if (ColonIndex != 0) {
+        StringRef LineOffs = Offs.slice(0, ColonIndex);
+        if (LineOffs.getAsInteger(10, LineOffset)) {
+          addError(MatchStart.data(), "expected line offset before '{{'");
+          continue;
+        }
+      }
+
+      // Check whether a column was provided
+      if (ColonIndex != StringRef::npos) {
+        Offs = Offs.slice(ColonIndex + 1, Offs.size());
+        int Column = 0;
+        if (Offs.getAsInteger(10, Column)) {
+          addError(MatchStart.data(), "expected column before '{{'");
+          continue;
+        }
+        Expected.ColumnNo = Column;
       }
     }
-
-    ExpectedDiagnosticInfo Expected(DiagnosticLoc, ExpectedClassification);
 
     unsigned Count = 1;
     if (TextStartIdx > 0) {
@@ -532,12 +558,20 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
     }
 
     if (I == CapturedDiagnostics.end()) continue;
-    
-    auto StartLoc = SMLoc::getFromPointer(expected.MessageRange.begin());
-    auto EndLoc = SMLoc::getFromPointer(expected.MessageRange.end());
-    
-    llvm::SMFixIt fixIt(llvm::SMRange{ StartLoc, EndLoc }, I->getMessage());
-    addError(expected.MessageRange.begin(), "incorrect message found", fixIt);
+
+    if (I->getMessage().find(expected.MessageStr) == StringRef::npos) {
+      auto StartLoc = SMLoc::getFromPointer(expected.MessageRange.begin());
+      auto EndLoc = SMLoc::getFromPointer(expected.MessageRange.end());
+
+      llvm::SMFixIt fixIt(llvm::SMRange{StartLoc, EndLoc}, I->getMessage());
+      addError(expected.MessageRange.begin(), "incorrect message found", fixIt);
+    } else {
+      // The difference must be only in the column
+      addError(expected.MessageRange.begin(),
+               llvm::formatv("message found at column {0} but was expected to "
+                             "appear at column {1}",
+                             I->getColumnNo() + 1, *expected.ColumnNo));
+    }
     CapturedDiagnostics.erase(I);
     ExpectedDiagnostics.erase(ExpectedDiagnostics.begin()+i);
   }

--- a/test/Sema/diag_deprecated_string_interpolation.swift
+++ b/test/Sema/diag_deprecated_string_interpolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 5 -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 extension DefaultStringInterpolation {
     @available(*, deprecated) func appendInterpolation(deprecated: Int) {}
@@ -6,19 +6,16 @@ extension DefaultStringInterpolation {
 
 // Make sure diagnostics emitted via string interpolations have a reasonable source location
 
-_ = "\(deprecated: 42)"
-// CHECK: [[@LINE-1]]:7: warning: 'appendInterpolation(deprecated:)' is deprecated
+_ = "\(deprecated: 42)" // expected-warning@:7 {{'appendInterpolation(deprecated:)' is deprecated}}
 
-_ = "hello, world\(deprecated: 42)!!!"
-// CHECK: [[@LINE-1]]:19: warning: 'appendInterpolation(deprecated:)' is deprecated
+_ = "hello, world\(deprecated: 42)!!!" // expected-warning@:19 {{'appendInterpolation(deprecated:)' is deprecated}}
 
 _ = "\(42)\(deprecated: 42)test\(deprecated: 42)"
-// CHECK: [[@LINE-1]]:12: warning: 'appendInterpolation(deprecated:)' is deprecated
-// CHECK: [[@LINE-2]]:33: warning: 'appendInterpolation(deprecated:)' is deprecated
-
+// expected-warning@-1:12 {{'appendInterpolation(deprecated:)' is deprecated}}
+// expected-warning@-2:33 {{'appendInterpolation(deprecated:)' is deprecated}}
 _ = """
 This is a multiline literal with a deprecated interpolation:
 
 \(deprecated: 42)
 """
-// CHECK: [[@LINE-2]]:2: warning: 'appendInterpolation(deprecated:)' is deprecated
+// expected-warning@-2:2 {{'appendInterpolation(deprecated:)' is deprecated}}


### PR DESCRIPTION
For example, `expected-warning@-2:2` looks for the warning 2 lines above at the second column, and `expected-warning@:4` looks at the fourth column of the current line. 

Column indexing, especially compared to fix-its, can be a bit confusing, but it matches printed diagnostic output.

There are probably at least a few other tests that can be migrated off FileCheck now, but I haven't found a good way to discover them yet. 

Resolves (SR-11320)[https://bugs.swift.org/browse/SR-11320]