### PR TITLE
Fix bad interaction between SIL function serialization and weak linking

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -940,9 +940,31 @@ public:
 
   bool isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
-  /// Whether this declaration is weak-imported.
-  bool isWeakImported(ModuleDecl *fromModule,
-                      AvailabilityContext fromContext) const;
+  AvailabilityContext getAvailabilityForLinkage() const;
+
+  /// Whether this declaration or one of its outer contexts has the
+  /// @_weakLinked attribute.
+  bool isAlwaysWeakImported() const;
+
+  /// Whether this declaration is weak-imported from the given module,
+  /// either because of the presence of the @_weakLinked attribute, or
+  /// because of availability.
+  ///
+  /// Note that \p fromModule should either be the "main module" or
+  /// nullptr. (This is because when it is non-null, we query the
+  /// current deployment target, and not the deployment target that
+  /// the module was built with.)
+  ///
+  /// If \p fromModule is the main module, this returns false when the
+  /// declaration is part of the main module, or if the declaration is
+  /// at least as available as the current deployment target.
+  ///
+  /// If \p fromModule is null, we instead return true if the
+  /// declaration is meant to be weak linked with _some_ deployment
+  /// target; that is, the presence of the @_weakLinked attribute or
+  /// any kind of availability is enough, irrespective of the current
+  /// deployment target.
+  bool isWeakImported(ModuleDecl *fromModule) const;
 
   /// Returns true if the nature of this declaration allows overrides.
   /// Note that this does not consider whether it is final or whether

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -640,6 +640,8 @@ ERROR(expected_sil_function_type, none,
       "sil function expected to have SIL function type", ())
 ERROR(sil_dynamically_replaced_func_not_found,none,
       "dynamically replaced function not found %0", (Identifier))
+ERROR(sil_availability_expected_version,none,
+      "expected version number in 'available' attribute", ())
 
 // SIL Stage
 ERROR(expected_sil_stage_name, none,

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -343,8 +343,7 @@ public:
   bool isInvalid() const;
 
   /// Whether this conformance is weak-imported.
-  bool isWeakImported(ModuleDecl *fromModule,
-                      AvailabilityContext fromContext) const;
+  bool isWeakImported(ModuleDecl *fromModule) const;
 
   bool hasWitness(ValueDecl *requirement) const;
   Witness getWitness(ValueDecl *requirement) const;

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1111,8 +1111,7 @@ public:
   }
 
   /// Determine whether this entity will be weak-imported.
-  bool isWeakImported(ModuleDecl *module,
-                      AvailabilityContext fromContext) const;
+  bool isWeakImported(ModuleDecl *module) const;
   
   /// Return the source file whose codegen should trigger emission of this
   /// link entity, if one can be identified.
@@ -1182,7 +1181,6 @@ public:
 
   static LinkInfo get(const UniversalLinkageInfo &linkInfo,
                       ModuleDecl *swiftModule,
-                      AvailabilityContext availabilityContext,
                       const LinkEntity &entity,
                       ForDefinition_t forDefinition);
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -165,6 +165,23 @@ private:
 
   Identifier ObjCReplacementFor;
 
+  /// The function's set of semantics attributes.
+  ///
+  /// TODO: Why is this using a std::string? Why don't we use uniqued
+  /// StringRefs?
+  std::vector<std::string> SemanticsAttrSet;
+
+  /// The function's remaining set of specialize attributes.
+  std::vector<SILSpecializeAttr*> SpecializeAttrSet;
+
+  /// Has value if there's a profile for this function
+  /// Contains Function Entry Count
+  ProfileCounter EntryCount;
+
+  /// This is the number of uses of this SILFunction inside the SIL.
+  /// It does not include references from debug scopes.
+  unsigned RefCount = 0;
+
   /// The function's bare attribute. Bare means that the function is SIL-only
   /// and does not require debug info.
   unsigned Bare : 1;
@@ -209,33 +226,9 @@ private:
   /// invoked with a `self` argument of the exact base class type.
   unsigned ExactSelfClass : 1;
 
-  /// If != OptimizationMode::NotSet, the optimization mode specified with an
-  /// function attribute.
-  OptimizationMode OptMode;
-
-  /// This is the number of uses of this SILFunction inside the SIL.
-  /// It does not include references from debug scopes.
-  unsigned RefCount = 0;
-
-  /// The function's set of semantics attributes.
-  ///
-  /// TODO: Why is this using a std::string? Why don't we use uniqued
-  /// StringRefs?
-  llvm::SmallVector<std::string, 1> SemanticsAttrSet;
-
-  /// The function's remaining set of specialize attributes.
-  std::vector<SILSpecializeAttr*> SpecializeAttrSet;
-
-  /// The function's effects attribute.
-  EffectsKind EffectsKindAttr;
-
-  /// Has value if there's a profile for this function
-  /// Contains Function Entry Count
-  ProfileCounter EntryCount;
-
   /// True if this function is inlined at least once. This means that the
   /// debug info keeps a pointer to this function.
