### PR TITLE
[Parse] Assert that the children of syntax tree nodes have contiguous source ranges

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -73,6 +73,10 @@ public:
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
                                  syntax::SyntaxKind kind);
+
+  #ifndef NDEBUG
+  static void verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
+  #endif
 };
 
 } // end namespace swift

--- a/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
@@ -62,9 +62,9 @@ public:
 %     end
 
   Parsed${node.name} build();
-  Parsed${node.name} makeDeferred();
 
 private:
+  Parsed${node.name} makeDeferred();
   Parsed${node.name} record();
   void finishLayout(bool deferred);
 };

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -43,23 +43,22 @@ struct ParsedSyntaxRecorder {
 %     end
 %     child_params = ', '.join(child_params)
 private:
-  static Parsed${node.name} record${node.syntax_kind}(${child_params},
+  static Parsed${node.name} record${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                               ParsedRawSyntaxRecorder &rec);
-public:
-  static Parsed${node.name} defer${node.syntax_kind}(${child_params},
+  static Parsed${node.name} defer${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                               SyntaxParsingContext &SPCtx);
+public:
   static Parsed${node.name} make${node.syntax_kind}(${child_params},
                                               SyntaxParsingContext &SPCtx);
 %   elif node.is_syntax_collection():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       ParsedRawSyntaxRecorder &rec);
-
-public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      MutableArrayRef<Parsed${node.collection_element_type}> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       SyntaxParsingContext &SPCtx);
+public:
   static Parsed${node.name} make${node.syntax_kind}(
       MutableArrayRef<Parsed${node.collection_element_type}> elts,
       SyntaxParsingContext &SPCtx);
@@ -69,14 +68,12 @@ public:
 %   elif node.is_unknown():
 private:
   static Parsed${node.name} record${node.syntax_kind}(
-      MutableArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       ParsedRawSyntaxRecorder &rec);
-
-public:
   static Parsed${node.name} defer${node.syntax_kind}(
-      MutableArrayRef<ParsedSyntax> elts,
+      MutableArrayRef<ParsedRawSyntaxNode> layout,
       SyntaxParsingContext &SPCtx);
-
+public:
   static Parsed${node.name} make${node.syntax_kind}(
       MutableArrayRef<ParsedSyntax> elts,
       SyntaxParsingContext &SPCtx);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1498,8 +1498,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
           ParsedSyntaxRecorder::makeIdentifierPattern(
                                   SyntaxContext->popToken(), *SyntaxContext);
       ParsedExprSyntax ExprNode =
-          ParsedSyntaxRecorder::deferUnresolvedPatternExpr(std::move(PatternNode),
-                                                           *SyntaxContext);
+          ParsedSyntaxRecorder::makeUnresolvedPatternExpr(std::move(PatternNode),
+                                                          *SyntaxContext);
       SyntaxContext->addSyntax(std::move(ExprNode));
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -399,7 +399,7 @@ Parser::TypeASTResult Parser::parseType(Diag<> MessageID,
       diagnose(Tok.getLoc(), DiagID)
           .fixItInsert(ArrowLoc, "throws ")
           .fixItRemove(Tok.getLoc());
-      Throws = consumeTokenSyntax();
+      ignoreToken();
     }
     ParserResult<TypeRepr> SecondHalf =
         parseType(diag::expected_type_function_result);
@@ -944,7 +944,8 @@ Parser::TypeResult Parser::parseOldStyleProtocolComposition() {
       replacement = "Any";
     } else {
       auto extractText = [&](ParsedTypeSyntax &Type) -> StringRef {
-        auto SourceRange = Type.getRaw().getDeferredRange();
+        auto SourceRange = Type.getRaw()
+          .getDeferredRange(/*includeTrivia=*/false);
         return SourceMgr.extractText(SourceRange);
       };
       auto Begin = Protocols.begin();
@@ -1061,18 +1062,15 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       // Consume a name.
       NameLoc = Tok.getLoc();
       Name = consumeArgumentLabelSyntax();
-      LocalJunk.push_back(Name->copyDeferred());
 
       // If there is a second name, consume it as well.
       if (Tok.canBeArgumentLabel()) {
         SecondNameLoc = Tok.getLoc();
         SecondName = consumeArgumentLabelSyntax();
-        LocalJunk.push_back(SecondName->copyDeferred());
       }
 
       // Consume the ':'.
       if ((Colon = consumeTokenSyntaxIf(tok::colon))) {
-        LocalJunk.push_back(Colon->copyDeferred());
         // If we succeed, then we successfully parsed a label.
         if (Backtracking)
           Backtracking->cancelBacktrack();
@@ -1089,6 +1087,18 @@ Parser::TypeResult Parser::parseTypeTupleBody() {
       IsInOutObsoleted = false;
     }
 
+    if (!Backtracking || !Backtracking->willBacktrack()) {
+      if (Name)
+        LocalJunk.push_back(Name->copyDeferred());
+      if (SecondName)
+        LocalJunk.push_back(SecondName->copyDeferred());
+      if (Colon)
+        LocalJunk.push_back(Colon->copyDeferred());
+    } else if (Backtracking && Backtracking->willBacktrack()) {
+      Name.reset();
+      SecondName.reset();
+      assert(!Colon.hasValue());
+    }
     Backtracking.reset();
 
     // Parse the type annotation.

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -120,6 +120,10 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
   }
 %     end
 %   end
+
+#ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(Layout);
+#endif
 % end
 }
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -90,67 +90,51 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %     child_params = ', '.join(child_params)
 %     child_move_args = ', '.join(child_move_args)
 Parsed${node.name}
-ParsedSyntaxRecorder::record${node.syntax_kind}(${child_params},
+ParsedSyntaxRecorder::record${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout,
                                        ParsedRawSyntaxRecorder &rec) {
-  ParsedRawSyntaxNode layout[] = {
-%     for child in node.children:
-%       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
-%       else:
-    ${child.name}.takeRaw(),
-%       end
-%     end
-  };
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
-ParsedSyntaxRecorder::defer${node.syntax_kind}(${child_params}, SyntaxParsingContext &SPCtx) {
-  ParsedRawSyntaxNode layout[] = {
-%     for child in node.children:
-%       if child.is_optional:
-    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
-%       else:
-    ${child.name}.takeRaw(),
-%       end
-%     end
-  };
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, llvm::makeMutableArrayRef(layout, ${len(node.children)}), SPCtx);
+ParsedSyntaxRecorder::defer${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout, SyntaxParsingContext &SPCtx) {
+  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(${child_params},
     SyntaxParsingContext &SPCtx) {
+  ParsedRawSyntaxNode layout[] = {
+%     for child in node.children:
+%       if child.is_optional:
+    ${child.name}.hasValue() ? ${child.name}->takeRaw() : ParsedRawSyntaxNode::null(),
+%       else:
+    ${child.name}.takeRaw(),
+%       end
+%     end
+  };
+  #ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
+  #endif
   if (SPCtx.shouldDefer())
-    return defer${node.syntax_kind}(${child_move_args}, SPCtx);
-  return record${node.syntax_kind}(${child_move_args}, SPCtx.getRecorder());
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
 }
 
 %   elif node.is_syntax_collection():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     ParsedRawSyntaxRecorder &rec) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    MutableArrayRef<Parsed${node.collection_element_type}> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     SyntaxParsingContext &SPCtx) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
@@ -160,9 +144,17 @@ Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
     MutableArrayRef<Parsed${node.collection_element_type}> elements,
     SyntaxParsingContext &SPCtx) {
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.takeRaw());
+  }
+  #ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
+  #endif
   if (SPCtx.shouldDefer())
