### PR TITLE
[TF] Set default RPATH to toolchain stdlib instead of `/usr/lib/swift` on macOS.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -513,6 +513,14 @@ def no_static_stdlib: Flag<["-"], "no-static-stdlib">,
 def toolchain_stdlib_rpath: Flag<["-"], "toolchain-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Add an rpath entry for the toolchain's standard library, rather than the OS's">;
+// SWIFT_ENABLE_TENSORFLOW
+// NOTE(TF-797): The default for `toolchain_stdlib_rpath` is set to true to
+// prevent TensorFlow linker errors. Thus, the `no_toolchain_stdlib_rpath` flag
+// is necessary to opt out of the default behavior.
+def no_toolchain_stdlib_rpath: Flag<["-"], "no-toolchain-stdlib-rpath">,
+  Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
+  HelpText<"Do not add an rpath entry for the toolchain's standard library, rather than the OS's">;
+// SWIFT_ENABLE_TENSORFLOW END
 def no_stdlib_rpath: Flag<["-"], "no-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Don't add any rpath entries.">;

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -395,7 +395,8 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
   // exist in `/usr/lib/swift` on Darwin platforms.
   // Relevant Swift-in-Darwin-OSs patch:
   // https://github.com/apple/swift/pull/24787.
-  if (context.Args.hasFlag(options::OPT_toolchain_stdlib_rpath,
+  if (!context.Args.hasArg(options::OPT_no_stdlib_rpath) &&
+      context.Args.hasFlag(options::OPT_toolchain_stdlib_rpath,
                            options::OPT_no_toolchain_stdlib_rpath, true)) {
   // SWIFT_ENABLE_TENSORFLOW END
     // If the user has explicitly asked for a toolchain stdlib, we should

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -389,7 +389,15 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
     Arguments.push_back(context.Args.MakeArgString(path));
   }
 
-  if (context.Args.hasArg(options::OPT_toolchain_stdlib_rpath)) {
+  // SWIFT_ENABLE_TENSORFLOW
+  // NOTE(TF-797): default true for toolchain stdlib rpath to prevent linker
+  // issues. This works around the fact that TensorFlow/Python modules do not
+  // exist in `/usr/lib/swift` on Darwin platforms.
+  // Relevant Swift-in-Darwin-OSs patch:
+  // https://github.com/apple/swift/pull/24787.
+  if (context.Args.hasFlag(options::OPT_toolchain_stdlib_rpath,
+                           options::OPT_no_toolchain_stdlib_rpath, true)) {
+  // SWIFT_ENABLE_TENSORFLOW END
     // If the user has explicitly asked for a toolchain stdlib, we should
     // provide one using -rpath. This used to be the default behaviour but it
     // was considered annoying in at least the SwiftPM scenario (see

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -2,26 +2,32 @@
 // Note: This is really about the /host/ environment, but since there are RUN
 // lines for multiple targets anyway it doesn't make a huge difference.
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// SWIFT_ENABLE_TENSORFLOW
+// All "-no-toolchain-stdlib-rpath" additions are SWIFT_ENABLE_TENSORFLOW.
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target armv7k-apple-watchos5 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target armv7k-apple-watchos5.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
+// SWIFT_ENABLE_TENSORFLOW END
 
 // RPATH: bin/ld{{"? }}
 // RPATH-SAME: -rpath {{"?/usr/lib/swift(-.+)?"? }}
@@ -36,6 +42,12 @@
 // ### Test with -toolchain-stdlib-rpath
 // RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
+
+// SWIFT_ENABLE_TENSORFLOW
+// ### Test with implicit -toolchain-stdlib-rpath
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
+// SWIFT_ENABLE_TENSORFLOW END
 
 // TOOLCHAIN-RPATH: bin/ld{{"? }}
 // TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}

--- a/test/Python/toolchain_stdlib_rpath_default_true.swift
+++ b/test/Python/toolchain_stdlib_rpath_default_true.swift
@@ -1,0 +1,15 @@
+// Note: RUN lines are copied from substitutions for %target-run-simple-swift.
+// Explicit references to `-toolchain-stdlib-rpath` are omitted.
+
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: xcrun --toolchain $TOOLCHAINS --sdk %sdk %swiftc_driver_plain %mcp_opt %s -o %t/a.out -module-name main
+// RUN: %target-codesign %t/a.out
+// RUN: %t/a.out
+
+// TF-797: test default true behavior for `-toolchain-stdlib-rpath` on Darwin platforms.
+// Verify no linker issues without explicitly specifying `-toolchain-stdlib-rpath`.
+
+import Python
+print(Python.import)

--- a/test/Python/toolchain_stdlib_rpath_false.swift
+++ b/test/Python/toolchain_stdlib_rpath_false.swift
@@ -1,0 +1,21 @@
+// Note: RUN lines are copied from substitutions for %target-run-simple-swift.
+// Explicit references to `-toolchain-stdlib-rpath` are omitted.
+// Explicit `-no-toolchain-stdlib-rpath` flag is added.
+
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: xcrun --toolchain $TOOLCHAINS --sdk %sdk %swiftc_driver_plain %mcp_opt -no-toolchain-stdlib-rpath %s -o %t/a.out -module-name main
+// RUN: %target-codesign %t/a.out
+// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s
+
+// TF-797: test `-no-toolchain-stdlib-rpath` on Darwin platforms.
+// Expected crash due to linker error because RPATH is `/usr/lib/swift` instead
+// of toolchain standard library.
+
+import Python
+print(Python.import)
+
+// CHECK: dyld: Library not loaded: @rpath/libswiftPython.dylib
+// CHECK: Referenced from: BUILD_DIR/test-macosx-x86_64/Python/Output/toolchain_stdlib_rpath_false.swift.tmp/a.out
+// CHECK: Reason: image not found


### PR DESCRIPTION
Previously, the default RPATH was set to `/usr/lib/swift`.
This caused linker issues on macOS, as tensorflow-branch-specific modules like
TensorFlow and Python do not exist in `/usr/lib/swift`.

This patch defaults the `-toolchain-stdlib-rpath` flag to be true, so the
default RPATH is the toolchain standard library instead of `/usr/lib/swift`.

With this default, the linker issues are fixed. A `-no-toolchain-stdlib-path`
flag is added to opt out of this default, making `/usr/lib/swift` the RPATH.

Add positive/negative tests.
`swift test` works on macOS for packages that import/use TensorFlow again (namely https://github.com/tensorflow/swift-apis).

Partially reverts https://github.com/apple/swift/pull/24787. Resolves [TF-797](https://bugs.swift.org/browse/TF-797).