### PR TITLE
[5.1 08-28-2019] [Type checker] Allow 'Self' reference in a lazy initializer.

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -769,6 +769,12 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
       maybeDiagnoseCaptures(expr, AFR);
 }
 
+static bool isLazy(PatternBindingDecl *PBD) {
+  if (auto var = PBD->getSingleVar())
+    return var->getAttrs().hasAttribute<LazyAttr>();
+  return false;
+}
+
 void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
   for (auto member : typeDecl->getMembers()) {
     // Ignore everything other than PBDs.
@@ -791,7 +797,7 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
                               /*ObjC=*/false);
       init->walk(finder);
 
-      if (finder.getDynamicSelfCaptureLoc().isValid()) {
+      if (finder.getDynamicSelfCaptureLoc().isValid() && !isLazy(PBD)) {
         diagnose(finder.getDynamicSelfCaptureLoc(),
                  diag::dynamic_self_stored_property_init);
       }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -183,3 +183,12 @@ class SelfStoredPropertyInit {
 
   var value = Self.myValue() // expected-error {{covariant 'Self' type cannot be referenced from a stored property initializer}}
 }
+
+// rdar://problem/55273931 - erroneously rejecting 'Self' in lazy initializer
+class Foo {
+  static var value: Int = 17
+
+  lazy var doubledValue: Int = {
+    Self.value * 2
+  }()
+}


### PR DESCRIPTION
Fixes rdar://problem/51561208
