### PR TITLE
Refactor typeCheckCheckedCast() and a few other things

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -47,10 +47,6 @@ namespace swift {
   /// \returns true on convertible, false on not.
   bool isConvertibleTo(Type T1, Type T2, bool openArchetypes, DeclContext &DC);
 
-  bool isEqual(Type T1, Type T2, DeclContext &DC);
-
-  bool canPossiblyEqual(Type T1, Type T2, DeclContext &DC);
-
   void collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                         llvm::SmallDenseMap<ValueDecl*, ValueDecl*> &DefaultMap);
 

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -87,8 +87,6 @@ public:
 // Type relation checking
 //----------------------------------------------------------------------------//
 enum class TypeRelation: uint8_t {
-  EqualTo,
-  PossiblyEqualTo,
   ConvertTo,
 };
 
@@ -158,8 +156,6 @@ struct TypeRelationCheckInput {
     out << " is ";
     switch(owner.Relation) {
 #define CASE(NAME) case TypeRelation::NAME: out << #NAME << " "; break;
-    CASE(EqualTo)
-    CASE(PossiblyEqualTo)
     CASE(ConvertTo)
 #undef CASE
     }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -88,25 +88,6 @@ PrintOptions PrintOptions::printDocInterface() {
   return result;
 }
 
-/// Erase any associated types within dependent member types, so we'll resolve
-/// them again.
-static Type eraseAssociatedTypes(Type type) {
-  if (!type->hasTypeParameter()) return type;
-
-  return type.transformRec([](TypeBase *type) -> Optional<Type> {
-    if (auto depMemType = dyn_cast<DependentMemberType>(type)) {
-      auto newBase = eraseAssociatedTypes(depMemType->getBase());
-      if (newBase.getPointer() == depMemType->getBase().getPointer() &&
-          !depMemType->getAssocType())
-        return None;
-
-      return Type(DependentMemberType::get(newBase, depMemType->getName()));
-    }
-
-    return None;
-  });
-}
-
 struct SynthesizedExtensionAnalyzer::Implementation {
   static bool isMemberFavored(const NominalTypeDecl* Target, const Decl* D) {
     DeclContext* DC = Target->getInnermostDeclContext();
@@ -186,11 +167,9 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     std::set<Requirement> Requirements;
     void addRequirement(GenericSignature *GenericSig,
                         Type First, Type Second, RequirementKind Kind) {
-      CanType CanFirst =
-        GenericSig->getCanonicalTypeInContext(eraseAssociatedTypes(First));
+      CanType CanFirst = GenericSig->getCanonicalTypeInContext(First);
       CanType CanSecond;
-      if (Second) CanSecond =
-        GenericSig->getCanonicalTypeInContext(eraseAssociatedTypes(Second));
+      if (Second) CanSecond = GenericSig->getCanonicalTypeInContext(Second);
 
       Requirements.insert({First, Second, Kind, CanFirst, CanSecond});
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7168,6 +7168,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   // T1 <c T2 && T2 : Hashable ===> T1 <c AnyHashable
   case ConversionRestrictionKind::HashableToAnyHashable: {
     // We never want to do this if the LHS is already AnyHashable.
+    type1 = simplifyType(type1);
     if (isAnyHashableType(
             type1->getRValueType()->lookThroughAllOptionalTypes())) {
       return SolutionKind::Error;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -728,8 +728,8 @@ Optional<Type> ConstraintSystem::isSetType(Type type) {
 }
 
 bool ConstraintSystem::isCollectionType(Type type) {
-  auto &ctx = type->getASTContext();
   if (auto *structType = type->getAs<BoundGenericStructType>()) {
+    auto &ctx = type->getASTContext();
     auto *decl = structType->getDecl();
     if (decl == ctx.getArrayDecl() || decl == ctx.getDictionaryDecl() ||
         decl == ctx.getSetDecl())
@@ -740,13 +740,9 @@ bool ConstraintSystem::isCollectionType(Type type) {
 }
 
 bool ConstraintSystem::isAnyHashableType(Type type) {
-  if (auto tv = type->getAs<TypeVariableType>()) {
-    auto fixedType = getFixedType(tv);
-    return fixedType && isAnyHashableType(fixedType);
-  }
-
   if (auto st = type->getAs<StructType>()) {
-    return st->getDecl() == TC.Context.getAnyHashableDecl();
+    auto &ctx = type->getASTContext();
+    return st->getDecl() == ctx.getAnyHashableDecl();
   }
 
   return false;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2491,7 +2491,7 @@ public:
   static bool isCollectionType(Type t);
 
   /// Determine if the type in question is AnyHashable.
-  bool isAnyHashableType(Type t);
+  static bool isAnyHashableType(Type t);
 
   /// Call Expr::isTypeReference on the given expression, using a
   /// custom accessor for the type on the expression that reads the

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -104,11 +104,6 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
                                    TypeRelationCheckInput Owner) const {
   Optional<constraints::ConstraintKind> CKind;
   switch (Owner.Relation) {
-  case TypeRelation::EqualTo:
-    return Owner.Pair.FirstTy->isEqual(Owner.Pair.SecondTy);
-  case TypeRelation::PossiblyEqualTo:
-    CKind = constraints::ConstraintKind::Bind;
-    break;
   case TypeRelation::ConvertTo:
     CKind = constraints::ConstraintKind::Conversion;
     break;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -4041,10 +4041,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   }
 
   // Check for casts between specific concrete types that cannot succeed.
-  ConstraintSystem cs(*this, dc, ConstraintSystemOptions());
-
-  if (auto toElementType = cs.isArrayType(toType)) {
-    if (auto fromElementType = cs.isArrayType(fromType)) {
+  if (auto toElementType = ConstraintSystem::isArrayType(toType)) {
+    if (auto fromElementType = ConstraintSystem::isArrayType(fromType)) {
       switch (typeCheckCheckedCast(*fromElementType, *toElementType,
                                    CheckedCastContextKind::None, dc,
                                    SourceLoc(), nullptr, SourceRange())) {
@@ -4066,8 +4064,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     }
   }
 
-  if (auto toKeyValue = cs.isDictionaryType(toType)) {
-    if (auto fromKeyValue = cs.isDictionaryType(fromType)) {
+  if (auto toKeyValue = ConstraintSystem::isDictionaryType(toType)) {
+    if (auto fromKeyValue = ConstraintSystem::isDictionaryType(fromType)) {
       bool hasCoercion = false;
       enum { NoBridging, BridgingCoercion }
         hasBridgingConversion = NoBridging;
@@ -4130,8 +4128,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     }
   }
 
-  if (auto toElementType = cs.isSetType(toType)) {
-    if (auto fromElementType = cs.isSetType(fromType)) {
+  if (auto toElementType = ConstraintSystem::isSetType(toType)) {
+    if (auto fromElementType = ConstraintSystem::isSetType(fromType)) {
       switch (typeCheckCheckedCast(*fromElementType, *toElementType,
                                    CheckedCastContextKind::None, dc,
                                    SourceLoc(), nullptr, SourceRange())) {
@@ -4254,9 +4252,9 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   bool toExistentialMetatype = false;
   bool fromExistentialMetatype = false;
   if (auto toMetatype = toType->getAs<AnyMetatypeType>()) {
-    toExistentialMetatype = toMetatype->is<ExistentialMetatypeType>();
     if (auto fromMetatype = fromType->getAs<AnyMetatypeType>()) {
-      fromExistentialMetatype = fromMetatype->is<ExistentialMetatypeType>();
+      toExistentialMetatype = toType->is<ExistentialMetatypeType>();
+      fromExistentialMetatype = fromType->is<ExistentialMetatypeType>();
       toType = toMetatype->getInstanceType();
       fromType = fromMetatype->getInstanceType();
     }
@@ -4266,23 +4264,43 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   bool fromArchetype = fromType->is<ArchetypeType>();
   bool toExistential = toType->isExistentialType();
   bool fromExistential = fromType->isExistentialType();
+
+  bool toRequiresClass;
+  if (toType->isExistentialType())
+    toRequiresClass = toType->getExistentialLayout().requiresClass();
+  else
+    toRequiresClass = toType->mayHaveSuperclass();
+
+  bool fromRequiresClass;
+  if (fromType->isExistentialType())
+    fromRequiresClass = fromType->getExistentialLayout().requiresClass();
+  else
+    fromRequiresClass = fromType->mayHaveSuperclass();
   
-  // If we're doing a metatype cast, it can only be existential if we're
-  // casting to/from the existential metatype. 'T.self as P.Protocol'
-  // can only succeed if T is exactly the type P, so is a concrete cast,
-  // whereas 'T.self as P.Type' succeeds for types conforming to the protocol
-  // P, and is an existential cast.
+  // Casts between protocol metatypes only succeed if the type is existential.
   if (metatypeCast) {
-    toExistential &= toExistentialMetatype;
-    fromExistential &= fromExistentialMetatype;
+    if (toExistential || fromExistential)
+      return failed();
   }
+
+  // Casts from an existential metatype to a protocol metatype always fail,
+  // except when the existential type is 'Any'.
+  if (fromExistentialMetatype &&
+      !fromType->isAny() &&
+      !toExistentialMetatype &&
+      toExistential)
+    return failed();
 
   // Casts to or from generic types can't be statically constrained in most
   // cases, because there may be protocol conformances we don't statically
   // know about.
-  if (toExistential || fromExistential || fromArchetype || toArchetype) {
+  if (toExistential || fromExistential || fromArchetype || toArchetype ||
+      toRequiresClass || fromRequiresClass) {
     // Cast to and from AnyObject always succeed.
-    if (toType->isAnyObject() || fromType->isAnyObject())
+    if (!metatypeCast &&
+        !fromExistentialMetatype &&
+        !toExistentialMetatype &&
+        (toType->isAnyObject() || fromType->isAnyObject()))
       return CheckedCastKind::ValueCast;
 
     // A cast from an existential type to a concrete type does not succeed. For
@@ -4315,18 +4333,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         }
       }
     }
-
-    bool toRequiresClass;
-    if (toType->isExistentialType())
-      toRequiresClass = toType->getExistentialLayout().requiresClass();
-    else
-      toRequiresClass = toType->mayHaveSuperclass();
-
-    bool fromRequiresClass;
-    if (fromType->isExistentialType())
-      fromRequiresClass = fromType->getExistentialLayout().requiresClass();
-    else
-      fromRequiresClass = fromType->mayHaveSuperclass();
 
     // If neither type is class-constrained, anything goes.
     if (!fromRequiresClass && !toRequiresClass)
@@ -4373,44 +4379,29 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         return CheckedCastKind::ValueCast;
 
       // Compare superclass bounds.
-      if (typesSatisfyConstraint(toSuperclass, fromSuperclass,
-                                 /*openArchetypes=*/true,
-                                 ConstraintKind::Subtype, dc))
+      if (fromSuperclass->isBindableToSuperclassOf(toSuperclass))
         return CheckedCastKind::ValueCast;
 
       // An upcast is also OK.
-      if (typesSatisfyConstraint(fromSuperclass, toSuperclass,
-                                 /*openArchetypes=*/true,
-                                 ConstraintKind::Subtype, dc))
+      if (toSuperclass->isBindableToSuperclassOf(fromSuperclass))
         return CheckedCastKind::ValueCast;
     }
   }
 
-  if (cs.isAnyHashableType(toType) || cs.isAnyHashableType(fromType)) {
+  if (ConstraintSystem::isAnyHashableType(toType) ||
+      ConstraintSystem::isAnyHashableType(fromType)) {
     return CheckedCastKind::ValueCast;
   }
 
   // If the destination type can be a supertype of the source type, we are
   // performing what looks like an upcast except it rebinds generic
   // parameters.
-  if (!metatypeCast &&
-      typesSatisfyConstraint(fromType, toType,
-                             /*openArchetypes=*/true,
-                             ConstraintKind::Subtype, dc)) {
+  if (fromType->isBindableTo(toType))
     return CheckedCastKind::ValueCast;
-  }
-
-  // If the destination type can be a subtype of the source type, we have
-  // a downcast.
-  if (typesSatisfyConstraint(toType, fromType,
-                             /*openArchetypes=*/true,
-                             ConstraintKind::Subtype, dc)) {
-    return CheckedCastKind::ValueCast;
-  }
   
   // Objective-C metaclasses are subclasses of NSObject in the ObjC runtime,
   // so casts from NSObject to potentially-class metatypes may succeed.
-  if (auto nsObject = cs.TC.getNSObjectType(dc)) {
+  if (auto nsObject = getNSObjectType(dc)) {
     if (fromType->isEqual(nsObject)) {
       if (auto toMeta = toType->getAs<MetatypeType>()) {
         if (toMeta->getInstanceType()->mayHaveSuperclass()

--- a/test/expr/cast/metatype_casts.swift
+++ b/test/expr/cast/metatype_casts.swift
@@ -23,15 +23,15 @@ use(any as! P.Protocol)
 
 let anyP: Any.Protocol = Any.self
 use(anyP is Any.Type) // expected-warning{{always true}}
-use(anyP as! Int.Type) // TODO: always fails
+use(anyP as! Int.Type) // expected-warning{{always fails}}
 
 let anyObj: AnyObject.Type = D.self
-use(anyObj as! Int.Type) // TODO: always fails
+use(anyObj as! Int.Type) // expected-warning{{always fails}}
 use(anyObj as! C.Type)
 use(anyObj as! D.Type)
-use(anyObj as! AnyObject.Protocol) // TODO: always fails
+use(anyObj as! AnyObject.Protocol) // expected-warning{{always fails}}
 use(anyObj as! P.Type)
-use(anyObj as! P.Protocol) // TODO: always fails
+use(anyObj as! P.Protocol) // expected-warning{{always fails}}
 
 let c: C.Type = D.self
 use(c as! D.Type)


### PR DESCRIPTION
Mostly a pointless diversion. For a while now I've wanted to remove `typesSatisfyConstraint()` because it creates an entire constraint system to solve a single constraint. This PR removes a few usages of this function, mostly from `typeCheckCheckedCast()`, improving a couple of diagnostics in the process.