### PR TITLE
[AutoDiff] Unify 'shouldDifferentiateInstruction' between JVP and VJP.

### DIFF
--- a/test/AutoDiff/control_flow_sil.swift
+++ b/test/AutoDiff/control_flow_sil.swift
@@ -172,7 +172,7 @@ func cond_tuple_var(_ x: Float) -> Float {
 // CHECK-SIL:   [[BB1_PRED:%.*]] = destructure_struct [[BB1_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
-// CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0.bb0!enumelt.1: bb5 // id: %81
+// CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0.bb0!enumelt.1: bb5
 
 // CHECK-SIL: bb3([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
 // CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)


### PR DESCRIPTION
Differentiation conditions were inconsistent between JVP and VJP. Originally, `shouldDifferentiateInstruction` blindly differentiated any side-effecting instruction that has active operands. This worked well with VJP but not with JVP, so #26743 added more specific conditions for JVP, but they did not work well with VJP because activity analysis was not yet unified. Now that activity analysis has been unified by #27358, `shouldDifferentiateInstruction` no longer needs to distinguish between JVP and VJP, and the JVP differentiation conditions now apply to VJP as well.

This PR makes both JVP and VJP use the same differentiation conditions. All existing tests pass.

Fixes [TF-800](https://bugs.swift.org/browse/TF-800).