### PR TITLE
Fix warnings

### DIFF
--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -109,6 +109,7 @@ struct PropertyWrapperMutability {
       }
       return std::max(Getter, Setter);
     }
+    llvm_unreachable("Unhandled Value in switch");
   }
   
   bool operator==(PropertyWrapperMutability other) const {

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -167,6 +167,7 @@ public:
     case RequirementKind::Layout:
       return lhs.getLayoutConstraint() == rhs.getLayoutConstraint();
     }
+    llvm_unreachable("Unhandled RequirementKind in switch");
   }
 };
 

--- a/include/swift/AST/ResilienceExpansion.h
+++ b/include/swift/AST/ResilienceExpansion.h
@@ -54,6 +54,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   case ResilienceExpansion::Maximal:
     return os << "Maximal";
   }
+  llvm_unreachable("Unhandled ResilienceExpansion in switch");
 }
 
 } // namespace swift

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -402,6 +402,7 @@ public:
     case Kind::Tuple:
       return false;
     }
+    llvm_unreachable("Unhandled AbstractionPatternKind in switch");
   }
 
   CanGenericSignature getGenericSignature() const {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4477,6 +4477,7 @@ bool ASTContext::overrideGenericSignatureReqsSatisfied(
   case OverrideGenericSignatureReqCheck::DerivedReqSatisfiedByBase:
     return derivedSig->requirementsNotSatisfiedBy(sig).empty();
   }
+  llvm_unreachable("Unhandled OverrideGenericSignatureReqCheck in switch");
 }
 
 SILLayout *SILLayout::get(ASTContext &C,

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -53,7 +53,17 @@ Optional<bool> ASTScope::computeIsCascadingUse(
   return ASTScopeImpl::computeIsCascadingUse(history, initialIsCascadingUse);
 }
 
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 void ASTScope::dump() const { impl->dump(); }
+
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(pop)
+#endif
+
 void ASTScope::print(llvm::raw_ostream &out) const { impl->print(out); }
 void ASTScope::dumpOneScopeMapLocation(std::pair<unsigned, unsigned> lineCol) {
   impl->dumpOneScopeMapLocation(lineCol);

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1178,6 +1178,7 @@ ConditionalClauseScope::expandAScopeThatCreatesANewInsertionPoint(
     return {ccPatternUseScope,
             "Succeeding code must be in scope of conditional variables"};
   }
+  llvm_unreachable("Unhandled StmtConditionKind in switch");
 }
 
 AnnotatedInsertionPoint

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7660,6 +7660,7 @@ ParseAbstractFunctionBodyRequest::getCachedResult() const {
   case BodyKind::Unparsed:
     return None;
   }
+  llvm_unreachable("Unhandled BodyKing in switch");
 }
 
 void ParseAbstractFunctionBodyRequest::cacheResult(BraceStmt *value) const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1037,6 +1037,7 @@ SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   case DeclContextKind::SerializedLocal:
     return extractNearestSourceLoc(dc->getParent());
   }
+  llvm_unreachable("Unhandled DeclCopntextKindin switch");
 }
 
 #define DECL(Id, Parent) \

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1091,4 +1091,5 @@ Requirement Requirement::getCanonical() const {
   case RequirementKind::Layout:
     return Requirement(getKind(), firstType, getLayoutConstraint());
   }
+  llvm_unreachable("Unhandled RequirementKind in switch");
 }

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -257,6 +257,7 @@ std::error_code swift::moveFileIfDifferent(const llvm::Twine &source,
     // Files are different; overwrite the destination file.
     return fs::rename(source, destination);
   }
+  llvm_unreachable("Unhandled FileDifference in switch");
 }
 
 llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -86,6 +86,7 @@ ArrayRef<StringRef> getSupportedConditionalCompilationValues(const PlatformCondi
   case PlatformConditionKind::TargetEnvironment:
     return SupportedConditionalCompilationTargetEnvironments;
   }
+  llvm_unreachable("Unhandled PlatformConditionKind in switch");
 }
 
 PlatformConditionKind suggestedPlatformConditionKind(PlatformConditionKind Kind, const StringRef &V,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2040,6 +2040,7 @@ public:
                              LookUpConformanceInModule(CurrModule));
     }
     }
