### PR TITLE
IRGen: Use correct generic sig when mangling opaque underlying type.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1683,14 +1683,16 @@ namespace {
     }
     
     void addUnderlyingTypeAndConformances() {
-      auto sig = O->getOpaqueInterfaceGenericSignature()
-        ? O->getOpaqueInterfaceGenericSignature()->getCanonicalSignature()
-        : CanGenericSignature();
+      auto sig = O->getOpaqueInterfaceGenericSignature();
       auto underlyingType = Type(O->getUnderlyingInterfaceType())
         .subst(*O->getUnderlyingTypeSubstitutions())
         ->getCanonicalType(sig);
+      
+      auto contextSig = O->getGenericSignature()
+        ? O->getGenericSignature()->getCanonicalSignature()
+        : CanGenericSignature();
 
-      B.addRelativeAddress(IGM.getTypeRef(underlyingType, sig,
+      B.addRelativeAddress(IGM.getTypeRef(underlyingType, contextSig,
                                           MangledTypeRefRole::Metadata).first);
       
       auto opaqueType = O->getDeclaredInterfaceType()
@@ -1704,7 +1706,7 @@ namespace {
         
         auto witnessTableRef = IGM.emitWitnessTableRefString(
                                           underlyingType, underlyingConformance,
-                                          O->getGenericSignature(),
+                                          contextSig,
                                           /*setLowBit*/ false);
         B.addRelativeAddress(witnessTableRef);
       }


### PR DESCRIPTION
Caught while testing on Swift 5.1.