### PR TITLE
Kill validateDeclForNameLookup Harder

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2947,6 +2947,8 @@ public:
 /// TypeAliasDecl's always have 'MetatypeType' type.
 ///
 class TypeAliasDecl : public GenericTypeDecl {
+  friend class UnderlyingTypeRequest;
+  
   /// The location of the 'typealias' keyword
   SourceLoc TypeAliasLoc;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2976,20 +2976,28 @@ public:
 
   void setTypeEndLoc(SourceLoc e) { TypeEndLoc = e; }
 
-  TypeLoc &getUnderlyingTypeLoc() {
-    return UnderlyingTy;
+  /// Retrieve the TypeRepr corresponding to the parsed underlying type.
+  TypeRepr *getUnderlyingTypeRepr() const {
+    return UnderlyingTy.getTypeRepr();
   }
-  const TypeLoc &getUnderlyingTypeLoc() const {
-    return UnderlyingTy;
+  void setUnderlyingTypeRepr(TypeRepr *repr) {
+    UnderlyingTy = repr;
   }
-
+  
+  /// Retrieve the interface type of the underlying type.
+  Type getUnderlyingType() const;
   void setUnderlyingType(Type type);
 
   /// For generic typealiases, return the unbound generic type.
   UnboundGenericType *getUnboundGenericType() const;
 
+  /// Retrieve a sugared interface type containing the structure of the interface
+  /// type before any semantic validation has occured.
   Type getStructuralType() const;
 
+  /// Set the interface type of this typealias declaration from the underlying type.
+  void computeType();
+  
   bool isCompatibilityAlias() const {
     return Bits.TypeAliasDecl.IsCompatibilityAlias;
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -434,6 +434,9 @@ public:
   // Source location
   SourceLoc getNearestLoc() const;
 
+  // Cycle handling.
+  void noteCycleStep(DiagnosticEngine &diags) const;
+                           
   // Separate caching.
   bool isCached() const;
   Optional<Requirement> getCachedResult() const;
@@ -1120,6 +1123,9 @@ public:
   SourceLoc getNearestLoc() const {
     return SourceLoc();
   }
+                           
+  // Cycle handling.
+  void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
 void simple_display(llvm::raw_ostream &out, const TypeLoc source);
@@ -1174,7 +1180,7 @@ private:
   llvm::Expected<GenericSignature *>
   evaluate(Evaluator &evaluator, GenericContext *value) const;
   
-public:              
+public:
   // Separate caching.
   bool isCached() const { return true; }
   Optional<GenericSignature *> getCachedResult() const;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1181,6 +1181,28 @@ public:
   void cacheResult(GenericSignature *value) const;
 };
 
+/// Compute the interface type of the underlying definition type of a typealias declaration.
+class UnderlyingTypeRequest :
+    public SimpleRequest<UnderlyingTypeRequest,
+                         Type(TypeAliasDecl *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<Type> evaluate(Evaluator &evaluator,
+                                TypeAliasDecl *decl) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+  Optional<Type> getCachedResult() const;
+  void cacheResult(Type value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -132,5 +132,7 @@ SWIFT_REQUEST(TypeChecker, SynthesizeAccessorRequest,
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyUntilRequest,
               bool(AbstractFunctionDecl *, SourceLoc), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, UnderlyingTypeRequest, Type(TypeAliasDecl *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),
               Cached, NoLocationInfo)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -616,9 +616,9 @@ namespace {
     void visitTypeAliasDecl(TypeAliasDecl *TAD) {
       printCommon(TAD, "typealias");
       PrintWithColorRAII(OS, TypeColor) << " type='";
-      if (TAD->getUnderlyingTypeLoc().getType()) {
+      if (auto underlying = TAD->getUnderlyingType()) {
         PrintWithColorRAII(OS, TypeColor)
-          << TAD->getUnderlyingTypeLoc().getType().getString();
+          << underlying.getString();
       } else {
         PrintWithColorRAII(OS, TypeColor) << "<<<unresolved>>>";
       }
@@ -3378,6 +3378,12 @@ namespace {
     void visitTypeAliasType(TypeAliasType *T, StringRef label) {
       printCommon(label, "type_alias_type");
       printField("decl", T->getDecl()->printRef());
+      PrintWithColorRAII(OS, TypeColor) << " underlying='";
+      if (auto underlying = T->getSinglyDesugaredType()) {
+        PrintWithColorRAII(OS, TypeColor) << underlying->getString();
+      } else {
+        PrintWithColorRAII(OS, TypeColor) << "<<<unresolved>>>";
+      }
       if (T->getParent())
         printRec("parent", T->getParent());
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2294,7 +2294,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
     // preserving sugar.
     llvm::SaveAndRestore<GenericEnvironment*> setGenericEnv(Options.GenericEnv,
                                                 decl->getGenericEnvironment());
-    printTypeLoc(TypeLoc::withoutLoc(Ty));
+    printTypeLoc(TypeLoc(decl->getUnderlyingTypeRepr(), Ty));
     printGenericDeclGenericRequirements(decl);
   }
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2276,7 +2276,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
       printGenericDeclGenericParams(decl);
     });
   bool ShouldPrint = true;
-  Type Ty = decl->getUnderlyingTypeLoc().getType();
+  Type Ty = decl->getUnderlyingType();
 
   // If the underlying type is private, don't print it.
   if (Options.SkipPrivateStdlibDecls && Ty && Ty.isPrivateStdlibType())
@@ -2294,7 +2294,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
     // preserving sugar.
     llvm::SaveAndRestore<GenericEnvironment*> setGenericEnv(Options.GenericEnv,
                                                 decl->getGenericEnvironment());
-    printTypeLoc(decl->getUnderlyingTypeLoc());
+    printTypeLoc(TypeLoc::withoutLoc(Ty));
     printGenericDeclGenericRequirements(decl);
   }
 }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -232,7 +232,10 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         return true;
     }
 
-    return doIt(TAD->getUnderlyingTypeLoc());
+    if (auto typerepr = TAD->getUnderlyingTypeRepr())
+      if (doIt(typerepr))
+        return true;
+    return false;
   }
   
   bool visitOpaqueTypeDecl(OpaqueTypeDecl *OTD) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3553,6 +3553,13 @@ Type TypeAliasDecl::getUnderlyingType() const {
 }
       
 void TypeAliasDecl::setUnderlyingType(Type underlying) {
+  // lldb creates global typealiases containing archetypes
+  // sometimes...
+  if (underlying->hasArchetype() && isGenericContext())
+    underlying = underlying->mapTypeOutOfContext();
+  getASTContext().evaluator.cacheOutput(
+          StructuralTypeRequest{const_cast<TypeAliasDecl *>(this)},
+          std::move(underlying));
   getASTContext().evaluator.cacheOutput(
           UnderlyingTypeRequest{const_cast<TypeAliasDecl *>(this)},
           std::move(underlying));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3527,34 +3527,35 @@ SourceRange TypeAliasDecl::getSourceRange() const {
   return { TypeAliasLoc, getNameLoc() };
 }
 
+void TypeAliasDecl::computeType() {
+  assert(!hasInterfaceType());
+      
+  // Set the interface type of this declaration.
+  ASTContext &ctx = getASTContext();
+
+  auto *genericSig = getGenericSignature();
+  SubstitutionMap subs;
+  if (genericSig)
+    subs = genericSig->getIdentitySubstitutionMap();
+
+  Type parent;
+  auto parentDC = getDeclContext();
+  if (parentDC->isTypeContext())
+    parent = parentDC->getDeclaredInterfaceType();
+  auto sugaredType = TypeAliasType::get(this, parent, subs, getUnderlyingType());
+  setInterfaceType(MetatypeType::get(sugaredType, ctx));
+}
+
+Type TypeAliasDecl::getUnderlyingType() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+           UnderlyingTypeRequest{const_cast<TypeAliasDecl *>(this)},
+           Type());
+}
+      
 void TypeAliasDecl::setUnderlyingType(Type underlying) {
-  setValidationToChecked();
-
-  // lldb creates global typealiases containing archetypes
-  // sometimes...
-  if (underlying->hasArchetype() && isGenericContext())
-    underlying = underlying->mapTypeOutOfContext();
-  UnderlyingTy.setType(underlying);
-
-  // FIXME -- if we already have an interface type, we're changing the
-  // underlying type. See the comment in the ProtocolDecl case of
-  // validateDecl().
-  if (!hasInterfaceType()) {
-    // Set the interface type of this declaration.
-    ASTContext &ctx = getASTContext();
-
-    auto *genericSig = getGenericSignature();
-    SubstitutionMap subs;
-    if (genericSig)
-      subs = genericSig->getIdentitySubstitutionMap();
-
-    Type parent;
-    auto parentDC = getDeclContext();
-    if (parentDC->isTypeContext())
-      parent = parentDC->getDeclaredInterfaceType();
-    auto sugaredType = TypeAliasType::get(this, parent, subs, underlying);
-    setInterfaceType(MetatypeType::get(sugaredType, ctx));
-  }
+  getASTContext().evaluator.cacheOutput(
+          UnderlyingTypeRequest{const_cast<TypeAliasDecl *>(this)},
+          std::move(underlying));
 }
 
 UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {
@@ -3571,12 +3572,10 @@ UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {
 }
 
 Type TypeAliasDecl::getStructuralType() const {
-  assert(!getGenericParams());
-  
   auto &context = getASTContext();
-  return evaluateOrDefault(context.evaluator,
-                           StructuralTypeRequest { const_cast<TypeAliasDecl *>(this) },
-                           Type());
+  return evaluateOrDefault(
+      context.evaluator,
+      StructuralTypeRequest{const_cast<TypeAliasDecl *>(this)}, Type());
 }
 
 Type AbstractTypeParamDecl::getSuperclass() const {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -379,7 +379,7 @@ static bool isInterestingTypealias(Type type) {
   // Compatibility aliases are only interesting insofar as their underlying
   // types are interesting.
   if (aliasDecl->isCompatibilityAlias()) {
-    auto underlyingTy = aliasDecl->getUnderlyingTypeLoc().getType();
+    auto underlyingTy = aliasDecl->getUnderlyingType();
     return isInterestingTypealias(underlyingTy);
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3785,7 +3785,13 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
 
 static Type getStructuralType(TypeDecl *typeDecl) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    return typealias->getStructuralType();
+	// When we're computing requirement signatures, the structural type
+	// suffices.  Otherwise we'll potentially try to validate incomplete 
+	// requirements.
+	auto *proto = dyn_cast_or_null<ProtocolDecl>(typealias->getDeclContext()->getAsDecl());
+	if (proto && proto->isComputingRequirementSignature())
+		return typealias->getStructuralType();
+    return typealias->getUnderlyingType();
   }
 
   return typeDecl->getDeclaredInterfaceType();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3785,9 +3785,8 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
 
 static Type getStructuralType(TypeDecl *typeDecl) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    if (auto resolved = typealias->getUnderlyingTypeLoc().getType())
-      return resolved;
-
+    if (typealias->hasInterfaceType())
+      return typealias->getDeclaredInterfaceType();
     return typealias->getStructuralType();
   }
 
@@ -4196,11 +4195,10 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
       out << start;
       out << type->getFullName() << " == ";
       if (auto typealias = dyn_cast<TypeAliasDecl>(type)) {
-        if (auto underlyingTypeRepr =
-              typealias->getUnderlyingTypeLoc().getTypeRepr())
+        if (auto underlyingTypeRepr = typealias->getUnderlyingTypeRepr())
           underlyingTypeRepr->print(out);
         else
-          typealias->getUnderlyingTypeLoc().getType().print(out);
+          typealias->getUnderlyingType().print(out);
       } else {
         type->print(out);
       }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3785,8 +3785,6 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
 
 static Type getStructuralType(TypeDecl *typeDecl) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    if (typealias->hasInterfaceType())
-      return typealias->getDeclaredInterfaceType();
     return typealias->getStructuralType();
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -101,6 +101,8 @@ void BuiltinUnit::LookupCache::lookupValue(
                                           const_cast<BuiltinUnit*>(&M));
       TAD->setUnderlyingType(Ty);
       TAD->setAccess(AccessLevel::Public);
+      TAD->setValidationToChecked();
+      TAD->computeType();
       Entry = TAD;
     }
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1813,7 +1813,7 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
       // Recognize Swift.AnyObject directly.
       if (typealias->getName().is("AnyObject")) {
         // TypeRepr version: Builtin.AnyObject
-        if (auto typeRepr = typealias->getUnderlyingTypeLoc().getTypeRepr()) {
+        if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
           if (auto compound = dyn_cast<CompoundIdentTypeRepr>(typeRepr)) {
             auto components = compound->getComponents();
             if (components.size() == 2 &&
@@ -1825,9 +1825,10 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
         }
 
         // Type version: an empty class-bound existential.
-        if (auto type = typealias->getUnderlyingTypeLoc().getType()) {
-          if (type->isAnyObject())
-            anyObject = true;
+        if (typealias->hasInterfaceType()) {
+          if (auto type = typealias->getUnderlyingType())
+            if (type->isAnyObject())
+              anyObject = true;
         }
       }
 
@@ -2091,7 +2092,7 @@ DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
     Evaluator &evaluator,
     TypeAliasDecl *typealias) const {
   // Prefer syntactic information when we have it.
-  if (auto typeRepr = typealias->getUnderlyingTypeLoc().getTypeRepr()) {
+  if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
     return directReferencesForTypeRepr(evaluator, typealias->getASTContext(),
                                        typeRepr, typealias);
   }
@@ -2099,7 +2100,7 @@ DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
   // Fall back to semantic types.
   // FIXME: In the long run, we shouldn't need this. Non-syntactic results
   // should be cached.
-  if (auto type = typealias->getUnderlyingTypeLoc().getType()) {
+  if (auto type = typealias->getUnderlyingType()) {
     return directReferencesForType(type);
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -364,6 +364,14 @@ SourceLoc RequirementRequest::getNearestLoc() const {
   return owner.getLoc();
 }
 
+void RequirementRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  // For now, the GSB does a better job of describing the exact structure of
+  // the cycle.
+  //
+  // FIXME: We should consider merging the circularity handling the GSB does
+  // into this request.  See rdar://55263708
+}
+
 MutableArrayRef<RequirementRepr> WhereClauseOwner::getRequirements() const {
   if (auto genericParams = source.dyn_cast<GenericParamList *>()) {
     return genericParams->getRequirements();
@@ -821,6 +829,18 @@ Optional<GenericSignature *> GenericSignatureRequest::getCachedResult() const {
 void GenericSignatureRequest::cacheResult(GenericSignature *value) const {
   auto *GC = std::get<0>(getStorage());
   GC->GenericSigAndBit.setPointerAndInt(value, true);
+}
+
+//----------------------------------------------------------------------------//
+// GenericSignatureRequest computation.
+//----------------------------------------------------------------------------//
+
+void InferredGenericSignatureRequest::noteCycleStep(DiagnosticEngine &d) const {
+  // For now, the GSB does a better job of describing the exact structure of
+  // the cycle.
+  //
+  // FIXME: We should consider merging the circularity handling the GSB does
+  // into this request.  See rdar://55263708
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -837,9 +837,5 @@ UnderlyingTypeRequest::getCachedResult() const {
 
 void UnderlyingTypeRequest::cacheResult(Type value) const {
   auto *typeAlias = std::get<0>(getStorage());
-  // lldb creates global typealiases containing archetypes
-  // sometimes...
-  if (value->hasArchetype() && typeAlias->isGenericContext())
-    value = value->mapTypeOutOfContext();
   typeAlias->UnderlyingTy.setType(value);
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -822,3 +822,24 @@ void GenericSignatureRequest::cacheResult(GenericSignature *value) const {
   auto *GC = std::get<0>(getStorage());
   GC->GenericSigAndBit.setPointerAndInt(value, true);
 }
+
+//----------------------------------------------------------------------------//
+// IsImplicitlyUnwrappedOptionalRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Type>
+UnderlyingTypeRequest::getCachedResult() const {
+  auto *typeAlias = std::get<0>(getStorage());
+  if (auto type = typeAlias->UnderlyingTy.getType())
+    return type;
+  return None;
+}
+
+void UnderlyingTypeRequest::cacheResult(Type value) const {
+  auto *typeAlias = std::get<0>(getStorage());
+  // lldb creates global typealiases containing archetypes
+  // sometimes...
+  if (value->hasArchetype() && typeAlias->isGenericContext())
+    value = value->mapTypeOutOfContext();
+  typeAlias->UnderlyingTy.setType(value);
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2659,7 +2659,7 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
       auto alias = dyn_cast<TypeAliasDecl>(importedDecl);
       if (!alias || !alias->isCompatibilityAlias()) continue;
 
-      auto aliasedTy = alias->getUnderlyingTypeLoc().getType();
+      auto aliasedTy = alias->getUnderlyingType();
       ext = nullptr;
       importedDecl = nullptr;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1493,6 +1493,7 @@ static void addSynthesizedTypealias(NominalTypeDecl *nominal, Identifier name,
   typealias->setAccess(AccessLevel::Public);
   typealias->setValidationToChecked();
   typealias->setImplicit();
+  typealias->computeType();
 
   nominal->addMember(typealias);
 }
@@ -2563,6 +2564,8 @@ namespace {
                             /*genericparams*/nullptr, DC);
               typealias->setUnderlyingType(
                   underlying->getDeclaredInterfaceType());
+              typealias->setValidationToChecked();
+              typealias->computeType();
 
               Impl.SpecialTypedefNames[Decl->getCanonicalDecl()] =
                 MappedTypeNameKind::DefineAndUse;
@@ -2582,6 +2585,8 @@ namespace {
                             /*genericparams*/nullptr, DC);
               typealias->setUnderlyingType(
                 Impl.SwiftContext.getAnyObjectType());
+              typealias->setValidationToChecked();
+              typealias->computeType();
 
               Impl.SpecialTypedefNames[Decl->getCanonicalDecl()] =
                 MappedTypeNameKind::DefineAndUse;
@@ -2649,7 +2654,9 @@ namespace {
                                       Loc,
                                       /*genericparams*/nullptr, DC);
       Result->setUnderlyingType(SwiftType);
-
+      Result->setValidationToChecked();
+      Result->computeType();
+      
       // Make Objective-C's 'id' unavailable.
       if (Impl.SwiftContext.LangOpts.EnableObjCInterop && isObjCId(Decl)) {
         auto attr = AvailableAttr::createPlatformAgnostic(
@@ -2943,6 +2950,8 @@ namespace {
                          C.Id_ErrorType, loc,
                          /*genericparams=*/nullptr, enumDecl);
           alias->setUnderlyingType(errorWrapper->getDeclaredInterfaceType());
+          alias->setValidationToChecked();
+          alias->computeType();
           enumDecl->addMember(alias);
 
           // Add the 'Code' enum to the error wrapper.
@@ -4027,7 +4036,9 @@ namespace {
           Loc,
           /*genericparams*/nullptr, DC);
       Result->setUnderlyingType(SwiftTypeDecl->getDeclaredInterfaceType());
-      
+      Result->setValidationToChecked();
+      Result->computeType();
+
       return Result;
     }
 
@@ -5163,6 +5174,8 @@ namespace {
       }
 
       typealias->setUnderlyingType(typeDecl->getDeclaredInterfaceType());
+      typealias->setValidationToChecked();
+      typealias->computeType();
       return typealias;
     }
 
@@ -5398,7 +5411,9 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
   }
 
   alias->setUnderlyingType(typeDecl->getDeclaredInterfaceType());
-
+  alias->setValidationToChecked();
+  alias->computeType();
+  
   // Record that this is the official version of this declaration.
   Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = alias;
   markAsVariant(alias, correctSwiftName);
@@ -8234,7 +8249,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
 
       auto maxFloatTypeDecl = context.get_MaxBuiltinFloatTypeDecl();
       floatExpr->setBuiltinType(
-          maxFloatTypeDecl->getUnderlyingTypeLoc().getType());
+          maxFloatTypeDecl->getUnderlyingType());
 
       auto *floatDecl = literalType->getAnyNominal();
       floatExpr->setBuiltinInitializer(

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2794,7 +2794,7 @@ public:
     addLeadingDot(Builder);
     Builder.addTextChunk(TAD->getName().str());
     if (TAD->hasInterfaceType()) {
-      auto underlyingType = TAD->getUnderlyingTypeLoc().getType();
+      auto underlyingType = TAD->getUnderlyingType();
       if (underlyingType->hasError()) {
         Type parentType;
         if (auto nominal = TAD->getDeclContext()->getSelfNominalTypeDecl()) {

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -734,6 +734,8 @@ private:
         NoLoc, NoLoc, IGM.Context.getIdentifier(ArchetypeName), NoLoc,
         /*genericparams*/ nullptr, IGM.Context.TheBuiltinModule);
     Entry->setUnderlyingType(IGM.Context.TheRawPointerType);
+    Entry->setValidationToChecked();
+    Entry->computeType();
     return Entry;
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -925,7 +925,7 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
         IndexSymbol Info;
         if (!reportRef(TAD, IdLoc, Info, None))
           return false;
-        if (auto Ty = TAD->getUnderlyingTypeLoc().getType()) {
+        if (auto Ty = TAD->getUnderlyingType()) {
           NTD = Ty->getAnyNominal();
           isImplicit = true;
         }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4198,7 +4198,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
     Status |= UnderlyingTy;
   }
 
-  TAD->getUnderlyingTypeLoc() = UnderlyingTy.getPtrOrNull();
+  TAD->setUnderlyingTypeRepr(UnderlyingTy.getPtrOrNull());
   TAD->getAttrs() = Attributes;
 
   // Parse a 'where' clause if present, adding it to our GenericParamList.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1927,7 +1927,7 @@ namespace {
       }
 
       tc.validateDecl(maxFloatTypeDecl);
-      auto maxType = maxFloatTypeDecl->getUnderlyingTypeLoc().getType();
+      auto maxType = maxFloatTypeDecl->getUnderlyingType();
 
       DeclName initName(tc.Context, DeclBaseName::createConstructor(),
                         { tc.Context.Id_floatLiteral });

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -594,7 +594,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
           CS.DC, instanceType, NameLookupFlags::IgnoreAccessControl);
       for (auto ctor : ctors) {
         if (!ctor.getValueDecl()->hasInterfaceType())
-          CS.getTypeChecker().validateDeclForNameLookup(ctor.getValueDecl());
+          CS.getTypeChecker().validateDecl(ctor.getValueDecl());
         if (ctor.getValueDecl()->hasInterfaceType())
           candidates.push_back({ ctor.getValueDecl(), 1 });
       }

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -333,7 +333,7 @@ void NameBinder::addImport(
             diag::imported_decl_is_wrong_kind_typealias,
             typealias->getDescriptiveKind(),
             TypeAliasType::get(typealias, Type(), SubstitutionMap(),
-                                typealias->getUnderlyingTypeLoc().getType()),
+                                typealias->getUnderlyingType()),
             getImportKindString(ID->getImportKind())));
       } else {
         emittedDiag.emplace(diagnose(ID, diag::imported_decl_is_wrong_kind,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -572,7 +572,8 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     checkGenericParamAccess(TAD->getGenericParams(), TAD);
 
-    checkTypeAccess(TAD->getUnderlyingTypeLoc(), TAD, /*mayBeInferred*/false,
+    checkTypeAccess(TAD->getUnderlyingType(),
+                    TAD->getUnderlyingTypeRepr(), TAD, /*mayBeInferred*/false,
                     [&](AccessScope typeAccessScope,
                         const TypeRepr *complainRepr,
                         DowngradeToWarning downgradeToWarning) {
@@ -1194,7 +1195,8 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     checkGenericParamAccess(TAD->getGenericParams(), TAD);
 
-    checkTypeAccess(TAD->getUnderlyingTypeLoc(), TAD, /*mayBeInferred*/false,
+    checkTypeAccess(TAD->getUnderlyingType(),
+                    TAD->getUnderlyingTypeRepr(), TAD, /*mayBeInferred*/false,
                     [&](AccessScope typeAccessScope,
                         const TypeRepr *complainRepr,
                         DowngradeToWarning downgradeToWarning) {
@@ -1832,7 +1834,8 @@ public:
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     checkGenericParams(TAD->getGenericParams(), TAD);
-    checkType(TAD->getUnderlyingTypeLoc(), TAD, getDiagnoseCallback(TAD),
+    checkType(TAD->getUnderlyingType(),
+              TAD->getUnderlyingTypeRepr(), TAD, getDiagnoseCallback(TAD),
               getDiagnoseCallback(TAD));
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1070,7 +1070,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   //    `ExpressibleByStringLiteral`.
   //    `D.Value` and the return type can be arbitrary.
 
-  TC.validateDeclForNameLookup(decl);
+  TC.validateDecl(decl);
   auto paramList = decl->getParameters();
   if (paramList->size() != 1 || paramList->get(0)->isVariadic()) return false;
   auto argType = paramList->get(0)->getType();
@@ -1241,7 +1241,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     auto oneCandidate = candidates.front().getValueDecl();
     candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
       auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      TC.validateDeclForNameLookup(cand);
+      TC.validateDecl(cand);
       return isValidDynamicMemberLookupSubscript(cand, decl, TC);
     });
 
@@ -1264,7 +1264,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    TC.validateDeclForNameLookup(cand);
+    TC.validateDecl(cand);
     return isValidDynamicMemberLookupSubscript(cand, decl, TC,
                                                /*ignoreLabel*/ true);
   });

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3492,14 +3492,14 @@ UnderlyingTypeRequest::evaluate(Evaluator &evaluator,
     return ErrorType::get(typeAlias->getASTContext());
   }
 
-  if (TypeChecker::validateType(typeAlias->getASTContext(),
-                                typeAlias->getUnderlyingTypeLoc(),
+  auto underlyingLoc = TypeLoc(typeAlias->getUnderlyingTypeRepr());
+  if (TypeChecker::validateType(typeAlias->getASTContext(), underlyingLoc,
                                 TypeResolution::forInterface(typeAlias),
                                 options)) {
     typeAlias->setInvalid();
     return ErrorType::get(typeAlias->getASTContext());
   }
-  return ty;
+  return underlyingLoc.getType();
 }
 
 /// Bind the given function declaration, which declares an operator, to the corresponding operator declaration.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -525,7 +525,7 @@ static Type formExtensionInterfaceType(
   auto nominal = dyn_cast<NominalTypeDecl>(genericDecl);
   auto typealias = dyn_cast<TypeAliasDecl>(genericDecl);
   if (!nominal) {
-    Type underlyingType = typealias->getUnderlyingTypeLoc().getType();
+    Type underlyingType = typealias->getUnderlyingType();
     nominal = underlyingType->getNominalOrBoundGenericNominal();
   }
 
@@ -556,7 +556,7 @@ static Type formExtensionInterfaceType(
   }
 
   // If we have a typealias, try to form type sugar.
-  if (typealias && TypeChecker::isPassThroughTypealias(typealias)) {
+  if (typealias && TypeChecker::isPassThroughTypealias(typealias, typealias->getUnderlyingType(), nominal)) {
     auto typealiasSig = typealias->getGenericSignature();
     SubstitutionMap subMap;
     if (typealiasSig) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -966,14 +966,7 @@ RequirementRequest::evaluate(Evaluator &evaluator,
 
 llvm::Expected<Type>
 StructuralTypeRequest::evaluate(Evaluator &evaluator,
-                                TypeAliasDecl *typeAlias) const {
-  // Fast path: If the interface type is already resolved, there's no need
-  // to compute the structural type.  This also prevents us from writing
-  // ErrorTypes into otherwise valid ASTs with generated typealiases.
-  if (typeAlias->hasInterfaceType()) {
-    return typeAlias->getInterfaceType()->getMetatypeInstanceType();
-  }
-  
+                                TypeAliasDecl *typeAlias) const {  
   TypeResolutionOptions options((typeAlias->getGenericParams()
                                      ? TypeResolverContext::GenericTypeAliasDecl
                                      : TypeResolverContext::TypeAliasDecl));

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1497,7 +1497,7 @@ recur:
     }
 
     // If there is a subpattern, push the enum element type down onto it.
-    validateDeclForNameLookup(elt);
+    validateDecl(elt);
     if (EEP->hasSubPattern()) {
       Pattern *sub = EEP->getSubPattern();
       if (!elt->hasAssociatedValues()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2480,7 +2480,9 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
                                                     DC);
     aliasDecl->setGenericSignature(DC->getGenericSignatureOfContext());
     aliasDecl->setUnderlyingType(type);
-
+    aliasDecl->setValidationToChecked();
+    aliasDecl->computeType();
+    
     aliasDecl->setImplicit();
     if (type->hasError())
       aliasDecl->setInvalid();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -768,7 +768,7 @@ Type TypeChecker::applyGenericArguments(Type type,
   }
 
   // FIXME: More principled handling of circularity.
-  if (!genericDecl->hasValidSignature()) {
+  if (!genericDecl->getGenericSignature()) {
     diags.diagnose(loc, diag::recursive_decl_reference,
              genericDecl->getDescriptiveKind(), genericDecl->getName());
     genericDecl->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -783,9 +783,6 @@ public:
   void validateDecl(OperatorDecl *decl);
   void validateDecl(PrecedenceGroupDecl *decl);
 
-  /// Perform just enough validation for looking up names using the Decl.
-  void validateDeclForNameLookup(ValueDecl *D);
-
   /// Validate the given extension declaration, ensuring that it
   /// properly extends the nominal type it names.
   void validateExtension(ExtensionDecl *ext);
@@ -882,7 +879,9 @@ public:
   /// typealias GX2<A> = X<A, A>
   /// typealias GX3<A, B> = X<B, A>
   /// \endcode
-  static bool isPassThroughTypealias(TypeAliasDecl *typealias);
+  static bool isPassThroughTypealias(TypeAliasDecl *typealias,
+                                     Type underlyingType,
+                                     NominalTypeDecl *nominal);
   
   /// Determine whether one type is a subtype of another.
   ///
@@ -1011,7 +1010,7 @@ public:
   void checkDefaultArguments(ParameterList *params, ValueDecl *VD);
 
   virtual void resolveDeclSignature(ValueDecl *VD) override {
-    validateDeclForNameLookup(VD);
+    validateDecl(VD);
   }
 
   virtual void resolveProtocolEnvironment(ProtocolDecl *proto) override {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2287,10 +2287,22 @@ public:
                                               SourceLoc(), genericParams, DC);
     declOrOffset = alias;
 
-    alias->setGenericSignature(MF.getGenericSignature(genericSigID));
+    auto *genericSig = MF.getGenericSignature(genericSigID);
+    alias->setGenericSignature(genericSig);
 
-    alias->setUnderlyingType(MF.getType(underlyingTypeID));
-
+    auto underlying = MF.getType(underlyingTypeID);
+    alias->setUnderlyingType(underlying);
+    SubstitutionMap subs;
+    if (genericSig) {
+      subs = genericSig->getIdentitySubstitutionMap();
+    }
+    Type parent;
+    if (DC->isTypeContext())
+      parent = DC->getDeclaredInterfaceType();
+    auto sugaredType = TypeAliasType::get(alias, parent, subs, underlying);
+    alias->setInterfaceType(MetatypeType::get(sugaredType, ctx));
+    alias->setValidationToChecked();
+    
     if (auto accessLevel = getActualAccessLevel(rawAccessLevel))
       alias->setAccess(*accessLevel);
     else
@@ -4395,7 +4407,7 @@ public:
     // Look through compatibility aliases that are now unavailable.
     if (alias->getAttrs().isUnavailable(ctx) &&
         alias->isCompatibilityAlias()) {
-      return alias->getUnderlyingTypeLoc().getType();
+      return alias->getUnderlyingType();
     }
 
     return alias->getDeclaredInterfaceType();
@@ -4463,7 +4475,7 @@ public:
     if (alias &&
         alias->getAttrs().isUnavailable(ctx) &&
         alias->isCompatibilityAlias()) {
-      return alias->getUnderlyingTypeLoc().getType().subst(subMap);
+      return alias->getUnderlyingType().subst(subMap);
     }
 
     auto parentType = parentTypeOrError.get();
@@ -4491,7 +4503,7 @@ public:
       // using the Type wrapper.
       const TypeBase *underlyingTy = nullptr;
       while (alias->isCompatibilityAlias()) {
-        underlyingTy = alias->getUnderlyingTypeLoc().getType().getPointer();
+        underlyingTy = alias->getUnderlyingType().getPointer();
 
         // If the underlying type is itself a typealias, it might be another
         // compatibility alias, meaning we need to go around the loop again.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2797,7 +2797,7 @@ public:
 
     auto contextID = S.addDeclContextRef(typeAlias->getDeclContext());
 
-    auto underlying = typeAlias->getUnderlyingTypeLoc().getType();
+    auto underlying = typeAlias->getUnderlyingType();
 
     llvm::SmallSetVector<Type, 4> dependencies;
     collectDependenciesFromType(dependencies, underlying->getCanonicalType(),
@@ -3717,7 +3717,7 @@ public:
   void visitTypeAliasType(const TypeAliasType *alias) {
     using namespace decls_block;
     const TypeAliasDecl *typeAlias = alias->getDecl();
-    auto underlyingType = typeAlias->getUnderlyingTypeLoc().getType();
+    auto underlyingType = typeAlias->getUnderlyingType();
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[TypeAliasTypeLayout::Code];
     TypeAliasTypeLayout::emitRecord(

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -230,6 +230,8 @@ class Top {}
 class Bottom<T : Bottom<Top>> {}
 // expected-error@-1 {{generic class 'Bottom' references itself}}
 // expected-note@-2 {{type declared here}}
+// expected-error@-3 {{circular reference}}
+// expected-note@-4 {{through reference here}}
 
 // Invalid inheritance clause
 

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -42,14 +42,14 @@ func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> =
 protocol P3 {
     typealias T = Int
 }
-protocol Q3: P3 { // expected-error{{generic signature requires types 'Int'}}
+protocol Q3: P3 { // expected-error{{generic signature requires types 'P3.T' (aka 'Int')}}
     typealias T = Float
 }
 
 protocol P3_1 {
     typealias T = Float
 }
-protocol Q3_1: P3, P3_1 {} // expected-error{{generic signature requires types 'Float'}}
+protocol Q3_1: P3, P3_1 {} // expected-error{{generic signature requires types 'P3_1.T' (aka 'Float')}}
 
 
 // Subprotocols can force associated types in their parents to be concrete, and

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -42,14 +42,14 @@ func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> =
 protocol P3 {
     typealias T = Int
 }
-protocol Q3: P3 { // expected-error{{generic signature requires types 'P3.T' (aka 'Int')}}
+protocol Q3: P3 { // expected-error{{generic signature requires types 'Int'}}
     typealias T = Float
 }
 
 protocol P3_1 {
     typealias T = Float
 }
-protocol Q3_1: P3, P3_1 {} // expected-error{{generic signature requires types 'P3_1.T' (aka 'Float')}}
+protocol Q3_1: P3, P3_1 {} // expected-error{{generic signature requires types 'Float'}}
 
 
 // Subprotocols can force associated types in their parents to be concrete, and

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -383,7 +383,7 @@ struct X28 : P2 {
 }
 
 // CHECK-LABEL: .P28@
-// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == X28>
+// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == P28.P3Assoc>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3, τ_0_0.P3Assoc == X28>
 protocol P28: P3 {
   typealias P3Assoc = X28   // expected-warning{{typealias overriding associated type}}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -43,7 +43,7 @@ public protocol P {
   associatedtype T
 }
 
-public struct S<A: P> where A.T == S<A> {
+public struct S<A: P> where A.T == S<A> { // expected-error {{circular reference}}
 // expected-note@-1 {{type declared here}}
 // expected-error@-2 {{generic struct 'S' references itself}}
   func f(a: A.T) {
@@ -71,7 +71,7 @@ protocol PI {
   associatedtype T : I
 }
 
-struct SI<A: PI> : I where A : I, A.T == SI<A> {
+struct SI<A: PI> : I where A : I, A.T == SI<A> { // expected-error {{circular reference}}
 // expected-note@-1 {{type declared here}}
 // expected-error@-2 {{generic struct 'SI' references itself}}
   func ggg<T : I>(t: T.Type) -> T {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -1679,7 +1679,7 @@ SwiftDeclCollector::constructVarNode(ValueDecl *VD) {
 SDKNode *swift::ide::api::
 SwiftDeclCollector::constructTypeAliasNode(TypeAliasDecl *TAD) {
   auto Alias = SDKNodeInitInfo(Ctx, TAD).createSDKNode(SDKNodeKind::DeclTypeAlias);
-  Alias->addChild(constructTypeNode(TAD->getUnderlyingTypeLoc().getType()));
+  Alias->addChild(constructTypeNode(TAD->getUnderlyingType()));
   return Alias;
 }
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -833,7 +833,7 @@ public:
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     auto ResultTD = std::make_shared<sma::TypealiasDecl>();
     ResultTD->Name = convertToIdentifier(TAD->getName());
-    ResultTD->Type = convertToTypeName(TAD->getUnderlyingTypeLoc().getType());
+    ResultTD->Type = convertToTypeName(TAD->getUnderlyingType());
     // FIXME
     // ResultTD->Attributes = ?;
     Result.Typealiases.emplace_back(std::move(ResultTD));

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -9,7 +9,7 @@ protocol P2 {
 }
 
 // CHECK-LABEL: .P3@
-// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == ConformsToP1>
+// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == P3.Assoc>
 protocol P3 : P2 { }
 
 struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc': 'P1'}}

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -9,7 +9,7 @@ protocol P2 {
 }
 
 // CHECK-LABEL: .P3@
-// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == P3.Assoc>
+// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == ConformsToP1>
 protocol P3 : P2 { }
 
 struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc': 'P1'}}


### PR DESCRIPTION
Using the techniques from @xymus' patch, try to kill validateDeclForNameLookup harder.  There are some changes from the exact code in #24957 that, unfortunately, I cannot get to pass the tests to land independently.  Namely, this patch

- Defines a new UnderlyingTypeRequest for computing the interface type of the underlying type if we have it.
- Changes the structural type request to resugar with a `TypeAliasType`.  I suspect this is what is causing the changes in requirement signatures in the few tests that are touched here.
- Separate computing the interface type of a TypeAliasDecl from computing its underlying type.  Not doing this makes reasoning about the laziness in UnderlyingTypeRequest interacting with the interface type of the typealias extremely difficult.

All of this should finally let us remove `validateDeclForNameLookup`.  I have great fears that this will fail the compatibility suite.  But there's only one way to find out!