### PR TITLE
[ClangImporter] Use external_source_symbol to identify Swift decls

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -513,19 +513,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     if (!triple.isOSDarwin())
       invocationArgStrs.insert(invocationArgStrs.end(),
                                {"-fobjc-runtime=ios-7.0"});
-
-    // Define macros that Swift bridging headers use.
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-          "-DSWIFT_CLASS_EXTRA=__attribute__((__annotate__("
-          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-          "-DSWIFT_PROTOCOL_EXTRA=__attribute__((__annotate__("
-          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-          "-DSWIFT_EXTENSION_EXTRA=__attribute__((__annotate__("
-          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-          "-DSWIFT_ENUM_EXTRA=__attribute__((__annotate__("
-          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-      });
-
   } else {
     bool EnableCXXInterop = LangOpts.EnableCXXInterop;
     invocationArgStrs.insert(invocationArgStrs.end(),
@@ -569,6 +556,10 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
       // Request new APIs from UIKit.
       "-DSWIFT_SDK_OVERLAY_UIKIT_EPOCH=2",
+
+      // Backwards compatibility for headers that were checking this instead of
+      // '__swift__'.
+      "-DSWIFT_CLASS_EXTRA=",
     });
 
     // Get the version of this compiler and pass it to C/Objective-C

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -220,8 +220,6 @@ enum class SpecialMethodKind {
   NSDictionarySubscriptGetter
 };
 
-#define SWIFT_NATIVE_ANNOTATION_STRING "__swift native"
-
 #define SWIFT_PROTOCOL_SUFFIX "Protocol"
 #define SWIFT_CFTYPE_SUFFIX "Ref"
 

--- a/test/ClangImporter/Inputs/enum-objc.h
+++ b/test/ClangImporter/Inputs/enum-objc.h
@@ -1,8 +1,17 @@
 @import Foundation;
 
+#ifndef SWIFT_ENUM_EXTRA
+# define SWIFT_ENUM_EXTRA
+#endif
+
 #define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
 #define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); enum SWIFT_COMPILE_NAME(SWIFT_NAME) __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name : _type
 #define SWIFT_EXHAUSTIVE_ENUM(_type, _name) enum _name : _type _name; enum __attribute__((enum_extensibility(closed))) SWIFT_ENUM_EXTRA _name : _type
+
+#pragma clang attribute push( \
+  __attribute__((external_source_symbol(language="Swift", \
+                 defined_in="Mixed",generated_declaration))), \
+  apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
 
 typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
     ObjCEnumOne = 1,
