### PR TITLE
[ownership] Now that we can run -Onone tests with both ownership and …

### DIFF
--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-static-assert -emit-sil %s -verify
+// RUN: %target-swift-frontend -enable-experimental-static-assert -enable-ownership-stripping-after-serialization -emit-sil %s -verify
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: asserts
@@ -65,18 +66,6 @@ func test_loops() {
   // expected-error @+2 {{#assert condition not constant}}
   // expected-note @+1 {{control-flow loop found during evaluation}}
   #assert(infiniteLoop() == 1)
-}
-
-// NOTE: We currently hit the limit of 512 on a debug_value in the prelude of
-// this function. TODO: What is the right thing to do here?
-func recursive(a: Int) -> Int {  // expected-note {{limit exceeded here}}
-  return a == 0 ? 0 : recursive(a: a-1)
-}
-
-func test_recursive() {
-  // expected-error @+2 {{#assert condition not constant}}
-  // expected-note @+1 {{exceeded instruction limit: 512 when evaluating the expression at compile time}}
-  #assert(recursive(a: 20000) > 42)
 }
 
 func conditional(_ x: Int) -> Int {

--- a/test/SILOptimizer/pound_assert_test_recursive.swift
+++ b/test/SILOptimizer/pound_assert_test_recursive.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend -enable-experimental-static-assert -emit-sil %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -enable-experimental-static-assert -enable-ownership-stripping-after-serialization -emit-sil %s 2>&1 | %FileCheck %s
+
+// This is a special FileCheck test for testing that we properly catch that we
+// are recursing here. The reason why this is separate from the other
+// pound_assert tests is that the "limit exceeded" here diagnostic can vary
+// depending on the codegen since we are using an arbitrary limit of 512. If the
+// codegen changes, the line where we stop evaluating can change meaning that
+// the note moves around lines. With FileCheck we have more flexibility to just
+// match what we actually want.
+
+// CHECK: error: #assert condition not constant
+// CHECK: note: exceeded instruction limit: 512 when evaluating the expression at compile time
+// CHECK: limit exceeded here
+func recursive(a: Int) -> Int {
+  return a == 0 ? 0 : recursive(a: a-1)
+}
+
+func test_recursive() {
+  #assert(recursive(a: 20000) > 42)
+}
+


### PR DESCRIPTION
…without, run pound_assert in both modes to prevent this test from breaking.

I also extracted out the recursion test into a FileCheck test so that we can
avoid having to do a -verify pattern match again the exact line where the
recursion limit was hit. This limit is noisy in the face of codegen changes
since we are IIRC counting instructions. Thus using -verify we can't pattern
match since the line can change easily.
