### PR TITLE
[NFC] Address review feedback from #27172

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3786,12 +3786,13 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
 
 static Type getStructuralType(TypeDecl *typeDecl) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-	// When we're computing requirement signatures, the structural type
-	// suffices.  Otherwise we'll potentially try to validate incomplete 
-	// requirements.
-	auto *proto = dyn_cast_or_null<ProtocolDecl>(typealias->getDeclContext()->getAsDecl());
-	if (proto && proto->isComputingRequirementSignature())
-		return typealias->getStructuralType();
+    // When we're computing requirement signatures, the structural type
+    // suffices.  Otherwise we'll potentially try to validate incomplete
+    // requirements.
+    auto *proto = dyn_cast_or_null<ProtocolDecl>(
+        typealias->getDeclContext()->getAsDecl());
+    if (proto && proto->isComputingRequirementSignature())
+      return typealias->getStructuralType();
     return typealias->getUnderlyingType();
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4302,16 +4302,20 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
       // Nested Hack to break cycles if this is called before validation has
       // finished.
       if (aliasDecl->hasInterfaceType()) {
-        auto extendedNominal = aliasDecl->getDeclaredInterfaceType()->getAnyNominal();
+        auto extendedNominal =
+            aliasDecl->getDeclaredInterfaceType()->getAnyNominal();
         if (extendedNominal)
-          return TypeChecker::isPassThroughTypealias(aliasDecl, aliasDecl->getUnderlyingType(), extendedNominal)
-                      ? extendedType
-                      : extendedNominal->getDeclaredType();
+          return TypeChecker::isPassThroughTypealias(
+                     aliasDecl, aliasDecl->getUnderlyingType(), extendedNominal)
+                     ? extendedType
+                     : extendedNominal->getDeclaredType();
       } else {
-        if (auto ty = aliasDecl->getStructuralType()->getAs<NominalOrBoundGenericNominalType>())
-          return TypeChecker::isPassThroughTypealias(aliasDecl, ty, ty->getDecl())
-                 ? extendedType
-                 : ty->getDecl()->getDeclaredType();
+        if (auto ty = aliasDecl->getStructuralType()
+                          ->getAs<NominalOrBoundGenericNominalType>())
+          return TypeChecker::isPassThroughTypealias(aliasDecl, ty,
+                                                     ty->getDecl())
+                     ? extendedType
+                     : ty->getDecl()->getDeclaredType();
       }
     }
   }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -556,7 +556,8 @@ static Type formExtensionInterfaceType(
   }
 
   // If we have a typealias, try to form type sugar.
-  if (typealias && TypeChecker::isPassThroughTypealias(typealias, typealias->getUnderlyingType(), nominal)) {
+  if (typealias && TypeChecker::isPassThroughTypealias(
+                       typealias, typealias->getUnderlyingType(), nominal)) {
     auto typealiasSig = typealias->getGenericSignature();
     SubstitutionMap subMap;
     if (typealiasSig) {
@@ -565,9 +566,9 @@ static Type formExtensionInterfaceType(
       mustInferRequirements = true;
     }
 
-    resultType = TypeAliasType::get(typealias, parentType, subMap,
-                                    resultType);
+    resultType = TypeAliasType::get(typealias, parentType, subMap, resultType);
   }
+
 
   return resultType;
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2292,15 +2292,7 @@ public:
 
     auto underlying = MF.getType(underlyingTypeID);
     alias->setUnderlyingType(underlying);
-    SubstitutionMap subs;
-    if (genericSig) {
-      subs = genericSig->getIdentitySubstitutionMap();
-    }
-    Type parent;
-    if (DC->isTypeContext())
-      parent = DC->getDeclaredInterfaceType();
-    auto sugaredType = TypeAliasType::get(alias, parent, subs, underlying);
-    alias->setInterfaceType(MetatypeType::get(sugaredType, ctx));
+    alias->computeType();
     alias->setValidationToChecked();
     
     if (auto accessLevel = getActualAccessLevel(rawAccessLevel))


### PR DESCRIPTION
- Clean up some errant formatting mistakes.
- Collapse some code that was duplicating computing the interface type.

The dumper kicking off requests is going to require a more holistic patch.