### PR TITLE
[IRGen] Change a pass to agree with a merged pair of passes upstream

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -140,7 +140,7 @@ static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,
                                      legacy::PassManagerBase &PM) {
   const PassManagerBuilderWrapper &BuilderWrapper =
       static_cast<const PassManagerBuilderWrapper &>(Builder);
-  PM.add(createSanitizerCoverageLegacyPassPass(
+  PM.add(createModuleSanitizerCoverageLegacyPassPass(
       BuilderWrapper.IRGOpts.SanitizeCoverage));
 }
 


### PR DESCRIPTION
SanitizerCoveragePass was meerged with ModuleSanitizerCoverage upstream
and thus this usage needs to agree.
