### PR TITLE
[NFC, NameLookup, ASTScope] Bug fix for eager scope tree construction & better failure messages

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -135,6 +135,8 @@ private:
   /// Must clear source range change whenever this changes
   Children storedChildren;
 
+  bool wasExpanded = false;
+
   /// Because expansion returns an insertion point,
   /// if a scope is reexpanded, the children added NOT by expansion must be
   /// rescued and reused.
@@ -340,11 +342,11 @@ public:
   ASTScopeImpl *expandAndBeCurrent(ScopeCreator &);
 
   unsigned getChildrenCountWhenLastExpanded() const;
-  bool wasEverExpanded() const;
+  bool getWasExpanded() const { return wasExpanded; }
 
 protected:
   void setChildrenCountWhenLastExpanded();
-  void recordThatIWasExpandedEvenIfNoChildrenWereAdded();
+  void setWasExpanded() { wasExpanded = true; }
   virtual ASTScopeImpl *expandSpecifically(ScopeCreator &) = 0;
   virtual void beCurrent();
   bool isCurrent() const;

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -193,12 +193,14 @@ protected:
 
 public: // for addReusedBodyScopes
   void addChild(ASTScopeImpl *child, ASTContext &);
-  std::vector<ASTScopeImpl *> rescueYoungestChildren(unsigned count);
+  std::vector<ASTScopeImpl *>
+  rescueASTAncestorScopesForReuseFromMe(unsigned count);
 
   /// When reexpanding, do we always create a new body?
-  virtual NullablePtr<ASTScopeImpl> getParentOfRescuedScopes();
-  std::vector<ASTScopeImpl *> rescueScopesToReuse();
-  void addReusedScopes(ArrayRef<ASTScopeImpl *>);
+  virtual NullablePtr<ASTScopeImpl> getParentOfASTAncestorScopesToBeRescued();
+  std::vector<ASTScopeImpl *>
+  rescueASTAncestorScopesForReuseFromMeOrDescendants();
+  void replaceASTAncestorScopes(ArrayRef<ASTScopeImpl *>);
 
 private:
   void removeChildren();
@@ -1073,7 +1075,7 @@ public:
   Decl *getDecl() const { return decl; }
   static bool isAMethod(const AbstractFunctionDecl *);
 
-  NullablePtr<ASTScopeImpl> getParentOfRescuedScopes() override;
+  NullablePtr<ASTScopeImpl> getParentOfASTAncestorScopesToBeRescued() override;
 
 protected:
   bool lookupLocalsOrMembers(ArrayRef<const ASTScopeImpl *>,
@@ -1496,7 +1498,7 @@ public:
   Decl *getDecl() const { return decl; }
   NullablePtr<const void> getReferrent() const override;
 
-  NullablePtr<ASTScopeImpl> getParentOfRescuedScopes() override;
+  NullablePtr<ASTScopeImpl> getParentOfASTAncestorScopesToBeRescued() override;
 };
 
 /// The \c _@specialize attribute.

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -527,6 +527,7 @@ public:
   /// The number of \c Decls in the \c SourceFile that were already seen.
   /// Since parsing can be interleaved with type-checking, on every
   /// lookup, look at creating scopes for any \c Decls beyond this number.
+  /// rdar://55562483 Unify with numberOfChildrenWhenLastExpanded
   int numberOfDeclsAlreadySeen = 0;
 
   ASTSourceFileScope(SourceFile *SF, ScopeCreator *scopeCreator);

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1114,6 +1114,8 @@ public:
   /// false positives, that that doesn't hurt anything. However, the result of
   /// the conservative source range computation doesn't seem to be stable. So
   /// keep the original here, and use it for source range queries.
+  /// rdar://55263708
+
   const SourceRange sourceRangeWhenCreated;
 
   AttachedPropertyWrapperScope(VarDecl *e)

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -209,6 +209,7 @@ private:
 
 public:
   void preOrderDo(function_ref<void(ASTScopeImpl *)>);
+  /// Like preorderDo but without myself.
   void preOrderChildrenDo(function_ref<void(ASTScopeImpl *)>);
   void postOrderDo(function_ref<void(ASTScopeImpl *)>);
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -234,6 +234,12 @@ public:
   bool doesRangeMatch(unsigned start, unsigned end, StringRef file = "",
                       StringRef className = "");
 
+  unsigned countDescendants() const;
+
+  /// Make sure that when the argument is executed, there are as many
+  /// descendants after as before.
+  void assertThatTreeDoesNotShrink(function_ref<void()>);
+
 private:
   SourceRange computeSourceRangeOfScope(bool omitAssertions = false) const;
   SourceRange

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -543,7 +543,9 @@ public:
   NullablePtr<DeclContext> getDeclContext() const override;
 
   void addNewDeclsToScopeTree();
-  void buildScopeTreeEagerly();
+  void buildFullyExpandedTree();
+  void
+  buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
 
   const SourceFile *getSourceFile() const override;
   NullablePtr<const void> addressForPrinting() const override { return SF; }

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -206,6 +206,7 @@ private:
 
 public:
   void preOrderDo(function_ref<void(ASTScopeImpl *)>);
+  void preOrderChildrenDo(function_ref<void(ASTScopeImpl *)>);
   void postOrderDo(function_ref<void(ASTScopeImpl *)>);
 
 #pragma mark - source ranges

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -40,9 +40,6 @@
 
 /// In case there's a bug in the ASTScope lookup system, suggest that the user
 /// try disabling it.
