### PR TITLE
[Evaluator Ergonomics] Add location information options to the requests

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -105,12 +105,12 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
-}
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+  template <>                                                                  \
+  inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
+                                     const RequestType &request) {             \
+    ++stats.getFrontendCounters().RequestType;                                 \
+  }
 #include "swift/AST/AccessTypeIDZone.def"
 #undef SWIFT_REQUEST
 

--- a/include/swift/AST/AccessTypeIDZone.def
+++ b/include/swift/AST/AccessTypeIDZone.def
@@ -16,8 +16,9 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(AccessControl, AccessLevelRequest, AccessLevel(ValueDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(AccessControl, DefaultAndMaxAccessLevelRequest,
-              DefaultAndMax(ExtensionDecl *), SeparatelyCached)
+              DefaultAndMax(ExtensionDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(AccessControl, SetterAccessLevelRequest,
-              AccessLevel(AbstractStorageDecl *), SeparatelyCached)
+              AccessLevel(AbstractStorageDecl *), SeparatelyCached,
+              NoLocationInfo)

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -448,6 +448,17 @@ getDirectlyInheritedNominalTypeDecls(
 SelfBounds getSelfBoundsFromWhereClause(
     llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl);
 
+/// Retrieve the TypeLoc at the given \c index from among the set of
+/// type declarations that are directly "inherited" by the given declaration.
+inline TypeLoc &
+getInheritedTypeLocAtIndex(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+                           unsigned index) {
+  if (auto typeDecl = decl.dyn_cast<TypeDecl *>())
+    return typeDecl->getInherited()[index];
+
+  return decl.get<ExtensionDecl *>()->getInherited()[index];
+}
+
 namespace namelookup {
 
 /// Searches through statements and patterns for local variable declarations.

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -62,10 +62,6 @@ class InheritedDeclsReferencedRequest :
                          unsigned),
                        CacheKind::Uncached> // FIXME: Cache these
 {
-  /// Retrieve the TypeLoc for this inherited type.
-  TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                      unsigned index) const;
-
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -265,12 +265,12 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
-}
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+  template <>                                                                  \
+  inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
+                                     const RequestType &request) {             \
+    ++stats.getFrontendCounters().RequestType;                                 \
+  }
 #include "swift/AST/NameLookupTypeIDZone.def"
 #undef SWIFT_REQUEST
 

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -16,21 +16,25 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
-              NominalTypeDecl *(CustomAttr *, DeclContext *), Cached)
+              NominalTypeDecl *(CustomAttr *, DeclContext *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
-              NominalTypeDecl *(ExtensionDecl *), SeparatelyCached)
+              NominalTypeDecl *(ExtensionDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, GetDestructorRequest, DestructorDecl *(ClassDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, InheritedDeclsReferencedRequest,
               DirectlyReferencedTypeDecls(
                   llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned),
-              Uncached)
+              Uncached, HasNearestLocation)
 SWIFT_REQUEST(NameLookup, SelfBoundsFromWhereClauseRequest,
               SelfBounds(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>),
-              Uncached)
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, SuperclassDeclRequest, ClassDecl *(NominalTypeDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(NameLookup, TypeDeclsFromWhereClauseRequest,
-              DirectlyReferencedTypeDecls(ExtensionDecl *), Uncached)
+              DirectlyReferencedTypeDecls(ExtensionDecl *), Uncached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, UnderlyingTypeDeclsReferencedRequest,
-              DirectlyReferencedTypeDecls(TypeAliasDecl *), Uncached)
+              DirectlyReferencedTypeDecls(TypeAliasDecl *), Uncached,
+              NoLocationInfo)

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -78,12 +78,12 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)           \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
-}
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+  template <>                                                                  \
+  inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
+                                     const RequestType &request) {             \
+    ++stats.getFrontendCounters().RequestType;                                 \
+  }
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST
 

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(Parse, ParseMembersRequest,
-              ArrayRef<Decl *>(IterableDeclContext *), Cached)
+              ArrayRef<Decl *>(IterableDeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(Parse, ParseAbstractFunctionBodyRequest,
-              BraceStmt *(AbstractFunctionDecl *), SeparatelyCached)
+              BraceStmt *(AbstractFunctionDecl *), SeparatelyCached,
+              NoLocationInfo)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -57,10 +57,6 @@ class InheritedTypeRequest :
                               TypeResolutionStage),
                          CacheKind::SeparatelyCached>
 {
-  /// Retrieve the TypeLoc for this inherited type.
-  TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                      unsigned index) const;
-
 public:
   using SimpleRequest::SimpleRequest;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1195,12 +1195,12 @@ void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
