### PR TITLE
[SyntaxParse] Re-apply move-only ParsedRawSyntaxNode

### DIFF
--- a/include/swift/Parse/HiddenLibSyntaxAction.h
+++ b/include/swift/Parse/HiddenLibSyntaxAction.h
@@ -70,6 +70,8 @@ public:
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
   OpaqueSyntaxNodeKind getOpaqueKind() override {
     return ExplicitAction->getOpaqueKind();
   }

--- a/include/swift/Parse/LibSyntaxGenerator.h
+++ b/include/swift/Parse/LibSyntaxGenerator.h
@@ -44,7 +44,7 @@ public:
 
     auto Recorded = Recorder.recordToken(Kind, Range, LeadingTriviaPieces,
                                          TrailingTriviaPieces);
-    auto Raw = static_cast<RawSyntax *>(Recorded.getOpaqueNode());
+    auto Raw = static_cast<RawSyntax *>(Recorded.takeOpaqueNode());
     return make<TokenSyntax>(Raw);
   }
 
@@ -55,7 +55,7 @@ public:
     auto Children = Node.getDeferredChildren();
 
     auto Recorded = Recorder.recordRawSyntax(Kind, Children);
-    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.getOpaqueNode()) };
+    RC<RawSyntax> Raw {static_cast<RawSyntax *>(Recorded.takeOpaqueNode()) };
     Raw->Release(); // -1 since it's transfer of ownership.
     return make<SyntaxNode>(Raw);
   }

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -51,7 +51,7 @@ class ParsedRawSyntaxNode {
     CharSourceRange Range;
   };
   struct DeferredLayoutNode {
-    ArrayRef<ParsedRawSyntaxNode> Children;
+    MutableArrayRef<ParsedRawSyntaxNode> Children;
   };
   struct DeferredTokenNode {
     const ParsedTriviaPiece *TriviaPieces;
@@ -73,8 +73,8 @@ class ParsedRawSyntaxNode {
   bool IsMissing = false;
 
   ParsedRawSyntaxNode(syntax::SyntaxKind k,
-                      ArrayRef<ParsedRawSyntaxNode> deferredNodes)
-    : DeferredLayout{deferredNodes},
+                      MutableArrayRef<ParsedRawSyntaxNode> deferredNodes)
+    : DeferredLayout({deferredNodes}),
       SynKind(uint16_t(k)), TokKind(uint16_t(tok::unknown)),
       DK(DataKind::DeferredLayout) {
     assert(getKind() == k && "Syntax kind with too large value!");
@@ -97,6 +97,8 @@ class ParsedRawSyntaxNode {
     assert(DeferredToken.NumTrailingTrivia == numTrailingTrivia &&
            "numLeadingTrivia is too large value!");
   }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &other) = delete;
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &other) = delete;
 
 public:
   ParsedRawSyntaxNode()
@@ -113,6 +115,35 @@ public:
       DK(DataKind::Recorded) {
     assert(getKind() == k && "Syntax kind with too large value!");
     assert(getTokenKind() == tokKind && "Token kind with too large value!");
+  }
+
+  ParsedRawSyntaxNode &operator=(ParsedRawSyntaxNode &&other) {
+    assert(DK != DataKind::Recorded);
+    switch (other.DK) {
+    case DataKind::Null:
+      break;
+    case DataKind::Recorded:
+      RecordedData = std::move(other.RecordedData);
+      break;
+    case DataKind::DeferredLayout:
+      DeferredLayout = std::move(other.DeferredLayout);
+      break;
+    case DataKind::DeferredToken:
+      DeferredToken = std::move(other.DeferredToken);
+      break;
+    }
+    SynKind = std::move(other.SynKind);
+    TokKind = std::move(other.TokKind);
+    DK = std::move(other.DK);
+    IsMissing = std::move(other.IsMissing);
+    other.reset();
+    return *this;
+  }
+  ParsedRawSyntaxNode(ParsedRawSyntaxNode &&other) : ParsedRawSyntaxNode() {
+    *this = std::move(other);
+  }
+  ~ParsedRawSyntaxNode() {
+    assert(DK != DataKind::Recorded);
   }
 
   syntax::SyntaxKind getKind() const { return syntax::SyntaxKind(SynKind); }
@@ -136,6 +167,36 @@ public:
   /// Primary used for a deferred missing token.
   bool isMissing() const { return IsMissing; }
 
+  void reset() {
+    RecordedData = {};
+    SynKind = uint16_t(syntax::SyntaxKind::Unknown);
+    TokKind = uint16_t(tok::unknown);
+    DK = DataKind::Null;
+    IsMissing = false;
+ }
+
+  ParsedRawSyntaxNode unsafeCopy() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    case DataKind::Recorded:
+      copy.RecordedData = RecordedData;
+      break;
+    case DataKind::Null:
+      break;
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
+  }
+
   CharSourceRange getDeferredRange() const {
     switch (DK) { 
     case DataKind::DeferredLayout:
@@ -153,9 +214,15 @@ public:
     assert(isRecorded());
     return RecordedData.Range;
   }
-  OpaqueSyntaxNode getOpaqueNode() const {
+  const OpaqueSyntaxNode &getOpaqueNode() const {
     assert(isRecorded());
     return RecordedData.OpaqueNode;
+  }
+  OpaqueSyntaxNode takeOpaqueNode() {
+    assert(isRecorded());
+    auto opaque = RecordedData.OpaqueNode;
+    reset();
+    return opaque;
   }
 
   // Deferred Layout Data ====================================================//
@@ -163,8 +230,8 @@ public:
   CharSourceRange getDeferredLayoutRange() const {
     assert(DK == DataKind::DeferredLayout);
     assert(!DeferredLayout.Children.empty());
-    auto getLastNonNullChild = [this]() {
-      for (auto &&Child : llvm::reverse(getDeferredChildren()))
+    auto getLastNonNullChild = [this]() -> const ParsedRawSyntaxNode & {
+      for (auto &Child : llvm::reverse(getDeferredChildren()))
         if (!Child.isNull())
           return Child;
       llvm_unreachable("layout node without non-null children");
@@ -177,6 +244,28 @@ public:
   ArrayRef<ParsedRawSyntaxNode> getDeferredChildren() const {
     assert(DK == DataKind::DeferredLayout);
     return DeferredLayout.Children;
+  }
+  MutableArrayRef<ParsedRawSyntaxNode> getDeferredChildren() {
+    assert(DK == DataKind::DeferredLayout);
+    return DeferredLayout.Children;
+  }
+  ParsedRawSyntaxNode copyDeferred() const {
+    ParsedRawSyntaxNode copy;
+    switch (DK) {
+    case DataKind::DeferredLayout:
+      copy.DeferredLayout = DeferredLayout;
+      break;
+    case DataKind::DeferredToken:
+      copy.DeferredToken = DeferredToken;
+      break;
+    default:
+      llvm_unreachable("node not deferred");
+    }
+    copy.SynKind = SynKind;
+    copy.TokKind = TokKind;
+    copy.DK = DK;
+    copy.IsMissing = IsMissing;
+    return copy;
   }
 
   // Deferred Token Data =====================================================//
@@ -214,7 +303,7 @@ public:
 
   /// Form a deferred syntax layout node.
   static ParsedRawSyntaxNode makeDeferred(syntax::SyntaxKind k,
-                        ArrayRef<ParsedRawSyntaxNode> deferredNodes,
+                        MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                           SyntaxParsingContext &ctx);
 
   /// Form a deferred token node.

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -60,13 +60,15 @@ public:
   /// \p kind. Missing optional elements are represented with a null
   /// ParsedRawSyntaxNode object.
   ParsedRawSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                     ArrayRef<ParsedRawSyntaxNode> elements);
+                                      MutableArrayRef<ParsedRawSyntaxNode> elements);
 
   /// Record a raw syntax collecton without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be
   /// if not missing.
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
+
+  void discardRecordedNode(ParsedRawSyntaxNode &node);
 
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,

--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -26,6 +26,7 @@ public:
     : RawNode(std::move(rawNode)) {}
 
   const ParsedRawSyntaxNode &getRaw() const { return RawNode; }
+  ParsedRawSyntaxNode takeRaw() { return std::move(RawNode); }
   syntax::SyntaxKind getKind() const { return RawNode.getKind(); }
 
   /// Returns true if the syntax node is of the given type.
@@ -39,7 +40,7 @@ public:
   template <typename T>
   T castTo() const {
     assert(is<T>() && "castTo<T>() node of incompatible type!");
-    return T { RawNode };
+    return T { RawNode.copyDeferred() };
   }
 
   /// If this Syntax node is of the right kind, cast and return it,
@@ -50,6 +51,10 @@ public:
       return castTo<T>();
     }
     return llvm::None;
+  }
+
+  ParsedSyntax copyDeferred() const {
+    return ParsedSyntax { RawNode.copyDeferred() };
   }
 
   static bool kindof(syntax::SyntaxKind Kind) {
@@ -65,7 +70,7 @@ public:
 class ParsedTokenSyntax final : public ParsedSyntax {
 public:
   explicit ParsedTokenSyntax(ParsedRawSyntaxNode rawNode)
-    : ParsedSyntax(rawNode) {}
+    : ParsedSyntax(std::move(rawNode)) {}
 
   tok getTokenKind() const {
     return getRaw().getTokenKind();

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -53,15 +53,15 @@ public:
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
   static Parsed${node.name} make${node.syntax_kind}(
-      ArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} makeBlank${node.syntax_kind}(SourceLoc loc,
@@ -69,16 +69,16 @@ public:
 %   elif node.is_unknown():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       ParsedRawSyntaxRecorder &rec);
 
 public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 
   static Parsed${node.name} make${node.syntax_kind}(
-      ArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);
 %   end
 % end
@@ -95,8 +95,8 @@ public:
   /// optional trailing comma.
   static ParsedTupleTypeElementSyntax
   makeTupleTypeElement(ParsedTypeSyntax Type,
-                         Optional<ParsedTokenSyntax> TrailingComma,
-                         SyntaxParsingContext &SPCtx);
+                       Optional<ParsedTokenSyntax> TrailingComma,
+                       SyntaxParsingContext &SPCtx);
 
   /// The provided \c elements are in the appropriate order for the syntax
   /// \c kind's layout but optional elements are not be included.
@@ -104,9 +104,12 @@ public:
   /// substituting missing parts with a null ParsedRawSyntaxNode object.
   ///
   /// \returns true if the layout could be formed, false otherwise.
-  static bool formExactLayoutFor(syntax::SyntaxKind kind,
-                                 ArrayRef<ParsedRawSyntaxNode> elements,
-         function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver);
+  static bool
+  formExactLayoutFor(syntax::SyntaxKind kind,
+                     MutableArrayRef<ParsedRawSyntaxNode> elements,
+                     function_ref<void(syntax::SyntaxKind,
+                                       MutableArrayRef<ParsedRawSyntaxNode>)>
+                         receiver);
 };
 }
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -61,6 +61,13 @@ public:
                                            ArrayRef<OpaqueSyntaxNode> elements,
                                            CharSourceRange range) = 0;
 
