### PR TITLE
Revert #26937, #27190, and #27132

### DIFF
--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -70,8 +70,6 @@ public:
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 
-  void discardRecordedNode(OpaqueSyntaxNode node) override;
-
   OpaqueSyntaxNodeKind getOpaqueKind() override {
     return ExplicitAction->getOpaqueKind();
   }

--- a/include/swift/Parse/LibSyntaxGenerator.h
+++ b/include/swift/Parse/LibSyntaxGenerator.h
@@ -44,7 +44,7 @@ public:
 
     auto Recorded = Recorder.recordToken(Kind, Range, LeadingTriviaPieces,
                                          TrailingTriviaPieces);
-    auto Raw = static_cast<RawSyntax *>(Recorded.takeOpaqueNode());
+    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
     return make<TokenSyntax>(Raw);
   }
 
@@ -55,7 +55,7 @@ public:
     auto Children = Node.getDeferredChildren();
 
     auto Recorded = Recorder.recordRawSyntax(Kind, Children);
-    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.takeOpaqueNode()) };
+    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.getOpaqueNode()) };
     Raw->Release(); // -1 since it's transfer of ownership.
     return make<SyntaxNode>(Raw);
   }

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -60,15 +60,13 @@ public:
   /// \p kind. Missing optional elements are represented with a null
   /// ParsedRawSyntaxNode object.
   ParsedRawSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                      MutableArrayRef<ParsedRawSyntaxNode> elements);
+                                     ArrayRef<ParsedRawSyntaxNode> elements);
 
   /// Record a raw syntax collecton without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be
   /// if not missing.
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
-
-  void discardRecordedNode(ParsedRawSyntaxNode &node);
 
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,

--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -26,7 +26,6 @@ public:
     : RawNode(std::move(rawNode)) {}
 
   const ParsedRawSyntaxNode &getRaw() const { return RawNode; }
-  ParsedRawSyntaxNode takeRaw() { return std::move(RawNode); }
   syntax::SyntaxKind getKind() const { return RawNode.getKind(); }
 
   /// Returns true if the syntax node is of the given type.
@@ -40,7 +39,7 @@ public:
   template <typename T>
   T castTo() const {
     assert(is<T>() && "castTo<T>() node of incompatible type!");
-    return T { RawNode.copyDeferred() };
+    return T { RawNode };
   }
 
   /// If this Syntax node is of the right kind, cast and return it,
@@ -51,10 +50,6 @@ public:
       return castTo<T>();
     }
     return llvm::None;
-  }
-
-  ParsedSyntax copyDeferred() const {
-    return ParsedSyntax { RawNode.copyDeferred() };
   }
 
   static bool kindof(syntax::SyntaxKind Kind) {
@@ -70,7 +65,7 @@ public:
 class ParsedTokenSyntax final : public ParsedSyntax {
 public:
   explicit ParsedTokenSyntax(ParsedRawSyntaxNode rawNode)
-    : ParsedSyntax(std::move(rawNode)) {}
+    : ParsedSyntax(rawNode) {}
 
   tok getTokenKind() const {
     return getRaw().getTokenKind();

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -53,15 +53,15 @@ public:
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      ArrayRef<Parsed${node.collection_element_type}> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      ArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
   static Parsed${node.name} make${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      ArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
@@ -69,16 +69,16 @@ public:
 %   elif node.is_unknown():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      MutableArrayRef<ParsedSyntax> elts,
+      ArrayRef<ParsedSyntax> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      MutableArrayRef<ParsedSyntax> elts,
+      ArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} make${node.syntax_kind}(
-      MutableArrayRef<ParsedSyntax> elts,
+      ArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 %   end
 % end
@@ -95,8 +95,8 @@ public:
   /// optional trailing comma.
   static ParsedTupleTypeElementSyntax
   makeTupleTypeElement(ParsedTypeSyntax Type,
-                       Optional<ParsedTokenSyntax> TrailingComma,
-                       SyntaxParsingContext &SPCtx);
+                         Optional<ParsedTokenSyntax> TrailingComma,
+                         SyntaxParsingContext &SPCtx);
 
   /// The provided \c elements are in the appropriate order for the syntax
   /// \c kind's layout but optional elements are not be included.
@@ -104,12 +104,9 @@ public:
   /// substituting missing parts with a null ParsedRawSyntaxNode object.
   ///
   /// \returns true if the layout could be formed, false otherwise.
-  static bool
-  formExactLayoutFor(syntax::SyntaxKind kind,
-                     MutableArrayRef<ParsedRawSyntaxNode> elements,
-                     function_ref<void(syntax::SyntaxKind,
-                                       MutableArrayRef<ParsedRawSyntaxNode>)>
-                         receiver);
+  static bool formExactLayoutFor(syntax::SyntaxKind kind,
+                                 ArrayRef<ParsedRawSyntaxNode> elements,
+         function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver);
 };
 }
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -61,13 +61,6 @@ public:
                                            ArrayRef<OpaqueSyntaxNode> elements,
                                            CharSourceRange range) = 0;
 
-  /// Discard raw syntax node.
-  /// 
-  /// FIXME: This breaks invariant that any recorded node will be a part of the
-  /// result SourceFile syntax. This method is a temporary workaround, and
-  /// should be removed when we fully migrate to libSyntax parsing.
-  virtual void discardRecordedNode(OpaqueSyntaxNode node) = 0;
-
   /// Used for incremental re-parsing.
   virtual std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {

--- a/include/swift/Parse/SyntaxParserResult.h
+++ b/include/swift/Parse/SyntaxParserResult.h
@@ -40,18 +40,18 @@ public:
     assert(Status.isError());
   }
 
-  explicit ParsedSyntaxResult(ParsedRawSyntaxNode &&Raw)
-      : Raw(std::move(Raw)), Status() {}
+  explicit ParsedSyntaxResult(ParsedRawSyntaxNode Raw)
+      : Raw(Raw), Status() {}
 
-  explicit ParsedSyntaxResult(ParsedSyntaxNode &&Node)
-      : ParsedSyntaxResult(Node.takeRaw()) {}
+  explicit ParsedSyntaxResult(ParsedSyntaxNode Node)
+      : ParsedSyntaxResult(Node.getRaw()) {}
 
   template <typename OtherParsedSyntaxNode,
             typename Enable = typename std::enable_if<std::is_base_of<
                 ParsedSyntaxNode, OtherParsedSyntaxNode>::value>::type>
