### PR TITLE
[Diagnostics] Improve handling of ambiguous type arguments to diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -660,6 +660,11 @@ namespace swift {
     /// This is required because diagnostics are not directly emitted
     /// but rather stored until all transactions complete.
     llvm::StringMap<char, llvm::BumpPtrAllocator &> TransactionStrings;
+    
+    /// All TypeDescriptions involved in the current transactional chain.
+    /// This is required because diagnostics are not directly emitted
+    /// but rather stored until all transactions complete.
+    SmallVector<TypeDescription, 8> TransactionTypeDescriptions;
 
     /// The number of open diagnostic transactions. Diagnostics are only
     /// emitted once all transactions have closed.
@@ -990,6 +995,7 @@ namespace swift {
 
       if (Depth == 0) {
         Engine.TransactionStrings.clear();
+        Engine.TransactionTypeDescriptions.clear();
         Engine.TransactionAllocator.Reset();
       }
     }

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -19,9 +19,10 @@
 #define SWIFT_BASIC_DIAGNOSTICENGINE_H
 
 #include "swift/AST/Attr.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/TypeLoc.h"
+#include "swift/AST/Types.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
 
@@ -88,6 +89,7 @@ namespace swift {
     DeclAttribute,
     VersionTuple,
     LayoutConstraint,
+    TypeDescription,
   };
 
   namespace diag {
@@ -117,6 +119,7 @@ namespace swift {
       const DeclAttribute *DeclAttributeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
+      TypeDescription TypeDescriptionVal;
     };
     
   public:
@@ -197,6 +200,10 @@ namespace swift {
 
     DiagnosticArgument(LayoutConstraint L)
       : Kind(DiagnosticArgumentKind::LayoutConstraint), LayoutConstraintVal(L) {
+    }
+
+    DiagnosticArgument(TypeDescription D)
+        : Kind(DiagnosticArgumentKind::TypeDescription), TypeDescriptionVal(D) {
     }
     /// Initializes a diagnostic argument using the underlying type of the
     /// given enum.
@@ -287,6 +294,11 @@ namespace swift {
     LayoutConstraint getAsLayoutConstraint() const {
       assert(Kind == DiagnosticArgumentKind::LayoutConstraint);
       return LayoutConstraintVal;
+    }
+
+    TypeDescription getAsTypeDescription() const {
+      assert(Kind == DiagnosticArgumentKind::TypeDescription);
+      return TypeDescriptionVal;
     }
   };
   

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -119,7 +119,7 @@ namespace swift {
       const DeclAttribute *DeclAttributeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
-      TypeDescription TypeDescriptionVal;
+      const TypeDescription *TypeDescriptionVal;
     };
     
   public:
@@ -202,7 +202,7 @@ namespace swift {
       : Kind(DiagnosticArgumentKind::LayoutConstraint), LayoutConstraintVal(L) {
     }
 
-    DiagnosticArgument(TypeDescription D)
+    DiagnosticArgument(const TypeDescription *D)
         : Kind(DiagnosticArgumentKind::TypeDescription), TypeDescriptionVal(D) {
     }
     /// Initializes a diagnostic argument using the underlying type of the
@@ -296,7 +296,7 @@ namespace swift {
       return LayoutConstraintVal;
     }
 
-    TypeDescription getAsTypeDescription() const {
+    const TypeDescription *getAsTypeDescription() const {
       assert(Kind == DiagnosticArgumentKind::TypeDescription);
       return TypeDescriptionVal;
     }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2297,10 +2297,10 @@ NOTE(convenience_init_override_here,none,
      "attempt to override convenience initializer here", ())
 NOTE(override_type_mismatch_with_fixits,none,
      "type does not match superclass %0 with type %1",
-     (DescriptiveDeclKind, Type))
+     (DescriptiveDeclKind, TypeDescription*))
 NOTE(override_type_mismatch_with_fixits_init,none,
      "type does not match superclass initializer with %select{no arguments|argument %1|arguments %1}0",
-     (unsigned, Type))
+     (unsigned, TypeDescription*))
 ERROR(override_nonclass_decl,none,
       "'override' can only be specified on class members", ())
 ERROR(nonoverride_wrong_decl_context,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -354,7 +354,7 @@ ERROR(cannot_throw_error_code,none,
       "instance", (Type, Type))
 
 FIXIT(insert_type_coercion,
-      " %select{as!|as}0 %1",(bool, TypeDescription))
+      " %select{as!|as}0 %1",(bool, TypeDescription*))
 
 ERROR(bad_yield_count,none,
       "expected %0 yield value(s)", (unsigned))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -354,7 +354,7 @@ ERROR(cannot_throw_error_code,none,
       "instance", (Type, Type))
 
 FIXIT(insert_type_coercion,
-      " %select{as!|as}0 %1",(bool, Type))
+      " %select{as!|as}0 %1",(bool, TypeDescription))
 
 ERROR(bad_yield_count,none,
       "expected %0 yield value(s)", (unsigned))

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -195,6 +195,11 @@ struct PrintOptions {
   /// type might be ambiguous.
   bool FullyQualifiedTypesIfAmbiguous = false;
 
+  /// A predicate to use in lieu of the default heuristics when determining if a
+  /// type is ambiguous. Is only considered if \c FullyQualifiedTypesIfAmbiguous
+  /// is \c true.
+  std::function<bool(Type)> IsTypeAmbiguous;
+
   /// If true, printed module names will use the "exported" name, which may be
   /// different from the regular name.
   ///

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1113,6 +1113,21 @@ public:
   void *operator new(size_t Bytes, void *Mem) throw() { return Mem; }
 };
 
+/// Holds the information needed to print a type for use in a specific context.
+/// Intended for use when printing a type as part of a fix-it or other
+/// diagnostic message where shadowing is a concern.
+struct TypeDescription {
+  /// The type being described.
+  Type Ty;
+  /// The DeclContext associated with a specific use of the type.
+  DeclContext *DC;
+  /// The SourceLoc associated with a specific use of the type.
+  SourceLoc Loc;
+
+  TypeDescription(Type Ty, DeclContext *DC, SourceLoc Loc)
+      : Ty(Ty), DC(DC), Loc(Loc) {}
+};
+
 /// AnyGenericType - This abstract class helps types ensure that fields
 /// exist at the same offset in memory to improve code generation of the
 /// compiler itself.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1119,13 +1119,12 @@ public:
 struct TypeDescription {
   /// The type being described.
   Type Ty;
-  /// The DeclContext associated with a specific use of the type.
-  DeclContext *DC;
-  /// The SourceLoc associated with a specific use of the type.
-  SourceLoc Loc;
+  /// The printed representation of the type in the given context.
+  std::string PrintedRepresentation;
+  /// Whether the type would be ambiguous if unqualified in the given context.
+  bool AmbiguousIfUnqualified;
 
-  TypeDescription(Type Ty, DeclContext *DC, SourceLoc Loc)
-      : Ty(Ty), DC(DC), Loc(Loc) {}
+  TypeDescription(Type Ty, DeclContext *DC, SourceLoc Loc);
 };
 
 /// AnyGenericType - This abstract class helps types ensure that fields

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3512,7 +3512,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
 
     // If present, IsTypeAmbiguous overrides the other heuristics.
     if (Options.IsTypeAmbiguous)
-      return  Options.IsTypeAmbiguous(T);
+      return Options.IsTypeAmbiguous(T);
 
     Decl *D;
     if (auto *TAT = dyn_cast<TypeAliasType>(T))

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3510,6 +3510,10 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     if (!Options.FullyQualifiedTypesIfAmbiguous)
       return false;
 
+    // If present, IsTypeAmbiguous overrides the other heuristics.
+    if (Options.IsTypeAmbiguous)
+      return  Options.IsTypeAmbiguous(T);
+
     Decl *D;
     if (auto *TAT = dyn_cast<TypeAliasType>(T))
       D = TAT->getDecl();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2424,8 +2424,9 @@ bool ContextualFailure::tryTypeCoercionFixIt(
       toType = OptionalType::get(toType);
     auto fixItLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
                                                anchor->getEndLoc());
+    auto description = TypeDescription(toType, getDC(), fixItLoc);
     diagnostic.fixItInsert(fixItLoc, diag::insert_type_coercion, canUseAs,
-                           TypeDescription(toType, getDC(), fixItLoc));
+                           &description);
     return true;
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2422,9 +2422,10 @@ bool ContextualFailure::tryTypeCoercionFixIt(
                     Kind == CheckedCastKind::BridgingCoercion;
     if (bothOptional && canUseAs)
       toType = OptionalType::get(toType);
-    diagnostic.fixItInsert(Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
-                                                      anchor->getEndLoc()),
-                           diag::insert_type_coercion, canUseAs, toType);
+    auto fixItLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
+                                               anchor->getEndLoc());
+    diagnostic.fixItInsert(fixItLoc, diag::insert_type_coercion, canUseAs,
+                           TypeDescription(toType, getDC(), fixItLoc));
     return true;
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -454,17 +454,19 @@ static bool noteFixableMismatchedTypes(ValueDecl *decl, const ValueDecl *base) {
                                               false);
       auto diagKind = diag::override_type_mismatch_with_fixits_init;
       unsigned numArgs = baseInit->getParameters()->size();
