### PR TITLE
[5.1][IDE] Fix ModelASTWalker passing syntax nodes before the corresponding AST nodes have been visited

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -516,13 +516,7 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     pushStructureNode(SN, E);
   } else if (auto *Tup = dyn_cast<TupleExpr>(E)) {
     auto *ParentE = Parent.getAsExpr();
-    if (isCurrentCallArgExpr(Tup)) {
-      for (unsigned I = 0; I < Tup->getNumElements(); ++ I) {
-        SourceLoc NameLoc = Tup->getElementNameLoc(I);
-        if (NameLoc.isValid())
-          passTokenNodesUntil(NameLoc, PassNodesBehavior::ExcludeNodeAtLocation);
-      }
-    } else if (!ParentE || !isa<InterpolatedStringLiteralExpr>(ParentE)) {
+    if (!isCurrentCallArgExpr(Tup) && (!ParentE || !isa<InterpolatedStringLiteralExpr>(ParentE))) {
       SyntaxStructureNode SN;
       SN.Kind = SyntaxStructureKind::TupleExpression;
       SN.Range = charSourceRangeFromSourceRange(SM, Tup->getSourceRange());

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -264,6 +264,8 @@ func bar(x: Int) -> (Int, Float) {
 
 // CHECK: <object-literal>#colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)</object-literal>
 #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+// CHECK: test(<object-literal>#imageLiteral(resourceName: "test")</object-literal>, test: <int>0</int>)
+test(#imageLiteral(resourceName: "test"), test: 0)
 
 class GenC<T1,T2> {}
 


### PR DESCRIPTION
This was causing the tokens comprising image literals to be output separately, rather than as a single object literal.

Resolves rdar://problem/55045797

Cherry-pick of https://github.com/apple/swift/pull/27329