### PR TITLE
Circular validation cleanups, part 1

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3248,13 +3248,10 @@ Type TypeDecl::getDeclaredInterfaceType() const {
   }
 
   Type interfaceType = getInterfaceType();
-  if (interfaceType.isNull() || interfaceType->is<ErrorType>())
-    return interfaceType;
+  if (!interfaceType)
+    return ErrorType::get(getASTContext());
 
-  if (isa<ModuleDecl>(this))
-    return interfaceType;
-
-  return interfaceType->castTo<MetatypeType>()->getInstanceType();
+  return interfaceType->getMetatypeInstanceType();
 }
 
 int TypeDecl::compare(const TypeDecl *type1, const TypeDecl *type2) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3551,9 +3551,10 @@ void TypeAliasDecl::computeType() {
 }
 
 Type TypeAliasDecl::getUnderlyingType() const {
-  return evaluateOrDefault(getASTContext().evaluator,
+  auto &ctx = getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
            UnderlyingTypeRequest{const_cast<TypeAliasDecl *>(this)},
-           Type());
+           ErrorType::get(ctx));
 }
       
 void TypeAliasDecl::setUnderlyingType(Type underlying) {
@@ -3583,10 +3584,11 @@ UnboundGenericType *TypeAliasDecl::getUnboundGenericType() const {
 }
 
 Type TypeAliasDecl::getStructuralType() const {
-  auto &context = getASTContext();
+  auto &ctx = getASTContext();
   return evaluateOrDefault(
-      context.evaluator,
-      StructuralTypeRequest{const_cast<TypeAliasDecl *>(this)}, Type());
+      ctx.evaluator,
+      StructuralTypeRequest{const_cast<TypeAliasDecl *>(this)},
+      ErrorType::get(ctx));
 }
 
 Type AbstractTypeParamDecl::getSuperclass() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3784,16 +3784,17 @@ PotentialArchetype *GenericSignatureBuilder::realizePotentialArchetype(
   return pa;
 }
 
-static Type getStructuralType(TypeDecl *typeDecl) {
+static Type getStructuralType(TypeDecl *typeDecl, bool keepSugar) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-    // When we're computing requirement signatures, the structural type
-    // suffices.  Otherwise we'll potentially try to validate incomplete
-    // requirements.
-    auto *proto = dyn_cast_or_null<ProtocolDecl>(
-        typealias->getDeclContext()->getAsDecl());
-    if (proto && proto->isComputingRequirementSignature())
-      return typealias->getStructuralType();
-    return typealias->getUnderlyingType();
+    if (typealias->getUnderlyingTypeRepr() != nullptr) {
+      auto type = typealias->getStructuralType();
+      if (!keepSugar)
+        if (auto *aliasTy = cast<TypeAliasType>(type.getPointer()))
+          return aliasTy->getSinglyDesugaredType();
+      return type;
+    }
+    if (!keepSugar)
+      return typealias->getUnderlyingType();
   }
 
   return typeDecl->getDeclaredInterfaceType();
@@ -3804,43 +3805,35 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
                                    TypeDecl *concreteDecl) {
   assert(concreteDecl);
 
-  auto *proto = concreteDecl->getDeclContext()->getSelfProtocolDecl();
+  auto *dc = concreteDecl->getDeclContext();
+  auto *proto = dc->getSelfProtocolDecl();
 
   // Form an unsubstituted type referring to the given type declaration,
   // for use in an inferred same-type requirement.
-  auto type = getStructuralType(concreteDecl);
+  auto type = getStructuralType(concreteDecl, /*keepSugar=*/true);
   if (!type)
     return Type();
 
-  Type parentType;
   SubstitutionMap subMap;
   if (proto) {
     // Substitute in the type of the current PotentialArchetype in
     // place of 'Self' here.
-    parentType = basePA->getDependentType(builder.getGenericParams());
+    auto parentType = basePA->getDependentType(builder.getGenericParams());
 
     subMap = SubstitutionMap::getProtocolSubstitutions(
         proto, parentType, ProtocolConformanceRef(proto));
-
-    type = type.subst(subMap);
   } else {
     // Substitute in the superclass type.
     auto parentPA = basePA->getEquivalenceClassIfPresent();
-    parentType =
+    auto parentType =
         parentPA->concreteType ? parentPA->concreteType : parentPA->superclass;
     auto parentDecl = parentType->getAnyNominal();
 
-    subMap = parentType->getMemberSubstitutionMap(parentDecl->getParentModule(),
-                                                  concreteDecl);
-    type = type.subst(subMap);
+    subMap = parentType->getContextSubstitutionMap(
+        parentDecl->getParentModule(), dc);
   }
 
-  // If we had a typealias, form a sugared type.
-  if (auto *typealias = dyn_cast<TypeAliasDecl>(concreteDecl)) {
-    type = TypeAliasType::get(typealias, parentType, subMap, type);
-  }
-
-  return type;
+  return type.subst(subMap);
 };
 
 ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
