### PR TITLE
[PropertyWrappers] Look for constructors with default args when finding default init 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4533,8 +4533,6 @@ ERROR(property_wrapper_wrong_initial_value_init, none,
       (DeclName, Type, Type))
 ERROR(property_wrapper_failable_init, none,
       "%0 cannot be failable", (DeclName))
-ERROR(property_wrapper_ambiguous_default_value_init, none,
-  "property wrapper type %0 has multiple default-value initializers", (Type))
 ERROR(property_wrapper_type_requirement_not_accessible,none,
       "%select{private|fileprivate|internal|public|open}0 %1 %2 cannot have "
       "more restrictive access than its enclosing property wrapper type %3 "

--- a/include/swift/AST/PropertyWrappers.h
+++ b/include/swift/AST/PropertyWrappers.h
@@ -43,9 +43,12 @@ struct PropertyWrapperTypeInfo {
     HasInitialValueInit
   } wrappedValueInit = NoWrappedValueInit;
 
-  /// The initializer `init()` that will be called to default-initialize a
+  /// The initializer that will be called to default-initialize a
   /// value with an attached property wrapper.
-  ConstructorDecl *defaultInit = nullptr;
+  enum {
+    NoDefaultValueInit = 0,
+    HasDefaultValueInit
+  } defaultInit = NoDefaultValueInit;
 
   /// The property through which the projection value ($foo) will be accessed.
   ///

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -26,6 +26,16 @@
 #include "swift/AST/TypeCheckRequests.h"
 using namespace swift;
 
+/// The kind of property initializer to look for
+enum class PropertyWrapperInitKind {
+  /// An initial-value initializer (i.e. `init(initialValue:)`)
+  InitialValue,
+  /// An wrapped-value initializer (i.e. `init(wrappedValue:)`)
+  WrappedValue,
+  /// An default-value initializer (i.e. `init()` or `init(defaultArgs...)`)
+  Default
+};
+
 /// Find the named property in a property wrapper to which access will
 /// be delegated.
 static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
@@ -79,53 +89,70 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   return var;
 }
 
