### PR TITLE
MemoryLifetime: fix a problem where DestroyHoisting moved a destroy_addr before a use of a trivial type.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2525,7 +2525,9 @@ except that ``destroy_addr`` may be used even if ``%0`` is of an
 address-only type.  This does not deallocate memory; it only destroys the
 pointed-to value, leaving the memory uninitialized.
 
-If ``T`` is a trivial type, then ``destroy_addr`` is a no-op.
+If ``T`` is a trivial type, then ``destroy_addr`` is a no-op. However, even a
+memory location ``%a`` with a trivial type must not be accessed after a
+``destroy_addr %a``.
 
 index_addr
 ``````````

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -21,6 +21,12 @@ struct Outer {
   var x: T
   var y: Inner
   var z: T
+  var i: Int
+}
+
+struct Mixed {
+  var t: T
+  var i: Int
 }
 
 sil [ossa] @test_struct : $@convention(thin) (@in Outer) -> @owned T {
@@ -133,6 +139,28 @@ bb1:
 bb2:
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_mixed_cfg_merge : $@convention(thin) (@owned T, Int) -> () {
+bb0(%0 : @owned $T, %1 : $Int):
+  %2 = alloc_stack $Mixed
+  %3 = struct_element_addr %2 : $*Mixed, #Mixed.t
+  %4 = struct_element_addr %2 : $*Mixed, #Mixed.i
+  store %0 to [init] %3 : $*T
+  cond_br undef, bb1, bb2
+
+bb1:
+  store %1 to [trivial] %4 : $*Int
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_addr %2 : $*Mixed
+  dealloc_stack %2 : $*Mixed
   %r = tuple ()
   return %r : $()
 }

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -23,6 +23,11 @@ struct Outer {
   var z: T
 }
 
+struct Mixed {
+  var t: T
+  var i: Int
+}
+
 // CHECK: SIL memory lifetime failure in @test_simple: indirect argument is not alive at function return
 sil [ossa] @test_simple : $@convention(thin) (@inout T) -> @owned T {
 bb0(%0 : $*T):
@@ -128,5 +133,36 @@ bb0(%0 : @owned $T):
   dealloc_stack %2 : $*T
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK: SIL memory lifetime failure in @test_mixed: memory is not initialized, but should
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> Int {
+bb0(%0 : $*Mixed, %1 : $Int):
+  %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
+  store %1 to [trivial] %2 : $*Int
+  destroy_addr %0 : $*Mixed
+  %3 = load [trivial] %2 : $*Int
+  return %3 : $Int
+}
+
+// CHECK: SIL memory lifetime failure in @test_missing_store_to_trivial: memory is not initialized, but should
+sil [ossa] @test_missing_store_to_trivial : $@convention(thin) () -> Int {
+bb0:
+  %1 = alloc_stack $Mixed
+  %2 = struct_element_addr %1 : $*Mixed, #Mixed.i
+  %3 = load [trivial] %2 : $*Int
+  dealloc_stack %1 : $*Mixed
+  return %3 : $Int
+}
+
+// CHECK: SIL memory lifetime failure in @test_load_after_dealloc: memory is not initialized, but should
+sil [ossa] @test_load_after_dealloc : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Mixed
+  %2 = struct_element_addr %1 : $*Mixed, #Mixed.i
+  store %0 to [trivial] %2 : $*Int
+  dealloc_stack %1 : $*Mixed
+  %3 = load [trivial] %2 : $*Int
+  return %3 : $Int
 }
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -49,19 +49,20 @@ bb0(%0 : $Int):
 // CHECK: return
 }
 // CHECK-LABEL: sil [ossa] @init_var
-sil [ossa] @init_var : $@convention(thin) () -> Int {
-bb0:
+sil [ossa] @init_var : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %1a = project_box %1 : ${ var Int }, 0
+  store %0 to [trivial] %1a : $*Int
   %3 = load [trivial] %1a : $*Int
   destroy_value %1 : ${ var Int }
   return %3 : $Int
 
-// CHECK: %0 = alloc_stack
+// CHECK: %1 = alloc_stack
 // CHECK-NOT: alloc_box
 // CHECK-NOT: destroy_value
 // CHECK-NOT: destroy_addr
-// CHECK: dealloc_stack %0 : $*Int
+// CHECK: dealloc_stack %1 : $*Int
 // CHECK: return
 }
 

--- a/test/SILOptimizer/destroy_hoisting.sil
+++ b/test/SILOptimizer/destroy_hoisting.sil
@@ -23,6 +23,11 @@ struct Outer {
   var ox: X
 }
 
+struct Mixed {
+  var x: X
+  var i: Int
+}
+
 sil @unknown : $@convention(thin) () -> ()
 sil @use_S : $@convention(thin) (@in_guaranteed S) -> ()
 
@@ -190,3 +195,17 @@ bb5:
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mixed
+// CHECK: load
+// CHECK: destroy_addr %0
+// CHECK: br bb1
+// CHECK: return
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed) -> Int {
+bb0(%0 : $*Mixed):
+  %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
+  %v = load [trivial] %2 : $*Int
+  br bb1
+bb1:
+  destroy_addr %0 : $*Mixed
+  return %v : $Int
+}


### PR DESCRIPTION
Even if a destroy_addr of a trivial type is a no-op, we must not end up with using such a value after a destroy_addr.
The fix is to also handle aggregate fields of trivial types in MemoryLifetime.

rdar://problem/55125020
