### PR TITLE
[SyntaxParse] Prevent memory leak in Syntax parsing

### DIFF
--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -70,6 +70,8 @@ public:
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
   OpaqueSyntaxNodeKind getOpaqueKind() override {
     return ExplicitAction->getOpaqueKind();
   }

--- a/include/swift/Parse/LibSyntaxGenerator.h
+++ b/include/swift/Parse/LibSyntaxGenerator.h
@@ -44,7 +44,7 @@ public:
 
     auto Recorded = Recorder.recordToken(Kind, Range, LeadingTriviaPieces,
                                          TrailingTriviaPieces);
-    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
+    auto Raw = static_cast<RawSyntax *>(Recorded.takeOpaqueNode());
     return make<TokenSyntax>(Raw);
   }
 
@@ -55,7 +55,7 @@ public:
     auto Children = Node.getDeferredChildren();
 
     auto Recorded = Recorder.recordRawSyntax(Kind, Children);
-    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.getOpaqueNode()) };
+    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.takeOpaqueNode()) };
     Raw->Release(); // -1 since it's transfer of ownership.
     return make<SyntaxNode>(Raw);
   }

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -51,7 +51,7 @@ class ParsedRawSyntaxNode {
     CharSourceRange Range;
   };
   struct DeferredLayoutNode {
-    ArrayRef<ParsedRawSyntaxNode> Children;
+    MutableArrayRef<ParsedRawSyntaxNode> Children;
   };
   struct DeferredTokenNode {
     const ParsedTriviaPiece *TriviaPieces;
@@ -73,8 +73,8 @@ class ParsedRawSyntaxNode {
   bool IsMissing = false;
 
   ParsedRawSyntaxNode(syntax::SyntaxKind k,
-                      ArrayRef<ParsedRawSyntaxNode> deferredNodes)
-    : DeferredLayout{deferredNodes},
+                      MutableArrayRef<ParsedRawSyntaxNode> deferredNodes)
+    : DeferredLayout({deferredNodes}),
       SynKind(uint16_t(k)), TokKind(uint16_t(tok::unknown)),
       DK(DataKind::DeferredLayout) {
     assert(getKind() == k && "Syntax kind with too large value!");
@@ -97,6 +97,8 @@ class ParsedRawSyntaxNode {
     assert(DeferredToken.NumTrailingTrivia == numTrailingTrivia &&
            "numLeadingTrivia is too large value!");
   }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &other) = delete;
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &other) = delete;
 
 public:
   ParsedRawSyntaxNode()
@@ -113,6 +115,35 @@ public:
       DK(DataKind::Recorded) {
     assert(getKind() == k && "Syntax kind with too large value!");
     assert(getTokenKind() == tokKind && "Token kind with too large value!");
+  }
+
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &&other) {
+    assert(DK != DataKind::Recorded);
+    switch (other.DK) {
+    case DataKind::Null:
+      break;
+    case DataKind::Recorded:
+      RecordedData = std::move(other.RecordedData);
+      break;
+    case DataKind::DeferredLayout:
+      DeferredLayout = std::move(other.DeferredLayout);
+      break;
+    case DataKind::DeferredToken:
+      DeferredToken = std::move(other.DeferredToken);
+      break;
+    }
+    SynKind = std::move(other.SynKind);
+    TokKind = std::move(other.TokKind);
+    DK = std::move(other.DK);
+    IsMissing = std::move(other.IsMissing);
+    other.reset();
+    return *this;
+  }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &&other) : ParsedRawSyntaxNode() {
+    *this = std::move(other);
+  }
+  ~ParsedRawSyntaxNode() {
+    assert(DK != DataKind::Recorded);
   }
 
   syntax::SyntaxKind getKind() const { return syntax::SyntaxKind(SynKind); }
@@ -136,6 +167,36 @@ public:
   /// Primary used for a deferred missing token.
   bool isMissing() const { return IsMissing; }
 
