### PR TITLE
[AutoDiff] Optimize derivative generic signature computation.

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -267,11 +267,11 @@ static GenericSignature *getConstrainedDerivativeGenericSignature(
       nullptr);
 }
 
-// Returns the canonical derivative generic signature for the given
-// `[differentiable]` attribute and original function.
-// - Return the `[differentiable]` attribute derivative generic signature if it
-//   exists.
-// - Otherwise, return the original function's generic signature.
+/// Returns the canonical derivative generic signature for the given
+/// `[differentiable]` attribute and original function.
+/// - Return the `[differentiable]` attribute derivative generic signature if
+///   it exists.
+/// - Otherwise, return the original function's generic signature.
 static CanGenericSignature getDerivativeGenericSignature(
     SILDifferentiableAttr *attr, SILFunction *original) {
   if (auto *attrDerivativeGenSig = attr->getDerivativeGenericSignature())

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -274,4 +274,64 @@ extension TF_697_Sequential: TF_697_Layer where Layer1: TF_697_Layer {
     }
 }
 
+// Test layout requirements.
+
+// The layout requirement is "contextual": the requirement is not on `T`, the
+// differentiable function parameter/result type.
+struct ContextualLayoutRequirement<T: Differentiable, U: AnyObject> {
+  var stored: T
+}
+extension ContextualLayoutRequirement {
+  func test(_ x: T) {
+    let _: @differentiable (T) -> T = { _ in self.stored }
+    let _: @differentiable (T) -> T = { $0 }
+  }
+}
+// The layout requirement directly involves `T`, the differentiable function
+// parameter/result type.
+// TODO(TF-851): Uncomment the tests below after `@differentiable` function
+// SILGen thunking is fixed.
+/*
+struct LayoutRequirement<T: AnyObject & Differentiable> {
+  var stored: T
+}
+extension LayoutRequirement {
+  func test(_ x: T) {
+    let _: @differentiable (T) -> T = { _ in self.stored }
+    let _: @differentiable (T) -> T = { $0 }
+  }
+}
+*/
+
+// Test superclass requirements.
+
+class Super: Differentiable {}
+
+// The superclass requirement is "contextual": the requirement is not on `T`,
+// the differentiable function parameter/result type.
+struct ContextualSuperclassRequirement<T: Differentiable, U: Super> {
+  var stored: T
+}
+extension ContextualSuperclassRequirement {
+  func test(_ x: T) {
+    let _: @differentiable (T) -> T = { _ in self.stored }
+    let _: @differentiable (T) -> T = { $0 }
+  }
+}
+// The superclass requirement directly involves `T`, the differentiable
+// function parameter/result type.
+// TODO(TF-851): Uncomment the tests below after `@differentiable` function
+// SILGen thunking is fixed.
+/*
+struct SuperclassRequirement<T: Super & Differentiable> {
+  var stored: T
+}
+extension SuperclassRequirement {
+  func test(_ x: T) {
+    let _: @differentiable (T) -> T = { _ in self.stored }
+    let _: @differentiable (T) -> T = { $0 }
+  }
+}
+*/
+
 // TODO: add more tests.


### PR DESCRIPTION
Computing constrained derivative generic signatures is costly: remove
unnecessary uses in the differentiation transform. The only remaining use
is `[differentiable]` attribute construction, where it is necessary for
correctness. Other users now extract the constrained derivative generic
signature from a `[differentiable]` attribute.

---

This should improve compiler performance. Will report benchmark results before merging.