### PR TITLE
[semantic-arc-opts] Change to always use the worklist.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2339,7 +2339,7 @@ std::string Demangler::demangleBridgedMethodParams() {
 
   while (!nextIf('_')) {
     auto c = nextChar();
-    if (c != 'n' && c != 'b')
+    if (c != 'n' && c != 'b' && c != 'g')
       return std::string();
     Str.push_back(c);
   }

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -18,16 +18,17 @@
 #include "swift/AST/Types.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "swift/SIL/ApplySite.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
-#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
@@ -50,6 +51,7 @@ class OutlinerMangler : public Mangle::ASTMangler {
   };
 
   llvm::BitVector *IsParameterBridged;
+  llvm::BitVector *IsParameterGuaranteed;
   SILDeclRef MethodDecl;
   MethodKind Kind;
   bool IsReturnBridged;
@@ -57,13 +59,15 @@ class OutlinerMangler : public Mangle::ASTMangler {
 public:
   /// Create an mangler for an outlined bridged method.
   OutlinerMangler(SILDeclRef Method, llvm::BitVector *ParameterBridged,
-                  bool ReturnBridged)
-      : IsParameterBridged(ParameterBridged), MethodDecl(Method),
+                  llvm::BitVector *IsParameterGuaranteed, bool ReturnBridged)
+      : IsParameterBridged(ParameterBridged),
+        IsParameterGuaranteed(IsParameterGuaranteed), MethodDecl(Method),
         Kind(BridgedMethod), IsReturnBridged(ReturnBridged) {}
 
   /// Create an mangler for an outlined bridged property.
   OutlinerMangler(SILDeclRef Method, bool IsAddress)
-      : IsParameterBridged(nullptr), MethodDecl(Method),
+      : IsParameterBridged(nullptr), IsParameterGuaranteed(nullptr),
+        MethodDecl(Method),
         Kind(IsAddress ? BridgedPropertyAddress : BridgedProperty),
         IsReturnBridged(true) {}
 
@@ -93,9 +97,14 @@ std::string OutlinerMangler::mangle() {
   llvm::raw_svector_ostream Out(Buffer);
 
   Out << getMethodKindMangling();
-  if (IsParameterBridged)
-    for (unsigned Idx = 0,  E = IsParameterBridged->size(); Idx != E; ++Idx)
+  if (IsParameterBridged) {
+    for (unsigned Idx = 0, E = IsParameterBridged->size(); Idx != E; ++Idx) {
       Out << (IsParameterBridged->test(Idx) ? 'b' : 'n');
+      // NOTE: We must keep owned as having nothing here to preserve ABI since
+      // mangling is part of ABI.
+      Out << (IsParameterGuaranteed->test(Idx) ? "g" : "");
+    }
+  }
   Out << (IsReturnBridged ? 'b' : 'n');
   Out << '_';
 
@@ -643,7 +652,10 @@ bool BridgedProperty::matchInstSequence(SILBasicBlock::iterator It) {
 
 
 namespace {
+
 /// Match a bridged argument.
+///
+///
 /// %15 = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
 /// %16 = apply %15(%14) :
 ///         $@convention(method) (@guaranteed String) -> @owned NSString
@@ -652,11 +664,16 @@ namespace {
 ///
 /// apply %objcMethod(%17, ...) : $@convention(objc_method) (Optional<NSString> ...) ->
 /// release_value %17 : $Optional<NSString>
+///
+/// NOTE: If release_value %14 is found, our outlined function will have an
+/// owned convention for self. Otherwise, if we do not find it, we will have a
+/// guaranteed one.
 class BridgedArgument {
 public:
   FunctionRefInst *BridgeFun;
   ApplyInst *BridgeCall;
   EnumInst *OptionalResult;
+  SILValue BridgedValue;
   ReleaseValueInst *ReleaseAfterBridge;
   ReleaseValueInst *ReleaseArgAfterCall;
   unsigned Idx = 0;
@@ -664,8 +681,9 @@ public:
   // Matched bridged argument.
   BridgedArgument(unsigned Idx, FunctionRefInst *F, ApplyInst *A, EnumInst *E,
                   ReleaseValueInst *R0, ReleaseValueInst *R1)
-      : BridgeFun(F), BridgeCall(A), OptionalResult(E), ReleaseAfterBridge(R0),
-        ReleaseArgAfterCall(R1), Idx(Idx) {}
+      : BridgeFun(F), BridgeCall(A), OptionalResult(E),
+        BridgedValue(FullApplySite(A).getSelfArgument()),
+        ReleaseAfterBridge(R0), ReleaseArgAfterCall(R1), Idx(Idx) {}
 
   /// Invalid argument constructor.
   BridgedArgument()
@@ -675,7 +693,14 @@ public:
   static BridgedArgument match(unsigned ArgIdx, SILValue Arg, ApplyInst *AI);
 
   operator bool() const { return BridgeFun != nullptr; }
-  SILValue bridgedValue() { return ReleaseAfterBridge->getOperand(); }
+  SILValue bridgedValue() { return BridgedValue; }
+
+  bool isGuaranteed() const { return ReleaseAfterBridge == nullptr; }
+  ParameterConvention getConvention() const {
+    if (isGuaranteed())
+      return ParameterConvention::Direct_Guaranteed;
+    return ParameterConvention::Direct_Owned;
+  }
 
   void eraseFromParent();
 
@@ -697,14 +722,17 @@ void BridgedArgument::transferTo(SILValue BridgedValue,
   DestBB->moveTo(SILBasicBlock::iterator(BridgedCall), BridgeCall);
   BridgeCall->setArgument(0, BridgedValue);
   DestBB->moveTo(SILBasicBlock::iterator(BridgedCall), OptionalResult);
-  DestBB->moveTo(SILBasicBlock::iterator(BridgedCall), ReleaseAfterBridge);
-  ReleaseAfterBridge->setOperand(BridgedValue);
+  if (ReleaseAfterBridge) {
+    DestBB->moveTo(SILBasicBlock::iterator(BridgedCall), ReleaseAfterBridge);
+    ReleaseAfterBridge->setOperand(BridgedValue);
+  }
   auto AfterCall = std::next(SILBasicBlock::iterator(BridgedCall));
   DestBB->moveTo(SILBasicBlock::iterator(AfterCall), ReleaseArgAfterCall);
 }
 
 void BridgedArgument::eraseFromParent() {
-  ReleaseAfterBridge->eraseFromParent();
+  if (ReleaseAfterBridge)
+    ReleaseAfterBridge->eraseFromParent();
   ReleaseArgAfterCall->eraseFromParent();
   OptionalResult->eraseFromParent();
   BridgeCall->eraseFromParent();
@@ -740,9 +768,12 @@ BridgedArgument BridgedArgument::match(unsigned ArgIdx, SILValue Arg,
   auto Next = std::next(SILBasicBlock::iterator(Enum));
   if (Next == Enum->getParent()->end())
     return BridgedArgument();
+
+  // Make sure that if we have a bridged value release that it is on the bridged
+  // value.
   auto *BridgedValueRelease =
       dyn_cast<ReleaseValueInst>(std::next(SILBasicBlock::iterator(Enum)));
-  if (!BridgedValueRelease || BridgedValueRelease->getOperand() != BridgedValue)
+  if (BridgedValueRelease && BridgedValueRelease->getOperand() != BridgedValue)
     return BridgedArgument();
 
   if (SILBasicBlock::iterator(BridgeCall) == BridgeCall->getParent()->begin())
@@ -885,6 +916,7 @@ class ObjCMethodCall : public OutlinePattern {
   SmallVector<BridgedArgument, 4> BridgedArguments;
   std::string OutlinedName;
   llvm::BitVector IsBridgedArgument;
+  llvm::BitVector IsGuaranteedArgument;
   BridgedReturn BridgedReturn;
 public:
   bool matchInstSequence(SILBasicBlock::iterator I) override;
@@ -913,6 +945,7 @@ void ObjCMethodCall::clearState() {
   BridgedArguments.clear();
   OutlinedName.clear();
   IsBridgedArgument.clear();
+  IsGuaranteedArgument.clear();
 }
 
 std::pair<SILFunction *, SILBasicBlock::iterator>
@@ -1018,7 +1051,7 @@ ObjCMethodCall::outline(SILModule &M) {
 std::string ObjCMethodCall::getOutlinedFunctionName() {
   if (OutlinedName.empty()) {
     OutlinerMangler Mangler(ObjCMethod->getMember(), &IsBridgedArgument,
-                            BridgedReturn);
+                            &IsGuaranteedArgument, BridgedReturn);
     OutlinedName = Mangler.mangle();
   }
   return OutlinedName;
@@ -1046,6 +1079,7 @@ bool ObjCMethodCall::matchInstSequence(SILBasicBlock::iterator I) {
   // Collect bridged parameters.
   unsigned Idx = 0;
   IsBridgedArgument.resize(BridgedCall->getNumArguments(), false);
+  IsGuaranteedArgument.resize(BridgedCall->getNumArguments(), false);
   for (auto &Param : BridgedCall->getArgumentOperands()) {
     unsigned CurIdx = Idx++;
 
@@ -1066,6 +1100,8 @@ bool ObjCMethodCall::matchInstSequence(SILBasicBlock::iterator I) {
 
     BridgedArguments.push_back(BridgedArg);
     IsBridgedArgument.set(CurIdx);
+    if (BridgedArg.isGuaranteed())
+      IsGuaranteedArgument.set(CurIdx);
   }
 
   // Try to match a bridged return value.
@@ -1097,11 +1133,12 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
     // Either use the bridged type passing it @owned.
     if (BridgedArgIdx < BridgedArguments.size() &&
         BridgedArguments[BridgedArgIdx].Idx == OrigSigIdx) {
+      auto convention = BridgedArguments[BridgedArgIdx].getConvention();
       Parameters.push_back(SILParameterInfo(BridgedArguments[BridgedArgIdx]
                                                 .bridgedValue()
                                                 ->getType()
                                                 .getASTType(),
-                                            ParameterConvention::Direct_Owned));
+                                            convention));
       ++BridgedArgIdx;
     } else {
       // Otherwise, use the original type convention.

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -293,6 +293,7 @@ _T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.In
 _T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int]
 _T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __C.UITextField.text.getter : Swift.String?
 _T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __C.UITextField.text.getter : Swift.String?
+$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any?
 _T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
 _T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
 _T0D ---> _T0D

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -11,21 +11,23 @@ public class MyGizmo {
 
    init() {
      gizmo = Gizmo()
-   }
-	 // CHECK-LABEL: sil @$s8outliner7MyGizmoC11usePropertyyyF
-	 // CHECK: [[A_FUN:%.*]] = function_ref @$sSo5GizmoC14stringPropertySSSgvgToTeab_
-	 // CHECK: apply [[A_FUN]]({{.*}}) : $@convention(thin) (@in_guaranteed Gizmo) -> @owned Optional<String>
-	 // CHECK-NOT: return
-         // CHECK: [[P_FUN:%.*]] = function_ref @$sSo5GizmoC14stringPropertySSSgvgToTepb_
-	 // CHECK: apply [[P_FUN]]({{.*}}) : $@convention(thin) (Gizmo) -> @owned Optional<String>
-	 // CHECK: return
+  }
+
+   // CHECK-LABEL: sil @$s8outliner7MyGizmoC11usePropertyyyF :
+   // CHECK: [[A_FUN:%.*]] = function_ref @$sSo5GizmoC14stringPropertySSSgvgToTeab_
+   // CHECK: apply [[A_FUN]]({{.*}}) : $@convention(thin) (@in_guaranteed Gizmo) -> @owned Optional<String>
+   // CHECK-NOT: return
+   // CHECK: [[P_FUN:%.*]] = function_ref @$sSo5GizmoC14stringPropertySSSgvgToTepb_
+   // CHECK: apply [[P_FUN]]({{.*}}) : $@convention(thin) (Gizmo) -> @owned Optional<String>
+   // CHECK: return
+   // CHECK: } // end sil function '$s8outliner7MyGizmoC11usePropertyyyF'
    public func useProperty() {
      print(gizmo.stringProperty)
      print(optionalGizmo!.stringProperty)
-	 }
+   }
 }
 
-// CHECK-LABEL: sil @$s8outliner13testOutliningyyF
+// CHECK-LABEL: sil @$s8outliner13testOutliningyyF :
 // CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC14stringPropertySSSgvgToTepb_
 // CHECK:  apply [[FUN]](%{{.*}}) : $@convention(thin) (Gizmo) -> @owned Optional<String>
 // CHECK:  apply [[FUN]](%{{.*}}) : $@convention(thin) (Gizmo) -> @owned Optional<String>
@@ -39,6 +41,7 @@ public class MyGizmo {
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject>
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject>
 // CHECK: return
+// CHECK: } // end sil function '$s8outliner13testOutliningyyF'
 public func testOutlining() {
   let gizmo = Gizmo()
   let foobar = Gizmo()
@@ -59,6 +62,7 @@ public func testOutlining() {
 // CHECK:  [[METH:%.*]] = objc_method [[OBJ]] : $@opened("{{.*}}") (AnyObject), #Treeish.treeishChildren!1.foreign : <Self where Self : Treeish> (Self) -> () -> [Any]?
 // CHECK:  [[RES:%.*]] = apply [[METH]]([[OBJ]]) : $@convention(objc_method)
 // CHECK:  switch_enum [[RES]]
+// CHECK: } // end sil function '$s8outliner9dontCrash1ayyp_tF'
 
 // CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC14stringPropertySSSgvgToTeab_ : $@convention(thin) (@in_guaranteed Gizmo) -> @owned Optional<String>
 // CHECK: bb0(%0 : $*Gizmo):
@@ -78,6 +82,7 @@ public func testOutlining() {
 // CHECK:   br bb3(%12 : $Optional<String>)
 // CHECK: bb3(%14 : $Optional<String>):
 // CHECK:   return %14 : $Optional<String>
+// CHECK: } // end sil function '$sSo5GizmoC14stringPropertySSSgvgToTeab_'
 
 // CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC14stringPropertySSSgvgToTepb_ : $@convention(thin) (Gizmo) -> @owned Optional<String>
 // CHECK: bb0(%0 : $Gizmo):
@@ -96,6 +101,7 @@ public func testOutlining() {
 // CHECK:  br bb3(%11 : $Optional<String>)
 // CHECK:bb3(%13 : $Optional<String>):
 // CHECK:  return %13 : $Optional<String>
+// CHECK: } // end sil function '$sSo5GizmoC14stringPropertySSSgvgToTepb_'
 
 // CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC14stringPropertySSSgvsToTembnn_ : $@convention(thin) (@owned String, Gizmo) -> () {
 // CHECK: bb0(%0 : $String, %1 : $Gizmo):
@@ -107,6 +113,7 @@ public func testOutlining() {
 // CHECK:   %7 = apply %2(%6, %1) : $@convention(objc_method) (Optional<NSString>, Gizmo) -> ()
 // CHECK:   strong_release %4 : $NSString
 // CHECK:   return %7 : $()
+// CHECK: } // end sil function '$sSo5GizmoC14stringPropertySSSgvsToTembnn_'
 
 // CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC12modifyString_10withNumber0D6FoobarSSSgAF_SiypSgtFToTembnnnb_ : $@convention(thin) (@owned String, Int, Optional<AnyObject>, Gizmo) -> @owned Optional<String> {
 // CHECK: bb0(%0 : $String, %1 : $Int, %2 : $Optional<AnyObject>, %3 : $Gizmo):
@@ -133,6 +140,7 @@ public func testOutlining() {
 //
 // CHECK: bb3(%21 : $Optional<String>):
 // CHECK:   return %21 : $Optional<String>
+// CHECK: } // end sil function '$sSo5GizmoC12modifyString_10withNumber0D6FoobarSSSgAF_SiypSgtFToTembnnnb_'
 
 // CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_ : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject> {
 // CHECK: bb0(%0 : $Array<String>, %1 : $Gizmo):
@@ -144,6 +152,7 @@ public func testOutlining() {
 // CHECK:   %7 = apply %2(%6, %1) : $@convention(objc_method) (Optional<NSArray>, Gizmo) -> @autoreleased Optional<AnyObject>
 // CHECK:   strong_release %4 : $NSArray
 // CHECK:   return %7 : $Optional<AnyObject>
+// CHECK: } // end sil function '$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_'
 
 public func dontCrash<T: Proto>(x : Gizmo2<T>) {
   let s = x.doSomething()

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -37,9 +37,9 @@ public class MyGizmo {
 // CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC12modifyString_10withNumber0D6FoobarSSSgAF_SiypSgtFToTembnnnb_
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned String, Int, Optional<AnyObject>, Gizmo) -> @owned Optional<String>
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned String, Int, Optional<AnyObject>, Gizmo) -> @owned Optional<String>
-// CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_
-// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject>
-// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject>
+// CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_
+// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@guaranteed Array<String>, Gizmo) -> @owned Optional<AnyObject>
+// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@guaranteed Array<String>, Gizmo) -> @owned Optional<AnyObject>
 // CHECK: return
 // CHECK: } // end sil function '$s8outliner13testOutliningyyF'
 public func testOutlining() {
@@ -142,17 +142,17 @@ public func testOutlining() {
 // CHECK:   return %21 : $Optional<String>
 // CHECK: } // end sil function '$sSo5GizmoC12modifyString_10withNumber0D6FoobarSSSgAF_SiypSgtFToTembnnnb_'
 
-// CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_ : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject> {
+// CHECK-LABEL: sil shared [noinline] @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ : $@convention(thin) (@guaranteed Array<String>, Gizmo) -> @owned Optional<AnyObject> {
 // CHECK: bb0(%0 : $Array<String>, %1 : $Gizmo):
 // CHECK:   %2 = objc_method %1 : $Gizmo, #Gizmo.doSomething!1.foreign : (Gizmo) -> ([String]?) -> Any?
 // CHECK:   %3 = function_ref @$sSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF : $@convention(method) <{{.*}}> (@guaranteed Array<{{.*}}>) -> @owned NSArray
 // CHECK:   %4 = apply %3<String>(%0) : $@convention(method) <{{.*}}> (@guaranteed Array<{{.*}}>) -> @owned NSArray
-// CHECK:   release_value %0 : $Array<String>
-// CHECK:   %6 = enum $Optional<NSArray>, #Optional.some!enumelt.1, %4 : $NSArray
-// CHECK:   %7 = apply %2(%6, %1) : $@convention(objc_method) (Optional<NSArray>, Gizmo) -> @autoreleased Optional<AnyObject>
+// CHECK-NOT:   release_value
+// CHECK:   %5 = enum $Optional<NSArray>, #Optional.some!enumelt.1, %4 : $NSArray
+// CHECK:   %6 = apply %2(%5, %1) : $@convention(objc_method) (Optional<NSArray>, Gizmo) -> @autoreleased Optional<AnyObject>
 // CHECK:   strong_release %4 : $NSArray
-// CHECK:   return %7 : $Optional<AnyObject>
-// CHECK: } // end sil function '$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_'
+// CHECK:   return %6 : $Optional<AnyObject>
+// CHECK: } // end sil function '$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_'
 
 public func dontCrash<T: Proto>(x : Gizmo2<T>) {
   let s = x.doSomething()


### PR DESCRIPTION
Previously we were:

1. Doing a linear scan, performing certain optimizations, and setting up a
worklist for future processing.

2. Draining the worklist of changed instructions until we reached a fix point.

The key thing here is that for (1) to be safe, we would need to not perform any
optimizations on block arguments since there was an ssumption that we would only
perform SSA-like optimizations.

I am going to be adding such optimizations soon, so it makes sense to just
convert the initial traversal to non-destructively seed the worklist and
eliminate that initial optimization pass.

This should be NFC.