-/// Determine whether we have a suitable wrapped-value initializer within
-/// a property wrapper type.
-static ConstructorDecl *findInitialValueInit(
-    ASTContext &ctx,
-    NominalTypeDecl *nominal,
-    VarDecl *valueVar,
-    Identifier argumentLabel) {
-  // Retrieve the type of the 'value' property.
-  Type valueVarType = valueVar->getValueInterfaceType();
-
+/// Determine whether we have a suitable initializer within a property wrapper
+/// type.
+static ConstructorDecl *
+findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
+                        VarDecl *valueVar, PropertyWrapperInitKind initKind) {
   enum class NonViableReason {
     Failable,
     ParameterTypeMismatch,
     Inaccessible,
   };
-  SmallVector<std::tuple<ConstructorDecl*, NonViableReason, Type>, 2> nonviable;
-  SmallVector<ConstructorDecl *, 2> initialValueInitializers;
 
+  SmallVector<std::tuple<ConstructorDecl *, NonViableReason, Type>, 2>
+      nonviable;
+  SmallVector<ConstructorDecl *, 2> viableInitializers;
   SmallVector<ValueDecl *, 2> decls;
+
+  Identifier argumentLabel;
+  switch (initKind) {
+  case PropertyWrapperInitKind::InitialValue:
+    argumentLabel = ctx.Id_initialValue;
+    break;
+  case PropertyWrapperInitKind::WrappedValue:
+    argumentLabel = ctx.Id_wrappedValue;
+    break;
+  case PropertyWrapperInitKind::Default:
+    break;
+  }
+
   nominal->lookupQualified(nominal, DeclBaseName::createConstructor(),
                            NL_QualifiedDefault, decls);
   for (const auto &decl : decls) {
     auto init = dyn_cast<ConstructorDecl>(decl);
-    if (!init || init->getDeclContext() != nominal || init->getGenericParams())
+    if (!init || init->getDeclContext() != nominal || init->isGeneric())
       continue;
 
+    ParamDecl *argumentParam = nullptr;
+    bool allArgsDefault = true;
     // Check whether every parameter meets one of the following criteria:
     //   (1) The parameter has a default argument, or
     //   (2) The parameter has the given argument label.
-    ParamDecl *wrappedValueParam = nullptr;
     for (auto param : *init->getParameters()) {
       // Recognize the first parameter with the requested argument label.
-      if (param->getArgumentName() == argumentLabel && !wrappedValueParam) {
-        wrappedValueParam = param;
+      if (param->getArgumentName() == argumentLabel && !argumentParam) {
+        argumentParam = param;
         continue;
       }
 
-      if (param->isDefaultArgument())
+      if (param->isDefaultArgument()) {
+        allArgsDefault &= true;
         continue;
-
-      // Forget we had a match.
-      wrappedValueParam = nullptr;
-      break;
+      } else {
+        // Forget we had a match.
+        allArgsDefault = false;
+        argumentParam = nullptr;
+        break;
+      }
     }
 
-    if (!wrappedValueParam)
+    if (initKind != PropertyWrapperInitKind::Default && !argumentParam)
       continue;
+
+    if (initKind == PropertyWrapperInitKind::Default && !allArgsDefault) {
+      continue;
+    }
 
     // Failable initializers cannot be used.
     if (init->isFailable()) {
@@ -141,33 +168,37 @@ static ConstructorDecl *findInitialValueInit(
       continue;
     }
 
-    if (!wrappedValueParam->hasInterfaceType())
-      continue;
+    // Additional checks for initial-value and wrapped-value initializers
+    if (initKind != PropertyWrapperInitKind::Default) {
+      if (!argumentParam)
+        continue;
 
-    if (wrappedValueParam->isInOut() || wrappedValueParam->isVariadic())
-      continue;
+      if (!argumentParam->hasInterfaceType())
+        continue;
 
-    auto paramType = wrappedValueParam->getInterfaceType();
-    if (wrappedValueParam->isAutoClosure()) {
-      if (auto *fnType = paramType->getAs<FunctionType>())
-        paramType = fnType->getResult();
+      if (argumentParam->isInOut() || argumentParam->isVariadic())
+        continue;
+
+      auto paramType = argumentParam->getInterfaceType();
+      if (argumentParam->isAutoClosure()) {
+        if (auto *fnType = paramType->getAs<FunctionType>())
+          paramType = fnType->getResult();
+      }
+
+      // The parameter type must be the same as the type of `valueVar` or an
+      // autoclosure thereof.
+      if (!paramType->isEqual(valueVarType)) {
+        nonviable.push_back(std::make_tuple(
+            init, NonViableReason::ParameterTypeMismatch, paramType));
+        continue;
+      }
     }
 
-    // The parameter type must be the same as the type of `valueVar` or an
-    // autoclosure thereof.
-    if (!paramType->isEqual(valueVarType)) {
-      nonviable.push_back(
-          std::make_tuple(init, NonViableReason::ParameterTypeMismatch,
-                          paramType));
-      continue;
-    }
-
-    // Check the type
-    initialValueInitializers.push_back(init);
+    viableInitializers.push_back(init);
   }
 
   // If we found some nonviable candidates but no viable ones, complain.
-  if (initialValueInitializers.empty() && !nonviable.empty()) {
+  if (viableInitializers.empty() && !nonviable.empty()) {
     for (const auto &candidate : nonviable) {
       auto init = std::get<0>(candidate);
       auto reason = std::get<1>(candidate);
@@ -187,110 +218,15 @@ static ConstructorDecl *findInitialValueInit(
 
       case NonViableReason::ParameterTypeMismatch:
         init->diagnose(diag::property_wrapper_wrong_initial_value_init,
-                       init->getFullName(), paramType, valueVarType);
+                       init->getFullName(), paramType,
+                       valueVar->getValueInterfaceType());
         valueVar->diagnose(diag::decl_declared_here, valueVar->getFullName());
         break;
       }
     }
   }
 
-  return initialValueInitializers.empty() ? nullptr
-                                          : initialValueInitializers.front();
-}
-
-/// Determine whether we have a suitable init() within a property
-/// wrapper type.
-static ConstructorDecl *findDefaultInit(ASTContext &ctx,
-                                        NominalTypeDecl *nominal) {
-  SmallVector<ConstructorDecl *, 2> defaultValueInitializers;
-  SmallVector<ValueDecl *, 2> decls;
-  auto initName = DeclBaseName::createConstructor();
-  nominal->lookupQualified(nominal, initName, NL_QualifiedDefault, decls);
-  for (const auto &decl : decls) {
-    auto init = dyn_cast<ConstructorDecl>(decl);
-    if (!init || init->getDeclContext() != nominal || init->isGeneric())
-      continue;
-
-    assert(init->hasParameterList());
-    // A constructor which does not have any parameters or where all the
-    // parameters have a default argument can be used to default initialize
-    // the property wrapper type.
-    //
-    // A constructor with no parameters will satisfy the check below.
-    bool allParamsHaveDefaultArg = llvm::all_of(
-        init->getParameters()->getArray(),
-        [](const ParamDecl *decl) { return decl->isDefaultArgument(); });
-
-    if (allParamsHaveDefaultArg) {
-      defaultValueInitializers.push_back(init);
-    }
-  }
-
-  if (defaultValueInitializers.size() > 1) {
-    // Let's find the single most specialized init. If we don't have one, then
-    // we'll diagnose later.
-    if (auto TC = static_cast<TypeChecker *>(ctx.getLazyResolver())) {
-      Optional<unsigned> bestIdx;
-      for (unsigned i = 1, n = defaultValueInitializers.size(); i != n; ++i) {
-        auto bestOrPrevIdx = bestIdx ? bestIdx.getValue() : i - 1;
-        auto firstInit =
-            cast<ValueDecl>(defaultValueInitializers[bestOrPrevIdx]);
-        auto secondInit = cast<ValueDecl>(defaultValueInitializers[i]);
-
-        switch (TC->compareDeclarations(nominal, firstInit, secondInit)) {
-        case Comparison::Better:
-          bestIdx = bestOrPrevIdx;
-          break;
-        case Comparison::Worse:
-          bestIdx = i;
-          break;
-        case Comparison::Unordered:
-          break;
-        }
-      }
-
-      if (bestIdx.hasValue()) {
-        auto bestInit = defaultValueInitializers[bestIdx.getValue()];
-        defaultValueInitializers = {bestInit};
-      }
-    }
-  }
-
-  switch (defaultValueInitializers.size()) {
-  case 0:
-    return nullptr;
-
-  case 1:
-    break;
-
-  default:
-    // Diagnose ambiguous default value initializers.
-    nominal->diagnose(diag::property_wrapper_ambiguous_default_value_init,
-                      nominal->getDeclaredType());
-    for (auto init : defaultValueInitializers) {
-      init->diagnose(diag::kind_declname_declared_here,
-                     init->getDescriptiveKind(), init->getFullName());
-    }
-    return nullptr;
-  }
-
-  // The initializer must be as accessible as the nominal type.
-  auto init = defaultValueInitializers.front();
-  if (init->getFormalAccess() < nominal->getFormalAccess()) {
-    init->diagnose(diag::property_wrapper_type_requirement_not_accessible,
-                     init->getFormalAccess(), init->getDescriptiveKind(),
-                     init->getFullName(), nominal->getDeclaredType(),
-                     nominal->getFormalAccess());
-    return nullptr;
-  }
-
-  // The initializer must not be failable.
-  if (init->isFailable()) {
-    init->diagnose(diag::property_wrapper_failable_init, initName);
-    return nullptr;
-  }
-
-  return init;
+  return viableInitializers.empty() ? nullptr : viableInitializers.front();
 }
 
 /// Determine whether we have a suitable static subscript to which we
@@ -376,10 +312,11 @@ PropertyWrapperTypeInfoRequest::evaluate(
   
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;
-  if (findInitialValueInit(ctx, nominal, valueVar, ctx.Id_wrappedValue))
+  if (findSuitableWrapperInit(ctx, nominal, valueVar,
+                              PropertyWrapperInitKind::WrappedValue))
     result.wrappedValueInit = PropertyWrapperTypeInfo::HasWrappedValueInit;
-  else if (auto init = findInitialValueInit(
-               ctx, nominal, valueVar, ctx.Id_initialValue)) {
+  else if (auto init = findSuitableWrapperInit(
+               ctx, nominal, valueVar, PropertyWrapperInitKind::InitialValue)) {
     result.wrappedValueInit = PropertyWrapperTypeInfo::HasInitialValueInit;
 
     if (init->getLoc().isValid()) {
@@ -396,7 +333,11 @@ PropertyWrapperTypeInfoRequest::evaluate(
     }
   }
 
-  result.defaultInit = findDefaultInit(ctx, nominal);
+  if (findSuitableWrapperInit(ctx, nominal, /*valueVar=*/nullptr,
+                              PropertyWrapperInitKind::Default)) {
+    result.defaultInit = PropertyWrapperTypeInfo::HasDefaultValueInit;
+  }
+
   result.projectedValueVar =
     findValueProperty(ctx, nominal, ctx.Id_projectedValue,
                       /*allowMissing=*/true);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -100,6 +100,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     Inaccessible,
   };
 
+  auto valueVarType = valueVar->getValueInterfaceType();
+
   SmallVector<std::tuple<ConstructorDecl *, NonViableReason, Type>, 2>
       nonviable;
   SmallVector<ConstructorDecl *, 2> viableInitializers;
@@ -212,8 +214,7 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
       case NonViableReason::ParameterTypeMismatch:
         init->diagnose(diag::property_wrapper_wrong_initial_value_init,
-                       init->getFullName(), paramType,
-                       valueVar->getValueInterfaceType());
+                       init->getFullName(), paramType, valueVarType);
         valueVar->diagnose(diag::decl_declared_here, valueVar->getFullName());
         break;
       }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -100,8 +100,6 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
     Inaccessible,
   };
 
-  auto valueVarType = valueVar->getValueInterfaceType();
-
   SmallVector<std::tuple<ConstructorDecl *, NonViableReason, Type>, 2>
       nonviable;
   SmallVector<ConstructorDecl *, 2> viableInitializers;
@@ -183,7 +181,7 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
       // The parameter type must be the same as the type of `valueVar` or an
       // autoclosure thereof.
-      if (!paramType->isEqual(valueVarType)) {
+      if (!paramType->isEqual(valueVar->getValueInterfaceType())) {
         nonviable.push_back(std::make_tuple(
             init, NonViableReason::ParameterTypeMismatch, paramType));
         continue;
@@ -214,7 +212,8 @@ findSuitableWrapperInit(ASTContext &ctx, NominalTypeDecl *nominal,
 
       case NonViableReason::ParameterTypeMismatch:
         init->diagnose(diag::property_wrapper_wrong_initial_value_init,
-                       init->getFullName(), paramType, valueVarType);
+                       init->getFullName(), paramType,
+                       valueVar->getValueInterfaceType());
         valueVar->diagnose(diag::decl_declared_here, valueVar->getFullName());
         break;
       }

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -437,17 +437,41 @@ struct SR_11477_W {
   }
 }
 
+@propertyWrapper
+ struct SR_11477_W1 {
+   let name: String
+
+   init() {
+     self.name = "Init"
+   }
+
+   init(name: String = "DefaultParamInit") {
+     self.name = name
+   }
+
+   var wrappedValue: Int {
+     get { return 0 }
+   }
+ }
+
 struct SR_11477_C {
   @SR_11477_W var property: Int
+  @SR_11477_W1 var property1: Int
+
   init() {}
   func foo() { print(_property.name) }
+  func foo1() { print(_property1.name) }
 }
 
 func testWrapperInitWithDefaultArg() {
+  // CHECK: ## InitWithDefaultArg
+  print("\n## InitWithDefaultArg")
   let use = SR_11477_C()
   
   use.foo()
-  // CHECK: DefaultParamInit
+  use.foo1()
+  // CHECK-NEXT: DefaultParamInit
+  // CHECK-NEXT: Init
 }
 
 testIntStruct()

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -422,6 +422,33 @@ func testComposed() {
   // CHECK-NEXT: .. init Wrapper2<Int>(wrappedValue: 17)
 }
 
+// SR-11477
+
+@propertyWrapper
+struct SR_11477_W {
+  let name: String
+
+  init(name: String = "DefaultParamInit") {
+    self.name = name
+  }
+
+  var wrappedValue: Int {
+    get { return 0 }
+  }
+}
+
+struct SR_11477_C {
+  @SR_11477_W var property: Int
+  init() {}
+  func foo() { print(_property.name) }
+}
+
+func testWrapperInitWithDefaultArg() {
+  let use = SR_11477_C()
+  
+  use.foo()
+  // CHECK: DefaultParamInit
+}
 
 testIntStruct()
 testIntClass()
@@ -431,3 +458,4 @@ testDefaultInit()
 testOptIntStruct()
 testDefaultNilOptIntStruct()
 testComposed()
+testWrapperInitWithDefaultArg()

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -46,3 +46,23 @@ struct IntStructWithClassWrapper {
   } // expected-error{{return from initializer without initializing all stored properties}}
   // expected-note@-1{{'self.wrapped' not initialized}}  
 }
+
+// SR_11477
+
+@propertyWrapper
+struct SR_11477_W {
+  let name: String
+
+  init<T: ExpressibleByIntegerLiteral>(_ value: T = 0) {
+    self.name = "Init"
+  }
+
+  var wrappedValue: Int {
+    get { return 0 }
+  }
+}
+
+struct SR_11477_S {
+  @SR_11477_W var foo: Int
+  init() {} // expected-error {{return from initializer without initializing all stored properties}} expected-note {{'self.foo' not initialized}}
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1730,12 +1730,14 @@ struct TestConcrete1 {
 // Two initializers that can default initialize the wrapper //
 
 @propertyWrapper
-struct SR_11477_W1 { // expected-error {{property wrapper type 'SR_11477_W1' has multiple default-value initializers}}
+struct SR_11477_W1 { // Okay, because we'll pick the best one here
   let name: String
 
-  init() {} // expected-note {{initializer 'init()' declared here}}
+  init() {
+    self.name = "Init"
+  }
 
-  init(name: String = "DefaultParamInit") { // expected-note {{initializer 'init(name:)' declared here}}
+  init(name: String = "DefaultParamInit") {
     self.name = name
   }
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1724,3 +1724,54 @@ struct TestConcrete1 {
     // ...
   }
 }
+
+// SR-11477
+
+// Two initializers that can default initialize the wrapper //
+
+@propertyWrapper
+struct SR_11477_W1 { // expected-error {{property wrapper type 'SR_11477_W1' has multiple default-value initializers}}
+  let name: String
+
+  init() {} // expected-note {{initializer 'init()' declared here}}
+
+  init(name: String = "DefaultParamInit") { // expected-note {{initializer 'init(name:)' declared here}}
+    self.name = name
+  }
+
+  var wrappedValue: Int {
+    get { return 0 }
+  }
+}
+
+// Two initializers with default arguments that can default initialize the wrapper //
+
+@propertyWrapper
+struct SR_11477_W2 { // expected-error {{property wrapper type 'SR_11477_W2' has multiple default-value initializers}}
+  let name: String
+
+  init(anotherName: String = "DefaultParamInit") {} // expected-note {{initializer 'init(anotherName:)' declared here}}
+
+  init(name: String = "DefaultParamInit") { // expected-note {{initializer 'init(name:)' declared here}}
+    self.name = name
+  }
+
+  var wrappedValue: Int {
+    get { return 0 }
+  }
+}
+
+// Single initializer that can default initialize the wrapper //
+
+@propertyWrapper
+struct SR_11477_W3 { // Okay
+  let name: String
+
+  init() {
+    self.name = "Init"
+  }
+
+  var wrappedValue: Int {
+    get { return 0 }
+  }
+}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1730,7 +1730,7 @@ struct TestConcrete1 {
 // Two initializers that can default initialize the wrapper //
 
 @propertyWrapper
-struct SR_11477_W1 { // Okay, because we'll pick the best one here
+struct SR_11477_W1 { // Okay
   let name: String
 
   init() {
@@ -1749,12 +1749,14 @@ struct SR_11477_W1 { // Okay, because we'll pick the best one here
 // Two initializers with default arguments that can default initialize the wrapper //
 
 @propertyWrapper
-struct SR_11477_W2 { // expected-error {{property wrapper type 'SR_11477_W2' has multiple default-value initializers}}
+struct SR_11477_W2 { // Okay
   let name: String
 
-  init(anotherName: String = "DefaultParamInit") {} // expected-note {{initializer 'init(anotherName:)' declared here}}
+  init(anotherName: String = "DefaultParamInit1") {
+    self.name = anotherName
+  }
 
-  init(name: String = "DefaultParamInit") { // expected-note {{initializer 'init(name:)' declared here}}
+  init(name: String = "DefaultParamInit2") {
     self.name = name
   }
 


### PR DESCRIPTION
At the moment, `findDefaultInit()` only looks for `init()` and ignores any constructors that have default args. This is a [bug](https://twitter.com/dgregor79/status/1172533772291473409) and it prevents the following code from working:

```swift
@propertyWrapper
struct Foo {
  let name: String

  init(name: String = "hello world") {
    self.name = name
  }

  var wrappedValue: Int {
    get { return 0 }
  }
}

struct Bar {
  @Foo var property: Int // error: property not initialized
  init() {}
}
```

When finding default initializers, also search for constructors with default args.

Resolves [SR-11477](https://bugs.swift.org/browse/SR-11477).