### PR TITLE
[mandatory-combiner] Some small cleanups.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -39,6 +39,23 @@
 
 using namespace swift;
 
+//===----------------------------------------------------------------------===//
+//                                  Utility
+//===----------------------------------------------------------------------===//
+
+/// \returns whether all the values are of trivial type in the provided
+///          function.
+template <typename Values>
+static bool areAllValuesTrivial(Values values, SILFunction &function) {
+  return llvm::all_of(values, [&](SILValue value) -> bool {
+    return value->getType().isTrivial(function);
+  });
+}
+
+//===----------------------------------------------------------------------===//
+//                        MandatoryCombiner Interface
+//===----------------------------------------------------------------------===//
+
 namespace {
 
 class MandatoryCombiner final
@@ -71,163 +88,16 @@ public:
             [&](SILInstruction *instruction) { worklist.add(instruction); }),
         createdInstructions(createdInstructions){};
 
-  /// Base visitor that does not do anything.
-  SILInstruction *visitSILInstruction(SILInstruction *) { return nullptr; }
-
-  /// \returns whether all the values are of trivial type in the provided
-  ///          function.
-  template <typename Values>
-  static bool areAllValuesTrivial(Values values, SILFunction &function) {
-    return llvm::all_of(values, [&](SILValue value) -> bool {
-      return value->getType().isTrivial(function);
-    });
-  }
-
-  SILInstruction *visitApplyInst(ApplyInst *instruction) {
-    // Apply this pass only to partial applies all of whose arguments are
-    // trivial.
-    auto calledValue = instruction->getCallee();
-    if (calledValue == nullptr) {
-      return nullptr;
-    }
-    auto fullApplyCallee = calledValue->getDefiningInstruction();
-    if (fullApplyCallee == nullptr) {
-      return nullptr;
-    }
-    auto partialApply = dyn_cast<PartialApplyInst>(fullApplyCallee);
-    if (partialApply == nullptr) {
-      return nullptr;
-    }
-    auto *function = partialApply->getCalleeFunction();
-    if (function == nullptr) {
-      return nullptr;
-    }
-    ApplySite fullApplySite(instruction);
-    auto fullApplyArguments = fullApplySite.getArguments();
-    if (!areAllValuesTrivial(fullApplyArguments, *function)) {
-      return nullptr;
-    }
-    auto partialApplyArguments = ApplySite(partialApply).getArguments();
-    if (!areAllValuesTrivial(partialApplyArguments, *function)) {
-      return nullptr;
-    }
-
-    auto callee = partialApply->getCallee();
-
-    ApplySite partialApplySite(partialApply);
-
-    SmallVector<SILValue, 8> argsVec;
-    llvm::copy(fullApplyArguments, std::back_inserter(argsVec));
-    llvm::copy(partialApplyArguments, std::back_inserter(argsVec));
-
-    SILBuilderWithScope builder(instruction, &createdInstructions);
-    ApplyInst *replacement = builder.createApply(
-        /*Loc=*/instruction->getDebugLocation().getLocation(), /*Fn=*/callee,
-        /*Subs=*/partialApply->getSubstitutionMap(),
-        /*Args*/ argsVec,
-        /*isNonThrowing=*/instruction->isNonThrowing(),
-        /*SpecializationInfo=*/partialApply->getSpecializationInfo());
-
-    worklist.replaceInstructionWithInstruction(instruction, replacement
-#ifndef NDEBUG
-                                               ,
-                                               /*instructionDescription=*/""
-#endif
-    );
-    tryDeleteDeadClosure(partialApply, instModCallbacks);
-    return nullptr;
-  }
-
-  void addReachableCodeToWorklist(SILFunction &function) {
-    SmallBlotSetVector<SILBasicBlock *, 32> blockWorklist;
-    SmallBlotSetVector<SILBasicBlock *, 32> blocksVisited;
-    SmallVector<SILInstruction *, 128> instructions;
-
-    blockWorklist.insert(&*function.begin());
-    while (!blockWorklist.empty()) {
-      auto *block = blockWorklist.pop_back_val().getValueOr(nullptr);
-      if (block == nullptr) {
-        continue;
-      }
-
-      if (!blocksVisited.insert(block).second) {
-        continue;
-      }
-
-      for (auto iterator = block->begin(), end = block->end(); iterator != end;) {
-        auto *instruction = &*iterator;
-        ++iterator;
-
-        if (isInstructionTriviallyDead(instruction)) {
-          continue;
-        }
-
-        instructions.push_back(instruction);
-      }
-
-      for_each(block->getSuccessorBlocks(), [&](SILBasicBlock *block) {
-        blockWorklist.insert(block);
-      });
-    }
-
-    worklist.addInitialGroup(instructions);
-  }
+  void addReachableCodeToWorklist(SILFunction &function);
 
   /// \return whether a change was made.
