### PR TITLE
[SILOptimizer] Alter FSO arg explosion heuristic.

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -22,11 +22,12 @@
 #ifndef SWIFT_SIL_PROJECTION_H
 #define SWIFT_SIL_PROJECTION_H
 
+#include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/PointerIntEnum.h"
-#include "swift/AST/TypeAlignments.h"
-#include "swift/SIL/SILValue.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "llvm/ADT/Hashing.h"
@@ -751,17 +752,17 @@ public:
   ~ProjectionTreeNode() = default;
   ProjectionTreeNode(const ProjectionTreeNode &) = default;
 
-  llvm::ArrayRef<unsigned> getChildProjections() {
-     return llvm::makeArrayRef(ChildProjections);
+  bool isLeaf() const { return ChildProjections.empty(); }
+
+  ArrayRef<unsigned> getChildProjections() const {
+    return llvm::makeArrayRef(ChildProjections);
   }
 
-  llvm::Optional<Projection> &getProjection() { return Proj; }
+  Optional<Projection> &getProjection() { return Proj; }
 
   const ArrayRef<Operand *> getNonProjUsers() const {
     return llvm::makeArrayRef(NonProjUsers);
   }
-
-  bool isLeaf() const { return ChildProjections.empty(); }
 
   SILType getType() const { return NodeType; }
 

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -757,9 +757,9 @@ public:
 
   llvm::Optional<Projection> &getProjection() { return Proj; }
 
-  llvm::SmallVector<Operand *, 4> getNonProjUsers() const {
-    return NonProjUsers;
-  };
+  const ArrayRef<Operand *> getNonProjUsers() const {
+    return llvm::makeArrayRef(NonProjUsers);
+  }
 
   bool isLeaf() const { return ChildProjections.empty(); }
 
@@ -960,7 +960,9 @@ public:
   void
   replaceValueUsesWithLeafUses(SILBuilder &B, SILLocation Loc,
                                llvm::SmallVectorImpl<SILValue> &Leafs);
- 
+
+  void getUsers(SmallPtrSetImpl<SILInstruction *> &users) const;
+
 private:
   void createRoot(SILType BaseTy) {
     assert(ProjectionTreeNodes.empty() &&

--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -332,6 +332,17 @@ public:
     return completeList.getValue();
   }
 
+  Optional<ArrayRef<SILInstruction *>>
+  getPartiallyPostDomReleaseSet(SILArgument *arg) const {
+    auto iter = ArgInstMap.find(arg);
+    if (iter == ArgInstMap.end())
+      return None;
+    auto partialList = iter->second.getPartiallyPostDomReleases();
+    if (!partialList)
+      return None;
+    return partialList;
+  }
+
   ArrayRef<SILInstruction *> getReleasesForArgument(SILValue value) const {
     auto *arg = dyn_cast<SILArgument>(value);
     if (!arg)

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -278,6 +278,10 @@ class CallerAnalysis::FunctionInfo {
   /// visibility of a protocol conformance or class.
   bool mayHaveIndirectCallers : 1;
 
+  /// Whether the function is sufficiently visible to be called by a different
+  /// module.
+  bool mayHaveExternalCallers : 1;
+
 public:
   FunctionInfo(SILFunction *f);
 
@@ -289,7 +293,8 @@ public:
   /// function (e.g. a specialized function) without needing to introduce a
   /// thunk since we can rewrite all of the callers to call the new function.
   bool foundAllCallers() const {
-    return hasOnlyCompleteDirectCallerSets() && !mayHaveIndirectCallers;
+    return hasOnlyCompleteDirectCallerSets() && !mayHaveIndirectCallers &&
+           !mayHaveExternalCallers;
   }
 
   /// Returns true if this function has at least one direct caller.

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -1514,3 +1514,11 @@ replaceValueUsesWithLeafUses(SILBuilder &Builder, SILLocation Loc,
     NewNodes.clear();
   }
 }
+
+void ProjectionTree::getUsers(SmallPtrSetImpl<SILInstruction *> &users) const {
+  for (auto *node : ProjectionTreeNodes) {
+    for (auto *op : node->getNonProjUsers()) {
+      users.insert(op->getUser());
+    }
+  }
+}

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -33,7 +33,9 @@ CallerAnalysis::FunctionInfo::FunctionInfo(SILFunction *f)
       // TODO: Make this more aggressive by considering
       // final/visibility/etc.
       mayHaveIndirectCallers(f->getDynamicallyReplacedFunction() ||
-                             canBeCalledIndirectly(f->getRepresentation())) {}
+                             canBeCalledIndirectly(f->getRepresentation())),
+      mayHaveExternalCallers(f->isPossiblyUsedExternally() ||
+                             f->isAvailableExternally()) {}
 
 //===----------------------------------------------------------------------===//
 //                   CallerAnalysis::ApplySiteFinderVisitor

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ArgumentExplosionTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ArgumentExplosionTransform.cpp
@@ -9,6 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains an implementation of the partial dead argument
+/// elimination optimization. We do this to attempt to remove non-trivial
+/// arguments of callees to eliminate lifetime constraints of a large argument
+/// on values in the caller.
+///
+//===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "fso-argument-explosion-transform"
 #include "FunctionSignatureOpts.h"
@@ -25,43 +34,282 @@ static llvm::cl::opt<bool> FSODisableArgExplosion(
 //                                  Utility
 //===----------------------------------------------------------------------===//
 
+/// Whether the known-to-date upper bound on the live leaf count is high enough
+/// so that argument explosion is possible.
+static bool
+mayExplodeGivenLiveLeafCountUpperBound(unsigned knownLiveLeafCountUpperBound) {
+  return knownLiveLeafCountUpperBound > 0;
+}
+
+static unsigned maxExplosionSizeWhenSpecializationWillIntroduceThunk(
+    bool willSpecializationIntroduceThunk) {
+  // 3 is the heuristic max explosion size for a single argument when the
+  // specializing the function will introduce a thunk.  If specializing the
+  // function may not introduce a thunk, then we rely on the maximum size
+  // imposed by shouldExpand.
+  return willSpecializationIntroduceThunk ? 3 : UINT_MAX;
+}
+
+static bool shouldExplode(unsigned knownLiveLeafCountUpperBound,
+                          bool hasKnownDeadLeaves,
+                          bool hasKnownDeadNontrivialLeaves,
+                          bool willSpecializationIntroduceThunk) {
+  unsigned maxExplosionSize =
+      maxExplosionSizeWhenSpecializationWillIntroduceThunk(
+          /*willSpecializationIntroduceThunk=*/
+          willSpecializationIntroduceThunk);
+  bool isLiveLeafCountInExplodableRange =
+      mayExplodeGivenLiveLeafCountUpperBound(knownLiveLeafCountUpperBound) &&
+      (knownLiveLeafCountUpperBound <= maxExplosionSize);
+  bool hasKnownDeadRelevantLeaves = willSpecializationIntroduceThunk
+                                        ? hasKnownDeadNontrivialLeaves
+                                        : hasKnownDeadLeaves;
+  return isLiveLeafCountInExplodableRange && hasKnownDeadRelevantLeaves;
+}
+
 /// Return true if it's both legal and a good idea to explode this argument.
-static bool shouldExplode(ArgumentDescriptor &argDesc,
-                          ConsumedArgToEpilogueReleaseMatcher &ERM) {
-  // We cannot optimize the argument.
-  if (!argDesc.canOptimizeLiveArg())
-    return false;
-
-  // See if the projection tree consists of potentially multiple levels of
-  // structs containing one field. In such a case, there is no point in
-  // exploding the argument.
+///
+/// Our main interest here is to expose more opportunities for ARC. This means
+/// that we are not interested in exploding (and partially DCEing) structs in
+/// the following cases:
+///
+/// 1. Completely dead arguments. This is handled by dead argument elimination.
+///
+/// 2. Structs with many live leaf nodes. Our heuristic is to explode if there
+///    are only 1-3 live leaf nodes for specializations and 1-6 live leaf nodes
+///    (in fact, the number specified in shouldExpand). Otherwise again we run
+///    into register pressure/spilling issues.
+///    TODO: Improve the 1-3 heuristic by having FSO consider the total
+///          resultant argument count.  Currently, there is no consideration of
+///          that, meaning we could end up with argument exploding even in the
+///          case of long argument lists where it isn't beneficial.
+///
+/// Perform argument exploding if one of the following sets of conditions hold:
+///
+/// 1. a. The live leaf count is less than or equal to 3.
+///    b. There is a dead non-trivial leaf.
+/// 2. a. The live leaf count is less than or equal to 6.
+///    b. There is a dead trivial leaf.
+///    c. Specializing the function will not result in a thunk.
+static bool
+shouldExplode(FunctionSignatureTransformDescriptor &transformDesc,
+              ArgumentDescriptor &argDesc,
+              ConsumedArgToEpilogueReleaseMatcher &epilogueReleaseMatcher) {
+  // The method is structured as follows:
   //
-  // Also, in case of a type can not be exploded, e.g an enum, we treat it
-  // as a singleton.
-  if (argDesc.ProjTree.isSingleton())
-    return false;
+  // First, do some basic checks and exit early.
+  // Then in three steps of increasing complexity, calculate data which could
+  // permit the heuristic to decide to explode the argument.  These steps
+  // provide information of increasing expense and fidelity.  Checking whether
+  // the heuristic allows explosion after each step unnecessary work to be
+  // avoided.
+  //
+  // In a bit more detail:
+  //
+  // 1) Do some basic checks and exit early, returning false.
+  //    - that we can optimize the argument at all
+  //    - that the argument has more than a single leaf node
+  //    - that the module permits the type to be expanded
+  // 2) Gather some basic leaf counts.
+  //    - calculate the unmodified (unmodified that is by the results of the
+  //      owned-to-guaranteed transformation) live leaf count
+  //    - calculate the total list of leaf types to obtain the total leaf count
+  // 3) Check whether the heuristic allows the argument to be exploded using
+  //    only potentially-trivial leaf counts.  At this point it is certainly not
+  //    known that there are dead non-trivial leaves, so exiting early here
+  //    is only possible if specializing the function will not result in a
+  //    thunk.
+  // 4) Gather the counts of non-trivial leaves.
+  //    - calculate the count of total non-trivial leaves by filtering the total
+  //      list of leaf types from step 2) according to whether leaf is trivial
+  //    - calculate an upper bound (upper bound because it doesn't consider the
+  //      results of the owned-to-guaranteed transformation) on the count of
+  //      live non-trivial leaves
+  // 5) Check whether the heuristic allows the argument to be exploded using the
+  //    upper bound on live non-trivial leaves.
+  // 6) Dial in the upper bounds calculated in steps 2) and 4) by compensating
+  //    for the effects of the owned-to-guaranteed transformation.
+  // 7) Check whether the heuristic allows the argument to be exploded using the
+  //    actual count of live leaves, both trivial and non-trivial.
 
-  auto *arg = argDesc.Arg;
-  if (!shouldExpand(arg->getModule(), arg->getType().getObjectType())) {
+  // No passes can optimize this argument, so just bail.
+  if (!argDesc.canOptimizeLiveArg()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "The argument is of a type that cannot be exploded.");
     return false;
   }
 
-  // If this argument is @owned and we can not find all the releases for it
-  // try to explode it, maybe we can find some of the releases and O2G some
-  // of its components.
+  // If the argument is a singleton, it will not be exploded.
   //
-  // This is a potentially a very profitable optimization. Ignore other
-  // heuristics.
-  if (arg->hasConvention(SILArgumentConvention::Direct_Owned) &&
-      ERM.hasSomeReleasesForArgument(arg))
-    return true;
+  // Explosion makes sense only if some but not all of the leaves are live.
+  //
+  // Note that ProjectionTree::isSingleton returns true for enums since they are
+  // sums and not products and so only have a single top-level node.
+  if (argDesc.ProjTree.isSingleton()) {
+    LLVM_DEBUG(llvm::dbgs() << "The argument's type is a singleton.");
+    return false;
+  }
 
-  unsigned explosionSize = argDesc.ProjTree.getLiveLeafCount();
-  return explosionSize >= 1 && explosionSize <= 3;
+  auto *argument = argDesc.Arg;
+  auto &module = argument->getModule();
+  auto type = argument->getType().getObjectType();
+
+  // If the global type expansion heuristic does not allow the type to be
+  // expanded, it will not be exploded.
+  if (!shouldExpand(module, type)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "The argument is of a type which should not be expanded.");
+    return false;
+  }
+
+  bool willSpecializationIntroduceThunk =
+      transformDesc.willSpecializationIntroduceThunk();
+
+  unsigned const liveLeafCountUpperBound = argDesc.ProjTree.getLiveLeafCount();
+
+  // If we know already that we may not explode given the upper bound we have
+  // established on the live leaf count, exit early.
+  //
+  // If the argument is completely dead, it will not be exploded.
+  //
+  // Explosion makes sense only if some but not all of the leaves are live.  The
+  // dead argument transformation will try to eliminate the argument.
+  if (!mayExplodeGivenLiveLeafCountUpperBound(liveLeafCountUpperBound)) {
+    LLVM_DEBUG(llvm::dbgs() << "The argument has no live leaves.");
+    return false;
+  }
+
+  // To determine whether some but not all of the leaves are used, the total
+  // leaf count must be retrieved.
+  llvm::SmallVector<SILType, 32> allLeaves;
+  argDesc.ProjTree.getAllLeafTypes(allLeaves);
+  unsigned const leafCount = allLeaves.size();
+
+  assert(
+      liveLeafCountUpperBound <= leafCount &&
+      "There should be no more *live* leaves than there are *total* leaves.");
+
+  if (shouldExplode(
+          /*knownLifeLeafCount=*/liveLeafCountUpperBound,
+          /*hasKnownDeadLeaves=*/liveLeafCountUpperBound < leafCount,
+          /*hasKnownDeadNontrivialLeaves=*/false,
+          /*willSpecializationIntroduceThunk=*/
+          willSpecializationIntroduceThunk)) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "Without considering the liveness of non-trivial leaves, it has "
+           "already been determined that there are already fewer ("
+        << liveLeafCountUpperBound
+        << ") live leaves of the relevant sort (trivial) than total leaves ("
+        << leafCount << ") and no more total live leaves ("
+        << liveLeafCountUpperBound << ") than the heuristic permits ("
+        << maxExplosionSizeWhenSpecializationWillIntroduceThunk(
+               /*willSpecializationIntroduceThunk=*/
+               willSpecializationIntroduceThunk)
+        << ").  Exploding.");
+    return true;
+  }
+
+  auto *function = argument->getFunction();
+  unsigned const nontrivialLeafCount = llvm::count_if(
+      allLeaves, [&](SILType type) { return !type.isTrivial(*function); });
+
+  llvm::SmallVector<const ProjectionTreeNode *, 32> liveLeaves;
+  argDesc.ProjTree.getLiveLeafNodes(liveLeaves);
+  // NOTE: The value obtained here is an upper bound because the
+  //       owned-to-guaranteed transformation may eliminate some live
+  //       non-trivial leaves, leaving the count lower.
+  unsigned const liveNontrivialLeafCountUpperBound =
+      llvm::count_if(liveLeaves, [&](const ProjectionTreeNode *leaf) {
+        return !leaf->getType().isTrivial(*function);
+      });
+
+  assert(liveNontrivialLeafCountUpperBound <= nontrivialLeafCount &&
+         "There should be no more *live* non-trivial leaves than there are "
+         "*total* non-trivial leaves.");
+  assert(nontrivialLeafCount <= leafCount &&
+         "There should be no more *non-trivial* leaves than there are *total* "
+         "leaves.");
+
+  // If it is known without taking the owned-to-guaranteed transformation into
+  // account both that exploding will reduce ARC traffic (because an upper bound
+  // for the number of live non-trivial leaves is less than the non-trivial
+  // leaf count) and also that the explosion will fit within the heuristic upper
+  // bound (because an upper bound for the total live leaf count falls within
+  // the limit imposed by the heuristic), then explode now.
+  bool shouldExplodeGivenUpperBounds = shouldExplode(
+      /*knownLiveLeafCount=*/liveLeafCountUpperBound,
+      /*hasKnownDeadLeaves=*/liveLeafCountUpperBound < leafCount,
+      /*hasKnownDeadNontrivialLeaves=*/liveNontrivialLeafCountUpperBound <
+          nontrivialLeafCount,
+      /*willSpecializationIntroduceThunk=*/willSpecializationIntroduceThunk);
+  if (shouldExplodeGivenUpperBounds) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "Without considering the expected results of the "
+           "owned-to-guaranteed transformation, there are already fewer ("
+        << liveNontrivialLeafCountUpperBound
+        << ") live non-trivial leaves than total leaves ("
+        << nontrivialLeafCount << ") and no more total live leaves ("
+        << liveLeafCountUpperBound << ") than the heuristic permits ("
+        << maxExplosionSizeWhenSpecializationWillIntroduceThunk(
+               /*willSpecializationIntroduceThunk=*/
+               willSpecializationIntroduceThunk)
+        << ").  Exploding.");
+    return true;
+  }
+
+  unsigned liveLeafCount = liveLeafCountUpperBound;
+  unsigned liveNontrivialLeafCount = liveNontrivialLeafCountUpperBound;
+
+  // The upper bounds that have been established for the live leaf counts are
+  // too high to permit us to explode.  That could be because it hasn't been
+  // established that any leaves are dead or alternatively that it hasn't been
+  // established that there are fewer total live leaves than the limit imposed
+  // by the heuristic.  In either case, if some live leaves are eliminated, the
+  // number of live leaves may decrease such that exploding will be possible.
+  // The results of the owned-to-guaranteed transformation are predicated.  If
+  // it is predicted that a leaf will be dead after the owned-to-guaranteed
+  // transformation, then the leaf count is decreased.
+  //
+  // The owned-to-guaranteed will only be applied to the argumehnt if its
+  // convention is Direct_Owned.  Additionally, it only applies to non-trivial
+  // leaves, which it may kill, so if it is already known that there are no live
+  // non-trivial leaves, owned-to-guaranteed will not eliminate anything.
+  if (argDesc.hasConvention(SILArgumentConvention::Direct_Owned) &&
+      liveNontrivialLeafCountUpperBound > 0) {
+    if (auto maybeReleases =
+            epilogueReleaseMatcher.getPartiallyPostDomReleaseSet(argument)) {
+      auto releases = maybeReleases.getValue();
+      llvm::SmallPtrSet<SILInstruction *, 8> users;
+      users.insert(std::begin(releases), std::end(releases));
+
+      for (auto *leaf : liveLeaves) {
+        if (llvm::all_of(leaf->getNonProjUsers(), [&](Operand *operand) {
+              return users.count(operand->getUser());
+            })) {
+          // Every non-projection user of the leaf is an epilogue release.  The
+          // owned-to-guaranteed transformation will eliminate this usage.  With
+          // the expectation of that usage being eliminated, stop considering
+          // this leaf to be live for the purposes of deciding whether the
+          // argument should be exploded.
+          --liveLeafCount;
+          --liveNontrivialLeafCount;
+        }
+      }
+    }
+  }
+
+  return shouldExplode(
+      /*knownLifeLeafCount=*/liveLeafCount,
+      /*hasKnownDeadLeaves=*/liveLeafCount < leafCount,
+      /*hasKnownDeadNontrivialLeaves=*/liveNontrivialLeafCount <
+          nontrivialLeafCount,
+      /*willSpecializationIntroduceThunk=*/willSpecializationIntroduceThunk);
 }
 
 //===----------------------------------------------------------------------===//
