### PR TITLE
[5.1] Compatibility50: Backport objc_getClass hook patch.

### DIFF
--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -36,3 +36,56 @@ __attribute__((used, section("__DATA,__swift_hooks"))) = {
 __attribute__((weak, visibility("hidden")))
 extern "C"
 char _swift_FORCE_LOAD_$_swiftCompatibility50 = 0;
+
+// Put a getClass hook in front of the system Swift runtime's hook to prevent it
+// from trying to interpret symbolic references. rdar://problem/55036306
+
+// FIXME: delete this #if and dlsym once we don't
+// need to build with older libobjc headers
+#if !OBJC_GETCLASSHOOK_DEFINED
+using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
+                                    Class _Nullable * _Nonnull outClass);
+#endif
+static objc_hook_getClass OldGetClassHook;
+
+static BOOL
+getObjCClassByMangledName_untrusted(const char * _Nonnull typeName,
+                                    Class _Nullable * _Nonnull outClass) {
+  // Scan the string for byte sequences that might be recognized as
+  // symbolic references, and reject them.
+  for (const char *c = typeName; *c != 0; ++c) {
+    if (*c < 0x20) {
+      *outClass = Nil;
+      return NO;
+    }
+  }
+  
+  if (OldGetClassHook) {
+    return OldGetClassHook(typeName, outClass);
+  }
+  // In case the OS runtime for some reason didn't install a hook, fallback to
+  // NO.
+  return NO;
+}
+
+__attribute__((constructor))
+static void installGetClassHook_untrusted() {
+  // FIXME: delete this #if and dlsym once we don't
+  // need to build with older libobjc headers
+#if !OBJC_GETCLASSHOOK_DEFINED
+  using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
+                                      Class _Nullable * _Nonnull outClass);
+  auto objc_setHook_getClass =
+    (void(*)(objc_hook_getClass _Nonnull,
+             objc_hook_getClass _Nullable * _Nonnull))
+    dlsym(RTLD_DEFAULT, "objc_setHook_getClass");
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+  if (objc_setHook_getClass) {
+    objc_setHook_getClass(getObjCClassByMangledName_untrusted,
+                          &OldGetClassHook);
+  }
+#pragma clang diagnostic pop
+}


### PR DESCRIPTION
Explanation: Applies the security fix from https://github.com/apple/swift/pull/27015 for rdar://problem/54724618 so that binaries built to deploy back to Swift 5.0 are not vulnerable to malformed class names getting passed into objc_getClass. This is a toolchain fix that does not requiring updating the runtime in the OS.

Scope: Possible security hole if untrusted strings can be fed to NSClassFromString on Swift 5.0 runtimes

Issue: rdar://problem/55036306

Risk: Low

Testing: Swift CI, locally tested on macOS 10.15 beta and 10.14.6

Reviewed by: @mikeash 