### PR TITLE
Add SwiftNSMutableArray expected failures to stability-stdlib-abi.ass…

### DIFF
--- a/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.asserts.additional.swift.expected
@@ -1,5 +1,3 @@
-Class _SwiftNSMutableArray is a new API without @available attribute
-Class _SwiftNativeNSMutableArray is a new API without @available attribute
 Func _collectReferencesInsideObject(_:) is a new API without @available attribute
 Func _loadDestroyTLSCounter() is a new API without @available attribute
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute

--- a/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.without.asserts.swift.expected
@@ -1,0 +1,2 @@
+Class _SwiftNSMutableArray is a new API without @available attribute
+Class _SwiftNativeNSMutableArray is a new API without @available attribute


### PR DESCRIPTION
…erts.

These symbols were introduced in the following commit, but the
expected ABI test output was not updated accordingly.

commit 096778317048303b95a7aa56d1de9601829bee69
Merge: c6d51a975c 1cce12f20c
Author: David Smith <david_smith@apple.com>
Date:   Thu Sep 26 15:20:45 2019

    Merge pull request #27341 from Catfish-Man/mutant-arrays

    Add an Array-based NSMutableArray subclass
