### PR TITLE
Compiler crash for SR11108

### DIFF
--- a/validation-test/compiler_crashers_2/sr11108.swift
+++ b/validation-test/compiler_crashers_2/sr11108.swift
@@ -1,0 +1,27 @@
+// RUN: not --crash %target-swift-emit-silgen %s
+
+// REQUIRES: asserts
+
+protocol Example {
+    associatedtype Signed: SignedInteger
+    associatedtype SP: StringProtocol
+    var string: String { get }
+}
+extension Example {
+    var string: String {
+        return "Foo"
+    }
+}
+class MyClass<T: SignedInteger, S: StringProtocol>: Example {
+    typealias Signed = T
+    typealias SP = S
+}
+extension MyClass where T == Int, S == String {
+    var string: String {
+        return "Bar"
+    }
+}
+
+let myclass = MyClass<Int, String>()
+
+print(myclass.string)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR adds a failing test for the bug SR11108 as described below.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Adds a failing test for [SR-11108](https://bugs.swift.org/browse/SR-11108).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
