### PR TITLE
[SIL] Extracted instruction methods from SILCombiner.

### DIFF
--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -22,11 +22,18 @@
 /// ensuring that removing an instruction is not unnecessarily expensive and
 /// that only valid instructions are removed from the list.
 ///
+/// Additionally, SILInstructionWorklist provides conveniences for simple
+/// instruction modifications and ensuring that the appropriate instructions
+/// will be visited accordingly.  For example, if provides a method for 
+/// replacing an operation which has already been removed with a new instruction
+/// determined by a SILInstructionVisitor.
+///
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -126,6 +133,171 @@ public:
     // Do an explicit clear, shrinking the storage if needed.
     worklist.clear();
   }
+
+  /// Find usages of \p I and replace them with usages of \p Result.
+  ///
+  /// Intended to be called during visitation after \p I has been removed from
+  /// the worklist.
+  ///
+  /// \p I the instruction whose usages will be replaced
+  /// \p Result the instruction whose usages will replace \p I
+  bool replaceInstructionWithInstruction(
+      SILInstruction *I, 
+      SILInstruction *Result
+#ifndef NDNEBUG
+     , std::string OrigI
+#endif
+  ) {
+    if (Result != I) {
+      assert(&*std::prev(SILBasicBlock::iterator(I)) == Result &&
+            "Expected new instruction inserted before existing instruction!");
+
+      withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+        stream << loggingName << ": Old = " << *I      << '\n'
+               << "  "        << "  New = " << *Result << '\n';
+      });
+
+      // Everything uses the new instruction now.
+      replaceInstUsesPairwiseWith(I, Result);
+
+      // Push the new instruction and any users onto the worklist.
+      add(Result);
+      addUsersOfAllResultsToWorklist(Result);
+
+      eraseInstFromFunction(*I);
+
+      return true;
+    } else {
+      withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+        stream << loggingName << ": Mod = " << OrigI << '\n'
+               << "  "        << "  New = " << *I    << '\n';
+      });
+
+      // If the instruction was modified, it's possible that it is now dead.
+      // if so, remove it.
+      if (isInstructionTriviallyDead(I)) {
+        eraseInstFromFunction(*I);
+      } else {
+        add(I);
+        addUsersOfAllResultsToWorklist(I);
+      }
+      return false;
+    }
+  }
+
+  // Insert the instruction New before instruction Old in Old's parent BB. Add
+  // New to the worklist.
+  SILInstruction *insertNewInstBefore(SILInstruction *New, SILInstruction &Old) {
+    assert(New && New->getParent() == nullptr &&
+           "New instruction already inserted into a basic block!");
+    SILBasicBlock *BB = Old.getParent();
+    BB->insert(&Old, New);  // Insert inst
+    add(New);
+    return New;
+  }
+
+  // This method is to be used when an instruction is found to be dead,
+  // replaceable with another preexisting expression. Here we add all uses of I
+  // to the worklist, and replace all uses of I with the new value.
+  void replaceInstUsesWith(SingleValueInstruction &I, ValueBase *V) {
+    addUsersToWorklist(&I);   // Add all modified instrs to worklist.
+
+    withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+      stream << loggingName << ": Replacing " << I << '\n'
+             << "  "        << "  with "      << *V << '\n';
+    });
+
+    I.replaceAllUsesWith(V);
+  }
+
+  // This method is to be used when a value is found to be dead,
+  // replaceable with another preexisting expression. Here we add all
+  // uses of oldValue to the worklist, replace all uses of oldValue
+  // with newValue.
+  void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
+    addUsersToWorklist(oldValue); // Add all modified instrs to worklist.
+
+    withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+      stream << loggingName << ": Replacing " << oldValue << '\n'
+             << "  "        << "  with "      << newValue << '\n';
+    });
+
+    oldValue->replaceAllUsesWith(newValue);
+  }
+
+  void replaceInstUsesPairwiseWith(SILInstruction *oldI, SILInstruction *newI) {
+    withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+      stream << loggingName << ": Replacing " << *oldI << '\n'
+             << "  "        << "  with "      << *newI << '\n';
+    });
+
+    auto oldResults = oldI->getResults();
+    auto newResults = newI->getResults();
+    assert(oldResults.size() == newResults.size());
+    for (auto i : indices(oldResults)) {
+      // Add all modified instrs to worklist.
+      addUsersToWorklist(oldResults[i]);
+
+      oldResults[i]->replaceAllUsesWith(newResults[i]);
+    }
+  }
+
+  // Some instructions can never be "trivially dead" due to side effects or
+  // producing a void value. In those cases visit methods should use this
+  // method to delete the given instruction and upon completion of their
+  // peephole return the value returned by this method.
+  void eraseInstFromFunction(SILInstruction &I,
+                                        SILBasicBlock::iterator &InstIter,
+                                        bool AddOperandsToWorklist = true) {
+    // Delete any debug users first.
+    for (auto result : I.getResults()) {
+      while (!result->use_empty()) {
+        auto *user = result->use_begin()->getUser();
+        assert(user->isDebugInstruction());
+        if (InstIter == user->getIterator())
+          ++InstIter;
+        erase(user);
+        user->eraseFromParent();
+      }
+    }
+    if (InstIter == I.getIterator())
+      ++InstIter;
+
+    eraseSingleInstFromFunction(I, AddOperandsToWorklist);
+  }
+
+  void eraseInstFromFunction(SILInstruction &I,
+                             bool AddOperandsToWorklist = true) {
+    SILBasicBlock::iterator nullIter;
+    return eraseInstFromFunction(I, nullIter, AddOperandsToWorklist);
+  }
+
+  void eraseSingleInstFromFunction(
+      SILInstruction &I,
+      bool AddOperandsToWorklist) {
+      withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+        stream << loggingName << ": ERASE " << I << '\n';
+      });
+
+    assert(!I.hasUsesOfAnyResult() && "Cannot erase instruction that is used!");
+
+    // Make sure that we reprocess all operands now that we reduced their
+    // use counts.
+    if (I.getNumOperands() < 8 && AddOperandsToWorklist) {
+      for (auto &OpI : I.getAllOperands()) {
+        if (auto *Op = OpI.get()->getDefiningInstruction()) {
+          withDebugStream([&](llvm::raw_ostream &stream, StringRef loggingName) {
+            stream << loggingName << ": add op " << *Op << '\n'
+                                  << " from erased inst to worklist\n";
+          });
+          add(Op);
+        }
+      }
+    }
+    erase(&I);
+    I.eraseFromParent();
+  }
+
 };
 
 // TODO: This name is somewhat unpleasant.  Once the type is templated over its

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -101,29 +101,6 @@ void SILCombiner::addReachableCodeToWorklist(SILBasicBlock *BB) {
   addInitialGroup(InstrsForSILCombineWorklist);
 }
 
