### PR TITLE
fix qualified decl name parsing for merge

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1239,9 +1239,9 @@ public:
   /// When `isParsingQualifiedDeclName` is true:
   /// - Parses the type qualifier from a qualified decl name, and returns a
   ///   parser result for the type of the qualifier.
-  /// - Positions the parser at the final declaration name.
+  /// - Positions the parser at the '.' before the final declaration name.
   /// - For example, 'Foo.Bar.f' parses as 'Foo.Bar' and the parser gets
-  ///   positioned at 'f'.
+  ///   positioned at '.f'.
   /// - If there is no type qualification (e.g. when parsing just 'f'), returns
   ///   an empty parser error.
   TypeResult parseTypeIdentifier(bool isParsingQualifiedDeclName = false);
@@ -1454,6 +1454,13 @@ public:
   bool canParseGenericArguments();
 
   bool canParseTypedPattern();
+
+  // SWIFT_ENABLE_TENSORFLOW
+  /// Determines whether a type qualifier for a decl name can be parsed. e.g.:
+  ///   'Foo.f' -> true
+  ///   'Foo.Bar.f' -> true
+  ///   'f' -> false
+  bool canParseTypeQualifierForDeclName();
 
   //===--------------------------------------------------------------------===//
   // Expression Parsing


### PR DESCRIPTION
Now `parseTypeIdentifier(/*isParsingQualifiedDeclName=*/true)` does not consume the final period in the qualified decl name. (e.g. with `Foo.Bar.f`, it now consumes `Foo.Bar` instead of `Foo.Bar.`).

This fixes an assertion failure that we get when parsing a qualified decl name. The assertion asserts that every syntax node gets included as a child of a larger node. The final period doesn't get included as a child of the type node, triggering the failure. For future reference, the trace was:
```
swift: /home/danielzheng/swift-merge/swift/include/swift/Parse/ParsedRawSyntaxNode.h:146: swift::ParsedRawSyntaxNode::~ParsedRawSyntaxNode(): Assertion `DK != DataKind::Recorded' failed.
Stack dump:
0.      Program arguments: /home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift -frontend -target x86_64-unknown-linux-gnu -module-cache-path /home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/clang-module-cache -swift-version 4 -typo-correction-limit 10 -typecheck -verify /home/danielzheng/swift-merge/swift/test/AutoDiff/transposing_attr_type_checking.swift
1.      Swift version 5.1-dev (LLVM c5340df2d1, Swift 7134768a38)
2.      With parser at source location: /home/danielzheng/swift-merge/swift/test/AutoDiff/transposing_attr_type_checking.swift:220:22
 #0 0x00000000047b9d44 PrintStackTraceSignalHandler(void*) (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x47b9d44)
 #1 0x00000000047b799e llvm::sys::RunSignalHandlers() (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x47b799e)
 #2 0x00000000047b9ff8 SignalHandler(int) (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x47b9ff8)
 #3 0x00007f3906d0a890 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x12890)
 #4 0x00007f390516de97 gsignal /build/glibc-OTsEL5/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:51:0
 #5 0x00007f390516f801 abort /build/glibc-OTsEL5/glibc-2.27/stdlib/abort.c:81:0
 #6 0x00007f390515f39a __assert_fail_base /build/glibc-OTsEL5/glibc-2.27/assert/assert.c:89:0
 #7 0x00007f390515f412 (/lib/x86_64-linux-gnu/libc.so.6+0x30412)
 #8 0x000000000136cbd9 swift::Parser::parseTypeIdentifier(bool) (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x136cbd9)
 #9 0x00000000012fee6a parseQualifiedDeclName(swift::Parser&, swift::Diag<>, swift::TypeRepr*&, swift::DeclNameWithLoc&) (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x12fee6a)
#10 0x00000000012ff413 swift::Parser::parseTransposingAttribute(swift::SourceLoc, swift::SourceLoc) (/home/danielzheng/swift-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x12ff413)
```

I also factored `parsedLastComponent` out into a new public function `canParseTypeQualifierForDeclName` because this allows the logic in `parseBaseTypeForQualifiedDeclName` to be simpler.

