### PR TITLE
[ownership] Only allow BranchPropagatedUser to be constructed from Operands.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -130,8 +130,13 @@ public:
     llvm_unreachable("covered switch");                                        \
   } while (0)
 
+  /// Return the callee operand as a value.
+  SILValue getCallee() const { return getCalleeOperand()->get(); }
+
   /// Return the callee operand.
-  SILValue getCallee() const { FOREACH_IMPL_RETURN(getCallee()); }
+  const Operand *getCalleeOperand() const {
+    FOREACH_IMPL_RETURN(getCalleeOperand());
+  }
 
   /// Return the callee value by looking through function conversions until we
   /// find a function_ref, partial_apply, or unrecognized callee value.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -310,14 +310,13 @@ struct BorrowScopeIntroducingValue {
   /// called with a scope that is not local.
   ///
   /// The intention is that this method can be used instead of
-  /// BorrowScopeIntroducingValue::getLocalScopeEndingInstructions() to avoid
+  /// BorrowScopeIntroducingValue::getLocalScopeEndingUses() to avoid
   /// introducing an intermediate array when one needs to transform the
   /// instructions before storing them.
   ///
   /// NOTE: To determine if a scope is a local scope, call
   /// BorrowScopeIntoducingValue::isLocalScope().
-  void visitLocalScopeEndingInstructions(
-      function_ref<void(SILInstruction *)> visitor) const;
+  void visitLocalScopeEndingUses(function_ref<void(Operand *)> visitor) const;
 
   bool isLocalScope() const { return kind.isLocalScope(); }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1861,7 +1861,8 @@ public:
   /// The operand number of the first argument.
   static unsigned getArgumentOperandNumber() { return NumStaticOperands; }
 
-  SILValue getCallee() const { return getAllOperands()[Callee].get(); }
+  const Operand *getCalleeOperand() const { return &getAllOperands()[Callee]; }
+  SILValue getCallee() const { return getCalleeOperand()->get(); }
 
   /// Gets the origin of the callee by looking through function type conversions
   /// until we find a function_ref, partial_apply, or unrecognized value.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7213,7 +7213,10 @@ private:
          ProfileCounter FalseBBCount, SILFunction &F);
 
 public:
-  SILValue getCondition() const { return getAllOperands()[ConditionIdx].get(); }
+  const Operand *getConditionOperand() const {
+    return &getAllOperands()[ConditionIdx];
+  }
+  SILValue getCondition() const { return getConditionOperand()->get(); }
   void setCondition(SILValue newCondition) {
     getAllOperands()[ConditionIdx].set(newCondition);
   }
