### PR TITLE
Make validateType a utility method

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1382,8 +1382,8 @@ namespace {
     Type resolveTypeReferenceInExpression(TypeLoc &loc) {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      bool hadError = CS.TC.validateType(
-          loc, TypeResolution::forContextual(CS.DC), options);
+      bool hadError = TypeChecker::validateType(
+          CS.TC.Context, loc, TypeResolution::forContextual(CS.DC), options);
       return hadError ? Type() : loc.getType();
     }
 
@@ -1640,7 +1640,8 @@ namespace {
           for (size_t i = 0, size = specializations.size(); i < size; ++i) {
             TypeResolutionOptions options(TypeResolverContext::InExpression);
             options |= TypeResolutionFlags::AllowUnboundGenerics;
-            if (tc.validateType(specializations[i],
+            if (TypeChecker::validateType(tc.Context,
+                                specializations[i],
                                 TypeResolution::forContextual(CS.DC),
                                 options))
               return Type();
@@ -2280,9 +2281,10 @@ namespace {
           // of is-patterns applied to an irrefutable pattern.
           pattern = pattern->getSemanticsProvidingPattern();
           while (auto isp = dyn_cast<IsPattern>(pattern)) {
-            if (CS.TC.validateType(isp->getCastTypeLoc(),
-                                   TypeResolution::forContextual(CS.DC),
-                                   TypeResolverContext::InExpression)) {
+            if (TypeChecker::validateType(CS.TC.Context,
+                                          isp->getCastTypeLoc(),
+                                          TypeResolution::forContextual(CS.DC),
+                                          TypeResolverContext::InExpression)) {
               return false;
             }
 
@@ -2618,8 +2620,10 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (tc.validateType(expr->getCastTypeLoc(),
-                          TypeResolution::forContextual(CS.DC), options))
+      if (TypeChecker::validateType(tc.Context,
+                                    expr->getCastTypeLoc(),
+                                    TypeResolution::forContextual(CS.DC),
+                                    options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -2648,9 +2652,10 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (tc.validateType(expr->getCastTypeLoc(),
-                          TypeResolution::forContextual(CS.DC),
-                          options))
+      if (TypeChecker::validateType(tc.Context,
+                                    expr->getCastTypeLoc(),
+                                    TypeResolution::forContextual(CS.DC),
+                                    options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -2684,8 +2689,10 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (tc.validateType(expr->getCastTypeLoc(),
-                          TypeResolution::forContextual(CS.DC), options))
+      if (TypeChecker::validateType(tc.Context,
+                                    expr->getCastTypeLoc(),
+                                    TypeResolution::forContextual(CS.DC),
+                                    options))
         return nullptr;
 
       // Open the type we're casting to.
@@ -2713,8 +2720,10 @@ namespace {
       auto &tc = CS.getTypeChecker();
       TypeResolutionOptions options(TypeResolverContext::ExplicitCastExpr);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      if (tc.validateType(expr->getCastTypeLoc(),
-                          TypeResolution::forContextual(CS.DC), options))
+      if (TypeChecker::validateType(tc.Context,
+                                    expr->getCastTypeLoc(),
+                                    TypeResolution::forContextual(CS.DC),
+                                    options))
         return nullptr;
 
       // Open up the type we're checking.

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -266,6 +266,7 @@ void TypeChecker::diagnoseGenericTypeExportability(const TypeLoc &TL,
     GenericTypeFinder(const SourceFile &SF, Callback callback)
         : SF(SF), callback(callback) {}
 
+
     Action visitBoundGenericType(BoundGenericType *ty) override {
       ModuleDecl *useModule = SF.getParentModule();
       SubstitutionMap subs = ty->getContextSubstitutionMap(useModule,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1140,8 +1140,9 @@ namespace {
 
       if (auto PlaceholderE = dyn_cast<EditorPlaceholderExpr>(expr)) {
         if (!PlaceholderE->getTypeLoc().isNull()) {
-          if (!TC.validateType(PlaceholderE->getTypeLoc(),
-                               TypeResolution::forContextual(DC), None))
+          if (!TypeChecker::validateType(TC.Context, PlaceholderE->getTypeLoc(),
+                                         TypeResolution::forContextual(DC),
+                                         None))
             expr->setType(PlaceholderE->getTypeLoc().getType());
         }
         return finish(true, expr);
@@ -1375,8 +1376,9 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
 
   // Validate the result type, if present.
   if (closure->hasExplicitResultType() &&
-      TC.validateType(closure->getExplicitResultTypeLoc(), resolution,
-                      TypeResolverContext::InExpression)) {
+      TypeChecker::validateType(TC.Context, closure->getExplicitResultTypeLoc(),
+                                resolution,
+                                TypeResolverContext::InExpression)) {
     return false;
   }
 
@@ -1392,7 +1394,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   // recurse into.
   assert((closure->getParent() == DC ||
           closure->getParent()->isChildContextOf(DC)) &&
-      "Decl context isn't correct");
+         "Decl context isn't correct");
   DC = closure;
   return true;
 }
@@ -1987,7 +1989,8 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
 
     auto &typeLoc = typeExpr->getTypeLoc();
     bool hadError =
-        TC.validateType(typeLoc, TypeResolution::forContextual(DC), options);
+        TypeChecker::validateType(TC.Context, typeLoc,
+                                  TypeResolution::forContextual(DC), options);
 
     if (hadError)
       return nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1836,7 +1836,8 @@ static NominalTypeDecl *resolveSingleNominalTypeDecl(
 
   TypeResolutionOptions options = TypeResolverContext::TypeAliasDecl;
   options |= flags;
-  if (tc.validateType(typeLoc, TypeResolution::forInterface(DC), options))
+  if (TypeChecker::validateType(tc.Context, typeLoc,
+                                TypeResolution::forInterface(DC), options))
     return nullptr;
 
   return typeLoc.getType()->getAnyNominal();
@@ -3477,8 +3478,9 @@ static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
     return;
   }
 
-  if (tc.validateType(typeAlias->getUnderlyingTypeLoc(),
-                    TypeResolution::forInterface(typeAlias, &tc), options)) {
+  if (TypeChecker::validateType(tc.Context, typeAlias->getUnderlyingTypeLoc(),
+                                TypeResolution::forInterface(typeAlias, &tc),
+                                options)) {
     typeAlias->setInvalid();
     typeAlias->getUnderlyingTypeLoc().setInvalidType(tc.Context);
   }
@@ -4202,8 +4204,10 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
              TypeResolverContext::TypeAliasDecl));
           auto &underlyingTL = typealias->getUnderlyingTypeLoc();
           if (underlyingTL.isNull() ||
-              validateType(underlyingTL,
-                           TypeResolution::forStructural(typealias), options)) {
+              TypeChecker::validateType(Context,
+                                        underlyingTL,
+                                        TypeResolution::forStructural(typealias),
+                                        options)) {
             typealias->setInvalid();
             underlyingTL.setInvalidType(Context);
           }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -129,7 +129,7 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   TypeLoc constraintTypeLoc(repr->getConstraint());
   // Pass along the error type if resolving the repr failed.
   bool validationError
-    = validateType(constraintTypeLoc, resolution, options);
+    = validateType(Context, constraintTypeLoc, resolution, options);
   auto constraintType = constraintTypeLoc.getType();
   if (validationError)
     return constraintType;
@@ -569,7 +569,7 @@ void TypeChecker::validateGenericFuncOrSubscriptSignature(
       resultTyLoc.setType(
           getOrCreateOpaqueResultType(resolution, decl, opaqueTy));
     } else {
-      validateType(resultTyLoc, resolution,
+      validateType(Context, resultTyLoc, resolution,
                    TypeResolverContext::FunctionResult);
     }
   }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -705,7 +705,7 @@ static bool validateTypedPattern(TypeChecker &TC,
       hadError = true;
     }
   } else {
-    hadError = TC.validateType(TL, resolution, options);
+    hadError = TypeChecker::validateType(TC.Context, TL, resolution, options);
   }
 
   if (hadError) {
@@ -765,7 +765,7 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
   // We might have a null typeLoc if this is a closure parameter list,
   // where parameters are allowed to elide their types.
   if (!TL.isNull()) {
-    hadError |= TC.validateType(TL, resolution, options);
+    hadError |= TypeChecker::validateType(TC.Context, TL, resolution, options);
   }
 
   Type Ty = TL.getType();
@@ -1296,7 +1296,7 @@ recur:
 
     // Type-check the type parameter.
     TypeResolutionOptions paramOptions(TypeResolverContext::InExpression); 
-    if (validateType(IP->getCastTypeLoc(), resolution, paramOptions))
+    if (validateType(Context, IP->getCastTypeLoc(), resolution, paramOptions))
       return true;
 
     auto castType = IP->getCastTypeLoc().getType();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -494,7 +494,8 @@ AttachedPropertyWrapperTypeRequest::evaluate(Evaluator &evaluator,
   options |= TypeResolutionFlags::AllowUnboundGenerics;
 
   auto &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
-  if (tc.validateType(customAttr->getTypeLoc(), resolution, options))
+  if (TypeChecker::validateType(tc.Context, customAttr->getTypeLoc(),
+                                resolution, options))
     return ErrorType::get(ctx);
 
   return customAttr->getTypeLoc().getType();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -590,7 +590,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
   TypeChecker &TC = createTypeChecker(Ctx);
-  return TC.validateType(T, resolution, options);
+  return TypeChecker::validateType(TC.Context, T, resolution, options);
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -757,8 +757,9 @@ public:
   /// \param options Options that alter type resolution.
   ///
   /// \returns true if type validation failed, or false otherwise.
-  bool validateType(TypeLoc &Loc, TypeResolution resolution,
-                    TypeResolutionOptions options);
+  static bool validateType(ASTContext &Ctx, TypeLoc &Loc,
+                           TypeResolution resolution,
+                           TypeResolutionOptions options);
 
   /// Check for unsupported protocol types in the given declaration.
   void checkUnsupportedProtocolType(Decl *decl);
@@ -1747,7 +1748,6 @@ private:
                                     const DeclContext *DC,
                                     FragileFunctionKind fragileKind);
 
-public:
   /// Given that a type is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if its
   /// generic arguments require the use of conformances that cannot reasonably
@@ -1755,9 +1755,10 @@ public:
   ///
   /// This method \e only checks how generic arguments are used; it is assumed
   /// that the declarations involved have already been checked elsewhere.
-  void diagnoseGenericTypeExportability(const TypeLoc &TL,
-                                        const DeclContext *DC);
+  static void diagnoseGenericTypeExportability(const TypeLoc &TL,
+                                               const DeclContext *DC);
 
+public:
   /// Given that \p DC is within a fragile context for some reason, describe
   /// why.
   ///


### PR DESCRIPTION
Move around some code so that TypeChecker::validateType is now a utility
method of the type checker.  This cleans up at least one request that no
longer needs to grab the type checker from the AST context.
