### PR TITLE
[Sema] Don't look through CoerceExprs in markDirectCallee

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -897,12 +897,6 @@ namespace {
         continue;
       }
 
-      // Coercions can be used for disambiguation.
-      if (auto coerce = dyn_cast<CoerceExpr>(callee)) {
-        callee = coerce->getSubExpr();
-        continue;
-      }
-
       // We're done.
       break;
     }

--- a/test/Sema/suppress-argument-labels-in-types.swift
+++ b/test/Sema/suppress-argument-labels-in-types.swift
@@ -204,3 +204,21 @@ class C0 {
 
 // Check diagnostics changes.
 let _ = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
+
+// SR-11429
+func testIntermediateCoercions() {
+  _ = (f1 as (Int, Int) -> Int)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}}
+  _ = (f1 as (Int, Int) -> Int)(0, 1)
+
+  typealias Magic<T> = T
+  _ = (f1 as Magic)(a: 0, b: 1) // expected-error {{extraneous argument labels 'a:b:' in call}}
+  _ = (f1 as Magic)(0, 1)
+
+  _ = (f4 as (Int, Int) -> Int)(0, 0)
+  _ = (f4 as (Double, Double) -> Double)(0, 0)
+
+  func iuoReturning() -> Int! {}
+  _ = (iuoReturning as () -> Int?)()
+  _ = (iuoReturning as Magic)()
+  _ = (iuoReturning as () -> Int)() // expected-error {{'() -> Int?' is not convertible to '() -> Int'; did you mean to use 'as!' to force downcast?}}
+}

--- a/test/Sema/suppress-argument-labels-in-types.swift
+++ b/test/Sema/suppress-argument-labels-in-types.swift
@@ -220,5 +220,5 @@ func testIntermediateCoercions() {
   func iuoReturning() -> Int! {}
   _ = (iuoReturning as () -> Int?)()
   _ = (iuoReturning as Magic)()
-  _ = (iuoReturning as () -> Int)() // expected-error {{'() -> Int?' is not convertible to '() -> Int'; did you mean to use 'as!' to force downcast?}}
+  _ = (iuoReturning as () -> Int)() // expected-error {{cannot convert value of type '() -> Int?' to type '() -> Int' in coercion}}
 }


### PR DESCRIPTION
Doing so prevented the coercion of a function with argument labels to a user-written function type, as the reference would keep its argument labels due to being marked as "directly applied", but this would then prevent its coercion as the written function type cannot contain argument labels:

```swift
func foo(x: Int) {}
(foo as (Int) -> ())(5)
// error: Cannot convert value of type '(Swift.Int) -> ()' to type '(Swift.Int) -> ()'
// in coercion
```

This PR changes the behaviour such that the referenced function is considered to be unapplied, meaning it has its argument labels stripped, therefore allowing the coercion.

I'm unsure if this change requires any Swift evolution discussion – it is technically source breaking, as it's currently possible to use a generic type alias to make the compiler infer a function type with argument labels:

```swift
typealias Magic<T> = T

func foo(x: Int) {}
(foo as Magic)(x: 5)
```

But I would hope nobody is actually writing code like this, and I can't think of any other compelling examples that would break because of this change.

Resolves [SR-11429](https://bugs.swift.org/browse/SR-11429).
