### PR TITLE
MetadataReader: Add an API for reading absolute pointers.

### DIFF
--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -433,27 +433,27 @@ struct MembersHelper<> {
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   static void copyConstruct(void *self, int index, const void *other) {
-    llvm_unreachable("bad index");
+    assert(false && "bad index");
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   static void moveConstruct(void *self, int index, void *other) {
-    llvm_unreachable("bad index");
+    assert(false && "bad index");
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   static void copyAssignSame(int index, void *self, const void *other) {
-    llvm_unreachable("bad index");
+    assert(false && "bad index");
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   static void moveAssignSame(int index, void *self, void *other) {
-    llvm_unreachable("bad index");
+    assert(false && "bad index");
   }
 
   LLVM_ATTRIBUTE_ALWAYS_INLINE
   static void destruct(int index, void *self) {
-    llvm_unreachable("bad index");
+    assert(false && "bad index");
   }
 };
 

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -608,6 +608,8 @@ public:
       auto CDAddr = this->readCaptureDescriptorFromMetadata(*MetadataAddress);
       if (!CDAddr)
         return nullptr;
+      if (!CDAddr->isResolved())
+        return nullptr;
 
       // FIXME: Non-generic SIL boxes also use the HeapLocalVariable metadata
       // kind, but with a null capture descriptor right now (see
@@ -615,7 +617,8 @@ public:
       //
       // Non-generic SIL boxes share metadata among types with compatible
       // layout, but we need some way to get an outgoing pointer map for them.
-      auto CD = getBuilder().getCaptureDescriptor(*CDAddr);
+      auto CD = getBuilder().getCaptureDescriptor(
+                                CDAddr->getResolvedAddress().getAddressData());
       if (CD == nullptr)
         return nullptr;
 

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -19,6 +19,9 @@
 #define SWIFT_REMOTE_REMOTEADDRESS_H
 
 #include <cstdint>
+#include <string>
+#include <llvm/ADT/StringRef.h>
+#include <cassert>
 
 namespace swift {
 namespace remote {
@@ -43,6 +46,40 @@ public:
 
   uint64_t getAddressData() const {
     return Data;
+  }
+};
+
+/// A symbolic relocated absolute pointer value.
+class RemoteAbsolutePointer {
+  /// The symbol name that the pointer refers to. Empty if the value is absolute.
+  std::string Symbol;
+  /// The offset from the symbol, or the resolved remote address if \c Symbol is empty.
+  int64_t Offset;
+
+public:
+  RemoteAbsolutePointer()
+    : Symbol(), Offset(0)
+  {}
+  
+  RemoteAbsolutePointer(std::nullptr_t)
+    : RemoteAbsolutePointer()
+  {}
+  
+  RemoteAbsolutePointer(llvm::StringRef Symbol, int64_t Offset)
+    : Symbol(Symbol), Offset(Offset)
+  {}
+  
+  bool isResolved() const { return Symbol.empty(); }
+  llvm::StringRef getSymbol() const { return Symbol; }
+  int64_t getOffset() const { return Offset; }
+  
+  RemoteAddress getResolvedAddress() const {
+    assert(isResolved());
+    return RemoteAddress(Offset);
+  }
+  
+  explicit operator bool() const {
+    return Offset != 0 || !Symbol.empty();
   }
 };
 

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -491,7 +491,7 @@ public:
 
   Result<OpenedExistential>
   getDynamicTypeAndAddressClassExistential(RemoteAddress object) {
-    auto pointerval = Reader.readPointerValue(object.getAddressData());
+    auto pointerval = Reader.readResolvedPointerValue(object.getAddressData());
     if (!pointerval)
       return getFailure<OpenedExistential>();
     auto result = Reader.readMetadataFromInstance(*pointerval);
@@ -508,7 +508,7 @@ public:
   getDynamicTypeAndAddressErrorExistential(RemoteAddress object,
                                            bool dereference=true) {
     if (dereference) {
-      auto pointerval = Reader.readPointerValue(object.getAddressData());
+      auto pointerval = Reader.readResolvedPointerValue(object.getAddressData());
       if (!pointerval)
         return getFailure<OpenedExistential>();
       object = RemoteAddress(*pointerval);
@@ -531,7 +531,7 @@ public:
     auto payloadAddress = result->PayloadAddress;
     if (!result->IsBridgedError &&
         typeResult->getClassOrBoundGenericClass()) {
-      auto pointerval = Reader.readPointerValue(
+      auto pointerval = Reader.readResolvedPointerValue(
           payloadAddress.getAddressData());
       if (!pointerval)
         return getFailure<OpenedExistential>();
@@ -559,7 +559,7 @@ public:
     // of the reference.
     auto payloadAddress = result->PayloadAddress;
     if (typeResult->getClassOrBoundGenericClass()) {
-      auto pointerval = Reader.readPointerValue(
+      auto pointerval = Reader.readResolvedPointerValue(
           payloadAddress.getAddressData());
       if (!pointerval)
         return getFailure<OpenedExistential>();
@@ -578,7 +578,7 @@ public:
     // 1) Loading a pointer from the input address
     // 2) Reading it as metadata and resolving the type
     // 3) Wrapping the resolved type in an existential metatype.
-    auto pointerval = Reader.readPointerValue(object.getAddressData());
+    auto pointerval = Reader.readResolvedPointerValue(object.getAddressData());
     if (!pointerval)
       return getFailure<OpenedExistential>();
     auto typeResult = Reader.readTypeFromMetadata(*pointerval);


### PR DESCRIPTION
Pointer data in some remote reflection targets may required relocation, or may not be
fully resolvable, such as when we're dumping info from a single image on disk that
references other dynamic libraries. Add a `RemoteAbsolutePointer` type that can hold a
symbol, offset, or combination of both, and add APIs to `MemoryReader` and `MetadataReader`
for reading pointers that can get unresolved relocation info from an image, or apply
relocations to pointer information. MetadataReader can use the symbol name information to
fill in demanglings of symbolic-reference-bearing mangled names by using the information
from the symbol name to fill in the name even though the context descriptors are not
available.

For now, this is NFC (MemoryReader::resolvePointer just forwards the pointer data), but
lays the groundwork for implementation of relocation in ObjectMemoryReader.