### PR TITLE
[polymorphic-builtins] Teach constant folding how to fold a polymorph…

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -142,6 +142,38 @@ bool onlyUsedByAssignByWrapper(PartialApplyInst *PAI);
 void findClosuresForFunctionValue(SILValue V,
                                   TinyPtrVector<PartialApplyInst *> &results);
 
+/// Given a polymorphic builtin \p bi that may be generic and thus have in/out
+/// params, stash all of the information needed for either specializing while
+/// inlining or propagating the type in constant propagation.
+///
+/// NOTE: If we perform this transformation, our builtin will no longer have any
+/// substitutions since we only substitute to concrete static overloads.
+struct PolymorphicBuiltinSpecializedOverloadInfo {
+  Identifier staticOverloadIdentifier;
+  SmallVector<SILType, 8> argTypes;
+  SILType resultType;
+  bool hasOutParam = false;
+
+#ifndef NDEBUG
+private:
+  bool isInitialized = false;
+#endif
+
+public:
+  PolymorphicBuiltinSpecializedOverloadInfo() = default;
+
+  bool init(SILFunction *fn, BuiltinValueKind builtinKind,
+            ArrayRef<SILType> oldOperandTypes, SILType oldResultType);
+
+  bool init(BuiltinInst *bi);
+};
+
+/// Given a polymorphic builtin \p bi, analyze its types and create a builtin
+/// for the static overload that the builtin corresponds to. If \p bi is not a
+/// polymorphic builtin or does not have any available overload for these types,
+/// return SILValue().
+SILValue getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi);
+
 } // end namespace swift
 
 #endif

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -14,10 +14,12 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/NullablePtr.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
 
 using namespace swift;
@@ -529,4 +531,147 @@ void swift::findClosuresForFunctionValue(
     }
     // Ignore other unrecognized values that feed this applied argument.
   }