-  ParsedSyntaxResult(ParsedSyntaxResult<OtherParsedSyntaxNode> &&other) {
-    Raw = std::move(other.Raw);
-    Status = std::move(other.Status);
+  ParsedSyntaxResult(ParsedSyntaxResult<OtherParsedSyntaxNode> other) {
+    Raw = other.Raw;
+    Status = other.Status;
   }
 
   bool isSuccess() const {
@@ -72,20 +72,11 @@ public:
     Status.setHasCodeCompletion();
   }
 
-  ParsedSyntaxNode get() {
+  ParsedSyntaxNode get() const {
     assert(!isNull());
-    return ParsedSyntaxNode(std::move(Raw));
+    return ParsedSyntaxNode(Raw);
   }
-
-  template<typename NewSyntaxNode>
-  Optional<NewSyntaxNode> getAs() {
-    assert(!isNull());
-    if (NewSyntaxNode::kindof(Raw.getKind()))
-      return NewSyntaxNode(std::move(Raw));
-    return None;
-  }
-
-  Optional<ParsedSyntaxNode> getOrNull() {
+  Optional<ParsedSyntaxNode> getOrNull() const {
     if (isNull())
       return None;
     return get();
@@ -103,13 +94,13 @@ public:
 template <typename ParsedSyntaxNode>
 static ParsedSyntaxResult<ParsedSyntaxNode>
 makeParsedResult(ParsedSyntaxNode node) {
-  return ParsedSyntaxResult<ParsedSyntaxNode>(std::move(node));
+  return ParsedSyntaxResult<ParsedSyntaxNode>(node);
 }
 
 template <typename ParsedSyntaxNode>
 static ParsedSyntaxResult<ParsedSyntaxNode>
 makeParsedError(ParsedSyntaxNode node) {
-  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(std::move(node));
+  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(node);
   result.setIsError();
   return result;
 }
@@ -122,7 +113,7 @@ static ParsedSyntaxResult<ParsedSyntaxNode> makeParsedError() {
 template <typename ParsedSyntaxNode>
 static ParsedSyntaxResult<ParsedSyntaxNode>
 makeParsedCodeCompletion(ParsedSyntaxNode node) {
-  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(std::move(node));
+  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(node);
   result.setHasCodeCompletion();
   return result;
 }
@@ -130,7 +121,7 @@ makeParsedCodeCompletion(ParsedSyntaxNode node) {
 template <typename ParsedSyntaxNode>
 static ParsedSyntaxResult<ParsedSyntaxNode>
 makeParsedResult(ParsedSyntaxNode node, ParserStatus Status) {
-  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(std::move(node));
+  auto result = ParsedSyntaxResult<ParsedSyntaxNode>(node);
   if (Status.hasCodeCompletion())
     result.setHasCodeCompletion();
   else if (Status.isError())

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -300,7 +300,7 @@ public:
     return SyntaxNode(std::move(rawNode));
   }
 
-  ParsedTokenSyntax &&popToken();
+  ParsedTokenSyntax popToken();
 
   /// Create a node using the tail of the collected parts. The number of parts
   /// is automatically determined from \c Kind. Node: limited number of \c Kind

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -180,17 +180,14 @@ private:
   ArrayRef<ParsedRawSyntaxNode> getParts() const {
     return llvm::makeArrayRef(getStorage()).drop_front(Offset);
   }
-  MutableArrayRef<ParsedRawSyntaxNode> getParts() {
-    return llvm::makeMutableArrayRef(getStorage().data(), getStorage().size()).drop_front(Offset);
-  }
 
   ParsedRawSyntaxNode makeUnknownSyntax(SyntaxKind Kind,
-                                  MutableArrayRef<ParsedRawSyntaxNode> Parts);
+                                  ArrayRef<ParsedRawSyntaxNode> Parts);
   ParsedRawSyntaxNode createSyntaxAs(SyntaxKind Kind,
-                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
+                                     ArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK);
   Optional<ParsedRawSyntaxNode> bridgeAs(SyntaxContextKind Kind,
-                              MutableArrayRef<ParsedRawSyntaxNode> Parts);
+                              ArrayRef<ParsedRawSyntaxNode> Parts);
 
   ParsedRawSyntaxNode finalizeSourceFile();
 
@@ -280,12 +277,14 @@ public:
 
   /// Returns the topmost Syntax node.
   template <typename SyntaxNode> SyntaxNode topNode() {
-    ParsedRawSyntaxNode &TopNode = getStorage().back();
+    ParsedRawSyntaxNode TopNode = getStorage().back();
+
     if (TopNode.isRecorded()) {
       OpaqueSyntaxNode OpaqueNode = TopNode.getOpaqueNode();
       return getSyntaxCreator().getLibSyntaxNodeFor<SyntaxNode>(OpaqueNode);
     }
-    return getSyntaxCreator().createNode<SyntaxNode>(TopNode.copyDeferred());
+    
+    return getSyntaxCreator().createNode<SyntaxNode>(TopNode);
   }
 
   template <typename SyntaxNode>
@@ -293,11 +292,11 @@ public:
     auto &Storage = getStorage();
     if (Storage.size() <= Offset)
       return llvm::None;
-    if (!SyntaxNode::kindof(Storage.back().getKind()))
+    auto rawNode = Storage.back();
+    if (!SyntaxNode::kindof(rawNode.getKind()))
       return llvm::None;
-    auto rawNode = std::move(Storage.back());
     Storage.pop_back();
-    return SyntaxNode(std::move(rawNode));
+    return SyntaxNode(rawNode);
   }
 
   ParsedTokenSyntax popToken();

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -64,8 +64,6 @@ public:
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) override;
 
-  void discardRecordedNode(OpaqueSyntaxNode node) override;
-
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 

--- a/lib/Parse/HiddenLibSyntaxAction.cpp
+++ b/lib/Parse/HiddenLibSyntaxAction.cpp
@@ -125,12 +125,3 @@ HiddenLibSyntaxAction::getExplicitNodeFor(OpaqueSyntaxNode node) {
   auto hiddenNode = (Node *)node;
   return hiddenNode->ExplicitActionNode;
 }
-
-void HiddenLibSyntaxAction::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
-  if (!opaqueN)
-    return;
-  auto node = static_cast<Node *>(opaqueN);
-  if (!areBothLibSyntax())
-    LibSyntaxAction->discardRecordedNode(node->LibSyntaxNode);
-  ExplicitAction->discardRecordedNode(node->ExplicitActionNode);
-}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4125,7 +4125,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   ParserPosition startPosition = getParserPosition();
   llvm::Optional<SyntaxParsingContext> TmpCtxt;
   TmpCtxt.emplace(SyntaxContext);
-  TmpCtxt->setBackTracking();
+  TmpCtxt->setTransparent();
 
   SourceLoc TypeAliasLoc = consumeToken(tok::kw_typealias);
   SourceLoc EqualLoc;
@@ -4164,13 +4164,13 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   }
 
   if (Flags.contains(PD_InProtocol) && !genericParams && !Tok.is(tok::equal)) {
+    TmpCtxt->setBackTracking();
     TmpCtxt.reset();
     // If we're in a protocol and don't see an '=' this looks like leftover Swift 2
     // code intending to be an associatedtype.
     backtrackToPosition(startPosition);
     return parseDeclAssociatedType(Flags, Attributes);
   }
-  TmpCtxt->setTransparent();
   TmpCtxt.reset();
 
   auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1312,25 +1312,25 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::integer_literal);
-  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(Token, *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<FloatLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::floating_literal);
-  return ParsedSyntaxRecorder::makeFloatLiteralExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makeFloatLiteralExpr(Token, *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<NilLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::kw_nil);
-  return ParsedSyntaxRecorder::makeNilLiteralExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makeNilLiteralExpr(Token, *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<BooleanLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax();
-  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(Token, *SyntaxContext);
 }
 
 template <>
@@ -1341,11 +1341,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFileExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FILE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_file);
-  return ParsedSyntaxRecorder::makePoundFileExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFileExpr(Token, *SyntaxContext);
 }
 
 template <>
@@ -1356,12 +1356,12 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundLineExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___LINE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
   }
 
   // FIXME: #line was renamed to #sourceLocation
   auto Token = consumeTokenSyntax(tok::pound_line);
-  return ParsedSyntaxRecorder::makePoundLineExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundLineExpr(Token, *SyntaxContext);
 }
 
 template <>
@@ -1372,11 +1372,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundColumnExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___COLUMN__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_column);
-  return ParsedSyntaxRecorder::makePoundColumnExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundColumnExpr(Token, *SyntaxContext);
 }
 
 template <>
@@ -1387,11 +1387,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFunctionExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FUNCTION__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_function);
-  return ParsedSyntaxRecorder::makePoundFunctionExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFunctionExpr(Token, *SyntaxContext);
 }
 
 template <>
