### PR TITLE
[PropertyWrappers] Fix a bug with property type being overwritten with wrong type

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2633,7 +2633,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
                           emptyLocator);
         return propertyType;
       }
-      
+
       // Otherwise, compute the wrapped value type directly.
       return computeWrappedValueType(wrappedVar, initType);
     }
@@ -2654,10 +2654,10 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         // is the initialization of the property wrapper instance.
         initType = cs.getType(expr);
 
-        // Add a conversion constraint between the pattern type and the
+        // Add an equal constraint between the pattern type and the
         // property wrapper's "value" type.
-        cs.addConstraint(ConstraintKind::Conversion, patternType,
-                         getPatternInitType(&cs), Locator, /*isFavored*/true);
+        cs.addConstraint(ConstraintKind::Equal, patternType,
+                         getPatternInitType(&cs), Locator, /*isFavored*/ true);
       } else {
         // The initializer type is the type of the pattern.
         initType = patternType;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1683,3 +1683,17 @@ final class SR_11478_C2 {
   @SR_11478_W class var bool2: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
   @SR_11478_W class final var bool3: Bool = true // expected-error {{class stored properties not supported in classes; did you mean 'static'?}}
 }
+
+// SR-11381
+
+@propertyWrapper
+struct SR_11381_W<T> {
+  init(wrappedValue: T) {}
+  var wrappedValue: T {
+    fatalError()
+  }
+}
+
+struct SR_11381_S {
+  @SR_11381_W var foo: Int = nil // expected-error {{'nil' is not compatible with expected argument type 'Int'}}
+}


### PR DESCRIPTION
In some cases, we were incorrectly setting the type of the property wrapper's value. For example:

```swift
@propertyWrapper
struct Foo<T> {
  init(wrappedValue: T) {}
  var wrappedValue: T {
    fatalError()
  }
}

struct Bar {
  @Foo var property: Int = nil // we are overwriting the type of 'property' to 'Int?'
}
```

We should be using an `Equal` constraint between the property type and the initializer's type, rather than a `Conversion` constraint.

Resolves [SR-10900](https://bugs.swift.org/browse/SR-10900), [SR-11381](https://bugs.swift.org/browse/SR-11381) & [SR-11443](https://bugs.swift.org/browse/SR-11443)
Resolves rdar://problem/55229986
