### PR TITLE
[ownership] Add a new class BorrowScopeIntroducer that enables code t…

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -14,6 +14,7 @@
 #define SWIFT_SIL_OWNERSHIPUTILS_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/SIL/BranchPropagatedUser.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
@@ -164,10 +165,152 @@ bool isOwnershipForwardingInst(SILInstruction *i);
 
 bool isGuaranteedForwardingInst(SILInstruction *i);
 
+struct BorrowScopeIntroducerKind {
+  using UnderlyingKindTy = std::underlying_type<ValueKind>::type;
+
+  /// Enum we use for exhaustive pattern matching over borrow scope introducers.
+  enum Kind : UnderlyingKindTy {
+    LoadBorrow = UnderlyingKindTy(ValueKind::LoadBorrowInst),
+    BeginBorrow = UnderlyingKindTy(ValueKind::BeginBorrowInst),
+    SILFunctionArgument = UnderlyingKindTy(ValueKind::SILFunctionArgument),
+  };
+
+  static Optional<BorrowScopeIntroducerKind> get(ValueKind kind) {
+    switch (kind) {
+    default:
+      return None;
+    case ValueKind::LoadBorrowInst:
+      return BorrowScopeIntroducerKind(LoadBorrow);
+    case ValueKind::BeginBorrowInst:
+      return BorrowScopeIntroducerKind(BeginBorrow);
+    case ValueKind::SILFunctionArgument:
+      return BorrowScopeIntroducerKind(SILFunctionArgument);
+    }
+  }
+
+  Kind value;
+
+  BorrowScopeIntroducerKind(Kind newValue) : value(newValue) {}
+  BorrowScopeIntroducerKind(const BorrowScopeIntroducerKind &other)
+      : value(other.value) {}
+  operator Kind() const { return value; }
+
+  /// Is this a borrow scope that begins and ends within the same function and
+  /// thus is guaranteed to have an "end_scope" instruction.
+  ///
+  /// In contrast, borrow scopes that are non-local (e.x. from
+  /// SILFunctionArguments) rely a construct like a SILFunction as the begin/end
+  /// of the scope.
+  bool isLocalScope() const {
+    switch (value) {
+    case BorrowScopeIntroducerKind::BeginBorrow:
+    case BorrowScopeIntroducerKind::LoadBorrow:
+      return true;
+    case BorrowScopeIntroducerKind::SILFunctionArgument:
+      return false;
+    }
+    llvm_unreachable("Covered switch isnt covered?!");
+  }
+
+  void print(llvm::raw_ostream &os) const;
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              BorrowScopeIntroducerKind kind);
+
+/// A higher level construct for working with values that represent the
+/// introduction of a new borrow scope.
+///
+/// DISCUSSION: A "borrow introducer" is a SILValue that represents the
+/// beginning of a borrow scope that the ownership verifier validates. The idea
+/// is this API allows one to work in a generic way with all of the various
+/// introducers.
+///
+/// Some examples of borrow introducers: guaranteed SILFunctionArgument,
+/// LoadBorrow, BeginBorrow, guaranteed BeginApply results.
+///
+/// NOTE: It is assumed that if a borrow introducer is a value of a
+/// SILInstruction with multiple results, that the all of the SILInstruction's
+/// guaranteed results are borrow introducers. In practice this means that
+/// borrow introducers can not have guaranteed results that are not creating a
+/// new borrow scope. No such instructions exist today.
+struct BorrowScopeIntroducingValue {
+  BorrowScopeIntroducerKind kind;
+  SILValue value;
+
+  BorrowScopeIntroducingValue(LoadBorrowInst *lbi)
+      : kind(BorrowScopeIntroducerKind::LoadBorrow), value(lbi) {}
+  BorrowScopeIntroducingValue(BeginBorrowInst *bbi)
+      : kind(BorrowScopeIntroducerKind::BeginBorrow), value(bbi) {}
+  BorrowScopeIntroducingValue(SILFunctionArgument *arg)
+      : kind(BorrowScopeIntroducerKind::SILFunctionArgument), value(arg) {
+    assert(arg->getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+  }
+
+  BorrowScopeIntroducingValue(SILValue v)
+      : kind(*BorrowScopeIntroducerKind::get(v->getKind())), value(v) {
+    assert(v.getOwnershipKind() == ValueOwnershipKind::Guaranteed);
+  }
+
+  /// If value is a borrow introducer return it after doing some checks.
+  static Optional<BorrowScopeIntroducingValue> get(SILValue value) {
+    auto kind = BorrowScopeIntroducerKind::get(value->getKind());
+    if (!kind || value.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
+      return None;
+    return BorrowScopeIntroducingValue(*kind, value);
+  }
+
+  /// If this value is introducing a local scope, gather all local end scope
+  /// instructions and append them to \p scopeEndingInsts. Asserts if this is
+  /// called with a scope that is not local.
+  ///
+  /// NOTE: To determine if a scope is a local scope, call
+  /// BorrowScopeIntoducingValue::isLocalScope().
+  void getLocalScopeEndingInstructions(
+      SmallVectorImpl<SILInstruction *> &scopeEndingInsts) const;
+
+  /// If this value is introducing a local scope, gather all local end scope
+  /// instructions and pass them individually to visitor. Asserts if this is
+  /// called with a scope that is not local.
+  ///
+  /// The intention is that this method can be used instead of
+  /// BorrowScopeIntroducingValue::getLocalScopeEndingInstructions() to avoid
+  /// introducing an intermediate array when one needs to transform the
+  /// instructions before storing them.
+  ///
+  /// NOTE: To determine if a scope is a local scope, call
+  /// BorrowScopeIntoducingValue::isLocalScope().
+  void visitLocalScopeEndingInstructions(
+      function_ref<void(SILInstruction *)> visitor) const;
+
+  bool isLocalScope() const { return kind.isLocalScope(); }
+
+  /// Returns true if the passed in set of instructions is completely within the
+  /// lifetime of this borrow introducer.
+  ///
+  /// NOTE: Scratch space is used internally to this method to store the end
+  /// borrow scopes if needed.
+  bool areInstructionsWithinScope(
+      ArrayRef<BranchPropagatedUser> instructions,
+      SmallVectorImpl<BranchPropagatedUser> &scratchSpace,
+      SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
+      DeadEndBlocks &deadEndBlocks) const;
+
+private:
+  /// Internal constructor for failable static constructor. Please do not expand
+  /// its usage since it assumes the code passed in is well formed.
+  BorrowScopeIntroducingValue(BorrowScopeIntroducerKind kind, SILValue value)
+      : kind(kind), value(value) {}
+};
+
 /// Look up through the def-use chain of \p inputValue, recording any "borrow"
-/// introducers that we find into \p out.
-bool getUnderlyingBorrowIntroducers(SILValue inputValue,
-                                    SmallVectorImpl<SILValue> &out);
+/// introducing values that we find into \p out. If at any point, we find a
+/// point in the chain we do not understand, we bail and return false. If we are
+/// able to understand all of the def-use graph, we know that we have found all
+/// of the borrow introducing values, we return true.
+bool getUnderlyingBorrowIntroducingValues(
+    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out);
 
 } // namespace swift
 

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/Basic/Defer.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 
@@ -76,8 +77,72 @@ bool swift::isOwnershipForwardingInst(SILInstruction *i) {
   return isOwnershipForwardingValueKind(SILNodeKind(i->getKind()));
 }
 
-bool swift::getUnderlyingBorrowIntroducers(SILValue inputValue,
-                                           SmallVectorImpl<SILValue> &out) {
+//===----------------------------------------------------------------------===//
+//                             Borrow Introducers
+//===----------------------------------------------------------------------===//
+
+void BorrowScopeIntroducerKind::print(llvm::raw_ostream &os) const {
+  switch (value) {
+  case BorrowScopeIntroducerKind::SILFunctionArgument:
+    os << "SILFunctionArgument";
+    return;
+  case BorrowScopeIntroducerKind::BeginBorrow:
+    os << "BeginBorrowInst";
+    return;
+  case BorrowScopeIntroducerKind::LoadBorrow:
+    os << "LoadBorrowInst";
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
+void BorrowScopeIntroducerKind::dump() const {
+#ifndef NDEBUG
+  print(llvm::dbgs());
+#endif
+}
+
+void BorrowScopeIntroducingValue::getLocalScopeEndingInstructions(
+    SmallVectorImpl<SILInstruction *> &scopeEndingInsts) const {
+  assert(isLocalScope() && "Should only call this given a local scope");
+
+  switch (kind) {
+  case BorrowScopeIntroducerKind::SILFunctionArgument:
+    llvm_unreachable("Should only call this with a local scope");
+  case BorrowScopeIntroducerKind::BeginBorrow:
+    llvm::copy(cast<BeginBorrowInst>(value)->getEndBorrows(),
+               std::back_inserter(scopeEndingInsts));
+    return;
+  case BorrowScopeIntroducerKind::LoadBorrow:
+    llvm::copy(cast<LoadBorrowInst>(value)->getEndBorrows(),
+               std::back_inserter(scopeEndingInsts));
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
+void BorrowScopeIntroducingValue::visitLocalScopeEndingInstructions(
+    function_ref<void(SILInstruction *)> visitor) const {
+  assert(isLocalScope() && "Should only call this given a local scope");
+  switch (kind) {
+  case BorrowScopeIntroducerKind::SILFunctionArgument:
+    llvm_unreachable("Should only call this with a local scope");
+  case BorrowScopeIntroducerKind::BeginBorrow:
+    for (auto *inst : cast<BeginBorrowInst>(value)->getEndBorrows()) {
+      visitor(inst);
+    }
+    return;
+  case BorrowScopeIntroducerKind::LoadBorrow:
+    for (auto *inst : cast<LoadBorrowInst>(value)->getEndBorrows()) {
+      visitor(inst);
+    }
+    return;
+  }
+  llvm_unreachable("Covered switch isn't covered?!");
+}
+
+bool swift::getUnderlyingBorrowIntroducingValues(
+    SILValue inputValue, SmallVectorImpl<BorrowScopeIntroducingValue> &out) {
   if (inputValue.getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return false;
 
@@ -88,23 +153,9 @@ bool swift::getUnderlyingBorrowIntroducers(SILValue inputValue,
     SILValue v = worklist.pop_back_val();
 
     // First check if v is an introducer. If so, stash it and continue.
-    if (isa<LoadBorrowInst>(v) ||
-        isa<BeginBorrowInst>(v)) {
-      out.push_back(v);
+    if (auto scopeIntroducer = BorrowScopeIntroducingValue::get(v)) {
+      out.push_back(*scopeIntroducer);
       continue;
-    }
-
-    // If we have a function argument with guaranteed convention, it is also an
-    // introducer.
-    if (auto *arg = dyn_cast<SILFunctionArgument>(v)) {
-      if (arg->getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
-        out.push_back(v);
-        continue;
-      }
-
-      // Otherwise, we do not know how to handle this function argument, so
-      // bail.
-      return false;
     }
 
     // Otherwise if v is an ownership forwarding value, add its defining
@@ -124,4 +175,39 @@ bool swift::getUnderlyingBorrowIntroducers(SILValue inputValue,
   }
 
   return true;
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
+                                     BorrowScopeIntroducerKind kind) {
+  kind.print(os);
+  return os;
+}
+
+bool BorrowScopeIntroducingValue::areInstructionsWithinScope(
+    ArrayRef<BranchPropagatedUser> instructions,
+    SmallVectorImpl<BranchPropagatedUser> &scratchSpace,
+    SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks,
+    DeadEndBlocks &deadEndBlocks) const {
+  // Make sure that we clear our scratch space/utilities before we exit.
+  SWIFT_DEFER {
+    scratchSpace.clear();
+    visitedBlocks.clear();
+  };
+
+  // First make sure that we actually have a local scope. If we have a non-local
+  // scope, then we have something (like a SILFunctionArgument) where a larger
+  // semantic construct (in the case of SILFunctionArgument, the function
+  // itself) acts as the scope. So we already know that our passed in
+  // instructions must be in the same scope.
+  if (!isLocalScope())
+    return true;
+
+  // Otherwise, gather up our local scope ending instructions.
+  visitLocalScopeEndingInstructions(
+      [&scratchSpace](SILInstruction *i) { scratchSpace.emplace_back(i); });
+
+  auto result = valueHasLinearLifetime(
+      value, scratchSpace, instructions, visitedBlocks, deadEndBlocks,
+      ownership::ErrorBehaviorKind::ReturnFalse);
+  return !result.getFoundError();
 }

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -299,18 +299,6 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   return true;
 }
 
-static bool canHandleOperand(SILValue operand, SmallVectorImpl<SILValue> &out) {
-  if (!getUnderlyingBorrowIntroducers(operand, out))
-    return false;
-
-  /// TODO: Add support for begin_borrow, load_borrow.
-  auto canHandleValue = [](SILValue v) -> bool {
-    return isa<SILFunctionArgument>(v) || isa<LoadBorrowInst>(v) ||
-           isa<BeginBorrowInst>(v);
-  };
-  return all_of(out, canHandleValue);
-}
-
 // Eliminate a copy of a borrowed value, if:
 //
 // 1. All of the copies users do not consume the copy (and thus can accept a
@@ -344,11 +332,13 @@ static bool canHandleOperand(SILValue operand, SmallVectorImpl<SILValue> &out) {
 //
 // TODO: This needs a better name.
 bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst *cvi) {
-  SmallVector<SILValue, 16> borrowIntroducers;
+  SmallVector<BorrowScopeIntroducingValue, 4> borrowScopeIntroducers;
 
-  // Whitelist the operands that we know how to support and make sure
-  // our operand is actually guaranteed.
-  if (!canHandleOperand(cvi->getOperand(), borrowIntroducers))
+  // Find all borrow introducers for our copy operand. If we are unable to find
+  // all of the reproducers (due to pattern matching failure), conservatively
+  // return false. We can not optimize.
+  if (!getUnderlyingBorrowIntroducingValues(cvi->getOperand(),
+                                            borrowScopeIntroducers))
     return false;
 
   // Then go over all of our uses and see if the value returned by our copy
@@ -361,10 +351,13 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
   if (!isDeadLiveRange(cvi, destroys, &guaranteedForwardingInsts))
     return false;
 
-  // Next check if we have any destroys at all of our copy_value and an operand
-  // that is not a function argument. Otherwise, due to the way we ignore dead
-  // end blocks, we may eliminate the copy_value, creating a use of the borrowed
-  // value after the end_borrow.
+  // Next check if we do not have any destroys of our copy_value and are
+  // processing a local borrow scope. In such a case, due to the way we ignore
+  // dead end blocks, we may eliminate the copy_value, creating a use of the
+  // borrowed value after the end_borrow. To avoid this, in such cases we
+  // bail. In contrast, a non-local borrow scope does not have any end scope
+  // instructions, implying we can avoid this hazard and still optimize in such
+  // a case.
   //
   // DISCUSSION: Consider the following SIL:
   //
@@ -411,48 +404,33 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
   // destroy_value /after/ the end_borrow we will not optimize here. This means
   // that this bug can only occur if the copy_value is only post-dominated by
   // dead end blocks that use the value in a non-consuming way.
-  if (destroys.empty() && llvm::any_of(borrowIntroducers, [](SILValue v) {
-        return !isa<SILFunctionArgument>(v);
-      })) {
+  //
+  // TODO: There may be some way of sinking this into the loop below.
+  if (destroys.empty() &&
+      llvm::any_of(borrowScopeIntroducers,
+                   [](BorrowScopeIntroducingValue borrowScope) {
+                     return borrowScope.isLocalScope();
+                   })) {
     return false;
   }
 
-  // If we reached this point, then we know that all of our users can
-  // accept a guaranteed value and our owned value is destroyed only
-  // by destroy_value. Check if all of our destroys are joint
-  // post-dominated by the end_borrow set. If they do not, then the
-  // copy_value is lifetime extending the guaranteed value, we can not
-  // eliminate it.
+  // If we reached this point, then we know that all of our users can accept a
+  // guaranteed value and our owned value is destroyed only by
+  // destroy_value. Check if all of our destroys are joint post-dominated by the
+  // our end borrow scope set. If they do not, then the copy_value is lifetime
+  // extending the guaranteed value, we can not eliminate it.
   {
     SmallVector<BranchPropagatedUser, 8> destroysForLinearLifetimeCheck(
         destroys.begin(), destroys.end());
-    SmallVector<BranchPropagatedUser, 8> endBorrowInsts;
+    SmallVector<BranchPropagatedUser, 8> scratchSpace;
     SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
-    for (SILValue v : borrowIntroducers) {
-      if (isa<SILFunctionArgument>(v)) {
-        continue;
-      }
-
-      SWIFT_DEFER {
-        endBorrowInsts.clear();
-        visitedBlocks.clear();
-      };
-
-      if (auto *lbi = dyn_cast<LoadBorrowInst>(v)) {
-        llvm::copy(lbi->getEndBorrows(), std::back_inserter(endBorrowInsts));
-      } else if (auto *bbi = dyn_cast<BeginBorrowInst>(v)) {
-        llvm::copy(bbi->getEndBorrows(), std::back_inserter(endBorrowInsts));
-      } else {
-        llvm_unreachable("Unhandled borrow introducer?!");
-      }
-
-      // Make sure that our destroys are properly nested within our end
-      // borrows. Otherwise, we can not optimize.
-      auto result = valueHasLinearLifetime(
-          v, endBorrowInsts, destroysForLinearLifetimeCheck, visitedBlocks,
-          getDeadEndBlocks(), ownership::ErrorBehaviorKind::ReturnFalse);
-      if (result.getFoundError())
-        return false;
+    if (llvm::any_of(borrowScopeIntroducers,
+                     [&](BorrowScopeIntroducingValue borrowScope) {
+                       return !borrowScope.areInstructionsWithinScope(
+                           destroysForLinearLifetimeCheck, scratchSpace,
+                           visitedBlocks, getDeadEndBlocks());
+                     })) {
+      return false;
     }
   }
 


### PR DESCRIPTION
…o work abstractly with values that introduce a new borrow scope.

The idea is that this can be used to work with things like load_borrow,
begin_borrow, SILFunctionArgument, BeginApply (in the future) and the like in a
generic way using exhaustive switches to make sure this code stays up to date.

I refactored code in SemanticARCOpts and some utilities in OwnershipUtils.cpp to
use these new APIs. The code looks a lot nicer and should be quite easy to
expand to handle new borrow introducers (e.x.: end_apply).

Should be a pure refactor so: NFCI.
