### PR TITLE
[TBD] Ensure swift-abi-version is kept in sync with IRGen

### DIFF
--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -36,6 +36,9 @@ createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
 /// Delete the IRGenModule and IRGenerator obtained by the above call.
 void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);
 
+/// Gets the ABI version number that'll be set as a flag in the module.
+uint32_t getSwiftABIVersion();
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -24,9 +24,6 @@ namespace swift {
 class FileUnit;
 class ModuleDecl;
 
-/// The current ABI version of Swift, as tapi labels it.
-const uint8_t TAPI_SWIFT_ABI_VERSION = 5;
-
 /// Options for controlling the exact set of symbols included in the TBD
 /// output.
 struct TBDGenOptions {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -22,6 +22,7 @@
 #include "swift/Basic/Dwarf.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Runtime/RuntimeFnWrappersGen.h"
 #include "swift/Runtime/Config.h"
@@ -1353,6 +1354,10 @@ IRGenModule *IRGenerator::getGenModule(SILFunction *f) {
     return getGenModule(dc);
 
   return getPrimaryIGM();
+}
+
+uint32_t swift::irgen::getSwiftABIVersion() {
+  return IRGenModule::swiftVersion;
 }
 
 llvm::Triple IRGenerator::getEffectiveClangTriple() {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILDeclRef.h"
@@ -609,7 +610,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   file.setCurrentVersion(convertToPacked(opts.CurrentVersion));
   file.setCompatibilityVersion(convertToPacked(opts.CompatibilityVersion));
   file.setTwoLevelNamespace();
-  file.setSwiftABIVersion(TAPI_SWIFT_ABI_VERSION);
+  file.setSwiftABIVersion(irgen::getSwiftABIVersion());
   file.setPlatform(tapi::internal::mapToSinglePlatform(target));
   auto arch = tapi::internal::getArchType(target.getArchName());
   file.setArch(arch);

--- a/test/TBD/abi-version.swift
+++ b/test/TBD/abi-version.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+
+// This test ensures that we see the same Swift ABI Version flag in the LLVM IR
+// and in the TBD.
+
+// 1. Emit IR and a TBD for this file
+
+// RUN: %target-swift-frontend -emit-ir -o %t/test.ll %s -emit-tbd-path %t/test.tbd
+
+// 2. Concatenate them and FileCheck them both in the same file, so we can capture
+//    the ABI version in a variable.
+
+// RUN: cat %t/test.ll %t/test.tbd | %FileCheck %s
+
+// 3. Look in the IR for the Swift Version flag
+
+// CHECK: !"Swift Version", i32 [[VERSION:[0-9]+]]
+
+// 4. Look in the TBD for the same version listed
+
+// CHECK: swift-abi-version: [[VERSION]]


### PR DESCRIPTION
The TAPI_SWIFT_ABI_VERSION macro was never updated in sync with
IRGen::swiftVersion, so just expose that value through
irgen::getSwiftABIVersion() and use it in TBDGen.

Fixes rdar://55643763