+  void reset() {
+    RecordedData = {};
+    SynKind = uint16_t(syntax::SyntaxKind::Unknown);
+    TokKind = uint16_t(tok::unknown);
+    DK = DataKind::Null;
+    IsMissing = false;
+ }
+
+  ParsedRawSyntaxNode unsafeCopy() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    case DataKind::Recorded:
+      copy.RecordedData = RecordedData;
+      break;
+    case DataKind::Null:
+      break;
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
+  }
+
   CharSourceRange getDeferredRange() const {
     switch (DK) { 
     case DataKind::DeferredLayout:
@@ -153,9 +214,15 @@ public:
     assert(isRecorded());
     return RecordedData.Range;
   }
-  OpaqueSyntaxNode getOpaqueNode() const {
+  const OpaqueSyntaxNode &getOpaqueNode() const {
     assert(isRecorded());
     return RecordedData.OpaqueNode;
+  }
+  OpaqueSyntaxNode takeOpaqueNode() {
+    assert(isRecorded());
+    auto opaque = RecordedData.OpaqueNode;
+    reset();
+    return opaque;
   }
 
   // Deferred Layout Data ====================================================//
@@ -163,8 +230,8 @@ public:
   CharSourceRange getDeferredLayoutRange() const {
     assert(DK == DataKind::DeferredLayout);
     assert(!DeferredLayout.Children.empty());
-    auto getLastNonNullChild = [this]() {
-      for (auto &&Child : llvm::reverse(getDeferredChildren()))
+    auto getLastNonNullChild = [this]() -> const ParsedRawSyntaxNode & {
+      for (auto &Child : llvm::reverse(getDeferredChildren()))
         if (!Child.isNull())
           return Child;
       llvm_unreachable("layout node without non-null children");
@@ -177,6 +244,28 @@ public:
   ArrayRef<ParsedRawSyntaxNode> getDeferredChildren() const {
     assert(DK == DataKind::DeferredLayout);
     return DeferredLayout.Children;
+  }
+  MutableArrayRef<ParsedRawSyntaxNode> getDeferredChildren() {
+    assert(DK == DataKind::DeferredLayout);
+    return DeferredLayout.Children;
+  }
+  ParsedRawSyntaxNode copyDeferred() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    default:
+      llvm_unreachable("node not deferred");
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
   }
 
   // Deferred Token Data =====================================================//
@@ -214,7 +303,7 @@ public:
 
   /// Form a deferred syntax layout node.
   static ParsedRawSyntaxNode makeDeferred(syntax::SyntaxKind k,
-                        ArrayRef<ParsedRawSyntaxNode> deferredNodes,
+                        MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                           SyntaxParsingContext &ctx);
 
   /// Form a deferred token node.

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -68,6 +68,8 @@ public:
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
 
+  void discardRecordedNode(ParsedRawSyntaxNode &node);
+
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
                                  syntax::SyntaxKind kind);

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -60,7 +60,7 @@ public:
   /// \p kind. Missing optional elements are represented with a null
   /// ParsedRawSyntaxNode object.
   ParsedRawSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                     ArrayRef<ParsedRawSyntaxNode> elements);
+                                      MutableArrayRef<ParsedRawSyntaxNode> elements);
 
   /// Record a raw syntax collecton without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be

--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -26,6 +26,7 @@ public:
     : RawNode(std::move(rawNode)) {}
 
   const ParsedRawSyntaxNode &getRaw() const { return RawNode; }
+  ParsedRawSyntaxNode takeRaw() { return std::move(RawNode); }
   syntax::SyntaxKind getKind() const { return RawNode.getKind(); }
 
   /// Returns true if the syntax node is of the given type.
@@ -39,7 +40,7 @@ public:
   template <typename T>
   T castTo() const {
     assert(is<T>() && "castTo<T>() node of incompatible type!");
-    return T { RawNode };
+    return T { RawNode.copyDeferred() };
   }
 
   /// If this Syntax node is of the right kind, cast and return it,
@@ -50,6 +51,10 @@ public:
       return castTo<T>();
     }
     return llvm::None;
