### PR TITLE
ABI/API checker: teach the tool to diagnose against a builtin empty baseline

### DIFF
--- a/test/api-digester/Outputs/color_vs_empty.txt
+++ b/test/api-digester/Outputs/color_vs_empty.txt
@@ -1,0 +1,1 @@
+Enum Color is a new API without @available attribute

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -12,6 +12,13 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
+// Compare color against an empty baseline
+// RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
+// RUN: %api-digester -diagnose-sdk -o %t.result -empty-baseline -I %S/Inputs/APINotesLeft -I %t.mod1 %clang-importer-sdk-nosource -module color -abi
+// RUN: %clang -E -P -x c %S/Outputs/color_vs_empty.txt -o - | sed '/^\s*$/d' > %t.expected
+// RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
+// RUN: diff -u %t.expected %t.result.tmp
+
 // Run another module API checking without -enable-library-evolution
 // RUN: %swift -emit-module -o %t.mod1/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource -module-name color
 // RUN: %swift -emit-module -o %t.mod2/color.swiftmodule %S/Inputs/cake_current/color.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource -module-name color

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -239,6 +239,11 @@ static llvm::cl::opt<std::string>
 BaselineFilePath("baseline-path",
                  llvm::cl::desc("The path to the Json file that we should use as the baseline"),
                  llvm::cl::cat(Category));
+
+static llvm::cl::opt<bool>
+UseEmptyBaseline("empty-baseline",
+                llvm::cl::desc("Use empty baseline for diagnostics"),
+                llvm::cl::cat(Category));
 } // namespace options
 
 namespace {
@@ -2570,28 +2575,33 @@ static SDKNodeRoot *getBaselineFromJson(const char *Main, SDKContext &Ctx) {
   llvm::SmallString<128> BaselinePath(ExePath);
   llvm::sys::path::remove_filename(BaselinePath); // Remove /swift-api-digester
   llvm::sys::path::remove_filename(BaselinePath); // Remove /bin
-  llvm::sys::path::append(BaselinePath, "lib", "swift", "FrameworkABIBaseline",
-                          Modules.begin()->getKey());
-  // Look for ABI or API baseline
-  if (Ctx.checkingABI())
-    llvm::sys::path::append(BaselinePath, "ABI");
-  else
-    llvm::sys::path::append(BaselinePath, "API");
-  // Look for deployment target specific baseline files.
-  auto Triple = Invok.getLangOptions().Target;
-  if (Triple.isMacCatalystEnvironment())
-    llvm::sys::path::append(BaselinePath, "iosmac.json");
-  else if (Triple.isMacOSX())
-    llvm::sys::path::append(BaselinePath, "macos.json");
-  else if (Triple.isiOS())
-    llvm::sys::path::append(BaselinePath, "iphoneos.json");
-  else if (Triple.isTvOS())
-    llvm::sys::path::append(BaselinePath, "appletvos.json");
-  else if (Triple.isWatchOS())
-    llvm::sys::path::append(BaselinePath, "watchos.json");
-  else {
-    llvm::errs() << "Unsupported triple target\n";
-    exit(1);
+  llvm::sys::path::append(BaselinePath, "lib", "swift", "FrameworkABIBaseline");
+  if (options::UseEmptyBaseline) {
+    // Use the empty baseline for comparison.
+    llvm::sys::path::append(BaselinePath, "nil.json");
+  } else {
+    llvm::sys::path::append(BaselinePath, Modules.begin()->getKey());
+    // Look for ABI or API baseline
+    if (Ctx.checkingABI())
+      llvm::sys::path::append(BaselinePath, "ABI");
+    else
+      llvm::sys::path::append(BaselinePath, "API");
+    // Look for deployment target specific baseline files.
+    auto Triple = Invok.getLangOptions().Target;
+    if (Triple.isMacCatalystEnvironment())
+      llvm::sys::path::append(BaselinePath, "iosmac.json");
+    else if (Triple.isMacOSX())
+      llvm::sys::path::append(BaselinePath, "macos.json");
+    else if (Triple.isiOS())
+      llvm::sys::path::append(BaselinePath, "iphoneos.json");
+    else if (Triple.isTvOS())
+      llvm::sys::path::append(BaselinePath, "appletvos.json");
+    else if (Triple.isWatchOS())
+      llvm::sys::path::append(BaselinePath, "watchos.json");
+    else {
+      llvm::errs() << "Unsupported triple target\n";
+      exit(1);
+    }
   }
   StringRef Path = BaselinePath.str();
   if (!fs::exists(Path)) {

--- a/utils/api_checker/FrameworkABIBaseline/nil.json
+++ b/utils/api_checker/FrameworkABIBaseline/nil.json
@@ -1,0 +1,6 @@
+{
+  "kind": "Root",
+  "name": "TopLevel",
+  "printedName": "TopLevel",
+  "json_format_version": 255
+}


### PR DESCRIPTION
Framework authors may be interested in comparing the current framework build
against an empty baseline to find public APIs without @available attributes. This
change makes such exercise easier.