+  /// Discard raw syntax node.
+  /// 
+  /// FIXME: This breaks invariant that any recorded node will be a part of the
+  /// result SourceFile syntax. This method is a temporary workaround, and
+  /// should be removed when we fully migrate to libSyntax parsing.
+  virtual void discardRecordedNode(OpaqueSyntaxNode node) = 0;
+
   /// Used for incremental re-parsing.
   virtual std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -180,14 +180,17 @@ private:
   ArrayRef<ParsedRawSyntaxNode> getParts() const {
     return llvm::makeArrayRef(getStorage()).drop_front(Offset);
   }
+  MutableArrayRef<ParsedRawSyntaxNode> getParts() {
+    return llvm::makeMutableArrayRef(getStorage().data(), getStorage().size()).drop_front(Offset);
+  }
 
   ParsedRawSyntaxNode makeUnknownSyntax(SyntaxKind Kind,
-                                  ArrayRef<ParsedRawSyntaxNode> Parts);
+                                  MutableArrayRef<ParsedRawSyntaxNode> Parts);
   ParsedRawSyntaxNode createSyntaxAs(SyntaxKind Kind,
-                                     ArrayRef<ParsedRawSyntaxNode> Parts,
+                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK);
   Optional<ParsedRawSyntaxNode> bridgeAs(SyntaxContextKind Kind,
-                              ArrayRef<ParsedRawSyntaxNode> Parts);
+                              MutableArrayRef<ParsedRawSyntaxNode> Parts);
 
   ParsedRawSyntaxNode finalizeSourceFile();
 
@@ -277,14 +280,12 @@ public:
 
   /// Returns the topmost Syntax node.
   template <typename SyntaxNode> SyntaxNode topNode() {
-    ParsedRawSyntaxNode TopNode = getStorage().back();
-
+    ParsedRawSyntaxNode &TopNode = getStorage().back();
     if (TopNode.isRecorded()) {
       OpaqueSyntaxNode OpaqueNode = TopNode.getOpaqueNode();
       return getSyntaxCreator().getLibSyntaxNodeFor<SyntaxNode>(OpaqueNode);
     }
-    
-    return getSyntaxCreator().createNode<SyntaxNode>(TopNode);
+    return getSyntaxCreator().createNode<SyntaxNode>(TopNode.copyDeferred());
   }
 
   template <typename SyntaxNode>
@@ -292,14 +293,14 @@ public:
     auto &Storage = getStorage();
     if (Storage.size() <= Offset)
       return llvm::None;
-    auto rawNode = Storage.back();
-    if (!SyntaxNode::kindof(rawNode.getKind()))
+    if (!SyntaxNode::kindof(Storage.back().getKind()))
       return llvm::None;
+    auto rawNode = std::move(Storage.back());
     Storage.pop_back();
-    return SyntaxNode(rawNode);
+    return SyntaxNode(std::move(rawNode));
   }
 
-  ParsedTokenSyntax popToken();
+  ParsedTokenSyntax &&popToken();
 
   /// Create a node using the tail of the collected parts. The number of parts
   /// is automatically determined from \c Kind. Node: limited number of \c Kind

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -300,7 +300,7 @@ public:
     return SyntaxNode(std::move(rawNode));
   }
 
-  ParsedTokenSyntax &&popToken();
+  ParsedTokenSyntax popToken();
 
   /// Create a node using the tail of the collected parts. The number of parts
   /// is automatically determined from \c Kind. Node: limited number of \c Kind

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -64,6 +64,8 @@ public:
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) override;
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override;
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 

--- a/lib/Parse/HiddenLibSyntaxAction.cpp
+++ b/lib/Parse/HiddenLibSyntaxAction.cpp
@@ -125,3 +125,12 @@ HiddenLibSyntaxAction::getExplicitNodeFor(OpaqueSyntaxNode node) {
   auto hiddenNode = (Node *)node;
   return hiddenNode->ExplicitActionNode;
 }
+
+void HiddenLibSyntaxAction::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN)
+    return;
+  auto node = static_cast<Node *>(opaqueN);
+  if (!areBothLibSyntax())
+    LibSyntaxAction->discardRecordedNode(node->LibSyntaxNode);
+  ExplicitAction->discardRecordedNode(node->ExplicitActionNode);
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4125,7 +4125,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   ParserPosition startPosition = getParserPosition();
   llvm::Optional<SyntaxParsingContext> TmpCtxt;
   TmpCtxt.emplace(SyntaxContext);
-  TmpCtxt->setTransparent();
+  TmpCtxt->setBackTracking();
 
   SourceLoc TypeAliasLoc = consumeToken(tok::kw_typealias);
   SourceLoc EqualLoc;
@@ -4164,13 +4164,13 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   }
 
   if (Flags.contains(PD_InProtocol) && !genericParams && !Tok.is(tok::equal)) {
-    TmpCtxt->setBackTracking();
     TmpCtxt.reset();
     // If we're in a protocol and don't see an '=' this looks like leftover Swift 2
     // code intending to be an associatedtype.
     backtrackToPosition(startPosition);
     return parseDeclAssociatedType(Flags, Attributes);
   }
+  TmpCtxt->setTransparent();
   TmpCtxt.reset();
 
   auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1312,25 +1312,25 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<IntegerLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::integer_literal);
-  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeIntegerLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<FloatLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::floating_literal);
-  return ParsedSyntaxRecorder::makeFloatLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeFloatLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<NilLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax(tok::kw_nil);
-  return ParsedSyntaxRecorder::makeNilLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeNilLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
 ParsedExprSyntax Parser::parseExprSyntax<BooleanLiteralExprSyntax>() {
   auto Token = consumeTokenSyntax();
-  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makeBooleanLiteralExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1341,11 +1341,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFileExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FILE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_file);
-  return ParsedSyntaxRecorder::makePoundFileExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFileExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1356,12 +1356,12 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundLineExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___LINE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   // FIXME: #line was renamed to #sourceLocation
   auto Token = consumeTokenSyntax(tok::pound_line);
-  return ParsedSyntaxRecorder::makePoundLineExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundLineExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1372,11 +1372,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundColumnExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___COLUMN__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_column);
-  return ParsedSyntaxRecorder::makePoundColumnExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundColumnExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1387,11 +1387,11 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundFunctionExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___FUNCTION__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_function);
-  return ParsedSyntaxRecorder::makePoundFunctionExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundFunctionExpr(std::move(Token), *SyntaxContext);
 }
 
 template <>