+  }
+
+  ParsedSyntax copyDeferred() const {
+    return ParsedSyntax { RawNode.copyDeferred() };
   }
 
   static bool kindof(syntax::SyntaxKind Kind) {
@@ -65,7 +70,7 @@ public:
 class ParsedTokenSyntax final : public ParsedSyntax {
 public:
   explicit ParsedTokenSyntax(ParsedRawSyntaxNode rawNode)
-    : ParsedSyntax(rawNode) {}
+    : ParsedSyntax(std::move(rawNode)) {}
 
   tok getTokenKind() const {
     return getRaw().getTokenKind();

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -53,15 +53,15 @@ public:
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
   static Parsed${node.name} make${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
@@ -69,16 +69,16 @@ public:
 %   elif node.is_unknown():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} make${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 %   end
 % end
@@ -95,8 +95,8 @@ public:
   /// optional trailing comma.
   static ParsedTupleTypeElementSyntax
   makeTupleTypeElement(ParsedTypeSyntax Type,
-                         Optional<ParsedTokenSyntax> TrailingComma,
-                         SyntaxParsingContext &SPCtx);
+                       Optional<ParsedTokenSyntax> TrailingComma,
+                       SyntaxParsingContext &SPCtx);
 
   /// The provided \c elements are in the appropriate order for the syntax
   /// \c kind's layout but optional elements are not be included.
@@ -104,9 +104,12 @@ public:
   /// substituting missing parts with a null ParsedRawSyntaxNode object.
   ///
   /// \returns true if the layout could be formed, false otherwise.
-  static bool formExactLayoutFor(syntax::SyntaxKind kind,
-                                 ArrayRef<ParsedRawSyntaxNode> elements,
-         function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver);
+  static bool
+  formExactLayoutFor(syntax::SyntaxKind kind,
+                     MutableArrayRef<ParsedRawSyntaxNode> elements,
+                     function_ref<void(syntax::SyntaxKind,
+                                       MutableArrayRef<ParsedRawSyntaxNode>)>
+                         receiver);
 };
 }
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -61,6 +61,13 @@ public:
                                            ArrayRef<OpaqueSyntaxNode> elements,
                                            CharSourceRange range) = 0;
 
+  /// Discard raw syntax node.
+  /// 
+  /// FIXME: This breaks invariant that any recorded node will be a part of the
+  /// result SourceFile syntax. This method is a temporary workaround, and
+  /// should be removed when we fully migrate to libSyntax parsing.
+  virtual void discardRecordedNode(OpaqueSyntaxNode node) = 0;
+
   /// Used for incremental re-parsing.
   virtual std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -64,6 +64,8 @@ public:
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) override;
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 

--- a/lib/Parse/HiddenLibSyntaxAction.cpp
+++ b/lib/Parse/HiddenLibSyntaxAction.cpp
@@ -125,3 +125,12 @@ HiddenLibSyntaxAction::getExplicitNodeFor(OpaqueSyntaxNode node) {
   auto hiddenNode = (Node *)node;
   return hiddenNode->ExplicitActionNode;
 }
+
+void HiddenLibSyntaxAction::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN)
+    return;
+  auto node = static_cast<Node *>(opaqueN);
+  if (!areBothLibSyntax())
+    LibSyntaxAction->discardRecordedNode(node->LibSyntaxNode);
+  ExplicitAction->discardRecordedNode(node->ExplicitActionNode);
+}

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1312,25 +1312,25 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::integer_literal);
-  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<FloatLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::floating_literal);
-  return ParsedSyntaxRecorder::makeFloatLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeFloatLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<NilLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::kw_nil);
-  return ParsedSyntaxRecorder::makeNilLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeNilLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<BooleanLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax();
-  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1341,11 +1341,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFileExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FILE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_file);
-  return ParsedSyntaxRecorder::makePoundFileExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFileExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1356,12 +1356,12 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundLineExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___LINE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   // FIXME: #line was renamed to #sourceLocation
   auto Token = consumeTokenSyntax(tok::pound_line);
