### PR TITLE
[opt-transform-range] Do not assume that Range::iterator exists.

### DIFF
--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -611,7 +611,7 @@ makeOptionalTransformIterator(Iterator current, Iterator end,
 
 /// A range filtered and transformed by the optional transform.
 template <typename Range, typename OptionalTransform,
-          typename Iterator = typename Range::iterator>
+          typename Iterator = decltype(std::declval<Range>().begin())>
 class OptionalTransformRange {
 
   Iterator First, Last;


### PR DESCRIPTION
The reason not to do this is that some important range
adapters (e.x. llvm::iterator_range) do not have such a typedef. Rather than
changing upstream this commit just fixes the problem by inferring the iterator
type from the result of Range::begin().

TLDR: This makes OptionalTransformRange work with llvm::iterator_range.
