### PR TITLE
utils: pass `CMAKE_Swift_COMPILER`

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3405,6 +3405,10 @@ for host in "${ALL_HOSTS[@]}"; do
                   continue
                 ;;
                 *)
+                  cmake_options=(
+                    ${cmake_options[@]}
+                    -DCMAKE_Swift_COMPILER:PATH="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                  )
                   results_targets=( "test" )
                   executable_target=""
                 ;;


### PR DESCRIPTION
This is the variable that the official CMake Swift support uses.  Define
this so that we can be forward compatible with CMake 3.15.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
