### PR TITLE
[Diagnostics] Port missing argument(s) diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1116,6 +1116,8 @@ ERROR(missing_argument_named,none,
       "missing argument for parameter %0 in call", (Identifier))
 ERROR(missing_argument_positional,none,
       "missing argument for parameter #%0 in call", (unsigned))
+ERROR(missing_arguments_in_call,none,
+      "missing arguments for parameters %0 in call", (StringRef))
 ERROR(extra_argument_named,none,
       "extra argument %0 in call", (Identifier))
 ERROR(extra_argument_positional,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3493,6 +3493,10 @@ ERROR(single_tuple_parameter_mismatch_normal,none,
       (DescriptiveDeclKind, DeclBaseName, Type, StringRef))
 ERROR(unknown_single_tuple_parameter_mismatch,none,
       "single parameter of type %0 is expected in call", (Type))
+ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,
+      "%0 %select{%1 |}2expects %3 separate arguments"
+      "%select{|; remove extra parentheses to change tuple into separate arguments}4",
+      (DescriptiveDeclKind, DeclName, bool, unsigned, bool))
 
 ERROR(enum_element_pattern_assoc_values_mismatch,none,
       "pattern with associated values does not match enum case %0",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2211,7 +2211,7 @@ public:
     Diagnosed = true;
   }
 
