### PR TITLE
Extensions Do Not Have Parent Signatures

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1094,7 +1094,7 @@ class InferredGenericSignatureRequest :
     public SimpleRequest<InferredGenericSignatureRequest,
                          GenericSignature *(ModuleDecl *,
                                             GenericSignature *,
-                                            SmallVector<GenericParamList *, 2>,
+                                            GenericParamList *,
                                             SmallVector<Requirement, 2>,
                                             SmallVector<TypeLoc, 2>,
                                             bool),
@@ -1110,7 +1110,7 @@ private:
   evaluate(Evaluator &evaluator,
            ModuleDecl *module,
            GenericSignature *baseSignature,
-           SmallVector<GenericParamList *, 2> addedParameters,
+           GenericParamList *gpl,
            SmallVector<Requirement, 2> addedRequirements,
            SmallVector<TypeLoc, 2> inferenceSources,
            bool allowConcreteGenericParams) const;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -54,7 +54,7 @@ SWIFT_REQUEST(NameLookup, GenericSignatureRequest,
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
               GenericSignature *(ModuleDecl *, GenericSignature *,
-                                 SmallVector<GenericParamList *, 2>,
+                                 GenericParamList *,
                                  SmallVector<Requirement, 2>,
                                  SmallVector<TypeLoc, 2>, bool),
               Cached, NoLocationInfo)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3086,10 +3086,7 @@ public:
 
     // Validate the nominal type declaration being extended.
     (void)nominal->getInterfaceType();
-    // Don't bother computing the generic signature if the extended nominal
-    // type didn't pass validation so we don't crash.
-    if (!nominal->isInvalid())
-      (void)ED->getGenericSignature();
+    (void)ED->getGenericSignature();
     ED->setValidationToChecked();
 
     if (extType && !extType->hasError()) {
@@ -3770,8 +3767,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         (void)nominal->getInterfaceType();
         
         // Eagerly validate the generic signature of the extension.
-        if (!nominal->isInvalid())
-          (void)ext->getGenericSignature();
+        (void)ext->getGenericSignature();
       }
     }
     if (ext->getValidationState() == Decl::ValidationState::Checking)

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -448,26 +448,16 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
 ///
 
 GenericSignature *TypeChecker::checkGenericSignature(
-                      GenericParamList *genericParams,
+                      GenericParamList *genericParamList,
                       DeclContext *dc,
                       GenericSignature *parentSig,
                       bool allowConcreteGenericParams,
                       SmallVector<Requirement, 2> additionalRequirements,
                       SmallVector<TypeLoc, 2> inferenceSources) {
-  assert(genericParams && "Missing generic parameters?");
-
-  // Type check the generic parameters, treating all generic type
-  // parameters as dependent, unresolved.
-  SmallVector<GenericParamList *, 2> gpLists;
-  for (auto *outerParams = genericParams;
-       outerParams != nullptr;
-       outerParams = outerParams->getOuterParameters()) {
-    gpLists.push_back(outerParams);
-  }
+  assert(genericParamList && "Missing generic parameters?");
 
   auto request = InferredGenericSignatureRequest{
-    dc->getParentModule(), parentSig,
-    gpLists,
+    dc->getParentModule(), parentSig, genericParamList,
     additionalRequirements, inferenceSources,
     allowConcreteGenericParams};
   auto *sig = evaluateOrDefault(dc->getASTContext().evaluator,
@@ -636,6 +626,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     return cast<SubscriptDecl>(accessor->getStorage())->getGenericSignature();
   }
 
+  auto *parentSig = GC->getParent()->getGenericSignatureOfContext();
   bool allowConcreteGenericParams = false;
   SmallVector<TypeLoc, 2> inferenceSources;
   SmallVector<Requirement, 2> sameTypeReqs;
@@ -716,13 +707,15 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
 
     // Allow parameters to be equated with concrete types.
     allowConcreteGenericParams = true;
+    // Extensions must occur at the top level, they have no
+    // (valid) parent signature.
+    parentSig = nullptr;
     inferenceSources.emplace_back(nullptr, extInterfaceType);
   }
 
   // EGREGIOUS HACK: The GSB cannot handle the addition of parent signatures
   // from malformed decls in many cases.  Check the invalid bit and null out the
   // parent signature.
-  auto *parentSig = GC->getParent()->getGenericSignatureOfContext();
   if (auto *DD = GC->getParent()->getAsDecl()) {
     parentSig = DD->isInvalid() ? nullptr : parentSig;
   }

--- a/validation-test/compiler_crashers_2_fixed/0207-rdar55502661.swift
+++ b/validation-test/compiler_crashers_2_fixed/0207-rdar55502661.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend %s -typecheck -o /dev/null
+
+extension Result {
+  extension Result where Result.Undefined == Int {


### PR DESCRIPTION
Remove the parent signature from consideration when computing the
generic signature for an extension.  This cuts off a series of crashers
that involved nested extensions with trailing where clauses a la

```
extension Foo {
  extension Foo where Self.Undefined == Bar {
  }
}
```

The inner (invalid) extension technically has a parent signature from
Foo itself.  Adding that signature to the GSB means when we go to
register the inner extension's generic parameters we crash.

Since extensions have to occur at the top level, just remove the parent
signature from consideration.

Fixes rdar://55502661

Also lets us drop the awful hacks in TypeCheckDecl that I used to think were necessary to work around this.  Yay!