### PR TITLE
Remove swift::DoAtScopeExit in favor of llvm::make_scope_exit

### DIFF
--- a/include/swift/Basic/Defer.h
+++ b/include/swift/Basic/Defer.h
@@ -18,25 +18,15 @@
 #ifndef SWIFT_BASIC_DEFER_H
 #define SWIFT_BASIC_DEFER_H
 
-#include <type_traits>
+#include "llvm/ADT/ScopeExit.h"
 
 namespace swift {
-  template <typename F>
-  class DoAtScopeExit {
-    F Fn;
-    void operator=(DoAtScopeExit&) = delete;
-  public:
-    DoAtScopeExit(F &&Fn) : Fn(std::move(Fn)) {}
-    ~DoAtScopeExit() {
-      Fn();
-    }
-  };
-
   namespace detail {
     struct DeferTask {};
     template<typename F>
-    DoAtScopeExit<typename std::decay<F>::type> operator+(DeferTask, F&& fn) {
-      return DoAtScopeExit<typename std::decay<F>::type>(std::move(fn));
+    auto operator+(DeferTask, F &&fn) ->
+        decltype(llvm::make_scope_exit(std::forward<F>(fn))) {
+      return llvm::make_scope_exit(std::forward<F>(fn));
     }
   }
 } // end namespace swift


### PR DESCRIPTION
Keep the `SWIFT_DEFER` macro, though, which is what everyone in the Swift codebase actually uses. No functionality change.