### PR TITLE
[Compatibility50] Look up swift_getObjCClassMetadata at runtime.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,7 +205,7 @@ foreach(SDK ${SWIFT_SDKS})
 
     # NOTE create a stub BlocksRuntime library that can be used for the
     # reflection tests
-    file(WRITE ${test_bin_dir}/BlocksRuntime.c
+    file(WRITE ${test_bin_dir}/Inputs/BlocksRuntime.c
       "void
 #if defined(_WIN32)
 __declspec(dllexport)
@@ -220,7 +220,7 @@ _Block_release(void) { }\n")
       ARCHITECTURE ${ARCH}
       SDK ${SDK}
       INSTALL_IN_COMPONENT dev
-      ${test_bin_dir}/BlocksRuntime.c)
+      ${test_bin_dir}/Inputs/BlocksRuntime.c)
     set_target_properties(BlocksRuntimeStub${VARIANT_SUFFIX} PROPERTIES
       ARCHIVE_OUTPUT_DIRECTORY ${test_bin_dir}
       LIBRARY_OUTPUT_DIRECTORY ${test_bin_dir}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -178,8 +178,8 @@ config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode,
                                           execute_external=not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.swiftinterface',
-                   '.test-sh']
+config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.c',
+                   '.swiftinterface', '.test-sh']
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent

--- a/test/stdlib/Compatibility50Linking.c
+++ b/test/stdlib/Compatibility50Linking.c
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %s -all_load %test-resource-dir/%target-sdk-name/libswiftCompatibility50.a -lobjc -o %t/main
+// RUN: %target-run %t/main
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+// The compatibility library needs to have no build-time dependencies on
+// libswiftCore so it can be linked into a program that doesn't link
+// libswiftCore, but will load it at runtime, such as xctest.
+//
+// Test this by linking it into a plain C program and making sure it builds.
+
+int main(void) {}


### PR DESCRIPTION
This is the only dependency it has on libswiftCore. Looking this up at runtime allows its use in programs that don't link libswiftCore but might eventually load and run Swift code, such as xctest.

While we're in there, enable tests in files ending with `.c`.

rdar://problem/55274114