### PR TITLE
Mangle associated types of opaque types like dependent member types.  …

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -551,6 +551,11 @@ Types
   type ::= assoc-type-name 'Qz'                      // shortcut for 'Qyz'
   type ::= assoc-type-list 'QY' GENERIC-PARAM-INDEX  // associated type at depth
   type ::= assoc-type-list 'QZ'                      // shortcut for 'QYz'
+  
+  #if SWIFT_RUNTIME_VERSION >= 5.2
+    type ::= type assoc-type-name 'Qx' // associated type relative to base `type`
+    type ::= type assoc-type-list 'QX' // associated type relative to base `type`
+  #endif
 
   protocol-list ::= protocol '_' protocol*
   protocol-list ::= empty-list

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1003,6 +1003,22 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       
     case TypeKind::NestedArchetype: {
       auto nestedType = cast<NestedArchetypeType>(tybase);
+      
+      // Mangle associated types of opaque archetypes like dependent member
+      // types, so that they can be accurately demangled at runtime.
+      if (auto opaque =
+            dyn_cast<OpaqueTypeArchetypeType>(nestedType->getRoot())) {
+        if (tryMangleTypeSubstitution(nestedType))
+          return;
+        
+        appendType(opaque);
+        bool isAssocTypeAtDepth = false;
+        appendAssocType(nestedType->getInterfaceType(), isAssocTypeAtDepth);
+        appendOperator(isAssocTypeAtDepth ? "QX" : "Qx");
+        addTypeSubstitution(nestedType);
+        return;
+      }
+      
       appendType(nestedType->getParent());
       appendIdentifier(nestedType->getName().str());
       appendOperator("Qa");

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -351,6 +351,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     if (Major == 10) {
       if (Minor <= 14) {
         return llvm::VersionTuple(5, 0);
+      } else if (Minor <= 15) {
+        return llvm::VersionTuple(5, 1);
       } else {
         return None;
       }
@@ -361,6 +363,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     Triple.getiOSVersion(Major, Minor, Micro);
     if (Major <= 12) {
       return llvm::VersionTuple(5, 0);
+    } else if (Major <= 13) {
+      return llvm::VersionTuple(5, 1);
     } else {
       return None;
     }
@@ -368,6 +372,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     Triple.getWatchOSVersion(Major, Minor, Micro);
     if (Major <= 5) {
       return llvm::VersionTuple(5, 0);
+    } else if (Major <= 6) {
+      return llvm::VersionTuple(5, 1);
     } else {
       return None;
     }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -424,7 +424,11 @@ std::pair<int, Node *> Remangler::mangleConstrainedType(Node *node) {
     Chain.push_back(node->getChild(1), Factory);
     node = getChildOfType(node->getFirstChild());
   }
-  assert(node->getKind() == Node::Kind::DependentGenericParamType);
+  
+  if (node->getKind() != Node::Kind::DependentGenericParamType) {
+    mangle(node);
+    node = nullptr;
+  }
 
   const char *ListSeparator = (Chain.size() > 1 ? "_" : "");
   for (unsigned i = 1, n = Chain.size(); i <= n; ++i) {
@@ -811,6 +815,7 @@ void Remangler::mangleDependentGenericConformanceRequirement(Node *node) {
   if (ProtoOrClass->getFirstChild()->getKind() == Node::Kind::Protocol) {
     manglePureProtocol(ProtoOrClass);
     auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0));
+    assert(NumMembersAndParamIdx.first < 0 || NumMembersAndParamIdx.second);
     switch (NumMembersAndParamIdx.first) {
       case -1: Buffer << "RQ"; return; // substitution
       case 0: Buffer << "R"; break;
@@ -822,6 +827,7 @@ void Remangler::mangleDependentGenericConformanceRequirement(Node *node) {
   }
   mangle(ProtoOrClass);
   auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0));
+  assert(NumMembersAndParamIdx.first < 0 || NumMembersAndParamIdx.second);
   switch (NumMembersAndParamIdx.first) {
     case -1: Buffer << "RB"; return; // substitution
     case 0: Buffer << "Rb"; break;
@@ -849,6 +855,7 @@ void Remangler::mangleDependentGenericParamType(Node *node) {
 void Remangler::mangleDependentGenericSameTypeRequirement(Node *node) {
   mangleChildNode(node, 1);
   auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0));
+  assert(NumMembersAndParamIdx.first < 0 || NumMembersAndParamIdx.second);
   switch (NumMembersAndParamIdx.first) {
     case -1: Buffer << "RS"; return; // substitution
     case 0: Buffer << "Rs"; break;
@@ -860,6 +867,7 @@ void Remangler::mangleDependentGenericSameTypeRequirement(Node *node) {
 
 void Remangler::mangleDependentGenericLayoutRequirement(Node *node) {
   auto NumMembersAndParamIdx = mangleConstrainedType(node->getChild(0));
+  assert(NumMembersAndParamIdx.first < 0 || NumMembersAndParamIdx.second);
   switch (NumMembersAndParamIdx.first) {
     case -1: Buffer << "RL"; break; // substitution
     case 0: Buffer << "Rl"; break;
@@ -922,11 +930,19 @@ void Remangler::mangleDependentMemberType(Node *node) {
       unreachable("wrong dependent member type");
     case 1:
       Buffer << 'Q';
-      mangleDependentGenericParamIndex(NumMembersAndParamIdx.second, "y", 'z');
+      if (auto dependentBase = NumMembersAndParamIdx.second) {
+        mangleDependentGenericParamIndex(dependentBase, "y", 'z');
+      } else {
+        Buffer << 'x';
+      }
       break;
     default:
       Buffer << 'Q';
-      mangleDependentGenericParamIndex(NumMembersAndParamIdx.second, "Y", 'Z');
+      if (auto dependentBase = NumMembersAndParamIdx.second) {
+        mangleDependentGenericParamIndex(dependentBase, "Y", 'Z');
+      } else {
+        Buffer << 'X';
+      }
       break;
   }
 }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -649,9 +649,10 @@ getInitializerForComputedComponent(IRGenModule &IGM,
 }
 
 static llvm::Constant *
-emitMetadataTypeRefForKeyPath(IRGenModule &IGM, CanType type) {
+emitMetadataTypeRefForKeyPath(IRGenModule &IGM, CanType type,
+                              CanGenericSignature sig) {
   // Produce a mangled name for the type.
-  auto constant = IGM.getTypeRef(type, MangledTypeRefRole::Metadata).first;
+  auto constant = IGM.getTypeRef(type, sig, MangledTypeRefRole::Metadata).first;
   
   // Mask the bottom bit to tell the key path runtime this is a mangled name
   // rather than a direct reference.
@@ -837,6 +838,10 @@ emitKeyPathComponent(IRGenModule &IGM,
       SmallVector<llvm::Constant *, 4> externalSubArgs;
       auto componentSig = externalDecl->getInnermostDeclContext()
         ->getGenericSignatureOfContext();
+      
+      auto componentCanSig = componentSig
+        ? componentSig->getCanonicalSignature()
+        : CanGenericSignature();
       auto subs = component.getExternalSubstitutions();
       if (!subs.empty()) {
         enumerateGenericSignatureRequirements(
@@ -847,7 +852,7 @@ emitKeyPathComponent(IRGenModule &IGM,
             if (!reqt.Protocol) {
               // Type requirement.
               externalSubArgs.push_back(
-                emitMetadataTypeRefForKeyPath(IGM, substType));
+                emitMetadataTypeRefForKeyPath(IGM, substType, componentCanSig));
             } else {
               // Protocol requirement.
               auto conformance = subs.lookupConformance(
@@ -1182,9 +1187,11 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
     getAddrOfGenericEnvironment(pattern->getGenericSignature()));
   // Store type references for the root and leaf.
   fields.addRelativeAddress(
-    emitMetadataTypeRefForKeyPath(*this, rootTy));
+    emitMetadataTypeRefForKeyPath(*this, rootTy,
+                                  pattern->getGenericSignature()));
   fields.addRelativeAddress(
-    emitMetadataTypeRefForKeyPath(*this, valueTy));
+    emitMetadataTypeRefForKeyPath(*this, valueTy,
+                                  pattern->getGenericSignature()));
   
   // Add a pointer to the ObjC KVC compatibility string, if there is one, or
   // null otherwise.
@@ -1238,7 +1245,9 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
     // For all but the last component, we pack in the type of the component.
     if (i + 1 != pattern->getComponents().size()) {
       fields.addRelativeAddress(
-        emitMetadataTypeRefForKeyPath(*this, component.getComponentType()));
+        emitMetadataTypeRefForKeyPath(*this,
+                                      component.getComponentType(),
+                                      pattern->getGenericSignature()));
     }
     baseTy = component.getComponentType();
   }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1683,11 +1683,14 @@ namespace {
     }
     
     void addUnderlyingTypeAndConformances() {
+      auto sig = O->getOpaqueInterfaceGenericSignature()
+        ? O->getOpaqueInterfaceGenericSignature()->getCanonicalSignature()
+        : CanGenericSignature();
       auto underlyingType = Type(O->getUnderlyingInterfaceType())
         .subst(*O->getUnderlyingTypeSubstitutions())
-        ->getCanonicalType(O->getOpaqueInterfaceGenericSignature());
+        ->getCanonicalType(sig);
 
-      B.addRelativeAddress(IGM.getTypeRef(underlyingType,
+      B.addRelativeAddress(IGM.getTypeRef(underlyingType, sig,
                                           MangledTypeRefRole::Metadata).first);
       
       auto opaqueType = O->getDeclaredInterfaceType()

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/Basic/Platform.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Reflection/MetadataSourceBuilder.h"
 #include "swift/Reflection/Records.h"
@@ -38,6 +39,7 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
+#include "MetadataRequest.h"
 
 using namespace swift;
 using namespace irgen;
@@ -168,10 +170,160 @@ public:
   }
 };
 
+// Return the minimum Swift runtime version that supports demangling a given
+// type.
+static llvm::VersionTuple
+getRuntimeVersionThatSupportsDemanglingType(IRGenModule &IGM,
+                                            CanType type) {
+  // Associated types of opaque types weren't mangled in a usable form by the
+  // Swift 5.1 runtime, so we needed to add a new mangling in 5.2.
+  if (type->hasOpaqueArchetype()) {
+    auto hasOpaqueAssocType = type.findIf([](CanType t) -> bool {
+      if (auto a = dyn_cast<NestedArchetypeType>(t)) {
+        return isa<OpaqueTypeArchetypeType>(a->getRoot());
+      }
+      return false;
+    });
+    
+    if (hasOpaqueAssocType)
+      return llvm::VersionTuple(5, 2);
+    // Although opaque types in general were only added in Swift 5.1,
+    // declarations that use them are already covered by availability
+    // guards, so we don't need to limit availability of mangled names
+    // involving them.
+  }
+  
+  return llvm::VersionTuple(5, 0);
+}
+
+// Produce a fallback mangled type name that uses an open-coded callback
+// to form the metadata. This is useful for working around bugs in older
+// runtimes, or supporting new type system features when deploying back.
+//
+// Note that this functionality is limited, because the demangler callback
+// mechanism can only produce complete metadata. It can't be used in situations
+// where completing the metadata during demangling might cause cyclic
+// dependencies.
+static std::pair<llvm::Constant *, unsigned>
+getTypeRefByFunction(IRGenModule &IGM,
+                     CanGenericSignature sig,
+                     CanType t) {
+  IRGenMangler mangler;
+  std::string symbolName =
+    mangler.mangleSymbolNameForMangledMetadataAccessorString(
+                                                   "get_type_metadata", sig, t);
+  auto constant = IGM.getAddrOfStringForMetadataRef(symbolName, /*align*/2,
+                                                    /*low bit*/false,
+    [&](ConstantInitBuilder &B) {
+      llvm::Function *accessor;
+      
+      // Otherwise, we need to emit a helper function to bind the arguments
+      // out of the demangler's argument buffer.
+      auto fnTy = llvm::FunctionType::get(IGM.TypeMetadataPtrTy,
+                                          {IGM.Int8PtrTy}, /*vararg*/ false);
+      accessor =
+        llvm::Function::Create(fnTy, llvm::GlobalValue::PrivateLinkage,
+                               symbolName, IGM.getModule());
+      accessor->setAttributes(IGM.constructInitialAttributes());
+      
+      SmallVector<GenericRequirement, 4> requirements;
+      GenericEnvironment *genericEnv = nullptr;
+      if (sig) {
+        enumerateGenericSignatureRequirements(sig,
+                [&](GenericRequirement reqt) { requirements.push_back(reqt); });
+        genericEnv = sig->createGenericEnvironment();
+      }
+      
+      {
+        IRGenFunction IGF(IGM, accessor);
+        if (IGM.DebugInfo)
+          IGM.DebugInfo->emitArtificialFunction(IGF, accessor);
+
+        auto bindingsBufPtr = IGF.collectParameters().claimNext();
+
+        auto substT = genericEnv
+          ? genericEnv->mapTypeIntoContext(t)->getCanonicalType()
+          : t;
+
+        bindFromGenericRequirementsBuffer(IGF, requirements,
+            Address(bindingsBufPtr, IGM.getPointerAlignment()),
+            MetadataState::Complete,
+            [&](CanType t) {
+              return genericEnv
+                ? genericEnv->mapTypeIntoContext(t)->getCanonicalType()
+                : t;
+            });
+
+        auto ret = IGF.emitTypeMetadataRef(substT);
+        IGF.Builder.CreateRet(ret);
+      }
+      // Form the mangled name with its relative reference.
+      auto S = B.beginStruct();
+      S.setPacked(true);
+      S.add(llvm::ConstantInt::get(IGM.Int8Ty, 255));
+      S.add(llvm::ConstantInt::get(IGM.Int8Ty, 9));
+      S.addRelativeAddress(accessor);
+
+      // And a null terminator!
+      S.addInt(IGM.Int8Ty, 0);
+
+      return S.finishAndCreateFuture();
+    });
+  return {constant, 6};
+}
+
+static std::pair<llvm::Constant *, unsigned>
+getTypeRefImpl(IRGenModule &IGM,
+               CanType type,
+               CanGenericSignature sig,
+               MangledTypeRefRole role) {
+  switch (role) {
+  case MangledTypeRefRole::DefaultAssociatedTypeWitness:
+  case MangledTypeRefRole::Metadata:
+    // Note that we're using all of the nominal types referenced by this type,
+    // ensuring that we can always reconstruct type metadata from a mangled name
+    // in-process.
+    IGM.IRGen.noteUseOfTypeMetadata(type);
+    
+    // If the minimum deployment target's runtime demangler wouldn't understand
+    // this mangled name, then fall back to generating a "mangled name" with a
+    // symbolic reference with a callback function.
+    if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget
+                                      (IGM.Context.LangOpts.Target)) {
+      if (*runtimeCompatVersion <
+            getRuntimeVersionThatSupportsDemanglingType(IGM, type)) {
+        return getTypeRefByFunction(IGM, sig, type);
+      }
+    }
+      
+    break;
+
+  case MangledTypeRefRole::Reflection:
+    // For reflection records only used for out-of-process reflection, we do not
+    // need to force emission of runtime type metadata.
+    IGM.IRGen.noteUseOfFieldDescriptors(type);
+    break;
+  }
+
+  IRGenMangler Mangler;
+  auto SymbolicName = Mangler.mangleTypeForReflection(IGM, type);
+  return {IGM.getAddrOfStringForTypeRef(SymbolicName, role),
+          SymbolicName.runtimeSizeInBytes()};
+}
+
+std::pair<llvm::Constant *, unsigned>
+IRGenModule::getTypeRef(CanType type, CanGenericSignature sig,
+                        MangledTypeRefRole role) {
+  type = substOpaqueTypesWithUnderlyingTypes(type);
+  return getTypeRefImpl(*this, type, sig, role);
+}
+
 std::pair<llvm::Constant *, unsigned>
 IRGenModule::getTypeRef(Type type, GenericSignature *genericSig,
                         MangledTypeRefRole role) {
-  return getTypeRef(type->getCanonicalType(genericSig), role);
+  return getTypeRef(type->getCanonicalType(genericSig),
+      genericSig ? genericSig->getCanonicalSignature() : CanGenericSignature(),
+      role);
 }
 
 std::pair<llvm::Constant *, unsigned>
@@ -179,57 +331,12 @@ IRGenModule::getLoweredTypeRef(SILType loweredType,
                                CanGenericSignature genericSig,
                                MangledTypeRefRole role) {
   auto substTy =
-      substOpaqueTypesWithUnderlyingTypes(loweredType, genericSig);
+    substOpaqueTypesWithUnderlyingTypes(loweredType, genericSig);
   auto type = substTy.getASTType();
   if (substTy.hasArchetype())
-    type = substTy.getASTType()->mapTypeOutOfContext()->getCanonicalType();
+    type = type->mapTypeOutOfContext()->getCanonicalType();
 
-  switch (role) {
-  case MangledTypeRefRole::DefaultAssociatedTypeWitness:
-  case MangledTypeRefRole::Metadata:
-    // Note that we're using all of the nominal types referenced by this type,
-    // ensuring that we can always reconstruct type metadata from a mangled name
-    // in-process.
-    IRGen.noteUseOfTypeMetadata(type);
-    break;
-
-  case MangledTypeRefRole::Reflection:
-    // For reflection records only used for out-of-process reflection, we do not
-    // need to force emission of runtime type metadata.
-    IRGen.noteUseOfFieldDescriptors(type);
-    break;
-  }
-
-  IRGenMangler Mangler;
-  auto SymbolicName = Mangler.mangleTypeForReflection(*this, type);
-  return {getAddrOfStringForTypeRef(SymbolicName, role),
-          SymbolicName.runtimeSizeInBytes()};
-}
-
-std::pair<llvm::Constant *, unsigned>
-IRGenModule::getTypeRef(CanType type, MangledTypeRefRole role) {
-  type = substOpaqueTypesWithUnderlyingTypes(type);
-  
-  switch (role) {
-  case MangledTypeRefRole::DefaultAssociatedTypeWitness:
-  case MangledTypeRefRole::Metadata:
-    // Note that we're using all of the nominal types referenced by this type,
-    // ensuring that we can always reconstruct type metadata from a mangled name
-    // in-process.
-    IRGen.noteUseOfTypeMetadata(type);
-    break;
-
-  case MangledTypeRefRole::Reflection:
-    // For reflection records only used for out-of-process reflection, we do not
-    // need to force emission of runtime type metadata.
-    IRGen.noteUseOfFieldDescriptors(type);
-    break;
-  }
-
-  IRGenMangler Mangler;
-  auto SymbolicName = Mangler.mangleTypeForReflection(*this, type);
-  return {getAddrOfStringForTypeRef(SymbolicName, role),
-          SymbolicName.runtimeSizeInBytes()};
+  return getTypeRefImpl(*this, type, genericSig, role);
 }
 
 /// Emit a mangled string referencing a specific protocol conformance, so that
@@ -260,7 +367,7 @@ IRGenModule::emitWitnessTableRefString(CanType type,
 
   IRGenMangler mangler;
   std::string symbolName =
-    mangler.mangleSymbolNameForKeyPathMetadata(
+    mangler.mangleSymbolNameForMangledConformanceAccessorString(
       "get_witness_table", genericSig, type, conformance);
 
   return getAddrOfStringForMetadataRef(symbolName, /*alignment=*/2,
@@ -413,7 +520,10 @@ protected:
   void addTypeRef(Type type, GenericSignature *genericSig,
                   MangledTypeRefRole role =
                       MangledTypeRefRole::Reflection) {
-    addTypeRef(type->getCanonicalType(genericSig), role);
+    addTypeRef(type->getCanonicalType(genericSig),
+               genericSig ? genericSig->getCanonicalSignature()
+                          : CanGenericSignature(),
+               role);
   }
 
   /// Add a 32-bit relative offset to a mangled typeref string
@@ -425,9 +535,10 @@ protected:
   /// For reflection records which are demangled to produce type metadata
   /// in-process, pass MangledTypeRefRole::Metadata instead.
   void addTypeRef(CanType type,
+                  CanGenericSignature sig,
                   MangledTypeRefRole role =
                       MangledTypeRefRole::Reflection) {
-    B.addRelativeAddress(IGM.getTypeRef(type, role).first);
+    B.addRelativeAddress(IGM.getTypeRef(type, sig, role).first);
     addBuiltinTypeRefs(type);
   }
 
@@ -533,7 +644,10 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
     for (auto AssocTy : AssociatedTypes) {
       auto NameGlobal = IGM.getAddrOfFieldName(AssocTy.first);
       B.addRelativeAddress(NameGlobal);
-      addTypeRef(AssocTy.second);
+      addTypeRef(AssocTy.second,
+                 Nominal->getGenericSignature()
+                   ? Nominal->getGenericSignature()->getCanonicalSignature()
+                   : CanGenericSignature());
     }
   }
 
@@ -733,7 +847,7 @@ public:
   }
   
   void layout() override {
-    addTypeRef(type);
+    addTypeRef(type, CanGenericSignature());
 
     B.addInt32(ti->getFixedSize().getValue());
 
@@ -972,13 +1086,13 @@ public:
     B.addInt32(MetadataSources.size());
     B.addInt32(Layout.getBindings().size());
 
+    auto sig = OrigCalleeType->getGenericSignature()
+              ? OrigCalleeType->getGenericSignature()->getCanonicalSignature()
+              : CanGenericSignature();
+    
     // Now add typerefs of all of the captures.
     for (auto CaptureType : CaptureTypes) {
-      addLoweredTypeRef(
-          CaptureType,
-          OrigCalleeType->getGenericSignature()
-              ? OrigCalleeType->getGenericSignature()->getCanonicalSignature()
-              : CanGenericSignature());
+      addLoweredTypeRef(CaptureType, sig);
     }
 
     // Add the pairs that make up the generic param -> metadata source map
@@ -987,7 +1101,7 @@ public:
       auto GenericParam = GenericAndSource.first->getCanonicalType();
       auto Source = GenericAndSource.second;
 
-      addTypeRef(GenericParam);
+      addTypeRef(GenericParam, sig);
       addMetadataSource(Source);
     }
   }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -277,7 +277,22 @@ std::string IRGenMangler::mangleSymbolNameForAssociatedConformanceWitness(
   return finalize();
 }
 
-std::string IRGenMangler::mangleSymbolNameForKeyPathMetadata(
+std::string IRGenMangler::mangleSymbolNameForMangledMetadataAccessorString(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type) {
+  beginManglingWithoutPrefix();
+  Buffer << kind << " ";
+
+  if (genericSig)
+    appendGenericSignature(genericSig);
+
+  if (type)
+    appendType(type);
+  return finalize();
+}
+
+std::string IRGenMangler::mangleSymbolNameForMangledConformanceAccessorString(
                                            const char *kind,
                                            CanGenericSignature genericSig,
                                            CanType type,

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -504,7 +504,12 @@ public:
                                   CanType associatedType,
                                   const ProtocolDecl *proto);
 
-  std::string mangleSymbolNameForKeyPathMetadata(
+  std::string mangleSymbolNameForMangledMetadataAccessorString(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type);
+
+  std::string mangleSymbolNameForMangledConformanceAccessorString(
                                            const char *kind,
                                            CanGenericSignature genericSig,
                                            CanType type,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1070,7 +1070,7 @@ public:
   getTypeRef(Type type, GenericSignature *genericSig, MangledTypeRefRole role);
   
   std::pair<llvm::Constant *, unsigned>
-  getTypeRef(CanType type, MangledTypeRefRole role);
+  getTypeRef(CanType type, CanGenericSignature sig, MangledTypeRefRole role);
 
   std::pair<llvm::Constant *, unsigned>
   getLoweredTypeRef(SILType loweredType, CanGenericSignature genericSig,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2168,7 +2168,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
   llvm::Constant *mangledString;
   unsigned mangledStringSize;
   std::tie(mangledString, mangledStringSize) =
-    IGM.getTypeRef(type, MangledTypeRefRole::Metadata);
+    IGM.getTypeRef(type, CanGenericSignature(), MangledTypeRefRole::Metadata);
   
   assert(mangledStringSize < 0x80000000u
          && "2GB of mangled name ought to be enough for anyone");

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -85,10 +85,25 @@ dynamic func opaqueAssocTypeUnderlyingType() -> some Any {
   return g().f()
 }
 
+extension Optional: Q where Wrapped: Q {
+  func f() -> Wrapped.A? {
+    return map { $0.f() }
+  }
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+dynamic func structuralOpaqueAssocTypeUnderlyingType() -> some Any {
+  return Optional(g()).f()
+}
+
 if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  // CHECK: {{[\1, 2, 3\]|too old}}
   let x = opaqueAssocTypeUnderlyingType()
-  // CHECK: {{[1, 2, 3]|too old}}
   print(x)
+  // CHECK: {{Optional\(\[1, 2, 3\]\)|too damn old}}
+  let y = structuralOpaqueAssocTypeUnderlyingType()
+  print(y)
 } else {
   print("nope, still too old")
+  print("too damn old")
 }

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -79,3 +79,16 @@ if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   print("i'm getting way too old for this sh")
   print("way too old")
 }
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+dynamic func opaqueAssocTypeUnderlyingType() -> some Any {
+  return g().f()
+}
+
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  let x = opaqueAssocTypeUnderlyingType()
+  // CHECK: {{[1, 2, 3]|too old}}
+  print(x)
+} else {
+  print("nope, still too old")
+}


### PR DESCRIPTION
The nested archetype mangling does not have enough information to accurately recover the associated type at runtime. This fixes rdar://problem/54084733.

Although this changes the mangling in both runtime and symbols, this should not affect ABI, because there is no way for associated types of opaque types to be surfaced in the types of public
declarations today.

Shipping Swift 5.1 runtimes do not support this new mangling, so back-deploy the fix by emitting a mangled string that refers to a `\9` accessor function when targeting Swift 5.1.