### PR TITLE
[NFC] Add a regression test for SR-5252

### DIFF
--- a/test/Constraints/sr5252.swift
+++ b/test/Constraints/sr5252.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+class Helper {}
+
+class Base {}
+class Sub<T>: Base {}
+
+// The superclass constraint was the culprit.
+func foo<T: Helper & P>(base: Base, arg: T) {
+    _ = base as? Sub<T>
+}


### PR DESCRIPTION
For [SR-5252](https://bugs.swift.org/browse/SR-5252), which was apparently fixed without direct intention.