@@ -1402,18 +1402,18 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundDsohandleExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___DSO_HANDLE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_dsohandle);
-  return ParsedSyntaxRecorder::makePoundDsohandleExpr(std::move(Token), *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundDsohandleExpr(Token, *SyntaxContext);
 }
 
 template <typename SyntaxNode>
 ParserResult<Expr> Parser::parseExprAST() {
   auto Loc = leadingTriviaLoc();
   auto ParsedExpr = parseExprSyntax<SyntaxNode>();
-  SyntaxContext->addSyntax(std::move(ParsedExpr));
+  SyntaxContext->addSyntax(ParsedExpr);
   // todo [gsoc]: improve this somehow
   if (SyntaxContext->isTopNode<UnknownExprSyntax>()) {
     auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
@@ -1519,9 +1519,9 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
           ParsedSyntaxRecorder::makeIdentifierPattern(
                                   SyntaxContext->popToken(), *SyntaxContext);
       ParsedExprSyntax ExprNode =
-          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
+          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
                                                            *SyntaxContext);
-      SyntaxContext->addSyntax(std::move(ExprNode));
+      SyntaxContext->addSyntax(ExprNode);
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1169,7 +1169,6 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // matching-pattern ::= expr
   // Fall back to expression parsing for ambiguous forms. Name lookup will
   // disambiguate.
-  DeferringContextRAII Deferring(*SyntaxContext);
   ParserResult<Expr> subExpr =
     parseExprImpl(diag::expected_pattern, isExprBasic);
   ParserStatus status = subExpr;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -123,7 +123,6 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
 
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
-    SyntaxParsingContext CCCtxt(SyntaxContext, SyntaxContextKind::Decl);
     consumeToken();
     if (CodeCompletion)
       CodeCompletion->completeAfterPoundDirective();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -408,7 +408,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
   }
 
   if (Tok.is(tok::arrow)) {
-    auto InputNode(std::move(SyntaxContext->popIf<ParsedTypeSyntax>().getValue()));
+    auto InputNode = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
     // Handle type-function if we have an arrow.
     auto ArrowLoc = Tok.getLoc();
     auto Arrow = consumeTokenSyntax();
@@ -741,7 +741,7 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     if (Base) {
       SyntaxContext->addSyntax(std::move(*Base));
       auto T = SyntaxContext->topNode<TypeSyntax>();
-      Junk.push_back(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
+      Junk.push_back(*SyntaxContext->popIf<ParsedTypeSyntax>());
       ITR = dyn_cast<IdentTypeRepr>(Generator.generate(T, BaseLoc));
     }
 
@@ -1164,10 +1164,9 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       auto InFlight = diagnose(EqualLoc, diag::tuple_type_init);
       if (Init.isNonNull())
         InFlight.fixItRemove(SourceRange(EqualLoc, Init.get()->getEndLoc()));
+      auto Expr = *SyntaxContext->popIf<ParsedExprSyntax>();
       Initializer = ParsedSyntaxRecorder::makeInitializerClause(
-          std::move(*Equal),
-          std::move(*SyntaxContext->popIf<ParsedExprSyntax>()),
-          *SyntaxContext);
+          std::move(*Equal), std::move(Expr), *SyntaxContext);
     }
 
     Comma = consumeTokenSyntaxIf(tok::comma);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -181,8 +181,8 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
     // Eat the code completion token because we handled it.
     auto CCTok = consumeTokenSyntax(tok::code_complete);
     ParsedTypeSyntax ty =
-        ParsedSyntaxRecorder::makeUnknownType({&CCTok, 1}, *SyntaxContext);
-    return makeParsedCodeCompletion(std::move(ty));
+        ParsedSyntaxRecorder::makeUnknownType({CCTok}, *SyntaxContext);
+    return makeParsedCodeCompletion(ty);
   }
   case tok::l_square:
     Result = parseTypeCollection();
@@ -203,10 +203,9 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
     }
 
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
-      auto token = consumeTokenSyntax();
       ParsedTypeSyntax ty = ParsedSyntaxRecorder::makeUnknownType(
-          {&token, 1}, *SyntaxContext);
-      return makeParsedError(std::move(ty));
+          {consumeTokenSyntax()}, *SyntaxContext);
+      return makeParsedError(ty);
     }
 
     checkForInputIncomplete();
@@ -257,7 +256,7 @@ Parser::parseTypeSyntax(Diag<> messageID, bool HandleCodeCompletion,
   auto tyR = parseType(messageID, HandleCodeCompletion, IsSILFuncDecl);
   if (auto ty = SyntaxContext->popIf<ParsedTypeSyntax>()) {
     Generator.addType(tyR.getPtrOrNull(), loc);
-    return makeParsedResult(std::move(*ty), tyR.getStatus());
+    return makeParsedResult(*ty, tyR.getStatus());
   }
   return tyR.getStatus();
 }
@@ -270,7 +269,7 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
                                               const TypeAttributes &attrs,
                                               Optional<Scope> &GenericsScope) {
   auto LBraceLoc = consumeToken(tok::l_brace);
-
+  
   SmallVector<SILBoxTypeRepr::Field, 4> Fields;
   if (!Tok.is(tok::r_brace)) {
     for (;;) {
@@ -284,30 +283,30 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
         return makeParserError();
       }
       SourceLoc VarOrLetLoc = consumeToken();
-
+      
       auto fieldTy = parseType();
       if (!fieldTy.getPtrOrNull())
         return makeParserError();
       Fields.push_back({VarOrLetLoc, Mutable, fieldTy.get()});
-
+      
       if (consumeIf(tok::comma))
         continue;
-
+      
       break;
     }
   }
-
+  
   if (!Tok.is(tok::r_brace)) {
     diagnose(Tok, diag::sil_box_expected_r_brace);
     return makeParserError();
   }
-
+  
   auto RBraceLoc = consumeToken(tok::r_brace);
-
+  
   // The generic arguments are taken from the enclosing scope. Pop the
   // box layout's scope now.
   GenericsScope.reset();
-
+  
   SourceLoc LAngleLoc, RAngleLoc;
   SmallVector<TypeRepr*, 4> Args;
   if (Tok.isContextualPunctuator("<")) {
@@ -325,7 +324,7 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
       diagnose(Tok, diag::sil_box_expected_r_angle);
       return makeParserError();
     }
-
+    
     RAngleLoc = consumeToken();
   }
 
@@ -371,7 +370,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
       GenericsScope.emplace(this, ScopeKind::Generics);
     generics = maybeParseGenericParams().getPtrOrNull();
   }
-
+  
   // In SIL mode, parse box types { ... }.
   if (isInSILMode() && Tok.is(tok::l_brace)) {
     auto SILBoxType = parseSILBoxType(generics, attrs, GenericsScope);
@@ -423,15 +422,16 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
         parseType(diag::expected_type_function_result);
     auto SecondTy = SyntaxContext->popIf<ParsedTypeSyntax>();
     if (SecondHalf.isParseError()) {
-      SyntaxContext->addSyntax(std::move(InputNode));
+      SyntaxContext->addSyntax(InputNode);
       if (Throws)
-        SyntaxContext->addSyntax(std::move(*Throws));
-      SyntaxContext->addSyntax(std::move(Arrow));
+        SyntaxContext->addSyntax(*Throws);
+      SyntaxContext->addSyntax(Arrow);
       if (SecondTy)
-        SyntaxContext->addSyntax(std::move(*SecondTy));
+        SyntaxContext->addSyntax(*SecondTy);
       if (SecondHalf.hasCodeCompletion())
         return makeParserCodeCompletionResult<TypeRepr>();
-      return makeParserErrorResult<TypeRepr>();
+      if (SecondHalf.isNull())
+        return nullptr;
     }
 
     ParsedFunctionTypeSyntaxBuilder Builder(*SyntaxContext);
@@ -442,9 +442,9 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
       auto Arguments = TupleTypeNode->getDeferredElements();
       auto RightParen = TupleTypeNode->getDeferredRightParen();
       Builder
-        .useLeftParen(std::move(LeftParen))
-        .useArguments(std::move(Arguments))
-        .useRightParen(std::move(RightParen));
+        .useLeftParen(LeftParen)
+        .useArguments(Arguments)
+        .useRightParen(RightParen);
     } else {
       // FIXME(syntaxparse): Extract 'Void' text from recoreded node.
       if (const auto Void = dyn_cast<SimpleIdentTypeRepr>(tyR))
@@ -460,13 +460,14 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
           .fixItInsertAfter(tyR->getEndLoc(), ")");
       }
       Builder.addArgumentsMember(ParsedSyntaxRecorder::makeTupleTypeElement(
-          std::move(InputNode), /*TrailingComma=*/None, *SyntaxContext));
+          InputNode, /*TrailingComma=*/None, *SyntaxContext));
     }
 
+    Builder.useReturnType(*SecondTy);
     if (Throws)
