### PR TITLE
[5.1] [Type checker] Don't replace function builder closures with their bodies

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7688,7 +7688,8 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
           auto *transformedExpr = result->second.second;
           // Since this closure has been transformed into something
           // else let's look inside transformed expression instead.
-          return {true, transformedExpr};
+          transformedExpr->walk(*this);
+          return {false, E};
         }
       }
 

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -172,3 +172,18 @@ func test_51167632() -> some P {
     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}} {{10-10=<<#L: P#>>}}
   })
 }
+
+func acceptInt(_: Int, _: () -> Void) { }
+
+// SR-11350 crash due to improper recontextualization.
+func erroneousSR11350(x: Int) {
+  tuplify(true) { b in
+    17
+    x + 25
+    Optional(tuplify(false) { b in
+      if b {
+        acceptInt(0) { }
+      }
+    }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
+  }
+}

--- a/test/Constraints/function_builder_diags.swift
+++ b/test/Constraints/function_builder_diags.swift
@@ -177,13 +177,13 @@ func acceptInt(_: Int, _: () -> Void) { }
 
 // SR-11350 crash due to improper recontextualization.
 func erroneousSR11350(x: Int) {
-  tuplify(true) { b in
+  tuplify(true) { b in  // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
     17
     x + 25
     Optional(tuplify(false) { b in
       if b {
         acceptInt(0) { }
       }
-    }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
+    }).domap(0)
   }
 }


### PR DESCRIPTION
When diagnosing failures in a function builder closure, we were
unnecessarily replacing the closure expression with its body,
destroying the AST and resulting in assertions due to DeclContext
mismatches. Fixes SR-11350 / rdar://problem/54590425.
