### PR TITLE
ClangImporter: repair build on Windows

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4550,7 +4550,7 @@ namespace {
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedTypeRequest{result},
                                               objcClass->getDeclaredType());
       Impl.SwiftContext.evaluator.cacheOutput(ExtendedNominalRequest{result},
-                                              objcClass);
+                                              std::move(objcClass));
       
       // Determine the type and generic args of the extension.
       if (objcClass->getGenericParams()) {


### PR DESCRIPTION
Explicitly apply the std::move as the signature of the callee is:
  `void swift::Evaluator::cacheOutput<swift::ExtendedNominalRequest, _>(const Request &, swift::NominalTypeDecl *&&)`

The second formal parameter here is a `swift::ClassDecl` which is a
subclass of NominalTypeDecl, however, the cast will construct a
`swift::NominalTypeDecl *`.  This is a lvalue and cannot be bound to a
r-value reference.  Explicitly construct the r-value reference via
`std::move`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