-//                               Implementation
+//                          Top Level Implementation
 //===----------------------------------------------------------------------===//
 
 bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
@@ -95,7 +343,7 @@ bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
       continue;
 
     A.ProjTree.computeUsesAndLiveness(A.Arg);
-    A.Explode = shouldExplode(A, ArgToReturnReleaseMap);
+    A.Explode = shouldExplode(TransformDescriptor, A, ArgToReturnReleaseMap);
 
     // Modified self argument.
     if (A.Explode && Args[i]->isSelf()) {

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -70,6 +70,12 @@ static llvm::cl::opt<bool>
                       llvm::cl::desc("Support function signature optimization "
                                      "of generic functions"));
 
+static llvm::cl::opt<bool>
+    FSOOptimizeIfNotCalled("sil-fso-optimize-if-not-called",
+                           llvm::cl::init(false),
+                           llvm::cl::desc("Optimize even if a function isn't "
+                                          "called. For testing only!"));
+
 static bool isSpecializableRepresentation(SILFunctionTypeRepresentation Rep,
                                           bool OptForPartialApply) {
   switch (Rep) {
@@ -631,6 +637,9 @@ bool FunctionSignatureTransform::run(bool hasCaller) {
     LLVM_DEBUG(llvm::dbgs() << "  FSO already performed on this thunk\n");
     return false;
   }
+
+  // If we are asked to assume a caller for testing purposes, set the flag.
+  hasCaller |= FSOOptimizeIfNotCalled;
 
   if (!hasCaller && (F->getDynamicallyReplacedFunction() ||
                      canBeCalledIndirectly(F->getRepresentation()))) {

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -65,7 +65,7 @@ using ArgumentIndexMap = llvm::SmallDenseMap<int, int>;
 //===----------------------------------------------------------------------===//
 
 /// Set to true to enable the support for partial specialization.
-llvm::cl::opt<bool>
+static llvm::cl::opt<bool>
     FSOEnableGenerics("sil-fso-enable-generics", llvm::cl::init(true),
                       llvm::cl::desc("Support function signature optimization "
                                      "of generic functions"));

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
@@ -111,9 +111,13 @@ struct ArgumentDescriptor {
     return Arg->hasConvention(P);
   }
 
+  /// Returns true if all function signature opt passes are able to process
+  /// this.
   bool canOptimizeLiveArg() const {
-    if (Arg->getType().isObject())
+    if (Arg->getType().isObject()) {
       return true;
+    }
+
     // @in arguments of generic types can be processed.
     if (Arg->getType().hasArchetype() &&
         Arg->getType().isAddress() &&

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
@@ -198,6 +198,13 @@ struct FunctionSignatureTransformDescriptor {
   /// will use during our optimization.
   MutableArrayRef<ResultDescriptor> ResultDescList;
 
+  /// Are we going to make a change to this function?
+  bool Changed;
+
+  /// Does this function only have direct callers. In such a case we know that
+  /// all thunks we create will be eliminated so we can be more aggressive.
+  bool hasOnlyDirectInModuleCallers;
+
   /// Return a function name based on the current state of ArgumentDescList and
   /// ResultDescList.
   ///
@@ -218,6 +225,19 @@ struct FunctionSignatureTransformDescriptor {
   /// simply passes it through.
   void addThunkArgument(ArgumentDescriptor &AD, SILBuilder &Builder,
                         SILBasicBlock *BB, SmallVectorImpl<SILValue> &NewArgs);
+
+  /// Whether specializing the function will result in a thunk with the same
+  /// signature as the original function that calls through to the specialized
+  /// function.
+  ///
+  /// Such a thunk is necessary if there is (or could be) code that calls the
+  /// function which we are unable to specialize to match the function's
+  /// specialization.
+  bool willSpecializationIntroduceThunk() {
+    return !hasOnlyDirectInModuleCallers ||
+           OriginalFunction->isPossiblyUsedExternally() ||
+          OriginalFunction->isAvailableExternally();
+  }
 };
 
 class FunctionSignatureTransform {
@@ -291,15 +311,17 @@ private:
 public:
   /// Constructor.
   FunctionSignatureTransform(
-      SILOptFunctionBuilder &FunctionBuilder,
-      SILFunction *F, RCIdentityAnalysis *RCIA, EpilogueARCAnalysis *EA,
+      SILOptFunctionBuilder &FunctionBuilder, SILFunction *F,
+      RCIdentityAnalysis *RCIA, EpilogueARCAnalysis *EA,
       Mangle::FunctionSignatureSpecializationMangler &Mangler,
       llvm::SmallDenseMap<int, int> &AIM,
       llvm::SmallVector<ArgumentDescriptor, 4> &ADL,
-      llvm::SmallVector<ResultDescriptor, 4> &RDL)
+      llvm::SmallVector<ResultDescriptor, 4> &RDL,
+      bool hasOnlyDirectInModuleCallers)
       : FunctionBuilder(FunctionBuilder),
-        TransformDescriptor{F, nullptr, AIM, false, ADL, RDL}, RCIA(RCIA),
-        EA(EA) {}
+        TransformDescriptor{F,   nullptr, AIM,   false,
+                            ADL, RDL,     false, hasOnlyDirectInModuleCallers},
+        RCIA(RCIA), EA(EA) {}
 
   /// Return the optimized function.
   SILFunction *getOptimizedFunction() {

--- a/test/SILOptimizer/caller_analysis.sil
+++ b/test/SILOptimizer/caller_analysis.sil
@@ -12,7 +12,7 @@ import Builtin
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil hidden @dead_func : $@convention(thin) () -> () {
+sil private @dead_func : $@convention(thin) () -> () {
   %2 = tuple ()
   return %2 : $()
 }
@@ -25,7 +25,7 @@ sil hidden @dead_func : $@convention(thin) () -> () {
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil hidden @call_top : $@convention(thin) () -> () {
+sil private @call_top : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @call_middle : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -42,7 +42,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - call_top
 // CHECK-NEXT:  ...
-sil hidden @call_middle : $@convention(thin) () -> () {
+sil private @call_middle : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @call_bottom : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -59,7 +59,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - call_middle
 // CHECK-NEXT:  ...
-sil hidden @call_bottom : $@convention(thin) () -> () {
+sil private @call_bottom : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
   return %0 : $()
@@ -74,7 +74,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - self_recursive_func
 // CHECK-NEXT:  ...
-sil hidden @self_recursive_func : $@convention(thin) () -> () {
+sil private @self_recursive_func : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @self_recursive_func : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -91,7 +91,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - mutual_recursive_func2
 // CHECK-NEXT:  ...
-sil hidden @mutual_recursive_func1 : $@convention(thin) () -> () {
+sil private @mutual_recursive_func1 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @mutual_recursive_func2 : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -108,7 +108,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - mutual_recursive_func1
 // CHECK-NEXT:  ...
-sil hidden @mutual_recursive_func2 : $@convention(thin) () -> () {
+sil private @mutual_recursive_func2 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @mutual_recursive_func1 : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -125,7 +125,7 @@ bb0:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - multi_calles
 // CHECK-NEXT:  ...
-sil hidden @multi_called : $@convention(thin) () -> () {
+sil private @multi_called : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
   return %2 : $()
@@ -139,7 +139,7 @@ bb0:
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil hidden @multi_calles : $@convention(thin) () -> () {
+sil private @multi_calles : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @multi_called : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -165,7 +165,7 @@ bb3:
 // CHECK-NEXT:    - multi_caller1
 // CHECK-NEXT:    - multi_caller2
 // CHECK-NEXT:  ...
-sil hidden @multi_callers : $@convention(thin) () -> () {
+sil private @multi_callers : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
   return %2 : $()
@@ -179,7 +179,7 @@ bb0:
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil hidden @multi_caller1 : $@convention(thin) () -> () {
+sil private @multi_caller1 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @multi_callers : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -195,7 +195,7 @@ bb0:
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil hidden @multi_caller2 : $@convention(thin) () -> () {
+sil private @multi_caller2 : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @multi_callers : $@convention(thin) () -> ()
   %1 = apply %0() : $@convention(thin) () -> ()
@@ -243,7 +243,7 @@ bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil @partial_apply_one_arg : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned (Builtin.Int32) -> Builtin.Int32 {
+sil private @partial_apply_one_arg : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned (Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
   %1 = function_ref @closure1 : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
   %2 = partial_apply %1(%0) : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
@@ -258,7 +258,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil @partial_apply_two_args1 : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned () -> Builtin.Int32 {
+sil private @partial_apply_two_args1 : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned () -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
   %1 = function_ref @closure1 : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
   %2 = partial_apply %1(%0, %0) : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
@@ -273,7 +273,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
-sil @partial_apply_two_args2 : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned () -> Builtin.Int32 {
+sil private @partial_apply_two_args2 : $@convention(thin) (Builtin.Int32) -> @owned @callee_owned () -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
   %1 = function_ref @closure2 : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
   %2 = partial_apply %1(%0, %0) : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32
@@ -290,7 +290,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  ...
-sil @called_closure : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
+sil private @called_closure : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
   return %0 : $Builtin.Int32
 }
@@ -317,7 +317,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  ...
-sil @called_closure_then_destroy : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
+sil private @called_closure_then_destroy : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
   return %0 : $Builtin.Int32
 }
@@ -367,7 +367,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  ...
-sil @called_closure_then_copy_destroy : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
+sil private @called_closure_then_copy_destroy : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
   return %0 : $Builtin.Int32
 }
@@ -414,7 +414,7 @@ bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
 // CHECK-NEXT:    - partial_apply_that_is_applied_and_passed_noescape
 // CHECK-NEXT:    - thin_to_thick_is_applied_and_passed_noescape
 // CHECK-NEXT:  ...
-sil @noescape_caller : $@convention(thin) (@noescape @callee_owned () -> Builtin.Int32) -> () {
+sil private @noescape_caller : $@convention(thin) (@noescape @callee_owned () -> Builtin.Int32) -> () {
 bb0(%0 : $@noescape @callee_owned () -> Builtin.Int32):
   %1 = apply %0() : $@noescape @callee_owned () -> Builtin.Int32
   %9999 = tuple()

--- a/test/SILOptimizer/funcsig_explode_heuristic.sil
+++ b/test/SILOptimizer/funcsig_explode_heuristic.sil
@@ -1,0 +1,207 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all -function-signature-opts -sil-fso-disable-dead-argument -sil-fso-disable-owned-to-guaranteed -enable-expand-all -sil-fso-optimize-if-not-called %s | %FileCheck %s
+
+// *NOTE* We turn off all other fso optimizations including dead arg so we can
+// make sure that we are not exploding those.
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+struct BigTrivial {
+  var x1: Builtin.Int32
+  var x2: Builtin.Int32
+  var x3: Builtin.Int32
+  var x4: Builtin.Int32
+  var x5: Builtin.Int32
+  var x6: Builtin.Int32
+}
+
+class Klass {}
+
+struct LargeNonTrivialStructOneNonTrivialField {
+  var k1: Klass
+  var k2: Klass
+  var x1: Builtin.Int32
+  var x2: Builtin.Int32
+  var x3: Builtin.Int32
+  var x4: Builtin.Int32
+}
+
+sil @int_user : $@convention(thin) (Builtin.Int32) -> ()
+sil @consuming_user : $@convention(thin) (@owned Klass) -> ()
+sil @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+
+///////////
+// Tests //
+///////////
+
+// We should never optimize this. If we did this would become a thunk, so we
+// know that just be checking NFC we have proven no optimization has occured.
+//
+// CHECK-LABEL: sil @never_explode_trivial : $@convention(thin) (BigTrivial) -> () {
+// CHECK: } // end sil function 'never_explode_trivial'
+sil @never_explode_trivial : $@convention(thin) (BigTrivial) -> () {
+bb0(%0 : $BigTrivial):
+  %1 = struct_extract %0 : $BigTrivial, #BigTrivial.x1
+  %intfunc = function_ref @int_user : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%1) : $@convention(thin) (Builtin.Int32) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If a value is never used, do not touch it. We leave it for dead argument
+// elimination. We have delibrately turned this off to test that behavior.
+//
+// CHECK-LABEL: sil @big_arg_with_no_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'big_arg_with_no_uses'
+sil @big_arg_with_no_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We are using a single non-trivial field of the struct. We should explode this
+// so we eliminate the second non-trivial leaf.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @big_arg_with_one_nontrivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s31big_arg_with_one_nontrivial_useTf4x_n
+// CHECK:   [[FIELD:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+// CHECK:   apply [[FUNC]]([[FIELD]])
+// CHECK: } // end sil function 'big_arg_with_one_nontrivial_use'
+sil @big_arg_with_one_nontrivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %2(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We are using a single non-trivial field and a single trivial field. We are
+// willing to blow this up.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @big_arg_with_one_nontrivial_use_one_trivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s032big_arg_with_one_nontrivial_use_d9_trivial_F0Tf4x_n : $@convention(thin) (@guaranteed Klass, Builtin.Int32) -> ()
+// CHECK:   [[TRIVIAL_FIELD:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x1
+// CHECK:   [[NON_TRIVIAL_FIELD:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+// CHECK:   apply [[FUNC]]([[NON_TRIVIAL_FIELD]], [[TRIVIAL_FIELD]])
+// CHECK: } // end sil function 'big_arg_with_one_nontrivial_use_one_trivial_use'
+sil @big_arg_with_one_nontrivial_use_one_trivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x1
+  %3 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %intfunc = function_ref @int_user : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%2) : $@convention(thin) (Builtin.Int32) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We can still explode this, since our limit is 3 values.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @big_arg_with_one_nontrivial_use_two_trivial_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s48big_arg_with_one_nontrivial_use_two_trivial_usesTf4x_n : $@convention(thin)
+// CHECK:   [[TRIVIAL_FIELD1:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x2
+// CHECK:   [[TRIVIAL_FIELD2:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x1
+// CHECK:   [[NON_TRIVIAL_FIELD:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+// CHECK:   apply [[FUNC]]([[NON_TRIVIAL_FIELD]], [[TRIVIAL_FIELD2]], [[TRIVIAL_FIELD1]])
+sil @big_arg_with_one_nontrivial_use_two_trivial_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x1
+  %3 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x2
+  %4 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %4(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %intfunc = function_ref @int_user : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%2) : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%3) : $@convention(thin) (Builtin.Int32) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We do not blow up the struct here since we have 4 uses, not 3.
+//
+// CHECK-LABEL: sil @big_arg_with_one_nontrivial_use_three_trivial_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+sil @big_arg_with_one_nontrivial_use_three_trivial_uses : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x1
+  %3 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x2
+  %3a = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.x3
+  %4 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %4(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %intfunc = function_ref @int_user : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%2) : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%3) : $@convention(thin) (Builtin.Int32) -> ()
+  apply %intfunc(%3a) : $@convention(thin) (Builtin.Int32) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// In this case, we shouldn't blow up the struct since we have not reduced the
+// number of non-trivial leaf nodes used.
+//
+// CHECK-LABEL: sil @big_arg_with_two_nontrivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+sil @big_arg_with_two_nontrivial_use : $@convention(thin) (@guaranteed LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k2
+  %3 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If we have one non-trivial value that is live and only live because of a
+// destroy, we can delete the argument after performing o2g.
+//
+// We are using a single non-trivial field of the struct. We should explode this
+// so we eliminate the second non-trivial leaf.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @big_arg_with_one_nontrivial_use_o2g_other_dead : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK-NOT: release_value
+// CHECK: apply
+// CHECK-NOT: release_value
+// CHECK: } // end sil function 'big_arg_with_one_nontrivial_use_o2g_other_dead'
+sil @big_arg_with_one_nontrivial_use_o2g_other_dead : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  release_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If we have two non-trivial values that are live and one is always dead and
+// the other is kept alive due to a release, we can get rid of both since FSO
+// reruns with o2g. Test here that we explode it appropriatel even though we
+// aren't reducing the number of non-trivial uses. The
+// funcsig_explode_heuristic_inline.sil test makes sure we in combination
+// produce the appropriate SIL.
+//
+// We check that we can inline this correctly in the inline test.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @big_arg_with_one_nontrivial_use_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FUNC:%.*]] = function_ref @$s35big_arg_with_one_nontrivial_use_o2gTf4x_n : $@convention(thin) (@owned Klass, @owned Klass) -> ()
+// CHECK:   apply [[FUNC]](
+// CHECK: } // end sil function 'big_arg_with_one_nontrivial_use_o2g'
+sil @big_arg_with_one_nontrivial_use_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k2
+  %3 = function_ref @consuming_user : $@convention(thin) (@owned Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@owned Klass) -> ()
+  release_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/funcsig_explode_heuristic_inline.sil
+++ b/test/SILOptimizer/funcsig_explode_heuristic_inline.sil
@@ -1,0 +1,90 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all -sil-inline-generics -inline -function-signature-opts -enable-expand-all %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct LargeNonTrivialStructOneNonTrivialField {
+  var k1: Klass
+  var k2: Klass
+  var x1: Builtin.Int32
+  var x2: Builtin.Int32
+  var x3: Builtin.Int32
+  var x4: Builtin.Int32
+}
+
+sil @consuming_user : $@convention(thin) (@owned Klass) -> ()
+sil @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+
+// This test makes sure that if we have two non-trivial values that are live and
+// one is always dead and the other is a value that we have a release for, we
+// can get rid of the first argument and FSO the other. Test here that we
+// explode it appropriately and do a partial o2g even though we aren't reducing
+// the number of non-trivial uses.
+
+// CHECK-LABEL: sil @caller1 : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FUNC:%.*]] = function_ref @partial_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+// CHECK:   apply [[FUNC]]([[ARG]]) : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+// CHECK: } // end sil function 'caller1'
+sil @caller1 : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = function_ref @partial_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+  apply %1(%0) : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If we have two non-trivial values that are live and one is always dead and
+// the other is kept alive due to a release, we can get rid of both since FSO
+// reruns with o2g. Test here that we explode it appropriately and do a partial
+// o2g even though we aren't reducing the number of non-trivial uses.
+sil hidden [noinline] @partial_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k2
+  %3 = function_ref @consuming_user : $@convention(thin) (@owned Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@owned Klass) -> ()
+  %4 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
+  apply %4(%1) :$@convention(thin) (@guaranteed Klass) -> ()
+  release_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @caller2 : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+// CHECK: bb0([[ARG:%.*]] : $LargeNonTrivialStructOneNonTrivialField):
+// CHECK:   [[FIELD1:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k2
+// CHECK:   [[FIELD2:%.*]] = struct_extract [[ARG]] : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+// CHECK:   [[FUNC:%.*]] = function_ref @$s23partiallydead_after_o2gTf4x_nTf4dn_n : $@convention(thin) (@owned Klass) -> ()
+// CHECK:   apply [[FUNC]]([[FIELD1]]) : $@convention(thin) (@owned Klass) -> ()
+// CHECK:   release_value [[FIELD2]]
+// CHECK: } // end sil function 'caller2'
+sil @caller2 : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = function_ref @partiallydead_after_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+  apply %1(%0) : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// If we have two non-trivial values that are live and one is always dead and
+// the other is kept alive due to a release, we can get rid of both since FSO
+// reruns with o2g. Test here that we explode it appropriately and do a partial
+// o2g even though we aren't reducing the number of non-trivial uses.
+sil hidden [noinline] @partiallydead_after_o2g : $@convention(thin) (@owned LargeNonTrivialStructOneNonTrivialField) -> () {
+bb0(%0 : $LargeNonTrivialStructOneNonTrivialField):
+  %1 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k1
+  %2 = struct_extract %0 : $LargeNonTrivialStructOneNonTrivialField, #LargeNonTrivialStructOneNonTrivialField.k2
+  %3 = function_ref @consuming_user : $@convention(thin) (@owned Klass) -> ()
+  apply %3(%2) : $@convention(thin) (@owned Klass) -> ()
+  release_value %1 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -184,6 +184,7 @@ bb0(%0 : $boo):
 // CHECK: [[IN2:%.*]] = struct_extract %0 : $lotsoffield, #lotsoffield.b
 // CHECK: [[IN3:%.*]] = struct_extract %0 : $lotsoffield, #lotsoffield.a
 // CHECK: apply [[FN1]]([[IN3]], [[IN2]], [[IN1]])
+// CHECK-LABEL: } // end sil function 'dead_argument_due_to_only_release_user_but__exploded'
 sil @dead_argument_due_to_only_release_user_but__exploded : $@convention(thin) (@owned lotsoffield) -> (Int, Int, Int) {
 bb0(%0 : $lotsoffield):
   // make it a non-trivial function
@@ -219,10 +220,16 @@ bb0(%0 : $lotsoffield):
   return %5 : $(Int, Int, Int)
 }
 
-// Make sure argument is exploded and the baz part is not passed in as argument, as its only use
-// is a release.
+// Since this is a value that contains only a singular owned type, there is no
+// point from an ARC perspective in splitting it up. We still want to perform
+// owned to guaranteed though.
+//
 // CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @dead_argument_due_to_more_than_release_user
-// CHECK: [[FN1:%.*]] = function_ref @$s43dead_argument_due_to_more_than_release_userTf4gX_n : $@convention(thin) (@guaranteed baz, Int) -> (Int, Int)
+// CHECK: bb{{[0-9]+}}([[BOO:%.*]] : $boo):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s43dead_argument_due_to_more_than_release_userTf4g_n : $@convention(thin) (@guaranteed boo) -> (Int, Int)
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[BOO]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'dead_argument_due_to_more_than_release_user'
 sil @dead_argument_due_to_more_than_release_user : $@convention(thin) (@owned boo) -> (Int, Int) {
 bb0(%0 : $boo):
   // make it a non-trivial function
@@ -468,12 +475,13 @@ bb3(%4 : $boo):
   return %4 : $boo
 }
 
-// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @single_owned_return_value_with_interfering_release
+// The function is public (hence possibly used externally) and the full boo 
+// argument is live.  Consequently, it is not specialized.
+// CHECK-LABEL: sil @single_owned_return_value_with_interfering_release
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
-// CHECK: [[IN1:%.*]] = function_ref @$s50single_owned_return_value_with_interfering_releaseTf4x_nTf4gnn_n
-// CHECK-NOT: retain_value
 // CHECK: return
-sil @single_owned_return_value_with_interfering_release : $@convention(thin) (@owned boo) ->  boo {
+// CHECK-LABEL: } // end sil function 'single_owned_return_value_with_interfering_release'
+sil @single_owned_return_value_with_interfering_release : $@convention(thin) (@owned boo) -> boo {
 bb0(%0 : $boo):
   // make it a non-trivial function
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
@@ -1347,6 +1355,7 @@ bb0(%0 : $Optional<(foo, foo)>):
 // CHECK: [[F:%[0-9]+]] = function_ref @dont_explode_single_enum : $@convention(thin) (@owned Optional<(foo, foo)>) -> @owned foo
 // CHECK: apply [[F]](%0)
 // CHECK: return
+// CHECK-LABEL: } // end sil function 'call_with_single_enum'
 sil @call_with_single_enum : $@convention(thin) (@owned Optional<(foo, foo)>) -> @owned foo {
 bb0(%0 : $Optional<(foo, foo)>):
   %f = function_ref @dont_explode_single_enum : $@convention(thin) (@owned Optional<(foo, foo)>) -> @owned foo
@@ -1364,9 +1373,11 @@ bb0(%0 : $foo):
 }
 
 // CHECK-LABEL: sil @call_externally_available
+// CHECK: bb{{[0-9]+}}([[FOO:%.*]] : $foo):
 // CHECK: [[F:%[0-9]+]] = function_ref @$s34externally_available_with_dead_argTf4d_n : $@convention(thin) () -> ()
 // CHECK: apply [[F]]()
 // CHECK: return
+// CHECK-LABEL: } // end sil function 'call_externally_available'
 sil @call_externally_available : $@convention(thin) (@guaranteed foo) -> () {
 bb0(%0 : $foo):
   %f = function_ref @externally_available_with_dead_arg : $@convention(thin) (@guaranteed foo) -> ()

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -54,6 +54,40 @@ struct S4 {
   var f1 : Builtin.NativeObject
 }
 
+sil @s4_user : $@convention(thin) (S4) -> ()
+sil @s4_pointer_user : $@convention(thin) (@in S4) -> ()
+sil @s4_user_twice : $@convention(thin) (S4, S4) -> ()
+
+struct S4Pair {
+  var f1 : S4
+  var f2 : S4
+}
+
+struct S4Triple {
+  var f1 : S4
+  var f2 : S4
+  var f3 : S4
+}
+
+struct S4Octet {
+  var f1 : S4
+  var f2 : S4
+  var f3 : S4
+  var f4 : S4
+  var f5 : S4
+  var f6 : S4
+  var f7 : S4
+  var f8 : S4
+}
+
+struct S4Fourtytet {
+  var f1 : S4Octet
+  var f2 : S4Octet
+  var f3 : S4Octet
+  var f4 : S4Octet
+  var f5 : S4Octet
+}
+
 struct S5 {
   var f1 : S4
   var f2 : S1
@@ -134,13 +168,12 @@ struct SingleFieldLvl3 {
 // Tests //
 ///////////
 
-/// This checks the case where we have a single level hierarchy and the root is
-/// dead.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
+/// Verify that an argument is not exploded if it is entirely trivial even if it
+/// is partly dead.
+// CHECK-LABEL: sil [serialized] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @$s29single_level_dead_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
-// CHECK: [[ARG:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
-// CHECK: apply [[FN]]([[ARG]])
+// CHECK: [[RESULT:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
+// CHECK: return [[RESULT]] : $Builtin.Int32
 sil [serialized] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 bb0(%0 : $S1):
   // make it a non-trivial function
@@ -173,7 +206,9 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [serialized] @single_level_dead_root_caller : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @$s29single_level_dead_root_calleeTfq4x_n
+// CHECK: [[FN:%[0-9]+]] = function_ref @single_level_dead_root_callee
+// CHECK: apply [[FN]]([[INPUT]])
+// CHECK-LABEL: } // end sil function 'single_level_dead_root_caller'
 sil [serialized] @single_level_dead_root_caller : $@convention(thin) (S1) -> () {
 bb0(%0 : $S1):
   %1 = function_ref @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32
@@ -182,12 +217,14 @@ bb0(%0 : $S1):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
+/// Verify that fully live trivial arguments are not exploded.
+// CHECK-LABEL: sil [serialized] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @$s29single_level_live_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
-// CHECK: [[ARG2:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
-// CHECK: [[ARG1:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[ARG1]], [[ARG2]])
+// CHECK: [[RESULT:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
+// CHECK: [[FN:%.*]] = function_ref @s1_user : $@convention(thin) (S1) -> ()
+// CHECK: apply [[FN]]([[INPUT]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'single_level_live_root_callee'
 sil [serialized] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 bb0(%0 : $S1):
   // make it a non-trivial function
@@ -222,7 +259,9 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [serialized] @single_level_live_root_caller : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @$s29single_level_live_root_calleeTfq4x_n
+// CHECK: [[FN:%[0-9]+]] = function_ref @single_level_live_root_callee
+// CHECK: apply [[FN]]([[INPUT]])
+// CHECK-LABEL: } // end sil function 'single_level_live_root_caller'
 sil [serialized] @single_level_live_root_caller : $@convention(thin) (S1) -> () {
 bb0(%0 : $S1):
   %1 = function_ref @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32
@@ -231,16 +270,16 @@ bb0(%0 : $S1):
   return %9999 : $()
 }
 
-// This test checks where we have a multiple level hierarchy, the root is dead,
-// but the root has all fields used. This means that we should extract
-// everything, but we should not "reform" the aggregate.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
+/// Verify that a two-level aggregate argument which is entirely trivial, whose 
+/// root is dead but all of whose leaves are live will not be exploded.
+// CHECK-LABEL: sil [serialized] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[INPUT:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @$s42multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT3]], [[EXT1]])
+// CHECK: [[INPUTF1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
+// CHECK: [[INPUTF1F1:%.*]] = struct_extract [[INPUTF1]] : $S1, #S1.f1
+// CHECK: [[INPUTF2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
+// CHECK: [[OUT:%.*]] = tuple ([[INPUTF1F1]] : $Builtin.Int16, [[INPUTF2]] : $Builtin.Int64)
+// CHECK: return [[OUT]]
+// CHECK-LABEL: } // end sil function 'multiple_level_all_root_fields_used_callee'
 sil [serialized] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 bb0(%0 : $S2):
   // make it a non-trivial function
@@ -278,11 +317,9 @@ bb0(%0 : $S2):
 
 // CHECK-LABEL: sil [serialized] @multiple_level_all_root_fields_used_caller : $@convention(thin) (S2) -> () {
 // CHECK: bb0([[INPUT:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @$s42multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT3]], [[EXT1]])
+// CHECK: [[FN:%.*]] = function_ref @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: apply [[FN]]([[INPUT]])
+// CHECK-LABEL: } // end sil function 'multiple_level_all_root_fields_used_caller'
 sil [serialized] @multiple_level_all_root_fields_used_caller : $@convention(thin) (S2) -> () {
 bb0(%0 : $S2):
   %1 = function_ref @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64)
@@ -291,16 +328,17 @@ bb0(%0 : $S2):
   return %9999 : $()
 }
 
-/// This test checks a multiple level hierarchy where the root has no fields used.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
-// CHECK: bb0([[IN:%.*]] : $S3):
-// CHECK: [[FN:%.*]] = function_ref @$s53multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S3, #S3.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S3, #S3.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f2
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f1
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT4]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT5]], [[EXT3]])
+/// Verify that a three-level aggregate argument which is entirely trivial, 
+/// whose first level nodes are dead but some of whose leaves are live will not
+/// be exploded.
+// CHECK-LABEL: sil [serialized] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK: bb0([[INPUT:%.*]] : $S3):
+// CHECK: [[INPUTF1:%.*]] = struct_extract [[INPUT]] : $S3, #S3.f1
+// CHECK: [[INPUTF1F1:%.*]] = struct_extract [[INPUTF1]] : $S2, #S2.f1
+// CHECK: [[INPUTF1F1F1:%.*]] = struct_extract [[INPUTF1F1]] : $S1, #S1.f1
+// CHECK: [[INPUTF1F2:%.*]] = struct_extract [[INPUTF1]] : $S2, #S2.f2
+// CHECK: [[RESULT:%.*]] = tuple ([[INPUTF1F1F1]] : $Builtin.Int16, [[INPUTF1F2]] : $Builtin.Int64)
+// CHECK-LABEL: } // end sil function 'multiple_level_no_root_fields_have_direct_uses_callee'
 sil [serialized] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
 bb0(%0 : $S3):
   // make it a non-trivial function
@@ -337,14 +375,10 @@ bb0(%0 : $S3):
 }
 
 // CHECK-LABEL: sil [serialized] @multiple_level_no_root_fields_have_direct_uses_caller : $@convention(thin) (S3) -> () {
-// CHECK: bb0([[IN:%.*]] : $S3):
-// CHECK: [[FN:%.*]] = function_ref @$s53multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S3, #S3.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S3, #S3.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f2
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f1
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT4]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT5]], [[EXT3]])
+// CHECK: bb0([[INPUT:%.*]] : $S3):
+// CHECK: [[FUNCTION:%.*]] = function_ref @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: apply [[FUNCTION]]([[INPUT]])
+// CHECK-LABEL: } // end sil function 'multiple_level_no_root_fields_have_direct_uses_caller'
 sil [serialized] @multiple_level_no_root_fields_have_direct_uses_caller : $@convention(thin) (S3) -> () {
 bb0(%0 : $S3):
   %1 = function_ref @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64)
@@ -353,16 +387,17 @@ bb0(%0 : $S3):
   return %9999 : $()
 }
 
-// This test checks a multiple level hierarchy where the root has its own use
-// and needs to be reformed via a struct.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
-// CHECK: bb0([[IN:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @$s43multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S2, #S2.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S2, #S2.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f2
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT4]], [[EXT3]], [[EXT1]])
+/// Verify that a two-level aggregate argument which is entirely trivial, some
+/// of whose leaves are live and which itself is live will not be exploded.
+// CHECK-LABEL: sil [serialized] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK: bb0([[INPUT:%.*]] : $S2):
+// CHECK: [[INPUTF1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
+// CHECK: [[INPUTF1F1:%.*]] = struct_extract [[INPUTF1]] : $S1, #S1.f1
+// CHECK: [[INPUTF2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
+// CHECK: [[OUT:%.*]] = tuple ([[INPUTF1F1]] : $Builtin.Int16, [[INPUTF2]] : $Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @s2_user : $@convention(thin) (S2) -> ()
+// CHECK: apply [[FN]]([[INPUT]]) : $@convention(thin) (S2) -> ()
+// CHECK-LABEL: } // end sil function 'multiple_level_root_must_be_reformed_callee'
 sil [serialized] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 bb0(%0 : $S2):
   // make it a non-trivial function
@@ -399,13 +434,10 @@ bb0(%0 : $S2):
 }
 
 // CHECK-LABEL: sil [serialized] @multiple_level_root_must_be_reformed_caller : $@convention(thin) (S2) -> () {
-// CHECK: bb0([[IN:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @$s43multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S2, #S2.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S2, #S2.f1
-// CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f2
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT4]], [[EXT3]], [[EXT1]])
+// CHECK: bb0([[INPUT:%.*]] : $S2):
+// CHECK: [[FUNCTION:%.*]] = function_ref @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: apply [[FUNCTION]]([[INPUT]])
+// CHECK-LABEL: } // end sil function 'multiple_level_root_must_be_reformed_caller'
 sil [serialized] @multiple_level_root_must_be_reformed_caller : $@convention(thin) (S2) -> () {
 bb0(%0 : $S2):
   // make it a non-trivial function
@@ -438,16 +470,16 @@ bb0(%0 : $S2):
   return %9999 : $()
 }
 
-// This test checks if we can handle @owned structs correctly
+/// Verify that an aggregate argument containing a single non-trivial live leaf
+/// is not exploded.
 // CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
-// CHECK: bb0([[IN1:%.*]] : $S5, [[IN2:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN2]] : $S5, #S5.f1
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT2]], [[EXT5]], [[EXT4]]) : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
-// CHECK: release_value [[IN]] : $S5
+// CHECK: bb0({{%.*}} : $S5, [[INPUT:%.*]] : $S5):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s21owned_struct_1_calleeTfq4dg_n : $@convention(thin) (@guaranteed S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INPUT]])
+// CHECK: release_value [[INPUT]] : $S5
+// CHECK: release_value {{%.*}} : $S5
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'owned_struct_1_callee'
 sil [serialized] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 bb0(%0 : $S5, %1 : $S5):
   // make it a non-trivial function
@@ -488,14 +520,12 @@ bb0(%0 : $S5, %1 : $S5):
 }
 
 // CHECK-LABEL: sil [serialized] @owned_struct_1_caller : $@convention(thin) (S5) -> () {
-// CHECK: bb0([[IN:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S5, #S5.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S5, #S5.f1
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT2]], [[EXT5]], [[EXT4]]) : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
-// CHECK: release_value [[IN]] : $S5
+// CHECK: bb0([[INPUT:%.*]] : $S5):
+// CHECK: [[INPUTF2:%.*]] = struct_extract [[INPUT]] : $S5, #S5.f2
+// CHECK: [[INPUTF2F1:%.*]] = struct_extract [[INPUTF2]] : $S1, #S1.f1
+// CHECK: [[INPUTF2F2:%.*]] = struct_extract [[INPUTF2]] : $S1, #S1.f2
+// CHECK: [[OUT:%.*]] = tuple ([[INPUTF2F1]] : $Builtin.Int16, [[INPUTF2F2]] : $Builtin.Int32, [[INPUTF2F1]] : $Builtin.Int16, [[INPUTF2F2]] : $Builtin.Int32)
+// CHECK-LABEL: } // end sil function 'owned_struct_1_caller'
 sil [serialized] @owned_struct_1_caller : $@convention(thin) (S5) -> () {
 bb0(%0 : $S5):
   %1 = function_ref @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
@@ -504,17 +534,19 @@ bb0(%0 : $S5):
   return %9999 : $()
 }
 
-// This test checks if we can properly insert arguments in between dead arguments.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $Builtin.Int256, [[IN3:%.*]] : $S5, [[IN4:%.*]] : $Builtin.Int128, [[IN5:%.*]] : $Builtin.Int128):
-// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN3]] : $S5, #S5.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S5, #S5.f1
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[IN1]], [[EXT2]], [[EXT5]], [[EXT4]], [[IN5]]) : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
-sil [serialized] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
-bb0(%0 : $Builtin.Int256, %1 : $Builtin.Int256, %2 : $S5, %3 : $Builtin.Int128, %4 : $Builtin.Int128):
+/// Verify that argument explosion that increases argument count before and
+/// after dead argument elimination behaves properly.
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S4Triple, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128) {
+// CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $Builtin.Int256, [[TRIPLE:%.*]] : $S4Triple, [[IN4:%.*]] : $Builtin.Int128, [[IN5:%.*]] : $Builtin.Int128):
+// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, @guaranteed S4, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+// CHECK: [[TRIPLEF3:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f3
+// CHECK: [[TRIPLEF2:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f2
+// CHECK: [[RESULT:%.*]] = apply [[FN]]([[IN1]], [[TRIPLEF2]], [[TRIPLEF3]], [[IN5]]) : $@convention(thin) (Builtin.Int256, @guaranteed S4, @guaranteed S4, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+// CHECK: release_value [[TRIPLE]] : $S4Triple
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'owned_struct_2_callee'
+sil [serialized] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S4Triple, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128) {
+bb0(%0 : $Builtin.Int256, %1 : $Builtin.Int256, %triple : $S4Triple, %3 : $Builtin.Int128, %4 : $Builtin.Int128):
   // make it a non-trivial function
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
@@ -539,42 +571,42 @@ bb0(%0 : $Builtin.Int256, %1 : $Builtin.Int256, %2 : $S5, %3 : $Builtin.Int128, 
   %c21 = builtin "assert_configuration"() : $Builtin.Int32
   %c22 = builtin "assert_configuration"() : $Builtin.Int32
 
-  %5 = struct_extract %2 : $S5, #S5.f2
-  %6 = struct_extract %5 : $S1, #S1.f1
-  %7 = struct_extract %5 : $S1, #S1.f2
-  %11 = function_ref @s5_user : $@convention(thin) (S5) -> ()
-  %12 = apply %11(%2) : $@convention(thin) (S5) -> ()
-  release_value %2 : $S5
-  %13 = tuple(%0 : $Builtin.Int256, %6 : $Builtin.Int16, %7 : $Builtin.Int32, %4 : $Builtin.Int128)
-  return %13 : $(Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
+  %triple_field2 = struct_extract %triple : $S4Triple, #S4Triple.f2
+  %triple_field3 = struct_extract %triple : $S4Triple, #S4Triple.f3
+  %func = function_ref @s4_user_twice : $@convention(thin) (S4, S4) -> ()
+  %_ = apply %func(%triple_field2, %triple_field3) : $@convention(thin) (S4, S4) -> ()
+  release_value %triple : $S4Triple
+  %result = tuple (%0 : $Builtin.Int256, %0 : $Builtin.Int256, %4 : $Builtin.Int128, %4 : $Builtin.Int128)
+  return %result : $(Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
 }
 
 
-// CHECK-LABEL: sil [serialized] @owned_struct_2_caller : $@convention(thin) (Builtin.Int256, S5, Builtin.Int128) -> () {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $S5, [[IN3:%.*]] : $Builtin.Int128):
-// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN2]] : $S5, #S5.f1
-// CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
-// CHECK: [[EXT5:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[IN1]], [[EXT2]], [[EXT5]], [[EXT4]], [[IN3]]) : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
-sil [serialized] @owned_struct_2_caller : $@convention(thin) (Builtin.Int256, S5, Builtin.Int128) -> () {
-bb0(%0 : $Builtin.Int256, %1 : $S5, %2 : $Builtin.Int128):
-  %3 = function_ref @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
-  %4 = apply %3(%0, %0, %1, %2, %2) : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
+// CHECK-LABEL: sil [serialized] @owned_struct_2_caller : $@convention(thin) (Builtin.Int256, S4Triple, Builtin.Int128) -> () {
+// CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[TRIPLE:%.*]] : $S4Triple, [[IN3:%.*]] : $Builtin.Int128):
+// CHECK: [[FN:%.*]] = function_ref @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, @guaranteed S4, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+// CHECK: [[TRIPLEF3:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f3
+// CHECK: [[TRIPLEF2:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f2
+// CHECK: apply [[FN]]([[IN1]], [[TRIPLEF2]], [[TRIPLEF3]], [[IN3]]) : $@convention(thin) (Builtin.Int256, @guaranteed S4, @guaranteed S4, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+// CHECK-LABEL: } // end sil function 'owned_struct_2_caller'
+sil [serialized] @owned_struct_2_caller : $@convention(thin) (Builtin.Int256, S4Triple, Builtin.Int128) -> () {
+bb0(%0 : $Builtin.Int256, %1 : $S4Triple, %2 : $Builtin.Int128):
+  %3 = function_ref @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S4Triple, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+  %4 = apply %3(%0, %0, %1, %2, %2) : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S4Triple, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
   %9999 = tuple()
   return %9999 : $()
 }
 
-/// This test makes sure that we ignore pointer arguments for now.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16) {
-// CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $S1, [[IN3:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S1, #S1.f1
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[IN1]], [[EXT1]], [[EXT2]]) : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
-sil [serialized] @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16) {
-bb0(%0 : $*S1, %1 : $S1, %2 : $S1):
+/// Verify that pointer arguments are ignored for now.
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @ignore_ptrs_callee : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> (S4, S4) {
+// CHECK: bb0([[POINTER:%.*]] : $*S4Pair, [[PAIR1:%.*]] : $S4Pair, [[PAIR2:%.*]] : $S4Pair):
+// CHECK: [[FN:%.*]] = function_ref @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S4Pair, S4, S4) -> (S4, S4)
+// CHECK: [[VALUE1:%.*]] = struct_extract [[PAIR1]] : $S4Pair, #S4Pair.f1
+// CHECK: [[VALUE2:%.*]] = struct_extract [[PAIR2]] : $S4Pair, #S4Pair.f1
+// CHECK: [[RESULT:%.*]] = apply [[FN]]([[POINTER]], [[VALUE1]], [[VALUE2]]) : $@convention(thin) (@in S4Pair, S4, S4) -> (S4, S4)
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'ignore_ptrs_callee'
+sil [serialized] @ignore_ptrs_callee : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> (S4, S4) {
+bb0(%pointer : $*S4Pair, %pair1 : $S4Pair, %pair2 : $S4Pair):
   // make it a non-trivial function
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
@@ -599,26 +631,27 @@ bb0(%0 : $*S1, %1 : $S1, %2 : $S1):
   %c21 = builtin "assert_configuration"() : $Builtin.Int32
   %c22 = builtin "assert_configuration"() : $Builtin.Int32
 
-  debug_value %1 : $S1
-  debug_value %2 : $S1
-  %3 = function_ref @s1_ptr_user : $@convention(thin) (@in S1) -> ()
-  %4 = apply %3(%0) : $@convention(thin) (@in S1) -> ()
-  %5 = struct_extract %1 : $S1, #S1.f1
-  %6 = struct_extract %2 : $S1, #S1.f1
-  %7 = tuple(%5 : $Builtin.Int16, %6 : $Builtin.Int16)
-  return %7 : $(Builtin.Int16, Builtin.Int16)
+  %func = function_ref @s4_user : $@convention(thin) (S4) -> ()
+  %pointee = load %pointer : $*S4Pair
+  %first_pointee = struct_extract %pointee : $S4Pair, #S4Pair.f1
+  %_ = apply %func(%first_pointee) : $@convention(thin) (S4) -> ()
+  %first1 = struct_extract %pair1 : $S4Pair, #S4Pair.f1
+  %first2 = struct_extract %pair2 : $S4Pair, #S4Pair.f1
+  %result = tuple (%first1 : $S4, %first2 : $S4)
+  return %result : $(S4, S4)
 }
 
-// CHECK-LABEL: sil [serialized] @ignore_ptrs_caller : $@convention(thin) (@in S1, S1, S1) -> () {
-// CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $S1, [[IN3:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S1, #S1.f1
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[IN1]], [[EXT1]], [[EXT2]]) : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
-sil [serialized] @ignore_ptrs_caller : $@convention(thin) (@in S1, S1, S1) -> () {
-bb0(%0 : $*S1, %1 : $S1, %2 : $S1):
-  %3 = function_ref @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16)
-  %4 = apply %3(%0, %1, %2) : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16)
+// CHECK-LABEL: sil [serialized] @ignore_ptrs_caller : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> () {
+// CHECK: bb0([[POINTER:%.*]] : $*S4Pair, [[PAIR1:%.*]] : $S4Pair, [[PAIR2:%.*]] : $S4Pair):
+// CHECK: [[FN:%.*]] = function_ref @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S4Pair, S4, S4) -> (S4, S4)
+// CHECK: [[VALUE1:%.*]] = struct_extract [[PAIR1]] : $S4Pair, #S4Pair.f1
+// CHECK: [[VALUE2:%.*]] = struct_extract [[PAIR2]] : $S4Pair, #S4Pair.f1
+// CHECK: apply [[FN]]([[POINTER]], [[VALUE1]], [[VALUE2]]) : $@convention(thin) (@in S4Pair, S4, S4) -> (S4, S4)
+// CHECK-LABEL: } // end sil function 'ignore_ptrs_caller'
+sil [serialized] @ignore_ptrs_caller : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> () {
+bb0(%0 : $*S4Pair, %1 : $S4Pair, %2 : $S4Pair):
+  %3 = function_ref @ignore_ptrs_callee : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> (S4, S4)
+  %4 = apply %3(%0, %1, %2) : $@convention(thin) (@in S4Pair, S4Pair, S4Pair) -> (S4, S4)
   %9999 = tuple()
   return %9999 : $()
 }