@@ -7257,6 +7260,11 @@ public:
   MutableArrayRef<Operand> getFalseOperands() {
     // The remaining arguments are 'false' operands.
     return getAllOperands().slice(NumFixedOpers + getNumTrueArgs());
+  }
+
+  /// Returns true if \p op is mapped to the condition operand of the cond_br.
+  bool isConditionOperand(Operand *op) const {
+    return getConditionOperand() == op;
   }
 
   bool isConditionOperandIndex(unsigned OpIndex) const {

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -93,11 +93,11 @@ class SILValueOwnershipChecker {
 
   /// The list of lifetime ending users that we found. Only valid if check is
   /// successful.
-  SmallVector<BranchPropagatedUser, 16> lifetimeEndingUsers;
+  SmallVector<Operand *, 16> lifetimeEndingUsers;
 
   /// The list of non lifetime ending users that we found. Only valid if check
   /// is successful.
-  SmallVector<BranchPropagatedUser, 16> regularUsers;
+  SmallVector<Operand *, 16> regularUsers;
 
   /// The list of implicit non lifetime ending users that we found. This
   /// consists of instructions like end_borrow that end a scoped lifetime. We
@@ -105,7 +105,7 @@ class SILValueOwnershipChecker {
   /// destroyed while that sub-scope is valid.
   ///
   /// TODO: Rename to SubBorrowScopeUsers?
-  SmallVector<BranchPropagatedUser, 4> implicitRegularUsers;
+  SmallVector<Operand *, 4> implicitRegularUsers;
 
   /// The set of blocks that we have visited.
   SmallPtrSetImpl<SILBasicBlock *> &visitedBlocks;
@@ -133,12 +133,15 @@ public:
     if (!result.getValue())
       return false;
 
+    SmallVector<BranchPropagatedUser, 32> allLifetimeEndingUsers;
+    llvm::copy(lifetimeEndingUsers, std::back_inserter(allLifetimeEndingUsers));
     SmallVector<BranchPropagatedUser, 32> allRegularUsers;
     llvm::copy(regularUsers, std::back_inserter(allRegularUsers));
     llvm::copy(implicitRegularUsers, std::back_inserter(allRegularUsers));
+
     LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
     auto linearLifetimeResult = checker.checkValue(
-        value, lifetimeEndingUsers, allRegularUsers, errorBehavior);
+        value, allLifetimeEndingUsers, allRegularUsers, errorBehavior);
     result = !linearLifetimeResult.getFoundError();
 
     return result.getValue();
@@ -146,9 +149,9 @@ public:
 
 private:
   bool checkUses();
-  bool gatherUsers(SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers,
-                   SmallVectorImpl<BranchPropagatedUser> &regularUsers,
-                   SmallVectorImpl<BranchPropagatedUser> &implicitRegularUsers);
+  bool gatherUsers(SmallVectorImpl<Operand *> &lifetimeEndingUsers,
+                   SmallVectorImpl<Operand *> &regularUsers,
+                   SmallVectorImpl<Operand *> &implicitRegularUsers);
 
   bool checkValueWithoutLifetimeEndingUses();
 
@@ -157,10 +160,10 @@ private:
 
   bool isGuaranteedFunctionArgWithLifetimeEndingUses(
       SILFunctionArgument *arg,
-      const SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers) const;
+      const SmallVectorImpl<Operand *> &lifetimeEndingUsers) const;
   bool isSubobjectProjectionWithLifetimeEndingUses(
       SILValue value,
-      const SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers) const;
+      const SmallVectorImpl<Operand *> &lifetimeEndingUsers) const;
 
   /// Depending on our initialization, either return false or call Func and
   /// throw an error.
