### PR TITLE
[AutoDiff] Fix member loading for AD-generated structs/enums.

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -820,14 +820,6 @@ bool IterableDeclContext::hasUnparsedMembers() const {
 }
 
 void IterableDeclContext::loadAllMembers() const {
-  // SWIFT_ENABLE_TENSORFLOW
-  // If it's an AD-synthesized decl, then the members are already "loaded"
-  // because we create the members eagerly when the synthesize it. Trying to
-  // load the members confuses the parser.
-  if (auto *typeDecl = dyn_cast<TypeDecl>(getDecl()))
-    if (typeDecl->getNameStr().startswith("_AD__"))
-      return;
-
   ASTContext &ctx = getASTContext();
 
   // For contexts within a source file, get the list of parsed members.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2787,7 +2787,6 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
     for (const Decl *D : topLevelDecls) {
       if (!WholeModuleMode && !(D->getDeclContext() == AssociatedDeclContext))
           continue;
-      // SWIFT_ENABLE_TENSORFLOW
       if ((isa<ValueDecl>(D) || isa<OperatorDecl>(D) ||
            isa<ExtensionDecl>(D) || isa<ImportDecl>(D)) &&
           !D->isImplicit()) {

--- a/test/AutoDiff/autodiff_generated_decl_member_loading.swift
+++ b/test/AutoDiff/autodiff_generated_decl_member_loading.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s -o %t/autodiff_generated_decl_member_loading_cross_module.swiftmodule
+// RUN: %target-swift-frontend -merge-modules -sil-merge-partial-modules -emit-module %t/autodiff_generated_decl_member_loading_cross_module.swiftmodule
+
+// Tests TF-805.
+//
+// Previously, `IterableDeclContext::loadAllMembers` was disabled for
+// AD-generated structs/enums:
+// https://github.com/apple/swift/commit/7e89bee39bfda4624f04dcc2c8d53599fbde6191
+//
+// This caused a SIL verification failure for because enum members were not loaded
+// when running `-emit-module` then `-merge-modules -sil-merge-partial-modules`:
+//
+//     SIL verification failed: switch_enum dispatches on same enum element
+//     more than once: unswitchedElts.count(elt)
+
+public struct Tensor<Scalar> {}
+
+extension Tensor: Differentiable where Scalar: Differentiable{
+  public typealias TangentVector = Float
+  public mutating func move(along direction: Float) {}
+}
+
+extension Tensor {
+  @inlinable
+  @differentiable(wrt: self where Scalar: Differentiable)
+  func TF_805(axis: Int) -> Tensor {
+    if axis != axis {}
+    return self
+  }
+}

--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
+// RUN: %target-swift-frontend -emit-sil -verify -Xllvm -debug-only=differentiation 2>&1 %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
 // RUN: %target-swift-frontend -emit-sil -verify -Xllvm -sil-print-after=differentiation -o /dev/null 2>&1 %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 // TODO: Add FileCheck tests.
@@ -19,15 +19,15 @@ func cond(_ x: Float) -> Float {
 // CHECK-DATA-STRUCTURES: struct _AD__cond_bb0__PB__src_0_wrt_0 {
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: struct _AD__cond_bb1__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   @_hasStorage var predecessor: _AD__cond_bb1__Pred__src_0_wrt_0 { get set }
-// CHECK-DATA-STRUCTURES:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb1__Pred__src_0_wrt_0
+// CHECK-DATA-STRUCTURES:   var pullback_0: (Float) -> (Float, Float)
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: struct _AD__cond_bb2__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   @_hasStorage var predecessor: _AD__cond_bb2__Pred__src_0_wrt_0 { get set }
-// CHECK-DATA-STRUCTURES:   @_hasStorage var pullback_1: (Float) -> (Float, Float) { get set }
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb2__Pred__src_0_wrt_0
+// CHECK-DATA-STRUCTURES:   var pullback_1: (Float) -> (Float, Float)
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: struct _AD__cond_bb3__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   @_hasStorage var predecessor: _AD__cond_bb3__Pred__src_0_wrt_0 { get set }
+// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb3__Pred__src_0_wrt_0
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__cond_bb0__Pred__src_0_wrt_0 {
 // CHECK-DATA-STRUCTURES: }

--- a/test/AutoDiff/forward_mode_sil.swift
+++ b/test/AutoDiff/forward_mode_sil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -run-jvp-generation  -verify %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
+// RUN: %target-swift-frontend -emit-sil -Xllvm -run-jvp-generation -Xllvm -debug-only=differentiation -verify %s 2>&1 | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
 // RUN: %target-swift-frontend -emit-sil -verify -Xllvm -sil-print-after=differentiation -Xllvm -run-jvp-generation -o /dev/null 2>&1 %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 
@@ -12,8 +12,8 @@ func unary(_ x: Float) -> Float {
   return x * x * x
 }
 // CHECK-DATA-STRUCTURES: struct _AD__unary_bb0__DF__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   @_hasStorage var differential_0: (Float, Float) -> Float { get set }
-// CHECK-DATA-STRUCTURES:   @_hasStorage var differential_1: (Float, Float) -> Float { get set }
+// CHECK-DATA-STRUCTURES:   var differential_0: (Float, Float) -> Float
+// CHECK-DATA-STRUCTURES:   var differential_1: (Float, Float) -> Float
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__unary_bb0__Succ__src_0_wrt_0 {
 // CHECK-DATA-STRUCTURES: }
@@ -58,7 +58,7 @@ func binary(x: Float, y: Float) -> Float {
 }
 
 // CHECK-DATA-STRUCTURES: struct _AD__binary_bb0__DF__src_0_wrt_0_1 {
-// CHECK-DATA-STRUCTURES:   @_hasStorage var differential_0: (Float, Float) -> Float { get set }
+// CHECK-DATA-STRUCTURES:   var differential_0: (Float, Float) -> Float
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__binary_bb0__Succ__src_0_wrt_0_1 {
 // CHECK-DATA-STRUCTURES: }

--- a/test/AutoDiff/refcounting.swift
+++ b/test/AutoDiff/refcounting.swift
@@ -1,3 +1,4 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -debug-only=differentiation 2>&1 %s | %FileCheck %s -check-prefix=CHECK-DATA-STRUCTURES
 // RUN: %target-swift-frontend -emit-sil -Xllvm -differentiation-skip-folding-autodiff-function-extraction %s | %FileCheck %s
 
 public class NonTrivialStuff : Equatable {
@@ -38,11 +39,11 @@ func testOwnedVector(_ x: Vector) -> Vector {
 }
 _ = pullback(at: Vector.zero, in: testOwnedVector)
 
-// CHECK-LABEL: struct {{.*}}testOwnedVector{{.*}}__PB__src_0_wrt_0 {
-// CHECK-NEXT:   @_hasStorage var pullback_0: (Vector) -> (Vector, Vector) { get set }
-// CHECK-NEXT: }
-// CHECK-LABEL: enum {{.*}}testOwnedVector{{.*}}__Pred__src_0_wrt_0 {
-// CHECK-NEXT: }
+// CHECK-DATA-STRUCTURES-LABEL: struct {{.*}}testOwnedVector{{.*}}__PB__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES-NEXT:   var pullback_0: (Vector) -> (Vector, Vector)
+// CHECK-DATA-STRUCTURES-NEXT: }
+// CHECK-DATA-STRUCTURES-LABEL: enum {{.*}}testOwnedVector{{.*}}__Pred__src_0_wrt_0 {
+// CHECK-DATA-STRUCTURES-NEXT: }
 
 // CHECK-LABEL: sil hidden @{{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__pullback_src_0_wrt_0_1
 // CHECK: bb0([[SEED:%.*]] : $Vector, [[PB_STRUCT:%.*]] : ${{.*}}UsesMethodOfNoDerivativeMember{{.*}}applied2to{{.*}}__PB__src_0_wrt_0_1):


### PR DESCRIPTION
Fix `IterableDeclContext::loadAllMembers` for structs/enums generated during differentiation transform.

Previously, https://github.com/apple/swift/commit/7e89bee39bfda4624f04dcc2c8d53599fbde6191 disabled `loadAllMembers` for AD-generated structs/enums.

This caused a SIL verification failure for `test/AutoDiff/autodiff_generated_decl_member_loading.swift` because enum members were not loaded.

Now, `loadAllMembers` is re-enabled. Other necessary fixes:
- Generated structs/enums are set to implicit.
  - Since implicit declarations are not printed via `-emit-sil`, data structure generation tests now rely on `-Xllvm -debug-only=differentiation`.
- Remove calls to `NominalTypeDecl::setBraces`.
- Strategically set `SourceLoc` for `EnumElementDecl` and `EnumCaseDecl` to prevent duplicate enum cases from printing.

Resolves [TF-805](https://bugs.swift.org/browse/TF-805).