### PR TITLE
Cherry-pick standard library parsing fix for debug builds.

### DIFF
--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -300,7 +300,7 @@ public:
     return SyntaxNode(std::move(rawNode));
   }
 
-  ParsedTokenSyntax &&popToken();
+  ParsedTokenSyntax popToken();
 
   /// Create a node using the tail of the collected parts. The number of parts
   /// is automatically determined from \c Kind. Node: limited number of \c Kind

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -163,8 +163,9 @@ const SyntaxParsingContext *SyntaxParsingContext::getRoot() const {
   return Curr;
 }
 
-ParsedTokenSyntax &&SyntaxParsingContext::popToken() {
-  return std::move(popIf<ParsedTokenSyntax>().getValue());
+ParsedTokenSyntax SyntaxParsingContext::popToken() {
+  auto tok = popIf<ParsedTokenSyntax>();
+  return std::move(tok.getValue());
 }
 
 /// Add Token with Trivia to the parts.


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/commit/fe02d508d0292e914a67af461f88f1bab66d0b04 to fix standard library parsing error for Debug builds, documented at https://github.com/apple/swift/pull/27203.

Resolves [TF-814](https://bugs.swift.org/browse/TF-814). Verified on macOS and Ubuntu.