-}
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+  template<>                                                                   \
+  inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
+                              const RequestType &request) {                    \
+    ++stats.getFrontendCounters().RequestType;                                 \
+  }
 #include "swift/AST/TypeCheckerTypeIDZone.def"
 #undef SWIFT_REQUEST
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -19,100 +19,115 @@ SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest,
               GenericSignature *(GenericSignature *,
                                  SmallVector<GenericTypeParamType *, 2>,
                                  SmallVector<Requirement, 2>),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedFunctionBuilderRequest,
-              CustomAttr *(ValueDecl *), Cached)
+              CustomAttr *(ValueDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedPropertyWrapperTypeRequest,
-              Type(VarDecl *, unsigned), Cached)
+              Type(VarDecl *, unsigned), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest,
-              llvm::TinyPtrVector<CustomAttr *>(VarDecl *), Cached)
+              llvm::TinyPtrVector<CustomAttr *>(VarDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
-              AncestryFlags(ClassDecl *), Cached)
+              AncestryFlags(ClassDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,
-              Type(AssociatedTypeDecl *), Cached)
+              Type(AssociatedTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultTypeRequest,
-              Type(KnownProtocolKind, const DeclContext *), SeparatelyCached)
+              Type(KnownProtocolKind, const DeclContext *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EmittedMembersRequest, DeclRange(ClassDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, EnumRawTypeRequest,
-              Type(EnumDecl *, TypeResolutionStage), SeparatelyCached)
+              Type(EnumDecl *, TypeResolutionStage), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExistentialConformsToSelfRequest,
-              bool(ProtocolDecl *), SeparatelyCached)
+              bool(ProtocolDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExistentialTypeSupportedRequest,
-              bool(ProtocolDecl *), SeparatelyCached)
-SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest, Type(ExtensionDecl *), Cached)
+              bool(ProtocolDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExtendedTypeRequest, Type(ExtensionDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature *(ModuleDecl *, GenericSignature *,
                                  SmallVector<GenericParamList *, 2>,
                                  SmallVector<Requirement, 2>,
                                  SmallVector<TypeLoc, 2>, bool),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InheritedTypeRequest,
               Type(llvm::PointerUnion<TypeDecl *, ExtensionDecl *>, unsigned,
                    TypeResolutionStage),
-              SeparatelyCached)
+              SeparatelyCached, HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, InitKindRequest,
-              CtorInitializerKind(ConstructorDecl *), Cached)
+              CtorInitializerKind(ConstructorDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsAccessorTransparentRequest, bool(AccessorDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDynamicRequest, bool(ValueDecl *),
-              SeparatelyCached)
-SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsFinalRequest, bool(ValueDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsGetterMutatingRequest, bool(AbstractStorageDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsImplicitlyUnwrappedOptionalRequest,
-              bool(ValueDecl *), SeparatelyCached)
-SWIFT_REQUEST(TypeChecker, IsObjCRequest, bool(ValueDecl *), SeparatelyCached)
+              bool(ValueDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsObjCRequest, bool(ValueDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsSetterMutatingRequest, bool(AbstractStorageDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LazyStoragePropertyRequest, VarDecl *(VarDecl *),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest,
-              std::string(const TypeDecl *), Cached)
+              std::string(const TypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
-              OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached)
+              OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OverriddenDeclsRequest,
-              llvm::TinyPtrVector<ValueDecl *>(ValueDecl *), SeparatelyCached)
+              llvm::TinyPtrVector<ValueDecl *>(ValueDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyInfoRequest,
-              PropertyWrapperBackingPropertyInfo(VarDecl *), Cached)
+              PropertyWrapperBackingPropertyInfo(VarDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PropertyWrapperBackingPropertyTypeRequest,
-              Type(VarDecl *), Cached)
+              Type(VarDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PropertyWrapperMutabilityRequest,
-              Optional<PropertyWrapperMutability>(VarDecl *), Cached)
+              Optional<PropertyWrapperMutability>(VarDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PropertyWrapperTypeInfoRequest,
-              PropertyWrapperTypeInfo(NominalTypeDecl *), Cached)
+              PropertyWrapperTypeInfo(NominalTypeDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest, bool(ProtocolDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequirementRequest,
               Requirement(WhereClauseOwner, unsigned, TypeResolutionStage),
-              SeparatelyCached)
+              SeparatelyCached, HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest,
-              ArrayRef<Requirement>(ProtocolDecl *), SeparatelyCached)
+              ArrayRef<Requirement>(ProtocolDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequiresOpaqueAccessorsRequest, bool(VarDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequiresOpaqueModifyCoroutineRequest,
-              bool(AbstractStorageDecl *), SeparatelyCached)
+              bool(AbstractStorageDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResilienceExpansionRequest,
-              ResilienceExpansion(DeclContext *), Cached)
+              ResilienceExpansion(DeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SelfAccessKindRequest, SelfAccessKind(FuncDecl *),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StorageImplInfoRequest,
-              StorageImplInfo(AbstractStorageDecl *), SeparatelyCached)
+              StorageImplInfo(AbstractStorageDecl *), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StoredPropertiesAndMissingMembersRequest,
-              ArrayRef<Decl *>(NominalTypeDecl *), Cached)
+              ArrayRef<Decl *>(NominalTypeDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, StoredPropertiesRequest,
-              ArrayRef<VarDecl *>(NominalTypeDecl *), Cached)
-SWIFT_REQUEST(TypeChecker, StructuralTypeRequest, Type(TypeAliasDecl *), Cached)
+              ArrayRef<VarDecl *>(NominalTypeDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, StructuralTypeRequest, Type(TypeAliasDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SuperclassTypeRequest,
-              Type(NominalTypeDecl *, TypeResolutionStage), SeparatelyCached)
+              Type(NominalTypeDecl *, TypeResolutionStage), SeparatelyCached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
               AccessorDecl *(AbstractStorageDecl *, AccessorKind),
-              SeparatelyCached)
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest,
-              bool(AbstractFunctionDecl *, SourceLoc), Cached)
+              bool(AbstractFunctionDecl *, SourceLoc), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),
-              Cached)
+              Cached, NoLocationInfo)

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -33,7 +33,7 @@
 
 // Define a TypeID where the type name and internal name are the same.
 #define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
