### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Swift Next
       mutableSelf.someProperty = newValue // Okay
     }
   }
-```
+  ```
 
 * [SE-0253][]:
 


### PR DESCRIPTION
Corrects a formatting error that causes Swift Next code to overrun to a non-code segment.

<!-- What's in this pull request? -->
The current changelog misses two spaces at the start of a code end segment, which causes the following text to be treated as code. This pull request inserts two spaces, correcting the formatting.