### PR TITLE
[SyntaxParse] Introduce CodeCompletionTypeSyntax

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -118,6 +118,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/AttributeNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/AvailabilityNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/CommonNodes.py"
+      "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/CompletionOnlyNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/DeclNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/ExprNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/GenericNodes.py"

--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -97,6 +97,8 @@ public:
                      const SourceLoc Loc);
   TypeRepr *generate(const syntax::ImplicitlyUnwrappedOptionalTypeSyntax &Type,
                      const SourceLoc Loc);
+  TypeRepr *generate(const syntax::CodeCompletionTypeSyntax &Type,
+                     const SourceLoc Loc);
   TypeRepr *generate(const syntax::UnknownTypeSyntax &Type,
                      const SourceLoc Loc);
 

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -40,6 +40,8 @@ protected:
   /// completion. This declaration contained the code completion token.
   Decl *ParsedDecl = nullptr;
 
+  TypeLoc ParsedTypeLoc;
+
   /// True if code completion is done inside a raw value expression of an enum
   /// case.
   bool InEnumElementRawValue = false;
@@ -74,6 +76,10 @@ public:
   /// CurDeclContext will not be where we want to perform lookup.
   void setParsedDecl(Decl *D) {
     ParsedDecl = D;
+  }
+
+  void setParsedTypeLoc(TypeLoc TyLoc) {
+    ParsedTypeLoc = TyLoc;
   }
 
   void setLeadingSequenceExprs(ArrayRef<Expr *> exprs) {
@@ -159,10 +165,10 @@ public:
   virtual void completeTypeSimpleBeginning() {};
 
   /// Complete a given type-identifier after we have consumed the dot.
-  virtual void completeTypeIdentifierWithDot(IdentTypeRepr *ITR) {};
+  virtual void completeTypeIdentifierWithDot() {};
 
   /// Complete a given type-identifier when there is no trailing dot.
-  virtual void completeTypeIdentifierWithoutDot(IdentTypeRepr *ITR) {};
+  virtual void completeTypeIdentifierWithoutDot() {};
 
   /// Complete the beginning of a case statement at the top of switch stmt.
   virtual void completeCaseStmtKeyword() {};

--- a/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
@@ -30,7 +30,7 @@ namespace swift {
 class ParsedRawSyntaxRecorder;
 class SyntaxParsingContext;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_buildable():
 %     child_count = len(node.children)
 class Parsed${node.name}Builder {

--- a/include/swift/Parse/ParsedSyntaxNodes.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxNodes.h.gyb
@@ -28,20 +28,20 @@ namespace swift {
 % # Emit the non-collection classes first, then emit the collection classes
 % # that reference these classes.
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if not node.is_syntax_collection():
 class Parsed${node.name};
 %   end
 % end
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_syntax_collection():
 using Parsed${node.name} =
   ParsedSyntaxCollection<syntax::SyntaxKind::${node.syntax_kind}>;
 %   end
 % end
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if not node.is_syntax_collection():
 %     qualifier = "" if node.is_base() else "final"
 %     for line in dedented_lines(node.description):

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -31,7 +31,7 @@ class SyntaxParsingContext;
 
 struct ParsedSyntaxRecorder {
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.children:
 %     child_params = []
 %     for child in node.children:

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -29,7 +29,7 @@ namespace syntax {
 
 class SyntaxArena;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_buildable():
 %     child_count = len(node.children)
 class ${node.name}Builder {

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -71,7 +71,7 @@ struct SyntaxFactory {
   static Syntax
   makeBlankCollectionSyntax(SyntaxKind Kind);
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.children:
 %     child_params = []
 %     for child in node.children:

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -2,7 +2,7 @@
   from gyb_syntax_support import *
   from gyb_syntax_support.kinds import SYNTAX_BASE_KINDS
   grouped_nodes = { kind: [] for kind in SYNTAX_BASE_KINDS }
-  for node in SYNTAX_NODES + SILONLY_NODES:
+  for node in SYNTAX_NODES + PARSEONLY_NODES:
     grouped_nodes[node.base_kind].append(node)
   # -*- mode: C++ -*-
   # Ignore the following admonition; it applies to the resulting .h file only
@@ -93,7 +93,7 @@ struct WrapperTypeTraits<syntax::SyntaxKind> {
     case syntax::SyntaxKind::${node.syntax_kind}: 
       return ${SYNTAX_NODE_SERIALIZATION_CODES[node.syntax_kind]};
 % end
-% for node in SILONLY_NODES:
+% for node in PARSEONLY_NODES:
     case syntax::SyntaxKind::${node.syntax_kind}:
 % end
       llvm_unreachable("unserializable syntax kind");
@@ -124,7 +124,7 @@ struct ScalarReferenceTraits<syntax::SyntaxKind> {
       case syntax::SyntaxKind::${node.syntax_kind}:
         return "\"${node.syntax_kind}\"";
 % end
-% for node in SILONLY_NODES:
+% for node in PARSEONLY_NODES:
       case syntax::SyntaxKind::${node.syntax_kind}:
 % end
         llvm_unreachable("unserializable syntax kind");

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -32,13 +32,13 @@ namespace syntax {
 % # Emit the non-collection classes first, then emit the collection classes
 % # that reference these classes.
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if not node.is_syntax_collection():
 class ${node.name};
 %   end
 % end
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_syntax_collection():
 using ${node.name} =
   SyntaxCollection<SyntaxKind::${node.syntax_kind},
@@ -46,7 +46,7 @@ using ${node.name} =
 %   end
 % end
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if not node.is_syntax_collection():
 %     qualifier = "" if node.is_base() else "final"
 %     for line in dedented_lines(node.description):

--- a/include/swift/Syntax/SyntaxVisitor.h.gyb
+++ b/include/swift/Syntax/SyntaxVisitor.h.gyb
@@ -32,7 +32,7 @@ namespace syntax {
 struct SyntaxVisitor {
   virtual ~SyntaxVisitor() {}
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if is_visitable(node):
   virtual void visit(${node.name} node);
 %   end

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1217,7 +1217,6 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
   CompletionKind Kind = CompletionKind::None;
   Expr *ParsedExpr = nullptr;
   SourceLoc DotLoc;
-  TypeLoc ParsedTypeLoc;
   DeclContext *CurDeclContext = nullptr;
   DeclAttrKind AttrKind;
 
@@ -1351,8 +1350,8 @@ public:
 
   void completeTypeDeclResultBeginning() override;
   void completeTypeSimpleBeginning() override;
-  void completeTypeIdentifierWithDot(IdentTypeRepr *ITR) override;
-  void completeTypeIdentifierWithoutDot(IdentTypeRepr *ITR) override;
+  void completeTypeIdentifierWithDot() override;
+  void completeTypeIdentifierWithoutDot() override;
 
   void completeCaseStmtKeyword() override;
   void completeCaseStmtBeginning(CodeCompletionExpr *E) override;
@@ -4609,22 +4608,13 @@ void CodeCompletionCallbacksImpl::completeInPrecedenceGroup(SyntaxKind SK) {
   CurDeclContext = P.CurDeclContext;
 }
 
-void CodeCompletionCallbacksImpl::completeTypeIdentifierWithDot(
-    IdentTypeRepr *ITR) {
-  if (!ITR) {
-    completeTypeSimpleBeginning();
-    return;
-  }
+void CodeCompletionCallbacksImpl::completeTypeIdentifierWithDot() {
   Kind = CompletionKind::TypeIdentifierWithDot;
-  ParsedTypeLoc = TypeLoc(ITR);
   CurDeclContext = P.CurDeclContext;
 }
 
-void CodeCompletionCallbacksImpl::completeTypeIdentifierWithoutDot(
-    IdentTypeRepr *ITR) {
-  assert(ITR);
+void CodeCompletionCallbacksImpl::completeTypeIdentifierWithoutDot() {
   Kind = CompletionKind::TypeIdentifierWithoutDot;
-  ParsedTypeLoc = TypeLoc(ITR);
   CurDeclContext = P.CurDeclContext;
 }
 

--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -13,6 +13,7 @@
 #include "swift/Parse/ASTGen.h"
 
 #include "swift/Basic/SourceManager.h"
+#include "swift/Parse/CodeCompletionCallbacks.h"
 #include "swift/Parse/Parser.h"
 
 using namespace swift;
@@ -123,6 +124,8 @@ TypeRepr *ASTGen::generate(const TypeSyntax &Type, const SourceLoc Loc) {
     TypeAST = generate(*Unwrapped, Loc);
   else if (auto Attributed = Type.getAs<AttributedTypeSyntax>())
     TypeAST = generate(*Attributed, Loc);
+  else if (auto CompletionTy = Type.getAs<CodeCompletionTypeSyntax>())
+    TypeAST = generate(*CompletionTy, Loc);
   else if (auto Unknown = Type.getAs<UnknownTypeSyntax>())
     TypeAST = generate(*Unknown, Loc);
 
@@ -445,34 +448,44 @@ TypeRepr *ASTGen::generate(const ImplicitlyUnwrappedOptionalTypeSyntax &Type,
       ImplicitlyUnwrappedOptionalTypeRepr(WrappedType, ExclamationLoc);
 }
 
+TypeRepr *ASTGen::generate(const CodeCompletionTypeSyntax &Type,
+                           const SourceLoc Loc) {
+  auto base = Type.getBase();
+  if (!base)
+    return nullptr;
+
+  TypeRepr *parsedTyR = generate(*base, Loc);
+  if (parsedTyR) {
+    if (P.CodeCompletion)
+      P.CodeCompletion->setParsedTypeLoc(parsedTyR);
+  }
+  return parsedTyR;
+}
+
 TypeRepr *ASTGen::generate(const UnknownTypeSyntax &Type, const SourceLoc Loc) {
   auto ChildrenCount = Type.getNumChildren();
 
   // Recover from old-style protocol composition:
   //   `protocol` `<` protocols `>`
   if (ChildrenCount >= 2) {
-    auto Protocol = Type.getChild(0)->getAs<TokenSyntax>();
+    auto keyword = Type.getChild(0)->getAs<TokenSyntax>();
 
-    if (Protocol && Protocol->getText() == "protocol") {
+    if (keyword && keyword->getText() == "protocol") {
+      auto keywordLoc = advanceLocBegin(Loc, *keyword);
       auto LAngle = Type.getChild(1);
-
-      SmallVector<TypeSyntax, 4> Protocols;
-      for (unsigned i = 2; i < Type.getNumChildren(); i++)
-        if (auto PType = Type.getChild(i)->getAs<TypeSyntax>())
-          Protocols.push_back(*PType);
-
       auto RAngle = Type.getChild(ChildrenCount - 1);
 
-      auto ProtocolLoc = advanceLocBegin(Loc, *Protocol);
       auto LAngleLoc = advanceLocBegin(Loc, *LAngle);
       auto RAngleLoc = advanceLocBegin(Loc, *RAngle);
 
-      SmallVector<TypeRepr *, 4> ProtocolTypes;
-      for (auto &&P : llvm::reverse(Protocols))
-        ProtocolTypes.push_back(generate(P, Loc));
-      std::reverse(std::begin(ProtocolTypes), std::end(ProtocolTypes));
+      SmallVector<TypeRepr *, 4> protocols;
+      for (unsigned i = 2; i < Type.getNumChildren(); i++) {
+        if (auto elem = Type.getChild(i)->getAs<TypeSyntax>())
+          if (auto proto = generate(*elem, Loc))
+            protocols.push_back(proto);
+      }
 
-      return CompositionTypeRepr::create(Context, ProtocolTypes, ProtocolLoc,
+      return CompositionTypeRepr::create(Context, protocols, keywordLoc,
                                          {LAngleLoc, RAngleLoc});
     }
   }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -623,8 +623,8 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
         CodeCompletion->completeTypeSimpleBeginning();
 
       auto CCTok = consumeTokenSyntax(tok::code_complete);
-      auto ty = ParsedSyntaxRecorder::makeUnknownType(
-          {&CCTok, 1}, *SyntaxContext);
+      auto ty = ParsedSyntaxRecorder::makeCodeCompletionType(
+          None, None, std::move(CCTok), *SyntaxContext);
       return makeParsedCodeCompletion(std::move(ty));
     }
 
@@ -634,8 +634,8 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
     // skip it as a recovery but rather keep it.
     if (Tok.isKeyword() && !Tok.isAtStartOfLine()) {
       auto kwTok = consumeTokenSyntax();
-      ParsedTypeSyntax ty = ParsedSyntaxRecorder::makeUnknownType(
-          {&kwTok, 1}, *SyntaxContext);
+      ParsedTypeSyntax ty =
+          ParsedSyntaxRecorder::makeUnknownType({&kwTok, 1}, *SyntaxContext);
       return makeParsedError(std::move(ty));
     }
 
@@ -644,110 +644,108 @@ Parser::TypeResult Parser::parseTypeIdentifier() {
 
   SmallVector<ParsedSyntax, 0> Junk;
 
-  auto BaseLoc = leadingTriviaLoc();
-  ParserStatus Status;
-  Optional<ParsedTypeSyntax> Base;
-  Optional<ParsedTokenSyntax> Period;
-  while (true) {
-    Optional<ParsedTokenSyntax> Identifier;
-    if (Tok.is(tok::kw_Self)) {
-      Identifier = consumeIdentifierSyntax();
-    } else {
-      // FIXME: specialize diagnostic for 'Type': type cannot start with
-      // 'metatype'
-      // FIXME: offer a fixit: 'self' -> 'Self'
-      Identifier =
-          parseIdentifierSyntax(diag::expected_identifier_in_dotted_type);
-    }
+  auto parseComponent =
+      [&](Optional<ParsedTokenSyntax> &Identifier,
+          Optional<ParsedGenericArgumentClauseSyntax> &GenericArgs) {
+        if (Tok.is(tok::kw_Self)) {
+          Identifier = consumeIdentifierSyntax();
+        } else {
+          // FIXME: specialize diagnostic for 'Type': type cannot start with
+          // 'metatype'
+          // FIXME: offer a fixit: 'self' -> 'Self'
+          Identifier =
+              parseIdentifierSyntax(diag::expected_identifier_in_dotted_type);
+        }
 
-    if (Identifier) {
-      Optional<ParsedGenericArgumentClauseSyntax> GenericArgs;
+        if (!Identifier)
+          return makeParserError();
 
-      if (startsWithLess(Tok)) {
+        if (!startsWithLess(Tok))
+          return makeParserSuccess();
+
         SmallVector<TypeRepr *, 4> GenericArgsAST;
         SourceLoc LAngleLoc, RAngleLoc;
         auto GenericArgsResult = parseGenericArgumentClauseSyntax();
-        if (GenericArgsResult.isError()) {
-          if (Base)
-            Junk.push_back(std::move(*Base));
-          if (Period)
-            Junk.push_back(std::move(*Period));
-          Junk.push_back(std::move(*Identifier));
-          if (!GenericArgsResult.isNull())
-            Junk.push_back(GenericArgsResult.get());
-          auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-          return makeParsedResult(std::move(ty), GenericArgsResult.getStatus());
-        }
-        GenericArgs = GenericArgsResult.get();
-      }
+        if (!GenericArgsResult.isNull())
+          GenericArgs = GenericArgsResult.get();
+        return GenericArgsResult.getStatus();
+      };
 
-      if (!Base)
-        Base = ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
-            std::move(*Identifier), std::move(GenericArgs), *SyntaxContext);
-      else
-        Base = ParsedSyntaxRecorder::makeMemberTypeIdentifier(
-            std::move(*Base), std::move(*Period), std::move(*Identifier),
-            std::move(GenericArgs), *SyntaxContext);
-    } else {
-      Status.setIsParseError();
-      if (Base)
-        Junk.push_back(std::move(*Base));
-      if (Period)
-        Junk.push_back(std::move(*Period));
-    }
+  ParsedSyntaxResult<ParsedTypeSyntax> result;
 
-    // Treat 'Foo.<anything>' as an attempt to write a dotted type
-    // unless <anything> is 'Type'.
-    if ((Tok.is(tok::period) || Tok.is(tok::period_prefix))) {
-      if (peekToken().is(tok::code_complete)) {
-        Status.setHasCodeCompletion();
-        break;
-      }
-      if (!peekToken().isContextualKeyword("Type") &&
-          !peekToken().isContextualKeyword("Protocol")) {
-        Period = consumeTokenSyntax();
-        continue;
-      }
-    } else if (Tok.is(tok::code_complete)) {
-      if (!Tok.isAtStartOfLine())
-        Status.setHasCodeCompletion();
+  // Parse the base identifier.
+  result = [&]() {
+    Optional<ParsedTokenSyntax> identifier;
+    Optional<ParsedGenericArgumentClauseSyntax> genericArgs;
+    auto status = parseComponent(identifier, genericArgs);
+    assert(identifier);
+    return makeParsedResult(
+        ParsedSyntaxRecorder::makeSimpleTypeIdentifier(
+            std::move(*identifier), std::move(genericArgs), *SyntaxContext),
+        status);
+  }();
+
+  // Parse member identifiers.
+  while (result.isSuccess() && Tok.isAny(tok::period, tok::period_prefix)) {
+    if (peekToken().isContextualKeyword("Type") ||
+        peekToken().isContextualKeyword("Protocol"))
       break;
+
+    // Parse '.'.
+    auto period = consumeTokenSyntax();
+
+    // Parse component;
+    Optional<ParsedTokenSyntax> identifier;
+    Optional<ParsedGenericArgumentClauseSyntax> genericArgs;
+    auto status = parseComponent(identifier, genericArgs);
+    if (identifier) {
+      ParsedMemberTypeIdentifierSyntaxBuilder builder(*SyntaxContext);
+      builder.useBaseType(result.get());
+      builder.usePeriod(std::move(period));
+      builder.useName(std::move(*identifier));
+      if (genericArgs)
+        builder.useGenericArgumentClause(std::move(*genericArgs));
+      result = makeParsedResult(builder.build(), status);
+      continue;
     }
-    break;
+
+    assert(!genericArgs);
+
+    if (Tok.is(tok::code_complete)) {
+      if (CodeCompletion)
+        CodeCompletion->completeTypeIdentifierWithDot();
+
+      auto ty = ParsedSyntaxRecorder::makeCodeCompletionType(
+          result.get(), std::move(period), consumeTokenSyntax(),
+          *SyntaxContext);
+      return makeParsedCodeCompletion(std::move(ty));
+    }
+
+    ParsedSyntax parts[] = {result.get(), std::move(period)};
+    return makeParsedResult(
+        ParsedSyntaxRecorder::makeUnknownType({parts, 2}, *SyntaxContext),
+        status);
   }
 
-  if (Status.hasCodeCompletion()) {
-    IdentTypeRepr *ITR = nullptr;
+  if (result.isSuccess() && Tok.is(tok::code_complete) &&
+      !Tok.isAtStartOfLine()) {
+    if (CodeCompletion)
+      CodeCompletion->completeTypeIdentifierWithoutDot();
 
-    if (Base) {
-      SyntaxContext->addSyntax(std::move(*Base));
-      auto T = SyntaxContext->topNode<TypeSyntax>();
-      Junk.push_back(std::move(*SyntaxContext->popIf<ParsedTypeSyntax>()));
-      ITR = dyn_cast<IdentTypeRepr>(Generator.generate(T, BaseLoc));
-    }
-
-    if (Tok.isNot(tok::code_complete)) {
-      // We have a dot.
-      auto Dot = consumeTokenSyntax();
-      Junk.push_back(std::move(Dot));
-      if (CodeCompletion)
-        CodeCompletion->completeTypeIdentifierWithDot(ITR);
-    } else {
-      if (CodeCompletion)
-        CodeCompletion->completeTypeIdentifierWithoutDot(ITR);
-    }
-    // Eat the code completion token because we handled it.
-    Junk.push_back(consumeTokenSyntax(tok::code_complete));
-    auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
+    auto ty = ParsedSyntaxRecorder::makeCodeCompletionType(
+        result.get(), None, consumeTokenSyntax(), *SyntaxContext);
     return makeParsedCodeCompletion(std::move(ty));
   }
 
-  if (Status.isError()) {
-    auto ty = ParsedSyntaxRecorder::makeUnknownType(Junk, *SyntaxContext);
-    return makeParsedError(std::move(ty));
+  // Don't propagate malformed type as valid type.
+  if (!result.isSuccess()) {
+    auto ty = result.get();
+    return makeParsedResult(
+        ParsedSyntaxRecorder::makeUnknownType({&ty, 1}, *SyntaxContext),
+        result.getStatus());
   }
 
-  return makeParsedResult(std::move(*Base));
+  return result;
 }
 
 Parser::TypeASTResult
@@ -907,7 +905,7 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       bool IsAny = Tok.getKind() == tok::kw_Any;
       auto TypeResult = parseTypeIdentifier();
       Status |= TypeResult.getStatus();
-      if (TypeResult.isSuccess()) {
+      if (!TypeResult.isNull()) {
         auto Type = TypeResult.get();
         Junk.push_back(Type.copyDeferred());
         if (!IsAny)

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -26,7 +26,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_buildable():
 %     for child in node.children:
 %       child_elt = None

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -23,7 +23,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   for child in node.children:
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -29,7 +29,7 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
         MutableArrayRef<ParsedRawSyntaxNode> Elements,
         function_ref<void(syntax::SyntaxKind, MutableArrayRef<ParsedRawSyntaxNode>)> receiver) {
   switch (Kind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
   case SyntaxKind::${node.syntax_kind}: {
 % if node.children:
 %   child_count = len(node.children)
@@ -77,7 +77,7 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
   }
 }
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.children:
 %     child_params = []
 %     child_move_args = []

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -25,7 +25,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_buildable():
 %     for child in node.children:
 ${node.name}Builder &

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -63,7 +63,7 @@ SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
 
 Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind) {
   switch(Kind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}: return makeBlank${node.syntax_kind}();
 %   end
@@ -76,7 +76,7 @@ Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind) {
 std::pair<unsigned, unsigned>
 SyntaxFactory::countChildren(SyntaxKind Kind){
   switch(Kind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if not node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}:
 %     child_count = len(node.children)
@@ -92,7 +92,7 @@ SyntaxFactory::countChildren(SyntaxKind Kind){
 bool SyntaxFactory::canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
                                                   SyntaxKind MemberKind) {
   switch (CollectionKind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}:
 %     if node.collection_element_choices:
@@ -125,7 +125,7 @@ RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
                                        llvm::ArrayRef<RC<RawSyntax>> Elements,
                                        RC<SyntaxArena> Arena) {
   switch (Kind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
   case SyntaxKind::${node.syntax_kind}: {
 % if node.children:
 %   child_count = len(node.children)
@@ -178,7 +178,7 @@ Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
     return None;
 }
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.children:
 %     child_params = []
 %     for child in node.children:

--- a/lib/Syntax/SyntaxKind.cpp.gyb
+++ b/lib/Syntax/SyntaxKind.cpp.gyb
@@ -52,7 +52,7 @@ bool isTokenKeyword(tok kind) {
 
 bool parserShallOmitWhenNoChildren(syntax::SyntaxKind Kind) {
   switch(Kind) {
-%   for node in SYNTAX_NODES + SILONLY_NODES:
+%   for node in SYNTAX_NODES + PARSEONLY_NODES:
 %     if node.shall_be_omitted_when_empty():
   case syntax::SyntaxKind::${node.syntax_kind}:
 %     end
@@ -73,7 +73,7 @@ void dumpSyntaxKind(llvm::raw_ostream &os, const SyntaxKind kind) {
   case SyntaxKind::Unknown:
     os << "Unknown";
     break;
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
   case SyntaxKind::${node.syntax_kind}:
     os << "${node.syntax_kind}";
     break;
@@ -83,7 +83,7 @@ void dumpSyntaxKind(llvm::raw_ostream &os, const SyntaxKind kind) {
 
 bool isCollectionKind(SyntaxKind Kind) {
   switch(Kind) {
-%   for node in SYNTAX_NODES + SILONLY_NODES:
+%   for node in SYNTAX_NODES + PARSEONLY_NODES:
 %     if node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}:
 %     end
@@ -147,7 +147,7 @@ SyntaxKind getUnknownKind(SyntaxKind Kind) {
 llvm::raw_ostream &llvm::operator<<(llvm::raw_ostream &OS,
                                     swift::syntax::SyntaxKind Kind) {
   switch (Kind) {
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
     case swift::syntax::SyntaxKind::${node.syntax_kind}:
     OS << "${node.syntax_kind}";
     break;

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -24,7 +24,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if node.requires_validation():
 void ${node.name}::validate() const {
 #ifndef NDEBUG

--- a/lib/Syntax/SyntaxVisitor.cpp.gyb
+++ b/lib/Syntax/SyntaxVisitor.cpp.gyb
@@ -21,7 +21,7 @@
 #include "swift/Syntax/SyntaxVisitor.h"
 #include "swift/Basic/Defer.h"
 
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if is_visitable(node):
 void swift::syntax::SyntaxVisitor::visit(${node.name} node) {
   visitChildren(node);
@@ -36,7 +36,7 @@ void swift::syntax::SyntaxVisitor::visit(Syntax node) {
   case SyntaxKind::Token:
     visit(node.castTo<TokenSyntax>());
     return;
-% for node in SYNTAX_NODES + SILONLY_NODES:
+% for node in SYNTAX_NODES + PARSEONLY_NODES:
 %   if is_visitable(node):
   case SyntaxKind::${node.syntax_kind}:
     visit(node.castTo<${node.name}>());

--- a/utils/gyb_syntax_support/CompletionOnlyNodes.py
+++ b/utils/gyb_syntax_support/CompletionOnlyNodes.py
@@ -1,0 +1,19 @@
+from Child import Child
+from Node import Node  # noqa: I201
+
+# These nodes are used only in code completion.
+
+COMPLETIONONLY_NODES = [
+    # type
+    Node('CodeCompletionType', kind='Type',
+         children=[
+             Child('Base', kind='Type', is_optional=True),
+             Child('Period', kind='Token',
+                   token_choices=[
+                       'PeriodToken',
+                       'PrefixPeriodToken',
+                   ],
+                   is_optional=True),
+             Child('CodeCompletionToken', kind='Token'),
+         ]),
+]

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -5,6 +5,7 @@ from .AttributeNodes import ATTRIBUTE_NODES
 from .AvailabilityNodes import AVAILABILITY_NODES
 from .Classification import SYNTAX_CLASSIFICATIONS
 from .CommonNodes import COMMON_NODES
+from .CompletionOnlyNodes import COMPLETIONONLY_NODES
 from .DeclNodes import DECL_NODES
 from .ExprNodes import EXPR_NODES
 from .GenericNodes import GENERIC_NODES
@@ -28,7 +29,7 @@ __all__ = [
     'GENERIC_NODES',
     'SYNTAX_NODE_SERIALIZATION_CODES',
     'PATTERN_NODES',
-    'SILONLY_NODES',
+    'PARSEONLY_NODES',
     'STMT_NODES',
     'SYNTAX_TOKENS',
     'SYNTAX_TOKEN_MAP',
@@ -49,6 +50,8 @@ __all__ = [
 SYNTAX_NODES = COMMON_NODES + EXPR_NODES + DECL_NODES + ATTRIBUTE_NODES + \
     STMT_NODES + GENERIC_NODES + TYPE_NODES + PATTERN_NODES + \
     AVAILABILITY_NODES
+
+PARSEONLY_NODES = SILONLY_NODES + COMPLETIONONLY_NODES
 
 verify_syntax_node_serialization_codes(SYNTAX_NODES,
                                        SYNTAX_NODE_SERIALIZATION_CODES)


### PR DESCRIPTION
To represent a type with code completion.

```
  type? '.'? <code-completion-token>
```

This is "parser only" node which is not exposed to SwiftSyntax.
Using this, defer to set the parsed type to code-completion callbacks.