+}
+
+bool PolymorphicBuiltinSpecializedOverloadInfo::init(
+    SILFunction *fn, BuiltinValueKind builtinKind,
+    ArrayRef<SILType> oldOperandTypes, SILType oldResultType) {
+#ifndef NDEBUG
+  assert(!isInitialized && "Expected uninitialized info");
+  SWIFT_DEFER { isInitialized = true; };
+#endif
+  if (!isPolymorphicBuiltin(builtinKind))
+    return false;
+
+  // Ok, at this point we know that we have a true polymorphic builtin. See if
+  // we have an overload for its current operand type.
+  StringRef name = getBuiltinName(builtinKind);
+  StringRef prefix = "generic_";
+  assert(name.startswith(prefix) &&
+         "Invalid polymorphic builtin name! Prefix should be Generic$OP?!");
+  SmallString<32> staticOverloadName;
+  staticOverloadName.append(name.drop_front(prefix.size()));
+
+  // If our first argument is an address, we know we have an indirect @out
+  // parameter by convention since all of these polymorphic builtins today never
+  // take indirect parameters without an indirect out result parameter. We stash
+  // this information and validate that if we have an out param, that our result
+  // is equal to the empty tuple type.
+  if (oldOperandTypes[0].isAddress()) {
+    if (oldResultType != fn->getModule().Types.getEmptyTupleType())
+      return false;
+
+    hasOutParam = true;
+    SILType firstType = oldOperandTypes.front();
+
+    // We only handle polymorphic builtins with trivial types today.
+    if (!firstType.is<BuiltinType>() || !firstType.isTrivial(*fn)) {
+      return false;
+    }
+
+    resultType = firstType.getObjectType();
+    oldOperandTypes = oldOperandTypes.drop_front();
+  } else {
+    resultType = oldResultType;
+  }
+
+  // Then go through all of our values and bail if any after substitution are
+  // not concrete builtin types. Otherwise, stash each of them in the argTypes
+  // array as objects. We will convert them as appropriate.
+  for (SILType ty : oldOperandTypes) {
+    // If after specialization, we do not have a trivial builtin type, bail.
+    if (!ty.is<BuiltinType>() || !ty.isTrivial(*fn)) {
+      return false;
+    }
+
+    // Otherwise, we have an object builtin type ready to go.
+    argTypes.push_back(ty.getObjectType());
+  }
+
+  // Ok, we have all builtin types. Infer the underlying polymorphic builtin
+  // name form our first argument.
+  CanBuiltinType builtinType = argTypes.front().getAs<BuiltinType>();
+  SmallString<32> builtinTypeNameStorage;
+  StringRef typeName = builtinType->getTypeName(builtinTypeNameStorage, false);
+  staticOverloadName.append("_");
+  staticOverloadName.append(typeName);
+
+  auto &ctx = fn->getASTContext();
+  staticOverloadIdentifier = ctx.getIdentifier(staticOverloadName);
+  return true;
+}
+
+bool PolymorphicBuiltinSpecializedOverloadInfo::init(BuiltinInst *bi) {
+#ifndef NDEBUG
+  assert(!isInitialized && "Can not init twice?!");
+  SWIFT_DEFER { isInitialized = true; };
+#endif
+
+  // First quickly make sure we have a /real/ BuiltinValueKind, not an intrinsic
+  // or None.
+  auto kind = bi->getBuiltinKind();
+  if (!kind)
+    return false;
+
+  SmallVector<SILType, 8> oldOperandTypes;
+  copy(bi->getOperandTypes(), std::back_inserter(oldOperandTypes));
+  assert(bi->getNumResults() == 1 &&
+         "We expect a tuple here instead of real args");
+  SILType oldResultType = bi->getResult(0)->getType();
+  return init(bi->getFunction(), *kind, oldOperandTypes, oldResultType);
+}
+
+SILValue
+swift::getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi) {
+
+  PolymorphicBuiltinSpecializedOverloadInfo info;
+  if (!info.init(bi))
+    return SILValue();
+
+  SmallVector<SILValue, 8> rawArgsData;
+  copy(bi->getOperandValues(), std::back_inserter(rawArgsData));
+
+  SILValue result = bi->getResult(0);
+  MutableArrayRef<SILValue> rawArgs = rawArgsData;
+
+  if (info.hasOutParam) {
+    result = rawArgs.front();
+    rawArgs = rawArgs.drop_front();
+  }
+
+  assert(bi->getNumResults() == 1 &&
+         "We assume that builtins have a single result today. If/when this "
+         "changes, this code needs to be updated");
+
+  SILBuilderWithScope builder(bi);
+
+  // Ok, now we know that we can convert this to our specialized
+  // builtin. Prepare the arguments for the specialized value, loading the
+  // values if needed and storing the result into an out parameter if needed.
+  //
+  // NOTE: We only support polymorphic builtins with trivial types today, so we
+  // use load/store trivial as a result.
+  SmallVector<SILValue, 8> newArgs;
+  for (SILValue arg : rawArgs) {
+    if (arg->getType().isObject()) {
+      newArgs.push_back(arg);
+      continue;
+    }
+
+    SILValue load = builder.emitLoadValueOperation(
+        bi->getLoc(), arg, LoadOwnershipQualifier::Trivial);
+    newArgs.push_back(load);
+  }
+
+  BuiltinInst *newBI =
+      builder.createBuiltin(bi->getLoc(), info.staticOverloadIdentifier,
+                            info.resultType, {}, newArgs);
+
+  // If we have an out parameter initialize it now.
+  if (info.hasOutParam) {
+    builder.emitStoreValueOperation(newBI->getLoc(), newBI->getResult(0),
+                                    result, StoreOwnershipQualifier::Trivial);
+  }
+
+  return newBI;
 }

