### PR TITLE
Fail early if getExtendedNominal is called before extension has been bound.

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -461,6 +461,10 @@ public:
   /// AnyObject dynamic lookup.
   bool mayContainMembersAccessedByDynamicLookup() const;
 
+  /// Extensions are only allowed at the level in a file
+  /// FIXME: do this for Protocols, too someday
+  bool canBeParentOfExtension() const;
+
   /// Returns true if lookups within this context could affect downstream files.
   ///
   /// \param functionsAreNonCascading If true, functions are considered non-

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -265,12 +265,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitNominalTypeDecl(NominalTypeDecl *NTD) {
-    bool WalkGenerics = NTD->getGenericParams() &&
-        Walker.shouldWalkIntoGenericParams();
 
-    if (WalkGenerics) {
-      visitGenericParamList(NTD->getGenericParams());
-    }
+    bool WalkGenerics = visitGenericParamListIfNeeded(NTD);
 
     for (auto &Inherit : NTD->getInherited()) {
       if (doIt(Inherit))
@@ -329,11 +325,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitSubscriptDecl(SubscriptDecl *SD) {
-    bool WalkGenerics = SD->getGenericParams() &&
-      Walker.shouldWalkIntoGenericParams();
-    if (WalkGenerics) {
-      visitGenericParamList(SD->getGenericParams());
-    }
+    bool WalkGenerics = visitGenericParamListIfNeeded(SD);
+
     visit(SD->getIndices());
     if (doIt(SD->getElementTypeLoc()))
       return true;
@@ -364,14 +357,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     PrettyStackTraceDecl debugStack("walking into body of", AFD);
 #endif
 
-    bool WalkGenerics = AFD->getGenericParams() &&
-        Walker.shouldWalkIntoGenericParams() &&
+    bool WalkGenerics =
         // accessor generics are visited from the storage decl
-        !isa<AccessorDecl>(AFD);
-
-    if (WalkGenerics) {
-      visitGenericParamList(AFD->getGenericParams());
-    }
+        !isa<AccessorDecl>(AFD) && visitGenericParamListIfNeeded(AFD);
 
     if (auto *PD = AFD->getImplicitSelfDecl(/*createIfNeeded=*/false))
       visit(PD);
@@ -1350,6 +1338,18 @@ public:
       if (doIt(Req.getFirstTypeLoc()))
         return true;
       break;
+    }
+    return false;
+  }
+
+private:
+  bool visitGenericParamListIfNeeded(GenericContext *gc) {
+    // Must check this first in case extensions have not been bound yet
+    if (Walker.shouldWalkIntoGenericParams()) {
+      if (auto *params = gc->getGenericParams()) {
+        visitGenericParamList(params);
+        return true;
+      }
     }
     return false;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1076,9 +1076,25 @@ ExtensionDecl::takeConformanceLoaderSlow() {
 }
 
 NominalTypeDecl *ExtensionDecl::getExtendedNominal() const {
+  assert((hasBeenBound() || canNeverBeBound()) &&
+         "Extension must have already been bound (by bindExtensions)");
+  return ExtendedNominal.getPointer();
+}
+
+NominalTypeDecl *ExtensionDecl::computeExtendedNominal() const {
   ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-    ExtendedNominalRequest{const_cast<ExtensionDecl *>(this)}, nullptr);
+  return evaluateOrDefault(
+      ctx.evaluator, ExtendedNominalRequest{const_cast<ExtensionDecl *>(this)},
+      nullptr);
+}
+
+bool ExtensionDecl::canNeverBeBound() const {
+  // \c bindExtensions() only looks at valid parents for extensions.
+  return !hasValidParent();
+}
+
+bool ExtensionDecl::hasValidParent() const {
+  return getDeclContext()->canBeParentOfExtension();
 }
 
 bool ExtensionDecl::isConstrainedExtension() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -478,6 +478,10 @@ bool DeclContext::mayContainMembersAccessedByDynamicLookup() const {
   return false;
 }
 
+bool DeclContext::canBeParentOfExtension() const {
+  return isa<SourceFile>(this);
+}
+
 bool DeclContext::walkContext(ASTWalker &Walker) {
   switch (getContextKind()) {
   case DeclContextKind::Module:

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -74,17 +74,19 @@ Optional<NominalTypeDecl *> ExtendedNominalRequest::getCachedResult() const {
   // Note: if we fail to compute any nominal declaration, it's considered
   // a cache miss. This allows us to recompute the extended nominal types
   // during extension binding.
+  // This recomputation is also what allows you to extend types defined inside
+  // other extensions, regardless of source file order. See \c bindExtensions(),
+  // which uses a worklist algorithm that attempts to bind everything until
+  // fixed point.
   auto ext = std::get<0>(getStorage());
-  if (ext->ExtendedNominal)
-    return ext->ExtendedNominal;
-
-  return None;
+  if (!ext->hasBeenBound() || !ext->getExtendedNominal())
+    return None;
+  return ext->getExtendedNominal();
 }
 
 void ExtendedNominalRequest::cacheResult(NominalTypeDecl *value) const {
   auto ext = std::get<0>(getStorage());
-  if (value)
-    ext->ExtendedNominal = value;
+  ext->setExtendedNominal(value);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -792,6 +792,9 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     pushStructureNode(SN, NTD);
 
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+    // Normally bindExtension() would take care of computing the extended
+    // nominal. It must be done before asking for generic parameters.
+    ED->computeExtendedNominal();
     SyntaxStructureNode SN;
     setDecl(SN, D);
     SN.Kind = SyntaxStructureKind::Extension;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3058,7 +3058,7 @@ public:
     // Produce any diagnostics for the extended type.
     auto extType = ED->getExtendedType();
 
-    auto nominal = ED->getExtendedNominal();
+    auto nominal = ED->computeExtendedNominal();
     if (nominal == nullptr) {
       const bool wasAlreadyInvalid = ED->isInvalid();
       ED->setInvalid();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -229,7 +229,9 @@ static void bindExtensions(SourceFile &SF) {
   // Utility function to try and resolve the extended type without diagnosing.
   // If we succeed, we go ahead and bind the extension. Otherwise, return false.
   auto tryBindExtension = [&](ExtensionDecl *ext) -> bool {
-    if (auto nominal = ext->getExtendedNominal()) {
+    assert(!ext->canNeverBeBound() &&
+           "Only extensions that can ever be bound get here.");
+    if (auto nominal = ext->computeExtendedNominal()) {
       bindExtensionToNominal(ext, nominal);
       return true;
     }
@@ -615,7 +617,7 @@ void swift::typeCheckCompletionDecl(Decl *D) {
   DiagnosticSuppression suppression(Ctx.Diags);
   (void)createTypeChecker(Ctx);
   if (auto ext = dyn_cast<ExtensionDecl>(D)) {
-    if (auto *nominal = ext->getExtendedNominal()) {
+    if (auto *nominal = ext->computeExtendedNominal()) {
       // FIXME(InterfaceTypeRequest): Remove this.
       (void)nominal->getInterfaceType();
     }


### PR DESCRIPTION
Trip an assertion if code in the compiler directly or indirectly attempts to `getExtendedNominal` too soon (i.e. before the extension has been bound).
Requires https://github.com/apple/swift-lldb/pull/2021