@@ -628,6 +661,7 @@ bb0(%0 : $*S1, %1 : $S1, %2 : $S1):
 // CHECK: bb0([[IN1:%.*]] : $FakeStaticString, [[IN2:%.*]] : $FakeString, [[IN3:%.*]] : $FakeStaticString):
 // CHECK: [[FN:%.*]] = function_ref @fakestaticstring_user : $@convention(thin) (FakeStaticString) -> ()
 // CHECK: apply [[FN]]([[IN1]]) : $@convention(thin) (FakeStaticString) -> ()
+// CHECK-LABEL: } // end sil function 'multiple_sroa_callee'
 sil [serialized] @multiple_sroa_callee : $@convention(thin) (FakeStaticString, @owned FakeString, FakeStaticString) -> () {
 bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
   // make it a non-trivial function
@@ -666,6 +700,7 @@ bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
 // CHECK-LABEL: sil [serialized] @multiple_sroa_caller : $@convention(thin) (FakeStaticString, @owned FakeString, FakeStaticString) -> () {
 // CHECK: bb0([[IN1:%.*]] : $FakeStaticString, [[IN2:%.*]] : $FakeString, [[IN3:%.*]] : $FakeStaticString):
 // CHECK: [[FN:%.*]] = function_ref @multiple_sroa_callee : $@convention(thin) (FakeStaticString, @owned FakeString, FakeStaticString) -> ()
+// CHECK-LABEL: } // end sil function 'multiple_sroa_caller'
 sil [serialized] @multiple_sroa_caller : $@convention(thin) (FakeStaticString, @owned FakeString, FakeStaticString) -> () {
 bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
   %3 = function_ref @multiple_sroa_callee : $@convention(thin) (FakeStaticString, @owned FakeString, FakeStaticString) -> ()
@@ -674,17 +709,18 @@ bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
   return %9999 : $()
 }
 
-// This test makes sure that we handle cases where the callee has field uses
-// that are processed in a different order than the fields are layed out in the
-// structure.
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @check_out_of_order_uses_callee : $@convention(thin) (S1) -> () {
-// CHECK: bb0([[IN:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S1, #S1.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT2]], [[EXT1]]) : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
-sil [serialized] @check_out_of_order_uses_callee : $@convention(thin) (S1) -> () {
-bb0(%0 : $S1):
+/// Verify that in the face of an exploded argument the ordering of arguments is
+/// based on ordering of fields in the original argument rather than ordering of
+/// usage in the function being specialized.
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @check_out_of_order_uses_callee : $@convention(thin) (S4Triple) -> () {
+// CHECK: bb0([[TRIPLE:%.*]] : $S4Triple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (S4, S4) -> ()
+// CHECK: [[INPUT1F2:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f2
+// CHECK: [[INPUT1F1:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f1
+// CHECK: apply [[FUNCTION]]([[INPUT1F1]], [[INPUT1F2]]) : $@convention(thin) (S4, S4) -> ()
+// CHECK-LABEL: } // end sil function 'check_out_of_order_uses_callee'
+sil [serialized] @check_out_of_order_uses_callee : $@convention(thin) (S4Triple) -> () {
+only(%triple : $S4Triple):
   // make it a non-trivial function
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
@@ -709,29 +745,28 @@ bb0(%0 : $S1):
   %c21 = builtin "assert_configuration"() : $Builtin.Int32
   %c22 = builtin "assert_configuration"() : $Builtin.Int32
 
-  debug_value %0 : $S1
-  %1 = struct_extract %0 : $S1, #S1.f2
-  %2 = function_ref @i32_user : $@convention(thin) (Builtin.Int32) -> ()
-  apply %2(%1) : $@convention(thin) (Builtin.Int32) -> ()
-  %3 = struct_extract %0 : $S1, #S1.f1
-  %4 = function_ref @i16_user : $@convention(thin) (Builtin.Int16) -> ()
-  apply %4(%3) : $@convention(thin) (Builtin.Int16) -> ()
-  %9999 = tuple()
-  return %9999 : $()
+  %second = struct_extract %triple : $S4Triple, #S4Triple.f2
+  %func = function_ref @s4_user : $@convention(thin) (S4) -> ()
+  apply %func(%second) : $@convention(thin) (S4) -> ()
+  %first = struct_extract %triple : $S4Triple, #S4Triple.f1
+  apply %func(%first) : $@convention(thin) (S4) -> ()
+  %result = tuple()
+  return %result : $()
 }
 
-// CHECK-LABEL: sil [serialized] @check_out_of_order_uses_caller : $@convention(thin) (S1) -> () {
-// CHECK: bb0([[IN:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
-// CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S1, #S1.f2
-// CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S1, #S1.f1
-// CHECK: apply [[FN]]([[EXT2]], [[EXT1]]) : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
-sil [serialized] @check_out_of_order_uses_caller : $@convention(thin) (S1) -> () {
-bb0(%0 : $S1):
-  %1 = function_ref @check_out_of_order_uses_callee : $@convention(thin) (S1) -> ()
-  apply %1(%0) : $@convention(thin) (S1) -> ()
-  %9999 = tuple()
-  return %9999 : $()
+// CHECK-LABEL: sil [serialized] @check_out_of_order_uses_caller : $@convention(thin) (S4Triple) -> () {
+// CHECK: bb0([[TRIPLE:%.*]] : $S4Triple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (S4, S4) -> ()
+// CHECK: [[TRIPLEF2:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f2
+// CHECK: [[TRIPLEF1:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[TRIPLEF1]], [[TRIPLEF2]]) : $@convention(thin) (S4, S4) -> ()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'check_out_of_order_uses_caller'
+sil [serialized] @check_out_of_order_uses_caller : $@convention(thin) (S4Triple) -> () {
+bb0(%0 : $S4Triple):
+  %1 = function_ref @check_out_of_order_uses_callee : $@convention(thin) (S4Triple) -> ()
+  %result = apply %1(%0) : $@convention(thin) (S4Triple) -> ()
+  return %result : $()
 }
 
 // Make sure that we do not SROA classes.
@@ -834,6 +869,7 @@ bb0(%0 : $*S1):
 // CHECK-NEXT: apply [[FN]]
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
+// CHECK-LABEL: } // end sil function 'inarg_caller'
 sil [serialized] @inarg_caller : $@convention(thin) (@in S1) -> () {
 bb0(%0 : $*S1):
   %1 = function_ref @inarg_callee : $@convention(thin) (@in S1) -> ()
@@ -847,18 +883,19 @@ bb0(%0 : $*S1):
 // were not handling the possibility of an std::vector resize invalidated
 // references. This cause the this pointer to become invalidated and other
 // shenanigans. So just make sure we don't crash
-// CHECK-LABEL: sil [serialized] @more_than_32_type_sized_caller : $@convention(thin) (ThirtySixFieldStruct) -> () {
-sil [serialized] @more_than_32_type_sized_caller : $@convention(thin) (ThirtySixFieldStruct) -> () {
-bb0(%0 : $ThirtySixFieldStruct):
-  %1 = function_ref @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32
-  %2 = apply %1(%0) : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32
-  %9999 = tuple()
-  return %9999 : $()
+// CHECK-LABEL: sil [serialized] @more_than_32_type_sized_caller : $@convention(thin) (S4Fourtytet) -> S4 {
+// CHECK-LABEL: } // end sil function 'more_than_32_type_sized_caller'
+sil [serialized] @more_than_32_type_sized_caller : $@convention(thin) (S4Fourtytet) -> S4 {
+only(%tet : $S4Fourtytet):
+  %func = function_ref @more_than_32_type_sized_callee : $@convention(thin) (S4Fourtytet) -> S4
+  %result = apply %func(%tet) : $@convention(thin) (S4Fourtytet) -> S4
+  return %result : $S4
 }
 
-// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32 {
-sil [serialized] @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32 {
-bb0(%0 : $ThirtySixFieldStruct):
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @more_than_32_type_sized_callee : $@convention(thin) (S4Fourtytet) -> S4 {
+// CHECK-LABEL: } // end sil function 'more_than_32_type_sized_callee'
+sil [serialized] @more_than_32_type_sized_callee : $@convention(thin) (S4Fourtytet) -> S4 {
+bb0(%tet : $S4Fourtytet):
   // make it a non-trivial function
   %c1 = builtin "assert_configuration"() : $Builtin.Int32
   %c2 = builtin "assert_configuration"() : $Builtin.Int32
@@ -883,9 +920,9 @@ bb0(%0 : $ThirtySixFieldStruct):
   %c21 = builtin "assert_configuration"() : $Builtin.Int32
   %c22 = builtin "assert_configuration"() : $Builtin.Int32
 
-  %1 = struct_extract %0 : $ThirtySixFieldStruct, #ThirtySixFieldStruct.b1
-  %2 = struct_extract %1 : $EightFieldStruct, #EightFieldStruct.a1
-  return %2 : $Builtin.Int32
+  %octet = struct_extract %tet : $S4Fourtytet, #S4Fourtytet.f1
+  %result = struct_extract %octet : $S4Octet, #S4Octet.f1
+  return %result : $S4
 }
 
 // We should not specialize this since SingleFieldLvl1 is a struct that is layout compatible with its only leaf node, %0.s2.s3.s4
@@ -908,104 +945,45 @@ bb0(%0 : $SingleFieldLvl1):
 
 // Check Statements for generated code.
 
-// CHECK-LABEL: sil shared [serialized] @$s29single_level_dead_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
-// CHECK: bb0([[IN:%.*]] : $Builtin.Int32):
-// CHECK: [[UN:%.*]] = struct $S1 (undef : $Builtin.Int16, [[IN]] : $Builtin.Int32)
-// CHECK: struct_extract [[UN]] : $S1, #S1.f2
-// CHECK: return [[IN]] : $Builtin.Int32
 
 
-// CHECK-LABEL: sil shared [serialized] @$s29single_level_live_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32 {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
-// CHECK: [[STRUCT:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
-// CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
-// CHECK: struct_extract [[STRUCT2]] : $S1, #S1.f2
-// CHECK: [[FN:%.*]] = function_ref @s1_user : $@convention(thin) (S1) -> ()
-// CHECK: apply [[FN]]([[STRUCT]])
-// CHECK: return [[IN2]]
-
-
-// CHECK-LABEL: sil shared [serialized] @$s42multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
-// CHECK: [[STRUCT2:%.*]] = struct $S2 (%2 : $S1, [[IN2]] : $Builtin.Int64)
-// CHECK: debug_value [[STRUCT2]] : $S2
-// CHECK: [[STRUCT3:%.*]] = struct_extract [[STRUCT2]] : $S2, #S2.f1
-// CHECK: debug_value [[STRUCT3]] : $S1
-// CHECK: [[OUT:%.*]] = tuple ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int64)
-// CHECK: return [[OUT]]
-
-
-// CHECK-LABEL: sil shared [serialized] @$s53multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
-// CHECK: [[STRUCT2:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN2]] : $Builtin.Int64)
-// CHECK: [[STRUCT4:%.*]] = struct $S3 ([[STRUCT2]] : $S2, undef : $S1)
-// CHECK: debug_value [[STRUCT4]]
-// CHECK: [[OUT:%.*]] = tuple ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int64)
-// CHECK: return [[OUT]]
-
-
-// CHECK-LABEL: sil shared [serialized] @$s43multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32, [[IN3:%.*]] : $Builtin.Int64):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
-// CHECK: [[STRUCT3:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN3]] : $Builtin.Int64)
-// CHECK: [[STRUCT4:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
-// CHECK: [[STRUCT5:%.*]] = struct $S2 ([[STRUCT4]] : $S1, [[IN3]] : $Builtin.Int64)
-// CHECK: struct_extract [[STRUCT5]] : $S2, #S2.f1
-// CHECK: [[OUT:%.*]] = tuple ([[IN1]] : $Builtin.Int16, [[IN3]] : $Builtin.Int64)
-// CHECK: [[FN:%.*]] = function_ref @s2_user : $@convention(thin) (S2) -> ()
-// CHECK: apply [[FN]]([[STRUCT3]]) : $@convention(thin) (S2) -> ()
-// CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int64)
-
-
-
-// CHECK-LABEL: sil shared [serialized] @$s21owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
-// CHECK: bb0([[IN1:%.*]] : $S4, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int32):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
-// CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN1]] : $S4, [[STRUCT1]] : $S1)
-// CHECK: [[STRUCT5:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
-// CHECK: [[STRUCT6:%.*]] = struct $S5 ([[IN1]] : $S4, [[STRUCT5]] : $S1)
-// CHECK: struct_extract [[STRUCT6]] : $S5, #S5.f2
-// CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32, [[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
+// CHECK-LABEL: sil shared [serialized] @$s21owned_struct_1_calleeTfq4dg_n : $@convention(thin) (@guaranteed S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
+// CHECK: bb0([[INPUT:%.*]] : $S5):
+// CHECK: [[INPUTF2:%.*]] = struct_extract [[INPUT]] : $S5, #S5.f2
+// CHECK: [[INPUTF2F1:%.*]] = struct_extract [[INPUTF2]] : $S1, #S1.f1
+// CHECK: [[INPUTF2F2:%.*]] = struct_extract [[INPUTF2]] : $S1, #S1.f2
+// CHECK: [[OUT:%.*]] = tuple ([[INPUTF2F1]] : $Builtin.Int16, [[INPUTF2F2]] : $Builtin.Int32, [[INPUTF2F1]] : $Builtin.Int16, [[INPUTF2F2]] : $Builtin.Int32)
 // CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK-LABEL: } // end sil function '$s21owned_struct_1_calleeTfq4dg_n'
 
-// CHECK-LABEL: sil shared [serialized] @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $S4, [[IN3:%.*]] : $Builtin.Int16, [[IN4:%.*]] : $Builtin.Int32, [[IN5:%.*]] : $Builtin.Int128):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, [[IN4]] : $Builtin.Int32)
-// CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN2]] : $S4, [[STRUCT1]] : $S1)
-// CHECK: [[STRUCT5:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16,  [[IN4]] : $Builtin.Int32)
-// CHECK: [[STRUCT6:%.*]] = struct $S5 ([[IN2]] : $S4, [[STRUCT5]] : $S1)
-// CHECK: struct_extract [[STRUCT6]] : $S5, #S5.f2
-// CHECK: [[FN:%.*]] = function_ref @s5_user : $@convention(thin) (S5) -> ()
-// CHECK: apply [[FN]]([[STRUCT3]]) : $@convention(thin) (S5) -> ()
-// CHECK: [[OUT:%.*]] = tuple ([[IN1]] : $Builtin.Int256, [[IN3]] : $Builtin.Int16, [[IN4]] : $Builtin.Int32, [[IN5]] : $Builtin.Int128)
-// CHECK: [[OUT]] : $(Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
+// CHECK-LABEL: sil shared [serialized] @$s21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, @guaranteed S4, Builtin.Int128) -> (Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128) {
+// CHECK: bb0([[O1:%.*]] : $Builtin.Int256, [[INPUT1:%.*]] : $S4, [[INPUT2:%.*]] : $S4, [[O4:%.*]] : $Builtin.Int128):
+// CHECK: [[FUNCTION:%.*]] = function_ref @s4_user_twice : $@convention(thin) (S4, S4) -> ()
+// CHECK: apply [[FUNCTION]]([[INPUT1]], [[INPUT2]]) : $@convention(thin) (S4, S4) -> ()
+// CHECK: [[RESULT:%.*]] = tuple ([[O1]] : $Builtin.Int256, [[O1]] : $Builtin.Int256, [[O4]] : $Builtin.Int128, [[O4]] : $Builtin.Int128)
+// CHECK: return [[RESULT]] : $(Builtin.Int256, Builtin.Int256, Builtin.Int128, Builtin.Int128)
+// CHECK-LABEL: } // end sil function '$s21owned_struct_2_calleeTfq4ndgXdn_n'
 
 
-// CHECK-LABEL: sil shared [serialized] @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
-// CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int16):
-// CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, undef : $Builtin.Int32)
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, undef : $Builtin.Int32)
-// CHECK: debug_value [[STRUCT2]]
-// CHECK: debug_value [[STRUCT1]]
-// CHECK: [[FN:%.*]] = function_ref @s1_ptr_user : $@convention(thin) (@in S1) -> ()
-// CHECK: apply [[FN]]([[IN1]]) : $@convention(thin) (@in S1) -> ()
-// CHECK: struct_extract [[STRUCT2]] : $S1, #S1.f1
-// CHECK: struct_extract [[STRUCT1]] : $S1, #S1.f1
-// CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int16)
-// CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int16)
+// CHECK-LABEL: sil shared [serialized] @$s18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S4Pair, S4, S4) -> (S4, S4) {
+// CHECK: bb0([[POINTER:%.*]] : $*S4Pair, [[VALUE1:%.*]] : $S4, [[VALUE2:%.*]] : $S4):
+// CHECK: [[FUNCTION:%.*]] = function_ref @s4_user : $@convention(thin) (S4) -> ()
+// CHECK: [[POINTEE:%.*]] = load [[POINTER]] : $*S4Pair
+// CHECK: [[VALUE:%.*]] = struct_extract [[POINTEE]] : $S4Pair, #S4Pair.f1
+// CHECK: apply [[FUNCTION]]([[VALUE]]) : $@convention(thin) (S4) -> ()
+// CHECK: [[OUT:%.*]] = tuple ([[VALUE1]] : $S4, [[VALUE2]] : $S4)
+// CHECK: return [[OUT]] : $(S4, S4)
+// CHECK-LABEL: } // end sil function '$s18ignore_ptrs_calleeTfq4nxx_n'
 
-// CHECK-LABEL: sil shared [serialized] @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> () {
-// CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
-// CHECK: [[STRUCT0:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
-// CHECK: debug_value [[STRUCT0]]
-// CHECK: struct_extract [[STRUCT0]] : $S1, #S1.f2
-// CHECK: [[FN1:%.*]] = function_ref @i32_user : $@convention(thin) (Builtin.Int32) -> ()
-// CHECK: apply [[FN1]]([[IN2]]) : $@convention(thin) (Builtin.Int32) -> ()
-// CHECK: struct_extract [[STRUCT0]] : $S1, #S1.f1
-// CHECK: [[FN2:%.*]] = function_ref @i16_user : $@convention(thin) (Builtin.Int16) -> ()
-// CHECK: apply [[FN2]]([[IN1]]) : $@convention(thin) (Builtin.Int16) -> ()
+// CHECK-LABEL: sil shared [serialized] @$s30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (S4, S4) -> () {
+// CHECK: bb{{[0-9]+}}([[FIRST:%.*]] : $S4, [[SECOND:%.*]] : $S4):
+// CHECK: [[TRIPLE:%.*]] = struct $S4Triple ([[FIRST]] : $S4, [[SECOND]] : $S4, undef : $S4)
+// CHECK: [[UNUSED_SECOND:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f2
+// CHECK: [[FUNCTION:%.*]] = function_ref @s4_user : $@convention(thin) (S4) -> ()
+// CHECK: apply [[FUNCTION]]([[IN2]]) : $@convention(thin) (S4) -> ()
+// CHECK: [[UNUSED_FIRST:%.*]] = struct_extract [[TRIPLE]] : $S4Triple, #S4Triple.f1
+// CHECK: apply [[FUNCTION]]([[IN1]]) : $@convention(thin) (S4) -> ()
+// CHECK-LABEL: } // end sil function '$s30check_out_of_order_uses_calleeTfq4x_n'
 
 
 // CHECK-LABEL: sil shared [serialized] @$s14class_callee_1Tfq4gn_n : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32 {

--- a/test/SILOptimizer/functionsigopts_string_fileprivate.swift
+++ b/test/SILOptimizer/functionsigopts_string_fileprivate.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
+
+private var _storage: String? = nil
+
+// CHECK-LABEL: sil private [noinline] @$s34functionsigopts_string_fileprivate10setStorage33_{{[a-zA-Z0-9]+}}_tF : $@convention(thin) (@guaranteed String) -> () {
+// CHECK-LABEL: } // end sil function '$s34functionsigopts_string_fileprivate10setStorage33_{{[a-zA-Z0-9]+}}_tF'
+@inline(never)
+fileprivate func setStorage(to newValue: String) {
+  _storage = newValue
+}
+
+// CHECK-LABEL: sil private [noinline] @$s34functionsigopts_string_fileprivate12setStorageTo33_{{[a-zA-Z0-9]+}} : $@convention(thin) (@guaranteed String) -> () {
+// CHECK: bb{{[0-9]+}}([[STRING:%.*]] : $String):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s34functionsigopts_string_fileprivate10setStorage33_{{[a-zA-Z0-9]+}}_tF
+// CHECK: apply [[FUNCTION]]([[STRING]])
+// CHECK-LABEL: } // end sil function '$s34functionsigopts_string_fileprivate12setStorageTo33_{{[a-zA-Z0-9]+}}'
+@inline(never)
+fileprivate func setStorageTo(_ newValue: String) {
+  setStorage(to: newValue)
+}
+
+setStorageTo("hi")

--- a/test/SILOptimizer/functionsigopts_string_internal.swift
+++ b/test/SILOptimizer/functionsigopts_string_internal.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
+
+private var _storage: String? = nil
+
+// CHECK-LABEL: sil hidden [noinline] @$s31functionsigopts_string_internal10setStorage2toySS_tF : $@convention(thin) (@guaranteed String) -> () {
+// CHECK-LABEL: } // end sil function '$s31functionsigopts_string_internal10setStorage2toySS_tF'
+@inline(never)
+func setStorage(to newValue: String) {
+  _storage = newValue
+}
+
+// CHECK-LABEL: sil hidden @$s31functionsigopts_string_internal12setStorageToyySSF : $@convention(thin) (@guaranteed String) -> () {
+// CHECK: bb{{[0-9]+}}([[STRING:%.*]] : $String):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s31functionsigopts_string_internal10setStorage2toySS_tF
+// CHECK: apply [[FUNCTION]]([[STRING]])
+// CHECK-LABEL: } // end sil function '$s31functionsigopts_string_internal12setStorageToyySSF'
+func setStorageTo(_ newValue: String) {
+  setStorage(to: newValue)
+}
+

--- a/test/SILOptimizer/functionsigopts_string_public.swift
+++ b/test/SILOptimizer/functionsigopts_string_public.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
+
+private var _storage: String? = nil
+
+
+// CHECK-LABEL: sil [noinline] @$s29functionsigopts_string_public10setStorage2toySS_tF : $@convention(thin) (@guaranteed String) -> () { 
+// CHECK-LABEL: } // end sil function '$s29functionsigopts_string_public10setStorage2toySS_tF'
+@inline(never)
+public func setStorage(to newValue: String) {
+  _storage = newValue
+}
+
+// CHECK-LABEL: sil @$s29functionsigopts_string_public12setStorageToyySSF : $@convention(thin) (@guaranteed String) -> () {
+// CHECK: bb{{[0-9]+}}([[STRING:%.*]] : $String):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s29functionsigopts_string_public10setStorage2toySS_tF
+// CHECK: apply [[FUNCTION]]([[STRING]])
+// CHECK-LABEL: } // end sil function '$s29functionsigopts_string_public12setStorageToyySSF'
+public func setStorageTo(_ newValue: String) {
+  setStorage(to: newValue)
+}
+

--- a/test/SILOptimizer/functionsigopts_trivial.sil
+++ b/test/SILOptimizer/functionsigopts_trivial.sil
@@ -1,0 +1,2110 @@
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+// ==========================================================================={{
+// =============================================================================
+// =====                            SUPPORT                                =====
+// =============================================================================
+// =============================================================================
+
+class Klass {
+  var value : Builtin.Int2048
+}
+
+struct Wrapper {
+  var klass: Klass
+  var int: Int
+}
+
+struct Pair {
+  var klass1: Klass
+  var klass2: Klass
+}
+
+struct Quintuple {
+  var klass1: Klass
+  var klass2: Klass
+  var klass3: Klass
+  var klass4: Klass
+  var klass5: Klass
+}
+
+sil @take_nothing : $@convention(thin) () -> ()
+sil @take_klass : $@convention(thin) (Klass) -> ()
+sil @take_klass_and_klass : $@convention(thin) (Klass, Klass) -> ()
+sil @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+sil @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+sil @take_int : $@convention(thin) (Int) -> ()
+
+// =============================================================================
+// =============================================================================
+// =====                            SUPPORT                                =====
+// =============================================================================
+// ===========================================================================}}
+
+
+
+// ==========================================================================={{
+// =============================================================================
+// =====                             TESTS                                 =====
+// =============================================================================
+// =============================================================================
+
+
+
+// ==========================================================================={{
+// =                                WRAPPER                                    =
+// =============================================================================
+
+// struct Wrapper {
+//   var klass: Klass
+//   var int: Int
+// }
+
+// = Wrapper, #Wrapper.klass ================================================={{
+
+
+
+// TEST_WrKlPu: TYPE: Wrapper, FIELD: #Wrapper.klass, VISIBILITY: public
+// VERIFY: NO-EXPLODE
+// The function take_wrapper has a single argument of type Wrapper from which
+// it uses only the klass field.  The int field goes unused.  Argument explosion
+// should *not* result in a specialization in this case because (1) the
+// function could be used outside this module (so a thunk would be generated if
+// we specialized) and (2) specializing does not reduce ARC traffic because the
+// stripped field is trivial.
+//
+// CHECK-LABEL: sil [noinline] @take_wrapper : $@convention(thin) (Wrapper) -> () {
+// CHECK: [[KLASS:%.*]] = struct_extract {{%.*}} : $Wrapper, #Wrapper.klass
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper'
+// CHECK-NOT: sil shared [noinline] @$s12take_wrapperTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK-NOT: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK-NOT: [[RESULT:%.*]] = apply [[FUNCTION]](%0)
+// CHECK-NOT: return [[RESULT]] : $()
+// CHECK-NOT: } // end sil function '$s12take_wrapperTf4x_n'
+sil public [noinline] @take_wrapper : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %klass = struct_extract %wrapper : $Wrapper, #Wrapper.klass
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper'
+
+// CHECK-LABEL: sil @take_wrapper_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_wrapper
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[WRAPPER]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_caller'
+sil @take_wrapper_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_caller'
+
+
+
+// TEST_WrKlPuEx: TYPE: Wrapper, FIELD: #Wrapper.klass, VISIBILITY: public_external
+// VERIFY: NO-EXPLODE
+// The function take_wrapper has a single argument of type Wrapper from which
+// it uses only the klass field.  The int field goes unused.  Argument explosion
+// should *not* result in a specialization in this case because (1) the
+// function is definend outside this module (so a thunk would be generated if
+// we specialized) and (2) specializing does not reduce ARC traffic because the
+// stripped field is trivial.
+// 
+// CHECK-LABEL: sil public_external [noinline] @take_wrapper_public_external : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_wrapper_public_external'
+sil public_external [noinline] @take_wrapper_public_external : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %klass = struct_extract %wrapper : $Wrapper, #Wrapper.klass
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_public_external'
+
+// CHECK-LABEL: sil @take_wrapper_public_external_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_wrapper_public_external
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[WRAPPER]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_wrapper_public_external_caller'
+sil @take_wrapper_public_external_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_public_external : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_public_external_caller'
+
+
+
+// TEST_WrKlSh: TYPE: Wrapper, FIELD: #Wrapper.klass, VISIBILITY: shared
+// VERIFY: EXPLODE: (Wrapper) => (#Wrapper.klass)
+// The function take_wrapper_shared has a single argument of type Wrapper from
+// which it uses only the klass field.  The int field goes unused.  Argument
+// explosion should result in a specialization in this case because because 
+// there are dead leaves of the relevant sort, the relevant sort here being
+// potentially trivial because specializing the function will not result in a
+// thunk.
+//
+// CHECK-LABEL: sil shared [signature_optimized_thunk] [always_inline] @take_wrapper_shared : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s19take_wrapper_sharedTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_shared'
+sil shared [noinline] @take_wrapper_shared : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %klass = struct_extract %wrapper : $Wrapper, #Wrapper.klass
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_shared'
+
+// CHECK-LABEL: sil @take_wrapper_shared_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s19take_wrapper_sharedTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_shared_caller'
+sil @take_wrapper_shared_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_shared : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_shared_caller'
+
+
+
+// TEST_WrKlHi: TYPE: Wrapper, FIELD: #Wrapper.klass, VISIBILITY: hidden
+// VERIFY: NO-EXPLODE
+// The function take_wrapper_hidden has a single argument of type Wrapper from
+// which it uses only the klass field.  The int field goes unused.  Argument
+// explosion should *not* result in a specialization in this case because, while
+// all the non-trivial leaves are live, there is only a single non-trivial
+// leaf, so there will be no downstream benefits from introducing a separate RC
+// identities for each leaf.
+//
+// CHECK-LABEL: sil hidden [noinline] @take_wrapper_hidden : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_hidden'
+sil hidden [noinline] @take_wrapper_hidden : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %klass = struct_extract %wrapper : $Wrapper, #Wrapper.klass
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_hidden'
+
+// CHECK-LABEL: sil @take_wrapper_hidden_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_wrapper_hidden
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[WRAPPER]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_hidden_caller'
+sil @take_wrapper_hidden_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_hidden : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil funcntion 'take_wrapper_hidden_caller'
+
+
+
+// TEST_WrKlPr: TYPE: Wrapper, FIELD: #Wrapper.klass, VISIBILITY: private
+// VERIFY: EXPLODE: (Wrapper) => (#Wrapper.klass)
+// The function take_wrapper_private has a single argument of type Wrapper from
+// which it uses only the klass field.  The int field goes unused.  Argument
+// explosion should result in a specialization in this case because, there are
+// dead leaves of the relevant sort, that being potentially trivial because
+// specializing the function will not result in a thunk.
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_wrapper_private : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_wrapper_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_private'
+sil private [noinline] @take_wrapper_private : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %klass = struct_extract %wrapper : $Wrapper, #Wrapper.klass
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_private'
+
+// CHECK-LABEL: sil @take_wrapper_private_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_wrapper_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_private_caller'
+sil @take_wrapper_private_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_private : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_private_caller'
+
+
+
+// = END: Wrapper, #Wrapper.klass ============================================}}
+
+
+
+// = Wrapper, #Wrapper.int ==================================================={{
+
+
+
+// TEST_WrInPu: TYPE: Wrapper, FIELD: #Wrapper.int, VISIBILITY: public
+// VERIFY: EXPLODE (Wrapper) => (#Wrapper.int)
+// The function take_wrapper_for_int has a single argument of type Wrapper from 
+// which it only uses the int field.  The klass field goes unused.  Without 
+// changes there would be needless ARC traffic around the klass field.  So, 
+// argument explosion *should* result in a specialization in this case.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_wrapper_for_int : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_wrapper_for_intTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_for_int'
+sil public [noinline] @take_wrapper_for_int : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %int = struct_extract %wrapper : $Wrapper, #Wrapper.int
+  %func = function_ref @take_int : $@convention(thin) (Int) -> ()
+  %result = apply %func(%int) : $@convention(thin) (Int) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int'
+
+// CHECK-LABEL: sil @take_wrapper_for_int_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_wrapper_for_intTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_for_int_caller'
+sil @take_wrapper_for_int_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_for_int : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_caller'
+
+
+
+// TEST_WrInPuEx: TYPE: Wrapper, FIELD: #Wrapper.int, VISIBILITY: public_external
+// VERIFY: EXPLODE (Wrapper) => (#Wrapper.int)
+// The function take_wrapper_for_int has a single argument of type Wrapper from 
+// which it only uses the int field.  The klass field goes unused.  Without 
+// changes there would be needless ARC traffic around the klass field.  So, 
+// argument explosion *should* result in a specialization in this case.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_wrapper_for_int_public_external : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_wrapper_for_int_public_externalTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_for_int_public_external'
+sil public_external [noinline] @take_wrapper_for_int_public_external : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %int = struct_extract %wrapper : $Wrapper, #Wrapper.int
+  %func = function_ref @take_int : $@convention(thin) (Int) -> ()
+  %result = apply %func(%int) : $@convention(thin) (Int) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_public_external'
+
+// CHECK-LABEL: sil @take_wrapper_for_int_public_external_caller : $@convention(thin) (Wrapper) -> () {
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_wrapper_for_int_public_externalTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_wrapper_for_int_public_external_caller'
+sil @take_wrapper_for_int_public_external_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_for_int_public_external : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_public_external_caller'
+
+
+
+// TEST_WrInHi: TYPE: Wrapper, FIELD: #Wrapper.int, VISIBILITY: hidden
+// VERIFY: EXPLODE (Wrapper) => (#Wrapper.int)
+// The function take_wrapper_for_int_hidden has a single argument of type
+// Wrapper from which it only uses the int field.  The klass field goes unused.
+// Without changes there would be needless ARC traffic around the klass field.
+// So, argument explosion *should* result in a specialization in this case.
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_wrapper_for_int_hidden
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_wrapper_for_int_hiddenTf4x_n : $@convention(thin) (Int) -> ()
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: // end sil function 'take_wrapper_for_int_hidden'
+sil hidden [noinline] @take_wrapper_for_int_hidden : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %int = struct_extract %wrapper : $Wrapper, #Wrapper.int
+  %func = function_ref @take_int : $@convention(thin) (Int) -> ()
+  %result = apply %func(%int) : $@convention(thin) (Int) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_hidden'
+
+// CHECK-LABEL: sil @take_wrapper_for_int_hidden_caller
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_wrapper_for_int_hiddenTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: // end sil function 'take_wrapper_for_int_hidden_caller'
+sil @take_wrapper_for_int_hidden_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_for_int_hidden : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_hidden_caller'
+
+
+
+// TEST_WrInPr: TYPE: Wrapper, FIELD: #Wrapper.int, VISIBILITY: private
+// VERIFY: EXPLODE (Wrapper) => (#Wrapper.int)
+// The function take_wrapper_for_int_private has a single argument of type
+// Wrapper from which it only uses the int field.  The klass field goes unused.
+// Without changes there would be needless ARC traffic around the klass field.
+// So, argument explosion *should* result in a specialization in this case.
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_wrapper_for_int_private
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_wrapper_for_int_privateTf4x_n : $@convention(thin) (Int) -> ()
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: // end sil function 'take_wrapper_for_int_private'
+sil private [noinline] @take_wrapper_for_int_private : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %int = struct_extract %wrapper : $Wrapper, #Wrapper.int
+  %func = function_ref @take_int : $@convention(thin) (Int) -> ()
+  %result = apply %func(%int) : $@convention(thin) (Int) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_private'
+
+// CHECK-LABEL: sil @take_wrapper_for_int_private_caller
+// CHECK: bb{{[0-9]*}}([[WRAPPER:%.*]] : $Wrapper)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_wrapper_for_int_privateTf4x_n
+// CHECK: [[INT:%.*]] = struct_extract [[WRAPPER]] : $Wrapper, #Wrapper.int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: // end sil function 'take_wrapper_for_int_private_caller'
+sil @take_wrapper_for_int_private_caller : $@convention(thin) (Wrapper) -> () {
+only(%wrapper : $Wrapper):
+  %func = function_ref @take_wrapper_for_int_private : $@convention(thin) (Wrapper) -> ()
+  %result = apply %func(%wrapper) : $@convention(thin) (Wrapper) -> ()
+  return %result : $()
+} // end sil function 'take_wrapper_for_int_private_caller'
+
+
+
+// = END: Wrapper, #Wrapper.int ==============================================}}
+
+
+
+// ===========================================================================}}
+// =                              END: WRAPPER                                 =
+// =============================================================================
+
+
+
+// ==========================================================================={{
+// =                                  PAIR                                     =
+// =============================================================================
+
+// struct Pair {
+//   var klass1: Klass
+//   var klass2: Klass
+// }
+
+// = Pair, No fields ========================================================={{
+
+
+
+// TEST_PaPu: TYPE: Pair, FIELD: , VISIBILITY: public
+// VERIFY: EXPLODE (Pair) => ()
+// The function take_pair_unused has a single argument of type Pair from which
+// it uses no fields.  Both the klass1 and klass2 fields go unused.  Argument
+// explosion *should* result in a specialization in this case because
+// specializing reduces ARC traffic on account of the fact that the stripped
+// fields are non-trivial.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_pair_unused : $@convention(thin) (Pair) -> ()
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s16take_pair_unusedTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: // end sil function 'take_pair_unused'
+sil public [noinline] @take_pair_unused : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_nothing : $@convention(thin) () -> ()
+  %result = apply %func() : $@convention(thin) () -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused'
+
+// CHECK-LABEL: sil @take_pair_unused_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s16take_pair_unusedTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_caller'
+sil @take_pair_unused_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_unused : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused_caller'
+
+
+
+// TEST_PaPuEx: TYPE: Pair, FIELD: , VISIBILITY: public_external
+// VERIFY: EXPLODE (Pair) => ()
+// The function take_pair_unused has a single argument of type Pair from which
+// it uses no fields.  Both the klass1 and klass2 fields go unused.  Argument
+// explosion *should* result in a specialization in this case because
+// specializing reduces ARC traffic on account of the fact that the stripped
+// fields are non-trivial.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_pair_unused_public_external : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s32take_pair_unused_public_externalTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_public_external'
+sil public_external [noinline] @take_pair_unused_public_external : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_nothing : $@convention(thin) () -> ()
+  %result = apply %func() : $@convention(thin) () -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused_public_external'
+
+// CHECK-LABEL: sil @take_pair_unused_public_external_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s32take_pair_unused_public_externalTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_public_external_caller'
+sil @take_pair_unused_public_external_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_unused_public_external : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused_public_external_caller'
+
+
+
+// TEST_PaHi: TYPE: Pair, FIELD: , VISIBILITY: hidden
+// VERIFY: EXPLODE: (Pair) => ()
+// The function take_pair_unused_hidden has a single argument of type Pair from
+// which it uses no fields.  Both the klass1 and klass2 fields go unused.
+// Argument explosion *should* result in a specialization in this case because
+// specializing reduces ARC traffic on account of the fact that the stripped
+// fields are non-trivial.
+//
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_pair_unused_hidden : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s23take_pair_unused_hiddenTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_hidden'
+sil hidden [noinline] @take_pair_unused_hidden : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_nothing : $@convention(thin) () -> ()
+  %result = apply %func() : $@convention(thin) () -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused_hidden'
+
+// CHECK-LABEL: sil @take_pair_unused_hidden_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s23take_pair_unused_hiddenTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_hidden_caller'
+sil @take_pair_unused_hidden_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_unused_hidden : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_unused_hidden_caller'
+
+
+
+// TEST_PaPr: TYPE: Pair, FIELD: , VISIBILITY: private
+// VERIFY: EXPLODE: (Pair) => ()
+// The function take_pair_unused_private has a single argument of type Pair from
+// which it uses no fields.  Both the klass1 and klass2 fields go unused.
+// Argument explosion *should* result in a specialization in this case because
+// specializing reduces ARC traffic on account of the fact that the stripped
+// fields are non-trivial.
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_pair_unused_private : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s24take_pair_unused_privateTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_private'
+sil private [noinline] @take_pair_unused_private : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_nothing : $@convention(thin) () -> ()
+  %result = apply %func() : $@convention(thin) () -> ()
+  return %result : $()
+} // end sil function 'take_pair_unused_private'
+
+// CHECK-LABEL: sil @take_pair_unused_private_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s24take_pair_unused_privateTf4d_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_unused_private_caller'
+sil @take_pair_unused_private_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_unused_private : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_unused_private_caller'
+
+
+
+// = END: Pair, No fields ====================================================}}
+
+
+
+// = Pair, #Pair.klass1 ======================================================{{
+
+
+
+// TEST_PaK1Pu: TYPE: Pair, FIELD: #Pair.klass1, VISIBILITY: public
+// VERIFY: EXPLODE (Pair) => (#Pair.klass1)
+// The function take_pair_for_klass1 has a single argument of type Pair 
+// from which it uses only the klass1 field.  The klass2 field goes unused.  
+// Argument explosion *should* result in a specialization in this case because 
+// specializing reduces ARC traffic on account of the fact that the stripped
+// field is non-trivial.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_pair_for_klass1 : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_pair_for_klass1Tf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1'
+sil public [noinline] @take_pair_for_klass1 : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass1
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_pair_for_klass1Tf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract {{%.*}} : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_caller'
+sil @take_pair_for_klass1_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1 : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_caller'
+
+
+
+// TEST_PaK1PuEx: TYPE: Pair, FIELD: #Pair.klass1, VISIBILITY: public_external
+// VERIFY: EXPLODE (Pair) => (#Pair.klass1)
+// The function take_pair_for_klass1 has a single argument of type Pair 
+// from which it uses only the klass1 field.  The klass2 field goes unused.  
+// Argument explosion *should* result in a specialization in this case because 
+// specializing reduces ARC traffic on account of the fact that the stripped
+// field is non-trivial.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_pair_for_klass1_public_external : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_pair_for_klass1_public_externalTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_public_external'
+sil public_external [noinline] @take_pair_for_klass1_public_external : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass1
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_public_external'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_public_external_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_pair_for_klass1_public_externalTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_public_external_caller'
+sil @take_pair_for_klass1_public_external_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_public_external : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_public_external_caller'
+
+
+
+// TEST_PaK1Hi: TYPE: Pair, FIELD: #Pair.klass1, VISIBILITY: hidden
+// VERIFY: EXPLODE: (Pair) => (#Pair.klass1)
+// The function take_pair_for_klass1_hidden has a single argument of type Pair from
+// which it uses only the klass1 field.  The klass2 field goes unused.  Argument
+// explosion should result in a specialization in this case both because (1) the
+// function can *not* be used outside this module (so no thunk
+// will remain after dead code elimination) because it is hidden and because (2)
+// avoiding passing the full Pair with its unused field klass2 avoids extraneous
+// ARC traffic around that field (i.e. #Pair.klass2).
+//
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_pair_for_klass1_hidden : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_pair_for_klass1_hiddenTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_hidden'
+sil hidden [noinline] @take_pair_for_klass1_hidden : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass1
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_hidden'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_hidden_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_pair_for_klass1_hiddenTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_hidden_caller'
+sil @take_pair_for_klass1_hidden_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_hidden : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass1_hidden_caller'
+
+
+
+// TEST_PaK1Pr: TYPE: Pair, FIELD: #Pair.klass1, VISIBILITY: private
+// VERIFY: EXPLODE: (Pair) => (#Pair.klass1)
+// The function take_pair_for_klass1_private has a single argument of type Pair from
+// which it uses only the klass1 field.  The klass2 field goes unused.  Argument
+// explosion should result in a specialization in this case both because (1) the
+// function can *not* be used outside this module (so no thunk
+// will remain after dead code elimination) because it is private and because
+// (2) avoiding passing the full Pair with its unused field klass2 avoids
+// extraneous ARC traffic around that field (i.e. #Pair.klass2).
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_pair_for_klass1_private : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_pair_for_klass1_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_private'
+sil private [noinline] @take_pair_for_klass1_private : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass1
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_private'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_private_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_pair_for_klass1_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_private_caller'
+sil @take_pair_for_klass1_private_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_private : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass1_private_caller'
+
+
+
+// = END: Pair, #Pair.klass1 =================================================}}
+
+
+
+// = Pair, #Pair.klass2 ======================================================{{
+
+
+
+// TEST_PaK2Pu: TYPE: Pair, FIELD: #Pair.klass2, VISIBILITY: public
+// VERIFY: EXPLODE (Pair) => (#Pair.klass2)
+// The function take_pair_for_klass2 has a single argument of type Pair 
+// from which it uses only the klass2 field.  The klass1 field goes unused.  
+// Argument explosion *should* result in a specialization in this case because 
+// specializing reduces ARC traffic on account of the fact that the stripped
+// field is non-trivial.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_pair_for_klass2 : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_pair_for_klass2Tf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2'
+sil public [noinline] @take_pair_for_klass2 : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2'
+
+// CHECK-LABEL: sil @take_pair_for_klass2_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s20take_pair_for_klass2Tf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract {{%.*}} : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_caller'
+sil @take_pair_for_klass2_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass2 : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2_caller'
+
+
+
+// TEST_PaK2PuEx: TYPE: Pair, FIELD: #Pair.klass2, VISIBILITY: public_external
+// VERIFY: EXPLODE (Pair) => (#Pair.klass2)
+// The function take_pair_for_klass2 has a single argument of type Pair 
+// from which it uses only the klass2 field.  The klass1 field goes unused.  
+// Argument explosion *should* result in a specialization in this case because 
+// specializing reduces ARC traffic on account of the fact that the stripped
+// field is non-trivial.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_pair_for_klass2_public_external : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_pair_for_klass2_public_externalTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_public_external'
+sil public_external [noinline] @take_pair_for_klass2_public_external : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2_public_external'
+
+// CHECK-LABEL: sil @take_pair_for_klass2_public_external_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s36take_pair_for_klass2_public_externalTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_public_external_caller'
+sil @take_pair_for_klass2_public_external_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass2_public_external : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2_public_external_caller'
+
+
+
+// TEST_PaK2Hi: TYPE: Pair, FIELD: #Pair.klass2, VISIBILITY: hidden
+// VERIFY: EXPLODE: (Pair) => (#Pair.klass2)
+// The function take_pair_for_klass2_hidden has a single argument of type Pair from
+// which it uses only the klass2 field.  The klass1 field goes unused.  Argument
+// explosion should result in a specialization in this case both because (1) the
+// function can *not* be used outside this module (so no thunk
+// will remain after dead code elimination) because it is hidden and because (2)
+// avoiding passing the full Pair with its unused field klass1 avoids extraneous
+// ARC traffic around that field (i.e. #Pair.klass1).
+//
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_pair_for_klass2_hidden : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_pair_for_klass2_hiddenTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_hidden'
+sil hidden [noinline] @take_pair_for_klass2_hidden : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2_hidden'
+
+// CHECK-LABEL: sil @take_pair_for_klass2_hidden_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s27take_pair_for_klass2_hiddenTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_hidden_caller'
+sil @take_pair_for_klass2_hidden_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass2_hidden : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass2_hidden_caller'
+
+
+
+// TEST_PaK2Pr: TYPE: Pair, FIELD: #Pair.klass2, VISIBILITY: private
+// VERIFY: EXPLODE: (Pair) => (#Pair.klass2)
+// The function take_pair_for_klass2_private has a single argument of type Pair from
+// which it uses only the klass2 field.  The klass1 field goes unused.  Argument
+// explosion should result in a specialization in this case both because (1) the
+// function can *not* be used outside this module (so no thunk
+// will remain after dead code elimination) because it is private and because
+// (2) avoiding passing the full Pair with its unused field klass1 avoids
+// extraneous ARC traffic around that field (i.e. #Pair.klass1).
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_pair_for_klass2_private : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_pair_for_klass2_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_private'
+sil private [noinline] @take_pair_for_klass2_private : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+  %result = apply %func(%klass) : $@convention(thin) (Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass2_private'
+
+// CHECK-LABEL: sil @take_pair_for_klass2_private_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s28take_pair_for_klass2_privateTf4x_n
+// CHECK: [[KLASS:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass2_private_caller'
+sil @take_pair_for_klass2_private_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass2_private : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass2_private_caller'
+
+
+
+// = END: Pair, #Pair.klass2 =================================================}}
+
+
+
+// = Pair, #Pair.klass1, #Pair.klass2 ========================================{{
+
+
+
+// TEST_PaK1K2Pu: TYPE: Pair,  FIELD: #Pair.klass1 & #Pair.klass2, VISIBILITY: public
+// VERIFY: NO-EXPLODE
+// The function take_pair_for_klass1_and_klass2 has a single argument of type
+// Pair from which it uses both the klass1 and klass2 fields.  Argument
+// explosion should *not* result in a specialization in this case because (1)
+// specializing does not affect ARC traffic on account of the fact that no
+// fields are stripped and (2) specializing increases code size.
+//
+// CHECK-LABEL: sil [noinline] @take_pair_for_klass1_and_klass2 : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[KLASS1:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_and_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2'
+sil public [noinline] @take_pair_for_klass1_and_klass2 : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass1 = struct_extract %pair : $Pair, #Pair.klass1
+  %klass2 = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass_and_klass : $@convention(thin) (Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2) : $@convention(thin) (Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_and_klass2_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_pair_for_klass1_and_klass2
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[PAIR]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_caller'
+sil @take_pair_for_klass1_and_klass2_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_and_klass2 : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2_caller'
+
+
+
+// TEST_PaK1K2PuEx: TYPE: Pair,  FIELD: #Pair.klass1 & #Pair.klass2, VISIBILITY: public_external
+// VERIFY: NO-EXPLODE
+// The function take_pair_for_klass1_and_klass2 has a single argument of type
+// Pair from which it uses both the klass1 and klass2 fields.  Argument
+// explosion should *not* result in a specialization in this case because (1)
+// specializing does not affect ARC traffic on account of the fact that no
+// fields are stripped and (2) specializing increases code size.
+//
+// CHECK-LABEL: sil public_external [noinline] @take_pair_for_klass1_and_klass2_public_external : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[KLASS1:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_public_external'
+sil public_external [noinline] @take_pair_for_klass1_and_klass2_public_external : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass1 = struct_extract %pair : $Pair, #Pair.klass1
+  %klass2 = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass_and_klass : $@convention(thin) (Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2) : $@convention(thin) (Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2_public_external'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_and_klass2_public_external_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_pair_for_klass1_and_klass2_public_external
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[PAIR]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_public_external_caller'
+sil @take_pair_for_klass1_and_klass2_public_external_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_and_klass2_public_external : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2_public_external_caller'
+
+
+
+// TEST_PaK1K2Hi: TYPE: Pair,  FIELD: #Pair.klass1 & #Pair.klass2, VISIBILITY: hidden
+// VERIFY: NO-EXPLODE
+// The function take_pair_for_klass1_and_klass2_hidden has a single argument of
+// type Pair from which it uses both the klass1 and klass2 fields.  Argument
+// explosion should *not* result in a specialization in this case because there
+// are no dead leaves.
+//
+// CHECK-LABEL: sil hidden [noinline] @take_pair_for_klass1_and_klass2_hidden : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[KLASS1:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_and_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_hidden'
+sil hidden [noinline] @take_pair_for_klass1_and_klass2_hidden : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass1 = struct_extract %pair : $Pair, #Pair.klass1
+  %klass2 = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass_and_klass : $@convention(thin) (Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2) : $@convention(thin) (Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2_hidden'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_and_klass2_hidden_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_pair_for_klass1_and_klass2_hidden
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[PAIR]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_hidden_caller'
+sil @take_pair_for_klass1_and_klass2_hidden_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_and_klass2_hidden : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass1_and_klass2_hidden_caller'
+
+
+
+// TEST_PaK1K2Pr: TYPE: Pair,  FIELD: #Pair.klass1 & #Pair.klass2, VISIBILITY: private
+// VERIFY: NO-EXPLODE
+// The function take_pair_for_klass1_and_klass2_private has a single argument of
+// type Pair from which it uses both the klass1 and klass2 fields.  Argument
+// explosion should *not* result in a specialization in this case because there 
+// are no dead leaves.
+//
+// CHECK-LABEL: sil private [noinline] @take_pair_for_klass1_and_klass2_private : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair):
+// CHECK: [[KLASS1:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[PAIR]] : $Pair, #Pair.klass2
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_and_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_private'
+sil private [noinline] @take_pair_for_klass1_and_klass2_private : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %klass1 = struct_extract %pair : $Pair, #Pair.klass1
+  %klass2 = struct_extract %pair : $Pair, #Pair.klass2
+  %func = function_ref @take_klass_and_klass : $@convention(thin) (Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2) : $@convention(thin) (Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_pair_for_klass1_and_klass2_private'
+
+// CHECK-LABEL: sil @take_pair_for_klass1_and_klass2_private_caller : $@convention(thin) (Pair) -> () {
+// CHECK: bb{{[0-9]*}}([[PAIR:%.*]] : $Pair)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_pair_for_klass1_and_klass2_private
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[PAIR]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_pair_for_klass1_and_klass2_private_caller'
+sil @take_pair_for_klass1_and_klass2_private_caller : $@convention(thin) (Pair) -> () {
+only(%pair : $Pair):
+  %func = function_ref @take_pair_for_klass1_and_klass2_private : $@convention(thin) (Pair) -> ()
+  %result = apply %func(%pair) : $@convention(thin) (Pair) -> ()
+  return %result : $()
+} // end sil funcntion 'take_pair_for_klass1_and_klass2_private_caller'
+
+
+
+// = END: Pair, #Pair.klass1, #Pair.klass2 ===================================}}
+
+
+
+// ===========================================================================}}
+// =                               END: PAIR                                   =
+// =============================================================================
+
+
+
+// ==========================================================================={{
+// =                                QUINTUPLE                                  =
+// =============================================================================
+
+
+
+// = Quintuple, #.klass1, #.klass2, #.klass3 ================================={{
+
+
+
+// TEST_QuK1K2K3Pu: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3, VISIBILITY: public
+// VERIFY: EXPLODE: (Quintuple) => (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klass3)
+// The function take_quintuple_for_klass1_through_3 has a single argument of
+// type Quintuple from which it uses the klass1, klass2, and klass3 fields.
+// The klass4 and klass5 fields goes unused.  Argument explosion *should*
+// result in specialization because there are only three (the heuristic for max
+// explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3 : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s35take_quintuple_for_klass1_through_3Tf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3'
+sil public [noinline] @take_quintuple_for_klass1_through_3 : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_3_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s35take_quintuple_for_klass1_through_3Tf4x_n
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_caller'
+sil @take_quintuple_for_klass1_through_3_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3 : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_caller'
+
+// TEST_QuK1K2K3PuEx: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3, VISIBILITY: public_external
+// VERIFY: EXPLODE: (Quintuple) => (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klass3)
+// The function take_quintuple_for_klass1_through_3 has a single argument of
+// type Quintuple from which it uses the klass1, klass2, and klass3 fields.
+// The klass4 and klass5 fields goes unused.  Argument explosion *should*
+// result in specialization because there are only three (the heuristic for max
+// explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_public_external : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s51take_quintuple_for_klass1_through_3_public_externalTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_public_external'
+sil public_external [noinline] @take_quintuple_for_klass1_through_3_public_external : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_public_external'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_3_public_external_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s51take_quintuple_for_klass1_through_3_public_externalTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_public_external_caller'
+sil @take_quintuple_for_klass1_through_3_public_external_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_public_external : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_public_external_caller'
+
+// TEST_QuK1K2K3Sh: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3, VISIBILITY: shared
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_3 has a single argument of
+// type Quintuple from which it uses the klass1, klass2, and klass3 fields.
+// The klass4 and klass5 fields goes unused.  Argument explosion *should*
+// result in specialization because there are only three (the heuristic for max
+// explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil shared [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_shared : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_3_sharedTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_shared'
+sil shared [noinline] @take_quintuple_for_klass1_through_3_shared : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_shared'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_3_shared_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_3_sharedTf4x_n
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_shared_caller'
+sil @take_quintuple_for_klass1_through_3_shared_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_shared : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_shared_caller'
+
+// TEST_QuK1K2K3Hi: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3, VISIBILITY: hidden
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_3 has a single argument of
+// type Quintuple from which it uses the klass1, klass2, and klass3 fields.
+// The klass4 and klass5 fields goes unused.  Argument explosion *should*
+// result in specialization because there are only three (the heuristic for max
+// explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_hidden : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_3_hiddenTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_hidden'
+sil hidden [noinline] @take_quintuple_for_klass1_through_3_hidden : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_hidden'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_3_hidden_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_3_hiddenTf4x_n
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_hidden_caller'
+sil @take_quintuple_for_klass1_through_3_hidden_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_hidden : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_hidden_caller'
+
+// TEST_QuK1K2K3Pr: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3, VISIBILITY: private
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_3 has a single argument of
+// type Quintuple from which it uses the klass1, klass2, and klass3 fields.
+// The klass4 and klass5 fields goes unused.  Argument explosion *should*
+// result in specialization because there are only three (the heuristic for max
+// explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_private : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s43take_quintuple_for_klass1_through_3_privateTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_private'
+sil private [noinline] @take_quintuple_for_klass1_through_3_private : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_private'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_3_private_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s43take_quintuple_for_klass1_through_3_privateTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_private_caller'
+sil @take_quintuple_for_klass1_through_3_private_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_private : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_private_caller'
+
+
+
+// = END: Quintuple, #.klass1, #.klass2, #.klass3 ============================}}
+
+
+
+// = Quintuple, #.klass1, #.klass2, #.klass3, #.klass4 ======================={{
+
+
+
+// TEST_QuK1K2K3K4Pu: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & #.klass4, VISIBILITY: public
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_4 has a single argument of 
+// type Quintuple from which it uses the klass1, klass2, klass3, and klass4
+// fields.  The klass5 field goes unused.  Argument explosion should *not* 
+// result in specialization because there are more than three (the heuristic
+// for max explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_4 : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4'
+sil public [noinline] @take_quintuple_for_klass1_through_4 : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %func = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3, %klass4) : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_4_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_quintuple_for_klass1_through_4
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[QUINTUPLE]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_caller'
+sil @take_quintuple_for_klass1_through_4_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_4 : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_caller'
+
+// TEST_QuK1K2K3K4PuEx: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & #.klass4, VISIBILITY: public_external
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_4 has a single argument of 
+// type Quintuple from which it uses the klass1, klass2, klass3, and klass4
+// fields.  The klass5 field goes unused.  Argument explosion should *not* 
+// result in specialization because there are more than three (the heuristic
+// for max explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil public_external [noinline] @take_quintuple_for_klass1_through_4_public_external : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_public_external'
+sil public_external [noinline] @take_quintuple_for_klass1_through_4_public_external : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %func = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3, %klass4) : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_public_external'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_4_public_external_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_quintuple_for_klass1_through_4_public_external
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[QUINTUPLE]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_public_external_caller'
+sil @take_quintuple_for_klass1_through_4_public_external_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_4_public_external : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_public_external_caller'
+
+// TEST_QuK1K2K3K4Sh: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & #.klass4, VISIBILITY: shared
+// VERIFY: EXPLODE (Quintuple) => (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klass3, #Quintuple.klass4)
+// The function take_quintuple_for_klass1_through_4 has a single argument of 
+// type Quintuple from which it uses the klass1, klass2, klass3, and klass4
+// fields.  The klass5 field goes unused.  Argument explosion *should*
+// result in specialization because there are dead leaves and there are fewer 
+// live than the limit imposed by the heuristic, six because the specializing
+// the function will not result in a thunk.
+//
+// CHECK-LABEL: sil shared [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_4_shared : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_4_sharedTf4x_n : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_shared'
+sil shared [noinline] @take_quintuple_for_klass1_through_4_shared : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %func = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3, %klass4) : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_shared'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_4_shared_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s42take_quintuple_for_klass1_through_4_sharedTf4x_n : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_shared_caller'
+sil @take_quintuple_for_klass1_through_4_shared_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_4_shared : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_shared_caller'
+
+
+
+// TEST_QuK1K2K3K4Hi: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & #.klass4, VISIBILITY: hidden
+// VERIFY: NO-EXPLODE
+// The function take_quintuple_for_klass1_through_4 has a single argument of 
+// type Quintuple from which it uses the klass1, klass2, klass3, and klass4
+// fields.  The klass5 field goes unused.  Argument explosion should *not* 
+// result in specialization because there are more than three (the heuristic
+// for max explosion size) live nodes in the type-tree.
+//
+// CHECK-LABEL: sil hidden [noinline] @take_quintuple_for_klass1_through_4_hidden : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_hidden'
+sil hidden [noinline] @take_quintuple_for_klass1_through_4_hidden : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %func = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3, %klass4) : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_hidden'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_4_hidden_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_quintuple_for_klass1_through_4_hidden
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[QUINTUPLE]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_hidden_caller'
+sil @take_quintuple_for_klass1_through_4_hidden_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_4_hidden : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_hidden_caller'
+
+// TEST_QuK1K2K3K4Pr: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & #.klass4, VISIBILITY: private
+// VERIFY: EXPLODE (Quintuple) => (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klass3, #Quintuple.klass4)
+// The function take_quintuple_for_klass1_through_4 has a single argument of 
+// type Quintuple from which it uses the klass1, klass2, klass3, and klass4
+// fields.  The klass5 field goes unused.  Argument explosion *should*
+// result in specialization because there are dead leaves and there are fewer 
+// live than the limit imposed by the heuristic, six because the specializing
+// the function will not result in a thunk.
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_4_private : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s43take_quintuple_for_klass1_through_4_privateTf4x_n : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_private'
+sil private [noinline] @take_quintuple_for_klass1_through_4_private : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %func = function_ref @take_klass_four_times : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  %result = apply %func(%klass1, %klass2, %klass3, %klass4) : $@convention(thin) (Klass, Klass, Klass, Klass) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_private'
+
+// CHECK-LABEL: sil @take_quintuple_for_klass1_through_4_private_caller : $@convention(thin) (Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s43take_quintuple_for_klass1_through_4_privateTf4x_n : $@convention(thin) (Klass, Klass, Klass, Klass) -> () 
+// CHECK: [[KLASS4:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass4
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]], [[KLASS4]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_4_private_caller'
+sil @take_quintuple_for_klass1_through_4_private_caller : $@convention(thin) (Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_4_private : $@convention(thin) (Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_4_private_caller'
+
+
+
+// = END: Quintuple, #.klass1, #.klass2, #.klass3, #.klass4 ==================}}
+
+
+
+// = Quintuple, #.klass1, #.klass2, #.klass3; owned #.klass4, #.klass5 ======={{
+
+
+
+// TEST_QuK1K2K3OwK4OwK5Pu: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & owned #.klass4 & owned #.klass5, VISIBILITY: public
+// VERIFY: EXPLODE: (Quintuple) -> (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klaass3)
+// The function take_quintuple_for_klass1_through_3_owned_klass4_through_5 has a 
+// single argument of type Quintuple from which it uses the klass1, klass2,
+// klass3 fields and releases the klass4 and klass5 fields.  Argument explosion
+// *should* result in specialization because there are only three live leaves in
+// the type tree after considering the owned-to-guaranteed transformation.
+//
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5 : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E2_5Tf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5'
+sil public [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5 : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %klass5 = struct_extract %quintuple : $Quintuple, #Quintuple.klass5
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  strong_release %klass4 : $Klass
+  strong_release %klass5 : $Klass
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5'
+
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_caller : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E2_5Tf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_caller'
+sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_caller : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_owned_klass4_through_5 : $@convention(thin) (@owned Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (@owned Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_caller'
+
+
+
+// TEST_QuK1K2K3OwK4OwK5PuEx: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & owned #.klass4 & owned #.klass5, VISIBILITY: public_external
+// VERIFY: EXPLODE: (Quintuple) -> (#Quintuple.klass1, #Quintuple.klass2, #Quintuple.klaass3)
+// The function take_quintuple_for_klass1_through_3_owned_klass4_through_5 has a 
+// single argument of type Quintuple from which it uses the klass1, klass2,
+// klass3 fields and releases the klass4 and klass5 fields.  Argument explosion
+// *should* result in specialization because there are only three live leaves in
+// the type tree after considering the owned-to-guaranteed transformation.
+//
+// CHECK-LABEL: sil public_external [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E18_5_public_externalTf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () 
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external'
+sil public_external [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %klass5 = struct_extract %quintuple : $Quintuple, #Quintuple.klass5
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  strong_release %klass4 : $Klass
+  strong_release %klass5 : $Klass
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external'
+
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external_caller : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E18_5_public_externalTf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () 
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external_caller'
+sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external_caller : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external : $@convention(thin) (@owned Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (@owned Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_public_external_caller'
+
+
+
+// TEST_QuK1K2K3OwK4OwK5Sh: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & owned #.klass4 & owned #.klass5, VISIBILITY: shared
+// VERIFY: EXPLODE
+// The function
+// take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared has a
+// single argument of type Quintuple from which it uses the klass1, klass2,
+// klass3 fields and releases the klass4 and klass5 fields.  Argument explosion
+// *should* result in specialization because there are only three live leaves
+// in the type tree after considering the owned-to-guaranteed transformation.
+//
+// CHECK-LABEL: sil shared [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_sharedTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared'
+sil shared [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %klass5 = struct_extract %quintuple : $Quintuple, #Quintuple.klass5
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  strong_release %klass4 : $Klass
+  strong_release %klass5 : $Klass
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared'
+
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared_caller : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_sharedTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared_caller'
+sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared_caller : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared : $@convention(thin) (@owned Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (@owned Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_shared_caller'
+
+
+
+// TEST_QuK1K2K3OwK4OwK5Hi: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & owned #.klass4 & owned #.klass5, VISIBILITY: hidden
+// VERIFY: EXPLODE
+// The function
+// take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden has a
+// single argument of type Quintuple from which it uses the klass1, klass2,
+// klass3 fields and releases the klass4 and klass5 fields.  Argument explosion
+// *should* result in specialization because there are only three live leaves
+// in the type tree after considering the owned-to-guaranteed transformation.
+//
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_hiddenTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden'
+sil hidden [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %klass5 = struct_extract %quintuple : $Quintuple, #Quintuple.klass5
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  strong_release %klass4 : $Klass
+  strong_release %klass5 : $Klass
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden'
+
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden_caller : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_hiddenTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden_caller'
+sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden_caller : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden : $@convention(thin) (@owned Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (@owned Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_hidden_caller'
+
+
+
+// TEST_QuK1K2K3OwK4OwK5Pr: TYPE: Quintuple, FIELD: #.klass1 & #.klass2 & #.klass3 & owned #.klass4 & owned #.klass5, VISIBILITY: private
+// VERIFY: EXPLODE
+// The function
+// take_quintuple_for_klass1_through_3_owned_klass4_through_5_private has a
+// single argument of type Quintuple from which it uses the klass1, klass2,
+// klass3 fields and releases the klass4 and klass5 fields.  Argument explosion
+// *should* result in specialization because there are only three live leaves
+// in the type tree after considering the owned-to-guaranteed transformation.
+//
+// CHECK-LABEL: sil private [signature_optimized_thunk] [always_inline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_private : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E10_5_privateTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]]
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_private'
+sil private [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_private : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+  %klass1 = struct_extract %quintuple : $Quintuple, #Quintuple.klass1
+  %klass2 = struct_extract %quintuple : $Quintuple, #Quintuple.klass2
+  %klass3 = struct_extract %quintuple : $Quintuple, #Quintuple.klass3
+  %klass4 = struct_extract %quintuple : $Quintuple, #Quintuple.klass4
+  %klass5 = struct_extract %quintuple : $Quintuple, #Quintuple.klass5
+  %result = apply %func(%klass1, %klass2, %klass3) : $@convention(thin) (Klass, Klass, Klass) -> ()
+  strong_release %klass4 : $Klass
+  strong_release %klass5 : $Klass
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_private'
+
+// CHECK-LABEL: sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_private_caller : $@convention(thin) (@owned Quintuple) -> () {
+// CHECK: bb{{[0-9]+}}([[QUINTUPLE:%.*]] : $Quintuple):
+// CHECK: [[KLASS3:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass3
+// CHECK: [[KLASS2:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass2
+// CHECK: [[KLASS1:%.*]] = struct_extract [[QUINTUPLE]] : $Quintuple, #Quintuple.klass1
+// CHECK: [[FUNCTION:%.*]] = function_ref @$s049take_quintuple_for_klass1_through_3_owned_klass4_E10_5_privateTf4x_nTf4nnndd_n
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_private_caller'
+sil [noinline] @take_quintuple_for_klass1_through_3_owned_klass4_through_5_private_caller : $@convention(thin) (@owned Quintuple) -> () {
+only(%quintuple : $Quintuple):
+  %func = function_ref @take_quintuple_for_klass1_through_3_owned_klass4_through_5_private : $@convention(thin) (@owned Quintuple) -> ()
+  %result = apply %func(%quintuple) : $@convention(thin) (@owned Quintuple) -> ()
+  return %result : $()
+} // end sil function 'take_quintuple_for_klass1_through_3_owned_klass4_through_5_private_caller'
+
+
+
+// = END: Quintuple, #.klass1, #.klass2, #.klass3; owned #.klass4, #.klass5 ==}}
+
+
+
+// ===========================================================================}}
+// =                             END: QUINTUPLE                                =
+// =============================================================================
+
+
+// =============================================================================
+// =============================================================================
+// =====                          END: TESTS                               =====
+// =============================================================================
+// ===========================================================================}}
+
+
+
+// ==========================================================================={{
+// =============================================================================
+// =====                       SPECIALIZATIONS                             =====
+// ===== All the specializations are added at the bottom of the output.    =====
+// ===== The tests around them follow.  They are tied back to the original =====
+// ===== code via a TEST_<FOO> identifier.                                 =====
+// =============================================================================
+// =============================================================================
+
+
+// TEST_WrKlPu:
+// Nothing to check.
+
+// TEST_WrKlPuEx:
+// Nothig to check.
+
+// TEST_WrKlSh:
+// CHECK: sil shared [noinline] @$s19take_wrapper_sharedTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]](%0)
+// CHECK: return [[RESULT]] : $()
+// CHECK: } // end sil function '$s19take_wrapper_sharedTf4x_n'
+
+// TEST_WrKlHi:
+// CHECK-NOT: sil shared [noinline] @$s19take_wrapper_hiddenTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK-NOT: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK-NOT: [[RESULT:%.*]] = apply [[FUNCTION]](%0)
+// CHECK-NOT: return [[RESULT]] : $()
+// CHECK-NOT: } // end sil function '$s19take_wrapper_hiddenTf4x_n'
+
+// TEST_WrKlPr:
+// CHECK: sil private [noinline] @$s20take_wrapper_privateTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]](%0)
+// CHECK: return [[RESULT]] : $()
+// CHECK: } // end sil function '$s20take_wrapper_privateTf4x_n'
+
+// TEST_WrInPu:
+// CHECK-LABEL: sil shared [noinline] @$s20take_wrapper_for_intTf4x_n : $@convention(thin) (Int) -> () {
+// CHECK: bb{{[0-9]*}}([[INT:%.*]] : $Int)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s20take_wrapper_for_intTf4x_n'
+
+// TEST_WrInPuEx:
+// CHECK-LABEL: sil shared [noinline] @$s36take_wrapper_for_int_public_externalTf4x_n : $@convention(thin) (Int) -> () {
+// CHECK: bb{{[0-9]*}}([[INT:%.*]] : $Int)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s36take_wrapper_for_int_public_externalTf4x_n'
+
+// TEST_WrInHi:
+// CHECK-LABEL: sil shared [noinline] @$s27take_wrapper_for_int_hiddenTf4x_n : $@convention(thin) (Int) -> () {
+// CHECK: bb{{[0-9]*}}([[INT:%.*]] : $Int)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s27take_wrapper_for_int_hiddenTf4x_n'
+
+// TEST_WrInPr:
+// CHECK-LABEL: sil private [noinline] @$s28take_wrapper_for_int_privateTf4x_n : $@convention(thin) (Int) -> () {
+// CHECK: bb{{[0-9]*}}([[INT:%.*]] : $Int)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_int
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[INT]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s28take_wrapper_for_int_privateTf4x_n'
+
+// TEST_PaPu:
+// CHECK-LABEL: sil shared [noinline] @$s16take_pair_unusedTf4d_n : $@convention(thin) () -> () {
+// CHECK: bb{{[0-9]*}}
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_nothing : $@convention(thin) () -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s16take_pair_unusedTf4d_n'
+
+// TEST_PaPuEx:
+// CHECK-LABEL: sil shared [noinline] @$s32take_pair_unused_public_externalTf4d_n
+// CHECK: bb{{[0-9]*}}
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_nothing : $@convention(thin) () -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s32take_pair_unused_public_externalTf4d_n'
+
+// TEST_PaHi: 
+// CHECK-LABEL: sil shared [noinline] @$s23take_pair_unused_hiddenTf4d_n : $@convention(thin) () -> () {
+// CHECK: bb{{[0-9]*}}
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_nothing : $@convention(thin) () -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s23take_pair_unused_hiddenTf4d_n'
+
+// TEST_PaPr:
+// CHECK-LABEL: sil private [noinline] @$s24take_pair_unused_privateTf4d_n : $@convention(thin) () -> () {
+// CHECK: bb{{[0-9]*}}
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_nothing : $@convention(thin) () -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]()
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s24take_pair_unused_privateTf4d_n'
+
+// TEST_PaK1Pu:
+// CHECK-LABEL: sil shared [noinline] @$s20take_pair_for_klass1Tf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS:%.*]] : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s20take_pair_for_klass1Tf4x_n'
+
+// TEST_PaK1PuEx:
+// CHECK-LABEL: sil shared [noinline] @$s36take_pair_for_klass1_public_externalTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS:%.*]] : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s36take_pair_for_klass1_public_externalTf4x_n'
+
+// TEST_PaK1Hi: 
+// CHECK-LABEL: sil shared [noinline] @$s27take_pair_for_klass1_hiddenTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s27take_pair_for_klass1_hiddenTf4x_n'
+
+// TEST_PaK1Pr:
+// CHECK-LABEL: sil private [noinline] @$s28take_pair_for_klass1_privateTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s28take_pair_for_klass1_privateTf4x_n'
+
+// TEST_PaK2Pu:
+// CHECK-LABEL: sil shared [noinline] @$s20take_pair_for_klass2Tf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s20take_pair_for_klass2Tf4x_n'
+
+// TEST_PaK2PuEx:
+// CHECK-LABEL: sil shared [noinline] @$s36take_pair_for_klass2_public_externalTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s36take_pair_for_klass2_public_externalTf4x_n'
+
+// TEST_PaK2Hi: 
+// CHECK-LABEL: sil shared [noinline] @$s27take_pair_for_klass2_hiddenTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s27take_pair_for_klass2_hiddenTf4x_n'
+
+// TEST_PaK2Pr:
+// CHECK-LABEL: sil private [noinline] @$s28take_pair_for_klass2_privateTf4x_n : $@convention(thin) (Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass)
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass : $@convention(thin) (Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s28take_pair_for_klass2_privateTf4x_n'
+
+// TEST_PaK1K2Pu:
+// Nothing to check.
+
+// TEST_PaK1K2PuEx:
+// Nothing to check.
+
+// TEST_PaK1K2Hi: 
+// Nothing to check.
+
+// TEST_PaK1K2Pr:
+// Nothing to check.
+
+
+// TEST_QuK1K2K3Pu:
+// CHECK-LABEL: sil shared [noinline] @$s35take_quintuple_for_klass1_through_3Tf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass, {{%.*}} : $Klass, {{%.*}} : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}}, {{%.*}}, {{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s35take_quintuple_for_klass1_through_3Tf4x_n'
+// Nothing to check.
+
+// TEST_QuK1K2K3PuEx:
+// FIXME: THIS CHANGED
+
+// TEST_QuK1K2K3Sh:
+// CHECK-LABEL: sil shared [noinline] @$s42take_quintuple_for_klass1_through_3_sharedTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass, {{%.*}} : $Klass, {{%.*}} : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}}, {{%.*}}, {{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s42take_quintuple_for_klass1_through_3_sharedTf4x_n'
+
+// Nothing to check.
+
+// TEST_QuK1K2K3Hi:
+// CHECK-LABEL: sil shared [noinline] @$s42take_quintuple_for_klass1_through_3_hiddenTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass, {{%.*}} : $Klass, {{%.*}} : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}}, {{%.*}}, {{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s42take_quintuple_for_klass1_through_3_hiddenTf4x_n'
+
+// TEST_QuK1K2K3Pr:
+// CHECK-LABEL: sil private [noinline] @$s43take_quintuple_for_klass1_through_3_privateTf4x_n : $@convention(thin) (Klass, Klass, Klass) -> () {
+// CHECK: bb{{[0-9]*}}({{%.*}} : $Klass, {{%.*}} : $Klass, {{%.*}} : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]({{%.*}}, {{%.*}}, {{%.*}})
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s43take_quintuple_for_klass1_through_3_privateTf4x_n'
+
+// TEST_QuK1K2K3K4Pu:
+// Nothing to check.
+
+// TEST_QuK1K2K3K4PuEx:
+// Nothing to check.
+
+// TEST_QuK1K2K3K4Sh:
+// FIXME: THIS CHANGED
+// Nothing to check.
+
+// TEST_QuK1K2K3K4Hi:
+// Nothing to check.
+
+// TEST_QuK1K2K3K4Pr:
+// Nothing to check.
+
+// TEST_QuK1K2K3OwK4OwK5Pu:
+// CHECK-LABEL: sil shared [noinline] @$s049take_quintuple_for_klass1_through_3_owned_klass4_E2_5Tf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS1:%.*]] : $Klass, [[KLASS2:%.*]] : $Klass, [[KLASS3:%.*]] : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s049take_quintuple_for_klass1_through_3_owned_klass4_E2_5Tf4x_nTf4nnndd_n'
+
+// TEST_QuK1K2K3OwK4OwK5PuEx:
+// FIXME: THIS CHANGED
+
+// TEST_QuK1K2K3OwK4OwK5Sh:
+// CHECK-LABEL: sil shared [noinline] @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_sharedTf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS1:%.*]] : $Klass, [[KLASS2:%.*]] : $Klass, [[KLASS3:%.*]] : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_sharedTf4x_nTf4nnndd_n'
+
+// TEST_QuK1K2K3OwK4OwK5Hi:
+// CHECK-LABEL: sil shared [noinline] @$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_hiddenTf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS1:%.*]] : $Klass, [[KLASS2:%.*]] : $Klass, [[KLASS3:%.*]] : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s049take_quintuple_for_klass1_through_3_owned_klass4_E9_5_hiddenTf4x_nTf4nnndd_n'
+
+// TEST_QuK1K2K3OwK4OwK5Pr:
+// CHECK-LABEL: sil private [noinline] @$s049take_quintuple_for_klass1_through_3_owned_klass4_E10_5_privateTf4x_nTf4nnndd_n : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+// CHECK: bb{{[0-9]*}}([[KLASS1:%.*]] : $Klass, [[KLASS2:%.*]] : $Klass, [[KLASS3:%.*]] : $Klass):
+// CHECK: [[FUNCTION:%.*]] = function_ref @take_klass_three_times : $@convention(thin) (Klass, Klass, Klass) -> ()
+// CHECK: [[RESULT:%.*]] = apply [[FUNCTION]]([[KLASS1]], [[KLASS2]], [[KLASS3]])
+// CHECK: return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function '$s049take_quintuple_for_klass1_through_3_owned_klass4_E10_5_privateTf4x_nTf4nnndd_n'
+
+// =============================================================================
+// =============================================================================
+// =====                    END: SPECIALIZATIONS                           =====
+// =============================================================================
+// ===========================================================================}}


### PR DESCRIPTION
The new rule on the basis of which an argument will be exploded is as follows:

(1) An argument with more than 3 live leaves after considering the results of the owned-to-guaranteed transformation will not be exploded.

(2) Rule (1) permitting, an argument all of whose non-trivial leaves are live will be exploded if and only if (a) there is more than one non-trivial leaf and (b) specialization will not result in a thunk.  This rule was beneficial before semantic ARC because it avoided collapsing RC identities.  It is not useful in the face of semantic ARC and should be retired.

(3) Rule (1) permitting, an argument with dead non-trivial leaves will be exploded.

rdar://problem/39957093