### PR TITLE
swift-reflection-dump: Virtualize logical-to-physical address mapping. 

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -237,18 +237,13 @@ public:
         ReflStrMdSec.first == nullptr)
       return false;
 
-    auto LocalStartAddress = reinterpret_cast<uint64_t>(SectBuf.get());
-    auto RemoteStartAddress = static_cast<uint64_t>(RangeStart);
-
     ReflectionInfo info = {
         {FieldMdSec.first, FieldMdSec.second},
         {AssocTySec.first, AssocTySec.second},
         {BuiltinTySec.first, BuiltinTySec.second},
         {CaptureSec.first, CaptureSec.second},
         {TypeRefMdSec.first, TypeRefMdSec.second},
-        {ReflStrMdSec.first, ReflStrMdSec.second},
-        LocalStartAddress,
-        RemoteStartAddress};
+        {ReflStrMdSec.first, ReflStrMdSec.second}};
 
     this->addReflectionInfo(info);
 
@@ -346,19 +341,13 @@ public:
         ReflStrMdSec.first == nullptr)
       return false;
 
-    auto LocalStartAddress = reinterpret_cast<uintptr_t>(DOSHdrBuf.get());
-    auto RemoteStartAddress =
-        static_cast<uintptr_t>(ImageStart.getAddressData());
-
     ReflectionInfo Info = {
         {FieldMdSec.first, FieldMdSec.second},
         {AssocTySec.first, AssocTySec.second},
         {BuiltinTySec.first, BuiltinTySec.second},
         {CaptureSec.first, CaptureSec.second},
         {TypeRefMdSec.first, TypeRefMdSec.second},
-        {ReflStrMdSec.first, ReflStrMdSec.second},
-        LocalStartAddress,
-        RemoteStartAddress};
+        {ReflStrMdSec.first, ReflStrMdSec.second}};
     this->addReflectionInfo(Info);
     return true;
   }
@@ -466,19 +455,13 @@ public:
         ReflStrMdSec.first == nullptr)
       return false;
 
-    auto LocalStartAddress = reinterpret_cast<uint64_t>(Buf.get());
-    auto RemoteStartAddress =
-        static_cast<uint64_t>(ImageStart.getAddressData());
-
     ReflectionInfo info = {
         {FieldMdSec.first, FieldMdSec.second},
         {AssocTySec.first, AssocTySec.second},
         {BuiltinTySec.first, BuiltinTySec.second},
         {CaptureSec.first, CaptureSec.second},
         {TypeRefMdSec.first, TypeRefMdSec.second},
-        {ReflStrMdSec.first, ReflStrMdSec.second},
-        LocalStartAddress,
-        RemoteStartAddress};
+        {ReflStrMdSec.first, ReflStrMdSec.second}};
 
     this->addReflectionInfo(info);
 

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -203,9 +203,6 @@ struct ReflectionInfo {
   CaptureSection Capture;
   GenericSection TypeReference;
   GenericSection ReflectionString;
-
-  uint64_t LocalStartAddress;
-  uint64_t RemoteStartAddress;
 };
 
 struct ClosureContextInfo {

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -90,7 +90,7 @@ static DemanglerPrinter &operator<<(DemanglerPrinter &printer,
         };
         printer << "\\x" << Hexdigit[c >> 4] << Hexdigit[c & 0xF];
       } else {
-        printer << c;
+        printer << (char)c;
       }
       break;
     }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -79,12 +79,11 @@ static DemanglerPrinter &operator<<(DemanglerPrinter &printer,
     case '\n': printer << "\\n"; break;
     case '\r': printer << "\\r"; break;
     case '"': printer << "\\\""; break;
-    case '\'': printer << '\''; break; // no need to escape these
     case '\0': printer << "\\0"; break;
     default:
-      auto c = static_cast<char>(C);
-      // Other ASCII control characters should get escaped.
-      if (c < 0x20 || c == 0x7F) {
+      auto c = static_cast<unsigned char>(C);
+      // Other control or high-bit characters should get escaped.
+      if (c < 0x20 || c >= 0x7F) {
         static const char Hexdigit[] = {
           '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
           'A', 'B', 'C', 'D', 'E', 'F'

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -268,15 +268,13 @@ TypeRefBuilder::getBuiltinTypeInfo(const TypeRef *TR) {
   return nullptr;
 }
 
-// TODO: This can probably be eliminated.
 RemoteRef<CaptureDescriptor>
 TypeRefBuilder::getCaptureDescriptor(uint64_t RemoteAddress) {
   for (auto Info : ReflectionInfos) {
     for (auto CD : Info.Capture) {
-      auto OtherAddr = (reinterpret_cast<uint64_t>(CD.getLocalBuffer()) -
-                        Info.LocalStartAddress + Info.RemoteStartAddress);
-      if (OtherAddr == RemoteAddress)
+      if (RemoteAddress == CD.getAddressData()) {
         return CD;
+      }
     }
   }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -149,10 +149,7 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
     sectionFromInfo<BuiltinTypeDescriptorIterator>(Info, Info.builtin_types),
     sectionFromInfo<CaptureDescriptorIterator>(Info, Info.capture),
     sectionFromInfo<const void *>(Info, Info.type_references),
-    sectionFromInfo<const void *>(Info, Info.reflection_strings),
-    Info.LocalStartAddress,
-    Info.RemoteStartAddress
-  };
+    sectionFromInfo<const void *>(Info, Info.reflection_strings)};
   
   Context->addReflectionInfo(ContextInfo);
 }


### PR DESCRIPTION
Instead of copying the entire object file and moving around its sections to make an approximate
representation of its mapped state, use the memory-mapped buffer from `llvm::ObjectFile`, and
deal with non-contiguous logical mappings entirely in readBytes.