### PR TITLE
[master-next] Update build presets to fix package bots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -20,7 +20,7 @@ swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;parse
 
 [preset: mixin_buildbot_install_components_with_clang]
 swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt;clangd
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.


### PR DESCRIPTION
Upstream clang renamed “clang-headers” to “clang-resource-headers” several months ago. We corrected for this in apple/swift#23034, but a subsequent change to build-presets.ini reintroduced the old name into a new part of the file. This change corrects that issue.