### PR TITLE
Remove dependency on libtensorflow_framework.so.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Below is more information about TensorFlow-related build arguments.
     * Default: None.
 * `tensorflow-host-include-dir`: A directory containing custom TensorFlow headers.
     * Default value: None.
-* `tensorflow-host-lib-dir`: A directory containing custom TensorFlow shared libraries (`libtensorflow.so` and `libtensorflow_framework.so`).
+* `tensorflow-host-lib-dir`: A directory containing custom TensorFlow shared libraries (`libtensorflow.so`).
     * Default value: None.
 * `tensorflow-swift-apis`: A path to the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) deep learning library repository.
     * Default value: `tensorflow-swift-apis` if the [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) repository is cloned. Otherwise, none.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -349,7 +349,7 @@ config.swift_test_options = '-swift-version ' + swift_version
 swift_tensorflow_test_run_extra_options = ''
 swift_tensorflow_extra_options = ''
 if 'tensorflow' in config.available_features:
-    swift_tensorflow_extra_options += (' -ltensorflow -ltensorflow_framework')
+    swift_tensorflow_extra_options += (' -ltensorflow')
 swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
     swift_tensorflow_extra_options += (' -L %s' % os.path.abspath(swift_tensorflow_path))

--- a/utils/build-script
+++ b/utils/build-script
@@ -141,7 +141,7 @@ class BuildScriptInvocation(object):
 
         # SWIFT_ENABLE_TENSORFLOW
         if args.enable_tensorflow:
-            tensorflow_libs = ["libtensorflow.so", "libtensorflow_framework.so"]
+            tensorflow_libs = ["libtensorflow.so"]
             tensorflow_dirs = [
                 ("tensorflow_host_lib_dir", True),
                 ("tensorflow_host_include_dir", False),

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1377,7 +1377,7 @@ function verify_tensorflow_directories() {
 
                 # Check that "LIB" arguments contain the necessary libraries.
                 if [[ "dir_type" == "LIB" ]]; then
-                    for lib_name in tensorflow tensorflow_framework; do
+                    for lib_name in tensorflow; do
                         lib="lib${lib_name}.so"
                         if [[ ! -e "${!dir_name}/${lib}" ]]; then
                             echo "Error: '${lib}' does not exist in TensorFlow ${lower_platform} ${lower_dir_type} directory (was '${!dir_name}')"
@@ -2585,7 +2585,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     # Bazel-built libraries do not have write permission, which is
                     # problematic for overwriting/stripping symbols. Thus, write
                     # permission is added here.
-                    for lib_name in tensorflow tensorflow_framework; do
+                    for lib_name in tensorflow; do
                         lib=".*lib${lib_name}.so[0-9.]*"
                         dylib=".*lib${lib_name}[0-9.]*.dylib"
                         find "${TF_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec rm -f {} \;
@@ -3040,7 +3040,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Configure TensorFlow and build using bazel.
                 (cd "${source_dir}"; echo yes "" | ./configure)
                 with_pushd "${source_dir}" \
-                    call bazel build -c opt "${TENSORFLOW_BAZEL_OPTIONS[@]}" --define framework_shared_object=false //tensorflow:libtensorflow.so //tensorflow:libtensorflow_framework.so
+                    call bazel build -c opt "${TENSORFLOW_BAZEL_OPTIONS[@]}" --define framework_shared_object=false //tensorflow:libtensorflow.so
 
                 # TensorFlow builds itself and doesn't use CMake.
                 continue
@@ -4011,8 +4011,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 TF_LIBDIR="$(build_directory ${host} swift)/lib/swift/${SWIFT_HOST_VARIANT}"
                 TF_DEST_DIR="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})lib/swift/${SWIFT_HOST_VARIANT}"
                 mkdir -p "${TF_DEST_DIR}"
-                for lib_name in tensorflow tensorflow_framework
-                do
+                for lib_name in tensorflow; do
                     lib=".*lib${lib_name}.so[0-9.]*"
                     dylib=".*lib${lib_name}[0-9.]*.dylib"
                     find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec echo "{} => ${TF_DEST_DIR}" \;

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -1045,8 +1045,7 @@ def create_argument_parser():
     option('--tensorflow-host-lib-dir', store_path,
            default=None,
            help='Path to a directory containing TensorFlow libraries '
-                '(libtensorflow.so and libtensorflow_framework.so). '
-                'Used for linking swiftc.')
+                '(libtensorflow.so). Used for linking swiftc.')
     option('--tensorflow-host-include-dir', store_path,
            default=None,
            help='Path to a directory containing TensorFlow headers. '
@@ -1054,8 +1053,7 @@ def create_argument_parser():
     option('--tensorflow-target-lib-dir', store_path,
            default=None,
            help='Path to a directory containing TensorFlow libraries '
-                '(libtensorflow.so and libtensorflow_framework.so). '
-                'Used for linking Swift programs.')
+                '(libtensorflow.so). Used for linking Swift programs.')
     option('--tensorflow-target-include-dir', store_path,
            default=None,
            help='Path to a directory containing TensorFlow headers. '


### PR DESCRIPTION
Remove `libtensorflow_framework.so` as a build product.
This should reduce toolchain size.

Follow-up attempt to https://github.com/apple/swift/pull/20898.