### PR TITLE
[Syntax] Abolish 'backtick' trivia

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -141,7 +141,7 @@ public:
     case DataKind::DeferredLayout:
       return getDeferredLayoutRange();
     case DataKind::DeferredToken:
-      return getDeferredTokenRangeWithoutBackticks();
+      return getDeferredTokenRange();
     default:
       llvm_unreachable("node not deferred");
     }
@@ -194,7 +194,7 @@ public:
 
     return CharSourceRange{begin, len};
   }
-  CharSourceRange getDeferredTokenRangeWithoutBackticks() const {
+  CharSourceRange getDeferredTokenRange() const {
     assert(DK == DataKind::DeferredToken);
     return CharSourceRange{DeferredToken.TokLoc, DeferredToken.TokLength};
   }

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -248,17 +248,6 @@ public:
     return CharSourceRange(getLoc(), getLength());
   }
 
-  CharSourceRange getRangeWithoutBackticks() const {
-    SourceLoc TokLoc = getLoc();
-    unsigned TokLength = getLength();
-    if (isEscapedIdentifier()) {
-      // Adjust to account for the backticks.
-      TokLoc = TokLoc.getAdvancedLoc(1);
-      TokLength -= 2;
-    }
-    return CharSourceRange(TokLoc, TokLength);
-  }
-
   bool hasComment() const {
     return CommentLength != 0;
   }

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -80,6 +80,15 @@ public:
     return getRaw()->getTokenText();
   }
 
+  StringRef getIdentifierText() const {
+    StringRef text = getText();
+    if (text.front() == '`') {
+      assert(text.back() == '`');
+      return text.slice(1, text.size() - 1);
+    }
+    return text;
+  }
+
   static bool kindof(SyntaxKind Kind) {
     return isTokenKind(Kind);
   }

--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -164,7 +164,7 @@ TupleTypeRepr *ASTGen::generateTuple(TokenSyntax LParen,
       ElementAST.NameLoc = generate(*Name, Loc);
       ElementAST.Name = Name->getText() == "_"
                             ? Identifier()
-                            : Context.getIdentifier(Name->getText());
+                            : Context.getIdentifier(Name->getIdentifierText());
     }
     if (auto Colon = Element.getColon())
       ElementAST.ColonLoc = generate(*Colon, Loc);
