### PR TITLE
Move access-path filtering into ModuleNameLookup (out of lookupValue)

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -361,7 +361,7 @@ public:
   /// within the current module.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
-  void lookupValue(AccessPathTy AccessPath, DeclName Name, NLKind LookupKind,
+  void lookupValue(DeclName Name, NLKind LookupKind,
                    SmallVectorImpl<ValueDecl*> &Result) const;
 
   /// Look up a local type declaration by its mangled name.
@@ -629,8 +629,7 @@ public:
   /// within this file.
   ///
   /// This does a simple local lookup, not recursively looking through imports.
-  virtual void lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                           NLKind lookupKind,
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const = 0;
 
   /// Look up a local type declaration by its mangled name.
@@ -1056,8 +1055,7 @@ public:
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
 
-  virtual void lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                           NLKind lookupKind,
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const override;
 
   virtual void lookupVisibleDecls(ModuleDecl::AccessPathTy accessPath,
@@ -1281,8 +1279,7 @@ private:
 public:
   explicit BuiltinUnit(ModuleDecl &M);
 
-  virtual void lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                           NLKind lookupKind,
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &result) const override;
 
   /// Find all Objective-C methods with the given selector.

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -64,8 +64,7 @@ public:
 
   virtual bool isSystemModule() const override;
 
-  virtual void lookupValue(ModuleDecl::AccessPathTy accessPath,
-                           DeclName name, NLKind lookupKind,
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &results) const override;
 
   virtual TypeDecl *

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -268,8 +268,7 @@ public:
 
   virtual bool isSystemModule() const override;
 
-  virtual void lookupValue(ModuleDecl::AccessPathTy accessPath,
-                           DeclName name, NLKind lookupKind,
+  virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &results) const override;
 
   virtual StringRef

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -654,7 +654,7 @@ void ASTContext::lookupInSwiftModule(
 
   // Find all of the declarations with this name in the Swift module.
   auto identifier = getIdentifier(name);
-  M->lookupValue({ }, identifier, NLKind::UnqualifiedLookup, results);
+  M->lookupValue(identifier, NLKind::UnqualifiedLookup, results);
 }
 
 FuncDecl *ASTContext::getPlusFunctionOnRangeReplaceableCollection() const {
@@ -832,7 +832,7 @@ StructDecl *ASTContext::getObjCBoolDecl() const {
     SmallVector<ValueDecl *, 1> results;
     auto *Context = const_cast<ASTContext *>(this);
     if (ModuleDecl *M = Context->getModuleByName(Id_ObjectiveC.str())) {
-      M->lookupValue({ }, getIdentifier("ObjCBool"), NLKind::UnqualifiedLookup,
+      M->lookupValue(getIdentifier("ObjCBool"), NLKind::UnqualifiedLookup,
                      results);
       for (auto result : results) {
         if (auto structDecl = dyn_cast<StructDecl>(result)) {
@@ -899,7 +899,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
 
   if (!M)
     return nullptr;
-  M->lookupValue({ }, getIdentifier(getProtocolName(kind)),
+  M->lookupValue(getIdentifier(getProtocolName(kind)),
                  NLKind::UnqualifiedLookup, results);
 
   for (auto result : results) {
@@ -3959,7 +3959,7 @@ static NominalTypeDecl *findUnderlyingTypeInModule(ASTContext &ctx,
                                                    ModuleDecl *module) {
   // Find all of the declarations with this name in the Swift module.
   SmallVector<ValueDecl *, 1> results;
-  module->lookupValue({ }, name, NLKind::UnqualifiedLookup, results);
+  module->lookupValue(name, NLKind::UnqualifiedLookup, results);
   for (auto result : results) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(result))
       return nominal;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -97,11 +97,9 @@ ASTBuilder::createBuiltinType(StringRef builtinName,
   if (builtinName.startswith(BUILTIN_TYPE_NAME_PREFIX)) {
     SmallVector<ValueDecl *, 1> decls;
 
-    ModuleDecl::AccessPathTy accessPath;
     StringRef strippedName =
         builtinName.drop_front(BUILTIN_TYPE_NAME_PREFIX.size());
-    Ctx.TheBuiltinModule->lookupValue(accessPath,
-                                      Ctx.getIdentifier(strippedName),
+    Ctx.TheBuiltinModule->lookupValue(Ctx.getIdentifier(strippedName),
                                       NLKind::QualifiedLookup,
                                       decls);
     

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -168,8 +168,8 @@ public:
   /// Throw away as much memory as possible.
   void invalidate();
   
-  void lookupValue(AccessPathTy AccessPath, DeclName Name,
-                   NLKind LookupKind, SmallVectorImpl<ValueDecl*> &Result);
+  void lookupValue(DeclName Name, NLKind LookupKind,
+                   SmallVectorImpl<ValueDecl*> &Result);
   
   void lookupVisibleDecls(AccessPathTy AccessPath,
                           VisibleDeclConsumer &Consumer,
@@ -284,14 +284,8 @@ SourceLookupCache::SourceLookupCache(const ModuleDecl &M) {
   }
 }
 
-void SourceLookupCache::lookupValue(AccessPathTy AccessPath, DeclName Name,
-                                    NLKind LookupKind,
+void SourceLookupCache::lookupValue(DeclName Name, NLKind LookupKind,
                                     SmallVectorImpl<ValueDecl*> &Result) {
-  // If this import is specific to some named type or decl ("import Swift.int")
-  // then filter out any lookups that don't match.
-  if (!ModuleDecl::matchesAccessPath(AccessPath, Name))
-    return;
-  
   auto I = TopLevelValues.find(Name);
   if (I == TopLevelValues.end()) return;
   
@@ -457,19 +451,18 @@ static bool isParsedModule(const ModuleDecl *mod) {
           cast<SourceFile>(files[0])->Kind != SourceFileKind::SIL);
 }
 
-void ModuleDecl::lookupValue(AccessPathTy AccessPath, DeclName Name,
-                             NLKind LookupKind, 
+void ModuleDecl::lookupValue(DeclName Name, NLKind LookupKind,
                              SmallVectorImpl<ValueDecl*> &Result) const {
   auto *stats = getASTContext().Stats;
   if (stats)
     stats->getFrontendCounters().NumModuleLookupValue++;
 
   if (isParsedModule(this)) {
-    getSourceLookupCache().lookupValue(AccessPath, Name, LookupKind, Result);
+    getSourceLookupCache().lookupValue(Name, LookupKind, Result);
     return;
   }
 
-  FORWARD(lookupValue, (AccessPath, Name, LookupKind, Result));
+  FORWARD(lookupValue, (Name, LookupKind, Result));
 }
 
 TypeDecl * ModuleDecl::lookupLocalType(StringRef MangledName) const {
@@ -517,7 +510,7 @@ void ModuleDecl::lookupMember(SmallVectorImpl<ValueDecl*> &results,
       alreadyInPrivateContext = true;
   } else if (isa<ModuleDecl>(containerDecl)) {
     assert(container == this);
-    this->lookupValue({}, name, NLKind::QualifiedLookup, results);
+    this->lookupValue(name, NLKind::QualifiedLookup, results);
   } else if (!isa<GenericTypeDecl>(containerDecl)) {
     // If ExtensionDecl, then use ExtensionDecl::lookupDirect instead.
     llvm_unreachable("This context does not support lookup.");
@@ -557,8 +550,7 @@ void ModuleDecl::lookupObjCMethods(
   FORWARD(lookupObjCMethods, (selector, results));
 }
 
-void BuiltinUnit::lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                              NLKind lookupKind,
+void BuiltinUnit::lookupValue(DeclName name, NLKind lookupKind,
                               SmallVectorImpl<ValueDecl*> &result) const {
   getCache().lookupValue(name.getBaseIdentifier(), lookupKind, *this, result);
 }
@@ -569,10 +561,9 @@ void BuiltinUnit::lookupObjCMethods(
   // No @objc methods in the Builtin module.
 }
 
-void SourceFile::lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                             NLKind lookupKind,
+void SourceFile::lookupValue(DeclName name, NLKind lookupKind,
                              SmallVectorImpl<ValueDecl*> &result) const {
-  getCache().lookupValue(accessPath, name, lookupKind, result);
+  getCache().lookupValue(name, lookupKind, result);
 }
 
 void ModuleDecl::lookupVisibleDecls(AccessPathTy AccessPath,

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -80,7 +80,11 @@ private:
 
   void doLocalLookup(ModuleDecl *module, ModuleDecl::AccessPathTy path,
                      SmallVectorImpl<ValueDecl *> &localDecls) {
-    module->lookupValue(path, name, lookupKind, localDecls);
+    // If this import is specific to some named decl ("import Swift.Int")
+    // then filter out any lookups that don't match.
+    if (!ModuleDecl::matchesAccessPath(path, name))
+      return;
+    module->lookupValue(name, lookupKind, localDecls);
   }
 };
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2728,12 +2728,8 @@ void ClangModuleUnit::getDisplayDecls(SmallVectorImpl<Decl*> &results) const {
   getTopLevelDecls(results);
 }
 
-void ClangModuleUnit::lookupValue(ModuleDecl::AccessPathTy accessPath,
-                                  DeclName name, NLKind lookupKind,
+void ClangModuleUnit::lookupValue(DeclName name, NLKind lookupKind,
                                   SmallVectorImpl<ValueDecl*> &results) const {
-  if (!ModuleDecl::matchesAccessPath(accessPath, name))
-    return;
-
   // FIXME: Ignore submodules, which are empty for now.
   if (clangModule && clangModule->isSubModule())
     return;

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -32,10 +32,9 @@ public:
   /// Forwards the request to the ClangImporter, which forwards it to the
   /// DWARFimporterDelegate.
   virtual void
-  lookupValue(ModuleDecl::AccessPathTy accessPath, DeclName name,
-              NLKind lookupKind,
+  lookupValue(DeclName name, NLKind lookupKind,
               SmallVectorImpl<ValueDecl *> &results) const override {
-    Owner.lookupValueDWARF(accessPath, name, lookupKind,
+    Owner.lookupValueDWARF(name, lookupKind,
                            getParentModule()->getName(), results);
   }
 
@@ -130,11 +129,8 @@ ModuleDecl *ClangImporter::Implementation::loadModuleDWARF(
 }
 
 void ClangImporter::Implementation::lookupValueDWARF(
-    ModuleDecl::AccessPathTy accessPath, DeclName name, NLKind lookupKind,
-    Identifier inModule, SmallVectorImpl<ValueDecl *> &results) {
-  if (!swift::ModuleDecl::matchesAccessPath(accessPath, name))
-    return;
-
+    DeclName name, NLKind lookupKind, Identifier inModule,
+    SmallVectorImpl<ValueDecl *> &results) {
   if (lookupKind != NLKind::QualifiedLookup)
     return;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4576,7 +4576,7 @@ namespace {
           Impl.SwiftContext.LangOpts.EffectiveLanguageVersion;
 
       SmallVector<ValueDecl *, 4> results;
-      overlay->lookupValue({}, name, NLKind::QualifiedLookup, results);
+      overlay->lookupValue(name, NLKind::QualifiedLookup, results);
       T *found = nullptr;
       for (auto result : results) {
         if (auto singleResult = dyn_cast<T>(result)) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2331,11 +2331,9 @@ Type ClangImporter::Implementation::getNamedSwiftType(ModuleDecl *module,
       // If we have an overlay, look in the overlay. Otherwise, skip
       // the lookup to avoid infinite recursion.
       if (auto module = clangUnit->getOverlayModule())
-        module->lookupValue({ }, identifier,
-                          NLKind::UnqualifiedLookup, results);
+        module->lookupValue(identifier, NLKind::UnqualifiedLookup, results);
     } else {
-      file->lookupValue({ }, identifier,
-                        NLKind::UnqualifiedLookup, results);
+      file->lookupValue(identifier, NLKind::UnqualifiedLookup, results);
     }
   }
 
@@ -2376,7 +2374,7 @@ getNamedSwiftTypeSpecialization(ModuleDecl *module, StringRef name,
 
   // Look for the type.
   SmallVector<ValueDecl *, 2> results;
-  module->lookupValue({ }, SwiftContext.getIdentifier(name),
+  module->lookupValue(SwiftContext.getIdentifier(name),
                       NLKind::UnqualifiedLookup, results);
   if (results.size() == 1) {
     if (auto nominalDecl = dyn_cast<NominalTypeDecl>(results.front())) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1285,8 +1285,7 @@ public:
   /// Look for namespace-scope values with the given name using the
   /// DWARFImporterDelegate.
   /// \param inModule only return results from this module.
-  void lookupValueDWARF(ModuleDecl::AccessPathTy accessPath, DeclName name,
-                        NLKind lookupKind, Identifier inModule,
+  void lookupValueDWARF(DeclName name, NLKind lookupKind, Identifier inModule,
                         SmallVectorImpl<ValueDecl *> &results);
 
   /// Look for top-level scope types with a name and kind using the

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -53,7 +53,7 @@ public:
 static CanType getNamedSwiftType(ModuleDecl *stdlib, StringRef name) {
   auto &ctx = stdlib->getASTContext();
   SmallVector<ValueDecl*, 1> results;
-  stdlib->lookupValue({}, ctx.getIdentifier(name), NLKind::QualifiedLookup,
+  stdlib->lookupValue(ctx.getIdentifier(name), NLKind::QualifiedLookup,
                       results);
 
   // If we have one single type decl, and that decl has been

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1219,8 +1219,7 @@ static ValueDecl *lookupMember(Parser &P, Type Ty, DeclBaseName Name,
       Lookup.append(found.begin(), found.end());
     }
   } else if (auto moduleTy = CheckTy->getAs<ModuleType>()) {
-    moduleTy->getModule()->lookupValue({ }, Name, NLKind::QualifiedLookup,
-                                       Lookup);
+    moduleTy->getModule()->lookupValue(Name, NLKind::QualifiedLookup, Lookup);
   } else {
     P.diagnose(Loc, diag::sil_member_lookup_bad_type, Name, Ty);
     return nullptr;
@@ -4525,7 +4524,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SmallVector<ValueDecl*, 4> CurModuleResults;
     // Perform a module level lookup on the first component of the
     // fully-qualified name.
-    P.SF.getParentModule()->lookupValue(ModuleDecl::AccessPathTy(), ProtocolName,
+    P.SF.getParentModule()->lookupValue(ProtocolName,
                                         NLKind::UnqualifiedLookup,
                                         CurModuleResults);
     assert(CurModuleResults.size() == 1);
@@ -5617,7 +5616,7 @@ static Optional<VarDecl *> lookupGlobalDecl(Identifier GlobalName,
 
   SmallVector<ValueDecl *, 4> CurModuleResults;
   P.SF.getParentModule()->lookupValue(
-      {}, P.Context.getIdentifier(GlobalDeclName), NLKind::UnqualifiedLookup,
+      P.Context.getIdentifier(GlobalDeclName), NLKind::UnqualifiedLookup,
       CurModuleResults);
   // Bail-out on clang-imported globals.
   if (CurModuleResults.empty())

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -86,7 +86,7 @@ getBridgingFn(Optional<SILDeclRef> &cacheSlot,
     }
 
     SmallVector<ValueDecl *, 2> decls;
-    mod->lookupValue(/*AccessPath=*/{}, ctx.getIdentifier(functionName),
+    mod->lookupValue(ctx.getIdentifier(functionName),
                      NLKind::QualifiedLookup, decls);
     if (decls.empty()) {
       SGM.diagnose(SourceLoc(), diag::bridging_function_missing,

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -126,9 +126,8 @@ struct GenGlobalAccessors : public PatternVisitor<GenGlobalAccessors>
     // Find Builtin.once.
     auto &C = SGM.M.getASTContext();
     SmallVector<ValueDecl*, 2> found;
-    C.TheBuiltinModule
-      ->lookupValue({}, C.getIdentifier("once"),
-                    NLKind::QualifiedLookup, found);
+    C.TheBuiltinModule->lookupValue(C.getIdentifier("once"),
+                                    NLKind::QualifiedLookup, found);
 
     assert(found.size() == 1 && "didn't find Builtin.once?!");
 

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -91,7 +91,7 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
 
   SmallVector<ValueDecl *, 1> results;
   TypeCheckDC->getParentModule()->lookupValue(
-      {}, moduleIdentifier, NLKind::UnqualifiedLookup, results);
+      moduleIdentifier, NLKind::UnqualifiedLookup, results);
 
   ModuleIdentifier = (results.size() == 1) ? moduleIdentifier : Identifier();
 
@@ -107,7 +107,7 @@ InstrumenterBase::InstrumenterBase(ASTContext &C, DeclContext *DC)
 
   results.clear();
   TypeCheckDC->getParentModule()->lookupValue(
-      {}, fileIdentifier, NLKind::UnqualifiedLookup, results);
+      fileIdentifier, NLKind::UnqualifiedLookup, results);
 
   FileIdentifier = (results.size() == 1) ? fileIdentifier : Identifier();
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -662,7 +662,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     }
   } else {
     // Look within a module context.
-    currentFile->getParentModule()->lookupValue({ }, current->getBaseName(),
+    currentFile->getParentModule()->lookupValue(current->getBaseName(),
                                                 NLKind::QualifiedLookup,
                                                 otherDefinitions);
     if (tracker)

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1015,15 +1015,14 @@ static void checkObjCBridgingFunctions(ModuleDecl *mod,
                                        StringRef forwardConversion,
                                        StringRef reverseConversion) {
   assert(mod);
-  ModuleDecl::AccessPathTy unscopedAccess = {};
   SmallVector<ValueDecl *, 4> results;
 
   auto &ctx = mod->getASTContext();
-  mod->lookupValue(unscopedAccess, ctx.getIdentifier(bridgedTypeName),
+  mod->lookupValue(ctx.getIdentifier(bridgedTypeName),
                    NLKind::QualifiedLookup, results);
-  mod->lookupValue(unscopedAccess, ctx.getIdentifier(forwardConversion),
+  mod->lookupValue(ctx.getIdentifier(forwardConversion),
                    NLKind::QualifiedLookup, results);
-  mod->lookupValue(unscopedAccess, ctx.getIdentifier(reverseConversion),
+  mod->lookupValue(ctx.getIdentifier(reverseConversion),
                    NLKind::QualifiedLookup, results);
 
   for (auto D : results) {
@@ -1340,7 +1339,7 @@ static bool isCIntegerType(Type type) {
   auto matchesStdlibTypeNamed = [&](StringRef name) {
     auto identifier = ctx.getIdentifier(name);
     SmallVector<ValueDecl *, 2> foundDecls;
-    stdlibModule->lookupValue({ }, identifier, NLKind::UnqualifiedLookup,
+    stdlibModule->lookupValue(identifier, NLKind::UnqualifiedLookup,
                               foundDecls);
     for (auto found : foundDecls) {
       auto foundType = dyn_cast<TypeDecl>(found);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3653,8 +3653,7 @@ static TypeAliasDecl *findTypeAliasForBuiltin(ASTContext &Ctx, Type T) {
   StringRef TypeName = FullName.substr(8);
 
   SmallVector<ValueDecl*, 4> CurModuleResults;
-  Ctx.TheBuiltinModule->lookupValue(ModuleDecl::AccessPathTy(),
-                                    Ctx.getIdentifier(TypeName),
+  Ctx.TheBuiltinModule->lookupValue(Ctx.getIdentifier(TypeName),
                                     NLKind::QualifiedLookup,
                                     CurModuleResults);
   assert(CurModuleResults.size() == 1);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -946,12 +946,8 @@ bool SerializedASTFile::isSystemModule() const {
   return false;
 }
 
-void SerializedASTFile::lookupValue(ModuleDecl::AccessPathTy accessPath,
-                                    DeclName name, NLKind lookupKind,
+void SerializedASTFile::lookupValue(DeclName name, NLKind lookupKind,
                                     SmallVectorImpl<ValueDecl*> &results) const{
-  if (!ModuleDecl::matchesAccessPath(accessPath, name))
-    return;
-  
   File.lookupValue(name, results);
 }
 


### PR DESCRIPTION
Removes duplicated logic from the implementations of FileUnit::lookupValue, and simplifies the interface to ModuleDecl::lookupValue, where everyone was passing an empty (non-filtering) access path anyway *except* during actual lookup from source code. No functionality change.