### PR TITLE
test: disable SIL tests on Windows

### DIFF
--- a/test/SIL/Parser/available.sil
+++ b/test/SIL/Parser/available.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt %s | %FileCheck %s
 // RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
+// UNSUPPORTED: OS=windows-msvc
 
 @available(*,unavailable,message: "it has been renamed")
 public struct mmConstUnsafePointer<T> {

--- a/test/SIL/Serialization/available.sil
+++ b/test/SIL/Serialization/available.sil
@@ -3,6 +3,7 @@
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name available
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name available
 // RUN: %target-sil-opt %t/tmp.2.sib -module-name available | %FileCheck %s
+// UNSUPPORTED: OS=windows-msvc
 
 import Builtin
 


### PR DESCRIPTION
`weak_imported` is not supported on Windows as it does not provide weak
linking semantics.  Disable the tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