@@ -1402,18 +1402,18 @@ ParsedExprSyntax Parser::parseExprSyntax<PoundDsohandleExprSyntax>() {
         .fixItReplace(Tok.getLoc(), fixit);
 
     auto Token = consumeTokenSyntax(tok::kw___DSO_HANDLE__);
-    return ParsedSyntaxRecorder::makeUnknownExpr({Token}, *SyntaxContext);
+    return ParsedSyntaxRecorder::makeUnknownExpr({&Token, 1}, *SyntaxContext);
   }
 
   auto Token = consumeTokenSyntax(tok::pound_dsohandle);
-  return ParsedSyntaxRecorder::makePoundDsohandleExpr(Token, *SyntaxContext);
+  return ParsedSyntaxRecorder::makePoundDsohandleExpr(std::move(Token), *SyntaxContext);
 }
 
 template <typename SyntaxNode>
 ParserResult<Expr> Parser::parseExprAST() {
   auto Loc = leadingTriviaLoc();
   auto ParsedExpr = parseExprSyntax<SyntaxNode>();
-  SyntaxContext->addSyntax(ParsedExpr);
+  SyntaxContext->addSyntax(std::move(ParsedExpr));
   // todo [gsoc]: improve this somehow
   if (SyntaxContext->isTopNode<UnknownExprSyntax>()) {
     auto Expr = SyntaxContext->topNode<UnknownExprSyntax>();
@@ -1519,9 +1519,9 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
           ParsedSyntaxRecorder::makeIdentifierPattern(
                                   SyntaxContext->popToken(), *SyntaxContext);
       ParsedExprSyntax ExprNode =
-          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(PatternNode,
+          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
                                                            *SyntaxContext);
-      SyntaxContext->addSyntax(ExprNode);
+      SyntaxContext->addSyntax(std::move(ExprNode));
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1169,6 +1169,7 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // matching-pattern ::= expr
   // Fall back to expression parsing for ambiguous forms. Name lookup will
   // disambiguate.
+  DeferringContextRAII Deferring(*SyntaxContext);
   ParserResult<Expr> subExpr =
     parseExprImpl(diag::expected_pattern, isExprBasic);
   ParserStatus status = subExpr;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -123,6 +123,7 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
 
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
+    SyntaxParsingContext CCCtxt(SyntaxContext, SyntaxContextKind::Decl);
     consumeToken();
     if (CodeCompletion)
       CodeCompletion->completeAfterPoundDirective();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -181,8 +181,8 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
     // Eat the code completion token because we handled it.
     auto CCTok = consumeTokenSyntax(tok::code_complete);
     ParsedTypeSyntax ty =
-        ParsedSyntaxRecorder::makeUnknownType({CCTok}, *SyntaxContext);
-    return makeParsedCodeCompletion(ty);
+        ParsedSyntaxRecorder::makeUnknownType({&CCTok, 1}, *SyntaxContext);
+    return makeParsedCodeCompletion(std::move(ty));
   }
   case tok::l_square:
     Result = parseTypeCollection();
@@ -203,9 +203,10 @@ Parser::TypeResult Parser::parseTypeSimple(Diag<> MessageID,
     }
 
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
+      auto token = consumeTokenSyntax();
       ParsedTypeSyntax ty = ParsedSyntaxRecorder::makeUnknownType(
-          {consumeTokenSyntax()}, *SyntaxContext);
-      return makeParsedError(ty);
+          {&token, 1}, *SyntaxContext);
+      return makeParsedError(std::move(ty));
     }
 
     checkForInputIncomplete();
@@ -256,7 +257,7 @@ Parser::parseTypeSyntax(Diag<> messageID, bool HandleCodeCompletion,
   auto tyR = parseType(messageID, HandleCodeCompletion, IsSILFuncDecl);
   if (auto ty = SyntaxContext->popIf<ParsedTypeSyntax>()) {
     Generator.addType(tyR.getPtrOrNull(), loc);
-    return makeParsedResult(*ty, tyR.getStatus());
+    return makeParsedResult(std::move(*ty), tyR.getStatus());
   }
   return tyR.getStatus();
 }
@@ -269,7 +270,7 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
                                               const TypeAttributes &attrs,
                                               Optional<Scope> &GenericsScope) {
   auto LBraceLoc = consumeToken(tok::l_brace);
-  
+
   SmallVector<SILBoxTypeRepr::Field, 4> Fields;
   if (!Tok.is(tok::r_brace)) {
     for (;;) {
@@ -283,30 +284,30 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
         return makeParserError();
       }
       SourceLoc VarOrLetLoc = consumeToken();
-      
+
       auto fieldTy = parseType();
       if (!fieldTy.getPtrOrNull())
         return makeParserError();
       Fields.push_back({VarOrLetLoc, Mutable, fieldTy.get()});
-      
+
       if (consumeIf(tok::comma))
         continue;
-      
+
       break;
     }
   }
-  
+
   if (!Tok.is(tok::r_brace)) {
     diagnose(Tok, diag::sil_box_expected_r_brace);
     return makeParserError();
   }
-  
+
   auto RBraceLoc = consumeToken(tok::r_brace);
-  
+
   // The generic arguments are taken from the enclosing scope. Pop the
   // box layout's scope now.
   GenericsScope.reset();
-  
+
   SourceLoc LAngleLoc, RAngleLoc;
   SmallVector<TypeRepr*, 4> Args;
   if (Tok.isContextualPunctuator("<")) {
@@ -324,7 +325,7 @@ Parser::TypeASTResult Parser::parseSILBoxType(GenericParamList *generics,
       diagnose(Tok, diag::sil_box_expected_r_angle);
       return makeParserError();
     }
-    
+
     RAngleLoc = consumeToken();
   }
 
@@ -370,7 +371,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
       GenericsScope.emplace(this, ScopeKind::Generics);
     generics = maybeParseGenericParams().getPtrOrNull();
   }
-  
+
   // In SIL mode, parse box types { ... }.
   if (isInSILMode() && Tok.is(tok::l_brace)) {
     auto SILBoxType = parseSILBoxType(generics, attrs, GenericsScope);
@@ -407,7 +408,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
   }
 
   if (Tok.is(tok::arrow)) {
-    auto InputNode = SyntaxContext->popIf<ParsedTypeSyntax>().getValue();
+    auto InputNode(std::move(SyntaxContext->popIf<ParsedTypeSyntax>().getValue()));
     // Handle type-function if we have an arrow.
     auto ArrowLoc = Tok.getLoc();
     auto Arrow = consumeTokenSyntax();
@@ -422,16 +423,15 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
         parseType(diag::expected_type_function_result);
     auto SecondTy = SyntaxContext->popIf<ParsedTypeSyntax>();
     if (SecondHalf.isParseError()) {
-      SyntaxContext->addSyntax(InputNode);
+      SyntaxContext->addSyntax(std::move(InputNode));
       if (Throws)
-        SyntaxContext->addSyntax(*Throws);
-      SyntaxContext->addSyntax(Arrow);
+        SyntaxContext->addSyntax(std::move(*Throws));
+      SyntaxContext->addSyntax(std::move(Arrow));
       if (SecondTy)
-        SyntaxContext->addSyntax(*SecondTy);
+        SyntaxContext->addSyntax(std::move(*SecondTy));
       if (SecondHalf.hasCodeCompletion())
         return makeParserCodeCompletionResult<TypeRepr>();
-      if (SecondHalf.isNull())
-        return nullptr;
+      return makeParserErrorResult<TypeRepr>();
     }
 
     ParsedFunctionTypeSyntaxBuilder Builder(*SyntaxContext);
@@ -442,9 +442,9 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
       auto Arguments = TupleTypeNode->getDeferredElements();
       auto RightParen = TupleTypeNode->getDeferredRightParen();
       Builder
-        .useLeftParen(LeftParen)
-        .useArguments(Arguments)
-        .useRightParen(RightParen);
+        .useLeftParen(std::move(LeftParen))
+        .useArguments(std::move(Arguments))
+        .useRightParen(std::move(RightParen));
     } else {
       // FIXME(syntaxparse): Extract 'Void' text from recoreded node.
       if (const auto Void = dyn_cast<SimpleIdentTypeRepr>(tyR))
@@ -460,14 +460,13 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
           .fixItInsertAfter(tyR->getEndLoc(), ")");
       }
       Builder.addArgumentsMember(ParsedSyntaxRecorder::makeTupleTypeElement(
-          InputNode, /*TrailingComma=*/None, *SyntaxContext));
+          std::move(InputNode), /*TrailingComma=*/None, *SyntaxContext));
     }
 
-    Builder.useReturnType(*SecondTy);
     if (Throws)
