### PR TITLE
[ConstraintSystem] Introduce a fix for assignment type mismatch

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -759,6 +759,26 @@ IgnoreContextualType *IgnoreContextualType::create(ConstraintSystem &cs,
       IgnoreContextualType(cs, resultTy, specifiedTy, locator);
 }
 
+bool IgnoreAssignmentDestinationType::diagnose(Expr *root, bool asNote) const {
+  auto &cs = getConstraintSystem();
+  auto *AE = cast<AssignExpr>(getAnchor());
+  auto CTP = isa<SubscriptExpr>(AE->getDest()) ? CTP_SubscriptAssignSource
+                                               : CTP_AssignSource;
+
+  ContextualFailure failure(
+      root, cs, CTP, getFromType(), getToType(),
+      cs.getConstraintLocator(AE->getSrc(), LocatorPathElt::ContextualType()));
+  return failure.diagnose(asNote);
+}
+
+IgnoreAssignmentDestinationType *
+IgnoreAssignmentDestinationType::create(ConstraintSystem &cs, Type sourceTy,
+                                        Type destTy,
+                                        ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreAssignmentDestinationType(cs, sourceTy, destTy, locator);
+}
+
 bool AllowInOutConversion::diagnose(Expr *root, bool asNote) const {
   auto &cs = getConstraintSystem();
   InOutConversionFailure failure(root, cs, getFromType(), getToType(),

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -1299,6 +1299,23 @@ public:
                                       ConstraintLocator *locator);
 };
 
+class IgnoreAssignmentDestinationType final : public ContextualMismatch {
+  IgnoreAssignmentDestinationType(ConstraintSystem &cs, Type sourceTy,
+                                  Type destTy, ConstraintLocator *locator)
+      : ContextualMismatch(cs, sourceTy, destTy, locator) {}
+
+public:
+  std::string getName() const override {
+    return "ignore type of the assignment destination";
+  }
+
+  bool diagnose(Expr *root, bool asNote = false) const override;
+
+  static IgnoreAssignmentDestinationType *create(ConstraintSystem &cs,
+                                                 Type sourceTy, Type destTy,
+                                                 ConstraintLocator *locator);
+};
+
 /// If this is an argument-to-parameter conversion which is associated with
 /// `inout` parameter, subtyping is not permitted, types have to
 /// be identical.

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -394,7 +394,7 @@ func rdar20868864(_ s: String) {
 func r22058555() {
   var firstChar: UInt8 = 0
   "abc".withCString { chars in
-    firstChar = chars[0]  // expected-error {{cannot assign value of type 'Int8' to type 'UInt8'}}
+    firstChar = chars[0]  // expected-error {{cannot assign value of type 'Int8' to type 'UInt8'}} {{17-17=UInt8(}} {{25-25=)}}
   }
 }
 

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -22,7 +22,7 @@ func useIdentity(_ x: Int, y: Float, i32: Int32) {
 
   // Deduction where the result type and input type can get different results
   var xx : X, yy : Y
-  xx = identity(yy) // expected-error{{cannot convert value of type 'Y' to expected argument type 'X'}}
+  xx = identity(yy) // expected-error{{cannot assign value of type 'Y' to type 'X'}}
   xx = identity2(yy) // expected-error{{cannot convert value of type 'Y' to expected argument type 'X'}}
 }
 

--- a/test/ModuleInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ModuleInterface/Inputs/opaque-result-types-client.swift
@@ -17,14 +17,14 @@ struct YourFoo: Foo {}
 func someTypeIsTheSame() {
   var a = foo(0)
   a = foo(0)
-  a = foo("") // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
+  a = foo("") // expected-error{{cannot assign value of type 'some Foo' (result of 'foo') to type 'some Foo' (result of 'foo')}}
 
   var b = foo("")
-  b = foo(0) // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
+  b = foo(0) // expected-error{{cannot assign value of type 'some Foo' (result of 'foo') to type 'some Foo' (result of 'foo')}}
   b = foo("")
 
   var c = foo(MyFoo())
-  c = foo(0) // expected-error{{cannot convert value of type 'Int' to expected argument type 'MyFoo'}}
+  c = foo(0) // expected-error{{cannot assign value of type 'some Foo' (result of 'foo') to type 'some Foo' (result of 'foo')}}
   c = foo(MyFoo())
   c = foo(YourFoo()) // expected-error{{cannot convert value of type 'YourFoo' to expected argument type 'MyFoo'}}
 


### PR DESCRIPTION
Introduce a fix/diagnostic when there is a contextual mismatch
between source and destination types of the assignment e.g.:

```swift
var x: Int = 0
x = 4.0 // destination expects an `Int`, but source is a `Double`
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
