### PR TITLE
utils: bump to CMake 3.15.1

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -77,7 +77,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
-                "cmake": "v3.15.0",
+                "cmake": "v3.15.1",
                 "clang-tools-extra": "stable",
                 "libcxx": "stable",
                 "indexstore-db": "master",
@@ -102,7 +102,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
-                "cmake": "v3.15.0",
+                "cmake": "v3.15.1",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master"
             }
@@ -129,7 +129,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
-                "cmake": "v3.15.0",
+                "cmake": "v3.15.1",
                 "clang-tools-extra": "upstream-with-swift",
                 "libcxx": "upstream-with-swift",
                 "indexstore-db": "master",
@@ -153,7 +153,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
-                "cmake": "v3.15.0",
+                "cmake": "v3.15.1",
                 "indexstore-db": "master",
                 "sourcekit-lsp": "master"
             }
@@ -425,7 +425,7 @@
                 "swift-xcode-playground-support": "master",
                 "ninja": "release",
                 "icu": "release-61-1",
-                "cmake": "v3.15.0",
+                "cmake": "v3.15.1",
                 "clang-tools-extra": "apple/stable/20190619",
                 "libcxx": "apple/stable/20190619",
                 "indexstore-db": "master",


### PR DESCRIPTION
CMake 3.15.3 is the current stable release.  Update to 3.15.1 as CMake usually
has bug fixes in the first release.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
