### PR TITLE
tests: repair Windows test failure (NFC)

### DIFF
--- a/test/Driver/merge-module.swift
+++ b/test/Driver/merge-module.swift
@@ -93,7 +93,7 @@
 // MERGE_1: -o [[PARTIAL_MODULE_B]].swiftmodule
 // MERGE_1: {{bin(/|\\\\)swiftc?(\.EXE)?"?}} -frontend -merge-modules -emit-module [[PARTIAL_MODULE_A]].swiftmodule{{"?}} [[PARTIAL_MODULE_B]].swiftmodule
 // MERGE_1: -parse-as-library
-// MERGE_1: -emit-module-doc-path /tmp/modules.swiftdoc
+// MERGE_1: -emit-module-doc-path /tmp{{(/|\\\\)}}modules.swiftdoc
 // MERGE_1: -module-name merge
 // MERGE_1: -o /tmp/modules
 


### PR DESCRIPTION
Account for escaped windows path separators (NFC).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
