### PR TITLE
[AutoDiff] Enable ownership for JVP/VJP SILGen thunks.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3659,56 +3659,6 @@ SILGenFunction::getThunkedAutoDiffLinearMap(
   return getThunkedResult();
 }
 
-/// Forward function arguments, converting ownership.
-/// Adapted from `forwardFunctionArguments` in SILGenPoly.cpp.
-static void forwardFunctionArgumentsConvertingOwnership(
-    SILGenFunction &SGF, SILLocation loc, CanSILFunctionType fromTy,
-    CanSILFunctionType toTy, ArrayRef<ManagedValue> managedArgs,
-    SmallVectorImpl<SILValue> &forwardedArgs,
-    SmallVectorImpl<AllocStackInst *> &localAllocations,
-    SmallVectorImpl<SILValue> &argumentsToFree) {
-  auto fromParameters = fromTy->getParameters();
-  auto toParameters = toTy->getParameters();
-  for (auto index : indices(managedArgs)) {
-    auto &arg = managedArgs[index];
-    auto fromParam = fromParameters[index];
-    auto toParam = toParameters[index];
-    // To convert owned argument to be guaranteed, retain the argument.
-    if (fromParam.isConsumed() && !toParam.isConsumed()) {
-      // If the argument has an object type, emit `retain_value`.
-      if (arg.getType().isObject()) {
-        SGF.B.createRetainValue(loc, arg.getValue(),
-                                SGF.B.getDefaultAtomicity());
-        forwardedArgs.push_back(arg.getValue());
-        continue;
-      }
-      // If the argument has a loadable address type, emit `retain_value_addr`.
-      if (arg.getType().isLoadable(SGF.F)) {
-        SGF.B.createRetainValueAddr(loc, arg.getValue(),
-                                    SGF.B.getDefaultAtomicity());
-        forwardedArgs.push_back(arg.getValue());
-        continue;
-      }
-      // If the argument is address-only, emit a local allocation and
-      // `copy_addr`.
-      auto *alloc = SGF.B.createAllocStack(loc, arg.getType());
-      SGF.B.createCopyAddr(
-          loc, arg.getValue(), alloc, IsNotTake, IsInitialization);
-      localAllocations.push_back(alloc);
-      forwardedArgs.push_back(alloc);
-      continue;
-    }
-    // To convert guaranteed argument to be owned, release the argument later.
-    if (fromParam.isGuaranteed() && !toParam.isGuaranteed()) {
-      forwardedArgs.push_back(arg.getValue());
-      argumentsToFree.push_back(arg.getValue());
-      continue;
-    }
-    // Otherwise, simply forward the argument.
-    forwardedArgs.push_back(arg.getValue());
-  }
-}
-
 // SWIFT_ENABLE_TENSORFLOW
 SILFunction *
 SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
@@ -3749,7 +3699,6 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
   if (!thunk->empty())
     return thunk;
   thunk->setGenericEnvironment(thunkGenericEnv);
-  thunk->setOwnershipEliminated();
 
   SILGenFunction thunkSGF(*this, *thunk, assocFn->getDeclContext());
   SmallVector<ManagedValue, 4> params;
@@ -3760,50 +3709,40 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
   auto assocFnRefType = assocFnRef->getType().castTo<SILFunctionType>();
 
   // Collect thunk arguments, converting ownership.
-  SmallVector<AllocStackInst *, 8> localAllocations;
-  SmallVector<SILValue, 8> argumentsToFree;
   SmallVector<SILValue, 8> arguments;
   for (auto *indRes : indirectResults)
     arguments.push_back(indRes);
-  forwardFunctionArgumentsConvertingOwnership(
-      thunkSGF, loc, assocFnRefType, origAssocFnType, params, arguments,
-      localAllocations, argumentsToFree);
+  forwardFunctionArguments(thunkSGF, loc, assocFnRefType, params, arguments);
   // Apply function argument.
   auto apply = thunkSGF.emitApplyWithRethrow(
       loc, assocFnRef, /*substFnType*/ assocFnRef->getType(),
       thunk->getForwardingSubstitutionMap(), arguments);
 
