### PR TITLE
Reflection: Share demangler with MetadataReader.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -107,9 +107,8 @@ public:
   using typename super::StoredPointer;
 
   explicit ReflectionContext(std::shared_ptr<MemoryReader> reader)
-    : super(std::move(reader)) {
-    getBuilder().setMetadataReader(*this);
-  }
+    : super(std::move(reader), *this)
+  {}
 
   ReflectionContext(const ReflectionContext &other) = delete;
   ReflectionContext &operator=(const ReflectionContext &other) = delete;

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -72,20 +72,20 @@ SWIFT_REMOTE_MIRROR_LINKAGE
 void
 swift_reflection_destroyReflectionContext(SwiftReflectionContextRef Context);
 
-/// Add reflection sections for a loaded Swift image.
+/// DEPRECATED. Add reflection sections for a loaded Swift image.
+///
+/// You probably want to use \c swift_reflection_addImage instead.
 SWIFT_REMOTE_MIRROR_LINKAGE
 void
 swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
                                    swift_reflection_info_t Info);
 
-#if defined(__APPLE__) && defined(__MACH__)
 /// Add reflection information from a loaded Swift image.
 /// Returns true on success, false if the image's memory couldn't be read.
 SWIFT_REMOTE_MIRROR_LINKAGE
 int
 swift_reflection_addImage(SwiftReflectionContextRef ContextRef,
                           swift_addr_t imageStart);
-#endif
 
 /// Returns a boolean indicating if the isa mask was successfully
 /// read, in which case it is stored in the isaMask out parameter.

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -55,6 +55,9 @@ typedef struct swift_reflection_section_pair {
 
 /// Represents the set of Swift reflection sections of an image.
 /// Not all sections may be present.
+///
+/// DEPRECATED. New RemoteMirror clients should use
+/// \c swift_reflection_addImage .
 typedef struct swift_reflection_info {
   swift_reflection_section_pair_t field;
   swift_reflection_section_pair_t associated_types;

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -31,7 +31,7 @@ static const std::string Shmrotocol = "Shmrotocol";
 using Param = remote::FunctionParam<const TypeRef *>;
 
 TEST(TypeRefTest, UniqueBuiltinTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto BI1 = Builder.createBuiltinType(ABC, ABC);
   auto BI2 = Builder.createBuiltinType(ABC, ABC);
@@ -42,7 +42,7 @@ TEST(TypeRefTest, UniqueBuiltinTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueNominalTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(ABC, nullptr);
@@ -58,7 +58,7 @@ TEST(TypeRefTest, UniqueNominalTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
@@ -82,7 +82,7 @@ TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueTupleTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(XYZ, nullptr);
@@ -114,7 +114,7 @@ TEST(TypeRefTest, UniqueTupleTypeRef) {
 
 TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   std::vector<const TypeRef *> Void;
   auto VoidResult = Builder.createTupleType(Void, "", false);
@@ -213,7 +213,7 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueProtocolTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   TypeRefBuilder::BuiltProtocolDecl P1 = std::make_pair(ABC, false);
   TypeRefBuilder::BuiltProtocolDecl P2 = std::make_pair(ABC, false);
@@ -237,7 +237,7 @@ TEST(TypeRefTest, UniqueProtocolTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueMetatypeTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto M1 = Builder.createMetatypeType(N1, None);
@@ -251,7 +251,7 @@ TEST(TypeRefTest, UniqueMetatypeTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueExistentialMetatypeTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto M1 = Builder.createExistentialMetatypeType(N1);
@@ -263,7 +263,7 @@ TEST(TypeRefTest, UniqueExistentialMetatypeTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueGenericTypeParameterTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP00_2 = Builder.createGenericTypeParameterType(0, 0);
@@ -276,7 +276,7 @@ TEST(TypeRefTest, UniqueGenericTypeParameterTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(ABC, nullptr);
   auto N2 = Builder.createNominalType(XYZ, nullptr);
@@ -296,7 +296,7 @@ TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueForeignClassTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto UN1 = Builder.getUnnamedForeignClassType();
   auto UN2 = Builder.getUnnamedForeignClassType();
@@ -310,7 +310,7 @@ TEST(TypeRefTest, UniqueForeignClassTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueObjCClassTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto UN1 = Builder.getUnnamedObjCClassType();
   auto UN2 = Builder.getUnnamedObjCClassType();
@@ -324,7 +324,7 @@ TEST(TypeRefTest, UniqueObjCClassTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueOpaqueTypeRef) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto Op = OpaqueTypeRef::get();
   auto Op1 = Builder.getOpaqueType();
@@ -335,7 +335,7 @@ TEST(TypeRefTest, UniqueOpaqueTypeRef) {
 }
 
 TEST(TypeRefTest, UniqueUnownedStorageType) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(MyClass, nullptr);
   auto N2 = Builder.createNominalType(NotMyClass, nullptr);
@@ -348,7 +348,7 @@ TEST(TypeRefTest, UniqueUnownedStorageType) {
 }
 
 TEST(TypeRefTest, UniqueWeakStorageType) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(MyClass, nullptr);
   auto N2 = Builder.createNominalType(NotMyClass, nullptr);
@@ -361,7 +361,7 @@ TEST(TypeRefTest, UniqueWeakStorageType) {
 }
 
 TEST(TypeRefTest, UniqueUnmanagedStorageType) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto N1 = Builder.createNominalType(MyClass, nullptr);
   auto N2 = Builder.createNominalType(NotMyClass, nullptr);
@@ -377,7 +377,7 @@ TEST(TypeRefTest, UniqueUnmanagedStorageType) {
 // (with the same pointer) as an ABC<T, U> that got substituted
 // with T : Int and U : Int.
 TEST(TypeRefTest, UniqueAfterSubstitution) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   std::string MangledIntName("Si");
   auto NominalInt = Builder.createNominalType(MangledIntName,
@@ -408,7 +408,7 @@ TEST(TypeRefTest, UniqueAfterSubstitution) {
 
 // Make sure subst() and isConcrete() walk into parent types
 TEST(TypeRefTest, NestedTypes) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
 
@@ -439,7 +439,7 @@ TEST(TypeRefTest, NestedTypes) {
 }
 
 TEST(TypeRefTest, DeriveSubstitutions) {
-  TypeRefBuilder Builder;
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP01 = Builder.createGenericTypeParameterType(0, 1);


### PR DESCRIPTION
TypeRefBuilder and MetadataReader had nearly identical symbolic reference resolvers,
but diverged because TypeRefBuilder had its own local/remote address management mechanism,
and because TypeRefBuilder tries to resolve opaque types to their underlying types, whereas
other MetadataReader clients want to preserve them as written in source. The first problem
has been addressed by making TypeRefBuilder use `RemoteRef` everywhere, and the second
can be handled with a flag (and might be able to be handled more elegantly with some more
refactoring of general opaque type handling in MetadataReader).