### PR TITLE
[Reflection] Reenable inherits_ObjCClasses and inherits_NSObject tests on watchOS.

### DIFF
--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -7,10 +7,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
-// REQUIRES: OS=macosx || OS=ios || OS=tvos
-// NOTE: Test is temporarily disabled for watchOS until we can figure out why
-// it's failing there. rdar://problem/50898688
-
 import Foundation
 import simd
 

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -9,9 +9,6 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=ios || OS=tvos
-// NOTE: Test is temporarily disabled for watchOS until we can figure out why
-// it's failing there. rdar://problem/50898688
 
 import simd
 import ObjCClasses


### PR DESCRIPTION
These are working again. I suspect that they were caused by a linker bug we've since worked around.

rdar://problem/50898688