### PR TITLE
[5.1] swift 5 stdlib tool

### DIFF
--- a/tools/swift-stdlib-tool/swift-stdlib-tool.mm
+++ b/tools/swift-stdlib-tool/swift-stdlib-tool.mm
@@ -985,7 +985,7 @@ int main(int argc, const char *argv[])
             src_dir = [[[self_executable stringByDeletingLastPathComponent]
                         stringByDeletingLastPathComponent]
                        sst_stringByAppendingPathComponents:
-                       @[ @"lib", @"swift", platform ]];
+                       @[ @"lib", @"swift-5.0", platform ]];
         } else if (!platform) {
             // src_dir is set but platform is not. 
             // Pick platform from src_dir's name.


### PR DESCRIPTION
Update swift-stdlib-tool for Swift 5. Resolves <rdar://problem/54747237>. Cherry pick of #27276.

