### PR TITLE
Customize Array.swapAt to pass down to the buffer.

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1314,9 +1314,8 @@ extension Array: RangeReplaceableCollection {
   
   @inlinable
   public mutating func swapAt(_ i: Int, _ j: Int) {
-    withUnsafeMutableBufferPointer { buffer in
-      buffer.swapAt(i, j)
-    }
+    _makeUniqueAndReserveCapacityIfNotUnique()
+    _buffer.swapAt(i, j)
   }
 }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1311,6 +1311,13 @@ extension Array: RangeReplaceableCollection {
     }
     return _copyCollectionToContiguousArray(self)
   }
+  
+  @inlinable
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    withUnsafeMutableBufferPointer { buffer in
+      buffer.swapAt(i, j)
+    }
+  }
 }
 
 // Implementations of + and += for same-type arrays. This combined

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -950,9 +950,8 @@ extension ContiguousArray: RangeReplaceableCollection {
   
   @inlinable
   public mutating func swapAt(_ i: Int, _ j: Int) {
-    withUnsafeMutableBufferPointer { buffer in
-      buffer.swapAt(i, j)
-    }
+    _makeUniqueAndReserveCapacityIfNotUnique()
+    _buffer.swapAt(i, j)
   }
 }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -947,6 +947,13 @@ extension ContiguousArray: RangeReplaceableCollection {
     }
     return _copyCollectionToContiguousArray(self)
   }
+  
+  @inlinable
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    withUnsafeMutableBufferPointer { buffer in
+      buffer.swapAt(i, j)
+    }
+  }
 }
 
 extension ContiguousArray: CustomReflectable {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -307,6 +307,19 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     return firstElementAddress[i]
   }
 
+  @inlinable
+  @inline(__always)
+  internal func swapAt(_ i: Int, _ j: Int) {
+    guard i != j else { return }
+    _internalInvariant(i >= 0 && i < count, "Array index out of range")
+    _internalInvariant(j >= 0 && j < count, "Array index out of range")
+    let pi = firstElementAddress + i
+    let pj = firstElementAddress + j
+    let tmp = pi.move()
+    pi.moveInitialize(from: pj, count: 1)
+    pj.initialize(to: tmp)
+  }
+
   /// Get or set the value of the ith element.
   @inlinable
   internal subscript(i: Int) -> Element {


### PR DESCRIPTION
It looks like we aren't dropping the retain/release when using the default
implementation from MutableCollection; buffers do this swap with moves.
