### PR TITLE
Requestify generic signatures

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1505,12 +1505,13 @@ public:
   TrailingWhereClause *TrailingWhere = nullptr;
 
   /// The generic signature of this declaration.
-  GenericSignature *GenericSig = nullptr;
+  llvm::PointerIntPair<GenericSignature *, 1, bool> GenericSigAndBit;
 };
 
 class GenericContext : private _GenericContext, public DeclContext {
   friend class GenericParamListRequest;
-
+  friend class GenericSignatureRequest;
+  
 protected:
   GenericContext(DeclContextKind Kind, DeclContext *Parent,
                  GenericParamList *Params);
@@ -1534,7 +1535,8 @@ public:
   /// }
   /// \endcode
   bool isGeneric() const { return getGenericParams() != nullptr; }
-
+  bool hasComputedGenericSignature() const;
+  
   /// Retrieve the trailing where clause for this extension, if any.
   TrailingWhereClause *getTrailingWhereClause() const {
     return TrailingWhere;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1160,6 +1160,27 @@ public:
   bool isCached() const { return true; }
 };
 
+class GenericSignatureRequest :
+    public SimpleRequest<GenericSignatureRequest,
+                         GenericSignature *(GenericContext *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+  
+private:
+  friend SimpleRequest;
+  
+  // Evaluation.
+  llvm::Expected<GenericSignature *>
+  evaluate(Evaluator &evaluator, GenericContext *value) const;
+  
+public:              
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<GenericSignature *> getCachedResult() const;
+  void cacheResult(GenericSignature *value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -49,6 +49,9 @@ SWIFT_REQUEST(TypeChecker, FunctionBuilderTypeRequest, Type(ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, FunctionOperatorRequest, OperatorDecl *(FuncDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(NameLookup, GenericSignatureRequest,
+              GenericSignature *(GenericContext *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature *(ModuleDecl *, GenericSignature *,
                                  SmallVector<GenericParamList *, 2>,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5296,6 +5296,12 @@ public:
     auto decl = ty->getAnyNominal();
     if (!decl) return Action::Continue;
 
+    // FIXME: The GSB and the request evaluator both detect a cycle here if we
+    // force a recursive generic signature.  We should look into moving cycle
+    // detection into the generic signature request(s) - see rdar://55263708
+    if (!decl->hasComputedGenericSignature())
+      return Action::Continue;
+    
     auto genericSig = decl->getGenericSignature();
     if (!genericSig)
       return Action::Continue;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -547,17 +547,9 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     return;
   }
 
-  auto extensionSig = ext->getGenericSignature();
-  if (!extensionSig) {
-    if (auto lazyResolver = ctxt.getLazyResolver()) {
-      lazyResolver->resolveExtension(ext);
-      extensionSig = ext->getGenericSignature();
-    }
-  }
-
   // The type is generic, but the extension doesn't have a signature yet, so
   // we might be in a recursive validation situation.
-  if (!extensionSig) {
+  if (!ext->hasComputedGenericSignature()) {
     // If the extension is invalid, it won't ever get a signature, so we
     // "succeed" with an empty result instead.
     if (ext->isInvalid()) {
@@ -568,6 +560,15 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     // Otherwise we'll try again later.
     failure();
     return;
+  }
+  
+  // FIXME: All of this will be removed when validateExtension goes away.
+  auto extensionSig = ext->getGenericSignature();
+  if (!extensionSig) {
+    if (auto lazyResolver = ctxt.getLazyResolver()) {
+      lazyResolver->resolveExtension(ext);
+      extensionSig = ext->getGenericSignature();
+    }
   }
 
   auto canExtensionSig = extensionSig->getCanonicalSignature();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -805,3 +805,20 @@ void IsImplicitlyUnwrappedOptionalRequest::cacheResult(bool value) const {
   auto *decl = std::get<0>(getStorage());
   decl->setImplicitlyUnwrappedOptional(value);
 }
+
+//----------------------------------------------------------------------------//
+// GenericSignatureRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<GenericSignature *> GenericSignatureRequest::getCachedResult() const {
+  auto *GC = std::get<0>(getStorage());
+  if (GC->GenericSigAndBit.getInt()) {
+    return GC->GenericSigAndBit.getPointer();
+  }
+  return None;
+}
+
+void GenericSignatureRequest::cacheResult(GenericSignature *value) const {
+  auto *GC = std::get<0>(getStorage());
+  GC->GenericSigAndBit.setPointerAndInt(value, true);
+}

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -501,7 +501,9 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
 
   // If the unbound decl hasn't been validated yet, we have a circular
   // dependency that isn't being diagnosed properly.
-  if (!unboundDecl->getGenericSignature()) {
+  //
+  // FIXME: Delete this condition.  He's dead Jim.
+  if (!unboundDecl->hasComputedGenericSignature()) {
     TC.diagnose(unboundDecl, diag::circular_reference);
     return Type();
   }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1478,9 +1478,13 @@ bool TypeChecker::getDefaultGenericArgumentsString(
     genericParamText << contextTy;
   };
 
-  interleave(typeDecl->getInnermostGenericParamTypes(),
-             printGenericParamSummary, [&]{ genericParamText << ", "; });
-
+  // FIXME: We can potentially be in the middle of creating a generic signature
+  // if we get here.  Break this cycle.
+  if (typeDecl->hasComputedGenericSignature()) {
+    interleave(typeDecl->getInnermostGenericParamTypes(),
+               printGenericParamSummary, [&]{ genericParamText << ", "; });
+  }
+  
   genericParamText << ">";
   return true;
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2416,6 +2416,8 @@ public:
   void visitSubscriptDecl(SubscriptDecl *SD) {
     TC.validateDecl(SD);
 
+    // Force creation of the generic signature.
+    (void)SD->getGenericSignature();
     if (!SD->isInvalid()) {
       TC.checkReferencedGenericParams(SD);
       checkGenericParams(SD->getGenericParams(), SD, TC);
@@ -2466,12 +2468,18 @@ public:
     TC.validateDecl(TAD);
     TC.checkDeclAttributes(TAD);
 
+    // Force the generic signature to be computed in case it emits diagnostics.
+    (void)TAD->getGenericSignature();
+    
     checkAccessControl(TC, TAD);
   }
   
   void visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {
     TC.validateDecl(OTD);
     TC.checkDeclAttributes(OTD);
+    
+    // Force the generic signature to be computed in case it emits diagnostics.
+    (void)OTD->getGenericSignature();
     
     checkAccessControl(TC, OTD);
   }
@@ -2526,6 +2534,7 @@ public:
       TC.diagnose(NTD->getLoc(),
                   diag::unsupported_nested_protocol,
                   NTD->getName());
+      NTD->setInvalid();
       return;
     }
 
@@ -2721,6 +2730,8 @@ public:
     checkUnsupportedNestedType(CD);
 
     TC.validateDecl(CD);
+    // Force creation of the generic signature.
+    (void)CD->getGenericSignature();
     checkGenericParams(CD->getGenericParams(), CD, TC);
 
     {
@@ -3693,6 +3704,27 @@ static Type buildAddressorResultType(TypeChecker &TC,
   return pointerType;
 }
 
+
+static void validateResultType(TypeChecker &TC,
+                               ValueDecl *decl, ParameterList *params,
+                               TypeLoc &resultTyLoc,
+                               TypeResolution resolution) {
+  // Nothing to do if there's no result type loc to set into.
+  if (resultTyLoc.isNull())
+    return;
+
+  // Check the result type. It is allowed to be opaque.
+  if (auto opaqueTy =
+          dyn_cast_or_null<OpaqueReturnTypeRepr>(resultTyLoc.getTypeRepr())) {
+    // Create the decl and type for it.
+    resultTyLoc.setType(
+        TC.getOrCreateOpaqueResultType(resolution, decl, opaqueTy));
+  } else {
+    TC.validateType(resultTyLoc, resolution,
+                    TypeResolverContext::FunctionResult);
+  }
+}
+
 void TypeChecker::validateDecl(ValueDecl *D) {
   // Generic parameters are validated as part of their context.
   if (isa<GenericTypeParamDecl>(D))
@@ -3782,8 +3814,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     auto typeAlias = cast<TypeAliasDecl>(D);
     // Check generic parameters, if needed.
     DeclValidationRAII IBV(typeAlias);
-
-    validateGenericTypeSignature(typeAlias);
     validateTypealiasType(*this, typeAlias);
     break;
   }
@@ -3791,7 +3821,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
   case DeclKind::OpaqueType: {
     auto opaque = cast<OpaqueTypeDecl>(D);
     DeclValidationRAII IBV(opaque);
-    validateGenericTypeSignature(opaque);
     break;
   }
 
@@ -3803,7 +3832,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     // Check generic parameters, if needed.
     DeclValidationRAII IBV(nominal);
-    validateGenericTypeSignature(nominal);
+    (void)nominal->getGenericSignature();
     nominal->setSignatureIsValidated();
 
     if (auto *ED = dyn_cast<EnumDecl>(nominal)) {
@@ -3823,7 +3852,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     // Validate the generic type signature, which is just <Self : P>.
     DeclValidationRAII IBV(proto);
-    validateGenericTypeSignature(proto);
+    (void)proto->getGenericSignature();
     proto->setSignatureIsValidated();
 
     // See the comment in validateDeclForNameLookup(); we may have validated
@@ -3833,10 +3862,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     for (auto member : proto->getMembers()) {
       if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
         if (!aliasDecl->isGeneric()) {
+          assert(aliasDecl->getGenericSignature() == proto->getGenericSignature());
           // FIXME: Force creation of the protocol's generic environment now.
           (void) proto->getGenericEnvironment();
-          aliasDecl->setGenericSignature(proto->getGenericSignature());
-
+          
           // The generic environment didn't exist until now, we may have
           // unresolved types we will need to deal with, and need to record the
           // appropriate substitutions for that environment. Wipe out the types
@@ -4026,11 +4055,17 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         break;
       }
     }
-
-    validateGenericFuncOrSubscriptSignature(FD, FD, FD);
     
     // We want the function to be available for name lookup as soon
     // as it has a valid interface type.
+    auto resolution = TypeResolution::forInterface(FD,
+                                                   FD->getGenericSignature());
+    typeCheckParameterList(FD->getParameters(), resolution,
+                           TypeResolverContext::AbstractFunctionDecl);
+    validateResultType(*this, FD, FD->getParameters(),
+                       FD->getBodyResultTypeLoc(), resolution);
+    // FIXME: Roll all of this interface type computation into a request.
+    FD->computeType();
     FD->setSignatureIsValidated();
 
     // Member functions need some special validation logic.
@@ -4072,7 +4107,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(CD);
 
-    validateGenericFuncOrSubscriptSignature(CD, CD, CD);
+    auto res = TypeResolution::forInterface(CD, CD->getGenericSignature());
+    typeCheckParameterList(CD->getParameters(), res,
+                           TypeResolverContext::AbstractFunctionDecl);
+    CD->computeType();
 
     // We want the constructor to be available for name lookup as soon
     // as it has a valid interface type.
@@ -4086,7 +4124,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(DD);
 
-    validateGenericFuncOrSubscriptSignature(DD, DD, DD);
+    auto res = TypeResolution::forInterface(DD, DD->getGenericSignature());
+    typeCheckParameterList(DD->getParameters(), res,
+                           TypeResolverContext::AbstractFunctionDecl);
+    DD->computeType();
 
     DD->setSignatureIsValidated();
     break;
@@ -4097,7 +4138,12 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(SD);
 
-    validateGenericFuncOrSubscriptSignature(SD, SD, SD);
+    auto res = TypeResolution::forInterface(SD, SD->getGenericSignature());
+    typeCheckParameterList(SD->getIndices(), res,
+                           TypeResolverContext::SubscriptDecl);
+    validateResultType(*this, SD, SD->getIndices(),
+                       SD->getElementTypeLoc(), res);
+    SD->computeType();
 
     SD->setSignatureIsValidated();
 
@@ -4282,25 +4328,7 @@ EmittedMembersRequest::evaluate(Evaluator &evaluator,
   return CD->getMembers();
 }
 
-/// Determine whether this is a "pass-through" typealias, which has the
-/// same type parameters as the nominal type it references and specializes
-/// the underlying nominal type with exactly those type parameters.
-/// For example, the following typealias \c GX is a pass-through typealias:
-///
-/// \code
-/// struct X<T, U> { }
-/// typealias GX<A, B> = X<A, B>
-/// \endcode
-///
-/// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
-/// different type parameters and \c GX3 doesn't pass its type parameters
-/// directly through.
-///
-/// \code
-/// typealias GX2<A> = X<A, A>
-/// typealias GX3<A, B> = X<B, A>
-/// \endcode
-static bool isPassThroughTypealias(TypeAliasDecl *typealias) {
+bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias) {
   // Pass-through only makes sense when the typealias refers to a nominal
   // type.
   Type underlyingType = typealias->getUnderlyingTypeLoc().getType();
@@ -4353,135 +4381,6 @@ static bool isPassThroughTypealias(TypeAliasDecl *typealias) {
                     });
 }
 
-/// Form the interface type of an extension from the raw type and the
-/// extension's list of generic parameters.
-static Type formExtensionInterfaceType(
-                         TypeChecker &tc, ExtensionDecl *ext,
-                         Type type,
-                         GenericParamList *genericParams,
-                         SmallVectorImpl<Requirement> &sameTypeReqs,
-                         bool &mustInferRequirements) {
-  if (type->is<ErrorType>())
-    return type;
-
-  // Find the nominal type declaration and its parent type.
-  if (type->is<ProtocolCompositionType>())
-    type = type->getCanonicalType();
-
-  Type parentType = type->getNominalParent();
-  GenericTypeDecl *genericDecl = type->getAnyGeneric();
-
-  // Reconstruct the parent, if there is one.
-  if (parentType) {
-    // Build the nested extension type.
-    auto parentGenericParams = genericDecl->getGenericParams()
-                                 ? genericParams->getOuterParameters()
-                                 : genericParams;
-    parentType =
-      formExtensionInterfaceType(tc, ext, parentType, parentGenericParams,
-                                 sameTypeReqs, mustInferRequirements);
-  }
-
-  // Find the nominal type.
-  auto nominal = dyn_cast<NominalTypeDecl>(genericDecl);
-  auto typealias = dyn_cast<TypeAliasDecl>(genericDecl);
-  if (!nominal) {
-    Type underlyingType = typealias->getUnderlyingTypeLoc().getType();
-    nominal = underlyingType->getNominalOrBoundGenericNominal();
-  }
-
-  // Form the result.
-  Type resultType;
-  SmallVector<Type, 2> genericArgs;
-  if (!nominal->isGeneric() || isa<ProtocolDecl>(nominal)) {
-    resultType = NominalType::get(nominal, parentType,
-                                  nominal->getASTContext());
-  } else {
-    auto currentBoundType = type->getAs<BoundGenericType>();
-
-    // Form the bound generic type with the type parameters provided.
-    unsigned gpIndex = 0;
-    for (auto gp : *genericParams) {
-      SWIFT_DEFER { ++gpIndex; };
-
-      auto gpType = gp->getDeclaredInterfaceType();
-      genericArgs.push_back(gpType);
-
-      if (currentBoundType) {
-        sameTypeReqs.emplace_back(RequirementKind::SameType, gpType,
-                                  currentBoundType->getGenericArgs()[gpIndex]);
-      }
-    }
-
-    resultType = BoundGenericType::get(nominal, parentType, genericArgs);
-  }
-
-  // If we have a typealias, try to form type sugar.
-  if (typealias && isPassThroughTypealias(typealias)) {
-    auto typealiasSig = typealias->getGenericSignature();
-    SubstitutionMap subMap;
-    if (typealiasSig) {
-      subMap = typealiasSig->getIdentitySubstitutionMap();
-
-      mustInferRequirements = true;
-    }
-
-    resultType = TypeAliasType::get(typealias, parentType, subMap,
-                                    resultType);
-  }
-
-  return resultType;
-}
-
-/// Retrieve the generic parameter depth of the extended type.
-static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
-  auto nominal = ext->getSelfNominalTypeDecl();
-  if (!nominal) return static_cast<unsigned>(-1);
-
-  auto sig = nominal->getGenericSignatureOfContext();
-  if (!sig) return static_cast<unsigned>(-1);
-
-  return sig->getGenericParams().back()->getDepth();
-}
-
-/// Check the generic parameters of an extension, recursively handling all of
-/// the parameter lists within the extension.
-static GenericSignature *
-checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext,
-                            GenericParamList *genericParams) {
-  assert(!ext->getGenericEnvironment());
-
-  // Form the interface type of the extension.
-  bool mustInferRequirements = false;
-  SmallVector<Requirement, 2> sameTypeReqs;
-  Type extInterfaceType =
-    formExtensionInterfaceType(tc, ext, ext->getExtendedType(),
-                               genericParams, sameTypeReqs,
-                               mustInferRequirements);
-
-  assert(genericParams && "Missing generic parameters?");
-  
-  auto cannotReuseNominalSignature = [&]() -> bool {
-    const auto finalDepth = genericParams->getParams().back()->getDepth();
-    return mustInferRequirements
-        || !sameTypeReqs.empty()
-        || ext->getTrailingWhereClause()
-        || (getExtendedTypeGenericDepth(ext) != finalDepth);
-  };
-  
-  // Re-use the signature of the type being extended by default.
-  if (cannotReuseNominalSignature()) {
-    return TypeChecker::checkGenericSignature(
-        genericParams, ext,
-        /*parent signature*/ nullptr,
-        /*allowConcreteGenericParams=*/true,
-        sameTypeReqs,
-        {TypeLoc{nullptr, extInterfaceType}});
-  }
-
-  return ext->getSelfNominalTypeDecl()->getGenericSignatureOfContext();
-}
-
 static bool isNonGenericTypeAliasType(Type type) {
   // A non-generic typealias can extend a specialized type.
   if (auto *aliasType = dyn_cast<TypeAliasType>(type.getPointer()))
@@ -4516,7 +4415,7 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(unboundGeneric->getDecl())) {
       auto extendedNominal = aliasDecl->getDeclaredInterfaceType()->getAnyNominal();
       if (extendedNominal)
-        return isPassThroughTypealias(aliasDecl)
+        return TypeChecker::isPassThroughTypealias(aliasDecl)
                ? extendedType
                : extendedNominal->getDeclaredType();
     }
@@ -4562,11 +4461,12 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   if (auto *nominal = ext->getExtendedNominal()) {
     // Validate the nominal type declaration being extended.
     validateDecl(nominal);
-
-    if (auto *genericParams = ext->getGenericParams()) {
-      auto *sig = checkExtensionGenericParams(*this, ext, genericParams);
-      ext->setGenericSignature(sig);
-    }
+    
+    // FIXME: validateExtension is going to disappear soon.  In the mean time
+    // don't bother computing the generic signature if the extended nominal type
+    // didn't pass validation so we don't crash.
+    if (!nominal->isInvalid())
+      (void)ext->getGenericSignature();
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3720,8 +3720,8 @@ static void validateResultType(TypeChecker &TC,
     resultTyLoc.setType(
         TC.getOrCreateOpaqueResultType(resolution, decl, opaqueTy));
   } else {
-    TC.validateType(resultTyLoc, resolution,
-                    TypeResolverContext::FunctionResult);
+    TypeChecker::validateType(TC.Context, resultTyLoc, resolution,
+                              TypeResolverContext::FunctionResult);
   }
 }
 
@@ -3862,7 +3862,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     for (auto member : proto->getMembers()) {
       if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
         if (!aliasDecl->isGeneric()) {
-          assert(aliasDecl->getGenericSignature() == proto->getGenericSignature());
           // FIXME: Force creation of the protocol's generic environment now.
           (void) proto->getGenericEnvironment();
           

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -443,144 +443,6 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
   }
 }
 
-void TypeChecker::validateGenericFuncOrSubscriptSignature(
-                PointerUnion<AbstractFunctionDecl *, SubscriptDecl *>
-                    funcOrSubscript,
-                ValueDecl *decl, GenericContext *genCtx) {
-  auto func = funcOrSubscript.dyn_cast<AbstractFunctionDecl *>();
-  auto subscr = funcOrSubscript.dyn_cast<SubscriptDecl *>();
-
-  auto gpList = genCtx->getGenericParams();
-  if (gpList) {
-    // Do some initial configuration of the generic parameter lists that's
-    // required in all cases.
-    gpList->setDepth(genCtx->getGenericContextDepth());
-  } else {
-    // Inherit the signature of the surrounding environment.
-    genCtx->setGenericSignature(
-        decl->getDeclContext()->getGenericSignatureOfContext());
-  }
-
-  // Accessors can always use the generic context of their storage
-  // declarations. This is a compile-time optimization since it lets us
-  // avoid the requirements-gathering phase, but it also simplifies that
-  // work for accessors which don't mention the value type in their formal
-  // signatures (like the read and modify coroutines, since yield types
-  // aren't tracked in the AST type yet).
-  if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
-    auto subscr = dyn_cast<SubscriptDecl>(accessor->getStorage());
-    if (gpList && subscr) {
-      genCtx->setGenericSignature(subscr->getGenericSignature());
-    }
-    // We've inherited all of the type information already.
-    accessor->computeType();
-    return;
-  }
-
-  // Use the generic signature of the surrounding context by default.
-  GenericSignature *sig =
-      decl->getDeclContext()->getGenericSignatureOfContext();
-
-  auto params = func ? func->getParameters() : subscr->getIndices();
-  TypeLoc emptyLoc;
-  TypeLoc &resultTyLoc = [&]() -> TypeLoc& {
-    if (subscr)
-      return subscr->getElementTypeLoc();
-    if (auto fn = dyn_cast<FuncDecl>(func))
-      return fn->getBodyResultTypeLoc();
-    return emptyLoc;
-  }();
-
-  if (gpList) {
-    // Gather requirements from the parameter list.
-    auto resolution = TypeResolution::forStructural(genCtx);
-
-    TypeResolutionOptions options =
-      (func
-       ? TypeResolverContext::AbstractFunctionDecl
-       : TypeResolverContext::SubscriptDecl);
-
-    SmallVector<TypeLoc, 2> inferenceSources;
-    for (auto param : *params) {
-      auto *typeRepr = param->getTypeLoc().getTypeRepr();
-      if (typeRepr == nullptr)
-        continue;
-
-      auto paramOptions = options;
-      paramOptions.setContext(param->isVariadic() ?
-                              TypeResolverContext::VariadicFunctionInput :
-                              TypeResolverContext::FunctionInput);
-      paramOptions |= TypeResolutionFlags::Direct;
-
-      auto type = resolution.resolveType(typeRepr, paramOptions);
-
-      if (auto *specifier = dyn_cast_or_null<SpecifierTypeRepr>(typeRepr))
-        typeRepr = specifier->getBase();
-
-      inferenceSources.emplace_back(typeRepr, type);
-    }
-
-    // Gather requirements from the result type.
-    auto *resultTypeRepr = resultTyLoc.getTypeRepr();
-    if (resultTypeRepr && !isa<OpaqueReturnTypeRepr>(resultTypeRepr)) {
-      TypeResolutionOptions resultOptions = TypeResolverContext::FunctionResult;
-
-      auto resultType = resolution.resolveType(resultTypeRepr, resultOptions);
-
-      inferenceSources.emplace_back(resultTypeRepr, resultType);
-    }
-
-    // The signature is complete and well-formed. Determine
-    // the type of the generic function or subscript.
-    auto request = InferredGenericSignatureRequest{
-      genCtx->getParentModule(),
-      decl->getDeclContext()
-          ->getGenericSignatureOfContext(),
-      {gpList}, {}, inferenceSources,
-      /*allowConcreteGenericParams=*/false};
-    sig = evaluateOrDefault(Context.evaluator, request, nullptr);
-
-    // Debugging of the generic signature.
-    if (Context.LangOpts.DebugGenericSignatures) {
-      decl->dumpRef(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "Generic signature: ";
-      sig->print(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "Canonical generic signature: ";
-      sig->getCanonicalSignature()->print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-
-    genCtx->setGenericSignature(sig);
-  }
-
-  auto resolution = TypeResolution::forInterface(genCtx, sig);
-  // Check parameter patterns.
-  typeCheckParameterList(params, resolution, func
-                           ? TypeResolverContext::AbstractFunctionDecl
-                           : TypeResolverContext::SubscriptDecl);
-
-  if (!resultTyLoc.isNull()) {
-    // Check the result type. It is allowed to be opaque.
-    if (auto opaqueTy = dyn_cast_or_null<OpaqueReturnTypeRepr>(
-                              resultTyLoc.getTypeRepr())) {
-      // Create the decl and type for it.
-      resultTyLoc.setType(
-          getOrCreateOpaqueResultType(resolution, decl, opaqueTy));
-    } else {
-      validateType(Context, resultTyLoc, resolution,
-                   TypeResolverContext::FunctionResult);
-    }
-  }
-
-  func ? func->computeType() : subscr->computeType();
-
-  // Make sure that there are no unresolved dependent types in the
-  // generic signature.
-  assert(!decl->getInterfaceType()->findUnresolvedDependentMemberType());
-}
-
 ///
 /// Generic types
 ///
@@ -614,7 +476,11 @@ GenericSignature *TypeChecker::checkGenericSignature(
   // Debugging of the generic signature builder and generic signature
   // generation.
   if (dc->getASTContext().LangOpts.DebugGenericSignatures) {
-    dc->printContext(llvm::errs());
+    if (auto *VD = dyn_cast_or_null<ValueDecl>(dc->getAsDecl())) {
+      VD->dumpRef(llvm::errs());
+    } else {
+      dc->printContext(llvm::errs());
+    }
     llvm::errs() << "\n";
     llvm::errs() << "Generic signature: ";
     sig->print(llvm::errs());
@@ -627,8 +493,107 @@ GenericSignature *TypeChecker::checkGenericSignature(
   return sig;
 }
 
-void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
-  if (auto *proto = dyn_cast<ProtocolDecl>(typeDecl)) {
+/// Form the interface type of an extension from the raw type and the
+/// extension's list of generic parameters.
+static Type formExtensionInterfaceType(
+                         ExtensionDecl *ext, Type type,
+                         GenericParamList *genericParams,
+                         SmallVectorImpl<Requirement> &sameTypeReqs,
+                         bool &mustInferRequirements) {
+  if (type->is<ErrorType>())
+    return type;
+
+  // Find the nominal type declaration and its parent type.
+  if (type->is<ProtocolCompositionType>())
+    type = type->getCanonicalType();
+
+  Type parentType = type->getNominalParent();
+  GenericTypeDecl *genericDecl = type->getAnyGeneric();
+
+  // Reconstruct the parent, if there is one.
+  if (parentType) {
+    // Build the nested extension type.
+    auto parentGenericParams = genericDecl->getGenericParams()
+                                 ? genericParams->getOuterParameters()
+                                 : genericParams;
+    parentType =
+      formExtensionInterfaceType(ext, parentType, parentGenericParams,
+                                 sameTypeReqs, mustInferRequirements);
+  }
+
+  // Find the nominal type.
+  auto nominal = dyn_cast<NominalTypeDecl>(genericDecl);
+  auto typealias = dyn_cast<TypeAliasDecl>(genericDecl);
+  if (!nominal) {
+    Type underlyingType = typealias->getUnderlyingTypeLoc().getType();
+    nominal = underlyingType->getNominalOrBoundGenericNominal();
+  }
+
+  // Form the result.
+  Type resultType;
+  SmallVector<Type, 2> genericArgs;
+  if (!nominal->isGeneric() || isa<ProtocolDecl>(nominal)) {
+    resultType = NominalType::get(nominal, parentType,
+                                  nominal->getASTContext());
+  } else {
+    auto currentBoundType = type->getAs<BoundGenericType>();
+
+    // Form the bound generic type with the type parameters provided.
+    unsigned gpIndex = 0;
+    for (auto gp : *genericParams) {
+      SWIFT_DEFER { ++gpIndex; };
+
+      auto gpType = gp->getDeclaredInterfaceType();
+      genericArgs.push_back(gpType);
+
+      if (currentBoundType) {
+        sameTypeReqs.emplace_back(RequirementKind::SameType, gpType,
+                                  currentBoundType->getGenericArgs()[gpIndex]);
+      }
+    }
+
+    resultType = BoundGenericType::get(nominal, parentType, genericArgs);
+  }
+
+  // If we have a typealias, try to form type sugar.
+  if (typealias && TypeChecker::isPassThroughTypealias(typealias)) {
+    auto typealiasSig = typealias->getGenericSignature();
+    SubstitutionMap subMap;
+    if (typealiasSig) {
+      subMap = typealiasSig->getIdentitySubstitutionMap();
+
+      mustInferRequirements = true;
+    }
+
+    resultType = TypeAliasType::get(typealias, parentType, subMap,
+                                    resultType);
+  }
+
+  return resultType;
+}
+
+/// Retrieve the generic parameter depth of the extended type.
+static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
+  auto nominal = ext->getSelfNominalTypeDecl();
+  if (!nominal) return static_cast<unsigned>(-1);
+
+  auto sig = nominal->getGenericSignatureOfContext();
+  if (!sig) return static_cast<unsigned>(-1);
+
+  return sig->getGenericParams().back()->getDepth();
+}
+
+llvm::Expected<GenericSignature *>
+GenericSignatureRequest::evaluate(Evaluator &evaluator,
+                                  GenericContext *GC) const {
+  // The signature of a Protocol is trivial (Self: TheProtocol) so let's compute
+  // it.
+  if (auto PD = dyn_cast<ProtocolDecl>(GC)) {
+    auto self = PD->getSelfInterfaceType()->castTo<GenericTypeParamType>();
+    auto req =
+        Requirement(RequirementKind::Conformance, self, PD->getDeclaredType());
+    auto *sig = GenericSignature::get({self}, {req});
+
     // The requirement signature is created lazily by
     // ProtocolDecl::getRequirementSignature().
     // The generic signature and environment is created lazily by
@@ -637,10 +602,8 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
 
     // Debugging of the generic signature builder and generic signature
     // generation.
-    if (Context.LangOpts.DebugGenericSignatures) {
-      auto *sig = proto->getGenericSignature();
-
-      proto->printContext(llvm::errs());
+    if (GC->getASTContext().LangOpts.DebugGenericSignatures) {
+      PD->printContext(llvm::errs());
       llvm::errs() << "\n";
       llvm::errs() << "Generic signature: ";
       sig->print(llvm::errs());
@@ -649,32 +612,124 @@ void TypeChecker::validateGenericTypeSignature(GenericTypeDecl *typeDecl) {
       sig->getCanonicalSignature()->print(llvm::errs());
       llvm::errs() << "\n";
     }
-
-    return;
+    return sig;
   }
 
-  assert(!typeDecl->getGenericEnvironment());
-
-  // We don't go down this path for protocols; instead, the generic signature
-  // is simple enough that GenericContext::getGenericSignature() can build it
-  // directly.
-  assert(!isa<ProtocolDecl>(typeDecl));
-
-  auto *gp = typeDecl->getGenericParams();
-  auto *dc = typeDecl->getDeclContext();
-
+  // We can fast-path computing the generic signature of non-generic
+  // declarations by re-using the parent context's signature.
+  auto *gp = GC->getGenericParams();
   if (!gp) {
-    typeDecl->setGenericSignature(dc->getGenericSignatureOfContext());
-    return;
+    return GC->getParent()->getGenericSignatureOfContext();
   }
 
-  gp->setDepth(typeDecl->getGenericContextDepth());
+  // Setup the depth of the generic parameters.
+  gp->setDepth(GC->getGenericContextDepth());
 
-  auto *sig = TypeChecker::checkGenericSignature(
-                  gp, dc,
-                  dc->getGenericSignatureOfContext(),
-                  /*allowConcreteGenericParams=*/false);
-  typeDecl->setGenericSignature(sig);
+  // Accessors can always use the generic context of their storage
+  // declarations. This is a compile-time optimization since it lets us
+  // avoid the requirements-gathering phase, but it also simplifies that
+  // work for accessors which don't mention the value type in their formal
+  // signatures (like the read and modify coroutines, since yield types
+  // aren't tracked in the AST type yet).
+  if (auto accessor = dyn_cast<AccessorDecl>(GC->getAsDecl())) {
+    return cast<SubscriptDecl>(accessor->getStorage())->getGenericSignature();
+  }
+
+  bool allowConcreteGenericParams = false;
+  SmallVector<TypeLoc, 2> inferenceSources;
+  SmallVector<Requirement, 2> sameTypeReqs;
+  if (auto VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl())) {
+    auto func = dyn_cast<AbstractFunctionDecl>(VD);
+    auto subscr = dyn_cast<SubscriptDecl>(VD);
+
+    // For functions and subscripts, resolve the parameter and result types and
+    // note them as inference sources.
+    if (subscr || func) {
+      // Gather requirements from the parameter list.
+      auto resolution = TypeResolution::forStructural(GC);
+
+      TypeResolutionOptions options =
+          (func ? TypeResolverContext::AbstractFunctionDecl
+                : TypeResolverContext::SubscriptDecl);
+
+      auto params = func ? func->getParameters() : subscr->getIndices();
+      for (auto param : *params) {
+        auto *typeRepr = param->getTypeLoc().getTypeRepr();
+        if (typeRepr == nullptr)
+          continue;
+
+        auto paramOptions = options;
+        paramOptions.setContext(param->isVariadic()
+                                    ? TypeResolverContext::VariadicFunctionInput
+                                    : TypeResolverContext::FunctionInput);
+        paramOptions |= TypeResolutionFlags::Direct;
+
+        auto type = resolution.resolveType(typeRepr, paramOptions);
+
+        if (auto *specifier = dyn_cast<SpecifierTypeRepr>(typeRepr))
+          typeRepr = specifier->getBase();
+
+        inferenceSources.emplace_back(typeRepr, type);
+      }
+
+      // Gather requirements from the result type.
+      auto *resultTypeRepr = [&subscr, &func]() -> TypeRepr * {
+        if (subscr) {
+          return subscr->getElementTypeLoc().getTypeRepr();
+        } else if (auto *FD = dyn_cast<FuncDecl>(func)) {
+          return FD->getBodyResultTypeLoc().getTypeRepr();
+        } else {
+          return nullptr;
+        }
+      }();
+      if (resultTypeRepr && !isa<OpaqueReturnTypeRepr>(resultTypeRepr)) {
+        auto resultType = resolution.resolveType(
+            resultTypeRepr, TypeResolverContext::FunctionResult);
+
+        inferenceSources.emplace_back(resultTypeRepr, resultType);
+      }
+    }
+  } else if (auto *ext = dyn_cast<ExtensionDecl>(GC)) {
+    // Form the interface type of the extension so we can use it as an inference
+    // source.
+    //
+    // FIXME: Push this into the "get interface type" request.
+    bool mustInferRequirements = false;
+    Type extInterfaceType =
+      formExtensionInterfaceType(ext, ext->getExtendedType(),
+                                 gp, sameTypeReqs,
+                                 mustInferRequirements);
+    
+    auto cannotReuseNominalSignature = [&]() -> bool {
+      const auto finalDepth = gp->getParams().back()->getDepth();
+      return mustInferRequirements
+          || !sameTypeReqs.empty()
+          || ext->getTrailingWhereClause()
+          || (getExtendedTypeGenericDepth(ext) != finalDepth);
+    };
+    
+    // Re-use the signature of the type being extended by default.
+    if (!cannotReuseNominalSignature()) {
+      return ext->getSelfNominalTypeDecl()->getGenericSignatureOfContext();
+    }
+
+    // Allow parameters to be equated with concrete types.
+    allowConcreteGenericParams = true;
+    inferenceSources.emplace_back(nullptr, extInterfaceType);
+  }
+
+  // EGREGIOUS HACK: The GSB cannot handle the addition of parent signatures
+  // from malformed decls in many cases.  Check the invalid bit and null out the
+  // parent signature.
+  auto *parentSig = GC->getParent()->getGenericSignatureOfContext();
+  if (auto *DD = GC->getParent()->getAsDecl()) {
+    parentSig = DD->isInvalid() ? nullptr : parentSig;
+  }
+  
+  return TypeChecker::checkGenericSignature(
+      gp, GC, parentSig,
+      allowConcreteGenericParams,
+      sameTypeReqs, inferenceSources);
 }
 
 ///

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -197,10 +197,11 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // Build a generic signature.
     tc.validateExtension(extension);
 
-    // The extension may not have a generic signature set up yet, as a
-    // recursion breaker, in which case we can't yet confidently reject its
-    // witnesses.
-    if (!extension->getGenericSignature())
+    // FIXME: The extension may not have a generic signature set up yet as
+    // resolving signatures may trigger associated type inference.  This cycle
+    // is now detectable and we should look into untangling it
+    // - see rdar://55263708
+    if (!extension->hasComputedGenericSignature())
       return true;
 
     // The condition here is a bit more fickle than

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -977,7 +977,7 @@ static Type resolveTypeDecl(TypeDecl *typeDecl, SourceLoc loc,
   if (!options.is(TypeResolverContext::ExtensionBinding) ||
       !isa<NominalTypeDecl>(typeDecl)) {
     // Validate the declaration.
-    if (lazyResolver)
+    if (lazyResolver && !typeDecl->hasInterfaceType())
       lazyResolver->resolveDeclSignature(typeDecl);
 
     // If we were not able to validate recursively, bail out.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -864,6 +864,26 @@ public:
   static Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member,
                                       Type baseTy, bool useArchetypes = true);
 
+  /// Determine whether this is a "pass-through" typealias, which has the
+  /// same type parameters as the nominal type it references and specializes
+  /// the underlying nominal type with exactly those type parameters.
+  /// For example, the following typealias \c GX is a pass-through typealias:
+  ///
+  /// \code
+  /// struct X<T, U> { }
+  /// typealias GX<A, B> = X<A, B>
+  /// \endcode
+  ///
+  /// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
+  /// different type parameters and \c GX3 doesn't pass its type parameters
+  /// directly through.
+  ///
+  /// \code
+  /// typealias GX2<A> = X<A, A>
+  /// typealias GX3<A, B> = X<B, A>
+  /// \endcode
+  static bool isPassThroughTypealias(TypeAliasDecl *typealias);
+  
   /// Determine whether one type is a subtype of another.
   ///
   /// \param t1 The potential subtype.
@@ -1013,13 +1033,6 @@ public:
   /// Infer default value witnesses for all requirements in the given protocol.
   void inferDefaultWitnesses(ProtocolDecl *proto);
 
-  /// Compute the generic signature, generic environment and interface type
-  /// of a generic function or subscript.
-  void validateGenericFuncOrSubscriptSignature(
-              PointerUnion<AbstractFunctionDecl *, SubscriptDecl *>
-                  funcOrSubscript,
-              ValueDecl *decl, GenericContext *genCtx);
-
   /// For a generic requirement in a protocol, make sure that the requirement
   /// set didn't add any requirements to Self or its associated types.
   void checkProtocolSelfRequirements(ValueDecl *decl);
@@ -1054,11 +1067,6 @@ public:
                         bool allowConcreteGenericParams,
                         SmallVector<Requirement, 2> additionalRequirements = {},
                         SmallVector<TypeLoc, 2> inferenceSources = {});
-
-  /// Validate the signature of a generic type.
-  ///
-  /// \param nominal The generic type.
-  void validateGenericTypeSignature(GenericTypeDecl *nominal);
 
   /// Create a text string that describes the bindings of generic parameters
   /// that are relevant to the given set of types, e.g.,

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -57,10 +57,10 @@ protocol SillyProtocol {
   class InnerClass<T> {} // expected-error {{type 'InnerClass' cannot be nested in protocol 'SillyProtocol'}}
 }
 
+// N.B. Redeclaration checks don't see this case because `protocol A` is invalid.
 enum OuterEnum {
   protocol C {} // expected-error{{protocol 'C' cannot be nested inside another declaration}}
-  // expected-note@-1{{'C' previously declared here}}
-  case C(C) // expected-error{{invalid redeclaration of 'C'}}
+  case C(C)
 }
 
 class OuterClass {
@@ -105,7 +105,9 @@ func testLookup(_ x: OuterForUFI.Inner) {
   x.req()
   x.extMethod()
 }
+
+// N.B. Lookup fails here because OuterForUFI.Inner is marked invalid.
 func testLookup<T: OuterForUFI.Inner>(_ x: T) {
-  x.req()
-  x.extMethod()
+  x.req() // expected-error {{value of type 'T' has no member 'req'}}
+  x.extMethod() // expected-error {{value of type 'T' has no member 'extMethod'}}
 }

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -536,9 +536,10 @@ enum SR_10084_E_2 {
   }
 }
 
+// N.B. Redeclaration checks don't see this case because `protocol A` is invalid.
 enum SR_10084_E_3 {
-  protocol A {} //expected-error {{protocol 'A' cannot be nested inside another declaration}} // expected-note {{'A' previously declared here}}
-  case A // expected-error {{invalid redeclaration of 'A'}}
+  protocol A {} //expected-error {{protocol 'A' cannot be nested inside another declaration}}
+  case A
 }
 
 enum SR_10084_E_4 {
@@ -551,9 +552,10 @@ enum SR_10084_E_5 {
   case C // expected-error {{invalid redeclaration of 'C'}}
 }
 
+// N.B. Redeclaration checks don't see this case because `protocol D` is invalid.
 enum SR_10084_E_6 {
-  case D // expected-note {{'D' previously declared here}}
-  protocol D {} //expected-error {{protocol 'D' cannot be nested inside another declaration}} // expected-error {{invalid redeclaration of 'D'}}
+  case D
+  protocol D {} //expected-error {{protocol 'D' cannot be nested inside another declaration}}
 }
 
 enum SR_10084_E_7 {


### PR DESCRIPTION
This just does the thing that @slavapestov's patch made trivial.  The real work is refining that assertion to read

```cxx
assert(!GenericSigAndBit.getInt() && "Generic signature cannot be changed");
```

so we can catch where we're double-computing signatures (*cough* validateDeclForNameLookup).