### PR TITLE
[SILOptimizer] Added MandatoryCombiner.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -312,6 +312,8 @@ PASS(SerializeSILPass, "serialize-sil",
 PASS(YieldOnceCheck, "yield-once-check",
     "Check correct usage of yields in yield-once coroutines")
 PASS(OSLogOptimization, "os-log-optimization", "Optimize os log calls")
+PASS(MandatoryCombine, "mandatory-combine",
+    "Perform mandatory peephole combines")
 PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS_RANGE(AllPasses, AADumper, BugReducerTester)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -21,5 +21,6 @@ silopt_register_sources(
   SemanticARCOpts.cpp
   SILGenCleanup.cpp
   YieldOnceCheck.cpp
+  MandatoryCombine.cpp
   OSLogOptimization.cpp
 )

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -1,0 +1,230 @@
+//===------- MandatoryCombiner.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  \file
+///
+///  Defines the MandatoryCombiner function transform.  The pass contains basic
+///  instruction combines to be performed at the begining of both the Onone and
+///  also the performance pass pipelines, after the diagnostics passes have been
+///  run.  It is intended to be run before and to be independent of other
+///  transforms.
+///
+///  The intention of this pass is to be a place for mandatory peepholes that
+///  are not needed for diagnostics. Please put any such peepholes here instead
+///  of in the diagnostic passes.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-mandatory-combiner"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/SIL/SILInstructionWorklist.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+
+using namespace swift;
+
+namespace {
+
+class MandatoryCombiner final
+    : public SILInstructionVisitor<MandatoryCombiner, SILInstruction *> {
+
+  using Worklist = SmallSILInstructionWorklist<256>;
+
+  /// The list of instructions remaining to visit, perhaps to combine.
+  Worklist worklist;
+
+  /// Whether any changes have been made.
+  bool madeChange;
+
+  /// The number of times that the worklist has been processed.
+  unsigned iteration;
+
+  InstModCallbacks instModCallbacks;
+  SmallVectorImpl<SILInstruction *> &createdInstructions;
+  SmallVector<SILInstruction *, 16> instructionsPendingDeletion;
+
+public:
+  MandatoryCombiner(
+      SmallVectorImpl<SILInstruction *> &createdInstructions)
+      : worklist("MC"), madeChange(false), iteration(0),
+        instModCallbacks(
+            [&](SILInstruction *instruction) {
+              worklist.erase(instruction);
+              instructionsPendingDeletion.push_back(instruction);
+            },
+            [&](SILInstruction *instruction) { worklist.add(instruction); }),
+        createdInstructions(createdInstructions){};
+
+  /// Base visitor that does not do anything.
+  SILInstruction *visitSILInstruction(SILInstruction *) { return nullptr; }
+
+  void addReachableCodeToWorklist(SILFunction &function) {
+    SmallBlotSetVector<SILBasicBlock *, 32> blockWorklist;
+    SmallBlotSetVector<SILBasicBlock *, 32> blocksVisited;
+    SmallVector<SILInstruction *, 128> instructions;
+
+    blockWorklist.insert(&*function.begin());
+    while (!blockWorklist.empty()) {
+      auto *block = blockWorklist.pop_back_val().getValueOr(nullptr);
+      if (block == nullptr) {
+        continue;
+      }
+
+      if (!blocksVisited.insert(block).second) {
+        continue;
+      }
+
+      for (auto iterator = block->begin(), end = block->end(); iterator != end;) {
+        auto *instruction = &*iterator;
+        ++iterator;
+
+        if (isInstructionTriviallyDead(instruction)) {
+          continue;
+        }
+
+        instructions.push_back(instruction);
+      }
+
+      for_each(block->getSuccessorBlocks(), [&](SILBasicBlock *block) {
+        blockWorklist.insert(block);
+      });
+    }
+
+    worklist.addInitialGroup(instructions);
+  }
+
+  /// \return whether a change was made.
+  bool doOneIteration(SILFunction &function, unsigned iteration) {
+    madeChange = false;
+
+    addReachableCodeToWorklist(function);
+
+    while (!worklist.isEmpty()) {
+      auto *instruction = worklist.pop_back_val();
+      if (instruction == nullptr) {
+        continue;
+      }
+
+#ifndef NDEBUG
+      std::string instructionDescription;
+#endif
+      LLVM_DEBUG(llvm::raw_string_ostream SS(instructionDescription);
+                 instruction->print(SS); instructionDescription = SS.str(););
+      LLVM_DEBUG(llvm::dbgs()
+                 << "MC: Visiting: " << instructionDescription << '\n');
+
+      if (auto replacement = visit(instruction)) {
+        worklist.replaceInstructionWithInstruction(instruction, replacement
+#ifndef NDEBUG
+            , instructionDescription
+#endif
+          );
+      }
+
+      for (SILInstruction *instruction : instructionsPendingDeletion) {
+        worklist.eraseInstFromFunction(*instruction);
+      }
+      instructionsPendingDeletion.clear();
+
+      // Our tracking list has been accumulating instructions created by the
+      // SILBuilder during this iteration. Go through the tracking list and add
+      // its contents to the worklist and then clear said list in preparation
+      // for the next iteration.
+      for (SILInstruction *instruction : createdInstructions) {
+        LLVM_DEBUG(llvm::dbgs() << "MC: add " << *instruction
+                                << " from tracking list to worklist\n");
+        worklist.add(instruction);
+      }
+      createdInstructions.clear();
+    }
+
+    worklist.resetChecked();
+    return madeChange;
+  }
+
+  void clear() {
+    iteration = 0;
+    worklist.resetChecked();
+    madeChange = false;
+  }
+
+
+  /// Applies the MandatoryCombiner to the provided function.
+  ///
+  /// \param function the function to which to apply the MandatoryCombiner.
+  ///
+  /// \return whether a change was made.
+  bool runOnFunction(SILFunction &function) {
+    bool changed = false;
+
+    while (doOneIteration(function, iteration)) {
+      changed = true;
+      ++iteration;
+    }
+
+    return changed;
+  }
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MandatoryCombine final : public SILFunctionTransform {
+
+  SmallVector<SILInstruction *, 64> createdInstructions;
+
+  void run() override {
+    auto *function = getFunction();
+
+    MandatoryCombiner combiner(createdInstructions);
+    bool madeChange = combiner.runOnFunction(*function);
+
+    if (madeChange) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+
+  void handleDeleteNotification(SILNode *node) override {
+    // Remove instructions that were both created and deleted from the list of
+    // created instructions which will eventually be added to the worklist.
+
+    auto *instruction = dyn_cast<SILInstruction>(node);
+    if (instruction == nullptr) {
+      return;
+    }
+
+    // Linear searching the tracking list doesn't hurt because usually it only
+    // contains a few elements.
+    auto iterator = find(createdInstructions, instruction);
+    if (createdInstructions.end() != iterator) {
+      createdInstructions.erase(iterator);
+    }
+  }
+
+  bool needsNotifications() override { return true; }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createMandatoryCombine() { return new MandatoryCombine(); }


### PR DESCRIPTION
Minimal commit to get the mandatory combiner rolling.  The intent of the mandatory combiner is to do basic transformations after the diagnostics passes have run at the beginning of both the Onone and the performance pipelines.  For now, it simply visits reachable instructions and does no work.  

In a subsequent commit, apply instructions will be processed and replaced if they are calls to partial applies defined in the same function.  At that point an attempt will be made to eliminate the partial apply altogether.

For now, the pass does no work and is not part of any pipeline.