### PR TITLE
[Evaluator Ergonomics] Shuffle Evaluator Infrastructure Out Of Requests 

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -507,20 +507,6 @@ public:
   bool isCached() const { return true; }
   Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
-
-private:
-  KnownProtocolKind getKnownProtocolKind() const {
-    return std::get<0>(getStorage());
-  }
-  const DeclContext *getDeclContext() const {
-    return std::get<1>(getStorage());
-  }
-
-  static const char *getTypeName(KnownProtocolKind);
-  static bool getPerformLocalLookup(KnownProtocolKind);
-  TypeChecker &getTypeChecker() const;
-  SourceFile *getSourceFile() const;
-  Type &getCache() const;
 };
 
 /// Retrieve information about a property wrapper type.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -374,10 +374,10 @@ struct WhereClauseOwner {
   WhereClauseOwner(Decl *decl);
 
   WhereClauseOwner(DeclContext *dc, GenericParamList *genericParams)
-    : dc(dc), source(genericParams) { }
+      : dc(dc), source(genericParams) {}
 
   WhereClauseOwner(DeclContext *dc, SpecializeAttr *attr)
-    : dc(dc), source(attr) { }
+      : dc(dc), source(attr) {}
 
   SourceLoc getLoc() const;
 
@@ -396,6 +396,19 @@ struct WhereClauseOwner {
                          const WhereClauseOwner &rhs) {
     return !(lhs == rhs);
   }
+
+public:
+  /// Retrieve the array of requirements.
+  MutableArrayRef<RequirementRepr> getRequirements() const;
+
+  /// Visit each of the requirements,
+  ///
+  /// \returns true after short-circuiting if the callback returned \c true
+  /// for any of the requirements.
+  bool
+  visitRequirements(TypeResolutionStage stage,
+                    llvm::function_ref<bool(Requirement, RequirementRepr *)>
+                        callback) const &&;
 };
 
 void simple_display(llvm::raw_ostream &out, const WhereClauseOwner &owner);
@@ -408,17 +421,6 @@ class RequirementRequest :
                          CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
-
-  /// Retrieve the array of requirements from the given owner.
-  static MutableArrayRef<RequirementRepr> getRequirements(WhereClauseOwner);
-
-  /// Visit each of the requirements in the given owner,
-  ///
-  /// \returns true after short-circuiting if the callback returned \c true
-  /// for any of the requirements.
-  static bool visitRequirements(
-      WhereClauseOwner, TypeResolutionStage stage,
-      llvm::function_ref<bool(Requirement, RequirementRepr*)> callback);
 
 private:
   friend SimpleRequest;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4114,7 +4114,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
   }
 
   // Add any requirements in the where clause on the protocol.
