### PR TITLE
stdlib: silence a unused function warning (NFC)

### DIFF
--- a/stdlib/public/stubs/ThreadLocalStorage.cpp
+++ b/stdlib/public/stubs/ThreadLocalStorage.cpp
@@ -23,6 +23,8 @@ void _stdlib_destroyTLS(void *);
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 void *_stdlib_createTLS(void);
 
+#if !SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC || (defined(_WIN32) && !defined(__CYGWIN__))
+
 static void
 #if defined(_M_IX86)
 __stdcall
@@ -30,6 +32,8 @@ __stdcall
 destroyTLS_CCAdjustmentThunk(void *ptr) {
   _stdlib_destroyTLS(ptr);
 }
+
+#endif
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 


### PR DESCRIPTION
Pre-process away the unused function on Darwin.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
