### PR TITLE
Minor simplification to `FixedWidthInteger._random(using: &generator)`.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3365,19 +3365,9 @@ extension FixedWidthInteger {
   public static func _random<R: RandomNumberGenerator>(
     using generator: inout R
   ) -> Self {
-    if bitWidth <= UInt64.bitWidth {
-      return Self(truncatingIfNeeded: generator.next() as UInt64)
+    stride(from: 0, to: bitWidth, by: 64).reduce(into: .zero) {
+      $0 |= Self(truncatingIfNeeded: generator.next()) &<< $1
     }
-
-    let (quotient, remainder) = bitWidth.quotientAndRemainder(
-      dividingBy: UInt64.bitWidth
-    )
-    var tmp: Self = 0
-    for i in 0 ..< quotient + remainder.signum() {
-      let next: UInt64 = generator.next()
-      tmp += Self(truncatingIfNeeded: next) &<< (UInt64.bitWidth * i)
-    }
-    return tmp
   }
 }
 

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -160,3 +160,9 @@ public struct SystemRandomNumberGenerator: RandomNumberGenerator {
     return random
   }
 }
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@_silgen_name("arc4random_buf")
+@usableFromInline
+internal func swift_stdlib_random(_: inout UInt64, _: Int)
+#endif


### PR DESCRIPTION
We don't actually need a divide or two paths or any of the other complexity here; the optimizer knows how to do this for us.