### PR TITLE
[ClangImporter] Remove now-unnecessary special case for IUO importing

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -152,13 +152,6 @@ enum class ImportTypeKind {
   /// This ensures that the parameter is not marked as Unmanaged.
   CFUnretainedOutParameter,
 
-  /// Import the type pointed to by a pointer or reference.
-  ///
-  /// This provides special treatment for pointer-to-ObjC-pointer
-  /// types, which get imported as pointers to *checked* optional,
-  /// *Pointer<NSFoo?>, instead of implicitly unwrapped optional as usual.
-  Pointee,
-
   /// Import the type of an ObjC property.
   ///
   /// This enables the conversion of bridged types. Properties are always


### PR DESCRIPTION
Back when IUO could be used anywhere in a type in Swift, we had a special case for imported pointer types that their pointees were never implicitly-unwrapped, even if they weren't nullability-audited on the Objective-C side. Now that IUO can only be used in top-level positions (SE-0054, only fully implemented last year), we don't need a special case for this; all non-top-level optionals are never implicitly-unwrapped.

No functionality change.