### PR TITLE
SR-11027 [TypeChecker][CompilerCrash] Disallow convention c/block and autoclosure 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2681,7 +2681,7 @@ ERROR(autoclosure_function_type,none,
       "@autoclosure attribute only applies to function types",
       ())
 
-ERROR(autoclosure_and_convention_function_type,none,
+ERROR(invalid_autoclosure_and_convention_attributes,none,
       "@convention(%0) attribute is not allowed on @autoclosure type",
       (StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2682,7 +2682,7 @@ ERROR(autoclosure_function_type,none,
       ())
 
 ERROR(autoclosure_and_convention_function_type,none,
-"@convention(%0) attribute is not allowed on a @autoclosure type",
+      "@convention(%0) attribute is not allowed on @autoclosure type",
       (StringRef))
 
 ERROR(autoclosure_function_input_nonunit,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2680,6 +2680,11 @@ ERROR(rethrows_without_throwing_parameter,none,
 ERROR(autoclosure_function_type,none,
       "@autoclosure attribute only applies to function types",
       ())
+
+ERROR(autoclosure_and_convention_function_type,none,
+"@convention(%0) attribute is not allowed on a @autoclosure type",
+      (StringRef))
+
 ERROR(autoclosure_function_input_nonunit,none,
       "argument type of @autoclosure parameter must be '()'", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2682,7 +2682,7 @@ ERROR(autoclosure_function_type,none,
       ())
 
 ERROR(invalid_autoclosure_and_convention_attributes,none,
-      "@convention(%0) attribute is not allowed on @autoclosure type",
+      "'@convention(%0)' attribute is not allowed on '@autoclosure' types",
       (StringRef))
 
 ERROR(autoclosure_function_input_nonunit,none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2258,12 +2258,11 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
         } else {
           auto convention = attrs.getConvention();
           if (attrs.has(TAK_autoclosure)) {
-            // @convention(c) and @convention(block) are not allowed with an autoclosure type.
+            // @convention(c) and @convention(block) are not allowed with an @autoclosure type.
             if (convention == "c" || convention == "block" ) {
               diagnose(attrs.getLoc(TAK_convention),
                        diag::autoclosure_and_convention_function_type,
-                       attrs.getConvention())
-                .fixItRemove(attrs.getLoc(TAK_convention));
+                       attrs.getConvention());
             }
           }
           rep = *parsedRep;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2256,6 +2256,16 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                    attrs.getConvention());
           rep = FunctionType::Representation::Swift;
         } else {
+          auto convention = attrs.getConvention();
+          if (attrs.has(TAK_autoclosure)) {
+            // @convention(c) and @convention(block) are not allowed with an autoclosure type.
+            if (convention == "c" || convention == "block" ) {
+              diagnose(attrs.getLoc(TAK_convention),
+                       diag::autoclosure_and_convention_function_type,
+                       attrs.getConvention())
+                .fixItRemove(attrs.getLoc(TAK_convention));
+            }
+          }
           rep = *parsedRep;
         }
       }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2261,7 +2261,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
             // @convention(c) and @convention(block) are not allowed with an @autoclosure type.
             if (convention == "c" || convention == "block" ) {
               diagnose(attrs.getLoc(TAK_convention),
-                       diag::autoclosure_and_convention_function_type,
+                       diag::invalid_autoclosure_and_convention_attributes,
                        attrs.getConvention());
             }
           }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2256,16 +2256,18 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
                    attrs.getConvention());
           rep = FunctionType::Representation::Swift;
         } else {
-          auto convention = attrs.getConvention();
+          rep = *parsedRep;
+          
           if (attrs.has(TAK_autoclosure)) {
             // @convention(c) and @convention(block) are not allowed with an @autoclosure type.
-            if (convention == "c" || convention == "block" ) {
+            if (rep == FunctionType::Representation::CFunctionPointer ||
+                rep == FunctionType::Representation::Block) {
               diagnose(attrs.getLoc(TAK_convention),
                        diag::invalid_autoclosure_and_convention_attributes,
                        attrs.getConvention());
+              attrs.clearAttribute(TAK_autoclosure);
             }
           }
-          rep = *parsedRep;
         }
       }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2265,7 +2265,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
               diagnose(attrs.getLoc(TAK_convention),
                        diag::invalid_autoclosure_and_convention_attributes,
                        attrs.getConvention());
-              attrs.clearAttribute(TAK_autoclosure);
+              attrs.clearAttribute(TAK_convention);
             }
           }
         }

--- a/test/attr/attr_convention.swift
+++ b/test/attr/attr_convention.swift
@@ -9,10 +9,10 @@ let f5: @convention(INTERCAL) (Int) -> Int = { $0 } // expected-error{{conventio
 
 // SR-11027
 