-      Builder.useThrowsOrRethrowsKeyword(*Throws);
-    Builder.useArrow(Arrow);
-    Builder.useReturnType(*SecondTy);
+      Builder.useThrowsOrRethrowsKeyword(std::move(*Throws));
+    Builder.useArrow(std::move(Arrow));
+    Builder.useReturnType(std::move(*SecondTy));
 
     SyntaxContext->addSyntax(Builder.build());
 
@@ -628,7 +627,7 @@ Parser::parseGenericArgumentsAST(SmallVectorImpl<TypeRepr *> &ArgsAST,
 }
 
 /// parseTypeIdentifier
-///   
+///
 ///   type-identifier:
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///
@@ -642,9 +641,10 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
       if (CodeCompletion)
         CodeCompletion->completeTypeSimpleBeginning();
 
+      auto CCTok = consumeTokenSyntax(tok::code_complete);
       auto ty = ParsedSyntaxRecorder::makeUnknownType(
-          {consumeTokenSyntax(tok::code_complete)}, *SyntaxContext);
-      return makeParsedCodeCompletion(ty);
+          {&CCTok, 1}, *SyntaxContext);
+      return makeParsedCodeCompletion(std::move(ty));
     }
 
     diagnose(Tok, diag::expected_identifier_for_type);
@@ -652,9 +652,10 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     // If there is a keyword at the start of a new line, we won't want to
     // skip it as a recovery but rather keep it.
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
+      auto kwTok = consumeTokenSyntax();
       ParsedTypeSyntax ty = ParsedSyntaxRecorder::makeUnknownType(
-          {consumeTokenSyntax()}, *SyntaxContext);
-      return makeParsedError(ty);
+          {&kwTok, 1}, *SyntaxContext);
+      return makeParsedError(std::move(ty));
     }
 
     return makeParsedError<ParsedTypeSyntax>();
@@ -676,42 +677,42 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
       // FIXME: offer a fixit: 'self' -> 'Self'
       Identifier =
           parseIdentifierSyntax(diag::expected_identifier_in_dotted_type);
-      if (!Identifier) {
-        Status.setIsParseError();
-        if (Base)
-          Junk.push_back(*Base);
-        if (Period)
-          Junk.push_back(*Period);
-      }
     }
 
     if (Identifier) {
       Optional<ParsedGenericArgumentClauseSyntax> GenericArgs;
-      
+
       if (startsWithLess(Tok)) {
         SmallVector<TypeRepr *, 4> GenericArgsAST;
         SourceLoc LAngleLoc, RAngleLoc;
         auto GenericArgsResult = parseGenericArgumentClauseSyntax();
         if (GenericArgsResult.isError()) {
           if (Base)
-            Junk.push_back(*Base);
+            Junk.push_back(std::move(*Base));
           if (Period)
-            Junk.push_back(*Period);
-          Junk.push_back(*Identifier);
+            Junk.push_back(std::move(*Period));
+          Junk.push_back(std::move(*Identifier));
           if (!GenericArgsResult.isNull())
             Junk.push_back(GenericArgsResult.get());
           auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-          return makeParsedResult(ty, GenericArgsResult.getStatus());
+          return makeParsedResult(std::move(ty), GenericArgsResult.getStatus());
         }
         GenericArgs = GenericArgsResult.get();
       }
 
       if (!Base)
         Base = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
-            *Identifier, GenericArgs, *SyntaxContext);
+            std::move(*Identifier), std::move(GenericArgs), *SyntaxContext);
       else
         Base = ParsedSyntaxRecorder::makeMemberTypeIdentifier(
-            *Base, *Period, *Identifier, GenericArgs, *SyntaxContext);
+            std::move(*Base), std::move(*Period), std::move(*Identifier),
+            std::move(GenericArgs), *SyntaxContext);
+    } else {
+      Status.setIsParseError();
+      if (Base)
+        Junk.push_back(std::move(*Base));
+      if (Period)
+        Junk.push_back(std::move(*Period));
     }
 
     // Treat 'Foo.<anything>' as an attempt to write a dotted type
@@ -738,17 +739,16 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     IdentTypeRepr *ITR = nullptr;
 
     if (Base) {
-      SyntaxContext->addSyntax(*Base);
+      SyntaxContext->addSyntax(std::move(*Base));
       auto T = SyntaxContext->topNode<TypeSyntax>();
-      SyntaxContext->popIf<ParsedTypeSyntax>();
+      Junk.push_back(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
       ITR = dyn_cast<IdentTypeRepr>(Generator.generate(T, BaseLoc));
-      Junk.push_back(*Base);
     }
 
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       auto Dot = consumeTokenSyntax();
-      Junk.push_back(Dot);
+      Junk.push_back(std::move(Dot));
       if (CodeCompletion)
         CodeCompletion->completeTypeIdentifierWithDot(ITR);
     } else {
@@ -758,15 +758,15 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     // Eat the code completion token because we handled it.
     Junk.push_back(consumeTokenSyntax(tok::code_complete));
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedCodeCompletion(ty);
-  }
-  
-  if (Status.isError()) {
-    auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedError(ty);
+    return makeParsedCodeCompletion(std::move(ty));
   }
 
-  return makeParsedResult(*Base);
+  if (Status.isError()) {
+    auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
+    return makeParsedError(std::move(ty));
+  }
+
+  return makeParsedResult(std::move(*Base));
 }
 
 Parser::TypeASTResult
@@ -803,9 +803,11 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
     FirstSome = consumeTokenSyntax();
   }
 
-  auto ApplySome = [this](ParsedTypeSyntax Type, Optional<ParsedTokenSyntax> Some) {
-    return Some ? ParsedSyntaxRecorder::makeSomeType(*Some, Type, *SyntaxContext)
-                : Type;
+  auto ApplySome = [this](ParsedTypeSyntax Type,
+                          Optional<ParsedTokenSyntax> Some) {
+    return Some ? ParsedSyntaxRecorder::makeSomeType(
+                      std::move(*Some), std::move(Type), *SyntaxContext)
+                : std::move(Type);
   };
 
   // Parse the first type
@@ -817,14 +819,15 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
   auto FirstType = FirstTypeResult.get();
 
   if (!Tok.isContextualPunctuator("&"))
-    return makeParsedResult(ApplySome(FirstType, FirstSome));
+    return makeParsedResult(
+        ApplySome(std::move(FirstType), std::move(FirstSome)));
 
   SmallVector<ParsedCompositionTypeElementSyntax, 4> Elements;
-  
+
   Optional<ParsedTokenSyntax> Ampersand = consumeTokenSyntax();
   auto FirstElement = ParsedSyntaxRecorder::makeCompositionTypeElement(
-      FirstType, *Ampersand, *SyntaxContext);
-  Elements.push_back(FirstElement);
+      std::move(FirstType), std::move(*Ampersand), *SyntaxContext);
+  Elements.push_back(std::move(FirstElement));
 
   ParserStatus Status;
 
@@ -848,45 +851,46 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
 
       SmallVector<ParsedSyntax, 0> nodes;
       if (FirstSome)
-        nodes.push_back(*FirstSome);
-      nodes.append(Elements.begin(), Elements.end());
+        nodes.push_back(std::move(*FirstSome));
+      std::move(Elements.begin(), Elements.end(), std::back_inserter(nodes));
       if (NextSome)
-        nodes.push_back(*NextSome);
+        nodes.push_back(std::move(*NextSome));
       nodes.push_back(NextTypeResult.get());
 
       auto ty = ParsedSyntaxRecorder::makeUnknownType(nodes, *SyntaxContext);
-      return makeParsedResult(ty, Status);
+      return makeParsedResult(std::move(ty), Status);
     }
 
-    auto NextType = ApplySome(NextTypeResult.get(), NextSome);
-    Ampersand = Tok.isContextualPunctuator("&") 
-        ? consumeTokenSyntax() 
+    auto NextType = ApplySome(NextTypeResult.get(), std::move(NextSome));
+    Ampersand = Tok.isContextualPunctuator("&")
+        ? consumeTokenSyntax()
         : llvm::Optional<ParsedTokenSyntax>();
     auto NextElement = ParsedSyntaxRecorder::makeCompositionTypeElement(
-        NextType, Ampersand, *SyntaxContext);
-    Elements.push_back(NextElement);
+        std::move(NextType), std::move(Ampersand), *SyntaxContext);
+    Elements.push_back(std::move(NextElement));
   } while (Ampersand);
 
   auto ElementList = ParsedSyntaxRecorder::makeCompositionTypeElementList(
       Elements, *SyntaxContext);
