### PR TITLE
[5.1] [Sema] Stop visiting existential exprs an extra time checking for uses

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -22,12 +22,15 @@
 #include "swift/AST/Pattern.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/SaveAndRestore.h"
+
+#define DEBUG_TYPE "Sema"
 using namespace swift;
 
 /// Return true if this expression is an implicit promotion from T to T?.
@@ -2045,6 +2048,10 @@ class VarDeclUsageChecker : public ASTWalker {
   /// This is a mapping from VarDecls to the if/while/guard statement that they
   /// occur in, when they are in a pattern in a StmtCondition.
   llvm::SmallDenseMap<VarDecl*, LabeledConditionalStmt*> StmtConditionForVD;
+
+#ifndef NDEBUG
+  llvm::SmallPtrSet<Expr*, 32> AllExprsSeen;
+#endif
   
   bool sawError = false;
   
@@ -2788,12 +2795,18 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
 
 /// The heavy lifting happens when visiting expressions.
 std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
+  STATISTIC(VarDeclUsageCheckerExprVisits,
+            "# of times VarDeclUsageChecker::walkToExprPre is called");
+  ++VarDeclUsageCheckerExprVisits;
+
   // Sema leaves some subexpressions null, which seems really unfortunate.  It
   // should replace them with ErrorExpr.
   if (E == nullptr || !E->getType() || E->getType()->hasError()) {
     sawError = true;
     return { false, E };
   }
+
+  assert(AllExprsSeen.insert(E).second && "duplicate traversal");
 
   // If this is a DeclRefExpr found in a random place, it is a load of the
   // vardecl.
@@ -2839,9 +2852,13 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
     return { false, E };
   }
   
-  // If we see an OpenExistentialExpr, remember the mapping for its OpaqueValue.
-  if (auto *oee = dyn_cast<OpenExistentialExpr>(E))
+  // If we see an OpenExistentialExpr, remember the mapping for its OpaqueValue
+  // and only walk the subexpr.
+  if (auto *oee = dyn_cast<OpenExistentialExpr>(E)) {
     OpaqueValueMap[oee->getOpaqueValue()] = oee->getExistentialValue();
+    oee->getSubExpr()->walk(*this);
+    return { false, E };
+  }
 
   // Visit bindings.
   if (auto ove = dyn_cast<OpaqueValueExpr>(E)) {

--- a/validation-test/compiler_scale/var_decl_usage_checker.swift.gyb
+++ b/validation-test/compiler_scale/var_decl_usage_checker.swift.gyb
@@ -1,0 +1,17 @@
+// RUN: %scale-test --begin 1 --end 5 --step 1 --select VarDeclUsageCheckerExprVisits %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+protocol Proto {}
+extension Proto {
+  var selfish: Proto { return self }
+}
+
+struct X: Proto {}
+
+func test(_ x: X) -> Proto {
+  return x
+%for i in range(0, N*5):
+    .selfish
+%end
+}


### PR DESCRIPTION
**Explanation**: In April John fixed a bug where protocol members were not considered as uses of their base values, leading to spurious "var 'blah' was never used" errors. However, in doing so he left in the old logic to visit the base values separately from their uses, which meant they ended up getting visited twice. If protocol member accesses are chained, this leads to an exponential amount of work in validating the use of these expressions. This patch skips the old path and only uses the new path.

**Scope**: Affects the time spent on validating type-checked expressions that access protocol members (i.e. not uncommon, just probably unnoticed).

**Issue**: [SR-11012](https://bugs.swift.org/browse/SR-11012) / rdar://problem/52194425

**Risk**: Low. Affects a lot of code, but the change is very straightforward.

**Testing**: Added a compiler regression test, verified that the Kitura test case in SR-11012 compiles quickly again.

**Reviewed by**: @slavapestov  