### PR TITLE
[Deserialization] Allow lookup into decls that don't have an interface type yet

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1120,11 +1120,14 @@ static void filterValues(Type expectedTy, ModuleDecl *expectedModule,
 
     if (isType != isa<TypeDecl>(value))
       return true;
-    auto ifaceTy = value->getInterfaceType();
-    if (!ifaceTy)
-      return true;
-    if (canTy && ifaceTy->getCanonicalType() != canTy)
-      return true;
+
+    // If we're expecting a type, make sure this decl has the expected type.
+    if (canTy)  {
+      auto ifaceTy = value->getInterfaceType();
+      if (!ifaceTy || !ifaceTy->isEqual(canTy))
+        return true;
+    }
+
     if (value->isStatic() != isStatic)
       return true;
     if (value->hasClangNode() != importedFromClang)

--- a/test/Serialization/Inputs/multi-file-subclass-generic-instantiation-extension.swift
+++ b/test/Serialization/Inputs/multi-file-subclass-generic-instantiation-extension.swift
@@ -1,0 +1,3 @@
+extension Subclass {
+  struct MemberTypeFromOtherFile {}
+}

--- a/test/Serialization/multi-file-subclass-generic-instantiation.swift
+++ b/test/Serialization/multi-file-subclass-generic-instantiation.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -emit-module -o %t/Module.swiftmodule %s %S/Inputs/multi-file-subclass-generic-instantiation-extension.swift
+
+// https://bugs.swift.org/browse/SR-11495
+
+class Superclass<T> {}
+class Subclass: Superclass<Subclass.MemberTypeFromOtherFile> {}


### PR DESCRIPTION
Fixes rdar://55560962 and https://bugs.swift.org/browse/SR-11495

This bug was caused because we'd fail to lookup C in B, because we
hadn't computed its type yet and therefore B is filtered from lookup.
Just remove the filter for interface type.