### PR TITLE
[Driver] Include more info in "crash because TMPDIR is borked" errors

### DIFF
--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1558,11 +1558,13 @@ const char *Compilation::getAllSourcesPath() const {
     std::error_code EC =
         llvm::sys::fs::createTemporaryFile("sources", "", Buffer);
     if (EC) {
-      Diags.diagnose(SourceLoc(),
-                     diag::error_unable_to_make_temporary_file,
-                     EC.message());
+      // Use the constructor that prints both the error code and the
+      // description.
       // FIXME: This should not take down the entire process.
-      llvm::report_fatal_error("unable to create list of input sources");
+      auto error = llvm::make_error<llvm::StringError>(
+          EC,
+          "- unable to create list of input sources");
+      llvm::report_fatal_error(std::move(error));
     }
     auto *mutableThis = const_cast<Compilation *>(this);
     mutableThis->addTemporaryFile(Buffer.str(), PreserveOnSignal::Yes);

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -52,8 +52,12 @@ ToolChain::JobContext::getTemporaryFilePath(const llvm::Twine &name,
   SmallString<128> buffer;
   std::error_code EC = llvm::sys::fs::createTemporaryFile(name, suffix, buffer);
   if (EC) {
+    // Use the constructor that prints both the error code and the description.
     // FIXME: This should not take down the entire process.
-    llvm::report_fatal_error("unable to create temporary file for filelist");
+    auto error = llvm::make_error<llvm::StringError>(
+        EC,
+        "- unable to create temporary file for " + name + "." + suffix);
+    llvm::report_fatal_error(std::move(error));
   }
 
   C.addTemporaryFile(buffer.str(), PreserveOnSignal::Yes);

--- a/test/Driver/bad_tmpdir.swift
+++ b/test/Driver/bad_tmpdir.swift
@@ -1,0 +1,16 @@
+// Check a handful of failures in the driver when TMPDIR can't be accessed.
+//
+// These particular error messages are kind of finicky to hit because they
+// depend on what commands the driver needs to execute on each platform, so the
+// test is somewhat artificially limited to macOS.
+//
+// REQUIRES: OS=macosx
+
+// RUN: env TMP="%t/fake/" TMPDIR="%t/fake/" not %target-build-swift -c -driver-filelist-threshold=0 %s 2>&1 | %FileCheck -check-prefix=CHECK-SOURCES %s
+
+// CHECK-SOURCES: - unable to create list of input sources
+
+// RUN: echo > %t.o
+// RUN: env TMP="%t/fake/" TMPDIR="%t/fake/" not %target-build-swift -driver-filelist-threshold=0 %t.o 2>&1 | %FileCheck -check-prefix=CHECK-FILELIST %s
+
+// CHECK-FILELIST: - unable to create temporary file for inputs.LinkFileList


### PR DESCRIPTION
Two places in Driver are creating temporary files at a point in the process where failure is not expected. We should do something better about this, but meanwhile harmonize their failures and include a little more info.

Filed [SR-11541](https://bugs.swift.org/browse/SR-11541) to improve this.