### PR TITLE
[CS] Allow getCalleeLocator to look through optional chaining

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -158,8 +158,8 @@ Type FailureDiagnostic::resolveInterfaceType(Type type,
 
 /// Given an apply expr, returns true if it is expected to have a direct callee
 /// overload, resolvable using `getChoiceFor`. Otherwise, returns false.
-static bool shouldHaveDirectCalleeOverload(const ApplyExpr *apply) {
-  auto *fnExpr = apply->getFn()->getValueProvidingExpr();
+static bool shouldHaveDirectCalleeOverload(const CallExpr *callExpr) {
+  auto *fnExpr = callExpr->getDirectCallee();
 
   // An apply of an apply/subscript doesn't have a direct callee.
   if (isa<ApplyExpr>(fnExpr) || isa<SubscriptExpr>(fnExpr))
@@ -169,11 +169,9 @@ static bool shouldHaveDirectCalleeOverload(const ApplyExpr *apply) {
   if (isa<ClosureExpr>(fnExpr))
     return false;
 
-  // If the optionality changes, there's no direct callee.
-  if (isa<BindOptionalExpr>(fnExpr) || isa<ForceValueExpr>(fnExpr) ||
-      isa<OptionalTryExpr>(fnExpr)) {
+  // No direct callee for a try!/try?.
+  if (isa<ForceTryExpr>(fnExpr) || isa<OptionalTryExpr>(fnExpr))
     return false;
-  }
 
   // If we have an intermediate cast, there's no direct callee.
   if (isa<ExplicitCastExpr>(fnExpr))

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -432,8 +432,15 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(Expr *expr) {
       return getConstraintLocator(fnLocator,
                                   ConstraintLocator::ConstructorMember);
     }
-    // Otherwise fall through and look for locators anchored on the fn expr.
-    expr = fnExpr->getSemanticsProvidingExpr();
+
+    // Otherwise fall through and look for locators anchored on the function
+    // expr. For CallExprs, this can look through things like parens and
+    // optional chaining.
+    if (auto *callExpr = dyn_cast<CallExpr>(expr)) {
+      expr = callExpr->getDirectCallee();
+    } else {
+      expr = fnExpr;
+    }
   }
 
   if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -169,7 +169,7 @@ func returnsTakesEscapingFn() -> (@escaping () -> Int) -> Void { takesEscapingFn
 prefix operator ^^^
 prefix func ^^^(_ x: Int) -> (@escaping () -> Int) -> Void { takesEscapingFn }
 
-func testWeirdFnExprs<T>(_ fn: () -> Int, _ cond: Bool, _ any: Any, genericArg: T) { // expected-note 11{{parameter 'fn' is implicitly non-escaping}}
+func testWeirdFnExprs<T>(_ fn: () -> Int, _ cond: Bool, _ any: Any, genericArg: T) { // expected-note 12{{parameter 'fn' is implicitly non-escaping}}
   (any as! (@escaping () -> Int) -> Void)(fn)
   // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 
@@ -181,6 +181,9 @@ func testWeirdFnExprs<T>(_ fn: () -> Int, _ cond: Bool, _ any: Any, genericArg: 
   // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 
   (^^^5)(fn)
+  // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+
+  (try! takesEscapingFn)(fn)
   // expected-error@-1 {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
 
   var optFn: Optional = takesEscapingFn

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -10,8 +10,8 @@ class A {
   @objc(do_b_2:) func do_b(_ x: Int) {}
   @objc func do_b(_ x: Float) {}
 
-  @objc func do_c(x: Int) {}
-  @objc func do_c(y: Int) {}
+  @objc func do_c(x: Int) {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(x:)')}}
+  @objc func do_c(y: Int) {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(y:)')}}
 }
 
 func test0(_ a: AnyObject) {
@@ -20,7 +20,7 @@ func test0(_ a: AnyObject) {
   a.do_b?(1)
   a.do_b?(5.0)
 
-  a.do_c?(1) // expected-error {{cannot invoke value of function type with argument list '(Int)'}}
+  a.do_c?(1) // expected-error {{no exact matches in call to instance method 'do_c'}}
   a.do_c?(x: 1)
 }
 


### PR DESCRIPTION
This is something that can happen for things like dynamic member lookup, and is therefore something we want to find callees for.