### PR TITLE
Fix some debugging on SIL level (-gsil) problems

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -152,6 +152,9 @@ private:
   /// The source location and scope of the function.
   const SILDebugScope *DebugScope;
 
+  /// The AST decl context of the function.
+  DeclContext *DeclCtxt;
+
   /// The profiler for instrumentation based profiling, or null if profiling is
   /// disabled.
   SILProfiler *Profiler = nullptr;
@@ -614,10 +617,8 @@ public:
     ExactSelfClass = t;
   }
 
-  /// Get the DeclContext of this function. (Debug info only).
-  DeclContext *getDeclContext() const {
-    return getLocation().getAsDeclContext();
-  }
+  /// Get the DeclContext of this function.
+  DeclContext *getDeclContext() const { return DeclCtxt; }
 
   /// \returns True if the function is marked with the @_semantics attribute
   /// and has special semantics that the optimizer can use to optimize the
@@ -704,8 +705,16 @@ public:
     return getDebugScope()->Loc;
   }
 
-  /// Initialize the debug scope of the function.
-  void setDebugScope(const SILDebugScope *DS) { DebugScope = DS; }
+  /// Initialize the debug scope of the function and also set the DeclCtxt.
+  void setDebugScope(const SILDebugScope *DS) {
+    DebugScope = DS;
+    DeclCtxt = (DS ? DebugScope->Loc.getAsDeclContext() : nullptr);
+  }
+
+  /// Initialize the debug scope for debug info on SIL level (-gsil).
+  void setSILDebugScope(const SILDebugScope *DS) {
+    DebugScope = DS;
+  }
 
   /// Get the source location of the function.
   const SILDebugScope *getDebugScope() const { return DebugScope; }

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -93,7 +93,7 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          IsExactSelfClass_t isExactSelfClass)
     : Module(Module), Name(Name), LoweredType(LoweredType),
       GenericEnv(genericEnv), SpecializationInfo(nullptr),
-      DebugScope(DebugScope), Bare(isBareSILFunction), Transparent(isTrans),
+      Bare(isBareSILFunction), Transparent(isTrans),
       Serialized(isSerialized), Thunk(isThunk),
       ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
       InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
@@ -104,6 +104,7 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
       EffectsKindAttr(E), EntryCount(entryCount) {
   assert(!Transparent || !IsDynamicReplaceable);
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
+  setDebugScope(DebugScope);
 
   if (InsertBefore)
     Module.functions.insert(SILModule::iterator(InsertBefore), this);

--- a/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
@@ -128,7 +128,7 @@ class SILDebugInfoGenerator : public SILModuleTransform {
         SILLocation::DebugLoc DL(Ctx.LCS.LineNum, 1, FileNameBuf);
         RegularLocation Loc(DL);
         SILDebugScope *Scope = new (*M) SILDebugScope(Loc, F);
-        F->setDebugScope(Scope);
+        F->setSILDebugScope(Scope);
 
         // Ensure that the function is visible for debugging.
         F->setBare(IsNotBare);
@@ -141,16 +141,24 @@ class SILDebugInfoGenerator : public SILModuleTransform {
       for (SILFunction *F : PrintedFuncs) {
         const SILDebugScope *Scope = F->getDebugScope();
         for (SILBasicBlock &BB : *F) {
-          for (SILInstruction &I : BB) {
-            SILLocation Loc = I.getLoc();
-            SILLocation::DebugLoc DL(Ctx.LineNums[&I], 1, FileNameBuf);
+          for (auto iter = BB.begin(), end = BB.end(); iter != end;) {
+            SILInstruction *I = &*iter;
+            ++iter;
+            if (isa<DebugValueInst>(I) || isa<DebugValueAddrInst>(I)) {
+              // debug_value and debug_value_addr are not needed anymore.
+              // Also, keeping them might trigger a verifier error.
+              I->eraseFromParent();
+              continue;
+            }
+            SILLocation Loc = I->getLoc();
+            SILLocation::DebugLoc DL(Ctx.LineNums[I], 1, FileNameBuf);
             assert(DL.Line && "no line set for instruction");
             if (Loc.is<ReturnLocation>() || Loc.is<ImplicitReturnLocation>()) {
               Loc.setDebugInfoLoc(DL);
-              I.setDebugLocation(SILDebugLocation(Loc, Scope));
+              I->setDebugLocation(SILDebugLocation(Loc, Scope));
             } else {
               RegularLocation RLoc(DL);
-              I.setDebugLocation(SILDebugLocation(RLoc, Scope));
+              I->setDebugLocation(SILDebugLocation(RLoc, Scope));
             }
           }
         }

--- a/test/DebugInfo/Inputs/testclass.swift
+++ b/test/DebugInfo/Inputs/testclass.swift
@@ -1,0 +1,5 @@
+
+open class X {
+  public var testvar: Int = 27
+}
+

--- a/test/DebugInfo/gsil.swift
+++ b/test/DebugInfo/gsil.swift
@@ -3,6 +3,9 @@
 // RUN: %FileCheck %s < %t/out.ir
 // RUN: %FileCheck %s --check-prefix=CHECK_OUT_SIL < %t/out.ir.gsil_0.sil
 
+// Second test: check that we don't crash with multi-threaded IRGen
+// RUN: %target-swift-frontend -c %s %S/Inputs/testclass.swift -wmo -O -num-threads 1 -gsil -o %t/gsil.o -o %t/testclass.o
+
 // CHECK: !DIFile(filename: "{{.+}}gsil.swift", directory: "{{.+}}")
 // CHECK: [[F:![0-9]+]] = !DIFile(filename: "{{.+}}out.ir.gsil_0.sil",
 // CHECK: !DISubprogram(linkageName: "$s3out6testityyF", scope: !{{[0-9]+}}, file: [[F]], line: {{[1-9][0-9]+}},


### PR DESCRIPTION
* Fix multi-threaded IRGen: store the DeclContext in a SILFunction explicitly instead of deriving it from the debug location. It's used in IRGen to decide into which module a function is emitted. With -gsil the debug location is changed and that should not change the module decision.

* Erase debug_value/debug_value_addr instructions when using -gsil. Those instructions are not needed anymore. They can also trigger a verifier error.
