### PR TITLE
[lit] Silenced notes/warnings on quiet.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -247,7 +247,8 @@ def inferSwiftBinary(binaryName):
             lit_config.note('using %s: %s' % (binaryName, execPath))
     else:
         msg = "couldn't find '%s' program, try setting %s in your environment"
-        lit_config.warning(msg % (binaryName, envVarName))
+        if not lit_config.quiet:
+            lit_config.warning(msg % (binaryName, envVarName))
 
         # Just substitute the plain executable name, so the run line remains
         # reasonable.
@@ -314,7 +315,8 @@ else:
 stdlib_resource_dir_opt = resource_dir_opt
 sourcekitd_framework_dir = config.swift_lib_dir
 config.substitutions.append( ('%test-resource-dir', test_resource_dir) )
-lit_config.note('Using resource dir: ' + test_resource_dir)
+if not lit_config.quiet:
+    lit_config.note('Using resource dir: ' + test_resource_dir)
 
 # Parse the variant triple.
 (run_cpu, run_vendor, run_os, run_vers) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
@@ -334,7 +336,8 @@ if test_sdk_overlay_dir is not None:
     sdk_overlay_linker_opt = (
         "-L %s -Xlinker -rpath -Xlinker %s" %
         (sdk_overlay_link_path_dir, sdk_overlay_link_path_dir))
-    lit_config.note('Using SDK overlay dir: ' + test_sdk_overlay_dir)
+    if not lit_config.quiet:
+        lit_config.note('Using SDK overlay dir: ' + test_sdk_overlay_dir)
     resource_dir_opt += (" %s" % sdk_overlay_dir_opt)
 
 # Default to Swift 4 for now.
@@ -342,7 +345,8 @@ if test_sdk_overlay_dir is not None:
 # and `--param swift_version` (like a lit configuration parameter).
 swift_version = lit_config.params.get('swift-version',
     lit_config.params.get('swift_version', '4'))
