### PR TITLE
[ASTMangler] Fix USR generation/mangling crash in invalid code

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2356,29 +2356,34 @@ CanType ASTMangler::getDeclTypeForMangling(
   }
 
 
-  CanType type = decl->getInterfaceType()
-                      ->getReferenceStorageReferent()
-                      ->getCanonicalType();
-  if (auto gft = dyn_cast<GenericFunctionType>(type)) {
+  Type type = decl->getInterfaceType()
+                  ->getReferenceStorageReferent();
+  if (type->hasArchetype()) {
+    assert(isa<ParamDecl>(decl) && "Only ParamDecl's still have archetypes");
+    type = type->mapTypeOutOfContext();
+  }
+  CanType canTy = type->getCanonicalType();
+
+  if (auto gft = dyn_cast<GenericFunctionType>(canTy)) {
     genericSig = gft.getGenericSignature();
     CurGenericSignature = gft.getGenericSignature();
 
-    type = CanFunctionType::get(gft.getParams(), gft.getResult(),
-                                gft->getExtInfo());
+    canTy = CanFunctionType::get(gft.getParams(), gft.getResult(),
+                                 gft->getExtInfo());
   }
 
-  if (!type->hasError()) {
+  if (!canTy->hasError()) {
     // Shed the 'self' type and generic requirements from method manglings.
     if (isMethodDecl(decl)) {
       // Drop the Self argument clause from the type.
-      type = cast<AnyFunctionType>(type).getResult();
+      canTy = cast<AnyFunctionType>(canTy).getResult();
     }
 
     if (isMethodDecl(decl) || isa<SubscriptDecl>(decl))
       parentGenericSig = decl->getDeclContext()->getGenericSignatureOfContext();
   }
 
-  return type;
+  return canTy;
 }
 
 void ASTMangler::appendDeclType(const ValueDecl *decl, bool isFunctionMangling) {

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s | %FileCheck %s
 
 // CHECK: [[@LINE+1]]:8 | struct/Swift | Int | {{.*}} | Ref | rel: 0
 var _: Int { get { return 1 } }
@@ -36,4 +36,16 @@ public struct BadCollection: Collection {
     public var endIndex: Index { }
     public func index(after index: Index) -> Index { }
     public subscript(position: Index) -> Element { }
+}
+
+struct Protector<T> {}
+extension Protector where T: RangeReplaceableCollection {
+  func append(_ newElement: T.Iterator.Element) {
+    undefined { (foo: T) in
+    // CHECK: [[@LINE-1]]:18 | param(local)/Swift | foo | {{.*}} | Def,RelChild
+    // CHECK: [[@LINE-2]]:18 | function/acc-get(local)/Swift | getter:foo | {{.*}} | Def,Impl,RelChild,RelAcc
+    // CHECK: [[@LINE-3]]:18 | function/acc-set(local)/Swift | setter:foo | {{.*}} | Def,Impl,RelChild,RelAcc
+      _ = newElement
+    }
+  }
 }


### PR DESCRIPTION
In invalid code it seems decls can end up with an opened archetype type that the mangler doesn't like (hitting [this](https://github.com/apple/swift/blob/01c4717/lib/AST/ASTMangler.cpp#L973) unreachable). We still want to be able to generate a USR for these decls so that we can index and rename their occurrences successfully. To allow this, this patch calls `mapTypeOutOfContext` on types that have primary or opened archetype types prior to mangling.

This is like the issue @rintaro fixed for sourcekitd's ConformingMethodList request in https://github.com/apple/swift/pull/25130, but for indexing.

Resolves rdar://problem/54310026