### PR TITLE
[doc] Avoid the use of "iff" in public API documentation

### DIFF
--- a/stdlib/public/Darwin/Foundation/Decimal.swift
+++ b/stdlib/public/Darwin/Foundation/Decimal.swift
@@ -538,31 +538,33 @@ extension Decimal {
 
     public var isCanonical: Bool { true }
 
-    /// `true` iff `self` is negative.
+    /// `true` if `self` is negative, `false` otherwise.
     public var isSignMinus: Bool { _isNegative != 0 }
 
-    /// `true` iff `self` is +0.0 or -0.0.
+    /// `true` if `self` is +0.0 or -0.0, `false` otherwise.
     public var isZero: Bool { _length == 0 && _isNegative == 0 }
 
-    /// `true` iff `self` is subnormal.
+    /// `true` if `self` is subnormal, `false` otherwise.
     public var isSubnormal: Bool { false }
 
-    /// `true` iff `self` is normal (not zero, subnormal, infinity, or NaN).
+    /// `true` if `self` is normal (not zero, subnormal, infinity, or NaN),
+    /// `false` otherwise.
     public var isNormal: Bool { !isZero && !isInfinite && !isNaN }
 
-    /// `true` iff `self` is zero, subnormal, or normal (not infinity or NaN).
+    /// `true` if `self` is zero, subnormal, or normal (not infinity or NaN),
+    /// `false` otherwise.
     public var isFinite: Bool { !isNaN }
 
-    /// `true` iff `self` is infinity.
+    /// `true` if `self` is infinity, `false` otherwise.
     public var isInfinite: Bool { false }
 
-    /// `true` iff `self` is NaN.
+    /// `true` if `self` is NaN, `false` otherwise.
     public var isNaN: Bool { _length == 0 && _isNegative == 1 }
 
-    /// `true` iff `self` is a signaling NaN.
+    /// `true` if `self` is a signaling NaN, `false` otherwise.
     public var isSignaling: Bool { false }
 
-    /// `true` iff `self` is a signaling NaN.
+    /// `true` if `self` is a signaling NaN, `false` otherwise.
     public var isSignalingNaN: Bool { false }
 
     public func isEqual(to other: Decimal) -> Bool {

--- a/stdlib/public/Darwin/Foundation/NSStringAPI.swift
+++ b/stdlib/public/Darwin/Foundation/NSStringAPI.swift
@@ -1368,7 +1368,7 @@ extension StringProtocol where Index == String.Index {
   /// - Parameter leftover: The remaining range. Pass `nil` If you do
   ///   not need this value.
   ///
-  /// - Returns: `true` iff some characters were converted.
+  /// - Returns: `true` if some characters were converted, `false` otherwise.
   ///
   /// - Note: Conversion stops when the buffer fills or when the
   ///   conversion isn't possible due to the chosen encoding.
@@ -1668,8 +1668,8 @@ extension StringProtocol where Index == String.Index {
   // No need to make these unavailable on earlier OSes, since they can
   // forward trivially to rangeOfString.
 
-  /// Returns `true` iff `other` is non-empty and contained within
-  /// `self` by case-sensitive, non-literal search.
+  /// Returns `true` if `other` is non-empty and contained within `self` by
+  /// case-sensitive, non-literal search. Otherwise, returns `false`.
   ///
   /// Equivalent to `self.rangeOfString(other) != nil`
   public func contains<T : StringProtocol>(_ other: T) -> Bool {

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -372,7 +372,8 @@ extension ManagedBufferPointer {
     return try body(_headerPointer, _elementPointer)
   }
 
-  /// Returns `true` iff `self` holds the only strong reference to its buffer.
+  /// Returns `true` if `self` holds the only strong reference to its
+  /// buffer. Otherwise, returns `false`.
   ///
   /// See `isUniquelyReferenced` for details.
   @inlinable

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -375,7 +375,7 @@ extension ManagedBufferPointer {
   /// Returns `true` if `self` holds the only strong reference to its
   /// buffer. Otherwise, returns `false`.
   ///
-  /// See `isUniquelyReferenced` for details.
+  /// See `isKnownUniquelyReferenced` for details.
   @inlinable
   public mutating func isUniqueReference() -> Bool {
     return _isUnique(&_nativeBuffer)


### PR DESCRIPTION
Not everyone understands this shorthand, and it's easy enough to expand it.

Also, fix a broken cross-reference in `ManagedBufferPointer`'s docs.

rdar://problem/55073802