+    llvm_unreachable("Unhandled DynamicLookupInfo Kind in switch");
   }
 
   Type getTypeOfMember(const ValueDecl *VD, Type ExprType) {

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -51,6 +51,7 @@ static StringRef getPlatformConditionName(PlatformConditionKind Kind) {
   case PlatformConditionKind::LABEL: return IDENTIFIER;
 #include "swift/AST/PlatformConditionKinds.def"
   }
+  llvm_unreachable("Unhandled PlatformConditionKind in switch");
 }
 
 /// Extract source text of the expression.

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -86,7 +86,7 @@ BraceStmt *ParseAbstractFunctionBodyRequest::evaluate(
     return body;
   }
   }
-
+  llvm_unreachable("Unhandled BodyKind in switch");
 }
 
 

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -145,6 +145,13 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser,
                      std::make_pair(CurScope->getDepth(), D));
 }
 
+
+// Disable the "for use only in debugger" warning.
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 void ScopeInfo::dump() const {
 #ifndef NDEBUG
   // Dump out the current list of scopes.
@@ -167,3 +174,7 @@ void ScopeInfo::dump() const {
   llvm::dbgs() << "\n";
 #endif
 }
+
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(pop)
+#endif

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2993,6 +2993,12 @@ void SILCoverageMap::dump() const {
 }
 
 #ifndef NDEBUG
+// Disable the "for use only in debugger" warning.
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 void SILDebugScope::dump(SourceManager &SM, llvm::raw_ostream &OS,
                          unsigned Indent) const {
   OS << "{\n";
@@ -3025,6 +3031,10 @@ void SILDebugScope::dump(SILModule &Mod) const {
   // We just use the default indent and llvm::errs().
   dump(Mod.getASTContext().SourceMgr);
 }
+
+#if SWIFT_COMPILER_IS_MSVC
+#pragma warning(pop)
+#endif
 
 #endif
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1887,6 +1887,7 @@ getContextualNilDiagnostic(ContextualTypePurpose CTP) {
   case CTP_SubscriptAssignSource:
     return diag::cannot_convert_subscript_assign_nil;
   }
+  llvm_unreachable("Unhandled ContextualTypePurpose in switch");
 }
 
 bool ContextualFailure::diagnoseConversionToNil() const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2129,6 +2129,7 @@ static ConstraintFix *fixPropertyWrapperFailure(
       return UseWrappedValue::create(cs, decl, baseTy, toType.getValueOr(type),
                                      locator);
     }
+    llvm_unreachable("Unhandled Fix type in switch");
   };
 
   if (auto storageWrapper = cs.getStorageWrapperInformation(resolvedOverload)) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1818,6 +1818,7 @@ SynthesizeAccessorRequest::evaluate(Evaluator &evaluator,
 #include "swift/AST/AccessorKinds.def"
     llvm_unreachable("not an opaque accessor");
   }
+  llvm_unreachable("Unhandled AccessorKind in switch");
 }
 
 llvm::Expected<bool>

--- a/lib/Syntax/Trivia.cpp.gyb
+++ b/lib/Syntax/Trivia.cpp.gyb
@@ -36,6 +36,7 @@ TriviaPiece TriviaPiece::fromText(TriviaKind kind, StringRef text) {
 % end
 % end
   }
+  llvm_unreachable("Unhandled TriviaKind in switch");
 }
 
 void TriviaPiece::dump(llvm::raw_ostream &OS, unsigned Indent) const {

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -40,6 +40,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, PassPipelineKind Kind) {
     return os << #NAME;
 #include "swift/SILOptimizer/PassManager/PassPipeline.def"
   }
+  llvm_unreachable("Unhandled PassPipelineKind in switch");
 }
 } // namespace llvm
 

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -363,6 +363,7 @@ StringRef SDKNodeType::getTypeRoleDescription() const {
   case SDKNodeKind::TypeWitness:
     return "type witness type";
   }
+  llvm_unreachable("Unhandled SDKNodeKind in switch");
 }
 
 SDKNode *SDKNodeRoot::getInstance(SDKContext &Ctx) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes a bunch of warnings, most of them complaining about not all code paths returning a value. Also fixes complaints about `dump` being for use only in the debugger when one `dump` function calls another. 