-  void missingArgument(unsigned missingParamIdx) override {
+  Optional<unsigned> missingArgument(unsigned missingParamIdx) override {
     auto &param = Parameters[missingParamIdx];
     Identifier name = param.getLabel();
 
@@ -2341,6 +2341,7 @@ public:
                   candidate.getDecl()->getFullName());
 
     Diagnosed = true;
+    return None;
   }
 
   bool isPropertyWrapperImplicitInit() {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2147,7 +2147,6 @@ bool FailureDiagnosis::diagnoseImplicitSelfErrors(
 
 class ArgumentMatcher : public MatchCallArgumentListener {
   TypeChecker &TC;
-  Expr *FnExpr;
   Expr *ArgExpr;
   ArrayRef<AnyFunctionType::Param> &Parameters;
   const ParameterListInfo &ParamInfo;
@@ -2164,12 +2163,12 @@ class ArgumentMatcher : public MatchCallArgumentListener {
   SmallVector<ParamBinding, 4> Bindings;
 
 public:
-  ArgumentMatcher(Expr *fnExpr, Expr *argExpr,
+  ArgumentMatcher(Expr *argExpr,
                   ArrayRef<AnyFunctionType::Param> &params,
                   const ParameterListInfo &paramInfo,
                   SmallVectorImpl<AnyFunctionType::Param> &args,
                   CalleeCandidateInfo &CCI, bool isSubscript)
-      : TC(CCI.CS.TC), FnExpr(fnExpr), ArgExpr(argExpr), Parameters(params),
+      : TC(CCI.CS.TC), ArgExpr(argExpr), Parameters(params),
         ParamInfo(paramInfo), Arguments(args), CandidateInfo(CCI),
         IsSubscript(isSubscript) {}
 
@@ -2209,160 +2208,6 @@ public:
           .highlight(arg->getSourceRange());
 
     Diagnosed = true;
-  }
-
-  Optional<unsigned> missingArgument(unsigned missingParamIdx) override {
-    auto &param = Parameters[missingParamIdx];
-    Identifier name = param.getLabel();
-
-    // Search insertion index.
-    unsigned argIdx = 0;
-    for (int Idx = missingParamIdx - 1; Idx >= 0; --Idx) {
-      if (Bindings[Idx].empty())
-        continue;
-      argIdx = Bindings[Idx].back() + 1;
-      break;
-    }
-
-    unsigned insertableEndIdx = Arguments.size();
-    if (CandidateInfo.hasTrailingClosure)
-      insertableEndIdx -= 1;
-
-    // Build argument string for fix-it.
-    SmallString<32> insertBuf;
-    llvm::raw_svector_ostream insertText(insertBuf);
-
-    if (argIdx != 0)
-      insertText << ", ";
-    if (!name.empty())
-      insertText << name.str() << ": ";
-    Type Ty = param.getOldType();
-    // Explode inout type.
-    if (param.isInOut()) {
-      insertText << "&";
-      Ty = param.getPlainType();
-    }
-    // @autoclosure; the type should be the result type.
-    if (param.isAutoClosure())
-      Ty = param.getPlainType()->castTo<FunctionType>()->getResult();
-    insertText << "<#" << Ty << "#>";
-    if (argIdx == 0 && insertableEndIdx != 0)
-      insertText << ", ";
-
-    SourceLoc insertLoc;
-    if (argIdx > insertableEndIdx) {
-      // Unreachable for now.
-      // FIXME: matchCallArguments() doesn't detect "missing argument after
-      // trailing closure". E.g.
-      //   func fn(x: Int, y: () -> Int, z: Int) { ... }
-      //   fn(x: 1) { return 1 }
-      // is diagnosed as "missing argument for 'y'" (missingParamIdx 1).
-      // It should be "missing argument for 'z'" (missingParamIdx 2).
-    } else if (auto *TE = dyn_cast<TupleExpr>(ArgExpr)) {
-      // fn():
-      //   fn([argMissing])
-      // fn(argX, argY):
-      //   fn([argMissing, ]argX, argY)
-      //   fn(argX[, argMissing], argY)
-      //   fn(argX, argY[, argMissing])
-      // fn(argX) { closure }:
-      //   fn([argMissing, ]argX) { closure }
-      //   fn(argX[, argMissing]) { closure }
-      //   fn(argX[, closureLabel: ]{closure}[, argMissing)] // Not impl.
-      if (insertableEndIdx == 0)
-        insertLoc = TE->getRParenLoc();
-      else if (argIdx != 0)
-        insertLoc = Lexer::getLocForEndOfToken(
-            TC.Context.SourceMgr, TE->getElement(argIdx - 1)->getEndLoc());
-      else {
-        insertLoc = TE->getElementNameLoc(0);
-        if (insertLoc.isInvalid())
-          insertLoc = TE->getElement(0)->getStartLoc();
-      }
-    } else if (auto *PE = dyn_cast<ParenExpr>(ArgExpr)) {
-      assert(argIdx <= 1);
-      if (PE->getRParenLoc().isValid()) {
-        // fn(argX):
-        //   fn([argMissing, ]argX)
-        //   fn(argX[, argMissing])
-        // fn() { closure }:
-        //   fn([argMissing]) {closure}
-        //   fn([closureLabel: ]{closure}[, argMissing]) // Not impl.
-        if (insertableEndIdx == 0)
-          insertLoc = PE->getRParenLoc();
-        else if (argIdx == 0)
-          insertLoc = PE->getSubExpr()->getStartLoc();
-        else
-          insertLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr,
-                                                 PE->getSubExpr()->getEndLoc());
-      } else {
-        // fn { closure }:
-        //   fn[(argMissing)] { closure }
-        //   fn[(closureLabel:] { closure }[, missingArg)]  // Not impl.
-        assert(!IsSubscript && "bracket less subscript");
-        assert(PE->hasTrailingClosure() &&
-               "paren less ParenExpr without trailing closure");
-        insertBuf.insert(insertBuf.begin(), '(');
-        insertBuf.insert(insertBuf.end(), ')');
-        insertLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr,
-                                               FnExpr->getEndLoc());
-      }
-    } else {
-      auto &CS = CandidateInfo.CS;
-      (void)CS;
-      // FIXME: Due to a quirk of CSApply, we can end up without a
-      // ParenExpr if the argument has an '@lvalue TupleType'.
-      assert((isa<TupleType>(CS.getType(ArgExpr).getPointer()) ||
-              CS.getType(ArgExpr)->hasParenSugar()) &&
-             "unexpected argument expression type");
-      insertLoc = ArgExpr->getLoc();
-    }
-
-    assert(insertLoc.isValid() && "missing argument after trailing closure?");
-
-    if (name.empty()) {
-      TC.diagnose(insertLoc, diag::missing_argument_positional,
-                  missingParamIdx + 1)
-          .fixItInsert(insertLoc, insertText.str());
-    } else {
-      if (isPropertyWrapperImplicitInit()) {
-        auto TE = cast<TypeExpr>(FnExpr);
-        TC.diagnose(TE->getLoc(), diag::property_wrapper_missing_arg_init, name,
-                    TE->getInstanceType()->getString());
-      } else {
-        TC.diagnose(insertLoc, diag::missing_argument_named, name)
-            .fixItInsert(insertLoc, insertText.str());
-      }
-    }
-
-    auto candidate = CandidateInfo[0];
-    if (candidate.getDecl())
-      TC.diagnose(candidate.getDecl(), diag::decl_declared_here,
-                  candidate.getDecl()->getFullName());
-
-    Diagnosed = true;
-    return None;
-  }
-
-  bool isPropertyWrapperImplicitInit() {
-    auto TE = dyn_cast<TypeExpr>(FnExpr);
-    if (!TE)
-      return false;
-
-    auto instanceTy = TE->getInstanceType();
-    if (!instanceTy)
-      return false;
-
-    auto nominalDecl = instanceTy->getAnyNominal();
-    if (!(nominalDecl &&
-          nominalDecl->getAttrs().hasAttribute<PropertyWrapperAttr>()))
-      return false;
-
-    if (auto *parentExpr = CandidateInfo.CS.getParentExpr(FnExpr)) {
-      return parentExpr->isImplicit() && isa<CallExpr>(parentExpr);
-    }
-
-    return false;
   }
 
   bool missingLabel(unsigned paramIdx) override {
@@ -2500,7 +2345,7 @@ diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI, Expr *fnExpr,
 
   // If we have a single candidate that failed to match the argument list,
   // attempt to use matchCallArguments to diagnose the problem.
-  return ArgumentMatcher(fnExpr, argExpr, params, paramInfo, args, CCI,
+  return ArgumentMatcher(argExpr, params, paramInfo, args, CCI,
                          isa<SubscriptExpr>(fnExpr))
       .diagnose();
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3508,6 +3508,20 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     return true;
   }
 
+  // Function type has fewer arguments than expected by context:
+  //
+  // ```
+  // func foo() {}
+  // let _: (Int) -> Void = foo
+  // ```
+  if (locator->isLastElement(ConstraintLocator::ContextualType)) {
+    auto &cs = getConstraintSystem();
+    emitDiagnostic(anchor->getLoc(), diag::cannot_convert_initializer_value,
+                   getType(anchor), resolveType(cs.getContextualType()));
+    // TODO: It would be great so somehow point out which arguments are missing.
+    return true;
+  }
+
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3598,14 +3598,15 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
   if (!funcType)
     return false;
 
-  auto diff = funcType->getNumParams() - NumSynthesized;
+  unsigned numSynthesized = SynthesizedArgs.size();
+  auto diff = funcType->getNumParams() - numSynthesized;
 
   // If the closure didn't specify any arguments and it is in a context that
   // needs some, produce a fixit to turn "{...}" into "{ _,_ in ...}".
   if (diff == 0) {
     auto diag =
         emitDiagnostic(closure->getStartLoc(),
-                       diag::closure_argument_list_missing, NumSynthesized);
+                       diag::closure_argument_list_missing, numSynthesized);
 
     std::string fixText; // Let's provide fixits for up to 10 args.
     if (funcType->getNumParams() <= 10) {
@@ -3649,9 +3650,9 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
     llvm::raw_svector_ostream OS(fixIt);
 
     OS << ",";
-    for (unsigned i = 0; i != NumSynthesized; ++i) {
+    for (unsigned i = 0; i != numSynthesized; ++i) {
       OS << ((onlyAnonymousParams) ? "_" : "<#arg#>");
-      OS << ((i == NumSynthesized - 1) ? " " : ",");
+      OS << ((i == numSynthesized - 1) ? " " : ",");
     }
 
     diag.fixItInsertAfter(params->getEndLoc(), OS.str());

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1186,12 +1186,14 @@ public:
 class MissingArgumentsFailure final : public FailureDiagnostic {
   using Param = AnyFunctionType::Param;
 
-  unsigned NumSynthesized;
+  SmallVector<Param, 4> SynthesizedArgs;
 
 public:
   MissingArgumentsFailure(Expr *root, ConstraintSystem &cs,
-                          unsigned numSynthesized, ConstraintLocator *locator)
-      : FailureDiagnostic(root, cs, locator), NumSynthesized(numSynthesized) {}
+                          ArrayRef<Param> synthesizedArgs,
+                          ConstraintLocator *locator)
+      : FailureDiagnostic(root, cs, locator),
+        SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {}
 
   bool diagnoseAsError() override;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1193,7 +1193,9 @@ public:
                           ArrayRef<Param> synthesizedArgs,
                           ConstraintLocator *locator)
       : FailureDiagnostic(root, cs, locator),
-        SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {}
+        SynthesizedArgs(synthesizedArgs.begin(), synthesizedArgs.end()) {
+    assert(!SynthesizedArgs.empty() && "No missing arguments?!");
+  }
 
   bool diagnoseAsError() override;
 
@@ -1212,6 +1214,16 @@ private:
   /// an implicit call to a property wrapper initializer e.g.
   /// `@Foo(answer: 42) var question = "ultimate question"`
   bool isPropertyWrapperInitialization() const;
+
+  /// Gather informatioin associated with expression that represents
+  /// a call - function, arguments, # of arguments and whether it has
+  /// a trailing closure.
+  std::tuple<Expr *, Expr *, unsigned, bool> getCallInfo(Expr *anchor) const;
+
+  /// Transform given argument into format suitable for a fix-it
+  /// text e.g. `[<label>:]? <#<type#>`
+  void forFixIt(llvm::raw_svector_ostream &out,
+                const AnyFunctionType::Param &argument) const;
 
 public:
   /// Due to the fact that `matchCallArgument` can't and

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1198,6 +1198,8 @@ public:
   bool diagnoseAsError() override;
 
 private:
+  bool diagnoseSingleMissingArgument() const;
+
   /// If missing arguments come from a closure,
   /// let's produce tailored diagnostics.
   bool diagnoseClosure(ClosureExpr *closure);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1201,6 +1201,10 @@ private:
   /// If missing arguments come from a closure,
   /// let's produce tailored diagnostics.
   bool diagnoseClosure(ClosureExpr *closure);
+
+  /// Diagnose cases when instead of multiple distinct arguments
+  /// call got a single tuple argument with expected arity/types.
+  bool diagnoseInvalidTupleDestructuring() const;
 };
 
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1207,6 +1207,11 @@ private:
   /// Diagnose cases when instead of multiple distinct arguments
   /// call got a single tuple argument with expected arity/types.
   bool diagnoseInvalidTupleDestructuring() const;
+
+  /// Determine whether missing arguments are associated with
+  /// an implicit call to a property wrapper initializer e.g.
+  /// `@Foo(answer: 42) var question = "ultimate question"`
+  bool isPropertyWrapperInitialization() const;
 };
 
 class OutOfOrderArgumentFailure final : public FailureDiagnostic {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -478,7 +478,8 @@ AllowClosureParamDestructuring::create(ConstraintSystem &cs,
 
 bool AddMissingArguments::diagnose(Expr *root, bool asNote) const {
   auto &cs = getConstraintSystem();
-  MissingArgumentsFailure failure(root, cs, NumSynthesized, getLocator());
+  MissingArgumentsFailure failure(root, cs, getSynthesizedArguments(),
+                                  getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -839,8 +839,8 @@ public:
     unsigned newArgIdx = Arguments.size();
     auto argLoc =
         Locator
-            .withPathElement(
-                LocatorPathElt::ApplyArgToParam(newArgIdx, paramIdx))
+            .withPathElement(LocatorPathElt::ApplyArgToParam(
+                newArgIdx, paramIdx, param.getParameterFlags()))
             .withPathElement(LocatorPathElt::SynthesizedArgument(newArgIdx));
 
     auto *argType = CS.createTypeVariable(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -36,7 +36,10 @@ MatchCallArgumentListener::~MatchCallArgumentListener() { }
 
 void MatchCallArgumentListener::extraArgument(unsigned argIdx) { }
 
-void MatchCallArgumentListener::missingArgument(unsigned paramIdx) { }
+Optional<unsigned>
+MatchCallArgumentListener::missingArgument(unsigned paramIdx) {
+  return None;
+}
 
 bool MatchCallArgumentListener::missingLabel(unsigned paramIdx) { return true; }
 bool MatchCallArgumentListener::extraneousLabel(unsigned paramIdx) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -847,6 +847,11 @@ public:
         CS.getConstraintLocator(argLoc),
         TVO_CanBindToInOut | TVO_CanBindToLValue | TVO_CanBindToNoEscape);
 
+    CS.recordHole(argType);
+    CS.addUnsolvedConstraint(Constraint::create(
+        CS, ConstraintKind::Defaultable, argType, CS.getASTContext().TheAnyType,
+        CS.getConstraintLocator(argLoc)));
+
     Arguments.push_back(param.withType(argType));
     ++NumSynthesizedArgs;
 

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -284,8 +284,9 @@ CalleeCandidateInfo::ClosenessResultTy CalleeCandidateInfo::evaluateCloseness(
     void extraArgument(unsigned argIdx) override {
       result = CC_ArgumentCountMismatch;
     }
-    void missingArgument(unsigned paramIdx) override {
+    Optional<unsigned> missingArgument(unsigned paramIdx) override {
       result = CC_ArgumentCountMismatch;
+      return None;
     }
     bool missingLabel(unsigned paramIdx) override {
       result = CC_ArgumentLabelMismatch;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2913,11 +2913,12 @@ void constraints::simplifyLocator(Expr *&anchor,
 
       // Extract subexpression in parentheses.
       if (auto parenExpr = dyn_cast<ParenExpr>(anchor)) {
-        assert(elt.getArgIdx() == 0);
-
-        anchor = parenExpr->getSubExpr();
-        path = path.slice(1);
-        continue;
+        // This simplication request could be for a synthesized argument.
+        if (elt.getArgIdx() == 0) {
+          anchor = parenExpr->getSubExpr();
+          path = path.slice(1);
+          continue;
+        }
       }
       break;
     }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3858,7 +3858,7 @@ public:
   /// indices.
   ///
   /// \param paramIdx The index of the parameter that is missing an argument.
-  virtual void missingArgument(unsigned paramIdx);
+  virtual Optional<unsigned> missingArgument(unsigned paramIdx);
 
   /// Indicate that there was no label given when one was expected by parameter.
   ///

--- a/test/APINotes/versioned-objc.swift
+++ b/test/APINotes/versioned-objc.swift
@@ -166,7 +166,7 @@ extension PrintingInterference {
   func testDroppingRenamedPrints() {
     // CHECK-DIAGS-4: [[@LINE+1]]:{{[0-9]+}}: warning: use of 'print' treated as a reference to instance method
     print(self)
-    // CHECK-DIAGS-5: [[@LINE-1]]:{{[0-9]+}}: error: use of 'print' nearly matches global function 'print(_:separator:terminator:)' in module 'Swift' rather than instance method 'print(_:extra:)'
+    // CHECK-DIAGS-5: [[@LINE-1]]:{{[0-9]+}}: error: missing argument for parameter 'extra' in call
 
     // CHECK-DIAGS-4-NOT: [[@LINE+1]]:{{[0-9]+}}:
     print(self, extra: self)

--- a/test/ClangImporter/foreign_errors.swift
+++ b/test/ClangImporter/foreign_errors.swift
@@ -77,10 +77,7 @@ func testBlockFinal() throws {
 #if !EMIT_SIL
 func testNonBlockFinal() throws {
   ErrorProne.runWithError(count: 0) // expected-error {{missing argument for parameter #1 in call}}
-  // TODO(diagnostics): For situations where both label and type where incorrect, we should produce a single error
-  // which would say something like `cannot invoke 'bar' with argument list (count: Int)`.
-  ErrorProne.run(count: 0) // expected-error {{incorrect argument label in call (have 'count:', expected 'callback:')}}
-  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '(() -> Void)?'}}
+  ErrorProne.run(count: 0) // expected-error {{missing argument for parameter 'withAnError' in call}} {{18-18=withAnError: <#AutoreleasingUnsafeMutablePointer<NSError?>?#>, }}
 }
 #endif
 

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -215,9 +215,8 @@ func rdar29894174(v: B?) {
 // we would fail to produce a diagnostic.
 func process(p: Any?) {
   compare(p is String)
-  // expected-error@-1 {{cannot invoke 'compare' with an argument list of type '(Bool)'}}
-  // expected-note@-2 {{overloads for 'compare' exist with these partially matching parameter lists: (T, T), (T?, T?)}}
+  // expected-error@-1 {{missing argument for parameter #2 in call}} {{22-22=, <#Bool#>}}
 }
 
-func compare<T>(_: T, _: T) {}
+func compare<T>(_: T, _: T) {} // expected-note {{'compare' declared here}}
 func compare<T>(_: T?, _: T?) {}

--- a/test/Constraints/diag_missing_arg.swift
+++ b/test/Constraints/diag_missing_arg.swift
@@ -19,11 +19,11 @@ func attributedInOutFunc(x: inout @convention(c) () -> Int32) {} // expected-not
 attributedInOutFunc() // expected-error {{missing argument for parameter 'x' in call}} {{21-21=x: &<#@convention(c) () -> Int32#>}}
 
 func genericFunc1<T>(x: T) {} // expected-note * {{here}}
-genericFunc1() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T#>}}
+genericFunc1() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#Any#>}}
 
 protocol P {}
 func genericFunc2<T : P>(x: T) {} // expected-note * {{here}}
-genericFunc2() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#T#>}}
+genericFunc2() // expected-error {{missing argument for parameter 'x' in call}} {{14-14=x: <#Any#>}}
 
 typealias MyInt = Int
 func aliasedFunc(x: MyInt) {} // expected-note * {{here}}
@@ -61,11 +61,10 @@ param2FuncNonNamed2("foo") // expected-error {{missing argument for parameter 'x
 
 func param2FuncNonNamed3(_ x: Int, _ y: String) {} // expected-note * {{here}}
 param2FuncNonNamed3(1) // expected-error {{missing argument for parameter #2 in call}} {{22-22=, <#String#>}}
-param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #2 in call}} {{26-26=, <#String#>}}
-                           // FIXME: Bad diagnostic. Could this be #1?
+param2FuncNonNamed3("foo") // expected-error {{missing argument for parameter #1 in call}} {{21-21=<#Int#>, }}
 
 func unlabeledParamFollowingVariadic(_: Any..., _: Any, _: Any) {} // expected-error {{a parameter following a variadic parameter requires a label}}; // expected-note {{here}}
-unlabeledParamFollowingVariadic(1, 1, 1) // expected-error {{missing argument for parameter #2 in call}} {{40-40=, <#Any#>}}
+unlabeledParamFollowingVariadic(1, 1, 1) // expected-error {{missing arguments for parameters #2, #3 in call}}
 
 func labeledParamFollowingVariadic(_: Any..., label: Any, _: Any) {}
 labeledParamFollowingVariadic(1, label: 1, 1)
@@ -97,14 +96,14 @@ _ = s1[x: 1, y: {1}]  // Ok.
 _ = s1[x: 1] { 1 } // Ok.
 _ = s1[x: 1] // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#() -> Int#>}}
 _ = s1[y: { 1 }] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>, }}
-_ = s1[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
+_ = s1[] { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>}}
 _ = s1 { 1 } // expected-error {{cannot call value of non-function type 'S1'}} {{none}}
-_ = s1[] // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>}}
+_ = s1[] // expected-error {{missing arguments for parameters 'x', 'y' in call}} {{8-8=x: <#Int#>, y: <#() -> Int#>}}
 s1[x: 1, y: {1}] = 1 // Ok.
 s1[x: 1] { 1 } = 1 // Ok.
 s1[x: 1] = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#() -> Int#>}}
 s1[y: { 1 }] = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#Int#>, }}
-s1[] { 1 } = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(x: Int, y: () -> Int)'}} {{none}}
+s1[] { 1 } = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#Int#>}}
 
 struct S2 {
   subscript(x: Int, y: () -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
@@ -112,26 +111,30 @@ struct S2 {
 var s2 = S2()
 _ = s2[1, {1}]  // Ok.
 _ = s2[1] { 1 } // Ok.
-_ = s2[1] // expected-error {{cannot convert value of type 'Int' to expected argument type '(Int, () -> Int)'}} {{none}}
-_ = s2[{ 1 }] // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
-_ = s2[] { 1 } // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+_ = s2[1] // expected-error {{missing argument for parameter #2 in call}} {{9-9=, <#() -> Int#>}}
+_ = s2[{ 1 }] // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#Int#>, }}
+_ = s2[] { 1 } // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#Int#>}}
 _ = s2 { 1 } // expected-error {{cannot call value of non-function type 'S2'}} {{none}}
-_ = s2[] // expected-error {{missing argument for parameter #1 in call}} {{8-8=<#Int#>}}
+_ = s2[] // expected-error {{missing arguments for parameters #1, #2 in call}} {{8-8=<#Int#>, <#() -> Int#>}}
 s2[1, {1}] = 1 // Ok.
 s2[1] { 1 } = 1 // Ok.
-s2[1] = 1 // expected-error {{cannot convert value of type 'Int' to expected argument type '(Int, () -> Int)'}} {{none}}
-s2[{ 1 }] = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
-s2[] { 1 } = 1 // expected-error {{cannot convert value of type '() -> Int' to expected argument type '(Int, () -> Int)'}} {{none}}
+s2[1] = 1 // expected-error {{missing argument for parameter #2 in call}} {{5-5=, <#() -> Int#>}}
+s2[{ 1 }] = 1 // expected-error {{missing argument for parameter #1 in call}} {{4-4=<#Int#>, }}
+s2[] { 1 } = 1 // expected-error {{missing argument for parameter #1 in call}} {{4-4=<#Int#>}}
 
 struct S3 {
       subscript(x x: Int, y y: Int, z z: (Int) -> Int) -> Int { get { return 1 } set { } } // expected-note * {{here}}
 }
 var s3 = S3()
 _ = s3[y: 1] { 1 } // expected-error {{missing argument for parameter 'x' in call}} {{8-8=x: <#Int#>, }}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{15-15= _ in}}
 _ = s3[x: 1] { 1 } // expected-error {{missing argument for parameter 'y' in call}} {{12-12=, y: <#Int#>}}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{15-15= _ in}}
 _ = s3[x: 1, y: 1] // expected-error {{missing argument for parameter 'z' in call}} {{18-18=, z: <#(Int) -> Int#>}}
 s3[y: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'x' in call}} {{4-4=x: <#Int#>, }}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{11-11= _ in}}
 s3[x: 1] { 1 } = 1 // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#Int#>}}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{11-11= _ in}}
 s3[x: 1, y: 1] = 1 // expected-error {{missing argument for parameter 'z' in call}} {{14-14=, z: <#(Int) -> Int#>}}
 
 struct S4 {
@@ -139,13 +142,15 @@ struct S4 {
 }
 var s4 = S4()
 _ = s4[1] { 1 } // expected-error {{missing argument for parameter #2 in call}} {{9-9=, <#Int#>}}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{12-12= _ in}}
 _ = s4[1, 1] // expected-error {{missing argument for parameter #3 in call}} {{12-12=, <#(Int) -> Int#>}}
 s4[1] { 1 } = 1 // expected-error {{missing argument for parameter #2 in call}} {{5-5=, <#Int#>}}
+// expected-error@-1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{8-8= _ in}}
 s4[1, 1] = 1 // expected-error {{missing argument for parameter #3 in call}} {{8-8=, <#(Int) -> Int#>}}
 
 func multiLine(x: Int, y: Int, z: Int) {} // expected-note * {{here}}
-multiLine(
-) // expected-error {{missing argument for parameter 'x' in call}} {{1-1=x: <#Int#>}}
+multiLine( // expected-error {{missing arguments for parameters 'x', 'y', 'z' in call}} {{11-11=x: <#Int#>, y: <#Int#>, z: <#Int#>}}
+)
 multiLine(
   y: 1, // expected-error {{missing argument for parameter 'x' in call}} {{3-3=x: <#Int#>, }}
   z: 1

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -409,7 +409,7 @@ f8(b: 1.0)         // expected-error {{extraneous argument label 'b:' in call}}
 class CurriedClass {
   func method1() {}
   func method2(_ a: Int) -> (_ b : Int) -> () { return { b in () } }
-  func method3(_ a: Int, b : Int) {}  // expected-note 5 {{'method3(_:b:)' declared here}}
+  func method3(_ a: Int, b : Int) {}  // expected-note 3 {{'method3(_:b:)' declared here}}
 }
 
 let c = CurriedClass()
@@ -449,15 +449,17 @@ _ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'me
 // expected-error@-1 {{missing argument label 'b:' in call}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
-CurriedClass.method3(c)(c: 1.0)          // expected-error {{missing argument for parameter #1 in call}}
+CurriedClass.method3(c)(c: 1.0)          // expected-error {{missing argument for parameter #1 in call}} expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 
 
 extension CurriedClass {
   func f() {
     method3(1, b: 2)
-    method3()            // expected-error {{missing argument for parameter #1 in call}}
+    method3()            // expected-error {{missing arguments for parameters #1, 'b' in call}} {{13-13=<#Int#>, b: <#Int#>}}
     method3(42)          // expected-error {{missing argument for parameter 'b' in call}}
-    method3(self)        // expected-error {{missing argument for parameter 'b' in call}}
+    method3(self)
+    // expected-error@-1:13 {{cannot convert value of type 'CurriedClass' to expected argument type 'Int'}}
+    // expected-error@-2:17 {{missing argument for parameter 'b' in call}} {{17-17=, b: <#Int#>}}
   }
 }
 

--- a/test/Constraints/diagnostics_swift4.swift
+++ b/test/Constraints/diagnostics_swift4.swift
@@ -34,7 +34,7 @@ enum R31898542<T> {
 }
 
 func foo() -> R31898542<()> {
-  return .success() // expected-error {{missing argument for parameter #1 in call}} {{19-19=<#T#>}}
+  return .success() // expected-error {{missing argument for parameter #1 in call}} {{19-19=<#()#>}}
 }
 
 // rdar://problem/31973368 - Cannot convert value of type '(K, V) -> ()' to expected argument type '((key: _, value: _)) -> Void'

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -54,7 +54,7 @@ bar_1(E.tuple) // Ok - it's going to be ((x: Int, y: Int))
 
 bar_2(G_E<String>.foo) // Ok
 bar_2(G_E<Int>.bar) // Ok
-bar_2(G_E<Int>.two) // expected-error {{cannot convert value of type '(Int, Int) -> G_E<Int>' to expected argument type '(_) -> G_E<_>'}}
+bar_2(G_E<Int>.two) // expected-error {{cannot convert value of type '(Int, Int) -> G_E<Int>' to expected argument type '(Int) -> G_E<Int>'}}
 bar_2(G_E<Int>.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(_) -> G_E<_>'}}
 bar_3(G_E<Int>.tuple) // Ok
 

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -620,13 +620,14 @@ func rdar_50467583_and_50909555() {
 
   // rdar://problem/50909555
   struct S {
-    static subscript(x: Int, y: Int) -> Int {
+    static subscript(x: Int, y: Int) -> Int { // expected-note {{'subscript(_:_:)' declared here}}
       return 1
     }
   }
 
   func test(_ s: S) {
     s[1] // expected-error {{static member 'subscript' cannot be used on instance of type 'S'}} {{5-6=S}}
+    // expected-error@-1 {{missing argument for parameter #2 in call}} {{8-8=, <#Int#>}}
   }
 }
 

--- a/test/Constraints/rdar45242032.swift
+++ b/test/Constraints/rdar45242032.swift
@@ -14,9 +14,9 @@ struct S {
 }
 
 do {
-  let _ = M.foo(bar & // expected-error {{missing argument for parameter 'bar' in call}}
+  let _ = M.foo(bar & // expected-error {{missing arguments for parameters 'bar', 'baz' in call}}
 } // expected-error {{expected expression after operator}}
 
 do {
-  let _ = S.bar(fiz & // expected-error {{missing argument for parameter 'fiz' in call}}
+  let _ = S.bar(fiz & // expected-error {{missing arguments for parameters 'fiz', 'baz' in call}}
 } // expected-error {{expected expression after operator}}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -18,7 +18,7 @@ do {
   // expected-error@-1 {{cannot convert value of type '(x: Int)' to expected argument type 'Int'}}
 
   concreteTwo(3, 4)
-  concreteTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  concreteTwo((3, 4)) // expected-error {{global function 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
 
   concreteTuple(3, 4) // expected-error {{global function 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   concreteTuple((3, 4))
@@ -35,8 +35,8 @@ do {
   concrete(c)
 
   concreteTwo(a, b)
-  concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  concreteTwo((a, b)) // expected-error {{global function 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  concreteTwo(d) // expected-error {{global function 'concreteTwo' expects 2 separate arguments}}
 
   concreteTuple(a, b) // expected-error {{global function 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   concreteTuple((a, b))
@@ -54,8 +54,8 @@ do {
   concrete(c)
 
   concreteTwo(a, b)
-  concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  concreteTwo((a, b)) // expected-error {{global function 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  concreteTwo(d) // expected-error {{global function 'concreteTwo' expects 2 separate arguments}}
 
   concreteTuple(a, b) // expected-error {{global function 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   concreteTuple((a, b))
@@ -79,7 +79,7 @@ do {
   genericLabeled(x: (3, 4))
 
   genericTwo(3, 4)
-  genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  genericTwo((3, 4)) // expected-error {{global function 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{14-15=}} {{19-20=}}
 
   genericTuple(3, 4) // expected-error {{global function 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{16-16=(}} {{20-20=)}}
   genericTuple((3, 4))
@@ -99,8 +99,8 @@ do {
   generic(d)
 
   genericTwo(a, b)
-  genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  genericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  genericTwo((a, b)) // expected-error {{global function 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{14-15=}} {{19-20=}}
+  genericTwo(d) // expected-error {{global function 'genericTwo' expects 2 separate arguments}}
 
   genericTuple(a, b) // expected-error {{global function 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{16-16=(}} {{20-20=)}}
   genericTuple((a, b))
@@ -121,8 +121,8 @@ do {
   generic(d)
 
   genericTwo(a, b)
-  genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  genericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  genericTwo((a, b)) // expected-error {{global function 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{14-15=}} {{19-20=}}
+  genericTwo(d) // expected-error {{global function 'genericTwo' expects 2 separate arguments}}
 
   genericTuple(a, b) // expected-error {{global function 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{16-16=(}} {{20-20=)}}
   genericTuple((a, b))
@@ -138,7 +138,7 @@ do {
   function((3))
 
   functionTwo(3, 4)
-  functionTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  functionTwo((3, 4)) // expected-error {{var 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
 
   functionTuple(3, 4) // expected-error {{var 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   functionTuple((3, 4))
@@ -155,8 +155,8 @@ do {
   function(c)
 
   functionTwo(a, b)
-  functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  functionTwo((a, b)) // expected-error {{var 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  functionTwo(d) // expected-error {{var 'functionTwo' expects 2 separate arguments}}
 
   functionTuple(a, b) // expected-error {{var 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   functionTuple((a, b))
@@ -174,8 +174,8 @@ do {
   function(c)
 
   functionTwo(a, b)
-  functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  functionTwo((a, b)) // expected-error {{var 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  functionTwo(d) // expected-error {{var 'functionTwo' expects 2 separate arguments}}
 
   functionTuple(a, b) // expected-error {{var 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   functionTuple((a, b))
@@ -197,7 +197,7 @@ do {
   s.concrete((3))
 
   s.concreteTwo(3, 4)
-  s.concreteTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  s.concreteTwo((3, 4)) // expected-error {{instance method 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
 
   s.concreteTuple(3, 4) // expected-error {{instance method 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.concreteTuple((3, 4))
@@ -216,8 +216,8 @@ do {
   s.concrete(c)
 
   s.concreteTwo(a, b)
-  s.concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.concreteTwo((a, b)) // expected-error {{instance method 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
+  s.concreteTwo(d) // expected-error {{instance method 'concreteTwo' expects 2 separate arguments}}
 
   s.concreteTuple(a, b) // expected-error {{instance method 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.concreteTuple((a, b))
@@ -237,8 +237,8 @@ do {
   s.concrete(c)
 
   s.concreteTwo(a, b)
-  s.concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.concreteTwo((a, b)) // expected-error {{instance method 'concreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
+  s.concreteTwo(d) // expected-error {{instance method 'concreteTwo' expects 2 separate arguments}}
 
   s.concreteTuple(a, b) // expected-error {{instance method 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.concreteTuple((a, b))
@@ -266,7 +266,7 @@ do {
   s.genericLabeled(x: (3, 4))
 
   s.genericTwo(3, 4)
-  s.genericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((3, 4)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
 
   s.genericTuple(3, 4) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((3, 4))
@@ -287,8 +287,8 @@ do {
   s.generic(d)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.genericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((a, b)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
+  s.genericTwo(d) // expected-error {{instance method 'genericTwo' expects 2 separate arguments}}
 
   s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((a, b))
@@ -310,8 +310,8 @@ do {
   s.generic(d)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.genericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((a, b)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
+  s.genericTwo(d) // expected-error {{instance method 'genericTwo' expects 2 separate arguments}}
 
   s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((a, b))
@@ -331,7 +331,7 @@ do {
   s.mutatingConcrete((3))
 
   s.mutatingConcreteTwo(3, 4)
-  s.mutatingConcreteTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingConcreteTwo((3, 4)) // expected-error {{instance method 'mutatingConcreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{30-31=}}
 
   s.mutatingConcreteTuple(3, 4) // expected-error {{instance method 'mutatingConcreteTuple' expects a single parameter of type '(Int, Int)'}} {{27-27=(}} {{31-31=)}}
   s.mutatingConcreteTuple((3, 4))
@@ -350,8 +350,8 @@ do {
   s.mutatingConcrete(c)
 
   s.mutatingConcreteTwo(a, b)
-  s.mutatingConcreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.mutatingConcreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingConcreteTwo((a, b)) // expected-error {{instance method 'mutatingConcreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{30-31=}}
+  s.mutatingConcreteTwo(d) // expected-error {{instance method 'mutatingConcreteTwo' expects 2 separate arguments}}
 
   s.mutatingConcreteTuple(a, b) // expected-error {{instance method 'mutatingConcreteTuple' expects a single parameter of type '(Int, Int)'}} {{27-27=(}} {{31-31=)}}
   s.mutatingConcreteTuple((a, b))
@@ -371,8 +371,8 @@ do {
   s.mutatingConcrete(c)
 
   s.mutatingConcreteTwo(a, b)
-  s.mutatingConcreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.mutatingConcreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingConcreteTwo((a, b)) // expected-error {{instance method 'mutatingConcreteTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{30-31=}}
+  s.mutatingConcreteTwo(d) // expected-error {{instance method 'mutatingConcreteTwo' expects 2 separate arguments}}
 
   s.mutatingConcreteTuple(a, b) // expected-error {{instance method 'mutatingConcreteTuple' expects a single parameter of type '(Int, Int)'}} {{27-27=(}} {{31-31=)}}
   s.mutatingConcreteTuple((a, b))
@@ -400,7 +400,7 @@ do {
   s.mutatingGenericLabeled(x: (3, 4))
 
   s.mutatingGenericTwo(3, 4)
-  s.mutatingGenericTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((3, 4)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
 
   s.mutatingGenericTuple(3, 4) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((3, 4))
@@ -421,8 +421,8 @@ do {
   s.mutatingGeneric(d)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.mutatingGenericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((a, b)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
+  s.mutatingGenericTwo(d) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments}}
 
   s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((a, b))
@@ -444,8 +444,8 @@ do {
   s.mutatingGeneric(d)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.mutatingGenericTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((a, b)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
+  s.mutatingGenericTwo(d) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments}}
 
   s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(T, U)' [with T = Int, U = Int]}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((a, b))
@@ -454,7 +454,7 @@ do {
 
 extension Concrete {
   var function: (Int) -> () { return concrete }
-  var functionTwo: (Int, Int) -> () { return concreteTwo }
+  var functionTwo: (Int, Int) -> () { return concreteTwo } // expected-note 5 {{'functionTwo' declared here}}
   var functionTuple: ((Int, Int)) -> () { return concreteTuple }
 }
 
@@ -465,7 +465,7 @@ do {
   s.function((3))
 
   s.functionTwo(3, 4)
-  s.functionTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  s.functionTwo((3, 4)) // expected-error {{property 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
 
   s.functionTuple(3, 4) // expected-error {{property 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.functionTuple((3, 4))
@@ -484,8 +484,8 @@ do {
   s.function(c)
 
   s.functionTwo(a, b)
-  s.functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.functionTwo((a, b)) // expected-error {{property 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
+  s.functionTwo(d) // expected-error {{property 'functionTwo' expects 2 separate arguments}}
 
 
   s.functionTuple(a, b) // expected-error {{property 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
@@ -506,8 +506,8 @@ do {
   s.function(c)
 
   s.functionTwo(a, b)
-  s.functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.functionTwo((a, b)) // expected-error {{property 'functionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{17-18=}} {{22-23=}}
+  s.functionTwo(d) // expected-error {{property 'functionTwo' expects 2 separate arguments}}
 
   s.functionTuple(a, b) // expected-error {{property 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.functionTuple((a, b))
@@ -528,7 +528,7 @@ struct InitLabeledTuple {
 
 do {
   _ = InitTwo(3, 4)
-  _ = InitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = InitTwo((3, 4)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
 
   _ = InitTuple(3, 4) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   _ = InitTuple((3, 4))
@@ -543,8 +543,8 @@ do {
   let c = (a, b)
 
   _ = InitTwo(a, b)
-  _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = InitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = InitTwo((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  _ = InitTwo(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = InitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   _ = InitTuple((a, b))
@@ -557,8 +557,8 @@ do {
   var c = (a, b)
 
   _ = InitTwo(a, b)
-  _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = InitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = InitTwo((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{15-16=}} {{20-21=}}
+  _ = InitTwo(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = InitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   _ = InitTuple((a, b))
@@ -580,7 +580,7 @@ struct SubscriptLabeledTuple {
 do {
   let s1 = SubscriptTwo()
   _ = s1[3, 4]
-  _ = s1[(3, 4)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s1[(3, 4)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{15-16=}}
 
   let s2 = SubscriptTuple()
   _ = s2[3, 4] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
@@ -594,8 +594,8 @@ do {
 
   let s1 = SubscriptTwo()
   _ = s1[a, b]
-  _ = s1[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s1[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s1[(a, b)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{15-16=}}
+  _ = s1[d] // expected-error {{subscript expects 2 separate arguments}}
 
   let s2 = SubscriptTuple()
   _ = s2[a, b] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
@@ -615,8 +615,8 @@ do {
 
   var s1 = SubscriptTwo()
   _ = s1[a, b]
-  _ = s1[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s1[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s1[(a, b)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{15-16=}}
+  _ = s1[d] // expected-error {{subscript expects 2 separate arguments}}
 
   var s2 = SubscriptTuple()
   _ = s2[a, b] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
@@ -632,7 +632,7 @@ enum Enum {
 
 do {
   _ = Enum.two(3, 4)
-  _ = Enum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two((3, 4)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
   _ = Enum.two(3 > 4 ? 3 : 4) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = Enum.tuple(3, 4) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
@@ -648,8 +648,8 @@ do {
   let c = (a, b)
 
   _ = Enum.two(a, b)
-  _ = Enum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = Enum.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
+  _ = Enum.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = Enum.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((a, b))
@@ -662,8 +662,8 @@ do {
   var c = (a, b)
 
   _ = Enum.two(a, b)
-  _ = Enum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = Enum.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
+  _ = Enum.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = Enum.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((a, b))
@@ -689,7 +689,7 @@ do {
   s.genericLabeled(x: (3.0))
 
   s.genericTwo(3.0, 4.0)
-  s.genericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((3.0, 4.0)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{25-26=}}
 
   s.genericTuple(3.0, 4.0) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(Double, Double)'}} {{18-18=(}} {{26-26=)}}
   s.genericTuple((3.0, 4.0))
@@ -716,7 +716,7 @@ do {
   s.generic(c)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((a, b)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
 
   s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(Double, Double)'}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((a, b))
@@ -741,7 +741,7 @@ do {
   s.generic(c)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((a, b)) // expected-error {{instance method 'genericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
 
   s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(Double, Double)'}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((a, b))
@@ -770,7 +770,7 @@ do {
   s.mutatingGenericLabeled(x: (3.0))
 
   s.mutatingGenericTwo(3.0, 4.0)
-  s.mutatingGenericTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((3.0, 4.0)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {24-25=}} {{33-34=}}
 
   s.mutatingGenericTuple(3.0, 4.0) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{34-34=)}}
   s.mutatingGenericTuple((3.0, 4.0))
@@ -797,7 +797,7 @@ do {
   s.mutatingGeneric(c)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((a, b)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {24-25=}} {{29-30=}}
 
   s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((a, b))
@@ -822,7 +822,7 @@ do {
   s.mutatingGeneric(c)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((a, b)) // expected-error {{instance method 'mutatingGenericTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
 
   s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((a, b))
@@ -836,7 +836,7 @@ do {
 
 extension Generic {
   var genericFunction: (T) -> () { return generic }
-  var genericFunctionTwo: (T, T) -> () { return genericTwo }
+  var genericFunctionTwo: (T, T) -> () { return genericTwo } // expected-note 3 {{'genericFunctionTwo' declared here}}
   var genericFunctionTuple: ((T, T)) -> () { return genericTuple }
 }
 
@@ -847,7 +847,7 @@ do {
   s.genericFunction((3.0))
 
   s.genericFunctionTwo(3.0, 4.0)
-  s.genericFunctionTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericFunctionTwo((3.0, 4.0)) // expected-error {{property 'genericFunctionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{33-34=}}
 
   s.genericFunctionTuple(3.0, 4.0) // expected-error {{property 'genericFunctionTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{34-34=)}}
   s.genericFunctionTuple((3.0, 4.0))
@@ -871,7 +871,7 @@ do {
   s.genericFunction(c)
 
   s.genericFunctionTwo(a, b)
-  s.genericFunctionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericFunctionTwo((a, b)) // expected-error {{property 'genericFunctionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
 
   s.genericFunctionTuple(a, b) // expected-error {{property 'genericFunctionTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
   s.genericFunctionTuple((a, b))
@@ -896,7 +896,7 @@ do {
   s.genericFunction(c)
 
   s.genericFunctionTwo(a, b)
-  s.genericFunctionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericFunctionTwo((a, b)) // expected-error {{property 'genericFunctionTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{24-25=}} {{29-30=}}
 
   s.genericFunctionTuple(a, b) // expected-error {{property 'genericFunctionTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
   s.genericFunctionTuple((a, b))
@@ -936,7 +936,7 @@ do {
   _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
-  _ = GenericInitTwo((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo((3, 4)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{22-23=}} {{27-28=}}
 
   _ = GenericInitTuple(3, 4) // expected-error {{initializer expects a single parameter of type '(T, T)' [with T = Int]}} {{24-24=(}} {{28-28=)}}
   _ = GenericInitTuple((3, 4))
@@ -953,7 +953,7 @@ do {
   _ = GenericInitLabeled<(Int, Int)>(x: (3, 4))
 
   _ = GenericInitTwo<Int>(3, 4)
-  _ = GenericInitTwo<Int>((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo<Int>((3, 4)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{27-28=}} {{32-33=}}
 
   _ = GenericInitTuple<Int>(3, 4) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{29-29=(}} {{33-33=)}}
   _ = GenericInitTuple<Int>((3, 4))
@@ -972,8 +972,8 @@ do {
   _ = GenericInit(c)
 
   _ = GenericInitTwo(a, b)
-  _ = GenericInitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericInitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{22-23=}} {{27-28=}}
+  _ = GenericInitTwo(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = GenericInitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(T, T)' [with T = Int]}} {{24-24=(}} {{28-28=)}}
   _ = GenericInitTuple((a, b))
@@ -990,8 +990,8 @@ do {
   _ = GenericInit<(Int, Int)>(c)
 
   _ = GenericInitTwo<Int>(a, b)
-  _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericInitTwo<Int>(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo<Int>((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{27-28=}} {{32-33=}}
+  _ = GenericInitTwo<Int>(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = GenericInitTuple<Int>(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{29-29=(}} {{33-33=)}}
   _ = GenericInitTuple<Int>((a, b))
@@ -1008,8 +1008,8 @@ do {
   _ = GenericInit(c)
 
   _ = GenericInitTwo(a, b)
-  _ = GenericInitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericInitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{22-23=}} {{27-28=}}
+  _ = GenericInitTwo(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = GenericInitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(T, T)' [with T = Int]}} {{24-24=(}} {{28-28=)}}
   _ = GenericInitTuple((a, b))
@@ -1026,8 +1026,8 @@ do {
    _ = GenericInit<(Int, Int)>(c)
 
   _ = GenericInitTwo<Int>(a, b)
-  _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericInitTwo<Int>(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo<Int>((a, b)) // expected-error {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{27-28=}} {{32-33=}}
+  _ = GenericInitTwo<Int>(c) // expected-error {{initializer expects 2 separate arguments}}
 
   _ = GenericInitTuple<Int>(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{29-29=(}} {{33-33=)}}
   _ = GenericInitTuple<Int>((a, b))
@@ -1065,7 +1065,7 @@ do {
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[3.0, 4.0]
-  _ = s2[(3.0, 4.0)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[(3.0, 4.0)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{19-20=}}
 
   let s3 = GenericSubscriptTuple<Double>()
   _ = s3[3.0, 4.0] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{10-10=(}} {{18-18=)}}
@@ -1088,8 +1088,8 @@ do {
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[(a, b)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{15-16=}}
+  _ = s2[d] // expected-error {{subscript expects 2 separate arguments}}
 
   let s3 = GenericSubscriptTuple<Double>()
   _ = s3[a, b] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{10-10=(}} {{14-14=)}}
@@ -1110,8 +1110,8 @@ do {
 
   var s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[(a, b)] // expected-error {{subscript expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{10-11=}} {{15-16=}}
+  _ = s2[d] // expected-error {{subscript expects 2 separate arguments}}
 
   var s3 = GenericSubscriptTuple<Double>()
   _ = s3[a, b] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{10-10=(}} {{14-14=)}}
@@ -1136,7 +1136,7 @@ do {
   _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
-  _ = GenericEnum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum.two((3, 4)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{23-24=}} {{28-29=}}
 
   _ = GenericEnum.tuple(3, 4) // expected-error {{enum case 'tuple' expects a single parameter of type '(T, T)' [with T = Int]}} {{25-25=(}} {{29-29=)}}
   _ = GenericEnum.tuple((3, 4))
@@ -1152,7 +1152,7 @@ do {
   _ = GenericEnum<(Int, Int)>.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum<Int>.two(3, 4)
-  _ = GenericEnum<Int>.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum<Int>.two((3, 4)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{28-29=}} {{33-34=}}
 
   _ = GenericEnum<Int>.tuple(3, 4) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{30-30=(}} {{34-34=)}}
   _ = GenericEnum<Int>.tuple((3, 4))
@@ -1168,8 +1168,8 @@ do {
   _ = GenericEnum.one(c)
 
   _ = GenericEnum.two(a, b)
-  _ = GenericEnum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericEnum.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{23-24=}} {{28-29=}}
+  _ = GenericEnum.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = GenericEnum.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(T, T)' [with T = Int]}} {{25-25=(}} {{29-29=)}}
   _ = GenericEnum.tuple((a, b))
@@ -1186,8 +1186,8 @@ do {
   _ = GenericEnum<(Int, Int)>.one(c)
 
   _ = GenericEnum<Int>.two(a, b)
-  _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericEnum<Int>.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum<Int>.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{28-29=}} {{33-34=}}
+  _ = GenericEnum<Int>.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = GenericEnum<Int>.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{30-30=(}} {{34-34=)}}
   _ = GenericEnum<Int>.tuple((a, b))
@@ -1204,8 +1204,8 @@ do {
   _ = GenericEnum.one(c)
 
   _ = GenericEnum.two(a, b)
-  _ = GenericEnum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericEnum.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{23-24=}} {{28-29=}}
+  _ = GenericEnum.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = GenericEnum.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(T, T)' [with T = Int]}} {{25-25=(}} {{29-29=)}}
   _ = GenericEnum.tuple((a, b))
@@ -1222,8 +1222,8 @@ do {
   _ = GenericEnum<(Int, Int)>.one(c)
 
   _ = GenericEnum<Int>.two(a, b)
-  _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericEnum<Int>.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum<Int>.two((a, b)) // expected-error {{enum case 'two' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{28-29=}} {{33-34=}}
+  _ = GenericEnum<Int>.two(c) // expected-error {{enum case 'two' expects 2 separate arguments}}
 
   _ = GenericEnum<Int>.tuple(a, b) // expected-error {{enum case 'tuple' expects a single parameter of type '(Int, Int)'}} {{30-30=(}} {{34-34=)}}
   _ = GenericEnum<Int>.tuple((a, b))
@@ -1255,7 +1255,7 @@ do {
   s.requirementLabeled(x: (3.0))
 
   s.requirementTwo(3.0, 4.0)
-  s.requirementTwo((3.0, 4.0)) // expected-error {{missing argument for parameter #2 in call}}
+  s.requirementTwo((3.0, 4.0)) // expected-error {{instance method 'requirementTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{20-21=}} {{29-30=}}
 
   s.requirementTuple(3.0, 4.0) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{30-30=)}}
   s.requirementTuple((3.0, 4.0))
@@ -1282,7 +1282,7 @@ do {
   s.requirement(c)
 
   s.requirementTwo(a, b)
-  s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.requirementTwo((a, b)) // expected-error {{instance method 'requirementTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{20-21=}} {{25-26=}}
 
   s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
   s.requirementTuple((a, b))
@@ -1307,7 +1307,7 @@ do {
   s.requirement(c)
 
   s.requirementTwo(a, b)
-  s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.requirementTwo((a, b)) // expected-error {{instance method 'requirementTwo' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{20-21=}} {{25-26=}}
 
   s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
   s.requirementTuple((a, b))
@@ -1406,8 +1406,8 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
 
   f2.forEach { block in
   // expected-note@-1 2{{'block' declared here}}
-    block(p) // expected-error {{missing argument for parameter #2 in call}}
-    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
+    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
+    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 
@@ -1420,8 +1420,8 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
 
   f2.forEach { (block: (Bool, Bool) -> ()) in
   // expected-note@-1 2{{'block' declared here}}
-    block(p) // expected-error {{missing argument for parameter #2 in call}}
-    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
+    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
+    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1716,7 +1716,7 @@ func rdar48443263() {
 
   func bar(_ s1: S1, _ s2: S2, _ fn: () -> Void) {
     foo(s1, fn) // Ok because s.V is Void
-    foo(s2, fn) // expected-error {{cannot convert value of type '() -> Void' to expected argument type '(_) -> Void'}}
+    foo(s2, fn) // expected-error {{cannot convert value of type '() -> Void' to expected argument type '(S2.V) -> Void' (aka '(Int) -> ()')}}
   }
 }
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -137,9 +137,9 @@ func test20770032() {
 
 func tuple_splat1(_ a : Int, _ b : Int) { // expected-note 2 {{'tuple_splat1' declared here}}
   let x = (1,2)
-  tuple_splat1(x)          // expected-error {{missing argument for parameter #2 in call}}
+  tuple_splat1(x)          // expected-error {{global function 'tuple_splat1' expects 2 separate arguments}}
   tuple_splat1(1, 2)       // Ok.
-  tuple_splat1((1, 2))     // expected-error {{missing argument for parameter #2 in call}}
+  tuple_splat1((1, 2))     // expected-error {{global function 'tuple_splat1' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{16-17=}} {{21-22=}}
 }
 
 // This take a tuple as a value, so it isn't a tuple splat.

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -114,7 +114,7 @@ struct Count { // expected-note {{'init(title:)' declared here}}
 func getCounts(_ scheduler: sr5154_Scheduler, _ handler: @escaping ([Count]) -> Void) {
   scheduler.inBackground(run: {
     return [Count()] // expected-error {{missing argument for parameter 'title' in call}}
-  }, completedBy: {
+  }, completedBy: { // expected-error {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{20-20= _ in}}
   })
 }
 

--- a/test/decl/func/constructor.swift
+++ b/test/decl/func/constructor.swift
@@ -79,7 +79,7 @@ extension D {
   init() { i = 17 }
 }
 
-F() // expected-error{{missing argument for parameter 'd'}}
+F() // expected-error{{missing arguments for parameters 'd', 'b', 'c' in call}}
 D() // okay // expected-warning{{unused}}
 B() // okay // expected-warning{{unused}}
 C() // expected-error{{missing argument for parameter 'd'}}

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -162,7 +162,7 @@ let fooThing4 = Foo(a: 0, b: true, d: 1, e: 2, f: false, g: 10, h: nil) // ok
 
 // Ensure that tuple init is not allowed
 // Here b = false and g = nil, but we're checking that e and f don't get a default value
-let fooThing5 = Foo(a: 0, d: 1, h: nil) // expected-error {{missing argument for parameter 'e' in call}}
+let fooThing5 = Foo(a: 0, d: 1, h: nil) // expected-error {{missing arguments for parameters 'e', 'f' in call}}
                                         // expected-note@-25 {{'init(a:b:d:e:f:g:h:)' declared here}}
 
 // Here b = false and g = nil, but we're checking that f doesn't get a default value

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -62,7 +62,7 @@ extension P1 {
 // ----------------------------------------------------------------------------
 // The 'self' type of a Self method is based on Self
 class C1 {
-  required init(int i: Int) {}
+  required init(int i: Int) {} // expected-note {{'init(int:)' declared here}}
 
   // Instance methods have a self of type Self.
   func f(_ b: Bool) -> Self {
@@ -89,7 +89,7 @@ class C1 {
 
     if b { return self.init(int: 5) }
 
-    return Self() // expected-error{{non-nominal type 'Self' does not support explicit initialization}}
+    return Self() // expected-error{{missing argument for parameter 'int' in call}} {{17-17=int: <#Int#>}}
   }
 
   // This used to crash because metatype construction went down a

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -43,6 +43,7 @@ func funcdecl5(_ a: Int, _ y: Int) {
 
   var testfunc : ((), Int) -> Int  // expected-note {{'testfunc' declared here}}
   testfunc({$0+1})  // expected-error {{missing argument for parameter #2 in call}}
+  // expected-error@-1 {{cannot convert value of type '(Int) -> Int' to expected argument type '()'}}
 
   funcdecl5(1, 2) // recursion.
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -858,10 +858,10 @@ _ = _.foo // expected-error {{type of expression is ambiguous without more conte
 
 // <rdar://problem/22211854> wrong arg list crashing sourcekit
 func r22211854() {
-    func f(_ x: Int, _ y: Int, _ z: String = "") {} // expected-note 2 {{'f' declared here}}
+    func f(_ x: Bool, _ y: Int, _ z: String = "") {} // expected-note 2 {{'f' declared here}}
     func g<T>(_ x: T, _ y: T, _ z: String = "") {} // expected-note 2 {{'g' declared here}}
 
-    f(1) // expected-error{{missing argument for parameter #2 in call}}
+    f(false) // expected-error{{missing argument for parameter #2 in call}}
     g(1) // expected-error{{missing argument for parameter #2 in call}}
     func h() -> Int { return 1 }
     f(h() == 1) // expected-error{{missing argument for parameter #2 in call}}

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -159,7 +159,7 @@ class RDar16666631 {
    var i: Int
    var d: Double
    var s: String
-   init(i: Int, d: Double, s: String) {
+   init(i: Int, d: Double, s: String) { // expected-note {{'init(i:d:s:)' declared here}}
       self.i = i
       self.d = d
       self.s = s
@@ -168,9 +168,7 @@ class RDar16666631 {
       self.init(i: i, d: 0.1, s: s)
    }
 }
-let rdar16666631 = RDar16666631(i: 5, d: 6) // expected-error {{incorrect argument label in call (have 'i:d:', expected 'i:s:')}}
-// expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
-
+let rdar16666631 = RDar16666631(i: 5, d: 6) // expected-error {{missing argument for parameter 's' in call}} {{43-43=, s: <#String#>}}
 
 struct S {
   init() {

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar48994658.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar48994658.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-struct Ref<Value> {
+struct Ref<Value> { // expected-note {{'Value' declared as parameter to type 'Ref'}}
   static func foo(_ value: Int) {} // expected-note {{declared here}}
 }
 
@@ -25,4 +25,6 @@ extension Ref : RefConvertible {
 
 func rdar_48994658() {
   Ref.foo() // expected-error {{missing argument for parameter #1 in call}}
+  // expected-error@-1 {{generic parameter 'Value' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}} {{6-6=<Any>}}
 }

--- a/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
+++ b/validation-test/compiler_crashers_2_fixed/0117-rdar33433087.swift
@@ -1,9 +1,11 @@
 // RUN: %target-typecheck-verify-swift
 
 class C {
-  private init() {} // expected-note {{declared here}}
-  init(n: Int) {}
+  private init() {}
+  init(n: Int) {} // expected-note {{'init(n:)' declared here}}
 }
 
+// TODO(diagnostics): Once "inaccessible members" are ported to the new framework it would be possible
+// to bring back `'C' initializer is inaccessible due to 'private' protection level` diagnostic here.
 _ = C()
-// expected-error@-1 {{'C' initializer is inaccessible due to 'private' protection level}}
+// expected-error@-1 {{missing argument for parameter 'n' in call}} {{7-7=n: <#Int#>}}


### PR DESCRIPTION
Detect and fix missing arguments in diagnostic mode by synthesizing new arguments to either assume a parameter type or be defaulted to `Any` (which means that new arguments are always considered "holes" in constraint system) and extend `MissingArgumentsFailure` to diagnose single/multiple missing argument(s) as well as contextual mismatches.

Resolves: rdar://problem/55603016
Resolves: rdar://problem/54851719
Resolves: rdar://problem/31331436
Resolves: [SR-3230](https://bugs.swift.org/browse/SR-3230)
Resolves: [SR-10126](https://bugs.swift.org/browse/SR-10126)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
