### PR TITLE
[5.1 EARLY] [Frontend] Avoid doing whole-module work under primary-file typecheck

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1058,10 +1058,12 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::ActionType::Typecheck) {
     if (emitIndexData(Invocation, Instance))
       return true;
-    if (emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance,
-                                                            Invocation,
-                                                            moduleIsPublic)) {
-      return true;
+    if (opts.InputsAndOutputs.isWholeModule()) {
+      if (emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance,
+                                                              Invocation,
+                                                              moduleIsPublic)) {
+        return true;
+      }
     }
     return false;
   }

--- a/test/Index/Store/driver-index-with-auxiliary-outputs.swift
+++ b/test/Index/Store/driver-index-with-auxiliary-outputs.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+
+// This test is very deliberately *not* indexing the current file; we need to
+// make sure the frontend job doesn't try to emit the auxiliary outputs based
+// on the non-indexed files. (This is how Xcode currently constructs -index-file
+// invocations: take a normal build command and add extra arguments to it.)
+// RUN: %target-build-swift -index-file -index-file-path %S/Inputs/SwiftModuleA.swift %S/Inputs/SwiftModuleA.swift %s -index-store-path %t/idx -module-name driver_index -emit-objc-header-path %t/out.h -emit-module-interface-path %t/out.swiftinterface
+
+// RUN: test ! -f %t/out.h
+// RUN: test ! -f %t/out.swiftinterface
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+// CHECK-LABEL: module-name: driver_index
+// CHECK: DEPEND START
+// CHECK-NOT: Record |
+// CHECK: Record | user | {{.+}}SwiftModuleA.swift
+// CHECK-NOT: Record |
+// CHECK: DEPEND END
+
+#if _runtime(_ObjC)
+
+// Do a stronger test here involving checking @objc
+import ObjectiveC
+
+public class PossiblyObjC: NSObject {
+  @objc public init(x: Int) {}
+}
+
+#else // _runtime(_ObjC)
+
+public class Boring {
+  init()
+}
+
+#endif // _runtime(_ObjC)


### PR DESCRIPTION
Same as #27158, but for the early cut 5.1 branch.

**Explanation**: Indexing logic in Xcode invokes `swiftc` in a way that just performs type-checking for a single file and then emits indexing data. However, the build invocation Xcode is using still implies the creation of auxiliary outputs that require whole-module knowledge, like module interface files. For now, avoid crashing on this by checking if we're not in a whole-module context and bailing out if so.

**Scope**: Only affects invocations of `swiftc` that use `-index-file` (and direct invocations of the compiler frontend, which is considered an unstable and unsupported interface for external tools).

**Issue**: rdar://problem/53117124

**Risk**: Very low. This code path is not used for compilation.

**Testing**: Added a compiler regression test that previously produced the same crash signature as in the Radar.

**Reviewed by**: @akyrtzi