### PR TITLE
[5.1] Compatibility50: Fix for high-bit characters.

### DIFF
--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -54,7 +54,7 @@ getObjCClassByMangledName_untrusted(const char * _Nonnull typeName,
   // Scan the string for byte sequences that might be recognized as
   // symbolic references, and reject them.
   for (const char *c = typeName; *c != 0; ++c) {
-    if (*c < 0x20) {
+    if (*c >= 1 && *c < 0x20) {
       *outClass = Nil;
       return NO;
     }

--- a/test/Interpreter/SDK/objc_getClass.swift
+++ b/test/Interpreter/SDK/objc_getClass.swift
@@ -150,6 +150,9 @@ testSuite.test("Basic")
   requireClass(named: "main.ObjCSuperclass")
 }
 
+class Çlass<T> {}
+class SubÇlass: Çlass<Int> {}
+
 testSuite.test("BasicMangled")
   .requireOwnProcess()
   .code {
@@ -188,6 +191,10 @@ testSuite.test("GenericMangled")
                demangledName: "main.ConstrainedObjCSubclass")
   requireClass(named:   "_TtC4main25ConstrainedObjCSuperclass",
                demangledName: "main.ConstrainedObjCSuperclass")
+
+  // Make sure we don't accidentally ban high-bit characters.
+  requireClass(named: "_TtC4main9SubÇlass", demangledName: "main.SubÇlass")
+  requireClass(named: "4main9SubÇlassC", demangledName: "main.SubÇlass")
 }
 
 testSuite.test("ResilientSubclass")


### PR DESCRIPTION
Explanation: The backport hook in https://github.com/apple/swift/pull/27037 accidentally would reject mangled names with high-bit characters in addition to symbolic reference strings.

Scope: Avoid a regression

Risk: Low

Issue: rdar://problem/55130240

Testing: Audited by eye, Swift CI

Reviewed by: @mikeash 