-  SmallVector<SILValue, 8> directResults;
-  extractAllElements(apply, loc, thunkSGF.B, directResults);
-  auto linearMap = ManagedValue::forUnmanaged(directResults.back());
-  auto linearMapFnType = linearMap.getType().castTo<SILFunctionType>();
-  auto targetLinearMapFnType = thunk->mapTypeIntoContext(
-      origAssocFnType->getResults().back().getSILStorageType())
-          .castTo<SILFunctionType>();
-
   // Create return instruction in the thunk, first deallocating local
   // allocations and freeing arguments-to-free.
   auto createReturn = [&](SILValue retValue) {
-    // Free arguments-to-free.
-    for (auto arg : argumentsToFree)
-      if (arg->getType().isObject())
-        thunkSGF.B.createReleaseValue(loc, arg,
-                                      thunkSGF.B.getDefaultAtomicity());
-      else
-        thunkSGF.B.createDestroyAddr(loc, arg);
-    // Deallocate local allocations.
-    for (auto *alloc : reversed(localAllocations))
-      thunkSGF.B.createDeallocStack(loc, alloc);
+    // Emit cleanups.
+    thunkSGF.Cleanups.emitCleanupsForReturn(
+        CleanupLocation::get(loc), NotForUnwind);
     // Create return.
     thunkSGF.B.createReturn(loc, retValue);
   };
 
   // If self ordering is not necessary and linear map types are unchanged,
   // return the `apply` instruction.
+  auto linearMapFnType =
+      cast<SILFunctionType>(assocFnRefType->getResults().back().getType());
+  auto targetLinearMapFnType = thunk->mapTypeIntoContext(
+      origAssocFnType->getResults().back().getSILStorageType())
+          .castTo<SILFunctionType>();
   if (!reorderSelf && linearMapFnType == targetLinearMapFnType) {
     createReturn(apply);
     return thunk;
   }
+
+  SmallVector<SILValue, 8> directResults;
+  extractAllElements(apply, loc, thunkSGF.B, directResults);
+  auto linearMap = ManagedValue::forBorrowedObjectRValue(directResults.back());
 
   // Otherwise, apply reabstraction/self reordering thunk to linear map.
   auto linearMapKind = assocFnKind.getLinearMapKind();
