### PR TITLE
[AutoDiff] Do not reuse activity analysis between forward-/reverse-mode.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -709,10 +709,30 @@ public:
 
 namespace llvm {
 
+using swift::AutoDiffAssociatedFunctionKind;
 using swift::SILAutoDiffIndices;
 using swift::OptionSet;
 
 template<typename T> struct DenseMapInfo;
+
+template<> struct DenseMapInfo<AutoDiffAssociatedFunctionKind> {
+  static AutoDiffAssociatedFunctionKind getEmptyKey() {
+    return AutoDiffAssociatedFunctionKind::innerty(DenseMapInfo<char>::getEmptyKey());
+  }
+
+  static AutoDiffAssociatedFunctionKind getTombstoneKey() {
+    return AutoDiffAssociatedFunctionKind::innerty(DenseMapInfo<char>::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const AutoDiffAssociatedFunctionKind &Val) {
+    return DenseMapInfo<char>::getHashValue(Val.rawValue);
+  }
+
+  static bool isEqual(const AutoDiffAssociatedFunctionKind &LHS,
+                      const AutoDiffAssociatedFunctionKind &RHS) {
+    return LHS == RHS;
+  }
+};
 
 template<> struct DenseMapInfo<SILAutoDiffIndices> {
   static SILAutoDiffIndices getEmptyKey() {

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1822,18 +1822,21 @@ void LinearMapInfo::generateDifferentiationDataStructures(
 
 class DifferentiableActivityCollection {
 public:
-  SmallDenseMap<GenericSignature *, DifferentiableActivityInfo> activityInfoMap;
+  SmallDenseMap<std::pair<GenericSignature *, AutoDiffAssociatedFunctionKind>,
+                DifferentiableActivityInfo>
+      activityInfoMap;
   SILFunction &function;
   DominanceInfo *domInfo;
   PostDominanceInfo *postDomInfo;
 
   DifferentiableActivityInfo &getActivityInfo(
       GenericSignature *assocGenSig, AutoDiffAssociatedFunctionKind kind) {
-    auto activityInfoLookup = activityInfoMap.find(assocGenSig);
+    auto activityInfoLookup = activityInfoMap.find({assocGenSig, kind});
     if (activityInfoLookup != activityInfoMap.end())
       return activityInfoLookup->getSecond();
+    DifferentiableActivityInfo activityInfo(*this, assocGenSig, kind);
     auto insertion = activityInfoMap.insert(
-        {assocGenSig, DifferentiableActivityInfo(*this, assocGenSig, kind)});
+        {{assocGenSig, kind}, activityInfo});
     return insertion.first->getSecond();
   }
 

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -1,4 +1,6 @@
 // RUN: %target-run-simple-swift
+// NOTE(TF-813): verify that enabling forward-mode does not affect reverse-mode.
+// RUN: %target_run_simple_swift_forward_mode_differentiation
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
As documented in [TF-800](https://bugs.swift.org/browse/TF-800), forward- and reverse-mode AD currently require
different activity analysis logic. Thus, activity analysis results for the
same function should not be shared between the two modes.

This fixes some reverse-mode correctness problems from merely enabling
forward-mode.

Resolves [TF-813](https://bugs.swift.org/browse/TF-813).