### PR TITLE
[NFC] Introduce isType and getDeclType

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -460,7 +460,10 @@ public:
   
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \
   /** Retrieve the declaration of Swift.NAME. */ \
-  DECL_CLASS *get##NAME##Decl() const;
+  DECL_CLASS *get##NAME##Decl() const; \
+\
+  /** Retrieve the type of Swift.NAME. */ \
+  Type get##NAME##Type() const;
 #include "swift/AST/KnownStdlibTypes.def"
 
   /// Retrieve the declaration of Swift.Optional<T>.Some.
@@ -474,9 +477,6 @@ public:
 
   /// Retrieve the type Swift.AnyObject.
   CanType getAnyObjectType() const;
-
-  /// Retrieve the type Swift.Never.
-  CanType getNeverType() const;
 
 #define KNOWN_OBJC_TYPE_DECL(MODULE, NAME, DECL_CLASS) \
   /** Retrieve the declaration of MODULE.NAME. */ \

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -70,6 +70,7 @@ PROTOCOL(OptionSet)
 PROTOCOL(CaseIterable)
 PROTOCOL(SIMDScalar)
 PROTOCOL(BinaryInteger)
+PROTOCOL(RangeReplaceableCollection)
 
 PROTOCOL_(BridgedNSError)
 PROTOCOL_(BridgedStoredNSError)

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -25,8 +25,6 @@
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS)
 #endif
 
-KNOWN_STDLIB_TYPE_DECL(Void, TypeAliasDecl, 0)
-
 KNOWN_STDLIB_TYPE_DECL(Bool, NominalTypeDecl, 0)
 
 KNOWN_STDLIB_TYPE_DECL(Int,   NominalTypeDecl, 0)