-  auto Composition =
-      ParsedSyntaxRecorder::makeCompositionType(ElementList, *SyntaxContext);
-  return makeParsedResult(ApplySome(Composition, FirstSome), Status);
+  auto Composition = ParsedSyntaxRecorder::makeCompositionType(
+      std::move(ElementList), *SyntaxContext);
+  return makeParsedResult(
+      ApplySome(std::move(Composition), std::move(FirstSome)), Status);
 }
 
 Parser::TypeASTResult Parser::parseAnyTypeAST() {
   auto AnyLoc = leadingTriviaLoc();
   auto ParsedAny = parseAnyType().get();
-  SyntaxContext->addSyntax(ParsedAny);
+  SyntaxContext->addSyntax(std::move(ParsedAny));
   auto Any = SyntaxContext->topNode<SimpleTypeIdentifierSyntax>();
   return makeParserResult(Generator.generate(Any, AnyLoc));
 }
 
 Parser::TypeResult Parser::parseAnyType() {
   auto Any = consumeTokenSyntax(tok::kw_Any);
-  auto Type = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(Any, llvm::None,
-                                                             *SyntaxContext);
-  return makeParsedResult(Type);
+  auto Type = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
+      std::move(Any), llvm::None, *SyntaxContext);
+  return makeParsedResult(std::move(Type));
 }
 
 /// parseOldStyleProtocolComposition
@@ -909,8 +913,8 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   auto LAngleLoc = Tok.getLoc();
   auto LAngle = consumeStartingLessSyntax();
 
-  Junk.push_back(Protocol);
-  Junk.push_back(LAngle);
+  Junk.push_back(Protocol.copyDeferred());
+  Junk.push_back(LAngle.copyDeferred());
 
   // Parse the type-composition-list.
   ParserStatus Status;
@@ -924,13 +928,13 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       Status |= TypeResult.getStatus();
       if (TypeResult.isSuccess()) {
         auto Type = TypeResult.get();
-        Junk.push_back(Type);
+        Junk.push_back(Type.copyDeferred());
         if (!IsAny)
-          Protocols.push_back(Type);
+          Protocols.push_back(std::move(Type));
       }
       Comma = consumeTokenSyntaxIf(tok::comma);
       if (Comma)
-        Junk.push_back(*Comma);
+        Junk.push_back(Comma->copyDeferred());
     } while (Comma);
   }
 
