### PR TITLE
SILGen: use the correct forwarding substitutions for the setter of an assign_by_wrapper.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1427,8 +1427,6 @@ namespace {
         // Create the allocating setter function. It captures the base address.
         auto setterInfo = SGF.getConstantInfo(setter);
         SILValue setterFRef = SGF.emitGlobalFunctionRef(loc, setter, setterInfo);
-        auto setterSubs = SGF.getFunction().getForwardingSubstitutionMap();
-
         CanSILFunctionType setterTy = setterFRef->getType().castTo<SILFunctionType>();
         SILFunctionConventions setterConv(setterTy, SGF.SGM.M);
 
@@ -1442,7 +1440,7 @@ namespace {
 
         PartialApplyInst *setterPAI =
           SGF.B.createPartialApply(loc, setterFRef,
-                                   setterSubs, { capturedBase },
+                                   Substitutions, { capturedBase },
                                    ParameterConvention::Direct_Guaranteed);
         ManagedValue setterFn = SGF.emitManagedRValueWithCleanup(setterPAI);
 

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -61,6 +61,12 @@ struct IntStruct {
      }
      wrapped = 27
   }
+
+  // Check that we don't crash if the function has unrelated generic parameters.
+  // SR-11484
+  mutating func setit<V>(_ v: V) {
+    wrapped = 5
+  }
 }
 
 final class IntClass {
@@ -142,8 +148,13 @@ func testIntStruct() {
 
   // CHECK-NEXT:   .. init 42
   // CHECK-NEXT:   .. set 27
-  let t1 = IntStruct()
+  var t1 = IntStruct()
   // CHECK-NEXT: 27
+  print(t1.wrapped)
+
+  // CHECK-NEXT:   .. set 5
+  t1.setit(false)
+  // CHECK-NEXT: 5
   print(t1.wrapped)
 
   // CHECK-NEXT:   .. init 42


### PR DESCRIPTION
Fixes a crash when a function, which assigns to a wrapped property has additional generic parameters.

https://bugs.swift.org/browse/SR-11484
rdar://problem/55442328
