### PR TITLE
[5.1][IDE] Fix document structure request output for interpolated string literals

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -242,6 +242,7 @@ class ModelASTWalker : public ASTWalker {
   const LangOptions &LangOpts;
   const SourceManager &SM;
   unsigned BufferID;
+  ASTContext &Ctx;
   std::vector<StructureElement> SubStructureStack;
   SourceLoc LastLoc;
   static const std::regex &getURLRegex(StringRef Protocol);
@@ -262,6 +263,7 @@ public:
         LangOpts(File.getASTContext().LangOpts),
         SM(File.getASTContext().SourceMgr),
         BufferID(File.getBufferID().getValue()),
+        Ctx(File.getASTContext()),
         Walker(Walker) { }
 
   void visitSourceFile(SourceFile &SrcFile, ArrayRef<SyntaxNode> Tokens);
@@ -513,13 +515,14 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     SN.BodyRange = innerCharSourceRangeFromSourceRange(SM, E->getSourceRange());
     pushStructureNode(SN, E);
   } else if (auto *Tup = dyn_cast<TupleExpr>(E)) {
+    auto *ParentE = Parent.getAsExpr();
     if (isCurrentCallArgExpr(Tup)) {
       for (unsigned I = 0; I < Tup->getNumElements(); ++ I) {
         SourceLoc NameLoc = Tup->getElementNameLoc(I);
         if (NameLoc.isValid())
           passTokenNodesUntil(NameLoc, PassNodesBehavior::ExcludeNodeAtLocation);
       }
-    } else {
+    } else if (!ParentE || !isa<InterpolatedStringLiteralExpr>(ParentE)) {
       SyntaxStructureNode SN;
       SN.Kind = SyntaxStructureKind::TupleExpression;
       SN.Range = charSourceRangeFromSourceRange(SM, Tup->getSourceRange());
@@ -554,6 +557,18 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
       subExpr->walk(*this);
     }
     return { false, walkToExprPost(SE) };
+  } else if (auto *ISL = dyn_cast<InterpolatedStringLiteralExpr>(E)) {
+    // Don't visit the child expressions directly. Instead visit the arguments
+    // of each appendStringLiteral/appendInterpolation CallExpr so we don't
+    // try to output structure nodes for those calls.
+    llvm::SaveAndRestore<ASTWalker::ParentTy> SetParent(Parent, E);
+    ISL->forEachSegment(Ctx, [&](bool isInterpolation, CallExpr *CE) {
+      if (isInterpolation) {
+        if (auto *Arg = CE->getArg())
+          Arg->walk(*this);
+      }
+    });
+    return { false, walkToExprPost(E) };
   }
 
   return { true, E };

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -293,3 +293,39 @@ myFunc(foo: 0,
        bar: baz == 0)
 // CHECK: <call><name>myFunc</name>(<arg><name>foo</name>: 0</arg>,
 // CHECK:        <arg><name>bar</name>: baz == 0</arg>)</call>
+
+
+enum FooEnum {
+// CHECK: <enum>enum <name>FooEnum</name> {
+  case blah(x: () -> () = {
+  // CHECK: <enum-case>case <enum-elem><name>blah(<param><name>x</name>: <type>() -> ()</type> = <closure><brace>{
+    @Tuples func foo(x: MyStruc) {}
+    // CHECK: @Tuples <ffunc>func <name>foo(<param><name>x</name>: <type>MyStruc</type></param>)</name> {}</ffunc>
+  })
+  // CHECK: }</brace></closure></param>)</name></enum-elem></enum-case>
+}
+// CHECK: }</enum>
+
+firstCall("\(1)", 1)
+// CHECK: <call><name>firstCall</name>(<arg>"\(1)"</arg>, <arg>1</arg>)</call>
+
+secondCall("\(a: {struct Foo {let x = 10}; return Foo().x}())", 1)
+// CHECK: <call><name>secondCall</name>(<arg>"\(a: <call><name><closure><brace>{<struct>struct <name>Foo</name> {<property>let <name>x</name> = 10</property>}</struct>; return <call><name>Foo</name>()</call>.x}</brace></closure></name>()</call>)"</arg>, <arg>1</arg>)</call>
+
+thirdCall("""
+\("""
+  \({
+  return a()
+  }())
+  """)
+""")
+// CHECK: <call><name>thirdCall</name>("""
+// CHECK-NEXT: \("""
+// CHECK-NEXT:   \(<call><name><closure>{
+// CHECK-NEXT:   return <call><name>a</name>()</call>
+// CHECK-NEXT:   }</closure></name>()</call>)
+// CHECK-NEXT:   """)
+// CHECK-NEXT: """)</call>
+
+fourthCall(a: @escaping () -> Int)
+// CHECK: <call><name>fourthCall</name>(<arg><name>a</name>: @escaping () -> Int</arg>)</call>


### PR DESCRIPTION
`InterpolatedStringLiteralExpr` has a `TapExpr`, which contains a `BraceStmt` containing `CallExpr`s to the builder `appendInterpolation` / `appendStringLiteral` methods used to construct the final string. This is all implementation detail that doesn't actually appear in the source code, but the document structure request didn't filter it out, resulting in bogus calls and brace ranges in its responses. When an interpolated string appears as the initial value of a stored property, its bogus entries cause syntax highlighting and structural selection on parts of the following declaration to be missing in Xcode.

Resolves rdar://problem/55183943

Cherry-pick of https://github.com/apple/swift/pull/26354, but without the potentially risky parser improvements.