+      TypeDescription argTyDesc(argTy, decl->getDeclContext(), decl->getLoc());
       activeDiag.emplace(diags.diagnose(decl, diagKind,
                                         /*plural*/std::min(numArgs, 2U),
-                                        argTy));
+                                        &argTyDesc));
     } else {
       if (isa<AbstractFunctionDecl>(base))
         baseTy = baseTy->getAs<AnyFunctionType>()->getResult();
-
+      TypeDescription baseTyDesc(baseTy, base->getDeclContext(),
+                                 base->getLoc());
       activeDiag.emplace(
         diags.diagnose(decl,
                        diag::override_type_mismatch_with_fixits,
-                       base->getDescriptiveKind(), baseTy));
+                       base->getDescriptiveKind(), &baseTyDesc));
     }
 
     if (fixItOverrideDeclarationTypes(*activeDiag, decl, base))

--- a/test/Constraints/diag_ambiguous_types.swift
+++ b/test/Constraints/diag_ambiguous_types.swift
@@ -1,0 +1,36 @@
+// RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck -check-prefix CHECK-NO-SHADOWING -check-prefix CHECK_ALL %s
+// RUN: not %target-swift-frontend -DSTRING_SHADOWED -typecheck %s 2>&1 | %FileCheck -check-prefix CHECK-STRING-SHADOWED -check-prefix CHECK_ALL %s
+
+#if STRING_SHADOWED
+struct String {}
+#endif
+
+let any: Any = ""
+
+let x: Swift.String = any
+// CHECK-NO-SHADOWING: cannot convert value of type 'Any' to specified type 'String'
+// CHECK-NO-SHADOWING: as! String
+// CHECK-STRING-SHADOWED: cannot convert value of type 'Any' to specified type 'String'
+// CHECK-STRING-SHADOWED: as! Swift.String
+
+let y: [Swift.String] = any
+// CHECK-NO-SHADOWING: cannot convert value of type 'Any' to specified type '[String]'
+// CHECK-NO-SHADOWING: as! [String]
+// CHECK-STRING-SHADOWED: cannot convert value of type 'Any' to specified type '[String]'
+// CHECK-STRING-SHADOWED: as! [Swift.String]
+
+let z: ((Swift.String) -> String) = any
+// CHECK-NO-SHADOWING: cannot convert value of type 'Any' to specified type '(String) -> String'
+// CHECK-NO-SHADOWING: as! (String) -> String
+// CHECK-STRING-SHADOWED: cannot convert value of type 'Any' to specified type '(String) -> String'
+// CHECK-STRING-SHADOWED: as! (Swift.String) -> String
+
+struct Foo {}
+
+struct Bar {
+  struct Foo {}
+  
+  let baz: (diag_ambiguous_types.Foo, Int, Int) = any
+  // CHECK-ALL: cannot convert value of type 'Any' to specified type '(Foo, Int, Int)'
+  // CHECK-ALL: as! (diag_ambiguous_types.Foo, Int, Int)
+}


### PR DESCRIPTION
Introduce a new kind of diagnostic argument, `TypeDescription`. A `TypeDescription` includes the context the printed description of the type will be used in. Diagnostics can leverage this information to correctly qualify types in diagnostics and fix-its when needed.

Right now, this is only being used for the type coercion fix-it. If this change lands, I plan on spending some time migrating all of the type related fix-its to use structured fix-its and `TypeDescription`. Errors/warnings/notes can potentially benefit from this too in order to improve clarity. I'm focusing on fix-its first because most of the existing fix-its which involve types can be tricked into suggesting invalid code with some creative use of shadowing.

This doesn't resolve [SR-11166](https://bugs.swift.org/browse/SR-11166), but it lays the remaining groundwork to resolve that issue, and related issues with fix-its and shadowing.

cc @jrose-apple 