@@ -173,7 +173,7 @@ TupleTypeRepr *ASTGen::generateTuple(TokenSyntax LParen,
       ElementAST.SecondName =
           SecondName->getText() == "_"
               ? Identifier()
-              : Context.getIdentifier(SecondName->getText());
+              : Context.getIdentifier(SecondName->getIdentifierText());
       if (IsFunction) {
         // Form the named parameter type representation.
         ElementAST.UnderscoreLoc = ElementAST.NameLoc;
@@ -351,7 +351,7 @@ TypeRepr *ASTGen::generateSimpleOrMemberIdentifier(T Type, SourceLoc &Loc) {
 template <typename T>
 ComponentIdentTypeRepr *ASTGen::generateIdentifier(T Type, SourceLoc &Loc) {
   auto IdentifierLoc = advanceLocBegin(Loc, Type.getName());
-  auto Identifier = Context.getIdentifier(Type.getName().getText());
+  auto Identifier = Context.getIdentifier(Type.getName().getIdentifierText());
   if (auto Clause = Type.getGenericArgumentClause()) {
     auto Args = Clause->getArguments();
     if (!Args.empty()) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1193,7 +1193,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
   auto GetNameText = [this](Optional<ParsedTokenSyntax> Name) {
     return !Name ? StringRef()
                  : SourceMgr.extractText(
-                       Name->getRaw().getDeferredTokenRangeWithoutBackticks(),
+                       Name->getRaw().getDeferredTokenRange(),
                        L->getBufferID());
   };
 
@@ -1208,7 +1208,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
         auto Diag = diagnose(NameLoc, diag::tuple_type_multiple_labels);
         auto Name = Element.getDeferredName();
         auto NameText = SourceMgr.extractText(
-            Name->getRaw().getDeferredTokenRangeWithoutBackticks(),
+            Name->getRaw().getDeferredTokenRange(),
             L->getBufferID());
         if (NameText == "_") {
           Diag.fixItRemoveChars(NameLoc, TypeLoc);

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -35,7 +35,7 @@ ParsedRawSyntaxNode::makeDeferred(Token tok,
                                   const ParsedTrivia &leadingTrivia,
                                   const ParsedTrivia &trailingTrivia,
                                   SyntaxParsingContext &ctx) {
-  CharSourceRange tokRange = tok.getRangeWithoutBackticks();
+  CharSourceRange tokRange = tok.getRange();
   size_t piecesCount = leadingTrivia.size() + trailingTrivia.size();
   ParsedTriviaPiece *piecesPtr = nullptr;
   if (piecesCount > 0) {

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -30,7 +30,7 @@ ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordToken(const Token &tok,
                                      const ParsedTrivia &leadingTrivia,
                                      const ParsedTrivia &trailingTrivia) {
-  return recordToken(tok.getKind(), tok.getRangeWithoutBackticks(),
+  return recordToken(tok.getKind(), tok.getRange(),
                      leadingTrivia.Pieces, trailingTrivia.Pieces);
 }
 
@@ -63,7 +63,7 @@ getRecordedNode(const ParsedRawSyntaxNode &node, ParsedRawSyntaxRecorder &rec) {
   if (node.isDeferredLayout())
     return rec.recordRawSyntax(node.getKind(), node.getDeferredChildren());
   assert(node.isDeferredToken());
-  CharSourceRange tokRange = node.getDeferredTokenRangeWithoutBackticks();
+  CharSourceRange tokRange = node.getDeferredTokenRange();
   tok tokKind = node.getTokenKind();
   if (node.isMissing())
     return rec.recordMissingToken(tokKind, tokRange.getStart());

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -319,7 +319,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
       /*SplitTokens=*/ArrayRef<Token>(),
       [&](const Token &Tok, const ParsedTrivia &LeadingTrivia,
           const ParsedTrivia &TrailingTrivia) {
-        CharSourceRange TokRange = Tok.getRangeWithoutBackticks();
+        CharSourceRange TokRange = Tok.getRange();
         SourceLoc LeadingTriviaLoc =
           TokRange.getStart().getAdvancedLoc(-LeadingTrivia.getLength());
         SourceLoc TrailingTriviaLoc =
@@ -328,7 +328,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
           LeadingTrivia.convertToSyntaxTrivia(LeadingTriviaLoc, SM, BufferID);
         Trivia syntaxTrailingTrivia =
           TrailingTrivia.convertToSyntaxTrivia(TrailingTriviaLoc, SM, BufferID);
-        auto Text = OwnedString::makeRefCounted(Tok.getText());
+        auto Text = OwnedString::makeRefCounted(Tok.getRawText());
         auto ThisToken =
             RawSyntax::make(Tok.getKind(), Text, syntaxLeadingTrivia.Pieces,
                             syntaxTrailingTrivia.Pieces,

--- a/test/Syntax/tokens_escaped_identifier.swift
+++ b/test/Syntax/tokens_escaped_identifier.swift
@@ -2,20 +2,16 @@
 let /*leading trivia*/ `if` = 3
 print(/*leading trivia*/ `if` )
 
-// CHECK-LABEL: 2:25
+// CHECK-LABEL: 2:24
 // CHECK-NEXT:(Token identifier
 // CHECK-NEXT: (trivia blockComment /*leading trivia*/)
 // CHECK-NEXT: (trivia space 1)
-// CHECK-NEXT: (trivia backtick 1)
-// CHECK-NEXT: (text="if")
-// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (text="`if`")
 // CHECK-NEXT: (trivia space 1))
 
-// CHECK-LABEL: 3:27
+// CHECK-LABEL: 3:26
 // CHECK-NEXT:(Token identifier
 // CHECK-NEXT: (trivia blockComment /*leading trivia*/)
 // CHECK-NEXT: (trivia space 1)
-// CHECK-NEXT: (trivia backtick 1)
-// CHECK-NEXT: (text="if")
-// CHECK-NEXT: (trivia backtick 1)
+// CHECK-NEXT: (text="`if`")
 // CHECK-NEXT: (trivia space 1))

--- a/unittests/Syntax/TriviaTests.cpp
+++ b/unittests/Syntax/TriviaTests.cpp
@@ -73,13 +73,6 @@ TEST(TriviaTests, EmptyEquivalence) {
   ASSERT_EQ(Trivia() + Trivia(), Trivia());
 }
 
-TEST(TriviaTests, Backtick) {
-  llvm::SmallString<1> Scratch;
-  llvm::raw_svector_ostream OS(Scratch);
-  Trivia::backtick().print(OS);
-  ASSERT_EQ(OS.str().str(), "`");
-}
-
 TEST(TriviaTests, PrintingSpaces) {
   llvm::SmallString<4> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
@@ -155,10 +148,9 @@ TEST(TriviaTests, PrintingCombinations) {
     llvm::raw_svector_ostream OS(Scratch);
     auto CCCCombo = Trivia::spaces(1) +
       Trivia::tabs(1) +
-      Trivia::newlines(1) +
-      Trivia::backtick();
+      Trivia::newlines(1);
     CCCCombo.print(OS);
-    ASSERT_EQ(OS.str().str(), " \t\n`");
+    ASSERT_EQ(OS.str().str(), " \t\n");
   }
 
   {
@@ -167,7 +159,6 @@ TEST(TriviaTests, PrintingCombinations) {
 }
 
 TEST(TriviaTests, Contains) {
-  ASSERT_FALSE(Trivia().contains(TriviaKind::Backtick));
   ASSERT_FALSE(Trivia().contains(TriviaKind::BlockComment));
   ASSERT_FALSE(Trivia().contains(TriviaKind::DocBlockComment));
   ASSERT_FALSE(Trivia().contains(TriviaKind::DocLineComment));
@@ -177,7 +168,6 @@ TEST(TriviaTests, Contains) {
   ASSERT_FALSE(Trivia().contains(TriviaKind::Newline));
   ASSERT_FALSE(Trivia().contains(TriviaKind::Space));
 
-  ASSERT_TRUE(Trivia::backtick().contains(TriviaKind::Backtick));
   ASSERT_TRUE(Trivia::blockComment("/**/").contains(TriviaKind::BlockComment));
   ASSERT_TRUE(Trivia::docBlockComment("/***/")
               .contains(TriviaKind::DocBlockComment));
@@ -188,12 +178,10 @@ TEST(TriviaTests, Contains) {
   ASSERT_TRUE(Trivia::newlines(1).contains(TriviaKind::Newline));
   ASSERT_TRUE(Trivia::spaces(1).contains(TriviaKind::Space));
 
-  auto Combo = Trivia::spaces(1) + Trivia::backtick() + Trivia::newlines(3)
-    + Trivia::spaces(1);
+  auto Combo = Trivia::spaces(1) + Trivia::newlines(3) + Trivia::spaces(1);
 
   ASSERT_TRUE(Combo.contains(TriviaKind::Space));
   ASSERT_TRUE(Combo.contains(TriviaKind::Newline));
-  ASSERT_TRUE(Combo.contains(TriviaKind::Backtick));
   ASSERT_FALSE(Combo.contains(TriviaKind::Tab));
   ASSERT_FALSE(Combo.contains(TriviaKind::LineComment));
   ASSERT_FALSE(Combo.contains(TriviaKind::Formfeed));
@@ -219,23 +207,23 @@ TEST(TriviaTests, push_back) {
   llvm::SmallString<3> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   Trivia Triv;
-  Triv.push_back(TriviaPiece::backtick());
-  Triv.push_back(TriviaPiece::backtick());
-  Triv.push_back(TriviaPiece::backtick());
+  Triv.push_back(TriviaPiece::newline());
+  Triv.push_back(TriviaPiece::newline());
+  Triv.push_back(TriviaPiece::newline());
   Triv.print(OS);
-  ASSERT_EQ(OS.str().str(), "```");
+  ASSERT_EQ(OS.str().str(), "\n\n\n");
 }
 
 TEST(TriviaTests, push_front) {
   llvm::SmallString<3> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   Trivia Triv;
-  Triv.push_back(TriviaPiece::backtick());
+  Triv.push_back(TriviaPiece::newline());
   Triv.push_front(TriviaPiece::spaces(1));
   Triv.push_back(TriviaPiece::spaces(1));
-  Triv.push_front(TriviaPiece::backtick());
+  Triv.push_front(TriviaPiece::newline());
   Triv.print(OS);
-  ASSERT_EQ(OS.str().str(), "` ` ");
+  ASSERT_EQ(OS.str().str(), "\n \n ");
 }
 
 TEST(TriviaTests, front) {

--- a/utils/gyb_syntax_support/Trivia.py
+++ b/utils/gyb_syntax_support/Trivia.py
@@ -4,7 +4,8 @@ from kinds import lowercase_first_word  # noqa: I201
 
 class Trivia(object):
     def __init__(self, name, comment, serialization_code, characters=[],
-                 swift_characters=[], is_new_line=False, is_comment=False):
+                 swift_characters=[], is_new_line=False, is_comment=False,
+                 deprecated=None):
         self.name = name
         self.comment = comment
         self.serialization_code = serialization_code
@@ -12,6 +13,7 @@ class Trivia(object):
         self.lower_name = lowercase_first_word(name)
         self.is_new_line = is_new_line
         self.is_comment = is_comment
+        self.deprecated = deprecated
 
         # Swift sometimes doesn't support escaped characters like \f or \v;
         # we should allow specifying alternatives explicitly.
@@ -43,9 +45,11 @@ TRIVIAS = [
     Trivia('CarriageReturnLineFeed',
            'A newline consists of contiguous \'\\r\' and \'\\n\' characters.',
            characters=['\\r', '\\n'], is_new_line=True, serialization_code=6),
+    # TODO: Romove 'Backtick' when all known clients are migrated.
     Trivia('Backtick',
            'A backtick \'`\' character, used to escape identifiers.',
-           characters=['`'], serialization_code=7),
+           characters=['`'], serialization_code=7,
+           deprecated="backticks are now part of the token text"),
     Trivia('LineComment', 'A developer line comment, starting with \'//\'',
            is_comment=True, serialization_code=8),
     Trivia('BlockComment',

--- a/utils/gyb_syntax_support/Trivia.py
+++ b/utils/gyb_syntax_support/Trivia.py
@@ -4,21 +4,21 @@ from kinds import lowercase_first_word  # noqa: I201
 
 class Trivia(object):
     def __init__(self, name, comment, serialization_code, characters=[],
-                 swift_characters=[], is_new_line=False, is_comment=False,
-                 deprecated=None):
+                 swift_characters=[], is_new_line=False, is_comment=False):
         self.name = name
         self.comment = comment
         self.serialization_code = serialization_code
-        self.characters = characters
+        self.characters = tuple(characters)
         self.lower_name = lowercase_first_word(name)
         self.is_new_line = is_new_line
         self.is_comment = is_comment
-        self.deprecated = deprecated
 
         # Swift sometimes doesn't support escaped characters like \f or \v;
         # we should allow specifying alternatives explicitly.
-        self.swift_characters = swift_characters if swift_characters else\
-            characters
+        if swift_characters:
+            self.swift_characters = tuple(swift_characters)
+        else:
+            self.swift_characters = characters
         assert len(self.swift_characters) == len(self.characters)
 
     def characters_len(self):
@@ -45,11 +45,6 @@ TRIVIAS = [
     Trivia('CarriageReturnLineFeed',
            'A newline consists of contiguous \'\\r\' and \'\\n\' characters.',
            characters=['\\r', '\\n'], is_new_line=True, serialization_code=6),
-    # TODO: Romove 'Backtick' when all known clients are migrated.
-    Trivia('Backtick',
-           'A backtick \'`\' character, used to escape identifiers.',
-           characters=['`'], serialization_code=7,
-           deprecated="backticks are now part of the token text"),
     Trivia('LineComment', 'A developer line comment, starting with \'//\'',
            is_comment=True, serialization_code=8),
     Trivia('BlockComment',

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -13,6 +13,7 @@ from NodeSerializationCodes import SYNTAX_NODE_SERIALIZATION_CODES, \
 from PatternNodes import PATTERN_NODES  # noqa: I201
 from StmtNodes import STMT_NODES  # noqa: I201
 import Token
+from Trivia import TRIVIAS  # noqa: I201
 from TypeNodes import TYPE_NODES  # noqa: I201
 
 
@@ -161,10 +162,16 @@ def hash_token_syntax(token):
     return hash((token.name, token.serialization_code))
 
 
+def hash_trivia(trivia):
+    return hash((trivia.name, trivia.serialization_code, trivia.characters))
+
+
 def calculate_node_hash():
     result = 0
     for node in SYNTAX_NODES:
         result = hash((result, hash_syntax_node(node)))
     for token in SYNTAX_TOKENS:
         result = hash((result, hash_token_syntax(token)))
+    for trivia in TRIVIAS:
+        result = hash((result, hash_trivia(trivia)))
     return result


### PR DESCRIPTION
- Stop producing 'backtick' trivia for escaped identifier token. `` ` ``s  are now parts of the token text
- Adjust and simplify C++ libSyntax APIs
- Remove backtick trivia declaration

rdar://problem/54810608

swift-syntax change: https://github.com/apple/swift-syntax/pull/142
