### PR TITLE
Revert "[sil] Teach the SILVerifier how to validate that a builtin in…

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1635,12 +1635,6 @@ public:
       return;
     }
 
-    // At this point, we know that we have a Builtin that is a Swift Builtin
-    // rather than an llvm intrinsic. Make sure our name corresponds to an
-    // actual ValueDecl. Otherwise, we have an invalid builtin.
-    require(getBuiltinValueDecl(BI->getModule().getASTContext(), BI->getName()),
-            "Invalid builtin name?!");
-
     require(BI->getModule().getStage() != SILStage::Lowered ||
                 !isPolymorphicBuiltin(*BI->getBuiltinKind()),
             "Polymorphic builtins are illegal in lowered SIL?!");


### PR DESCRIPTION
…sts are always mapped to a known builtin."

This reverts commit e2a9a432209affcd5b427481795cc859bd5ae19d.

Going to put a cache in front of this to ensure we aren't bloating compile
time.

Conflicts:
	lib/SIL/SILVerifier.cpp
