### PR TITLE
Reflection: Remove vestigial Offset fields from ReflectionInfo

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -80,14 +80,12 @@ public:
     return MangledTypeName;
   }
 
-  StringRef getMangledTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char *)((uintptr_t)MangledTypeName.get() + Offset));
+  StringRef getMangledTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(MangledTypeName.get());
   }
 
-  StringRef getFieldName(uintptr_t Offset, uintptr_t Low,
-                         uintptr_t High) const {
-    uintptr_t nameAddr = (uintptr_t)FieldName.get() + Offset;
+  StringRef getFieldName(uintptr_t Low, uintptr_t High) const {
+    uintptr_t nameAddr = (uintptr_t)FieldName.get();
     if (nameAddr < Low || nameAddr > High)
       return "";
     return (const char *)nameAddr;
@@ -216,18 +214,16 @@ public:
     return MangledTypeName;
   }
 
-  StringRef getMangledTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char *)((uintptr_t)MangledTypeName.get() + Offset));
+  StringRef getMangledTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(MangledTypeName.get());
   }
 
   bool hasSuperclass() const {
     return Superclass;
   }
 
-  StringRef getSuperclass(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)Superclass.get() + Offset));
+  StringRef getSuperclass() const {
+    return Demangle::makeSymbolicMangledNameStringRef(Superclass.get());
   }
 };
 
@@ -271,13 +267,13 @@ class AssociatedTypeRecord {
   const RelativeDirectPointer<const char> SubstitutedTypeName;
 
 public:
-  StringRef getName(uintptr_t Offset) const {
-    return (const char*)((uintptr_t)Name.get() + Offset);
+  StringRef getName() const {
+    return Name.get();
   }
 
-  StringRef getMangledSubstitutedTypeName(uintptr_t Offset) const {
+  StringRef getMangledSubstitutedTypeName() const {
     return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)SubstitutedTypeName.get() + Offset));
+                                                    SubstitutedTypeName.get());
   }
 };
 
@@ -352,14 +348,12 @@ public:
     return const_iterator { End, End };
   }
 
-  StringRef getMangledProtocolTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)ProtocolTypeName.get() + Offset));
+  StringRef getMangledProtocolTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(ProtocolTypeName.get());
   }
 
-  StringRef getMangledConformingTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)ConformingTypeName.get() + Offset));
+  StringRef getMangledConformingTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(ConformingTypeName.get());
   }
 };
 
@@ -425,9 +419,8 @@ public:
     return TypeName;
   }
 
-  StringRef getMangledTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)TypeName.get() + Offset));
+  StringRef getMangledTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(TypeName.get());
   }
 };
 
@@ -473,9 +466,8 @@ public:
     return MangledTypeName;
   }
 
-  StringRef getMangledTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)MangledTypeName.get() + Offset));
+  StringRef getMangledTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(MangledTypeName.get());
   }
 };
 
@@ -520,18 +512,17 @@ public:
     return MangledTypeName;
   }
 
-  StringRef getMangledTypeName(uintptr_t Offset) const {
-    return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)MangledTypeName.get() + Offset));
+  StringRef getMangledTypeName() const {
+    return Demangle::makeSymbolicMangledNameStringRef(MangledTypeName.get());
   }
 
   bool hasMangledMetadataSource() const {
     return MangledMetadataSource;
   }
 
-  StringRef getMangledMetadataSource(uintptr_t Offset) const {
+  StringRef getMangledMetadataSource() const {
     return Demangle::makeSymbolicMangledNameStringRef(
-      (const char*)((uintptr_t)MangledMetadataSource.get() + Offset));
+                                                   MangledMetadataSource.get());
   }
 };
 

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -242,12 +242,12 @@ public:
     auto RemoteStartAddress = static_cast<uint64_t>(RangeStart);
 
     ReflectionInfo info = {
-        {{FieldMdSec.first, FieldMdSec.second}, 0},
-        {{AssocTySec.first, AssocTySec.second}, 0},
-        {{BuiltinTySec.first, BuiltinTySec.second}, 0},
-        {{CaptureSec.first, CaptureSec.second}, 0},
-        {{TypeRefMdSec.first, TypeRefMdSec.second}, 0},
-        {{ReflStrMdSec.first, ReflStrMdSec.second}, 0},
+        {FieldMdSec.first, FieldMdSec.second},
+        {AssocTySec.first, AssocTySec.second},
+        {BuiltinTySec.first, BuiltinTySec.second},
+        {CaptureSec.first, CaptureSec.second},
+        {TypeRefMdSec.first, TypeRefMdSec.second},
+        {ReflStrMdSec.first, ReflStrMdSec.second},
         LocalStartAddress,
         RemoteStartAddress};
 
