### PR TITLE
[Type checker] Don't replace function builder closures with their bodies

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7577,7 +7577,8 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
           auto *transformedExpr = result->second.second;
           // Since this closure has been transformed into something
           // else let's look inside transformed expression instead.
-          return {true, transformedExpr};
+          transformedExpr->walk(*this);
+          return {false, E};
         }
       }
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -199,3 +199,18 @@ struct SR11440 {
     })
   }
 }
+
+func acceptInt(_: Int, _: () -> Void) { }
+
+// SR-11350 crash due to improper recontextualization.
+func erroneousSR11350(x: Int) {
+  tuplify(true) { b in
+    17
+    x + 25
+    Optional(tuplify(false) { b in
+      if b {
+        acceptInt(0) { }
+      }
+    }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
+  }
+}


### PR DESCRIPTION
When diagnosing failures in a function builder closure, we were
unnecessarily replacing the closure expression with its body,
destroying the AST and resulting in assertions due to DeclContext
mismatches. Fixes SR-11350 / rdar://problem/54590425.