### PR TITLE
[ClangImporter] Don't transform NSObject<...> when there's no NSObject protocol

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -921,27 +921,32 @@ namespace {
             return {};
           }
           if (nsObjectTy && importedType->isEqual(nsObjectTy)) {
-            SmallVector<clang::ObjCProtocolDecl *, 4> protocols{
-              type->qual_begin(), type->qual_end()
-            };
-            auto *nsObjectProto =
-                Impl.getNSObjectProtocolType()->getAnyNominal();
-            if (!nsObjectProto) {
-              // Input is malformed
-              return {};
-            }
-            auto *clangProto =
-                cast<clang::ObjCProtocolDecl>(nsObjectProto->getClangDecl());
-            protocols.push_back(
-                const_cast<clang::ObjCProtocolDecl *>(clangProto));
+            // Skip if there is no NSObject protocol.
+            auto nsObjectProtoType =
+                Impl.getNSObjectProtocolType();
+            if (nsObjectProtoType) {
+              auto *nsObjectProto = nsObjectProtoType->getAnyNominal();
+              if (!nsObjectProto) {
+                // Input is malformed
+                return {};
+              }
 
-            clang::ASTContext &clangCtx = Impl.getClangASTContext();
-            clang::QualType protosOnlyType =
-                clangCtx.getObjCObjectType(clangCtx.ObjCBuiltinIdTy,
-                                           /*type args*/{},
-                                           protocols,
-                                           /*kindof*/false);
-            return Visit(clangCtx.getObjCObjectPointerType(protosOnlyType));
+              SmallVector<clang::ObjCProtocolDecl *, 4> protocols{
+                type->qual_begin(), type->qual_end()
+              };
+              auto *clangProto =
+                  cast<clang::ObjCProtocolDecl>(nsObjectProto->getClangDecl());
+              protocols.push_back(
+                  const_cast<clang::ObjCProtocolDecl *>(clangProto));
+
+              clang::ASTContext &clangCtx = Impl.getClangASTContext();
+              clang::QualType protosOnlyType =
+                  clangCtx.getObjCObjectType(clangCtx.ObjCBuiltinIdTy,
+                                             /*type args*/{},
+                                             protocols,
+                                             /*kindof*/false);
+              return Visit(clangCtx.getObjCObjectPointerType(protosOnlyType));
+            }
           }
         }
 

--- a/test/ClangImporter/Inputs/no-nsobject-protocol.h
+++ b/test/ClangImporter/Inputs/no-nsobject-protocol.h
@@ -1,0 +1,15 @@
+// Define our own NSObject interface, but not the protocol.
+@interface NSObject
+  - nsobjectFunc;
+@end
+
+@protocol FooProtocol
+  - fooFunc;
+@end
+
+typedef NSObject<FooProtocol> Foo;
+
+@interface Bar : Foo
+- (instancetype)init;
+- (NSObject<FooProtocol> *)barFunc;
+@end

--- a/test/ClangImporter/no-nsobject-protocol.swift
+++ b/test/ClangImporter/no-nsobject-protocol.swift
@@ -1,0 +1,9 @@
+/// Don't crash when there's no NSObject protocol.
+/// rdar://problem/34597302
+
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/no-nsobject-protocol.h -enable-objc-interop
+
+var a = Bar()!
+var b = a.barFunc()!;
+b.nsobjectFunc()
+b.fooFunc()


### PR DESCRIPTION
If there is no NSObject protocol skip a special case when importing types like `NSObject <NSCopying>` that converts them to `id <NSObject, NSCopying>`.

Fix rdar://problem/34597302