### PR TITLE
Add comments to `destroy_addr` in SIL.rst.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2525,9 +2525,10 @@ except that ``destroy_addr`` may be used even if ``%0`` is of an
 address-only type.  This does not deallocate memory; it only destroys the
 pointed-to value, leaving the memory uninitialized.
 
-If ``T`` is a trivial type, then ``destroy_addr`` is a no-op. However, even a
-memory location ``%a`` with a trivial type must not be accessed after a
-``destroy_addr %a``.
+If ``T`` is a trivial type, then ``destroy_addr`` can be safely
+eliminated. However, a memory location ``%a`` must not be accessed
+after ``destroy_addr %a`` (which has not yet been eliminated)
+regardless of its type.
 
 index_addr
 ``````````


### PR DESCRIPTION
`destroy_addr` is never semantically a "no-op". Just because an
instruction can be safely eliminated does not mean the instruction has
no semantics! That would be like saying we could move an unknown
memory read below an otherwise dead store!