### PR TITLE
[parser] Fix invalid tuple type round-tripping issue

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -876,7 +876,7 @@ public:
   ///
   /// If the input is malformed, this emits the specified error diagnostic.
   bool parseToken(tok K, SourceLoc &TokLoc, const Diagnostic &D);
-  llvm::Optional<ParsedTokenSyntax> parseTokenSyntax(tok K,
+  llvm::Optional<ParsedTokenSyntax> parseTokenSyntax(tok K, SourceLoc &TokLoc,
                                                      const Diagnostic &D);
 
   template<typename ...DiagArgTypes, typename ...ArgTypes>
@@ -896,7 +896,8 @@ public:
                           SourceLoc OtherLoc);
 
   llvm::Optional<ParsedTokenSyntax>
-  parseMatchingTokenSyntax(tok K, Diag<> ErrorDiag, SourceLoc OtherLoc);
+  parseMatchingTokenSyntax(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
+                           SourceLoc OtherLoc);
 
   /// Returns the proper location for a missing right brace, parenthesis, etc.
   SourceLoc getLocForMissingMatchingToken() const;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -109,7 +109,8 @@ Parser::parseLayoutConstraintSyntax() {
     if (Tok.is(tok::r_paren))
       builder.useRightParen(consumeTokenSyntax(tok::r_paren));
   } else {
-    auto rParen = parseMatchingTokenSyntax(tok::r_paren,
+    SourceLoc rParenLoc;
+    auto rParen = parseMatchingTokenSyntax(tok::r_paren, rParenLoc,
                              diag::expected_rparen_layout_constraint,
                              lParenLoc);
     if (rParen)
@@ -1166,6 +1167,8 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
   });
 
   if (!Status.isSuccess()) {
+    if (RParen)
+      Junk.push_back(std::move(*RParen));
     auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
     return makeParsedResult(std::move(ty), Status);
   }
@@ -1253,9 +1256,9 @@ Parser::TypeResult Parser::parseTypeArray(ParsedTypeSyntax Base,
   // Ignore integer literal between '[' and ']'
   ignoreIf(tok::integer_literal);
 
-  auto RSquareLoc = Tok.getLoc();
+  SourceLoc RSquareLoc;
   auto RSquare = parseMatchingTokenSyntax(
-      tok::r_square, diag::expected_rbracket_array_type, LSquareLoc);
+      tok::r_square, RSquareLoc, diag::expected_rbracket_array_type, LSquareLoc);
 
   if (RSquare) {
     // If we parsed something valid, diagnose it with a fixit to rewrite it to
@@ -1301,7 +1304,9 @@ Parser::TypeResult Parser::parseTypeCollection() {
   auto Diag = Colon ? diag::expected_rbracket_dictionary_type
                     : diag::expected_rbracket_array_type;
 
-  auto RSquare = parseMatchingTokenSyntax(tok::r_square, Diag, LSquareLoc);
+  SourceLoc RSquareLoc;
+  auto RSquare = parseMatchingTokenSyntax(tok::r_square, RSquareLoc, Diag,
+                                          LSquareLoc);
   if (!RSquare)
     Status.setIsParseError();
 

--- a/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
@@ -19,4 +19,5 @@ class C <MemberDeclBlock>{<MemberDeclListItem><StructDecl>
 struct S <MemberDeclBlock>{<MemberDeclListItem><EnumDecl>
 enum E <MemberDeclBlock>{<MemberDeclListItem><ProtocolDecl>
 protocol P <MemberDeclBlock>{<MemberDeclListItem><ExtensionDecl>
-extension <SimpleTypeIdentifier>P </SimpleTypeIdentifier><MemberDeclBlock>{</MemberDeclBlock></ExtensionDecl></MemberDeclListItem></MemberDeclBlock></ProtocolDecl></MemberDeclListItem></MemberDeclBlock></EnumDecl></MemberDeclListItem></MemberDeclBlock></StructDecl></MemberDeclListItem></MemberDeclBlock></ClassDecl></CodeBlock></FunctionDecl>
+extension <SimpleTypeIdentifier>P </SimpleTypeIdentifier><MemberDeclBlock>{<MemberDeclListItem><InitializerDecl><DeclModifier>
+public </DeclModifier>init<ParameterClause>(<FunctionParameter>a: (<TupleTypeElement><SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TupleTypeElement>|| String)</FunctionParameter>)</ParameterClause></InitializerDecl></MemberDeclListItem></MemberDeclBlock></ExtensionDecl></MemberDeclListItem></MemberDeclBlock></ProtocolDecl></MemberDeclListItem></MemberDeclBlock></EnumDecl></MemberDeclListItem></MemberDeclBlock></StructDecl></MemberDeclListItem></MemberDeclBlock></ClassDecl></CodeBlock></FunctionDecl>

--- a/test/Syntax/round_trip_invalid.swift
+++ b/test/Syntax/round_trip_invalid.swift
@@ -20,3 +20,4 @@ struct S {
 enum E {
 protocol P {
 extension P {
+public init(a: (Int || String))


### PR DESCRIPTION
`public init(a: (b || c))` became `public init(a: )(b || c)` after round-tripping.

Resolves rdar://problem/55280477