### PR TITLE
Add `-no-toolchain-stdlib-rpath` flag.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -508,6 +508,9 @@ def no_static_stdlib: Flag<["-"], "no-static-stdlib">,
 def toolchain_stdlib_rpath: Flag<["-"], "toolchain-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Add an rpath entry for the toolchain's standard library, rather than the OS's">;
+def no_toolchain_stdlib_rpath: Flag<["-"], "no-toolchain-stdlib-rpath">,
+  Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
+  HelpText<"Do not add an rpath entry for the toolchain's standard library, rather than the OS's">;
 def no_stdlib_rpath: Flag<["-"], "no-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Don't add any rpath entries.">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -510,7 +510,7 @@ def toolchain_stdlib_rpath: Flag<["-"], "toolchain-stdlib-rpath">,
   HelpText<"Add an rpath entry for the toolchain's standard library, rather than the OS's">;
 def no_toolchain_stdlib_rpath: Flag<["-"], "no-toolchain-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
-  HelpText<"Do not add an rpath entry for the toolchain's standard library, rather than the OS's">;
+  HelpText<"Do not add an rpath entry for the toolchain's standard library (default)">;
 def no_stdlib_rpath: Flag<["-"], "no-stdlib-rpath">,
   Flags<[HelpHidden,DoesNotAffectIncrementalBuild]>,
   HelpText<"Don't add any rpath entries.">;

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -389,7 +389,8 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
     Arguments.push_back(context.Args.MakeArgString(path));
   }
 
-  if (context.Args.hasArg(options::OPT_toolchain_stdlib_rpath)) {
+  if (context.Args.hasFlag(options::OPT_toolchain_stdlib_rpath,
+                           options::OPT_no_toolchain_stdlib_rpath, false)) {
     // If the user has explicitly asked for a toolchain stdlib, we should
     // provide one using -rpath. This used to be the default behaviour but it
     // was considered annoying in at least the SwiftPM scenario (see

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -37,6 +37,10 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift -resource-dir garbage/ | %FileCheck -check-prefix TOOLCHAIN-RPATH -DPLATFORM=%target-sdk-name %s
 
+// ### Test with -no-toolchain-stdlib-rpath
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
 // TOOLCHAIN-RPATH: bin/ld{{"? }}
 // TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}
 // TOOLCHAIN-RPATH-SAME: -o {{[^ ]+}}


### PR DESCRIPTION
Add `-no-toolchain-stdlib-rpath` flag: the negative version of
`-toolchain-stdlib-rpath`.

Make `-no-toolchain-stdlib-rpath` be the default: use `/usr/lib/swift` as
default RPATH on Darwin platforms instead of toolchain standard library.

---

Adapted from https://github.com/apple/swift/pull/27206.

tensorflow branch requires the opposite default (use toolchain standard
library as RPATH) because some stdlib modules like TensorFlow do not exist in
`/usr/lib/swift`.