### PR TITLE
Dispatch: Allow dispatch workitems to be dynamically callable

### DIFF
--- a/stdlib/public/Darwin/Dispatch/Block.swift
+++ b/stdlib/public/Darwin/Dispatch/Block.swift
@@ -39,6 +39,7 @@ public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 // used in the new runtime. _TtC8Dispatch17_DispatchWorkItem is the
 // mangled name for Dispatch._DispatchWorkItem.
 @available(macOS 10.10, iOS 8.0, *)
+@dynamicCallable
 @_objcRuntimeName(_TtC8Dispatch17_DispatchWorkItem)
 public class DispatchWorkItem {
 	internal var _block: _DispatchBlock
@@ -96,6 +97,10 @@ public class DispatchWorkItem {
 
 	public var isCancelled: Bool {
 		return _swift_dispatch_block_testcancel(_block) != 0
+	}
+
+	public func dynamicallyCall(withArguments: [()]) -> Void {
+		perform()
 	}
 }
 

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -57,15 +57,23 @@ DispatchAPI.test("dispatch_block_t conversions") {
 }
 
 if #available(OSX 10.10, iOS 8.0, *) {
-  DispatchAPI.test("dispatch_block_t identity") {
-    let block = DispatchWorkItem(flags: .inheritQoS) {
-      _ = 1
-    }
+	DispatchAPI.test("dispatch_block_t identity") {
+		let block = DispatchWorkItem(flags: .inheritQoS) {
+			_ = 1
+		}
 
-    DispatchQueue.main.async(execute: block)
-    // This will trap if the block's pointer identity is not preserved.
-    block.cancel()
-  }
+		DispatchQueue.main.async(execute: block)
+		// This will trap if the block's pointer identity is not preserved.
+		block.cancel()
+	}
+
+	DispatchAPI.test("DispatchBlock dynamic call") {
+		let block = DispatchWorkItem(flags: .inheritQoS) {
+			_ = 1
+		}
+
+		block()
+	}
 }
 
 DispatchAPI.test("DispatchTime comparisons") {


### PR DESCRIPTION
Add `@dynamicCallable` to `DispatchWorkItem` and add a test to make sure
it remains as such.

Fixes: <rdar://problem/50892592>