### PR TITLE
[5.1 08-28-2019] [Type checker] Compute "mutating" for projected variables of wrapped properties

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1911,11 +1911,24 @@ static bool computeIsGetterMutating(TypeChecker &TC,
   // the "value" property of the outermost wrapper type is mutating and we're
   // in a context that has value semantics.
   if (auto var = dyn_cast<VarDecl>(storage)) {
-    if (auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo(0)) {
-      if (wrapperInfo.valueVar &&
+    VarDecl *originalVar = var->getOriginalWrappedProperty(
+        PropertyWrapperSynthesizedPropertyKind::StorageWrapper);
+    bool isProjectedValue = true;
+    if (!originalVar) {
+      originalVar = var;
+      isProjectedValue = false;
+    }
+
+    if (auto wrapperInfo = originalVar->getAttachedPropertyWrapperTypeInfo(0)) {
+      // Figure out which member we're looking through.
+      auto varMember = isProjectedValue
+        ? &PropertyWrapperTypeInfo::projectedValueVar
+        : &PropertyWrapperTypeInfo::valueVar;
+
+      if (wrapperInfo.*varMember &&
           (!storage->getGetter() || storage->getGetter()->isImplicit())) {
-        TC.validateDecl(wrapperInfo.valueVar);
-        return wrapperInfo.valueVar->isGetterMutating() &&
+        TC.validateDecl(wrapperInfo.*varMember);
+        return (wrapperInfo.*varMember)->isGetterMutating() &&
             var->isInstanceMember() &&
             doesContextHaveValueSemantics(var->getDeclContext());
       }
@@ -1946,11 +1959,24 @@ static bool computeIsSetterMutating(TypeChecker &TC,
   // the "value" property of the outermost wrapper type is mutating and we're
   // in a context that has value semantics.
   if (auto var = dyn_cast<VarDecl>(storage)) {
-    if (auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo(0)) {
-      if (wrapperInfo.valueVar &&
+    VarDecl *originalVar = var->getOriginalWrappedProperty(
+        PropertyWrapperSynthesizedPropertyKind::StorageWrapper);
+    bool isProjectedValue = true;
+    if (!originalVar) {
+      originalVar = var;
+      isProjectedValue = false;
+    }
+
+    if (auto wrapperInfo = originalVar->getAttachedPropertyWrapperTypeInfo(0)) {
+      // Figure out which member we're looking through.
+      auto varMember = isProjectedValue
+        ? &PropertyWrapperTypeInfo::projectedValueVar
+        : &PropertyWrapperTypeInfo::valueVar;
+
+      if (wrapperInfo.*varMember &&
           (!storage->getSetter() || storage->getSetter()->isImplicit())) {
-        TC.validateDecl(wrapperInfo.valueVar);
-        return wrapperInfo.valueVar->isSetterMutating() &&
+        TC.validateDecl(wrapperInfo.*varMember);
+        return (wrapperInfo.*varMember)->isSetterMutating() &&
             var->isInstanceMember() &&
             doesContextHaveValueSemantics(var->getDeclContext());
       }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1068,3 +1068,66 @@ struct MissingPropertyWrapperUnwrap {
     d(self._usesProjectedValue) // expected-error {{cannot convert value '_usesProjectedValue' of type 'Baz<W>' to expected type 'W', use wrapped value instead}}{{12-13=}}
   }
 }
+
+// SR-11393
+protocol Copyable: AnyObject {
+    func copy() -> Self
+}
+
+@propertyWrapper
+struct CopyOnWrite<Value: Copyable> {
+  init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+
+  var wrappedValue: Value
+
+  var projectedValue: Value {
+    mutating get {
+      if !isKnownUniquelyReferenced(&wrappedValue) {
+        wrappedValue = wrappedValue.copy()
+      }
+      return wrappedValue
+    }
+    set {
+      wrappedValue = newValue
+    }
+  }
+}
+
+final class CopyOnWriteTest: Copyable {
+    let a: Int
+    init(a: Int) {
+        self.a = a
+    }
+
+    func copy() -> Self {
+        Self.init(a: a)
+    }
+}
+
+struct CopyOnWriteDemo1 {
+  @CopyOnWrite var a = CopyOnWriteTest(a: 3)
+
+  func foo() { // expected-note{{mark method 'mutating' to make 'self' mutable}}
+    _ = $a // expected-error{{cannot use mutating getter on immutable value: 'self' is immutable}}
+  }
+}
+
+@propertyWrapper
+struct NonMutatingProjectedValueSetWrapper<Value> {
+  var wrappedValue: Value
+  var projectedValue: Value {
+    get { wrappedValue }
+    nonmutating set { } 
+  }
+}
+
+struct UseNonMutatingProjectedValueSet {
+  @NonMutatingProjectedValueSetWrapper var x = 17
+
+  func test() { // expected-note{{mark method 'mutating' to make 'self' mutable}}
+    $x = 42 // okay
+    x = 42  // expected-error{{cannot assign to property: 'self' is immutable}}
+  }
+}


### PR DESCRIPTION
Extend the logic for determining whether the
getter/setter for a wrapped property is "mutating" to also consider
the projection variables (e.g., $foo). Fixes SR-11393 /
rdar://problem/54839570.