@@ -181,9 +184,9 @@ private:
 } // end anonymous namespace
 
 bool SILValueOwnershipChecker::gatherUsers(
-    SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers,
-    SmallVectorImpl<BranchPropagatedUser> &nonLifetimeEndingUsers,
-    SmallVectorImpl<BranchPropagatedUser> &implicitRegularUsers) {
+    SmallVectorImpl<Operand *> &lifetimeEndingUsers,
+    SmallVectorImpl<Operand *> &nonLifetimeEndingUsers,
+    SmallVectorImpl<Operand *> &implicitRegularUsers) {
 
   // See if Value is guaranteed. If we are guaranteed and not forwarding, then
   // we need to look through subobject uses for more uses. Otherwise, if we are
@@ -198,19 +201,7 @@ bool SILValueOwnershipChecker::gatherUsers(
 
   // Then gather up our initial list of users.
   SmallVector<Operand *, 8> users;
-  std::copy(value->use_begin(), value->use_end(), std::back_inserter(users));
-
-  auto addCondBranchToList = [](SmallVectorImpl<BranchPropagatedUser> &list,
-                                CondBranchInst *cbi, unsigned operandIndex) {
-    if (cbi->isConditionOperandIndex(operandIndex)) {
-      list.emplace_back(cbi);
-      return;
-    }
-
-    bool isTrueOperand = cbi->isTrueOperandIndex(operandIndex);
-    list.emplace_back(cbi, isTrueOperand ? CondBranchInst::TrueIdx
-                                         : CondBranchInst::FalseIdx);
-  };
+  llvm::copy(value->getUses(), std::back_inserter(users));
 
   bool foundError = false;
   while (!users.empty()) {
@@ -267,19 +258,10 @@ bool SILValueOwnershipChecker::gatherUsers(
         opOwnershipKindMap.getLifetimeConstraint(ownershipKind);
     if (lifetimeConstraint == UseLifetimeConstraint::MustBeInvalidated) {
       LLVM_DEBUG(llvm::dbgs() << "        Lifetime Ending User: " << *user);
-      if (auto *cbi = dyn_cast<CondBranchInst>(user)) {
-        addCondBranchToList(lifetimeEndingUsers, cbi, op->getOperandNumber());
-      } else {
-        lifetimeEndingUsers.emplace_back(user);
-      }
+      lifetimeEndingUsers.push_back(op);
     } else {
       LLVM_DEBUG(llvm::dbgs() << "        Regular User: " << *user);
-      if (auto *cbi = dyn_cast<CondBranchInst>(user)) {
-        addCondBranchToList(nonLifetimeEndingUsers, cbi,
-                            op->getOperandNumber());
-      } else {
-        nonLifetimeEndingUsers.emplace_back(user);
-      }
+      nonLifetimeEndingUsers.push_back(op);
     }
 
     // If our base value is not guaranteed, we do not to try to visit
@@ -296,12 +278,14 @@ bool SILValueOwnershipChecker::gatherUsers(
         // For correctness reasons we use indices to make sure that we can
         // append to NonLifetimeEndingUsers without needing to deal with
         // iterator invalidation.
-        SmallVector<SILInstruction *, 4> endBorrowInsts;
         for (unsigned i : indices(nonLifetimeEndingUsers)) {
           if (auto *bbi = dyn_cast<BeginBorrowInst>(
-                  nonLifetimeEndingUsers[i].getInst())) {
-            llvm::copy(bbi->getEndBorrows(),
-                       std::back_inserter(implicitRegularUsers));
+                  nonLifetimeEndingUsers[i]->getUser())) {
+            for (auto *use : bbi->getUses()) {
+              if (isa<EndBorrowInst>(use->getUser())) {
+                implicitRegularUsers.push_back(use);
+              }
+            }
           }
         }
       }
@@ -381,8 +365,8 @@ bool SILValueOwnershipChecker::gatherUsers(
         // them to ensure that all of BBArg's uses are completely
         // enclosed within the end_borrow of this argument.
         for (auto *op : succArg->getUses()) {
-          if (auto *ebi = dyn_cast<EndBorrowInst>(op->getUser())) {
-            implicitRegularUsers.push_back(ebi);
+          if (isa<EndBorrowInst>(op->getUser())) {
+            implicitRegularUsers.push_back(op);
           }
         }
       }
@@ -493,8 +477,7 @@ bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses() {
 
 bool SILValueOwnershipChecker::isGuaranteedFunctionArgWithLifetimeEndingUses(
     SILFunctionArgument *arg,
-    const llvm::SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers)
-    const {
+    const llvm::SmallVectorImpl<Operand *> &lifetimeEndingUsers) const {
   if (arg->getOwnershipKind() != ValueOwnershipKind::Guaranteed)
     return true;
 
@@ -502,8 +485,8 @@ bool SILValueOwnershipChecker::isGuaranteedFunctionArgWithLifetimeEndingUses(
     llvm::errs() << "    Function: '" << arg->getFunction()->getName() << "'\n"
                  << "    Guaranteed function parameter with life ending uses!\n"
                  << "    Value: " << *arg;
-    for (const auto &user : lifetimeEndingUsers) {
-      llvm::errs() << "    Lifetime Ending User: " << *user;
+    for (const auto *use : lifetimeEndingUsers) {
+      llvm::errs() << "    Lifetime Ending User: " << *use->getUser();
     }
     llvm::errs() << '\n';
   });
@@ -511,15 +494,14 @@ bool SILValueOwnershipChecker::isGuaranteedFunctionArgWithLifetimeEndingUses(
 
 bool SILValueOwnershipChecker::isSubobjectProjectionWithLifetimeEndingUses(
     SILValue value,
-    const llvm::SmallVectorImpl<BranchPropagatedUser> &lifetimeEndingUsers)
-    const {
+    const llvm::SmallVectorImpl<Operand *> &lifetimeEndingUsers) const {
   return handleError([&] {
     llvm::errs() << "    Function: '" << value->getFunction()->getName()
                  << "'\n"
                  << "    Subobject projection with life ending uses!\n"
                  << "    Value: " << *value;
-    for (const auto &user : lifetimeEndingUsers) {
-      llvm::errs() << "    Lifetime Ending User: " << *user;
+    for (const auto *use : lifetimeEndingUsers) {
+      llvm::errs() << "    Lifetime Ending User: " << *use->getUser();
     }
     llvm::errs() << '\n';
   });

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -75,7 +75,7 @@ insertAfterApply(SILInstruction *applySite,
 /// apply site, or the callee value are control dependent in any way. This
 /// requires us to need to be very careful. See inline comments.
 static void fixupReferenceCounts(
-    PartialApplyInst *pai, SILInstruction *applySite, SILValue calleeValue,
+    PartialApplyInst *pai, FullApplySite applySite, SILValue calleeValue,
     ArrayRef<ParameterConvention> captureArgConventions,
     MutableArrayRef<SILValue> capturedArgs, bool isCalleeGuaranteed) {
 
@@ -108,7 +108,7 @@ static void fixupReferenceCounts(
       continue;
     }
 
-    auto *f = applySite->getFunction();
+    auto *f = applySite.getFunction();
 
     // See if we have a trivial value. In such a case, just continue. We do not
     // need to fix up anything.
@@ -151,8 +151,9 @@ static void fixupReferenceCounts(
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
       LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
-      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
-                                      &leakingBlocks);
+      auto error = checker.checkValue(
+          pai, {BranchPropagatedUser(applySite.getCalleeOperand())}, {},
+          errorBehavior, &leakingBlocks);
       if (error.getFoundLeak()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();
@@ -173,12 +174,13 @@ static void fixupReferenceCounts(
       // insert a destroy after the apply since the leak will just cover the
       // other path.
       if (!error.getFoundOverConsume()) {
-        insertAfterApply(applySite, [&](SILBasicBlock::iterator iter) {
-          if (hasOwnership) {
-            SILBuilderWithScope(iter).createEndBorrow(loc, argument);
-          }
-          SILBuilderWithScope(iter).emitDestroyValueOperation(loc, copy);
-        });
+        insertAfterApply(
+            applySite.getInstruction(), [&](SILBasicBlock::iterator iter) {
+              if (hasOwnership) {
+                SILBuilderWithScope(iter).createEndBorrow(loc, argument);
+              }
+              SILBuilderWithScope(iter).emitDestroyValueOperation(loc, copy);
+            });
       }
       v = argument;
       break;
@@ -202,8 +204,8 @@ static void fixupReferenceCounts(
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
       LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
-      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
-                                      &leakingBlocks);
+      auto error = checker.checkValue(pai, {applySite.getCalleeOperand()}, {},
+                                      errorBehavior, &leakingBlocks);
       if (error.getFoundError()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();
@@ -213,9 +215,10 @@ static void fixupReferenceCounts(
         }
       }
 
-      insertAfterApply(applySite, [&](SILBasicBlock::iterator iter) {
-        SILBuilderWithScope(iter).emitDestroyValueOperation(loc, v);
-      });
+      insertAfterApply(
+          applySite.getInstruction(), [&](SILBasicBlock::iterator iter) {
+            SILBuilderWithScope(iter).emitDestroyValueOperation(loc, v);
+          });
       break;
     }
 
@@ -241,8 +244,8 @@ static void fixupReferenceCounts(
       // am going to change this to use a different API on the linear lifetime
       // checker that makes this clearer.
       LinearLifetimeChecker checker(visitedBlocks, deadEndBlocks);
-      auto error = checker.checkValue(pai, {applySite}, {}, errorBehavior,
-                                      &leakingBlocks);
+      auto error = checker.checkValue(pai, {applySite.getCalleeOperand()}, {},
+                                      errorBehavior, &leakingBlocks);
       if (error.getFoundError()) {
         while (!leakingBlocks.empty()) {
           auto *leakingBlock = leakingBlocks.pop_back_val();
@@ -260,9 +263,10 @@ static void fixupReferenceCounts(
   // Destroy the callee as the apply would have done if our function is not
   // callee guaranteed.
   if (!isCalleeGuaranteed) {
-    insertAfterApply(applySite, [&](SILBasicBlock::iterator iter) {
-      SILBuilderWithScope(iter).emitDestroyValueOperation(loc, calleeValue);
-    });
+    insertAfterApply(
+        applySite.getInstruction(), [&](SILBasicBlock::iterator iter) {
+          SILBuilderWithScope(iter).emitDestroyValueOperation(loc, calleeValue);
+        });
   }
 }
 
@@ -923,9 +927,8 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
         // We need to insert the copies before the partial_apply since if we can
         // not remove the partial_apply the captured values will be dead by the
         // time we hit the call site.
-        fixupReferenceCounts(PAI, InnerAI.getInstruction(), CalleeValue,
-                             CapturedArgConventions, CapturedArgs,
-                             IsCalleeGuaranteed);
+        fixupReferenceCounts(PAI, InnerAI, CalleeValue, CapturedArgConventions,
+                             CapturedArgs, IsCalleeGuaranteed);
       }
 
       // Register a callback to record potentially unused function values after

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -420,8 +420,10 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(CopyValueInst
   // our end borrow scope set. If they do not, then the copy_value is lifetime
   // extending the guaranteed value, we can not eliminate it.
   {
-    SmallVector<BranchPropagatedUser, 8> destroysForLinearLifetimeCheck(
-        destroys.begin(), destroys.end());
+    SmallVector<BranchPropagatedUser, 8> destroysForLinearLifetimeCheck;
+    for (auto *dvi : destroys) {
+      destroysForLinearLifetimeCheck.push_back(&dvi->getAllOperands()[0]);
+    }
     SmallVector<BranchPropagatedUser, 8> scratchSpace;
     SmallPtrSet<SILBasicBlock *, 4> visitedBlocks;
     if (llvm::any_of(borrowScopeIntroducers,
@@ -659,14 +661,14 @@ public:
     SmallVector<BranchPropagatedUser, 4> baseEndBorrows;
     for (auto *use : borrowInst->getUses()) {
       if (isa<EndBorrowInst>(use->getUser())) {
-        baseEndBorrows.push_back(BranchPropagatedUser(use->getUser()));
+        baseEndBorrows.emplace_back(use);
       }
     }
     
     SmallVector<BranchPropagatedUser, 4> valueDestroys;
     for (auto *use : Load->getUses()) {
       if (isa<DestroyValueInst>(use->getUser())) {
-        valueDestroys.push_back(BranchPropagatedUser(use->getUser()));
+        valueDestroys.emplace_back(use);
       }
     }
     


### PR DESCRIPTION
This commit only changes how BranchPropagatedUser is constructed and does not
change the internal representation. This is a result of my noticing that
BranchPropagatedUser could also use an operand internally to represent its
state. To simplify how I am making the change, I am splitting the change into
two PRs that should be easy to validate:

1. A commit that maps how the various users of BranchPropagatedUser have been
constructing BPUs to a single routine that takes an Operand. This leaves
BranchPropagatedUser's internal state alone as well as its user the Linear
Lifetime Checker.

2. A second commit that changes the internal bits of the BranchPropagatedUser to
store an Operand instead of a PointerUnion.

This will allow me to use the first commit to validate the second.

----

NOTE: I split off two small helper adding commits.