### PR TITLE
[Runtime] Remove bogus data from NOTES section

### DIFF
--- a/stdlib/public/runtime/ImageInspectionELF.h
+++ b/stdlib/public/runtime/ImageInspectionELF.h
@@ -19,8 +19,6 @@
 #ifndef SWIFT_RUNTIME_IMAGEINSPECTIONELF_H
 #define SWIFT_RUNTIME_IMAGEINSPECTIONELF_H
 
-#define SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING "swift_reflection_metadata_magic_string"
-
 #if defined(__ELF__)
 
 #include "../SwiftShims/Visibility.h"

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -75,14 +75,3 @@ static void swift_image_constructor() {
 
   swift_addNewDSOImage(&sections);
 }
-
-__asm__(".section \".note.swift_reflection_metadata\", \"aw\"");
-
-static __attribute__((__used__))
-__attribute__((__section__(".note.swift_reflection_metadata")))
-__attribute__((__aligned__(1)))
-struct {
-  const char MagicString[sizeof(SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING)];
-  const swift::MetadataSections *Sections;
-} __attribute__((__packed__))
-Note = {SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING, &sections};


### PR DESCRIPTION
The "notes" section of an ELF binary is structured data and therefore Swift must not place unrelated data into this section.

More importantly, if external programs want to introspect a binary, they should (as the code does today), walk the ELF *sections* looking for the data in question. Code must not walk ELF binaries looking for magic data.

CC: @alexshap