@@ -19,6 +28,8 @@ typedef SWIFT_EXHAUSTIVE_ENUM(NSInteger, ExhaustiveEnum) {
 enum BareForwardEnum;
 enum ForwardEnumWithUnderlyingType : int;
 typedef SWIFT_ENUM_NAMED(NSInteger, ForwardObjCEnum, "ForwardSwiftEnum");
+
+#pragma clang attribute pop
 
 void forwardBarePointer(enum BareForwardEnum * _Nonnull);
 void forwardWithUnderlyingValue(enum ForwardEnumWithUnderlyingType);

--- a/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangImporter/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -7,6 +7,8 @@ struct PureClangType {
 
 #ifndef SWIFT_CLASS_EXTRA
 #  define SWIFT_CLASS_EXTRA
+#endif
+#ifndef SWIFT_PROTOCOL_EXTRA
 #  define SWIFT_PROTOCOL_EXTRA
 #endif
 
@@ -32,6 +34,11 @@ struct PureClangType {
     __attribute__((swift_name(SWIFT_NAME))) SWIFT_PROTOCOL_EXTRA
 #endif
 
+#pragma clang attribute push( \
+  __attribute__((external_source_symbol(language="Swift", \
+                 defined_in="Mixed",generated_declaration))), \
+  apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
+
 SWIFT_CLASS("SwiftClass")
 __attribute__((objc_root_class))
 @interface SwiftClass
@@ -41,10 +48,6 @@ __attribute__((objc_root_class))
 
 @interface SwiftClass (SWIFT_EXTENSION(foo))
 - (void)extensionMethod;
-@end
-
-@interface SwiftClass (Category)
-- (void)categoryMethod:(struct PureClangType)arg;
 @end
 
 SWIFT_PROTOCOL_NAMED("CustomName")
@@ -67,4 +70,10 @@ convertToProto(SwiftClassWithCustomName *_Nonnull obj);
 
 SWIFT_CLASS("BOGUS")
 @interface BogusClass
+@end
+
+# pragma clang attribute pop
+
+@interface SwiftClass (Category)
+- (void)categoryMethod:(struct PureClangType)arg;
 @end

--- a/test/IDE/Inputs/print_clang_header_swift_name.h
+++ b/test/IDE/Inputs/print_clang_header_swift_name.h
@@ -1,8 +1,17 @@
 @import Foundation;
 
+#ifndef SWIFT_ENUM_EXTRA
+# define SWIFT_ENUM_EXTRA
+#endif
+
 #define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
 
 #define SWIFT_ENUM(_type, _name) enum _name : _type _name; enum __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name : _type
+
+#pragma clang attribute push( \
+  __attribute__((external_source_symbol(language="Swift", \
+                 defined_in="Mixed",generated_declaration))), \
+  apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
 
 typedef SWIFT_ENUM(NSInteger, Normal) {
     NormalOne = 0,
@@ -24,3 +33,5 @@ typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnumTwo, "SwiftEnumTwo") {
     SwiftEnumTwoB,
     SwiftEnumTwoC
 };
+
+#pragma clang attribute pop

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -7,7 +7,10 @@
 #ifndef SWIFT_ENUM
 #  define SWIFT_ENUM(_name)    \
   enum _name _name;            \
-  enum __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name
+  enum __attribute__((enum_extensibility(open))) \
+       __attribute__((external_source_symbol(language="Swift", \
+                      defined_in="swift_name", generated_declaration))) \
+       SWIFT_ENUM_EXTRA _name
 #endif
 
 // Renaming global variables.

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -2,16 +2,6 @@
 
 #define SWIFT_NAME(X) __attribute__((swift_name(#X)))
 
-#ifndef SWIFT_ENUM_EXTRA
-#  define SWIFT_ENUM_EXTRA
-#endif
-
-#ifndef SWIFT_ENUM
-#  define SWIFT_ENUM(_type, _name)    \
-  enum _name : _type _name;           \
-  enum SWIFT_ENUM_EXTRA _name : _type
-#endif
-
 // Renaming classes
 SWIFT_NAME(SomeClass)
 @interface SNSomeClass : NSObject

--- a/test/SourceKit/Inputs/libIDE-mock-sdk/Mixed.framework/Headers/Mixed.h
+++ b/test/SourceKit/Inputs/libIDE-mock-sdk/Mixed.framework/Headers/Mixed.h
@@ -6,6 +6,9 @@ struct PureClangType {
 #ifndef SWIFT_CLASS_EXTRA
 #  define SWIFT_CLASS_EXTRA
 #endif
+#ifndef SWIFT_PROTOCOL_EXTRA
+#  define SWIFT_PROTOCOL_EXTRA
+#endif
 
 #ifndef SWIFT_CLASS
 #  define SWIFT_CLASS(SWIFT_NAME) SWIFT_CLASS_EXTRA
@@ -21,13 +24,14 @@ struct PureClangType {
     __attribute__((swift_name(SWIFT_NAME))) SWIFT_PROTOCOL_EXTRA
 #endif
 
+#pragma clang attribute push( \
+  __attribute__((external_source_symbol(language="Swift", \
+                 defined_in="Mixed",generated_declaration))), \
+  apply_to=any(function,enum,objc_interface,objc_category,objc_protocol))
+
 SWIFT_CLASS("SwiftClass")
 __attribute__((objc_root_class))
 @interface SwiftClass
-@end
-
-@interface SwiftClass (Category)
-- (void)categoryMethod:(struct PureClangType)arg;
 @end
 
 SWIFT_PROTOCOL_NAMED("CustomNameType")
@@ -44,4 +48,10 @@ convertToProto(SwiftClassWithCustomName *_Nonnull obj);
 
 SWIFT_CLASS("BOGUS")
 @interface BogusClass
+@end
+
+# pragma clang attribute pop
+
+@interface SwiftClass (Category)
+- (void)categoryMethod:(struct PureClangType)arg;
 @end


### PR DESCRIPTION
...rather than replacing particular macros with an `annotate` attribute and then looking for that. This isn't *really* any particular win except maybe ever-so-slightly faster module imports (with one fewer attribute being added to each declaration in a mixed-source header).

This doesn't remove the `SWIFT_CLASS_EXTRA`, `SWIFT_PROTOCOL_EXTRA`, or `SWIFT_ENUM_EXTRA` macros from PrintAsObjC (note that `SWIFT_EXTENSION_EXTRA` was never used). They're not exactly needed anymore, but they're not doing any harm if someone else is using them.