### PR TITLE
Fix handling of null relative references in RemoteRef.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -95,6 +95,8 @@ public:
   uint64_t resolveRelativeAddressData() const {
     int32_t offset;
     memcpy(&offset, LocalBuffer, sizeof(int32_t));
+    if (offset == 0)
+      return 0;
     return Address + (int64_t)offset;
   }
   


### PR DESCRIPTION
Caught on full CI when testing the iOS simulator.