### PR TITLE
build-script-impl: Fix passing extra args to dotest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2496,7 +2496,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 # Only set the extra arguments if they're not empty.
                 if [[ -z "${results_targets[@]}" ]]; then
-                    DOTEST_ARGS="${DOTEST_ARGS};-E;\"${DOTEST_EXTRA}\""
+                    DOTEST_ARGS="${DOTEST_ARGS};-E;\\\"${DOTEST_EXTRA}\\\""
                 fi
 
                 cmake_options=(


### PR DESCRIPTION
This breaks the Linux bots: https://ci.swift.org/job/oss-lldb-master-rebranch-incremental-linux-ubuntu-18_04//1/console