@@ -939,7 +943,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   if (startsWithGreater(Tok)) {
     RAngleLoc = Tok.getLoc();
     auto RAngle = consumeStartingGreaterSyntax();
-    Junk.push_back(RAngle);
+    Junk.push_back(RAngle.copyDeferred());
   } else {
     if (Status.isSuccess()) {
       diagnose(Tok, diag::expected_rangle_protocol);
@@ -951,7 +955,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
     // Skip until we hit the '>'.
     skipUntilGreaterInTypeListSyntax(RAngleJunk, /*protocolComposition=*/true);
     for (auto &&Piece : RAngleJunk)
-      Junk.push_back(Piece);
+      Junk.push_back(Piece.copyDeferred());
   }
 
   if (Status.isSuccess()) {
@@ -959,7 +963,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
     if (Protocols.empty()) {
       replacement = "Any";
     } else {
-      auto extractText = [&](ParsedTypeSyntax Type) -> StringRef {
+      auto extractText = [&](ParsedTypeSyntax &Type) -> StringRef {
         auto SourceRange = Type.getRaw().getDeferredRange();
         return SourceMgr.extractText(SourceRange);
       };
@@ -975,7 +979,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       // Need parenthesis if the next token looks like postfix TypeRepr.
       // i.e. '?', '!', '.Type', '.Protocol'
       bool needParen = false;
-      needParen |= !Tok.isAtStartOfLine() && 
+      needParen |= !Tok.isAtStartOfLine() &&
           (isOptionalToken(Tok) || isImplicitlyUnwrappedOptionalToken(Tok));
       needParen |= Tok.isAny(tok::period, tok::period_prefix);
       if (needParen) {
@@ -1001,7 +1005,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
   }
 
   auto Unknown = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-  return makeParsedResult(Unknown);
+  return makeParsedResult(std::move(Unknown));
 }
 
 /// parseTypeTupleBody
@@ -1022,15 +1026,14 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     return makeParsedError<ParsedTypeSyntax>();
 
   SmallVector<ParsedSyntax, 0> Junk;
-  
+
   auto LParenLoc = Tok.getLoc();
   auto LParen = consumeTokenSyntax(tok::l_paren);
 
-  Junk.push_back(LParen);
+  Junk.push_back(LParen.copyDeferred());
 
   SmallVector<ParsedTupleTypeElementSyntax, 4> Elements;
   SmallVector<std::tuple<SourceLoc, SourceLoc, SourceLoc>, 4> ElementsLoc;
-  Optional<ParsedTokenSyntax> FirstEllipsis;
   SourceLoc FirstEllipsisLoc;
 
   Optional<ParsedTokenSyntax> Comma;
@@ -1055,7 +1058,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       InOut = consumeTokenSyntax(tok::kw_inout);
       IsInOutObsoleted = true;
 
-      LocalJunk.push_back(*InOut);
+      LocalJunk.push_back(InOut->copyDeferred());
     }
 
     // If the label is "some", this could end up being an opaque type
@@ -1078,18 +1081,18 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       // Consume a name.
       NameLoc = Tok.getLoc();
       Name = consumeArgumentLabelSyntax();
-      LocalJunk.push_back(*Name);
+      LocalJunk.push_back(Name->copyDeferred());
 
       // If there is a second name, consume it as well.
       if (Tok.canBeArgumentLabel()) {
         SecondNameLoc = Tok.getLoc();
         SecondName = consumeArgumentLabelSyntax();
-        LocalJunk.push_back(*SecondName);
+        LocalJunk.push_back(SecondName->copyDeferred());
       }
 
       // Consume the ':'.
       if ((Colon = consumeTokenSyntaxIf(tok::colon))) {
-        LocalJunk.push_back(*Colon);
+        LocalJunk.push_back(Colon->copyDeferred());
         // If we succeed, then we successfully parsed a label.
         if (Backtracking)
           Backtracking->cancelBacktrack();
@@ -1110,19 +1113,22 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
 
     // Parse the type annotation.
     auto TypeLoc = Tok.getLoc();
-    auto Type = parseTypeSyntax(diag::expected_type);
-    if (Type.hasCodeCompletion() || Type.isNull()) {
-      Junk.append(LocalJunk.begin(), LocalJunk.end());
-      if (!Type.isNull())
-        Junk.push_back(Type.get());
+    auto ty = parseTypeSyntax(diag::expected_type);
+    if (ty.hasCodeCompletion() || ty.isNull()) {
+      std::move(LocalJunk.begin(), LocalJunk.end(), std::back_inserter(Junk));
+      if (!ty.isNull())
+        Junk.push_back(ty.get());
       skipListUntilDeclRBraceSyntax(Junk, LParenLoc, tok::r_paren, tok::comma);
-      return Type.getStatus();
+      return ty.getStatus();
     }
 
     if (IsInOutObsoleted) {
       bool IsTypeAlreadyAttributed = false;
-      if (auto AttributedType = Type.get().getAs<ParsedAttributedTypeSyntax>())
-        IsTypeAlreadyAttributed = AttributedType->getDeferredSpecifier().hasValue();
+      if (auto AttributedType = ty.getAs<ParsedAttributedTypeSyntax>()) {
+        IsTypeAlreadyAttributed =
+            AttributedType->getDeferredSpecifier().hasValue();
+        ty = makeParsedResult(std::move(*AttributedType), ty.getStatus());
+      }
 
       if (IsTypeAlreadyAttributed) {
         // If the parsed type is already attributed, suggest removing `inout`.
@@ -1140,8 +1146,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       Tok.setKind(tok::ellipsis);
       auto ElementEllipsisLoc = Tok.getLoc();
       ElementEllipsis = consumeTokenSyntax();
-      if (!FirstEllipsis) {
-        FirstEllipsis = ElementEllipsis;
+      if (!FirstEllipsisLoc.isValid()) {
         FirstEllipsisLoc = ElementEllipsisLoc;
       } else {
         diagnose(ElementEllipsisLoc, diag::multiple_ellipsis_in_tuple)
@@ -1159,20 +1164,22 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       auto InFlight = diagnose(EqualLoc, diag::tuple_type_init);
       if (Init.isNonNull())
         InFlight.fixItRemove(SourceRange(EqualLoc, Init.get()->getEndLoc()));
-      auto Expr = *SyntaxContext->popIf<ParsedExprSyntax>();
-      Initializer = ParsedSyntaxRecorder::makeInitializerClause(*Equal, Expr,
-                                                                *SyntaxContext);
+      Initializer = ParsedSyntaxRecorder::makeInitializerClause(
+          std::move(*Equal),
+          std::move(*SyntaxContext->popIf<ParsedExprSyntax>()),
+          *SyntaxContext);
     }
 
     Comma = consumeTokenSyntaxIf(tok::comma);
 
     auto Element = ParsedSyntaxRecorder::makeTupleTypeElement(
-        InOut, Name, SecondName, Colon, Type.get(), ElementEllipsis, Initializer,
-        Comma, *SyntaxContext);
+        std::move(InOut), std::move(Name), std::move(SecondName),
+        std::move(Colon), ty.get(), std::move(ElementEllipsis),
+        std::move(Initializer), std::move(Comma), *SyntaxContext);
 
-    Junk.push_back(Element);
+    Junk.push_back(Element.copyDeferred());
 
-    Elements.push_back(Element);
+    Elements.push_back(std::move(Element));
     ElementsLoc.emplace_back(NameLoc, SecondNameLoc, TypeLoc);
 
     return makeParserSuccess();
@@ -1180,14 +1187,8 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
 
   if (!Status.isSuccess()) {
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedResult(ty, Status);
+    return makeParsedResult(std::move(ty), Status);
   }
-
-  auto ElementList =
-      ParsedSyntaxRecorder::makeTupleTypeElementList(Elements, *SyntaxContext);
-
-  auto TupleType = ParsedSyntaxRecorder::makeTupleType(LParen, ElementList,
-                                                       *RParen, *SyntaxContext);
 
   bool IsFunctionType = Tok.isAny(tok::arrow, tok::kw_throws, tok::kw_rethrows);
 
@@ -1201,7 +1202,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
   if (!IsFunctionType) {
     for (unsigned i = 0; i < Elements.size(); i++) {
       // true tuples have labels
-      auto Element = Elements[i];
+      auto &Element = Elements[i];
       SourceLoc NameLoc, SecondNameLoc, TypeLoc;
       std::tie(NameLoc, SecondNameLoc, TypeLoc) = ElementsLoc[i];
       // If there were two names, complain.
@@ -1223,7 +1224,7 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     for (unsigned i = 0; i < Elements.size(); i++) {
       // If there was a first name, complain; arguments in function types are
       // always unlabeled.
-      auto Element = Elements[i];
+      auto &Element = Elements[i];
       SourceLoc NameLoc, SecondNameLoc, TypeLoc;
       std::tie(NameLoc, SecondNameLoc, TypeLoc) = ElementsLoc[i];
       if (NameLoc.isValid()) {
@@ -1244,7 +1245,14 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
     }
   }
 
-  return makeParsedResult(TupleType);
+  auto ElementList =
+      ParsedSyntaxRecorder::makeTupleTypeElementList(Elements, *SyntaxContext);
+
+  auto TupleType = ParsedSyntaxRecorder::makeTupleType(
+      std::move(LParen), std::move(ElementList), std::move(*RParen),
+      *SyntaxContext);
+
+  return makeParsedResult(std::move(TupleType));
 }
 
 /// parseTypeArray - Parse the type-array production, given that we
@@ -1278,9 +1286,9 @@ Parser::TypeResult Parser::parseTypeArray(ParsedTypeSyntax Base,
   }
 
   ParsedArrayTypeSyntaxBuilder builder(*SyntaxContext);
-  builder.useElementType(Base);
+  builder.useElementType(std::move(Base));
   if (RSquare)
-    builder.useRightSquareBracket(*RSquare);
+    builder.useRightSquareBracket(std::move(*RSquare));
 
   return makeParsedError(builder.build());
 }
@@ -1319,35 +1327,37 @@ Parser::TypeResult Parser::parseTypeCollection() {
 
   if (!Status.isSuccess()) {
     SmallVector<ParsedSyntax, 0> Pieces;
-    Pieces.push_back(LSquare);
+    Pieces.push_back(std::move(LSquare));
     if (ElementType)
-      Pieces.push_back(*ElementType);
+      Pieces.push_back(std::move(*ElementType));
     if (Colon)
-      Pieces.push_back(*Colon);
+      Pieces.push_back(std::move(*Colon));
     if (ValueType)
-      Pieces.push_back(*ValueType);
+      Pieces.push_back(std::move(*ValueType));
     if (RSquare)
-      Pieces.push_back(*RSquare);
+      Pieces.push_back(std::move(*RSquare));
 
     ParsedTypeSyntax ty =
         ParsedSyntaxRecorder::makeUnknownType(Pieces, *SyntaxContext);
-    return makeParsedResult(ty, Status);
+    return makeParsedResult(std::move(ty), Status);
   }
 
   if (Colon)
     return makeParsedResult(ParsedSyntaxRecorder::makeDictionaryType(
-        LSquare, *ElementType, *Colon, *ValueType, *RSquare, *SyntaxContext));
+        std::move(LSquare), std::move(*ElementType), std::move(*Colon),
+        std::move(*ValueType), std::move(*RSquare), *SyntaxContext));
 
   return makeParsedResult(ParsedSyntaxRecorder::makeArrayType(
-      LSquare, *ElementType, *RSquare, *SyntaxContext));
+      std::move(LSquare), std::move(*ElementType), std::move(*RSquare),
+      *SyntaxContext));
 }
 
 Parser::TypeResult Parser::parseMetatypeType(ParsedTypeSyntax Base) {
   auto Period = consumeTokenSyntax(); // tok::period or tok::period_prefix
   auto Keyword = consumeTokenSyntax(tok::identifier); // "Type" or "Protocol"
   auto MetatypeType = ParsedSyntaxRecorder::makeMetatypeType(
-      Base, Period, Keyword, *SyntaxContext);
-  return makeParsedResult(MetatypeType);
+      std::move(Base), std::move(Period), std::move(Keyword), *SyntaxContext);
+  return makeParsedResult(std::move(MetatypeType));
 }
 
 bool Parser::isOptionalToken(const Token &T) const {
@@ -1403,17 +1413,17 @@ SourceLoc Parser::consumeImplicitlyUnwrappedOptionalToken() {
 
 Parser::TypeResult Parser::parseOptionalType(ParsedTypeSyntax Base) {
   auto Question = consumeOptionalTokenSyntax();
-  auto Optional =
-      ParsedSyntaxRecorder::makeOptionalType(Base, Question, *SyntaxContext);
-  return makeParsedResult(Optional);
+  auto Optional = ParsedSyntaxRecorder::makeOptionalType(
+      std::move(Base), std::move(Question), *SyntaxContext);
+  return makeParsedResult(std::move(Optional));
 }
 
 Parser::TypeResult
 Parser::parseImplicitlyUnwrappedOptionalType(ParsedTypeSyntax Base) {
   auto Exclamation = consumeImplicitlyUnwrappedOptionalTokenSyntax();
   auto Unwrapped = ParsedSyntaxRecorder::makeImplicitlyUnwrappedOptionalType(
-      Base, Exclamation, *SyntaxContext);
-  return makeParsedResult(Unwrapped);
+      std::move(Base), std::move(Exclamation), *SyntaxContext);
+  return makeParsedResult(std::move(Unwrapped));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -19,15 +19,20 @@ using namespace llvm;
 
 ParsedRawSyntaxNode
 ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
-                                  ArrayRef<ParsedRawSyntaxNode> deferredNodes,
+                                  MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                                   SyntaxParsingContext &ctx) {
   if (deferredNodes.empty()) {
     return ParsedRawSyntaxNode(k, {});
   }
   ParsedRawSyntaxNode *newPtr =
     ctx.getScratchAlloc().Allocate<ParsedRawSyntaxNode>(deferredNodes.size());
-  std::uninitialized_copy(deferredNodes.begin(), deferredNodes.end(), newPtr);
-  return ParsedRawSyntaxNode(k, makeArrayRef(newPtr, deferredNodes.size()));
+
+  // uninitialized move;
+  auto ptr = newPtr;
+  for (auto &node : deferredNodes)
+    :: new (static_cast<void *>(ptr++)) ParsedRawSyntaxNode(std::move(node));
+
+  return ParsedRawSyntaxNode(k, makeMutableArrayRef(newPtr, deferredNodes.size()));
 }
 
 ParsedRawSyntaxNode
@@ -59,13 +64,13 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   for (decltype(Indent) i = 0; i < Indent; ++i)
     OS << ' ';
   OS << '(';
-  dumpSyntaxKind(OS, getKind());
 
   switch (DK) {
     case DataKind::Null:
       OS << "<NULL>";
       break;
     case DataKind::Recorded:
+      dumpSyntaxKind(OS, getKind());
       OS << " [recorded] ";
       if (isToken()) {
         dumpTokenKind(OS, getTokenKind());
@@ -74,6 +79,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
       }
       break;
     case DataKind::DeferredLayout:
+      dumpSyntaxKind(OS, getKind());
       OS << " [deferred]";
       for (const auto &child : getDeferredChildren()) {
         OS << "\n";
@@ -81,6 +87,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
       }
       break;
     case DataKind::DeferredToken:
+      dumpSyntaxKind(OS, getKind());
       OS << " [deferred] ";
       dumpTokenKind(OS, getTokenKind());
       break;

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -43,14 +43,14 @@ Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} ${child.nam
   assert(${child_elt_name}s.empty() && "use either 'use' function or 'add', not both");
 %       end
   Layout[cursorIndex(${node.name}::Cursor::${child.name})] =
-    ${child.name}.getRaw();
+    ${child.name}.takeRaw();
   return *this;
 }
 %       if child_elt:
 Parsed${node.name}Builder &
 Parsed${node.name}Builder::add${child_elt_name}(Parsed${child_elt_type} ${child_elt}) {
   assert(Layout[cursorIndex(${node.name}::Cursor::${child.name})].isNull() && "use either 'use' function or 'add', not both");
-  ${child_elt_name}s.push_back(std::move(${child_elt}.getRaw()));
+  ${child_elt_name}s.push_back(${child_elt}.takeRaw());
   return *this;
 }
 %       end

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -28,14 +28,14 @@ using namespace swift::syntax;
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
 Parsed${node.name}::getDeferred${child.name}() {
-  auto RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
+  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
   if (RawChild.isNull())
     return None;
-  return Parsed${child.type_name} {RawChild};
+  return Parsed${child.type_name} {RawChild.copyDeferred()};
 }
 %     else:
 Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}]};
