### PR TITLE
Bring this Float80 availability check up to date.

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -94,7 +94,7 @@ public func ldexp(_ x: ${T}, _ n : Int) -> ${T} {
 // SWIFT_ENABLE_TENSORFLOW
 %for T in ['Float', 'Double', 'Float80']:
 %   if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !os(Windows)
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %   end
 @usableFromInline
 func _vjpExp(_ x: ${T}) -> (${T}, (${T}) -> ${T}) {


### PR DESCRIPTION
It had gotten out-of-sync with the equivalent check in [stdlib/public/core/FloatingPointTypes.swift.gyb](https://github.com/apple/swift/blob/d80b1d39a3ba28cb69c3ed01032e344cb59b6adb/stdlib/public/core/FloatingPointTypes.swift.gyb#L57), so this change copies it verbatim from there.