@@ -3818,10 +3757,10 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
     auto originalDirectResult =
         joinElements(originalDirectResults, thunkSGF.B, apply.getLoc());
     auto thunkResult = joinElements(
-        {originalDirectResult, linearMap.getValue()}, thunkSGF.B, loc);
+        {originalDirectResult, linearMap.forward(thunkSGF)}, thunkSGF.B, loc);
     createReturn(thunkResult);
   } else {
-    createReturn(linearMap.getValue());
+    createReturn(linearMap.forward(thunkSGF));
   }
   return thunk;
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3744,7 +3744,7 @@ SILGenModule::getOrCreateAutoDiffAssociatedFunctionThunk(
   // Otherwise, apply reabstraction/self reordering thunk to linear map.
   SmallVector<SILValue, 8> directResults;
   extractAllElements(apply, loc, thunkSGF.B, directResults);
-  auto linearMap = ManagedValue::forBorrowedObjectRValue(directResults.back());
+  auto linearMap = thunkSGF.emitManagedRValueWithCleanup(directResults.back());
   assert(linearMap.getType().castTo<SILFunctionType>() == linearMapFnType);
   auto linearMapKind = assocFnKind.getLinearMapKind();
   linearMap = thunkSGF.getThunkedAutoDiffLinearMap(

--- a/test/AutoDiff/silgen_thunking/main.swift
+++ b/test/AutoDiff/silgen_thunking/main.swift
@@ -40,12 +40,11 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
     return (value, { v in (Self(1), Self(2), Self(3)) })
   }
 
-// CHECK-LABEL: sil hidden @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__jvp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> @owned SelfReordering)
-// CHECK: bb0([[X:%.*]] : $SelfReordering, [[Y:%.*]] : $SelfReordering, [[SELF:%.*]] : $SelfReordering):
+// CHECK-LABEL: sil hidden [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__jvp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> @owned SelfReordering)
+// CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
 // CHECK: [[JVP:%.*]] = function_ref @$s4main14SelfReorderingV23jvpThreeParameterMethodyAC_A2C_A2CtctAC_ACtF
 // CHECK: [[JVP_RESULT:%.*]] = apply [[JVP]]([[X]], [[Y]], [[SELF]])
-// CHECK: [[JVP_ORIG_RESULT:%.*]] = tuple_extract [[JVP_RESULT]] : {{.*}}, 0
-// CHECK: [[DF:%.*]] = tuple_extract [[JVP_RESULT]] : {{.*}}, 1
+// CHECK: ([[JVP_ORIG_RESULT:%.*]], [[DF:%.*]]) = destructure_tuple [[JVP_RESULT]]
 // CHECK: [[DF_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main14SelfReorderingVA3CIeggggo_A4CIeggggo_TR_differential_self_reordering_thunk
 // CHECK: [[THUNKED_DF:%.*]] = partial_apply [callee_guaranteed] [[DF_SELF_REORDER_THUNK]]([[DF]])
 // CHECK: [[RESULT:%.*]] = tuple ([[JVP_ORIG_RESULT]] : $SelfReordering, [[THUNKED_DF]] : {{.*}})
@@ -56,12 +55,11 @@ struct SelfReordering : Differentiable & AdditiveArithmetic {
 // CHECK: [[DF_RESULT:%.*]] = apply [[DF]]([[DSELF]], [[DX]], [[DY]])
 // CHECK: return [[DF_RESULT]]
 
-// CHECK-LABEL: sil hidden @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__vjp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering) -> (@owned SelfReordering, @owned SelfReordering, @owned SelfReordering))
-// CHECK: bb0([[X:%.*]] : $SelfReordering, [[Y:%.*]] : $SelfReordering, [[SELF:%.*]] : $SelfReordering):
+// CHECK-LABEL: sil hidden [ossa] @AD__$s4main14SelfReorderingV20threeParameterMethodyA2C_ACtF__vjp_src_0_wrt_0_1_2 : $@convention(method) (@guaranteed SelfReordering, @guaranteed SelfReordering, @guaranteed SelfReordering) -> (@owned SelfReordering, @owned @callee_guaranteed (@guaranteed SelfReordering) -> (@owned SelfReordering, @owned SelfReordering, @owned SelfReordering))
+// CHECK: bb0([[X:%.*]] : @guaranteed $SelfReordering, [[Y:%.*]] : @guaranteed $SelfReordering, [[SELF:%.*]] : @guaranteed $SelfReordering):
 // CHECK: [[VJP:%.*]] = function_ref @$s4main14SelfReorderingV23vjpThreeParameterMethodyAC_AC_A2CtACctAC_ACtF
 // CHECK: [[VJP_RESULT:%.*]] = apply [[VJP]]([[X]], [[Y]], [[SELF]])
-// CHECK: [[VJP_ORIG_RESULT:%.*]] = tuple_extract [[VJP_RESULT]] : {{.*}}, 0
-// CHECK: [[PB:%.*]] = tuple_extract [[VJP_RESULT]] : {{.*}}, 1
+// CHECK: ([[VJP_ORIG_RESULT:%.*]], [[PB:%.*]]) = destructure_tuple [[VJP_RESULT]]
 // CHECK: [[PB_SELF_REORDER_THUNK:%.*]] = function_ref @AD__$s4main14SelfReorderingVA3CIeggooo_A4CIeggooo_TR_pullback_self_reordering_thunk
 // CHECK: [[THUNKED_PB:%.*]] = partial_apply [callee_guaranteed] [[PB_SELF_REORDER_THUNK]]([[PB]])
 // CHECK: [[RESULT:%.*]] = tuple ([[VJP_ORIG_RESULT]] : $SelfReordering, [[THUNKED_PB]] : {{.*}})
@@ -106,7 +104,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
     return (value, { v in (v, 2.0, 3.0) })
   }
 
-// CHECK-LABEL: sil hidden @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__jvp_src_0_wrt_0_1_2 : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed τ_1_0.TangentVector, @in_guaranteed τ_1_1.TangentVector, @in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> @out SelfReorderingGeneric<τ_0_0>.TangentVector)
+// CHECK-LABEL: sil hidden [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__jvp_src_0_wrt_0_1_2 : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed τ_1_0.TangentVector, @in_guaranteed τ_1_1.TangentVector, @in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> @out SelfReorderingGeneric<τ_0_0>.TangentVector)
 // CHECK: bb0([[JVP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
 // CHECK: [[JVP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23jvpThreeParameterMethodyACyxG_AC13TangentVectorVyx_GAH_AFQyd__AFQyd_0_tctqd___qd_0_ts14DifferentiableRd__sAKRd_0_s25ExpressibleByFloatLiteralAIRQsAlJRQr0_lF
 // CHECK: [[DF:%.*]] = apply [[JVP]]<τ_0_0, τ_1_0, τ_1_1>([[JVP_RESULT]], [[X]], [[Y]], [[SELF]])
@@ -120,7 +118,7 @@ where Dummy: Differentiable & ExpressibleByIntegerLiteral {
 // CHECK: [[VOID:%.*]] = tuple ()
 // CHECK: return [[VOID]]
 
-// CHECK-LABEL: sil hidden @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__vjp_src_0_wrt_0_1_2 : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> (@out τ_1_0.TangentVector, @out τ_1_1.TangentVector, @out SelfReorderingGeneric<τ_0_0>.TangentVector))
+// CHECK-LABEL: sil hidden [ossa] @AD__$s4main21SelfReorderingGenericV20threeParameterMethodyACyxGqd___qd_0_ts14DifferentiableRd__sAFRd_0_s25ExpressibleByFloatLiteral13TangentVectorRpd__sAgHRpd_0_r0_lF__vjp_src_0_wrt_0_1_2 : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 : ExpressibleByIntegerLiteral><τ_1_0, τ_1_1 where τ_1_0 : Differentiable, τ_1_1 : Differentiable, τ_1_0.TangentVector : ExpressibleByFloatLiteral, τ_1_1.TangentVector : ExpressibleByFloatLiteral> (@in_guaranteed τ_1_0, @in_guaranteed τ_1_1, @in_guaranteed SelfReorderingGeneric<τ_0_0>) -> (@out SelfReorderingGeneric<τ_0_0>, @owned @callee_guaranteed (@in_guaranteed SelfReorderingGeneric<τ_0_0>.TangentVector) -> (@out τ_1_0.TangentVector, @out τ_1_1.TangentVector, @out SelfReorderingGeneric<τ_0_0>.TangentVector))
 // CHECK: bb0([[VJP_RESULT:%.*]] : $*SelfReorderingGeneric<τ_0_0>, [[X:%.*]] : $*τ_1_0, [[Y:%.*]] : $*τ_1_1, [[SELF:%.*]] : $*SelfReorderingGeneric<τ_0_0>):
 // CHECK: [[VJP:%.*]] = function_ref @$s4main21SelfReorderingGenericV23vjpThreeParameterMethodyACyxG_AC13TangentVectorVyx_G_AFQyd__AFQyd_0_tAHctqd___qd_0_ts14DifferentiableRd__sAKRd_0_s25ExpressibleByFloatLiteralAIRQsAlJRQr0_lF
 // CHECK: [[PB:%.*]] = apply [[VJP]]<τ_0_0, τ_1_0, τ_1_1>([[VJP_RESULT]], [[X]], [[Y]], [[SELF]])


### PR DESCRIPTION
Enable ownership for JVP/VJP SILGen thunks.
Ownership verification ensures that these thunks do not leak memory.

Delete redundant helper `forwardFunctionArgumentsConvertingOwnership`,
which is no longer necessary.

Various thunk leak-checking tests already exist in
`test/AutoDiff/leakchecking.swift`.

Resolves [TF-703](https://bugs.swift.org/browse/TF-703): all AutoDiff SILGen thunks now use ownership.