### PR TITLE
[5.1] Fix crash when using generic base class constraint with opaque types.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4382,6 +4382,14 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
   auto opaqueInterfaceTy = Decl->getUnderlyingInterfaceType();
   auto layout = signature->getLayoutConstraint(opaqueInterfaceTy);
   auto superclass = signature->getSuperclassBound(opaqueInterfaceTy);
+  #if !DO_IT_CORRECTLY
+    // Ad-hoc substitute the generic parameters of the superclass.
+    // If we correctly applied the substitutions to the generic signature
+    // constraints above, this would be unnecessary.
+    if (superclass && superclass->hasTypeParameter()) {
+      superclass = superclass.subst(Substitutions);
+    }
+  #endif
   SmallVector<ProtocolDecl*, 4> protos;
   for (auto proto : signature->getConformsTo(opaqueInterfaceTy)) {
     protos.push_back(proto);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -231,6 +231,9 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
              diag::opaque_type_invalid_constraint);
     return constraintTypeLoc.getType();
   }
+  
+  if (constraintType->hasArchetype())
+    constraintType = constraintType->mapTypeOutOfContext();
 
   // Create a generic signature for the opaque environment. This is the outer
   // generic signature with an added generic parameter representing the opaque

--- a/test/type/opaque_generic_superclass_constraint.swift
+++ b/test/type/opaque_generic_superclass_constraint.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
+
+// rdar://problem/53318811
+
+class Foo<T> {
+  var x: T { fatalError() }
+}
+
+func foo<T>(_: T) -> some Foo<T> {
+  let localProp: some Foo<T> = Foo()
+  return localProp
+}
+
+class C<T> {
+  func bar() -> some Foo<T> {
+    return Foo()
+  }
+
+  var prop: some Foo<T> = Foo()
+}
+
+func bar() -> Int {
+  var x = 0
+  x = foo(0).x
+  x = C<Int>().bar().x
+  x = C<Int>().prop.x
+  return x
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash when trying to declare something with a return type of `some GenericClass<T>`.

Scope: Fixes a compiler crash on code that should be supported.

Issue: rdar://problem/53318811

Risk: Low

Testing: Swift CI, case from bug report

Reviewed by: @slavapestov 
