### PR TITLE
[Typechecker] Disallow passing expression pattern inout to the match function

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3122,7 +3122,12 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
   
   SmallVector<ValueDecl*, 4> choices;
   for (auto &result : matchLookup) {
-    choices.push_back(result.getValueDecl());
+    auto FD = cast<FuncDecl>(result.getValueDecl());
+    // We don't allow the pattern to be passed inout to the ~= method.
+    if (FD->getParameters()->size() > 0 &&
+        FD->getParameters()->get(0)->isInOut())
+      continue;
+    choices.push_back(FD);
   }
   
   if (choices.empty()) {

--- a/test/stmt/switch_expr_pattern_inout.swift
+++ b/test/stmt/switch_expr_pattern_inout.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+func ~= (pattern: inout Int, value: Int) -> Bool {
+  pattern = value
+  return true
+}
+
+var x = 0
+
+switch 49 {
+case x:
+  print("yup")
+default:
+  print("nope")
+}
+
+// CHECK: nope
+// CHECK: 0
+print(x)


### PR DESCRIPTION
The following code is legal:

```swift
func ~= (pattern: inout Int, value: Int) -> Bool {
  pattern = value
  return true
}

var x = 0

switch 49 {
case x:
  print("yup")
default:
  print("nope")
}

print(x) // 49
```

Disallow passing the expression pattern inout to the pattern matching function (`~=`). This is a source-breaking change, but is deemed acceptable by Joe Groff.

Resolves [SR-11488](https://bugs.swift.org/browse/SR-11488).