### PR TITLE
Preparations for subst() preserving sugared TypeAliasTypes

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -60,9 +60,6 @@ public:
   /// consistency and provides the value a type.
   virtual void resolveDeclSignature(ValueDecl *VD) = 0;
 
-  /// Resolve the generic environment of the given protocol.
-  virtual void resolveProtocolEnvironment(ProtocolDecl *proto) = 0;
-
   /// Resolve the type of an extension.
   ///
   /// This can be called to ensure that the members of an extension can be

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -128,10 +128,12 @@ ProtocolConformanceRef::subst(Type origType,
 
   // If the type is an existential, it must be self-conforming.
   if (substType->isExistentialType()) {
-    auto optConformance =
-      proto->getModuleContext()->lookupExistentialConformance(substType, proto);
-    assert(optConformance && "existential type didn't self-conform");
-    return *optConformance;
+    if (auto optConformance =
+          proto->getModuleContext()->lookupExistentialConformance(
+            substType, proto))
+      return *optConformance;
+
+    return ProtocolConformanceRef::forInvalid();
   }
 
   // Check the conformance map.
@@ -140,7 +142,7 @@ ProtocolConformanceRef::subst(Type origType,
     return *result;
   }
 
-  llvm_unreachable("Invalid conformance substitution");
+  return ProtocolConformanceRef::forInvalid();
 }
 
 ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() const {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -486,27 +486,9 @@ SubstitutionMap
 SubstitutionMap::getProtocolSubstitutions(ProtocolDecl *protocol,
                                           Type selfType,
                                           ProtocolConformanceRef conformance) {
-  auto protocolSelfType = protocol->getSelfInterfaceType();
-
-  return get(
-    protocol->getGenericSignature(),
-    [&](SubstitutableType *type) -> Type {
-      if (type->isEqual(protocolSelfType))
-        return selfType;
-
-      // This will need to change if we ever support protocols
-      // inside generic types.
-      return Type();
-    },
-    [&](CanType origType, Type replacementType, ProtocolDecl *protoType)
-      -> Optional<ProtocolConformanceRef> {
-      if (origType->isEqual(protocolSelfType) && protoType == protocol)
-        return conformance;
-
-      // This will need to change if we ever support protocols
-      // inside generic types.
-      return None;
-    });
+  return get(protocol->getGenericSignature(),
+             llvm::makeArrayRef<Type>(selfType),
+             llvm::makeArrayRef<ProtocolConformanceRef>(conformance));
 }
 
 SubstitutionMap

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -304,15 +304,17 @@ struct SynthesizedExtensionAnalyzer::Implementation {
         }
 
         switch (Kind) {
-        case RequirementKind::Conformance:
-          // FIXME: This could be more accurate; check
-          // conformance instead of subtyping
-          if (!isConvertibleTo(First, Second, /*openArchetypes=*/true, *DC))
+        case RequirementKind::Conformance: {
+          auto *M = DC->getParentModule();
+          auto *Proto = Second->castTo<ProtocolType>()->getDecl();
+          if (!First->isTypeParameter() &&
+              !First->is<ArchetypeType>() &&
+              !M->conformsToProtocol(First, Proto))
             return true;
-          else if (!isConvertibleTo(First, Second, /*openArchetypes=*/false,
-                                    *DC))
+          if (!M->conformsToProtocol(First, Proto))
             MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           break;
+        }
 
         case RequirementKind::Superclass:
           if (!Second->isBindableToSuperclassOf(First)) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3405,6 +3405,8 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
 
+  // FIXME: This is incorrect; depTy is written in terms of the protocol's
+  // associated types, and we need to substitute in known type witnesses.
   if (auto superclass = genericSig->getSuperclassBound(depTy)) {
     if (!superclass->isExactSuperclassOf(contextType))
       return superclass;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3445,15 +3445,6 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
           aliasDecl, baseTy,
           aliasDecl->getASTContext());
     }
-
-    // FIXME: If this is a protocol typealias and we haven't built the
-    // protocol's generic environment yet, do so now, to ensure the
-    // typealias's underlying type has fully resolved dependent
-    // member types.
-    if (auto *protoDecl = dyn_cast<ProtocolDecl>(aliasDecl->getDeclContext())) {
-      ASTContext &ctx = protoDecl->getASTContext();
-      ctx.getLazyResolver()->resolveProtocolEnvironment(protoDecl);
-    }
   }
 
   Type resultType;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1013,10 +1013,6 @@ public:
     validateDecl(VD);
   }
 
