### PR TITLE
Fix bad interaction between SIL deserialization and weak linking [5.1]

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -975,9 +975,31 @@ public:
 
   bool isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
-  /// Whether this declaration is weak-imported.
-  bool isWeakImported(ModuleDecl *fromModule,
-                      AvailabilityContext fromContext) const;
+  AvailabilityContext getAvailabilityForLinkage() const;
+
+  /// Whether this declaration or one of its outer contexts has the
+  /// @_weakLinked attribute.
+  bool isAlwaysWeakImported() const;
+
+  /// Whether this declaration is weak-imported from the given module,
+  /// either because of the presence of the @_weakLinked attribute, or
+  /// because of availability.
+  ///
+  /// Note that \p fromModule should either be the "main module" or
+  /// nullptr. (This is because when it is non-null, we query the
+  /// current deployment target, and not the deployment target that
+  /// the module was built with.)
+  ///
+  /// If \p fromModule is the main module, this returns false when the
+  /// declaration is part of the main module, or if the declaration is
+  /// at least as available as the current deployment target.
+  ///
+  /// If \p fromModule is null, we instead return true if the
+  /// declaration is meant to be weak linked with _some_ deployment
+  /// target; that is, the presence of the @_weakLinked attribute or
+  /// any kind of availability is enough, irrespective of the current
+  /// deployment target.
+  bool isWeakImported(ModuleDecl *fromModule) const;
 
   /// Returns true if the nature of this declaration allows overrides.
   /// Note that this does not consider whether it is final or whether

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -631,6 +631,8 @@ ERROR(expected_sil_function_type, none,
       "sil function expected to have SIL function type", ())
 ERROR(sil_dynamically_replaced_func_not_found,none,
       "dynamically replaced function not found %0", (Identifier))
+ERROR(sil_availability_expected_version,none,
+      "expected version number in 'available' attribute", ())
 
 // SIL Stage
 ERROR(expected_sil_stage_name, none,

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -349,8 +349,7 @@ public:
   bool isInvalid() const;
 
   /// Whether this conformance is weak-imported.
-  bool isWeakImported(ModuleDecl *fromModule,
-                      AvailabilityContext fromContext) const;
+  bool isWeakImported(ModuleDecl *fromModule) const;
 
   bool hasWitness(ValueDecl *requirement) const;
   Witness getWitness(ValueDecl *requirement, LazyResolver *resolver) const;

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1102,8 +1102,7 @@ public:
   }
 
   /// Determine whether this entity will be weak-imported.
-  bool isWeakImported(ModuleDecl *module,
-                      AvailabilityContext fromContext) const;
+  bool isWeakImported(ModuleDecl *module) const;
   
   /// Return the source file whose codegen should trigger emission of this
   /// link entity, if one can be identified.
@@ -1173,7 +1172,6 @@ public:
 
   static LinkInfo get(const UniversalLinkageInfo &linkInfo,
                       ModuleDecl *swiftModule,
-                      AvailabilityContext availabilityContext,
                       const LinkEntity &entity,
                       ForDefinition_t forDefinition);
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -18,6 +18,7 @@
 #define SWIFT_SIL_SILFUNCTION_H
 
 #include "swift/AST/ASTNode.h"
+#include "swift/AST/Availability.h"
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/SIL/SILBasicBlock.h"
@@ -173,6 +174,10 @@ private:
   /// Contains Function Entry Count
   ProfileCounter EntryCount;
 
+  /// The availability used to determine if declarations of this function
+  /// should use weak linking.
+  AvailabilityContext Availability;
+
   /// This is the number of uses of this SILFunction inside the SIL.
   /// It does not include references from debug scopes.
   unsigned RefCount = 0;
@@ -211,8 +216,9 @@ private:
   /// would indicate.
   unsigned HasCReferences : 1;
 
-  /// Whether cross-module references to this function should use weak linking.
-  unsigned IsWeakLinked : 1;
+  /// Whether cross-module references to this function should always use
+  /// weak linking.
+  unsigned IsWeakImported : 1;
 
   // Whether the implementation can be dynamically replaced.
   unsigned IsDynamicReplaceable : 1;
@@ -575,17 +581,27 @@ public:
   bool hasCReferences() const { return HasCReferences; }
   void setHasCReferences(bool value) { HasCReferences = value; }
 
