### PR TITLE
[NFC] Simplify Opaque Type Registration

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -60,8 +60,7 @@ public:
 
   /// Look up an opaque return type by the mangled name of the declaration
   /// that defines it.
-  virtual OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                                 LazyResolver *resolver) {
+  virtual OpaqueTypeDecl *lookupOpaqueResultTypeByName(StringRef MangledName) {
     return nullptr;
   }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -354,8 +354,7 @@ public:
 
   /// Look up an opaque return type by the mangled name of the declaration
   /// that defines it.
-  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                         LazyResolver *resolver);
+  OpaqueTypeDecl *lookupOpaqueResultTypeByName(StringRef MangledName);
   
   /// Find ValueDecls in the module and pass them to the given consumer object.
   ///

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -132,11 +132,8 @@ public:
 
   /// The set of validated opaque return type decls in the source file.
   llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
-  llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
-  /// The set of parsed decls with opaque return types that have not yet
-  /// been validated.
-  llvm::DenseSet<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
-
+  llvm::StringMap<OpaqueTypeDecl *> OpaqueReturnTypesByName;
+  
   /// A set of special declaration attributes which require the
   /// Foundation module to be imported to work. If the foundation
   /// module is still not imported by the time type checking is
@@ -430,14 +427,9 @@ public:
   void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
   bool hasSyntaxRoot() const;
 
-  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                         LazyResolver *resolver) override;
+  OpaqueTypeDecl *lookupOpaqueResultTypeByName(StringRef MangledName) override;
 
-  void addUnvalidatedDeclWithOpaqueResultType(ValueDecl *vd) {
-    UnvalidatedDeclsWithOpaqueReturnTypes.insert(vd);
-  }
-
-  void markDeclWithOpaqueResultTypeAsValidated(ValueDecl *vd);
+  void registerDeclWithOpaqueResultType(ValueDecl *vd);
 
 private:
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -278,7 +278,7 @@ public:
   virtual TypeDecl *lookupLocalType(StringRef MangledName) const override;
   
   virtual OpaqueTypeDecl *
-  lookupOpaqueResultType(StringRef MangledName, LazyResolver *resolver) override;
+  lookupOpaqueResultTypeByName(StringRef MangledName) override;
 
   virtual TypeDecl *
   lookupNestedType(Identifier name,

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -261,9 +261,8 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
     if (!parentModule)
       return Type();
 
-    auto opaqueDecl = parentModule->lookupOpaqueResultType(mangledName,
-                                                           Resolver);
-    if (!opaqueDecl)
+    auto opaqueDecl = parentModule->lookupOpaqueResultTypeByName(mangledName);
+    if (!opaqueDecl || !opaqueDecl->getInterfaceType())
       return Type();
     // TODO: multiple opaque types
     assert(ordinal == 0 && "not implemented");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5033,7 +5033,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       setLocalDiscriminator(VD);
       Decls.push_back(VD);
       if (hasOpaqueReturnTy && sf) {
-        sf->addUnvalidatedDeclWithOpaqueResultType(VD);
+        sf->registerDeclWithOpaqueResultType(VD);
       }
     });
 
@@ -5350,7 +5350,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
   // Let the source file track the opaque return type mapping, if any.
   if (FuncRetTy && isa<OpaqueReturnTypeRepr>(FuncRetTy)) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
-      sf->addUnvalidatedDeclWithOpaqueResultType(FD);
+      sf->registerDeclWithOpaqueResultType(FD);
     }
   }
   
@@ -6225,7 +6225,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   // Let the source file track the opaque return type mapping, if any.
   if (ElementTy.get() && isa<OpaqueReturnTypeRepr>(ElementTy.get())) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
-      sf->addUnvalidatedDeclWithOpaqueResultType(Subscript);
+      sf->registerDeclWithOpaqueResultType(Subscript);
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3922,7 +3922,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     if (VD->getOpaqueResultTypeDecl()) {
       if (auto SF = VD->getInnermostDeclContext()->getParentSourceFile()) {
-        SF->markDeclWithOpaqueResultTypeAsValidated(VD);
+        SF->registerDeclWithOpaqueResultType(VD);
       }
     }
 
@@ -4071,7 +4071,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     // Mark the opaque result type as validated, if there is one.
     if (FD->getOpaqueResultTypeDecl()) {
       if (auto sf = FD->getDeclContext()->getParentSourceFile()) {
-        sf->markDeclWithOpaqueResultTypeAsValidated(FD);
+        sf->registerDeclWithOpaqueResultType(FD);
       }
     }
     
@@ -4116,7 +4116,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     if (SD->getOpaqueResultTypeDecl()) {
       if (auto SF = SD->getInnermostDeclContext()->getParentSourceFile()) {
-        SF->markDeclWithOpaqueResultTypeAsValidated(SD);
+        SF->registerDeclWithOpaqueResultType(SD);
       }
     }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1258,7 +1258,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     auto name = getIdentifier(DefiningDeclNameID);
     pathTrace.addOpaqueReturnType(name);
     
-    if (auto opaque = baseModule->lookupOpaqueResultType(name.str(), nullptr)) {
+    if (auto opaque = baseModule->lookupOpaqueResultTypeByName(name.str())) {
       values.push_back(opaque);
     }
     break;
@@ -1661,8 +1661,7 @@ giveUpFastPath:
       pathTrace.addOpaqueReturnType(name);
     
       auto lookupModule = M ? M : baseModule;
-      if (auto opaqueTy = lookupModule->lookupOpaqueResultType(name.str(),
-                                                               nullptr)) {
+      if (auto opaqueTy = lookupModule->lookupOpaqueResultTypeByName(name.str())) {
         values.push_back(opaqueTy);
       }
       break;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -961,8 +961,7 @@ TypeDecl *SerializedASTFile::lookupLocalType(llvm::StringRef MangledName) const{
 }
 
 OpaqueTypeDecl *
-SerializedASTFile::lookupOpaqueResultType(StringRef MangledName,
-                                          LazyResolver *resolver) {
+SerializedASTFile::lookupOpaqueResultTypeByName(StringRef MangledName) {
   return File.lookupOpaqueResultType(MangledName);
 }
 


### PR DESCRIPTION
Drop the table of unvalidated declarations and rename the accessor so
it's a little clearer what kind of lookup this will perform.  On lookup,
the declaration will be validated via the call to getInterfaceType().

In the future, we should investigate making this even lazier by letting
the client control where validation should occur unless we're absolutely
certain this entrypoint should return a fully validated declaration.