-  RequirementRequest::visitRequirements(proto, TypeResolutionStage::Structural,
+  WhereClauseOwner(proto).visitRequirements(TypeResolutionStage::Structural,
       [&](const Requirement &req, RequirementRepr *reqRepr) {
         // If we're only looking at same-type constraints, skip everything else.
         if (onlySameTypeConstraints &&
@@ -4240,8 +4240,8 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     }
 
     // Add requirements from this associated type's where clause.
-    RequirementRequest::visitRequirements(assocTypeDecl,
-                                          TypeResolutionStage::Structural,
+    WhereClauseOwner(assocTypeDecl).visitRequirements(
+        TypeResolutionStage::Structural,
         [&](const Requirement &req, RequirementRepr *reqRepr) {
           // If we're only looking at same-type constraints, skip everything else.
           if (onlySameTypeConstraints &&
@@ -7714,10 +7714,10 @@ InferredGenericSignatureRequest::evaluate(
 
     // Add the requirements clause to the builder.
 
-    WhereClauseOwner owner(lookupDC, genericParams);
     using FloatingRequirementSource =
       GenericSignatureBuilder::FloatingRequirementSource;
-    RequirementRequest::visitRequirements(owner, TypeResolutionStage::Structural,
+    WhereClauseOwner(lookupDC, genericParams).visitRequirements(
+        TypeResolutionStage::Structural,
         [&](const Requirement &req, RequirementRepr *reqRepr) {
           auto source = FloatingRequirementSource::forExplicit(reqRepr);
           
@@ -7725,7 +7725,7 @@ InferredGenericSignatureRequest::evaluate(
           // for example, `extension Foo where Self: Foo`, then emit a
           // diagnostic.
           
-          if (auto decl = owner.dc->getAsDecl()) {
+          if (auto decl = lookupDC->getAsDecl()) {
             if (auto extDecl = dyn_cast<ExtensionDecl>(decl)) {
               auto extType = extDecl->getDeclaredInterfaceType();
               auto extSelfType = extDecl->getSelfInterfaceType();

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -44,11 +44,10 @@ enum class DowngradeToWarning: bool {
 /// Calls \p callback for each type in each requirement provided by
 /// \p source.
 static void forAllRequirementTypes(
-    WhereClauseOwner source,
+    WhereClauseOwner &&source,
     llvm::function_ref<void(Type, TypeRepr *)> callback) {
-  RequirementRequest::visitRequirements(
-      source, TypeResolutionStage::Interface,
-      [&](const Requirement &req, RequirementRepr* reqRepr) {
+  std::move(source).visitRequirements(TypeResolutionStage::Interface,
+      [&](const Requirement &req, RequirementRepr *reqRepr) {
     switch (req.getKind()) {
     case RequirementKind::Conformance:
     case RequirementKind::SameType:
@@ -95,11 +94,11 @@ protected:
   }
 
   void checkRequirementAccess(
-      WhereClauseOwner source,
+      WhereClauseOwner &&source,
       AccessScope accessScope,
       const DeclContext *useDC,
       llvm::function_ref<CheckTypeAccessCallback> diagnose) {
-    forAllRequirementTypes(source, [&](Type type, TypeRepr *typeRepr) {
+    forAllRequirementTypes(std::move(source), [&](Type type, TypeRepr *typeRepr) {
       checkTypeAccessImpl(type, typeRepr, accessScope, useDC,
                           /*mayBeInferred*/false, diagnose);
     });

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1852,8 +1852,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   SmallPtrSet<TypeBase *, 4> constrainedGenericParams;
 
   // Go over the set of requirements, adding them to the builder.
-  RequirementRequest::visitRequirements(
-      WhereClauseOwner(FD, attr), TypeResolutionStage::Interface,
+  WhereClauseOwner(FD, attr).visitRequirements(TypeResolutionStage::Interface,
       [&](const Requirement &req, RequirementRepr *reqRepr) {
         // Collect all of the generic parameters used by these types.
         switch (req.getKind()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -485,8 +485,7 @@ static void checkInheritanceClause(
 /// Check the inheritance clauses generic parameters along with any
 /// requirements stored within the generic parameter list.
 static void checkGenericParams(GenericParamList *genericParams,
-                               DeclContext *owningDC,
-                               TypeChecker &tc) {
+                               DeclContext *owningDC, TypeChecker &tc) {
   if (!genericParams)
     return;
 
@@ -496,12 +495,9 @@ static void checkGenericParams(GenericParamList *genericParams,
   }
 
   // Force visitation of each of the requirements here.
-  RequirementRequest::visitRequirements(WhereClauseOwner(owningDC,
-                                                         genericParams),
-                                        TypeResolutionStage::Interface,
-                                        [](Requirement, RequirementRepr *) {
-                                          return false;
-                                        });
+  WhereClauseOwner(owningDC, genericParams)
+      .visitRequirements(TypeResolutionStage::Interface,
+                         [](Requirement, RequirementRepr *) { return false; });
 }
 
 /// Retrieve the set of protocols the given protocol inherits.
@@ -2011,7 +2007,8 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
 /// to ensure that they don't introduce additional 'Self' requirements.
 static void checkProtocolSelfRequirements(ProtocolDecl *proto,
                                           TypeDecl *source) {
-  RequirementRequest::visitRequirements(source, TypeResolutionStage::Interface,
+  WhereClauseOwner(source).visitRequirements(
+      TypeResolutionStage::Interface,
       [&](const Requirement &req, RequirementRepr *reqRepr) {
         switch (req.getKind()) {
         case RequirementKind::Conformance:

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -209,17 +209,11 @@ Type TypeChecker::getObjectLiteralParameterType(ObjectLiteralExpr *expr,
 }
 
 ModuleDecl *TypeChecker::getStdlibModule(const DeclContext *dc) {
-  if (StdlibModule)
-    return StdlibModule;
-
-  StdlibModule = Context.getStdlibModule();
-
-  if (!StdlibModule) {
-    return dc->getParentModule();
+  if (auto *stdlib = Context.getStdlibModule()) {
+    return stdlib;
   }
 
-  assert(StdlibModule && "no main module found");
-  return StdlibModule;
+  return dc->getParentModule();
 }
 
 /// Bind the given extension to the given nominal type.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -574,8 +574,6 @@ private:
   /// The set of expressions currently being analyzed for failures.
   llvm::DenseMap<Expr*, Expr*> DiagnosedExprs;
 
-  ModuleDecl *StdlibModule = nullptr;
-
   /// The index of the next response metavariable to bind to a REPL result.
   unsigned NextResponseVariableIndex = 0;
 


### PR DESCRIPTION
Shuffle extra infrastructure that was supporting requests out of the requests.  All requests should now consist of the requirements of a `SimpleRequest`.

In particular

- `WhereClauseOwner` owns the requirement iteration API now
- DefaultTypeRequest, while well-structured, contained a lot of unnecessary getters

Also drop the extra stdlib module ref kept around by the type checker for no reason if we can just grab this from the ASTContext.