-      Builder.useThrowsOrRethrowsKeyword(std::move(*Throws));
-    Builder.useArrow(std::move(Arrow));
-    Builder.useReturnType(std::move(*SecondTy));
+      Builder.useThrowsOrRethrowsKeyword(*Throws);
+    Builder.useArrow(Arrow);
+    Builder.useReturnType(*SecondTy);
 
     SyntaxContext->addSyntax(Builder.build());
 
@@ -627,7 +628,7 @@ Parser::parseGenericArgumentsAST(SmallVectorImpl<TypeRepr *> &ArgsAST,
 }
 
 /// parseTypeIdentifier
-///
+///   
 ///   type-identifier:
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///
@@ -641,10 +642,9 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
       if (CodeCompletion)
         CodeCompletion->completeTypeSimpleBeginning();
 
-      auto CCTok = consumeTokenSyntax(tok::code_complete);
       auto ty = ParsedSyntaxRecorder::makeUnknownType(
-          {&CCTok, 1}, *SyntaxContext);
-      return makeParsedCodeCompletion(std::move(ty));
+          {consumeTokenSyntax(tok::code_complete)}, *SyntaxContext);
+      return makeParsedCodeCompletion(ty);
     }
 
     diagnose(Tok, diag::expected_identifier_for_type);
@@ -652,10 +652,9 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     // If there is a keyword at the start of a new line, we won't want to
     // skip it as a recovery but rather keep it.
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
-      auto kwTok = consumeTokenSyntax();
       ParsedTypeSyntax ty = ParsedSyntaxRecorder::makeUnknownType(
-          {&kwTok, 1}, *SyntaxContext);
-      return makeParsedError(std::move(ty));
+          {consumeTokenSyntax()}, *SyntaxContext);
+      return makeParsedError(ty);
     }
 
     return makeParsedError<ParsedTypeSyntax>();
@@ -677,42 +676,42 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
       // FIXME: offer a fixit: 'self' -> 'Self'
       Identifier =
           parseIdentifierSyntax(diag::expected_identifier_in_dotted_type);
+      if (!Identifier) {
+        Status.setIsParseError();
+        if (Base)
+          Junk.push_back(*Base);
+        if (Period)
+          Junk.push_back(*Period);
+      }
     }
 
     if (Identifier) {
       Optional<ParsedGenericArgumentClauseSyntax> GenericArgs;
-
+      
       if (startsWithLess(Tok)) {
         SmallVector<TypeRepr *, 4> GenericArgsAST;
         SourceLoc LAngleLoc, RAngleLoc;
         auto GenericArgsResult = parseGenericArgumentClauseSyntax();
         if (GenericArgsResult.isError()) {
           if (Base)
-            Junk.push_back(std::move(*Base));
+            Junk.push_back(*Base);
           if (Period)
-            Junk.push_back(std::move(*Period));
-          Junk.push_back(std::move(*Identifier));
+            Junk.push_back(*Period);
+          Junk.push_back(*Identifier);
           if (!GenericArgsResult.isNull())
             Junk.push_back(GenericArgsResult.get());
           auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-          return makeParsedResult(std::move(ty), GenericArgsResult.getStatus());
+          return makeParsedResult(ty, GenericArgsResult.getStatus());
         }
         GenericArgs = GenericArgsResult.get();
       }
 
       if (!Base)
         Base = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
-            std::move(*Identifier), std::move(GenericArgs), *SyntaxContext);
+            *Identifier, GenericArgs, *SyntaxContext);
       else
         Base = ParsedSyntaxRecorder::makeMemberTypeIdentifier(
-            std::move(*Base), std::move(*Period), std::move(*Identifier),
-            std::move(GenericArgs), *SyntaxContext);
-    } else {
-      Status.setIsParseError();
-      if (Base)
-        Junk.push_back(std::move(*Base));
-      if (Period)
-        Junk.push_back(std::move(*Period));
+            *Base, *Period, *Identifier, GenericArgs, *SyntaxContext);
     }
 
     // Treat 'Foo.<anything>' as an attempt to write a dotted type
@@ -739,16 +738,17 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     IdentTypeRepr *ITR = nullptr;
 
     if (Base) {
-      SyntaxContext->addSyntax(std::move(*Base));
+      SyntaxContext->addSyntax(*Base);
       auto T = SyntaxContext->topNode<TypeSyntax>();
-      Junk.push_back(*SyntaxContext->popIf<ParsedTypeSyntax>());
+      SyntaxContext->popIf<ParsedTypeSyntax>();
       ITR = dyn_cast<IdentTypeRepr>(Generator.generate(T, BaseLoc));
+      Junk.push_back(*Base);
     }
 
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       auto Dot = consumeTokenSyntax();
-      Junk.push_back(std::move(Dot));
+      Junk.push_back(Dot);
       if (CodeCompletion)
         CodeCompletion->completeTypeIdentifierWithDot(ITR);
     } else {
@@ -758,15 +758,15 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     // Eat the code completion token because we handled it.
     Junk.push_back(consumeTokenSyntax(tok::code_complete));
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedCodeCompletion(std::move(ty));
+    return makeParsedCodeCompletion(ty);
   }
-
+  
   if (Status.isError()) {
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedError(std::move(ty));
+    return makeParsedError(ty);
   }
 
-  return makeParsedResult(std::move(*Base));
+  return makeParsedResult(*Base);
 }
 
 Parser::TypeASTResult
@@ -803,11 +803,9 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     FirstSome = consumeTokenSyntax();
   }
 
-  auto ApplySome = [this](ParsedTypeSyntax Type,
-                          Optional<ParsedTokenSyntax> Some) {
-    return Some ? ParsedSyntaxRecorder::makeSomeType(
-                      std::move(*Some), std::move(Type), *SyntaxContext)
-                : std::move(Type);
+  auto ApplySome = [this](ParsedTypeSyntax Type, Optional<ParsedTokenSyntax> Some) {
+    return Some ? ParsedSyntaxRecorder::makeSomeType(*Some, Type, *SyntaxContext)
+                : Type;
   };
 
   // Parse the first type
@@ -819,15 +817,14 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
   auto FirstType = FirstTypeResult.get();
 
   if (!Tok.isContextualPunctuator("&"))
-    return makeParsedResult(
-        ApplySome(std::move(FirstType), std::move(FirstSome)));
+    return makeParsedResult(ApplySome(FirstType, FirstSome));
 
   SmallVector<ParsedCompositionTypeElementSyntax, 4> Elements;
-
+  
   Optional<ParsedTokenSyntax> Ampersand = consumeTokenSyntax();
   auto FirstElement = ParsedSyntaxRecorder::makeCompositionTypeElement(
-      std::move(FirstType), std::move(*Ampersand), *SyntaxContext);
-  Elements.push_back(std::move(FirstElement));
+      FirstType, *Ampersand, *SyntaxContext);
+  Elements.push_back(FirstElement);
 
   ParserStatus Status;
 
@@ -851,46 +848,45 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
 
       SmallVector<ParsedSyntax, 0> nodes;
       if (FirstSome)
-        nodes.push_back(std::move(*FirstSome));
-      std::move(Elements.begin(), Elements.end(), std::back_inserter(nodes));
+        nodes.push_back(*FirstSome);
+      nodes.append(Elements.begin(), Elements.end());
       if (NextSome)
-        nodes.push_back(std::move(*NextSome));
+        nodes.push_back(*NextSome);
       nodes.push_back(NextTypeResult.get());
 
       auto ty = ParsedSyntaxRecorder::makeUnknownType(nodes, *SyntaxContext);
-      return makeParsedResult(std::move(ty), Status);
+      return makeParsedResult(ty, Status);
     }
 
