### PR TITLE
[Diagnostics] A couple of clean-ups for `AddMissingArguments`

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4091,10 +4091,8 @@ bool FailureDiagnosis::diagnoseClosureExpr(
         return true;
       }
 
-      MissingArgumentsFailure failure(
-          expr, CS, inferredArgCount - actualArgCount,
-          CS.getConstraintLocator(CE, LocatorPathElt::ContextualType()));
-      return failure.diagnoseAsError();
+      // Missing arguments are already diagnosed via new diagnostic framework.
+      return false;
     }
 
     // Coerce parameter types here only if there are no unresolved

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4092,7 +4092,7 @@ bool FailureDiagnosis::diagnoseClosureExpr(
       }
 
       MissingArgumentsFailure failure(
-          expr, CS, fnType, inferredArgCount - actualArgCount,
+          expr, CS, inferredArgCount - actualArgCount,
           CS.getConstraintLocator(CE, LocatorPathElt::ContextualType()));
       return failure.diagnoseAsError();
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3504,7 +3504,11 @@ bool MissingArgumentsFailure::diagnoseAsError() {
         path.back().getKind() == ConstraintLocator::ContextualType))
     return false;
 
-  if (auto *closure = dyn_cast<ClosureExpr>(getAnchor()))
+  auto *anchor = getAnchor();
+  if (auto *captureList = dyn_cast<CaptureListExpr>(anchor))
+    anchor = captureList->getClosureBody();
+
+  if (auto *closure = dyn_cast<ClosureExpr>(anchor))
     return diagnoseTrailingClosure(closure);
 
   return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3509,12 +3509,12 @@ bool MissingArgumentsFailure::diagnoseAsError() {
     anchor = captureList->getClosureBody();
 
   if (auto *closure = dyn_cast<ClosureExpr>(anchor))
-    return diagnoseTrailingClosure(closure);
+    return diagnoseClosure(closure);
 
   return false;
 }
 
-bool MissingArgumentsFailure::diagnoseTrailingClosure(ClosureExpr *closure) {
+bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
   auto &cs = getConstraintSystem();
   FunctionType *funcType = nullptr;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1182,16 +1182,12 @@ public:
 class MissingArgumentsFailure final : public FailureDiagnostic {
   using Param = AnyFunctionType::Param;
 
-  FunctionType *Fn;
   unsigned NumSynthesized;
 
 public:
   MissingArgumentsFailure(Expr *root, ConstraintSystem &cs,
-                          FunctionType *funcType,
-                          unsigned numSynthesized,
-                          ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), Fn(funcType),
-        NumSynthesized(numSynthesized) {}
+                          unsigned numSynthesized, ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator), NumSynthesized(numSynthesized) {}
 
   bool diagnoseAsError() override;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1192,9 +1192,9 @@ public:
   bool diagnoseAsError() override;
 
 private:
-  /// If missing arguments come from trailing closure,
+  /// If missing arguments come from a closure,
   /// let's produce tailored diagnostics.
-  bool diagnoseTrailingClosure(ClosureExpr *closure);
+  bool diagnoseClosure(ClosureExpr *closure);
 };
 
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -477,18 +477,18 @@ AllowClosureParamDestructuring::create(ConstraintSystem &cs,
 }
 
 bool AddMissingArguments::diagnose(Expr *root, bool asNote) const {
-  MissingArgumentsFailure failure(root, getConstraintSystem(), Fn,
-                                  NumSynthesized, getLocator());
+  auto &cs = getConstraintSystem();
+  MissingArgumentsFailure failure(root, cs, NumSynthesized, getLocator());
   return failure.diagnose(asNote);
 }
 
 AddMissingArguments *
-AddMissingArguments::create(ConstraintSystem &cs, FunctionType *funcType,
+AddMissingArguments::create(ConstraintSystem &cs,
                             llvm::ArrayRef<Param> synthesizedArgs,
                             ConstraintLocator *locator) {
   unsigned size = totalSizeToAlloc<Param>(synthesizedArgs.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(AddMissingArguments));
-  return new (mem) AddMissingArguments(cs, funcType, synthesizedArgs, locator);
+  return new (mem) AddMissingArguments(cs, synthesizedArgs, locator);
 }
 
 bool MoveOutOfOrderArgument::diagnose(Expr *root, bool asNote) const {

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1001,13 +1001,12 @@ class AddMissingArguments final
 
   using Param = AnyFunctionType::Param;
 
-  FunctionType *Fn;
   unsigned NumSynthesized;
 
-  AddMissingArguments(ConstraintSystem &cs, FunctionType *funcType,
-                      llvm::ArrayRef<AnyFunctionType::Param> synthesizedArgs,
+  AddMissingArguments(ConstraintSystem &cs,
+                      llvm::ArrayRef<Param> synthesizedArgs,
                       ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AddMissingArguments, locator), Fn(funcType),
+      : ConstraintFix(cs, FixKind::AddMissingArguments, locator),
         NumSynthesized(synthesizedArgs.size()) {
     std::uninitialized_copy(synthesizedArgs.begin(), synthesizedArgs.end(),
                             getSynthesizedArgumentsBuf().begin());
@@ -1022,7 +1021,7 @@ public:
 
   bool diagnose(Expr *root, bool asNote = false) const override;
 
-  static AddMissingArguments *create(ConstraintSystem &cs, FunctionType *fnType,
+  static AddMissingArguments *create(ConstraintSystem &cs,
                                      llvm::ArrayRef<Param> synthesizedArgs,
                                      ConstraintLocator *locator);
 


### PR DESCRIPTION
In preparation to extend this fix to support more then just closures:

- Cover single explicit tuple argument -> N parameters via missing arguments fix

Expand tuple into N arguments to cover expect parameters.

This covers cases like this:

```swift
func foo(_: (Int, Int) -> Void) {}
foo { (bar: (Int, Int)) in } // used a single tuple type `(Int, Int)`
                             // instead of two distinct arguments
```

- Fix `missing argument` diagnostic to support closures with captures
- NFC: Remove "trailing" from method name for closures with missing args

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
