### PR TITLE
Kill validateExtension

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1536,6 +1536,7 @@ public:
   /// \endcode
   bool isGeneric() const { return getGenericParams() != nullptr; }
   bool hasComputedGenericSignature() const;
+  bool isComputingGenericSignature() const;
   
   /// Retrieve the trailing where clause for this extension, if any.
   TrailingWhereClause *getTrailingWhereClause() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -859,6 +859,11 @@ GenericParamList *GenericContext::getGenericParams() const {
 bool GenericContext::hasComputedGenericSignature() const {
   return GenericSigAndBit.getInt();
 }
+      
+bool GenericContext::isComputingGenericSignature() const {
+  return getASTContext().evaluator.hasActiveRequest(
+                 GenericSignatureRequest{const_cast<GenericContext*>(this)});
+}
 
 GenericSignature *GenericContext::getGenericSignature() const {
   return evaluateOrDefault(

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -470,7 +470,7 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
       // If the decl is currently being validated, this is likely a recursive
       // reference and we'll want to skip ahead so as to avoid having its type
       // attempt to desugar itself.
-      if (!decl->hasValidSignature())
+      if (!decl->hasInterfaceType())
         continue;
 
       // FIXME: the canonical type makes a poor signature, because we don't

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -498,16 +498,6 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
                                               ConstraintLocatorBuilder locator,
                                               OpenedTypeMap &replacements) {
   auto unboundDecl = unbound->getDecl();
-
-  // If the unbound decl hasn't been validated yet, we have a circular
-  // dependency that isn't being diagnosed properly.
-  //
-  // FIXME: Delete this condition.  He's dead Jim.
-  if (!unboundDecl->hasComputedGenericSignature()) {
-    TC.diagnose(unboundDecl, diag::circular_reference);
-    return Type();
-  }
-
   auto parentTy = unbound->getParent();
   if (parentTy) {
     parentTy = openUnboundGenericType(parentTy, locator);


### PR DESCRIPTION
Discharge the work the callers of `validateExtension` actually wanted done into those callers.  This patch is bittersweet: It kills one dead cycle check, but adds another unrelated one.