### PR TITLE
[NameLookup ASTScope] Ensure memberCount includes unparsed members

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -760,7 +760,7 @@ public:
   void addMember(Decl *member, Decl *hint = nullptr);
 
   /// See \c MemberCount
-  unsigned getMemberCount() const { return MemberCount; }
+  unsigned getMemberCount() const;
 
   /// Check whether there are lazily-loaded members.
   bool hasLazyMembers() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -807,6 +807,12 @@ bool IterableDeclContext::hasUnparsedMembers() const {
   return true;
 }
 
+unsigned IterableDeclContext::getMemberCount() const {
+  if (hasUnparsedMembers())
+    loadAllMembers();
+  return MemberCount;
+}
+
 void IterableDeclContext::loadAllMembers() const {
   ASTContext &ctx = getASTContext();
 


### PR DESCRIPTION
The recent change to delay member parsing broke `memberCount`. This PR fixes it. `memberCount` is only used for ASTScope lookup, so as soon as that is turned on, this PR will be tested by existing tests.