### PR TITLE
[Evaluator Ergonomics] Add Request Signatures

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -75,14 +75,15 @@ public:
   void cacheResult(AccessLevel value) const;
 };
 
+using DefaultAndMax = std::pair<AccessLevel, AccessLevel>;
+
 /// Request the Default and Max AccessLevels of the given ExtensionDecl.
 class DefaultAndMaxAccessLevelRequest :
     public SimpleRequest<DefaultAndMaxAccessLevelRequest,
-                         std::pair<AccessLevel, AccessLevel>(ExtensionDecl *),
+                         DefaultAndMax(ExtensionDecl *),
                          CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
-  using DefaultAndMax = std::pair<AccessLevel, AccessLevel>;
 private:
   friend SimpleRequest;
 
@@ -104,7 +105,7 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/include/swift/AST/AccessTypeIDZone.def
+++ b/include/swift/AST/AccessTypeIDZone.def
@@ -15,6 +15,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(AccessControl, AccessLevelRequest)
-SWIFT_REQUEST(AccessControl, DefaultAndMaxAccessLevelRequest)
-SWIFT_REQUEST(AccessControl, SetterAccessLevelRequest)
+SWIFT_REQUEST(AccessControl, AccessLevelRequest, AccessLevel(ValueDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(AccessControl, DefaultAndMaxAccessLevelRequest,
+              DefaultAndMax(ExtensionDecl *), SeparatelyCached)
+SWIFT_REQUEST(AccessControl, SetterAccessLevelRequest,
+              AccessLevel(AbstractStorageDecl *), SeparatelyCached)

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -265,7 +265,7 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -15,12 +15,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest)
-SWIFT_REQUEST(NameLookup, ExtendedNominalRequest)
-SWIFT_REQUEST(NameLookup, GetDestructorRequest)
-SWIFT_REQUEST(NameLookup, InheritedDeclsReferencedRequest)
-SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest)
-SWIFT_REQUEST(NameLookup, SuperclassDeclRequest)
-SWIFT_REQUEST(NameLookup, TypeDeclsFromWhereClauseRequest)
-SWIFT_REQUEST(NameLookup, UnderlyingTypeDeclsReferencedRequest)
-
+SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
+              NominalTypeDecl *(CustomAttr *, DeclContext *), Cached)
+SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
+              NominalTypeDecl *(ExtensionDecl *), SeparatelyCached)
+SWIFT_REQUEST(NameLookup, GetDestructorRequest, DestructorDecl *(ClassDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(NameLookup, InheritedDeclsReferencedRequest,
+              DirectlyReferencedTypeDecls(
+                  llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned),
+              Uncached)
+SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest,
+              SelfBounds(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>),
+              Uncached)
+SWIFT_REQUEST(NameLookup, SuperclassDeclRequest, ClassDecl *(NominalTypeDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(NameLookup, TypeDeclsFromWhereClauseRequest,
+              DirectlyReferencedTypeDecls(ExtensionDecl *), Uncached)
+SWIFT_REQUEST(NameLookup, UnderlyingTypeDeclsReferencedRequest,
+              DirectlyReferencedTypeDecls(TypeAliasDecl *), Uncached)

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -78,7 +78,7 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)           \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -14,5 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(Parse, ParseMembersRequest)
-SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest)
+SWIFT_REQUEST(Parse, ParseMembersRequest,
+              ArrayRef<Decl *>(IterableDeclContext *), Cached)
+SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest,
+              BraceStmt *(AbstractFunctionDecl *), SeparatelyCached)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -138,10 +138,10 @@ public:
 
 /// Request to determine the set of declarations that were are overridden
 /// by the given declaration.
