### PR TITLE
runtime: add a workaround for Windows build

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -730,8 +730,14 @@ _findContextDescriptorInCache(TypeMetadataPrivateState &T,
   $sS ## CHAR ## SUFFIX
 #define DESCRIPTOR_MANGLING(CHAR, SUFFIX) DESCRIPTOR_MANGLING_(CHAR, SUFFIX)
 
+#if defined(_WIN32)
+#define swiftCore_EXPORTS __declspec(dllimport)
+#else
+#define swiftCore_EXPORTS
+#endif
+
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME) \
-  extern "C" const ContextDescriptor DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND));
+  extern "C" swiftCore_EXPORTS const ContextDescriptor DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND));
 
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)


### PR DESCRIPTION
The runtime tests will statically link the runtime and dynamically link
to the standard library.  This fails to build on Windows.  This is a
horrible workaround for the time being.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
