### PR TITLE
[TBDGen] disable tests for linux

### DIFF
--- a/test/TBD/abi-version.swift
+++ b/test/TBD/abi-version.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 
 // This test ensures that we see the same Swift ABI Version flag in the LLVM IR

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/safe.tbd
 // RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/not-safe.tbd

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing

--- a/test/TBD/dylib-version.swift
+++ b/test/TBD/dylib-version.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-current-version 2.0.3 -tbd-compatibility-version 1.7 -emit-tbd -emit-tbd-path %t/both_provided.tbd
 // RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-current-version 2.0 -emit-tbd -emit-tbd-path %t/only_current_provided.tbd

--- a/test/TBD/enum.swift
+++ b/test/TBD/enum.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -O

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -O

--- a/test/TBD/global.swift
+++ b/test/TBD/global.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-library-evolution %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing

--- a/test/TBD/installapi-flag.swift
+++ b/test/TBD/installapi-flag.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 
 // 1. Emit two TBDs, one with -tbd-is-installapi set, and one without

--- a/test/TBD/main.swift
+++ b/test/TBD/main.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s -O
 

--- a/test/TBD/opaque_result_type.swift
+++ b/test/TBD/opaque_result_type.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-availability-checking -emit-ir -o /dev/null -module-name opaque_result_type -emit-tbd -emit-tbd-path %t/opaque_result_type.tbd %s -validate-tbd-against-ir=missing
 

--- a/test/TBD/output-path-deduction.swift
+++ b/test/TBD/output-path-deduction.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 
 // RUN: cd %t; %target-build-swift -emit-module -emit-tbd %s

--- a/test/TBD/protocol.swift
+++ b/test/TBD/protocol.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -enable-library-evolution -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // Validate the the specializations actually exist (if they don't then we're not
 // validating that they end up with the correct linkages):
 // RUN: %target-swift-frontend -emit-sil -o- -O -validate-tbd-against-ir=none %s | %FileCheck %s

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-library-evolution
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -499,6 +499,7 @@ for target in config.llvm_code_generators:
 config.available_features.add("CPU=" + run_cpu)
 config.available_features.add("OS=" + run_os)
 config.available_features.add("PTRSIZE=" + run_ptrsize)
+config.available_features.add("VENDOR=" + run_vendor)
 
 config.available_features.add("SWIFT_VERSION=" + swift_version)
 

--- a/test/reproducible-builds/swiftc-emit-tbd.swift
+++ b/test/reproducible-builds/swiftc-emit-tbd.swift
@@ -1,3 +1,4 @@
+// REQUIRES: VENDOR=apple 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-1.tbd -force-single-frontend-invocation
 // RUN: %target-build-swift -O -g -module-name foo %s -emit-tbd-path %t/run-2.tbd -force-single-frontend-invocation


### PR DESCRIPTION
<!-- What's in this pull request? -->
It doesn't make sense for tbd files to be generated on linux machine since linux linkers wouldn't consume them anyway. This should be reflected in the tests and repair the failing tests from <https://github.com/apple/swift/pull/27073>
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves <rdar://problem/55635561>
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