-  return ParsedSyntaxRecorder::makePoundLineExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundLineExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1372,11 +1372,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundColumnExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___COLUMN__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_column);
-  return ParsedSyntaxRecorder::makePoundColumnExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundColumnExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1387,11 +1387,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFunctionExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FUNCTION__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_function);
-  return ParsedSyntaxRecorder::makePoundFunctionExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFunctionExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1402,18 +1402,18 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundDsohandleExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___DSO_HANDLE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_dsohandle);
-  return ParsedSyntaxRecorder::makePoundDsohandleExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundDsohandleExpr(std::move(Token), *SyntaxContext);
 }
 
 template <typename SyntaxNode>
 ParserResult<Expr> Parser::parseExprAST() {
   auto Loc = leadingTriviaLoc();
   auto ParsedExpr = parseExprSyntax<SyntaxNode>();
-  SyntaxContext->addSyntax(ParsedExpr);
+  SyntaxContext->addSyntax(std::move(ParsedExpr));
   // todo [gsoc]: improve this somehow
   if (SyntaxContext->isTopNode<UnknownExprSyntax>()) {
     auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
@@ -1519,9 +1519,9 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
           ParsedSyntaxRecorder::makeIdentifierPattern(
                                   SyntaxContext->popToken(), *SyntaxContext);
       ParsedExprSyntax ExprNode =
-          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
+          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
                                                            *SyntaxContext);
-      SyntaxContext->addSyntax(ExprNode);
+      SyntaxContext->addSyntax(std::move(ExprNode));
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1169,6 +1169,7 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // matching-pattern ::= expr
   // Fall back to expression parsing for ambiguous forms. Name lookup will
   // disambiguate.
+  DeferringContextRAII Deferring(*SyntaxContext);
   ParserResult<Expr> subExpr =
     parseExprImpl(diag::expected_pattern, isExprBasic);
   ParserStatus status = subExpr;

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -19,15 +19,20 @@ using namespace llvm;
 
 ParsedRawSyntaxNode
 ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
-                                  ArrayRef<ParsedRawSyntaxNode> deferredNodes,
+                                  MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                   SyntaxParsingContext &ctx) {
   if (deferredNodes.empty()) {
     return ParsedRawSyntaxNode(k, {});
   }
   ParsedRawSyntaxNode *newPtr =
     ctx.getScratchAlloc().Allocate<ParsedRawSyntaxNode>(deferredNodes.size());
-  std::uninitialized_copy(deferredNodes.begin(), deferredNodes.end(), newPtr);
-  return ParsedRawSyntaxNode(k, makeArrayRef(newPtr, deferredNodes.size()));
+
+  // uninitialized move;
+  auto ptr = newPtr;
+  for (auto &node : deferredNodes)
+    :: new (static_cast<void *>(ptr++)) ParsedRawSyntaxNode(std::move(node));
+
+  return ParsedRawSyntaxNode(k, makeMutableArrayRef(newPtr, deferredNodes.size()));
 }
 
 ParsedRawSyntaxNode
@@ -59,13 +64,13 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   for (decltype(Indent) i = 0; i < Indent; ++i)
     OS << ' ';
   OS << '(';