-#define ASTScopeAssert(predicate)                                              \
-  assert((predicate) && "Try compiling with '-disable-astScope-lookup'."))
-
 /// \p message must be a string literal
 #define ASTScopeAssert(predicate, message)                                     \
   assert((predicate) && message                                                \
@@ -175,7 +172,7 @@ public:
   void *operator new(size_t bytes, const ASTContext &ctx,
                      unsigned alignment = alignof(ASTScopeImpl));
   void *operator new(size_t Bytes, void *Mem) {
-    ASTScopeAssert(Mem);
+    ASTScopeAssert(Mem, "Allocation failed");
     return Mem;
   }
 
@@ -565,7 +562,7 @@ public:
   void *operator new(size_t bytes, const ASTContext &ctx,
                      unsigned alignment = alignof(ASTScopeImpl));
   void *operator new(size_t Bytes, void *Mem) {
-    ASTScopeAssert(Mem);
+    ASTScopeAssert(Mem, "Allocation failed");
     return Mem;
   }
 
@@ -1093,7 +1090,8 @@ public:
 
   AttachedPropertyWrapperScope(VarDecl *e)
       : decl(e), sourceRangeWhenCreated(getSourceRangeOfVarDecl(e)) {
-    ASTScopeAssert(sourceRangeWhenCreated.isValid());
+    ASTScopeAssert(sourceRangeWhenCreated.isValid(),
+                   "VarDecls must have ranges to be looked-up");
   }
   virtual ~AttachedPropertyWrapperScope() {}
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -48,6 +48,9 @@
   assert((predicate) && message                                                \
          " Try compiling with '-disable-astScope-lookup'.")
 
+#define ASTScope_unreachable(message)                                          \
+  llvm_unreachable(message " Try compiling with '-disable-astScope-lookup'.")
+
 namespace swift {
 
 #pragma mark Forward-references

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -38,6 +38,16 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+/// In case there's a bug in the ASTScope lookup system, suggest that the user
+/// try disabling it.
+#define ASTScopeAssert(predicate)                                              \
+  assert((predicate) && "Try compiling with '-disable-astScope-lookup'."))
+
+/// \p message must be a string literal
+#define ASTScopeAssert(predicate, message)                                     \
+  assert((predicate) && message                                                \
+         " Try compiling with '-disable-astScope-lookup'.")
+
 namespace swift {
 
 #pragma mark Forward-references
@@ -162,7 +172,7 @@ public:
   void *operator new(size_t bytes, const ASTContext &ctx,
                      unsigned alignment = alignof(ASTScopeImpl));
   void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
+    ASTScopeAssert(Mem);
     return Mem;
   }
 
@@ -552,7 +562,7 @@ public:
   void *operator new(size_t bytes, const ASTContext &ctx,
                      unsigned alignment = alignof(ASTScopeImpl));
   void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
+    ASTScopeAssert(Mem);
     return Mem;
   }
 
