### PR TITLE
Sema: Properly handle inference for abstract fixed type witnesses

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -334,9 +334,9 @@ public:
   bool isConcreteType(Type type);
 
   /// Return the concrete type that the given dependent type is constrained to,
-  /// or the null Type if it is not the subject of a concrete same-type
-  /// constraint.
-  Type getConcreteType(Type type);
+  /// the null Type if it is not the subject of a concrete same-type
+  /// constraint, or None if the equivalence class failed to resolve.
+  Optional<Type> maybeGetConcreteType(Type type);
 
   /// Return the layout constraint that the given dependent type is constrained
   /// to, or the null LayoutConstraint if it is not the subject of layout

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -467,13 +467,10 @@ bool GenericSignatureImpl::conformsToProtocol(Type type, ProtocolDecl *proto) {
 
 /// Determine whether the given dependent type is equal to a concrete type.
 bool GenericSignatureImpl::isConcreteType(Type type) {
-  return bool(getConcreteType(type));
+  return bool(maybeGetConcreteType(type).getValueOr(Type()));
 }
 
-/// Return the concrete type that the given dependent type is constrained to,
-/// or the null Type if it is not the subject of a concrete same-type
-/// constraint.
-Type GenericSignatureImpl::getConcreteType(Type type) {
+Optional<Type> GenericSignatureImpl::maybeGetConcreteType(Type type) {
   if (!type->isTypeParameter()) return Type();
 
   auto &builder = *getGenericSignatureBuilder();
@@ -481,7 +478,7 @@ Type GenericSignatureImpl::getConcreteType(Type type) {
     builder.resolveEquivalenceClass(
                                   type,
                                   ArchetypeResolutionKind::CompleteWellFormed);
-  if (!equivClass) return Type();
+  if (!equivClass) return None;
 
   return equivClass->concreteType;
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2165,6 +2165,18 @@ void EquivalenceClass::dump(llvm::raw_ostream &out,
              }, [&] {
                out << ", ";
              });
+  if (!concreteTypeConstraints.empty()) {
+    out << "\nConcrete-type constraints:";
+    interleave(concreteTypeConstraints, [&](const Constraint<Type> &c) {
+      out << "\n  " << c.getSubjectDependentType({ })
+          << " == " << c.value;
+
+      if (c.source->isDerivedRequirement())
+        out << " [derived]";
+    }, [&] {
+      out << ", ";
+    });
+  }
   if (concreteType)
     out << "\nConcrete type: " << concreteType.getString();
   if (superclass)

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -266,7 +266,8 @@ Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
 
   // The generic parameter may have been made concrete by the generic signature,
   // substitute into the concrete type.
-  if (auto concreteType = genericSig->getConcreteType(genericParam)){
+  if (auto concreteType = genericSig
+          ->maybeGetConcreteType(genericParam).getValueOr(Type())) {
     // Set the replacement type to an error, to block infinite recursion.
     replacementType = ErrorType::get(concreteType);
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -256,9 +256,9 @@ namespace {
       if (auto genericSig = getGenericSignature()) {
         if (genericSig->requiresClass(type)) {
           return asImpl().handleReference(type);
-        } else if (genericSig->isConcreteType(type)) {
-          return asImpl().visit(genericSig->getConcreteType(type)
-                                    ->getCanonicalType());
+        } else if (auto concreteTy = genericSig
+                      ->maybeGetConcreteType(type).getValueOr(Type())) {
+          return asImpl().visit(concreteTy->getCanonicalType());
         } else {
           return asImpl().handleAddressOnly(type,
                                             RecursiveProperties::forOpaque());
@@ -281,7 +281,8 @@ namespace {
         auto signature = getGenericSignature();
         assert(signature && "dependent type without generic signature?!");
 
-        if (auto concreteType = signature->getConcreteType(type))
+        if (auto concreteType = signature
+                ->maybeGetConcreteType(type).getValueOr(Type()))
           return concreteType->getCanonicalType();
 
         assert(signature->requiresClass(type));

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -print-ast %s | %FileCheck %s
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 
@@ -91,7 +91,11 @@ protocol SR10831_P1 {
 protocol SR10831_P2: SR10831_P1 where A == G<G<C?>> {}
 protocol SR10831_P3: SR10831_P2 where B == Int, C == G<B> {}
 
-struct SR10831: SR10831_P3 {} // OK
+struct SR10831: SR10831_P3 { // OK
+  // CHECK: typealias A = G<G<G<Int>?>>
+  // CHECK: typealias B = Int
+  // CHECK: typealias C = G<Int>
+}
 
 
 // SR-11671:
@@ -102,6 +106,12 @@ protocol SR11671_P1 {
 protocol SR11671_P2: SR11671_P1 where A == Self {}
 protocol SR11671_P3: SR11671_P2 where B == G<Self?> {}
 
-struct SR11671_S1: SR11671_P3 {} // OK
+struct SR11671_S1: SR11671_P3 { // OK
+  // CHECK: typealias A = SR11671_S1
+  // CHECK: typealias B = G<SR11671_S1?>
+}
 
-struct SR11671_S2<T, U>: SR11671_P3 {} // OK
+struct SR11671_S2<T, U>: SR11671_P3 { // OK
+  // CHECK: typealias A = SR11671_S2<T, U>
+  // CHECK: typealias B = G<SR11671_S2<T, U>?>
+}

--- a/test/Generics/protocol_where_clause.swift
+++ b/test/Generics/protocol_where_clause.swift
@@ -77,3 +77,31 @@ protocol P2 {
   associatedtype AT
 }
 protocol P3: P2 where AT == Y<X> {}
+
+
+// SR-10831:
+struct G<T> {}
+
+protocol SR10831_P1 {
+  associatedtype A
+  associatedtype B
+  associatedtype C
+}
+
+protocol SR10831_P2: SR10831_P1 where A == G<G<C?>> {}
+protocol SR10831_P3: SR10831_P2 where B == Int, C == G<B> {}
+
+struct SR10831: SR10831_P3 {} // OK
+
+
+// SR-11671:
+protocol SR11671_P1 {
+  associatedtype A
+  associatedtype B
+}
+protocol SR11671_P2: SR11671_P1 where A == Self {}
+protocol SR11671_P3: SR11671_P2 where B == G<Self?> {}
+
+struct SR11671_S1: SR11671_P3 {} // OK
+
+struct SR11671_S2<T, U>: SR11671_P3 {} // OK


### PR DESCRIPTION
This fixes inference for some fixed type witness chains - SR-10831, for example:
```swift
protocol P {
  associatedtype A
  associatedtype B
}
protocol Q: P where A == G<B> {}
protocol R: Q where B == Int {}

struct Foo: R {} // OK
```

And adds inference of fixed type witnesses containing `Self` - SR-11671:
```swift 
protocol P {
  associatedtype A
}
protocol Q: P where A == Self {}

struct Foo: Q {} // OK, Self == Foo
```
@slavapestov 
