### PR TITLE
[ownership] Create a context structure for the linear lifetime checker.

### DIFF
--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -206,8 +206,8 @@ bool BorrowScopeIntroducingValue::areInstructionsWithinScope(
   visitLocalScopeEndingInstructions(
       [&scratchSpace](SILInstruction *i) { scratchSpace.emplace_back(i); });
 
-  auto result = valueHasLinearLifetime(
-      value, scratchSpace, instructions, visitedBlocks, deadEndBlocks,
-      ownership::ErrorBehaviorKind::ReturnFalse);
+  LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+  auto result = checker.checkValue(value, scratchSpace, instructions,
+                                   ownership::ErrorBehaviorKind::ReturnFalse);
   return !result.getFoundError();
 }

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -136,9 +136,9 @@ public:
     SmallVector<BranchPropagatedUser, 32> allRegularUsers;
     llvm::copy(regularUsers, std::back_inserter(allRegularUsers));
     llvm::copy(implicitRegularUsers, std::back_inserter(allRegularUsers));
-    auto linearLifetimeResult =
-        valueHasLinearLifetime(value, lifetimeEndingUsers, allRegularUsers,
-                               visitedBlocks, deadEndBlocks, errorBehavior);
+    LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+    auto linearLifetimeResult = checker.checkValue(
+        value, lifetimeEndingUsers, allRegularUsers, errorBehavior);
     result = !linearLifetimeResult.getFoundError();
 
     return result.getValue();

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -150,9 +150,9 @@ static void fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      auto error =
-          valueHasLinearLifetime(pai, {applySite}, {}, visitedBlocks,
-                                 deadEndBlocks, errorBehavior, &leakingBlocks);
+      LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
+                                      &leakingBlocks);
       if (error.getFoundLeak()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();
@@ -201,9 +201,9 @@ static void fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      auto error =
-          valueHasLinearLifetime(pai, {applySite}, {}, visitedBlocks,
-                                 deadEndBlocks, errorBehavior, &leakingBlocks);
+      LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
+                                      &leakingBlocks);
       if (error.getFoundError()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();
@@ -240,9 +240,9 @@ static void fixupReferenceCounts(
       // just cares about the block the value is in. In a forthcoming commit, I
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
-      auto error =
-          valueHasLinearLifetime(pai, {applySite}, {}, visitedBlocks,
-                                 deadEndBlocks, errorBehavior, &leakingBlocks);
+      LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
+                                      &leakingBlocks);
       if (error.getFoundError()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -780,9 +780,8 @@ AvailableValueAggregator::addMissingDestroysForCopiedValues(
     // Then perform the linear lifetime check. If we succeed, continue. We have
     // no further work to do.
     auto errorKind = ownership::ErrorBehaviorKind::ReturnFalse;
-    auto error =
-        valueHasLinearLifetime(cvi, {svi}, {}, visitedBlocks, deadEndBlocks,
-                               errorKind, &leakingBlocks);
+    LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
+    auto error = checker.checkValue(cvi, {svi}, {}, errorKind, &leakingBlocks);
     if (!error.getFoundError())
       continue;
 

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -671,11 +671,10 @@ public:
     }
     
     SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
-    
-    auto result = valueHasLinearLifetime(baseObject, baseEndBorrows,
-                                   valueDestroys, visitedBlocks,
-                                   ARCOpt.getDeadEndBlocks(),
-                                   ownership::ErrorBehaviorKind::ReturnFalse);
+
+    LinearLifetimeChecker checker(visitedBlocks, ARCOpt.getDeadEndBlocks());
+    auto result = checker.checkValue(baseObject, baseEndBorrows, valueDestroys,
+                                     ownership::ErrorBehaviorKind::ReturnFalse);
     return answer(result.getFoundError());
   }
   


### PR DESCRIPTION
This is just a simple refactoring commit in preparation for hiding more of the
details of the linear lifetime checker. This is NFC, just moving around code.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
