### PR TITLE
[Serialization] Recover from more conformances with missing decls

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -978,13 +978,14 @@ public:
   llvm::Expected<ProtocolConformanceRef>
   readConformanceChecked(llvm::BitstreamCursor &Cursor,
                          GenericEnvironment *genericEnv = nullptr);
-  
+
   /// Read a SILLayout from the given cursor.
   SILLayout *readSILLayout(llvm::BitstreamCursor &Cursor);
 
-  /// Read the given normal conformance from the current module file.
-  NormalProtocolConformance *
-  readNormalConformance(serialization::NormalConformanceID id);
+  /// Read the given normal conformance from the current module file,
+  /// returns the conformance or the first error.
+  llvm::Expected<NormalProtocolConformance *>
+  readNormalConformanceChecked(serialization::NormalConformanceID id);
 
   /// Reads a foreign error conformance from \c DeclTypeCursor, if present.
   Optional<ForeignErrorConvention> maybeReadForeignErrorConvention();


### PR DESCRIPTION
Components of a requirement may be hidden behind an implementation-only importation and reading them would fail on a 'module ... was not loaded' error.