### PR TITLE
Remove resolveExtension and validateExtension

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -279,7 +279,6 @@ public:
   enum class ValidationState {
     Unchecked,
     Checking,
-    CheckingWithValidSignature,
     Checked,
   };
 
@@ -850,17 +849,9 @@ public:
     case ValidationState::Checked:
       return false;
     case ValidationState::Checking:
-    case ValidationState::CheckingWithValidSignature:
       return true;
     }
     llvm_unreachable("Unknown ValidationState");
-  }
-
-  /// Update the validation state for the declaration to allow access to the
-  /// generic signature.
-  void setSignatureIsValidated() {
-    assert(getValidationState() == ValidationState::Checking);
-    setValidationState(ValidationState::CheckingWithValidSignature);
   }
 
   bool hasValidationStarted() const {
@@ -1769,11 +1760,6 @@ public:
 
   void setInherited(MutableArrayRef<TypeLoc> i) { Inherited = i; }
 
-  /// Whether we have fully checked the extension signature.
-  bool hasValidSignature() const {
-    return getValidationState() > ValidationState::CheckingWithValidSignature;
-  }
-
   bool hasDefaultAccessLevel() const {
     return Bits.ExtensionDecl.DefaultAndMaxAccessLevel != 0;
   }
@@ -2608,8 +2594,6 @@ public:
 
   /// Set the interface type for the given value.
   void setInterfaceType(Type type);
-
-  bool hasValidSignature() const;
   
   /// isInstanceMember - Determine whether this value is an instance member
   /// of an enum or protocol.

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -60,12 +60,6 @@ public:
   /// consistency and provides the value a type.
   virtual void resolveDeclSignature(ValueDecl *VD) = 0;
 
-  /// Resolve the type of an extension.
-  ///
-  /// This can be called to ensure that the members of an extension can be
-  /// considered to be members of the extended type.
-  virtual void resolveExtension(ExtensionDecl *ext) = 0;
-
   /// Resolve any implicitly-declared constructors within the given nominal.
   virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) = 0;
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2968,7 +2968,7 @@ public:
     void verifyChecked(AbstractFunctionDecl *AFD) {
       PrettyStackTraceDecl debugStack("verifying AbstractFunctionDecl", AFD);
 
-      if (!AFD->hasValidSignature()) {
+      if (!AFD->hasInterfaceType()) {
         if (isa<AccessorDecl>(AFD) && AFD->isImplicit())
           return;
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -798,8 +798,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
   // Everything about this conformance is nailed down, so we can now ensure that
   // the extension is fully resolved.
   if (auto resolver = nominal->getASTContext().getLazyResolver()) {
-    if (auto ED = dyn_cast<ExtensionDecl>(conformingDC)) {
-      resolver->resolveExtension(ED);
+    if (auto ext = dyn_cast<ExtensionDecl>(conformingDC)) {
+      resolver->resolveDeclSignature(ext->getExtendedNominal());
     } else {
       resolver->resolveDeclSignature(cast<NominalTypeDecl>(conformingDC));
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2720,14 +2720,6 @@ void ValueDecl::setInterfaceType(Type type) {
   TypeAndAccess.setPointer(type);
 }
 
-bool ValueDecl::hasValidSignature() const {
-  if (!hasInterfaceType())
-    return false;
-  // FIXME -- The build blows up if the correct code is used:
-  // return getValidationState() > ValidationState::CheckingWithValidSignature;
-  return getValidationState() != ValidationState::Checking;
-}
-
 Optional<ObjCSelector> ValueDecl::getObjCRuntimeName(
                                               bool skipIsObjCResolution) const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1098,8 +1098,8 @@ CanType TypeBase::computeCanonicalType() {
       assert(resolver && "Need to resolve generic parameter depth");
       if (auto decl =
             gpDecl->getDeclContext()->getInnermostDeclarationDeclContext())
-        if (auto valueDecl = dyn_cast<ValueDecl>(decl))
-          resolver->resolveDeclSignature(valueDecl);
+        if (auto valueDecl = decl->getAsGenericContext())
+          (void)valueDecl->getGenericSignature();
     }
 
     assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2046,7 +2046,7 @@ public:
     auto *GenericSig = VD->getInnermostDeclContext()
         ->getGenericSignatureOfContext();
 
-    assert(VD->hasValidSignature());
+    assert(VD->hasInterfaceType());
     Type T = VD->getInterfaceType();
 
     if (ExprType) {
@@ -2135,7 +2135,7 @@ public:
     addValueBaseName(Builder, Name);
     setClangDeclKeywords(VD, Pairs, Builder);
 
-    if (!VD->hasValidSignature())
+    if (!VD->hasInterfaceType())
       return;
 
     // Add a type annotation.

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1329,7 +1329,7 @@ DeclContext *FailureDiagnosis::findDeclContext(Expr *subExpr) const {
         // variables would be accessible to name lookup of the subexpression and
         // may thus leak in.  Reset them to UnresolvedTypes for safe measures.
         assert(llvm::all_of(*closure->getParameters(), [](const ParamDecl *PD) {
-          if (PD->hasValidSignature()) {
+          if (PD->hasInterfaceType()) {
             auto paramTy = PD->getType();
             return !(paramTy->hasTypeVariable() || paramTy->hasError());
           }
@@ -5345,7 +5345,7 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
         if (auto DRE = dyn_cast<DeclRefExpr>(childExpr)) {
           if (auto param = dyn_cast<ParamDecl>(DRE->getDecl())) {
             auto paramType =
-                param->hasValidSignature() ? param->getType() : Type();
+                param->hasInterfaceType() ? param->getType() : Type();
             if (!paramType || paramType->hasTypeVariable()) {
               hasUnresolvedParams = true;
               return nullptr;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1473,7 +1473,7 @@ bool TrailingClosureAmbiguityFailure::diagnoseAsNote() {
     const ParamDecl *param = paramList->getArray().back();
 
     // Sanity-check that the trailing closure corresponds to this parameter.
-    if (!param->hasValidSignature() ||
+    if (!param->hasInterfaceType() ||
         !param->getInterfaceType()->is<AnyFunctionType>())
       return false;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2144,7 +2144,7 @@ static ConstraintFix *fixPropertyWrapperFailure(
   };
 
   auto applyFix = [&](Fix fix, VarDecl *decl, Type type) -> ConstraintFix * {
-    if (!decl->hasValidSignature() || !type)
+    if (!decl->hasInterfaceType() || !type)
       return nullptr;
 
     if (baseTy->isEqual(type))

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -61,7 +61,7 @@ OverloadCandidate::OverloadCandidate(ValueDecl *decl, bool skipCurriedSelf)
     : declOrExpr(decl), skipCurriedSelf(skipCurriedSelf), substituted(false) {
 
   if (auto *PD = dyn_cast<ParamDecl>(decl)) {
-    if (PD->hasValidSignature())
+    if (PD->hasInterfaceType())
       entityType = PD->getType();
     else
       entityType = PD->getASTContext().TheUnresolvedType;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -540,7 +540,7 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
 
   auto *superclassCtor = (ConstructorDecl *) context;
 
-  if (!superclassCtor->hasValidSignature())
+  if (!superclassCtor->hasInterfaceType())
     ctx.getLazyResolver()->resolveDeclSignature(superclassCtor);
 
   // Reference to super.init.
@@ -856,9 +856,9 @@ static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
       if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
         continue;
 
-      if (!var->hasValidSignature())
+      if (!var->hasInterfaceType())
         ctx.getLazyResolver()->resolveDeclSignature(var);
-      if (!var->hasValidSignature())
+      if (!var->hasInterfaceType())
         return;
     }
   }
@@ -923,9 +923,9 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
   if (!decl->hasClangNode()) {
     for (auto member : decl->getMembers()) {
       if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
-        if (!ctor->hasValidSignature())
+        if (!ctor->hasInterfaceType())
           ctx.getLazyResolver()->resolveDeclSignature(ctor);
-        if (!ctor->hasValidSignature())
+        if (!ctor->hasInterfaceType())
           return;
       }
     }
@@ -1081,7 +1081,7 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
 
       // We have a designated initializer. Create an override of it.
       // FIXME: Validation makes sure we get a generic signature here.
-      if (!decl->hasValidSignature())
+      if (!decl->hasInterfaceType())
         ctx.getLazyResolver()->resolveDeclSignature(decl);
 
       if (auto ctor = createDesignatedInitOverride(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -819,7 +819,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
         if (auto *param = dyn_cast<ParamDecl>(var))
           return getType(param);
 
-        if (!var->hasValidSignature()) {
+        if (!var->hasInterfaceType()) {
           if (!var->isInvalid()) {
             TC.diagnose(var->getLoc(), diag::recursive_decl_reference,
                         var->getDescriptiveKind(), var->getName());

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -56,9 +56,7 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
   if (!ED->isConstrainedExtension())
     return true;
 
-  TypeChecker *TC = &TypeChecker::createForContext((DC->getASTContext()));
-  TC->validateExtension(const_cast<ExtensionDecl *>(ED));
-
+  (void)TypeChecker::createForContext(DC->getASTContext());
   GenericSignature *genericSig = ED->getGenericSignature();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
       DC->getParentModule(), ED->getExtendedNominal());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1151,7 +1151,7 @@ static bool hasSingleNonVariadicParam(SubscriptDecl *decl,
     return false;
 
   auto *index = indices->get(0);
-  if (index->isVariadic() || !index->hasValidSignature())
+  if (index->isVariadic() || !index->hasInterfaceType())
     return false;
 
   if (ignoreLabel) {

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -497,7 +497,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
 
       // If we're validating the protocol recursively, bail out.
-      if (!protocol->hasValidSignature())
+      if (!protocol->hasInterfaceType())
         continue;
 
       auto conformance = conformsToProtocol(type, protocol, dc,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -330,7 +330,7 @@ swift::matchWitness(
     return RequirementMatch(witness, MatchKind::KindConflict);
 
   // If the witness has not been validated yet, do so now.
-  if (!witness->hasValidSignature()) {
+  if (!witness->hasInterfaceType()) {
     auto &ctx = dc->getASTContext();
     ctx.getLazyResolver()->resolveDeclSignature(witness);
   }
@@ -340,7 +340,7 @@ swift::matchWitness(
     return RequirementMatch(witness, MatchKind::WitnessInvalid);
 
   // If we're currently validating the witness, bail out.
-  if (!witness->hasValidSignature())
+  if (!witness->hasInterfaceType())
     return RequirementMatch(witness, MatchKind::Circularity);
 
   // Get the requirement and witness attributes.
@@ -3854,11 +3854,11 @@ void ConformanceChecker::resolveValueWitnesses() {
       continue;
     }
 
-    // Make sure we've validated the requirement.
+    // Make sure we've got an interface type.
     if (!requirement->hasInterfaceType())
       TC.validateDecl(requirement);
 
-    if (requirement->isInvalid() || !requirement->hasValidSignature()) {
+    if (requirement->isInvalid() || !requirement->hasInterfaceType()) {
       Conformance->setInvalid();
       continue;
     }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -453,7 +453,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
 
     // Validate the requirement.
     tc.validateDecl(req);
-    if (req->isInvalid() || !req->hasValidSignature())
+    if (req->isInvalid() || !req->hasInterfaceType())
       continue;
 
     // Check whether any of the associated types we care about are
@@ -501,7 +501,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   if (!witness->hasInterfaceType())
     tc.validateDecl(witness);
 
-  if (witness->isInvalid() || !witness->hasValidSignature())
+  if (witness->isInvalid() || !witness->hasInterfaceType())
     return Type();
 
   if (!witness->getDeclContext()->isTypeContext()) {
@@ -2039,7 +2039,7 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   if (!requirement->hasInterfaceType())
     TC.validateDecl(requirement);
 
-  if (requirement->isInvalid() || !requirement->hasValidSignature()) {
+  if (requirement->isInvalid() || !requirement->hasInterfaceType()) {
     Conformance->setInvalid();
     return;
   }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -188,15 +188,17 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // Invalid case.
     if (extendedNominal == nullptr)
       return true;
-
+    
+    // Validate the nominal type being extended.
+    tc.validateDecl(extendedNominal);
+    if (extendedNominal->isInvalid())
+      return true;
+    
     // Assume unconstrained concrete extensions we found witnesses in are
     // always viable.
     if (!isa<ProtocolDecl>(extendedNominal))
       return !extension->isConstrainedExtension();
-
-    // Build a generic signature.
-    tc.validateExtension(extension);
-
+    
     // FIXME: The extension may not have a generic signature set up yet as
     // resolving signatures may trigger associated type inference.  This cycle
     // is now detectable and we should look into untangling it
@@ -204,6 +206,9 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     if (!extension->hasComputedGenericSignature())
       return true;
 
+    // Build a generic signature.
+    auto *extensionSig = extension->getGenericSignature();
+    
     // The condition here is a bit more fickle than
     // `isExtensionApplied`. That check would prematurely reject
     // extensions like `P where AssocType == T` if we're relying on a
@@ -212,8 +217,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // because those have to be explicitly declared on the type somewhere
     // so won't be affected by whatever answer inference comes up with.
     auto selfTy = extension->getSelfInterfaceType();
-    for (const Requirement &reqt
-         : extension->getGenericSignature()->getRequirements()) {
+    for (const Requirement &reqt : extensionSig->getRequirements()) {
       switch (reqt.getKind()) {
       case RequirementKind::Conformance:
       case RequirementKind::Superclass:

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -614,10 +614,14 @@ void swift::typeCheckCompletionDecl(Decl *D) {
   DiagnosticSuppression suppression(Ctx.Diags);
   TypeChecker &TC = createTypeChecker(Ctx);
 
-  if (auto ext = dyn_cast<ExtensionDecl>(D))
-    TC.validateExtension(ext);
-  else
+  if (auto ext = dyn_cast<ExtensionDecl>(D)) {
+    if (auto *nominal = ext->getExtendedNominal()) {
+      // Validate the nominal type declaration being extended.
+      TC.validateDecl(nominal);
+    }
+  } else {
     TC.validateDecl(cast<ValueDecl>(D));
+  }
 }
 
 void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1015,10 +1015,6 @@ public:
     validateDecl(VD);
   }
 
-  virtual void resolveExtension(ExtensionDecl *ext) override {
-    validateExtension(ext);
-  }
-
   virtual void resolveImplicitConstructors(NominalTypeDecl *nominal) override {
     addImplicitConstructors(nominal);
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1423,7 +1423,7 @@ public:
         [&](VarDecl *var) -> Type {
           validateDecl(var);
 
-          if (!var->hasValidSignature() || var->isInvalid())
+          if (!var->hasInterfaceType() || var->isInvalid())
             return ErrorType::get(Context);
 
           return wantInterfaceType ? value->getInterfaceType()

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3262,7 +3262,7 @@ public:
     //
     // FIXME: Once accessor synthesis and getInterfaceType() itself are
     // request-ified this goes away.
-    if (!fn->hasValidSignature()) {
+    if (!fn->hasInterfaceType()) {
       assert(fn->isImplicit());
       S.M->getASTContext().getLazyResolver()->resolveDeclSignature(
           const_cast<AccessorDecl *>(fn));


### PR DESCRIPTION
Drop these two and simplify the decl validation state machine by removing the signature checking phase.

The first commit was supposed to be included in #27279, but it got lost - probably during the rebase before I pushed.