### PR TITLE
[5.1] [PropertyWrapper] Fix a bug with static property wrapper being rejected in a class

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1779,8 +1779,8 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
   pbdPattern->setType(storageType);
   pbdPattern = TypedPattern::createImplicit(ctx, pbdPattern, storageType);
   auto pbd = PatternBindingDecl::createImplicit(
-      ctx, backingVar->getCorrectStaticSpelling(), pbdPattern,
-      /*init*/nullptr, dc, SourceLoc());
+      ctx, var->getCorrectStaticSpelling(), pbdPattern,
+      /*init*/ nullptr, dc, SourceLoc());
   addMemberToContextIfNeeded(pbd, dc, var);
   pbd->setStatic(var->isStatic());
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1131,3 +1131,22 @@ struct UseNonMutatingProjectedValueSet {
     x = 42  // expected-error{{cannot assign to property: 'self' is immutable}}
   }
 }
+
+// SR-11478
+
+@propertyWrapper
+struct SR_11478_W<Value> {
+  var wrappedValue: Value
+}
+
+class SR_11478_C1 {
+  @SR_11478_W static var bool1: Bool = true // Ok
+  @SR_11478_W class var bool2: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
+  @SR_11478_W class final var bool3: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
+}
+
+final class SR_11478_C2 {
+  @SR_11478_W static var bool1: Bool = true // Ok
+  @SR_11478_W class var bool2: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
+  @SR_11478_W class final var bool3: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
+}


### PR DESCRIPTION
Cherry-picking #27198. The first commit is new because we don't have TypeCheckStorage.cpp in the 5.1 branch. The second commit is from the original PR.

**Explanation**: We were rejecting the following valid code:

```swift
@propertyWrapper
struct Foo<Value> {
  var wrappedValue: Value
}

class Bar {
  // error: class stored properties not supported in classes; did you mean 'static'?
  @Foo static var bool: Bool = true
}
```

The problem here was that we were using the backing variable's static spelling, which is not present (because we haven't created its pattern binding at the time we access the spelling), so the check was falling down to calling `getCorrectStaticSpellingForDecl()` which returned `class` as the spelling since the context is a class. 

We should be using the original variable's static spelling instead (we already use its static-ness to decide whether the backing variable should be static or not, might as well use its static spelling too).

**Scope**: Property wrapper usage inside a class

**Issue**: [SR-11478](https://bugs.swift.org/browse/SR-11478)

**Testing**: Swift CI

**Risk**: Low. This allows code that was previously rejected (incorrectly)

**Reviewed by**: @jrose-apple 
