### PR TITLE
[SyntaxParse] Parse 'self' as an 'identifier' token in type parsing

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -547,11 +547,10 @@ public:
   ParsedTokenSyntax consumeIdentifierSyntax(bool allowDollarIdentifier = false) {
     assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
 
-    Context.getIdentifier(Tok.getText());
-
     if (Tok.getText()[0] == '$' && !allowDollarIdentifier)
       diagnoseDollarIdentifier(Tok);
 
+    Tok.setKind(tok::identifier);
     return consumeTokenSyntax();
   }
 

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -193,3 +193,5 @@ var _: sr5505 = sr5505 // expected-error {{use of undeclared type 'sr5505'}}
 typealias A = (inout Int ..., Int ... = [42, 12]) -> Void // expected-error {{'inout' must not be used on variadic parameters}}
                                                           // expected-error@-1 {{only a single element can be variadic}} {{35-39=}}
                                                           // expected-error@-2 {{default argument not permitted in a tuple type}} {{39-49=}}
+
+typealias rdar55075237 = Int.self // expected-error {{'self' is not a member type of 'Int'}}


### PR DESCRIPTION
Fixes an assertion failure in Syntax validation

rdar://problem/55075237
