### PR TITLE
Preserve TypeAliasType sugar when substituting types

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2177,18 +2177,11 @@ TypeAliasType *TypeAliasType::get(TypeAliasDecl *typealias, Type parent,
   // Compute the recursive properties.
   //
   auto properties = underlying->getRecursiveProperties();
-  auto storedProperties = properties;
-  if (parent) {
+  if (parent)
     properties |= parent->getRecursiveProperties();
-    if (parent->hasTypeVariable())
-      storedProperties |= RecursiveTypeProperties::HasTypeVariable;
-  }
 
-  for (auto substGP : substitutions.getReplacementTypes()) {
+  for (auto substGP : substitutions.getReplacementTypes())
     properties |= substGP->getRecursiveProperties();
-    if (substGP->hasTypeVariable())
-      storedProperties |= RecursiveTypeProperties::HasTypeVariable;
-  }
 
   // Figure out which arena this type will go into.
   auto &ctx = underlying->getASTContext();
@@ -2210,7 +2203,7 @@ TypeAliasType *TypeAliasType::get(TypeAliasDecl *typealias, Type parent,
                                                       genericSig ? 1 : 0);
   auto mem = ctx.Allocate(size, alignof(TypeAliasType), arena);
   auto result = new (mem) TypeAliasType(typealias, parent, substitutions,
-                                        underlying, storedProperties);
+                                        underlying, properties);
   types.InsertNode(result, insertPos);
   return result;
 }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -190,9 +190,7 @@ Type ASTBuilder::createTypeAliasType(GenericTypeDecl *decl, Type parent) {
   auto *dc = aliasDecl->getDeclContext();
   auto subs = parent->getContextSubstitutionMap(dc->getParentModule(), dc);
 
-  // FIXME: subst() should build the sugar for us
-  declaredType = declaredType.subst(subs);
-  return TypeAliasType::get(aliasDecl, parent, subs, declaredType);
+  return declaredType.subst(subs);
 }
 
 static SubstitutionMap
