### PR TITLE
Requestify getInterfaceType() in Name Only

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -922,8 +922,8 @@ static FuncDecl *findLibraryIntrinsic(const ASTContext &ctx,
   ctx.lookupInSwiftModule(name, results);
   if (results.size() == 1) {
     if (auto FD = dyn_cast<FuncDecl>(results.front())) {
-      if (auto *resolver = ctx.getLazyResolver())
-        resolver->resolveDeclSignature(FD);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)FD->getInterfaceType();
       return FD;
     }
   }
@@ -986,9 +986,6 @@ lookupOperatorFunc(const ASTContext &ctx, StringRef oper, Type contextType,
       auto contextTy = fnDecl->getDeclContext()->getDeclaredInterfaceType();
       if (!contextTy->isEqual(contextType)) continue;
     }
-
-    if (auto resolver = ctx.getLazyResolver())
-      resolver->resolveDeclSignature(fnDecl);
 
     auto *funcTy = getIntrinsicCandidateType(fnDecl, /*allowTypeMembers=*/true);
     if (!funcTy)
@@ -3969,8 +3966,6 @@ static NominalTypeDecl *findUnderlyingTypeInModule(ASTContext &ctx,
 
     // Look through typealiases.
     if (auto typealias = dyn_cast<TypeAliasDecl>(result)) {
-      if (auto resolver = ctx.getLazyResolver())
-        resolver->resolveDeclSignature(typealias);
       return typealias->getDeclaredInterfaceType()->getAnyNominal();
     }
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2343,13 +2343,7 @@ CanType ASTMangler::getDeclTypeForMangling(
   parentGenericSig = nullptr;
 
   auto &C = decl->getASTContext();
-  if (!decl->hasInterfaceType() && !decl->getDeclContext()->isLocalContext()) {
-    if (auto *resolver = C.getLazyResolver()) {
-      resolver->resolveDeclSignature(const_cast<ValueDecl *>(decl));
-    }
-  }
-
-  if (!decl->hasInterfaceType() || decl->getInterfaceType()->is<ErrorType>()) {
+  if (!decl->getInterfaceType() || decl->getInterfaceType()->is<ErrorType>()) {
     if (isa<AbstractFunctionDecl>(decl))
       return CanFunctionType::get({AnyFunctionType::Param(C.TheErrorType)},
                                   C.TheErrorType);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2697,7 +2697,13 @@ bool ValueDecl::hasInterfaceType() const {
 }
 
 Type ValueDecl::getInterfaceType() const {
-  assert(hasInterfaceType() && "No interface type was set");
+  if (!hasInterfaceType()) {
+    // Our clients that don't register the lazy resolver are relying on the
+    // fact that they can't pull an interface type out to avoid doing work.
+    // This is a necessary evil until we can wean them off.
+    if (auto resolver = getASTContext().getLazyResolver())
+      resolver->resolveDeclSignature(const_cast<ValueDecl *>(this));
+  }
   return TypeAndAccess.getPointer();
 }
 
@@ -3241,7 +3247,7 @@ Type TypeDecl::getDeclaredInterfaceType() const {
         selfTy, const_cast<AssociatedTypeDecl *>(ATD));
   }
 
-  Type interfaceType = hasInterfaceType() ? getInterfaceType() : nullptr;
+  Type interfaceType = getInterfaceType();
   if (interfaceType.isNull() || interfaceType->is<ErrorType>())
     return interfaceType;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6555,17 +6555,6 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
   if (decl->isEffectiveLinkageMoreVisibleThan(base))
     return true;
 
-  // FIXME: Remove this once getInterfaceType() has been request-ified.
-  if (!decl->hasInterfaceType()) {
-    ctx.getLazyResolver()->resolveDeclSignature(
-      const_cast<AbstractFunctionDecl *>(decl));
-  }
-
-  if (!base->hasInterfaceType()) {
-    ctx.getLazyResolver()->resolveDeclSignature(
-      const_cast<AbstractFunctionDecl *>(base));
-  }
-
   // If the method overrides something, we only need a new entry if the
   // override has a more general AST type. However an abstraction
   // change is OK; we don't want to add a whole new vtable entry just

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1817,14 +1817,15 @@ SourceFile::lookupOpaqueResultType(StringRef MangledName,
   auto found = ValidatedOpaqueReturnTypes.find(MangledName);
   if (found != ValidatedOpaqueReturnTypes.end())
     return found->second;
-  
+    
   // If there are unvalidated decls with opaque types, go through and validate
   // them now.
   if (resolver && !UnvalidatedDeclsWithOpaqueReturnTypes.empty()) {
     while (!UnvalidatedDeclsWithOpaqueReturnTypes.empty()) {
       ValueDecl *decl = *UnvalidatedDeclsWithOpaqueReturnTypes.begin();
       UnvalidatedDeclsWithOpaqueReturnTypes.erase(decl);
-      resolver->resolveDeclSignature(decl);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)decl->getInterfaceType();
     }
     
     found = ValidatedOpaqueReturnTypes.find(MangledName);

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -241,11 +241,12 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  if (!D->hasInterfaceType())
+  auto declIFaceTy = D->getInterfaceType();
+  if (!declIFaceTy)
     return std::string();
 
   // Invalid code.
-  if (D->getInterfaceType().findIf([](Type t) -> bool {
+  if (declIFaceTy.findIf([](Type t) -> bool {
         return t->is<ModuleType>();
       }))
     return std::string();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2297,9 +2297,6 @@ Type ClangImporter::Implementation::getNamedSwiftType(ModuleDecl *module,
 
   assert(!decl->hasClangNode() && "picked up the original type?");
 
-  if (auto *lazyResolver = SwiftContext.getLazyResolver())
-    lazyResolver->resolveDeclSignature(decl);
-
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
     return nominalDecl->getDeclaredType();
   return decl->getDeclaredInterfaceType();

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2046,8 +2046,8 @@ public:
     auto *GenericSig = VD->getInnermostDeclContext()
         ->getGenericSignatureOfContext();
 
-    assert(VD->hasInterfaceType());
     Type T = VD->getInterfaceType();
+    assert(!T.isNull());
 
     if (ExprType) {
       Type ContextTy = VD->getDeclContext()->getDeclaredInterfaceType();
@@ -2984,10 +2984,9 @@ public:
 
     if (IsSwiftKeyPathExpr && !SwiftKeyPathFilter(D, Reason))
       return;
-
-    if (!D->hasInterfaceType())
-      D->getASTContext().getLazyResolver()->resolveDeclSignature(D);
-
+    
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)D->getInterfaceType();
     switch (Kind) {
     case LookupKind::ValueExpr:
       if (auto *CD = dyn_cast<ConstructorDecl>(D)) {
@@ -3144,9 +3143,9 @@ public:
 
   bool handleEnumElement(ValueDecl *D, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo) {
-    if (!D->hasInterfaceType())
-      D->getASTContext().getLazyResolver()->resolveDeclSignature(D);
-
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)D->getInterfaceType();
+    
     if (auto *EED = dyn_cast<EnumElementDecl>(D)) {
       addEnumElementRef(EED, Reason, dynamicLookupInfo,
                         /*HasTypeContext=*/true);
@@ -3155,8 +3154,8 @@ public:
       llvm::DenseSet<EnumElementDecl *> Elements;
       ED->getAllElements(Elements);
       for (auto *Ele : Elements) {
-        if (!Ele->hasInterfaceType())
-          D->getASTContext().getLazyResolver()->resolveDeclSignature(Ele);
+        // FIXME(InterfaceTypeRequest): Remove this.
+        (void)Ele->getInterfaceType();
         addEnumElementRef(Ele, Reason, dynamicLookupInfo,
                           /*HasTypeContext=*/true);
       }
@@ -4330,8 +4329,8 @@ public:
         (D->isStatic() && D->getAttrs().hasAttribute<HasInitialValueAttr>()))
       return;
 
-    if (!D->hasInterfaceType())
-      D->getASTContext().getLazyResolver()->resolveDeclSignature(D);
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)D->getInterfaceType();
 
     bool hasIntroducer = hasFuncIntroducer ||
                          hasVarIntroducer ||

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -284,12 +284,10 @@ static void collectPossibleCalleesByQualifiedLookup(
       continue;
     if (!isMemberDeclApplied(&DC, baseTy->getMetatypeInstanceType(), VD))
       continue;
-    if (!VD->hasInterfaceType()) {
-      VD->getASTContext().getLazyResolver()->resolveDeclSignature(VD);
-      if (!VD->hasInterfaceType())
-        continue;
-    }
     Type declaredMemberType = VD->getInterfaceType();
+    if (!declaredMemberType) {
+      continue;
+    }
     if (!declaredMemberType->is<AnyFunctionType>())
       continue;
     if (VD->getDeclContext()->isTypeContext()) {
@@ -899,7 +897,7 @@ bool swift::ide::isReferenceableByImplicitMemberExpr(
   if (VD->isOperator())
     return false;
 
-  if (!VD->hasInterfaceType())
+  if (!VD->getInterfaceType())
     return false;
 
   if (T->getOptionalObjectType() &&

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -139,10 +139,8 @@ void ContextInfoCallbacks::getImplicitMembers(
       if (VD->isOperator())
         return false;
 
-      if (!VD->hasInterfaceType()) {
-        TypeResolver->resolveDeclSignature(VD);
-        if (!VD->hasInterfaceType())
-          return false;
+      if (!VD->getInterfaceType()) {
+        return false;
       }
 
       // Enum element decls can always be referenced by implicit member

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5777,10 +5777,7 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
       elementsWithPayload.push_back({elt, nativeTI, nativeTI});
       continue;
     }
-
-    if (!elt->hasInterfaceType())
-      TC.IGM.Context.getLazyResolver()->resolveDeclSignature(elt);
-
+    
     // Compute whether this gives us an apparent payload or dynamic layout.
     // Note that we do *not* apply substitutions from a bound generic instance
     // yet. We want all instances of a generic enum to share an implementation

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1920,9 +1920,6 @@ namespace {
         return true;
 
       for (auto field : decl->getStoredProperties()) {
-        if (!field->hasInterfaceType())
-          IGM.Context.getLazyResolver()->resolveDeclSignature(field);
-
         if (visit(field->getInterfaceType()->getCanonicalType()))
           return true;
       }
@@ -1946,9 +1943,6 @@ namespace {
       for (auto elt : decl->getAllElements()) {
         if (!elt->hasAssociatedValues() || elt->isIndirect())
           continue;
-
-        if (!elt->hasInterfaceType())
-          IGM.Context.getLazyResolver()->resolveDeclSignature(elt);
 
         if (visit(elt->getArgumentInterfaceType()->getCanonicalType()))
           return true;

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -139,18 +139,13 @@ bool SILType::canRefCast(SILType operTy, SILType resultTy, SILModule &M) {
 
 SILType SILType::getFieldType(VarDecl *field,
                               TypeConverter &TC) const {
-  auto baseTy = getASTType();
-
-  if (!field->hasInterfaceType())
-    TC.Context.getLazyResolver()->resolveDeclSignature(field);
-
   AbstractionPattern origFieldTy = TC.getAbstractionPattern(field);
   CanType substFieldTy;
   if (field->hasClangNode()) {
     substFieldTy = origFieldTy.getType();
   } else {
     substFieldTy =
-      baseTy->getTypeOfMember(&TC.M, field, nullptr)->getCanonicalType();
+      getASTType()->getTypeOfMember(&TC.M, field, nullptr)->getCanonicalType();
   }
 
   auto loweredTy = TC.getLoweredRValueType(origFieldTy, substFieldTy);
@@ -174,9 +169,6 @@ SILType SILType::getEnumElementType(EnumElementDecl *elt,
     assert(elt == TC.Context.getOptionalSomeDecl());
     return SILType(objectType, getCategory());
   }
-
-  if (!elt->hasInterfaceType())
-    TC.Context.getLazyResolver()->resolveDeclSignature(elt);
 
   // If the case is indirect, then the payload is boxed.
   if (elt->isIndirect() || elt->getParentEnum()->isIndirect()) {

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1267,10 +1267,6 @@ namespace {
 
       // Classify the type according to its stored properties.
       for (auto field : D->getStoredProperties()) {
-        // FIXME: Remove this once getInterfaceType() is a request.
-        if (!field->hasInterfaceType())
-          TC.Context.getLazyResolver()->resolveDeclSignature(field);
-
         auto substFieldType =
           field->getInterfaceType().subst(subMap)->getCanonicalType();
 
@@ -1313,11 +1309,7 @@ namespace {
           properties.setNonTrivial();
           continue;
         }
-
-        // FIXME: Remove this once getInterfaceType() is a request.
-        if (!elt->hasInterfaceType())
-          TC.Context.getLazyResolver()->resolveDeclSignature(elt);
-
+        
         auto substEltType =
           elt->getArgumentInterfaceType().subst(subMap)->getCanonicalType();
         
@@ -1895,11 +1887,6 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   auto *vd = c.loc.dyn_cast<ValueDecl *>();
-
-  if (vd && !vd->hasInterfaceType()) {
-    Context.getLazyResolver()->resolveDeclSignature(vd);
-  }
-
   switch (c.kind) {
   case SILDeclRef::Kind::Func: {
     CanAnyFunctionType funcTy;
@@ -2612,11 +2599,6 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
   assert(elt->isIndirect() || elt->getParentEnum()->isIndirect());
 
   auto &C = M.getASTContext();
-
-  // FIXME: Remove this once getInterfaceType() is a request.
-  if (!elt->hasInterfaceType())
-    Context.getLazyResolver()->resolveDeclSignature(elt);
-
   auto boxSignature = getCanonicalSignatureOrNull(
       enumDecl->getGenericSignature());
 
@@ -2687,9 +2669,6 @@ static void countNumberOfInnerFields(unsigned &fieldsCount, TypeConverter &TC,
 
       if (elt->isIndirect())
         continue;
-
-      if (!elt->hasInterfaceType())
-        TC.Context.getLazyResolver()->resolveDeclSignature(elt);
 
       // Although one might assume enums have a fields count of 1
       // Which holds true for current uses of this code

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -74,11 +74,6 @@ bool DestructorAnalysis::isSafeType(CanType Ty) {
 
     // Check the stored properties.
     for (auto SP : Struct->getStoredProperties()) {
-      // FIXME: Remove this once getInterfaceType() is a request.
-      if (!SP->hasInterfaceType()) {
-        ASTContext &Ctx = Mod->getSwiftModule()->getASTContext();
-        Ctx.getLazyResolver()->resolveDeclSignature(SP);
-      }
       if (!isSafeType(SP->getInterfaceType()->getCanonicalType()))
         return cacheResult(Ty, false);
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1740,7 +1740,8 @@ namespace {
         return nullptr;
       }
 
-      tc.validateDecl(fn);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)fn->getInterfaceType();
       
       // Form a reference to the function. The bridging operations are generic,
       // so we need to form substitutions and compute the resulting type.
@@ -1926,7 +1927,8 @@ namespace {
         return nullptr;
       }
 
-      tc.validateDecl(maxFloatTypeDecl);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)maxFloatTypeDecl->getInterfaceType();
       auto maxType = maxFloatTypeDecl->getUnderlyingType();
 
       DeclName initName(tc.Context, DeclBaseName::createConstructor(),
@@ -4116,7 +4118,8 @@ namespace {
       assert(method && "Didn't find a method?");
 
       // The declaration we found must be exposed to Objective-C.
-      tc.validateDecl(method);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)method->getInterfaceType();
       if (!method->isObjC()) {
         // If the method declaration lies in a protocol and we're providing
         // a default implementation of the method through a protocol extension

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4300,8 +4300,6 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
 
     // Handle property references.
     if (auto var = dyn_cast<VarDecl>(found)) {
-      TC.validateDecl(var);
-
       // Resolve this component to the variable we found.
       auto varRef = ConcreteDeclRef(var);
       auto resolved =

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -962,7 +962,8 @@ namespace {
       if (!decl)
         return nullptr;
       
-      CS.getTypeChecker().validateDecl(decl);
+      // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+      (void)decl->getInterfaceType();
       if (decl->isInvalid())
         return nullptr;
 
@@ -1310,9 +1311,9 @@ namespace {
       // FIXME: If the decl is in error, we get no information from this.
       // We may, alternatively, want to use a type variable in that case,
       // and possibly infer the type of the variable that way.
-      CS.getTypeChecker().validateDecl(E->getDecl());
+      auto oldInterfaceTy = E->getDecl()->getInterfaceType();
       if (E->getDecl()->isInvalid()) {
-        CS.setType(E, E->getDecl()->getInterfaceType());
+        CS.setType(E, oldInterfaceTy);
         return nullptr;
       }
 
@@ -1425,7 +1426,8 @@ namespace {
         // If the result is invalid, skip it.
         // FIXME: Note this as invalid, in case we don't find a solution,
         // so we don't let errors cascade further.
-        CS.getTypeChecker().validateDecl(decls[i]);
+        // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+        (void)decls[i]->getInterfaceType();
         if (decls[i]->isInvalid())
           continue;
 
@@ -1983,7 +1985,6 @@ namespace {
       if (dictionaryKeyTy->isTypeVariableOrMember() &&
           tc.Context.getAnyHashableDecl()) {
         auto anyHashable = tc.Context.getAnyHashableDecl();
-        tc.validateDecl(anyHashable);
         CS.addConstraint(ConstraintKind::Defaultable, dictionaryKeyTy,
                          anyHashable->getDeclaredInterfaceType(), locator);
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4696,7 +4696,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     auto decl = candidate.getDecl();
     
     // If the result is invalid, skip it.
-    TC.validateDecl(decl);
+    // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+    (void)decl->getInterfaceType();
     if (decl->isInvalid()) {
       result.markErrorAlreadyDiagnosed();
       return;
@@ -5070,7 +5071,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       auto *cand = entry.getValueDecl();
 
       // If the result is invalid, skip it.
-      TC.validateDecl(cand);
+      // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+      (void)cand->getInterfaceType();
       if (cand->isInvalid()) {
         result.markErrorAlreadyDiagnosed();
         return result;
@@ -7000,7 +7002,8 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
   // Record the 'dynamicallyCall` method overload set.
   SmallVector<OverloadChoice, 4> choices;
   for (auto candidate : candidates) {
-    TC.validateDecl(candidate);
+    // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+    (void)candidate->getInterfaceType();
     if (candidate->isInvalid()) continue;
     choices.push_back(
       OverloadChoice(type2, candidate, FunctionRefKind::SingleApply));

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -593,9 +593,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
       auto ctors = TypeChecker::lookupConstructors(
           CS.DC, instanceType, NameLookupFlags::IgnoreAccessControl);
       for (auto ctor : ctors) {
-        if (!ctor.getValueDecl()->hasInterfaceType())
-          CS.getTypeChecker().validateDecl(ctor.getValueDecl());
-        if (ctor.getValueDecl()->hasInterfaceType())
+        if (ctor.getValueDecl()->getInterfaceType())
           candidates.push_back({ ctor.getValueDecl(), 1 });
       }
     }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -213,7 +213,6 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
 
       accessLevel = std::min(accessLevel, var->getFormalAccess());
 
-      ctx.getLazyResolver()->resolveDeclSignature(var);
       auto varInterfaceType = var->getValueInterfaceType();
 
       if (var->getAttrs().hasAttribute<LazyAttr>()) {
@@ -540,9 +539,6 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
 
   auto *superclassCtor = (ConstructorDecl *) context;
 
-  if (!superclassCtor->hasInterfaceType())
-    ctx.getLazyResolver()->resolveDeclSignature(superclassCtor);
-
   // Reference to super.init.
   auto *selfDecl = ctor->getImplicitSelfDecl();
   auto *superRef = buildSelfReference(selfDecl, SelfAccessorKind::Super,
@@ -856,9 +852,7 @@ static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
       if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
         continue;
 
-      if (!var->hasInterfaceType())
-        ctx.getLazyResolver()->resolveDeclSignature(var);
-      if (!var->hasInterfaceType())
+      if (!var->getInterfaceType())
         return;
     }
   }
@@ -923,9 +917,7 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
   if (!decl->hasClangNode()) {
     for (auto member : decl->getMembers()) {
       if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
-        if (!ctor->hasInterfaceType())
-          ctx.getLazyResolver()->resolveDeclSignature(ctor);
-        if (!ctor->hasInterfaceType())
+        if (!ctor->getInterfaceType())
           return;
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1463,7 +1463,6 @@ Type ConstraintSystem::getEffectiveOverloadType(const OverloadChoice &overload,
   // Retrieve the interface type.
   auto type = decl->getInterfaceType();
   if (!type) {
-    decl->getASTContext().getLazyResolver()->resolveDeclSignature(decl);
     type = decl->getInterfaceType();
     if (!type) {
       return Type();

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -118,13 +118,9 @@ static CodableConformanceType varConformsToCodable(TypeChecker &tc,
   //              //    hasn't yet been evaluated
   // }
   //
-  // Validate the decl eagerly.
-  if (!varDecl->hasInterfaceType())
-    tc.validateDecl(varDecl);
-
   // If the var decl didn't validate, it may still not have a type; confirm it
   // has a type before ensuring the type conforms to Codable.
-  if (!varDecl->hasInterfaceType())
+  if (!varDecl->getInterfaceType())
     return TypeNotValidated;
 
   bool isIUO = varDecl->isImplicitlyUnwrappedOptional();
@@ -271,9 +267,6 @@ static CodingKeysValidity hasValidCodingKeysEnum(DerivedConformance &derived) {
                 derived.getProtocolType());
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
-
-  // If the decl hasn't been validated yet, do so.
-  tc.validateDecl(codingKeysTypeDecl);
 
   // CodingKeys may be a typealias. If so, follow the alias to its canonical
   // type.

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -333,8 +333,6 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
 static bool canSynthesizeCodingKey(DerivedConformance &derived) {
   auto enumDecl = cast<EnumDecl>(derived.Nominal);
   // Validate the enum and its raw type.
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)enumDecl->getInterfaceType();
   
   // If the enum has a raw type (optional), it must be String or Int.
   Type rawType = enumDecl->getRawType();

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -333,8 +333,9 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
 static bool canSynthesizeCodingKey(DerivedConformance &derived) {
   auto enumDecl = cast<EnumDecl>(derived.Nominal);
   // Validate the enum and its raw type.
-  derived.TC.validateDecl(enumDecl);
-
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)enumDecl->getInterfaceType();
+  
   // If the enum has a raw type (optional), it must be String or Int.
   Type rawType = enumDecl->getRawType();
   if (rawType) {

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -466,7 +466,8 @@ static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
   auto &tc = derived.TC;
 
   // Validate the enum and its raw type.
-  tc.validateDecl(enumDecl);
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)enumDecl->getInterfaceType();
 
   // It must have a valid raw type.
   Type rawType = enumDecl->getRawType();
@@ -504,7 +505,8 @@ static bool canSynthesizeRawRepresentable(DerivedConformance &derived) {
     if (elt->hasAssociatedValues())
       return false;
 
-    tc.validateDecl(elt);
+    // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface type.
+    (void)elt->getInterfaceType();
     if (elt->isInvalid()) {
       return false;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4174,10 +4174,7 @@ static OmissionTypeName getTypeNameForOmission(Type type) {
 Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
   auto &Context = afd->getASTContext();
 
-  if (!afd->hasInterfaceType())
-    validateDecl(afd);
-
-  if (afd->isInvalid() || isa<DestructorDecl>(afd))
+  if (!afd->getInterfaceType() || afd->isInvalid() || isa<DestructorDecl>(afd))
     return None;
 
   DeclName name = afd->getFullName();
@@ -4257,10 +4254,7 @@ Optional<DeclName> TypeChecker::omitNeedlessWords(AbstractFunctionDecl *afd) {
 Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   auto &Context = var->getASTContext();
 
-  if (!var->hasInterfaceType())
-    validateDecl(var);
-
-  if (var->isInvalid() || !var->hasInterfaceType())
+  if (!var->getInterfaceType() || var->isInvalid())
     return None;
 
   if (var->getName().empty())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1071,7 +1071,8 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   //    `ExpressibleByStringLiteral`.
   //    `D.Value` and the return type can be arbitrary.
 
-  TC.validateDecl(decl);
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)decl->getInterfaceType();
   auto paramList = decl->getParameters();
   if (paramList->size() != 1 || paramList->get(0)->isVariadic()) return false;
   auto argType = paramList->get(0)->getType();
@@ -1242,7 +1243,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     auto oneCandidate = candidates.front().getValueDecl();
     candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
       auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      TC.validateDecl(cand);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)cand->getInterfaceType();
       return isValidDynamicMemberLookupSubscript(cand, decl, TC);
     });
 
@@ -1265,7 +1267,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    TC.validateDecl(cand);
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)cand->getInterfaceType();
     return isValidDynamicMemberLookupSubscript(cand, decl, TC,
                                                /*ignoreLabel*/ true);
   });
@@ -2133,7 +2136,8 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   // Filter out any accessors that won't work.
   if (!results.empty()) {
     auto replacementStorage = replacement->getStorage();
-    TC.validateDecl(replacementStorage);
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)replacementStorage->getInterfaceType();
     Type replacementStorageType = getDynamicComparisonType(replacementStorage);
     results.erase(std::remove_if(results.begin(), results.end(),
         [&](ValueDecl *result) {
@@ -2145,7 +2149,8 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
             return true;
 
           // Check for type mismatch.
-          TC.validateDecl(result);
+          // FIXME(InterfaceTypeRequest): Remove this.
+          (void)result->getInterfaceType();
           auto resultType = getDynamicComparisonType(result);
           if (!resultType->isEqual(replacementStorageType) &&
               !resultType->matches(
@@ -2179,7 +2184,9 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   }
 
   assert(!isa<FuncDecl>(results[0]));
-  TC.validateDecl(results[0]);
+  
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)results[0]->getInterfaceType();
   auto *origStorage = cast<AbstractStorageDecl>(results[0]);
   if (!origStorage->isDynamic()) {
     TC.diagnose(attr->getLocation(),
@@ -2195,8 +2202,8 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   if (!origAccessor)
     return nullptr;
 
-  TC.validateDecl(origAccessor);
-
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)origAccessor->getInterfaceType();
   if (origAccessor->isImplicit() &&
       !(origStorage->getReadImpl() == ReadImplKind::Stored &&
         origStorage->getWriteImpl() == WriteImplKind::Stored)) {
@@ -2228,9 +2235,9 @@ findReplacedFunction(DeclName replacedFunctionName,
     // Check for static/instance mismatch.
     if (result->isStatic() != replacement->isStatic())
       continue;
-
-    if (TC)
-      TC->validateDecl(result);
+    
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)result->getInterfaceType();
     TypeMatchOptions matchMode = TypeMatchFlags::AllowABICompatible;
     matchMode |= TypeMatchFlags::AllowCompatibleOpaqueTypeArchetypes;
     if (result->getInterfaceType()->getCanonicalType()->matches(
@@ -2351,7 +2358,8 @@ void AttributeChecker::visitDynamicReplacementAttr(DynamicReplacementAttr *attr)
       if (attr->isInvalid())
         return;
 
-       TC.validateDecl(accessor);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)accessor->getInterfaceType();
        auto *orig = findReplacedAccessor(attr->getReplacedFunctionName(),
                                          accessor, attr, TC);
        if (!orig)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2136,8 +2136,6 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
   // Filter out any accessors that won't work.
   if (!results.empty()) {
     auto replacementStorage = replacement->getStorage();
-    // FIXME(InterfaceTypeRequest): Remove this.
-    (void)replacementStorage->getInterfaceType();
     Type replacementStorageType = getDynamicComparisonType(replacementStorage);
     results.erase(std::remove_if(results.begin(), results.end(),
         [&](ValueDecl *result) {
@@ -2149,8 +2147,6 @@ static FuncDecl *findReplacedAccessor(DeclName replacedVarName,
             return true;
 
           // Check for type mismatch.
-          // FIXME(InterfaceTypeRequest): Remove this.
-          (void)result->getInterfaceType();
           auto resultType = getDynamicComparisonType(result);
           if (!resultType->isEqual(replacementStorageType) &&
               !resultType->matches(
@@ -2236,8 +2232,6 @@ findReplacedFunction(DeclName replacedFunctionName,
     if (result->isStatic() != replacement->isStatic())
       continue;
     
-    // FIXME(InterfaceTypeRequest): Remove this.
-    (void)result->getInterfaceType();
     TypeMatchOptions matchMode = TypeMatchFlags::AllowABICompatible;
     matchMode |= TypeMatchFlags::AllowCompatibleOpaqueTypeArchetypes;
     if (result->getInterfaceType()->getCanonicalType()->matches(

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -249,11 +249,8 @@ bool CircularityChecker::expandStruct(CanType type, StructDecl *S,
       S->getModuleContext(), S);
 
   for (auto field: S->getStoredProperties()) {
-    if (!field->hasInterfaceType()) {
-      TC.validateDecl(field);
-      if (!field->hasInterfaceType())
-        continue;
-    }
+    if (!field->getInterfaceType())
+      continue;
 
     auto fieldType =field->getInterfaceType().subst(subMap);
     if (addMember(type, field, fieldType, depth))
@@ -286,11 +283,8 @@ bool CircularityChecker::expandEnum(CanType type, EnumDecl *E,
     if (!elt->hasAssociatedValues())
       continue;
 
-    if (!elt->hasInterfaceType()) {
-      TC.validateDecl(elt);
-      if (!elt->hasInterfaceType())
-        continue;
-    }
+    if (!elt->getInterfaceType())
+      continue;
 
     auto eltType = elt->getArgumentInterfaceType().subst(subMap);
     if (addMember(type, elt, eltType, depth))
@@ -620,11 +614,8 @@ void CircularityChecker::diagnoseNonWellFoundedEnum(EnumDecl *E) {
       return false;
 
     for (auto elt: elts) {
-      if (!elt->hasInterfaceType()) {
-        TC.validateDecl(elt);
-        if (!elt->hasInterfaceType())
-          return false;
-      }
+      if (!elt->getInterfaceType())
+        return false;
 
       if (!elt->isIndirect() && !E->isIndirect())
         return false;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -440,11 +440,8 @@ static bool findNonMembers(TypeChecker &TC,
     if (!isValid(D))
       return false;
 
-    if (!D->hasInterfaceType())
-      TC.validateDecl(D);
-
     // FIXME: Circularity hack.
-    if (!D->hasInterfaceType()) {
+    if (!D->getInterfaceType()) {
       AllDeclRefs = false;
       continue;
     }
@@ -4430,11 +4427,6 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
                              ConformanceCheckFlags::InExpression)) {
         auto nsError = Context.getNSErrorDecl();
         if (nsError) {
-          if (!nsError->hasInterfaceType()) {
-            auto resolver = Context.getLazyResolver();
-            assert(resolver);
-            resolver->resolveDeclSignature(nsError);
-          }
           Type NSErrorTy = nsError->getDeclaredInterfaceType();
           if (isSubtypeOf(fromType, NSErrorTy, dc)
               // Don't mask "always true" warnings if NSError is cast to

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -241,12 +241,6 @@ static bool isParamListRepresentableInObjC(const AbstractFunctionDecl *AFD,
   // If you change this function, you must add or modify a test in PrintAsObjC.
   ASTContext &ctx = AFD->getASTContext();
   auto &diags = ctx.Diags;
-
-  if (!AFD->hasInterfaceType()) {
-    ctx.getLazyResolver()->resolveDeclSignature(
-                                      const_cast<AbstractFunctionDecl *>(AFD));
-  }
-
   bool Diagnose = shouldDiagnoseObjCReason(Reason, ctx);
   bool IsObjC = true;
   unsigned NumParams = PL->size();
@@ -494,6 +488,8 @@ bool swift::isRepresentableInObjC(
 
   // If you change this function, you must add or modify a test in PrintAsObjC.
   ASTContext &ctx = AFD->getASTContext();
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)AFD->getInterfaceType();
   bool Diagnose = shouldDiagnoseObjCReason(Reason, ctx);
 
   if (checkObjCInForeignClassContext(AFD, Reason))
@@ -689,11 +685,6 @@ bool swift::isRepresentableInObjC(
     auto nsError = ctx.getNSErrorDecl();
     Type errorParameterType;
     if (nsError) {
-      if (!nsError->hasInterfaceType()) {
-        auto resolver = ctx.getLazyResolver();
-        assert(resolver);
-        resolver->resolveDeclSignature(nsError);
-      }
       errorParameterType = nsError->getDeclaredInterfaceType();
       errorParameterType = OptionalType::get(errorParameterType);
       errorParameterType
@@ -822,18 +813,14 @@ bool swift::isRepresentableInObjC(
 bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
   // If you change this function, you must add or modify a test in PrintAsObjC.
 
+  if (!VD->getInterfaceType()) {
+    VD->diagnose(diag::recursive_decl_reference, VD->getDescriptiveKind(),
+                 VD->getName());
+    return false;
+  }
+
   if (VD->isInvalid())
     return false;
-
-  if (!VD->hasInterfaceType()) {
-    VD->getASTContext().getLazyResolver()->resolveDeclSignature(
-                                              const_cast<VarDecl *>(VD));
-    if (!VD->hasInterfaceType()) {
-      VD->diagnose(diag::recursive_decl_reference, VD->getDescriptiveKind(),
-                   VD->getName());
-      return false;
-    }
-  }
 
   Type T = VD->getDeclContext()->mapTypeIntoContext(VD->getInterfaceType());
   if (auto *RST = T->getAs<ReferenceStorageType>()) {
@@ -888,11 +875,6 @@ bool swift::isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason) {
       describeObjCReason(SD, Reason);
     }
     return true;
-  }
-
-  if (!SD->hasInterfaceType()) {
-    SD->getASTContext().getLazyResolver()->resolveDeclSignature(
-                                              const_cast<SubscriptDecl *>(SD));
   }
 
   // Figure out the type of the indices.
@@ -1027,11 +1009,8 @@ static void checkObjCBridgingFunctions(ModuleDecl *mod,
                    NLKind::QualifiedLookup, results);
 
   for (auto D : results) {
-    if (!D->hasInterfaceType()) {
-      auto resolver = ctx.getLazyResolver();
-      assert(resolver);
-      resolver->resolveDeclSignature(D);
-    }
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)D->getInterfaceType();
   }
 }
 
@@ -1344,13 +1323,8 @@ static bool isCIntegerType(Type type) {
                               foundDecls);
     for (auto found : foundDecls) {
       auto foundType = dyn_cast<TypeDecl>(found);
-      if (!foundType) continue;
-
-      if (!foundType->hasInterfaceType()) {
-        auto resolver = ctx.getLazyResolver();
-        assert(resolver);
-        resolver->resolveDeclSignature(foundType);
-      }
+      if (!foundType)
+        continue;
 
       if (foundType->getDeclaredInterfaceType()->isEqual(type))
         return true;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -76,20 +76,8 @@ Type swift::getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
   assert((method || abstractStorage) && "Not a method or abstractStorage?");
   SubscriptDecl *subscript = dyn_cast_or_null<SubscriptDecl>(abstractStorage);
 
-  if (!member->hasInterfaceType()) {
-    auto lazyResolver = ctx.getLazyResolver();
-    assert(lazyResolver && "Need to resolve interface type");
-    lazyResolver->resolveDeclSignature(member);
-  }
-
   auto memberType = member->getInterfaceType();
   if (derivedDecl) {
-    if (!derivedDecl->hasInterfaceType()) {
-      auto lazyResolver = ctx.getLazyResolver();
-      assert(lazyResolver && "Need to resolve interface type");
-      lazyResolver->resolveDeclSignature(derivedDecl);
-    }
-
     auto *dc = derivedDecl->getDeclContext();
     auto owningType = dc->getDeclaredInterfaceType();
     assert(owningType);

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -650,8 +650,10 @@ static Type lookupDefaultLiteralType(TypeChecker &TC, const DeclContext *dc,
   TypeDecl *TD = lookup.getSingleTypeResult();
   if (!TD)
     return Type();
-  TC.validateDecl(TD);
-
+  
+  // FIXME: Make isInvalid ask for the interface type.
+  (void)TD->getInterfaceType();
+  
   if (TD->isInvalid())
     return Type();
 

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -318,8 +318,6 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
 
     // Handle property references.
     if (auto var = dyn_cast<VarDecl>(found)) {
-      validateDecl(var);
-
       // Resolve this component to the variable we found.
       auto varRef = ConcreteDeclRef(var);
       auto resolved =

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -423,10 +423,9 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     auto *typeDecl = cast<TypeDecl>(decl);
 
     // FIXME: This should happen before we attempt shadowing checks.
-    if (!typeDecl->hasInterfaceType()) {
-      dc->getASTContext().getLazyResolver()->resolveDeclSignature(typeDecl);
-      if (!typeDecl->hasInterfaceType()) // FIXME: recursion-breaking hack
-        continue;
+    if (!typeDecl->getInterfaceType()) {
+      // FIXME: recursion-breaking hack
+      continue;
     }
 
     auto memberType = typeDecl->getDeclaredInterfaceType();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1497,7 +1497,7 @@ recur:
     }
 
     // If there is a subpattern, push the enum element type down onto it.
-    validateDecl(elt);
+    auto argType = elt->getArgumentInterfaceType();
     if (EEP->hasSubPattern()) {
       Pattern *sub = EEP->getSubPattern();
       if (!elt->hasAssociatedValues()) {
@@ -1510,7 +1510,7 @@ recur:
       }
       
       Type elementType;
-      if (auto argType = elt->getArgumentInterfaceType())
+      if (argType)
         elementType = enumTy->getTypeOfMember(elt->getModuleContext(),
                                               elt, argType);
       else
@@ -1524,7 +1524,7 @@ recur:
       if (coercePatternToType(sub, resolution, elementType, newSubOptions))
         return true;
       EEP->setSubPattern(sub);
-    } else if (auto argType = elt->getArgumentInterfaceType()) {
+    } else if (argType) {
       // Else if the element pattern has no sub-pattern but the element type has
       // associated values, expand it to be semantically equivalent to an
       // element pattern of wildcards.

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -126,13 +126,9 @@ static ConstructorDecl *findInitialValueInit(ASTContext &ctx,
   }
 
   // Retrieve the type of the 'value' property.
-  if (!valueVar->hasInterfaceType())
-    ctx.getLazyResolver()->resolveDeclSignature(valueVar);
   Type valueVarType = valueVar->getValueInterfaceType();
 
   // Retrieve the parameter type of the initializer.
-  if (!init->hasInterfaceType())
-    ctx.getLazyResolver()->resolveDeclSignature(init);
   Type paramType;
   if (auto *curriedInitType =
           init->getInterfaceType()->getAs<AnyFunctionType>()) {
@@ -301,9 +297,9 @@ PropertyWrapperTypeInfoRequest::evaluate(
   if (!valueVar)
     return PropertyWrapperTypeInfo();
 
-  if (!valueVar->hasInterfaceType())
-    static_cast<TypeChecker &>(*ctx.getLazyResolver()).validateDecl(valueVar);
-
+  // FIXME: Remove this one
+  (void)valueVar->getInterfaceType();
+  
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;
   result.wrappedValueInit =
@@ -529,7 +525,8 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   unsigned index = binding->getPatternEntryIndexForVarDecl(var);
   TypeChecker &tc = *static_cast<TypeChecker *>(ctx.getLazyResolver());
   if (binding->isInitialized(index)) {
-    tc.validateDecl(var);
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)var->getInterfaceType();
     if (!binding->isInitializerChecked(index))
       tc.typeCheckPatternBinding(binding, index);
 
@@ -539,7 +536,8 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   }
 
   // Compute the type of the property to plug in to the wrapper type.
-  tc.validateDecl(var);
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)var->getInterfaceType();
   Type propertyType = var->getType();
   if (!propertyType || propertyType->hasError())
     return Type();
@@ -609,17 +607,11 @@ Type swift::computeWrappedValueType(VarDecl *var, Type backingStorageType,
   // Follow the chain of wrapped value properties.
   Type wrappedValueType = backingStorageType;
   DeclContext *dc = var->getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
   for (unsigned i : range(realLimit)) {
     auto wrappedInfo = var->getAttachedPropertyWrapperTypeInfo(i);
     if (!wrappedInfo)
       return wrappedValueType;
 
-    if (!wrappedInfo.valueVar->hasInterfaceType()) {
-      static_cast<TypeChecker&>(*ctx.getLazyResolver()).validateDecl(
-          wrappedInfo.valueVar);
-    }
-    
     wrappedValueType = wrappedValueType->getTypeOfMember(
         dc->getParentModule(),
         wrappedInfo.valueVar,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -329,18 +329,12 @@ swift::matchWitness(
   if (req->getKind() != witness->getKind())
     return RequirementMatch(witness, MatchKind::KindConflict);
 
-  // If the witness has not been validated yet, do so now.
-  if (!witness->hasInterfaceType()) {
-    auto &ctx = dc->getASTContext();
-    ctx.getLazyResolver()->resolveDeclSignature(witness);
-  }
-
   // If the witness is invalid, record that and stop now.
   if (witness->isInvalid())
     return RequirementMatch(witness, MatchKind::WitnessInvalid);
 
   // If we're currently validating the witness, bail out.
-  if (!witness->hasInterfaceType())
+  if (!witness->getInterfaceType())
     return RequirementMatch(witness, MatchKind::Circularity);
 
   // Get the requirement and witness attributes.
@@ -1543,8 +1537,10 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   conformance->setState(ProtocolConformanceState::Checking);
   SWIFT_DEFER { conformance->setState(ProtocolConformanceState::Complete); };
 
-  TC.validateDecl(Proto);
-
+  // FIXME(InterfaceTypeRequest): isInvalid() should be based on the interface
+  // type.
+  (void)Proto->getInterfaceType();
+  
   // If the protocol itself is invalid, there's nothing we can do.
   if (Proto->isInvalid()) {
     conformance->setInvalid();
@@ -3851,10 +3847,7 @@ void ConformanceChecker::resolveValueWitnesses() {
     }
 
     // Make sure we've got an interface type.
-    if (!requirement->hasInterfaceType())
-      TC.validateDecl(requirement);
-
-    if (requirement->isInvalid() || !requirement->hasInterfaceType()) {
+    if (!requirement->getInterfaceType() || requirement->isInvalid()) {
       Conformance->setInvalid();
       continue;
     }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -447,8 +447,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     }
 
     // Validate the requirement.
-    tc.validateDecl(req);
-    if (req->isInvalid() || !req->hasInterfaceType())
+    if (!req->getInterfaceType() || req->isInvalid())
       continue;
 
     // Check whether any of the associated types we care about are
@@ -493,10 +492,10 @@ static Type mapErrorTypeToOriginal(Type type) {
 static Type getWitnessTypeForMatching(TypeChecker &tc,
                                       NormalProtocolConformance *conformance,
                                       ValueDecl *witness) {
-  if (!witness->hasInterfaceType())
-    tc.validateDecl(witness);
+  if (!witness->getInterfaceType())
+    return Type();
 
-  if (witness->isInvalid() || !witness->hasInterfaceType())
+  if (witness->isInvalid())
     return Type();
 
   if (!witness->getDeclContext()->isTypeContext()) {
@@ -765,7 +764,8 @@ AssociatedTypeDecl *AssociatedTypeInference::findDefaultedAssociatedType(
                                              TypeChecker &tc,
                                              AssociatedTypeDecl *assocType) {
   // If this associated type has a default, we're done.
-  tc.validateDecl(assocType);
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)assocType->getInterfaceType();
   if (assocType->hasDefaultDefinitionType())
     return assocType;
 
@@ -2031,10 +2031,7 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   SWIFT_DEFER { ResolvingWitnesses.erase(requirement); };
 
   // Make sure we've validated the requirement.
-  if (!requirement->hasInterfaceType())
-    TC.validateDecl(requirement);
-
-  if (requirement->isInvalid() || !requirement->hasInterfaceType()) {
+  if (!requirement->getInterfaceType() || requirement->isInvalid()) {
     Conformance->setInvalid();
     return;
   }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -764,8 +764,6 @@ AssociatedTypeDecl *AssociatedTypeInference::findDefaultedAssociatedType(
                                              TypeChecker &tc,
                                              AssociatedTypeDecl *assocType) {
   // If this associated type has a default, we're done.
-  // FIXME(InterfaceTypeRequest): Remove this.
-  (void)assocType->getInterfaceType();
   if (assocType->hasDefaultDefinitionType())
     return assocType;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2143,7 +2143,8 @@ TypeCheckFunctionBodyUntilRequest::evaluate(Evaluator &evaluator,
   if (tc.DebugTimeFunctionBodies || tc.WarnLongFunctionBodies)
     timer.emplace(AFD, tc.DebugTimeFunctionBodies, tc.WarnLongFunctionBodies);
 
-  tc.validateDecl(AFD);
+  // FIXME(InterfaceTypeRequest): Remove this.
+  (void)AFD->getInterfaceType();
   tc.checkDefaultArguments(AFD->getParameters(), AFD);
 
   BraceStmt *body = AFD->getBody();

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -774,15 +774,9 @@ namespace {
           auto children = E->getAllElements();
           std::transform(children.begin(), children.end(),
                          std::back_inserter(arr), [&](EnumElementDecl *eed) {
-            // We need the interface type of this enum case but it may
-            // not have been computed.
-            if (!eed->hasInterfaceType()) {
-              TC.validateDecl(eed);
-            }
-
-            // If there's still no interface type after validation then there's
+            // If there's still no interface type then there's
             // not much else we can do here.
-            if (!eed->hasInterfaceType()) {
+            if (!eed->getInterfaceType()) {
               return Space();
             }
 
@@ -1429,7 +1423,8 @@ namespace {
       }
       case PatternKind::EnumElement: {
         auto *VP = cast<EnumElementPattern>(item);
-        TC.validateDecl(item->getType()->getEnumOrBoundGenericEnum());
+        // FIXME(InterfaceTypeRequest): Remove this.
+        (void)item->getType()->getEnumOrBoundGenericEnum()->getInterfaceType();
         
         auto *SP = VP->getSubPattern();
         if (!SP) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -68,8 +68,7 @@ ProtocolDecl *TypeChecker::getProtocol(SourceLoc loc, KnownProtocolKind kind) {
              Context.getIdentifier(getProtocolName(kind)));
   }
 
-  if (protocol && !protocol->hasInterfaceType()) {
-    validateDecl(protocol);
+  if (protocol && !protocol->getInterfaceType()) {
     if (protocol->isInvalid())
       return nullptr;
   }
@@ -614,15 +613,15 @@ void swift::typeCheckCompletionDecl(Decl *D) {
   auto &Ctx = D->getASTContext();
 
   DiagnosticSuppression suppression(Ctx.Diags);
-  TypeChecker &TC = createTypeChecker(Ctx);
-
+  (void)createTypeChecker(Ctx);
   if (auto ext = dyn_cast<ExtensionDecl>(D)) {
     if (auto *nominal = ext->getExtendedNominal()) {
-      // Validate the nominal type declaration being extended.
-      TC.validateDecl(nominal);
+      // FIXME(InterfaceTypeRequest): Remove this.
+      (void)nominal->getInterfaceType();
     }
   } else {
-    TC.validateDecl(cast<ValueDecl>(D));
+    // FIXME(InterfaceTypeRequest): Remove this.
+    (void)cast<ValueDecl>(D)->getInterfaceType();
   }
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1421,9 +1421,7 @@ public:
     return getUnopenedTypeOfReference(
         value, baseType, UseDC,
         [&](VarDecl *var) -> Type {
-          validateDecl(var);
-
-          if (!var->hasInterfaceType() || var->isInvalid())
+          if (!var->getInterfaceType() || var->isInvalid())
             return ErrorType::get(Context);
 
           return wantInterfaceType ? value->getInterfaceType()

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1120,9 +1120,10 @@ static void filterValues(Type expectedTy, ModuleDecl *expectedModule,
 
     if (isType != isa<TypeDecl>(value))
       return true;
-    if (!value->hasInterfaceType())
+    auto ifaceTy = value->getInterfaceType();
+    if (!ifaceTy)
       return true;
-    if (canTy && value->getInterfaceType()->getCanonicalType() != canTy)
+    if (canTy && ifaceTy->getCanonicalType() != canTy)
       return true;
     if (value->isStatic() != isStatic)
       return true;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3264,8 +3264,8 @@ public:
     // request-ified this goes away.
     if (!fn->hasInterfaceType()) {
       assert(fn->isImplicit());
-      S.M->getASTContext().getLazyResolver()->resolveDeclSignature(
-          const_cast<AccessorDecl *>(fn));
+      // FIXME: Remove this one
+      (void)fn->getInterfaceType();
     }
 
     using namespace decls_block;

--- a/test/SourceKit/CursorInfo/cursor_invalid.swift
+++ b/test/SourceKit/CursorInfo/cursor_invalid.swift
@@ -25,7 +25,7 @@ func resyncParser2() {}
 // RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: source.lang.swift.decl.var.local (4:13-4:14)
 // CHECK1: c
-// CHECK1: <Declaration>let c</Declaration>
+// CHECK1: <Declaration>let c: <Type usr="s:14cursor_invalid1CC">C</Type></Declaration>
 // CHECK1: OVERRIDES BEGIN
 // CHECK1: OVERRIDES END
 

--- a/test/SourceKit/Indexing/index.swift
+++ b/test/SourceKit/Indexing/index.swift
@@ -52,7 +52,7 @@ extension CC : Prot {
   var extV : Int { return 0 }
 }
 
-class SubCC : CC, Prot {}
+class SubCC : CC {}
 
 var globV2: SubCC
 

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -501,13 +501,6 @@
           key.usr: <usr>,
           key.line: 55,
           key.column: 15
-        },
-        {
-          key.kind: source.lang.swift.ref.protocol,
-          key.name: "Prot",
-          key.usr: <usr>,
-          key.line: 55,
-          key.column: 19
         }
       ],
       key.entities: [
@@ -533,17 +526,10 @@
           key.column: 15
         },
         {
-          key.kind: source.lang.swift.ref.protocol,
-          key.name: "Prot",
-          key.usr: <usr>,
-          key.line: 55,
-          key.column: 19
-        },
-        {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: <usr>,
           key.line: 55,
-          key.column: 24,
+          key.column: 18,
           key.is_implicit: 1,
           key.related: [
             {
@@ -1221,6 +1207,13 @@
           key.receiver_usr: "s:5index2S2V"
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "meth()",
+      key.usr: <usr>,
+      key.line: 134,
+      key.column: 8
     },
     {
       key.kind: source.lang.swift.decl.class,

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -533,10 +533,9 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
 
   } else if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
 
-    if (TAD->hasInterfaceType()) {
+    if (auto Ty = TAD->getDeclaredInterfaceType()) {
       // If underlying type exists, report the inheritance and conformance of the
       // underlying type.
-      auto Ty = TAD->getDeclaredInterfaceType();
       if (auto NM = Ty->getAnyNominal()) {
         passInherits(NM->getInherited(), Consumer);
         passConforms(NM->getSatisfiedProtocolRequirements(/*Sorted=*/true),

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -778,11 +778,11 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   unsigned USREnd = SS.size();
 
   unsigned TypenameBegin = SS.size();
-  if (VD->hasInterfaceType()) {
+  if (auto vdType = VD->getInterfaceType()) {
     llvm::raw_svector_ostream OS(SS);
     PrintOptions Options;
     Options.PrintTypeAliasUnderlyingType = true;
-    VD->getInterfaceType().print(OS, Options);
+    vdType.print(OS, Options);
   }
   unsigned TypenameEnd = SS.size();
 


### PR DESCRIPTION
Make getInterfaceType() call validateDecl on behalf of its clients.  In effect, this makes the interface type behave like a request.  It also means that its clients no longer need to perform a number of undesirable anti-patterns in order to sidestep the bizarre API contract validateDecl has at the moment

In particular, the following things are no longer necessary:

- Checking for a missing interface type then validating
- Validating the interface type then retrieving it
- Validating the interface type then retrieving a derived value

This patchset is a purely mechanical translation to the new API.  There are an enormous number of places that no longer/never need to retrieve the interface type.  I have tried my best to mark them off, but this patch does not go out of its way to fix them because it's already big enough as it is.

There is also one remaining use of `validateDecl` for VarDecls because that triggers a ton of extra side-effects that we need to untangle first.