### PR TITLE
Update README to use clean command in Build Failues (#17069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ compiler crashes.
 Make sure you are using the [correct release](#macos) of Xcode.
 
 If you have changed Xcode versions but still encounter errors that appear to
-be related to the Xcode version, try passing `--rebuild` to `build-script`.
+be related to the Xcode version, try passing `--clean` to `build-script`.
 
 When a new version of Xcode is released, you can update your build without
 recompiling the entire project by passing the `--reconfigure` option.


### PR DESCRIPTION
This has been fixed already in d1c92f8f430f638516f8ac3e76a03da1f0e10b90

Resolves [TF-798](https://bugs.swift.org/browse/TF-798).