### PR TITLE
Fix master-next build

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4788,8 +4788,8 @@ void swift::serializeToBuffers(
       return false;
     });
     if (moduleSourceInfoBuffer)
-      *moduleSourceInfoBuffer = llvm::make_unique<llvm::SmallVectorMemoryBuffer>(
-        std::move(buf), options.SourceInfoOutputPath);
+      *moduleSourceInfoBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
+          std::move(buf), options.SourceInfoOutputPath);
   }
 }
 


### PR DESCRIPTION
This looks to be a mismerge from master. master-next uses std::make_unique instead of the now defunct llvm::make_unique.

cc @compnerd @JDevlieghere 