### PR TITLE
[Typechecker] Perform capture analysis for enums as well

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2589,6 +2589,8 @@ public:
 
     checkAccessControl(TC, ED);
 
+    TC.checkPatternBindingCaptures(ED);
+
     if (ED->hasRawType() && !ED->isObjC()) {
       // ObjC enums have already had their raw values checked, but pure Swift
       // enums haven't.

--- a/validation-test/compiler_crashers_2_fixed/sr11509.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11509.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -typecheck -verify
+
+@propertyWrapper
+public struct Wrapper<Value> {
+  public init(someValue unused: Int) {
+    _ = unused
+  }
+  
+  public var wrappedValue: Value?
+}
+
+
+func functionScope() {
+  let scopedValue = 3 // expected-note {{'scopedValue' declared here}}
+  // expected-warning@-1 {{initialization of immutable value 'scopedValue' was never used; consider replacing with assignment to '_' or removing it}}
+  
+  enum StaticScope { // expected-note {{type declared here}}
+    @Wrapper(someValue: scopedValue) static var foo: String? // expected-error {{enum declaration cannot close over value 'scopedValue' defined in outer scope}}
+  }
+  
+  _ = StaticScope.foo
+}


### PR DESCRIPTION
We weren't calling `checkPatternBindingCaptures()` for enums, only for structs and classes. If you look at the crasher code, the PBD for the property `foo` is inside the enum and was never checked.

Resolves [SR-11509](https://bugs.swift.org/browse/SR-11509).