-  /// Returns whether this function's symbol must always be weakly referenced
-  /// across module boundaries.
-  bool isWeakLinked() const { return IsWeakLinked; }
-  /// Forces IRGen to treat references to this function as weak across module
-  /// boundaries (i.e. if it has external linkage).
-  void setWeakLinked(bool value = true) {
-    assert(!IsWeakLinked && "already set");
-    IsWeakLinked = value;
+  /// Returns the availability context used to determine if the function's
+  /// symbol should be weakly referenced across module boundaries.
+  AvailabilityContext getAvailabilityForLinkage() const {
+    return Availability;
   }
 
-  /// Returs whether this function implementation can be dynamically replaced.
+  void setAvailabilityForLinkage(AvailabilityContext availability) {
+    Availability = availability;
+  }
+
+  /// Returns whether this function's symbol must always be weakly referenced
+  /// across module boundaries.
+  bool isAlwaysWeakImported() const { return IsWeakImported; }
+
+  void setAlwaysWeakImported(bool value) {
+    IsWeakImported = value;
+  }
+
+  bool isWeakImported() const;
+
+  /// Returns whether this function implementation can be dynamically replaced.
   IsDynamicallyReplaceable_t isDynamicallyReplaceable() const {
     return IsDynamicallyReplaceable_t(IsDynamicReplaceable);
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -609,40 +609,64 @@ bool Decl::isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic) const {
   return false;
 }
 
-bool Decl::isWeakImported(ModuleDecl *fromModule,
-                          AvailabilityContext fromContext) const {
+AvailabilityContext Decl::getAvailabilityForLinkage() const {
+  auto containingContext =
+      AvailabilityInference::annotatedAvailableRange(this, getASTContext());
+  if (containingContext.hasValue())
+    return *containingContext;
+
+  if (auto *accessor = dyn_cast<AccessorDecl>(this))
+    return accessor->getStorage()->getAvailabilityForLinkage();
+
+  auto *dc = getDeclContext();
+  if (auto *ext = dyn_cast<ExtensionDecl>(dc))
+    return ext->getAvailabilityForLinkage();
+  else if (auto *nominal = dyn_cast<NominalTypeDecl>(dc))
+    return nominal->getAvailabilityForLinkage();
+
+  return AvailabilityContext::alwaysAvailable();
+}
+
+bool Decl::isAlwaysWeakImported() const {
   // For a Clang declaration, trust Clang.
   if (auto clangDecl = getClangDecl()) {
     return clangDecl->isWeakImported();
   }
 
-  auto *containingModule = getModuleContext();
-  if (containingModule == fromModule)
-    return false;
-
-  auto containingContext =
-      AvailabilityInference::availableRange(this,
-                                            containingModule->getASTContext());
-  if (!fromContext.isContainedIn(containingContext))
-    return true;
-
   if (getAttrs().hasAttribute<WeakLinkedAttr>())
     return true;
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
-    return accessor->getStorage()->isWeakImported(fromModule, fromContext);
-
-  if (auto *dtor = dyn_cast<DestructorDecl>(this))
-    return cast<ClassDecl>(dtor->getDeclContext())->isWeakImported(
-        fromModule, fromContext);
+    return accessor->getStorage()->isAlwaysWeakImported();
 
   auto *dc = getDeclContext();
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))
-    return ext->isWeakImported(fromModule, fromContext);
-  if (auto *ntd = dyn_cast<NominalTypeDecl>(dc))
-    return ntd->isWeakImported(fromModule, fromContext);
+    return ext->isAlwaysWeakImported();
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(dc))
+    return nominal->isAlwaysWeakImported();
 
   return false;
