### PR TITLE
[CS] Simplify getCalleeDeclAndArgs

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6326,21 +6326,17 @@ void FailureDiagnosis::diagnoseAmbiguity(Expr *E) {
 /// If an UnresolvedDotExpr, SubscriptMember, etc has been resolved by the
 /// constraint system, return the decl that it references.
 ValueDecl *ConstraintSystem::findResolvedMemberRef(ConstraintLocator *locator) {
-  auto *resolvedOverloadSets = this->getResolvedOverloadSets();
-  if (!resolvedOverloadSets) return nullptr;
-  
   // Search through the resolvedOverloadSets to see if we have a resolution for
   // this member.  This is an O(n) search, but only happens when producing an
   // error diagnostic.
-  for (auto resolved = resolvedOverloadSets;
-       resolved; resolved = resolved->Previous) {
-    if (resolved->Locator != locator) continue;
-    
-    // We only handle the simplest decl binding.
-    if (resolved->Choice.getKind() != OverloadChoiceKind::Decl)
-      return nullptr;
-    return resolved->Choice.getDecl();
-  }
-  
-  return nullptr;
+  auto *overload = findSelectedOverloadFor(locator);
+  if (!overload)
+    return nullptr;
+
+  // We only want to handle the simplest decl binding.
+  auto choice = overload->Choice;
+  if (choice.getKind() != OverloadChoiceKind::Decl)
+    return nullptr;
+
+  return choice.getDecl();
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -144,13 +144,7 @@ protected:
   /// by the constraint solver.
   ResolvedOverloadSetListItem *
   getResolvedOverload(ConstraintLocator *locator) const {
-    auto resolvedOverload = CS.getResolvedOverloadSets();
-    while (resolvedOverload) {
-      if (resolvedOverload->Locator == locator)
-        return resolvedOverload;
-      resolvedOverload = resolvedOverload->Previous;
-    }
-    return nullptr;
+    return CS.findSelectedOverloadFor(locator);
   }
 
   /// Retrive the constraint locator for the given anchor and

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1592,6 +1592,17 @@ public:
     return resolvedOverloadSets;
   }
 
+  ResolvedOverloadSetListItem *
+  findSelectedOverloadFor(ConstraintLocator *locator) const {
+    auto resolvedOverload = getResolvedOverloadSets();
+    while (resolvedOverload) {
+      if (resolvedOverload->Locator == locator)
+        return resolvedOverload;
+      resolvedOverload = resolvedOverload->Previous;
+    }
+    return nullptr;
+  }
+
   ResolvedOverloadSetListItem *findSelectedOverloadFor(Expr *expr) const {
     auto resolvedOverload = getResolvedOverloadSets();
     while (resolvedOverload) {

--- a/test/Constraints/function_builder.swift
+++ b/test/Constraints/function_builder.swift
@@ -212,6 +212,18 @@ print(mbuilders.methodBuilder(13))
 // CHECK: ("propertyBuilder", 12)
 print(mbuilders.propertyBuilder)
 
+// SR-11439: Operator builders
+infix operator ^^^
+func ^^^ (lhs: Int, @TupleBuilder rhs: (Int) -> (String, Int)) -> (String, Int) {
+  return rhs(lhs)
+}
+
+// CHECK: ("hello", 6)
+print(5 ^^^ {
+  "hello"
+  $0 + 1
+})
+
 struct Tagged<Tag, Entity> {
   let tag: Tag
   let entity: Entity

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -172,3 +172,30 @@ func test_51167632() -> some P {
     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{10-10=<<#L: P#>>}}
   })
 }
+
+struct SR11440 {
+  typealias ReturnsTuple<T> = () -> (T, T)
+  subscript<T, U>(@TupleBuilder x: ReturnsTuple<T>) -> (ReturnsTuple<U>) -> Void { //expected-note {{in call to 'subscript(_:)'}}
+    return { _ in }
+  }
+
+  func foo() {
+    // This is okay, we apply the function builder for the subscript arg.
+    self[{
+      5
+      5
+    }]({
+      (5, 5)
+    })
+
+    // But we shouldn't perform the transform for the argument to the call
+    // made on the function returned from the subscript.
+    self[{ // expected-error {{generic parameter 'U' could not be inferred}}
+      5
+      5
+    }]({
+      5
+      5
+    })
+  }
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -541,23 +541,19 @@ func testImplicitConversionInSubscriptIndex() {
   _ = \BassSubscript.["hello"] // expected-error{{must be Hashable}}
 }
 
-// Crash in diagnostics
-struct AmbiguousSubscript {
+// Crash in diagnostics + SR-11438
+struct UnambiguousSubscript {
   subscript(sub: Sub) -> Int { get { } set { } }
-  // expected-note@-1 {{'subscript(_:)' declared here}}
-
   subscript(y y: Sub) -> Int { get { } set { } }
-  // expected-note@-1 {{'subscript(y:)' declared here}}
 }
 
-func useAmbiguousSubscript(_ sub: Sub) {
-  let _: PartialKeyPath<AmbiguousSubscript> = \.[sub]
-  // expected-error@-1 {{ambiguous reference to member 'subscript'}}
+func useUnambiguousSubscript(_ sub: Sub) {
+  let _: PartialKeyPath<UnambiguousSubscript> = \.[sub]
 }
 
 struct BothUnavailableSubscript {
   @available(*, unavailable)
-  subscript(sub: Sub) -> Int { get { } set { } }
+  subscript(sub: Sub) -> Int { get { } set { } } // expected-note {{'subscript(_:)' has been explicitly marked unavailable here}}
 
   @available(*, unavailable)
   subscript(y y: Sub) -> Int { get { } set { } }
@@ -565,7 +561,7 @@ struct BothUnavailableSubscript {
 
 func useBothUnavailableSubscript(_ sub: Sub) {
   let _: PartialKeyPath<BothUnavailableSubscript> = \.[sub]
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-1 {{'subscript(_:)' is unavailable}}
 }
 
 // SR-6106


### PR DESCRIPTION
This PR starts associating argument labels for key path subscript components, which allows the special case for them in `getCalleeDeclAndArgs` to be removed, and also allows us to correctly ignore choices with mismatching labels in some cases.

This PR then uses `getCalleeLocator` in order to find callees in `getCalleeDeclAndArgs`, which fixes one case where we weren't finding callees for operator calls, and another case where we were incorrectly returning a subscript callee for a call made on the result of a subscript such as `x[]()`.

Resolves [SR-11438](https://bugs.swift.org/browse/SR-11438), [SR-11439](https://bugs.swift.org/browse/SR-11439) & [SR-11440](https://bugs.swift.org/browse/SR-11440).