@@ -372,12 +372,12 @@ public:
         static_cast<uintptr_t>(ImageStart.getAddressData());
 
     ReflectionInfo Info = {
-        {{FieldMdSec.first, FieldMdSec.second}, 0},
-        {{AssocTySec.first, AssocTySec.second}, 0},
-        {{BuiltinTySec.first, BuiltinTySec.second}, 0},
-        {{CaptureSec.first, CaptureSec.second}, 0},
-        {{TypeRefMdSec.first, TypeRefMdSec.second}, 0},
-        {{ReflStrMdSec.first, ReflStrMdSec.second}, 0},
+        {FieldMdSec.first, FieldMdSec.second},
+        {AssocTySec.first, AssocTySec.second},
+        {BuiltinTySec.first, BuiltinTySec.second},
+        {CaptureSec.first, CaptureSec.second},
+        {TypeRefMdSec.first, TypeRefMdSec.second},
+        {ReflStrMdSec.first, ReflStrMdSec.second},
         LocalStartAddress,
         RemoteStartAddress};
     this->addReflectionInfo(Info);
@@ -492,12 +492,12 @@ public:
         static_cast<uint64_t>(ImageStart.getAddressData());
 
     ReflectionInfo info = {
-        {{FieldMdSec.first, FieldMdSec.second}, 0},
-        {{AssocTySec.first, AssocTySec.second}, 0},
-        {{BuiltinTySec.first, BuiltinTySec.second}, 0},
-        {{CaptureSec.first, CaptureSec.second}, 0},
-        {{TypeRefMdSec.first, TypeRefMdSec.second}, 0},
-        {{ReflStrMdSec.first, ReflStrMdSec.second}, 0},
+        {FieldMdSec.first, FieldMdSec.second},
+        {AssocTySec.first, AssocTySec.second},
+        {BuiltinTySec.first, BuiltinTySec.second},
+        {CaptureSec.first, CaptureSec.second},
+        {TypeRefMdSec.first, TypeRefMdSec.second},
+        {ReflStrMdSec.first, ReflStrMdSec.second},
         LocalStartAddress,
         RemoteStartAddress};
 
@@ -621,7 +621,7 @@ public:
       if (CD == nullptr)
         return nullptr;
 