+}
+
+bool Decl::isWeakImported(ModuleDecl *fromModule) const {
+  if (fromModule == nullptr) {
+    return (isAlwaysWeakImported() ||
+            !getAvailabilityForLinkage().isAlwaysAvailable());
+  }
+
+  if (getModuleContext() == fromModule)
+    return false;
+
+  if (isAlwaysWeakImported())
+    return true;
+
+  auto containingContext = getAvailabilityForLinkage();
+  if (containingContext.isAlwaysAvailable())
+    return false;
+
+  auto fromContext = AvailabilityContext::forDeploymentTarget(
+      fromModule->getASTContext());
+  return !fromContext.isContainedIn(containingContext);
 }
 
 GenericParamList::GenericParamList(SourceLoc LAngleLoc,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -395,25 +395,24 @@ SourceLoc RootProtocolConformance::getLoc() const {
 }
 
 bool
-RootProtocolConformance::isWeakImported(ModuleDecl *fromModule,
-                                        AvailabilityContext fromContext) const {
+RootProtocolConformance::isWeakImported(ModuleDecl *fromModule) const {
   auto *dc = getDeclContext();
   if (dc->getParentModule() == fromModule)
     return false;
 
   // If the protocol is weak imported, so are any conformances to it.
-  if (getProtocol()->isWeakImported(fromModule, fromContext))
+  if (getProtocol()->isWeakImported(fromModule))
     return true;
 
   // If the conforming type is weak imported, so are any of its conformances.
   if (auto *nominal = getType()->getAnyNominal())
-    if (nominal->isWeakImported(fromModule, fromContext))
+    if (nominal->isWeakImported(fromModule))
       return true;
 
   // If the conformance is declared in an extension with the @_weakLinked
   // attribute, it is weak imported.
   if (auto *ext = dyn_cast<ExtensionDecl>(dc))
-    if (ext->isWeakImported(fromModule, fromContext))
+    if (ext->isWeakImported(fromModule))
       return true;
 
   return false;

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -62,8 +62,7 @@ static bool isHoistable(AllocStackInst *Inst, irgen::IRGenModule &Mod) {
   bool foundWeaklyImported =
       SILTy.getASTType().findIf([&Mod](CanType type) -> bool {
         if (auto nominal = type->getNominalOrBoundGenericNominal())
-          if (nominal->isWeakImported(Mod.getSwiftModule(),
-                                      Mod.getAvailabilityContext())) {
+          if (nominal->isWeakImported(Mod.getSwiftModule())) {
             return true;
           }
         return false;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1718,8 +1718,7 @@ void irgen::updateLinkageForDefinition(IRGenModule &IGM,
   // TODO: there are probably cases where we can avoid redoing the
   // entire linkage computation.
   UniversalLinkageInfo linkInfo(IGM);
-  bool weakImported = entity.isWeakImported(IGM.getSwiftModule(),
-                                            IGM.getAvailabilityContext());
+  bool weakImported = entity.isWeakImported(IGM.getSwiftModule());
   auto IRL =
       getIRLinkage(linkInfo, entity.getLinkage(ForDefinition),
                    ForDefinition, weakImported);
@@ -1739,13 +1738,11 @@ LinkInfo LinkInfo::get(IRGenModule &IGM, const LinkEntity &entity,
                        ForDefinition_t isDefinition) {
   return LinkInfo::get(UniversalLinkageInfo(IGM),
                        IGM.getSwiftModule(),
-                       IGM.getAvailabilityContext(),
                        entity, isDefinition);
 }
 
 LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
                        ModuleDecl *swiftModule,
-                       AvailabilityContext availabilityContext,
                        const LinkEntity &entity,
                        ForDefinition_t isDefinition) {
   LinkInfo result;
@@ -1761,7 +1758,7 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
       ForDefinition_t(swiftModule->isStdlibModule() || isDefinition);
 
   entity.mangle(result.Name);
-  bool weakImported = entity.isWeakImported(swiftModule, availabilityContext);
+  bool weakImported = entity.isWeakImported(swiftModule);
   result.IRL = getIRLinkage(linkInfo, entity.getLinkage(isStdlibOrDefinition),
                             isDefinition, weakImported);
   result.ForDefinition = isDefinition;

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5465,8 +5465,7 @@ namespace {
       llvm::BasicBlock *conditionalBlock = nullptr;
       llvm::BasicBlock *afterConditionalBlock = nullptr;
       llvm::BasicBlock *beforeNullPtrCheck = nullptr;
-      if (Case->isWeakImported(IGM.getSwiftModule(),
-                               IGM.getAvailabilityContext())) {
+      if (Case->isWeakImported(IGM.getSwiftModule())) {
         beforeNullPtrCheck = IGF.Builder.GetInsertBlock();
         auto address = IGM.getAddrOfEnumCase(Case, NotForDefinition);
         conditionalBlock = llvm::BasicBlock::Create(C);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -950,13 +950,12 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   }
 }
 
-bool LinkEntity::isWeakImported(ModuleDecl *module,
-                                AvailabilityContext context) const {
+bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   switch (getKind()) {
   case Kind::SILGlobalVariable:
     if (getSILGlobalVariable()->getDecl()) {
       return getSILGlobalVariable()->getDecl()
-          ->isWeakImported(module, context);
+          ->isWeakImported(module);
     }
     return false;
   case Kind::DynamicallyReplaceableFunctionKey:
@@ -964,7 +963,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
   case Kind::SILFunction: {
     // For imported functions check the Clang declaration.
     if (auto clangOwner = getSILFunction()->getClangNodeOwner())
-      return clangOwner->isWeakImported(module, context);
+      return clangOwner->isWeakImported(module);
 
     // For native functions check a flag on the SILFunction
     // itself.
@@ -980,16 +979,16 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
     // type stored in extra storage area is weak linked.
     auto assocConformance = getAssociatedConformance();
     auto *depMemTy = assocConformance.first->castTo<DependentMemberType>();
-    return depMemTy->getAssocType()->isWeakImported(module, context);
+    return depMemTy->getAssocType()->isWeakImported(module);
   }
 
   case Kind::BaseConformanceDescriptor:
-    return cast<ProtocolDecl>(getDecl())->isWeakImported(module, context);
+    return cast<ProtocolDecl>(getDecl())->isWeakImported(module);
 
   case Kind::TypeMetadata:
   case Kind::TypeMetadataAccessFunction: {
     if (auto *nominalDecl = getType()->getAnyNominal())
-      return nominalDecl->isWeakImported(module, context);
+      return nominalDecl->isWeakImported(module);
     return false;
   }
 
@@ -1021,12 +1020,12 @@ bool LinkEntity::isWeakImported(ModuleDecl *module,
   case Kind::OpaqueTypeDescriptorAccessorImpl:
   case Kind::OpaqueTypeDescriptorAccessorKey:
   case Kind::OpaqueTypeDescriptorAccessorVar:
-    return getDecl()->isWeakImported(module, context);
+    return getDecl()->isWeakImported(module);
 
   case Kind::ProtocolWitnessTable:
   case Kind::ProtocolConformanceDescriptor:
     return getProtocolConformance()->getRootConformance()
-                                   ->isWeakImported(module, context);
+                                   ->isWeakImported(module);
 
   // TODO: Revisit some of the below, for weak conformances.
   case Kind::ObjCMetadataUpdateFunction:

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -18,7 +18,6 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "swift/AST/ASTMangler.h"
-#include "swift/AST/Availability.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILGlobalVariable.h"
@@ -954,22 +953,13 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   switch (getKind()) {
   case Kind::SILGlobalVariable:
     if (getSILGlobalVariable()->getDecl()) {
-      return getSILGlobalVariable()->getDecl()
-          ->isWeakImported(module);
+      return getSILGlobalVariable()->getDecl()->isWeakImported(module);
     }
     return false;
   case Kind::DynamicallyReplaceableFunctionKey:
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::SILFunction: {
-    // For imported functions check the Clang declaration.
-    if (auto clangOwner = getSILFunction()->getClangNodeOwner())
-      return clangOwner->isWeakImported(module);
-
-    // For native functions check a flag on the SILFunction
-    // itself.
-    if (getSILFunction()->isWeakLinked())
-      return getSILFunction()->isAvailableExternally();
-    return false;
+    return getSILFunction()->isWeakImported();
   }
 
   case Kind::AssociatedConformanceDescriptor:

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -981,7 +981,9 @@ static bool parseDeclSILOptional(bool *isTransparent,
                                  bool *isGlobalInit,
                                  Inline_t *inlineStrategy,
                                  OptimizationMode *optimizationMode,
-                                 bool *isLet, bool *isWeakLinked,
+                                 bool *isLet,
+                                 bool *isWeakImported,
+                                 AvailabilityContext *availability,
                                  bool *isWithoutActuallyEscapingThunk,
                                  SmallVectorImpl<std::string> *Semantics,
                                  SmallVectorImpl<ParsedSpecAttr> *SpecAttrs,
@@ -1021,14 +1023,27 @@ static bool parseDeclSILOptional(bool *isTransparent,
       *isWithoutActuallyEscapingThunk = true;
     else if (isGlobalInit && SP.P.Tok.getText() == "global_init")
       *isGlobalInit = true;
-    else if (isWeakLinked && SP.P.Tok.getText() == "_weakLinked")
+    else if (isWeakImported && SP.P.Tok.getText() == "weak_imported") {
       if (M.getASTContext().LangOpts.Target.isOSBinFormatCOFF())
         SP.P.diagnose(SP.P.Tok, diag::attr_unsupported_on_target,
                       SP.P.Tok.getText(),
                       M.getASTContext().LangOpts.Target.str());
       else
-        *isWeakLinked = true;
-    else if (inlineStrategy && SP.P.Tok.getText() == "noinline")
+        *isWeakImported = true;
+    } else if (availability && SP.P.Tok.getText() == "available") {
+      SP.P.consumeToken(tok::identifier);
+
+      SourceRange range;
+      llvm::VersionTuple version;
+      if (SP.P.parseVersionTuple(version, range,
+                                 diag::sil_availability_expected_version))
+        return true;
+
+      *availability = AvailabilityContext(VersionRange::allGTE(version));
+
+      SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
+      continue;
+    } else if (inlineStrategy && SP.P.Tok.getText() == "noinline")
       *inlineStrategy = NoInline;
     else if (optimizationMode && SP.P.Tok.getText() == "Onone")
       *optimizationMode = OptimizationMode::NoOptimization;
@@ -5352,7 +5367,8 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
   IsDynamicallyReplaceable_t isDynamic = IsNotDynamic;
   bool hasOwnershipSSA = false;
   IsThunk_t isThunk = IsNotThunk;
-  bool isGlobalInit = false, isWeakLinked = false;
+  bool isGlobalInit = false, isWeakImported = false;
+  AvailabilityContext availability = AvailabilityContext::alwaysAvailable();
   bool isWithoutActuallyEscapingThunk = false;
   Inline_t inlineStrategy = InlineDefault;
   OptimizationMode optimizationMode = OptimizationMode::NotSet;
@@ -5367,7 +5383,7 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
           &isTransparent, &isSerialized, &isCanonical, &hasOwnershipSSA,
           &isThunk, &isDynamic, &DynamicallyReplacedFunction,
           &objCReplacementFor, &isGlobalInit, &inlineStrategy, &optimizationMode, nullptr,
-          &isWeakLinked, &isWithoutActuallyEscapingThunk, &Semantics,
+          &isWeakImported, &availability, &isWithoutActuallyEscapingThunk, &Semantics,
           &SpecAttrs, &ClangDecl, &MRK, FunctionState, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_function_name) ||
       P.parseIdentifier(FnName, FnNameLoc, diag::expected_sil_function_name) ||
@@ -5401,7 +5417,8 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
     if (!objCReplacementFor.empty())
       FunctionState.F->setObjCReplacement(objCReplacementFor);
     FunctionState.F->setGlobalInit(isGlobalInit);
-    FunctionState.F->setWeakLinked(isWeakLinked);
+    FunctionState.F->setAlwaysWeakImported(isWeakImported);
+    FunctionState.F->setAvailabilityForLinkage(availability);
     FunctionState.F->setWithoutActuallyEscapingThunk(
       isWithoutActuallyEscapingThunk);
     FunctionState.F->setInlineStrategy(inlineStrategy);
@@ -5583,7 +5600,8 @@ bool SILParserTUState::parseSILGlobal(Parser &P) {
   if (parseSILLinkage(GlobalLinkage, P) ||
       parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                           &isLet, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, State, M) ||
+                           &isLet, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, State, M) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
       P.parseIdentifier(GlobalName, NameLoc, diag::expected_sil_value_name) ||
       P.parseToken(tok::colon, diag::expected_sil_type))
@@ -5630,7 +5648,7 @@ bool SILParserTUState::parseSILProperty(Parser &P) {
   
   IsSerialized_t Serialized = IsNotSerialized;
   if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, SP, M))
     return true;
   
@@ -5698,7 +5716,7 @@ bool SILParserTUState::parseSILVTable(Parser &P) {
 
   IsSerialized_t Serialized = IsNotSerialized;
   if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            VTableState, M))
     return true;
@@ -6234,7 +6252,7 @@ bool SILParserTUState::parseSILWitnessTable(Parser &P) {
   
   IsSerialized_t isSerialized = IsNotSerialized;
   if (parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
-                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                           nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            WitnessState, M))
     return true;

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -98,13 +98,16 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          IsDynamicallyReplaceable_t isDynamic)
     : Module(Module), Name(Name), LoweredType(LoweredType),
       GenericEnv(genericEnv), SpecializationInfo(nullptr),
-      DebugScope(DebugScope), Bare(isBareSILFunction), Transparent(isTrans),
-      Serialized(isSerialized), Thunk(isThunk),
+      DebugScope(DebugScope), EntryCount(entryCount), Bare(isBareSILFunction),
+      Transparent(isTrans), Serialized(isSerialized), Thunk(isThunk),
       ClassSubclassScope(unsigned(classSubclassScope)), GlobalInitFlag(false),
       InlineStrategy(inlineStrategy), Linkage(unsigned(Linkage)),
       HasCReferences(false), IsWeakLinked(false),
-      IsDynamicReplaceable(isDynamic), OptMode(OptimizationMode::NotSet),
-      EffectsKindAttr(E), EntryCount(entryCount) {
+      IsDynamicReplaceable(isDynamic),
+      Inlined(false), Zombie(false), HasOwnership(true),
+      WasDeserializedCanonical(false), IsWithoutActuallyEscapingThunk(false),
+      OptMode(unsigned(OptimizationMode::NotSet)),
+      EffectsKindAttr(unsigned(E)) {
   assert(!Transparent || !IsDynamicReplaceable);
   validateSubclassScope(classSubclassScope, isThunk, nullptr);
 
@@ -189,8 +192,8 @@ ASTContext &SILFunction::getASTContext() const {
 }
 
 OptimizationMode SILFunction::getEffectiveOptimizationMode() const {
-  if (OptMode != OptimizationMode::NotSet)
-    return OptMode;
+  if (OptimizationMode(OptMode) != OptimizationMode::NotSet)
+    return OptimizationMode(OptMode);
 
   return getModule().getOptions().OptMode;
 }

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -159,17 +159,8 @@ SILFunctionBuilder::getOrCreateFunction(SILLocation loc, SILDeclRef constant,
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
-    if (decl->isAlwaysWeakImported())
-      F->setWeakLinked();
-    else {
-      auto containingContext = decl->getAvailabilityForLinkage();
-      if (!containingContext.isAlwaysAvailable()) {
-        auto fromContext = AvailabilityContext::forDeploymentTarget(
-          decl->getASTContext());
-        if (!fromContext.isContainedIn(containingContext))
-          F->setWeakLinked();
-      }
-    }
+    F->setAvailabilityForLinkage(decl->getAvailabilityForLinkage());
+    F->setAlwaysWeakImported(decl->isAlwaysWeakImported());
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2322,8 +2322,13 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
 
   if (isGlobalInit())
     OS << "[global_init] ";
-  if (isWeakLinked())
-    OS << "[_weakLinked] ";
+  if (isAlwaysWeakImported())
+    OS << "[weak_imported] ";
+  auto availability = getAvailabilityForLinkage();
+  if (!availability.isAlwaysAvailable()) {
+    auto version = availability.getOSVersion().getLowerEndpoint();
+    OS << "[available " << version.getAsString() << "] ";
+  }
 
   switch (getInlineStrategy()) {
     case NoInline: OS << "[noinline] "; break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4109,18 +4109,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
       }
 
       case decls_block::Available_DECL_ATTR: {
-#define LIST_VER_TUPLE_PIECES(X)\
-  X##_Major, X##_Minor, X##_Subminor, X##_HasMinor, X##_HasSubminor
-#define DEF_VER_TUPLE_PIECES(X) unsigned LIST_VER_TUPLE_PIECES(X)
-#define DECODE_VER_TUPLE(X)\
-  if (X##_HasMinor) {\
-    if (X##_HasSubminor)\
-      X = llvm::VersionTuple(X##_Major, X##_Minor, X##_Subminor);\
-    else\
-      X = llvm::VersionTuple(X##_Major, X##_Minor);\
-    }\
-  else X = llvm::VersionTuple(X##_Major);
-
         bool isImplicit;
         bool isUnavailable;
         bool isDeprecated;
@@ -4169,10 +4157,6 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
           Obsoleted, SourceRange(),
           platformAgnostic, isImplicit);
         break;
-
-#undef DEF_VER_TUPLE_PIECES
-#undef LIST_VER_TUPLE_PIECES
-#undef DECODE_VER_TUPLE
       }
 
       case decls_block::ObjC_DECL_ATTR: {

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -289,7 +289,8 @@ namespace sil_block {
                      BCFixed<3>,  // side effect info.
                      BCVBR<8>,    // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership
-                     BCFixed<1>,  // must be weakly referenced
+                     BCFixed<1>,  // force weak linking
+                     BC_AVAIL_TUPLE, // availability for weak linking
                      BCFixed<1>,  // is dynamically replacable
                      TypeIDField, // SILFunctionType
                      DeclIDField,  // SILFunction name or 0 (replaced function)

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -70,8 +70,7 @@ void TBDGenVisitor::addSymbol(SILDeclRef declRef) {
 
 void TBDGenVisitor::addSymbol(LinkEntity entity) {
   auto linkage =
-      LinkInfo::get(UniversalLinkInfo, SwiftModule, AvailCtx,
-                    entity, ForDefinition);
+      LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
 
   auto externallyVisible =
       llvm::GlobalValue::isExternalLinkage(linkage.getLinkage()) &&
@@ -630,8 +629,6 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   const auto &target = ctx.LangOpts.Target;
   UniversalLinkageInfo linkInfo(target, opts.HasMultipleIGMs, false,
                                 isWholeModule);
-  auto availCtx = AvailabilityContext::forDeploymentTarget(ctx);
-
   tapi::internal::InterfaceFile file;
   file.setFileType(tapi::internal::FileType::TBD_V3);
   file.setApplicationExtensionSafe(
@@ -646,7 +643,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   file.setArch(arch);
   file.setInstallAPI();
 
-  TBDGenVisitor visitor(file, arch, symbols, linkInfo, M, availCtx, opts);
+  TBDGenVisitor visitor(file, arch, symbols, linkInfo, M, opts);
 
   auto visitFile = [&](FileUnit *file) {
     if (file == M->getFiles()[0]) {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -48,7 +48,6 @@ public:
 
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
-  AvailabilityContext AvailCtx;
   const TBDGenOptions &Opts;
 
 private:
@@ -74,11 +73,10 @@ public:
   TBDGenVisitor(tapi::internal::InterfaceFile &symbols,
                 tapi::internal::ArchitectureSet archs, StringSet *stringSymbols,
                 const UniversalLinkageInfo &universalLinkInfo,
-                ModuleDecl *swiftModule, AvailabilityContext availCtx,
-                const TBDGenOptions &opts)
+                ModuleDecl *swiftModule, const TBDGenOptions &opts)
       : Symbols(symbols), Archs(archs), StringSymbols(stringSymbols),
         UniversalLinkInfo(universalLinkInfo), SwiftModule(swiftModule),
-        AvailCtx(availCtx), Opts(opts) {}
+        Opts(opts) {}
 
   void addMainIfNecessary(FileUnit *file) {
     // HACK: 'main' is a special symbol that's always emitted in SILGen if

--- a/test/IRGen/Inputs/weak_import_deployment_target_helper.swift
+++ b/test/IRGen/Inputs/weak_import_deployment_target_helper.swift
@@ -1,0 +1,11 @@
+@available(macOS 10.50, *)
+public func function() -> Int { return 0 }
+
+@available(macOS 10.50, *)
+public func hasDefaultArg(_: Int = function()) {}
+
+@available(macOS 10.60, *)
+public func availableFunction() -> Int { return 0 }
+
+@available(macOS 10.60, *)
+public func hasAvailableDefaultArg(_: Int = availableFunction()) {}

--- a/test/IRGen/weakLinked.sil
+++ b/test/IRGen/weakLinked.sil
@@ -2,8 +2,8 @@
 
 sil_stage canonical
 
-// expected-error@+1{{attribute '_weakLinked' is unsupported on target 'x86_64-unknown-windows-msvc'}}
-sil [_weakLinked] @f : $@convention(thin) () -> () {
+// expected-error@+1{{attribute 'weak_imported' is unsupported on target 'x86_64-unknown-windows-msvc'}}
+sil [weak_imported] @f : $@convention(thin) () -> () {
   %unit = tuple()
   return %unit : $()
 }

--- a/test/IRGen/weak_import_deployment_target.swift
+++ b/test/IRGen/weak_import_deployment_target.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -target x86_64-apple-macosx10.50 -emit-module-path %t/weak_import_deployment_target_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_deployment_target_helper.swift
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+//
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -target x86_64-apple-macosx10.60 -emit-module-path %t/weak_import_deployment_target_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_deployment_target_helper.swift
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+//
+// REQUIRES: OS=macosx
+
+import weak_import_deployment_target_helper
+
+@available(macOS 10.50, *)
+public func callsOld() {
+  hasDefaultArg()
+}
+
+@available(macOS 10.60, *)
+public func callsNew() {
+  hasAvailableDefaultArg()
+}
+
+// CHECK-OLD-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-OLD-LABEL: declare extern_weak swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
+// CHECK-OLD-LABEL: declare extern_weak swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
+// CHECK-OLD-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()
+
+// CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper13hasDefaultArgyySiF"(i64)
+// CHECK-NEW-LABEL: declare swiftcc void @"$s36weak_import_deployment_target_helper22hasAvailableDefaultArgyySiF"(i64)
+// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper17availableFunctionSiyF"()
+// CHECK-NEW-LABEL: declare swiftcc i64 @"$s36weak_import_deployment_target_helper8functionSiyF"()

--- a/test/IRGen/weak_import_native.sil
+++ b/test/IRGen/weak_import_native.sil
@@ -6,15 +6,15 @@
 sil_stage canonical
 
 // CHECK-DAG: define{{( protected)?}} swiftcc void @weakButDefined() {{#[0-9]+}} {
-sil public [_weakLinked] @weakButDefined : $@convention(thin) () -> () {
+sil public [weak_imported] @weakButDefined : $@convention(thin) () -> () {
   %unit = tuple()
   return %unit : $()
 }
 
 // CHECK-DAG: declare extern_weak swiftcc void @weakExternal()
-sil public_external [_weakLinked] @weakExternal : $@convention(thin) () -> ()
+sil public_external [weak_imported] @weakExternal : $@convention(thin) () -> ()
 
-sil [_weakLinked] @testWeak : $@convention(thin) () -> () {
+sil [weak_imported] @testWeak : $@convention(thin) () -> () {
   %weakButDefined = function_ref @weakButDefined : $@convention(thin) () -> ()
   %wbdResult      = apply %weakButDefined() : $@convention(thin) () -> ()
   %weakExternal   = function_ref @weakExternal : $@convention(thin) () -> ()

--- a/test/SIL/Parser/available.sil
+++ b/test/SIL/Parser/available.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt %s | %FileCheck %s
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
 
 @available(*,unavailable,message: "it has been renamed")
 public struct mmConstUnsafePointer<T> {
@@ -11,3 +12,15 @@ bb0(%0 : $@thin mmConstUnsafePointer<T>.Type):
   %1 = struct $mmConstUnsafePointer<T> ()
   return %1 : $mmConstUnsafePointer<T>
 }
+
+// CHECK-LABEL: sil [available 123] @version_major : $@convention(thin) () -> ()
+sil [available 123] @version_major : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [available 123.321] @version_minor : $@convention(thin) () -> ()
+sil [available 123.321] @version_minor : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+sil [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [weak_imported] @weak_func : $@convention(thin) () -> ()
+sil [weak_imported] @weak_func : $@convention(thin) () -> ()

--- a/test/SIL/Serialization/available.sil
+++ b/test/SIL/Serialization/available.sil
@@ -1,0 +1,31 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name available
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name available
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name available | %FileCheck %s
+
+import Builtin
+
+// CHECK-LABEL: sil [serialized] [available 123.321] @version_minor : $@convention(thin) () -> ()
+sil [serialized] [available 123.321] @version_minor : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> ()
+sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
+sil [serialized] [available 123.321.444] @version_subminor : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [serialized] [available 123] @version_major : $@convention(thin) () -> ()
+sil [serialized] [available 123] @version_major : $@convention(thin) () -> () {
+bb0:
+  return undef : $()
+}

--- a/test/SILGen/availability_attribute.swift
+++ b/test/SILGen/availability_attribute.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target x86_64-apple-macosx10.60 | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute17availableFunctionyyF : $@convention(thin) () -> ()
+@available(macOS 10.50, *) public func availableFunction() {}
+
+public struct Struct {
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV12availableVarSivg : $@convention(method) (Struct) -> Int
+    @available(macOS 10.50, *)
+    public var availableVar: Int { return 0 }
+
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV24varWithAvailableAccessorSivg : $@convention(method) (Struct) -> Int
+    public var varWithAvailableAccessor: Int {
+        @available(macOS 10.50, *)
+        get {
+            return 0
+        }
+    }
+}
+
+@available(macOS 10.50, *)
+extension Struct {
+    // CHECK-LABEL: sil [available 10.50] [ossa] @$s22availability_attribute6StructV24availableExtensionMethodyyF : $@convention(method) (Struct) -> ()
+    public func availableExtensionMethod() {}
+}
+
+@available(macOS 10.50, *)
+public struct AvailableStruct {
+    public func availableMethod() {}
+
+    public struct Nested {
+        public func availableNestedMethod() {}
+    }
+}

--- a/test/SILGen/weak_linked_attribute.swift
+++ b/test/SILGen/weak_linked_attribute.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
 // UNSUPPORTED: OS=windows-msvc
 
-// CHECK-LABEL: sil [_weakLinked] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [weak_imported] [ossa] @$s21weak_linked_attribute0A8FunctionyyF : $@convention(thin) () -> ()
 @_weakLinked public func weakFunction() {}


### PR DESCRIPTION
* Description: When using conditionally-available framework declarations from a client app, we're supposed to weak link those declarations. However if the reference came from deserialized SIL code, eg if the client calls a function in the framework that has a default argument, then that reference was not weak linked. This is because SIL functions only stored a single 'weak linked' bit that was computed from the deployment target of the framework together with the declaration's availability. But instead we need to store the version range in the SIL function and make the determination based on the deployment target of the client into which the SIL function is deserialized.

* Scope of the issue: This affects anyone that's writing an app that deploys to OS version N, but takes advantage of a Swift-only framework that's available in version N+1.

* Origination: The problem has been there ever since weak linking was introduced in Swift 5.0.

* Risk: It's a big change, so medium, but mostly it's a straightforward change.

* Reviewed by: @jrose-apple 

* Radar: rdar://problem/52783668