### PR TITLE
[AutoDiff] Forward-mode `unconditional_checked_cast_addr` support.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1584,33 +1584,29 @@ bool LinearMapInfo::shouldDifferentiateInstruction(SILInstruction *inst) {
   // differentiate logic" and update comment.
   switch (kind) {
   case AutoDiffLinearMapKind::Differential: {
-
-#define CHECK_INST_TYPE_ACTIVE_OPERANDS(TYPE) \
-if (isa<TYPE>(inst) && hasActiveOperands) \
-  return true;
-
-#define CHECK_INST_TYPE_ACTIVE_DEST(TYPE) \
-if (auto *castInst = dyn_cast<TYPE>(inst)) { \
-  return activityInfo.isActive(castInst->getDest(), indices); \
-}
-
-    CHECK_INST_TYPE_ACTIVE_DEST(StoreInst)
-    CHECK_INST_TYPE_ACTIVE_DEST(StoreBorrowInst)
-    CHECK_INST_TYPE_ACTIVE_DEST(CopyAddrInst)
-    CHECK_INST_TYPE_ACTIVE_DEST(UnconditionalCheckedCastAddrInst)
+#define CHECK_INST_TYPE_ACTIVE_DEST(INST) \
+    if (auto *castInst = dyn_cast<INST##Inst>(inst)) \
+      return activityInfo.isActive(castInst->getDest(), indices);
+    CHECK_INST_TYPE_ACTIVE_DEST(Store)
+    CHECK_INST_TYPE_ACTIVE_DEST(StoreBorrow)
+    CHECK_INST_TYPE_ACTIVE_DEST(CopyAddr)
+    CHECK_INST_TYPE_ACTIVE_DEST(UnconditionalCheckedCastAddr)
+#undef CHECK_INST_TYPE_ACTIVE_DEST
     if ((isa<AllocationInst>(inst) && hasActiveResults))
       return true;
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(RefCountingInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(EndAccessInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(EndBorrowInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(DeallocationInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(CopyValueInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(DestroyValueInst)
-    CHECK_INST_TYPE_ACTIVE_OPERANDS(DestroyAddrInst)
-    break;
 
+#define CHECK_INST_TYPE_ACTIVE_OPERANDS(INST) \
+    if (isa<INST##Inst>(inst) && hasActiveOperands) \
+      return true;
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(RefCounting)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(EndAccess)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(EndBorrow)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(Deallocation)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(CopyValue)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(DestroyValue)
+    CHECK_INST_TYPE_ACTIVE_OPERANDS(DestroyAddr)
+    break;
 #undef CHECK_INST_TYPE_ACTIVE_OPERANDS
-#undef CHECK_INST_TYPE_ACTIVE_DEST
   }
   case AutoDiffLinearMapKind::Pullback: {
     if (inst->mayHaveSideEffects() && hasActiveOperands)

--- a/test/AutoDiff/forward_mode_runtime.swift
+++ b/test/AutoDiff/forward_mode_runtime.swift
@@ -1284,4 +1284,13 @@ ForwardModeTests.test("SubsetIndices") {
   expectEqual(4, derivWRTNonDiff { x, y in x + Float(y) })
 }
 
+ForwardModeTests.test("ForceUnwrapping") {
+  func forceUnwrap<T: Differentiable & FloatingPoint>(_ t: T) -> Float where T == T.TangentVector {
+    derivative(at: t, Float(3)) { (x, y) in
+      (x as! Float) * y
+    }
+  }
+  expectEqual(5, forceUnwrap(Float(2)))
+}
+
 runAllTests()

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -315,12 +315,13 @@ SimpleMathTests.test("SubsetIndices") {
 }
 
 SimpleMathTests.test("ForceUnwrapping") {
-  func bla<T: Differentiable & FloatingPoint>(_ t: T) -> (T, Float) where T == T.TangentVector {
+  func forceUnwrap<T: Differentiable & FloatingPoint>(_ t: T)
+    -> (T, Float) where T == T.TangentVector {
     gradient(at: t, Float(1)) { (x, y) in
       (x as! Float) * y
     }
   }
-  expectEqual((1, 2), bla(Float(2)))
+  expectEqual((1, 2), forceUnwrap(Float(2)))
 }
 
 runAllTests()


### PR DESCRIPTION
Add forward-mode support for `unconditional_checked_cast_addr` instruction.

```
Original: unconditional_checked_cast_addr $X in x to $Y in y
 Tangent: unconditional_checked_cast_addr $X.Tan in tan[x] to $Y.Tan in tan[y]
```

Port reverse-mode test from `simple_math.swift` to `forward_mode_runtime.swift`.