### PR TITLE
Fix RangeIteration and StringWalk benchmarks' use of globals

### DIFF
--- a/benchmark/single-source/RangeIteration.swift
+++ b/benchmark/single-source/RangeIteration.swift
@@ -40,8 +40,6 @@ public let RangeIteration = [
 ]
 #endif
 
-public var check: UInt64 = 0
-
 @inline(never)
 func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
   return x &+ y
@@ -50,7 +48,7 @@ func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
 @inline(never)
 public func run_RangeIterationSigned(_ N: Int) {
   let range = 0..<100000
-  check = 0
+  var check: UInt64 = 0
   for _ in 1...N {
     for e in range {
       check = sum(check, UInt64(e))
@@ -65,7 +63,7 @@ public func run_RangeIterationSigned(_ N: Int) {
 @inline(never)
 public func run_RangeIterationSigned64(_ N: Int) {
   let range: Range<Int64> = 0..<100000
-  check = 0
+  var check: UInt64 = 0
   for _ in 1...N {
     for e in range {
       check = sum(check, UInt64(e))
@@ -78,7 +76,7 @@ public func run_RangeIterationSigned64(_ N: Int) {
 @inline(never)
 public func run_RangeIterationUnsigned(_ N: Int) {
   let range: Range<UInt> = 0..<100000
-  check = 0
+  var check: UInt64 = 0
   for _ in 1...N {
     for e in range {
       check = sum(check, UInt64(e))

--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -23,35 +23,41 @@
 
 import TestsUtils
 
-var count: Int = 0
-
 //
 // Helper functionality
 //
 
 @inline(never) func count_unicodeScalars(_ s: String.UnicodeScalarView) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_characters(_ s: String) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_unicodeScalars_rev(
   _ s: ReversedCollection<String.UnicodeScalarView>
 ) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_characters_rev(
   _ s: ReversedCollection<String>
 ) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 
 //
@@ -603,6 +609,7 @@ let asciiCharacters = Array(ascii)
 
 @inline(never)
 public func run_CharIteration_ascii_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in asciiCharacters {
       for u in c.unicodeScalars {
@@ -610,10 +617,12 @@ public func run_CharIteration_ascii_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_ascii_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in asciiCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -621,10 +630,12 @@ public func run_CharIteration_ascii_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_ascii_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in asciiCharacters {
       let s = c.unicodeScalars
@@ -633,10 +644,12 @@ public func run_CharIndexing_ascii_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_ascii_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in asciiCharacters {
       let s = c.unicodeScalars
@@ -645,6 +658,7 @@ public func run_CharIndexing_ascii_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -684,6 +698,7 @@ let utf16Characters = Array(utf16)
 
 @inline(never)
 public func run_CharIteration_utf16_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in utf16Characters {
       for u in c.unicodeScalars {
@@ -691,10 +706,12 @@ public func run_CharIteration_utf16_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_utf16_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in utf16Characters {
       for u in c.unicodeScalars.reversed() {
@@ -702,10 +719,12 @@ public func run_CharIteration_utf16_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_utf16_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in utf16Characters {
       let s = c.unicodeScalars
@@ -714,10 +733,12 @@ public func run_CharIndexing_utf16_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_utf16_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in utf16Characters {
       let s = c.unicodeScalars
@@ -726,6 +747,7 @@ public func run_CharIndexing_utf16_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -765,6 +787,7 @@ let tweetCharacters = Array(tweet)
 
 @inline(never)
 public func run_CharIteration_tweet_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in tweetCharacters {
       for u in c.unicodeScalars {
@@ -772,10 +795,12 @@ public func run_CharIteration_tweet_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_tweet_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in tweetCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -783,10 +808,12 @@ public func run_CharIteration_tweet_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_tweet_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in tweetCharacters {
       let s = c.unicodeScalars
@@ -795,10 +822,12 @@ public func run_CharIndexing_tweet_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_tweet_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in tweetCharacters {
       let s = c.unicodeScalars
@@ -807,6 +836,7 @@ public func run_CharIndexing_tweet_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -846,6 +876,7 @@ let japaneseCharacters = Array(japanese)
 
 @inline(never)
 public func run_CharIteration_japanese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in japaneseCharacters {
       for u in c.unicodeScalars {
@@ -853,10 +884,12 @@ public func run_CharIteration_japanese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_japanese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in japaneseCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -864,10 +897,12 @@ public func run_CharIteration_japanese_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_japanese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in japaneseCharacters {
       let s = c.unicodeScalars
@@ -876,10 +911,12 @@ public func run_CharIndexing_japanese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_japanese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in japaneseCharacters {
       let s = c.unicodeScalars
@@ -888,6 +925,7 @@ public func run_CharIndexing_japanese_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -927,6 +965,7 @@ let chineseCharacters = Array(chinese)
 
 @inline(never)
 public func run_CharIteration_chinese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in chineseCharacters {
       for u in c.unicodeScalars {
@@ -934,10 +973,12 @@ public func run_CharIteration_chinese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_chinese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in chineseCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -945,10 +986,12 @@ public func run_CharIteration_chinese_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_chinese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in chineseCharacters {
       let s = c.unicodeScalars
@@ -957,10 +1000,12 @@ public func run_CharIndexing_chinese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_chinese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in chineseCharacters {
       let s = c.unicodeScalars
@@ -969,6 +1014,7 @@ public func run_CharIndexing_chinese_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -1008,6 +1054,7 @@ let koreanCharacters = Array(korean)
 
 @inline(never)
 public func run_CharIteration_korean_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in koreanCharacters {
       for u in c.unicodeScalars {
@@ -1015,10 +1062,12 @@ public func run_CharIteration_korean_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_korean_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in koreanCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -1026,10 +1075,12 @@ public func run_CharIteration_korean_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_korean_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in koreanCharacters {
       let s = c.unicodeScalars
@@ -1038,10 +1089,12 @@ public func run_CharIndexing_korean_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_korean_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in koreanCharacters {
       let s = c.unicodeScalars
@@ -1050,6 +1103,7 @@ public func run_CharIndexing_korean_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -1089,6 +1143,7 @@ let russianCharacters = Array(russian)
 
 @inline(never)
 public func run_CharIteration_russian_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in russianCharacters {
       for u in c.unicodeScalars {
@@ -1096,10 +1151,12 @@ public func run_CharIteration_russian_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_russian_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in russianCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -1107,10 +1164,12 @@ public func run_CharIteration_russian_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_russian_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in russianCharacters {
       let s = c.unicodeScalars
@@ -1119,10 +1178,12 @@ public func run_CharIndexing_russian_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_russian_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in russianCharacters {
       let s = c.unicodeScalars
@@ -1131,6 +1192,7 @@ public func run_CharIndexing_russian_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -1170,6 +1232,7 @@ let punctuatedCharacters = Array(punctuated)
 
 @inline(never)
 public func run_CharIteration_punctuated_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedCharacters {
       for u in c.unicodeScalars {
@@ -1177,10 +1240,12 @@ public func run_CharIteration_punctuated_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_punctuated_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -1188,10 +1253,12 @@ public func run_CharIteration_punctuated_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_punctuated_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedCharacters {
       let s = c.unicodeScalars
@@ -1200,10 +1267,12 @@ public func run_CharIndexing_punctuated_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_punctuated_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedCharacters {
       let s = c.unicodeScalars
@@ -1212,6 +1281,7 @@ public func run_CharIndexing_punctuated_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 
@@ -1251,6 +1321,7 @@ let punctuatedJapaneseCharacters = Array(punctuatedJapanese)
 
 @inline(never)
 public func run_CharIteration_punctuatedJapanese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedJapaneseCharacters {
       for u in c.unicodeScalars {
@@ -1258,10 +1329,12 @@ public func run_CharIteration_punctuatedJapanese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_punctuatedJapanese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedJapaneseCharacters {
       for u in c.unicodeScalars.reversed() {
@@ -1269,10 +1342,12 @@ public func run_CharIteration_punctuatedJapanese_unicodeScalars_Backwards(_ N: I
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_punctuatedJapanese_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedJapaneseCharacters {
       let s = c.unicodeScalars
@@ -1281,10 +1356,12 @@ public func run_CharIndexing_punctuatedJapanese_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_punctuatedJapanese_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in punctuatedJapaneseCharacters {
       let s = c.unicodeScalars
@@ -1293,6 +1370,7 @@ public func run_CharIndexing_punctuatedJapanese_unicodeScalars_Backwards(_ N: In
       }
     }
   }
+  blackHole(count)
 }
 
 

--- a/benchmark/single-source/StringWalk.swift.gyb
+++ b/benchmark/single-source/StringWalk.swift.gyb
@@ -24,35 +24,41 @@
 
 import TestsUtils
 
-var count: Int = 0
-
 //
 // Helper functionality
 //
 
 @inline(never) func count_unicodeScalars(_ s: String.UnicodeScalarView) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_characters(_ s: String) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_unicodeScalars_rev(
   _ s: ReversedCollection<String.UnicodeScalarView>
 ) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 @inline(never) func count_characters_rev(
   _ s: ReversedCollection<String>
 ) {
+  var count = 0
   for _ in s {
     count += 1
   }
+  blackHole(count)
 }
 
 //
@@ -152,6 +158,7 @@ let ${Name}Characters = Array(${Name})
 
 @inline(never)
 public func run_CharIteration_${Name}_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in ${Name}Characters {
       for u in c.unicodeScalars {
@@ -159,10 +166,12 @@ public func run_CharIteration_${Name}_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIteration_${Name}_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in ${Name}Characters {
       for u in c.unicodeScalars.reversed() {
@@ -170,10 +179,12 @@ public func run_CharIteration_${Name}_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_${Name}_unicodeScalars(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in ${Name}Characters {
       let s = c.unicodeScalars
@@ -182,10 +193,12 @@ public func run_CharIndexing_${Name}_unicodeScalars(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 @inline(never)
 public func run_CharIndexing_${Name}_unicodeScalars_Backwards(_ N: Int) {
+  var count = 0
   for _ in 1...unicodeScalarsMultiplier*N {
     for c in ${Name}Characters {
       let s = c.unicodeScalars
@@ -194,6 +207,7 @@ public func run_CharIndexing_${Name}_unicodeScalars_Backwards(_ N: Int) {
       }
     }
   }
+  blackHole(count)
 }
 
 


### PR DESCRIPTION
    StringWalk benchmark: remove global variable access from the loop.
    
    Global variables are being used as if they are "free black
    holes". They might be even more expensive than actually calling
    blackHole. But the right thing to do is use local variables and pass
    them into a black hole at the end of computation.

    RangeIteration benchmark: remove global variable access from the critical path.
    
    This benchmark was "accidentally" accessing a global variable in the
    main iteration loop, which is in some situations very expensive and
    has nothing to do with what the benchmark is trying to test.