### PR TITLE
[ownership] Add verification that parent borrow scopes completely enclose implicit child borrow scopes introduced via BorrowScopeOperand

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -288,10 +288,22 @@ bool SILValueOwnershipChecker::gatherUsers(
       continue;
     }
 
-    // If we are guaranteed, but are not a guaranteed forwarding inst,
-    // just continue. This user is just treated as a normal use.
-    if (!isGuaranteedForwardingInst(user))
+    // If we are guaranteed, but are not a guaranteed forwarding inst, we add
+    // the end scope instructions of any new sub-scopes. This ensures that the
+    // parent scope completely encloses the child borrow scope.
+    //
+    // Example: A guaranteed parameter of a co-routine.
+    if (!isGuaranteedForwardingInst(user)) {
+      // First check if we are visiting an operand that introduces a new
+      // sub-scope. If we do, we need to preserve
+      if (auto scopedOperand = BorrowScopeOperand::get(op)) {
+        scopedOperand->visitEndScopeInstructions(
+            [&](Operand *op) { implicitRegularUsers.push_back(op); });
+      }
+
+      // Then continue.
       continue;
+    }
 
     // At this point, we know that we must have a forwarded subobject. Since the
     // base type is guaranteed, we know that the subobject is either guaranteed

--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands.sil
@@ -100,3 +100,77 @@ bb3:
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine'
+// CHECK: Found use after free?!
+// CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_apply %3
+// CHECK: Block: bb0
+sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %1 : $Builtin.NativeObject
+  end_apply %token
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_2'
+// CHECK: Found use after free?!
+// CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   abort_apply %3
+// CHECK: Block: bb0
+sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %1 : $Builtin.NativeObject
+  abort_apply %token
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
+// CHECK: Found use after free?!
+// CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   abort_apply %3
+// CHECK: Block: bb1
+
+// CHECK-LABEL: Function: 'parent_borrow_scope_end_before_end_borrow_coroutine_3'
+// CHECK: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK: Value: %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK:     Remaining Users:
+// CHECK: User:  abort_apply %3
+// CHECK: Block: bb1
+
+sil [ossa] @parent_borrow_scope_end_before_end_borrow_coroutine_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %1 : $Builtin.NativeObject
+  abort_apply %token
+  br bb3
+
+bb2:
+  end_apply %token
+  end_borrow %1 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
@@ -7,15 +7,6 @@
 
 import Builtin
 
-sil [ossa] @destroy_value_before_end_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : @owned $Builtin.NativeObject):
-  %1 = begin_borrow %0 : $Builtin.NativeObject
-  end_borrow %1 : $Builtin.NativeObject
-  destroy_value %0 : $Builtin.NativeObject
-  %9999 = tuple()
-  return %9999 : $()
-}
-
 sil [ossa] @coroutine_callee : $@yield_once (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   yield (), resume bb1, unwind bb2
@@ -26,6 +17,15 @@ bb1:
 
 bb2:
   unwind
+}
+
+sil [ossa] @destroy_value_before_end_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
 }
 
 sil [ossa] @destroy_value_before_end_borrow_coroutine : $@convention(thin) (@owned Builtin.NativeObject) -> () {
@@ -87,6 +87,84 @@ bb1:
 
 bb2:
   end_apply %token
+  destroy_value %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @end_parent_scope_before_end_borrow_coroutine : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_apply %token
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @end_parent_scope_before_end_borrow_coroutine_1a : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_apply %token
+  br bb1
+
+bb1:
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @end_parent_scope_before_end_borrow_coroutine_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  abort_apply %token
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @end_parent_scope_before_end_borrow_coroutine_2b : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  abort_apply %token
+  br bb1
+
+bb1:
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @positive_end_parent_scope_before_end_borrow_coroutine_3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %coro = function_ref @coroutine_callee : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %token = begin_apply %coro(%1) : $@yield_once @convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  abort_apply %token
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  end_apply %token
+  end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   br bb3
 


### PR DESCRIPTION
As an example consider a begin_borrow/end_borrow scope and a coroutine:

```
  %0 = begin_borrow %...
  ...
  %token = apply %coroutine(%0)
  ...
  end_apply %token
  ...
  end_borrow %0
```

With this change, we will validate that the end_borrow never enters the region
of code until the coroutine is actually finished executing (as shown by the
end_apply).
