### PR TITLE
AST: promote API/ABI impact bit of decl attributes to AST, NFC

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -121,11 +121,12 @@ DECL_ATTR(available, Available,
   1)
 CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
   OnClass | OnFunc | OnAccessor | OnVar | OnSubscript |
-  DeclModifier,
+  DeclModifier | ABIBreakingToAdd | ABIBreakingToRemove |
+  APIBreakingToAdd,
   2)
 DECL_ATTR(objc, ObjC,
   OnAbstractFunction | OnClass | OnProtocol | OnExtension | OnVar |
-  OnSubscript | OnEnum | OnEnumElement,
+  OnSubscript | OnEnum | OnEnumElement | ABIBreakingToAdd | ABIBreakingToRemove,
   3)
 CONTEXTUAL_SIMPLE_DECL_ATTR(required, Required,
   OnConstructor |
@@ -187,7 +188,7 @@ DECL_ATTR(_semantics, Semantics,
   21)
 CONTEXTUAL_SIMPLE_DECL_ATTR(dynamic, Dynamic,
   OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
-  DeclModifier,
+  DeclModifier | ABIBreakingToAdd | ABIBreakingToRemove,
   22)
 CONTEXTUAL_SIMPLE_DECL_ATTR(infix, Infix,
   OnFunc | OnOperator |
@@ -212,7 +213,7 @@ SIMPLE_DECL_ATTR(nonobjc, NonObjC,
   30)
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
   OnVar | OnClass | OnStruct |
-  UserInaccessible,
+  UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove,
   31)
 SIMPLE_DECL_ATTR(inlinable, Inlinable,
   OnVar | OnSubscript | OnAbstractFunction,
@@ -362,7 +363,7 @@ SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
   OnSubscript | OnConstructor | OnEnumElement | OnExtension | UserInaccessible,
   75)
 SIMPLE_DECL_ATTR(frozen, Frozen,
-  OnEnum | OnStruct,
+  OnEnum | OnStruct | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToRemove,
   76)
 DECL_ATTR_ALIAS(_frozen, Frozen)
 SIMPLE_DECL_ATTR(_forbidSerializingReference, ForbidSerializingReference,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -353,6 +353,18 @@ public:
 
     /// Whether client code cannot use the attribute.
     UserInaccessible = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 7),
+
+    /// Whether adding this attribute can break API
+    APIBreakingToAdd = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 8),
+
+    /// Whether removing this attribute can break API
+    APIBreakingToRemove = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 9),
+
+    /// Whether adding this attribute can break ABI
+    ABIBreakingToAdd = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 10),
+
+    /// Whether removing this attribute can break ABI
+    ABIBreakingToRemove = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 11),
   };
 
   LLVM_READNONE
@@ -433,6 +445,21 @@ public:
 
   static bool isUserInaccessible(DeclAttrKind DK) {
     return getOptions(DK) & UserInaccessible;
+  }
+
+  static bool isAddingBreakingABI(DeclAttrKind DK) {
+    return getOptions(DK) & ABIBreakingToAdd;
+  }
+
+  static bool isAddingBreakingAPI(DeclAttrKind DK) {
+    return getOptions(DK) & APIBreakingToAdd;
+  }
+
+  static bool isRemovingBreakingABI(DeclAttrKind DK) {
+    return getOptions(DK) & ABIBreakingToRemove;
+  }
+  static bool isRemovingBreakingAPI(DeclAttrKind DK) {
+    return getOptions(DK) & APIBreakingToRemove;
   }
 
   bool isDeclModifier() const {

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -38,9 +38,9 @@ cake: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
 cake: TypeAlias TChangesFromIntToString.T has underlying type change from Swift.Int to Swift.String
 
 /* Decl Attribute changes */
+cake: Enum IceKind is now without @frozen
 cake: Func C1.foo1() is now not static
 cake: Func FinalFuncContainer.NewFinalFunc() is now with final
-cake: Func FinalFuncContainer.NoLongerFinalFunc() is now without final
 cake: Func HasMutatingMethodClone.foo() has self access kind changing from Mutating to NonMutating
 cake: Func S1.foo1() has self access kind changing from NonMutating to Mutating
 cake: Func S1.foo3() is now static


### PR DESCRIPTION
ABI/API checker used to hard-code whether adding or removing of a
decl attribute could break the existing ABI/API. This is not ideal because
new attributes may be added to AST without updating the checker. After this
change, new decl attribute could be specified whether it has ABI/API
impact and the checker could pick up the knowledge instantly.