-func sr11027(_ f: @convention(block) @autoclosure () -> Int) -> Void {} // expected-error {{@convention(block) attribute is not allowed on @autoclosure type}} 
+func sr11027(_ f: @convention(block) @autoclosure () -> Int) -> Void {} // expected-error {{'@convention(block)' attribute is not allowed on '@autoclosure' types}} 
 sr11027(1)
 
-func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {} // expected-error{{@convention(c) attribute is not allowed on @autoclosure type}}
+func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {} // expected-error{{'@convention(c)' attribute is not allowed on '@autoclosure' types}}
 sr11027_c(1)
 
 func sr11027_swift(_ f: @convention(swift) @autoclosure () -> Int) -> Void {} // OK
@@ -20,3 +20,15 @@ sr11027_swift(1)
 
 func sr11027_thin(_ f: @convention(thin) @autoclosure () -> Int) -> Void {} // OK
 sr11027_thin(1)
+
+func sr11027_2(_ f: @autoclosure @convention(block) () -> Int) -> Void {} // expected-error {{'@convention(block)' attribute is not allowed on '@autoclosure' types}} 
+sr11027_2(1)
+
+func sr11027_c_2(_ f: @autoclosure @convention(c) () -> Int) -> Void {} // expected-error {{'@convention(c)' attribute is not allowed on '@autoclosure' types}} 
+sr11027_c_2(1)
+
+func sr11027_swift_2(_ f: @autoclosure @convention(swift) () -> Int) -> Void {} // OK
+sr11027_swift_2(1)
+
+func sr11027_thin_2(_ f: @autoclosure @convention(thin) () -> Int) -> Void {} // OK
+sr11027_thin_2(1)

--- a/test/attr/attr_convention.swift
+++ b/test/attr/attr_convention.swift
@@ -14,3 +14,9 @@ sr11027(1)
 
 func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {} // expected-error{{@convention(c) attribute is not allowed on @autoclosure type}}
 sr11027_c(1)
+
+func sr11027_swift(_ f: @convention(swift) @autoclosure () -> Int) -> Void {} // OK
+sr11027_swift(1)
+
+func sr11027_thin(_ f: @convention(thin) @autoclosure () -> Int) -> Void {} // OK
+sr11027_thin(1)

--- a/test/attr/attr_convention.swift
+++ b/test/attr/attr_convention.swift
@@ -7,3 +7,10 @@ let f4: @convention(c) (Int) -> Int = { $0 }
 
 let f5: @convention(INTERCAL) (Int) -> Int = { $0 } // expected-error{{convention 'INTERCAL' not supported}}
 
+// SR-11027
+
+func sr11027(_ f: @convention(block) @autoclosure () -> Int) -> Void {} // expected-error {{@convention(block) attribute is not allowed on @autoclosure type}} 
+sr11027(1)
+
+func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {} // expected-error{{@convention(c) attribute is not allowed on @autoclosure type}}
+sr11027_c(1)

--- a/validation-test/compiler_crashers_2_fixed/sr11027.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11027.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend %s -emit-silgen
+
+func foo(_ f: @convention(c) @autoclosure () -> Int) -> Void {}
+foo(1)

--- a/validation-test/compiler_crashers_2_fixed/sr11027.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11027.swift
@@ -18,3 +18,15 @@ sr11027_swift(1)
 
 func sr11027_thin(_ f: @convention(thin) @autoclosure () -> Int) -> Void {} // OK
 sr11027_thin(1)
+
+func sr11027_2(_ f: @autoclosure @convention(block) () -> Int) -> Void {}
+sr11027_2(1)
+
+func sr11027_c_2(_ f: @autoclosure @convention(c) () -> Int) -> Void {}
+sr11027_c_2(1)
+
+func sr11027_swift_2(_ f: @autoclosure @convention(swift) () -> Int) -> Void {} // OK
+sr11027_swift_2(1)
+
+func sr11027_thin_2(_ f: @autoclosure @convention(thin) () -> Int) -> Void {} // OK
+sr11027_thin_2(1)

--- a/validation-test/compiler_crashers_2_fixed/sr11027.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11027.swift
@@ -1,4 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -emit-silgen
 
-func foo(_ f: @convention(c) @autoclosure () -> Int) -> Void {}
-foo(1)
+func sr11027(_ f: @convention(block) @autoclosure () -> Int) -> Void {}
+sr11027(1)
+
+func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {}
+sr11027_c(1)

--- a/validation-test/compiler_crashers_2_fixed/sr11027.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11027.swift
@@ -12,3 +12,9 @@ sr11027(1)
 
 func sr11027_c(_ f: @convention(c) @autoclosure () -> Int) -> Void {}
 sr11027_c(1)
+
+func sr11027_swift(_ f: @convention(swift) @autoclosure () -> Int) -> Void {} // OK
+sr11027_swift(1)
+
+func sr11027_thin(_ f: @convention(thin) @autoclosure () -> Int) -> Void {} // OK
+sr11027_thin(1)


### PR DESCRIPTION
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11027](https://bugs.swift.org/browse/SR-11027).
cc @dan-zheng 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
