### PR TITLE
Revert "Fix parsing of ELF images"

### DIFF
--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -21,6 +21,8 @@
 
 #define SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING "swift_reflection_metadata_magic_string"
 
+#if defined(__ELF__)
+
 #include "../SwiftShims/Visibility.h"
 #include <cstdint>
 #include <cstddef>
@@ -59,10 +61,10 @@ struct MetadataSections {
 };
 } // namespace swift
 
-#if defined(__ELF__)
 // Called by injected constructors when a dynamic library is loaded.
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(const void *addr);
+
 #endif // defined(__ELF__)
 
 #endif // SWIFT_RUNTIME_IMAGE_INSPECTION_ELF_H

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -13,14 +13,12 @@
 // binaries.
 //===----------------------------------------------------------------------===//
 
-#include "../../stdlib/public/runtime/ImageInspectionELF.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Reflection/ReflectionContext.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
-
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/COFF.h"
@@ -82,26 +80,22 @@ template <typename T> static T unwrap(llvm::Expected<T> value) {
   exit(EXIT_FAILURE);
 }
 
-static void reportError(StringRef Message) {
-  llvm::errs() << "swift-reflection-test error: " << Message << ".\n";
+static void reportError(std::error_code EC) {
+  assert(EC);
+  llvm::errs() << "swift-reflection-test error: " << EC.message() << ".\n";
   exit(EXIT_FAILURE);
 }
 
-static void reportError(std::error_code EC) {
-  assert(EC);
-  reportError(EC.message());
-}
-
-using NativeReflectionContext = swift::reflection::ReflectionContext<
-    External<RuntimeTarget<sizeof(uintptr_t)>>>;
+using NativeReflectionContext =
+    swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
 using ReadBytesResult = swift::remote::MemoryReader::ReadBytesResult;
 
 static uint64_t getSectionAddress(SectionRef S) {
-  // See COFFObjectFile.cpp for the implementation of
+  // See COFFObjectFile.cpp for the implementation of 
   // COFFObjectFile::getSectionAddress. The image base address is added
-  // to all the addresses of the sections, thus the behavior is slightly
-  // different from the other platforms.
+  // to all the addresses of the sections, thus the behavior is slightly different from
+  // the other platforms.
   if (auto C = dyn_cast<COFFObjectFile>(S.getObject()))
     return S.getAddress() - C->getImageBase();
   return S.getAddress();
@@ -113,19 +107,9 @@ static bool needToRelocate(SectionRef S) {
 
   if (auto EO = dyn_cast<ELFObjectFileBase>(S.getObject())) {
     static const llvm::StringSet<> ELFSectionsList = {
-        ".data",
-        ".rodata",
-        ".note.swift_reflection_metadata",
-        "swift5_protocols",
-        "swift5_protocol_conformances",
-        "swift5_typeref",
-        "swift5_reflstr",
-        "swift5_assocty",
-        "swift5_replace",
-        "swift5_type_metadata",
-        "swift5_fieldmd",
-        "swift5_capture",
-        "swift5_builtin",
+      ".data", ".rodata", "swift5_protocols", "swift5_protocol_conformances",
+      "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
+      "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
     };
     StringRef Name;
     if (auto EC = S.getName(Name))
@@ -136,91 +120,6 @@ static bool needToRelocate(SectionRef S) {
   return true;
 }
 
-static section_iterator findSectionByName(StringRef Name, const ObjectFile &O) {
-  auto Sections = O.sections();
-  SmallVector<section_iterator, 1> FoundSections;
-  std::copy_if(Sections.begin(), Sections.end(),
-               std::back_inserter(FoundSections), [Name](SectionRef S) {
-                 StringRef N;
-                 if (auto EC = S.getName(N))
-                   reportError(EC);
-                 return N == Name;
-               });
-  if (FoundSections.size() != 1)
-    return Sections.end();
-  return FoundSections.front();
-}
-
-template <class ELFObj,
-          typename std::enable_if<
-              std::is_base_of<ELFObjectFileBase, ELFObj>::value, int>::type = 0>
-const typename ELFObj::Elf_Rela *findRelaForOffset(uint64_t Offset,
-                                                   const ELFObj &O) {
-  for (const SectionRef &S :
-       static_cast<const ObjectFile *>(&O)->dynamic_relocation_sections()) {
-    const auto *Sec = O.getSection(S.getRawDataRefImpl());
-    if (Sec->sh_type != llvm::ELF::SHT_RELA)
-      continue;
-    for (const RelocationRef &R : S.relocations()) {
-      const auto *Rela = O.getRela(R.getRawDataRefImpl());
-      if (Rela->r_offset == Offset &&
-          Rela->getType(false /* isMips64EL */) == llvm::ELF::R_X86_64_RELATIVE)
-        return Rela;
-    }
-  }
-  return nullptr;
-}
-
-static void updateReflectionMetdataNote(const ObjectFile &O, char *Memory) {
-  auto EO = dyn_cast<const ELFObjectFileBase>(&O);
-  if (!EO)
-    return;
-  auto Note = findSectionByName(".note.swift_reflection_metadata", O);
-  if (Note == O.sections().end())
-    return;
-  const StringRef MagicString = SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING;
-  if (StringRef(Memory + Note->getAddress(), MagicString.size()) != MagicString)
-    reportError(".note.swift_reflection_metadata is invalid");
-
-  const uint64_t Offset = Note->getAddress() + MagicString.size() + 1;
-  uint64_t Addend = 0;
-  if (auto *ELF32LEObj = dyn_cast<ELF32LEObjectFile>(EO))
-    if (auto *Rela = findRelaForOffset(Offset, *ELF32LEObj))
-      Addend = static_cast<uint64_t>(Rela->r_addend);
-  if (auto *ELF64LEObj = dyn_cast<ELF64LEObjectFile>(EO))
-    if (auto *Rela = findRelaForOffset(Offset, *ELF64LEObj))
-      Addend = static_cast<uint64_t>(Rela->r_addend);
-  if (!Addend)
-    reportError("No supported relocations found");
-  uintptr_t PtrValue = reinterpret_cast<uintptr_t>(Memory) + Addend;
-  *reinterpret_cast<uintptr_t *>(Memory + Note->getAddress() +
-                                 MagicString.size() + 1) = PtrValue;
-  auto S = reinterpret_cast<MetadataSections *>(PtrValue);
-
-#define STRINGIFY(s) #s
-#define UPDATE_SECTION_RANGE(Name)                                             \
-  [&]() {                                                                      \
-    auto It = findSectionByName(STRINGIFY(Name), O);                           \
-    if (It == O.sections().end())                                              \
-      return;                                                                  \
-    uintptr_t Addr = reinterpret_cast<uintptr_t>(Memory) + It->getAddress();   \
-    S->Name = {Addr, It->getSize()};                                           \
-  }();
-
-  UPDATE_SECTION_RANGE(swift5_protocols)
-  UPDATE_SECTION_RANGE(swift5_protocol_conformances)
-  UPDATE_SECTION_RANGE(swift5_type_metadata)
-  UPDATE_SECTION_RANGE(swift5_typeref)
-  UPDATE_SECTION_RANGE(swift5_reflstr)
-  UPDATE_SECTION_RANGE(swift5_fieldmd)
-  UPDATE_SECTION_RANGE(swift5_assocty)
-  UPDATE_SECTION_RANGE(swift5_replace)
-  UPDATE_SECTION_RANGE(swift5_replac2)
-  UPDATE_SECTION_RANGE(swift5_builtin)
-  UPDATE_SECTION_RANGE(swift5_capture)
-#undef STRINGIFY
-#undef UPDATE_SECTION_RANGE
-}
 
 class Image {
   std::vector<char> Memory;
@@ -244,7 +143,6 @@ public:
       std::memcpy(&Memory[getSectionAddress(S)], Content.data(),
                   Content.size());
     }
-    updateReflectionMetdataNote(*O, Memory.data());
   }
 
   RemoteAddress getStartAddress() const {


### PR DESCRIPTION
This reverts commit e2b6a3d98287176606b8a9b3a43c6c4d399c4d62.  This
broke on the handling of x86_64 relocation as well as the Windows build
process.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
