### PR TITLE
[build-script] Remove --lldb-build-with-* option

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -53,8 +53,7 @@ def _apply_default_arguments(args):
 
     # Build LLDB if any LLDB-related options were specified.
     if args.lldb_build_variant is not None or \
-       args.lldb_assertions is not None or \
-       args.lldb_build_with_xcode is not None:
+       args.lldb_assertions is not None:
         args.build_lldb = True
 
     # Set the default build variant.
@@ -75,9 +74,6 @@ def _apply_default_arguments(args):
 
     if args.lldb_build_variant is None:
         args.lldb_build_variant = args.build_variant
-
-    if args.lldb_build_with_xcode is None:
-        args.lldb_build_with_xcode = '0'
 
     if args.foundation_build_variant is None:
         args.foundation_build_variant = args.build_variant
@@ -645,14 +641,6 @@ def create_argument_parser():
     option('--debug-lldb', store('lldb_build_variant'),
            const='Debug',
            help='build the Debug variant of LLDB')
-
-    option('--lldb-build-with-xcode', store('lldb_build_with_xcode'),
-           const='1',
-           help='build LLDB using xcodebuild, if possible')
-
-    option('--lldb-build-with-cmake', store('lldb_build_with_xcode'),
-           const='0',
-           help='build LLDB using CMake')
 
     option('--debug-cmark', store('cmark_build_variant'),
            const='Debug',

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -154,7 +154,6 @@ EXPECTED_DEFAULTS = {
     'llbuild_assertions': True,
     'lldb_assertions': True,
     'lldb_build_variant': 'Debug',
-    'lldb_build_with_xcode': '0',
     'llvm_assertions': True,
     'llvm_build_variant': 'Debug',
     'llvm_max_parallel_lto_link_jobs':
@@ -355,10 +354,6 @@ EXPECTED_OPTIONS = [
               dest='libdispatch_build_variant', value='Debug'),
     SetOption('--debug-libicu', dest='libicu_build_variant', value='Debug'),
     SetOption('--debug-lldb', dest='lldb_build_variant', value='Debug'),
-    SetOption('--lldb-build-with-xcode', dest='lldb_build_with_xcode',
-              value='1'),
-    SetOption('--lldb-build-with-cmake', dest='lldb_build_with_xcode',
-              value='0'),
     SetOption('--debug-llvm', dest='llvm_build_variant', value='Debug'),
     SetOption('--debug-swift', dest='swift_build_variant', value='Debug'),
     SetOption('--debug-swift-stdlib',


### PR DESCRIPTION
Now that CMake is the one true way to build LLDB, we no longer need this
option in build-script.