### PR TITLE
[CSApply] Don't diagnose a 'static let none' as ambiguous none unless its an enum type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2487,7 +2487,14 @@ namespace {
             if (member->isInstanceMember()) {
               return;
             }
-            
+
+            // If we have something like 'static let none = 1', then ignore.
+            if (auto VD = dyn_cast<VarDecl>(member)) {
+              if (!VD->getInterfaceType()->isEqual(
+                      baseTyNominalDecl->getDeclaredInterfaceType()))
+                return;
+            }
+
             // Return if the member is an enum case w/ assoc values, as we only
             // care (for now) about cases with no assoc values (like none)
             if (auto EED = dyn_cast<EnumElementDecl>(member)) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2494,7 +2494,10 @@ namespace {
               }
             }
 
-            return true;
+            // Filter out anything that's not one of the above. We don't care
+            // if we have a typealias named 'none' or a struct/class named
+            // 'none'.
+            return false;
           });
 
           if (results.empty()) {

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -442,3 +442,20 @@ protocol P {}
 
 enum E : C & P {}
 // expected-error@-1 {{inheritance from class-constrained protocol composition type 'C & P'}}
+
+// SR-11522
+
+enum EnumWithStaticNone1 {
+  case a
+  static let none = 1
+}
+
+enum EnumWithStaticNone2 {
+  case a
+  static let none = EnumWithStaticNone2.a
+}
+
+let _: EnumWithStaticNone1? = .none // Okay
+let _: EnumWithStaticNone2? = .none // expected-warning {{assuming you mean 'Optional<EnumWithStaticNone2>.none'; did you mean 'EnumWithStaticNone2.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{31-31=Optional}}
+// expected-note@-2 {{use 'EnumWithStaticNone2.none' instead}}{{31-31=EnumWithStaticNone2}}

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -455,7 +455,45 @@ enum EnumWithStaticNone2 {
   static let none = EnumWithStaticNone2.a
 }
 
+enum EnumWithStaticNone3 {
+  case a
+  static let none = EnumWithStaticNone3.a
+  var none: EnumWithStaticNone3 { return .a }
+}
+
+enum EnumWithStaticNone4 {
+  case a
+  var none: EnumWithStaticNone4 { return .a }
+  static let none = EnumWithStaticNone4.a
+}
+
+enum EnumWithStaticFuncNone1 {
+  case a
+  static func none() -> Int { return 1 }
+}
+
+enum EnumWithStaticFuncNone2 {
+  case a
+  static func none() -> EnumWithStaticFuncNone2 { return .a }
+}
+
+/// Make sure we don't diagnose 'static let none = 1', but do diagnose 'static let none = TheEnum.anotherCase' ///
+
 let _: EnumWithStaticNone1? = .none // Okay
 let _: EnumWithStaticNone2? = .none // expected-warning {{assuming you mean 'Optional<EnumWithStaticNone2>.none'; did you mean 'EnumWithStaticNone2.none' instead?}}
 // expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{31-31=Optional}}
 // expected-note@-2 {{use 'EnumWithStaticNone2.none' instead}}{{31-31=EnumWithStaticNone2}}
+
+/// Make sure we diagnose if we have both static and instance 'none' member regardless of source order ///
+
+let _: EnumWithStaticNone3? = .none // expected-warning {{assuming you mean 'Optional<EnumWithStaticNone3>.none'; did you mean 'EnumWithStaticNone3.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{31-31=Optional}}
+// expected-note@-2 {{use 'EnumWithStaticNone3.none' instead}}{{31-31=EnumWithStaticNone3}}
+let _: EnumWithStaticNone4? = .none // expected-warning {{assuming you mean 'Optional<EnumWithStaticNone4>.none'; did you mean 'EnumWithStaticNone4.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{31-31=Optional}}
+// expected-note@-2 {{use 'EnumWithStaticNone4.none' instead}}{{31-31=EnumWithStaticNone4}}
+
+/// Make sure we don't diagnose 'static func none -> T' ///
+
+let _: EnumWithStaticFuncNone1? = .none // Okay
+let _: EnumWithStaticFuncNone2? = .none // Okay

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -523,3 +523,32 @@ let _: GenericEnumWithoutNone<Int>? = .none // expected-warning {{assuming you m
 // expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{39-39=Optional}}
 // expected-note@-2 {{use 'GenericEnumWithoutNone<Int>.none' instead}}{{39-39=GenericEnumWithoutNone<Int>}}
 let _: GenericEnumWithoutNone<String>? = .none // Okay
+
+// A couple of edge cases that shouldn't trigger the warning //
+
+enum EnumWithStructNone {
+  case bar
+  struct none {}
+}
+
+enum EnumWithTypealiasNone {
+  case bar
+  typealias none = EnumWithTypealiasNone
+}
+
+enum EnumWithBothStructAndComputedNone {
+  case bar
+  struct none {}
+  var none: EnumWithBothStructAndComputedNone { . bar }
+}
+
+enum EnumWithBothTypealiasAndComputedNone {
+  case bar
+  typealias none = EnumWithBothTypealiasAndComputedNone
+  var none: EnumWithBothTypealiasAndComputedNone { . bar }
+}
+
+let _: EnumWithStructNone? = .none // Okay
+let _: EnumWithTypealiasNone? = .none // Okay
+let _: EnumWithBothStructAndComputedNone? = .none // Okay
+let _: EnumWithBothTypealiasAndComputedNone? = .none // Okay

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -509,7 +509,7 @@ let _: GenericEnumWithStaticNone<Int>? = .none // expected-warning {{assuming yo
 // expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{42-42=Optional}}
 // expected-note@-2 {{use 'GenericEnumWithStaticNone<Int>.none' instead}}{{42-42=GenericEnumWithStaticNone<Int>}}
 let _: GenericEnumWithStaticNone<String>? = .none // Okay
-let _: GenericEnumWithStaticNone? = .none // Okay
+let _: GenericEnumWithStaticNone? = .none // FIXME(SR-11535): This should be diagnosed
 
 enum GenericEnumWithoutNone<T> {
   case a

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -497,3 +497,29 @@ let _: EnumWithStaticNone4? = .none // expected-warning {{assuming you mean 'Opt
 
 let _: EnumWithStaticFuncNone1? = .none // Okay
 let _: EnumWithStaticFuncNone2? = .none // Okay
+
+/// Make sure we diagnose generic ones as well including conditional ones ///
+
+enum GenericEnumWithStaticNone<T> {
+  case a
+  static var none: GenericEnumWithStaticNone<Int> { .a }
+}
+
+let _: GenericEnumWithStaticNone<Int>? = .none // expected-warning {{assuming you mean 'Optional<GenericEnumWithStaticNone<Int>>.none'; did you mean 'GenericEnumWithStaticNone<Int>.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{42-42=Optional}}
+// expected-note@-2 {{use 'GenericEnumWithStaticNone<Int>.none' instead}}{{42-42=GenericEnumWithStaticNone<Int>}}
+let _: GenericEnumWithStaticNone<String>? = .none // Okay
+let _: GenericEnumWithStaticNone? = .none // Okay
+
+enum GenericEnumWithoutNone<T> {
+  case a
+}
+
+extension GenericEnumWithoutNone where T == Int {
+  static var none: GenericEnumWithoutNone<Int> { .a }
+}
+
+let _: GenericEnumWithoutNone<Int>? = .none // expected-warning {{assuming you mean 'Optional<GenericEnumWithoutNone<Int>>.none'; did you mean 'GenericEnumWithoutNone<Int>.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}}{{39-39=Optional}}
+// expected-note@-2 {{use 'GenericEnumWithoutNone<Int>.none' instead}}{{39-39=GenericEnumWithoutNone<Int>}}
+let _: GenericEnumWithoutNone<String>? = .none // Okay


### PR DESCRIPTION
We were incorrectly diagnosing the following:

```swift
enum Foo {
  case bar
  static let none = 1
}

let optionalFoo: Foo? = .none // warning: assuming you mean 'Optional<Foo>.none'; 
                              // did you mean 'Foo.none' instead?
```

There's no ambiguity here because `.none` could only refer to `Optional.none`, since the type of `Foo.none` is `Int`.

We should still offer a warning in case the user does something like this:

```swift
enum Foo {
  case bar
  static let none = Foo.bar
}

let optionalFoo: Foo? = .none // warning
```

Resolves [SR-11522](https://bugs.swift.org/browse/SR-11522).