### PR TITLE
IRGen: Clean up types of outlined existential buffer operations

### DIFF
--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -117,6 +117,9 @@ private:
   llvm::StringMap<YAMLTypeInfoNode> LegacyTypeInfos;
   llvm::DenseMap<NominalTypeDecl *, std::string> DeclMangledNames;
 
+  /// The key is the number of witness tables.
+  llvm::DenseMap<unsigned, llvm::StructType *> OpaqueExistentialTypes;
+
   const LoadableTypeInfo *createPrimitive(llvm::Type *T,
                                           Size size, Alignment align);
   const LoadableTypeInfo *createPrimitiveForAlignedPointer(llvm::PointerType *T,
@@ -181,6 +184,8 @@ public:
                                             ReferenceCounting style, \
                                             bool isOptional);
 #include "swift/AST/ReferenceStorage.def"
+
+  llvm::Type *getExistentialType(unsigned numWitnessTables);
 
   /// Enter a generic context for lowering the parameters of a generic function
   /// type.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -725,6 +725,7 @@ public:
                                                ReferenceCounting style) const;
 
   llvm::Type *getFixedBufferTy();
+  llvm::PointerType *getExistentialPtrTy(unsigned numTables);
   llvm::Type *getValueWitnessTy(ValueWitness index);
   Signature getValueWitnessSignature(ValueWitness index);
 

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -6,24 +6,27 @@ import Swift
 
 protocol Existential {}
 
