### PR TITLE
[windows] Force a downcast to make VC++ happy.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4550,7 +4550,7 @@ namespace {
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedTypeRequest{result},
                                               objcClass->getDeclaredType());
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{result},
-                                              objcClass);
+                                              static_cast<swift::NominalTypeDecl *>(objcClass));
       
       // Determine the type and generic args of the extension.
       if (objcClass->getGenericParams()) {


### PR DESCRIPTION
For some reason VC++ is not seeing that ClassDecl is a subtype of
NominalTypeDecl, and failing to compile this new code.

As a workaround, one can force a downcast to the parent type, and it
seems to compile and pass the ClangImporter tests.

I don't completely like the solution, if anyone has some better idea or workaround, I will be happy to apply it.

The Windows builds have been broken since this midday because of this since the introduction of #27008 (see https://ci-external.swift.org/job/oss-swift-windows-x86_64/1243/)

/cc @gmittert @compnerd @varungandhi-apple 