### PR TITLE
Reduce toolchain size by preserving TensorFlow library symlinks.

### DIFF
--- a/stdlib/public/CTensorFlow/CMakeLists.txt
+++ b/stdlib/public/CTensorFlow/CMakeLists.txt
@@ -98,17 +98,6 @@ foreach(sdk ${TARGET_SDKS})
       COMPONENT stdlib
       )
   endforeach()
-
-  # Install TensorFlow libraries in each SDK subdirectory.
-  # FIXME: Currently, this installs the same version of TensorFlow libraries
-  # everywhere.
-  # To properly support multiple targets, TF library/include variables should be
-  # SDK/architecture-specific, just like the ones for ICU.
-  swift_install_in_component(
-    FILES "${TF_LIBRARIES}"
-    DESTINATION "lib/swift/${SWIFT_SDK_${sdk}_LIB_SUBDIR}"
-    COMPONENT stdlib
-    )
 endforeach()
 add_custom_target(ctensorflow_modulemap DEPENDS ${ctensorflow_modulemap_target_list})
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2583,15 +2583,18 @@ for host in "${ALL_HOSTS[@]}"; do
                     TF_LIB_DIR="${SWIFT_LIB_PATH}/swift/${SWIFT_HOST_VARIANT}"
                     call mkdir -p "${TF_LIB_DIR}"
 
-                    # Bazel-built libraries do not have write permission, which is
-                    # problematic for overwriting/stripping symbols. Thus, write
-                    # permission is added here.
                     for lib_name in tensorflow; do
-                        lib=".*lib${lib_name}.so[0-9.]*"
-                        dylib=".*lib${lib_name}[0-9.]*.dylib"
-                        find "${TF_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec rm -f {} \;
-                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec chmod +w {} +
-                        find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -p {} "${TF_LIB_DIR}" \;
+                        lib_full_name="lib${lib_name}.so"
+                        # Wipe existing TensorFlow libraries in the destination
+                        # directory. This ensures that old versions of libraries
+                        # are not copied, taking up unnecessary space.
+                        call rm -rf "${TF_LIB_DIR}/${lib_full_name}"*
+                        # Copy TensorFlow libraries, preserving symlinks.
+                        call find "${TENSORFLOW_HOST_LIB_DIR}" \( -regex ".*${lib_full_name}[0-9.]*" \) -exec cp -a -v {} "${TF_LIB_DIR}" \;
+                        # Bazel-built libraries do not have write permission, which is
+                        # problematic for overwriting/stripping symbols. Thus, write
+                        # permission is added here.
+                        call chmod +w "${TF_LIB_DIR}/${lib_full_name}"*
                     done
 
                     cmake_options=(
@@ -4008,15 +4011,17 @@ for host in "${ALL_HOSTS[@]}"; do
                     exit 1
                 fi
                 echo "--- Installing ${product} ---"
-                TF_BUILD_DIR="$(build_directory ${host} ${product})"
-                TF_LIBDIR="$(build_directory ${host} swift)/lib/swift/${SWIFT_HOST_VARIANT}"
+                TF_LIB_DIR="$(build_directory ${host} swift)/lib/swift/${SWIFT_HOST_VARIANT}"
                 TF_DEST_DIR="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})lib/swift/${SWIFT_HOST_VARIANT}"
                 mkdir -p "${TF_DEST_DIR}"
                 for lib_name in tensorflow; do
-                    lib=".*lib${lib_name}.so[0-9.]*"
-                    dylib=".*lib${lib_name}[0-9.]*.dylib"
-                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec echo "{} => ${TF_DEST_DIR}" \;
-                    find "${TF_LIBDIR}" \( -regex "${lib}" -o -regex "${dylib}" \) -exec cp -a {} "${TF_DEST_DIR}" \;
+                    lib_full_name="lib${lib_name}.so"
+                    # Wipe existing TensorFlow libraries in the destination
+                    # directory. This ensures that old versions of libraries
+                    # are not copied, taking up unnecessary space.
+                    call rm -rf "${TF_DEST_DIR}/${lib_full_name}"*
+                    # Copy TensorFlow libraries, preserving symlinks.
+                    call find "${TF_LIB_DIR}" \( -regex ".*${lib_full_name}[0-9.]*" \) -exec cp -a -v {} "${TF_DEST_DIR}" \;
                 done
                 continue
                 ;;


### PR DESCRIPTION
Bazel produces multiple TensorFlow library artifacts:
```console
$ ls -alh tensorflow/bazel-bin/tensorflow
 18B libtensorflow.so -> libtensorflow.so.1
 23B libtensorflow.so.1 -> libtensorflow.so.1.14.0
277M libtensorflow.so.1.14.0
```

Previously, TensorFlow libraries were copied via `cp -p`.
This did not preserve symlinks, leading to library duplication:
```console
$ ls -alh <TOOLCHAIN_BEFORE>.xctoolchain/usr/lib/swift/macosx
 18B libtensorflow.so -> libtensorflow.so.1
277M libtensorflow.so.1
277M libtensorflow.so.1.14.0 # duplicate library
```

Now, `cp -a` is used, which preserves symlinks:
```console
$ ls -alh <TOOLCHAIN_AFTER>.xctoolchain/usr/lib/swift/macosx
 18B libtensorflow.so -> libtensorflow.so.1
277M libtensorflow.so.1
```

This combined with removing libtensorflow_framework.so dependency (https://github.com/apple/swift/pull/27029) led to a macOS toolchain size reduction from 3.99 GB to 3.62 GB on the `tensorflow-0.5` branch.

---

Before (larger):
<img width="732" alt="Screen Shot 2019-09-18 at 3 01 10 AM" src="https://user-images.githubusercontent.com/5590046/65138908-99df3080-d9c0-11e9-8430-0f14cf1b7f61.png">
After (smaller):
<img width="737" alt="Screen Shot 2019-09-18 at 3 01 17 AM" src="https://user-images.githubusercontent.com/5590046/65138915-9c418a80-d9c0-11e9-9dba-b61afcee590d.png">

---

Fixed version of https://github.com/apple/swift/pull/27032.
* The toolchain size reduction cause has been identified correctly.
* `build-toolchain-tensorflow` and `swift test` for [tensorflow/swift-apis](https://github.com/tensorflow/swift-apis) have been tested on both macOS and Ubuntu. https://github.com/apple/swift/pull/27032 caused a `swift test` linker error on Ubuntu.

---

Please see https://groups.google.com/a/tensorflow.org/d/msg/swift/aw1wFSp9i7M/SrFH2Lq2AQAJ for discussion and future steps.

Todos:
* Fix library duplication issue for LLDB. LLDB also stores a copy of TensorFlow libraries, which is suboptimal.
```
$ ls -alh <TOOLCHAIN_AFTER>.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/Swift/macosx
277M libtensorflow.so
277M libtensorflow.so.1
277M libtensorflow.so.1.14.0
```
* @ematejska found that significant toolchain size increase is from upstream by measuring the size difference between latest 5.1/trunk development toolchains: [SR-11486](https://bugs.swift.org/browse/SR-11486). Investigate if this was intentional.