### PR TITLE
Move swift apis to 9e7cb33803de8fdb3e85c58f8c25692aff440a0a

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -469,7 +469,7 @@
             "repos": {
                 "llvm": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "clang": "ecfead281dab91cee05d78a5699c72cd3c93b08f",
-                "swift": "tensorflow",
+                "swift": "tensorflow-0.5",
                 "lldb": "2d11a3502600c9ceb27c93340b6f7e943477ae8c",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
@@ -487,7 +487,7 @@
                 "clang-tools-extra": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "libcxx": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "tensorflow": "7c7d924821a8b1b20433c2f3f484bbd409873a84",
-                "tensorflow-swift-apis": "33fe7f360ef8b379d727f714bbc18f1916b8f198",
+                "tensorflow-swift-apis": "9e7cb33803de8fdb3e85c58f8c25692aff440a0a",
                 "tensorflow-swift-quote": "03a61b10adfff4d08c23ed487b0a0a786932a07d",
                 "indexstore-db": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a",
                 "sourcekit-lsp": "swift-DEVELOPMENT-SNAPSHOT-2019-08-12-a"


### PR DESCRIPTION
Moves swift-apis to https://github.com/tensorflow/swift-apis/commit/9e7cb33803de8fdb3e85c58f8c25692aff440a0a