### PR TITLE
[Gardening] Remove unnecessary options and files from tests

### DIFF
--- a/test/Constraints/interpolation_segments.swift
+++ b/test/Constraints/interpolation_segments.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck -debug-constraints %s > %t.dump 2>&1 
+// RUN: %target-typecheck-verify-swift -debug-constraints > %t.dump 2>&1 
 // RUN: %FileCheck %s < %t.dump
 
 // Make sure that the type checker doesn't initially try to solve the appendLiteral and 

--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1 %s
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1
 // REQUIRES: rdar44305428
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift
 
 protocol P0 { }
 protocol P0b { }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 {}

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck -verify
+// RUN: %target-typecheck-verify-swift
 
 // rdar://problem/38461036 , https://bugs.swift.org/browse/SR-7192 and highlights the real problem in https://bugs.swift.org/browse/SR-6941
 

--- a/test/Generics/conditional_conformances_operators.swift
+++ b/test/Generics/conditional_conformances_operators.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
+// RUN: %target-typecheck-verify-swift
 
 // rdar://problem/35480952
 

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck -swift-version 4 %s -verify
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 protocol P0 { }
 protocol Q0: P0 { }

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 { 

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 class A {

--- a/test/Generics/validate_stdlib_generic_signatures.swift
+++ b/test/Generics/validate_stdlib_generic_signatures.swift
@@ -1,7 +1,7 @@
 // Verifies that all of the generic signatures in the standard library are
 // minimal and canonical.
 
-// RUN: not %target-typecheck-verify-swift -typecheck -verify-generic-signatures Swift 2> %t.log
+// RUN: not %target-typecheck-verify-swift -verify-generic-signatures Swift 2> %t.log
 
 // RUN: grep -c "error:" %t.log | count 1
 // RUN: %FileCheck %s < %t.log

--- a/test/IDE/compatibility_alias.swift
+++ b/test/IDE/compatibility_alias.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=CompatibilityAlias > %t.printed.CompatibilityAlias.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.CompatibilityAlias.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC > %t.printed.NewtypeObjC.txt
 // RUN: %FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.NewtypeObjC.txt
-// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t %s
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -1,6 +1,6 @@
 // Verify errors in this file to ensure that parse and type checker errors
 // occur where we expect them.
-// RUN: %target-typecheck-verify-swift -show-diagnostics-after-fatal %s
+// RUN: %target-typecheck-verify-swift -show-diagnostics-after-fatal
 
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename %s -prefer-type-repr=false > %t.printed.txt
 // RUN: %FileCheck %s -strict-whitespace < %t.printed.txt

--- a/test/attr/attr_availability_swift_v4.swift
+++ b/test/attr/attr_availability_swift_v4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 %s
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 @available(swift 3)
 func swiftShortThree() {}

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P {

--- a/test/decl/protocol/special/coding/class_missing_init_multi.swift
+++ b/test/decl/protocol/special/coding/class_missing_init_multi.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -verify %S/Inputs/class_missing_init_multi1.swift %S/Inputs/class_missing_init_multi2.swift
-// RUN: %target-typecheck-verify-swift -verify %S/Inputs/class_missing_init_multi2.swift %S/Inputs/class_missing_init_multi1.swift
+// RUN: %target-typecheck-verify-swift %S/Inputs/class_missing_init_multi1.swift %S/Inputs/class_missing_init_multi2.swift
+// RUN: %target-typecheck-verify-swift %S/Inputs/class_missing_init_multi2.swift %S/Inputs/class_missing_init_multi1.swift
 
-// RUN: %target-typecheck-verify-swift -verify -primary-file %S/Inputs/class_missing_init_multi1.swift %S/Inputs/class_missing_init_multi2.swift
-// RUN: %target-typecheck-verify-swift -verify %S/Inputs/class_missing_init_multi1.swift -primary-file %S/Inputs/class_missing_init_multi2.swift
+// RUN: %target-typecheck-verify-swift -primary-file %S/Inputs/class_missing_init_multi1.swift %S/Inputs/class_missing_init_multi2.swift
+// RUN: %target-typecheck-verify-swift %S/Inputs/class_missing_init_multi1.swift -primary-file %S/Inputs/class_missing_init_multi2.swift
 
-// RUN: %target-typecheck-verify-swift -verify -primary-file %S/Inputs/class_missing_init_multi2.swift %S/Inputs/class_missing_init_multi1.swift
-// RUN: %target-typecheck-verify-swift -verify %S/Inputs/class_missing_init_multi2.swift -primary-file %S/Inputs/class_missing_init_multi1.swift
+// RUN: %target-typecheck-verify-swift -primary-file %S/Inputs/class_missing_init_multi2.swift %S/Inputs/class_missing_init_multi1.swift
+// RUN: %target-typecheck-verify-swift %S/Inputs/class_missing_init_multi2.swift -primary-file %S/Inputs/class_missing_init_multi1.swift

--- a/test/stmt/c_style_for.swift
+++ b/test/stmt/c_style_for.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s
+// RUN: %target-typecheck-verify-swift
 
 for var i = 0; i < 10; i++ {}
 // expected-error @-1 {{C-style for statement has been removed in Swift 3}}  {{none}}


### PR DESCRIPTION
`%target-typecheck-verify-swift` implies `-typecheck -verify %s`