### PR TITLE
IRGen: Save the current generic signature before mangling an opaque type decl

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -736,7 +736,9 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
   if (canSymbolicReference(opaqueDecl)) {
     appendSymbolicReference(opaqueDecl);
   } else if (auto namingDecl = opaqueDecl->getNamingDecl()) {
+    CanGenericSignature savedSignature = CurGenericSignature;
     appendEntity(namingDecl);
+    CurGenericSignature = savedSignature;
     appendOperator("QO");
   } else {
     llvm_unreachable("todo: independent opaque type decls");

--- a/test/IRGen/Inputs/mangle-opaque-return-types-A.swift
+++ b/test/IRGen/Inputs/mangle-opaque-return-types-A.swift
@@ -1,0 +1,73 @@
+public protocol Proto {
+  associatedtype Assoc : Proto
+  var value: Assoc { get }
+}
+
+extension Never : Proto {}
+
+extension Never {
+    public typealias Assoc = Never
+
+    public var value: Never {
+        switch self {}
+    }
+}
+protocol PrimitiveProto : Proto {}
+
+extension PrimitiveProto {
+    public var value: Never { valueError() }
+}
+
+extension Proto {
+    func valueError() -> Never {
+        fatalError("value() should not be called on \(Self.self).")
+    }
+}
+
+public struct EmptyProto : PrimitiveProto {
+  public init() {}
+}
+
+struct M<Content: Proto> : Proto {
+  var t: Content
+
+  init(_ t: Content) {
+    self.t = t
+  }
+
+  var value: some Proto {
+    return t.value
+  }
+}
+
+public struct Group<T> {
+  var t: T
+
+  public init(_ t: T) {
+    self.t = t
+  }
+}
+
+extension Group : Proto, PrimitiveProto where T : Proto {
+  public typealias Assoc = Never
+}
+
+public struct Choice<T, V>{
+  var v: V
+
+  public init(_ t: T, _ v: V) {
+    self.v = v
+  }
+}
+
+extension Choice : Proto where T: Proto, V: Proto {
+  public var value: some Proto {
+    return v.value
+  }
+}
+
+extension Proto {
+  public func add() -> some Proto  {
+    return M(self)
+  }
+}

--- a/test/IRGen/mangle-opaque-return-type.swift
+++ b/test/IRGen/mangle-opaque-return-type.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module -enable-library-evolution -emit-module-path=%t/A.swiftmodule -module-name=A %S/Inputs/mangle-opaque-return-types-A.swift
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -emit-ir  %s
+import A
+
+public struct C<T, Content: Proto> {
+  let data: T
+  let content: Content
+
+  init(_ t: T, _ c: Content) {
+    data = t
+    content = c
+  }
+
+  public var dontCrash : some Proto {
+    return Group(Choice(content, EmptyProto().add()))
+  }
+}
+


### PR DESCRIPTION
It comes with its own generic signature.

rdar://54824119

