### PR TITLE
Revert "runtime: add a workaround for Windows build"

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -730,14 +730,8 @@ _findContextDescriptorInCache(TypeMetadataPrivateState &T,
   $sS ## CHAR ## SUFFIX
 #define DESCRIPTOR_MANGLING(CHAR, SUFFIX) DESCRIPTOR_MANGLING_(CHAR, SUFFIX)
 
-#if defined(_WIN32)
-#define swiftCore_EXPORTS __declspec(dllimport)
-#else
-#define swiftCore_EXPORTS
-#endif
-
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME) \
-  extern "C" swiftCore_EXPORTS const ContextDescriptor DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND));
+  extern "C" const ContextDescriptor DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND));
 
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -204,6 +204,221 @@ const long long $ssSeVMn[1] = {0};
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $sShMn[1] = {0};
 
+// Bool
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSbMn[1] = {0};
+
+// Binary Floating Point
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSBMp[1] = {0};
+
+// Double
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSdMn[1] = {0};
+
+// RandomNumberGenerator
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSGMp[1] = {0};
+
+// Int
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSiMn[1] = {0};
+
+// DefaultIndicis
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSIMn[1] = {0};
+
+// Character
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSJMn[1] = {0};
+
+// Numeric
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSjMp[1] = {0};
+
+// RandomAccessCollection
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSkMp[1] = {0};
+
+// BidirectionalCollection
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSKMp[1] = {0};
+
+// RangeReplacementCollection
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSmMp[1] = {0};
+
+// MutationCollection
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSMMp[1] = {0};
+
+// Range
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSnMn[1] = {0};
+
+// ClosedRange
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSNMn[1] = {0};
+
+// ObjectIdentifier
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSOMn[1] = {0};
+
+// UnsafeMutablePointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSpMn[1] = {0};
+
+// Optional
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSqMn[1] = {0};
+
+// Equatable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSQMp[1] = {0};
+
+// UnsafeMutableBufferPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSrMn[1] = {0};
+
+// UnsafeBufferPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSRMn[1] = {0};
+
+// String
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSSMn[1] = {0};
+
+// Sequence
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSTMp[1] = {0};
+
+// UInt
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSuMn[1] = {0};
+
+// UnsignedInteger
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSUMp[1] = {0};
+
+// UnsafeMutableRawPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSvMn[1] = {0};
+
+// Strideable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSxMp[1] = {0};
+
+// RangeExpression
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSXMp[1] = {0};
+
+// StringProtocol
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSyMp[1] = {0};
+
+// RawRepresentable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSYMp[1] = {0};
+
+// BinaryInteger
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSzMp[1] = {0};
+
+// Decodable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSeMp[1] = {0};
+
+// Encodable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSEMp[1] = {0};
+
+// Float
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSfMn[1] = {0};
+
+// FloatingPoint
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSFMp[1] = {0};
+
+// Collection
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSlMp[1] = {0};
+
+// Comparable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSLMp[1] = {0};
+
+// UnsafePointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSPMn[1] = {0};
+
+// Substring
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSsMn[1] = {0};
+
+// IteratorProtocol
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sStMp[1] = {0};
+
+// UnsafeRawPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSVMn[1] = {0};
+
+// UnsafeMutableRawBufferPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSwMn[1] = {0};
+
+// UnsafeRawBufferPointer
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSWMn[1] = {0};
+
+// SignedInteger
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $sSZMp[1] = {0};
+
 // Mirror
 
 // protocol witness table for Swift._ClassSuperMirror : Swift._Mirror in Swift


### PR DESCRIPTION
This reverts commit efaf1fbefa7fc94ff535b35b964689735637458b.
Add a much more palatable workaround for the unit tests.  Rather than
adding the dllimport for the symbols, locally define the required
symbols.  This list is sufficient to restore the ability to build tests
for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
