### PR TITLE
[5.1] [SILGen] Properly substitute contextual archetypes when generating assign_by_wrapper

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1382,7 +1382,9 @@ namespace {
         VarDecl *field = dyn_cast<VarDecl>(Storage);
         VarDecl *backingVar = field->getPropertyWrapperBackingProperty();
         assert(backingVar);
-        CanType ValType = backingVar->getType()->getCanonicalType();
+        CanType ValType =
+            SGF.F.mapTypeIntoContext(backingVar->getInterfaceType())
+              ->getCanonicalType();
         SILType varStorageType =
           SGF.SGM.Types.getSubstitutedStorageType(backingVar, ValType);
         auto typeData =
@@ -1405,7 +1407,7 @@ namespace {
         assert(field->getAttachedPropertyWrappers().size() == 1);
         auto wrapperInfo = field->getAttachedPropertyWrapperTypeInfo(0);
         auto ctor = wrapperInfo.wrappedValueInit;
-        SubstitutionMap subs = backingVar->getType()->getMemberSubstitutionMap(
+        SubstitutionMap subs = ValType->getMemberSubstitutionMap(
                         SGF.getModule().getSwiftModule(), ctor);
 
         Type ity = ctor->getInterfaceType();
@@ -1416,8 +1418,8 @@ namespace {
           .asForeign(requiresForeignEntryPoint(ctor));
         RValue initFuncRV =
           SGF.emitApplyPropertyWrapperAllocator(loc, subs,initRef,
-                                                 backingVar->getType(),
-                                                 CanAnyFunctionType(substIty));
+                                                ValType,
+                                                CanAnyFunctionType(substIty));
         ManagedValue initFn = std::move(initFuncRV).getAsSingleValue(SGF, loc);
 
         // Create the allocating setter function. It captures the base address.

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -449,6 +449,20 @@ public class Container {
   }
 }
 
+// SR-11303 / rdar://problem/54311335 - crash due to wrong archetype used in generated SIL
+public protocol TestProtocol {}
+public class TestClass<T> {
+  @WrapperWithInitialValue var value: T
+
+  // CHECK-LABEL: sil hidden [ossa] @$s17property_wrappers9TestClassC5value8protocolACyxGx_qd__tcAA0C8ProtocolRd__lufc
+  // CHECK: metatype $@thin WrapperWithInitialValue<T>.Type
+  // CHECK: function_ref @$s17property_wrappers23WrapperWithInitialValueV07wrappedF0ACyxGx_tcfCTc
+  init<U: TestProtocol>(value: T, protocol: U) {
+    self.value = value
+  }
+}
+
+
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
 // CHECK:  #ClassUsingWrapper.x!setter.1: (ClassUsingWrapper) -> (Int) -> () : @$s17property_wrappers17ClassUsingWrapperC1xSivs // ClassUsingWrapper.x.setter


### PR DESCRIPTION
Fixes SR-11303 / rdar://problem/54311335
