### PR TITLE
[Constant Evaluator] Improve assertion failure and condfail_message support in constant evaluator

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -377,14 +377,9 @@ NOTE(constexpr_overflow,none, "integer overflow detected", ())
 NOTE(constexpr_overflow_operation,none, "operation"
      "%select{| performed during this call}0 overflows", (bool))
 
-NOTE(constexpr_trap,none, "trap detected", ())
-NOTE(constexpr_trap_operation,none, "operation"
+NOTE(constexpr_trap, none, "%0", (StringRef))
+NOTE(constexpr_trap_operation, none, "operation"
      "%select{| performed during this call}0 traps", (bool))
-
-NOTE(constexpr_assertion_failed, none, "assertion failed with message: %0",
-    (StringRef))
-NOTE(constexpr_assertion_failed_here, none, "assertion failed"
-     "%select{ here| during this call}0 ", (bool))
 
 NOTE(constexpr_invalid_operand_seen, none,
     "operation with invalid operands encountered during evaluation",())

--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -45,6 +45,10 @@ class UnknownReason;
 class ConstExprEvaluator {
   SymbolicValueAllocator &allocator;
 
+  // Assert configuration that must be used by the evaluator. This determines
+  // the result of the builtin "assert_configuration".
+  unsigned assertConfig;
+
   /// The current call stack, used for providing accurate diagnostics.
   llvm::SmallVector<SourceLoc, 4> callStack;
 
@@ -58,12 +62,14 @@ class ConstExprEvaluator {
 
 public:
   explicit ConstExprEvaluator(SymbolicValueAllocator &alloc,
-                              bool trackCallees = false);
+                              unsigned assertConf, bool trackCallees = false);
   ~ConstExprEvaluator();
 
   explicit ConstExprEvaluator(const ConstExprEvaluator &other);
 
   SymbolicValueAllocator &getAllocator() { return allocator; }
+
+  unsigned getAssertConfig() { return assertConfig; }
 
   void pushCallStack(SourceLoc loc) { callStack.push_back(loc); }
 
@@ -124,7 +130,8 @@ public:
   /// Constructs a step evaluator given an allocator and a non-null pointer to a
   /// SILFunction.
   explicit ConstExprStepEvaluator(SymbolicValueAllocator &alloc,
-                                  SILFunction *fun, bool trackCallees = false);
+                                  SILFunction *fun, unsigned assertConf,
+                                  bool trackCallees = false);
   ~ConstExprStepEvaluator();
 
   /// Evaluate an instruction in the current interpreter state.

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -656,18 +656,11 @@ void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
       diagnose(ctx, triggerLoc, diag::constexpr_overflow_operation,
                triggerLocSkipsInternalLocs);
     return;
-  case UnknownReason::Trap:
-    diagnose(ctx, diagLoc, diag::constexpr_trap);
+  case UnknownReason::Trap: {
+    const char *message = unknownReason.getTrapMessage();
+    diagnose(ctx, diagLoc, diag::constexpr_trap, StringRef(message));
     if (emitTriggerLocInDiag)
       diagnose(ctx, triggerLoc, diag::constexpr_trap_operation,
-               triggerLocSkipsInternalLocs);
-    return;
-  case UnknownReason::AssertionFailure: {
-    const char *message = unknownReason.getAssertionFailureMessage();
-    diagnose(ctx, diagLoc, diag::constexpr_assertion_failed,
-             StringRef(message));
-    if (emitTriggerLocInDiag)
-      diagnose(ctx, triggerLoc, diag::constexpr_assertion_failed_here,
                triggerLocSkipsInternalLocs);
     return;
   }

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -194,7 +194,8 @@ class EmitDFDiagnostics : public SILFunctionTransform {
 
     if (M.getASTContext().LangOpts.EnableExperimentalStaticAssert) {
       SymbolicValueBumpAllocator allocator;
-      ConstExprEvaluator constantEvaluator(allocator);
+      ConstExprEvaluator constantEvaluator(allocator,
+                                           getOptions().AssertConfig);
       for (auto &BB : *getFunction())
         for (auto &I : BB)
           diagnosePoundAssert(&I, M, constantEvaluator);

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -186,9 +186,10 @@ private:
   SmallVector<SILValue, 4> constantSILValues;
 
 public:
-  FoldState(SILFunction *fun, SILInstruction *beginInst,
+  FoldState(SILFunction *fun, unsigned assertConfig, SILInstruction *beginInst,
             ArrayRef<SILInstruction *> endInsts)
-      : constantEvaluator(allocator, fun), beginInstruction(beginInst),
+      : constantEvaluator(allocator, fun, assertConfig),
+        beginInstruction(beginInst),
         endInstructions(endInsts.begin(), endInsts.end()) {}
 
   void addConstantSILValue(SILValue value) {
@@ -627,13 +628,14 @@ static bool detectAndDiagnoseErrors(Optional<SymbolicValue> errorInfo,
 /// Constant evaluate instructions starting from 'start' and fold the uses
 /// of the value 'oslogMessage'. Stop when oslogMessageValue is released.
 static void constantFold(SILInstruction *start,
-                         SingleValueInstruction *oslogMessage) {
+                         SingleValueInstruction *oslogMessage,
+                         unsigned assertConfig) {
 
   // Initialize fold state.
   SmallVector<SILInstruction *, 2> lifetimeEndInsts;
   getLifetimeEndInstructionsOfSILValue(oslogMessage, lifetimeEndInsts);
 
-  FoldState state(start->getFunction(), start, lifetimeEndInsts);
+  FoldState state(start->getFunction(), assertConfig, start, lifetimeEndInsts);
 
   auto errorInfo = collectConstants(state);
 
@@ -738,6 +740,7 @@ class OSLogOptimization : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
     auto &fun = *getFunction();
+    unsigned assertConfig = getOptions().AssertConfig;
 
     // Don't rerun optimization on deserialized functions or stdlib functions.
     if (fun.wasDeserializedCanonical()) {
@@ -778,7 +781,7 @@ class OSLogOptimization : public SILFunctionTransform {
         continue;
       }
 
-      constantFold(interpolationStart, oslogInit);
+      constantFold(interpolationStart, oslogInit, assertConfig);
     }
   }
 };

--- a/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ConstantEvaluableSubsetChecker.cpp
@@ -64,6 +64,7 @@ class ConstantEvaluableSubsetChecker : public SILModuleTransform {
     // Create a step evaluator and run it on the function.
     SymbolicValueBumpAllocator allocator;
     ConstExprStepEvaluator stepEvaluator(allocator, fun,
+                                         getOptions().AssertConfig,
                                          /*trackCallees*/ true);
     bool previousEvaluationHadFatalError = false;
 

--- a/lib/SILOptimizer/UtilityPasses/ConstantEvaluatorTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ConstantEvaluatorTester.cpp
@@ -59,7 +59,8 @@ class ConstantEvaluatorTester : public SILFunctionTransform {
     llvm::errs() << "@" << fun->getName() << "\n";
 
     SymbolicValueBumpAllocator allocator;
-    ConstExprStepEvaluator stepEvaluator(allocator, fun);
+    ConstExprStepEvaluator stepEvaluator(allocator, fun,
+                                         getOptions().AssertConfig);
 
     for (auto currI = fun->getEntryBlock()->begin();;) {
       auto *inst = &(*currI);

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -192,8 +192,8 @@ internal func interpretIntTruncations() -> Int8 {
 @_semantics("constant_evaluable")
 internal func testInvalidIntTruncations(a: Int32) -> Int8 {
   return Int8(a)
-    // CHECK: note: assertion failed with message: Fatal error: Not enough bits to represent the passed value: {{.*}}/Integers.swift:
-    // CHECK: note: assertion failed during this call
+    // CHECK: note: {{.*}}: Not enough bits to represent the passed value
+    // CHECK: note: operation performed during this call traps
     // CHECK: function_ref @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
 }
 
@@ -238,8 +238,8 @@ internal func interpretSingedUnsignedConversions() -> UInt32 {
 @_semantics("constant_evaluable")
 internal func testInvalidSingedUnsignedConversions(a: Int64) -> UInt64 {
   return UInt64(a)
-    // CHECK: note: assertion failed with message: Fatal error: Negative value is not representable: {{.*}}/Integers.swift:
-    // CHECK: note: assertion failed during this call
+    // CHECK: note: {{.*}}: Negative value is not representable
+    // CHECK: note: operation performed during this call traps
     // CHECK: function_ref @$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
 }
 
@@ -341,8 +341,8 @@ func interpretIntAddOverflow() -> Int8 {
 @_semantics("constant_evaluable")
 func testDivideByZero(_ x: Int, _ y: Int) -> Int {
   return x / y
-    // CHECK: note: assertion failed with message: Fatal error: Division by zero: {{.*}}/IntegerTypes.swift:
-    // CHECK: note: assertion failed here
+    // CHECK: note: {{.*}}: Division by zero
+    // CHECK: note: operation traps
 }
 
 @_semantics("test_driver")
@@ -355,8 +355,8 @@ func interpretDivideByZero() -> Int {
 @_semantics("constant_evaluable")
 func testDivideOverflow(_ x: Int8, _ y: Int8) -> Int8 {
   return x / y
-    // CHECK: note: assertion failed with message: Fatal error: Division results in an overflow: {{.*}}/IntegerTypes.swift:
-    // CHECK: note: assertion failed here
+    // CHECK: note: {{.*}}: Division results in an overflow
+    // CHECK: note: operation traps
 }
 
 @_semantics("test_driver")

--- a/test/SILOptimizer/constant_evaluable_subset_test_arch64.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test_arch64.swift
@@ -70,8 +70,8 @@ internal func interpretIntTruncations() -> Int16 {
 @_semantics("constant_evaluable")
 internal func testInvalidIntTruncations(a: Int64) -> Int8 {
   return Int8(a)
-    // CHECK: note: assertion failed with message: Fatal error: Not enough bits to represent the passed value: {{.*}}/Integers.swift:
-    // CHECK: note: assertion failed during this call
+    // CHECK: note: {{.*}} Not enough bits to represent the passed value
+    // CHECK: note: operation performed during this call traps
     // CHECK: function_ref @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC
 }
 

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1191,8 +1191,8 @@ sil [noinline] [_semantics "programtermination_point"] [canonical] @$assertionFa
 // CHECK-LABEL: @interpretAssertionFailure
 sil @interpretAssertionFailure : $@convention(thin) () -> Never {
   // Construct error prefix.
-  %0 = string_literal utf8 "prefix"
-  %1 = integer_literal $Builtin.Word, 6
+  %0 = string_literal utf8 "error-prefix"
+  %1 = integer_literal $Builtin.Word, 12
   %2 = builtin "ptrtoint_Word"(%0 : $Builtin.RawPointer) : $Builtin.Word
   %3 = integer_literal $Builtin.Int8, 2
   %4 = struct $StaticString (%2 : $Builtin.Word, %1 : $Builtin.Word, %3 : $Builtin.Int8)
@@ -1210,6 +1210,6 @@ sil @interpretAssertionFailure : $@convention(thin) () -> Never {
 
   %22 = function_ref @$assertionFailure : $@convention(thin) (StaticString, StaticString, UInt64) -> Never
   %23 = apply %22(%4, %14, %21) : $@convention(thin) (StaticString, StaticString, UInt64) -> Never
-    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: assertion failed with message: prefix: message:
+    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: error-prefix: message
   unreachable
 }


### PR DESCRIPTION
Pass assert configuration option to the constant evaluator in order to precisely evaluate Builtin.assert_configuration.

Unify UnknownReason::Trap and UnknownReason::AssertionFailure error
values in the constant evaluator, now that we have 'condfail_message'
SIL instruction, which provides an error message for the traps.