### PR TITLE
[TBDGen] Set `installapi` flag only when building in installapi

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -86,6 +86,10 @@ def tbd_compatibility_version
 def tbd_compatibility_version_EQ : Joined<["-"], "tbd-compatibility-version=">,
   Alias<tbd_compatibility_version>;
 
+def tbd_is_installapi: Flag<["-"], "tbd-is-installapi">,
+  HelpText<"If the TBD file should indicate it's being generated during "
+           "InstallAPI">;
+
 def verify : Flag<["-"], "verify">,
   HelpText<"Verify diagnostics against expected-{error|warning|note} "
            "annotations">;

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -33,6 +33,9 @@ struct TBDGenOptions {
   /// Whether this compilation has multiple IRGen instances.
   bool HasMultipleIGMs;
 
+  /// Whether this compilation is producing a TBD for InstallAPI.
+  bool IsInstallAPI;
+
   /// The install_name to use in the TBD file.
   std::string InstallName;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -940,6 +940,8 @@ static bool ParseTBDGenArgs(TBDGenOptions &Opts, ArgList &Args,
     Opts.InstallName = A->getValue();
   }
 
+  Opts.IsInstallAPI = Args.hasArg(OPT_tbd_is_installapi);
+
   if (const Arg *A = Args.getLastArg(OPT_tbd_compatibility_version)) {
     if (auto vers = version::Version::parseVersionString(
           A->getValue(), SourceLoc(), &Diags)) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -613,7 +613,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   file.setPlatform(tapi::internal::mapToSinglePlatform(target));
   auto arch = tapi::internal::getArchType(target.getArchName());
   file.setArch(arch);
-  file.setInstallAPI();
+  file.setInstallAPI(opts.IsInstallAPI);
 
   TBDGenVisitor visitor(file, arch, symbols, linkInfo, M, opts);
 

--- a/test/TBD/installapi-flag.swift
+++ b/test/TBD/installapi-flag.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// 1. Emit two TBDs, one with -tbd-is-installapi set, and one without
+
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -tbd-is-installapi -emit-tbd -emit-tbd-path %t/flag-provided.tbd
+// RUN: %target-swift-frontend -emit-ir -o /dev/null %s -emit-tbd -emit-tbd-path %t/flag-omitted.tbd
+
+// 2. Ensure that the file with -tbd-is-installapi passed includes the installapi flag
+
+// RUN: %FileCheck %s --check-prefix FLAG-PROVIDED < %t/flag-provided.tbd
+
+// 3. Ensure that the file without -tbd-is-installapi passed does not include the installapi flag
+
+// RUN: %FileCheck %s --check-prefix FLAG-OMITTED < %t/flag-omitted.tbd
+
+// FLAG-PROVIDED: installapi
+// FLAG-OMITTED-NOT: installapi


### PR DESCRIPTION
Previously, we would unconditionally set the `installapi` flag, which
hard errors when trying to merge with a TAPI-generated TBD file that
was generated during the install phase.

Fixes rdar://55644041