-    auto NextType = ApplySome(NextTypeResult.get(), std::move(NextSome));
-    Ampersand = Tok.isContextualPunctuator("&")
-        ? consumeTokenSyntax()
+    auto NextType = ApplySome(NextTypeResult.get(), NextSome);
+    Ampersand = Tok.isContextualPunctuator("&") 
+        ? consumeTokenSyntax() 
         : llvm::Optional<ParsedTokenSyntax>();
     auto NextElement = ParsedSyntaxRecorder::makeCompositionTypeElement(
-        std::move(NextType), std::move(Ampersand), *SyntaxContext);
-    Elements.push_back(std::move(NextElement));
+        NextType, Ampersand, *SyntaxContext);
+    Elements.push_back(NextElement);
   } while (Ampersand);
 
   auto ElementList = ParsedSyntaxRecorder::makeCompositionTypeElementList(
       Elements, *SyntaxContext);
-  auto Composition = ParsedSyntaxRecorder::makeCompositionType(
-      std::move(ElementList), *SyntaxContext);
-  return makeParsedResult(
-      ApplySome(std::move(Composition), std::move(FirstSome)), Status);
+  auto Composition =
+      ParsedSyntaxRecorder::makeCompositionType(ElementList, *SyntaxContext);
+  return makeParsedResult(ApplySome(Composition, FirstSome), Status);
 }
 
 Parser::TypeASTResult Parser::parseAnyTypeAST() {
   auto AnyLoc = leadingTriviaLoc();
   auto ParsedAny = parseAnyType().get();
-  SyntaxContext->addSyntax(std::move(ParsedAny));
+  SyntaxContext->addSyntax(ParsedAny);
   auto Any = SyntaxContext->topNode<SimpleTypeIdentifierSyntax>();
   return makeParserResult(Generator.generate(Any, AnyLoc));
 }
 
 Parser::TypeResult Parser::parseAnyType() {
   auto Any = consumeTokenSyntax(tok::kw_Any);
-  auto Type = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
-      std::move(Any), llvm::None, *SyntaxContext);
-  return makeParsedResult(std::move(Type));
+  auto Type = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(Any, llvm::None,
+                                                             *SyntaxContext);
+  return makeParsedResult(Type);
 }
 
 /// parseOldStyleProtocolComposition
@@ -913,8 +909,8 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   auto LAngleLoc = Tok.getLoc();
   auto LAngle = consumeStartingLessSyntax();
 
-  Junk.push_back(Protocol.copyDeferred());
-  Junk.push_back(LAngle.copyDeferred());
+  Junk.push_back(Protocol);
+  Junk.push_back(LAngle);
 
   // Parse the type-composition-list.
   ParserStatus Status;
@@ -928,13 +924,13 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       Status |= TypeResult.getStatus();
       if (TypeResult.isSuccess()) {
         auto Type = TypeResult.get();
-        Junk.push_back(Type.copyDeferred());
+        Junk.push_back(Type);
         if (!IsAny)
-          Protocols.push_back(std::move(Type));
+          Protocols.push_back(Type);
       }
       Comma = consumeTokenSyntaxIf(tok::comma);
       if (Comma)
-        Junk.push_back(Comma->copyDeferred());
+        Junk.push_back(*Comma);
     } while (Comma);
   }
 
