### PR TITLE
Demangler: Make symbolic reference resolver part of `demangle(Symbol|Type)` calls.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -456,9 +456,11 @@ protected:
     int NumWords;
     StringRef Text;
     size_t Pos;
+    std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver;
     
   public:
-    DemangleInitRAII(Demangler &Dem, StringRef MangledName);
+    DemangleInitRAII(Demangler &Dem, StringRef MangledName,
+         std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver);
     ~DemangleInitRAII();
   };
   friend DemangleInitRAII;
@@ -587,39 +589,35 @@ public:
   
   void clear() override;
 
-  /// Install a resolver for symbolic references in a mangled string.
-  void setSymbolicReferenceResolver(
-                          std::function<SymbolicReferenceResolver_t> resolver) {
-    SymbolicReferenceResolver = resolver;
-  }
-
-  /// Take the symbolic reference resolver.
-  std::function<SymbolicReferenceResolver_t> &&
-  takeSymbolicReferenceResolver() {
-    return std::move(SymbolicReferenceResolver);
-  }
-
   /// Demangle the given symbol and return the parse tree.
   ///
   /// \param MangledName The mangled symbol string, which start with the
   /// mangling prefix $S.
+  /// \param SymbolicReferenceResolver A function invoked to resolve symbolic references in
+  /// the string. If null, then symbolic references will cause the demangle to fail.
   ///
   /// \returns A parse tree for the demangled string - or a null pointer
   /// on failure.
   /// The lifetime of the returned node tree ends with the lifetime of the
   /// Demangler or with a call of clear().
-  NodePointer demangleSymbol(StringRef MangledName);
+  NodePointer demangleSymbol(StringRef MangledName,
+            std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver
+               = nullptr);
 
   /// Demangle the given type and return the parse tree.
   ///
   /// \param MangledName The mangled type string, which does _not_ start with
   /// the mangling prefix $S.
+  /// \param SymbolicReferenceResolver A function invoked to resolve symbolic references in
+  /// the string. If null, then symbolic references will cause the demangle to fail.
   ///
   /// \returns A parse tree for the demangled string - or a null pointer
   /// on failure.
   /// The lifetime of the returned node tree ends with the lifetime of the
   /// Demangler or with a call of clear().
-  NodePointer demangleType(StringRef MangledName);
+  NodePointer demangleType(StringRef MangledName,
+            std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver
+              = nullptr);
 };
 
 /// A demangler which uses stack space for its initial memory.

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -108,7 +108,7 @@ public:
 
   explicit ReflectionContext(std::shared_ptr<MemoryReader> reader)
     : super(std::move(reader)) {
-    getBuilder().setSymbolicReferenceResolverReader(*this);
+    getBuilder().setMetadataReader(*this);
   }
 
   ReflectionContext(const ReflectionContext &other) = delete;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1690,9 +1690,8 @@ private:
       break;
     }
 
-    // Install our own symbolic reference resolver
-    auto oldSymbolicReferenceResolver = dem.takeSymbolicReferenceResolver();
-    dem.setSymbolicReferenceResolver([&](SymbolicReferenceKind kind,
+    // Symbolic reference resolver for the demangle operation below.
+    auto symbolicReferenceResolver = [&](SymbolicReferenceKind kind,
                                          Directness directness,
                                          int32_t offset,
                                          const void *base) ->
@@ -1726,20 +1725,19 @@ private:
       }
 
       return nullptr;
-    });
+    };
 
     swift::Demangle::NodePointer result;
     switch (kind) {
     case MangledNameKind::Type:
-      result = dem.demangleType(mangledName);
+      result = dem.demangleType(mangledName, symbolicReferenceResolver);
       break;
 
     case MangledNameKind::Symbol:
-      result = dem.demangleSymbol(mangledName);
+      result = dem.demangleSymbol(mangledName, symbolicReferenceResolver);
       break;
     }
 
-    dem.setSymbolicReferenceResolver(std::move(oldSymbolicReferenceResolver));
     return result;
   }
 

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -33,7 +33,7 @@ class AttributeDemangler : public Demangle::Demangler {
 public:
   void demangleAndAddAsChildren(StringRef MangledSpecialization,
                                 NodePointer Parent) {
-    DemangleInitRAII state(*this, MangledSpecialization);
+    DemangleInitRAII state(*this, MangledSpecialization, nullptr);
     if (!parseAndPushNodes()) {
       llvm::errs() << "Can't demangle: " << MangledSpecialization << '\n';
       abort();

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -99,10 +99,6 @@ static void _buildNameForMetadata(const Metadata *type,
   // Use the remangler to generate a mangled name from the type metadata.
   
   Demangle::Demangler Dem;
-  // We want to resolve symbolic references to a user-comprehensible
-  // representation of the referenced context.
-  Dem.setSymbolicReferenceResolver(ResolveToDemanglingForContext(Dem));
-  
   auto demangling = _swift_buildDemanglingForMetadata(type, Dem);
   if (demangling == nullptr) {
     result = "<<< invalid type >>>";

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -80,7 +80,8 @@ swift::_buildDemanglingForContext(const ContextDescriptor *context,
     case ContextDescriptorKind::Extension: {
       auto extension = llvm::cast<ExtensionContextDescriptor>(component);
       // Demangle the extension self type.
-      auto selfType = Dem.demangleType(extension->getMangledExtendedContext());
+      auto selfType = Dem.demangleType(extension->getMangledExtendedContext(),
+                                       ResolveToDemanglingForContext(Dem));
       if (selfType->getKind() == Node::Kind::Type)
         selfType = selfType->getChild(0);
       

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2197,9 +2197,6 @@ static inline ClassROData *getROData(ClassMetadata *theClass) {
 static void initGenericClassObjCName(ClassMetadata *theClass) {
   // Use the remangler to generate a mangled name from the type metadata.
   Demangle::StackAllocatedDemangler<4096> Dem;
-  // Resolve symbolic references to a unique mangling that can be encoded in
-  // the class name.
-  Dem.setSymbolicReferenceResolver(ResolveToDemanglingForContext(Dem));
 
   auto demangling = _swift_buildDemanglingForMetadata(theClass, Dem);
 
@@ -5155,8 +5152,6 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
   if (!verificationEnabled) return;
   
   Demangle::StackAllocatedDemangler<1024> Dem;
-  Dem.setSymbolicReferenceResolver(ResolveToDemanglingForContext(Dem));
-
   auto node = _swift_buildDemanglingForMetadata(metadata, Dem);
   // If the mangled node involves types in an AnonymousContext, then by design,
   // it cannot be looked up by name.


### PR DESCRIPTION
This makes for a cleaner and less implicit-context-heavy API, and makes it easier for symbolic reference resolvers to do context-dependent things (like map the in-memory base address back to a remote address in MetadataReader).