### PR TITLE
[AutoDiff] Add VJP for 'Array.init(repeating:count:)'.

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -867,6 +867,8 @@ extension Array: RangeReplaceableCollection {
   ///     `repeating` parameter. `count` must be zero or greater.
   @inlinable
   @_semantics("array.init")
+  @differentiable(wrt: repeatedValue, vjp: _vjpInit(repeating:count:)
+                  where Element: Differentiable)
   public init(repeating repeatedValue: Element, count: Int) {
     var p: UnsafeMutablePointer<Element>
     (self, p) = Array._allocateUninitialized(count)
@@ -2102,5 +2104,16 @@ extension Array where Element : Differentiable {
             gradientIn.base[lhs.count...])))
       }
       return (lhs + rhs, pullback)
+  }
+}
+
+extension Array where Element: Differentiable {
+  @usableFromInline
+  static func _vjpInit(repeating repeatedValue: Element, count: Int) -> (
+    value: Self, pullback: (TangentVector) -> Element.TangentVector
+  ) {
+    (value: Self(repeating: repeatedValue, count: count), pullback: { v in
+      v.base.reduce(.zero, +)
+    })
   }
 }

--- a/test/AutoDiff/array.swift
+++ b/test/AutoDiff/array.swift
@@ -90,6 +90,19 @@ ArrayAutoDiffTests.test("ArrayConcat") {
       in: sumFirstThreeConcatted))
 }
 
+ArrayAutoDiffTests.test("Array.init(repeating:count:)") {
+  @differentiable
+  func repeating(_ x: Tracked<Float>) -> [Tracked<Float>] {
+    Array(repeating: x, count: 10)
+  }
+  expectEqual(Tracked<Float>(10), gradient(at: .zero) { x in
+    repeating(x).differentiableReduce(0, {$0 + $1}).value
+  })
+  expectEqual(Tracked<Float>(20), pullback(at: .zero, in: { x in
+    repeating(x).differentiableReduce(0, {$0 + $1}).value
+  })(2))
+}
+
 ArrayAutoDiffTests.test("Array.DifferentiableView.init") {
   @differentiable
   func constructView(_ x: [Float]) -> Array<Float>.DifferentiableView {


### PR DESCRIPTION
Add a VJP for `Array.init(repeating:count:)` so that it can be differentiated. The VJP is merely a transpose since `init(repeating:count:)` is linear w.r.t. the repeated value. Its tranpose is a linear map that takes an `Array.TangentVector` and returns the sum of all of its elements.

Resolves [TF-802](https://bugs.swift.org/browse/TF-802).