### PR TITLE
Remove warnings from TestJSONEncoder compilation.

### DIFF
--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -669,7 +669,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     do {
       _ = try encoder.encode(toEncode)
-    } catch EncodingError.invalidValue(let (_, context)) {
+    } catch EncodingError.invalidValue(_, let context) {
       expectEqual(2, context.codingPath.count)
       expectEqual("key", context.codingPath[0].stringValue)
       expectEqual("someValue", context.codingPath[1].stringValue)
@@ -685,7 +685,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     do {
       _ = try encoder.encode(toEncode)
-    } catch EncodingError.invalidValue(let (_, context)) {
+    } catch EncodingError.invalidValue(_, let context) {
       expectEqual(4, context.codingPath.count)
       expectEqual("key", context.codingPath[0].stringValue)
       expectEqual("sub_key", context.codingPath[1].stringValue)
@@ -838,7 +838,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     do {
       _ = try decoder.decode([String: Int].self, from: input)
-    } catch DecodingError.typeMismatch(let (_, context)) {
+    } catch DecodingError.typeMismatch(_, let context) {
       expectEqual(1, context.codingPath.count)
       expectEqual("leave_me_alone", context.codingPath[0].stringValue)
     } catch {
@@ -860,7 +860,7 @@ class TestJSONEncoder : TestJSONEncoderSuper {
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     do {
       _ = try decoder.decode([String: [String : DecodeFailureNested]].self, from: input)
-    } catch DecodingError.typeMismatch(let (_, context)) {
+    } catch DecodingError.typeMismatch(_, let context) {
       expectEqual(4, context.codingPath.count)
       expectEqual("top_level", context.codingPath[0].stringValue)
       expectEqual("sub_level", context.codingPath[1].stringValue)


### PR DESCRIPTION
Since the introduction of #26357/SR-11160 the TestJSONEncoder seems to
have been emitting the new warnings related to tuples being incorrectly
pattern matched.

The changes remove the incorrect code (removing the parenthesis around
the pattern).

Should not have any other effect (and the effect was not normally
visible if the test was successful, anyway).

/cc @varungandhi-apple 