### PR TITLE
[AutoDiff] Store derivative generic signature in (SIL)DifferentiableA…

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -132,18 +132,14 @@ private:
   SILAutoDiffIndices indices;
   /// The JVP and VJP function names.
   StringRef JVPName, VJPName;
-  /// The trailing constraint clause.
+  /// The trailing where clause (optional).
+  /// This is defined only for parsed attributes and is resolved to
+  /// `DerivativeGenericSignature` by the SIL parser.
   TrailingWhereClause *WhereClause = nullptr;
-  /// The number of constraint clause requirements.
-  unsigned NumRequirements;
-  /// The constraint clause requirements.
-  ArrayRef<Requirement> Requirements;
+  /// The derivative generic signature (optional).
+  GenericSignature *DerivativeGenericSignature = nullptr;
   /// The original function.
   SILFunction *Original = nullptr;
-
-  Requirement *getRequirementsData() {
-    return reinterpret_cast<Requirement *>(this+1);
-  }
 
   SILDifferentiableAttr(const SILAutoDiffIndices &indices,
                         StringRef jvpName,
@@ -153,7 +149,7 @@ private:
   SILDifferentiableAttr(const SILAutoDiffIndices &indices,
                         StringRef jvpName,
                         StringRef vjpName,
-                        ArrayRef<Requirement> requirements);
+                        GenericSignature *derivativeGenSig);
 
 public:
   static SILDifferentiableAttr *create(
@@ -163,8 +159,8 @@ public:
 
   static SILDifferentiableAttr *create(
       SILModule &M, const SILAutoDiffIndices &indices,
-      ArrayRef<Requirement> requirements, StringRef jvpName = StringRef(),
-      StringRef vjpName = StringRef());
+      StringRef jvpName = StringRef(), StringRef vjpName = StringRef(),
+      GenericSignature *derivativeGenSig = nullptr);
 
   bool hasJVP() const { return !JVPName.empty(); }
   StringRef getJVPName() const { assert(hasJVP()); return JVPName; }
@@ -183,11 +179,12 @@ public:
 
   TrailingWhereClause *getWhereClause() const { return WhereClause; }
 
-  ArrayRef<Requirement> getRequirements() const {
-    return {const_cast<SILDifferentiableAttr *>(this)->getRequirementsData(),
-            NumRequirements};
+  GenericSignature *getDerivativeGenericSignature() const {
+    return DerivativeGenericSignature;
   }
-  void setRequirements(ArrayRef<Requirement> requirements);
+  void setDerivativeGenericSignature(GenericSignature *derivativeGenSig) {
+    DerivativeGenericSignature = derivativeGenSig;
+  };
 
   void print(llvm::raw_ostream &OS) const;
 };

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5825,7 +5825,14 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
         FunctionState.convertRequirements(
             FunctionState.F, attr->getWhereClause()->getRequirements(),
             requirements);
