### PR TITLE
[NFC] Remove unnecessary validation noise

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -795,16 +795,6 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
   if (!conformingDC)
     return nullptr;
 
-  // Everything about this conformance is nailed down, so we can now ensure that
-  // the extension is fully resolved.
-  if (auto resolver = nominal->getASTContext().getLazyResolver()) {
-    if (auto ext = dyn_cast<ExtensionDecl>(conformingDC)) {
-      resolver->resolveDeclSignature(ext->getExtendedNominal());
-    } else {
-      resolver->resolveDeclSignature(cast<NominalTypeDecl>(conformingDC));
-    }
-  }
-
   auto *conformingNominal = conformingDC->getSelfNominalTypeDecl();
 
   // Form the conformance.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2959,11 +2959,6 @@ NecessaryBindings::forFunctionInvocations(IRGenModule &IGM,
 GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,
                                                  NominalTypeDecl *typeDecl)
     : TheDecl(typeDecl) {
-
-  // FIXME: Remove this once getGenericSignature() is a request.
-  if (!typeDecl->hasInterfaceType())
-    IGM.Context.getLazyResolver()->resolveDeclSignature(typeDecl);
-
   // We only need to do something here if the declaration context is
   // somehow generic.
   auto ncGenerics = typeDecl->getGenericSignatureOfContext();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1079,11 +1079,6 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
                     ? DesignatedInitKind::Chaining
                     : DesignatedInitKind::Stub;
 
-      // We have a designated initializer. Create an override of it.
-      // FIXME: Validation makes sure we get a generic signature here.
-      if (!decl->hasInterfaceType())
-        ctx.getLazyResolver()->resolveDeclSignature(decl);
-
       if (auto ctor = createDesignatedInitOverride(
                         decl, superclassCtor, kind, ctx)) {
         decl->addMember(ctor);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2205,11 +2205,7 @@ ConformanceChecker::ConformanceChecker(
       Conformance(conformance), Loc(conformance->getLoc()),
       GlobalMissingWitnesses(GlobalMissingWitnesses),
       LocalMissingWitnessesStartIndex(GlobalMissingWitnesses.size()),
-      SuppressDiagnostics(suppressDiagnostics) {
-  // The protocol may have only been validatedDeclForNameLookup'd until
-  // here, so fill in any information that's missing.
-  tc.validateDecl(conformance->getProtocol());
-}
+      SuppressDiagnostics(suppressDiagnostics) { }
 
 ArrayRef<AssociatedTypeDecl *>
 ConformanceChecker::getReferencedAssociatedTypes(ValueDecl *req) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -189,11 +189,6 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     if (extendedNominal == nullptr)
       return true;
     
-    // Validate the nominal type being extended.
-    tc.validateDecl(extendedNominal);
-    if (extendedNominal->isInvalid())
-      return true;
-    
     // Assume unconstrained concrete extensions we found witnesses in are
     // always viable.
     if (!isa<ProtocolDecl>(extendedNominal))


### PR DESCRIPTION
Drop some callers to validateDecl and resolveDeclSignature that did not
actually need the interface type, or could trivially recover the
interface type.