### PR TITLE
[Sema] Point to declaration when looking for a member type

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1223,6 +1223,12 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       diags.diagnose(comp->getIdLoc(), diag::invalid_member_type,
                      comp->getIdentifier(), parentType)
         .highlight(parentRange);
+      // Note where the type was defined, this can help diagnose if the user
+      // expected name lookup to find a module when there's a conflicting type.
+      if (auto typeDecl = parentType->getNominalOrBoundGenericNominal()) {
+        ctx.Diags.diagnose(typeDecl, diag::decl_declared_here,
+                           typeDecl->getFullName());
+      }
     }
   }
   return ErrorType::get(ctx);

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -189,7 +189,7 @@ var yarray : YArray = [1, 2, 3]
 var xarray : XArray = [1, 2, 3]
 
 // Type parameters can be referenced only via unqualified name lookup
-struct XParam<T> {
+struct XParam<T> { // expected-note{{'XParam' declared here}}
   func foo(_ x: T) {
     _ = x as T
   }

--- a/test/Sema/diag_module_conflict_with_type.swift
+++ b/test/Sema/diag_module_conflict_with_type.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// Step 1. Create a module with the name ModuleType
+// RUN: echo 'public struct MyStruct {}' | %target-swift-frontend -emit-module -o %t/ModuleType.swiftmodule -
+
+// Step 2. Create a second module with a type named ModuleType
+// RUN: echo 'public struct ModuleType {}' | %target-swift-frontend -emit-module -o %t/SecondModule.swiftmodule -
+
+// Step 3. Import both modules and try to use `ModuleType.MyStruct`
+//         Make sure we emitted a note saying that we failed while trying to
+//         look up into `SecondModule.ModuleType`
+// RUN: not %target-swift-frontend -typecheck %s -I %t 2>&1 | %FileCheck %s
+
+import ModuleType
+import SecondModule
+
+public func f(_ x: ModuleType.MyStruct) {}
+
+// CHECK: error: 'MyStruct' is not a member type of 'ModuleType'
+// CHECK: SecondModule.ModuleType:1:15: note: 'ModuleType' declared here
+// CHECK: public struct ModuleType {
+// CHECK:               ^

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -103,7 +103,7 @@ protocol P3 {
   func foo() -> Assoc
 }
 
-struct X3 : P3 {
+struct X3 : P3 { // expected-note{{'X3' declared here}}
 }
 
 extension X3.Assoc { // expected-error{{'Assoc' is not a member type of 'X3'}}

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -129,7 +129,7 @@ func genericFunction<T>(t: T) {
   class First : Second<T>.UnknownType { }
   // expected-error@-1 {{type 'First' cannot be nested in generic function 'genericFunction(t:)'}}
   // expected-error@-2 {{'UnknownType' is not a member type of 'Second<T>'}}
-  class Second<T> : Second { }
+  class Second<T> : Second { } // expected-note{{'Second' declared here}}
   // expected-error@-1 {{type 'Second' cannot be nested in generic function 'genericFunction(t:)'}}
   // expected-error@-2 {{'Second' inherits from itself}}
 }

--- a/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
@@ -174,7 +174,7 @@ struct SynthesizedClass : Codable {
 
 // Classes which don't get synthesized Codable implementations should expose the
 // appropriate CodingKeys type.
-struct NonSynthesizedClass : Codable {
+struct NonSynthesizedClass : Codable { // expected-note 4 {{'NonSynthesizedClass' declared here}}
   // No synthesized type since we implemented both methods.
   init(from decoder: Decoder) throws {}
   func encode(to encoder: Encoder) throws {}

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -174,7 +174,7 @@ struct SynthesizedStruct : Codable {
 
 // Structs which don't get synthesized Codable implementations should expose the
 // appropriate CodingKeys type.
-struct NonSynthesizedStruct : Codable {
+struct NonSynthesizedStruct : Codable { // expected-note 4 {{'NonSynthesizedStruct' declared here}}
   // No synthesized type since we implemented both methods.
   init(from decoder: Decoder) throws {}
   func encode(to encoder: Encoder) throws {}


### PR DESCRIPTION
When there's a module with the same name as a type in a
different module, lookup will look into the type, not the module, when
resolving members. Until that behavior is fixed, add a note showing what
lookup was trying to look into, to make the behavior more clear.

Helps rdar://54770139