-  dumpSyntaxKind(OS, getKind());
 
   switch (DK) {
     case DataKind::Null:
       OS << "<NULL>";
       break;
     case DataKind::Recorded:
+      dumpSyntaxKind(OS, getKind());
       OS << " [recorded] ";
       if (isToken()) {
         dumpTokenKind(OS, getTokenKind());
@@ -74,6 +79,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
       }
       break;
     case DataKind::DeferredLayout:
+      dumpSyntaxKind(OS, getKind());
       OS << " [deferred]";
       for (const auto &child : getDeferredChildren()) {
         OS << "\n";
@@ -81,6 +87,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
       }
       break;
     case DataKind::DeferredToken:
+      dumpSyntaxKind(OS, getKind());
       OS << " [deferred] ";
       dumpTokenKind(OS, getTokenKind());
       break;

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -57,9 +57,8 @@ ParsedRawSyntaxRecorder::recordMissingToken(tok tokenKind, SourceLoc loc) {
 }
 
 static ParsedRawSyntaxNode
-getRecordedNode(const ParsedRawSyntaxNode &node, ParsedRawSyntaxRecorder &rec) {
-  if (node.isNull() || node.isRecorded())
-    return node;
+getRecordedNode(ParsedRawSyntaxNode node, ParsedRawSyntaxRecorder &rec) {
+  assert(!node.isNull() && !node.isRecorded());
   if (node.isDeferredLayout())
     return rec.recordRawSyntax(node.getKind(), node.getDeferredChildren());
   assert(node.isDeferredToken());
@@ -74,24 +73,29 @@ getRecordedNode(const ParsedRawSyntaxNode &node, ParsedRawSyntaxRecorder &rec) {
 
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordRawSyntax(SyntaxKind kind,
-                                    ArrayRef<ParsedRawSyntaxNode> elements) {
+                                         MutableArrayRef<ParsedRawSyntaxNode> elements) {
   CharSourceRange range;
   SmallVector<OpaqueSyntaxNode, 16> subnodes;
   if (!elements.empty()) {
     SourceLoc offset;
     unsigned length = 0;
-    for (const auto &elem : elements) {
-      auto subnode = getRecordedNode(elem, *this);
+    for (auto &subnode : elements) {
+      CharSourceRange localRange;
       if (subnode.isNull()) {
         subnodes.push_back(nullptr);
+      } else if (subnode.isRecorded()) {
+        localRange = subnode.getRecordedRange();
+        subnodes.push_back(subnode.takeOpaqueNode());
       } else {
-        subnodes.push_back(subnode.getOpaqueNode());
-        auto range = subnode.getRecordedRange();
-        if (range.isValid()) {
-          if (offset.isInvalid())
-            offset = range.getStart();
-          length += subnode.getRecordedRange().getByteLength();
-        }
+        auto recorded = getRecordedNode(subnode.copyDeferred(), *this);
+        localRange = recorded.getRecordedRange();
+        subnodes.push_back(recorded.takeOpaqueNode());
+      }
+
+      if (localRange.isValid()) {
+        if (offset.isInvalid())
+          offset = localRange.getStart();
+        length += localRange.getByteLength();
       }
     }
     range = CharSourceRange{offset, length};

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -112,6 +112,10 @@ ParsedRawSyntaxRecorder::recordEmptyRawSyntaxCollection(SyntaxKind kind,
   return ParsedRawSyntaxNode{kind, tok::unknown, range, n};
 }
 
+void ParsedRawSyntaxRecorder::discardRecordedNode(ParsedRawSyntaxNode &node) {
+  SPActions->discardRecordedNode(node.takeOpaqueNode());
+}
+
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::lookupNode(size_t lexerOffset, SourceLoc loc,
                                     SyntaxKind kind) {

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -43,14 +43,14 @@ Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} ${child.nam
   assert(${child_elt_name}s.empty() && "use either 'use' function or 'add', not both");
 %       end
   Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
-    ${child.name}.getRaw();
+    ${child.name}.takeRaw();
   return *this;
 }
 %       if child_elt:
 Parsed${node.name}Builder &
 Parsed${node.name}Builder::add${child_elt_name}(Parsed${child_elt_type} ${child_elt}) {
   assert(Layout[cursorIndex(${node.name}::Cursor::${child.name})].isNull() && "use either 'use' function or 'add', not both");
-  ${child_elt_name}s.push_back(std::move(${child_elt}.getRaw()));
+  ${child_elt_name}s.push_back(${child_elt}.takeRaw());
   return *this;
 }
 %       end

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -28,14 +28,14 @@ using namespace swift::syntax;
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
 Parsed${node.name}::getDeferred${child.name}() {
-  auto RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
+  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
   if (RawChild.isNull())
     return None;
-  return Parsed${child.type_name} {RawChild};
+  return Parsed${child.type_name} {RawChild.copyDeferred()};
 }
 %     else:
 Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}]};
+  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
 }
 %     end
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -26,8 +26,8 @@ using namespace swift;
 using namespace swift::syntax;
 
 bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
-        ArrayRef<ParsedRawSyntaxNode> Elements,
-        function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver) {
+        MutableArrayRef<ParsedRawSyntaxNode> Elements,
+        function_ref<void(syntax::SyntaxKind, MutableArrayRef<ParsedRawSyntaxNode>)> receiver) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -42,16 +42,23 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     if child.is_optional:
       Layout[${child_idx}] = ParsedRawSyntaxNode::null();
 %     else:
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
 %     end
     } else {
-      Layout[${child_idx}] = Elements[I];
+      Layout[${child_idx}] = Elements[I].unsafeCopy();
       ++I;
     }
 %   end
-    if (I != Elements.size())
+    if (I != Elements.size()) {
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
+    }
     receiver(Kind, Layout);
+    for (unsigned i = 0, e = Elements.size(); i != e; ++i)
+      Elements[i].reset();
     return true;
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
@@ -85,29 +92,31 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
                                        ParsedRawSyntaxRecorder &rec) {
-  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  });
+  };
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  }, SPCtx);
+  };
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
@@ -122,12 +131,12 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -135,12 +144,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
@@ -149,7 +158,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -171,12 +180,12 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
 %   elif node.is_unknown():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -184,12 +193,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