+  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
 }
 %     end
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -26,8 +26,8 @@ using namespace swift;
 using namespace swift::syntax;
 
 bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
-        ArrayRef<ParsedRawSyntaxNode> Elements,
-        function_ref<void(syntax::SyntaxKind, ArrayRef<ParsedRawSyntaxNode>)> receiver) {
+        MutableArrayRef<ParsedRawSyntaxNode> Elements,
+        function_ref<void(syntax::SyntaxKind, MutableArrayRef<ParsedRawSyntaxNode>)> receiver) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -42,16 +42,23 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     if child.is_optional:
       Layout[${child_idx}] = ParsedRawSyntaxNode::null();
 %     else:
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
 %     end
     } else {
-      Layout[${child_idx}] = Elements[I];
+      Layout[${child_idx}] = Elements[I].unsafeCopy();
       ++I;
     }
 %   end
-    if (I != Elements.size())
+    if (I != Elements.size()) {
+      for (unsigned i = 0, e = ${child_count}; i != e; ++i)
+        Layout[i].reset();
       return false;
+    }
     receiver(Kind, Layout);
+    for (unsigned i = 0, e = Elements.size(); i != e; ++i)
+      Elements[i].reset();
     return true;
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
@@ -85,29 +92,31 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
                                        ParsedRawSyntaxRecorder &rec) {
-  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  });
+  };
+  auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {
+  ParsedRawSyntaxNode layout[] = {
 %     for child in node.children:
 %       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->getRaw() : ParsedRawSyntaxNode::null(),
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
 %       else:
-    ${child.name}.getRaw(),
+    ${child.name}.takeRaw(),
 %       end
 %     end
-  }, SPCtx);
+  };
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
@@ -122,12 +131,12 @@ ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -135,12 +144,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
@@ -149,7 +158,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    ArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -171,12 +180,12 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
 %   elif node.is_unknown():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     ParsedRawSyntaxRecorder &rec) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
@@ -184,12 +193,12 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   SmallVector<ParsedRawSyntaxNode, 16> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
-    layout.push_back(element.getRaw());
+    layout.push_back(element.takeRaw());
   }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
@@ -197,7 +206,7 @@ ParsedSyntaxRecorder::defer${node.syntax_kind}(
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
-    ArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
   if (SPCtx.shouldDefer())
     return defer${node.syntax_kind}(elements, SPCtx);
@@ -224,6 +233,6 @@ ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,
                                     llvm::Optional<ParsedTokenSyntax> TrailingComma,
                                     SyntaxParsingContext &SPCtx) {
-  return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma, SPCtx);
+  return makeTupleTypeElement(None, None, None, None, std::move(Type), None, None,
+                              std::move(TrailingComma), SPCtx);
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -684,19 +684,19 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_paren);
     if (auto RParen = consumeTokenSyntaxIf(tok::r_paren))
-      Skipped.push_back(*RParen);
+      Skipped.push_back(std::move(*RParen));
     break;
   case tok::l_brace:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_brace);
     if (auto RBrace = consumeTokenSyntaxIf(tok::r_brace))
-      Skipped.push_back(*RBrace);
+      Skipped.push_back(std::move(*RBrace));
     break;
   case tok::l_square:
     Skipped.push_back(consumeTokenSyntax());
     skipUntilSyntax(Skipped, tok::r_square);
     if (auto RSquare = consumeTokenSyntaxIf(tok::r_square))
-      Skipped.push_back(*RSquare);
+      Skipped.push_back(std::move(*RSquare));
     break;
   case tok::pound_if:
   case tok::pound_else:
