### PR TITLE
ASTPrinter: Fix generic signatures with requirements on outer parameters [5.1 08/28]

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1332,22 +1332,21 @@ void PrintAST::printGenericSignature(const GenericSignature *genericSig,
                         // print everything
                         [&](const Requirement &) { return true; });
 }
+
 void PrintAST::printGenericSignature(
     const GenericSignature *genericSig, unsigned flags,
     llvm::function_ref<bool(const Requirement &)> filter) {
+  auto requirements = genericSig->getRequirements();
+
   if (flags & InnermostOnly) {
     auto genericParams = genericSig->getInnermostGenericParams();
-    unsigned depth = genericParams[0]->getDepth();
-    SmallVector<Requirement, 2> requirementsAtDepth;
-    getRequirementsAtDepth(genericSig, depth, requirementsAtDepth);
 
-    printSingleDepthOfGenericSignature(genericParams, requirementsAtDepth,
-                                       flags, filter);
+    printSingleDepthOfGenericSignature(genericParams, requirements, flags,
+                                       filter);
     return;
   }
 
   auto genericParams = genericSig->getGenericParams();
-  auto requirements = genericSig->getRequirements();
 
   if (!Options.PrintInSILBody) {
     printSingleDepthOfGenericSignature(genericParams, requirements, flags,
@@ -1963,15 +1962,24 @@ void PrintAST::printMembers(ArrayRef<Decl *> members, bool needComma,
 }
 
 void PrintAST::printGenericDeclGenericParams(GenericContext *decl) {
-  if (decl->getGenericParams())
+  if (decl->isGeneric())
     if (auto GenericSig = decl->getGenericSignature())
       printGenericSignature(GenericSig, PrintParams | InnermostOnly);
 }
 
 void PrintAST::printGenericDeclGenericRequirements(GenericContext *decl) {
-  if (decl->getGenericParams())
-    if (auto GenericSig = decl->getGenericSignature())
-      printGenericSignature(GenericSig, PrintRequirements | InnermostOnly);
+  if (decl->isGeneric()) {
+    if (auto genericSig = decl->getGenericSignature()) {
+      auto *baseGenericSig = decl->getParent()
+          ->getGenericSignatureOfContext();
+      printGenericSignature(genericSig, PrintRequirements,
+                            [baseGenericSig](const Requirement &req) {
+                              if (baseGenericSig)
+                                return !baseGenericSig->isRequirementSatisfied(req);
+                              return true;
+                            });
+    }
+  }
 }
 
 void PrintAST::printInherited(const Decl *decl) {
@@ -2112,7 +2120,7 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
       auto *baseGenericSig = decl->getExtendedNominal()->getGenericSignature();
       assert(baseGenericSig &&
              "an extension can't be generic if the base type isn't");
-      printGenericSignature(genericSig, PrintRequirements | InnermostOnly,
+      printGenericSignature(genericSig, PrintRequirements,
                             [baseGenericSig](const Requirement &req) -> bool {
         // Only include constraints that are not satisfied by the base type.
         return !baseGenericSig->isRequirementSatisfied(req);

--- a/test/ParseableInterface/where-clause.swift
+++ b/test/ParseableInterface/where-clause.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// RUN: %target-build-swift %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// RUN: %target-build-swift %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -wmo
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// CHECK: import Swift
+
+// CHECK: public struct Holder<Value> {
+public struct Holder<Value> {
+    var value: Value
+
+    // CHECK-NEXT: public init(value: Value){{$}}
+    public init(value: Value) {
+        self.value = value
+    }
+
+    // CHECK-NEXT: public init<T>(_ value: T) where Value == Swift.AnyHashable, T : Swift.Hashable{{$}}
+    public init<T : Hashable>(_ value: T) where Value == AnyHashable {
+        self.value = value
+    }
+
+    // CHECK-NEXT: public struct Transform<Result> {
+    public struct Transform<Result> {
+        var fn: (Value) -> Result
+
+        // CHECK-NEXT: public init(fn: @escaping (Value) -> Result){{$}}
+        public init(fn: @escaping (Value) -> Result) {
+            self.fn = fn
+        }
+
+        // CHECK-NEXT: func transform(_ holder: main.Holder<Value>) -> Result{{$}}
+        public func transform(_ holder: Holder<Value>) -> Result {
+            return fn(holder.value)
+        }
+    
+    // CHECK-NEXT: }
+    }
+
+// CHECK-NEXT: }
+}
+
+// CHECK-NEXT: extension Holder.Transform where Value == Swift.Int {
+extension Holder.Transform where Value == Int {
+    // CHECK-NEXT: public func negate(_ holder: main.Holder<Value>) -> Result{{$}}
+    public func negate(_ holder: Holder<Value>) -> Result {
+        return transform(Holder(value: -holder.value))
+    }
+}


### PR DESCRIPTION
We incorrectly assumed that a requirement 'rooted' in an outer parameter
must be necessarily defined as part of the outer context's signature,
and thus we were skipping it when printing the 'where' clause of a
nested declaration or an extension of a nested type.

Instead, actually get the outer generic signature and filter requirements
that the outer signature satisfies.

Fixes rdar://problem/53769896, https://bugs.swift.org/browse/SR-11221.