-#define SWIFT_REQUEST(Zone, Type, Sig, Caching) SWIFT_TYPEID_NAMED(Type, Type)
+#define SWIFT_REQUEST(Zone, Type, Sig, Caching, LocOptions) SWIFT_TYPEID_NAMED(Type, Type)
 
 // First pass: put all of the names into an enum so we get values for them.
 template<> struct TypeIDZoneTypes<Zone::SWIFT_TYPEID_ZONE> {

--- a/include/swift/Basic/ImplementTypeIDZone.h
+++ b/include/swift/Basic/ImplementTypeIDZone.h
@@ -33,7 +33,7 @@
 #endif
 
 // Define a TypeID where the type name and internal name are the same.
-#define SWIFT_REQUEST(Zone, Type, Sig, Caching) SWIFT_TYPEID_NAMED(Type, Type)
+#define SWIFT_REQUEST(Zone, Type, Sig, Caching, LocOptions) SWIFT_TYPEID_NAMED(Type, Type)
 #define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
 
 // Out-of-line definitions.

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -195,7 +195,7 @@ FRONTEND_STATISTIC(Parse, NumFunctionsParsed)
 /// Number of full braced decl list parsed.
 FRONTEND_STATISTIC(Parse, NumIterableDeclContextParsed)
 
-#define SWIFT_REQUEST(ZONE, NAME, SIG, CACHE) FRONTEND_STATISTIC(Parse, NAME)
+#define SWIFT_REQUEST(ZONE, NAME, SIG, CACHE, LocOptions) FRONTEND_STATISTIC(Parse, NAME)
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST
 
@@ -285,7 +285,7 @@ FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 /// Number of lookups into a module and its imports.
 
 /// All type check requests go into the Sema area.
-#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching) FRONTEND_STATISTIC(Sema, NAME)
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(Sema, NAME)
 #include "swift/AST/AccessTypeIDZone.def"
 #include "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/AST/TypeCheckerTypeIDZone.def"

--- a/include/swift/IDE/IDERequestIDZone.def
+++ b/include/swift/IDE/IDERequestIDZone.def
@@ -16,12 +16,15 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(IDE, CollectOverriddenDeclsRequest,
-              ArrayRef<ValueDecl *>(OverridenDeclsOwner), Cached)
+              ArrayRef<ValueDecl *>(OverridenDeclsOwner), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(IDE, CursorInfoRequest, ide::ResolvedCursorInfo(CursorInfoOwner),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(IDE, ProvideDefaultImplForRequest,
-              ArrayRef<ValueDecl *>(ValueDecl *), Cached)
+              ArrayRef<ValueDecl *>(ValueDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(IDE, RangeInfoRequest, ide::ResolvedRangeInfo(RangeInfoOwner),
-              Cached)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(IDE, ResolveProtocolNameRequest,
-              ProtocolDecl *(ProtocolNameOwner), Cached)
+              ProtocolDecl *(ProtocolNameOwner), Cached,
+              NoLocationInfo)

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -289,11 +289,11 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+template<>                                                                     \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
+                            const RequestType &request) {                      \
+  ++stats.getFrontendCounters().RequestType;                                   \
 }
 #include "swift/IDE/IDERequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/Sema/IDETypeCheckingRequestIDZone.def
+++ b/include/swift/Sema/IDETypeCheckingRequestIDZone.def
@@ -16,12 +16,12 @@
 //===----------------------------------------------------------------------===//
 
 SWIFT_REQUEST(IDETypeChecking, HasDynamicMemberLookupAttributeRequest,
-              bool(TypeBase *), Cached)
+              bool(TypeBase *), Cached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, IsDeclApplicableRequest,
-              bool(DeclApplicabilityOwner), Cached)
+              bool(DeclApplicabilityOwner), Cached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, RootAndResultTypeOfKeypathDynamicMemberRequest,
-              TypePair(SubscriptDecl *), Cached)
+              TypePair(SubscriptDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, RootTypeOfKeypathDynamicMemberRequest,
-              Type(SubscriptDecl *), Uncached)
+              Type(SubscriptDecl *), Uncached, NoLocationInfo)
 SWIFT_REQUEST(IDETypeChecking, TypeRelationCheckRequest,
-              bool(TypeRelationCheckInput), Cached)
+              bool(TypeRelationCheckInput), Cached, NoLocationInfo)

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -265,11 +265,11 @@ public:
 #undef SWIFT_TYPEID_HEADER
 
 // Set up reporting of evaluated requests.
