### PR TITLE
[5.1 08-28-2019] ReflectionContext: Keep read range properly aligned.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -193,6 +193,11 @@ public:
       }
       RangeStart = std::min(RangeStart, (uint64_t)S->addr + Slide);
       RangeEnd = std::max(RangeEnd, (uint64_t)(S->addr + S->size + Slide));
+      // Keep the range rounded to 8 byte alignment on both ends so we don't
+      // introduce misaligned pointers mapping between local and remote
+      // address space.
+      RangeStart = RangeStart & ~7;
+      RangeEnd = RangeEnd + 7 & ~7;      
     }
  
     if (RangeStart == UINT64_MAX && RangeEnd == UINT64_MAX)


### PR DESCRIPTION
Explanation: The RemoteMirror library could in certain cases end up mapping object files at a skewed address, causing unaligned loads to happen.

Scope: Crash when using out-of-process reflection tools such as leaks.

Issue: rdar://problem/54556791

Risk: Low

Testing: Swift CI

Reviewed by: @jrose-apple 