### PR TITLE
Add a comment to SemanticARC.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -751,8 +751,9 @@ bool SemanticARCOptVisitor::visitLoadInst(LoadInst *li) {
   if (!isDeadLiveRange(li, destroyValues))
     return false;
 
-  // Then check if our address is ever written to. If it is, then we
-  // can not use the load_borrow.
+  // Then check if our address is ever written to. If it is, then we cannot use
+  // the load_borrow because the stored value may be released during the loaded
+  // value's live range.
   if (isWrittenTo(li))
     return false;
 


### PR DESCRIPTION
To explain something subtle: copying a loaded value is only required
because assignment may cause the in-memory value to be released.