-#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching)                         \
-template<>                                                       \
-inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
-                            const RequestType &request) {        \
-  ++stats.getFrontendCounters().RequestType;                     \
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+template<>                                                                     \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
+                            const RequestType &request) {                      \
+  ++stats.getFrontendCounters().RequestType;                                   \
 }
 #include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -321,7 +321,7 @@ DefaultAndMaxAccessLevelRequest::cacheResult(
 
 // Define request evaluation functions for each of the access requests.
 static AbstractRequestFunction *accessRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)         \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/AccessTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2030,7 +2030,7 @@ DirectlyReferencedTypeDecls InheritedDeclsReferencedRequest::evaluate(
     unsigned index) const {
 
   // Prefer syntactic information when we have it.
-  TypeLoc &typeLoc = getTypeLoc(decl, index);
+  TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);
   if (auto typeRepr = typeLoc.getTypeRepr()) {
     // Figure out the context in which name lookup will occur.
     DeclContext *dc;

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/Subsystems.h"
 #include "swift/AST/ASTContext.h"
@@ -31,19 +32,11 @@ namespace swift {
 //----------------------------------------------------------------------------//
 // Referenced inherited decls computation.
 //----------------------------------------------------------------------------//
-TypeLoc &InheritedDeclsReferencedRequest::getTypeLoc(
-                        llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-                        unsigned index) const {
-  // FIXME: Copy-pasted from InheritedTypeRequest. We need to consolidate here.
-  if (auto typeDecl = decl.dyn_cast<TypeDecl *>())
-    return typeDecl->getInherited()[index];
-
-  return decl.get<ExtensionDecl *>()->getInherited()[index];
-}
 
 SourceLoc InheritedDeclsReferencedRequest::getNearestLoc() const {
   const auto &storage = getStorage();
-  auto &typeLoc = getTypeLoc(std::get<0>(storage), std::get<1>(storage));
+  auto &typeLoc = getInheritedTypeLocAtIndex(std::get<0>(storage),
+                                             std::get<1>(storage));
   return typeLoc.getLoc();
 }
 

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -113,7 +113,7 @@ void GetDestructorRequest::cacheResult(DestructorDecl *value) const {
 
 // Define request evaluation functions for each of the name lookup requests.
 static AbstractRequestFunction *nameLookupRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/NameLookupTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -38,7 +38,7 @@ namespace swift {
 
 // Define request evaluation functions for each of the IDE requests.
 static AbstractRequestFunction *ideRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
 reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/IDE/IDERequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -92,7 +92,7 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
 
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *parseRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -34,7 +34,7 @@ namespace swift {
 
 // Define request evaluation functions for each of the IDE type check requests.
 static AbstractRequestFunction *ideTypeCheckRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
 reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -234,7 +234,7 @@ FunctionBuilderTypeRequest::evaluate(Evaluator &evaluator,
 
 // Define request evaluation functions for each of the type checker requests.
 static AbstractRequestFunction *typeCheckerRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "swift/AST/TypeCheckerTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -68,7 +68,7 @@ InheritedTypeRequest::evaluate(
   }
   }
 
-  TypeLoc &typeLoc = getTypeLoc(decl, index);
+  TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);
 
   Type inheritedType;
   if (typeLoc.getTypeRepr())

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -186,7 +186,7 @@ namespace swift {
 
 /// All of the arithmetic request functions.
 static AbstractRequestFunction *arithmeticRequestFunctions[] = {
-#define SWIFT_REQUEST(Zone, Name, Sig, Caching)                      \
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
   reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
 #include "ArithmeticEvaluatorTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
+++ b/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 SWIFT_REQUEST(ArithmeticEvaluator, UncachedEvaluationRule,
-              double(ArithmeticExpr *), Uncached)
+              double(ArithmeticExpr *), Uncached, HasNearestLocation)
 SWIFT_REQUEST(ArithmeticEvaluator, InternallyCachedEvaluationRule,
-              double(ArithmeticExpr *), Cached)
+              double(ArithmeticExpr *), Cached, HasNearestLocation)
 SWIFT_REQUEST(ArithmeticEvaluator, ExternallyCachedEvaluationRule,
-              double(ArithmeticExpr *), SeparatelyCached)
+              double(ArithmeticExpr *), SeparatelyCached, HasNearestLocation)


### PR DESCRIPTION
For now, support an option on all the requests that can be used to generate the `getNearestLoc()` requirement.