### PR TITLE
[ConstraintSystem] Materialize locator only once per missing argument

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -837,20 +837,20 @@ public:
     const auto &param = Parameters[paramIdx];
 
     unsigned newArgIdx = Arguments.size();
-    auto argLoc =
+    auto *argLoc = CS.getConstraintLocator(
         Locator
             .withPathElement(LocatorPathElt::ApplyArgToParam(
                 newArgIdx, paramIdx, param.getParameterFlags()))
-            .withPathElement(LocatorPathElt::SynthesizedArgument(newArgIdx));
+            .withPathElement(LocatorPathElt::SynthesizedArgument(newArgIdx)));
 
-    auto *argType = CS.createTypeVariable(
-        CS.getConstraintLocator(argLoc),
-        TVO_CanBindToInOut | TVO_CanBindToLValue | TVO_CanBindToNoEscape);
+    auto *argType =
+        CS.createTypeVariable(argLoc, TVO_CanBindToInOut | TVO_CanBindToLValue |
+                                          TVO_CanBindToNoEscape);
 
     CS.recordHole(argType);
-    CS.addUnsolvedConstraint(Constraint::create(
-        CS, ConstraintKind::Defaultable, argType, CS.getASTContext().TheAnyType,
-        CS.getConstraintLocator(argLoc)));
+    CS.addUnsolvedConstraint(
+        Constraint::create(CS, ConstraintKind::Defaultable, argType,
+                           CS.getASTContext().TheAnyType, argLoc));
 
     Arguments.push_back(param.withType(argType));
     ++NumSynthesizedArgs;


### PR DESCRIPTION
Instead of materializing locator twice from the same builder per
missing argument, do it only once and use result to create argument
type variable and its "defaults to Any" constraint.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
