### PR TITLE
[AST] Shrink CaptureInfo down to a PointerIntPair

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2310,15 +2310,12 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   }
 
   // Cache the uniqued set of transitive captures.
-  auto inserted = LoweredCaptures.insert({fn, CaptureInfo()});
+  CaptureInfo info{Context, resultingCaptures, capturesDynamicSelf,
+                   capturesOpaqueValue, capturesGenericParams};
+  auto inserted = LoweredCaptures.insert({fn, info});
   assert(inserted.second && "already in map?!");
-  auto &cachedCaptures = inserted.first->second;
-  cachedCaptures.setGenericParamCaptures(capturesGenericParams);
-  cachedCaptures.setDynamicSelfType(capturesDynamicSelf);
-  cachedCaptures.setOpaqueValue(capturesOpaqueValue);
-  cachedCaptures.setCaptures(Context.AllocateCopy(resultingCaptures));
-  
-  return cachedCaptures;
+  (void)inserted;
+  return info;
 }
 
 /// Given that type1 is known to be a subtype of type2, check if the two

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -42,39 +42,33 @@ class FindCapturedVars : public ASTWalker {
   OpaqueValueExpr *OpaqueValue = nullptr;
   SourceLoc CaptureLoc;
   DeclContext *CurDC;
-  bool NoEscape, ObjC;
+  bool NoEscape, ObjC, IsGenericFunction;
 
 public:
   FindCapturedVars(ASTContext &Context,
                    SourceLoc CaptureLoc,
                    DeclContext *CurDC,
                    bool NoEscape,
-                   bool ObjC)
+                   bool ObjC,
+                   bool IsGenericFunction)
       : Context(Context), CaptureLoc(CaptureLoc), CurDC(CurDC),
-        NoEscape(NoEscape), ObjC(ObjC) {}
+        NoEscape(NoEscape), ObjC(ObjC), IsGenericFunction(IsGenericFunction) {}
 
   CaptureInfo getCaptureInfo() const {
-    CaptureInfo result;
-
-    // Anything can capture an opaque value placeholder.
-    if (OpaqueValue)
-      result.setOpaqueValue(OpaqueValue);
+    DynamicSelfType *dynamicSelfToRecord = nullptr;
+    bool hasGenericParamCaptures = IsGenericFunction;
 
     // Only local functions capture dynamic 'Self'.
     if (CurDC->getParent()->isLocalContext()) {
       if (GenericParamCaptureLoc.isValid())
-        result.setGenericParamCaptures(true);
+        hasGenericParamCaptures = true;
 
       if (DynamicSelfCaptureLoc.isValid())
-        result.setDynamicSelfType(DynamicSelf);
+        dynamicSelfToRecord = DynamicSelf;
     }
 
-    if (Captures.empty())
-      result.setCaptures(None);
-    else
-      result.setCaptures(Context.AllocateCopy(Captures));
-
-    return result;
+    return CaptureInfo(Context, Captures, dynamicSelfToRecord, OpaqueValue,
+                       hasGenericParamCaptures);
   }
 
   SourceLoc getGenericParamCaptureLoc() const {
@@ -590,28 +584,26 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
 
   PrettyStackTraceAnyFunctionRef trace("computing captures for", AFR);
 
+  // A generic function always captures outer generic parameters.
+  bool isGeneric = false;
+  auto *AFD = AFR.getAbstractFunctionDecl();
+  if (AFD)
+    isGeneric = (AFD->getGenericParams() != nullptr);
+
   auto &Context = AFR.getAsDeclContext()->getASTContext();
   FindCapturedVars finder(Context,
                           AFR.getLoc(),
                           AFR.getAsDeclContext(),
                           AFR.isKnownNoEscape(),
-                          AFR.isObjC());
+                          AFR.isObjC(),
+                          isGeneric);
   AFR.getBody()->walk(finder);
 
   if (AFR.hasType() && !AFR.isObjC()) {
     finder.checkType(AFR.getType(), AFR.getLoc());
   }
 
-  // A generic function always captures outer generic parameters.
-  bool isGeneric = false;
-  auto *AFD = AFR.getAbstractFunctionDecl();
-  if (AFD)
-    isGeneric = AFD->isGeneric();
-
-  auto captures = finder.getCaptureInfo();
-  if (isGeneric)
-    captures.setGenericParamCaptures(true);
-  AFR.setCaptureInfo(captures);
+  AFR.setCaptureInfo(finder.getCaptureInfo());
 
   // Compute captures for default argument expressions.
   if (auto *AFD = AFR.getAbstractFunctionDecl()) {
@@ -621,7 +613,8 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
                                 E->getLoc(),
                                 AFD,
                                 /*isNoEscape=*/false,
-                                /*isObjC=*/false);
+                                /*isObjC=*/false,
+                                /*IsGeneric*/isGeneric);
         E->walk(finder);
 
         if (!AFD->getDeclContext()->isLocalContext() &&
@@ -630,10 +623,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
                                  diag::dynamic_self_default_arg);
         }
 
-        auto captures = finder.getCaptureInfo();
-        if (isGeneric)
-          captures.setGenericParamCaptures(true);
-        P->setDefaultArgumentCaptureInfo(captures);
+        P->setDefaultArgumentCaptureInfo(finder.getCaptureInfo());
       }
     }
   }
@@ -690,7 +680,8 @@ void TypeChecker::checkPatternBindingCaptures(NominalTypeDecl *typeDecl) {
                               init->getLoc(),
                               PBD->getInitContext(i),
                               /*NoEscape=*/false,
-                              /*ObjC=*/false);
+                              /*ObjC=*/false,
+                              /*IsGenericFunction*/false);
       init->walk(finder);
 
       if (finder.getDynamicSelfCaptureLoc().isValid() && !isLazy(PBD)) {


### PR DESCRIPTION
If there are any actual captures, a CaptureInfoStorage will be allocated in the ASTContext, matching the previous behavior of allocating the array of captures there.

No functionality change. I *tried* to change the functionality to assert everywhere capture info was used but hadn't explicitly been computed, but it turns out we do that *all over the place* for any declaration that's been synthesized, imported, or deserialized. I left in some groundwork for someone to make this more explicit (or requestify it) in the future.