-    return defer${node.syntax_kind}(elements, SPCtx);
-  return record${node.syntax_kind}(elements, SPCtx.getRecorder());
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
 }
 
 Parsed${node.name}
@@ -180,26 +172,16 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
 %   elif node.is_unknown():
 Parsed${node.name}
 ParsedSyntaxRecorder::record${node.syntax_kind}(
-    MutableArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     ParsedRawSyntaxRecorder &rec) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = rec.recordRawSyntax(SyntaxKind::${node.syntax_kind}, layout);
   return Parsed${node.name}(std::move(raw));
 }
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
-    MutableArrayRef<ParsedSyntax> elements,
+    MutableArrayRef<ParsedRawSyntaxNode> layout,
     SyntaxParsingContext &SPCtx) {
-  SmallVector<ParsedRawSyntaxNode, 16> layout;
-  layout.reserve(elements.size());
-  for (auto &element : elements) {
-    layout.push_back(element.takeRaw());
-  }
   auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
@@ -208,9 +190,17 @@ Parsed${node.name}
 ParsedSyntaxRecorder::make${node.syntax_kind}(
     MutableArrayRef<ParsedSyntax> elements,
     SyntaxParsingContext &SPCtx) {
+  SmallVector<ParsedRawSyntaxNode, 16> layout;
+  layout.reserve(elements.size());
+  for (auto &element : elements) {
+    layout.push_back(element.takeRaw());
+  }
+  #ifndef NDEBUG
+  ParsedRawSyntaxRecorder::verifyElementRanges(layout);
+  #endif
   if (SPCtx.shouldDefer())
-    return defer${node.syntax_kind}(elements, SPCtx);
-  return record${node.syntax_kind}(elements, SPCtx.getRecorder());
+    return defer${node.syntax_kind}(layout, SPCtx);
+  return record${node.syntax_kind}(layout, SPCtx.getRecorder());
 }
 %   end
 % end


### PR DESCRIPTION
Also fix the places the new assertion was being hit. This should help us catch syntax tree round-tripping issues earlier going forward.

The assertion is currently failing on some of the SIL tests, but that should go away once https://github.com/apple/swift/pull/27377 lands.