### PR TITLE
Remove stdlib and runtime dependencies on Foundation and CF

### DIFF
--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -79,6 +79,11 @@ namespace swift {
 SWIFT_RUNTIME_EXPORT
 void swift_rootObjCDealloc(HeapObject *self);
 
+// Uses Swift bridging to box a C string into an NSString without introducing
+// a link-time dependency on NSString.
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+id swift_stdlib_NSStringFromUTF8(const char *cstr, int len);
+
 }
 
 #endif // SWIFT_OBJC_INTEROP

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -85,6 +85,22 @@ public protocol _ObjectiveCBridgeable {
 
 #if _runtime(_ObjC)
 
+@_silgen_name("swift_stdlib_connectNSBaseClasses")
+internal func _connectNSBaseClasses() -> Bool
+
+
+private let _bridgeInitializedSuccessfully = _connectNSBaseClasses()
+internal var _orphanedFoundationSubclassesReparented: Bool = false
+
+/// Reparents the SwiftNativeNS*Base classes to be subclasses of their respective
+/// Foundation types, or is false if they couldn't be reparented. Must be run
+/// in order to bridge Swift Strings, Arrays, Dictionarys, Sets, or Enumerators to ObjC.
+ internal func _connectOrphanedFoundationSubclassesIfNeeded() -> Void {
+  let bridgeWorks = _bridgeInitializedSuccessfully
+  _debugPrecondition(bridgeWorks)
+  _orphanedFoundationSubclassesReparented = true
+}
+
 //===--- Bridging for metatypes -------------------------------------------===//
 
 /// A stand-in for a value of metatype type.

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -229,8 +229,6 @@ set(swift_core_private_link_libraries)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
 if(SWIFT_PRIMARY_VARIANT_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
   list(APPEND swift_core_link_flags "-all_load")
-  list(APPEND swift_core_framework_depends Foundation)
-  list(APPEND swift_core_framework_depends CoreFoundation)
   list(APPEND swift_core_private_link_libraries icucore)
 else()
   # With the GNU linker the equivalent of -all_load is to tell the linker

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -417,13 +417,27 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 
 #if _runtime(_ObjC)
+  
   /// Convert to an NSArray.
   ///
   /// - Precondition: `Element` is bridged to Objective-C.
   ///
   /// - Complexity: O(1).
-  @inlinable
+  @usableFromInline
   internal __consuming func _asCocoaArray() -> AnyObject {
+    // _asCocoaArray was @inlinable in Swift 5.0 and 5.1, which means that there
+    // are existing apps out there that effectively have the old implementation
+    // Be careful with future changes to this function. Here be dragons!
+    // The old implementation was
+    // if count == 0 {
+    //   return _emptyArrayStorage
+    // }
+    // if _isBridgedVerbatimToObjectiveC(Element.self) {
+    //   return _storage
+    // }
+    // return __SwiftDeferredNSArray(_nativeStorage: _storage)
+    
+    _connectOrphanedFoundationSubclassesIfNeeded()
     if count == 0 {
       return _emptyArrayStorage
     }

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -29,6 +29,7 @@ internal func _stdlib_NSDictionary_allKeys(
 extension _NativeDictionary { // Bridging
   @usableFromInline
   __consuming internal func bridged() -> AnyObject {
+    _connectOrphanedFoundationSubclassesIfNeeded()
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
 
@@ -67,6 +68,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
 
   internal init(_ base: __owned _NativeDictionary<Key, Value>) {
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Key.self))
+    _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = base
     self.bridgedKeys = nil
     self.nextBucket = base.hashTable.startBucket
@@ -77,6 +79,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
   @nonobjc
   internal init(_ deferred: __owned _SwiftDeferredNSDictionary<Key, Value>) {
     _internalInvariant(!_isBridgedVerbatimToObjectiveC(Key.self))
+    _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = deferred.native
     self.bridgedKeys = deferred.bridgeKeys()
     self.nextBucket = base.hashTable.startBucket

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -76,7 +76,10 @@ internal struct _UnmanagedAnyObjectArray {
 // renamed. The old name must not be used in the new runtime.
 final internal class __SwiftEmptyNSEnumerator
   : __SwiftNativeNSEnumerator, _NSEnumerator {
-  internal override required init() { super.init() }
+  internal override required init() {
+    super.init()
+    _internalInvariant(_orphanedFoundationSubclassesReparented)
+  }
 
   @objc
   internal func nextObject() -> AnyObject? {

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -47,10 +47,12 @@ internal func getChild<T>(of value: T, type: Any.Type, index: Int) -> (label: St
 internal func _getQuickLookObject<T>(_: T) -> AnyObject?
 
 @_silgen_name("_swift_stdlib_NSObject_isKindOfClass")
-internal func _isImpl(_ object: AnyObject, kindOf: AnyObject) -> Bool
+internal func _isImpl(_ object: AnyObject, kindOf: UnsafePointer<CChar>) -> Bool
 
 internal func _is(_ object: AnyObject, kindOf `class`: String) -> Bool {
-  return _isImpl(object, kindOf: `class` as AnyObject)
+  return `class`.withCString {
+    return _isImpl(object, kindOf: $0)
+  }
 }
 
 internal func _getClassPlaygroundQuickLook(

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -14,24 +14,21 @@
 
 import SwiftShims
 
-@_silgen_name("swift_stdlib_CFSetGetValues")
-internal
-func _stdlib_CFSetGetValues(
-  _ nss: AnyObject,
-  _: UnsafeMutablePointer<AnyObject>)
-
 /// Equivalent to `NSSet.allObjects`, but does not leave objects on the
 /// autorelease pool.
 internal func _stdlib_NSSet_allObjects(_ object: AnyObject) -> _BridgingBuffer {
   let nss = unsafeBitCast(object, to: _NSSet.self)
-  let storage = _BridgingBuffer(nss.count)
-  _stdlib_CFSetGetValues(nss, storage.baseAddress)
+  let count = nss.count
+  let storage = _BridgingBuffer(count)
+  nss.getObjects(storage.baseAddress, count: count)
   return storage
 }
 
 extension _NativeSet { // Bridging
   @usableFromInline
   internal __consuming func bridged() -> AnyObject {
+    _connectOrphanedFoundationSubclassesIfNeeded()
+    
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
 
@@ -70,6 +67,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
 
   internal init(_ base: __owned _NativeSet<Element>) {
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self))
+    _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = base
     self.bridgedElements = nil
     self.nextBucket = base.hashTable.startBucket
@@ -80,6 +78,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
   @nonobjc
   internal init(_ deferred: __owned _SwiftDeferredNSSet<Element>) {
     _internalInvariant(!_isBridgedVerbatimToObjectiveC(Element.self))
+    _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = deferred.native
     self.bridgedElements = deferred.bridgeElements()
     self.nextBucket = base.hashTable.startBucket

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -171,6 +171,10 @@ internal protocol _NSSetCore: _NSCopying, _NSFastEnumeration {
 /// supplies.
 @unsafe_no_objc_tagged_pointer @objc
 internal protocol _NSSet: _NSSetCore {
+  @objc(getObjects:count:) func getObjects(
+    _ buffer: UnsafeMutablePointer<AnyObject>,
+    count: Int
+  )
 }
 
 /// A shadow for the API of NSNumber we will use in the core

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -442,6 +442,9 @@ extension String {
   @_effects(releasenone)
   public // SPI(Foundation)
   func _bridgeToObjectiveCImpl() -> AnyObject {
+    
+    _connectOrphanedFoundationSubclassesIfNeeded()
+    
     // Smol ASCII a) may bridge to tagged pointers, b) can't contain a BOM
     if _guts.isSmallASCII {
       let maybeTagged = _guts.asSmall.withUTF8 { bufPtr in
@@ -453,6 +456,7 @@ extension String {
       }
       if let tagged = maybeTagged { return tagged }
     }
+    
     if _guts.isSmall {
         // We can't form a tagged pointer String, so grow to a non-small String,
         // and bridge that instead. Also avoids CF deleting any BOM that may be
@@ -495,6 +499,17 @@ class __SwiftNativeNSString {
 @_silgen_name("swift_stdlib_getDescription")
 public func _getDescription<T>(_ x: T) -> AnyObject {
   return String(reflecting: x)._bridgeToObjectiveCImpl()
+}
+
+@_silgen_name("swift_stdlib_NSStringFromUTF8")
+@usableFromInline //this makes the symbol available to the runtime :(
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+internal func _NSStringFromUTF8(_ s: UnsafePointer<UInt8>, _ len: Int)
+  -> AnyObject {
+  return String(
+    decoding: UnsafeBufferPointer(start: s, count: len),
+    as: UTF8.self
+  )._bridgeToObjectiveCImpl()
 }
 
 #else // !_runtime(_ObjC)

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -72,13 +72,13 @@ SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
 - (instancetype)autorelease;
 - (NSUInteger)retainCount;
 
-- (NSString *)description;
-- (NSString *)debugDescription;
+- (id /* NSString */)description;
+- (id /* NSString */)debugDescription;
 @end
 
 namespace swift {
 
-NSString *getDescription(OpaqueValue *value, const Metadata *type);
+id getDescription(OpaqueValue *value, const Metadata *type);
 
 }
 

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -336,7 +336,7 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
       selfHeader->type, hashableConformance);
 }
 
-static NSString *getValueDescription(__SwiftValue *self) {
+static id getValueDescription(__SwiftValue *self) {
   const Metadata *type;
   const OpaqueValue *value;
   std::tie(type, value) = getValueFromSwiftValue(self);
@@ -346,15 +346,15 @@ static NSString *getValueDescription(__SwiftValue *self) {
   auto copy = type->allocateBufferIn(&copyBuf);
   type->vw_initializeWithCopy(copy, const_cast<OpaqueValue *>(value));
 
-  NSString *string = getDescription(copy, type);
+  id string = getDescription(copy, type);
   type->deallocateBufferIn(&copyBuf);
   return string;
 }
 
-- (NSString *)description {
+- (id /* NSString */)description {
   return getValueDescription(self);
 }
-- (NSString *)debugDescription {
+- (id /* NSString */)debugDescription {
   return getValueDescription(self);
 }
 
@@ -363,11 +363,11 @@ static NSString *getValueDescription(__SwiftValue *self) {
 - (const Metadata *)_swiftTypeMetadata {
   return getSwiftValueTypeMetadata(self);
 }
-- (NSString *)_swiftTypeName {
+- (id /* NSString */)_swiftTypeName {
   TypeNamePair typeName
     = swift_getTypeName(getSwiftValueTypeMetadata(self), true);
-
-  return [NSString stringWithUTF8String: typeName.data];
+  id str = swift_stdlib_NSStringFromUTF8(typeName.data, typeName.length);
+  return [str autorelease];
 }
 - (const OpaqueValue *)_swiftValue {
   return getValueFromSwiftValue(self).second;

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -19,82 +19,34 @@
 #if SWIFT_OBJC_INTEROP
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Debug.h"
-#import <Foundation/Foundation.h>
 #include <TargetConditionals.h>
 #include "../SwiftShims/FoundationShims.h"
+#include <dlfcn.h>
+
+struct os_system_version_s {
+    unsigned int major;
+    unsigned int minor;
+    unsigned int patch;
+};
+
+static os_system_version_s getOSVersion() {
+  auto lookup =
+    (int(*)(struct os_system_version_s * _Nonnull))
+    dlsym(RTLD_DEFAULT, "os_system_version_get_current_version");
+  
+  struct os_system_version_s vers = { 0, 0, 0 };
+  lookup(&vers);
+  return vers;
+}
 
 using namespace swift;
-
-/// Load the contents of the SystemVersion plist, looking in the appropriate
-/// place if running on the iOS simulator.
-static NSDictionary *systemVersionDictionaryFromPlist() {
-  NSString *plistPath = @"/System/Library/CoreServices/SystemVersion.plist";
-
-#if TARGET_OS_SIMULATOR
-  // When targeting the iOS simulator, look in a special location so we do
-  // not pick up the host OS version.
-  const char *simulatorRoot = getenv("IPHONE_SIMULATOR_ROOT");
-  if (!simulatorRoot) {
-    fatalError(/* flags = */ 0,
-               "Unable to check API availability: "
-               "IPHONE_SIMULATOR_ROOT not set when running under simulator");
-  }
-
-  plistPath = [NSString stringWithFormat:@"%s%@", simulatorRoot, plistPath];
-#endif
-
-  return [NSDictionary dictionaryWithContentsOfFile:plistPath];
-}
-
-/// Load and parse the SystemVersion dictionary to determine the current
-/// operating system version.
-static NSOperatingSystemVersion operatingSystemVersionFromPlist() {
-  NSDictionary *plistDictionary = systemVersionDictionaryFromPlist();
-  if (!plistDictionary) {
-    fatalError(/* flags = */ 0,
-               "Unable to check API availability: "
-               "system version dictionary not found");
-  }
-
-  NSString *versionString = [plistDictionary objectForKey:@"ProductVersion"];
-  if (!versionString) {
-    fatalError(/* flags = */ 0,
-               "Unable to check API availability: "
-               "ProductVersion not present in system version dictionary");
-  }
-
-  // We expect versionString to be of the form x[.y[.z]].
-  NSArray *components = [versionString componentsSeparatedByString:@"."];
-  NSUInteger cnt = [components count];
-
-  NSOperatingSystemVersion versionStruct;
-  versionStruct.majorVersion = [[components objectAtIndex:0] integerValue];
-  versionStruct.minorVersion =
-      (1 < cnt) ? [[components objectAtIndex:1] integerValue] : 0;
-  versionStruct.patchVersion =
-      (2 < cnt) ? [[components objectAtIndex:2] integerValue] : 0;
-
-  return versionStruct;
-}
-
-static NSOperatingSystemVersion getOSVersion() {
-  // Use -[NSProcessInfo.operatingSystemVersion] when present
-  // (on iOS 8 and OS X 10.10 and above).
-  if ([NSProcessInfo
-       instancesRespondToSelector:@selector(operatingSystemVersion)]) {
-    return [[NSProcessInfo processInfo] operatingSystemVersion];
-  } else {
-    // Otherwise load and parse from SystemVersion dictionary.
-    return operatingSystemVersionFromPlist();
-  }
-}
 
 /// Return the version of the operating system currently running for use in
 /// API availability queries.
 _SwiftNSOperatingSystemVersion swift::_swift_stdlib_operatingSystemVersion() {
-  NSOperatingSystemVersion version = SWIFT_LAZY_CONSTANT(getOSVersion());
+  os_system_version_s version = SWIFT_LAZY_CONSTANT(getOSVersion());
 
-  return { version.majorVersion, version.minorVersion, version.patchVersion };
+  return { (int)version.major, (int)version.minor, (int)version.patch };
 }
 #endif
 

--- a/stdlib/public/stubs/Reflection.mm
+++ b/stdlib/public/stubs/Reflection.mm
@@ -13,14 +13,16 @@
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
-#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/NSObject.h>
 
 SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_API
 bool _swift_stdlib_NSObject_isKindOfClass(
     id _Nonnull object,
-    NSString * _Nonnull className) {
-  return [object isKindOfClass:NSClassFromString(className)];
+    char * _Nonnull className) {
+  Class cls = objc_lookUpClass(className);
+  return [object isKindOfClass:cls];
 }
 #endif
 

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -52,7 +52,7 @@ using namespace swift;
 // runtime.
 % for Class in ('Array', 'Dictionary', 'Set', 'String', 'Enumerator'):
 SWIFT_RUNTIME_STDLIB_API
-@interface __SwiftNativeNS${Class}Base : NS${Class}
+@interface __SwiftNativeNS${Class}Base : NSObject
 {
  @private
   SWIFT_HEAPOBJECT_NON_OBJC_MEMBERS;
@@ -112,37 +112,27 @@ SWIFT_RUNTIME_STDLIB_API
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
 bool
-swift_stdlib_NSObject_isEqual(NSObject *lhs,
-                              NSObject *rhs) {
+swift_stdlib_NSObject_isEqual(id lhs,
+                              id rhs) {
   return (lhs == rhs) || [lhs isEqual:rhs];
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
-    NSString *lhs, NSString *rhs) {
-  // 'kCFCompareNonliteral' actually means "normalize to NFD".
-  return CFStringCompare((__bridge CFStringRef)lhs,
-                         (__bridge CFStringRef)rhs, kCFCompareNonliteral);
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+bool
+swift_stdlib_connectNSBaseClasses() {
+% for Class in ('Array', 'Dictionary', 'Set', 'String', 'Enumerator'):
+  Class NS${Class}Super = objc_lookUpClass("NS${Class}");
+  if (!NS${Class}Super) return false;
+  Class NS${Class}OurClass = objc_lookUpClass("__SwiftNativeNS${Class}Base");
+  if (!NS${Class}OurClass) return false;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  class_setSuperclass(NS${Class}OurClass, NS${Class}Super);
+#pragma clang diagnostic pop
+% end
+  return true;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-int32_t
-swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr(void *Lhs,
-                                                             void *Rhs) {
-  NSString *lhs = (NSString *)Lhs;
-  NSString *rhs = (NSString *)Rhs;
-
-  // 'kCFCompareNonliteral' actually means "normalize to NFD".
-  int Result = CFStringCompare((__bridge CFStringRef)lhs,
-                               (__bridge CFStringRef)rhs, kCFCompareNonliteral);
-  return Result;
-}
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-void swift_stdlib_CFSetGetValues(NSSet *set,
-                                 const void **values) {
-  CFSetGetValues((__bridge CFSetRef)set, values);
-}
 #endif
 
 // ${'Local Variables'}:

--- a/test/Inputs/SmallStringTestUtilities.swift
+++ b/test/Inputs/SmallStringTestUtilities.swift
@@ -1,0 +1,123 @@
+#if _runtime(_ObjC)
+import Foundation
+#endif
+import StdlibUnittest
+
+extension String: Error {}
+
+func verifySmallString(_ small: _SmallString, _ input: String,
+ file: String = #file, line: UInt = #line
+) {
+  let loc = SourceLoc(file, line, comment: "test data")
+  expectEqual(_SmallString.capacity, small.count + small.unusedCapacity,
+              stackTrace: SourceLocStack().with(loc))
+  let tiny = Array(input.utf8)
+  expectEqual(tiny.count, small.count, stackTrace: SourceLocStack().with(loc))
+  for (lhs, rhs) in zip(tiny, small) {
+    expectEqual(lhs, rhs, stackTrace: SourceLocStack().with(loc))
+  }
+
+  let smallFromUTF16 = _SmallString(Array(input.utf16))
+  expectNotNil(smallFromUTF16,
+               stackTrace: SourceLocStack().with(loc))
+  expectEqualSequence(small, smallFromUTF16!,
+                      stackTrace: SourceLocStack().with(loc))
+
+  // Test slicing
+  //
+  for i in 0..<small.count {
+    for j in i...small.count {
+      expectEqualSequence(tiny[i..<j], small[i..<j],
+                          stackTrace: SourceLocStack().with(loc))
+      if j < small.count {
+        expectEqualSequence(tiny[i...j], small[i...j],
+                            stackTrace: SourceLocStack().with(loc))
+      }
+    }
+  }
+
+  // Test RAC and Mutable
+  var copy = small
+  for i in 0..<small.count / 2 {
+    let tmp = copy[i]
+    copy[i] = copy[copy.count - 1 - i]
+    copy[copy.count - 1 - i] = tmp
+  }
+  expectEqualSequence(small.reversed(), copy,
+                      stackTrace: SourceLocStack().with(loc))
+}
+
+// Testing helper inits
+extension _SmallString {
+  init?(_ codeUnits: Array<UInt8>) {
+    guard let smol = codeUnits.withUnsafeBufferPointer({
+      return _SmallString($0)
+    }) else {
+      return nil
+    }
+    self = smol
+  }
+
+  init?(_ codeUnits: Array<UInt16>) {
+    let str = codeUnits.withUnsafeBufferPointer {
+      return String._uncheckedFromUTF16($0)
+    }
+    if !str._guts.isSmall {
+      return nil
+    }
+    self.init(str._guts._object)
+  }
+
+ 
+#if _runtime(_ObjC)
+  init?(_cocoaString ns: NSString) {
+#if arch(i386) || arch(arm)
+    return nil
+#else
+    guard _isObjCTaggedPointer(ns) else { return nil }
+    self.init(taggedCocoa: ns)
+#endif
+  }
+#endif
+
+  func _appending(_ other: _SmallString) -> _SmallString? {
+    return _SmallString(self, appending: other)
+  }
+
+  func _repeated(_ n: Int) -> _SmallString? {
+    var base = self
+    let toAppend = self
+    for _ in 0..<(n &- 1) {
+      guard let s = _SmallString(
+        base, appending: toAppend)
+      else { return nil }
+      base = s
+    }
+    return base
+  }
+}
+
+func expectSmall(_ str: String,
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+ ) {
+  switch str._classify()._form {
+    case ._small: return
+    default: expectationFailure("expected: small", trace: "",
+      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  }
+}
+
+func expectCocoa(_ str: String,
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+ ) {
+  switch str._classify()._form {
+    case ._cocoa: return
+    default: expectationFailure("expected: cocoa", trace: "",
+      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  }
+}
+

--- a/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
+++ b/test/Interpreter/SDK/SwiftNativeNSXXXCoding.swift
@@ -47,14 +47,6 @@ if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   testSuite.test("NSString") {
     test(type: NSString.self)
   }
-
-  testSuite.test("NSData") {
-    test(type: NSData.self)
-  }
-
-  testSuite.test("NSIndexSet") {
-    test(type: NSIndexSet.self)
-  }
 }
 
 runAllTests()

--- a/test/stdlib/NSObject.swift
+++ b/test/stdlib/NSObject.swift
@@ -139,7 +139,6 @@ print("done NSMutableString hashValue")
 // CHECK-NEXT: [[H2]]
 // CHECK-NEXT: done NSMutableString hashValue
 
-
 class NoisyHash : NSObject {
   override var hash : Int {
     print("so hash")
@@ -263,3 +262,8 @@ print( // CHECK-NEXT: true
   _getSuperclass(_getSuperclass(E.self)!) == NSObject.self)
 print( // CHECK-NEXT: true
   _getSuperclass(_getSuperclass(_getSuperclass(E.self)!)!) == nil)
+
+print("NSObject's type id")
+print(CFGetTypeID(NSObject()))
+// CHECK: NSObject's type id
+// CHECK-NEXT: 1


### PR DESCRIPTION
Relanding https://github.com/apple/swift/pull/26630, with some fixes and improvements (now also decouples from CF properly!)

Fixes rdar://34198279