@@ -89,6 +87,5 @@ KNOWN_STDLIB_TYPE_DECL(Encoder, ProtocolDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(Decoder, ProtocolDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(KeyedEncodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(KeyedDecodingContainer, NominalTypeDecl, 1)
-KNOWN_STDLIB_TYPE_DECL(RangeReplaceableCollection, ProtocolDecl, 1)
 
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -774,11 +774,13 @@ public:
   /// These are the types of the Swift type system.
   bool isLegalFormalType();
 
-  /// Check if this type is equal to the empty tuple type.
+  // Whether or not this is equal to ()
   bool isVoid();
 
-  /// Check if this type is equal to Swift.Bool.
-  bool isBool();
+  #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \
+  /** Whether or not this is equal to Swift.NAME. */ \
+  bool is##NAME();
+  #include "swift/AST/KnownStdlibTypes.def"
 
   /// Check if this type is equal to Builtin.IntN.
   bool isBuiltinIntegerType(unsigned bitWidth);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3777,15 +3777,13 @@ public:
 
   void visitBoundGenericType(BoundGenericType *T) {
     if (Options.SynthesizeSugarOnTypes) {
-      auto *NT = T->getDecl();
-      auto &Ctx = T->getASTContext();
-      if (NT == Ctx.getArrayDecl()) {
+      if (T->isArray()) {
         Printer << "[";
         visit(T->getGenericArgs()[0]);
         Printer << "]";
         return;
       }
-      if (NT == Ctx.getDictionaryDecl()) {
+      if (T->isDictionary()) {
         Printer << "[";
         visit(T->getGenericArgs()[0]);
         Printer << " : ";
@@ -3793,7 +3791,7 @@ public:
         Printer << "]";
         return;
       }
-      if (NT == Ctx.getOptionalDecl()) {
+      if (T->isOptional()) {
         printWithParensIfNotSimple(T->getGenericArgs()[0]);
         Printer << "?";
         return;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1032,8 +1032,7 @@ public:
       case StmtConditionElement::CK_Boolean: {
         auto *E = elt.getBoolean();
         if (shouldVerifyChecked(E))
-          checkSameType(E->getType(), Ctx.getBoolDecl()->getDeclaredType(),
-                        "condition type");
+          checkSameType(E->getType(), Ctx.getBoolType(), "condition type");
         break;
       }
 
@@ -1376,9 +1375,7 @@ public:
       }
       
       // Ensure we don't convert an array to a void pointer this way.
-      
-      if (fromElement->getNominalOrBoundGenericNominal() == Ctx.getArrayDecl()
-          && toElement->isEqual(Ctx.TheEmptyTupleType)) {
+      if (fromElement->isArray() && toElement->isVoid()) {
         Out << "InOutToPointer is converting an array to a void pointer; "
                "ArrayToPointer should be used instead:\n";
         E->dump(Out);
@@ -1401,7 +1398,7 @@ public:
       // The source may be optionally inout.
       auto fromArray = E->getSubExpr()->getType()->getInOutObjectType();
       
-      if (fromArray->getNominalOrBoundGenericNominal() != Ctx.getArrayDecl()) {
+      if (!fromArray->isArray()) {
         Out << "ArrayToPointer does not convert from array:\n";
         E->dump(Out);
         Out << "\n";
@@ -1422,8 +1419,7 @@ public:
       PrettyStackTraceExpr debugStack(Ctx,
                                       "verifying StringToPointer", E);
       
-      if (E->getSubExpr()->getType()->getNominalOrBoundGenericNominal()
-            != Ctx.getStringDecl()) {
+      if (!E->getSubExpr()->getType()->isString()) {
         Out << "StringToPointer does not convert from string:\n";
         E->dump(Out);
         Out << "\n";
@@ -2188,22 +2184,20 @@ public:
       auto keyPathTy = E->getKeyPath()->getType();
       auto resultTy = E->getType();
       
-      if (auto nom = keyPathTy->getAs<NominalType>()) {
-        if (nom->getDecl() == Ctx.getAnyKeyPathDecl()) {
-          // AnyKeyPath application is <T> rvalue T -> rvalue Any?
-          if (baseTy->is<LValueType>()) {
-            Out << "AnyKeyPath application base is not an rvalue\n";
-            abort();
-          }
-          auto resultObjTy = resultTy->getOptionalObjectType();
-          if (!resultObjTy || !resultObjTy->isAny()) {
-            Out << "AnyKeyPath application result must be Any?\n";
-            abort();
-          }
-          return;
+      if (keyPathTy->isAnyKeyPath()) {
+        // AnyKeyPath application is <T> rvalue T -> rvalue Any?
+        if (baseTy->is<LValueType>()) {
+          Out << "AnyKeyPath application base is not an rvalue\n";
+          abort();
         }
+        auto resultObjTy = resultTy->getOptionalObjectType();
+        if (!resultObjTy || !resultObjTy->isAny()) {
+          Out << "AnyKeyPath application result must be Any?\n";
+          abort();
+        }
+        return;
       } else if (auto bgt = keyPathTy->getAs<BoundGenericType>()) {
-        if (bgt->getDecl() == Ctx.getPartialKeyPathDecl()) {
+        if (keyPathTy->isPartialKeyPath()) {
           // PartialKeyPath<T> application is rvalue T -> rvalue Any
           if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
             Out << "PartialKeyPath application base doesn't match type\n";
@@ -2214,7 +2208,7 @@ public:
             abort();
           }
           return;
-        } else if (bgt->getDecl() == Ctx.getKeyPathDecl()) {
+        } else if (keyPathTy->isKeyPath()) {
           // KeyPath<T, U> application is rvalue T -> rvalue U
           if (!baseTy->isEqual(bgt->getGenericArgs()[0])) {
             Out << "KeyPath application base doesn't match type\n";
@@ -2225,7 +2219,7 @@ public:
             abort();
           }
           return;
-        } else if (bgt->getDecl() == Ctx.getWritableKeyPathDecl()) {
+        } else if (keyPathTy->isWritableKeyPath()) {
           // WritableKeyPath<T, U> application is
           //    lvalue T -> lvalue U
           // or rvalue T -> rvalue U
@@ -2247,7 +2241,7 @@ public:
             abort();
           }
           return;
-        } else if (bgt->getDecl() == Ctx.getReferenceWritableKeyPathDecl()) {
+        } else if (keyPathTy->isReferenceWritableKeyPath()) {
           // ReferenceWritableKeyPath<T, U> application is
           //    rvalue T -> lvalue U
           // or lvalue T -> lvalue U
@@ -2873,8 +2867,7 @@ public:
       // Verify that the optionality of the result type of the
       // initializer matches the failability of the initializer.
       if (!CD->isInvalid() &&
-          CD->getDeclContext()->getDeclaredInterfaceType()->getAnyNominal() !=
-              Ctx.getOptionalDecl()) {
+          !CD->getDeclContext()->getDeclaredInterfaceType()->isOptional()) {
         bool resultIsOptional = (bool) CD->getResultInterfaceType()
             ->getOptionalObjectType();
         auto declIsOptional = CD->isFailable();

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1268,8 +1268,8 @@ static ValueDecl *getLinearFunctionConstructor(
 static ValueDecl *getGlobalStringTablePointer(ASTContext &Context,
                                               Identifier Id) {
   // String -> Builtin.RawPointer
-  auto stringType = NominalType::get(Context.getStringDecl(), Type(), Context);
-  return getBuiltinFunction(Id, {stringType}, Context.TheRawPointerType);
+  return getBuiltinFunction(Id, {Context.getStringType()},
+                            Context.TheRawPointerType);
 }
 
 static ValueDecl *getConvertStrongToUnownedUnsafe(ASTContext &ctx,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -398,7 +398,7 @@ static bool isInterestingTypealias(Type type) {
   else
     return false;
 
-  if (aliasDecl == type->getASTContext().getVoidDecl())
+  if (type->isVoid())
     return false;
 
   // The 'Swift.AnyObject' typealias is not 'interesting'.

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -558,38 +558,38 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     } else if (tokenI[1].is(clang::tok::pipepipe)) {
       bool result  = firstValue.getBoolValue() || secondValue.getBoolValue();
       resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Logical AND.
     } else if (tokenI[1].is(clang::tok::ampamp)) {
       bool result  = firstValue.getBoolValue() && secondValue.getBoolValue();
       resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Equality.
     } else if (tokenI[1].is(clang::tok::equalequal)) {
       resultValue     = llvm::APSInt::get(firstValue == secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Less than.
     } else if (tokenI[1].is(clang::tok::less)) {
       resultValue     = llvm::APSInt::get(firstValue < secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Less than or equal.
     } else if (tokenI[1].is(clang::tok::lessequal)) {
       resultValue     = llvm::APSInt::get(firstValue <= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Greater than.
     } else if (tokenI[1].is(clang::tok::greater)) {
       resultValue     = llvm::APSInt::get(firstValue > secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Greater than or equal.
     } else if (tokenI[1].is(clang::tok::greaterequal)) {
       resultValue     = llvm::APSInt::get(firstValue >= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      resultSwiftType = impl.SwiftContext.getBoolType();
 
     // Unhandled operators.
     } else {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -757,8 +757,7 @@ namespace {
       case ImportHint::NSUInteger:
         // NSUInteger might be imported as Int rather than UInt depending
         // on where the import lives.
-        if (underlyingResult.AbstractType->getAnyNominal() ==
-            Impl.SwiftContext.getIntDecl())
+        if (underlyingResult.AbstractType->isInt())
           break;
         LLVM_FALLTHROUGH;
       default:
@@ -990,7 +989,7 @@ namespace {
         if (auto objcClassDef = objcClass->getDefinition())
           bridgedType = mapSwiftBridgeAttr(objcClassDef);
         else if (objcClass->getName() == "NSString")
-          bridgedType = Impl.SwiftContext.getStringDecl()->getDeclaredType();
+          bridgedType = Impl.SwiftContext.getStringType();
 
         if (bridgedType) {
           // Gather the type arguments.
@@ -1032,31 +1031,25 @@ namespace {
             // The first type argument for Dictionary or Set needs
             // to be Hashable. If something isn't Hashable, fall back
             // to AnyHashable as a key type.
-            if (unboundDecl == Impl.SwiftContext.getDictionaryDecl() ||
-                unboundDecl == Impl.SwiftContext.getSetDecl()) {
+            if (unboundType->isDictionary() || unboundType->isSet()) {
               auto &keyType = importedTypeArgs[0];
-              auto keyStructDecl = keyType->getStructOrBoundGenericStruct();
               if (!Impl.matchesHashableBound(keyType) ||
                   // Dictionary and Array conditionally conform to Hashable,
                   // but the conformance doesn't necessarily apply with the
                   // imported versions of their type arguments.
                   // FIXME: Import their non-Hashable type parameters as
                   // AnyHashable in this context.
-                  keyStructDecl == Impl.SwiftContext.getDictionaryDecl() ||
-                  keyStructDecl == Impl.SwiftContext.getArrayDecl()) {
-                if (auto anyHashable = Impl.SwiftContext.getAnyHashableDecl())
-                  keyType = anyHashable->getDeclaredType();
-                else
-                  keyType = Type();
+                  keyType->isDictionary() || keyType->isArray()) {
+                keyType = Impl.SwiftContext.getAnyHashableType();
               }
             }
 
             // Form the specialized type.
-            if (unboundDecl == Impl.SwiftContext.getArrayDecl()) {
+            if (unboundType->isArray()) {
               // Type sugar for arrays.
               assert(importedTypeArgs.size() == 1);
               bridgedType = ArraySliceType::get(importedTypeArgs[0]);
-            } else if (unboundDecl == Impl.SwiftContext.getDictionaryDecl()) {
+            } else if (unboundType->isDictionary()) {
               // Type sugar for dictionaries.
               assert(importedTypeArgs.size() == 2);
               bridgedType = DictionaryType::get(importedTypeArgs[0],
@@ -1248,11 +1241,7 @@ static Type maybeImportCFOutParameter(ClangImporter::Implementation &impl,
     insideOptionalType = elementType;
 
   auto boundGenericTy = insideOptionalType->getAs<BoundGenericType>();
-  if (!boundGenericTy)
-    return Type();
-
-  auto boundGenericBase = boundGenericTy->getDecl();
-  if (boundGenericBase != impl.SwiftContext.getUnmanagedDecl())
+  if (!boundGenericTy && !boundGenericTy->isUnmanaged())
     return Type();
 
   assert(boundGenericTy->getGenericArgs().size() == 1 &&
@@ -1371,14 +1360,14 @@ static ImportedType adjustTypeForConcreteImport(
     // Turn BOOL and DarwinBoolean into Bool in contexts that can bridge types
     // losslessly.
     if (bridging == Bridgeability::Full && canBridgeTypes(importKind))
-      importedType = impl.SwiftContext.getBoolDecl()->getDeclaredType();
+      importedType = impl.SwiftContext.getBoolType();
     break;
 
   case ImportHint::NSUInteger:
     // When NSUInteger is used as an enum's underlying type or if it does not
     // come from a system module, make sure it stays unsigned.
     if (importKind == ImportTypeKind::Enum || !allowNSUIntegerAsInt)
-      importedType = impl.SwiftContext.getUIntDecl()->getDeclaredType();
+      importedType = impl.SwiftContext.getUIntType();
     break;
 
   case ImportHint::CFPointer:
@@ -1609,7 +1598,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     switch (getClangASTContext().BuiltinInfo.getTypeString(builtinID)[0]) {
     case 'z': // size_t
     case 'Y': // ptrdiff_t
-      return {SwiftContext.getIntDecl()->getDeclaredType(), false};
+      return {SwiftContext.getIntType(), false};
     default:
       break;
     }
@@ -2212,7 +2201,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   *bodyParams = ParameterList::create(SwiftContext, swiftParams);
 
   if (clangDecl->hasAttr<clang::NoReturnAttr>()) {
-    origSwiftResultTy = SwiftContext.getNeverType();
+    origSwiftResultTy = CanType(SwiftContext.getNeverType());
     swiftResultTy = SwiftContext.getNeverType();
   }
 
@@ -2278,7 +2267,7 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     paramInfo->setInterfaceType(propertyTy);
 
     *params = ParameterList::create(SwiftContext, paramInfo);
-    resultTy = SwiftContext.getVoidDecl()->getDeclaredInterfaceType();
+    resultTy = SwiftContext.TheEmptyTupleType;
     isIUO = false;
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3940,7 +3940,7 @@ public:
       builder.addRightBracket();
     });
 
-    auto floatType = context.getFloatDecl()->getDeclaredType();
+    auto floatType = context.getFloatType();
     addFromProto(LK::ColorLiteral, "", [&](Builder &builder) {
       builder.addBaseName("#colorLiteral");
       builder.addLeftParen();
@@ -3954,12 +3954,11 @@ public:
       builder.addRightParen();
     });
 
-    auto stringType = context.getStringDecl()->getDeclaredType();
     addFromProto(LK::ImageLiteral, "", [&](Builder &builder) {
       builder.addBaseName("#imageLiteral");
       builder.addLeftParen();
       builder.addCallParameter(context.getIdentifier("resourceName"),
-                               stringType);
+                               context.getStringType());
       builder.addRightParen();
     });
 
@@ -4004,7 +4003,7 @@ public:
         }
       }
 
-      if (!addedKeyPath && T->getAnyNominal() == Ctx.getStringDecl()) {
+      if (!addedKeyPath && T->isString()) {
         addPoundKeyPath(needPound);
         if (addedSelector)
           break;

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -670,7 +670,7 @@ class ExprContextAnalyzer {
         if (auto boundGenericT = arrayT->getAs<BoundGenericType>()) {
           // let _: [Element] = [#HERE#]
           // In this case, 'Element' is the expected type.
-          if (boundGenericT->getDecl() == Context.getArrayDecl())
+          if (boundGenericT->isArray())
             recordPossibleType(boundGenericT->getGenericArgs()[0]);
 
           // let _: [Key : Value] = [#HERE#]
@@ -789,7 +789,7 @@ class ExprContextAnalyzer {
       if (auto SEQ = cast<ForEachStmt>(Parent)->getSequence()) {
         if (containsTarget(SEQ)) {
           recordPossibleType(
-              Context.getSequenceDecl()->getDeclaredInterfaceType());
+              Context.getSequenceType());
         }
       }
       break;
@@ -798,7 +798,7 @@ class ExprContextAnalyzer {
     case StmtKind::While:
     case StmtKind::Guard:
       if (isBoolConditionOf(Parent)) {
-        recordPossibleType(Context.getBoolDecl()->getDeclaredInterfaceType());
+        recordPossibleType(Context.getBoolType());
       }
       break;
     default:

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -464,7 +464,7 @@ private:
 
   /// Collect the type that an ASTNode should be evaluated to.
   ReturnInfo resolveNodeType(ASTNode N, RangeKind Kind) {
-    auto *VoidTy = Ctx.getVoidDecl()->getDeclaredInterfaceType().getPointer();
+    auto *VoidTy = Ctx.TheEmptyTupleType.getPointer();
     if (N.isNull())
       return {VoidTy, ExitState::Negative};
     switch(Kind) {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1814,20 +1814,19 @@ findConcatenatedExpressions(ResolvedRangeInfo Info, ASTContext &Ctx) {
       // FIXME: we should have ErrorType instead of null.
       if (E->getType().isNull())
         return true;
-      auto ExprType = E->getType()->getNominalOrBoundGenericNominal();
       //Only binary concatenation operators should exist in expression
       if (E->getKind() == ExprKind::Binary) {
         auto *BE = dyn_cast<BinaryExpr>(E);
         auto *OperatorDeclRef = BE->getSemanticFn()->getMemberOperatorRef();
         if (!(isConcatenationExpr(OperatorDeclRef)
-            && ExprType == Ctx.getStringDecl())) {
+            && E->getType()->isString())) {
           IsValidInterpolation = false;
           return false;
         }
         return true;
       }
       // Everything that evaluates to string should be gathered.
-      if (ExprType == Ctx.getStringDecl()) {
+      if (E->getType()->isString()) {
         Bucket->insert(E);
         return false;
       }

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -303,12 +303,12 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
     // Handle Int and UInt specially. On Apple platforms, these correspond to
     // the NSInteger and NSUInteger typedefs, so map them back to those typedefs
     // if they're available, to ensure we get consistent ObjC @encode strings.
-    if (swiftType->getAnyNominal() == IGM.Context.getIntDecl()) {
+    if (swiftType->isInt()) {
       if (auto NSIntegerTy = getClangBuiltinTypeFromTypedef(sema, "NSInteger")){
         Cache.insert({swiftType, NSIntegerTy});
         return;
       }
-    } else if (swiftType->getAnyNominal() == IGM.Context.getUIntDecl()) {
+    } else if (swiftType->isUInt()) {
       if (auto NSUIntegerTy =
             getClangBuiltinTypeFromTypedef(sema, "NSUInteger")) {
         Cache.insert({swiftType, NSUIntegerTy});

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4641,6 +4641,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::StringInterpolationProtocol:
   case KnownProtocolKind::AdditiveArithmetic:
   case KnownProtocolKind::Differentiable:
+  case KnownProtocolKind::RangeReplaceableCollection:
     return SpecialProtocol::None;
   }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -942,7 +942,7 @@ private:
       } else {
         // Discriminated union case without argument. Fallback to Int
         // as the element type; there is no storage here.
-        Type IntTy = IGM.Context.getIntDecl()->getDeclaredType();
+        Type IntTy = IGM.Context.getIntType();
         ElemDbgTy = DebugTypeInfo(IntTy, DbgTy.getStorageType(), Size(0),
                                   Alignment(1), true, false);
       }

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -1042,7 +1042,7 @@ private:
       ty = unwrapped;
 
     auto genericTy = ty->getAs<BoundGenericStructType>();
-    if (!genericTy || genericTy->getDecl() != getASTContext().getArrayDecl())
+    if (!genericTy || !genericTy->isArray())
       return false;
 
     assert(genericTy->getGenericArgs().size() == 1);
@@ -1149,14 +1149,12 @@ private:
 
       auto nominal = copyTy->getNominalOrBoundGenericNominal();
       if (nominal && isa<StructDecl>(nominal)) {
-        if (nominal == ctx.getArrayDecl() ||
-            nominal == ctx.getDictionaryDecl() ||
-            nominal == ctx.getSetDecl() ||
-            nominal == ctx.getStringDecl() ||
+        if (copyTy->isArray() || copyTy->isDictionary() || copyTy->isSet() ||
+            copyTy->isString() ||
             (!getKnownTypeInfo(nominal) && getObjCBridgedClass(nominal))) {
           // We fast-path the most common cases in the condition above.
           os << ", copy";
-        } else if (nominal == ctx.getUnmanagedDecl()) {
+        } else if (copyTy->isUnmanaged()) {
           os << ", unsafe_unretained";
           // Don't print unsafe_unretained twice.
           if (auto boundTy = copyTy->getAs<BoundGenericType>()) {
@@ -1669,9 +1667,7 @@ private:
     const StructDecl *SD = ty->getStructOrBoundGenericStruct();
     if (ty->isAny()) {
       ty = ctx.getAnyObjectType();
-    } else if (SD != ctx.getArrayDecl() &&
-        SD != ctx.getDictionaryDecl() &&
-        SD != ctx.getSetDecl() &&
+    } else if (!ty->isArray() && !ty->isDictionary() && !ty->isSet() &&
         !isSwiftNewtype(SD)) {
       ty = ctx.getBridgedToObjC(&owningPrinter.M, ty);
     }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1292,8 +1292,7 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
       return isClangTypeMoreIndirectThanSubstType(TC,
                     clangTy->getPointeeType().getTypePtr(), CanType(eltTy));
 
-    if (substTy->getAnyNominal() ==
-          TC.Context.getOpaquePointerDecl())
+    if (substTy->isOpaquePointer())
       // TODO: We could conceivably have an indirect opaque ** imported
       // as COpaquePointer. That shouldn't ever happen today, though,
       // since we only ever indirect the 'self' parameter of functions

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -174,9 +174,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(substEqualsType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substEqualsType->getResults()[0].getInterfaceType()
-                               ->getAnyNominal()
-                  == C.getBoolDecl(),
+        require(substEqualsType->getResults()[0].getInterfaceType()->isBool(),
                 "result should be Bool");
       }
       {
@@ -205,9 +203,7 @@ void verifyKeyPathComponent(SILModule &M,
         require(substHashType->getResults()[0].getConvention()
                   == ResultConvention::Unowned,
                 "result should be unowned");
-        require(substHashType->getResults()[0].getInterfaceType()
-                             ->getAnyNominal()
-                  == C.getIntDecl(),
+        require(substHashType->getResults()[0].getInterfaceType()->isInt(),
                 "result should be Int");
       }
     } else {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -453,17 +453,13 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
 
   // Use standard library types if we have them; otherwise, fall back to
   // builtins.
-  CanType Int32Ty;
-  if (auto Int32Decl = C.getInt32Decl()) {
-    Int32Ty = Int32Decl->getDeclaredInterfaceType()->getCanonicalType();
-  } else {
+  CanType Int32Ty = CanType(C.getInt32Type());
+  if (!Int32Ty)
     Int32Ty = CanType(BuiltinIntegerType::get(32, C));
-  }
 
   CanType PtrPtrInt8Ty = C.TheRawPointerType;
   if (auto PointerDecl = C.getUnsafeMutablePointerDecl()) {
-    if (auto Int8Decl = C.getInt8Decl()) {
-      Type Int8Ty = Int8Decl->getDeclaredInterfaceType();
+    if (auto Int8Ty = C.getInt8Type()) {
       Type PointerInt8Ty = BoundGenericType::get(PointerDecl,
                                                  nullptr,
                                                  Int8Ty);

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -351,16 +351,15 @@ static RValue emitCollectionDowncastExpr(SILGenFunction &SGF,
   auto fromCollection = sourceType->getCanonicalType();
   auto toCollection = destType->getCanonicalType();
   // Get the intrinsic function.
-  auto &ctx = SGF.getASTContext();
   FuncDecl *fn = nullptr;
-  if (fromCollection->getAnyNominal() == ctx.getArrayDecl()) {
+  if (fromCollection->isArray()) {
     fn = conditional ? SGF.SGM.getArrayConditionalCast(loc)
                      : SGF.SGM.getArrayForceCast(loc);
-  } else if (fromCollection->getAnyNominal() == ctx.getDictionaryDecl()) {
+  } else if (fromCollection->isDictionary()) {
     fn = (conditional
            ? SGF.SGM.getDictionaryDownCastConditional(loc)
            : SGF.SGM.getDictionaryDownCast(loc));
-  } else if (fromCollection->getAnyNominal() == ctx.getSetDecl()) {
+  } else if (fromCollection->isSet()) {
     fn = (conditional
            ? SGF.SGM.getSetDownCastConditional(loc)
            : SGF.SGM.getSetDownCast(loc));

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -608,9 +608,7 @@ ManagedValue Transform::transform(ManagedValue v,
   }
 
   // - T : Hashable to AnyHashable
-  if (isa<StructType>(outputSubstType) &&
-      outputSubstType->getAnyNominal() ==
-        SGF.getASTContext().getAnyHashableDecl()) {
+  if (outputSubstType->isAnyHashable()) {
     auto *protocol = SGF.getASTContext().getProtocol(
         KnownProtocolKind::Hashable);
     auto conformance = SGF.SGM.M.getSwiftModule()->lookupConformance(

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -921,11 +921,6 @@ public:
   }
 };
 
-static bool hasArrayType(SILValue Value, SILModule &M) {
-  return Value->getType().getNominalOrBoundGenericNominal() ==
-           M.getASTContext().getArrayDecl();
-}
-
 /// Hoist bounds check in the loop to the loop preheader.
 static bool hoistChecksInLoop(DominanceInfo *DT, DominanceInfoNode *DTNode,
                               ABCAnalysis &ABC, InductionAnalysis &IndVars,
@@ -998,7 +993,7 @@ static bool hoistChecksInLoop(DominanceInfo *DT, DominanceInfoNode *DTNode,
     // Check if the loop iterates from 0 to the count of this array.
     if (F.isZeroToCount(ArrayVal) &&
         // This works only for Arrays but not e.g. for ArraySlice.
-        hasArrayType(ArrayVal, Header->getModule())) {
+        ArrayVal->getType().getASTType()->isArray()) {
       // We can remove the check. This is even possible if the block does not
       // dominate the loop exit block.
       Changed = true;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -854,7 +854,8 @@ static void emitFatalError(ADContext &context, SILFunction *f,
       builder.emitDestroyOperation(loc, arg);
   // Fatal error with a nice message.
   auto neverResultInfo =
-      SILResultInfo(context.getModule().getASTContext().getNeverType(),
+      SILResultInfo(context.getModule().getASTContext().getNeverType()
+                           ->getCanonicalType(),
                     ResultConvention::Unowned);
   // Fatal error function must have type `@convention(thin) () -> Never`.
   auto fatalErrorFnType = SILFunctionType::get(

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -278,11 +278,8 @@ bool ArrayAllocation::replaceAppendContentOf() {
     ArraySemanticsCall AppendContentsOf(AppendContentOfCall);
     assert(AppendContentsOf && "Must be AppendContentsOf call");
 
-    NominalTypeDecl *AppendSelfArray = AppendContentsOf.getSelf()->getType().
-    getASTType()->getAnyNominal();
-
     // In case if it's not an Array, but e.g. an ContiguousArray
-    if (AppendSelfArray != Ctx.getArrayDecl())
+    if (!AppendContentsOf.getSelf()->getType().getASTType()->isArray())
       continue;
 
     SILType ArrayType = ArrayValue->getType();

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -260,11 +260,8 @@ CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
 
   // AnyHashable is a special case that we do not handle since we only handle
   // objc targets in this function. Bailout early.
-  if (auto dt = target.getNominalOrBoundGenericNominal()) {
-    if (dt == mod.getASTContext().getAnyHashableDecl()) {
-      return nullptr;
-    }
-  }
+  if (target->isAnyHashable())
+    return nullptr;
 
   SILValue src = dynamicCast.getSource();
 

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1116,9 +1116,7 @@ bool maybeExplicitFPCons(BuiltinInst *BI, const BuiltinInfo &Builtin) {
   // intermediate step. So we conservatively assume that an implicit
   // construction of Double could be a part of an explicit conversion
   // and suppress the warning.
-  auto &astCtx = BI->getModule().getASTContext();
-  auto *typeDecl = callExpr->getType()->getCanonicalType().getAnyNominal();
-  return (typeDecl && typeDecl == astCtx.getDoubleDecl());
+  return callExpr->getType()->isDouble();
 }
 
 static SILValue foldFPTrunc(BuiltinInst *BI, const BuiltinInfo &Builtin,

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -621,9 +621,12 @@ protected:
   }
 
   Expr *buildSomeExpr(Expr *arg) {
+    auto optionalDecl = ctx.getOptionalDecl();
+    auto optionalType = optionalDecl->getDeclaredType();
+
     auto loc = arg->getStartLoc();
     auto optionalTypeExpr =
-      TypeExpr::createImplicitHack(loc, ctx.getOptionalType(), ctx);
+      TypeExpr::createImplicitHack(loc, optionalType, ctx);
     auto someRef = new (ctx) UnresolvedDotExpr(
         optionalTypeExpr, loc, DeclNameRef(ctx.getIdentifier("some")),
         DeclNameLoc(loc), /*implicit=*/true);
@@ -631,8 +634,11 @@ protected:
   }
 
   Expr *buildNoneExpr(SourceLoc endLoc) {
+    auto optionalDecl = ctx.getOptionalDecl();
+    auto optionalType = optionalDecl->getDeclaredType();
+
     auto optionalTypeExpr =
-      TypeExpr::createImplicitHack(endLoc, ctx.getOptionalType(), ctx);
+      TypeExpr::createImplicitHack(endLoc, optionalType, ctx);
     return new (ctx) UnresolvedDotExpr(
         optionalTypeExpr, endLoc, DeclNameRef(ctx.getIdentifier("none")),
         DeclNameLoc(endLoc), /*implicit=*/true);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -621,12 +621,9 @@ protected:
   }
 
   Expr *buildSomeExpr(Expr *arg) {
-    auto optionalDecl = ctx.getOptionalDecl();
-    auto optionalType = optionalDecl->getDeclaredType();
-
     auto loc = arg->getStartLoc();
     auto optionalTypeExpr =
-      TypeExpr::createImplicitHack(loc, optionalType, ctx);
+      TypeExpr::createImplicitHack(loc, ctx.getOptionalType(), ctx);
     auto someRef = new (ctx) UnresolvedDotExpr(
         optionalTypeExpr, loc, DeclNameRef(ctx.getIdentifier("some")),
         DeclNameLoc(loc), /*implicit=*/true);
@@ -634,11 +631,8 @@ protected:
   }
 
   Expr *buildNoneExpr(SourceLoc endLoc) {
-    auto optionalDecl = ctx.getOptionalDecl();
-    auto optionalType = optionalDecl->getDeclaredType();
-
     auto optionalTypeExpr =
-      TypeExpr::createImplicitHack(endLoc, optionalType, ctx);
+      TypeExpr::createImplicitHack(endLoc, ctx.getOptionalType(), ctx);
     return new (ctx) UnresolvedDotExpr(
         optionalTypeExpr, endLoc, DeclNameRef(ctx.getIdentifier("none")),
         DeclNameLoc(endLoc), /*implicit=*/true);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2576,7 +2576,7 @@ namespace {
       // Make the integer literals for the parameters.
       auto buildExprFromUnsigned = [&](unsigned value) {
         LiteralExpr *expr = IntegerLiteralExpr::createFromUnsigned(ctx, value);
-        cs.setType(expr, TypeChecker::getIntType(ctx));
+        cs.setType(expr, ctx.getIntType());
         return handleIntegerLiteralExpr(expr);
       };
 
@@ -3671,13 +3671,12 @@ namespace {
         // Match the optional value against its `Some` case.
         auto *someDecl = ctx.getOptionalSomeDecl();
         auto isSomeExpr = new (ctx) EnumIsCaseExpr(result, someDecl);
-        auto boolDecl = ctx.getBoolDecl();
 
-        if (!boolDecl) {
+        if (!ctx.getBoolDecl()) {
           ctx.Diags.diagnose(SourceLoc(), diag::broken_bool);
         }
 
-        cs.setType(isSomeExpr, boolDecl ? boolDecl->getDeclaredType() : Type());
+        cs.setType(isSomeExpr, ctx.getBoolType());
         return isSomeExpr;
       }
 
@@ -4790,7 +4789,7 @@ namespace {
                                  StringRef(stringCopy, compatStringBuf.size()),
                                  SourceRange(),
                                  /*implicit*/ true);
-          cs.setType(stringExpr, TypeChecker::getStringType(cs.getASTContext()));
+          cs.setType(stringExpr, cs.getASTContext().getStringType());
           E->setObjCStringLiteralExpr(stringExpr);
         }
       }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -347,7 +347,7 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     if (locator->isKeyPathType()) {
       auto *BGT =
           type->lookThroughAllOptionalTypes()->getAs<BoundGenericType>();
-      if (!BGT || !isKnownKeyPathDecl(getASTContext(), BGT->getDecl()))
+      if (!BGT || !isKnownKeyPathType(BGT))
         return None;
     }
   }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2694,16 +2694,10 @@ bool ContextualFailure::trySequenceSubsequenceFixIts(
   if (!getASTContext().getStdlibModule())
     return false;
 
-  auto String = TypeChecker::getStringType(getASTContext());
-  auto Substring = TypeChecker::getSubstringType(getASTContext());
-
-  if (!String || !Substring)
-    return false;
-
   // Substring -> String conversion
   // Wrap in String.init
-  if (getFromType()->isEqual(Substring)) {
-    if (getToType()->isEqual(String)) {
+  if (getFromType()->isSubstring()) {
+    if (getToType()->isString()) {
       auto anchor =
           getAnchor().get<const Expr *>()->getSemanticsProvidingExpr();
       if (auto *CE = dyn_cast<CoerceExpr>(anchor)) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2935,13 +2935,12 @@ namespace {
     
     Type visitIfExpr(IfExpr *expr) {
       // Condition must convert to Bool.
-      auto boolDecl = CS.getASTContext().getBoolDecl();
-      if (!boolDecl)
+      if (!CS.getASTContext().getBoolDecl())
         return Type();
 
       CS.addConstraint(
           ConstraintKind::Conversion, CS.getType(expr->getCondExpr()),
-          boolDecl->getDeclaredType(),
+          CS.getASTContext().getBoolType(),
           CS.getConstraintLocator(expr, ConstraintLocator::Condition));
 
       // The branches must be convertible to a common type.
@@ -3091,15 +3090,13 @@ namespace {
       CS.addConstraint(ConstraintKind::CheckedCast, fromType, toType,
                        CS.getConstraintLocator(expr));
 
-      // The result is Bool.
-      auto boolDecl = ctx.getBoolDecl();
-
-      if (!boolDecl) {
+      if (!ctx.getBoolDecl()) {
         ctx.Diags.diagnose(SourceLoc(), diag::broken_bool);
         return Type();
       }
 
-      return boolDecl->getDeclaredType();
+      // The result is Bool.
+      return ctx.getBoolType();
     }
 
     Type visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
@@ -3276,7 +3273,7 @@ namespace {
     }
     
     Type visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
-      return CS.getASTContext().getBoolDecl()->getDeclaredType();
+      return CS.getASTContext().getBoolType();
     }
 
     Type visitLazyInitializerExpr(LazyInitializerExpr *expr) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -173,7 +173,7 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   bool isNilInitialized =
     var->getAttrs().hasAttribute<LazyAttr>() ||
     (!isExplicitlyInitialized && isDefaultInitializable &&
-     var->getValueInterfaceType()->getAnyNominal() == ctx.getOptionalDecl() &&
+     var->getValueInterfaceType()->isOptional() &&
      (var->getAttachedPropertyWrappers().empty() ||
       var->isPropertyMemberwiseInitializedWithWrappedType()));
   if (isNilInitialized) {
@@ -325,9 +325,7 @@ synthesizeStubBody(AbstractFunctionDecl *fn, void *) {
   auto staticStringType = staticStringDecl->getDeclaredType();
   auto staticStringInit = ctx.getStringBuiltinInitDecl(staticStringDecl);
 
-  auto *uintDecl = ctx.getUIntDecl();
-  auto uintType = uintDecl->getDeclaredType();
-  auto uintInit = ctx.getIntBuiltinInitDecl(uintDecl);
+  auto uintInit = ctx.getIntBuiltinInitDecl(ctx.getUIntDecl());
 
   // Create a call to Swift._unimplementedInitializer
   auto loc = classDecl->getLoc();
@@ -361,12 +359,12 @@ synthesizeStubBody(AbstractFunctionDecl *fn, void *) {
 
   auto *line = new (ctx) MagicIdentifierLiteralExpr(
     MagicIdentifierLiteralExpr::Line, loc, /*Implicit=*/true);
-  line->setType(uintType);
+  line->setType(ctx.getUIntType());
   line->setBuiltinInitializer(uintInit);
 
   auto *column = new (ctx) MagicIdentifierLiteralExpr(
     MagicIdentifierLiteralExpr::Column, loc, /*Implicit=*/true);
-  column->setType(uintType);
+  column->setType(ctx.getUIntType());
   column->setBuiltinInitializer(uintInit);
 
   auto *call = CallExpr::createImplicit(

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3217,9 +3217,6 @@ public:
   /// Determine if the type in question is one of the known collection types.
   static bool isCollectionType(Type t);
 
-  /// Determine if the type in question is AnyHashable.
-  static bool isAnyHashableType(Type t);
-
   /// Call Expr::isTypeReference on the given expression, using a
   /// custom accessor for the type on the expression that reads the
   /// type from the ConstraintSystem expression type map.
@@ -5257,10 +5254,6 @@ public:
 /// Determine whether given type is a known one
 /// for a key path `{Writable, ReferenceWritable}KeyPath`.
 bool isKnownKeyPathType(Type type);
-
-/// Determine whether given declaration is one for a key path
-/// `{Writable, ReferenceWritable}KeyPath`.
-bool isKnownKeyPathDecl(ASTContext &ctx, ValueDecl *decl);
 
 /// Determine whether givne closure has any explicit `return`
 /// statements that could produce non-void result.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -703,15 +703,12 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   //                         output: ()
   // Create from the inside out:
 
-  auto encoderType = C.getEncoderDecl()->getDeclaredInterfaceType();
-  auto returnType = TupleType::getEmpty(C);
-
   // Params: (Encoder)
   auto *encoderParam = new (C)
       ParamDecl(SourceLoc(), SourceLoc(), C.Id_to,
                 SourceLoc(), C.Id_encoder, conformanceDC);
   encoderParam->setSpecifier(ParamSpecifier::Default);
-  encoderParam->setInterfaceType(encoderType);
+  encoderParam->setInterfaceType(C.getEncoderType());
 
   ParameterList *params = ParameterList::createWithoutLoc(encoderParam);
 
@@ -720,7 +717,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   auto *encodeDecl = FuncDecl::create(
       C, SourceLoc(), StaticSpellingKind::None, SourceLoc(), name, SourceLoc(),
       /*Throws=*/true, SourceLoc(), nullptr, params,
-      TypeLoc::withoutLoc(returnType), conformanceDC);
+      TypeLoc::withoutLoc(C.TheEmptyTupleType), conformanceDC);
   encodeDecl->setImplicit();
   encodeDecl->setSynthesized();
   encodeDecl->setBodySynthesizer(deriveBodyEncodable_encode);
@@ -1032,13 +1029,12 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
   // Compute from the inside out:
 
   // Params: (Decoder)
-  auto decoderType = C.getDecoderDecl()->getDeclaredInterfaceType();
   auto *decoderParamDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_from,
       SourceLoc(), C.Id_decoder, conformanceDC);
   decoderParamDecl->setImplicit();
   decoderParamDecl->setSpecifier(ParamSpecifier::Default);
-  decoderParamDecl->setInterfaceType(decoderType);
+  decoderParamDecl->setInterfaceType(C.getDecoderType());
 
   auto *paramList = ParameterList::createWithoutLoc(decoderParamDecl);
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -78,7 +78,7 @@ deriveRawValueInit(AbstractFunctionDecl *initDecl, void *) {
   auto *rawValueDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_rawValue,
       SourceLoc(), C.Id_rawValue, parentDC);
-  rawValueDecl->setInterfaceType(C.getIntDecl()->getDeclaredType());
+  rawValueDecl->setInterfaceType(C.getIntType());
   rawValueDecl->setSpecifier(ParamSpecifier::Default);
   rawValueDecl->setImplicit();
   auto *paramList = ParameterList::createWithoutLoc(rawValueDecl);
@@ -332,9 +332,7 @@ static bool canSynthesizeCodingKey(DerivedConformance &derived) {
     auto *parentDC = derived.getConformanceContext();
     rawType = parentDC->mapTypeIntoContext(rawType);
 
-    auto &C = derived.Context;
-    auto *nominal = rawType->getCanonicalType()->getAnyNominal();
-    if (nominal != C.getStringDecl() && nominal != C.getIntDecl())
+    if (!rawType->isString() && !rawType->isInt())
       return false;
   }
 
@@ -363,9 +361,8 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
   auto name = requirement->getBaseName();
   if (name == Context.Id_stringValue) {
     // Synthesize `var stringValue: String { get }`
-    auto stringType = Context.getStringDecl()->getDeclaredType();
-    auto synth = [rawType, stringType](AbstractFunctionDecl *getterDecl) {
-      if (rawType && rawType->isEqual(stringType)) {
+    auto synth = [rawType](AbstractFunctionDecl *getterDecl) {
+      if (rawType && rawType->isString()) {
         // enum SomeStringEnum : String {
         //   case A, B, C
         //   @derived var stringValue: String {
@@ -390,15 +387,15 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
       }
     };
 
-    return deriveProperty(*this, stringType, Context.Id_stringValue, synth);
+    return deriveProperty(*this, Context.getStringType(), Context.Id_stringValue,
+                          synth);
 
   } else if (name == Context.Id_intValue) {
     // Synthesize `var intValue: Int? { get }`
-    auto intType = Context.getIntDecl()->getDeclaredType();
-    auto optionalIntType = OptionalType::get(intType);
+    auto optionalIntType = OptionalType::get(Context.getIntType());
 
-    auto synth = [rawType, intType](AbstractFunctionDecl *getterDecl) {
-      if (rawType && rawType->isEqual(intType)) {
+    auto synth = [rawType](AbstractFunctionDecl *getterDecl) {
+      if (rawType && rawType->isInt()) {
         // enum SomeIntEnum : Int {
         //   case A = 1, B = 2, C = 3
         //   @derived var intValue: Int? {
@@ -423,9 +420,8 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
     if (argumentNames.size() == 1) {
       if (argumentNames[0] == Context.Id_stringValue) {
         // Derive `init?(stringValue:)`
-        auto stringType = Context.getStringDecl()->getDeclaredType();
-        auto synth = [rawType, stringType](AbstractFunctionDecl *initDecl) {
-          if (rawType && rawType->isEqual(stringType)) {
+        auto synth = [rawType](AbstractFunctionDecl *initDecl) {
+          if (rawType && rawType->isString()) {
             // enum SomeStringEnum : String {
             //   case A = "a", B = "b", C = "c"
             //   @derived init?(stringValue: String) {
@@ -453,12 +449,12 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
           }
         };
 
-        return deriveInitDecl(*this, stringType, Context.Id_stringValue, synth);
+        return deriveInitDecl(*this, Context.getStringType(),
+                              Context.Id_stringValue, synth);
       } else if (argumentNames[0] == Context.Id_intValue) {
         // Synthesize `init?(intValue:)`
-        auto intType = Context.getIntDecl()->getDeclaredType();
-        auto synthesizer = [rawType, intType](AbstractFunctionDecl *initDecl) {
-          if (rawType && rawType->isEqual(intType)) {
+        auto synthesizer = [rawType](AbstractFunctionDecl *initDecl) {
+          if (rawType && rawType->isInt()) {
             // enum SomeIntEnum : Int {
             //   case A = 1, B = 2, C = 3
             //   @derived init?(intValue: Int) {
@@ -477,7 +473,8 @@ ValueDecl *DerivedConformance::deriveCodingKey(ValueDecl *requirement) {
           }
         };
 
-        return deriveInitDecl(*this, intType, Context.Id_intValue, synthesizer);
+        return deriveInitDecl(*this, Context.getIntType(), Context.Id_intValue,
+                              synthesizer);
       }
     }
   }

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -90,18 +90,18 @@ deriveBridgedNSError_enum_nsErrorDomain(
   //   }
   // }
 
-  auto stringTy = derived.Context.getStringDecl()->getDeclaredType();
+  ASTContext &ctx = derived.Context;
 
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      derived.Context.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
-      /*isFinal=*/true);
+      ctx.Id_nsErrorDomain, ctx.getStringType(), ctx.getStringType(),
+      /*isStatic=*/true, /*isFinal=*/true);
 
   // Define the getter.
   auto getterDecl = derived.addGetterToReadOnlyDerivedProperty(
-      propDecl, stringTy);
+      propDecl, ctx.getStringType());
   getterDecl->setBodySynthesizer(synthesizer);
 
   derived.addMembersToConformanceContext({propDecl, pbDecl});

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -290,8 +290,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
   assert(rawTy);
   rawTy = initDecl->mapTypeIntoContext(rawTy);
 
-  bool isStringEnum =
-    (rawTy->getNominalOrBoundGenericNominal() == C.getStringDecl());
+  bool isStringEnum = rawTy->isString();
   llvm::SmallVector<Expr *, 16> stringExprs;
 
   Type enumType = parentDC->getDeclaredTypeInContext();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -111,11 +111,7 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
       case KnownDerivableProtocolKind::CodingKey: {
         Type rawType = enumDecl->getRawType();
         if (rawType) {
-          auto parentDC = enumDecl->getDeclContext();
-          ASTContext &C = parentDC->getASTContext();
-
-          auto nominal = rawType->getAnyNominal();
-          return nominal == C.getStringDecl() || nominal == C.getIntDecl();
+          return rawType->isString() || rawType->isInt();
         }
 
         // hasOnlyCasesWithoutAssociatedValues will return true for empty enums;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4434,9 +4434,6 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     return "";
 
   ASTContext &ctx = type->getASTContext();
-  Type boolType;
-  if (auto boolDecl = ctx.getBoolDecl())
-    boolType = boolDecl->getDeclaredInterfaceType();
   auto objcBoolType = ctx.getObjCBoolType();
 
   /// Determine the options associated with the given type.
@@ -4445,7 +4442,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
     OmissionTypeOptions options;
 
     // Look for Boolean types.
-    if (boolType && type->isEqual(boolType)) {
+    if (ctx.getBoolType() && type->isBool()) {
       // Swift.Bool
       options |= OmissionTypeFlags::Boolean;
     } else if (objcBoolType && type->isEqual(objcBoolType)) {
@@ -4493,11 +4490,8 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
   if (auto nominal = type->getAnyNominal()) {
     // If we have a collection, get the element type.
     if (auto bound = type->getAs<BoundGenericType>()) {
-      ASTContext &ctx = nominal->getASTContext();
       auto args = bound->getGenericArgs();
-      if (!args.empty() &&
-          (bound->getDecl() == ctx.getArrayDecl() ||
-           bound->getDecl() == ctx.getSetDecl())) {
+      if (!args.empty() && (bound->isArray() || bound->isSet())) {
         return OmissionTypeName(nominal->getName().str(),
                                 getOptions(bound),
                                 getTypeNameForOmission(args[0]).Name);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -531,13 +531,13 @@ isAcceptableOutletType(Type type, bool &isArray, ASTContext &ctx) {
     return diag::iboutlet_nonobjc_class;
   }
 
-  if (nominal == ctx.getStringDecl()) {
+  if (type->isString()) {
     // String is okay because it is bridged to NSString.
     // FIXME: BridgesTypes.def is almost sufficient for this.
     return None;
   }
 
-  if (nominal == ctx.getArrayDecl()) {
+  if (type->isArray()) {
     // Arrays of arrays are not allowed.
     if (isArray)
       return diag::iboutlet_nonobject_type;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2145,19 +2145,18 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
 
   // The subscripts taking T<Int> do not return Substring, and our
   // special fixit does not help here.
-  auto intDecl = Context.getIntDecl();
   auto nominalTypeParam = genericArgs[0]->getAs<NominalType>();
   if (!nominalTypeParam)
     return false;
 
-  if (nominalTypeParam->getDecl() == intDecl)
+  if (nominalTypeParam->isInt())
     return false;
 
   auto resultTy = fnTy->getResult()->getAs<NominalType>();
   if (!resultTy)
     return false;
 
-  return resultTy->getDecl() == stringDecl;
+  return resultTy->isString();
 }
 
 bool swift::diagnoseExplicitUnavailability(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3814,10 +3814,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     }
   }
 
-  if (ConstraintSystem::isAnyHashableType(toType) ||
-      ConstraintSystem::isAnyHashableType(fromType)) {
+  if (toType->isAnyHashable() || fromType->isAnyHashable())
     return CheckedCastKind::ValueCast;
-  }
 
   // If the destination type can be a supertype of the source type, we are
   // performing what looks like an upcast except it rebinds generic

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -95,10 +95,8 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // We're updating to a property. Determine whether we're looking
     // into a bridged Swift collection of some sort.
     if (auto boundGeneric = newType->getAs<BoundGenericType>()) {
-      auto nominal = boundGeneric->getDecl();
-
       // Array<T>
-      if (nominal == Context.getArrayDecl()) {
+      if (boundGeneric->isArray()) {
         // Further lookups into the element type.
         state = ResolvingArray;
         currentType = boundGeneric->getGenericArgs()[0];
@@ -106,7 +104,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       }
 
       // Set<T>
-      if (nominal == Context.getSetDecl()) {
+      if (boundGeneric->isSet()) {
         // Further lookups into the element type.
         state = ResolvingSet;
         currentType = boundGeneric->getGenericArgs()[0];
@@ -114,7 +112,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
       }
 
       // Dictionary<K, V>
-      if (nominal == Context.getDictionaryDecl()) {
+      if (boundGeneric->isDictionary()) {
         // Key paths look into the keys of a dictionary; further
         // lookups into the value type.
         state = ResolvingDictionary;

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1171,7 +1171,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
   case PatternKind::Expr: {
     assert(cast<ExprPattern>(P)->isResolved()
            && "coercing unresolved expr pattern!");
-    if (type->getAnyNominal() == Context.getBoolDecl()) {
+    if (type->isBool()) {
       // The type is Bool.
       // Check if the pattern is a Bool literal
       auto EP = cast<ExprPattern>(P);
@@ -1228,7 +1228,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     if (numExtraOptionals > 0) {
       Pattern *sub = IP;
       for (int i = 0; i < numExtraOptionals; ++i) {
-        auto some = Context.getOptionalDecl()->getUniqueElement(/*hasVal*/true);
+        auto some = Context.getOptionalSomeDecl();
         sub = new (Context) EnumElementPattern(TypeLoc(),
                                                IP->getStartLoc(),
                                                DeclNameLoc(IP->getEndLoc()),
@@ -1320,7 +1320,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
           // so we have to do this check here. Additionally, .Some
           // isn't a static VarDecl, so the existing mechanics in
           // extractEnumElement won't work.
-          if (type->getAnyNominal() == Context.getOptionalDecl()) {
+          if (type->isOptional()) {
             if (EEP->getName().isSimpleName("None") ||
                 EEP->getName().isSimpleName("Some")) {
               SmallString<4> Rename;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -378,41 +378,6 @@ Type TypeChecker::getOptionalType(SourceLoc loc, Type elementType) {
   return OptionalType::get(elementType);
 }
 
-Type TypeChecker::getStringType(ASTContext &Context) {
-  if (auto typeDecl = Context.getStringDecl())
-    return typeDecl->getDeclaredInterfaceType();
-
-  return Type();
-}
-
-Type TypeChecker::getSubstringType(ASTContext &Context) {
-  if (auto typeDecl = Context.getSubstringDecl())
-    return typeDecl->getDeclaredInterfaceType();
-
-  return Type();
-}
-
-Type TypeChecker::getIntType(ASTContext &Context) {
-  if (auto typeDecl = Context.getIntDecl())
-    return typeDecl->getDeclaredInterfaceType();
-
-  return Type();
-}
-
-Type TypeChecker::getInt8Type(ASTContext &Context) {
-  if (auto typeDecl = Context.getInt8Decl())
-    return typeDecl->getDeclaredInterfaceType();
-
-  return Type();
-}
-
-Type TypeChecker::getUInt8Type(ASTContext &Context) {
-  if (auto typeDecl = Context.getUInt8Decl())
-    return typeDecl->getDeclaredInterfaceType();
-
-  return Type();
-}
-
 Type
 TypeChecker::getDynamicBridgedThroughObjCClass(DeclContext *dc,
                                                Type dynamicType,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -378,11 +378,6 @@ namespace TypeChecker {
 Type getArraySliceType(SourceLoc loc, Type elementType);
 Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
 Type getOptionalType(SourceLoc loc, Type elementType);
-Type getStringType(ASTContext &ctx);
-Type getSubstringType(ASTContext &ctx);
-Type getIntType(ASTContext &ctx);
-Type getInt8Type(ASTContext &ctx);
-Type getUInt8Type(ASTContext &ctx);
 
 /// Try to resolve an IdentTypeRepr, returning either the referenced
 /// Type or an ErrorType in case of error.


### PR DESCRIPTION
I've noticed that there are a lot of cases where we dance around types by grabbing their nominal type and comparing that to some stdlib decl. Let's clean this up a little bit and introduce `isType` so that instead of dancing around this:
```cpp
if (type->getAnyNominal() == C.getIntDecl())
```
it becomes:
```cpp
if (type->isInt())
```
Note: this is only applied to those stdlib types defined in `KnownStdlibTypes`.

I've also introduced `getDeclType` which is shorthand for e.g. `C.getBoolDecl()->getDeclaredInterfaceType()` == `C.getBoolType()`.

@slavapestov @jrose-apple (Sorry if this is a lot to review!)