--- a/test/SILOptimizer/polymorphic_builtins.sil
+++ b/test/SILOptimizer/polymorphic_builtins.sil
@@ -1,0 +1,54 @@
+// RUN: %target-sil-opt -module-name Swift -diagnostic-constant-propagation %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+struct MyInt {
+  var i : Builtin.Int32
+}
+
+// CHECK-LABEL: sil @concrete_type_object_test : $@convention(thin) (Builtin.Vec4xInt32, Builtin.Vec4xInt32) -> Builtin.Vec4xInt32 {
+// CHECK: builtin "add_Vec4xInt32"(
+// CHECK: return
+// CHECK: } // end sil function 'concrete_type_object_test'
+sil @concrete_type_object_test : $@convention(thin) (Builtin.Vec4xInt32, Builtin.Vec4xInt32) -> Builtin.Vec4xInt32 {
+bb0(%0 : $Builtin.Vec4xInt32, %1 : $Builtin.Vec4xInt32):
+  %2 = builtin "generic_add"(%0 : $Builtin.Vec4xInt32, %1 : $Builtin.Vec4xInt32) : $Builtin.Vec4xInt32
+  return %2 : $Builtin.Vec4xInt32
+}
+
+// CHECK-LABEL: sil @concrete_type_address_test : $@convention(thin) (@in_guaranteed Builtin.Vec4xInt32, @in_guaranteed Builtin.Vec4xInt32) -> @out Builtin.Vec4xInt32 {
+// CHECK: bb0([[RESULT:%.*]] : $*Builtin.Vec4xInt32, [[ARG0:%.*]] : $*Builtin.Vec4xInt32, [[ARG1:%.*]] : $*Builtin.Vec4xInt32):
+// CHECK:   [[LOADED_ARG0:%.*]] = load [[ARG0]]
+// CHECK:   [[LOADED_ARG1:%.*]] = load [[ARG1]]
+// CHECK:   [[LOADED_RESULT:%.*]] = builtin "add_Vec4xInt32"([[LOADED_ARG0]] : $Builtin.Vec4xInt32, [[LOADED_ARG1]] : $Builtin.Vec4xInt32) : $Builtin.Vec4xInt32
+// CHECK:   store [[LOADED_RESULT]] to [[RESULT]]
+// CHECK: } // end sil function 'concrete_type_address_test'
+sil @concrete_type_address_test : $@convention(thin) (@in_guaranteed Builtin.Vec4xInt32, @in_guaranteed Builtin.Vec4xInt32) -> @out Builtin.Vec4xInt32 {
+bb0(%0 : $*Builtin.Vec4xInt32, %1 : $*Builtin.Vec4xInt32, %2 : $*Builtin.Vec4xInt32):
+  builtin "generic_add"<Builtin.Vec4xInt32>(%0 : $*Builtin.Vec4xInt32, %1 : $*Builtin.Vec4xInt32, %2 : $*Builtin.Vec4xInt32) : $()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @concrete_type_object_fail : $@convention(thin) (MyInt, MyInt) -> MyInt {
+// CHECK: builtin "generic_add"<MyInt>(
+// CHECK: return
+// CHECK: } // end sil function 'concrete_type_object_fail'
+sil @concrete_type_object_fail : $@convention(thin) (MyInt, MyInt) -> MyInt {
+bb0(%0 : $MyInt, %1 : $MyInt):
+  %2 = builtin "generic_add"<MyInt>(%0 : $MyInt, %1 : $MyInt) : $MyInt
+  return %2 : $MyInt
+}
+
+// CHECK-LABEL: sil @concrete_type_address_fail : $@convention(thin) (@in_guaranteed MyInt, @in_guaranteed MyInt) -> @out MyInt {
+// CHECK: builtin "generic_add"<MyInt>(
+// CHECK: return
+// CHECK: } // end sil function 'concrete_type_address_fail'
+sil @concrete_type_address_fail : $@convention(thin) (@in_guaranteed MyInt, @in_guaranteed MyInt) -> @out MyInt {
+bb0(%0 : $*MyInt, %1 : $*MyInt, %2 : $*MyInt):
+  %3 = builtin "generic_add"<MyInt>(%0 : $*MyInt, %1 : $*MyInt, %2 : $*MyInt) : $()
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…ic builtin to its static overload if the passed in type is a concrete builtin type

Specifically, this transforms:

builtin "generic_add"<Builtin.Vec4xInt32>(

  ->

builtin "add_Vec4xInt32"(

If we do not have a static overload for the type, we just leave the generic call
alone. If the generic builtin takes addresses as its arguments (i.e. 2x
in_guaranteed + 1x out), we load the arguments, evaluate the static overloaded
builtin and then store the result into the out parameter.
