### PR TITLE
Cherry pick 0641a22 to 'tensorflow-0.5'

### DIFF
--- a/lib/SIL/ValueOwnership.cpp
+++ b/lib/SIL/ValueOwnership.cpp
@@ -163,6 +163,8 @@ CONSTANT_OWNERSHIP_INST(Unowned, ValueToBridgeObject)
   }
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, StructExtract)
 CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, TupleExtract)
+// SWIFT_ENABLE_TENSORFLOW
+CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, AutoDiffFunctionExtract)
 // OpenExistentialValue opens the boxed value inside an existential
 // CoW box. The semantics of an existential CoW box implies that we
 // can only consume the projected value inside the box if the box is
@@ -254,7 +256,6 @@ FORWARDING_OWNERSHIP_INST(SelectEnum)
 FORWARDING_OWNERSHIP_INST(Enum)
 // SWIFT_ENABLE_TENSORFLOW
 FORWARDING_OWNERSHIP_INST(AutoDiffFunction)
-FORWARDING_OWNERSHIP_INST(AutoDiffFunctionExtract)
 #undef FORWARDING_OWNERSHIP_INST
 
 ValueOwnershipKind


### PR DESCRIPTION
0641a22b8e0f5235542c2842d36c4fd55fbb8207 fixes a memory leak regression.