-struct Fixed : Existential {
+protocol OtherExistential {}
+
+struct Fixed : Existential, OtherExistential {
   var x: Int
 }
 
-struct NotInlineFixed : Existential {
+struct NotInlineFixed : Existential, OtherExistential {
   var x1: Double
   var x2: Double
   var x3: Double
   var x4: Double
 }
 
-struct NonFixed<T> : Existential {
+struct NonFixed<T> : Existential, OtherExistential {
   var x: T
 }
 
 // CHECK-LABEL: define {{.*}} @test_init_existential_non_fixed
 // CHECK: [[CONTAINER:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK: [[CALL:%.*]] = call %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]])
+// CHECK: [[BITCAST:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]] to %__opaque_existential_type_1*
+// CHECK: [[CALL:%.*]] = call %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BITCAST]])
 // CHECK: [[INIT_EXIST_ADDR:%.*]] = bitcast %swift.opaque* [[CALL]] to %T25existentials_opaque_boxed8NonFixedV*
 
 sil @test_init_existential_non_fixed : $@convention(thin) <T> (@in T) -> () {
@@ -35,8 +38,17 @@ entry(%0 : $*T):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
-// CHECK:  [[METATYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
+sil @test_init_other_existential_non_fixed : $@convention(thin) <T> (@in T) -> () {
+entry(%0 : $*T):
+  %exist_container = alloc_stack $OtherExistential
+  %value_addr = init_existential_addr %exist_container : $*OtherExistential, $NonFixed<T>
+  dealloc_stack %exist_container : $*OtherExistential
+  %t = tuple()
+  return %t : $()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%__opaque_existential_type_1*)
+// CHECK:  [[METATYPE_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 1
 // CHECK:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_ADDR]]
 // CHECK:  [[CAST:%.*]] = bitcast %swift.type* [[METATYPE]]
 // CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
@@ -46,7 +58,7 @@ entry(%0 : $*T):
 // CHECK:  [[FLAGS:%.*]] = load i32, i32* [[FLAGS_ADDR]]
 // CHECK:  [[ISNOTINLINE:%.*]] = and i32 [[FLAGS]], 131072
 // CHECK:  [[ISINLINE:%.*]] = icmp eq i32 [[ISNOTINLINE]], 0
-// CHECK:  [[EXISTENTIAL_BUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:  [[EXISTENTIAL_BUFFER:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 0
 // CHECK:  [[EXISTENTIAL_BUFFER_OPAQUE:%.*]] = bitcast [{{(24|12)}} x i8]* [[EXISTENTIAL_BUFFER]] to %swift.opaque*
 // CHECK:  br i1 [[ISINLINE]], label %done, label %allocateBox
 //
@@ -76,6 +88,15 @@ entry:
   return %t : $()
 }
 
+sil @test_init_other_existential_fixed : $@convention(thin) () -> () {
+entry:
+  %exist_container = alloc_stack $OtherExistential
+  %value_addr = init_existential_addr %exist_container : $*OtherExistential, $Fixed
+  dealloc_stack %exist_container : $*OtherExistential
+  %t = tuple()
+  return %t : $()
+}
+
 // CHECK-LABEL: define {{.*}} @test_init_existential_fixed_not_inline()
 // CHECK:  [[CONTAINER:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:  [[INLINEBUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]], i32 0, i32 0
@@ -96,9 +117,19 @@ entry:
   return %t : $()
 }
 
+sil @test_init_other_existential_fixed_not_inline : $@convention(thin) () -> () {
+entry:
+  %exist_container = alloc_stack $OtherExistential
+  %value_addr = init_existential_addr %exist_container : $*OtherExistential, $NotInlineFixed
+  dealloc_stack %exist_container : $*OtherExistential
+  %t = tuple()
+  return %t : $()
+}
+
 // CHECK-LABEL: define {{.*}} @test_deinit_existential
 // CHECK:  [[CONTAINER:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:  call void @__swift_deallocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]])
+// CHECK:  [[BITCAST:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]] to %__opaque_existential_type_1*
+// CHECK:  call void @__swift_deallocate_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BITCAST]])
 // CHECK:  ret void
 sil @test_deinit_existential : $@convention(thin) () -> () {
 entry:
@@ -109,8 +140,17 @@ entry:
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_deallocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
-// CHECK:   [[META_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
+sil @test_deinit_other_existential : $@convention(thin) () -> () {
+entry:
+  %exist_container = alloc_stack $OtherExistential
+  deinit_existential_addr %exist_container : $*OtherExistential
+  dealloc_stack %exist_container : $*OtherExistential
+  %t = tuple()
+  return %t : $()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_deallocate_boxed_opaque_existential_1(%__opaque_existential_type_1*)
+// CHECK:   [[META_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 1
 // CHECK:   [[META:%.*]] = load %swift.type*, %swift.type** [[META_ADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[META]] to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** %3, {{(i64|i32)}} -1
@@ -126,7 +166,7 @@ entry:
 // CHECK: ret void
 
 // CHECK:  deallocateBox:
-// CHECK:   [[BUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:   [[BUFFER:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 0
 // CHECK:   [[REFERENCE_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* [[BUFFER]] to %swift.refcounted**
 // CHECK:   [[REFERENCE:%.*]] = load %swift.refcounted*, %swift.refcounted** [[REFERENCE_ADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[META]] to i8***
@@ -154,8 +194,8 @@ entry:
 // CHECK:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[META_ADDR]]
 // CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 2
 // CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:  [[BUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
-// CHECK:  [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_project_boxed_opaque_existential_1([{{(24|12)}} x i8]* [[BUFFER]], %swift.type* [[METATYPE]])
+// CHECK:  [[BUFFER:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* %0 to %__opaque_existential_type_1
+// CHECK:  [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_project_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BUFFER]], %swift.type* [[METATYPE]])
 // CHECK: ret void
 sil @test_open_existential_addr_immutable :$@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -164,7 +204,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_project_boxed_opaque_existential_1(%__opaque_existential_type_1*, %swift.type*)
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* %1 to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -173,14 +213,14 @@ bb0(%0 : $*Existential):
 // CHECK:   [[FLAGS:%.*]] = load i32, i32* [[FLAGS_ADDR]]
 // CHECK:   [[ISNOTINLINE:%.*]] = and i32 [[FLAGS]], 131072
 // CHECK:   [[ISINLINE:%.*]] = icmp eq i32 [[ISNOTINLINE]], 0
-// CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
+// CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast %__opaque_existential_type_1* %0 to %swift.opaque*
 // CHECK:   br i1 [[ISINLINE]], label %done, label %boxed
 //
 // CHECK: done:
 // CHECK:   ret %swift.opaque* [[VALUEADDRINLINE]]
 //
 // CHECK: boxed:
-// CHECK:   [[REFADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.refcounted**
+// CHECK:   [[REFADDR:%.*]] = bitcast %__opaque_existential_type_1* %0 to %swift.refcounted**
 // CHECK:   [[REF:%.*]] = load %swift.refcounted*, %swift.refcounted** [[REFADDR]]
 // CHECK-64:[[T0:%.*]] = zext i32 [[FLAGS]] to i64
 // CHECK-64:[[ALIGNMASK:%.*]] = and i64 [[T0]], 255
@@ -201,8 +241,8 @@ bb0(%0 : $*Existential):
 // CHECK:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[META_ADDR]]
 // CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 2
 // CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
-// CHECK:  [[BUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
-// CHECK:  [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1([{{(24|12)}} x i8]* [[BUFFER]], %swift.type* [[METATYPE]])
+// CHECK:  [[BUFFER:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* %0 to %__opaque_existential_type_1
+// CHECK:  [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BUFFER]], %swift.type* [[METATYPE]])
 // CHECK: ret void
 sil @test_open_existential_addr_mutable :$@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -211,7 +251,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1(%__opaque_existential_type_1*, %swift.type*)
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* %1 to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -220,7 +260,7 @@ bb0(%0 : $*Existential):
 // CHECK:   [[FLAGS:%.*]] = load i32, i32* [[FLAGS_ADDR]]
 // CHECK:   [[ISNOTINLINE:%.*]] = and i32 [[FLAGS]], 131072
 // CHECK:   [[ISINLINE:%.*]] = icmp eq i32 [[ISNOTINLINE]], 0
-// CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
+// CHECK:   [[VALUEADDRINLINE:%.*]] = bitcast %__opaque_existential_type_1* %0 to %swift.opaque*
 // CHECK:   br i1 [[ISINLINE]], label %done, label %boxed
 //
 // CHECK: done:
@@ -232,7 +272,7 @@ bb0(%0 : $*Existential):
 // CHECK-32:[[ALIGNMASK:%.*]] = and i32 [[FLAGS]], 255
 // CHECK-16:[[T0:%.*]] = trunc i32 [[FLAGS]] to i16
 // CHECK-16:[[ALIGNMASK:%.*]] = and i16 [[T0]], 255
-// CHECK:  [[OPAQUE_ADDR:%.*]] = bitcast [{{(24|12)}} x i8]* %0 to %swift.opaque*
+// CHECK:  [[OPAQUE_ADDR:%.*]] = bitcast %__opaque_existential_type_1* %0 to %swift.opaque*
 // CHECK:  [[REFANDADDR:%.*]] = call swiftcc { %swift.refcounted*, %swift.opaque* } @swift_makeBoxUnique(%swift.opaque* [[OPAQUE_ADDR]], %swift.type* %1, {{(i64|i32)}} [[ALIGNMASK]])
 // CHECK:  [[REF:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[REFANDADDR]], 0
 // CHECK:  [[ADDR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[REFANDADDR]], 1
@@ -240,7 +280,8 @@ bb0(%0 : $*Existential):
 
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_destroy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
-// CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* %0)
+// CHECK:   [[BITCAST:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* %0 to %__opaque_existential_type_1
+// CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BITCAST]])
 // CHECK:   ret void
 sil @test_destroy_existential_addr :$@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
@@ -249,10 +290,17 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
-// CHECK:  [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
+sil @test_destroy_other_existential_addr :$@convention(thin) (@in OtherExistential) -> () {
+bb0(%0 : $*OtherExistential):
+  destroy_addr %0 : $*OtherExistential
+	%t = tuple()
+  return %t : $()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_destroy_boxed_opaque_existential_1(%__opaque_existential_type_1*)
+// CHECK:  [[METADATA_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 1
 // CHECK:  [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
-// CHECK:  [[BUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
+// CHECK:  [[BUFFER_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 0
 // CHECK:  [[CAST:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
 // CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:  [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -282,7 +330,9 @@ bb0(%0 : $*Existential):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_assignWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:  [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:  call void @__swift_assign_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], %T25existentials_opaque_boxed11ExistentialP* %0)
+// CHECK:  [[DST:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]] to %__opaque_existential_type_1
+// CHECK:  [[SRC:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* %0 to %__opaque_existential_type_1
+// CHECK:  call void @__swift_assign_boxed_opaque_existential_1(%__opaque_existential_type_1* [[DST]], %__opaque_existential_type_1* [[SRC]])
 // CHECK:  ret void
 // CHECK:}
 sil @test_assignWithCopy_existential_addr : $@convention(thin) (@in Existential) -> () {
@@ -294,17 +344,26 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_assign_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+sil @test_assignWithCopy_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
+bb0(%0 : $*OtherExistential):
+  %s = alloc_stack $OtherExistential
+  copy_addr %0 to %s : $*OtherExistential
+  dealloc_stack %s : $*OtherExistential
+	%t = tuple()
+  return %t : $()
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_assign_boxed_opaque_existential_1(%__opaque_existential_type_1*, %__opaque_existential_type_1*)
 // CHECK:  [[TMPBUFFER:%.*]] = alloca [{{(24|12)}} x i8]
-// CHECK:  [[SELFASSIGN:%.*]] = icmp eq %T25existentials_opaque_boxed11ExistentialP* %0, %1
+// CHECK:  [[SELFASSIGN:%.*]] = icmp eq %__opaque_existential_type_1* %0, %1
 // CHECK:  br i1 [[SELFASSIGN]], label %done, label %cont
 //
 // CHECK: cont:
-// CHECK:   [[DEST_BUFFERADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
-// CHECK:   [[SRC_BUFFERADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 0
-// CHECK:   [[DEST_TYPEADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
+// CHECK:   [[DEST_BUFFERADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 0
+// CHECK:   [[SRC_BUFFERADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %1, i32 0, i32 0
+// CHECK:   [[DEST_TYPEADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 1
 // CHECK:   [[DEST_TYPE:%.*]] = load %swift.type*, %swift.type** [[DEST_TYPEADDR]]
-// CHECK:   [[SRC_TYPEADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 1
+// CHECK:   [[SRC_TYPEADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %1, i32 0, i32 1
 // CHECK:   [[SRC_TYPE:%.*]] = load %swift.type*, %swift.type** [[SRC_TYPEADDR]]
 // CHECK:   [[ISSAME:%.*]] = icmp eq %swift.type* [[DEST_TYPE]], [[SRC_TYPE]]
 // CHECK:   br i1 [[ISSAME]], label %match, label %no-match
@@ -344,8 +403,8 @@ bb0(%0 : $*Existential):
 
 // CHECK: no-match:
 // CHECK:   store %swift.type* [[SRC_TYPE]], %swift.type** [[DEST_TYPEADDR]]
-// CHECK:   [[DEST_PWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 2
-// CHECK:   [[SRC_PWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %1, i32 0, i32 2
+// CHECK:   [[DEST_PWT_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %0, i32 0, i32 2
+// CHECK:   [[SRC_PWT_ADDR:%.*]] = getelementptr inbounds %__opaque_existential_type_1, %__opaque_existential_type_1* %1, i32 0, i32 2
 // CHECK:   [[SRC_PTW:%.*]] = load i8**, i8*** [[SRC_PWT_ADDR]]
 // CHECK:   store i8** [[SRC_PTW]], i8*** [[DEST_PWT_ADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[DEST_TYPE]] to i8***
@@ -443,7 +502,8 @@ bb0(%0 : $*Existential):
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
-// CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
+// CHECK:   [[BITCAST:%.*]] = bitcast %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]] to %__opaque_existential_type_1
+// CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BITCAST]])
 // CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @"$s25existentials_opaque_boxed11Existential_pWOb"(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
 // CHECK:   ret void
 sil @test_assignWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
@@ -451,6 +511,15 @@ bb0(%0 : $*Existential):
   %s = alloc_stack $Existential
   copy_addr [take] %0 to %s : $*Existential
   dealloc_stack %s : $*Existential
+	%t = tuple()
+  return %t : $()
+}
+
+sil @test_assignWithTake_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
+bb0(%0 : $*OtherExistential):
+  %s = alloc_stack $OtherExistential
+  copy_addr [take] %0 to %s : $*OtherExistential
+  dealloc_stack %s : $*OtherExistential
 	%t = tuple()
   return %t : $()
 }
@@ -470,6 +539,15 @@ bb0(%0 : $*Existential):
   %s = alloc_stack $Existential
   copy_addr [take] %0 to [initialization] %s : $*Existential
   dealloc_stack %s : $*Existential
+	%t = tuple()
+  return %t : $()
+}
+
+sil @test_initWithTake_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
+bb0(%0 : $*OtherExistential):
+  %s = alloc_stack $OtherExistential
+  copy_addr [take] %0 to [initialization] %s : $*OtherExistential
+  dealloc_stack %s : $*OtherExistential
 	%t = tuple()
   return %t : $()
 }
@@ -505,6 +583,15 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
+sil @test_initWithCopy_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
+bb0(%0 : $*OtherExistential):
+  %s = alloc_stack $OtherExistential
+  copy_addr %0 to [initialization] %s : $*OtherExistential
+  dealloc_stack %s : $*OtherExistential
+	%t = tuple()
+  return %t : $()
+}
+
 @_alignment(16)
 struct FixedOveralign : Existential {
 	var x : Int64
@@ -516,7 +603,7 @@ struct FixedOveralign : Existential {
 // CHECK:  [[CONTAINER:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:  [[INLINEBUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]], i32 0, i32 0
 // CHECK:  [[INLINEBUFFER:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* [[CONTAINER]], i32 0, i32 0
-// CHECK:  [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.3, i32 0, i32 2), {{(i64|i32)}} 32, {{(i64|i32)}} 15)
+// CHECK:  [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.4, i32 0, i32 2), {{(i64|i32)}} 32, {{(i64|i32)}} 15)
 // CHECK-64:  [[BOX_ADDR:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[BOX_TYPE:<{ %swift.refcounted, \[16 x i8\] }>]]*
 // CHECK-32:  [[BOX_ADDR:%.*]] = bitcast %swift.refcounted* [[BOX]] to [[BOX_TYPE:<{ %swift.refcounted, \[8 x i8\], \[16 x i8\] }>]]*
 // CHECK:  [[VALUE_ADDR:%.*]] = getelementptr inbounds [[BOX_TYPE]], [[BOX_TYPE]]* [[BOX_ADDR]], i32 0, i32 {{(1|2)}}

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -62,8 +62,8 @@ protocol Bas {}
 func protocolTypeof(_ x: Bas) -> Bas.Type {
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T17generic_metatypes3BasP, %T17generic_metatypes3BasP* [[X:%.*]], i32 0, i32 1
   // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
-  // CHECK: [[BUFFER:%.*]] = getelementptr inbounds %T17generic_metatypes3BasP, %T17generic_metatypes3BasP* [[X]], i32 0, i32 0
-  // CHECK: [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_project_boxed_opaque_existential_1({{.*}} [[BUFFER]], %swift.type* [[METADATA]])
+  // CHECK: [[BUFFER:%.*]] = bitcast %T17generic_metatypes3BasP* [[X]] to %__opaque_existential_type_1*
+  // CHECK: [[VALUE_ADDR:%.*]] = call %swift.opaque* @__swift_project_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BUFFER]], %swift.type* [[METADATA]])
   // CHECK: [[METATYPE:%.*]] = call %swift.type* @swift_getDynamicType(%swift.opaque* [[VALUE_ADDR]], %swift.type* [[METADATA]], i1 true)
   // CHECK: [[WTABLE_ADDR:%.*]] = getelementptr inbounds %T17generic_metatypes3BasP, %T17generic_metatypes3BasP* %0, i32 0, i32 2
   // CHECK: [[WTABLE:%.*]] = load i8**, i8*** [[WTABLE_ADDR]]

--- a/test/IRGen/protocol_accessor_multifile.swift
+++ b/test/IRGen/protocol_accessor_multifile.swift
@@ -8,10 +8,11 @@
 // CHECK-LABEL: define{{.*}} void @"$s27protocol_accessor_multifile14useExistentialyyF"()
 func useExistential() {
   // CHECK: [[BOX:%.+]] = alloca %T27protocol_accessor_multifile5ProtoP,
-  // CHECK: call swiftcc void @"$s27protocol_accessor_multifile17globalExistentialAA5Proto_pvg"({{%.+}} [[BOX]])
+  // CHECK: call swiftcc void @"$s27protocol_accessor_multifile17globalExistentialAA5Proto_pvg"(%T27protocol_accessor_multifile5ProtoP* noalias nocapture sret [[BOX]])
   // CHECK: call swiftcc void @"$s27protocol_accessor_multifile5ProtoPAAE6methodyyF"
   globalExistential.method()
-  // CHECK: call void @__swift_destroy_boxed_opaque_existential_1({{%.+}} [[BOX]])
+  // CHECK: [[BITCAST:%.*]] = bitcast %T27protocol_accessor_multifile5ProtoP* [[BOX]] to %__opaque_existential_type_1*
+  // CHECK: call void @__swift_destroy_boxed_opaque_existential_1(%__opaque_existential_type_1* [[BITCAST]])
   // CHECK: ret void
 }
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -205,12 +205,14 @@ public func resilientAny(s : ResilientWeakRef) {
 // CHECK: [[ANY:%.*]] = alloca %Any
 // CHECK: [[META:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct16ResilientWeakRefVMa"([[INT]] 0)
 // CHECK: [[META2:%.*]] = extractvalue %swift.metadata_response %3, 0
-// CHECK: [[TYADDR:%.*]] = getelementptr inbounds %Any, %Any* %1, i32 0, i32 1
-// CHECK:  store %swift.type* [[META2]], %swift.type** [[TYADDR]]
-// CHECK:  call %swift.opaque* @__swift_allocate_boxed_opaque_existential_0(%Any* [[ANY]])
-// CHECK:  call swiftcc void @"$s17struct_resilience8wantsAnyyyypF"(%Any* noalias nocapture dereferenceable({{(32|16)}}) [[ANY]])
-// CHECK:  call void @__swift_destroy_boxed_opaque_existential_0(%Any* [[ANY]])
-// CHECK:  ret void
+// CHECK: [[TYADDR:%.*]] = getelementptr inbounds %Any, %Any* [[ANY]], i32 0, i32 1
+// CHECK: store %swift.type* [[META2]], %swift.type** [[TYADDR]]
+// CHECK: [[BITCAST:%.*]] = bitcast %Any* [[ANY]] to %__opaque_existential_type_0*
+// CHECK: call %swift.opaque* @__swift_allocate_boxed_opaque_existential_0(%__opaque_existential_type_0* [[BITCAST]])
+// CHECK: call swiftcc void @"$s17struct_resilience8wantsAnyyyypF"(%Any* noalias nocapture dereferenceable({{(32|16)}}) [[ANY]])
+// CHECK: [[BITCAST:%.*]] = bitcast %Any* [[ANY]] to %__opaque_existential_type_0*
+// CHECK: call void @__swift_destroy_boxed_opaque_existential_0(%__opaque_existential_type_0* [[BITCAST]])
+// CHECK: ret void
 
 // Make sure that MemoryLayout properties access resilient types' metadata
 // instead of hardcoding sizes based on compile-time layouts.


### PR DESCRIPTION
The uniquing key for these was just the number of witness tables,
but the function itself referenced the specific existential type
it was instantiated with.

Everything still worked because getOrCreateHelperFunction() would
bitcast an existing function to the correct type, and in practice
the layout of an existential type only depends on the number of
witness tables.

However on master-next, other changes were made that stripped
off the bitcasts. This would result in assertions or LLVM
verifier failures when multiple existential types were used in
a single translation unit.

Fixes <rdar://problem/54780404>.