### PR TITLE
[ownership] Add a new checkValue overload to LinearLifetimeChecker th…

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -170,6 +170,18 @@ public:
              ArrayRef<BranchPropagatedUser> nonConsumingUses,
              ownership::ErrorBehaviorKind errorBehavior,
              SmallVectorImpl<SILBasicBlock *> *leakingBlocks = nullptr);
+
+  /// Returns true that \p value forms a linear lifetime with consuming uses \p
+  /// consumingUses, non consuming uses \p nonConsumingUses. Returns false
+  /// otherwise.
+  bool validateLifetime(SILValue value,
+                        ArrayRef<BranchPropagatedUser> consumingUses,
+                        ArrayRef<BranchPropagatedUser> nonConsumingUses) {
+    return !checkValue(value, consumingUses, nonConsumingUses,
+                       ownership::ErrorBehaviorKind::ReturnFalse,
+                       nullptr /*leakingBlocks*/)
+                .getFoundError();
+  }
 };
 
 /// Returns true if v is an address or trivial.

--- a/lib/SIL/OwnershipUtils.cpp
+++ b/lib/SIL/OwnershipUtils.cpp
@@ -207,7 +207,5 @@ bool BorrowScopeIntroducingValue::areInstructionsWithinScope(
       [&scratchSpace](SILInstruction *i) { scratchSpace.emplace_back(i); });
 
   LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
-  auto result = checker.checkValue(value, scratchSpace, instructions,
-                                   ownership::ErrorBehaviorKind::ReturnFalse);
-  return !result.getFoundError();
+  return checker.validateLifetime(value, scratchSpace, instructions);
 }

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -673,9 +673,10 @@ public:
     SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
 
     LinearLifetimeChecker checker(visitedBlocks, ARCOpt.getDeadEndBlocks());
-    auto result = checker.checkValue(baseObject, baseEndBorrows, valueDestroys,
-                                     ownership::ErrorBehaviorKind::ReturnFalse);
-    return answer(result.getFoundError());
+    // Returns true on success. So we invert.
+    bool foundError =
+        !checker.validateLifetime(baseObject, baseEndBorrows, valueDestroys);
+    return answer(foundError);
   }
   
   // TODO: Handle other access kinds?


### PR DESCRIPTION
…at validates the linear lifetime of the passed in value and returns bool to indicate success/failure.

This is the first in a series of patches that begin to hide the underlying
linear lifetime implementation underneath the facade of the linear lifetime
checker. I only updated the users that this applies to.
