### PR TITLE
Optimize toolchain size by preserving TensorFlow library symlinks.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -393,6 +393,27 @@ function is_swift_lto_enabled() {
     fi
 }
 
+# SWIFT_ENABLE_TENSORFLOW
+# Copy a file to a destination directory.
+# If the file is a symbolic link, then copy the underlying file to the
+# destination and create a new symlink. Otherwise, copy the file directly.
+function copy_file_preserving_symlinks() {
+  # $1: source directory.
+  # $2: source file basename.
+  # $3: destination directory.
+
+  # If source file is a symlink, then copy the underlying file to the
+  # destination and create a new symlink.
+  if [[ -L "$1/$2" ]]; then
+    local target=`readlink "$1/$2"`
+    copy_file_preserving_symlinks "$1" "$target" "$3"
+    ln -sv "$3/$target" -f -r "$3/$2"
+  # Otherwise, directly copy the source file to the destination.
+  else
+    cp -v "$1/$2" "$3"
+  fi
+}
+
 # Support for performing isolated actions.
 #
 # This is part of refactoring more work to be done or controllable via
@@ -4013,9 +4034,12 @@ for host in "${ALL_HOSTS[@]}"; do
                 mkdir -p "${TF_DEST_DIR}"
                 for lib_name in tensorflow; do
                     lib=".*lib${lib_name}.so[0-9.]*"
-                    dylib=".*lib${lib_name}[0-9.]*.dylib"
-                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec echo "{} => ${TF_DEST_DIR}" \;
-                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -a {} "${TF_DEST_DIR}" \;
+                    # Wipe existing TensorFlow libraries in the destination
+                    # directory. This ensures that old versions of libraries
+                    # are not copied, taking up unnecessary space.
+                    rm -rf "${TF_DEST_DIR}/${lib}"
+                    # Copy TensorFlow library, preserving symlinks.
+                    copy_file_preserving_symlinks "${TF_LIBDIR}" "lib${lib_name}.so" "${TF_DEST_DIR}"
                 done
                 continue
                 ;;


### PR DESCRIPTION
Bazel produces multiple TensorFlow library artifacts:
```
$ ls -alh tensorflow/bazel-bin/tensorflow
 18B libtensorflow.so -> libtensorflow.so.1
 23B libtensorflow.so.1 -> libtensorflow.so.1.14.0
277M libtensorflow.so.1.14.0
```

Previously, TensorFlow libraries were copied using `cp -a` via a glob pattern. For some reason, symlinks were not preserved:
```
$ ls -alh <TOOLCHAIN_BEFORE>.xctoolchain/usr/lib/swift/macosx
 18B libtensorflow.so -> libtensorflow.so.1
277M libtensorflow.so.1
277M libtensorflow.so.1.14.0 # duplicate library
```

Now, rather than copying all libraries via glob, `copy_file_preserving_symlinks` copies exactly the necessary source files to the destination while preserving symlinks:
```
$ ls -alh <TOOLCHAIN_AFTER>.xctoolchain/usr/lib/swift/macosx
 18B libtensorflow.so -> libtensorflow.so.1
277M libtensorflow.so.1
```

[Original logic](https://github.com/tensorflow/swift-apis/blob/893f47b56e57c30ce9df798bea7e346caab4d87f/Tools/install.sh#L9) by @pschuh.

---

This combined with removing `libtensorflow_framework.so` dependency (https://github.com/apple/swift/pull/27029) led to a macOS toolchain size reduction from 4.91 GB to 3.45 GB. Ubuntu toolchain size reduction has not been yet measured.

Before:
<img width="400" alt="Screen Shot 2019-09-05 at 9 29 48 AM" src="https://user-images.githubusercontent.com/5590046/64306963-13415100-cfc7-11e9-8985-9835ad651a3f.png">

After:
<img width="400" alt="Screen Shot 2019-09-05 at 9 29 54 AM" src="https://user-images.githubusercontent.com/5590046/64306975-18060500-cfc7-11e9-8b5f-e4cc9dea71a2.png">

---

Please see https://groups.google.com/a/tensorflow.org/d/msg/swift/aw1wFSp9i7M/SrFH2Lq2AQAJ for discussion and future steps.

Todos:
* Fix library duplication issue for LLDB. LLDB also stores a copy of TensorFlow libraries, which is suboptimal. I forgot what code is responsible for this, haven't found it yet.
```
$ ls -alh <TOOLCHAIN_AFTER>.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/Swift/macosx
277M libtensorflow.so
277M libtensorflow.so.1
277M libtensorflow.so.1.14.0
```
* Investigate other reasons why toolchain size increased drastically between releases. Consider removing `install-xxx` flags from [TensorFlow build presets](https://github.com/apple/swift/blob/d67c913a03d0a124ab0fb8cc93b2f9de3742e77b/utils/build-presets.ini#L2156).