### PR TITLE
Don't inherit the unavailability of extensions for imported decls [5.1 08-28]

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1073,8 +1073,15 @@ const AvailableAttr *AvailableAttr::isUnavailable(const Decl *D) {
     return attr;
 
   // If D is an extension member, check if the extension is unavailable.
-  if (auto ext = dyn_cast<ExtensionDecl>(D->getDeclContext()))
-    return AvailableAttr::isUnavailable(ext);
+  //
+  // Skip decls imported from Clang, they could be associated to the wrong
+  // extension and inherit undesired unavailability. The ClangImporter
+  // associates Objective-C protocol members to the first category where the
+  // protocol is directly or indirectly adopted, no matter its availability
+  // and the availability of other categories. rdar://problem/53956555
+  if (!D->getClangNode())
+    if (auto ext = dyn_cast<ExtensionDecl>(D->getDeclContext()))
+        return AvailableAttr::isUnavailable(ext);
 
   return nullptr;
 }

--- a/test/ClangImporter/Inputs/availability_platform_categories.h
+++ b/test/ClangImporter/Inputs/availability_platform_categories.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+@interface SharedInterface
+@end
+
+@protocol SharedProtocol <NSObject>
++ (NSInteger)foo;
+@end
+
+// ClangImporter imports the first category as the extension parent of
+// SharedInterface.foo, making foo unavailable on macOS when the extension
+// unavailability is inherited by its members.
+API_UNAVAILABLE(macos)
+@interface SharedInterface (IOSCategory) <SharedProtocol>
+@end
+
+API_UNAVAILABLE(ios)
+@interface SharedInterface (MacOSCategory) <SharedProtocol>
+@end

--- a/test/ClangImporter/availability_platform_categories.swift
+++ b/test/ClangImporter/availability_platform_categories.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/availability_platform_categories.h
+
+// REQUIRES: OS=macos
+
+// Test when a function is associated to an Objective-C category with the
+// wrong unavailability. rdar://problem/53956555
+
+print(SharedInterface.foo())


### PR DESCRIPTION
Description: The ClangImporter associates Objective-C protocol members to the first category where the protocol is directly or indirectly adopted, no matter its availability and the availability of other categories. In some cases, this results in imported decls being marked unavailable by the wrong Objective-C category. This fix simply ignores the extension unavailability for imported decls.

Scope of the issue: This affects the XCTest framework where it wrongfully makes some APIs unavailable.

Risk: Low, the fix limits a recent change in the Swift compiler and brings back the old behavior on decls imported from Objective-C.

Reviewed-by: @jrose-apple

Radar: rdar://problem/55350717