-  bool Inlined = false;
+  unsigned Inlined : 1;
 
   /// True if this function is a zombie function. This means that the function
   /// is dead and not referenced from anywhere inside the SIL. But it is kept
@@ -244,7 +237,7 @@ private:
   /// *) It is a dead method of a class which has higher visibility than the
   ///    method itself. In this case we need to create a vtable stub for it.
   /// *) It is a function referenced by the specialization information.
-  bool Zombie = false;
+  unsigned Zombie : 1;
 
   /// True if this function is in Ownership SSA form and thus must pass
   /// ownership verification.
@@ -252,12 +245,12 @@ private:
   /// This enables the verifier to easily prove that before the Ownership Model
   /// Eliminator runs on a function, we only see a non-semantic-arc world and
   /// after the pass runs, we only see a semantic-arc world.
-  bool HasOwnership = true;
+  unsigned HasOwnership : 1;
 
   /// Set if the function body was deserialized from canonical SIL. This implies
   /// that the function's home module performed SIL diagnostics prior to
   /// serialization.
-  bool WasDeserializedCanonical = false;
+  unsigned WasDeserializedCanonical : 1;
 
   /// True if this is a reabstraction thunk of escaping function type whose
   /// single argument is a potentially non-escaping closure. This is an escape
@@ -265,7 +258,14 @@ private:
   /// argument with escaping function type. The thunk argument's function type
   /// is not necessarily @noescape. The only relevant aspect of the argument is
   /// that it may have unboxed capture (i.e. @inout_aliasable parameters).
-  bool IsWithoutActuallyEscapingThunk = false;
+  unsigned IsWithoutActuallyEscapingThunk : 1;
+
+  /// If != OptimizationMode::NotSet, the optimization mode specified with an
+  /// function attribute.
+  unsigned OptMode : NumOptimizationModeBits;
+
+  /// The function's effects attribute.
+  unsigned EffectsKindAttr : NumEffectsKindBits;
 
   static void
   validateSubclassScope(SubclassScope scope, IsThunk_t isThunk,
@@ -671,13 +671,17 @@ public:
 
   /// Get this function's optimization mode or OptimizationMode::NotSet if it is
   /// not set for this specific function.
-  OptimizationMode getOptimizationMode() const { return OptMode; }
+  OptimizationMode getOptimizationMode() const {
+    return OptimizationMode(OptMode);
+  }
 
   /// Returns the optimization mode for the function. If no mode is set for the
   /// function, returns the global mode, i.e. the mode of the module's options.
   OptimizationMode getEffectiveOptimizationMode() const;
 
-  void setOptimizationMode(OptimizationMode mode) { OptMode = mode; }
+  void setOptimizationMode(OptimizationMode mode) {
+    OptMode = unsigned(mode);
+  }
 
   /// \returns True if the function is optimizable (i.e. not marked as no-opt),
   ///          or is raw SIL (so that the mandatory passes still run).
@@ -755,16 +759,16 @@ public:
   void setInlineStrategy(Inline_t inStr) { InlineStrategy = inStr; }
 
   /// \return the function side effects information.
-  EffectsKind getEffectsKind() const { return EffectsKindAttr; }
+  EffectsKind getEffectsKind() const { return EffectsKind(EffectsKindAttr); }
 
   /// \return True if the function is annotated with the @_effects attribute.
   bool hasEffectsKind() const {
-    return EffectsKindAttr != EffectsKind::Unspecified;
+    return EffectsKind(EffectsKindAttr) != EffectsKind::Unspecified;
   }
 
   /// Set the function side effect information.
   void setEffectsKind(EffectsKind E) {
-    EffectsKindAttr = E;
+    EffectsKindAttr = unsigned(E);
   }
 
   /// Get this function's global_init attribute.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -400,25 +400,24 @@ SourceLoc RootProtocolConformance::getLoc() const {
 }
 
 bool