-static void eraseSingleInstFromFunction(
-    SILInstruction &I,
-    SmallSILInstructionWorklist<256> &Worklist,
-    bool AddOperandsToWorklist) {
-  LLVM_DEBUG(llvm::dbgs() << "SC: ERASE " << I << '\n');
-
-  assert(!I.hasUsesOfAnyResult() && "Cannot erase instruction that is used!");
-
-  // Make sure that we reprocess all operands now that we reduced their
-  // use counts.
-  if (I.getNumOperands() < 8 && AddOperandsToWorklist) {
-    for (auto &OpI : I.getAllOperands()) {
-      if (auto *Op = OpI.get()->getDefiningInstruction()) {
-        LLVM_DEBUG(llvm::dbgs() << "SC: add op " << *Op
-                                << " from erased inst to worklist\n");
-        Worklist.add(Op);
-      }
-    }
-  }
-  Worklist.erase(&I);
-  I.eraseFromParent();
-}
-
 //===----------------------------------------------------------------------===//
 //                               Implementation
 //===----------------------------------------------------------------------===//
@@ -147,8 +124,8 @@ public:
   // Just delete the given 'inst' and record its operands. The callback isn't
   // allowed to mutate any other instructions.
   void killInstruction(SILInstruction *inst) override {
-    eraseSingleInstFromFunction(*inst, Worklist,
-                                /*AddOperandsToWorklist*/ true);
+    Worklist.eraseSingleInstFromFunction(*inst,
+                                         /*AddOperandsToWorklist*/ true);
     changed = true;
   }
 