@@ -197,7 +206,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -224,6 +233,6 @@ ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,
                                     llvm::Optional<ParsedTokenSyntax> TrailingComma,
                                     SyntaxParsingContext &SPCtx) {
-  return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma, SPCtx);
+  return makeTupleTypeElement(None, None, None, None, std::move(Type), None, None,
+                              std::move(TrailingComma), SPCtx);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -684,19 +684,19 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_paren);
     if (auto RParen = consumeTokenSyntaxIf(tok::r_paren))
-      Skipped.push_back(*RParen);
+      Skipped.push_back(std::move(*RParen));
     break;
   case tok::l_brace:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_brace);
     if (auto RBrace = consumeTokenSyntaxIf(tok::r_brace))
-      Skipped.push_back(*RBrace);
+      Skipped.push_back(std::move(*RBrace));
     break;
   case tok::l_square:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_square);
     if (auto RSquare = consumeTokenSyntaxIf(tok::r_square))
-      Skipped.push_back(*RSquare);
+      Skipped.push_back(std::move(*RSquare));
     break;
   case tok::pound_if:
   case tok::pound_else:
@@ -708,7 +708,7 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     if (Tok.isAny(tok::pound_else, tok::pound_elseif))
       skipSingleSyntax(Skipped);
     else if (auto Endif = consumeTokenSyntaxIf(tok::pound_endif))
-      Skipped.push_back(*Endif);
+      Skipped.push_back(std::move(*Endif));
     break;
 
   default:
