### PR TITLE
Use llvm.used for __objc_protorefs and __objc_protolist

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -363,6 +363,11 @@ IRGenModule::getObjCProtocolGlobalVars(ProtocolDecl *proto) {
   protocolLabel->setSection(GetObjCSectionName("__objc_protolist",
                                                "coalesced,no_dead_strip"));
 
+  // Mark used to prevent DCE of public unreferenced protocols to ensure
+  // that they are available for external use when a used module is used
+  // as a library.
+  addUsedGlobal(protocolLabel);
+
   // Introduce a variable to reference the protocol.
   auto *protocolRef =
       new llvm::GlobalVariable(Module, Int8PtrTy, /*constant*/ false,
@@ -373,6 +378,11 @@ IRGenModule::getObjCProtocolGlobalVars(ProtocolDecl *proto) {
   protocolRef->setVisibility(llvm::GlobalValue::HiddenVisibility);
   protocolRef->setSection(GetObjCSectionName("__objc_protorefs",
                                              "coalesced,no_dead_strip"));
+
+  // Mark used to prevent DCE of public unreferenced protocols to ensure
+  // that they are available for external use when a used module is used
+  // as a library.
+  addUsedGlobal(protocolRef);
 
   ObjCProtocolPair pair{protocolRecord, protocolRef};
   ObjCProtocols.insert({proto, pair});

--- a/test/IRGen/objc_protocol_vars.sil
+++ b/test/IRGen/objc_protocol_vars.sil
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -parse-as-library -emit-ir %s | %FileCheck %s
+
+// It tests whether the vars @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_"
+// and @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" are in llvm.used.
+//
+// import Foundation
+// @objc
+// public protocol T: AnyObject {
+//
+//    var current: Int32 { get }
+//
+//    func clone() -> T
+//
+//}
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+import Foundation
+
+@objc public protocol T : AnyObject {
+  @objc var current: Int32 { get }
+  @objc func clone() -> T
+}
+
+// CHECK: @llvm.used = appending global [{{.*}}] [{{.*}}, i8* bitcast (i8** @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_" to i8*), i8* bitcast (i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" to i8*), {{.*}}], {{.*}}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
The purpose of the changes is to use llvm.used for __objc_protorefs and __objc_protolist 
in the IRGen in Swift compiler to avoid runtime crash. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-11246](https://bugs.swift.org/browse/SR-11246).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
