### PR TITLE
[5.1] IRGen: Backport workaround for rdar://problem/53836960

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2562,13 +2562,22 @@ static llvm::GlobalVariable *createGOTEquivalent(IRGenModule &IGM,
   // rdar://problem/50968433: Unnamed_addr constants appear to get emitted
   // with incorrect alignment by the LLVM JIT in some cases. Don't use
   // unnamed_addr as a workaround.
-  if (!IGM.getOptions().UseJIT) {
+  // rdar://problem/53836960: LLVM miscompiles relative references to local
+  // symbols.
+  if (!IGM.getOptions().UseJIT
+      && (!IGM.Triple.isOSDarwin()
+          || (IGM.Triple.getArch() != llvm::Triple::x86 &&
+              IGM.Triple.getArchName() != "armv7" &&
+              IGM.Triple.getArchName() != "armv7s" &&
+              IGM.Triple.getArchName() != "thumbv7" &&
+              IGM.Triple.getArchName() != "thumbv7s" &&
+              !IGM.Triple.isWatchABI()))) {
     gotEquivalent->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
   } else {
     ApplyIRLinkage(IRLinkage::InternalLinkOnceODR)
       .to(gotEquivalent);
   }
-  
+
   return gotEquivalent;
 }
 


### PR DESCRIPTION
Explanation: The Swift 5.1 version of LLVM miscompiles relative references to lazy_ptr symbols for symbols
defined in the same translation unit. Work around that by making GOT equivalents not appear as
GOT equivalents to the backend by withholding `unnamed_addr`.

Scope: Fixes a miscompile that leads to runtime crashes

Issue: rdar://problem/55082864

Testing: Swift CI

Risk: Low. We've used the same workaround for several other similar issues in the past.

Reviewed by: @DougGregor 