### PR TITLE
[5.1-Early] IDE: avoid merging extensions with @available attributes when synthesizing extensions

### DIFF
--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -179,7 +179,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       }
     };
 
-    bool HasDocComment;
+    bool Unmergable;
     unsigned InheritsCount;
     std::set<Requirement> Requirements;
     void addRequirement(GenericSignature *GenericSig,
@@ -194,14 +194,14 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     }
     bool operator== (const ExtensionMergeInfo& Another) const {
       // Trivially unmergeable.
-      if (HasDocComment || Another.HasDocComment)
+      if (Unmergable || Another.Unmergable)
         return false;
       if (InheritsCount != 0 || Another.InheritsCount != 0)
         return false;
       return Requirements == Another.Requirements;
     }
     bool isMergeableWithTypeDef() {
-      return !HasDocComment && InheritsCount == 0 && Requirements.empty();
+      return !Unmergable && InheritsCount == 0 && Requirements.empty();
     }
   };
 
@@ -279,7 +279,8 @@ struct SynthesizedExtensionAnalyzer::Implementation {
                ExtensionDecl *EnablingExt, NormalProtocolConformance *Conf) {
     SynthesizedExtensionInfo Result(IsSynthesized, EnablingExt);
     ExtensionMergeInfo MergeInfo;
-    MergeInfo.HasDocComment = !Ext->getRawComment().isEmpty();
+    MergeInfo.Unmergable = !Ext->getRawComment().isEmpty() || // With comments
+                           Ext->getAttrs().hasAttribute<AvailableAttr>(); // With @available
     MergeInfo.InheritsCount = countInherits(Ext);
 
     // There's (up to) two extensions here: the extension with the items that we

--- a/test/IDE/print_synthesized_extensions_nomerge.swift
+++ b/test/IDE/print_synthesized_extensions_nomerge.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/print_synthesized_extensions_nomerge.swiftmodule -emit-module-doc -emit-module-doc-path %t/print_synthesized_extensions.swiftdoc %s
+// RUN: %target-swift-ide-test -print-module -annotate-print -synthesize-extension -print-interface -no-empty-line-between-members -module-to-print=print_synthesized_extensions_nomerge -I %t -source-filename=%s > %t.syn.txt
+// RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt
+
+public struct S1 {}
+
+@available(macOS 10.15, *)
+public extension S1 {
+  func foo() {}
+}
+
+@available(iOS 13, *)
+public extension S1 {
+  func bar() {}
+}
+
+// CHECK1: <decl:Extension>@available(OSX 10.15, *)
+// CHECK1:  extension <loc><ref:Struct>S1</ref></loc> {
+// CHECK1: <decl:Extension>@available(iOS 13, *)
+// CHECK1: extension <loc><ref:Struct>S1</ref></loc> {


### PR DESCRIPTION
rdar://54804607