@@ -1080,7 +1090,7 @@ public:
 
   AttachedPropertyWrapperScope(VarDecl *e)
       : decl(e), sourceRangeWhenCreated(getSourceRangeOfVarDecl(e)) {
-    assert(sourceRangeWhenCreated.isValid());
+    ASTScopeAssert(sourceRangeWhenCreated.isValid());
   }
   virtual ~AttachedPropertyWrapperScope() {}
 

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -592,9 +592,11 @@ class ASTScope {
 public:
   ASTScope(SourceFile *);
 
-  /// Cannot be lazy during type-checking because it mutates the AST.
-  /// So build eagerly before type-checking
-  void buildScopeTreeEagerly();
+  void
+  buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
+
+  /// Flesh out the tree for dumping
+  void buildFullyExpandedTree();
 
   /// \return the scopes traversed
   static llvm::SmallVector<const ast_scope::ASTScopeImpl *, 0>

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -252,7 +252,7 @@ namespace swift {
     bool DisableParserLookup = false;
 
     /// Should  we compare to ASTScope-based resolution for debugging?
-    bool CompareToASTScopeLookup = false;
+    bool CrosscheckUnqualifiedLookup = false;
 
     /// Should  we stress ASTScope-based resolution for debugging?
     bool StressASTScopeLookup = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -122,8 +122,8 @@ def disable_target_os_checking :
   Flag<["-"], "disable-target-os-checking">,
   HelpText<"Disable checking the target OS of serialized modules">;
   
-def compare_to_astscope_lookup : Flag<["-"], "compare-to-astscope-lookup">,
-  HelpText<"Compare legacy to ASTScope-based unqualified name lookup (for debugging)">;
+def crosscheck_unqualified_lookup : Flag<["-"], "crosscheck-unqualified-lookup">,
+  HelpText<"Compare legacy DeclContext- to ASTScope-based unqualified name lookup (for debugging)">;
 
 def stress_astscope_lookup : Flag<["-"], "stress-astscope-lookup">,
   HelpText<"Stress ASTScope-based unqualified name lookup (for testing)">;

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -267,6 +267,9 @@ ExtensionScope::getCorrespondingNominalTypeDecl() const {
 
 void ASTScopeImpl::preOrderDo(function_ref<void(ASTScopeImpl *)> fn) {
   fn(this);
+  preOrderChildrenDo(fn);
+}
+void ASTScopeImpl::preOrderChildrenDo(function_ref<void(ASTScopeImpl *)> fn) {
   for (auto *child : getChildren())
     child->preOrderDo(fn);
 }

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -288,3 +288,21 @@ const StmtConditionElement &
 ConditionalClauseScope::getStmtConditionElement() const {
   return getCond()[index];
 }
+
+unsigned ASTScopeImpl::countDescendants() const {
+  unsigned count = 0;
+  const_cast<ASTScopeImpl *>(this)->preOrderDo(
+      [&](ASTScopeImpl *) { ++count; });
+  return count - 1;
+}
+
+void ASTScopeImpl::assertThatTreeDoesNotShrink(function_ref<void()> fn) {
+#ifndef NDEBUG
+  unsigned beforeCount = countDescendants();
+#endif
+  fn();
+#ifndef NDEBUG
+  unsigned afterCount = countDescendants();
+  ASTScopeAssert(beforeCount <= afterCount, "shrank?!");
+#endif
+}

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -296,6 +296,7 @@ unsigned ASTScopeImpl::countDescendants() const {
   return count - 1;
 }
 
+// Can fail if a subscope is lazy and not reexpanded
 void ASTScopeImpl::assertThatTreeDoesNotShrink(function_ref<void()> fn) {
 #ifndef NDEBUG
   unsigned beforeCount = countDescendants();

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -178,7 +178,7 @@ NullablePtr<DeclContext> BraceStmtScope::getDeclContext() const {
 NullablePtr<DeclContext>
 DefaultArgumentInitializerScope::getDeclContext() const {
   auto *dc = decl->getDefaultArgumentInitContext();
-  assert(dc && "If scope exists, this must exist");
+  ASTScopeAssert(dc, "If scope exists, this must exist");
   return dc;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -747,7 +747,6 @@ void ASTScope::buildScopeTreeEagerly() {
 
 ASTSourceFileScope *ASTScope::createScopeTree(SourceFile *SF) {
   ScopeCreator *scopeCreator = new (SF->getASTContext()) ScopeCreator(SF);
-  scopeCreator->sourceFileScope->addNewDeclsToScopeTree();
   return scopeCreator->sourceFileScope;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1741,7 +1741,7 @@ bool ASTScopeImpl::reexpandIfObsolete(ScopeCreator &scopeCreator) {
     ASTScopeAssert(getWasExpanded(), "Cannot be current if unexpanded.");
     return false;
   }
-  this->reexpand(scopeCreator);
+  reexpand(scopeCreator);
   return true;
 }
 
@@ -1941,9 +1941,6 @@ TopLevelCodeScope::getParentOfASTAncestorScopesToBeRescued() {
 #pragma mark rescuing & reusing
 std::vector<ASTScopeImpl *>
 ASTScopeImpl::rescueASTAncestorScopesForReuseFromMeOrDescendants() {
-// If I was never expanded, then there won't be any rescuable scopes.
-  if (!getWasExpanded())
-    return {};
   if (auto *p = getParentOfASTAncestorScopesToBeRescued().getPtrOrNull()) {
     return p->rescueASTAncestorScopesForReuseFromMe();
   }
@@ -1962,7 +1959,7 @@ void ASTScopeImpl::replaceASTAncestorScopes(
   }
   auto &ctx = getASTContext();
   for (auto *s : scopesToAdd) {
-    p->addChild(s, ctx); // NONORGANIC
+    p->addChild(s, ctx);
     ASTScopeAssert(s->verifyThatThisNodeComeAfterItsPriorSibling(),
                    "Ensure search will work");
   }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -773,6 +773,9 @@ void ASTSourceFileScope::addNewDeclsToScopeTree() {
   std::vector<ASTNode> newNodes(newDecls.begin(), newDecls.end());
   insertionPoint =
       scopeCreator->addSiblingsToScopeTree(insertionPoint, newNodes);
+
+  // TODO: use childrenCountWhenLastExpanded & regular expansion machinery for ASTSourceFileScope
+  // rdar://55562483
   numberOfDeclsAlreadySeen = SF->Decls.size();
   recordThatIWasExpandedEvenIfNoChildrenWereAdded();
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -724,8 +724,11 @@ public:
 
 ASTScope::ASTScope(SourceFile *SF) : impl(createScopeTree(SF)) {}
 
-void ASTScope::buildScopeTreeEagerly() {
-  impl->buildScopeTreeEagerly();
+void ASTScope::buildFullyExpandedTree() { impl->buildFullyExpandedTree(); }
+
+void ASTScope::
+    buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals() {
+  impl->buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
 }
 
 ASTSourceFileScope *ASTScope::createScopeTree(SourceFile *SF) {
@@ -733,10 +736,14 @@ ASTSourceFileScope *ASTScope::createScopeTree(SourceFile *SF) {
   return scopeCreator->sourceFileScope;
 }
 
-void ASTSourceFileScope::buildScopeTreeEagerly() {
-  // Eagerly expand any decls already in the tree.
+void ASTSourceFileScope::buildFullyExpandedTree() {
+  addNewDeclsToScopeTree();
   preOrderChildrenDo(
       [&](ASTScopeImpl *s) { s->reexpandIfObsolete(*scopeCreator); });
+}
+
+void ASTSourceFileScope::
+    buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals() {
   addNewDeclsToScopeTree();
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1734,7 +1734,7 @@ bool ASTScopeImpl::reexpandIfObsolete(ScopeCreator &scopeCreator) {
     ASTScopeAssert(wasEverExpanded(), "Cannot be current if unexpanded.");
     return false;
   }
-  reexpand(scopeCreator);
+  assertThatTreeDoesNotShrink([&] { this->reexpand(scopeCreator); });
   return true;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1741,7 +1741,7 @@ bool ASTScopeImpl::reexpandIfObsolete(ScopeCreator &scopeCreator) {
     ASTScopeAssert(getWasExpanded(), "Cannot be current if unexpanded.");
     return false;
   }
-  assertThatTreeDoesNotShrink([&] { this->reexpand(scopeCreator); });
+  this->reexpand(scopeCreator);
   return true;
 }
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -651,7 +651,7 @@ public:
   }
 
   bool shouldBeLazy() const {
-    return !getIsFreezing() && ctx.LangOpts.LazyASTScopes;
+    return /*!getIsFreezing() &&*/ ctx.LangOpts.LazyASTScopes;
   }
 
 public:
@@ -1746,7 +1746,7 @@ void IterableTypeScope::expandBody(ScopeCreator &scopeCreator) {
 #pragma mark - reexpandIfObsolete
 
 bool ASTScopeImpl::reexpandIfObsolete(ScopeCreator &scopeCreator) {
-  if (scopeCreator.getIsFrozen() ||
+  if (/* scopeCreator.getIsFrozen() || */
       (isCurrent() &&
        !scopeCreator.getASTContext().LangOpts.StressASTScopeLookup)) {
     ASTScopeAssert(wasEverExpanded(), "Cannot be current if unexpanded.");

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -758,7 +758,8 @@ ASTSourceFileScope *ASTScope::createScopeTree(SourceFile *SF) {
 void ASTSourceFileScope::buildScopeTreeEagerly() {
   scopeCreator->beFreezing();
   // Eagerly expand any decls already in the tree.
-  preOrderDo([&](ASTScopeImpl *s) { s->reexpandIfObsolete(*scopeCreator); });
+  preOrderChildrenDo(
+      [&](ASTScopeImpl *s) { s->reexpandIfObsolete(*scopeCreator); });
   addNewDeclsToScopeTree();
   scopeCreator->beFrozen();
 }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -388,6 +388,7 @@ private:
 
   // A safe way to discover this, without creating a circular request.
   // Cannot call getAttachedPropertyWrappers.
+  // rdar://55263708
   static bool hasAttachedPropertyWrapper(VarDecl *vd) {
     return AttachedPropertyWrapperScope::getSourceRangeOfVarDecl(vd).isValid();
   }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1876,7 +1876,6 @@ void AbstractFunctionBodyScope::beCurrent() {
 }
 bool AbstractFunctionBodyScope::isCurrent() const {
   return bodyWhenLastExpanded == decl->getBody(false);
-  ;
 }
 
 void TopLevelCodeScope::beCurrent() { bodyWhenLastExpanded = decl->getBody(); }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -335,7 +335,7 @@ public:
                                                          Args... args) {
     if (auto s = ifUniqueConstructExpandAndInsert<Scope>(parent, args...))
       return s.get();
-    llvm_unreachable("Scope should have been unique");
+    ASTScope_unreachable("Scope should have been unique");
   }
 
 private:
@@ -578,13 +578,13 @@ private:
         dumpPBD(pbd, "prev");
       if (auto *pbd = dyn_cast<PatternBindingDecl>(d)) {
         dumpPBD(pbd, "curr");
-        llvm_unreachable("found colliding pattern binding decls");
+        ASTScope_unreachable("found colliding pattern binding decls");
       }
       llvm::errs() << "Two same kind decls at same loc: \n";
       lastD->dump(llvm::errs());
       llvm::errs() << "and\n";
       d->dump(llvm::errs());
-      llvm_unreachable("Two same kind decls; unexpected kinds");
+      ASTScope_unreachable("Two same kind decls; unexpected kinds");
     }
   }
 
@@ -764,6 +764,7 @@ void ASTSourceFileScope::buildScopeTreeEagerly() {
 
 void ASTSourceFileScope::addNewDeclsToScopeTree() {
   ASTScopeAssert(false && SF && scopeCreator);
+  ASTScope_unreachable("gazorp");
   ArrayRef<Decl *> decls = SF->Decls;
   // Assume that decls are only added at the end, in source order
   ArrayRef<Decl *> newDecls = decls.slice(numberOfDeclsAlreadySeen);
@@ -899,7 +900,7 @@ public:
 #pragma mark special-case creation
 
   ASTScopeImpl *visitSourceFile(SourceFile *, ASTScopeImpl *, ScopeCreator &) {
-    llvm_unreachable("SourceFiles are orphans.");
+    ASTScope_unreachable("SourceFiles are orphans.");
   }
 
   NullablePtr<ASTScopeImpl> visitYieldStmt(YieldStmt *ys, ASTScopeImpl *p,
@@ -977,8 +978,9 @@ public:
   NullablePtr<ASTScopeImpl> visitIfConfigDecl(IfConfigDecl *icd,
                                               ASTScopeImpl *p,
                                               ScopeCreator &scopeCreator) {
-    llvm_unreachable("Should be handled inside of "
-                     "expandIfConfigClausesThenCullAndSortElementsOrMembers");
+    ASTScope_unreachable(
+        "Should be handled inside of "
+        "expandIfConfigClausesThenCullAndSortElementsOrMembers");
   }
 
   NullablePtr<ASTScopeImpl> visitReturnStmt(ReturnStmt *rs, ASTScopeImpl *p,
@@ -1234,7 +1236,7 @@ ConditionalClauseScope::expandAScopeThatCreatesANewInsertionPoint(
     return {ccPatternUseScope,
             "Succeeding code must be in scope of conditional variables"};
   }
-  llvm_unreachable("Unhandled StmtConditionKind in switch");
+  ASTScope_unreachable("Unhandled StmtConditionKind in switch");
 }
 
 AnnotatedInsertionPoint
@@ -1293,7 +1295,7 @@ TopLevelCodeScope::expandAScopeThatCreatesANewInsertionPoint(ScopeCreator &
 
 void ASTSourceFileScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
     ScopeCreator &scopeCreator) {
-  llvm_unreachable("expanded by addNewDeclsToScopeTree()");
+  ASTScope_unreachable("expanded by addNewDeclsToScopeTree()");
 }
 
 // Create child scopes for every declaration in a body.

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -96,8 +96,9 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     //    fileScope->dump();
     llvm::errs() << "\n\n";
 
-    if (fileScope->crossCheckWithAST())
-      llvm::errs() << "Tree creation missed some DeclContexts.\n";
+    // Might distort things
+    //    if (fileScope->crossCheckWithAST())
+    //      llvm::errs() << "Tree creation missed some DeclContexts.\n";
   }
 
   ASTScopeAssert(startingScope, "ASTScopeImpl: could not find startingScope");

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -62,6 +62,14 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
   if (name.isOperator())
     return fileScope; // operators always at file scope
 
+  {
+    const SourceManager &SM = fileScope->getSourceManager();
+    if (SM.getLineAndColumn(loc) ==
+            std::make_pair<unsigned, unsigned>(271, 38) &&
+        SM.getIdentifierForBuffer(SM.findBufferContainingLoc(loc))
+            .endswith("CompilerProtocols.swift"))
+      llvm::errs() << "HERE\n";
+  }
   const auto innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
 
   // The legacy lookup code gets passed both a SourceLoc and a starting context.
@@ -94,8 +102,8 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     //    fileScope->dump();
     llvm::errs() << "\n\n";
 
-    ASTScopeAssert(fileScope->crossCheckWithAST(),
-                   "Tree creation missed some DeclContexts.");
+    if (fileScope->crossCheckWithAST())
+      llvm::errs() << "Tree creation missed some DeclContexts.\n";
   }
 
   ASTScopeAssert(startingScope, "ASTScopeImpl: could not find startingScope");

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -63,7 +63,7 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     return fileScope; // operators always at file scope
 
   const auto innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
-  ASTScopeAssert(innermost->wasEverExpanded(),
+  ASTScopeAssert(innermost->getWasExpanded(),
                  "If looking in a scope, it must have been expanded.");
 
   // The legacy lookup code gets passed both a SourceLoc and a starting context.

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -62,14 +62,6 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
   if (name.isOperator())
     return fileScope; // operators always at file scope
 
-  {
-    const SourceManager &SM = fileScope->getSourceManager();
-    if (SM.getLineAndColumn(loc) ==
-            std::make_pair<unsigned, unsigned>(271, 38) &&
-        SM.getIdentifierForBuffer(SM.findBufferContainingLoc(loc))
-            .endswith("CompilerProtocols.swift"))
-      llvm::errs() << "HERE\n";
-  }
   const auto innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
 
   // The legacy lookup code gets passed both a SourceLoc and a starting context.

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -63,6 +63,8 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     return fileScope; // operators always at file scope
 
   const auto innermost = fileScope->findInnermostEnclosingScope(loc, nullptr);
+  ASTScopeAssert(innermost->wasEverExpanded(),
+                 "If looking in a scope, it must have been expanded.");
 
   // The legacy lookup code gets passed both a SourceLoc and a starting context.
   // However, our ultimate intent is for clients to not have to pass in a

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -168,7 +168,7 @@ bool ASTScopeImpl::doesContextMatchStartingContext(
   if (auto p = getParent())
     return p.get()->doesContextMatchStartingContext(context);
   // Topmost scope always has a context, the SourceFile.
-  llvm_unreachable("topmost scope always has a context, the SourceFile");
+  ASTScope_unreachable("topmost scope always has a context, the SourceFile");
 }
 
 // For a SubscriptDecl with generic parameters, the call tries to do lookups
@@ -631,7 +631,7 @@ Optional<bool> GenericParamScope::resolveIsCascadingUseForThisScope(
     Optional<bool> isCascadingUse) const {
   if (auto *dc = getDeclContext().getPtrOrNull())
     return ifUnknownIsCascadingUseAccordingTo(isCascadingUse, dc);
-  llvm_unreachable("generic what?");
+  ASTScope_unreachable("generic what?");
 }
 
 Optional<bool> AbstractFunctionDeclScope::resolveIsCascadingUseForThisScope(

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -94,10 +94,10 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
     //    fileScope->dump();
     llvm::errs() << "\n\n";
 
-    assert(fileScope->crossCheckWithAST());
+    ASTScopeAssert(fileScope->crossCheckWithAST());
   }
 
-  assert(startingScope && "ASTScopeImpl: could not find startingScope");
+  ASTScopeAssert(startingScope, "ASTScopeImpl: could not find startingScope");
   return startingScope;
 }
 
@@ -122,7 +122,7 @@ const ASTScopeImpl *ASTScopeImpl::findInnermostEnclosingScopeImpl(
 bool ASTScopeImpl::checkSourceRangeOfThisASTNode() const {
   const auto r = getSourceRangeOfThisASTNode();
   (void)r;
-  assert(!getSourceManager().isBeforeInBuffer(r.End, r.Start));
+  ASTScopeAssert(!getSourceManager().isBeforeInBuffer(r.End, r.Start));
   return true;
 }
 
@@ -134,12 +134,12 @@ ASTScopeImpl::findChildContaining(SourceLoc loc,
     SourceManager &sourceMgr;
 
     bool operator()(const ASTScopeImpl *scope, SourceLoc loc) {
-      assert(scope->checkSourceRangeOfThisASTNode());
+      ASTScopeAssert(scope->checkSourceRangeOfThisASTNode());
       return sourceMgr.isBeforeInBuffer(scope->getSourceRangeOfScope().End,
                                         loc);
     }
     bool operator()(SourceLoc loc, const ASTScopeImpl *scope) {
-      assert(scope->checkSourceRangeOfThisASTNode());
+      ASTScopeAssert(scope->checkSourceRangeOfThisASTNode());
       return sourceMgr.isBeforeInBuffer(loc,
                                         scope->getSourceRangeOfScope().End);
     }
@@ -382,7 +382,7 @@ bool AbstractFunctionBodyScope::lookupLocalsOrMembers(
 
 bool MethodBodyScope::lookupLocalsOrMembers(
     ArrayRef<const ASTScopeImpl *> history, DeclConsumer consumer) const {
-  assert(isAMethod(decl));
+  ASTScopeAssert(isAMethod(decl));
   if (AbstractFunctionBodyScope::lookupLocalsOrMembers(history, consumer))
     return true;
   return consumer.consume({decl->getImplicitSelfDecl()},
@@ -391,7 +391,7 @@ bool MethodBodyScope::lookupLocalsOrMembers(
 
 bool PureFunctionBodyScope::lookupLocalsOrMembers(
     ArrayRef<const ASTScopeImpl *> history, DeclConsumer consumer) const {
-  assert(!isAMethod(decl));
+  ASTScopeAssert(!isAMethod(decl));
   if (AbstractFunctionBodyScope::lookupLocalsOrMembers(history, consumer))
     return true;
 
@@ -490,7 +490,7 @@ bool ASTScopeImpl::lookupLocalBindingsInPattern(Pattern *p,
 NullablePtr<DeclContext>
 GenericTypeOrExtensionWhereOrBodyPortion::computeSelfDC(
     ArrayRef<const ASTScopeImpl *> history) {
-  assert(history.size() != 0 && "includes current scope");
+  ASTScopeAssert(history.size() != 0, "includes current scope");
   size_t i = history.size() - 1; // skip last entry (this scope)
   while (i != 0) {
     Optional<NullablePtr<DeclContext>> maybeSelfDC =

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -309,7 +309,12 @@ SourceRange GenericTypeOrExtensionWholePortion::getChildlessSourceRangeOf(
 
 SourceRange
 ExtensionScope::moveStartPastExtendedNominal(const SourceRange sr) const {
-  return SourceRange(getLocAfterExtendedNominal(decl), sr.End);
+  const auto start = getLocAfterExtendedNominal(decl);
+  // Illegal code can have an endLoc that is before the end of the
+  // ExtendedNominal, so push the end back, too, in that case.
+  const auto end =
+      getSourceManager().isBeforeInBuffer(sr.End, start) ? start : sr.End;
+  return SourceRange(start, end);
 }
 
 SourceRange

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -591,9 +591,25 @@ SourceRange AbstractFunctionBodyScope::sourceRangeForDeferredExpansion() const {
   return SourceRange(bsr.Start,
                      endEvenIfNoCloseBraceAndEndsWithInterpolatedStringLiteral);
 }
-SourceRange
-Portion::sourceRangeForDeferredExpansion(const IterableTypeScope *) const {
+
+SourceRange GenericTypeOrExtensionWholePortion::sourceRangeForDeferredExpansion(
+    const IterableTypeScope *s) const {
+  const auto range = getChildlessSourceRangeOf(s, false);
+  return SourceRange(range.Start, getLocEncompassingPotentialLookups(
+                                      s->getSourceManager(), range.End));
+}
+
+SourceRange GenericTypeOrExtensionWherePortion::sourceRangeForDeferredExpansion(
+    const IterableTypeScope *) const {
   return SourceRange();
+}
+
+SourceRange IterableTypeBodyPortion::sourceRangeForDeferredExpansion(
+    const IterableTypeScope *s) const {
+  const auto bracesRange = getChildlessSourceRangeOf(s, false);
+  return SourceRange(bracesRange.Start,
+                     getLocEncompassingPotentialLookups(s->getSourceManager(),
+                                                        bracesRange.End));
 }
 
 SourceRange ASTScopeImpl::getEffectiveSourceRange(const ASTNode n) const {
@@ -697,14 +713,4 @@ AbstractFunctionDeclScope::getParmsSourceLocOfAFD(AbstractFunctionDecl *decl) {
        : fd->isDeferBody()     ? fd->getNameLoc()
        :                         fd->getParameters()->getLParenLoc();
   // clang-format on
-}
-
-#pragma mark deferred scope source ranges
-
-SourceRange IterableTypeBodyPortion::sourceRangeForDeferredExpansion(
-    const IterableTypeScope *s) const {
-  const auto bracesRange = getChildlessSourceRangeOf(s, false);
-  const auto &SM = s->getSourceManager();
-  return SourceRange(bracesRange.Start,
-                     getLocEncompassingPotentialLookups(SM, bracesRange.End));
 }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -52,7 +52,7 @@ SourceRange
 ASTScopeImpl::widenSourceRangeForChildren(const SourceRange range,
                                           const bool omitAssertions) const {
   if (getChildren().empty()) {
-    ASTScopeAssert(omitAssertions || range.Start.isValid());
+    ASTScopeAssert(omitAssertions || range.Start.isValid(), "Bad range.");
     return range;
   }
   const auto childStart =
@@ -60,7 +60,7 @@ ASTScopeImpl::widenSourceRangeForChildren(const SourceRange range,
   const auto childEnd =
       getChildren().back()->getSourceRangeOfScope(omitAssertions).End;
   auto childRange = SourceRange(childStart, childEnd);
-  ASTScopeAssert(omitAssertions || childRange.isValid());
+  ASTScopeAssert(omitAssertions || childRange.isValid(), "Bad range.");
 
   if (range.isInvalid())
     return childRange;
@@ -295,7 +295,7 @@ SourceRange GenericTypeOrExtensionWholePortion::getChildlessSourceRangeOf(
   auto *d = scope->getDecl();
   auto r = d->getSourceRangeIncludingAttrs();
   if (r.Start.isValid()) {
-    ASTScopeAssert(r.End.isValid());
+    ASTScopeAssert(r.End.isValid(), "Start valid imples end valid.");
     return r;
   }
   return d->getSourceRange();
@@ -324,7 +324,7 @@ SourceRange AbstractFunctionDeclScope::getSourceRangeOfThisASTNode(
   // them at the start location of the accessor.
   auto r = decl->getSourceRangeIncludingAttrs();
   if (r.Start.isValid()) {
-    ASTScopeAssert(r.End.isValid());
+    ASTScopeAssert(r.End.isValid(), "Start valid imples end valid.");
     return r;
   }
   return decl->getBodySourceRange();
@@ -461,7 +461,8 @@ ASTScopeImpl::getSourceRangeOfScope(const bool omitAssertions) const {
 bool ASTScopeImpl::isSourceRangeCached(const bool omitAssertions) const {
   const bool isCached = cachedSourceRange.hasValue();
   ASTScopeAssert(omitAssertions || isCached ||
-                 ensureNoAncestorsSourceRangeIsCached());
+                     ensureNoAncestorsSourceRangeIsCached(),
+                 "Cached ancestor's range likely is obsolete.");
   return isCached;
 }
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -145,7 +145,7 @@ bool ASTScopeImpl::verifyThatThisNodeComeAfterItsPriorSibling() const {
   //                      .getRangeForBuffer(
   //                          getSourceFile()->getBufferID().getValue())
   //                      .str();
-  llvm_unreachable("unexpected out-of-order nodes");
+  ASTScope_unreachable("unexpected out-of-order nodes");
   return false;
 }
 
@@ -315,7 +315,7 @@ SourceRange IterableTypeBodyPortion::getChildlessSourceRangeOf(
     return e->getBraces();
   if (omitAssertions)
     return SourceRange();
-  llvm_unreachable("No body!");
+  ASTScope_unreachable("No body!");
 }
 
 SourceRange AbstractFunctionDeclScope::getSourceRangeOfThisASTNode(
@@ -470,7 +470,7 @@ bool ASTScopeImpl::ensureNoAncestorsSourceRangeIsCached() const {
     auto r = !p->isSourceRangeCached(true) &&
              p->ensureNoAncestorsSourceRangeIsCached();
     if (!r)
-      llvm_unreachable("found a violation");
+      ASTScope_unreachable("found a violation");
     return true;
   }
   return true;

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -473,6 +473,7 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
 #ifndef NDEBUG
   ++lookupCounter;
   auto localCounter = lookupCounter;
+  (void)localCounter; // for debugging
 #endif
   FrontendStatsTracer StatsTracer(Ctx.Stats, "performUnqualifedLookup",
                                   DC->getParentSourceFile());

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -472,7 +472,7 @@ UnqualifiedLookupFactory::UnqualifiedLookupFactory(
 void UnqualifiedLookupFactory::performUnqualifiedLookup() {
 #ifndef NDEBUG
   ++lookupCounter;
-  stopForDebuggingIfStartingTargetLookup(false);
+  auto localCounter = lookupCounter;
 #endif
   FrontendStatsTracer StatsTracer(Ctx.Stats, "performUnqualifedLookup",
                                   DC->getParentSourceFile());
@@ -491,6 +491,10 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
     experimentallyLookInASTScopes();
     return;
   }
+
+#ifndef NDEBUG
+  stopForDebuggingIfStartingTargetLookup(false);
+#endif
 
   if (Name.isOperator())
     lookupOperatorInDeclContexts(contextAndIsCascadingUse);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -337,7 +337,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Args.hasFlag(options::OPT_enable_astscope_lookup,
                    options::OPT_disable_astscope_lookup, Opts.EnableASTScopeLookup) ||
       Opts.DisableParserLookup;
-  Opts.CompareToASTScopeLookup |= Args.hasArg(OPT_compare_to_astscope_lookup);
+  Opts.CrosscheckUnqualifiedLookup |=
+      Args.hasArg(OPT_crosscheck_unqualified_lookup);
   Opts.StressASTScopeLookup |= Args.hasArg(OPT_stress_astscope_lookup);
   Opts.WarnIfASTScopeLookup |= Args.hasArg(OPT_warn_if_astscope_lookup);
   Opts.LazyASTScopes |= Args.hasArg(OPT_lazy_astscopes);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -749,13 +749,16 @@ static void dumpAndPrintScopeMap(CompilerInvocation &Invocation,
 
   if (Invocation.getFrontendOptions().DumpScopeMapLocations.empty()) {
     llvm::errs() << "***Complete scope map***\n";
+    scope.buildFullyExpandedTree();
     scope.print(llvm::errs());
     return;
   }
   // Probe each of the locations, and dump what we find.
   for (auto lineColumn :
-       Invocation.getFrontendOptions().DumpScopeMapLocations)
+       Invocation.getFrontendOptions().DumpScopeMapLocations) {
+    scope.buildFullyExpandedTree();
     scope.dumpOneScopeMapLocation(lineColumn);
+  }
 }
 
 static SourceFile *getPrimaryOrMainSourceFile(CompilerInvocation &Invocation,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -351,12 +351,14 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
   if (SF.ASTStage == SourceFile::TypeChecked)
     return;
 
-  // Eagerly build a scope tree before type checking
-  // because type-checking mutates the AST and that throws off the scope-based
-  // lookups.
+  // Eagerly build the top-level scopes tree before type checking
+  // because type-checking expressions mutates the AST and that throws off the
+  // scope-based lookups. Only the top-level scopes because extensions have not
+  // been bound yet.
   if (SF.getASTContext().LangOpts.EnableASTScopeLookup &&
       SF.isSuitableForASTScopes())
-    SF.getScope().buildScopeTreeEagerly();
+    SF.getScope()
+        .buildEnoughOfTreeForTopLevelExpressionsButDontRequestGenericsOrExtendedNominals();
 
   auto &Ctx = SF.getASTContext();
   BufferIndirectlyCausingDiagnosticRAII cpr(SF);

--- a/test/NameBinding/scope_map_top_level.swift
+++ b/test/NameBinding/scope_map_top_level.swift
@@ -37,7 +37,7 @@ var i: Int = b.my_identity()
 // CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:           |-ConditionalClauseScope, [8:7 - 8:22] index 0
-// CHECK-EXPANDED-NEXT:             `-ConditionalClausePatternUseScope, [8:22 - 8:22] let b?
+// CHECK-EXPANDED-NEXT:             `-ConditionalClausePatternUseScope, [8:22 - 8:22] let b{{\??}}
 // CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [8:22 - 9:1]
 // CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [9:1 - 21:28]
 // CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:13] 'foo()'

--- a/test/NameBinding/scope_map_top_level.swift
+++ b/test/NameBinding/scope_map_top_level.swift
@@ -27,31 +27,36 @@ var i: Int = b.my_identity()
 
 // CHECK-EXPANDED:      ***Complete scope map***
 // CHECK-EXPANDED-NEXT: ASTSourceFileScope {{.*}}, (uncached) [1:1 - 6{{.*}}:1] 'SOURCE_DIR{{[/\\]}}test{{[/\\]}}NameBinding{{[/\\]}}scope_map_top_level.swift'
-// CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [4:1 - 4:13] 
-// CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [4:11 - 4:13] 
-// CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 21:28] 
-// CHECK-EXPANDED-NEXT:   `-BraceStmtScope {{.*}}, [6:1 - 21:28] 
+// CHECK-EXPANDED-NEXT: |-NominalTypeDeclScope {{.*}}, [4:1 - 4:13]
+// CHECK-EXPANDED-NEXT:   `-NominalTypeBodyScope {{.*}}, [4:11 - 4:13]
+// CHECK-EXPANDED-NEXT: `-TopLevelCodeScope {{.*}}, [6:1 - 21:28]
+// CHECK-EXPANDED-NEXT:   `-BraceStmtScope {{.*}}, [6:1 - 21:28]
 // CHECK-EXPANDED-NEXT:     |-PatternEntryDeclScope {{.*}}, [6:5 - 6:15] entry 0 'a'
 // CHECK-EXPANDED-NEXT:       `-PatternEntryInitializerScope {{.*}}, [6:15 - 6:15] entry 0 'a'
-// CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 21:28] 
-// CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28] 
-// CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28] 
+// CHECK-EXPANDED-NEXT:     `-TopLevelCodeScope {{.*}}, [8:1 - 21:28]
+// CHECK-EXPANDED-NEXT:       `-BraceStmtScope {{.*}}, [8:1 - 21:28]
+// CHECK-EXPANDED-NEXT:         `-GuardStmtScope {{.*}}, [8:1 - 21:28]
 // CHECK-EXPANDED-NEXT:           |-ConditionalClauseScope, [8:7 - 8:22] index 0
 // CHECK-EXPANDED-NEXT:             `-ConditionalClausePatternUseScope, [8:22 - 8:22] let b?
-// CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [8:22 - 9:1] 
-// CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [9:1 - 21:28] 
+// CHECK-EXPANDED-NEXT:           |-BraceStmtScope {{.*}}, [8:22 - 9:1]
+// CHECK-EXPANDED-NEXT:           `-LookupParentDiversionScope, [9:1 - 21:28]
 // CHECK-EXPANDED-NEXT:             |-AbstractFunctionDeclScope {{.*}}, [11:1 - 11:13] 'foo()'
-// CHECK-EXPANDED-NEXT:               `-ParameterListScope {{.*}}, [11:9 - 11:13] 
-// CHECK-EXPANDED-NEXT:                 `-PureFunctionBodyScope {{.*}}, [11:12 - 11:13] 
-// CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28] 
-// CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28] 
+// CHECK-EXPANDED-NEXT:               `-ParameterListScope {{.*}}, [11:9 - 11:13]
+// CHECK-EXPANDED-NEXT:                 `-PureFunctionBodyScope {{.*}}, [11:12 - 11:13]
+// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [11:12 - 11:13]
+// CHECK-EXPANDED-NEXT:             `-TopLevelCodeScope {{.*}}, [13:1 - 21:28]
+// CHECK-EXPANDED-NEXT:               `-BraceStmtScope {{.*}}, [13:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                 |-PatternEntryDeclScope {{.*}}, [13:5 - 13:9] entry 0 'c'
 // CHECK-EXPANDED-NEXT:                   `-PatternEntryInitializerScope {{.*}}, [13:9 - 13:9] entry 0 'c'
-// CHECK-EXPANDED-NEXT:                 |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15] 
-// CHECK-EXPANDED-NEXT:                 |-ExtensionDeclScope {{.*}}, [17:1 - 19:1] 
-// CHECK-EXPANDED-NEXT:                   `-ExtensionBodyScope {{.*}}, [17:15 - 19:1] 
-// CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 21:28] 
-// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 21:28] 
+// CHECK-EXPANDED-NEXT:                 |-TypeAliasDeclScope {{.*}}, [15:1 - 15:15]
+// CHECK-EXPANDED-NEXT:                 |-ExtensionDeclScope {{.*}}, [17:14 - 19:1]
+// CHECK-EXPANDED-NEXT:                   `-ExtensionBodyScope {{.*}}, [17:15 - 19:1]
+// CHECK-EXPANDED-NEXT:                     `-AbstractFunctionDeclScope {{.*}}, [18:3 - 18:43] 'my_identity()'
+// CHECK-EXPANDED-NEXT:                       `-ParameterListScope {{.*}}, [18:19 - 18:43]
+// CHECK-EXPANDED-NEXT:                         `-MethodBodyScope {{.*}}, [18:29 - 18:43]
+// CHECK-EXPANDED-NEXT:                           `-BraceStmtScope {{.*}}, [18:29 - 18:43]
+// CHECK-EXPANDED-NEXT:                 `-TopLevelCodeScope {{.*}}, [21:1 - 21:28]
+// CHECK-EXPANDED-NEXT:                   `-BraceStmtScope {{.*}}, [21:1 - 21:28]
 // CHECK-EXPANDED-NEXT:                     `-PatternEntryDeclScope {{.*}}, [21:5 - 21:28] entry 0 'i'
 // CHECK-EXPANDED-NEXT:                       `-PatternEntryInitializerScope {{.*}}, [21:14 - 21:28] entry 0 'i'
 


### PR DESCRIPTION
ASTScopes still off-by-default. Bug fix for eager scope tree construction. Also when an assertion failes in the ASTScope system, suggest trying -disable-astscope-lookup.