### PR TITLE
[test] Run scale-tests on Linux too

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/array_of_tuples.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let a = [

--- a/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/more_specialized_generic_func.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 8 --end 40 --step 2 --select NumLeafScopes %s --expected-exit-code 0
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 protocol P { }

--- a/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18360240.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 10 --step 2 --select NumConstraintScopes --polynomial-threshold 1.5 %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let empty: [Int] = []

--- a/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18699199.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 public enum E
 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar18724501.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 typealias X = (Range<Int>, [Range<Int>])

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 public func test(_ fn: @escaping () -> Void) {}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 30 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct A<T> {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class rdar19394804 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19738292.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 7 --end 12 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 // REQUIRES: rdar42650365
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19777895.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_any.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _ = (UInt8(0)

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_explicit_overloads.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 func overload(_ x: Int) -> Int { return x }

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_named.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let tuple = (UInt8(0)

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_typed.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let tuple: (UInt8

--- a/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20233198_weak.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s -Xfrontend=-verify
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 weak var tuple = (UInt8(0)   // expected-error {{'weak' may only be applied to}}

--- a/validation-test/Sema/type_checker_perf/fast/rdar20818064.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar20818064.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 typealias D = [String: Any]

--- a/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21070413.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 enum E: UInt {

--- a/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21328584.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct S {

--- a/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21720888.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar21930551.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22532650.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 10 --end 15 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22626740.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 var a: [UInt32]

--- a/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22810685.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _: [String : (Int, Int) -> Bool] = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar22836718.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22836718.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 5 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23327871.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 8 --end 16 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let i = 1

--- a/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar24543332.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 5 --end 20 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 _ = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar25866240.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 10 --step 1 --select NumConstraintScopes %s -Xfrontend=-solver-disable-shrink -Xfrontend=-disable-constraint-solver-performance-hacks -Xfrontend=-solver-enable-operator-designated-types
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 func f(

--- a/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26939465.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class NSNumber {

--- a/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar29025667.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let s: String? = nil

--- a/validation-test/Sema/type_checker_perf/fast/rdar29358447.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar29358447.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 0 --end 10000 --step 1000 --typecheck --select incrementConstraintsPerContractionCounter %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _: [Int] = [

--- a/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30213053.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 let _: [Int: (Int, Int) -> Bool] =

--- a/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30389602.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class C {

--- a/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 15 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 enum X : String {

--- a/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31563957.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct rdar33511986 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32999041.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 3 --end 8 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 // FIXME: https://bugs.swift.org/browse/SR-6997
 // REQUIRES: SR6997

--- a/validation-test/Sema/type_checker_perf/fast/rdar33292740.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33292740.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 2 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct V3 {

--- a/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 3 --end 20  --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 protocol P {}

--- a/validation-test/Sema/type_checker_perf/fast/simd_add.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/simd_add.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 3 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 func test(_ s: SIMD4<Float>,

--- a/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 // REQUIRES: rdar38963783
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar20959612.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20959612.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 3 --end 7 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 func curry<T0

--- a/validation-test/Sema/type_checker_perf/slow/rdar21198787.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar21198787.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 1 --end 10 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 private let _: [Any?] = [[

--- a/validation-test/Sema/type_checker_perf/slow/rdar27585838.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar27585838.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s --polynomial-threshold=1.7
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 enum Operation {

--- a/validation-test/Sema/type_checker_perf/slow/rdar30596744_1.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30596744_1.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s --expected-exit-code 1
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 % enum_cases = N

--- a/validation-test/Sema/type_checker_perf/slow/rdar30596744_2.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30596744_2.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select NumLeafScopes %s --expected-exit-code 1
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 % enum_cases = 3

--- a/validation-test/Sema/type_checker_perf/slow/rdar30606089.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar30606089.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select NumLeafScopes %s --polynomial-threshold 1.7
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 // FIXME: https://bugs.swift.org/browse/SR-6520

--- a/validation-test/Sema/type_checker_perf/slow/rdar33289839.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar33289839.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --invert-result --begin 2 --end 6 --step 1 --select NumLeafScopes %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 // REQUIRES: rdar42969824
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar54580427.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar54580427.swift
@@ -1,6 +1,5 @@
 // FIXME: This should be linear instead of exponential.
 // RUN: %scale-test --begin 1 --end 10 --step 1 --select NumLeafScopes --invert-result %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 enum Val {

--- a/validation-test/Sema/type_checker_perf/slow/rdar54926602.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar54926602.swift
@@ -1,6 +1,5 @@
 // FIXME: We shouldn't be consuming a lot of memory here but we do.
 // RUN: %scale-test --begin 1 --end 4 --step 1 --select NumLeafScopes %s --expected-exit-code 1 --invert-result
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class God {

--- a/validation-test/compiler_scale/array_init.swift.gyb
+++ b/validation-test/compiler_scale/array_init.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test -Onone --begin 0 --end 10 --step 1 --select transferNodesFromList %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 // Test that mandatory inlining is linear on a long series of integer

--- a/validation-test/compiler_scale/bind_extension_decl.gyb
+++ b/validation-test/compiler_scale/bind_extension_decl.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Struct${N} {}

--- a/validation-test/compiler_scale/bind_nested_extension_decl.gyb
+++ b/validation-test/compiler_scale/bind_nested_extension_decl.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Outer${N} {

--- a/validation-test/compiler_scale/callee_analysis_invalidation.gyb
+++ b/validation-test/compiler_scale/callee_analysis_invalidation.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test -O --polynomial-threshold 0.2 --begin 20 --end 25 --step 1 --select computeMethodCallees %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class C0<T:FixedWidthInteger> {

--- a/validation-test/compiler_scale/class_members.gyb
+++ b/validation-test/compiler_scale/class_members.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 class Class${N} {

--- a/validation-test/compiler_scale/dynamic_lookup.gyb
+++ b/validation-test/compiler_scale/dynamic_lookup.gyb
@@ -1,5 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select Sema.IsObjCRequest -Xfrontend=-disable-objc-attr-requires-foundation-module %s
-// REQUIRES: OS=macosx
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select Sema.IsObjCRequest -Xfrontend=-enable-objc-interop -Xfrontend=-disable-objc-attr-requires-foundation-module %s
 // REQUIRES: asserts
 
 class C${N} {

--- a/validation-test/compiler_scale/dynamic_lookup_2.swift
+++ b/validation-test/compiler_scale/dynamic_lookup_2.swift
@@ -1,5 +1,4 @@
-// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed -Xfrontend=-disable-objc-attr-requires-foundation-module %s
-// REQUIRES: OS=macosx
+// RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed -Xfrontend=-enable-objc-interop -Xfrontend=-disable-objc-attr-requires-foundation-module %s
 // REQUIRES: asserts
 
 // Dynamic member lookup should not force delayed parsing of structs, enums or protocol

--- a/validation-test/compiler_scale/enum_indirect.gyb
+++ b/validation-test/compiler_scale/enum_indirect.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 indirect enum Enum${N} {

--- a/validation-test/compiler_scale/enum_members.gyb
+++ b/validation-test/compiler_scale/enum_members.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 enum Enum${N} {

--- a/validation-test/compiler_scale/function_bodies.gyb
+++ b/validation-test/compiler_scale/function_bodies.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumFunctionsParsed %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 func method${N}() {}

--- a/validation-test/compiler_scale/lazy_class_props.gyb
+++ b/validation-test/compiler_scale/lazy_class_props.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test -O --begin 5 --end 21 --step 5 --select StoredPropertiesRequest %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 //
 // Single file with many stored properties.

--- a/validation-test/compiler_scale/nominal_bodies.gyb
+++ b/validation-test/compiler_scale/nominal_bodies.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumIterableDeclContextParsed %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct S${N} {}

--- a/validation-test/compiler_scale/protocol_members.gyb
+++ b/validation-test/compiler_scale/protocol_members.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 protocol Protocol${N} {

--- a/validation-test/compiler_scale/scale_neighbouring_getset.gyb
+++ b/validation-test/compiler_scale/scale_neighbouring_getset.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumFunctionsTypechecked %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Struct${N} {

--- a/validation-test/compiler_scale/struct_members.gyb
+++ b/validation-test/compiler_scale/struct_members.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Struct${N} {

--- a/validation-test/compiler_scale/struct_nested.gyb
+++ b/validation-test/compiler_scale/struct_nested.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Struct${N} {

--- a/validation-test/compiler_scale/used_conformances.gyb
+++ b/validation-test/compiler_scale/used_conformances.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --sum-multi --begin 5 --end 16 --step 5 --select NumDeclsValidated %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 struct Generic${N}<T : Protocol${N}> {}

--- a/validation-test/compiler_scale/var_decl_usage_checker.swift.gyb
+++ b/validation-test/compiler_scale/var_decl_usage_checker.swift.gyb
@@ -1,5 +1,4 @@
 // RUN: %scale-test --begin 1 --end 5 --step 1 --select VarDeclUsageCheckerExprVisits %s
-// REQUIRES: OS=macosx
 // REQUIRES: asserts
 
 protocol Proto {}


### PR DESCRIPTION
It's likely that these were listed as "REQUIRES: OS=macosx" to not redundantly run them for iOS et al, but they don't take that long and so it's more useful for Linux devs to be able to run them locally if need be. Or to catch something that really is different on non-macOS.