### PR TITLE
fix parseQualifiedDeclName for merge

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1220,9 +1220,16 @@ public:
   TypeResult parseTypeSimple(Diag<> MessageID, bool HandleCodeCompletion);
   TypeResult parseTypeSimpleOrComposition(Diag<> MessageID, bool HandleCodeCompletion);
   // SWIFT_ENABLE_TENSORFLOW: Added `isParsingQualifiedDeclName` flag.
-  /// The `isParsingQualifiedDeclName` flag controls whether parsing is done as
-  /// if this type identifier is the prefix to a qualified declaration name. If
-  /// true, backtrack parsing the last identifier.
+  /// Parses a type identifier (e.g. 'Foo' or 'Foo.Bar.Baz').
+  ///
+  /// When `isParsingQualifiedDeclName` is true:
+  /// - Parses the type qualifier from a qualified decl name, and returns a
+  ///   parser result for the type of the qualifier.
+  /// - Positions the parser at the final declaration name.
+  /// - For example, 'Foo.Bar.f' parses as 'Foo.Bar' and the parser gets
+  ///   positioned at 'f'.
+  /// - If there is no type qualification (e.g. when parsing just 'f'), returns
+  ///   an empty parser error.
   TypeResult parseTypeIdentifier(bool isParsingQualifiedDeclName = false);
   TypeResult parseAnyType();
   TypeResult parseTypeTupleBody();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -756,7 +756,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclName) {
     // standalone token.
     } else if (isParsingQualifiedDeclName && startsWithSymbol(Tok, '.') &&
                Tok.getLength() != 1) {
-      consumeStartingCharacterOfCurrentToken(tok::period);
+      Period = consumeStartingCharacterOfCurrentTokenSyntax(tok::period);
       continue;
     }
     break;
@@ -787,9 +787,17 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclName) {
     Junk.push_back(consumeTokenSyntax(tok::code_complete));
     return makeParsedCodeCompletion<ParsedTypeSyntax>(Junk);
   }
-  
   if (Status.isError())
     return makeParsedError<ParsedTypeSyntax>(Junk);
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // When parsing a qualified decl name (`isParsingQualifiedDeclName`), it is
+  // possible that there are no type qualifications and therefore we have an
+  // empty result. In this case, return an empty parser error.
+  if (!Base) {
+    assert(isParsingQualifiedDeclName);
+    return makeParsedErrorEmpty<ParsedTypeSyntax>();
+  }
 
   return makeParsedSuccess(*Base);
 }


### PR DESCRIPTION
The merge broke `parseQualifiedDeclName`, and this PR fixes it.

The main problem is that an upstream refactoring changed `Parser::parseTypeIdentifier` to assume that it will always parse and return a type. Our `isParsingQualifiedDeclName` modification adds the possibility that `Parser::parseTypeIdentifier` parses no type when it tries to parse a decl name without a type qualification. When this happens, `Parser::parseTypeIdentifier` ends up dereferencing an empty optional on its last line `return makeParsedSuccess(*Base);`.

To fix this, I added a check to `Parser::parseTypeIdentifier` that makes it return an empty error result when there is no type. Then, I modified `parseQualifiedDeclName` to understand that this empty error result means that there is no type qualifier.

A smaller unrelated problem was that we needed to set `Period` in one of the cases inside `Parser::parseTypeIdentifier`. So I added `Period = consumeStartingCharacterOfCurrentTokenSyntax(tok::period);` to do that.

This PR fixes the following tests in our merge branch:
```
    Swift(linux-x86_64) :: AutoDiff/transposing_attr_type_checking.swift
    Swift(linux-x86_64) :: AutoDiff/transposing_attr_parse.swift
```