@@ -943,7 +939,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   if (startsWithGreater(Tok)) {
     RAngleLoc = Tok.getLoc();
     auto RAngle = consumeStartingGreaterSyntax();
-    Junk.push_back(RAngle.copyDeferred());
+    Junk.push_back(RAngle);
   } else {
     if (Status.isSuccess()) {
       diagnose(Tok, diag::expected_rangle_protocol);
@@ -955,7 +951,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
     // Skip until we hit the '>'.
     skipUntilGreaterInTypeListSyntax(RAngleJunk, /*protocolComposition=*/true);
     for (auto &&Piece : RAngleJunk)
-      Junk.push_back(Piece.copyDeferred());
+      Junk.push_back(Piece);
   }
 
   if (Status.isSuccess()) {
@@ -963,7 +959,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
     if (Protocols.empty()) {
       replacement = "Any";
     } else {
-      auto extractText = [&](ParsedTypeSyntax &Type) -> StringRef {
+      auto extractText = [&](ParsedTypeSyntax Type) -> StringRef {
         auto SourceRange = Type.getRaw().getDeferredRange();
         return SourceMgr.extractText(SourceRange);
       };
@@ -979,7 +975,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       // Need parenthesis if the next token looks like postfix TypeRepr.
       // i.e. '?', '!', '.Type', '.Protocol'
       bool needParen = false;
-      needParen |= !Tok.isAtStartOfLine() &&
+      needParen |= !Tok.isAtStartOfLine() && 
           (isOptionalToken(Tok) || isImplicitlyUnwrappedOptionalToken(Tok));
       needParen |= Tok.isAny(tok::period, tok::period_prefix);
       if (needParen) {
@@ -1005,7 +1001,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   }
 
   auto Unknown = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-  return makeParsedResult(std::move(Unknown));
+  return makeParsedResult(Unknown);
 }
 
 /// parseTypeTupleBody
@@ -1026,14 +1022,15 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     return makeParsedError<ParsedTypeSyntax>();
 
   SmallVector<ParsedSyntax, 0> Junk;
-
+  
   auto LParenLoc = Tok.getLoc();
   auto LParen = consumeTokenSyntax(tok::l_paren);
 
-  Junk.push_back(LParen.copyDeferred());
+  Junk.push_back(LParen);
 
   SmallVector<ParsedTupleTypeElementSyntax, 4> Elements;
   SmallVector<std::tuple<SourceLoc, SourceLoc, SourceLoc>, 4> ElementsLoc;
+  Optional<ParsedTokenSyntax> FirstEllipsis;
   SourceLoc FirstEllipsisLoc;
 
   Optional<ParsedTokenSyntax> Comma;
@@ -1058,7 +1055,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       InOut = consumeTokenSyntax(tok::kw_inout);
       IsInOutObsoleted = true;
 
-      LocalJunk.push_back(InOut->copyDeferred());
+      LocalJunk.push_back(*InOut);
     }
 
     // If the label is "some", this could end up being an opaque type
@@ -1081,18 +1078,18 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       // Consume a name.
       NameLoc = Tok.getLoc();
       Name = consumeArgumentLabelSyntax();
-      LocalJunk.push_back(Name->copyDeferred());
+      LocalJunk.push_back(*Name);
 
       // If there is a second name, consume it as well.
       if (Tok.canBeArgumentLabel()) {
         SecondNameLoc = Tok.getLoc();
         SecondName = consumeArgumentLabelSyntax();
-        LocalJunk.push_back(SecondName->copyDeferred());
+        LocalJunk.push_back(*SecondName);
       }
 
       // Consume the ':'.
       if ((Colon = consumeTokenSyntaxIf(tok::colon))) {
-        LocalJunk.push_back(Colon->copyDeferred());
+        LocalJunk.push_back(*Colon);
         // If we succeed, then we successfully parsed a label.
         if (Backtracking)
           Backtracking->cancelBacktrack();
@@ -1113,22 +1110,19 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
 
     // Parse the type annotation.
     auto TypeLoc = Tok.getLoc();
-    auto ty = parseTypeSyntax(diag::expected_type);
-    if (ty.hasCodeCompletion() || ty.isNull()) {
-      std::move(LocalJunk.begin(), LocalJunk.end(), std::back_inserter(Junk));
-      if (!ty.isNull())
-        Junk.push_back(ty.get());
+    auto Type = parseTypeSyntax(diag::expected_type);
+    if (Type.hasCodeCompletion() || Type.isNull()) {
+      Junk.append(LocalJunk.begin(), LocalJunk.end());
+      if (!Type.isNull())
+        Junk.push_back(Type.get());
       skipListUntilDeclRBraceSyntax(Junk, LParenLoc, tok::r_paren, tok::comma);
-      return ty.getStatus();
+      return Type.getStatus();
     }
 
     if (IsInOutObsoleted) {
       bool IsTypeAlreadyAttributed = false;
-      if (auto AttributedType = ty.getAs<ParsedAttributedTypeSyntax>()) {
-        IsTypeAlreadyAttributed =
-            AttributedType->getDeferredSpecifier().hasValue();
-        ty = makeParsedResult(std::move(*AttributedType), ty.getStatus());
-      }
+      if (auto AttributedType = Type.get().getAs<ParsedAttributedTypeSyntax>())
+        IsTypeAlreadyAttributed = AttributedType->getDeferredSpecifier().hasValue();
 
       if (IsTypeAlreadyAttributed) {
         // If the parsed type is already attributed, suggest removing `inout`.
@@ -1146,7 +1140,8 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       Tok.setKind(tok::ellipsis);
       auto ElementEllipsisLoc = Tok.getLoc();
       ElementEllipsis = consumeTokenSyntax();
-      if (!FirstEllipsisLoc.isValid()) {
+      if (!FirstEllipsis) {
+        FirstEllipsis = ElementEllipsis;
         FirstEllipsisLoc = ElementEllipsisLoc;
       } else {
         diagnose(ElementEllipsisLoc, diag::multiple_ellipsis_in_tuple)
@@ -1165,20 +1160,19 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       if (Init.isNonNull())
         InFlight.fixItRemove(SourceRange(EqualLoc, Init.get()->getEndLoc()));
       auto Expr = *SyntaxContext->popIf<ParsedExprSyntax>();
-      Initializer = ParsedSyntaxRecorder::makeInitializerClause(
-          std::move(*Equal), std::move(Expr), *SyntaxContext);
+      Initializer = ParsedSyntaxRecorder::makeInitializerClause(*Equal, Expr,
+                                                                *SyntaxContext);
     }
 
     Comma = consumeTokenSyntaxIf(tok::comma);
 
     auto Element = ParsedSyntaxRecorder::makeTupleTypeElement(
-        std::move(InOut), std::move(Name), std::move(SecondName),
-        std::move(Colon), ty.get(), std::move(ElementEllipsis),
-        std::move(Initializer), std::move(Comma), *SyntaxContext);
+        InOut, Name, SecondName, Colon, Type.get(), ElementEllipsis, Initializer,
+        Comma, *SyntaxContext);
 
-    Junk.push_back(Element.copyDeferred());
+    Junk.push_back(Element);
 
-    Elements.push_back(std::move(Element));
+    Elements.push_back(Element);
     ElementsLoc.emplace_back(NameLoc, SecondNameLoc, TypeLoc);
 
     return makeParserSuccess();
@@ -1186,8 +1180,14 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
 
   if (!Status.isSuccess()) {
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedResult(std::move(ty), Status);
+    return makeParsedResult(ty, Status);
   }
+
+  auto ElementList =
+      ParsedSyntaxRecorder::makeTupleTypeElementList(Elements, *SyntaxContext);
+
+  auto TupleType = ParsedSyntaxRecorder::makeTupleType(LParen, ElementList,
+                                                       *RParen, *SyntaxContext);
 
   bool IsFunctionType = Tok.isAny(tok::arrow, tok::kw_throws, tok::kw_rethrows);
 
@@ -1201,7 +1201,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
   if (!IsFunctionType) {
     for (unsigned i = 0; i < Elements.size(); i++) {
       // true tuples have labels
-      auto &Element = Elements[i];
+      auto Element = Elements[i];
       SourceLoc NameLoc, SecondNameLoc, TypeLoc;
       std::tie(NameLoc, SecondNameLoc, TypeLoc) = ElementsLoc[i];
       // If there were two names, complain.
@@ -1223,7 +1223,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     for (unsigned i = 0; i < Elements.size(); i++) {
       // If there was a first name, complain; arguments in function types are
       // always unlabeled.
-      auto &Element = Elements[i];
+      auto Element = Elements[i];
       SourceLoc NameLoc, SecondNameLoc, TypeLoc;
       std::tie(NameLoc, SecondNameLoc, TypeLoc) = ElementsLoc[i];
       if (NameLoc.isValid()) {
@@ -1244,14 +1244,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     }
   }
 
-  auto ElementList =
-      ParsedSyntaxRecorder::makeTupleTypeElementList(Elements, *SyntaxContext);
-
-  auto TupleType = ParsedSyntaxRecorder::makeTupleType(
-      std::move(LParen), std::move(ElementList), std::move(*RParen),
-      *SyntaxContext);
-
-  return makeParsedResult(std::move(TupleType));
+  return makeParsedResult(TupleType);
 }
 
 /// parseTypeArray - Parse the type-array production, given that we
@@ -1285,9 +1278,9 @@ Parser::TypeResult Parser::parseTypeArray(ParsedTypeSyntax Base,
   }
 
   ParsedArrayTypeSyntaxBuilder builder(*SyntaxContext);
-  builder.useElementType(std::move(Base));
+  builder.useElementType(Base);
   if (RSquare)
-    builder.useRightSquareBracket(std::move(*RSquare));
+    builder.useRightSquareBracket(*RSquare);
 
   return makeParsedError(builder.build());
 }
@@ -1326,37 +1319,35 @@ Parser::TypeResult Parser::parseTypeCollection() {
 
   if (!Status.isSuccess()) {
     SmallVector<ParsedSyntax, 0> Pieces;
-    Pieces.push_back(std::move(LSquare));
+    Pieces.push_back(LSquare);
     if (ElementType)
-      Pieces.push_back(std::move(*ElementType));
+      Pieces.push_back(*ElementType);
     if (Colon)
-      Pieces.push_back(std::move(*Colon));
+      Pieces.push_back(*Colon);
     if (ValueType)
-      Pieces.push_back(std::move(*ValueType));
+      Pieces.push_back(*ValueType);
     if (RSquare)
-      Pieces.push_back(std::move(*RSquare));
+      Pieces.push_back(*RSquare);
 
     ParsedTypeSyntax ty =
         ParsedSyntaxRecorder::makeUnknownType(Pieces, *SyntaxContext);
-    return makeParsedResult(std::move(ty), Status);
+    return makeParsedResult(ty, Status);
   }
 
   if (Colon)
     return makeParsedResult(ParsedSyntaxRecorder::makeDictionaryType(
-        std::move(LSquare), std::move(*ElementType), std::move(*Colon),
-        std::move(*ValueType), std::move(*RSquare), *SyntaxContext));
+        LSquare, *ElementType, *Colon, *ValueType, *RSquare, *SyntaxContext));
 
   return makeParsedResult(ParsedSyntaxRecorder::makeArrayType(
-      std::move(LSquare), std::move(*ElementType), std::move(*RSquare),
-      *SyntaxContext));
+      LSquare, *ElementType, *RSquare, *SyntaxContext));
 }
 
 Parser::TypeResult Parser::parseMetatypeType(ParsedTypeSyntax Base) {
   auto Period = consumeTokenSyntax(); // tok::period or tok::period_prefix
   auto Keyword = consumeTokenSyntax(tok::identifier); // "Type" or "Protocol"
   auto MetatypeType = ParsedSyntaxRecorder::makeMetatypeType(
-      std::move(Base), std::move(Period), std::move(Keyword), *SyntaxContext);
-  return makeParsedResult(std::move(MetatypeType));
+      Base, Period, Keyword, *SyntaxContext);
+  return makeParsedResult(MetatypeType);
 }
 
 bool Parser::isOptionalToken(const Token &T) const {
@@ -1412,17 +1403,17 @@ SourceLoc Parser::consumeImplicitlyUnwrappedOptionalToken() {
 
 Parser::TypeResult Parser::parseOptionalType(ParsedTypeSyntax Base) {
   auto Question = consumeOptionalTokenSyntax();
-  auto Optional = ParsedSyntaxRecorder::makeOptionalType(
-      std::move(Base), std::move(Question), *SyntaxContext);
-  return makeParsedResult(std::move(Optional));
+  auto Optional =
+      ParsedSyntaxRecorder::makeOptionalType(Base, Question, *SyntaxContext);
+  return makeParsedResult(Optional);
 }
 
 Parser::TypeResult
 Parser::parseImplicitlyUnwrappedOptionalType(ParsedTypeSyntax Base) {
   auto Exclamation = consumeImplicitlyUnwrappedOptionalTokenSyntax();
   auto Unwrapped = ParsedSyntaxRecorder::makeImplicitlyUnwrappedOptionalType(
-      std::move(Base), std::move(Exclamation), *SyntaxContext);
-  return makeParsedResult(std::move(Unwrapped));
+      Base, Exclamation, *SyntaxContext);
+  return makeParsedResult(Unwrapped);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -43,14 +43,14 @@ Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} ${child.nam
   assert(${child_elt_name}s.empty() && "use either 'use' function or 'add', not both");
 %       end
   Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
-    ${child.name}.takeRaw();
+    ${child.name}.getRaw();
   return *this;
 }
 %       if child_elt:
 Parsed${node.name}Builder &
 Parsed${node.name}Builder::add${child_elt_name}(Parsed${child_elt_type} ${child_elt}) {
   assert(Layout[cursorIndex(${node.name}::Cursor::${child.name})].isNull() && "use either 'use' function or 'add', not both");
-  ${child_elt_name}s.push_back(${child_elt}.takeRaw());
+  ${child_elt_name}s.push_back(std::move(${child_elt}.getRaw()));
   return *this;
 }
 %       end

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -28,14 +28,14 @@ using namespace swift::syntax;
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
 Parsed${node.name}::getDeferred${child.name}() {
-  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
+  auto RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
   if (RawChild.isNull())
     return None;
-  return Parsed${child.type_name} {RawChild.copyDeferred()};
+  return Parsed${child.type_name} {RawChild};
 }
 %     else:
 Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
+  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}]};
 }
 %     end
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -26,8 +26,8 @@ using namespace swift;
 using namespace swift::syntax;
 
 bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