@@ -323,9 +321,7 @@ Type ASTBuilder::createBoundGenericType(GenericTypeDecl *decl,
   if (!subMap)
     return Type();
 
-  // FIXME: subst() should build the sugar for us
-  auto declaredType = aliasDecl->getDeclaredInterfaceType().subst(subMap);
-  return TypeAliasType::get(aliasDecl, parent, subMap, declaredType);
+  return aliasDecl->getDeclaredInterfaceType().subst(subMap);
 }
 
 Type ASTBuilder::createTupleType(ArrayRef<Type> eltTypes,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -814,10 +814,16 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       // It's not possible to mangle the context of the builtin module.
       // For the DWARF output we want to mangle the type alias + context,
       // unless the type alias references a builtin type.
+      auto underlyingType = aliasTy->getSinglyDesugaredType();
       TypeAliasDecl *decl = aliasTy->getDecl();
       if (decl->getModuleContext() == decl->getASTContext().TheBuiltinModule) {
-        return appendType(aliasTy->getSinglyDesugaredType(),
-                          forDecl);
+        return appendType(underlyingType, forDecl);
+      }
+
+      if (decl->getDeclaredInterfaceType()
+            .subst(aliasTy->getSubstitutionMap()).getPointer()
+            != aliasTy) {
+        return appendType(underlyingType, forDecl);
       }
 
       if (aliasTy->getSubstitutionMap()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3545,7 +3545,7 @@ void TypeAliasDecl::computeType() {
   Type parent;
   auto parentDC = getDeclContext();
   if (parentDC->isTypeContext())
-    parent = parentDC->getDeclaredInterfaceType();
+    parent = parentDC->getSelfInterfaceType();
   auto sugaredType = TypeAliasType::get(this, parent, subs, getUnderlyingType());
   setInterfaceType(MetatypeType::get(sugaredType, ctx));
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -398,7 +398,7 @@ static bool shouldShowAKA(Type type, StringRef typeName) {
     return false;
 
   // Don't show generic type parameters.
-  if (type->hasTypeParameter())
+  if (type->getCanonicalType()->hasTypeParameter())
     return false;
 
   // Only show 'aka' if there's a typealias involved; other kinds of sugar

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3963,29 +3963,25 @@ case TypeKind::Id:
 
     Type oldParentType = alias->getParent();
     Type newParentType;
-    if (oldParentType && !oldParentType->hasTypeParameter() &&
-        !oldParentType->hasArchetype()) {
+    if (oldParentType) {
       newParentType = oldParentType.transformRec(fn);
       if (!newParentType) return newUnderlyingType;
     }
 
     auto subMap = alias->getSubstitutionMap();
     for (Type oldReplacementType : subMap.getReplacementTypes()) {
-      if (oldReplacementType->hasTypeParameter() ||
-          oldReplacementType->hasArchetype())
-        return newUnderlyingType;
-
       Type newReplacementType = oldReplacementType.transformRec(fn);
       if (!newReplacementType)
         return newUnderlyingType;
 
       // If anything changed with the replacement type, we lose the sugar.
       // FIXME: This is really unfortunate.
-      if (!newReplacementType->isEqual(oldReplacementType))
+      if (newReplacementType.getPointer() != oldReplacementType.getPointer())
         return newUnderlyingType;
     }
 
-    if (oldUnderlyingType.getPointer() == newUnderlyingType.getPointer())
+    if (oldParentType.getPointer() == newParentType.getPointer() &&
+        oldUnderlyingType.getPointer() == newUnderlyingType.getPointer())
       return *this;
 
     return TypeAliasType::get(alias->getDecl(), newParentType, subMap,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -863,7 +863,7 @@ static bool hasDependentTypeWitness(
             return false;
 
           // RESILIENCE: this could be an opaque conformance
-          return type->hasTypeParameter();
+          return type->getCanonicalType()->hasTypeParameter();
        },
        /*useResolver=*/true)) {
     return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4823,7 +4823,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // to access the type with a protocol metatype base.
     } else if (instanceTy->isExistentialType() &&
                isa<TypeAliasDecl>(decl) &&
-               !cast<TypeAliasDecl>(decl)->getInterfaceType()->hasTypeParameter()) {
+               !cast<TypeAliasDecl>(decl)
+                  ->getUnderlyingType()->getCanonicalType()
+                    ->hasTypeParameter()) {
 
       /* We're OK */
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -622,7 +622,7 @@ static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
 
 Type ConstraintSystem::openUnboundGenericType(
     Type type, ConstraintLocatorBuilder locator) {
-  assert(!type->hasTypeParameter());
+  assert(!type->getCanonicalType()->hasTypeParameter());
 
   checkNestedTypeConstraints(*this, type, locator);
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -997,6 +997,6 @@ StructuralTypeRequest::evaluate(Evaluator &evaluator,
   Type parent;
   auto parentDC = typeAlias->getDeclContext();
   if (parentDC->isTypeContext())
-    parent = parentDC->getDeclaredInterfaceType();
+    parent = parentDC->getSelfInterfaceType();
   return TypeAliasType::get(typeAlias, parent, subs, type);
 }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -358,8 +358,6 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
 }
 
 bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
-  auto memberType = typeDecl->getDeclaredInterfaceType();
-
   // We don't allow lookups of a non-generic typealias of an unbound
   // generic type, because we have no way to model such a type in the
   // AST.
@@ -370,28 +368,38 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
   //
   // FIXME: Could lift this restriction once we have sugared
   // "member types".
-  if (type->is<UnboundGenericType>() &&
-      isa<TypeAliasDecl>(typeDecl) &&
-      cast<TypeAliasDecl>(typeDecl)->getGenericParams() == nullptr &&
-      memberType->hasTypeParameter()) {
-    return true;
-  }
+  if (type->is<UnboundGenericType>()) {
+    // Generic typealiases can be accessed with an unbound generic
+    // base, since we represent the member type as an unbound generic
+    // type.
+    //
+    // Non-generic type aliases can only be accessed if the
+    // underlying type is not dependent.
+    if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
+      if (!aliasDecl->isGeneric() &&
+          aliasDecl->getUnderlyingType()->getCanonicalType()
+            ->hasTypeParameter()) {
+        return true;
+      }
+    }
 
-  if (type->is<UnboundGenericType>() &&
-      isa<AssociatedTypeDecl>(typeDecl)) {
-    return true;
+    if (isa<AssociatedTypeDecl>(typeDecl))
+      return true;
   }
 
   if (type->isExistentialType() &&
       typeDecl->getDeclContext()->getSelfProtocolDecl()) {
-    // TODO: Temporarily allow typealias and associated type lookup on
-    //       existential type iff it doesn't have any type parameters.
-    if (isa<TypeAliasDecl>(typeDecl) || isa<AssociatedTypeDecl>(typeDecl))
-      return memberType->hasTypeParameter();
-
-    // Don't allow lookups of nested types of an existential type,
-    // because there is no way to represent such types.
-    return true;
+    // Allow typealias member access on existential types if the underlying
+    // type does not have any type parameters.
+    if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
+      if (aliasDecl->getUnderlyingType()->getCanonicalType()
+          ->hasTypeParameter())
+        return true;
+    } else {
+      // Don't allow lookups of other nested types of an existential type,
+      // because there is no way to represent such types.
+      return true;
+    }
   }
 
   return false;
@@ -454,11 +462,12 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
       // FIXME: This is a hack, we should be able to remove this entire 'if'
       // statement once we learn how to deal with the circularity here.
-      if (isa<TypeAliasDecl>(typeDecl) &&
-          isa<ProtocolDecl>(typeDecl->getDeclContext())) {
-        if (!type->is<ArchetypeType>() &&
+      if (auto *aliasDecl = dyn_cast<TypeAliasDecl>(typeDecl)) {
+        if (isa<ProtocolDecl>(aliasDecl->getDeclContext()) &&
+            !type->is<ArchetypeType>() &&
             !type->isTypeParameter() &&
-            memberType->hasTypeParameter() &&
+            aliasDecl->getUnderlyingType()->getCanonicalType()
+              ->hasTypeParameter() &&
             !options.contains(NameLookupFlags::PerformConformanceCheck)) {
           continue;
         }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2315,7 +2315,7 @@ bool ConformanceChecker::checkObjCTypeErasedGenerics(
   if (!classDecl->usesObjCGenericsModel()) return false;
 
   // Concrete types are okay.
-  if (!type->hasTypeParameter()) return false;
+  if (!type->getCanonicalType()->hasTypeParameter()) return false;
 
   // Find one of the generic parameters named. It doesn't matter
   // which one.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1072,6 +1072,11 @@ AssociatedTypeInference::getSubstOptionsWithCurrentTypeWitnesses() {
       }
 
       Type type = self->typeWitnesses.begin(assocType)->first;
+
+      // FIXME: Get rid of this hack.
+      if (auto *aliasTy = dyn_cast<TypeAliasType>(type.getPointer()))
+        type = aliasTy->getSinglyDesugaredType();
+
       return type->mapTypeOutOfContext().getPointer();
     };
   return options;

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -31,7 +31,7 @@ useDictStringInt(["Hello" : nil])
 
 typealias FuncBoolToInt = (Bool) -> Int
 let dict1: MyDictionary<String, FuncBoolToInt> = ["Hello": nil]
-// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'FuncBoolToInt' (aka '(Bool) -> Int')}}
+// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'MyDictionary<String, FuncBoolToInt>.Value' (aka '(Bool) -> Int')}}
 
 // Generic dictionary literals.
 useDict(["Hello" : 1])
@@ -66,7 +66,7 @@ var _: MyDictionary<String, Int>? = ["foo", 1, "bar", 42]  // expected-error {{d
 var _: MyDictionary<String, Int>? = ["foo", 1.0, 2]  // expected-error {{cannot convert value of type '[Double]' to specified type 'MyDictionary<String, Int>?'}}
 // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Double'}}
 
-var _: MyDictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
+var _: MyDictionary<String, Int>? = ["foo" : 1.0]  // expected-error {{cannot convert value of type 'Double' to expected dictionary value type 'MyDictionary<String, Int>.Value' (aka 'Int')}}
 
 
 // <rdar://problem/24058895> QoI: Should handle [] in dictionary contexts better

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -190,14 +190,14 @@ protocol Kingdom {
   associatedtype King
 }
 struct Victory<General> {
-  init<K: Kingdom>(_ king: K) where K.King == General {} // expected-note {{where 'General' = '(x: Int, y: Int)', 'K.King' = '(Int, Int)'}}
+  init<K: Kingdom>(_ king: K) where K.King == General {} // expected-note {{where 'General' = '(x: Int, y: Int)', 'K.King' = 'MagicKingdom<(Int, Int)>.King' (aka '(Int, Int)')}}
 }
 struct MagicKingdom<K> : Kingdom {
   typealias King = K
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
+  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and 'MagicKingdom<(Int, Int)>.King' (aka '(Int, Int)') be equivalent}}
 }
 
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1257,7 +1257,7 @@ do {
   s.requirementTwo(3.0, 4.0)
   s.requirementTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.requirementTuple(3.0, 4.0) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{30-30=)}}
+  s.requirementTuple(3.0, 4.0) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element)' (aka '(Double, Double)')}} {{22-22=(}} {{30-30=)}}
   s.requirementTuple((3.0, 4.0))
 
   let sTwo = GenericConforms<(Double, Double)>()
@@ -1284,7 +1284,7 @@ do {
   s.requirementTwo(a, b)
   s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
+  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element)' (aka '(Double, Double)')}} {{22-22=(}} {{26-26=)}}
   s.requirementTuple((a, b))
 
   let sTwo = GenericConforms<(Double, Double)>()
@@ -1309,7 +1309,7 @@ do {
   s.requirementTwo(a, b)
   s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
+  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element)' (aka '(Double, Double)')}} {{22-22=(}} {{26-26=)}}
   s.requirementTuple((a, b))
 
   var sTwo = GenericConforms<(Double, Double)>()
@@ -1331,9 +1331,9 @@ do {
   s.takesClosure({ x in })
   s.takesClosure({ (x: Double) in })
 
-  s.takesClosureTwo({ _ = $0 }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  s.takesClosureTwo({ x in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  s.takesClosureTwo({ (x: (Double, Double)) in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ _ = $0 }) // expected-error {{contextual closure type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element) -> ()' (aka '(Double, Double) -> ()') expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ x in }) // expected-error {{contextual closure type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element) -> ()' (aka '(Double, Double) -> ()') expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ (x: (Double, Double)) in }) // expected-error {{contextual closure type '(GenericConforms<Double>.Element, GenericConforms<Double>.Element) -> ()' (aka '(Double, Double) -> ()') expects 2 arguments, but 1 was used in closure body}}
   s.takesClosureTwo({ _ = $0; _ = $1 })
   s.takesClosureTwo({ (x, y) in })
   s.takesClosureTwo({ (x: Double, y:Double) in })

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -2,6 +2,8 @@
 
 func markUsed<T>(_ t: T) {}
 
+// CHECK-DAG: ![[INTTYPE:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", {{.*}})
+
 public class DWARF {
 // CHECK-DAG: ![[BASE:.*]] = !DICompositeType({{.*}}identifier: "$ss6UInt32VD"
 // CHECK-DAG: ![[DIEOFFSET:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$s9typealias5DWARFC9DIEOffsetaD",{{.*}} line: [[@LINE+1]], baseType: ![[BASE]])
@@ -108,3 +110,20 @@ extension Ox where T == Int {
 }
 
 var v: Ox<Int>.Plow = 0
+
+public protocol Up {
+  associatedtype A : Down
+}
+
+public protocol Down {
+  associatedtype A
+}
+
+public typealias DependentAlias<T : Up> = T.A.A
+
+extension Up where A.A == Int {
+  public func foo() {
+    // CHECK-DAG: !DILocalVariable(name: "gg",{{.*}} type: ![[INTTYPE]]
+    var gg: DependentAlias<Self> = 123
+  }
+}

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -208,20 +208,20 @@ func callMin(_ x: Int, y: Int, a: Float, b: Float) {
   min2(a, b) // expected-error{{argument type 'Float' does not conform to expected type 'IsBefore'}}
 }
 
-func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {} // expected-note {{'R.Element' = 'Double'}}
+func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {} // expected-note {{where 'R.Element' = 'IndexingIterator<[Double]>.Element' (aka 'Double')}}
 
 func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
   rangeOfIsBefore(ia.makeIterator())
-  rangeOfIsBefore(da.makeIterator()) // expected-error{{global function 'rangeOfIsBefore' requires that 'Double' conform to 'IsBefore'}}
+  rangeOfIsBefore(da.makeIterator()) // expected-error{{global function 'rangeOfIsBefore' requires that 'IndexingIterator<[Double]>.Element' (aka 'Double') conform to 'IsBefore'}}
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}
-// expected-note@-1 {{where 'A.Element' = 'Int', 'B.Element' = 'Double'}}
+// expected-note@-1 {{where 'A.Element' = 'IndexingIterator<[Int]>.Element' (aka 'Int'), 'B.Element' = 'IndexingIterator<[Double]>.Element' (aka 'Double')}}
 func compareIterators() {
   var a: [Int] = []
   var b: [Double] = []
   testEqualIterElementTypes(a.makeIterator(), b.makeIterator())
-  // expected-error@-1 {{global function 'testEqualIterElementTypes' requires the types 'Int' and 'Double' be equivalent}}
+  // expected-error@-1 {{global function 'testEqualIterElementTypes' requires the types 'IndexingIterator<[Int]>.Element' (aka 'Int') and 'IndexingIterator<[Double]>.Element' (aka 'Double') be equivalent}}
 }
 
 protocol P_GI {

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -35,7 +35,7 @@ func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
-// expected-warning@-1 {{neither type in same-type constraint ('S<T.C>' or 'S<T.B.A>') refers to a generic parameter or associated type}}
+// expected-warning@-1 {{neither type in same-type constraint ('S<T.C>' or 'T.B.X') refers to a generic parameter or associated type}}
 
 
 // Incompatible concrete typealias types are flagged as such

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -383,7 +383,7 @@ struct X28 : P2 {
 }
 
 // CHECK-LABEL: .P28@
-// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == P28.P3Assoc>
+// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == Self.P3Assoc>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3, τ_0_0.P3Assoc == X28>
 protocol P28: P3 {
   typealias P3Assoc = X28   // expected-warning{{typealias overriding associated type}}

--- a/test/IDE/complete_override_typealias.swift
+++ b/test/IDE/complete_override_typealias.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_1 | %FileCheck %s -check-prefix=OVERRIDE_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_2 | %FileCheck %s -check-prefix=OVERRIDE_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OVERRIDE_3 | %FileCheck %s -check-prefix=OVERRIDE_3
+
+struct Generic<T> {}
+
+protocol MyProtocol {
+  associatedtype Result
+  typealias Arg1 = Generic<Self>
+  typealias Arg2<X> = Generic<X>
+  func foo<U>(arg1: Arg1, arg2: Arg2<U>, arg3: Arg2<Int>, arg4: [Arg1], arg5: Arg2<U>? arg6: Generic<Arg2<Generic<Arg2<Int>>>>) -> Result
+  func bar() -> Result
+}
+
+struct MyStruct1 : MyProtocol {
+  // No 'Result' witness.
+  func #^OVERRIDE_1^#
+}
+
+struct MyStruct2 : MyProtocol {
+  // Explicit 'Result' witness by 'typealias'.
+  typealias Result = String
+  func #^OVERRIDE_2^#
+}
+
+struct MyStruct3 : MyProtocol {
+  // Implicit 'Result' witness by inference.
+  func bar() -> String
+  func #^OVERRIDE_3^#
+}
+
+// OVERRIDE_1: Begin completions, 2 items
+// OVERRIDE_1-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: MyStruct1.Arg1, arg2: MyStruct1.Arg2<U>, arg3: MyStruct1.Arg2<Int>, arg4: [MyStruct1.Arg1], arg5: MyStruct1.Arg2<U>?, arg6: Generic<MyStruct1.Arg2<Generic<MyStruct1.Arg2<Int>>>>) -> MyStruct1.Result {|};
+// OVERRIDE_1-DAG: Decl[InstanceMethod]/Super: bar() -> MyStruct1.Result {|};
+// OVERRIDE_1: End completions
+
+// OVERRIDE_2: Begin completions, 2 items
+// OVERRIDE_2-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: MyStruct2.Arg1, arg2: MyStruct2.Arg2<U>, arg3: MyStruct2.Arg2<Int>, arg4: [MyStruct2.Arg1], arg5: MyStruct2.Arg2<U>?, arg6: Generic<MyStruct2.Arg2<Generic<MyStruct2.Arg2<Int>>>>) -> String {|};
+// OVERRIDE_2-DAG: Decl[InstanceMethod]/Super: bar() -> String {|};
+// OVERRIDE_2: End completions
+
+// OVERRIDE_3-DAG: Begin completions, 1 items
+// OVERRIDE_3-DAG: Decl[InstanceMethod]/Super: foo<U>(arg1: MyStruct3.Arg1, arg2: MyStruct3.Arg2<U>, arg3: MyStruct3.Arg2<Int>, arg4: [MyStruct3.Arg1], arg5: MyStruct3.Arg2<U>?, arg6: Generic<MyStruct3.Arg2<Generic<MyStruct3.Arg2<Int>>>>) -> String {|};
+// OVERRIDE_3-DAG: End completions
+

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -158,7 +158,7 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
-    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'MyType<T, Int>'}}
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'GenericClass<T>.TA<S>' (aka 'MyType<T, S>') to return type 'MyType<T, Int>'}}
   }
 
   func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -158,7 +158,7 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
-    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'GenericClass<T>.TA<S>' (aka 'MyType<T, S>') to return type 'MyType<T, Int>'}}
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'GenericClass<T>.TA<S>' (aka 'MyType<T, S>') to return type 'GenericClass<T>.TA<Int>' (aka 'MyType<T, Int>')}}
   }
 
   func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -29,6 +29,6 @@ func outerGeneric<T>(t: T, x: AnyObject) {
   // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type='<T> (tt: TT) -> ()' {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
-  // CHECK: closure_expr type='((a: T, b: T)) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: closure_expr type='(TT) -> ()' {{.*}} captures=(<generic> )
   let _: (TT) -> () = { _ in }
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -60,8 +60,8 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
   var sumf : Float
   for i : Int in gir { sum = sum + i }
   for i in gir { sum = sum + i }
-  for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'Int' to expected type 'Float'}}
-  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'Int' does not conform to expected protocol 'ElementProtocol'}}
+  for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'GoodRange<Int>.Element' (aka 'Int') to expected type 'Float'}}
+  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'GoodRange<Int>.Element' (aka 'Int') does not conform to expected protocol 'ElementProtocol'}}
 
   for (i, f) : (Int, Float) in gtr { sum = sum + i }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -2,5 +2,5 @@
 
 var d = [String:String]()
 _ = "\(d.map{ [$0 : $0] })"
-// expected-error@-1 {{type '(key: String, value: String)' cannot conform to 'Hashable'; only struct/enum/class types can conform to protocols}}
-// expected-note@-2 {{required by generic struct 'Dictionary' where 'Key' = '(key: String, value: String)'}}
+// expected-error@-1 {{type 'Dictionary<String, String>.Element' (aka '(key: String, value: String)') cannot conform to 'Hashable'; only struct/enum/class types can conform to protocols}}
+// expected-note@-2 {{required by generic struct 'Dictionary' where 'Key' = 'Dictionary<String, String>.Element' (aka '(key: String, value: String)')}}


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/27280. Fixes <rdar://problem/45313760>.