### PR TITLE
Parse: repair build after #27132

### DIFF
--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -300,7 +300,7 @@ public:
     return SyntaxNode(std::move(rawNode));
   }
 
-  ParsedTokenSyntax popToken();
+  ParsedTokenSyntax &&popToken();
 
   /// Create a node using the tail of the collected parts. The number of parts
   /// is automatically determined from \c Kind. Node: limited number of \c Kind

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -408,7 +408,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
   }
 
   if (Tok.is(tok::arrow)) {
-    auto InputNode = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    auto InputNode(std::move(SyntaxContext->popIf<ParsedTypeSyntax>().getValue()));
     // Handle type-function if we have an arrow.
     auto ArrowLoc = Tok.getLoc();
     auto Arrow = consumeTokenSyntax();
@@ -741,7 +741,7 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     if (Base) {
       SyntaxContext->addSyntax(std::move(*Base));
       auto T = SyntaxContext->topNode<TypeSyntax>();
-      Junk.push_back(*SyntaxContext->popIf<ParsedTypeSyntax>());
+      Junk.push_back(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
       ITR = dyn_cast<IdentTypeRepr>(Generator.generate(T, BaseLoc));
     }
 
@@ -1164,9 +1164,10 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       auto InFlight = diagnose(EqualLoc, diag::tuple_type_init);
       if (Init.isNonNull())
         InFlight.fixItRemove(SourceRange(EqualLoc, Init.get()->getEndLoc()));
-      auto Expr = *SyntaxContext->popIf<ParsedExprSyntax>();
       Initializer = ParsedSyntaxRecorder::makeInitializerClause(
-          std::move(*Equal), std::move(Expr), *SyntaxContext);
+          std::move(*Equal),
+          std::move(*SyntaxContext->popIf<ParsedExprSyntax>()),
+          *SyntaxContext);
     }
 
     Comma = consumeTokenSyntaxIf(tok::comma);

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -163,8 +163,8 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
   return Curr;
 }
 
-ParsedTokenSyntax SyntaxParsingContext::popToken() {
-  return popIf<ParsedTokenSyntax>().getValue();
+ParsedTokenSyntax &&SyntaxParsingContext::popToken() {
+  return std::move(popIf<ParsedTokenSyntax>().getValue());
 }
 
 /// Add Token with Trivia to the parts.
@@ -334,7 +334,7 @@ SyntaxParsingContext::~SyntaxParsingContext() {
         Storage.push_back(std::move(BridgedNode.getValue()));
       }
     } else {
-      auto node = bridgeAs(CtxtKind, getParts()).getValue();
+      auto node(std::move(bridgeAs(CtxtKind, getParts()).getValue()));
       Storage.erase(Storage.begin() + Offset, Storage.end());
       Storage.emplace_back(std::move(node));
     }


### PR DESCRIPTION
The type deduction here will copy the returned `ParsedTypeSyntax` which
is no longer copy constructible.  Use a reference to hold the result
instead which should fix the build on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
