### PR TITLE
[5.1] Add presets for llbuild smoke tests and add testing of sourcekit-lsp

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1386,37 +1386,80 @@ skip-test-osx
 
 
 #===------------------------------------------------------------------------===#
-# Test swiftPM on macOS builder
+# Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
-
-[preset: buildbot_swiftpm_macos_platform,tools=RA,stdlib=RA]
-mixin-preset=
-    buildbot_incremental_base
-    mixin_buildbot_install_components_with_clang
-
+[preset: mixin_swiftpm_base]
+mixin-preset=buildbot_incremental_base
 build-subdir=buildbot_incremental
 
-# Build Release without debug info, because it is faster to build.
-release
-assertions
-
 libcxx
-
-# Build llbuild & swiftpm here
 llbuild
 swiftpm
-
-sourcekit-lsp
 
 install-swift
 install-llbuild
 install-swiftpm
 install-libcxx
 
-dash-dash
-
 skip-test-swift
 skip-test-cmark
+
+[preset: mixin_swiftpm_macos_platform]
+mixin-preset=
+    mixin_swiftpm_base
+    mixin_buildbot_install_components_with_clang
+
+[preset: mixin_swiftpm_linux_platform]
+mixin-preset=
+    mixin_swiftpm_base
+    mixin_linux_install_components_with_clang
+
+libdispatch
+foundation
+xctest
+
+install-foundation
+install-libdispatch
+install-xctest
+
+skip-test-foundation
+skip-test-libdispatch
+skip-test-xctest
+
+# Builds enough of the the toolchain to build a swift pacakge on macOS.
+[preset: mixin_swiftpm_package_macos_platform]
+mixin-preset=mixin_swiftpm_macos_platform
+
+# Build stdlib for all platforms.
+ios
+tvos
+watchos
+
+skip-test-llbuild
+skip-test-swiftpm
+
+# Builds enough of the the toolchain to build a swift pacakge on Linux.
+[preset: mixin_swiftpm_package_linux_platform]
+mixin-preset=mixin_swiftpm_linux_platform
+
+skip-test-llbuild
+skip-test-swiftpm
+
+
+#===------------------------------------------------------------------------===#
+# Test swiftPM on macOS builder
+#===------------------------------------------------------------------------===#
+
+[preset: buildbot_swiftpm_macos_platform,tools=RA,stdlib=RA]
+mixin-preset=mixin_swiftpm_macos_platform
+
+# Build Release without debug info, because it is faster to build.
+release
+assertions
+
+# Downstream projects that import llbuild+SwiftPM.
+sourcekit-lsp
+
 skip-test-llbuild
 
 #===------------------------------------------------------------------------===#
@@ -1424,39 +1467,16 @@ skip-test-llbuild
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_swiftpm_linux_platform,tools=RA,stdlib=RA]
-mixin-preset=
-    buildbot_incremental_base
-    mixin_linux_install_components_with_clang
-
-build-subdir=buildbot_incremental
+mixin-preset=mixin_swiftpm_linux_platform
 
 # Build Release without debug info, because it is faster to build.
 release
 assertions
 
-swiftpm
-
-xctest
-foundation
-libdispatch
-llbuild
-libcxx
+# Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
 
-install-swift
-install-llbuild
-install-swiftpm
-install-foundation
-install-libdispatch
-install-xctest
-install-libcxx
-
-skip-test-swift
-skip-test-cmark
 skip-test-llbuild
-skip-test-libdispatch
-skip-test-foundation
-skip-test-xctest
 
 #===------------------------------------------------------------------------===#
 # Test llbuild on macOS builder
@@ -1506,72 +1526,19 @@ skip-test-libdispatch
 skip-test-xctest
 
 #===------------------------------------------------------------------------===#