-RootProtocolConformance::isWeakImported(ModuleDecl *fromModule,
-                                        AvailabilityContext fromContext) const {
+RootProtocolConformance::isWeakImported(ModuleDecl *fromModule) const {
   auto *dc = getDeclContext();
   if (dc->getParentModule() == fromModule)
     return false;
 
   // If the protocol is weak imported, so are any conformances to it.
-  if (getProtocol()->isWeakImported(fromModule, fromContext))
+  if (getProtocol()->isWeakImported(fromModule))
     return true;
 
   // If the conforming type is weak imported, so are any of its conformances.
   if (auto *nominal = getType()->getAnyNominal())
-    if (nominal->isWeakImported(fromModule, fromContext))
+    if (nominal->isWeakImported(fromModule))
       return true;
 
   // If the conformance is declared in an extension with the @_weakLinked
   // attribute, it is weak imported.
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))
-    if (ext->isWeakImported(fromModule, fromContext))
+    if (ext->isWeakImported(fromModule))
       return true;
 
   return false;

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -62,8 +62,7 @@ static bool isHoistable(AllocStackInst *Inst, irgen::IRGenModule &Mod) {
   bool foundWeaklyImported =
       SILTy.getASTType().findIf([&Mod](CanType type) -> bool {
         if (auto nominal = type->getNominalOrBoundGenericNominal())
-          if (nominal->isWeakImported(Mod.getSwiftModule(),
-                                      Mod.getAvailabilityContext())) {
+          if (nominal->isWeakImported(Mod.getSwiftModule())) {
             return true;
           }
         return false;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1728,8 +1728,7 @@ void irgen::updateLinkageForDefinition(IRGenModule &IGM,
   // TODO: there are probably cases where we can avoid redoing the
   // entire linkage computation.
   UniversalLinkageInfo linkInfo(IGM);
-  bool weakImported = entity.isWeakImported(IGM.getSwiftModule(),
-                                            IGM.getAvailabilityContext());
+  bool weakImported = entity.isWeakImported(IGM.getSwiftModule());
   auto IRL =
       getIRLinkage(linkInfo, entity.getLinkage(ForDefinition),
                    ForDefinition, weakImported);
@@ -1749,13 +1748,11 @@ LinkInfo LinkInfo::get(IRGenModule &IGM, const LinkEntity &entity,
                        ForDefinition_t isDefinition) {
   return LinkInfo::get(UniversalLinkageInfo(IGM),
                        IGM.getSwiftModule(),
-                       IGM.getAvailabilityContext(),
                        entity, isDefinition);
 }
 
 LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
                        ModuleDecl *swiftModule,
-                       AvailabilityContext availabilityContext,
                        const LinkEntity &entity,
                        ForDefinition_t isDefinition) {
   LinkInfo result;
@@ -1771,7 +1768,7 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
       ForDefinition_t(swiftModule->isStdlibModule() || isDefinition);
 
   entity.mangle(result.Name);
-  bool weakImported = entity.isWeakImported(swiftModule, availabilityContext);
+  bool weakImported = entity.isWeakImported(swiftModule);
   result.IRL = getIRLinkage(linkInfo, entity.getLinkage(isStdlibOrDefinition),
                             isDefinition, weakImported);
   result.ForDefinition = isDefinition;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5395,8 +5395,7 @@ namespace {
       llvm::BasicBlock *conditionalBlock = nullptr;
       llvm::BasicBlock *afterConditionalBlock = nullptr;
       llvm::BasicBlock *beforeNullPtrCheck = nullptr;
-      if (Case->isWeakImported(IGM.getSwiftModule(),
-                               IGM.getAvailabilityContext())) {
+      if (Case->isWeakImported(IGM.getSwiftModule())) {
         beforeNullPtrCheck = IGF.Builder.GetInsertBlock();
         auto address = IGM.getAddrOfEnumCase(Case, NotForDefinition);
         conditionalBlock = llvm::BasicBlock::Create(C);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -962,13 +962,12 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   }
 }
 
-bool LinkEntity::isWeakImported(ModuleDecl *module,
-                                AvailabilityContext context) const {
+bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   switch (getKind()) {
   case Kind::SILGlobalVariable:
     if (getSILGlobalVariable()->getDecl()) {
       return getSILGlobalVariable()->getDecl()
-          ->isWeakImported(module, context);
+          ->isWeakImported(module);
     }
     return false;
   case Kind::DynamicallyReplaceableFunctionKey:
@@ -976,7 +975,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
   case Kind::SILFunction: {
     // For imported functions check the Clang declaration.
     if (auto clangOwner = getSILFunction()->getClangNodeOwner())
-      return clangOwner->isWeakImported(module, context);
+      return clangOwner->isWeakImported(module);
 
     // For native functions check a flag on the SILFunction
     // itself.
@@ -992,16 +991,16 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
     // type stored in extra storage area is weak linked.
     auto assocConformance = getAssociatedConformance();
     auto *depMemTy = assocConformance.first->castTo<DependentMemberType>();
-    return depMemTy->getAssocType()->isWeakImported(module, context);
+    return depMemTy->getAssocType()->isWeakImported(module);
   }
 
   case Kind::BaseConformanceDescriptor:
-    return cast<ProtocolDecl>(getDecl())->isWeakImported(module, context);
+    return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
 
   case Kind::TypeMetadata:
   case Kind::TypeMetadataAccessFunction: {
     if (auto *nominalDecl = getType()->getAnyNominal())
-      return nominalDecl->isWeakImported(module, context);
+      return nominalDecl->isWeakImported(module);
     return false;
   }
 
@@ -1033,12 +1032,12 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
   case Kind::OpaqueTypeDescriptorAccessorImpl:
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
-    return getDecl()->isWeakImported(module, context);
+    return getDecl()->isWeakImported(module);
 
   case Kind::ProtocolWitnessTable:
   case Kind::ProtocolConformanceDescriptor:
     return getProtocolConformance()->getRootConformance()
-                                   ->isWeakImported(module, context);
+                                   ->isWeakImported(module);
 
   // TODO: Revisit some of the below, for weak conformances.
   case Kind::ObjCMetadataUpdateFunction:

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -18,7 +18,6 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "swift/AST/ASTMangler.h"
-#include "swift/AST/Availability.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILGlobalVariable.h"
@@ -966,22 +965,13 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   switch (getKind()) {
   case Kind::SILGlobalVariable:
     if (getSILGlobalVariable()->getDecl()) {
-      return getSILGlobalVariable()->getDecl()
-          ->isWeakImported(module);
+      return getSILGlobalVariable()->getDecl()->isWeakImported(module);
     }
     return false;
   case Kind::DynamicallyReplaceableFunctionKey:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::SILFunction: {
-    // For imported functions check the Clang declaration.
-    if (auto clangOwner = getSILFunction()->getClangNodeOwner())
-      return clangOwner->isWeakImported(module);
-
-    // For native functions check a flag on the SILFunction
-    // itself.
-    if (getSILFunction()->isWeakLinked())
-      return getSILFunction()->isAvailableExternally();
-    return false;
+    return getSILFunction()->isWeakImported();
   }
 
   case Kind::AssociatedConformanceDescriptor:

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -18,12 +18,15 @@
 #include "swift/SIL/SILProfiler.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/PrettyStackTrace.h"
+#include "swift/AST/Availability.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/OptimizationMode.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/GraphWriter.h"
+#include "clang/AST/Decl.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -93,11 +96,13 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          IsExactSelfClass_t isExactSelfClass)
     : Module(Module), Name(Name), LoweredType(LoweredType),
       GenericEnv(genericEnv), SpecializationInfo(nullptr),
-      EntryCount(entryCount), Bare(isBareSILFunction), Transparent(isTrans),
+      EntryCount(entryCount),
+      Availability(AvailabilityContext::alwaysAvailable()),
+      Bare(isBareSILFunction), Transparent(isTrans),
       Serialized(isSerialized), Thunk(isThunk),
       ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
       InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
-      HasCReferences(false), IsWeakLinked(false),
+      HasCReferences(false), IsWeakImported(false),
       IsDynamicReplaceable(isDynamic),
       ExactSelfClass(isExactSelfClass),
       Inlined(false), Zombie(false), HasOwnership(true),
@@ -257,6 +262,27 @@ const TypeLowering &SILFunction::getTypeLowering(SILType type) const {
 
 bool SILFunction::isTypeABIAccessible(SILType type) const {
   return getModule().isTypeABIAccessible(type, getResilienceExpansion());
+}
+
+bool SILFunction::isWeakImported() const {
+  // For imported functions check the Clang declaration.
+  if (ClangNodeOwner)
+    return ClangNodeOwner->getClangDecl()->isWeakImported();
+
+  // For native functions check a flag on the SILFunction
+  // itself.
+  if (!isAvailableExternally())
+    return false;
+
+  if (isAlwaysWeakImported())
+    return true;
+
+  if (Availability.isAlwaysAvailable())
+    return false;
+
+  auto fromContext = AvailabilityContext::forDeploymentTarget(
+      getASTContext());
+  return !fromContext.isContainedIn(Availability);
 }
 
 SILBasicBlock *SILFunction::createBasicBlock() {

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -93,15 +93,17 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          IsExactSelfClass_t isExactSelfClass)
     : Module(Module), Name(Name), LoweredType(LoweredType),
       GenericEnv(genericEnv), SpecializationInfo(nullptr),
-      Bare(isBareSILFunction), Transparent(isTrans),
+      EntryCount(entryCount), Bare(isBareSILFunction), Transparent(isTrans),
       Serialized(isSerialized), Thunk(isThunk),
       ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
       InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
       HasCReferences(false), IsWeakLinked(false),
       IsDynamicReplaceable(isDynamic),
       ExactSelfClass(isExactSelfClass),
-      OptMode(OptimizationMode::NotSet),
-      EffectsKindAttr(E), EntryCount(entryCount) {
+      Inlined(false), Zombie(false), HasOwnership(true),
+      WasDeserializedCanonical(false), IsWithoutActuallyEscapingThunk(false),
+      OptMode(unsigned(OptimizationMode::NotSet)),
+      EffectsKindAttr(unsigned(E)) {
   assert(!Transparent || !IsDynamicReplaceable);
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
   setDebugScope(DebugScope);
@@ -188,8 +190,8 @@ ASTContext &SILFunction::getASTContext() const {
 }
 
 OptimizationMode SILFunction::getEffectiveOptimizationMode() const {
-  if (OptMode != OptimizationMode::NotSet)
-    return OptMode;
+  if (OptimizationMode(OptMode) != OptimizationMode::NotSet)
+    return OptimizationMode(OptMode);
 
   return getModule().getOptions().OptMode;
 }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -162,17 +162,8 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
-    if (decl->isAlwaysWeakImported())
-      F->setWeakLinked();
-    else {
-      auto containingContext = decl->getAvailabilityForLinkage();
-      if (!containingContext.isAlwaysAvailable()) {
-        auto fromContext = AvailabilityContext::forDeploymentTarget(
-          decl->getASTContext());
-        if (!fromContext.isContainedIn(containingContext))
-          F->setWeakLinked();
-      }
-    }
+    F->setAvailabilityForLinkage(decl->getAvailabilityForLinkage());
+    F->setAlwaysWeakImported(decl->isAlwaysWeakImported());
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -162,8 +162,17 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
-    if (decl->isWeakImported(/*forModule=*/nullptr, availCtx))
+    if (decl->isAlwaysWeakImported())
       F->setWeakLinked();
+    else {
+      auto containingContext = decl->getAvailabilityForLinkage();
+      if (!containingContext.isAlwaysAvailable()) {
+        auto fromContext = AvailabilityContext::forDeploymentTarget(
+          decl->getASTContext());
+        if (!fromContext.isContainedIn(containingContext))
+          F->setWeakLinked();
+      }
+    }
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2332,8 +2332,13 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   if (isGlobalInit())
     OS << "[global_init] ";
-  if (isWeakLinked())
-    OS << "[_weakLinked] ";
+  if (isAlwaysWeakImported())
+    OS << "[weak_imported] ";
+  auto availability = getAvailabilityForLinkage();
+  if (!availability.isAlwaysAvailable()) {
+    auto version = availability.getOSVersion().getLowerEndpoint();
+    OS << "[available " << version.getAsString() << "] ";
+  }
 
   switch (getInlineStrategy()) {
     case NoInline: OS << "[noinline] "; break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3872,18 +3872,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
       }
 
       case decls_block::Available_DECL_ATTR: {
-#define LIST_VER_TUPLE_PIECES(X)\
-  X##_Major, X##_Minor, X##_Subminor, X##_HasMinor, X##_HasSubminor
-#define DEF_VER_TUPLE_PIECES(X) unsigned LIST_VER_TUPLE_PIECES(X)
-#define DECODE_VER_TUPLE(X)\
-  if (X##_HasMinor) {\
-    if (X##_HasSubminor)\
-      X = llvm::VersionTuple(X##_Major, X##_Minor, X##_Subminor);\
-    else\
-      X = llvm::VersionTuple(X##_Major, X##_Minor);\
-    }\
-  else X = llvm::VersionTuple(X##_Major);
-
         bool isImplicit;
         bool isUnavailable;
         bool isDeprecated;
@@ -3932,10 +3920,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
           Obsoleted, SourceRange(),
           platformAgnostic, isImplicit);
         break;
-
-#undef DEF_VER_TUPLE_PIECES
-#undef LIST_VER_TUPLE_PIECES
-#undef DECODE_VER_TUPLE
       }
 
       case decls_block::ObjC_DECL_ATTR: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 518; // save extended nominal separately when serializing extensions
+const uint16_t SWIFTMODULE_VERSION_MINOR = 519; // SIL function availability
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -520,6 +520,44 @@ enum class ImportControl : uint8_t {
   ImplementationOnly
 };
 using ImportControlField = BCFixed<2>;
+
+// Encodes a VersionTuple:
+//
+//  Major
+//  Minor
+//  Subminor
+//  HasMinor
+//  HasSubminor
+#define BC_AVAIL_TUPLE\
+    BCVBR<5>,\
+    BCVBR<5>,\
+    BCVBR<4>,\
+    BCFixed<1>,\
+    BCFixed<1>
+
+#define LIST_VER_TUPLE_PIECES(X)\
+  X##_Major, X##_Minor, X##_Subminor, X##_HasMinor, X##_HasSubminor
+#define DEF_VER_TUPLE_PIECES(X) unsigned LIST_VER_TUPLE_PIECES(X)
+#define DECODE_VER_TUPLE(X)\
+  if (X##_HasMinor) {\
+    if (X##_HasSubminor)\
+      X = llvm::VersionTuple(X##_Major, X##_Minor, X##_Subminor);\
+    else\
+      X = llvm::VersionTuple(X##_Major, X##_Minor);\
+    }\
+  else X = llvm::VersionTuple(X##_Major);
+#define ENCODE_VER_TUPLE(X, X_Expr)\
+    unsigned X##_Major = 0, X##_Minor = 0, X##_Subminor = 0,\
+             X##_HasMinor = 0, X##_HasSubminor = 0;\
+    const auto &X##_Val = X_Expr;\
+    if (X##_Val.hasValue()) {\
+      const auto &Y = X##_Val.getValue();\
+      X##_Major = Y.getMajor();\
+      X##_Minor = Y.getMinor().getValueOr(0);\
+      X##_Subminor = Y.getSubminor().getValueOr(0);\
+      X##_HasMinor = Y.getMinor().hasValue();\
+      X##_HasSubminor = Y.getSubminor().hasValue();\
+    }
 
 /// The various types of blocks that can occur within a serialized Swift
 /// module.
@@ -1640,20 +1678,6 @@ namespace decls_block {
     BCFixed<2>  // optimize value
   >;
 
-  // Encodes a VersionTuple:
-  //
-  //  Major
-  //  Minor
-  //  Subminor
-  //  HasMinor
-  //  HasSubminor
-#define BC_AVAIL_TUPLE\
-    BCVBR<5>,\
-    BCVBR<5>,\
-    BCVBR<4>,\
-    BCFixed<1>,\
-    BCFixed<1>
-
   using AvailableDeclAttrLayout = BCRecordLayout<
     Available_DECL_ATTR,
     BCFixed<1>, // implicit flag
@@ -1668,8 +1692,6 @@ namespace decls_block {
     BCVBR<5>,   // number of bytes in rename string
     BCBlob      // platform, followed by message
   >;
-
-#undef BC_AVAIL_TUPLE
 
   using ObjCDeclAttrLayout = BCRecordLayout<
     ObjC_DECL_ATTR,

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -288,7 +288,8 @@ namespace sil_block {
                      BCFixed<3>,  // side effect info.
                      BCVBR<8>,    // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership
-                     BCFixed<1>,  // must be weakly referenced
+                     BCFixed<1>,  // force weak linking
+                     BC_AVAIL_TUPLE, // availability for weak linking
                      BCFixed<1>,  // is dynamically replacable
                      BCFixed<1>,  // exact self class
                      TypeIDField, // SILFunctionType

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2180,25 +2180,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     }
 
     case DAK_Available: {
-#define LIST_VER_TUPLE_PIECES(X)\
-    X##_Major, X##_Minor, X##_Subminor, X##_HasMinor, X##_HasSubminor
-#define DEF_VER_TUPLE_PIECES(X, X_Expr)\
-    unsigned X##_Major = 0, X##_Minor = 0, X##_Subminor = 0,\
-             X##_HasMinor = 0, X##_HasSubminor = 0;\
-    const auto &X##_Val = X_Expr;\
-    if (X##_Val.hasValue()) {\
-      const auto &Y = X##_Val.getValue();\
-      X##_Major = Y.getMajor();\
-      X##_Minor = Y.getMinor().getValueOr(0);\
-      X##_Subminor = Y.getSubminor().getValueOr(0);\
-      X##_HasMinor = Y.getMinor().hasValue();\
-      X##_HasSubminor = Y.getSubminor().hasValue();\
-    }
-
       auto *theAttr = cast<AvailableAttr>(DA);
-      DEF_VER_TUPLE_PIECES(Introduced, theAttr->Introduced)
-      DEF_VER_TUPLE_PIECES(Deprecated, theAttr->Deprecated)
-      DEF_VER_TUPLE_PIECES(Obsoleted, theAttr->Obsoleted)
+      ENCODE_VER_TUPLE(Introduced, theAttr->Introduced)
+      ENCODE_VER_TUPLE(Deprecated, theAttr->Deprecated)
+      ENCODE_VER_TUPLE(Obsoleted, theAttr->Obsoleted)
 
       llvm::SmallString<32> blob;
       blob.append(theAttr->Message);
@@ -2218,8 +2203,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->Rename.size(),
           blob);
       return;
-#undef LIST_VER_TUPLE_PIECES
-#undef DEF_VER_TUPLE_PIECES
     }
 
     case DAK_ObjC: {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -410,6 +410,14 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
         S.addUniquedStringRef(F.getObjCReplacement().str());
   }
   unsigned numSpecAttrs = NoBody ? 0 : F.getSpecializeAttrs().size();
+
+  Optional<llvm::VersionTuple> available;
+  auto availability = F.getAvailabilityForLinkage();
+  if (!availability.isAlwaysAvailable()) {
+    available = availability.getOSVersion().getLowerEndpoint();
+  }
+  ENCODE_VER_TUPLE(available, available)
+
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
       (unsigned)F.isTransparent(), (unsigned)F.isSerialized(),
@@ -417,7 +425,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.isGlobalInit(), (unsigned)F.getInlineStrategy(),
       (unsigned)F.getOptimizationMode(), (unsigned)F.getEffectsKind(),
       (unsigned)numSpecAttrs, (unsigned)F.hasOwnership(),
-      F.isWeakLinked(), (unsigned)F.isDynamicallyReplaceable(),
+      F.isAlwaysWeakImported(), LIST_VER_TUPLE_PIECES(available),
+      (unsigned)F.isDynamicallyReplaceable(),
       (unsigned)F.isExactSelfClass(),
       FnID, replacedFunctionID, genericSigID, clangNodeOwnerID, SemanticsIDs);
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -71,8 +71,7 @@ void TBDGenVisitor::addSymbol(SILDeclRef declRef) {
 
 void TBDGenVisitor::addSymbol(LinkEntity entity) {
   auto linkage =
-      LinkInfo::get(UniversalLinkInfo, SwiftModule, AvailCtx,
-                    entity, ForDefinition);
+      LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
 
   auto externallyVisible =
       llvm::GlobalValue::isExternalLinkage(linkage.getLinkage()) &&
@@ -602,8 +601,6 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   const auto &target = ctx.LangOpts.Target;
   UniversalLinkageInfo linkInfo(target, opts.HasMultipleIGMs, false,
                                 isWholeModule);
-  auto availCtx = AvailabilityContext::forDeploymentTarget(ctx);
-
   tapi::internal::InterfaceFile file;
   file.setFileType(tapi::internal::FileType::TBD_V3);
   file.setApplicationExtensionSafe(
@@ -618,7 +615,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   file.setArch(arch);
   file.setInstallAPI();
 
-  TBDGenVisitor visitor(file, arch, symbols, linkInfo, M, availCtx, opts);
+  TBDGenVisitor visitor(file, arch, symbols, linkInfo, M, opts);
 
   auto visitFile = [&](FileUnit *file) {
     if (file == M->getFiles()[0]) {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -48,7 +48,6 @@ public:
 
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
-  AvailabilityContext AvailCtx;
   const TBDGenOptions &Opts;
 
 private:
@@ -74,11 +73,10 @@ public:
   TBDGenVisitor(tapi::internal::InterfaceFile &symbols,
                 tapi::internal::ArchitectureSet archs, StringSet *stringSymbols,
                 const UniversalLinkageInfo &universalLinkInfo,
-                ModuleDecl *swiftModule, AvailabilityContext availCtx,
-                const TBDGenOptions &opts)
+                ModuleDecl *swiftModule, const TBDGenOptions &opts)
       : Symbols(symbols), Archs(archs), StringSymbols(stringSymbols),
         UniversalLinkInfo(universalLinkInfo), SwiftModule(swiftModule),
-        AvailCtx(availCtx), Opts(opts) {}
+        Opts(opts) {}
 
   void addMainIfNecessary(FileUnit *file) {
     // HACK: 'main' is a special symbol that's always emitted in SILGen if

--- a/test/IRGen/Inputs/weak_import_deployment_target_helper.swift
+++ b/test/IRGen/Inputs/weak_import_deployment_target_helper.swift
@@ -1,0 +1,11 @@
+@available(macOS 10.50, *)
+public func function() -> Int { return 0 }
+
+@available(macOS 10.50, *)
+public func hasDefaultArg(_: Int = function()) {}
+
+@available(macOS 10.60, *)
+public func availableFunction() -> Int { return 0 }
+
+@available(macOS 10.60, *)
+public func hasAvailableDefaultArg(_: Int = availableFunction()) {}

--- a/test/IRGen/weakLinked.sil
+++ b/test/IRGen/weakLinked.sil
@@ -2,8 +2,8 @@
 
 sil_stage canonical
 
-// expected-error@+1{{attribute '_weakLinked' is unsupported on target 'x86_64-unknown-windows-msvc'}}
-sil [_weakLinked] @f : $@convention(thin) () -> () {
+// expected-error@+1{{attribute 'weak_imported' is unsupported on target 'x86_64-unknown-windows-msvc'}}
+sil [weak_imported] @f : $@convention(thin) () -> () {
   %unit = tuple()
   return %unit : $()
 }

--- a/test/IRGen/weak_import_deployment_target.swift
+++ b/test/IRGen/weak_import_deployment_target.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -target x86_64-apple-macosx10.50 -emit-module-path %t/weak_import_deployment_target_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_deployment_target_helper.swift
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+//
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -target x86_64-apple-macosx10.60 -emit-module-path %t/weak_import_deployment_target_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_deployment_target_helper.swift
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+//
+// REQUIRES: OS=macosx
+
+import weak_import_deployment_target_helper
+
+@available(macOS 10.50, *)
+public func callsOld() {
+  hasDefaultArg()
+}
+
+@available(macOS 10.60, *)
+public func callsNew() {
+  hasAvailableDefaultArg()
+}
+
+// CHECK-OLD-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
+// CHECK-OLD-LABEL: declare extern_weak swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
+// CHECK-OLD-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()
+
+// CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
+// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
+// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()

--- a/test/IRGen/weak_import_native.sil
+++ b/test/IRGen/weak_import_native.sil
@@ -6,15 +6,15 @@
 sil_stage canonical
 
 // CHECK-DAG: define{{( protected)?}} swiftcc void @weakButDefined() {{#[0-9]+}} {
-sil public [_weakLinked] @weakButDefined : $@convention(thin) () -> () {
+sil public [weak_imported] @weakButDefined : $@convention(thin) () -> () {
   %unit = tuple()
   return %unit : $()
 }
 
 // CHECK-DAG: declare extern_weak swiftcc void @weakExternal()
-sil public_external [_weakLinked] @weakExternal : $@convention(thin) () -> ()
+sil public_external [weak_imported] @weakExternal : $@convention(thin) () -> ()
 
-sil [_weakLinked] @testWeak : $@convention(thin) () -> () {
+sil [weak_imported] @testWeak : $@convention(thin) () -> () {
   %weakButDefined = function_ref @weakButDefined : $@convention(thin) () -> ()
   %wbdResult      = apply %weakButDefined() : $@convention(thin) () -> ()
   %weakExternal   = function_ref @weakExternal : $@convention(thin) () -> ()

--- a/test/SIL/Parser/available.sil
+++ b/test/SIL/Parser/available.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 @available(*,unavailable,message: "it has been renamed")
 public struct mmConstUnsafePointer<T> {
@@ -11,3 +12,15 @@ bb0(%0 : $@thin mmConstUnsafePointer<T>.Type):
   %1 = struct $mmConstUnsafePointer<T> ()
   return %1 : $mmConstUnsafePointer<T>
 }
+
+// CHECK-LABEL: sil [available 123] @version_major : $@convention(thin) () -> ()
+sil [available 123] @version_major : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [available 123.321] @version_minor : $@convention(thin) () -> ()
+sil [available 123.321] @version_minor : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+sil [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [weak_imported] @weak_func : $@convention(thin) () -> ()
+sil [weak_imported] @weak_func : $@convention(thin) () -> ()

--- a/test/SIL/Serialization/available.sil
+++ b/test/SIL/Serialization/available.sil
@@ -1,0 +1,31 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name available
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name available
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name available | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> ()
+sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+sil [serialized] [available 123.321.444] @version_subminor : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [available 123] @version_major : $@convention(thin) () -> ()
+sil [serialized] [available 123] @version_major : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [available 123.321] @version_minor : $@convention(thin) () -> ()
+sil [serialized] [available 123.321] @version_minor : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}

--- a/test/SILGen/availability_attribute.swift
+++ b/test/SILGen/availability_attribute.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.60 | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute17availableFunctionyyF : $@convention(thin) () -> ()
+@available(macOS 10.50, *) public func availableFunction() {}
+
+public struct Struct {
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV12availableVarSivg : $@convention(method) (Struct) -> Int
+    @available(macOS 10.50, *)
+    public var availableVar: Int { return 0 }
+
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV24varWithAvailableAccessorSivg : $@convention(method) (Struct) -> Int
+    public var varWithAvailableAccessor: Int {
+        @available(macOS 10.50, *)
+        get {
+            return 0
+        }
+    }
+}
+
+@available(macOS 10.50, *)
+extension Struct {
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV24availableExtensionMethodyyF : $@convention(method) (Struct) -> ()
+    public func availableExtensionMethod() {}
+}
+
+@available(macOS 10.50, *)
+public struct AvailableStruct {
+    public func availableMethod() {}
+
+    public struct Nested {
+        public func availableNestedMethod() {}
+    }
+}

--- a/test/SILGen/weak_linked_attribute.swift
+++ b/test/SILGen/weak_linked_attribute.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
 // UNSUPPORTED: OS=windows-msvc
 
-// CHECK-LABEL: sil [_weakLinked] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [weak_imported] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
 @_weakLinked public func weakFunction() {}


### PR DESCRIPTION
If a declaration in a module is `@available(fooOS 20, *)`, it should still be weak linked when referenced from another module with a deployment target of fooOS 10, but not when referenced from any module built with a deployment target of fooOS 20.

Previously we would only serialize a single isWeakLinked bit in the SILFunction, which was computed by checking the availability of the original AST function declaration against the module's own deployment target, but this is insufficient if a SIL function is serialized and deserialized inside another module.

Instead, record the original OS version in which the declaration was introduced, and serialize that together with the SIL function.

Fixes <rdar://problem/52783668>.