-  bool doOneIteration(SILFunction &function, unsigned iteration) {
-    madeChange = false;
-
-    addReachableCodeToWorklist(function);
-
-    while (!worklist.isEmpty()) {
-      auto *instruction = worklist.pop_back_val();
-      if (instruction == nullptr) {
-        continue;
-      }
-
-#ifndef NDEBUG
-      std::string instructionDescription;
-#endif
-      LLVM_DEBUG(llvm::raw_string_ostream SS(instructionDescription);
-                 instruction->print(SS); instructionDescription = SS.str(););
-      LLVM_DEBUG(llvm::dbgs()
-                 << "MC: Visiting: " << instructionDescription << '\n');
-
-      if (auto replacement = visit(instruction)) {
-        worklist.replaceInstructionWithInstruction(instruction, replacement
-#ifndef NDEBUG
-            , instructionDescription
-#endif
-          );
-      }
-
-      for (SILInstruction *instruction : instructionsPendingDeletion) {
-        worklist.eraseInstFromFunction(*instruction);
-      }
-      instructionsPendingDeletion.clear();
-
-      // Our tracking list has been accumulating instructions created by the
-      // SILBuilder during this iteration. Go through the tracking list and add
-      // its contents to the worklist and then clear said list in preparation
-      // for the next iteration.
-      for (SILInstruction *instruction : createdInstructions) {
-        LLVM_DEBUG(llvm::dbgs() << "MC: add " << *instruction
-                                << " from tracking list to worklist\n");
-        worklist.add(instruction);
-      }
-      createdInstructions.clear();
-    }
-
-    worklist.resetChecked();
-    return madeChange;
-  }
+  bool doOneIteration(SILFunction &function, unsigned iteration);
 
   void clear() {
     iteration = 0;
     worklist.resetChecked();
     madeChange = false;
   }
-
 
   /// Applies the MandatoryCombiner to the provided function.
   ///
@@ -244,9 +114,160 @@ public:
 
     return changed;
   }
+
+  /// Base visitor that does not do anything.
+  SILInstruction *visitSILInstruction(SILInstruction *) { return nullptr; }
+  SILInstruction *visitApplyInst(ApplyInst *instruction);
 };
 
 } // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//               MandatoryCombiner Non-Visitor Utility Methods