-class OverriddenDeclsRequest
-  : public SimpleRequest<OverriddenDeclsRequest,
-                         llvm::TinyPtrVector<ValueDecl *>(ValueDecl *),
-                         CacheKind::SeparatelyCached> {
+class OverriddenDeclsRequest :
+  public SimpleRequest<OverriddenDeclsRequest,
+                       llvm::TinyPtrVector<ValueDecl *>(ValueDecl *),
+                       CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -183,7 +183,7 @@ public:
 void simple_display(llvm::raw_ostream &out, CtorInitializerKind initKind);
 
 /// Computes the kind of initializer for a given \c ConstructorDecl
-class InitKindRequest:
+class InitKindRequest :
     public SimpleRequest<InitKindRequest,
                          CtorInitializerKind(ConstructorDecl *),
                          CacheKind::Cached> {
@@ -203,7 +203,7 @@ public:
 };
 
 /// Determine whether the given protocol declaration is class-bounded.
-class ProtocolRequiresClassRequest:
+class ProtocolRequiresClassRequest :
     public SimpleRequest<ProtocolRequiresClassRequest,
                          bool(ProtocolDecl *),
                          CacheKind::SeparatelyCached> {
@@ -229,7 +229,7 @@ public:
 
 /// Determine whether an existential conforming to a protocol can be matched
 /// with a generic type parameter constrained to that protocol.
-class ExistentialConformsToSelfRequest:
+class ExistentialConformsToSelfRequest :
     public SimpleRequest<ExistentialConformsToSelfRequest,
                          bool(ProtocolDecl *),
                          CacheKind::SeparatelyCached> {
@@ -255,7 +255,7 @@ public:
 
 /// Determine whether we are allowed to refer to an existential type conforming
 /// to this protocol.
-class ExistentialTypeSupportedRequest:
+class ExistentialTypeSupportedRequest :
     public SimpleRequest<ExistentialTypeSupportedRequest,
                          bool(ProtocolDecl *),
                          CacheKind::SeparatelyCached> {
@@ -1195,7 +1195,7 @@ void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -15,50 +15,104 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest)
-SWIFT_REQUEST(TypeChecker, AttachedFunctionBuilderRequest)
-SWIFT_REQUEST(TypeChecker, AttachedPropertyWrapperTypeRequest)
-SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest)
-SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest)
-SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest)
-SWIFT_REQUEST(TypeChecker, DefaultTypeRequest)
-SWIFT_REQUEST(TypeChecker, EmittedMembersRequest)
-SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest)
-SWIFT_REQUEST(TypeChecker, ExistentialConformsToSelfRequest)
-SWIFT_REQUEST(TypeChecker, ExistentialTypeSupportedRequest)
-SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest)
-SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest)
-SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest)
-SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest)
-SWIFT_REQUEST(TypeChecker, InheritedTypeRequest)
-SWIFT_REQUEST(TypeChecker, InitKindRequest)
-SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest)
-SWIFT_REQUEST(TypeChecker, IsDynamicRequest)
-SWIFT_REQUEST(TypeChecker, IsFinalRequest)
-SWIFT_REQUEST(TypeChecker, IsGetterMutatingRequest)
-SWIFT_REQUEST(TypeChecker, IsImplicitlyUnwrappedOptionalRequest)
-SWIFT_REQUEST(TypeChecker, IsObjCRequest)
-SWIFT_REQUEST(TypeChecker, IsSetterMutatingRequest)
-SWIFT_REQUEST(TypeChecker, LazyStoragePropertyRequest)
-SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest)
-SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest)
-SWIFT_REQUEST(TypeChecker, OverriddenDeclsRequest)
-SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyInfoRequest)
-SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyTypeRequest)
-SWIFT_REQUEST(TypeChecker, PropertyWrapperMutabilityRequest)
-SWIFT_REQUEST(TypeChecker, PropertyWrapperTypeInfoRequest)
-SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest)
-SWIFT_REQUEST(TypeChecker, RequirementRequest)
-SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest)
-SWIFT_REQUEST(TypeChecker, RequiresOpaqueAccessorsRequest)
-SWIFT_REQUEST(TypeChecker, RequiresOpaqueModifyCoroutineRequest)
-SWIFT_REQUEST(TypeChecker, ResilienceExpansionRequest)
-SWIFT_REQUEST(TypeChecker, SelfAccessKindRequest)
-SWIFT_REQUEST(TypeChecker, StorageImplInfoRequest)
-SWIFT_REQUEST(TypeChecker, StoredPropertiesAndMissingMembersRequest)
-SWIFT_REQUEST(TypeChecker, StoredPropertiesRequest)
-SWIFT_REQUEST(TypeChecker, StructuralTypeRequest)
-SWIFT_REQUEST(TypeChecker, SuperclassTypeRequest)
-SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest)
-SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest)
-SWIFT_REQUEST(TypeChecker, USRGenerationRequest)
+SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest,
+              GenericSignature *(GenericSignature *,
+                                 SmallVector<GenericTypeParamType *, 2>,
+                                 SmallVector<Requirement, 2>),
+              Cached)
+SWIFT_REQUEST(TypeChecker, AttachedFunctionBuilderRequest,
+              CustomAttr *(ValueDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, AttachedPropertyWrapperTypeRequest,
+              Type(VarDecl *, unsigned), Cached)
+SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest,
+              llvm::TinyPtrVector<CustomAttr *>(VarDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
+              AncestryFlags(ClassDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
+              Type(AssociatedTypeDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,
+              Type(KnownProtocolKind, const DeclContext *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, DeclRange(ClassDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest,
+              Type(EnumDecl *, TypeResolutionStage), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, ExistentialConformsToSelfRequest,
+              bool(ProtocolDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, ExistentialTypeSupportedRequest,
+              bool(ProtocolDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest, Type(ExtensionDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
+              Cached)
+SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
+              Cached)
+SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
+              GenericSignature *(ModuleDecl *, GenericSignature *,
+                                 SmallVector<GenericParamList *, 2>,
+                                 SmallVector<Requirement, 2>,
+                                 SmallVector<TypeLoc, 2>, bool),
+              CacheKind::Cached)
+SWIFT_REQUEST(TypeChecker, InheritedTypeRequest,
+              Type(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned,
+                   TypeResolutionStage),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, InitKindRequest,
+              CtorInitializerKind(ConstructorDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest, bool(AccessorDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsGetterMutatingRequest, bool(AbstractStorageDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsImplicitlyUnwrappedOptionalRequest,
+              bool(ValueDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsObjCRequest, bool(ValueDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, IsSetterMutatingRequest, bool(AbstractStorageDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, LazyStoragePropertyRequest, VarDecl *(VarDecl *),
+              Cached)
+SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest,
+              std::string(const TypeDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
+              OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, OverriddenDeclsRequest,
+              llvm::TinyPtrVector<ValueDecl *>(ValueDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyInfoRequest,
+              PropertyWrapperBackingPropertyInfo(VarDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyTypeRequest,
+              Type(VarDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, PropertyWrapperMutabilityRequest,
+              Optional<PropertyWrapperMutability>(VarDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, PropertyWrapperTypeInfoRequest,
+              PropertyWrapperTypeInfo(NominalTypeDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest, bool(ProtocolDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, RequirementRequest,
+              Requirement(WhereClauseOwner, unsigned, TypeResolutionStage),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest,
+              ArrayRef<Requirement>(ProtocolDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, RequiresOpaqueAccessorsRequest, bool(VarDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, RequiresOpaqueModifyCoroutineRequest,
+              bool(AbstractStorageDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, ResilienceExpansionRequest,
+              ResilienceExpansion(DeclContext *), Cached)
+SWIFT_REQUEST(TypeChecker, SelfAccessKindRequest, SelfAccessKind(FuncDecl *),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, StorageImplInfoRequest,
+              StorageImplInfo(AbstractStorageDecl *), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, StoredPropertiesAndMissingMembersRequest,
+              ArrayRef<Decl *>(NominalTypeDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, StoredPropertiesRequest,
+              ArrayRef<VarDecl *>(NominalTypeDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, StructuralTypeRequest, Type(TypeAliasDecl *), Cached)
+SWIFT_REQUEST(TypeChecker, SuperclassTypeRequest,
+              Type(NominalTypeDecl *, TypeResolutionStage), SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
+              AccessorDecl *(AbstractStorageDecl *, AccessorKind),
+              SeparatelyCached)
+SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest,
+              bool(AbstractFunctionDecl *, SourceLoc), Cached)
+SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),
+              Cached)

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -33,7 +33,7 @@
 
 // Define a TypeID where the type name and internal name are the same.
 #define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
-#define SWIFT_REQUEST(Zone, Type) SWIFT_TYPEID_NAMED(Type, Type)
+#define SWIFT_REQUEST(Zone, Type, Sig, Caching) SWIFT_TYPEID_NAMED(Type, Type)
 
 // First pass: put all of the names into an enum so we get values for them.
 template<> struct TypeIDZoneTypes<Zone::SWIFT_TYPEID_ZONE> {

--- a/include/swift/Basic/ImplementTypeIDZone.h
+++ b/include/swift/Basic/ImplementTypeIDZone.h
@@ -33,7 +33,7 @@
 #endif
 
 // Define a TypeID where the type name and internal name are the same.
-#define SWIFT_REQUEST(Zone, Type) SWIFT_TYPEID_NAMED(Type, Type)
+#define SWIFT_REQUEST(Zone, Type, Sig, Caching) SWIFT_TYPEID_NAMED(Type, Type)
 #define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
 
 // Out-of-line definitions.

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -195,7 +195,7 @@ FRONTEND_STATISTIC(Parse, NumFunctionsParsed)
 /// Number of full braced decl list parsed.
 FRONTEND_STATISTIC(Parse, NumIterableDeclContextParsed)
 
-#define SWIFT_REQUEST(ZONE, NAME) FRONTEND_STATISTIC(Parse, NAME)
+#define SWIFT_REQUEST(ZONE, NAME, SIG, CACHE) FRONTEND_STATISTIC(Parse, NAME)
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST
 
@@ -285,7 +285,7 @@ FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 /// Number of lookups into a module and its imports.
 
 /// All type check requests go into the Sema area.
-#define SWIFT_REQUEST(ZONE, NAME) FRONTEND_STATISTIC(Sema, NAME)
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching) FRONTEND_STATISTIC(Sema, NAME)
 #include "swift/AST/AccessTypeIDZone.def"
 #include "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/AST/TypeCheckerTypeIDZone.def"

--- a/include/swift/IDE/IDERequestIDZone.def
+++ b/include/swift/IDE/IDERequestIDZone.def
@@ -15,8 +15,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(IDE, CollectOverriddenDeclsRequest)
-SWIFT_REQUEST(IDE, CursorInfoRequest)
-SWIFT_REQUEST(IDE, ProvideDefaultImplForRequest)
-SWIFT_REQUEST(IDE, RangeInfoRequest)
-SWIFT_REQUEST(IDE, ResolveProtocolNameRequest)
+SWIFT_REQUEST(IDE, CollectOverriddenDeclsRequest,
+              ArrayRef<ValueDecl *>(OverridenDeclsOwner), CacheKind::Cached)
+SWIFT_REQUEST(IDE, CursorInfoRequest, ide::ResolvedCursorInfo(CursorInfoOwner),
+              CacheKind::Cached)
+SWIFT_REQUEST(IDE, ProvideDefaultImplForRequest,
+              ArrayRef<ValueDecl *>(ValueDecl *), CacheKind::Cached)
+SWIFT_REQUEST(IDE, RangeInfoRequest, ide::ResolvedRangeInfo(RangeInfoOwner),
+              CacheKind::Cached)
+SWIFT_REQUEST(IDE, ResolveProtocolNameRequest,
+              ProtocolDecl *(ProtocolNameOwner), CacheKind::Cached)

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -289,7 +289,7 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/include/swift/Sema/IDETypeCheckingRequestIDZone.def
+++ b/include/swift/Sema/IDETypeCheckingRequestIDZone.def
@@ -15,8 +15,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(IDETypeChecking, HasDynamicMemberLookupAttributeRequest)
-SWIFT_REQUEST(IDETypeChecking, IsDeclApplicableRequest)
-SWIFT_REQUEST(IDETypeChecking, RootAndResultTypeOfKeypathDynamicMemberRequest)
-SWIFT_REQUEST(IDETypeChecking, RootTypeOfKeypathDynamicMemberRequest)
-SWIFT_REQUEST(IDETypeChecking, TypeRelationCheckRequest)
+SWIFT_REQUEST(IDETypeChecking, HasDynamicMemberLookupAttributeRequest,
+              bool(TypeBase *), Cached)
+SWIFT_REQUEST(IDETypeChecking, IsDeclApplicableRequest,
+              bool(DeclApplicabilityOwner), Cached)
+SWIFT_REQUEST(IDETypeChecking, RootAndResultTypeOfKeypathDynamicMemberRequest,
+              TypePair(SubscriptDecl *), Cached)
+SWIFT_REQUEST(IDETypeChecking, RootTypeOfKeypathDynamicMemberRequest,
+              Type(SubscriptDecl *), Uncached)
+SWIFT_REQUEST(IDETypeChecking, TypeRelationCheckRequest,
+              bool(TypeRelationCheckInput), Cached)

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -265,7 +265,7 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType)                         \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
 template<>                                                       \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
                             const RequestType &request) {        \

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -321,7 +321,7 @@ DefaultAndMaxAccessLevelRequest::cacheResult(
 
 // Define request evaluation functions for each of the access requests.
 static AbstractRequestFunction *accessRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/AccessTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -113,7 +113,7 @@ void GetDestructorRequest::cacheResult(DestructorDecl *value) const {
 
 // Define request evaluation functions for each of the name lookup requests.
 static AbstractRequestFunction *nameLookupRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/NameLookupTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -38,7 +38,7 @@ namespace swift {
 
 // Define request evaluation functions for each of the IDE requests.
 static AbstractRequestFunction *ideRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
 reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/IDE/IDERequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -92,7 +92,7 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
 
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *parseRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -34,7 +34,7 @@ namespace swift {
 
 // Define request evaluation functions for each of the IDE type check requests.
 static AbstractRequestFunction *ideTypeCheckRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
 reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -234,7 +234,7 @@ FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
 
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *typeCheckerRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/TypeCheckerTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -186,7 +186,7 @@ namespace swift {
 
 /// All of the arithmetic request functions.
 static AbstractRequestFunction *arithmeticRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "ArithmeticEvaluatorTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
+++ b/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
@@ -14,6 +14,9 @@
 //  TypeID zone, for use with the TypeID template.
 //
 //===----------------------------------------------------------------------===//
-SWIFT_REQUEST(ArithmeticEvaluator, UncachedEvaluationRule)
-SWIFT_REQUEST(ArithmeticEvaluator, InternallyCachedEvaluationRule)
-SWIFT_REQUEST(ArithmeticEvaluator, ExternallyCachedEvaluationRule)
+SWIFT_REQUEST(ArithmeticEvaluator, UncachedEvaluationRule,
+              double(ArithmeticExpr *), Uncached)
+SWIFT_REQUEST(ArithmeticEvaluator, InternallyCachedEvaluationRule,
+              double(ArithmeticExpr *), Cached)
+SWIFT_REQUEST(ArithmeticEvaluator, ExternallyCachedEvaluationRule,
+              double(ArithmeticExpr *), SeparatelyCached)


### PR DESCRIPTION
Also add their caching kinds.  This information will be used to remove
the need to define classes at all.

Internal commas remain an issue, but only one request required a `using` declaration to work around that.

Should be NFC. 