@@ -1003,11 +1003,12 @@ void Parser::skipListUntilDeclRBraceSyntax(
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif)) {
     auto Comma = consumeTokenSyntaxIf(tok::comma);
-    if (Comma)
-      Skipped.push_back(*Comma);
-    
+
     bool hasDelimiter = Tok.getLoc() == startLoc || Comma;
     bool possibleDeclStartsLine = Tok.isAtStartOfLine();
+
+    if (Comma)
+      Skipped.push_back(std::move(*Comma));
 
     if (isStartOfDecl()) {
       // Could have encountered something like `_ var:` 
@@ -1020,7 +1021,7 @@ void Parser::skipListUntilDeclRBraceSyntax(
         Parser::BacktrackingScope backtrack(*this);
         // Consume the let or var
         auto LetOrVar = consumeTokenSyntax();
-        Skipped.push_back(LetOrVar);
+        Skipped.push_back(std::move(LetOrVar));
         
         // If the following token is either <identifier> or :, it means that
         // this `var` or `let` should be interpreted as a label
@@ -1338,7 +1339,7 @@ Parser::parseListSyntax(tok RightK, SourceLoc LeftLoc,
       diagnose(Tok, diag::unexpected_separator, ",")
           .fixItRemove(SourceRange(Tok.getLoc()));
       auto Comma = consumeTokenSyntax();
-      Junk.push_back(Comma);
+      Junk.push_back(std::move(Comma));
     }
     SourceLoc StartLoc = Tok.getLoc();
 

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -54,13 +54,14 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  getStorage().push_back(foundNode);
-  return foundNode.getRecordedRange().getByteLength();
+  auto length = foundNode.getRecordedRange().getByteLength();
+  getStorage().push_back(std::move(foundNode));
+  return length;
 }
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
-                                        ArrayRef<ParsedRawSyntaxNode> Parts) {
+                                        MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   assert(isUnknownKind(Kind));
   if (shouldDefer())
     return ParsedRawSyntaxNode::makeDeferred(Kind, Parts, *this);
@@ -70,12 +71,12 @@ SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
-                                     ArrayRef<ParsedRawSyntaxNode> Parts,
+                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK) {
   // Try to create the node of the given syntax.
   ParsedRawSyntaxNode rawNode;
   auto &rec = getRecorder();
-  auto formNode = [&](SyntaxKind kind, ArrayRef<ParsedRawSyntaxNode> layout) {
+  auto formNode = [&](SyntaxKind kind, MutableArrayRef<ParsedRawSyntaxNode> layout) {
     if (nodeCreateK == SyntaxNodeCreationKind::Deferred || shouldDefer()) {
       rawNode = ParsedRawSyntaxNode::makeDeferred(kind, layout, *this);
     } else {
@@ -91,9 +92,9 @@ SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
 
 Optional<ParsedRawSyntaxNode>
 SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
-                               ArrayRef<ParsedRawSyntaxNode> Parts) {
+                               MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   if (Parts.size() == 1) {
-    auto RawNode = Parts.front();
+    auto &RawNode = Parts.front();
     SyntaxKind RawNodeKind = RawNode.getKind();
     switch (Kind) {
     case SyntaxContextKind::Stmt:
@@ -120,7 +121,7 @@ SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
       // We don't need to coerce in this case.
       break;
     }
-    return RawNode;
+    return std::move(RawNode);
   } else if (Parts.empty()) {
     // Just omit the unknown node if it does not have any children
     return None;
@@ -181,7 +182,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
 
 /// Add Syntax to the parts.
 void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
-  addRawSyntax(Node.getRaw());
+  addRawSyntax(Node.takeRaw());
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
@@ -192,12 +193,10 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
     return;
   }
 
-  auto I = getStorage().end() - N;
-  *I = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
-
-  // Remove consumed parts.
-  if (N != 1)
-    getStorage().erase(I + 1, getStorage().end());
+  auto node = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
+  auto &storage = getStorage();
+  getStorage().erase(storage.end() - N, getStorage().end());
+  getStorage().emplace_back(std::move(node));
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
@@ -250,21 +249,21 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
 
 ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
   ParsedRawSyntaxRecorder &Recorder = getRecorder();
-  ArrayRef<ParsedRawSyntaxNode> Parts = getParts();
-  std::vector<ParsedRawSyntaxNode> AllTopLevel;
+  auto Parts = getParts();
+  ParsedRawSyntaxNode Layout[2];
 
   assert(!Parts.empty() && Parts.back().isToken(tok::eof));
-  ParsedRawSyntaxNode EOFToken = Parts.back();
+  Layout[1] = std::move(Parts.back());
   Parts = Parts.drop_back();
 
   assert(llvm::all_of(Parts, [](const ParsedRawSyntaxNode& node) {
     return node.getKind() == SyntaxKind::CodeBlockItem;
   }) && "all top level element must be 'CodeBlockItem'");
 
-  auto itemList = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList,
-                                           Parts);
+  Layout[0] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
+
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
-                                  { itemList, EOFToken });
+                                  llvm::makeMutableArrayRef(Layout, 2));
 }
 
   OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
@@ -275,7 +274,7 @@ ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
     return nullptr; // already finalized.
   }
   ParsedRawSyntaxNode root = finalizeSourceFile();