-lit_config.note('Compiling with -swift-version ' + swift_version)
+if not lit_config.quiet:
+    lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
@@ -358,13 +362,15 @@ clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module
 shutil.rmtree(clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
-lit_config.note("Using Clang module cache: " + clang_module_cache_path)
-lit_config.note("Using test results dir: " + config.swift_test_results_dir)
+if not lit_config.quiet:
+    lit_config.note("Using Clang module cache: " + clang_module_cache_path)
+    lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
 completion_cache_path = make_path(config.swift_test_results_dir, "completion-cache")
 shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
-lit_config.note("Using code completion cache: " + completion_cache_path)
+if not lit_config.quiet:
+    lit_config.note("Using code completion cache: " + completion_cache_path)
 
 config.substitutions.append( ('%validate-incrparse', '%{python} %utils/incrparse/validate_parse.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
 config.substitutions.append( ('%incr-transfer-tree', '%{python} %utils/incrparse/incr_transfer_tree.py --temp-dir %t --swift-syntax-test %swift-syntax-test') )
@@ -766,13 +772,16 @@ if run_vendor == 'apple':
     if 'arm' in run_cpu:
        # iOS/tvOS/watchOS device
        if run_os == 'ios':
-           lit_config.note('Testing iOS ' + config.variant_triple)
+           if not lit_config.quiet:
+               lit_config.note('Testing iOS ' + config.variant_triple)
            xcrun_sdk_name = "iphoneos"
        elif run_os == 'tvos':
-           lit_config.note('Testing AppleTV ' + config.variant_triple)
+           if not lit_config.quiet:
+               lit_config.note('Testing AppleTV ' + config.variant_triple)
            xcrun_sdk_name = "appletvos"
        elif run_os == 'watchos':
-           lit_config.note('Testing watchOS ' + config.variant_triple)
+           if not lit_config.quiet:
+               lit_config.note('Testing watchOS ' + config.variant_triple)
            xcrun_sdk_name = "watchos"
 
        config.target_cc_options = (
@@ -797,15 +806,18 @@ if run_vendor == 'apple':
         # iOS/tvOS/watchOS simulator
         if run_os == 'ios':
             config.available_features.add('DARWIN_SIMULATOR=ios')
-            lit_config.note("Testing iOS simulator " + config.variant_triple)
+            if not lit_config.quiet:
+                lit_config.note("Testing iOS simulator " + config.variant_triple)
             xcrun_sdk_name = "iphonesimulator"
         elif run_os == 'watchos':
             config.available_features.add('DARWIN_SIMULATOR=watchos')
-            lit_config.note("Testing watchOS simulator " + config.variant_triple)
+            if not lit_config.quiet:
+                lit_config.note("Testing watchOS simulator " + config.variant_triple)
             xcrun_sdk_name = "watchsimulator"
         else:
             config.available_features.add('DARWIN_SIMULATOR=tvos')
-            lit_config.note("Testing AppleTV simulator " + config.variant_triple)
+            if not lit_config.quiet:
+                lit_config.note("Testing AppleTV simulator " + config.variant_triple)
             xcrun_sdk_name = "appletvsimulator"
 
         target_specific_module_triple += "-simulator"
@@ -841,7 +853,8 @@ if run_vendor == 'apple':
 
     elif run_os == 'macosx':
         # OS X
-        lit_config.note("Testing OS X " + config.variant_triple)
+        if not lit_config.quiet:
+            lit_config.note("Testing OS X " + config.variant_triple)
 
         xcrun_sdk_name = "macosx"
         config.target_cc_options = (
@@ -870,9 +883,10 @@ if run_vendor == 'apple':
         lit_config.fatal("Unknown Apple OS '" + run_os + "' " +
                          "(from " + config.variant_triple + ")")
 
-    lit_config.note(
-        'Running tests on %s version %s (%s)' %
-        (sw_vers_name, sw_vers_vers, sw_vers_build))
+    if not lit_config.quiet:
+        lit_config.note(
+            'Running tests on %s version %s (%s)' %
+            (sw_vers_name, sw_vers_vers, sw_vers_build))
 
     config.target_sdk_name = xcrun_sdk_name
     config.target_ld = "%s ld -L%r" % (xcrun_prefix, make_path(test_resource_dir, config.target_sdk_name))
@@ -914,7 +928,8 @@ if run_vendor == 'apple':
     config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
 
 elif run_os in ['windows-msvc']:
-    lit_config.note('Testing Windows ' + config.variant_triple)
+    if not lit_config.quiet:
+        lit_config.note('Testing Windows ' + config.variant_triple)
     config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
     if 'PROCESSOR_ARCHITEW6432' in os.environ:
         config.environment['PROCESSOR_ARCHITEW6432'] = os.environ['PROCESSOR_ARCHITEW6432']
@@ -984,31 +999,36 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'w
       # ie the NDK and adb aren't needed, so use this instead.
     # Linux/FreeBSD/Cygwin/Android
     if run_os == 'windows-cygnus':
-      lit_config.note("Testing Cygwin " + config.variant_triple)
+      if not lit_config.quiet:
+          lit_config.note("Testing Cygwin " + config.variant_triple)
       config.target_object_format = "coff"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "cygwin"
     elif run_os == 'windows-gnu':
-      lit_config.note("Testing MinGW " + config.variant_triple)
+      if not lit_config.quiet:
+          lit_config.note("Testing MinGW " + config.variant_triple)
       config.target_object_format = "coff"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".dll"
       config.target_sdk_name = "mingw"
     elif run_os == 'freebsd':
-      lit_config.note("Testing FreeBSD " + config.variant_triple)
+      if not lit_config.quiet:
+          lit_config.note("Testing FreeBSD " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "freebsd"
     elif kIsAndroid:
-      lit_config.note("Testing Android " + config.variant_triple)
+      if not lit_config.quiet:
+          lit_config.note("Testing Android " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "android"
     else:
-      lit_config.note("Testing Linux " + config.variant_triple)
+      if not lit_config.quiet:
+          lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"
       config.target_shared_library_prefix = 'lib'
       config.target_shared_library_suffix = ".so"
@@ -1104,7 +1124,8 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         "prebuilt", prebuilt_directory)
     tools_directory = pipes.quote(make_path(
         toolchain_directory, ndk_platform_triple, "bin"))
-    lit_config.note("Testing Android " + config.variant_triple)
+    if not lit_config.quiet:
+        lit_config.note("Testing Android " + config.variant_triple)
     config.target_object_format = "elf"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".so"
@@ -1247,9 +1268,10 @@ if 'remote_run_host' in lit_config.params:
         remote_run_extra_args += ['-i', remote_run_identity]
 
     if 'remote_run_skip_upload_stdlib' not in lit_config.params:
-        lit_config.note(
-            "Uploading resources to {0} on {1}".format(remote_lib_dir,
-                                                       remote_run_host))
+        if not lit_config.quiet:
+            lit_config.note(
+                "Uploading resources to {0} on {1}".format(remote_lib_dir,
+                                                           remote_run_host))
 
         def upload_files(files, input_prefix, remote_input_prefix):
             subprocess.check_call(
@@ -1429,7 +1451,8 @@ if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_impli
 platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
 if run_vendor != 'apple':
     platform_module_dir = make_path(platform_module_dir, run_cpu)
-lit_config.note('Using platform module dir: ' + platform_module_dir)
+if not lit_config.quiet:
+    lit_config.note('Using platform module dir: ' + platform_module_dir)
 if test_sdk_overlay_dir:
     platform_sdk_overlay_dir = test_sdk_overlay_dir
 else:
@@ -1441,7 +1464,8 @@ static_libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
 if os.path.exists(static_libswiftCore_path):
     config.available_features.add("static_stdlib")
     config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))
-    lit_config.note('using static stdlib path: %s' % static_stdlib_path)
+    if not lit_config.quiet:
+        lit_config.note('using static stdlib path: %s' % static_stdlib_path)
 
 # Set up testing with the standard libraries coming from the OS / just-built libraries
 # default Swift tests to use the just-built libraries
@@ -1449,7 +1473,8 @@ target_stdlib_path = platform_module_dir
 if not kIsWindows:
 	libdispatch_path = getattr(config, 'libdispatch_artifact_dir', '')
 	if 'use_os_stdlib' not in lit_config.params:
-		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
+		if not lit_config.quiet:
+			lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
 		config.target_run = (
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
@@ -1462,7 +1487,8 @@ if not kIsWindows:
 			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
 			os_stdlib_path = "/usr/lib/swift"
 		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
-		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
+		if not lit_config.quiet:
+			lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
 		config.target_run = (
 			"/usr/bin/env "
 			"DYLD_LIBRARY_PATH='{0}' " # Apple option
@@ -1662,7 +1688,9 @@ if platform.system() == 'Linux':
     (distributor, release) = linux_get_lsb_release()
     if distributor != '' and release != '':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
-        lit_config.note('Running tests on %s-%s' % (distributor, release))
+        if not lit_config.quiet:
+            lit_config.note('Running tests on %s-%s' % (distributor, release))
 
 
-lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))
+if not lit_config.quiet:
+  lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))


### PR DESCRIPTION
Lit can take a "quiet" option, -q, which is documented to "suppress no error output".  Previously, test/lit.cfg displayed notes and warnings when the quiet option was specified.  The result was that it was not possible to get only pertinent file/line information to be used by an editor to jump to the location where checks were failing without passing a number of unhelpful locations first.  Here, all notes and warnings displayed by test/lit.cfg are suppressed if the quiet option is set.