-        MutableArrayRef<ParsedRawSyntaxNode> Elements,
-        function_ref<void(syntax::SyntaxKind, MutableArrayRef<ParsedRawSyntaxNode>)> receiver) {
+        ArrayRef<ParsedRawSyntaxNode> Elements,
+        function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -42,23 +42,16 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     if child.is_optional:
       Layout[${child_idx}] = ParsedRawSyntaxNode::null();
 %     else:
-      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
-        Layout[i].reset();
       return false;
 %     end
     } else {
-      Layout[${child_idx}] = Elements[I].unsafeCopy();
+      Layout[${child_idx}] = Elements[I];
       ++I;
     }
 %   end
-    if (I != Elements.size()) {
-      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
-        Layout[i].reset();
+    if (I != Elements.size())
       return false;
-    }
     receiver(Kind, Layout);
-    for (unsigned i = 0, e = Elements.size(); i != e; ++i)
-      Elements[i].reset();
     return true;
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
@@ -92,31 +85,29 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
                                        ParsedRawSyntaxRecorder &rec) {
-  ParsedRawSyntaxNode layout[] = {
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.takeRaw(),
+    ${child.name}.getRaw(),
 %       end
 %     end
-  };
-  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
+  });
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  ParsedRawSyntaxNode layout[] = {
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.takeRaw(),
+    ${child.name}.getRaw(),
 %       end
 %     end
-  };
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
+  }, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
@@ -131,12 +122,12 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    ArrayRef<Parsed${node.collection_element_type}> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
+    layout.push_back(element.getRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -144,12 +135,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    ArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
+    layout.push_back(element.getRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
@@ -158,7 +149,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    ArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -180,12 +171,12 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
 %   elif node.is_unknown():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    MutableArrayRef<ParsedSyntax> elements,
+    ArrayRef<ParsedSyntax> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
+    layout.push_back(element.getRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -193,12 +184,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    MutableArrayRef<ParsedSyntax> elements,
+    ArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
+    layout.push_back(element.getRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
@@ -206,7 +197,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    MutableArrayRef<ParsedSyntax> elements,
+    ArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -233,6 +224,6 @@ ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,
                                     llvm::Optional<ParsedTokenSyntax> TrailingComma,
                                     SyntaxParsingContext &SPCtx) {
-  return makeTupleTypeElement(None, None, None, None, std::move(Type), None, None,
-                              std::move(TrailingComma), SPCtx);
+  return makeTupleTypeElement(None, None, None, None, Type, None, None,
+                              TrailingComma, SPCtx);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -684,19 +684,19 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_paren);
     if (auto RParen = consumeTokenSyntaxIf(tok::r_paren))
-      Skipped.push_back(std::move(*RParen));
+      Skipped.push_back(*RParen);
     break;
   case tok::l_brace:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_brace);
     if (auto RBrace = consumeTokenSyntaxIf(tok::r_brace))
-      Skipped.push_back(std::move(*RBrace));
+      Skipped.push_back(*RBrace);
     break;
   case tok::l_square:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_square);
     if (auto RSquare = consumeTokenSyntaxIf(tok::r_square))
-      Skipped.push_back(std::move(*RSquare));
+      Skipped.push_back(*RSquare);
     break;
   case tok::pound_if:
   case tok::pound_else:
@@ -708,7 +708,7 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     if (Tok.isAny(tok::pound_else, tok::pound_elseif))
       skipSingleSyntax(Skipped);
     else if (auto Endif = consumeTokenSyntaxIf(tok::pound_endif))
-      Skipped.push_back(std::move(*Endif));
+      Skipped.push_back(*Endif);
     break;
 
   default:
@@ -1003,12 +1003,11 @@ void Parser::skipListUntilDeclRBraceSyntax(
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif)) {
     auto Comma = consumeTokenSyntaxIf(tok::comma);
-
+    if (Comma)
+      Skipped.push_back(*Comma);
+    
     bool hasDelimiter = Tok.getLoc() == startLoc || Comma;
     bool possibleDeclStartsLine = Tok.isAtStartOfLine();
-
-    if (Comma)
-      Skipped.push_back(std::move(*Comma));
 
     if (isStartOfDecl()) {
       // Could have encountered something like `_ var:` 
@@ -1021,7 +1020,7 @@ void Parser::skipListUntilDeclRBraceSyntax(
         Parser::BacktrackingScope backtrack(*this);
         // Consume the let or var
         auto LetOrVar = consumeTokenSyntax();
-        Skipped.push_back(std::move(LetOrVar));
+        Skipped.push_back(LetOrVar);
         
         // If the following token is either <identifier> or :, it means that
         // this `var` or `let` should be interpreted as a label
@@ -1339,7 +1338,7 @@ Parser::parseListSyntax(tok RightK, SourceLoc LeftLoc,
       diagnose(Tok, diag::unexpected_separator, ",")
           .fixItRemove(SourceRange(Tok.getLoc()));
       auto Comma = consumeTokenSyntax();
-      Junk.push_back(std::move(Comma));
+      Junk.push_back(Comma);
     }
     SourceLoc StartLoc = Tok.getLoc();
 

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -163,8 +163,8 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
   return Curr;
 }
 
-ParsedTokenSyntax &&SyntaxParsingContext::popToken() {
-  return std::move(popIf<ParsedTokenSyntax>().getValue());
+ParsedTokenSyntax SyntaxParsingContext::popToken() {
+  return popIf<ParsedTokenSyntax>().getValue();
 }
 
 /// Add Token with Trivia to the parts.
@@ -342,7 +342,7 @@ SyntaxParsingContext::~SyntaxParsingContext() {
         Storage.push_back(std::move(BridgedNode.getValue()));
       }
     } else {
-      auto node(std::move(bridgeAs(CtxtKind, getParts()).getValue()));
+      auto node = bridgeAs(CtxtKind, getParts()).getValue();
       Storage.erase(Storage.begin() + Offset, Storage.end());
       Storage.emplace_back(std::move(node));
     }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -54,14 +54,13 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  auto length = foundNode.getRecordedRange().getByteLength();
-  getStorage().push_back(std::move(foundNode));
-  return length;
+  getStorage().push_back(foundNode);
+  return foundNode.getRecordedRange().getByteLength();
 }
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
-                                        MutableArrayRef<ParsedRawSyntaxNode> Parts) {
+                                        ArrayRef<ParsedRawSyntaxNode> Parts) {
   assert(isUnknownKind(Kind));
   if (shouldDefer())
     return ParsedRawSyntaxNode::makeDeferred(Kind, Parts, *this);
@@ -71,12 +70,12 @@ SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
-                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
+                                     ArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK) {
   // Try to create the node of the given syntax.
   ParsedRawSyntaxNode rawNode;
   auto &rec = getRecorder();
-  auto formNode = [&](SyntaxKind kind, MutableArrayRef<ParsedRawSyntaxNode> layout) {
+  auto formNode = [&](SyntaxKind kind, ArrayRef<ParsedRawSyntaxNode> layout) {
     if (nodeCreateK == SyntaxNodeCreationKind::Deferred || shouldDefer()) {
       rawNode = ParsedRawSyntaxNode::makeDeferred(kind, layout, *this);
     } else {
@@ -92,9 +91,9 @@ SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
 
 Optional<ParsedRawSyntaxNode>
 SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
-                               MutableArrayRef<ParsedRawSyntaxNode> Parts) {
+                               ArrayRef<ParsedRawSyntaxNode> Parts) {
   if (Parts.size() == 1) {
-    auto &RawNode = Parts.front();
+    auto RawNode = Parts.front();
     SyntaxKind RawNodeKind = RawNode.getKind();
     switch (Kind) {
     case SyntaxContextKind::Stmt:
@@ -121,7 +120,7 @@ SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
       // We don't need to coerce in this case.
       break;
     }
-    return std::move(RawNode);
+    return RawNode;
   } else if (Parts.empty()) {
     // Just omit the unknown node if it does not have any children
     return None;
@@ -182,7 +181,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
 
 /// Add Syntax to the parts.
 void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
-  addRawSyntax(Node.takeRaw());
+  addRawSyntax(Node.getRaw());
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
@@ -193,10 +192,12 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
     return;
   }
 
-  auto node = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
-  auto &storage = getStorage();
-  getStorage().erase(storage.end() - N, getStorage().end());
-  getStorage().emplace_back(std::move(node));
+  auto I = getStorage().end() - N;
+  *I = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
+
+  // Remove consumed parts.
+  if (N != 1)
+    getStorage().erase(I + 1, getStorage().end());
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
@@ -249,11 +250,11 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
 
 ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
   ParsedRawSyntaxRecorder &Recorder = getRecorder();
-  auto Parts = getParts();
-  ParsedRawSyntaxNode Layout[2];
+  ArrayRef<ParsedRawSyntaxNode> Parts = getParts();
+  std::vector<ParsedRawSyntaxNode> AllTopLevel;
 
   assert(!Parts.empty() && Parts.back().isToken(tok::eof));
-  Layout[1] = std::move(Parts.back());
+  ParsedRawSyntaxNode EOFToken = Parts.back();
   Parts = Parts.drop_back();
 
   for (auto RawNode : Parts) {
@@ -268,13 +269,13 @@ ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
     AllTopLevel.push_back(RawNode);
   }
 
-  Layout[0] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
-
+  auto itemList = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList,
+                                           Parts);
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
-                                  llvm::makeMutableArrayRef(Layout, 2));
+                                  { itemList, EOFToken });
 }
 
-OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
+  OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
   assert(isTopOfContextStack() && "some sub-contexts are not destructed");
   assert(isRoot() && "only root context can finalize the tree");
   assert(Mode == AccumulationMode::Root);
@@ -282,7 +283,7 @@ OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
     return nullptr; // already finalized.
   }
   ParsedRawSyntaxNode root = finalizeSourceFile();
-  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.takeOpaqueNode());
+  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.getOpaqueNode());
 
   // Clear the parts because we will call this function again when destroying
   // the root context.
@@ -302,12 +303,9 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 
 void SyntaxParsingContext::dumpStorage() const  {
   llvm::errs() << "======================\n";
-  auto &storage = getStorage();
-  for (unsigned i = 0; i != storage.size(); ++i) {
-    storage[i].dump(llvm::errs());
-    llvm::errs() << "\n";
-    if (i + 1 == Offset)
-      llvm::errs() << "--------------\n";
+  for (auto Node : getStorage()) {
+    Node.dump(llvm::errs());
+    llvm::errs() << "\n--------------\n";
   }
 }
 
@@ -339,12 +337,14 @@ SyntaxParsingContext::~SyntaxParsingContext() {
     assert(!isRoot());
     if (Storage.size() == Offset) {
       if (auto BridgedNode = bridgeAs(CtxtKind, {})) {
-        Storage.push_back(std::move(BridgedNode.getValue()));
+        Storage.push_back(BridgedNode.getValue());
       }
     } else {
-      auto node = bridgeAs(CtxtKind, getParts()).getValue();
-      Storage.erase(Storage.begin() + Offset, Storage.end());
-      Storage.emplace_back(std::move(node));
+      auto I = Storage.begin() + Offset;
+      *I = bridgeAs(CtxtKind, getParts()).getValue();
+      // Remove used parts.
+      if (Storage.size() > Offset + 1)
+        Storage.erase(Storage.begin() + (Offset + 1), Storage.end());
     }
     break;
   }
@@ -357,12 +357,10 @@ SyntaxParsingContext::~SyntaxParsingContext() {
   // Remove all parts in this context.
   case AccumulationMode::Discard: {
     auto &nodes = getStorage();
-    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i) {
-      // FIXME: This should not be needed. This breaks invariant that any
-      // recorded node must be a part of result souce syntax tree.
+    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i)
       if (i->isRecorded())
-        getRecorder().discardRecordedNode(*i);
-    }
+        getSyntaxCreator().finalizeNode(i->getOpaqueNode());
+
     nodes.erase(nodes.begin()+Offset, nodes.end());
     break;
   }

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -39,8 +39,7 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RC<syntax::RawSyntax> &Obj,
-                     const llvm::FoldingSetNodeIDRef IDRef)
+  RawSyntaxCacheNode(RC<syntax::RawSyntax> Obj, const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -173,9 +173,3 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   raw.resetWithoutRelease();
   return {length, opaqueN};
 }
-
-void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
-  if (!opaqueN)
-    return;
-  static_cast<RawSyntax *>(opaqueN)->Release();
-}

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -17,7 +17,7 @@
                 null,
                 null,
                 {
-                  "id": 33,
+                  "id": 1,
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
@@ -48,7 +48,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 34,
+                  "id": 2,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "x"
@@ -64,11 +64,11 @@
                 },
                 null,
                 {
-                  "id": 32,
+                  "id": 34,
                   "kind": "TypeInitializerClause",
                   "layout": [
                     {
-                      "id": 1,
+                      "id": 3,
                       "tokenKind": {
                         "kind": "equal"
                       },
@@ -82,11 +82,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 31,
+                      "id": 33,
                       "kind": "TupleType",
                       "layout": [
                         {
-                          "id": 18,
+                          "id": 20,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -95,16 +95,16 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 29,
+                          "id": 31,
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
-                              "id": 24,
+                              "id": 26,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 19,
+                                  "id": 21,
                                   "tokenKind": {
                                     "kind": "identifier",
                                     "text": "b"
@@ -115,7 +115,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 20,
+                                  "id": 22,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -129,11 +129,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 22,
+                                  "id": 24,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 21,
+                                      "id": 23,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "Int"
@@ -149,7 +149,7 @@
                                 null,
                                 null,
                                 {
-                                  "id": 23,
+                                  "id": 25,
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
@@ -166,12 +166,12 @@
                               "presence": "Present"
                             },
                             {
-                              "id": 28,
+                              "id": 30,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 25,
+                                  "id": 27,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -181,7 +181,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 20,
+                                  "id": 22,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -195,11 +195,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 27,
+                                  "id": 29,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 26,
+                                      "id": 28,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "String"
@@ -222,7 +222,7 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 30,
+                          "id": 32,
                           "tokenKind": {
                             "kind": "r_paren"
                           },

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -190,10 +190,6 @@ public:
     return getNodeHandler()(&node);
   }
 
-  void discardRecordedNode(OpaqueSyntaxNode node) override {
-    // FIXME: This method should not be called at all.
-  }
-
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, SyntaxKind kind) override {
     auto NodeLookup = getNodeLookup();


### PR DESCRIPTION
Changes in the libSyntax parser seem to have caused parsing the standard library to break in Debug(Asserts) builds.  Revert this patchset.

Sorry y'all.

@rintaro @compnerd 