### PR TITLE
[SIMD] Add disambiguating += and -= operators.

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -1407,3 +1407,16 @@ where T: SIMD, T.Scalar: FloatingPoint {
   }
   return result
 }
+
+// Break the ambiguity between AdditiveArithmetic and SIMD for += and -=
+extension SIMD where Self: AdditiveArithmetic, Self.Scalar: FloatingPoint {
+  @_transparent
+  public static func +=(lhs: inout Self, rhs: Self) {
+    lhs = lhs + rhs
+  }
+
+  @_transparent
+  public static func -=(lhs: inout Self, rhs: Self) {
+    lhs = lhs - rhs
+  }
+}

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -1410,12 +1410,12 @@ where T: SIMD, T.Scalar: FloatingPoint {
 
 // Break the ambiguity between AdditiveArithmetic and SIMD for += and -=
 extension SIMD where Self: AdditiveArithmetic, Self.Scalar: FloatingPoint {
-  @_transparent
+  @_alwaysEmitIntoClient
   public static func +=(lhs: inout Self, rhs: Self) {
     lhs = lhs + rhs
   }
 
-  @_transparent
+  @_alwaysEmitIntoClient
   public static func -=(lhs: inout Self, rhs: Self) {
     lhs = lhs - rhs
   }

--- a/test/stdlib/SIMD_as_AdditiveArithmetic.swift
+++ b/test/stdlib/SIMD_as_AdditiveArithmetic.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+extension SIMD2: AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD3: AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD4: AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD8: AdditiveArithmetic where Scalar: FloatingPoint { }


### PR DESCRIPTION
The introduction of += and -= default implementations on
AdditiveArithmetic introduces an ambiguity with the += and -=
implementations on SIMD (where Scalar: FloatingPoint). Break the
ambiguity by adding another set of definitions of += and -= on
AdditiveArithmetic & SIMD where Self.Scalar: FloatingPoint.

Fixes rdar://problem/55278156.
