### PR TITLE
[ModuleInterfaces] Escape `Type` and `Protocol` when module-qualifying

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -136,7 +136,11 @@ public:
   /// \param T the original \c Type being referenced. May be null.
   /// \param RefTo the \c TypeDecl this is considered a reference to.
   /// \param Name the name to be printed.
-  virtual void printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name);
+  /// \param NameContext the \c PrintNameContext which this type is being
+  ///                    printed in, used to determine how to escape type names.
+  virtual void printTypeRef(
+      Type T, const TypeDecl *RefTo, Identifier Name,
+      PrintNameContext NameContext = PrintNameContext::Normal);
 
   /// Called when printing the referenced name of a module.
   virtual void printModuleRef(ModuleEntity Mod, Identifier Name);

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -74,8 +74,9 @@ private:
   void printTypePost(const TypeLoc &TL) override {
     return OtherPrinter.printTypePost(TL);
   }
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name) override {
-    return OtherPrinter.printTypeRef(T, TD, Name);
+  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name,
+                    PrintNameContext NameContext) override {
+    return OtherPrinter.printTypeRef(T, TD, Name, NameContext);
   }
   void printModuleRef(ModuleEntity Mod, Identifier Name) override {
     return OtherPrinter.printModuleRef(Mod, Name);

--- a/test/ParseableInterface/top-level-Type-and-Protocol.swift
+++ b/test/ParseableInterface/top-level-Type-and-Protocol.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution %s -module-name MyModule
+// RUN: %FileCheck %s < %t/MyModule.swiftinterface
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/MyModule.swiftinterface -o %t/MyModule.swiftmodule
+
+// CHECK: public struct Type {
+// CHECK-NEXT: }
+public struct Type {}
+
+// CHECK: public protocol Protocol {
+// CHECK-NEXT: }
+public protocol Protocol {}
+
+// CHECK: public func usesType(_ x: MyModule.`Type`)
+public func usesType(_ x: Type) {}
+
+// CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule.`Protocol`
+public func genericProtocol<T: Protocol>(_ x: T) {}
+
+// CHECK: public func existentialProtocol(_ x: MyModule.`Protocol`)
+public func existentialProtocol(_ x: Protocol) {}
+
+// CHECK: public struct Parent {
+public struct Parent {
+  // CHECK: public struct `Type` {
+  public struct `Type` {
+    // CHECK: public struct `Protocol` {
+    // CHECK-NEXT: }
+    public struct `Protocol` {}
+    // CHECK-NEXT: }
+  }
+  // CHECK: public struct `Protocol` {
+  // CHECK-NEXT: }
+  public struct `Protocol` {}
+  // CHECK-NEXT: }
+}
+
+// CHECK: public func usesNestedType(_ x: MyModule.Parent.`Type`)
+public func usesNestedType(_ x: Parent.`Type`) {}
+
+// CHECK: public func usesNestedTypeProtocol(_ x: MyModule.Parent.`Type`.`Protocol`)
+public func usesNestedTypeProtocol(_ x: Parent.`Type`.`Protocol`) {}
+
+// CHECK: public func usesNestedProtocol(_ x: MyModule.Parent.`Protocol`)
+public func usesNestedProtocol(_ x: Parent.`Protocol`) {}

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -241,10 +241,12 @@ public:
     deinitDefaultMapToUse(D);
   }
 
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name) override {
+  void printTypeRef(
+      Type T, const TypeDecl *TD, Identifier Name,
+      PrintNameContext NameContext = PrintNameContext::Normal) override {
     unsigned StartOffset = OS.tell();
     References.emplace_back(TD, StartOffset, Name.str().size());
-    StreamPrinter::printTypeRef(T, TD, Name);
+    StreamPrinter::printTypeRef(T, TD, Name, NameContext);
   }
 };
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -191,10 +191,12 @@ public:
     }
   }
 
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name) override {
+  void printTypeRef(
+      Type T, const TypeDecl *TD, Identifier Name,
+      PrintNameContext NameContext = PrintNameContext::Normal) override {
     unsigned StartOffset = OS.tell();
     Info.References.emplace_back(TD, StartOffset, Name.str().size());
-    StreamPrinter::printTypeRef(T, TD, Name);
+    StreamPrinter::printTypeRef(T, TD, Name, NameContext);
   }
 
   void printModuleRef(ModuleEntity Mod, Identifier Name) override {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -57,11 +57,13 @@ public:
     :XMLEscapingPrinter(OS) { }
 
 private:
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name) override {
+  void printTypeRef(
+      Type T, const TypeDecl *TD, Identifier Name,
+      PrintNameContext NameContext = PrintNameContext::Normal) override {
     printXML("<Type usr=\"");
     SwiftLangSupport::printUSR(TD, OS);
     printXML("\">");
-    StreamPrinter::printTypeRef(T, TD, Name);
+    StreamPrinter::printTypeRef(T, TD, Name, NameContext);
     printXML("</Type>");
   }
 };
@@ -272,11 +274,13 @@ private:
       closeTag(tag);
   }
 
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier name) override {
+  void printTypeRef(
+      Type T, const TypeDecl *TD, Identifier name,
+      PrintNameContext NameContext = PrintNameContext::Normal) override {
     auto tag = getTagForDecl(TD, /*isRef=*/true);
     openTagWithUSRForDecl(tag, TD);
     insideRef = true;
-    XMLEscapingPrinter::printTypeRef(T, TD, name);
+    XMLEscapingPrinter::printTypeRef(T, TD, name, NameContext);
     insideRef = false;
     closeTag(tag);
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1965,9 +1965,11 @@ public:
     OS << "</synthesized>";
   }
 
-  void printTypeRef(Type T, const TypeDecl *TD, Identifier Name) override {
+  void printTypeRef(
+      Type T, const TypeDecl *TD, Identifier Name,
+      PrintNameContext NameContext = PrintNameContext::Normal) override {
     OS << "<ref:" << Decl::getKindName(TD->getKind()) << '>';
-    StreamPrinter::printTypeRef(T, TD, Name);
+    StreamPrinter::printTypeRef(T, TD, Name, NameContext);
     OS << "</ref>";
   }
   void printModuleRef(ModuleEntity Mod, Identifier Name) override {


### PR DESCRIPTION
If we see `MyModule.Type`, the parser thinks this is a metatype type.
Escape the name `Type` and `Protocol` so the parser can recognize they're type names.

Fixes #53823
Fixes rdar://55094784
