### PR TITLE
Reflection: Traffic in RemoteRefs.

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -70,10 +70,11 @@ public:
 
 class FieldRecord {
   const FieldRecordFlags Flags;
+
+public:
   const RelativeDirectPointer<const char> MangledTypeName;
   const RelativeDirectPointer<const char> FieldName;
 
-public:
   FieldRecord() = delete;
 
   bool hasMangledTypeName() const {
@@ -84,11 +85,8 @@ public:
     return Demangle::makeSymbolicMangledNameStringRef(MangledTypeName.get());
   }
 
-  StringRef getFieldName(uintptr_t Low, uintptr_t High) const {
-    uintptr_t nameAddr = (uintptr_t)FieldName.get();
-    if (nameAddr < Low || nameAddr > High)
-      return "";
-    return (const char *)nameAddr;
+  StringRef getFieldName() const {
+    return FieldName.get();
   }
 
   bool isIndirectCase() const {
@@ -162,10 +160,10 @@ class FieldDescriptor {
     return reinterpret_cast<const FieldRecord *>(this + 1);
   }
 
+public:
   const RelativeDirectPointer<const char> MangledTypeName;
   const RelativeDirectPointer<const char> Superclass;
 
-public:
   FieldDescriptor() = delete;
 
   const FieldDescriptorKind Kind;
@@ -227,46 +225,13 @@ public:
   }
 };
 
-class FieldDescriptorIterator
-  : public std::iterator<std::forward_iterator_tag, FieldDescriptor> {
-public:
-  const void *Cur;
-  const void * const End;
-  FieldDescriptorIterator(const void *Cur, const void * const End)
-    : Cur(Cur), End(End) {}
-
-  const FieldDescriptor &operator*() const {
-    return *reinterpret_cast<const FieldDescriptor *>(Cur);
-  }
-
-  const FieldDescriptor *operator->() const {
-    return reinterpret_cast<const FieldDescriptor *>(Cur);
-  }
-
-  FieldDescriptorIterator &operator++() {
-    const auto &FR = this->operator*();
-    const void *Next = reinterpret_cast<const char *>(Cur)
-      + sizeof(FieldDescriptor) + FR.NumFields * FR.FieldRecordSize;
-    Cur = Next;
-    return *this;
-  }
-
-  bool operator==(FieldDescriptorIterator const &other) const {
-    return Cur == other.Cur && End == other.End;
-  }
-
-  bool operator!=(FieldDescriptorIterator const &other) const {
-    return !(*this == other);
-  }
-};
-
 // Associated type records describe the mapping from an associated
 // type to the type witness of a conformance.
 class AssociatedTypeRecord {
+public:
   const RelativeDirectPointer<const char> Name;
   const RelativeDirectPointer<const char> SubstitutedTypeName;
 
-public:
   StringRef getName() const {
     return Name.get();
   }
@@ -322,10 +287,9 @@ struct AssociatedTypeRecordIterator {
 // An associated type descriptor contains a collection of associated
 // type records for a conformance.
 struct AssociatedTypeDescriptor {
-private:
+public:
   const RelativeDirectPointer<const char> ConformingTypeName;
   const RelativeDirectPointer<const char> ProtocolTypeName;
-public:
 
   uint32_t NumAssociatedTypes;
   uint32_t AssociatedTypeRecordSize;
@@ -357,46 +321,12 @@ public:
   }
 };
 
-class AssociatedTypeIterator
-  : public std::iterator<std::forward_iterator_tag, AssociatedTypeDescriptor> {
-public:
-  const void *Cur;
-  const void * const End;
-  AssociatedTypeIterator(const void *Cur, const void * const End)
-    : Cur(Cur), End(End) {}
-
-  const AssociatedTypeDescriptor &operator*() const {
-    return *reinterpret_cast<const AssociatedTypeDescriptor *>(Cur);
-  }
-
-  const AssociatedTypeDescriptor *operator->() const {
-    return reinterpret_cast<const AssociatedTypeDescriptor *>(Cur);
-  }
-
-  AssociatedTypeIterator &operator++() {
-    const auto &ATR = this->operator*();
-    size_t Size = sizeof(AssociatedTypeDescriptor) +
-      ATR.NumAssociatedTypes * ATR.AssociatedTypeRecordSize;
-    const void *Next = reinterpret_cast<const char *>(Cur) + Size;
-    Cur = Next;
-    return *this;
-  }
-
-  bool operator==(AssociatedTypeIterator const &other) const {
-    return Cur == other.Cur && End == other.End;
-  }
-
-  bool operator!=(AssociatedTypeIterator const &other) const {
-    return !(*this == other);
-  }
-};
-
 // Builtin type records describe basic layout information about
 // any builtin types referenced from the other sections.
 class BuiltinTypeDescriptor {
+public:
   const RelativeDirectPointer<const char> TypeName;
 
-public:
   uint32_t Size;
 
   // - Least significant 16 bits are the alignment.
@@ -424,42 +354,10 @@ public:
   }
 };
 
-class BuiltinTypeDescriptorIterator
-  : public std::iterator<std::forward_iterator_tag, BuiltinTypeDescriptor> {
-public:
-  const void *Cur;
-  const void * const End;
-  BuiltinTypeDescriptorIterator(const void *Cur, const void * const End)
-    : Cur(Cur), End(End) {}
-
-  const BuiltinTypeDescriptor &operator*() const {
-    return *reinterpret_cast<const BuiltinTypeDescriptor *>(Cur);
-  }
-
-  const BuiltinTypeDescriptor *operator->() const {
-    return reinterpret_cast<const BuiltinTypeDescriptor *>(Cur);;
-  }
-
-  BuiltinTypeDescriptorIterator &operator++() {
-    const void *Next = reinterpret_cast<const char *>(Cur)
-      + sizeof(BuiltinTypeDescriptor);
-    Cur = Next;
-    return *this;
-  }
-
-  bool operator==(BuiltinTypeDescriptorIterator const &other) const {
-    return Cur == other.Cur && End == other.End;
-  }
-
-  bool operator!=(BuiltinTypeDescriptorIterator const &other) const {
-    return !(*this == other);
-  }
-};
-
 class CaptureTypeRecord {
+public:
   const RelativeDirectPointer<const char> MangledTypeName;
 
-public:
   CaptureTypeRecord() = delete;
 
   bool hasMangledTypeName() const {
@@ -502,10 +400,10 @@ struct CaptureTypeRecordIterator {
 };
 
 class MetadataSourceRecord {
+public:
   const RelativeDirectPointer<const char> MangledTypeName;
   const RelativeDirectPointer<const char> MangledMetadataSource;
 
-public:
   MetadataSourceRecord() = delete;
 
   bool hasMangledTypeName() const {
@@ -605,41 +503,6 @@ public:
     auto Begin = getMetadataSourceRecordBuffer();
     auto End = Begin + NumMetadataSources;
     return { End, End };
-  }
-};
-
-class CaptureDescriptorIterator
-  : public std::iterator<std::forward_iterator_tag, CaptureDescriptor> {
-public:
-  const void *Cur;
-  const void * const End;
-  CaptureDescriptorIterator(const void *Cur, const void * const End)
-    : Cur(Cur), End(End) {}
-
-  const CaptureDescriptor &operator*() const {
-    return *reinterpret_cast<const CaptureDescriptor *>(Cur);
-  }
-
-  const CaptureDescriptor *operator->() const {
-    return reinterpret_cast<const CaptureDescriptor *>(Cur);
-  }
-
-  CaptureDescriptorIterator &operator++() {
-    const auto &CR = this->operator*();
-    const void *Next = reinterpret_cast<const char *>(Cur)
-      + sizeof(CaptureDescriptor)
-      + CR.NumCaptureTypes * sizeof(CaptureTypeRecord)
-      + CR.NumMetadataSources * sizeof(MetadataSourceRecord);
-    Cur = Next;
-    return *this;
-  }
-
-  bool operator==(CaptureDescriptorIterator const &other) const {
-    return Cur == other.Cur && End == other.End;
-  }
-
-  bool operator!=(CaptureDescriptorIterator const &other) const {
-    return !(*this == other);
   }
 };
 

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Casting.h"
+#include "swift/Remote/MetadataReader.h"
 
 #include <iostream>
 #include <memory>
@@ -30,6 +31,7 @@ namespace reflection {
 
 using llvm::cast;
 using llvm::dyn_cast;
+using remote::RemoteRef;
 
 class TypeRef;
 class TypeRefBuilder;
@@ -147,7 +149,8 @@ class BuiltinTypeInfo : public TypeInfo {
   std::string Name;
 
 public:
-  explicit BuiltinTypeInfo(const BuiltinTypeDescriptor *descriptor);
+  explicit BuiltinTypeInfo(TypeRefBuilder &builder,
+                           RemoteRef<BuiltinTypeDescriptor> descriptor);
 
   const std::string &getMangledTypeName() const {
     return Name;
@@ -280,7 +283,7 @@ private:
   const TypeInfo *getEmptyTypeInfo();
 
   template <typename TypeInfoTy, typename... Args>
-  const TypeInfoTy *makeTypeInfo(Args... args) {
+  const TypeInfoTy *makeTypeInfo(Args &&... args) {
     auto TI = new TypeInfoTy(::std::forward<Args>(args)...);
     Pool.push_back(std::unique_ptr<const TypeInfo>(TI));
     return TI;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -50,9 +50,11 @@ private:
   const T *LocalBuffer;
 
 public:
-  /*implicit*/
-  RemoteRef(std::nullptr_t _)
+  RemoteRef()
     : Address(0), LocalBuffer(nullptr) {}
+
+  /*implicit*/
+  RemoteRef(std::nullptr_t _) : RemoteRef() {}
 
   template<typename StoredPointer>
   explicit RemoteRef(StoredPointer address, const T *localBuffer)
@@ -69,7 +71,7 @@ public:
   explicit operator bool() const {
     return LocalBuffer != nullptr;
   }
-
+  
   const T *operator->() const {
     assert(LocalBuffer);
     return LocalBuffer;
@@ -103,6 +105,11 @@ public:
   template<typename U>
   uint64_t resolveRelativeFieldData(U &field) const {
     return getField(field).resolveRelativeAddressData();
+  }
+  
+  RemoteRef atByteOffset(int64_t Offset) const {
+    return RemoteRef(Address + Offset,
+                     (const T *)((intptr_t)LocalBuffer + Offset));
   }
 };
 

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -48,38 +48,20 @@ typedef struct swift_reflection_section {
   void *End;
 } swift_reflection_section_t;
 
+typedef struct swift_reflection_section_pair {
+  swift_reflection_section_t section;
+  swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
+} swift_reflection_section_pair_t;
+
 /// Represents the set of Swift reflection sections of an image.
 /// Not all sections may be present.
 typedef struct swift_reflection_info {
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } field;
-
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } associated_types;
-
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } builtin_types;
-
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } capture;
-
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } type_references;
-
-  struct {
-    swift_reflection_section_t section;
-    swift_reflection_ptr_t offset; ///< DEPRECATED. Must be zero
-  } reflection_strings;
+  swift_reflection_section_pair_t field;
+  swift_reflection_section_pair_t associated_types;
+  swift_reflection_section_pair_t builtin_types;
+  swift_reflection_section_pair_t capture;
+  swift_reflection_section_pair_t type_references;
+  swift_reflection_section_pair_t reflection_strings;
 
   // Start address in local and remote address spaces.
   swift_reflection_ptr_t LocalStartAddress;

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -191,14 +191,17 @@ void TypeInfo::dump(std::ostream &OS, unsigned Indent) const {
   OS << '\n';
 }
 
-BuiltinTypeInfo::BuiltinTypeInfo(const BuiltinTypeDescriptor *descriptor)
+BuiltinTypeInfo::BuiltinTypeInfo(TypeRefBuilder &builder,
+                                 RemoteRef<BuiltinTypeDescriptor> descriptor)
     : TypeInfo(TypeInfoKind::Builtin,
                descriptor->Size,
                descriptor->getAlignment(),
                descriptor->Stride,
                descriptor->NumExtraInhabitants,
                descriptor->isBitwiseTakable()),
-      Name(descriptor->getMangledTypeName()) {}
+      Name(builder.getTypeRefString(
+              builder.readTypeRef(descriptor, descriptor->TypeName)))
+{}
 
 /// Utility class for building values that contain witness tables.
 class ExistentialTypeInfoBuilder {
@@ -253,15 +256,14 @@ class ExistentialTypeInfoBuilder {
         continue;
       }
 
-      std::pair<const FieldDescriptor *, const ReflectionInfo *> FD =
-          TC.getBuilder().getFieldTypeInfo(P);
-      if (FD.first == nullptr) {
+      auto FD = TC.getBuilder().getFieldTypeInfo(P);
+      if (FD == nullptr) {
         DEBUG_LOG(std::cerr << "No field descriptor: "; P->dump())
         Invalid = true;
         continue;
       }
 
-      switch (FD.first->Kind) {
+      switch (FD->Kind) {
         case FieldDescriptorKind::ObjCProtocol:
           // Objective-C protocols do not have any witness tables.
           ObjC = true;
@@ -344,7 +346,7 @@ public:
       }
 
       const auto &FD = TC.getBuilder().getFieldTypeInfo(T);
-      if (FD.first == nullptr) {
+      if (FD == nullptr) {
         DEBUG_LOG(std::cerr << "No field descriptor: "; T->dump())
         Invalid = true;
         return;
@@ -352,7 +354,7 @@ public:
 
       // We have a valid superclass constraint. It only affects
       // lowering by class-constraining the entire existential.
-      switch (FD.first->Kind) {
+      switch (FD->Kind) {
       case FieldDescriptorKind::Class:
         Refcounting = ReferenceCounting::Native;
         LLVM_FALLTHROUGH;
@@ -579,7 +581,7 @@ TypeConverter::getReferenceTypeInfo(ReferenceKind Kind,
   //
   // Weak references do not have any extra inhabitants.
 
-  auto *BuiltinTI = Builder.getBuiltinTypeInfo(TR);
+  auto BuiltinTI = Builder.getBuiltinTypeInfo(TR);
   if (BuiltinTI == nullptr) {
     DEBUG_LOG(std::cerr << "No TypeInfo for reference type: "; TR->dump());
     return nullptr;
@@ -620,14 +622,13 @@ TypeConverter::getThinFunctionTypeInfo() {
   if (ThinFunctionTI != nullptr)
     return ThinFunctionTI;
 
-  auto *descriptor = getBuilder().getBuiltinTypeInfo(
-      getThinFunctionTypeRef());
+  auto descriptor = getBuilder().getBuiltinTypeInfo(getThinFunctionTypeRef());
   if (descriptor == nullptr) {
     DEBUG_LOG(std::cerr << "No TypeInfo for function type\n");
     return nullptr;
   }
 
-  ThinFunctionTI = makeTypeInfo<BuiltinTypeInfo>(descriptor);
+  ThinFunctionTI = makeTypeInfo<BuiltinTypeInfo>(getBuilder(), descriptor);
 
   return ThinFunctionTI;
 }
@@ -656,14 +657,13 @@ TypeConverter::getAnyMetatypeTypeInfo() {
   if (AnyMetatypeTI != nullptr)
     return AnyMetatypeTI;
 
-  auto *descriptor = getBuilder().getBuiltinTypeInfo(
-      getAnyMetatypeTypeRef());
+  auto descriptor = getBuilder().getBuiltinTypeInfo(getAnyMetatypeTypeRef());
   if (descriptor == nullptr) {
     DEBUG_LOG(std::cerr << "No TypeInfo for metatype type\n");
     return nullptr;
   }
 
-  AnyMetatypeTI = makeTypeInfo<BuiltinTypeInfo>(descriptor);
+  AnyMetatypeTI = makeTypeInfo<BuiltinTypeInfo>(getBuilder(), descriptor);
 
   return AnyMetatypeTI;
 }
@@ -987,8 +987,7 @@ public:
       BitwiseTakable(true), Kind(RecordKind::Invalid), Invalid(false) {}
 
   const TypeInfo *
-  build(const TypeRef *TR,
-        const std::pair<const FieldDescriptor *, const ReflectionInfo *> &FD) {
+  build(const TypeRef *TR, RemoteRef<FieldDescriptor> FD) {
     // Sort enum into payload and no-payload cases.
     unsigned NoPayloadCases = 0;
     std::vector<FieldTypeInfo> PayloadCases;
@@ -1060,7 +1059,7 @@ public:
 
       // If we have a fixed descriptor for this type, it is a fixed-size
       // multi-payload enum that possibly uses payload spare bits.
-      auto *FixedDescriptor = TC.getBuilder().getBuiltinTypeInfo(TR);
+      auto FixedDescriptor = TC.getBuilder().getBuiltinTypeInfo(TR);
       if (FixedDescriptor) {
         Size = FixedDescriptor->Size;
         Alignment = FixedDescriptor->getAlignment();
@@ -1124,31 +1123,32 @@ public:
 
     /// Otherwise, get the fixed layout information from reflection
     /// metadata.
-    auto *descriptor = TC.getBuilder().getBuiltinTypeInfo(B);
+    auto descriptor = TC.getBuilder().getBuiltinTypeInfo(B);
     if (descriptor == nullptr) {
       DEBUG_LOG(std::cerr << "No TypeInfo for builtin type: "; B->dump());
       return nullptr;
     }
-    return TC.makeTypeInfo<BuiltinTypeInfo>(descriptor);
+    return TC.makeTypeInfo<BuiltinTypeInfo>(TC.getBuilder(), descriptor);
   }
 
   const TypeInfo *visitAnyNominalTypeRef(const TypeRef *TR) {
-    const auto &FD = TC.getBuilder().getFieldTypeInfo(TR);
-    if (FD.first == nullptr || FD.first->isStruct()) {
+    auto FD = TC.getBuilder().getFieldTypeInfo(TR);
+    if (FD == nullptr || FD->isStruct()) {
       // Maybe this type is opaque -- look for a builtin
       // descriptor to see if we at least know its size
       // and alignment.
       if (auto ImportedTypeDescriptor = TC.getBuilder().getBuiltinTypeInfo(TR))
-        return TC.makeTypeInfo<BuiltinTypeInfo>(ImportedTypeDescriptor);
+        return TC.makeTypeInfo<BuiltinTypeInfo>(TC.getBuilder(),
+                                                ImportedTypeDescriptor);
 
       // Otherwise, we're out of luck.
-      if (FD.first == nullptr) {
+      if (FD == nullptr) {
         DEBUG_LOG(std::cerr << "No TypeInfo for nominal type: "; TR->dump());
         return nullptr;
       }
     }
 
-    switch (FD.first->Kind) {
+    switch (FD->Kind) {
     case FieldDescriptorKind::Class:
       // A value of class type is a single retainable pointer.
       return TC.getReferenceTypeInfo(ReferenceKind::Strong,
@@ -1382,14 +1382,13 @@ const TypeInfo *TypeConverter::getTypeInfo(const TypeRef *TR) {
 
 const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
                                                         unsigned start) {
-  std::pair<const FieldDescriptor *, const ReflectionInfo *> FD =
-      getBuilder().getFieldTypeInfo(TR);
-  if (FD.first == nullptr) {
+  auto FD = getBuilder().getFieldTypeInfo(TR);
+  if (FD == nullptr) {
     DEBUG_LOG(std::cerr << "No field descriptor: "; TR->dump());
     return nullptr;
   }
 
-  switch (FD.first->Kind) {
+  switch (FD->Kind) {
   case FieldDescriptorKind::Class:
   case FieldDescriptorKind::ObjCClass: {
     // Lower the class's fields using substitutions from the

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -990,36 +990,6 @@ public:
   }
 };
 
-class StaticFieldSection {
-  const void *Begin;
-  const void *End;
-
-public:
-  StaticFieldSection(const void *begin, const void *end)
-      : Begin(begin), End(end) {}
-
-  FieldDescriptorIterator begin() const {
-    return FieldDescriptorIterator(Begin, End);
-  }
-
-  FieldDescriptorIterator end() const {
-    return FieldDescriptorIterator(End, End);
-  }
-};
-
-class DynamicFieldSection {
-  const FieldDescriptor **Begin;
-  const FieldDescriptor **End;
-
-public:
-  DynamicFieldSection(const FieldDescriptor **fields, size_t size)
-      : Begin(fields), End(fields + size) {}
-
-  const FieldDescriptor **begin() const { return Begin; }
-
-  const FieldDescriptor **end() const { return End; }
-};
-
 } // namespace
 
 #pragma mark Metadata lookup via mangled name

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -328,7 +328,7 @@ getFieldAt(const Metadata *base, unsigned index) {
   const FieldDescriptor &descriptor = *fields;
   auto &field = descriptor.getFields()[index];
   // Bounds are always valid as the offset is constant.
-  auto name = field.getFieldName(0, std::numeric_limits<uintptr_t>::max());
+  auto name = field.getFieldName();
 
   // Enum cases don't always have types.
   if (!field.hasMangledTypeName())


### PR DESCRIPTION
Instead of passing around raw local pointers and references, and spreading
tricky offset arithmetic around with the Local/RemoteAddress fields in
ReflectionInfo, have the TypeRefBuilder code use RemoteRefs everywhere,
which keep the remote/local mapping together in one unit and provide
centralized API for this logic.

This doesn't yet change how code uses the RemoteRef address data to
follow pointers across objects, for things like reading type refs, but
that should be much easier to do after this lands.