### PR TITLE
ModuleLoader: move PreferInterfaceForModules from SerializedModuleLoaderBase to ParseableInterfaceModuleLoader, NFC

### DIFF
--- a/include/swift/Frontend/ParseableInterfaceModuleLoader.h
+++ b/include/swift/Frontend/ParseableInterfaceModuleLoader.h
@@ -134,14 +134,16 @@ class ParseableInterfaceModuleLoader : public SerializedModuleLoaderBase {
       DependencyTracker *tracker, ModuleLoadingMode loadMode,
       ArrayRef<std::string> PreferInterfaceForModules,
       bool RemarkOnRebuildFromInterface)
-  : SerializedModuleLoaderBase(ctx, tracker, loadMode, PreferInterfaceForModules),
+  : SerializedModuleLoaderBase(ctx, tracker, loadMode),
   CacheDir(cacheDir), PrebuiltCacheDir(prebuiltCacheDir),
-  RemarkOnRebuildFromInterface(RemarkOnRebuildFromInterface)
+  RemarkOnRebuildFromInterface(RemarkOnRebuildFromInterface),
+  PreferInterfaceForModules(PreferInterfaceForModules)
   {}
 
   std::string CacheDir;
   std::string PrebuiltCacheDir;
   bool RemarkOnRebuildFromInterface;
+  ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -42,10 +42,8 @@ class SerializedModuleLoaderBase : public ModuleLoader {
 protected:
   ASTContext &Ctx;
   ModuleLoadingMode LoadMode;
-  ArrayRef<std::string> PreferInterfaceForModules;
   SerializedModuleLoaderBase(ASTContext &ctx, DependencyTracker *tracker,
-                             ModuleLoadingMode LoadMode,
-                             ArrayRef<std::string> PreferInterfaceForModules = {});
+                             ModuleLoadingMode LoadMode);
 
   void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
                                              StringRef extension) const;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -104,10 +104,8 @@ Optional<bool> forEachModuleSearchPath(
 
 // Defined out-of-line so that we can see ~ModuleFile.
 SerializedModuleLoaderBase::SerializedModuleLoaderBase(
-    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode,
-    ArrayRef<std::string> PreferInterfaceForModules)
-    : ModuleLoader(tracker), Ctx(ctx), LoadMode(loadMode),
-      PreferInterfaceForModules(PreferInterfaceForModules) {}
+    ASTContext &ctx, DependencyTracker *tracker, ModuleLoadingMode loadMode)
+    : ModuleLoader(tracker), Ctx(ctx), LoadMode(loadMode) {}
 
 SerializedModuleLoaderBase::~SerializedModuleLoaderBase() = default;
 SerializedModuleLoader::~SerializedModuleLoader() = default;


### PR DESCRIPTION
We shouldn't over-expose this field since only ParseableInterfaceModuleLoader
is using it.