### PR TITLE
[Type checker] Compute "mutating" for projected variables of wrapped properties

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1775,12 +1775,15 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
   //   argumentLabelIDs = {"w", "x", "", "", "z"}
   auto I = argumentLabelIDs.begin();
 
-  auto updateLabelsForArg = [&](Expr *expr) {
+  auto updateLabelsForArg = [&](Expr *expr) -> bool {
     if (isa<DefaultArgumentExpr>(expr) ||
         isa<CallerDefaultArgumentExpr>(expr)) {
       // Defaulted: remove param label of it.
+      if (I == argumentLabelIDs.end())
+        return true;
+
       I = argumentLabelIDs.erase(I);
-      return;
+      return false;
     }
 
     if (auto *varargExpr = dyn_cast<VarargExpansionExpr>(expr)) {
@@ -1800,19 +1803,26 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
           I = argumentLabelIDs.insert(I, variadicArgsNum, Identifier());
           I += variadicArgsNum;
         }
-        return;
+        return false;
       }
     }
 
     // Normal: Just advance.
+    if (I == argumentLabelIDs.end())
+      return true;
+
     ++I;
+    return false;
   };
 
   if (auto *parenExpr = dyn_cast<ParenExpr>(argExpr)) {
-    updateLabelsForArg(parenExpr->getSubExpr());
+    if (updateLabelsForArg(parenExpr->getSubExpr()))
+      return;
   } else {
-    for (auto *arg : cast<TupleExpr>(argExpr)->getElements())
-      updateLabelsForArg(arg);
+    for (auto *arg : cast<TupleExpr>(argExpr)->getElements()) {
+      if (updateLabelsForArg(arg))
+        return;
+    }
   }
 
   if (argumentLabelIDs.size() != argList.args.size()) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2214,27 +2214,43 @@ getSetterMutatingness(VarDecl *var, DeclContext *dc) {
 llvm::Expected<Optional<PropertyWrapperMutability>>
 PropertyWrapperMutabilityRequest::evaluate(Evaluator &,
                                            VarDecl *var) const {
-  unsigned numWrappers = var->getAttachedPropertyWrappers().size();
-  if (numWrappers < 1)
-    return None;
+  VarDecl *originalVar = var;
+  unsigned numWrappers = originalVar->getAttachedPropertyWrappers().size();
+  bool isProjectedValue = false;
+  if (numWrappers < 1) {
+    originalVar = var->getOriginalWrappedProperty(
+        PropertyWrapperSynthesizedPropertyKind::StorageWrapper);
+    if (!originalVar)
+      return None;
+
+    numWrappers = originalVar->getAttachedPropertyWrappers().size();
+    isProjectedValue = true;
+  }
+
   if (var->getParsedAccessor(AccessorKind::Get))
     return None;
   if (var->getParsedAccessor(AccessorKind::Set))
     return None;
 
+  // Figure out which member we're looking through.
+  auto varMember = isProjectedValue
+    ? &PropertyWrapperTypeInfo::projectedValueVar
+    : &PropertyWrapperTypeInfo::valueVar;
+
   // Start with the traits from the outermost wrapper.
-  auto firstWrapper = var->getAttachedPropertyWrapperTypeInfo(0);
-  if (!firstWrapper.valueVar)
+  auto firstWrapper = originalVar->getAttachedPropertyWrapperTypeInfo(0);
+  if (firstWrapper.*varMember == nullptr)
     return None;
   
   PropertyWrapperMutability result;
   
-  result.Getter = getGetterMutatingness(firstWrapper.valueVar);
-  result.Setter = getSetterMutatingness(firstWrapper.valueVar,
+  result.Getter = getGetterMutatingness(firstWrapper.*varMember);
+  result.Setter = getSetterMutatingness(firstWrapper.*varMember,
                                         var->getInnermostDeclContext());
   
   // Compose the traits of the following wrappers.
-  for (unsigned i = 1; i < numWrappers; ++i) {
+  for (unsigned i = 1; i < numWrappers && !isProjectedValue; ++i) {
+    assert(var == originalVar);
     auto wrapper = var->getAttachedPropertyWrapperTypeInfo(i);
     if (!wrapper.valueVar)
       return None;

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1100,3 +1100,16 @@ func unavailableFunc(_ arg: UnavailableProto) -> UnavailableProto {}
 struct S {
   var a: UnavailableProto
 }
+
+// Bad rename.
+struct BadRename {
+  @available(*, deprecated, renamed: "init(range:step:)")
+  init(from: Int, to: Int, step: Int = 1) { }
+
+  init(range: Range<Int>, step: Int) { }
+}
+
+func testBadRename() {
+  _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: replaced by 'init(range:step:)'}}
+  // expected-note@-1{{use 'init(range:step:)' instead}}
+}


### PR DESCRIPTION
Extend the recently-refactored logic for determining whether the
getter/setter for a wrapped property is "mutating" to also consider
the projection variables (e.g., $foo). Fixes SR-11393 /
rdar://problem/54839570.