-  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.getOpaqueNode());
+  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.takeOpaqueNode());
 
   // Clear the parts because we will call this function again when destroying
   // the root context.
@@ -295,9 +294,12 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 
 void SyntaxParsingContext::dumpStorage() const  {
   llvm::errs() << "======================\n";
-  for (auto Node : getStorage()) {
-    Node.dump(llvm::errs());
-    llvm::errs() << "\n--------------\n";
+  auto &storage = getStorage();
+  for (unsigned i = 0; i != storage.size(); ++i) {
+    storage[i].dump(llvm::errs());
+    llvm::errs() << "\n";
+    if (i + 1 == Offset)
+      llvm::errs() << "--------------\n";
   }
 }
 
@@ -329,14 +331,12 @@ SyntaxParsingContext::~SyntaxParsingContext() {
     assert(!isRoot());
     if (Storage.size() == Offset) {
       if (auto BridgedNode = bridgeAs(CtxtKind, {})) {
-        Storage.push_back(BridgedNode.getValue());
+        Storage.push_back(std::move(BridgedNode.getValue()));
       }
     } else {
-      auto I = Storage.begin() + Offset;
-      *I = bridgeAs(CtxtKind, getParts()).getValue();
-      // Remove used parts.
-      if (Storage.size() > Offset + 1)
-        Storage.erase(Storage.begin() + (Offset + 1), Storage.end());
+      auto node = bridgeAs(CtxtKind, getParts()).getValue();
+      Storage.erase(Storage.begin() + Offset, Storage.end());
+      Storage.emplace_back(std::move(node));
     }
     break;
   }
@@ -350,9 +350,10 @@ SyntaxParsingContext::~SyntaxParsingContext() {
   case AccumulationMode::Discard: {
     auto &nodes = getStorage();
     for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i)
-      if (i->isRecorded())
+      if (i->isRecorded()) {
         getSyntaxCreator().finalizeNode(i->getOpaqueNode());
-
+        i->reset();
+      }
     nodes.erase(nodes.begin()+Offset, nodes.end());
     break;
   }

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -39,7 +39,8 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RC<syntax::RawSyntax> Obj, const llvm::FoldingSetNodeIDRef IDRef)
+  RawSyntaxCacheNode(RC<syntax::RawSyntax> &Obj,
+                     const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -173,3 +173,9 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   raw.resetWithoutRelease();
   return {length, opaqueN};
 }
+
+void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN)
+    return;
+  static_cast<RawSyntax *>(opaqueN)->Release();
+}

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -190,6 +190,10 @@ public:
     return getNodeHandler()(&node);
   }
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override {
+    // FIXME: This method should not be called at all.
+  }
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, SyntaxKind kind) override {
     auto NodeLookup = getNodeLookup();


### PR DESCRIPTION
`ParsedRawSyntaxNode` holds opaque pointer `void *` pointer for "recorded" node. The parser doesn't know how the memory is managed. When any `ParsedRawSyntaxNode` holding "recorded" node is discarded, that leaks because the parser doesn't know how to release it.

In this patch, to prevent that kind of leaking, make `ParsedRawSyntaxNode` move-only, nullify the original node when moved, assert the it does not hold recorded node in the destructor.