+//===----------------------------------------------------------------------===//
+
+void MandatoryCombiner::addReachableCodeToWorklist(SILFunction &function) {
+  SmallBlotSetVector<SILBasicBlock *, 32> blockWorklist;
+  SmallBlotSetVector<SILBasicBlock *, 32> blocksVisited;
+  SmallVector<SILInstruction *, 128> instructions;
+
+  blockWorklist.insert(&*function.begin());
+  while (!blockWorklist.empty()) {
+    auto *block = blockWorklist.pop_back_val().getValueOr(nullptr);
+    if (block == nullptr) {
+      continue;
+    }
+
+    if (!blocksVisited.insert(block).second) {
+      continue;
+    }
+
+    for (auto iterator = block->begin(), end = block->end(); iterator != end;) {
+      auto *instruction = &*iterator;
+      ++iterator;
+
+      if (isInstructionTriviallyDead(instruction)) {
+        continue;
+      }
+
+      instructions.push_back(instruction);
+    }
+
+    for_each(block->getSuccessorBlocks(),
+             [&](SILBasicBlock *block) { blockWorklist.insert(block); });
+  }
+
+  worklist.addInitialGroup(instructions);
+}
+
+bool MandatoryCombiner::doOneIteration(SILFunction &function,
+                                       unsigned iteration) {
+  madeChange = false;
+
+  addReachableCodeToWorklist(function);
+
+  while (!worklist.isEmpty()) {
+    auto *instruction = worklist.pop_back_val();
+    if (instruction == nullptr) {
+      continue;
+    }
+
+#ifndef NDEBUG
+    std::string instructionDescription;
+#endif
+    LLVM_DEBUG(llvm::raw_string_ostream SS(instructionDescription);
+               instruction->print(SS); instructionDescription = SS.str(););
+    LLVM_DEBUG(llvm::dbgs()
+               << "MC: Visiting: " << instructionDescription << '\n');
+
+    if (auto replacement = visit(instruction)) {
+      worklist.replaceInstructionWithInstruction(instruction, replacement
+#ifndef NDEBUG
+                                                 ,
+                                                 instructionDescription
+#endif
+      );
+    }
+
+    for (SILInstruction *instruction : instructionsPendingDeletion) {
+      worklist.eraseInstFromFunction(*instruction);
+    }
+    instructionsPendingDeletion.clear();
+
+    // Our tracking list has been accumulating instructions created by the
+    // SILBuilder during this iteration. Go through the tracking list and add
+    // its contents to the worklist and then clear said list in preparation
+    // for the next iteration.
+    for (SILInstruction *instruction : createdInstructions) {
+      LLVM_DEBUG(llvm::dbgs() << "MC: add " << *instruction
+                              << " from tracking list to worklist\n");
+      worklist.add(instruction);
+    }
+    createdInstructions.clear();
+  }
+
+  worklist.resetChecked();
+  return madeChange;
+}
+
+//===----------------------------------------------------------------------===//
+//                     MandatoryCombiner Visitor Methods
+//===----------------------------------------------------------------------===//
+
+SILInstruction *MandatoryCombiner::visitApplyInst(ApplyInst *instruction) {
+  // Apply this pass only to partial applies all of whose arguments are
+  // trivial.
+  auto calledValue = instruction->getCallee();
+  if (calledValue == nullptr) {
+    return nullptr;
+  }
+  auto fullApplyCallee = calledValue->getDefiningInstruction();
+  if (fullApplyCallee == nullptr) {
+    return nullptr;
+  }
+  auto partialApply = dyn_cast<PartialApplyInst>(fullApplyCallee);
+  if (partialApply == nullptr) {
+    return nullptr;
+  }
+  auto *function = partialApply->getCalleeFunction();
+  if (function == nullptr) {
+    return nullptr;
+  }
+  ApplySite fullApplySite(instruction);
+  auto fullApplyArguments = fullApplySite.getArguments();
+  if (!areAllValuesTrivial(fullApplyArguments, *function)) {
+    return nullptr;
+  }
+  auto partialApplyArguments = ApplySite(partialApply).getArguments();
+  if (!areAllValuesTrivial(partialApplyArguments, *function)) {
+    return nullptr;
+  }
+
+  auto callee = partialApply->getCallee();
+
+  ApplySite partialApplySite(partialApply);
+
+  SmallVector<SILValue, 8> argsVec;
+  llvm::copy(fullApplyArguments, std::back_inserter(argsVec));
+  llvm::copy(partialApplyArguments, std::back_inserter(argsVec));
+
+  SILBuilderWithScope builder(instruction, &createdInstructions);
+  ApplyInst *replacement = builder.createApply(
+      /*Loc=*/instruction->getDebugLocation().getLocation(), /*Fn=*/callee,
+      /*Subs=*/partialApply->getSubstitutionMap(),
+      /*Args*/ argsVec,
+      /*isNonThrowing=*/instruction->isNonThrowing(),
+      /*SpecializationInfo=*/partialApply->getSpecializationInfo());
+
+  worklist.replaceInstructionWithInstruction(instruction, replacement
+#ifndef NDEBUG
+                                             ,
+                                             /*instructionDescription=*/""
+#endif
+  );
+  tryDeleteDeadClosure(partialApply, instModCallbacks);
+  return nullptr;
+}
 
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint


### PR DESCRIPTION
Specifically, I split the mandatory combiner class into four different sections:

1. Utility. Small little high level loops that really do not need to be in the
combiner class. E.x.: allValuesAreTrivial.
2. Interface.
3. Non-Visitor Implementation.
4. Visitor Implementation.

This section will allow this code to grow more naturally and be split eventually
into headers and separate implementation files for the visitors and the
"utility" functionality that assist the visitors. The visitors part of this code
is the natural place where this code will grow as shown by the growth in
SILCombine itself.

I am doing this in preparation for moving some non-diagnostic transforms from
diagnostic constant propagation into this pass.
