### PR TITLE
Reflection: Make RemoteRef template not depend on Runtime.

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -531,8 +531,8 @@ public:
         // underlying type if available.
         if (context->getKind() == ContextDescriptorKind::OpaqueType) {
           return Dem.createNode(
-                              Node::Kind::OpaqueTypeDescriptorSymbolicReference,
-                              (uintptr_t)context.getAddress());
+                            Node::Kind::OpaqueTypeDescriptorSymbolicReference,
+                            (uintptr_t)context.template getAddress<Runtime>());
         }
           
         return reader.buildContextMangling(context, Dem);

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -532,7 +532,7 @@ public:
         if (context->getKind() == ContextDescriptorKind::OpaqueType) {
           return Dem.createNode(
                             Node::Kind::OpaqueTypeDescriptorSymbolicReference,
-                            (uintptr_t)context.template getAddress<Runtime>());
+                            context.getAddressData());
         }
           
         return reader.buildContextMangling(context, Dem);


### PR DESCRIPTION
The only thing the Runtime affects is the width of the StoredPointer for the remote address, for
which storing a uint64_t ought to be enough for anyone we care about so far. This will make it
easier to store and use RemoteRefs in code that isn't or shouldn't ideally be templatized on
Runtime (such as TypeRefBuilder, and ultimately ReflectionContext, from the Reflection library.)