### PR TITLE
PerformanceInliner: enable generic inlining of co-routines

### DIFF
--- a/test/SILOptimizer/inline_generic_coroutines.swift
+++ b/test/SILOptimizer/inline_generic_coroutines.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-sil  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+@inline(never)
+func useit<T>(_ t: T) {
+  print(t)
+}
+
+// Check that we inline the Array.subscript.read coroutine
+
+// CHECK-LABEL: sil @{{.*}}testit
+// CHECK-NOT:     begin_apply
+// CHECK-NOT:     end_apply
+// CHECK:       } // end sil function {{.*}}testit
+public func testit<T>(_ a: [T]) {
+  for t in a {
+    useit(t)
+  }
+}
+
+// Check that we inline the ManagedBufferPointer.header.read coroutine
+
+public final class MyBuffer<Element> {
+    typealias Manager = ManagedBufferPointer<Int, Element>
+
+    // CHECK-LABEL: sil @{{.*}}MyBuffer{{.*}}countSivg
+    // CHECK-NOT:     begin_apply
+    // CHECK-NOT:     end_apply
+    // CHECK:       } // end sil function {{.*}}MyBuffer{{.*}}countSivg
+    public var count: Int {
+        return Manager(unsafeBufferObject: self).header
+    }
+}
+


### PR DESCRIPTION
Co-routines are so expensive (e.g. Array.subscript.read) that it makes sense to enable generic inlining of co-routines.
This will speed up array iteration (e.g. for elem in array { }) in a generic context significantly.
Another example is ManagedBuffer.header.read, which gets much faster.
In both cases, the speedup is mainly because there is no malloc happening anymore.

https://bugs.swift.org/browse/SR-11231
rdar://problem/53777612
