### PR TITLE
[5.1] [PropertyWrappers] Fix a bug with property type being overwritten with wrong type

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2632,7 +2632,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
                           emptyLocator);
         return propertyType;
       }
-      
+
       // Otherwise, compute the wrapped value type directly.
       return computeWrappedValueType(wrappedVar, initType);
     }
@@ -2654,10 +2654,10 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         // is the initialization of the property wrapper instance.
         initType = cs.getType(expr);
 
-        // Add a conversion constraint between the pattern type and the
+        // Add an equal constraint between the pattern type and the
         // property wrapper's "value" type.
-        cs.addConstraint(ConstraintKind::Conversion, patternType,
-                         getPatternInitType(&cs), Locator, /*isFavored*/true);
+        cs.addConstraint(ConstraintKind::Equal, patternType,
+                         getPatternInitType(&cs), Locator, /*isFavored*/ true);
       } else {
         // The initializer type is the type of the pattern.
         initType = patternType;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1131,3 +1131,17 @@ struct UseNonMutatingProjectedValueSet {
     x = 42  // expected-error{{cannot assign to property: 'self' is immutable}}
   }
 }
+
+// SR-11381
+
+@propertyWrapper
+struct SR_11381_W<T> {
+  init(wrappedValue: T) {}
+  var wrappedValue: T {
+    fatalError()
+  }
+}
+
+struct SR_11381_S {
+  @SR_11381_W var foo: Int = nil // expected-error {{'nil' is not compatible with expected argument type 'Int'}}
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1143,5 +1143,5 @@ struct SR_11381_W<T> {
 }
 
 struct SR_11381_S {
-  @SR_11381_W var foo: Int = nil // expected-error {{'nil' is not compatible with expected argument type 'Int'}}
+  @SR_11381_W var foo: Int = nil // expected-error {{'nil' requires a contextual type}}
 }


### PR DESCRIPTION
Cherry pick of #27226.

**Explanation**: 

In some cases, we were incorrectly setting the type of the property wrapper's value. For example:

```swift
@propertyWrapper
struct Foo<T> {
  init(wrappedValue: T) {}
  var wrappedValue: T {
    fatalError()
  }
}

struct Bar {
  @Foo var property: Int = nil // we are overwriting the type of 'property' to 'Int?'
}
```

**Scope**: Property wrappers

**Issue**: [SR-10900](https://bugs.swift.org/browse/SR-10900), [SR-11381](https://bugs.swift.org/browse/SR-11381) & [SR-11443](https://bugs.swift.org/browse/SR-11443) | rdar://problem/55229986

**Testing**: Swift CI

**Risk**: Low. We were incorrectly rewriting the type of a property when the types didn't match, instead of rejecting it.

**Reviewed by**: @DougGregor