@@ -216,34 +193,12 @@ bool SILCombiner::doOneIteration(SILFunction &F, unsigned Iteration) {
     if (SILInstruction *Result = visit(I)) {
       ++NumCombined;
       // Should we replace the old instruction with a new one?
-      if (Result != I) {
-        assert(&*std::prev(SILBasicBlock::iterator(I)) == Result &&
-              "Expected new instruction inserted before existing instruction!");
-
-        LLVM_DEBUG(llvm::dbgs() << "SC: Old = " << *I << '\n'
-                                << "    New = " << *Result << '\n');
-
-        // Everything uses the new instruction now.
-        replaceInstUsesPairwiseWith(I, Result);
-
-        // Push the new instruction and any users onto the worklist.
-        Worklist.add(Result);
-        Worklist.addUsersOfAllResultsToWorklist(Result);
-
-        eraseInstFromFunction(*I);
-      } else {
-        LLVM_DEBUG(llvm::dbgs() << "SC: Mod = " << OrigI << '\n'
-                                << "    New = " << *I << '\n');
-
-        // If the instruction was modified, it's possible that it is now dead.
-        // if so, remove it.
-        if (isInstructionTriviallyDead(I)) {
-          eraseInstFromFunction(*I);
-        } else {
-          Worklist.add(I);
-          Worklist.addUsersOfAllResultsToWorklist(I);
-        }
-      }
+      Worklist.replaceInstructionWithInstruction(I, Result
+#ifndef NDEBUG
+          ,
+          OrigI
+#endif
+      );
       MadeChange = true;
     }
 
@@ -276,88 +231,6 @@ bool SILCombiner::runOnFunction(SILFunction &F) {
 
   // Cleanup the builder and return whether or not we made any changes.
   return Changed;
-}
-
-// Insert the instruction New before instruction Old in Old's parent BB. Add
-// New to the worklist.
-SILInstruction *SILCombiner::insertNewInstBefore(SILInstruction *New,
-                                                 SILInstruction &Old) {
-  assert(New && New->getParent() == nullptr &&
-         "New instruction already inserted into a basic block!");
-  SILBasicBlock *BB = Old.getParent();
-  BB->insert(&Old, New);  // Insert inst
-  Worklist.add(New);
-  return New;
-}
-
-// This method is to be used when an instruction is found to be dead,
-// replaceable with another preexisting expression. Here we add all uses of I
-// to the worklist, replace all uses of I with the new value, then return I,
-// so that the combiner will know that I was modified.
-void SILCombiner::replaceInstUsesWith(SingleValueInstruction &I, ValueBase *V) {
-  Worklist.addUsersToWorklist(&I);   // Add all modified instrs to worklist.
-
-  LLVM_DEBUG(llvm::dbgs() << "SC: Replacing " << I << "\n"
-                          << "    with " << *V << '\n');
-
-  I.replaceAllUsesWith(V);
-}
-
-void SILCombiner::replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
-  Worklist.addUsersToWorklist(oldValue); // Add all modified instrs to worklist.
-
-  LLVM_DEBUG(llvm::dbgs() << "SC: Replacing " << oldValue << "\n"
-                          << "    with " << newValue << '\n');
-
-  oldValue->replaceAllUsesWith(newValue);
-}
-
-/// Replace all of the results of the old instruction with the
-/// corresponding results of the new instruction.
-void SILCombiner::replaceInstUsesPairwiseWith(SILInstruction *oldI,
-                                              SILInstruction *newI) {
-  LLVM_DEBUG(llvm::dbgs() << "SC: Replacing " << *oldI << "\n"
-                          << "    with " << *newI << '\n');
-
-  auto oldResults = oldI->getResults();
-  auto newResults = newI->getResults();
-  assert(oldResults.size() == newResults.size());
-  for (auto i : indices(oldResults)) {
-    // Add all modified instrs to worklist.
-    Worklist.addUsersToWorklist(oldResults[i]);
-
-    oldResults[i]->replaceAllUsesWith(newResults[i]);
-  }
-}
-
-// Some instructions can never be "trivially dead" due to side effects or
-// producing a void value. In those cases, since we cannot rely on
-// SILCombines trivially dead instruction DCE in order to delete the
-// instruction, visit methods should use this method to delete the given
-// instruction and upon completion of their peephole return the value returned
-// by this method.
-SILInstruction *
-SILCombiner::eraseInstFromFunction(SILInstruction &I,
-                                   SILBasicBlock::iterator &InstIter,
-                                   bool AddOperandsToWorklist) {
-  // Delete any debug users first.
-  for (auto result : I.getResults()) {
-    while (!result->use_empty()) {
-      auto *user = result->use_begin()->getUser();
-      assert(user->isDebugInstruction());
-      if (InstIter == user->getIterator())
-        ++InstIter;
-      Worklist.erase(user);
-      user->eraseFromParent();
-    }
-  }
-  if (InstIter == I.getIterator())
-    ++InstIter;
-
-  eraseSingleInstFromFunction(I, Worklist, AddOperandsToWorklist);
-  MadeChange = true;
-  // Dummy return, so the caller doesn't need to explicitly return nullptr.
-  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -103,21 +103,30 @@ public:
 
   // Insert the instruction New before instruction Old in Old's parent BB. Add
   // New to the worklist.
-  SILInstruction *insertNewInstBefore(SILInstruction *New, SILInstruction &Old);
+  SILInstruction *insertNewInstBefore(SILInstruction *New,
+                                      SILInstruction &Old) {
+    return Worklist.insertNewInstBefore(New, Old);
+  }
 
   // This method is to be used when an instruction is found to be dead,
   // replaceable with another preexisting expression. Here we add all uses of I
   // to the worklist, replace all uses of I with the new value, then return I,
   // so that the combiner will know that I was modified.
-  void replaceInstUsesWith(SingleValueInstruction &I, ValueBase *V);
+  void replaceInstUsesWith(SingleValueInstruction &I, ValueBase *V) {
+    return Worklist.replaceInstUsesWith(I, V);
+  }
 
   // This method is to be used when a value is found to be dead,
   // replaceable with another preexisting expression. Here we add all
   // uses of oldValue to the worklist, replace all uses of oldValue
   // with newValue.
-  void replaceValueUsesWith(SILValue oldValue, SILValue newValue);
+  void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
+    Worklist.replaceValueUsesWith(oldValue, newValue);
+  }
 