@@ -4215,10 +4208,10 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
   // An inferred same-type requirement between the two type declarations
   // within this protocol or a protocol it inherits.
   auto addInferredSameTypeReq = [&](TypeDecl *first, TypeDecl *second) {
-    Type firstType = getStructuralType(first);
+    Type firstType = getStructuralType(first, /*keepSugar=*/false);
     if (!firstType) return;
 
-    Type secondType = getStructuralType(second);
+    Type secondType = getStructuralType(second, /*keepSugar=*/false);
     if (!secondType) return;
 
     auto inferredSameTypeSource =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3811,8 +3811,6 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
   // Form an unsubstituted type referring to the given type declaration,
   // for use in an inferred same-type requirement.
   auto type = getStructuralType(concreteDecl, /*keepSugar=*/true);
-  if (!type)
-    return Type();
 
   SubstitutionMap subMap;
   if (proto) {
@@ -4209,10 +4207,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
   // within this protocol or a protocol it inherits.
   auto addInferredSameTypeReq = [&](TypeDecl *first, TypeDecl *second) {
     Type firstType = getStructuralType(first, /*keepSugar=*/false);
-    if (!firstType) return;
-
     Type secondType = getStructuralType(second, /*keepSugar=*/false);
-    if (!secondType) return;
 
     auto inferredSameTypeSource =
       FloatingRequirementSource::viaProtocolRequirement(

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3961,7 +3961,7 @@ void swift::performSyntacticExprDiagnostics(TypeChecker &TC, const Expr *E,
   if (!TC.Context.isSwiftVersionAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(TC, E, DC);
   if (!TC.getLangOpts().DisableAvailabilityChecking)
-    diagAvailability(TC, E, const_cast<DeclContext*>(DC));
+    diagAvailability(E, const_cast<DeclContext*>(DC));
   if (TC.Context.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(TC, DC, E);
 }

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -143,6 +143,8 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
                               TreatUsableFromInlineAsPublic).isPublic())
     return false;
 
+  auto &Context = DC->getASTContext();
+
   // Dynamic declarations were mistakenly not checked in Swift 4.2.
   // Do enforce the restriction even in pre-Swift-5 modes if the module we're
   // building is resilient, though.
@@ -194,18 +196,19 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   if (downgradeToWarning == DowngradeToWarning::Yes)
     diagID = diag::resilience_decl_unavailable_warn;
 
-  diagnose(loc, diagID,
+  Context.Diags.diagnose(
+           loc, diagID,
            D->getDescriptiveKind(), diagName,
            D->getFormalAccessScope().accessLevelForDiagnostics(),
            static_cast<unsigned>(Kind),
            isAccessor);
 
   if (TreatUsableFromInlineAsPublic) {
-    diagnose(D, diag::resilience_decl_declared_here,
-             D->getDescriptiveKind(), diagName, isAccessor);
+    Context.Diags.diagnose(D, diag::resilience_decl_declared_here,
+                           D->getDescriptiveKind(), diagName, isAccessor);
   } else {
-    diagnose(D, diag::resilience_decl_declared_here_public,
-             D->getDescriptiveKind(), diagName, isAccessor);
+    Context.Diags.diagnose(D, diag::resilience_decl_declared_here_public,
+                           D->getDescriptiveKind(), diagName, isAccessor);
   }
 
   return (downgradeToWarning == DowngradeToWarning::No);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -72,7 +72,7 @@ class TypeRefinementContextBuilder : private ASTWalker {
   };
 
   std::vector<ContextInfo> ContextStack;
-  TypeChecker &TC;
+  ASTContext &Context;
 
   /// A mapping from abstract storage declarations with accessors to
   /// to the type refinement contexts for those declarations. We refer to
@@ -93,8 +93,8 @@ class TypeRefinementContextBuilder : private ASTWalker {
   }
 
 public:
-  TypeRefinementContextBuilder(TypeRefinementContext *TRC, TypeChecker &TC)
-      : TC(TC) {
+  TypeRefinementContextBuilder(TypeRefinementContext *TRC, ASTContext &Context)
+      : Context(Context) {
     assert(TRC);
     pushContext(TRC, ParentTy());
   }
@@ -171,11 +171,11 @@ private:
     // the declared availability of the declaration and the potential versions
     // of its lexical context.
     AvailabilityContext DeclInfo =
-        swift::AvailabilityInference::availableRange(D, TC.Context);
+        swift::AvailabilityInference::availableRange(D, Context);
     DeclInfo.intersectWith(getCurrentTRC()->getAvailabilityInfo());
 
     TypeRefinementContext *NewTRC =
-        TypeRefinementContext::createForDecl(TC.Context, D, getCurrentTRC(),
+        TypeRefinementContext::createForDecl(Context, D, getCurrentTRC(),
                                              DeclInfo,
                                              refinementSourceRangeForDecl(D));
     
@@ -199,7 +199,7 @@ private:
     
     // No need to introduce a context if the declaration does not have an
     // availability attribute.
-    if (!hasActiveAvailableAttribute(D, TC.Context)) {
+    if (!hasActiveAvailableAttribute(D, Context)) {
       return false;
     }
     
@@ -295,10 +295,10 @@ private:
       // Create a new context for the Then branch and traverse it in that new
       // context.
       auto *ThenTRC =
-          TypeRefinementContext::createForIfStmtThen(TC.Context, IS,
+          TypeRefinementContext::createForIfStmtThen(Context, IS,
                                                      getCurrentTRC(),
                                                      ThenRange.getValue());
-      TypeRefinementContextBuilder(ThenTRC, TC).build(IS->getThenStmt());
+      TypeRefinementContextBuilder(ThenTRC, Context).build(IS->getThenStmt());
     } else {
       build(IS->getThenStmt());
     }
@@ -318,10 +318,10 @@ private:
       // Create a new context for the Then branch and traverse it in that new
       // context.
       auto *ElseTRC =
-          TypeRefinementContext::createForIfStmtElse(TC.Context, IS,
+          TypeRefinementContext::createForIfStmtElse(Context, IS,
                                                      getCurrentTRC(),
                                                      ElseRange.getValue());
-      TypeRefinementContextBuilder(ElseTRC, TC).build(ElseStmt);
+      TypeRefinementContextBuilder(ElseTRC, Context).build(ElseStmt);
     } else {
       build(IS->getElseStmt());
     }
@@ -339,8 +339,8 @@ private:
       // Create a new context for the body and traverse it in the new
       // context.
       auto *BodyTRC = TypeRefinementContext::createForWhileStmtBody(
-          TC.Context, WS, getCurrentTRC(), BodyRange.getValue());
-      TypeRefinementContextBuilder(BodyTRC, TC).build(WS->getBody());
+          Context, WS, getCurrentTRC(), BodyRange.getValue());
+      TypeRefinementContextBuilder(BodyTRC, Context).build(WS->getBody());
     } else {
       build(WS->getBody());
     }
@@ -370,9 +370,9 @@ private:
     if (Stmt *ElseBody = GS->getBody()) {
       if (ElseRange.hasValue()) {
         auto *TrueTRC = TypeRefinementContext::createForGuardStmtElse(
-            TC.Context, GS, getCurrentTRC(), ElseRange.getValue());
+            Context, GS, getCurrentTRC(), ElseRange.getValue());
 
-        TypeRefinementContextBuilder(TrueTRC, TC).build(ElseBody);
+        TypeRefinementContextBuilder(TrueTRC, Context).build(ElseBody);
       } else {
         build(ElseBody);
       }
@@ -386,7 +386,7 @@ private:
     // Create a new context for the fallthrough.
 
     auto *FallthroughTRC =
-          TypeRefinementContext::createForGuardStmtFallthrough(TC.Context, GS,
+          TypeRefinementContext::createForGuardStmtFallthrough(Context, GS,
               ParentBrace, getCurrentTRC(), FallthroughRange.getValue());
 
     pushContext(FallthroughTRC, ParentBrace);
@@ -445,9 +445,10 @@ private:
         // We couldn't find an appropriate spec for the current platform,
         // so rather than refining, emit a diagnostic and just use the current
         // TRC.
-        TC.Diags.diagnose(Query->getLoc(),
-                          diag::availability_query_required_for_platform,
-                          platformString(targetPlatform(TC.getLangOpts())));
+        Context.Diags.diagnose(
+            Query->getLoc(),
+            diag::availability_query_required_for_platform,
+            platformString(targetPlatform(Context.LangOpts)));
         
         continue;
       }
@@ -469,7 +470,7 @@ private:
       // the range for the spec, then a version query can never be false, so the
       // spec is useless. If so, report this.
       if (CurrentInfo.isContainedIn(NewConstraint)) {
-        DiagnosticEngine &Diags = TC.Diags;
+        DiagnosticEngine &Diags = Context.Diags;
         // Some availability checks will always pass because the minimum
         // deployment target guarantees they will never be false. We don't
         // diagnose these checks as useless because the source file may
@@ -481,7 +482,7 @@ private:
         if (CurrentTRC->getReason() != TypeRefinementContext::Reason::Root) {
           Diags.diagnose(Query->getLoc(),
                          diag::availability_query_useless_enclosing_scope,
-                         platformString(targetPlatform(TC.getLangOpts())));
+                         platformString(targetPlatform(Context.LangOpts)));
           Diags.diagnose(CurrentTRC->getIntroductionLoc(),
                          diag::availability_query_useless_enclosing_scope_here);
         }
@@ -499,7 +500,7 @@ private:
       FalseFlow.unionWith(CurrentInfo);
 
       auto *TRC = TypeRefinementContext::createForConditionFollowingQuery(
-          TC.Context, Query, LastElement, CurrentTRC, NewConstraint);
+          Context, Query, LastElement, CurrentTRC, NewConstraint);
 
       pushContext(TRC, ParentTy());
       NestedCount++;
@@ -550,7 +551,7 @@ private:
       // properly. For example, on the OSXApplicationExtension platform
       // we want to chose the OS X spec unless there is an explicit
       // OSXApplicationExtension spec.
-      if (isPlatformActive(VersionSpec->getPlatform(), TC.getLangOpts())) {
+      if (isPlatformActive(VersionSpec->getPlatform(), Context.LangOpts)) {
         return VersionSpec;
       }
     }
@@ -589,20 +590,20 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF,
   // already have a root type refinement context.
   assert(StartElem == 0 || RootTRC);
 
-  ASTContext &AC = SF.getASTContext();
+  ASTContext &Context = SF.getASTContext();
 
   if (!RootTRC) {
     // The root type refinement context reflects the fact that all parts of
     // the source file are guaranteed to be executing on at least the minimum
     // platform version.
-    auto MinPlatformReq = AvailabilityContext::forDeploymentTarget(AC);
+    auto MinPlatformReq = AvailabilityContext::forDeploymentTarget(Context);
     RootTRC = TypeRefinementContext::createRoot(&SF, MinPlatformReq);
     SF.setTypeRefinementContext(RootTRC);
   }
 
   // Build refinement contexts, if necessary, for all declarations starting
   // with StartElem.
-  TypeRefinementContextBuilder Builder(RootTRC, *this);
+  TypeRefinementContextBuilder Builder(RootTRC, Context);
   for (auto D : llvm::makeArrayRef(SF.Decls).slice(StartElem)) {
     Builder.build(D);
   }
@@ -624,6 +625,7 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
                                                    const DeclContext *DC,
                                                    const TypeRefinementContext **MostRefined) {
   SourceFile *SF = DC->getParentSourceFile();
+  auto &Context = DC->getASTContext();
 
   // If our source location is invalid (this may be synthesized code), climb
   // the decl context hierarchy until we find a location that is valid,
@@ -676,6 +678,7 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
 bool TypeChecker::isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
                                   const DeclContext *referenceDC,
                                   AvailabilityContext &OutAvailableInfo) {
+  ASTContext &Context = referenceDC->getASTContext();
 
   AvailabilityContext safeRangeUnderApprox{
       AvailabilityInference::availableRange(D, Context)};
@@ -698,6 +701,7 @@ bool TypeChecker::isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
 Optional<UnavailabilityReason>
 TypeChecker::checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
                                           const DeclContext *referenceDC) {
+  ASTContext &Context = referenceDC->getASTContext();
   if (Context.LangOpts.DisableAvailabilityChecking) {
     return None;
   }
@@ -1137,15 +1141,15 @@ static void findAvailabilityFixItNodes(SourceRange ReferenceRange,
 /// on the given declaration for the given version range.
 static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
                                    const VersionRange &RequiredRange,
-                                   TypeChecker &TC) {
+                                   ASTContext &Context) {
   assert(D);
 
   // Don't suggest adding an @available() to a declaration where we would
   // emit a diagnostic saying it is not allowed.
-  if (TC.diagnosticIfDeclCannotBePotentiallyUnavailable(D).hasValue())
+  if (TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D).hasValue())
     return;
 
-  if (getActiveAvailableAttribute(D, TC.Context)) {
+  if (getActiveAvailableAttribute(D, Context)) {
     // For QoI, in future should emit a fixit to update the existing attribute.
     return;
   }
@@ -1180,11 +1184,10 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
     return;
 
   StringRef OriginalIndent =
-      Lexer::getIndentationForLine(TC.Context.SourceMgr, InsertLoc);
-  PlatformKind Target = targetPlatform(TC.getLangOpts());
+      Lexer::getIndentationForLine(Context.SourceMgr, InsertLoc);
+  PlatformKind Target = targetPlatform(Context.LangOpts);
 
-  TC.diagnose(D, diag::availability_add_attribute,
-              KindForDiagnostic)
+  D->diagnose(diag::availability_add_attribute, KindForDiagnostic)
       .fixItInsert(InsertLoc, diag::insert_available_attr,
                    platformString(Target),
                    RequiredRange.getLowerEndpoint().getAsString(),
@@ -1200,12 +1203,12 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     SourceRange ReferenceRange,
     const DeclContext *ReferenceDC,
     const VersionRange &RequiredRange,
-    TypeChecker &TC,
+    ASTContext &Context,
     InFlightDiagnostic &Err) {
   const TypeRefinementContext *TRC = nullptr;
   AvailabilityContext RunningOSOverApprox =
-    TC.overApproximateAvailabilityAtLocation(ReferenceRange.Start,
-                                             ReferenceDC, &TRC);
+    TypeChecker::overApproximateAvailabilityAtLocation(ReferenceRange.Start,
+                                                       ReferenceDC, &TRC);
   VersionRange RunningRange = RunningOSOverApprox.getOSVersion();
   if (RunningRange.hasLowerEndpoint() &&
       RequiredRange.hasLowerEndpoint() &&
@@ -1217,7 +1220,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     // or disagreement on a subminor-or-less version for macOS.
     auto RunningVers = RunningRange.getLowerEndpoint();
     auto RequiredVers = RequiredRange.getLowerEndpoint();
-    auto Platform = targetPlatform(TC.Context.LangOpts);
+    auto Platform = targetPlatform(Context.LangOpts);
     if (RunningVers.getMajor() != RequiredVers.getMajor())
       return false;
     if ((Platform == PlatformKind::OSX ||
@@ -1243,7 +1246,7 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
 /// that checks for the given version range around the given node.
 static void fixAvailabilityByAddingVersionCheck(
     ASTNode NodeToWrap, const VersionRange &RequiredRange,
-    SourceRange ReferenceRange, TypeChecker &TC) {
+    SourceRange ReferenceRange, ASTContext &Context) {
   SourceRange RangeToWrap = NodeToWrap.getSourceRange();
   if (RangeToWrap.isInvalid())
     return;
@@ -1251,19 +1254,19 @@ static void fixAvailabilityByAddingVersionCheck(
   SourceLoc ReplaceLocStart = RangeToWrap.Start;
   StringRef ExtraIndent;
   StringRef OriginalIndent = Lexer::getIndentationForLine(
-      TC.Context.SourceMgr, ReplaceLocStart, &ExtraIndent);
+      Context.SourceMgr, ReplaceLocStart, &ExtraIndent);
 
   std::string IfText;
   {
     llvm::raw_string_ostream Out(IfText);
 
     SourceLoc ReplaceLocEnd =
-        Lexer::getLocForEndOfToken(TC.Context.SourceMgr, RangeToWrap.End);
+        Lexer::getLocForEndOfToken(Context.SourceMgr, RangeToWrap.End);
 
     std::string GuardedText =
-        TC.Context.SourceMgr.extractText(CharSourceRange(TC.Context.SourceMgr,
-                                                         ReplaceLocStart,
-                                                         ReplaceLocEnd)).str();
+        Context.SourceMgr.extractText(CharSourceRange(Context.SourceMgr,
+                                                      ReplaceLocStart,
+                                                      ReplaceLocEnd)).str();
 
     std::string NewLine = "\n";
     std::string NewLineReplacement = (NewLine + ExtraIndent).str();
@@ -1277,7 +1280,7 @@ static void fixAvailabilityByAddingVersionCheck(
       StartAt += NewLine.length();
     }
 
-    PlatformKind Target = targetPlatform(TC.getLangOpts());
+    PlatformKind Target = targetPlatform(Context.LangOpts);
 
     Out << "if #available(" << platformString(Target)
         << " " << RequiredRange.getLowerEndpoint().getAsString()
@@ -1292,7 +1295,8 @@ static void fixAvailabilityByAddingVersionCheck(
     Out << OriginalIndent << "}";
   }
 
-  TC.diagnose(ReferenceRange.Start, diag::availability_guard_with_version_check)
+  Context.Diags.diagnose(
+      ReferenceRange.Start, diag::availability_guard_with_version_check)
       .fixItReplace(RangeToWrap, IfText);
 }
 
@@ -1301,7 +1305,7 @@ static void fixAvailabilityByAddingVersionCheck(
 static void fixAvailability(SourceRange ReferenceRange,
                             const DeclContext *ReferenceDC,
                             const VersionRange &RequiredRange,
-                            TypeChecker &TC) {
+                            ASTContext &Context) {
   if (ReferenceRange.isInvalid())
     return;
 
@@ -1309,30 +1313,33 @@ static void fixAvailability(SourceRange ReferenceRange,
   const Decl *FoundMemberDecl = nullptr;
   const Decl *FoundTypeLevelDecl = nullptr;
 
-  findAvailabilityFixItNodes(ReferenceRange, ReferenceDC, TC.Context.SourceMgr,
+  findAvailabilityFixItNodes(ReferenceRange, ReferenceDC, Context.SourceMgr,
                              NodeToWrapInVersionCheck, FoundMemberDecl,
                              FoundTypeLevelDecl);
 
   // Suggest wrapping in if #available(...) { ... } if possible.
   if (NodeToWrapInVersionCheck.hasValue()) {
     fixAvailabilityByAddingVersionCheck(NodeToWrapInVersionCheck.getValue(),
-                                        RequiredRange, ReferenceRange, TC);
+                                        RequiredRange, ReferenceRange, Context);
   }
 
   // Suggest adding availability attributes.
   if (FoundMemberDecl) {
-    fixAvailabilityForDecl(ReferenceRange, FoundMemberDecl, RequiredRange, TC);
+    fixAvailabilityForDecl(ReferenceRange, FoundMemberDecl, RequiredRange,
+                           Context);
   }
 
   if (FoundTypeLevelDecl) {
     fixAvailabilityForDecl(ReferenceRange, FoundTypeLevelDecl, RequiredRange,
-                           TC);
+                           Context);
   }
 }
 
 void TypeChecker::diagnosePotentialOpaqueTypeUnavailability(
     SourceRange ReferenceRange, const DeclContext *ReferenceDC,
     const UnavailabilityReason &Reason) {
+  ASTContext &Context = ReferenceDC->getASTContext();
+
   // We only emit diagnostics for API unavailability, not for explicitly
   // weak-linked symbols.
   if (Reason.getReasonKind() !=
@@ -1343,22 +1350,24 @@ void TypeChecker::diagnosePotentialOpaqueTypeUnavailability(
   auto RequiredRange = Reason.getRequiredOSVersionRange();
   {
     auto Err =
-      diagnose(ReferenceRange.Start, diag::availability_opaque_types_only_version_newer,
+      Context.Diags.diagnose(
+               ReferenceRange.Start, diag::availability_opaque_types_only_version_newer,
                prettyPlatformString(targetPlatform(Context.LangOpts)),
                Reason.getRequiredOSVersionRange().getLowerEndpoint());
 
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(ReferenceRange,
                                                      ReferenceDC,
-                                                     RequiredRange, *this, Err))
+                                                     RequiredRange, Context, Err))
       return;
   }
-  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, *this);
+  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, Context);
 }
 
 void TypeChecker::diagnosePotentialUnavailability(
     const Decl *D, DeclName Name, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC, const UnavailabilityReason &Reason) {
+  ASTContext &Context = ReferenceDC->getASTContext();
 
   // We only emit diagnostics for API unavailability, not for explicitly
   // weak-linked symbols.
@@ -1370,24 +1379,27 @@ void TypeChecker::diagnosePotentialUnavailability(
   auto RequiredRange = Reason.getRequiredOSVersionRange();
   {
     auto Err =
-      diagnose(ReferenceRange.Start, diag::availability_decl_only_version_newer,
+      Context.Diags.diagnose(
+               ReferenceRange.Start, diag::availability_decl_only_version_newer,
                Name, prettyPlatformString(targetPlatform(Context.LangOpts)),
                Reason.getRequiredOSVersionRange().getLowerEndpoint());
 
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(ReferenceRange,
                                                      ReferenceDC,
-                                                     RequiredRange, *this, Err))
+                                                     RequiredRange, Context, Err))
       return;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, *this);
+  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, Context);
 }
 
 void TypeChecker::diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
     bool ForInout) {
+  ASTContext &Context = ReferenceDC->getASTContext();
+
   assert(Accessor->isGetterOrSetter());
 
   const AbstractStorageDecl *ASD = Accessor->getStorage();
@@ -1399,7 +1411,8 @@ void TypeChecker::diagnosePotentialAccessorUnavailability(
   auto RequiredRange = Reason.getRequiredOSVersionRange();
   {
     auto Err =
-      diagnose(ReferenceRange.Start, diag,
+      Context.Diags.diagnose(
+               ReferenceRange.Start, diag,
                static_cast<unsigned>(Accessor->getAccessorKind()), Name,
                prettyPlatformString(targetPlatform(Context.LangOpts)),
                Reason.getRequiredOSVersionRange().getLowerEndpoint());
@@ -1408,11 +1421,11 @@ void TypeChecker::diagnosePotentialAccessorUnavailability(
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(ReferenceRange,
                                                      ReferenceDC,
-                                                     RequiredRange, *this, Err))
+                                                     RequiredRange, Context, Err))
       return;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, *this);
+  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, Context);
 }
 
 const AvailableAttr *TypeChecker::getDeprecated(const Decl *D) {
@@ -1937,6 +1950,7 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
     return;
   }
 
+  auto &Context = ReferenceDC->getASTContext();
   if (!Context.LangOpts.DisableAvailabilityChecking) {
     AvailabilityContext RunningOSVersions =
         overApproximateAvailabilityAtLocation(ReferenceRange.Start,ReferenceDC);
@@ -1959,7 +1973,8 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
     DeprecatedVersion = Attr->Deprecated.getValue();
 
   if (Attr->Message.empty() && Attr->Rename.empty()) {
-    diagnose(ReferenceRange.Start, diag::availability_deprecated,
+    Context.Diags.diagnose(
+             ReferenceRange.Start, diag::availability_deprecated,
              RawAccessorKind, Name, Attr->hasPlatform(), Platform,
              Attr->Deprecated.hasValue(), DeprecatedVersion,
              /*message*/ StringRef())
@@ -1974,7 +1989,8 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
 
   if (!Attr->Message.empty()) {
     EncodedDiagnosticMessage EncodedMessage(Attr->Message);
-    diagnose(ReferenceRange.Start, diag::availability_deprecated,
+    Context.Diags.diagnose(
+             ReferenceRange.Start, diag::availability_deprecated,
              RawAccessorKind, Name, Attr->hasPlatform(), Platform,
              Attr->Deprecated.hasValue(), DeprecatedVersion,
              EncodedMessage.Message)
@@ -1982,7 +1998,8 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
   } else {
     unsigned rawReplaceKind = static_cast<unsigned>(
         replacementDeclKind.getValueOr(ReplacementDeclKind::None));
-    diagnose(ReferenceRange.Start, diag::availability_deprecated_rename,
+    Context.Diags.diagnose(
+             ReferenceRange.Start, diag::availability_deprecated_rename,
              RawAccessorKind, Name, Attr->hasPlatform(), Platform,
              Attr->Deprecated.hasValue(), DeprecatedVersion,
              replacementDeclKind.hasValue(), rawReplaceKind, newName)
@@ -1990,7 +2007,8 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
   }
 
   if (!Attr->Rename.empty() && !isa<AccessorDecl>(DeprecatedDecl)) {
-    auto renameDiag = diagnose(ReferenceRange.Start,
+    auto renameDiag = Context.Diags.diagnose(
+                               ReferenceRange.Start,
                                diag::note_deprecated_rename,
                                newName);
     fixItAvailableAttrRename(renameDiag, ReferenceRange, DeprecatedDecl,
@@ -2274,7 +2292,7 @@ class AvailabilityWalker : public ASTWalker {
     InOut
   };
 
-  TypeChecker &TC;
+  ASTContext &Context;
   DeclContext *DC;
   MemberAccessContext AccessContext = MemberAccessContext::Getter;
   SmallVector<const Expr *, 16> ExprStack;
@@ -2292,16 +2310,15 @@ class AvailabilityWalker : public ASTWalker {
            init->isImplicit() &&
            init->getParameters()->size() == 1 &&
            init->getParameters()->get(0)->getArgumentName() ==
-                   TC.Context.Id_rawValue;
+                   Context.Id_rawValue;
   }
 
 public:
-  AvailabilityWalker(
-      TypeChecker &TC, DeclContext *DC) : TC(TC), DC(DC) {
+  AvailabilityWalker(DeclContext *DC) : Context(DC->getASTContext()), DC(DC) {
     Expansion = DC->getResilienceExpansion();
     if (Expansion == ResilienceExpansion::Minimal)
       std::tie(FragileKind, TreatUsableFromInlineAsPublic)
-        = TC.getFragileFunctionKind(DC);
+        = TypeChecker::getFragileFunctionKind(DC);
   }
 
   // FIXME: Remove this
@@ -2502,7 +2519,7 @@ private:
   void maybeDiagStorageAccess(const ValueDecl *VD,
                               SourceRange ReferenceRange,
                               const DeclContext *ReferenceDC) const {
-    if (TC.getLangOpts().DisableAvailabilityChecking)
+    if (Context.LangOpts.DisableAvailabilityChecking)
       return;
 
     auto *D = dyn_cast<AbstractStorageDecl>(VD);
@@ -2581,8 +2598,8 @@ AvailabilityWalker::diagAvailability(ConcreteDeclRef declRef, SourceRange R,
 
   if (FragileKind)
     if (R.isValid())
-      if (TC.diagnoseInlinableDeclRef(R.Start, declRef, DC, *FragileKind,
-                                      TreatUsableFromInlineAsPublic))
+      if (TypeChecker::diagnoseInlinableDeclRef(R.Start, declRef, DC, *FragileKind,
+                                                TreatUsableFromInlineAsPublic))
         return true;
 
   if (diagnoseExplicitUnavailability(D, R, DC, call))
@@ -2595,7 +2612,7 @@ AvailabilityWalker::diagAvailability(ConcreteDeclRef declRef, SourceRange R,
 
   // Diagnose for deprecation
   if (!isAccessorWithDeprecatedStorage)
-    TC.diagnoseIfDeprecated(R, DC, D, call);
+    TypeChecker::diagnoseIfDeprecated(R, DC, D, call);
 
   if (Flags.contains(DeclAvailabilityFlag::AllowPotentiallyUnavailable))
     return false;
@@ -2605,15 +2622,15 @@ AvailabilityWalker::diagAvailability(ConcreteDeclRef declRef, SourceRange R,
     return false;
 
   // Diagnose (and possibly signal) for potential unavailability
-  auto maybeUnavail = TC.checkDeclarationAvailability(D, R.Start, DC);
+  auto maybeUnavail = TypeChecker::checkDeclarationAvailability(D, R.Start, DC);
   if (maybeUnavail.hasValue()) {
     if (accessor) {
       bool forInout = Flags.contains(DeclAvailabilityFlag::ForInout);
-      TC.diagnosePotentialAccessorUnavailability(accessor, R, DC,
-                                                 maybeUnavail.getValue(),
-                                                 forInout);
+      TypeChecker::diagnosePotentialAccessorUnavailability(accessor, R, DC,
+                                                           maybeUnavail.getValue(),
+                                                           forInout);
     } else {
-      TC.diagnosePotentialUnavailability(D, R, DC, maybeUnavail.getValue());
+      TypeChecker::diagnosePotentialUnavailability(D, R, DC, maybeUnavail.getValue());
     }
     if (!Flags.contains(DeclAvailabilityFlag::ContinueOnPotentialUnavailability))
       return true;
@@ -2625,13 +2642,11 @@ AvailabilityWalker::diagAvailability(ConcreteDeclRef declRef, SourceRange R,
 /// Return true if the specified type looks like an integer of floating point
 /// type.
 static bool isIntegerOrFloatingPointType(Type ty, DeclContext *DC,
-                                         TypeChecker &TC) {
+                                         ASTContext &Context) {
   auto integerType =
-    TC.getProtocol(SourceLoc(),
-                   KnownProtocolKind::ExpressibleByIntegerLiteral);
+    Context.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
   auto floatingType =
-    TC.getProtocol(SourceLoc(),
-                   KnownProtocolKind::ExpressibleByFloatLiteral);
+    Context.getProtocol(KnownProtocolKind::ExpressibleByFloatLiteral);
   if (!integerType || !floatingType) return false;
 
   return
@@ -2667,12 +2682,12 @@ AvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
   // If the expression type is integer or floating point, then we can rewrite it
   // to "lvalue += 1".
   std::string replacement;
-  if (isIntegerOrFloatingPointType(call->getType(), DC, TC))
+  if (isIntegerOrFloatingPointType(call->getType(), DC, Context))
     replacement = isInc ? " += 1" : " -= 1";
   else {
     // Otherwise, it must be an index type.  Rewrite to:
     // "lvalue = lvalue.successor()".
-    auto &SM = TC.Context.SourceMgr;
+    auto &SM = Context.SourceMgr;
     auto CSR = Lexer::getCharSourceRangeFromSourceRange(SM,
                                          call->getArg()->getSourceRange());
     replacement = " = " + SM.extractText(CSR).str();
@@ -2685,9 +2700,10 @@ AvailabilityWalker::diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
     std::tie(RawAccessorKind, Name) = getAccessorKindAndNameForDiagnostics(D);
 
     // If we emit a deprecation diagnostic, produce a fixit hint as well.
-    auto diag = TC.diagnose(R.Start, diag::availability_decl_unavailable,
-                            RawAccessorKind, Name, true, "",
-                            "it has been removed in Swift 3");
+    auto diag = Context.Diags.diagnose(
+        R.Start, diag::availability_decl_unavailable,
+        RawAccessorKind, Name, true, "",
+        "it has been removed in Swift 3");
     if (isa<PrefixUnaryExpr>(call)) {
       // Prefix: remove the ++ or --.
       diag.fixItRemove(call->getFn()->getSourceRange());
@@ -2737,8 +2753,9 @@ AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
 
   EncodedDiagnosticMessage EncodedMessage(Attr->Message);
   auto diag =
-      TC.diagnose(R.Start, diag::availability_decl_unavailable, RawAccessorKind,
-                  Name, true, "", EncodedMessage.Message);
+      Context.Diags.diagnose(
+          R.Start, diag::availability_decl_unavailable, RawAccessorKind,
+          Name, true, "", EncodedMessage.Message);
   diag.highlight(R);
 
   auto subject = args->getSubExpr();
@@ -2778,9 +2795,8 @@ AvailabilityWalker::diagnoseMemoryLayoutMigration(const ValueDecl *D,
 }
 
 /// Diagnose uses of unavailable declarations.
-void swift::diagAvailability(TypeChecker &TC, const Expr *E,
-                             DeclContext *DC) {
-  AvailabilityWalker walker(TC, DC);
+void swift::diagAvailability(const Expr *E, DeclContext *DC) {
+  AvailabilityWalker walker(DC);
   const_cast<Expr*>(E)->walk(walker);
 }
 
@@ -2788,12 +2804,11 @@ void swift::diagAvailability(TypeChecker &TC, const Expr *E,
 /// context, but for non-expr contexts such as TypeDecls referenced from
 /// TypeReprs.
 bool swift::diagnoseDeclAvailability(const ValueDecl *Decl,
-                                     TypeChecker &TC,
                                      DeclContext *DC,
                                      SourceRange R,
                                      DeclAvailabilityFlags Flags)
 {
-  AvailabilityWalker AW(TC, DC);
+  AvailabilityWalker AW(DC);
   return AW.diagAvailability(const_cast<ValueDecl *>(Decl), R, nullptr, Flags);
 }
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -27,13 +27,11 @@ namespace swift {
   class DeclContext;
   class Expr;
   class InFlightDiagnostic;
-  class TypeChecker;
   class Decl;
   class ValueDecl;
 
 /// Diagnose uses of unavailable declarations.
-void diagAvailability(TypeChecker &TC, const Expr *E,
-                      DeclContext *DC);
+void diagAvailability(const Expr *E, DeclContext *DC);
 
 enum class DeclAvailabilityFlag : uint8_t {
   /// Do not diagnose uses of protocols in versions before they were introduced.
@@ -59,7 +57,6 @@ using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
 /// context, but for non-expr contexts such as TypeDecls referenced from
 /// TypeReprs.
 bool diagnoseDeclAvailability(const ValueDecl *Decl,
-                              TypeChecker &TC,
                               DeclContext *DC,
                               SourceRange R,
                               DeclAvailabilityFlags Options);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -585,12 +585,6 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
         Requirement(RequirementKind::Conformance, self, PD->getDeclaredType());
     auto *sig = GenericSignature::get({self}, {req});
 
-    // The requirement signature is created lazily by
-    // ProtocolDecl::getRequirementSignature().
-    // The generic signature and environment is created lazily by
-    // GenericContext::getGenericSignature(), so there is nothing we
-    // need to do.
-
     // Debugging of the generic signature builder and generic signature
     // generation.
     if (GC->getASTContext().LangOpts.DebugGenericSignatures) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -534,9 +534,8 @@ Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
                     dyn_cast<TypeAliasDecl>(unboundGeneric->getAnyGeneric())) {
               if (ugAliasDecl == aliasDecl) {
                 if (resolution.getStage() == TypeResolutionStage::Structural &&
-                    !aliasDecl->hasInterfaceType()) {
-                  return resolution.mapTypeIntoContext(
-                      aliasDecl->getStructuralType());
+                    aliasDecl->getUnderlyingTypeRepr() != nullptr) {
+                  return aliasDecl->getStructuralType();
                 }
                 return resolution.mapTypeIntoContext(
                     aliasDecl->getDeclaredInterfaceType());
@@ -550,9 +549,8 @@ Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
                   dyn_cast<TypeAliasType>(extendedType.getPointer())) {
             if (aliasType->getDecl() == aliasDecl) {
               if (resolution.getStage() == TypeResolutionStage::Structural &&
-                  !aliasDecl->hasInterfaceType()) {
-                return resolution.mapTypeIntoContext(
-                    aliasDecl->getStructuralType());
+                  aliasDecl->getUnderlyingTypeRepr() != nullptr) {
+                return aliasDecl->getStructuralType();
               }
               return resolution.mapTypeIntoContext(
                   aliasDecl->getDeclaredInterfaceType());
@@ -577,8 +575,8 @@ Type TypeChecker::resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
 
       // Otherwise, return the appropriate type.
       if (resolution.getStage() == TypeResolutionStage::Structural &&
-          !aliasDecl->hasInterfaceType()) {
-        return resolution.mapTypeIntoContext(aliasDecl->getStructuralType());
+          aliasDecl->getUnderlyingTypeRepr() != nullptr) {
+        return aliasDecl->getStructuralType();
       }
       return resolution.mapTypeIntoContext(
           aliasDecl->getDeclaredInterfaceType());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1630,13 +1630,10 @@ static bool diagnoseAvailability(IdentTypeRepr *IdType,
     DeclAvailabilityFlag::ContinueOnPotentialUnavailability;
   if (AllowPotentiallyUnavailableProtocol)
     flags |= DeclAvailabilityFlag::AllowPotentiallyUnavailableProtocol;
-  ASTContext &ctx = DC->getASTContext();
   auto componentRange = IdType->getComponentRange();
   for (auto comp : componentRange) {
     if (auto *typeDecl = comp->getBoundDecl()) {
-      assert(ctx.getLazyResolver() && "Must have a type checker!");
-      TypeChecker &tc = static_cast<TypeChecker &>(*ctx.getLazyResolver());
-      if (diagnoseDeclAvailability(typeDecl, tc, DC, comp->getIdLoc(), flags)) {
+      if (diagnoseDeclAvailability(typeDecl, DC, comp->getIdLoc(), flags)) {
         return true;
       }
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1727,25 +1727,25 @@ public:
     PropertyInitializer
   };
 
-  bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
-                                const DeclContext *DC,
-                                FragileFunctionKind Kind,
-                                bool TreatUsableFromInlineAsPublic);
+  static bool diagnoseInlinableDeclRef(SourceLoc loc, ConcreteDeclRef declRef,
+                                       const DeclContext *DC,
+                                       FragileFunctionKind Kind,
+                                       bool TreatUsableFromInlineAsPublic);
 
   Expr *buildDefaultInitializer(Type type);
   
 private:
-  bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
-                                      const DeclContext *DC,
-                                      FragileFunctionKind Kind,
-                                      bool TreatUsableFromInlineAsPublic);
+  static bool diagnoseInlinableDeclRefAccess(SourceLoc loc, const ValueDecl *D,
+                                             const DeclContext *DC,
+                                             FragileFunctionKind Kind,
+                                             bool TreatUsableFromInlineAsPublic);
 
   /// Given that a declaration is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if it cannot
   /// reasonably be shared.
-  bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
-                                    const DeclContext *DC,
-                                    FragileFunctionKind fragileKind);
+  static bool diagnoseDeclRefExportability(SourceLoc loc, ConcreteDeclRef declRef,
+                                           const DeclContext *DC,
+                                           FragileFunctionKind fragileKind);
 
   /// Given that a type is used from a particular context which
   /// exposes it in the interface of the current module, diagnose if its
@@ -1787,7 +1787,7 @@ public:
   /// that could the passed-in location could be executing upon for
   /// the target platform. If MostRefined != nullptr, set to the most-refined
   /// TRC found while approximating.
-  AvailabilityContext
+  static AvailabilityContext
   overApproximateAvailabilityAtLocation(SourceLoc loc, const DeclContext *DC,
                                         const TypeRefinementContext **MostRefined=nullptr);
 
@@ -1795,18 +1795,18 @@ public:
   ///
   /// \param StartElem Where to start for incremental building of refinement
   /// contexts
-  void buildTypeRefinementContextHierarchy(SourceFile &SF,
-                                           unsigned StartElem);
+  static void buildTypeRefinementContextHierarchy(SourceFile &SF,
+                                                  unsigned StartElem);
 
   /// Build the hierarchy of TypeRefinementContexts for the entire
   /// source file, if it has not already been built. Returns the root
   /// TypeRefinementContext for the source file.
-  TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
+  static TypeRefinementContext *getOrBuildTypeRefinementContext(SourceFile *SF);
 
   /// Returns a diagnostic indicating why the declaration cannot be annotated
   /// with an @available() attribute indicating it is potentially unavailable
   /// or None if this is allowed.
-  Optional<Diag<>>
+  static Optional<Diag<>>
   diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 
   /// Checks whether a declaration is available when referred to at the given
@@ -1816,15 +1816,15 @@ public:
   /// If the declaration is not available, return false and write the
   /// declaration's availability info to the out parameter
   /// \p OutAvailableRange.
-  bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
-                       const DeclContext *referenceDC,
-                       AvailabilityContext &OutAvailableRange);
+  static bool isDeclAvailable(const Decl *D, SourceLoc referenceLoc,
+                              const DeclContext *referenceDC,
+                              AvailabilityContext &OutAvailableRange);
 
   /// Checks whether a declaration should be considered unavailable when
   /// referred to at the given location and, if so, returns the reason why the
   /// declaration is unavailable. Returns None is the declaration is
   /// definitely available.
-  Optional<UnavailabilityReason>
+  static Optional<UnavailabilityReason>
   checkDeclarationAvailability(const Decl *D, SourceLoc referenceLoc,
                                const DeclContext *referenceDC);
 
@@ -1836,26 +1836,26 @@ public:
 
   // Emits a diagnostic, if necessary, for a reference to a declaration
   // that is potentially unavailable at the given source location.
-  void diagnosePotentialUnavailability(const ValueDecl *D,
-                                       SourceRange ReferenceRange,
-                                       const DeclContext *ReferenceDC,
-                                       const UnavailabilityReason &Reason);
+  static void diagnosePotentialUnavailability(const ValueDecl *D,
+                                              SourceRange ReferenceRange,
+                                              const DeclContext *ReferenceDC,
+                                              const UnavailabilityReason &Reason);
 
   // Emits a diagnostic, if necessary, for a reference to a declaration
   // that is potentially unavailable at the given source location, using
   // Name as the diagnostic name.
-  void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
-                                       SourceRange ReferenceRange,
-                                       const DeclContext *ReferenceDC,
-                                       const UnavailabilityReason &Reason);
+  static void diagnosePotentialUnavailability(const Decl *D, DeclName Name,
+                                              SourceRange ReferenceRange,
+                                              const DeclContext *ReferenceDC,
+                                              const UnavailabilityReason &Reason);
 
-  void diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
+  static void diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
                                            const DeclContext *ReferenceDC,
                                            const UnavailabilityReason &Reason);
   
   /// Emits a diagnostic for a reference to a storage accessor that is
   /// potentially unavailable.
-  void diagnosePotentialAccessorUnavailability(
+  static void diagnosePotentialAccessorUnavailability(
       const AccessorDecl *Accessor, SourceRange ReferenceRange,
       const DeclContext *ReferenceDC, const UnavailabilityReason &Reason,
       bool ForInout);
@@ -1867,10 +1867,10 @@ public:
   /// Emits a diagnostic for a reference to a declaration that is deprecated.
   /// Callers can provide a lambda that adds additional information (such as a
   /// fixit hint) to the deprecation diagnostic, if it is emitted.
-  void diagnoseIfDeprecated(SourceRange SourceRange,
-                            const DeclContext *ReferenceDC,
-                            const ValueDecl *DeprecatedDecl,
-                            const ApplyExpr *Call);
+  static void diagnoseIfDeprecated(SourceRange SourceRange,
+                                   const DeclContext *ReferenceDC,
+                                   const ValueDecl *DeprecatedDecl,
+                                   const ApplyExpr *Call);
   /// @}
 
   /// If LangOptions::DebugForbidTypecheckPrefix is set and the given decl

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -383,7 +383,7 @@ struct X28 : P2 {
 }
 
 // CHECK-LABEL: .P28@
-// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == Self.P3Assoc>
+// CHECK-NEXT: Requirement signature: <Self where Self : P3, Self.P3Assoc == X28>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : P3, τ_0_0.P3Assoc == X28>
 protocol P28: P3 {
   typealias P3Assoc = X28   // expected-warning{{typealias overriding associated type}}


### PR DESCRIPTION
I'm chipping away at validateDecl() cycles, so that we can have validateDecl() diagnose instead of silently returning if the declaration is already being validated. This PR has some preliminary cleanups.