### PR TITLE
Runtime: Fast path lookup for short manglings.

### DIFF
--- a/include/swift/Demangling/StandardTypesMangling.def
+++ b/include/swift/Demangling/StandardTypesMangling.def
@@ -16,7 +16,6 @@
 STANDARD_TYPE(Structure, A, AutoreleasingUnsafeMutablePointer)
 STANDARD_TYPE(Structure, a, Array)
 STANDARD_TYPE(Structure, b, Bool)
-STANDARD_TYPE(Structure, c, UnicodeScalar)
 STANDARD_TYPE(Structure, D, Dictionary)
 STANDARD_TYPE(Structure, d, Double)
 STANDARD_TYPE(Structure, f, Float)

--- a/include/swift/Demangling/StandardTypesMangling.def
+++ b/include/swift/Demangling/StandardTypesMangling.def
@@ -13,7 +13,16 @@
 /// STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND.
 
-STANDARD_TYPE(Structure, A, AutoreleasingUnsafeMutablePointer)
+/// OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
+///   The 1-character MANGLING for a known TYPENAME of KIND, for a type that's
+///   only available with ObjC interop enabled.
+
+#ifndef OBJC_INTEROP_STANDARD_TYPE
+#define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME) \
+  STANDARD_TYPE(KIND, MANGLING, TYPENAME)
+#endif
+
+OBJC_INTEROP_STANDARD_TYPE(Structure, A, AutoreleasingUnsafeMutablePointer)
 STANDARD_TYPE(Structure, a, Array)
 STANDARD_TYPE(Structure, b, Bool)
 STANDARD_TYPE(Structure, D, Dictionary)
@@ -65,3 +74,4 @@ STANDARD_TYPE(Protocol, Z, SignedInteger)
 STANDARD_TYPE(Protocol, z, BinaryInteger)
 
 #undef STANDARD_TYPE
+#undef OBJC_INTEROP_STANDARD_TYPE

--- a/test/SILGen/arguments.swift
+++ b/test/SILGen/arguments.swift
@@ -25,7 +25,7 @@ func arg_tuple(x: Int, y: Float) {}
 arg_tuple(x: i, y: f)
 
 func arg_deep_tuples(x: Int, y: (Float, UnicodeScalar)) {}
-// CHECK-LABEL: sil hidden [ossa] @$ss15arg_deep_tuples1x1yySi_Sf_ScttF
+// CHECK-LABEL: sil hidden [ossa] @$ss15arg_deep_tuples1x1yySi_Sf_s13UnicodeScalarVttF
 // CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y_0:%[0-9]+]] : $Float, [[Y_1:%[0-9]+]] : $UnicodeScalar):
 
 arg_deep_tuples(x:i, y:(f, c))
@@ -37,7 +37,7 @@ var named_subtuple = (x:f, y:c)
 arg_deep_tuples(x:i, y: named_subtuple)
 
 func arg_deep_tuples_2(x: Int, _: (y: Float, z: UnicodeScalar)) {}
-// CHECK-LABEL: sil hidden [ossa] @$ss17arg_deep_tuples_21x_ySi_Sf1y_Sc1zttF
+// CHECK-LABEL: sil hidden [ossa] @$ss17arg_deep_tuples_21x_ySi_Sf1y_s13UnicodeScalarV1zttF
 // CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Float, [[Z:%[0-9]+]] : $UnicodeScalar):
 
 arg_deep_tuples_2(x: i, (f, c))


### PR DESCRIPTION
Mangling these common types takes only two bytes, which is shorter than a symbolic reference. We know where their metadata is in the standard library, too, so we don't need to search the lookup
tables for them.