-  virtual void resolveProtocolEnvironment(ProtocolDecl *proto) override {
-    validateDecl(proto);
-  }
-
   virtual void resolveExtension(ExtensionDecl *ext) override {
     validateExtension(ext);
   }

--- a/validation-test/compiler_crashers_2/0207-sr7371.swift
+++ b/validation-test/compiler_crashers_2/0207-sr7371.swift
@@ -1,0 +1,36 @@
+// RUN: not --crash %target-swift-frontend -emit-ir %s
+
+public protocol TypedParserResultTransferType {
+    // Remove type constraint
+    associatedtype Result: ParserResult
+}
+
+public struct AnyTypedParserResultTransferType<P: ParserResult>: TypedParserResultTransferType {
+    public typealias Result = P
+    // Remove property
+    public let result: P
+}
+
+public protocol ParserResult {}
+public protocol StaticParser: ParserResult {}
+
+// Change comformance to ParserResult
+public protocol TypedStaticParser: StaticParser {
+    // Remove type constraint
+    associatedtype ResultTransferType: TypedParserResultTransferType
+}
+
+// Remove where clause
+public protocol MutableSelfStaticParser: TypedStaticParser where ResultTransferType == AnyTypedParserResultTransferType<Self> {
+    func parseTypeVar() -> AnyTypedParserResultTransferType<Self>
+}
+
+extension MutableSelfStaticParser {
+
+    public func anyFunction() -> () {
+        let t = self.parseTypeVar
+        // Remove this and below
+        _ = t()
+        _ = self.parseTypeVar()
+    }
+}

--- a/validation-test/compiler_crashers_2/0208-sr8751.swift
+++ b/validation-test/compiler_crashers_2/0208-sr8751.swift
@@ -1,0 +1,58 @@
+// RUN: not --crash %target-swift-frontend -emit-ir %s
+
+protocol TreeProtocol {
+
+    typealias NodeProtocol = _TreeNodeProtocol
+    associatedtype Node : NodeProtocol where Node.Tree == Self
+    associatedtype NValuesTraversedBreadthFirst : Sequence = FooVals<Self> where NValuesTraversedBreadthFirst.Iterator.Element == Node.Val
+    
+    var root: Node? { get }
+    
+}
+
+protocol _TreeNodeProtocol {
+
+    associatedtype Tree : TreeProtocol where Tree.Node == Self
+    associatedtype Val
+
+    var value: Val { get }
+    var children: [Tree.Node] { get }
+
+}
+
+struct Foo<V> : TreeProtocol {
+
+    struct Node : _TreeNodeProtocol {
+        typealias Tree = Foo
+        typealias Val = V
+
+        var value: Val {
+            fatalError()
+        }
+        var children: [Tree.Node] {
+            fatalError()
+        }
+    }
+    
+    var root: Foo<V>.Node? {
+        fatalError()
+    }
+
+}
+
+struct FooVals<F : TreeProtocol> : Sequence {
+
+    struct Iterator : IteratorProtocol {
+        
+        typealias Element = F.Node.Val
+        
+        mutating func next() -> F.Node.Val? {
+            fatalError()
+        }
+    }
+    
+    func makeIterator() -> FooVals<F>.Iterator {
+        fatalError()
+    }
+
+}


### PR DESCRIPTION
Mostly NFC, except for the change to have ProtocolConformanceRef::subst() return invalid conformances instead of asserting. That's necessary for the next PR, but shouldn't impact anything today.

Also, I'm adding a couple of crashing test cases for unrelated bugs.