-      auto Info = getBuilder().getClosureContextInfo(*CD, 0);
+      auto Info = getBuilder().getClosureContextInfo(*CD);
 
       return getClosureContextInfo(ObjectAddress, Info);
     }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -80,35 +80,12 @@ using CaptureSection = ReflectionSection<CaptureDescriptorIterator>;
 using GenericSection = ReflectionSection<const void *>;
 
 struct ReflectionInfo {
-  struct {
-    FieldSection Metadata;
-    uint64_t SectionOffset;
-  } Field;
-
-  struct {
-    AssociatedTypeSection Metadata;
-    uint64_t SectionOffset;
-  } AssociatedType;
-
-  struct {
-    BuiltinTypeSection Metadata;
-    uint64_t SectionOffset;
-  } Builtin;
-
-  struct {
-    CaptureSection Metadata;
-    uint64_t SectionOffset;
-  } Capture;
-
-  struct {
-    GenericSection Metadata;
-    uint64_t SectionOffset;
-  } TypeReference;
-
-  struct {
-    GenericSection Metadata;
-    uint64_t SectionOffset;
-  } ReflectionString;
+  FieldSection Field;
+  AssociatedTypeSection AssociatedType;
+  BuiltinTypeSection Builtin;
+  CaptureSection Capture;
+  GenericSection TypeReference;
+  GenericSection ReflectionString;
 
   uint64_t LocalStartAddress;
   uint64_t RemoteStartAddress;
@@ -580,8 +557,7 @@ public:
   const CaptureDescriptor *getCaptureDescriptor(uint64_t RemoteAddress);
 
   /// Get the unsubstituted capture types for a closure context.
-  ClosureContextInfo getClosureContextInfo(const CaptureDescriptor &CD,
-                                           uint64_t Offset);
+  ClosureContextInfo getClosureContextInfo(const CaptureDescriptor &CD);
 
   ///
   /// Dumping typerefs, field declarations, associated types

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -53,32 +53,32 @@ typedef struct swift_reflection_section {
 typedef struct swift_reflection_info {
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } field;
 
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } associated_types;
 
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } builtin_types;
 
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } capture;
 
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } type_references;
 
   struct {
     swift_reflection_section_t section;
-    swift_reflection_ptr_t offset;
+    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
   } reflection_strings;
 
   // Start address in local and remote address spaces.

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -198,7 +198,7 @@ BuiltinTypeInfo::BuiltinTypeInfo(const BuiltinTypeDescriptor *descriptor)
                descriptor->Stride,
                descriptor->NumExtraInhabitants,
                descriptor->isBitwiseTakable()),
-      Name(descriptor->getMangledTypeName(0)) {}
+      Name(descriptor->getMangledTypeName()) {}
 
 /// Utility class for building values that contain witness tables.
 class ExistentialTypeInfoBuilder {

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -119,7 +119,29 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
                                    swift_reflection_info_t Info) {
   auto Context = ContextRef->nativeContext;
   
-  Context->addReflectionInfo(*reinterpret_cast<ReflectionInfo *>(&Info));
+  // The `offset` fields must be zero.
+  if (Info.field.offset != 0
+      || Info.associated_types.offset != 0
+      || Info.builtin_types.offset != 0
+      || Info.capture.offset != 0
+      || Info.type_references.offset != 0
+      || Info.reflection_strings.offset != 0) {
+    fprintf(stderr, "reserved field in swift_reflection_info_t is not zero\n");
+    abort();
+  }
+  
+  ReflectionInfo ContextInfo{
+    {Info.field.section.Begin, Info.field.section.End},
+    {Info.associated_types.section.Begin, Info.associated_types.section.End},
+    {Info.builtin_types.section.Begin, Info.builtin_types.section.End},
+    {Info.capture.section.Begin, Info.capture.section.End},
+    {Info.type_references.section.Begin, Info.type_references.section.End},
+    {Info.reflection_strings.section.Begin, Info.reflection_strings.section.End},
+    Info.LocalStartAddress,
+    Info.RemoteStartAddress
+  };
+  
+  Context->addReflectionInfo(ContextInfo);
 }
 
 int

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -328,13 +328,13 @@ getFieldAt(const Metadata *base, unsigned index) {
   const FieldDescriptor &descriptor = *fields;
   auto &field = descriptor.getFields()[index];
   // Bounds are always valid as the offset is constant.
-  auto name = field.getFieldName(0, 0, std::numeric_limits<uintptr_t>::max());
+  auto name = field.getFieldName(0, std::numeric_limits<uintptr_t>::max());
 
   // Enum cases don't always have types.
   if (!field.hasMangledTypeName())
     return {name, FieldType().withIndirect(field.isIndirectCase())};
 
-  auto typeName = field.getMangledTypeName(0);
+  auto typeName = field.getMangledTypeName();
 
   SubstGenericParametersFromMetadata substitutions(base);
   auto typeInfo = swift_getTypeByMangledName(MetadataState::Complete,


### PR DESCRIPTION
These are now always zero, because memory readers handle virtual address mapping.
The `swift_reflection_info_t` structure used by the C RemoteMirror API keeps
its offset fields because it's supposed to be a stable API, but we now assert that
the values are always zero.