### PR TITLE
Using %sil-opt is inconsistent with the rest of the tests in this directory

### DIFF
--- a/test/SIL/Parser/ossa_needs_ownership_on_args.sil
+++ b/test/SIL/Parser/ossa_needs_ownership_on_args.sil
@@ -1,4 +1,4 @@
-// RUN: not %sil-opt -verify %s
+// RUN: not %target-sil-opt -verify %s
 
 // Make sure that we error if ossa functions do not parse unless the argument
 // has the proper ownership specifier on it.


### PR DESCRIPTION
Using %sil-opt is inconsistent with the rest of the tests in this directory which use %target-sil-opt. This causes problems if some lit systems don't recognize %sil-opt and only recognize %target-sil-opt. Updating for consistency.