@@ -708,7 +708,7 @@ void Parser::skipSingleSyntax(SmallVectorImpl<ParsedSyntax> &Skipped) {
     if (Tok.isAny(tok::pound_else, tok::pound_elseif))
       skipSingleSyntax(Skipped);
     else if (auto Endif = consumeTokenSyntaxIf(tok::pound_endif))
-      Skipped.push_back(*Endif);
+      Skipped.push_back(std::move(*Endif));
     break;
 
   default:
@@ -1003,11 +1003,12 @@ void Parser::skipListUntilDeclRBraceSyntax(
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif)) {
     auto Comma = consumeTokenSyntaxIf(tok::comma);
-    if (Comma)
-      Skipped.push_back(*Comma);
-    
+
     bool hasDelimiter = Tok.getLoc() == startLoc || Comma;
     bool possibleDeclStartsLine = Tok.isAtStartOfLine();
+
+    if (Comma)
+      Skipped.push_back(std::move(*Comma));
 
     if (isStartOfDecl()) {
       // Could have encountered something like `_ var:` 
@@ -1020,7 +1021,7 @@ void Parser::skipListUntilDeclRBraceSyntax(
         Parser::BacktrackingScope backtrack(*this);
         // Consume the let or var
         auto LetOrVar = consumeTokenSyntax();
-        Skipped.push_back(LetOrVar);
+        Skipped.push_back(std::move(LetOrVar));
         
         // If the following token is either <identifier> or :, it means that
         // this `var` or `let` should be interpreted as a label
@@ -1338,7 +1339,7 @@ Parser::parseListSyntax(tok RightK, SourceLoc LeftLoc,
       diagnose(Tok, diag::unexpected_separator, ",")
           .fixItRemove(SourceRange(Tok.getLoc()));
       auto Comma = consumeTokenSyntax();
-      Junk.push_back(Comma);
+      Junk.push_back(std::move(Comma));
     }
     SourceLoc StartLoc = Tok.getLoc();
 

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -163,8 +163,9 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
   return Curr;
 }
 
-ParsedTokenSyntax &&SyntaxParsingContext::popToken() {
-  return std::move(popIf<ParsedTokenSyntax>().getValue());
+ParsedTokenSyntax SyntaxParsingContext::popToken() {
+  auto tok = popIf<ParsedTokenSyntax>();
+  return std::move(tok.getValue());
 }
 
 /// Add Token with Trivia to the parts.

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -54,13 +54,14 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  getStorage().push_back(foundNode);
-  return foundNode.getRecordedRange().getByteLength();
+  auto length = foundNode.getRecordedRange().getByteLength();
+  getStorage().push_back(std::move(foundNode));
+  return length;
 }
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
-                                        ArrayRef<ParsedRawSyntaxNode> Parts) {
+                                        MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   assert(isUnknownKind(Kind));
   if (shouldDefer())
     return ParsedRawSyntaxNode::makeDeferred(Kind, Parts, *this);
@@ -70,12 +71,12 @@ SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
 
 ParsedRawSyntaxNode
 SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
-                                     ArrayRef<ParsedRawSyntaxNode> Parts,
+                                     MutableArrayRef<ParsedRawSyntaxNode> Parts,
                                      SyntaxNodeCreationKind nodeCreateK) {
   // Try to create the node of the given syntax.
   ParsedRawSyntaxNode rawNode;
   auto &rec = getRecorder();
-  auto formNode = [&](SyntaxKind kind, ArrayRef<ParsedRawSyntaxNode> layout) {
+  auto formNode = [&](SyntaxKind kind, MutableArrayRef<ParsedRawSyntaxNode> layout) {
     if (nodeCreateK == SyntaxNodeCreationKind::Deferred || shouldDefer()) {
       rawNode = ParsedRawSyntaxNode::makeDeferred(kind, layout, *this);
     } else {
@@ -91,9 +92,9 @@ SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
 
 Optional<ParsedRawSyntaxNode>
 SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
-                               ArrayRef<ParsedRawSyntaxNode> Parts) {
+                               MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   if (Parts.size() == 1) {
-    auto RawNode = Parts.front();
+    auto &RawNode = Parts.front();
     SyntaxKind RawNodeKind = RawNode.getKind();
     switch (Kind) {
     case SyntaxContextKind::Stmt:
@@ -120,7 +121,7 @@ SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
       // We don't need to coerce in this case.
       break;
     }
-    return RawNode;
+    return std::move(RawNode);
   } else if (Parts.empty()) {
     // Just omit the unknown node if it does not have any children
     return None;
@@ -162,8 +163,8 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
   return Curr;
 }
 
-ParsedTokenSyntax SyntaxParsingContext::popToken() {
-  return popIf<ParsedTokenSyntax>().getValue();
+ParsedTokenSyntax &&SyntaxParsingContext::popToken() {
+  return std::move(popIf<ParsedTokenSyntax>().getValue());
 }
 
 /// Add Token with Trivia to the parts.
@@ -181,7 +182,7 @@ void SyntaxParsingContext::addToken(Token &Tok,
 
 /// Add Syntax to the parts.
 void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
-  addRawSyntax(Node.getRaw());
+  addRawSyntax(Node.takeRaw());
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
@@ -192,12 +193,10 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind, size_t N,
     return;
   }
 
-  auto I = getStorage().end() - N;
-  *I = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
-
-  // Remove consumed parts.
-  if (N != 1)
-    getStorage().erase(I + 1, getStorage().end());
+  auto node = createSyntaxAs(Kind, getParts().take_back(N), nodeCreateK);
+  auto &storage = getStorage();
+  getStorage().erase(storage.end() - N, getStorage().end());
+  getStorage().emplace_back(std::move(node));
 }
 
 void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
@@ -250,32 +249,24 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
 
 ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
   ParsedRawSyntaxRecorder &Recorder = getRecorder();
-  ArrayRef<ParsedRawSyntaxNode> Parts = getParts();
-  std::vector<ParsedRawSyntaxNode> AllTopLevel;
+  auto Parts = getParts();
+  ParsedRawSyntaxNode Layout[2];
 
   assert(!Parts.empty() && Parts.back().isToken(tok::eof));
-  ParsedRawSyntaxNode EOFToken = Parts.back();
+  Layout[1] = std::move(Parts.back());
   Parts = Parts.drop_back();
 
-  for (auto RawNode : Parts) {
-    if (RawNode.getKind() != SyntaxKind::CodeBlockItem) {
-      // FIXME: Skip toplevel garbage nodes for now. we shouldn't emit them in
-      // the first place.
-      if (RawNode.isRecorded())
-        getSyntaxCreator().finalizeNode(RawNode.getOpaqueNode());
-      continue;
-    }
+  assert(llvm::all_of(Parts, [](const ParsedRawSyntaxNode& node) {
+    return node.getKind() == SyntaxKind::CodeBlockItem;
+  }) && "all top level element must be 'CodeBlockItem'");
 
-    AllTopLevel.push_back(RawNode);
-  }
+  Layout[0] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
 
-  auto itemList = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList,
-                                           Parts);
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
-                                  { itemList, EOFToken });
+                                  llvm::makeMutableArrayRef(Layout, 2));
 }
 
-  OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
+OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
   assert(isTopOfContextStack() && "some sub-contexts are not destructed");
   assert(isRoot() && "only root context can finalize the tree");
   assert(Mode == AccumulationMode::Root);
@@ -283,7 +274,7 @@ ParsedRawSyntaxNode SyntaxParsingContext::finalizeSourceFile() {
     return nullptr; // already finalized.
   }
   ParsedRawSyntaxNode root = finalizeSourceFile();
-  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.getOpaqueNode());
+  auto opaqueRoot = getSyntaxCreator().finalizeNode(root.takeOpaqueNode());
 
   // Clear the parts because we will call this function again when destroying
   // the root context.
@@ -303,9 +294,12 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 
 void SyntaxParsingContext::dumpStorage() const  {
   llvm::errs() << "======================\n";
-  for (auto Node : getStorage()) {
-    Node.dump(llvm::errs());
-    llvm::errs() << "\n--------------\n";
+  auto &storage = getStorage();
+  for (unsigned i = 0; i != storage.size(); ++i) {
+    storage[i].dump(llvm::errs());
+    llvm::errs() << "\n";
+    if (i + 1 == Offset)
+      llvm::errs() << "--------------\n";
   }
 }
 
@@ -337,14 +331,12 @@ SyntaxParsingContext::~SyntaxParsingContext() {
     assert(!isRoot());
     if (Storage.size() == Offset) {
       if (auto BridgedNode = bridgeAs(CtxtKind, {})) {
-        Storage.push_back(BridgedNode.getValue());
+        Storage.push_back(std::move(BridgedNode.getValue()));
       }
     } else {
-      auto I = Storage.begin() + Offset;
-      *I = bridgeAs(CtxtKind, getParts()).getValue();
-      // Remove used parts.
-      if (Storage.size() > Offset + 1)
-        Storage.erase(Storage.begin() + (Offset + 1), Storage.end());
+      auto node(std::move(bridgeAs(CtxtKind, getParts()).getValue()));
+      Storage.erase(Storage.begin() + Offset, Storage.end());
+      Storage.emplace_back(std::move(node));
     }
     break;
   }
@@ -357,10 +349,12 @@ SyntaxParsingContext::~SyntaxParsingContext() {
   // Remove all parts in this context.
   case AccumulationMode::Discard: {
     auto &nodes = getStorage();
-    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i)
+    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i) {
+      // FIXME: This should not be needed. This breaks invariant that any
+      // recorded node must be a part of result souce syntax tree.
       if (i->isRecorded())
-        getSyntaxCreator().finalizeNode(i->getOpaqueNode());
-
+        getRecorder().discardRecordedNode(*i);
+    }
     nodes.erase(nodes.begin()+Offset, nodes.end());
     break;
   }

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -39,7 +39,8 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RC<syntax::RawSyntax> Obj, const llvm::FoldingSetNodeIDRef IDRef)
+  RawSyntaxCacheNode(RC<syntax::RawSyntax> &Obj,
+                     const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -173,3 +173,9 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   raw.resetWithoutRelease();
   return {length, opaqueN};
 }
+
+void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
+  if (!opaqueN)
+    return;
+  static_cast<RawSyntax *>(opaqueN)->Release();
+}

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -17,7 +17,7 @@
                 null,
                 null,
                 {
-                  "id": 1,
+                  "id": 33,
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
@@ -48,7 +48,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 2,
+                  "id": 34,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "x"
@@ -64,11 +64,11 @@
                 },
                 null,
                 {
-                  "id": 34,
+                  "id": 32,
                   "kind": "TypeInitializerClause",
                   "layout": [
                     {
-                      "id": 3,
+                      "id": 1,
                       "tokenKind": {
                         "kind": "equal"
                       },
@@ -82,11 +82,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 33,
+                      "id": 31,
                       "kind": "TupleType",
                       "layout": [
                         {
-                          "id": 20,
+                          "id": 18,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -95,16 +95,16 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 31,
+                          "id": 29,
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
-                              "id": 26,
+                              "id": 24,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 21,
+                                  "id": 19,
                                   "tokenKind": {
                                     "kind": "identifier",
                                     "text": "b"
@@ -115,7 +115,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 22,
+                                  "id": 20,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -129,11 +129,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 24,
+                                  "id": 22,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 23,
+                                      "id": 21,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "Int"
@@ -149,7 +149,7 @@
                                 null,
                                 null,
                                 {
-                                  "id": 25,
+                                  "id": 23,
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
@@ -166,12 +166,12 @@
                               "presence": "Present"
                             },
                             {
-                              "id": 30,
+                              "id": 28,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 27,
+                                  "id": 25,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -181,7 +181,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 22,
+                                  "id": 20,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -195,11 +195,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 29,
+                                  "id": 27,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 28,
+                                      "id": 26,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "String"
@@ -222,7 +222,7 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 32,
+                          "id": 30,
                           "tokenKind": {
                             "kind": "r_paren"
                           },

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -190,6 +190,10 @@ public:
     return getNodeHandler()(&node);
   }
 
+  void discardRecordedNode(OpaqueSyntaxNode node) override {
+    // FIXME: This method should not be called at all.
+  }
+
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, SyntaxKind kind) override {
     auto NodeLookup = getNodeLookup();


### PR DESCRIPTION
Revert #27203 with a fix.

Locally confirmed this successfully compiles stdlib with asan+ubsan in both debug and release build.

rdar://problem/55421369