-        attr->setRequirements(requirements);
+        auto *derivativeGenSig = evaluateOrDefault(
+            P.Context.evaluator,
+            AbstractGenericSignatureRequest{
+              FunctionState.F->getGenericEnvironment()->getGenericSignature(),
+              /*addedGenericParams=*/{},
+              std::move(requirements)},
+              nullptr);
+        attr->setDerivativeGenericSignature(derivativeGenSig);
       }
 
       // Parse the basic block list.

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -112,8 +112,8 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
                 indices)).str();
       }
       auto *silDiffAttr = SILDifferentiableAttr::create(
-          M, indices, A->getRequirements(), M.allocateCopy(jvpName),
-          M.allocateCopy(vjpName));
+          M, indices, M.allocateCopy(jvpName), M.allocateCopy(vjpName),
+          A->getDerivativeGenericSignature());
 #ifndef NDEBUG
       // Verify that no existing attributes have the same indices.
       for (auto *existingAttr : F->getDifferentiableAttrs()) {

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3164,13 +3164,16 @@ void SILDifferentiableAttr::print(llvm::raw_ostream &OS) const {
   if (!VJPName.empty()) {
     OS << " vjp @" << VJPName;
   }
-  if (!getRequirements().empty()) {
+  if (!getDerivativeGenericSignature())
+    return;
+  auto requirements = getDerivativeGenericSignature()->getRequirements();
+  if (!requirements.empty()) {
     OS << " where ";
     SILFunction *original = getOriginal();
     assert(original);
     auto genericEnv = original->getGenericEnvironment();
     PrintOptions SubPrinter = PrintOptions::printSIL();
-    interleave(getRequirements(), [&](Requirement req) {
+    interleave(requirements, [&](Requirement req) {
       if (!genericEnv) {
          req.print(OS, SubPrinter);
          return;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/Projection.h"
@@ -233,37 +234,42 @@ static FuncDecl *findOperatorDeclInProtocol(DeclName operatorName,
   return nullptr;
 }
 
-// Return the expected generic signature for autodiff associated functions given
-// a SILDifferentiableAttr. The expected generic signature is built from the
-// original generic signature and the attribute's requirements.
-static CanGenericSignature
-getAssociatedFunctionGenericSignature(SILDifferentiableAttr *attr,
-                                      SILFunction *original) {
+// Return the canonical derivative generic signature for the given original
+// function and (possibly uncanonical) derivative generic signature.
+// The canonical derivative generic signature constrains all wrt parameters
+// to conform to `Differentiable`.
+// TODO(TF-818): Change `@differentiable` attribute type-checking and
+// `[differentiable]` construction so that all derivative generic signatures
+// constrain wrt parameters to `Differentiable`. Then, this helper will no
+// longer be needed (except for constructing attributes in
+// `ADContext::getOrCreateDifferentiableAttr`), improving compiler
+// performance.
+static CanGenericSignature getCanonicalDerivativeGenericSignature(
+    SILDifferentiableAttr *attr, SILFunction *original) {
   auto originalFnTy = original->getLoweredFunctionType();
-  auto originalGenSig = originalFnTy->getGenericSignature();
-  if (!originalGenSig)
+  CanGenericSignature derivativeGenSig = originalFnTy->getGenericSignature();
+  if (auto *attrDerivativeGenSig = attr->getDerivativeGenericSignature())
+    derivativeGenSig = attrDerivativeGenSig->getCanonicalSignature();
+  if (!derivativeGenSig)
     return nullptr;
+  // Constrain all wrt parameters to `Differentiable`.
   auto &ctx = original->getASTContext();
-  GenericSignatureBuilder builder(ctx);
-  // Add original generic signature.
-  builder.addGenericSignature(originalGenSig);
-  // Add where clause requirements.
-  auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
-  for (auto &req : attr->getRequirements())
-    builder.addRequirement(req, source, original->getModule().getSwiftModule());
-  // Constrain all wrt parameters to conform to `Differentiable`.
   auto *diffableProto = ctx.getProtocol(KnownProtocolKind::Differentiable);
   auto paramIndexSet = attr->getIndices().parameters;
+  SmallVector<Requirement, 4> requirements;
   for (unsigned paramIdx : paramIndexSet->getIndices()) {
     auto paramType = originalFnTy->getParameters()[paramIdx].getType();
     Requirement req(RequirementKind::Conformance, paramType,
                     diffableProto->getDeclaredType());
-    builder.addRequirement(req, source, original->getModule().getSwiftModule());
+    requirements.push_back(req);
   }
-  return std::move(builder)
-      .computeGenericSignature(SourceLoc(), /*allowConcreteGenericParams*/ true)
-      ->getCanonicalSignature();
+  return evaluateOrDefault(
+      ctx.evaluator,
+      AbstractGenericSignatureRequest{
+        derivativeGenSig,
+        /*addedGenericParams*/ {},
+        std::move(requirements)},
+        nullptr)->getCanonicalSignature();
 }
 
 // Clone the generic parameters of the given generic signature and return a new
@@ -1055,10 +1061,12 @@ public:
   /// with the specified parameter indices.
   SILDifferentiableAttr *createDifferentiableAttr(
       SILFunction *original, const SILAutoDiffIndices &indices,
-      ArrayRef<Requirement> contextualRequirements) const {
+      GenericSignature *derivativeGenericSignature) const {
     assert(!lookUpDifferentiableAttr(original, indices));
     auto *attr = SILDifferentiableAttr::create(getModule(), indices,
-                                               contextualRequirements);
+                                               /*jvpName*/ StringRef(),
+                                               /*vjpName*/ StringRef(),
+                                               derivativeGenericSignature);
     original->addDifferentiableAttr(attr);
     return attr;
   }
@@ -1067,11 +1075,12 @@ public:
   /// original function corresponding to the specified parameter indices.
   SILDifferentiableAttr *getOrCreateDifferentiableAttr(
       SILFunction *original, const SILAutoDiffIndices &indices,
-      ArrayRef<Requirement> contextualRequirements) {
+      GenericSignature *derivativeGenericSignature) {
     if (auto *attr = lookUpDifferentiableAttr(original, indices))
       return attr;
     assert(original->isDefinition());
-    return createDifferentiableAttr(original, indices, contextualRequirements);
+    return createDifferentiableAttr(original, indices,
+                                    derivativeGenericSignature);
   }
 
   /// Creates an `autodiff_function` instruction using the given builder and
@@ -2240,18 +2249,23 @@ static bool diagnoseUnsupportedControlFlow(ADContext &context,
   return false;
 }
 
-/// Check whether the given requirements are satisfied, with the given original
-/// function and substitution map. Returns true if error is emitted.
+/// Check whether the given requirements are satisfied, with the given
+/// derivative generic signature (containing requirements), original function,
+/// and substitution map. Returns true if error is emitted.
 static bool diagnoseUnsatisfiedRequirements(ADContext &context,
-                                            ArrayRef<Requirement> requirements,
+                                            GenericSignature *derivativeGenSig,
                                             SILFunction *original,
                                             SubstitutionMap substMap,
                                             DifferentiationInvoker invoker,
                                             SourceLoc loc) {
+  // If there are no derivative requirements, return false.
+  if (!derivativeGenSig)
+    return false;
+  auto requirements = derivativeGenSig->getRequirements();
   if (requirements.empty())
     return false;
-  auto *swiftModule = context.getModule().getSwiftModule();
   // Iterate through all requirements and check whether they are satisfied.
+  auto *swiftModule = context.getModule().getSwiftModule();
   SmallVector<Requirement, 2> unsatisfiedRequirements;
   for (auto req : requirements) {
     auto firstType = req.getFirstType();
@@ -2564,13 +2578,13 @@ emitAssociatedFunctionReference(
       }
       // Sanity check passed. Create a new `[differentiable]` attribute and
       // process it it.
-      ArrayRef<Requirement> contextualRequirements;
+      GenericSignature *contextualDerivativeGenSig = nullptr;
       if (invoker.getKind() ==
           DifferentiationInvoker::Kind::IndirectDifferentiation)
-        contextualRequirements =
-            invoker.getIndirectDifferentiation().second->getRequirements();
+        contextualDerivativeGenSig = invoker.getIndirectDifferentiation().second
+            ->getDerivativeGenericSignature();
       auto *newAttr = context.getOrCreateDifferentiableAttr(
-          originalFn, desiredIndices, contextualRequirements);
+          originalFn, desiredIndices, contextualDerivativeGenSig);
       if (context.processDifferentiableAttribute(originalFn, newAttr, invoker))
         return None;
       minimalAttr = newAttr;
@@ -2578,9 +2592,9 @@ emitAssociatedFunctionReference(
     assert(minimalAttr);
     // TODO(TF-482): Move generic requirement checking logic to
     // `lookUpMinimalDifferentiableAttr`.
-    if (diagnoseUnsatisfiedRequirements(context, minimalAttr->getRequirements(),
-                                        originalFn, substMap, invoker,
-                                        original.getLoc().getSourceLoc()))
+    if (diagnoseUnsatisfiedRequirements(
+            context, minimalAttr->getDerivativeGenericSignature(), originalFn,
+            substMap, invoker, original.getLoc().getSourceLoc()))
       return None;
     if (context.processDifferentiableAttribute(
             originalFn, minimalAttr, invoker))
@@ -3365,7 +3379,7 @@ public:
         mangler.mangleAutoDiffLinearMapHelper(
             original->getName(), AutoDiffLinearMapKind::Pullback,
             indices)).str();
-    auto pbGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+    auto pbGenericSig = getCanonicalDerivativeGenericSignature(attr, original);
     auto *pbGenericEnv =
         pbGenericSig ? pbGenericSig->getGenericEnvironment() : nullptr;
     auto pbType = SILFunctionType::get(
@@ -5232,7 +5246,8 @@ public:
         mangler.mangleAutoDiffLinearMapHelper(
             original->getName(), AutoDiffLinearMapKind::Differential,
             indices)).str();
-    auto diffGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+    auto diffGenericSig =
+        getCanonicalDerivativeGenericSignature(attr, original);
     auto *diffGenericEnv =
         diffGenericSig ? diffGenericSig->getGenericEnvironment() : nullptr;
     auto diffType = SILFunctionType::get(
@@ -7771,7 +7786,7 @@ ADContext::declareExternalAssociatedFunction(
   auto &indices = attr->getIndices();
   auto originalTy = original->getLoweredFunctionType();
   auto originalLoc = original->getLocation();
-  auto assocGenSig = getAssociatedFunctionGenericSignature(attr, original);
+  auto assocGenSig = getCanonicalDerivativeGenericSignature(attr, original);
   auto assocFnTy = originalTy->getAutoDiffAssociatedFunctionType(
       indices.parameters, indices.source, /*differentiationOrder*/ 1, kind,
       module.Types, LookUpConformanceInModule(module.getSwiftModule()),
@@ -7806,7 +7821,7 @@ static SILFunction *createEmptyVJP(
       mangler.mangleAutoDiffAssociatedFunctionHelper(
           original->getName(), AutoDiffAssociatedFunctionKind::VJP, indices))
               .str();
-  auto vjpGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+  auto vjpGenericSig = getCanonicalDerivativeGenericSignature(attr, original);
 
   // RAII that pushes the original function's generic signature to
   // `module.Types` so that calls to `module.Types.getTypeLowering()` below
@@ -7856,7 +7871,7 @@ static SILFunction *createEmptyJVP(
       mangler.mangleAutoDiffAssociatedFunctionHelper(
           original->getName(), AutoDiffAssociatedFunctionKind::JVP, indices))
               .str();
-  auto jvpGenericSig = getAssociatedFunctionGenericSignature(attr, original);
+  auto jvpGenericSig = getCanonicalDerivativeGenericSignature(attr, original);
 
   // RAII that pushes the original function's generic signature to
   // `module.Types` so that calls to `module.Types.getTypeLowering()` below

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -636,15 +636,15 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
               ->getAttrs()
               .hasAttribute<DifferentiableAttr>())
         continue;
-      ArrayRef<Requirement> requirements;
+      GenericSignature *derivativeGenSig = nullptr;
       // If the parent declaration context is an extension, the nominal type may
-      // conditionally conform to `Differentiable`. Use the conditional
-      // conformance requirements in getter `@differentiable` attributes.
+      // conditionally conform to `Differentiable`. Use the extension generic
+      // requirements in getter `@differentiable` attributes.
       if (auto *extDecl = dyn_cast<ExtensionDecl>(parentDC->getAsDecl()))
-        requirements = extDecl->getGenericRequirements();
+        derivativeGenSig = extDecl->getGenericSignature();
       auto *diffableAttr = DifferentiableAttr::create(
           C, /*implicit*/ true, SourceLoc(), SourceLoc(),
-          /*linear*/ false, {}, None, None, requirements);
+          /*linear*/ false, {}, None, None, derivativeGenSig);
       member->getAttrs().add(diffableAttr);
       // Compute getter parameter indices.
       auto *getterType = member->getAccessor(AccessorKind::Get)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3394,8 +3394,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     whereClauseGenSig = std::move(builder).computeGenericSignature(
         attr->getLocation(), /*allowConcreteGenericParams=*/true);
     whereClauseGenEnv = whereClauseGenSig->getGenericEnvironment();
-    // Store the resolved requirements in the attribute.
-    attr->setRequirements(ctx, whereClauseGenSig->getRequirements());
+    // Store the resolved derivative generic signature in the attribute.
+    attr->setDerivativeGenericSignature(ctx, whereClauseGenSig);
   }
 
   // Validate the 'wrt:' parameters.
@@ -3520,7 +3520,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     auto *newAttr = DifferentiableAttr::create(
         ctx, /*implicit*/ true, attr->AtLoc, attr->getRange(), attr->isLinear(),
         attr->getParameterIndices(), attr->getJVP(), attr->getVJP(),
-        attr->getRequirements());
+        attr->getDerivativeGenericSignature());
     newAttr->setJVPFunction(attr->getJVPFunction());
     newAttr->setVJPFunction(attr->getVJPFunction());
     auto insertion = ctx.DifferentiableAttrs.try_emplace(
@@ -3805,16 +3805,6 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     return;
   }
 
-  // Compute derivative generic requirements that are not satisfied by original
-  // function.
-  SmallVector<Requirement, 8> derivativeRequirements;
-  if (auto derivativeGenSig = derivative->getGenericSignature()) {
-    auto originalGenSig = originalFn->getGenericSignature();
-    for (auto req : derivativeGenSig->getRequirements())
-      if (!originalGenSig->isRequirementSatisfied(req))
-        derivativeRequirements.push_back(req);
-  }
-
   // Try to find a `@differentiable` attribute on the original function with the
   // same differentiation parameters.
   DifferentiableAttr *da = nullptr;
@@ -3827,7 +3817,8 @@ void AttributeChecker::visitDifferentiatingAttr(DifferentiatingAttr *attr) {
     da = DifferentiableAttr::create(ctx, /*implicit*/ true, attr->AtLoc,
                                     attr->getRange(), attr->isLinear(),
                                     checkedWrtParamIndices, /*jvp*/ None,
-                                    /*vjp*/ None, derivativeRequirements);
+                                    /*vjp*/ None,
+                                    derivative->getGenericSignature());
     switch (kind) {
     case AutoDiffAssociatedFunctionKind::JVP:
       da->setJVPFunction(derivative);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -579,7 +579,7 @@ swift::matchWitness(
               ctx, /*implicit*/ true, reqDiffAttr->AtLoc,
               reqDiffAttr->getRange(), reqDiffAttr->isLinear(),
               reqDiffAttr->getParameterIndices(), /*jvp*/ None,
-              /*vjp*/ None, reqDiffAttr->getRequirements());
+              /*vjp*/ None, reqDiffAttr->getDerivativeGenericSignature());
           auto insertion = ctx.DifferentiableAttrs.try_emplace(
               {witness, newAttr->getParameterIndices()}, newAttr);
           // Valid `@differentiable` attributes are uniqued by their parameter
@@ -2260,7 +2260,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     // inferred differentiation parameters.
     auto *original = cast<AbstractFunctionDecl>(match.Witness);
     auto *whereClauseGenEnv =
-        reqAttr->computeDerivativeGenericEnvironment(original);
+        reqAttr->getDerivativeGenericEnvironment(original);
     auto *inferredParameters = TypeChecker::inferDifferentiableParameters(
         original, whereClauseGenEnv);
     bool omitWrtClause = reqAttr->getParameterIndices()->parameters.count() ==

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4049,12 +4049,12 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         DeclID jvpDeclId;
         uint64_t vjpNameId;
         DeclID vjpDeclId;
+        GenericSignatureID derivativeGenSigId;
         ArrayRef<uint64_t> parameters;
-        SmallVector<Requirement, 4> requirements;
 
         serialization::decls_block::DifferentiableDeclAttrLayout::readRecord(
             scratch, isImplicit, linear, jvpNameId, jvpDeclId, vjpNameId,
-            vjpDeclId, parameters);
+            vjpDeclId, derivativeGenSigId, parameters);
 
         Optional<DeclNameWithLoc> jvp;
         FuncDecl *jvpDecl = nullptr;
@@ -4070,17 +4070,17 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
         if (vjpDeclId != 0)
           vjpDecl = cast<FuncDecl>(MF.getDecl(vjpDeclId));
 
+        auto derivativeGenSig = MF.getGenericSignature(derivativeGenSigId);
+
         llvm::SmallBitVector parametersBitVector(parameters.size());
         for (unsigned i : indices(parameters))
           parametersBitVector[i] = parameters[i];
         auto *indices = AutoDiffParameterIndices::get(parametersBitVector, ctx);
 
-        MF.readGenericRequirements(requirements, MF.DeclTypeCursor);
-
         auto diffAttr =
             DifferentiableAttr::create(ctx, isImplicit, SourceLoc(),
                                        SourceRange(), linear, indices, jvp, vjp,
-                                       requirements);
+                                       derivativeGenSig);
         diffAttr->setJVPFunction(jvpDecl);
         diffAttr->setVJPFunction(vjpDecl);
         Attr = diffAttr;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -52,7 +52,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 519; // SIL function availability
+const uint16_t SWIFTMODULE_VERSION_MINOR = 520; // store generic signature in AST/SIL differentiable attributes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1733,6 +1733,7 @@ namespace decls_block {
     DeclIDField, // JVP function declaration.
     IdentifierIDField, // VJP name.
     DeclIDField, // VJP function declaration.
+    GenericSignatureIDField, // Derivative generic signature.
     BCArray<BCFixed<1>> // Differentiation parameter indices' bitvector.
   >;
 

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -321,6 +321,7 @@ namespace sil_block {
     SIL_DIFFERENTIABLE_ATTR,
     IdentifierIDField,    // JVP name.
     IdentifierIDField,    // VJP name.
+    GenericSignatureIDField, // Derivative function generic signature.
     BCVBR<8>,             // Result index.
     BCArray<ValueIDField> // Parameter indices.
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2299,7 +2299,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     // SWIFT_ENABLE_TENSORFLOW
     case DAK_Differentiable: {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
-      auto attr = cast<DifferentiableAttr>(DA);
+      auto *attr = cast<DifferentiableAttr>(DA);
 
       IdentifierID jvpName = 0;
       DeclID jvpRef = 0;
@@ -2323,9 +2323,9 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       DifferentiableDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
-          attr->isLinear(), jvpName, jvpRef, vjpName, vjpRef, indices);
-
-      S.writeGenericRequirements(attr->getRequirements(), S.DeclTypeAbbrCodes);
+          attr->isLinear(), jvpName, jvpRef, vjpName, vjpRef,
+          S.addGenericSignatureRef(attr->getDerivativeGenericSignature()),
+          indices);
       return;
     }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -466,8 +466,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
         DA->hasVJP()
             ? S.addDeclBaseNameRef(Ctx.getIdentifier(DA->getVJPName()))
             : IdentifierID(),
+        S.addGenericSignatureRef(DA->getDerivativeGenericSignature()),
         indices.source, parameters);
-    S.writeGenericRequirements(DA->getRequirements(), SILAbbrCodes);
   }
 
   // Assign a unique ID to each basic block of the SILFunction.


### PR DESCRIPTION
…ttr.

Previously, `(SIL)DifferentiableAttr` stored derivative requirements as
`ArrayRef<Requirement>`. Computing derivative generic signatures from these
requirements is costly and was done during SILGen and the differentiation
transform.

Now, `(SIL)DifferentiableAttr` directly stores derivative generic signature.
This should improve compile-time performance.

---

[Related forum discussion.](https://forums.swift.org/t/store-differentiable-attribute-requirements-as-genericsignature-instead-of-arrayref-requirement-s/28488?u=dan-zheng)

A compilation benchmark for `tensorflow/swift-apis` was added in https://github.com/tensorflow/swift-apis/pull/506 and will track the performance of this and future improvements.