### PR TITLE
[ClangImporter] Remove manual setting of Protocol Self depth

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4696,9 +4696,6 @@ namespace {
           /*TrailingWhere=*/nullptr);
       result->computeType();
 
-      // FIXME: Kind of awkward that we have to do this here
-      result->getGenericParams()->getParams()[0]->setDepth(0);
-
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)


### PR DESCRIPTION
At one point in the past we probably needed to set this explicitly, but now it seems to be handled for us or derived somewhere.

No functionality change.