### PR TITLE
[5.1] IRGen: Backward-deploy associated types on opaque types using open-coded accessors

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -323,6 +323,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     if (Major == 10) {
       if (Minor <= 14) {
         return llvm::VersionTuple(5, 0);
+      } else if (Minor <= 15) {
+        return llvm::VersionTuple(5, 1);
       } else {
         return None;
       }
@@ -333,6 +335,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     Triple.getiOSVersion(Major, Minor, Micro);
     if (Major <= 12) {
       return llvm::VersionTuple(5, 0);
+    } else if (Major <= 13) {
+      return llvm::VersionTuple(5, 1);
     } else {
       return None;
     }
@@ -340,6 +344,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple){
     Triple.getWatchOSVersion(Major, Minor, Micro);
     if (Major <= 5) {
       return llvm::VersionTuple(5, 0);
+    } else if (Major <= 6) {
+      return llvm::VersionTuple(5, 1);
     } else {
       return None;
     }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1680,11 +1680,16 @@ namespace {
     }
     
     void addUnderlyingTypeAndConformances() {
+      auto sig = O->getOpaqueInterfaceGenericSignature();
       auto underlyingType = Type(O->getUnderlyingInterfaceType())
         .subst(*O->getUnderlyingTypeSubstitutions())
-        ->getCanonicalType(O->getOpaqueInterfaceGenericSignature());
+        ->getCanonicalType(sig);
 
-      B.addRelativeAddress(IGM.getTypeRef(underlyingType,
+      auto contextSig = O->getGenericSignature()
+        ? O->getGenericSignature()->getCanonicalSignature()
+        : CanGenericSignature();
+
+      B.addRelativeAddress(IGM.getTypeRef(underlyingType, contextSig,
                                           MangledTypeRefRole::Metadata));
       
       auto opaqueType = O->getDeclaredInterfaceType()
@@ -1698,7 +1703,7 @@ namespace {
         
         auto witnessTableRef = IGM.emitWitnessTableRefString(
                                           underlyingType, underlyingConformance,
-                                          O->getGenericSignature(),
+                                          contextSig,
                                           /*setLowBit*/ false);
         B.addRelativeAddress(witnessTableRef);
       }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -277,7 +277,22 @@ std::string IRGenMangler::mangleSymbolNameForAssociatedConformanceWitness(
   return finalize();
 }
 
-std::string IRGenMangler::mangleSymbolNameForKeyPathMetadata(
+std::string IRGenMangler::mangleSymbolNameForMangledMetadataAccessorString(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type) {
+  beginManglingWithoutPrefix();
+  Buffer << kind << " ";
+
+  if (genericSig)
+    appendGenericSignature(genericSig);
+
+  if (type)
+    appendType(type);
+  return finalize();
+}
+
+std::string IRGenMangler::mangleSymbolNameForMangledConformanceAccessorString(
                                            const char *kind,
                                            CanGenericSignature genericSig,
                                            CanType type,

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -503,7 +503,12 @@ public:
                                   CanType associatedType,
                                   const ProtocolDecl *proto);
 
-  std::string mangleSymbolNameForKeyPathMetadata(
+  std::string mangleSymbolNameForMangledMetadataAccessorString(
+                                           const char *kind,
+                                           CanGenericSignature genericSig,
+                                           CanType type);
+
+  std::string mangleSymbolNameForMangledConformanceAccessorString(
                                            const char *kind,
                                            CanGenericSignature genericSig,
                                            CanType type,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1061,7 +1061,9 @@ public:
 
   llvm::Constant *getTypeRef(Type type, GenericSignature *genericSig,
                              MangledTypeRefRole role);
-  llvm::Constant *getTypeRef(CanType type, MangledTypeRefRole role);
+  llvm::Constant *getTypeRef(CanType type, CanGenericSignature genericSig,
+                             MangledTypeRefRole role);
+
   llvm::Constant *emitWitnessTableRefString(CanType type,
                                             ProtocolConformanceRef conformance,
                                             GenericSignature *genericSig,

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -39,3 +39,68 @@ if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
 } else {
   print("i'm getting too old for this sh")
 }
+
+// rdar://problem/54084733
+
+protocol Q {
+  associatedtype A
+  func f() -> A
+}
+struct X: Q {
+  typealias A = Array<Int>
+  func f() -> A {
+    return [1, 2, 3]
+  }
+}
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+func g() -> some Q {
+  return X()
+}
+
+func h<T: Q>(x: T) -> (T.A?, T.A?) {
+  return (.some(x.f()), .some(x.f()))
+}
+
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  let x = g()
+  // CHECK: {{X()|no really}}
+  print(x)
+  // CHECK: {{[1, 2, 3]|too old}}
+  let y = x.f()
+  print(y)
+  // CHECK: {{[1, 2, 3]|too old}}
+  let z = h(x: x)
+  print(z)
+} else {
+  print("no really")
+  print("i'm getting way too old for this sh")
+  print("way too old")
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+func opaqueAssocTypeUnderlyingType() -> some Any {
+  return g().f()
+}
+
+extension Optional: Q where Wrapped: Q {
+  func f() -> Wrapped.A? {
+    return map { $0.f() }
+  }
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+func structuralOpaqueAssocTypeUnderlyingType() -> some Any {
+  return Optional(g()).f()
+}
+
+if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+  // CHECK: {{[\1, 2, 3\]|too old}}
+  let x = opaqueAssocTypeUnderlyingType()
+  print(x)
+  // CHECK: {{Optional\(\[1, 2, 3\]\)|too damn old}}
+  let y = structuralOpaqueAssocTypeUnderlyingType()
+  print(y)
+} else {
+  print("nope, still too old")
+  print("too damn old")
+}


### PR DESCRIPTION
Explanation: The Swift 5.1 compiler mangled associated types of opaque types in a form that can't be reliably demangled, and the Swift 5.1 runtime can't demangle the new mangling defined for them in #27014. If we mangled an opaque associated type while targeting an older OS, we can use a `\9`
accessor reference string to instantiate the associated type.

Scope: Runtime crash due to unsupported mangling. Fix is entirely compiler-side.

Issue: rdar://problem/54084733

Testing: Swift CI

Risk: Low. The new code should only affect code that would have crashed in Swift 5.1.

Reviewed by: @DougGregor 