-# Test Swift Packages
-#===------------------------------------------------------------------------===#
-
-[preset: buildbot_swiftpm_package_base]
-mixin-preset=buildbot_incremental_base
-
-build-subdir=buildbot_incremental
-
-release
-assertions
-
-libcxx
-llbuild
-swiftpm
-indexstore-db
-sourcekit-lsp
-
-install-swift
-install-llbuild
-install-swiftpm
-install-libcxx
-
-skip-test-swift
-skip-test-cmark
-skip-test-llbuild
-skip-test-swiftpm
-
-[preset: buildbot_swiftpm_package_macos]
-mixin-preset=
-    buildbot_swiftpm_package_base
-    mixin_buildbot_install_components_with_clang
-
-# Build stdlib for all platforms.
-ios
-tvos
-watchos
-
-[preset: buildbot_swiftpm_package_linux]
-mixin-preset=
-    buildbot_swiftpm_package_base
-    mixin_linux_install_components_with_clang
-
-libdispatch
-foundation
-xctest
-
-install-foundation
-install-libdispatch
-install-xctest
-
-skip-test-foundation
-skip-test-libdispatch
-skip-test-xctest
-
-#===------------------------------------------------------------------------===#
 # Test SourceKit-LSP
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_sourcekitlsp_macos]
-mixin-preset=buildbot_swiftpm_package_macos
-
+mixin-preset=mixin_swiftpm_package_macos_platform
+release
+assertions
 sourcekit-lsp
 
 [preset: buildbot_sourcekitlsp_linux]
-mixin-preset=buildbot_swiftpm_package_linux
-
+mixin-preset=mixin_swiftpm_package_linux_platform
+release
+assertions
 sourcekit-lsp
 
 #===------------------------------------------------------------------------===#
@@ -1579,14 +1546,16 @@ sourcekit-lsp
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_indexstoredb_macos]
-mixin-preset=buildbot_swiftpm_package_macos
-
+mixin-preset=mixin_swiftpm_package_macos_platform
+release
+assertions
 indexstore-db
 sourcekit-lsp
 
 [preset: buildbot_indexstoredb_linux]
-mixin-preset=buildbot_swiftpm_package_linux
-
+mixin-preset=mixin_swiftpm_package_linux_platform
+release
+assertions
 indexstore-db
 sourcekit-lsp
 

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1483,47 +1483,28 @@ skip-test-llbuild
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_llbuild_macos_platform,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base
-
-build-subdir=buildbot_incremental
+mixin-preset=mixin_swiftpm_macos_platform
 
 # Build Release without debug info, because it is faster to build.
 release
 assertions
 
-# Build llbuild & swiftpm here
-llbuild
-swiftpm
-
-skip-test-swift
-skip-test-cmark
+# Downstream projects that import llbuild+SwiftPM.
+sourcekit-lsp
 
 #===------------------------------------------------------------------------===#
 # Test llbuild on Linux builder
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_llbuild_linux_platform,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base
-
-build-subdir=buildbot_incremental
+mixin-preset=mixin_swiftpm_linux_platform
 
 # Build Release without debug info, because it is faster to build.
 release
 assertions
 
-# Build llbuild & swiftpm here
-llbuild
-swiftpm
-
-xctest
-foundation
-llbuild
-
-skip-test-swift
-skip-test-cmark
-skip-test-foundation
-skip-test-libdispatch
-skip-test-xctest
+# Downstream projects that import llbuild+SwiftPM.
+sourcekit-lsp
 
 #===------------------------------------------------------------------------===#
 # Test SourceKit-LSP

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1475,10 +1475,35 @@ assertions
 llbuild
 swiftpm
 
-dash-dash
+skip-test-swift
+skip-test-cmark
+
+#===------------------------------------------------------------------------===#
+# Test llbuild on Linux builder
+#===------------------------------------------------------------------------===#
+
+[preset: buildbot_llbuild_linux_platform,tools=RA,stdlib=RA]
+mixin-preset=buildbot_incremental_base
+
+build-subdir=buildbot_incremental
+
+# Build Release without debug info, because it is faster to build.
+release
+assertions
+
+# Build llbuild & swiftpm here
+llbuild
+swiftpm
+
+xctest
+foundation
+llbuild
 
 skip-test-swift
 skip-test-cmark
+skip-test-foundation
+skip-test-libdispatch
+skip-test-xctest
 
 #===------------------------------------------------------------------------===#
 # Test Swift Packages


### PR DESCRIPTION
Cherry-pick #27103 to swift-5.1-branch

---

Adds presets for the llbuild smoke test jobs, and adds testing of sourcekit-lsp to prevent downstream CI failures.

Based on https://forums.swift.org/t/pr-test-presets-for-llbuild/28669/