### PR TITLE
[SILGen] Made SIL function for defer transparent.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -721,6 +721,14 @@ void SILGenModule::preEmitFunction(SILDeclRef constant,
   if (F->getLoweredFunctionType()->isPolymorphic())
     F->setGenericEnvironment(Types.getConstantGenericEnvironment(constant));
 
+  if (constant.hasFuncDecl()) {
+    if (auto function = constant.getFuncDecl()) {
+      if (function->isDeferBody()) {
+        F->setTransparent(IsTransparent);
+      }
+    }
+  }
+
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));
 

--- a/test/SILGen/dynamically_replaceable.swift
+++ b/test/SILGen/dynamically_replaceable.swift
@@ -384,7 +384,7 @@ dynamic func funcWithDefaultArg(_ arg : String = String("hello")) {
 func foobar() {
 }
 
-// IMPLICIT-LABEL: sil private [ossa] @$s23dynamically_replaceable6$deferL_yyF
+// IMPLICIT-LABEL: sil private [transparent] [ossa] @$s23dynamically_replaceable6$deferL_yyF
 var x = 10
 defer {
   let y = x

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -458,10 +458,10 @@ func defer_test1() {
   // CHECK: [[C1:%.*]] = function_ref @$s10statements11defer_test1yyF6
   // CHECK: apply [[C1]]
 }
-// CHECK: sil private [ossa] @$s10statements11defer_test1yyF6
+// CHECK: sil private [transparent] [ossa] @$s10statements11defer_test1yyF6
 // CHECK: function_ref @{{.*}}callee1yyF
 
-// CHECK: sil private [ossa] @$s10statements11defer_test1yyF6
+// CHECK: sil private [transparent] [ossa] @$s10statements11defer_test1yyF6
 // CHECK: function_ref @{{.*}}callee2yyF
 
 // CHECK-LABEL: sil hidden [ossa] @$s10statements11defer_test2yySbF
@@ -517,7 +517,7 @@ func defer_in_generic<T>(_ x: T) {
 func defer_in_closure_in_generic<T>(_ x: T) {
   // CHECK-LABEL: sil private [ossa] @$s10statements017defer_in_closure_C8_genericyyxlFyycfU_ : $@convention(thin) <T> () -> ()
   _ = {
-    // CHECK-LABEL: sil private [ossa] @$s10statements017defer_in_closure_C8_genericyyxlFyycfU_6$deferL_yylF : $@convention(thin) <T> () -> ()
+    // CHECK-LABEL: sil private [transparent] [ossa] @$s10statements017defer_in_closure_C8_genericyyxlFyycfU_6$deferL_yylF : $@convention(thin) <T> () -> ()
     defer { generic_callee_1(T.self) } // expected-warning {{'defer' statement at end of scope always executes immediately}}{{5-10=do}}
   }
 }
@@ -541,6 +541,21 @@ func testDeferOpenExistential(_ b: Bool, type: StaticFooProtocol.Type) {
   if b { return }
   return
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s10statements14testDeferNeveryyF 
+// CHECK: [[DEFER_REF:%.*]] = function_ref @$s10statements14testDeferNeveryyF6$deferL_yyF
+// CHECK: {{%.*}} = apply [[DEFER_REF]]()
+// CHECK: } // end sil function '$s10statements14testDeferNeveryyF'
+// CHECK: sil private [transparent] [ossa] @$s10statements14testDeferNeveryyF6$deferL_yyF
+// CHECK: [[FUNCTION_REF:%.*]] = function_ref @$s10statements9exitEarlys5NeverOyF
+// CHECK: {{%.*}} = apply [[FUNCTION_REF]]()
+// CHECK: } // end sil function '$s10statements14testDeferNeveryyF6$deferL_yyF'
+func testDeferNever() {
+  defer { exitEarly() } // expected-warning {{'defer' statement at end of scope always executes immediately; replace with 'do' statement to silence this warning}}
+} // end function 'testDeferNever'
+
+func exitEarly() -> Never { fatalError() } 
+
 
 
 


### PR DESCRIPTION
Made the SILFunction corresponding to a FuncDecl for which isDeferBody is true be transparent.  

Doing so enables DataflowDiagnostics to see through the call to the generated defer closure to the Never-returning function contained within.

rdar://problem/31760201