### PR TITLE
MetadataReader: Correct size measurement reading AnonymousContextDescriptors.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -761,7 +761,7 @@ public:
       baseSize = sizeof(TargetAnonymousContextDescriptor<Runtime>);
       if (AnonymousContextDescriptorFlags(flags.getKindSpecificFlags())
             .hasMangledName()) {
-        baseSize += sizeof(TargetMangledContextName<Runtime>);
+        metadataInitSize = sizeof(TargetMangledContextName<Runtime>);
       }
       break;
     case ContextDescriptorKind::Class:


### PR DESCRIPTION
By including the trailing mangled name reference in the baseSize, we computed the wrong offset for
the generic parameter header, and then miscomputed the size of the trailing generic context info.
This would lead to accesses into the context sometimes reading from uninitialized memory.
Fixes rdar://problem/55711107