-  void replaceInstUsesPairwiseWith(SILInstruction *oldI, SILInstruction *newI);
+  void replaceInstUsesPairwiseWith(SILInstruction *oldI, SILInstruction *newI) {
+    Worklist.replaceInstUsesPairwiseWith(oldI, newI);
+  }
 
   // Some instructions can never be "trivially dead" due to side effects or
   // producing a void value. In those cases, since we cannot rely on
@@ -127,7 +136,12 @@ public:
   // by this method.
   SILInstruction *eraseInstFromFunction(SILInstruction &I,
                                         SILBasicBlock::iterator &InstIter,
-                                        bool AddOperandsToWorklist = true);
+                                        bool AddOperandsToWorklist = true) {
+    Worklist.eraseInstFromFunction(I, InstIter, AddOperandsToWorklist);
+    MadeChange = true;
+    // Dummy return, so the caller doesn't need to explicitly return nullptr.
+    return nullptr;
+  }
 
   SILInstruction *eraseInstFromFunction(SILInstruction &I,
                                         bool AddOperandsToWorklist = true) {


### PR DESCRIPTION
`SILCombiner` has a number of conveniences for inserting, replacing, and removing instructions that involve modifying a worklist as part of their behavior.  

The conveniences are added to `SILInstructionWorklist` in the first commit ("[SIL] Extracted instruction methods from SILCombiner."). 

In the second commit ("[SILCombiner] Use methods from SILInstructionWorklist."), `SILCombiner` is modified to call through to the methods which were added to `SILInstructionWorklist`.

In the third commit ("[SIL] Tweaked worklist instruction methods' style."), the methods' style is tweaked slightly.

At the moment there is an extra commit stemming from the PR (https://github.com/apple/swift/pull/27028) that this is based on.