### PR TITLE
StackNesting: fix a corner case crash related to unreachable blocks

### DIFF
--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -155,10 +155,13 @@ private:
     return bitNumberForAlloc(AllocInst);
   }
 
+  /// Insert deallocations at block boundaries.
+  Changes insertDeallocsAtBlockBoundaries();
+
   /// Modifies the SIL to end up with a correct stack nesting.
   ///
   /// Returns the status of what changes were made.
-  Changes adaptDeallocs();
+  bool adaptDeallocs();
 };
 
 } // end namespace swift

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1086,8 +1086,38 @@ bb2:
 bb3:
   strong_release %1 : ${ var Int }
   unreachable
-
 }
+
+
+// Verify that we don't crash on this one:
+//
+// CHECK-LABEL: sil @unreachable_with_two_predecessors
+sil @unreachable_with_two_predecessors : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  cond_br undef, bb1, bb4
+
+bb1:
+  %4 = alloc_stack $Bool
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  store %0 to %1a : $*Int
+  cond_br undef, bb3, bb2
+
+bb2:
+  dealloc_stack %4 : $*Bool
+  br bb4
+
+bb3:
+  %9 = load %1a : $*Int
+  strong_release %1 : ${ var Int }
+  dealloc_stack %4 : $*Bool
+  %13 = tuple ()
+  return %13 : $()
+
+bb4:
+  unreachable
+}
+
 
 // Verify the case in which a box used by a partial apply which is then used by a try_apply.
 //


### PR DESCRIPTION
When deallocs are inserted at block boundaries, it's necessary to recompute the data flow.

rdar://problem/55249524
