### PR TITLE
[CS] Define a class for every locator path element kind

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -767,8 +767,8 @@ void GenericArgumentsMismatchFailure::emitNoteForMismatch(int position) {
   // to parameter conversions, let's use parameter type as a source of
   // generic parameter information.
   auto paramSourceTy =
-      locator->isLastElement(ConstraintLocator::ApplyArgToParam) ? getRequired()
-                                                                 : getActual();
+      locator->isLastElement<LocatorPathElt::ApplyArgToParam>() ? getRequired()
+                                                                : getActual();
 
   auto genericTypeDecl = paramSourceTy->getAnyGeneric();
   auto param = genericTypeDecl->getGenericParams()->getParams()[position];
@@ -1246,7 +1246,7 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   // r-value adjustment because base could be an l-value type.
   // We want to fix both cases by only diagnose one of them,
   // otherwise this is just going to result in a duplcate diagnostic.
-  if (getLocator()->isLastElement(ConstraintLocator::UnresolvedMember))
+  if (getLocator()->isLastElement<LocatorPathElt::UnresolvedMember>())
     return false;
 
   if (auto assignExpr = dyn_cast<AssignExpr>(anchor))
@@ -2035,7 +2035,7 @@ bool ContextualFailure::diagnoseConversionToNil() const {
 
   Optional<ContextualTypePurpose> CTP;
   // Easy case were failure has been identified as contextual already.
-  if (locator->isLastElement(ConstraintLocator::ContextualType)) {
+  if (locator->isLastElement<LocatorPathElt::ContextualType>()) {
     CTP = getContextualTypePurpose();
   } else {
     // Here we need to figure out where where `nil` is located.
@@ -3596,7 +3596,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   //
   // foo(bar) // `() -> Void` vs. `(Int) -> Void`
   // ```
-  if (locator->isLastElement(ConstraintLocator::ApplyArgToParam)) {
+  if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
     auto info = *getFunctionArgApplyInfo(locator);
 
     auto *argExpr = info.getArgExpr();
@@ -3612,7 +3612,7 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   // func foo() {}
   // let _: (Int) -> Void = foo
   // ```
-  if (locator->isLastElement(ConstraintLocator::ContextualType)) {
+  if (locator->isLastElement<LocatorPathElt::ContextualType>()) {
     auto &cs = getConstraintSystem();
     emitDiagnostic(anchor->getLoc(), diag::cannot_convert_initializer_value,
                    getType(anchor), resolveType(cs.getContextualType()));
@@ -3885,7 +3885,7 @@ bool MissingArgumentsFailure::diagnoseClosure(ClosureExpr *closure) {
 
 bool MissingArgumentsFailure::diagnoseInvalidTupleDestructuring() const {
   auto *locator = getLocator();
-  if (!locator->isLastElement(ConstraintLocator::ApplyArgument))
+  if (!locator->isLastElement<LocatorPathElt::ApplyArgument>())
     return false;
 
   if (SynthesizedArgs.size() < 2)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -995,7 +995,7 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
   auto isSynthesizedArgument = [](const AnyFunctionType::Param &arg) -> bool {
     if (auto *typeVar = arg.getPlainType()->getAs<TypeVariableType>()) {
       auto *locator = typeVar->getImpl().getLocator();
-      return locator->isLastElement(ConstraintLocator::SynthesizedArgument);
+      return locator->isLastElement<LocatorPathElt::SynthesizedArgument>();
     }
 
     return false;
@@ -3233,7 +3233,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           // TODO(diagnostics): Only binding here for function types, because
           // doing so for KeyPath types leaves the constraint system in an
           // unexpected state for key path diagnostics should we fail.
-          if (locator->isLastElement(ConstraintLocator::KeyPathType) &&
+          if (locator->isLastElement<LocatorPathElt::KeyPathType>() &&
               type2->is<AnyFunctionType>())
             return matchTypesBindTypeVar(typeVar1, type2, kind, flags, locator,
                                          formUnsolvedResult);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -175,22 +175,16 @@ bool ConstraintLocator::isForKeyPathComponent() const {
   });
 }
 
-bool ConstraintLocator::isLastElement(
-    ConstraintLocator::PathElementKind expectedKind) const {
-  auto path = getPath();
-  return !path.empty() && path.back().getKind() == expectedKind;
-}
-
 bool ConstraintLocator::isForGenericParameter() const {
-  return isLastElement(ConstraintLocator::GenericParameter);
+  return isLastElement<LocatorPathElt::GenericParameter>();
 }
 
 bool ConstraintLocator::isForSequenceElementType() const {
-  return isLastElement(ConstraintLocator::SequenceElementType);
+  return isLastElement<LocatorPathElt::SequenceElementType>();
 }
 
 bool ConstraintLocator::isForContextualType() const {
-  return isLastElement(ConstraintLocator::ContextualType);
+  return isLastElement<LocatorPathElt::ContextualType>();
 }
 
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -37,9 +37,11 @@ void ConstraintLocator::Profile(llvm::FoldingSetNodeID &id, Expr *anchor,
       id.AddPointer(elt.castTo<LocatorPathElt::GenericParameter>().getType());
       break;
 
-    case Requirement:
-      id.AddPointer(elt.castTo<LocatorPathElt::Requirement>().getDecl());
+    case ProtocolRequirement: {
+      auto reqElt = elt.castTo<LocatorPathElt::ProtocolRequirement>();
+      id.AddPointer(reqElt.getDecl());
       break;
+    }
 
     case Witness:
       id.AddPointer(elt.castTo<LocatorPathElt::Witness>().getDecl());
@@ -338,9 +340,9 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       out << "key path component #" << llvm::utostr(kpElt.getIndex());
       break;
     }
-    case Requirement: {
-      auto reqElt = elt.castTo<LocatorPathElt::Requirement>();
-      out << "requirement ";
+    case ProtocolRequirement: {
+      auto reqElt = elt.castTo<LocatorPathElt::ProtocolRequirement>();
+      out << "protocol requirement ";
       reqElt.getDecl()->dumpRef(out);
       break;
     }

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -53,90 +53,9 @@ public:
   /// Describes the kind of a particular path element, e.g.,
   /// "tuple element", "call result", "base of member lookup", etc.
   enum PathElementKind : unsigned char {
-    /// The argument of function application.
-    ApplyArgument,
-    /// The function being applied.
-    ApplyFunction,
-    /// Matching an argument to a parameter.
-    ApplyArgToParam,
-    /// A generic parameter being opened.
-    ///
-    /// Also contains the generic parameter type itself.
-    GenericParameter,
-    /// The argument type of a function.
-    FunctionArgument,
-    /// The result type of a function.
-    FunctionResult,
-    /// A tuple element referenced by position.
-    TupleElement,
-    /// A tuple element referenced by name.
-    NamedTupleElement,
-    /// An optional payload.
-    OptionalPayload,
-    /// A generic argument.
-    /// FIXME: Add support for named generic arguments?
-    GenericArgument,
-    /// A member.
-    /// FIXME: Do we need the actual member name here?
-    Member,
-    /// An unresolved member.
-    UnresolvedMember,
-    /// The base of a member expression.
-    MemberRefBase,
-    /// The lookup for a subscript member.
-    SubscriptMember,
-    /// The lookup for a constructor member.
-    ConstructorMember,
-    /// An implicit @lvalue-to-inout conversion; only valid for operator
-    /// arguments.
-    LValueConversion,
-    /// RValue adjustment.
-    RValueAdjustment,
-    /// The result of a closure.
-    ClosureResult,
-    /// The parent of a nested type.
-    ParentType,
-    /// The superclass of a protocol existential type.
-    ExistentialSuperclassType,
-    /// The instance of a metatype type.
-    InstanceType,
-    /// The element type of a sequence in a for ... in ... loop.
-    SequenceElementType,
-    /// An argument passed in an autoclosure parameter
-    /// position, which must match the autoclosure return type.
-    AutoclosureResult,
-    /// The requirement that we're matching during protocol conformance
-    /// checking.
-    Requirement,
-    /// The candidate witness during protocol conformance checking.
-    Witness,
-    /// This is referring to a type produced by opening a generic type at the
-    /// base of the locator.
-    OpenedGeneric,
-    /// A component of a key path.
-    KeyPathComponent,
-    /// The Nth conditional requirement in the parent locator's conformance.
-    ConditionalRequirement,
-    /// A single requirement placed on the type parameters.
-    TypeParameterRequirement,
-    /// Locator for a binding from an IUO disjunction choice.
-    ImplicitlyUnwrappedDisjunctionChoice,
-    /// A result of an expression involving dynamic lookup.
-    DynamicLookupResult,
-    /// The desired contextual type passed in to the constraint system.
-    ContextualType,
-    /// The missing argument synthesized by the solver.
-    SynthesizedArgument,
-    /// The member looked up via keypath based dynamic lookup.
-    KeyPathDynamicMember,
-    /// The type of the key path expression
-    KeyPathType,
-    /// The root of a key path
-    KeyPathRoot,
-    /// The value of a key path
-    KeyPathValue,
-    /// The result type of a key path component. Not used for subscripts.
-    KeyPathComponentResult,
+#define LOCATOR_PATH_ELT(Name) Name,
+#define ABSTRACT_LOCATOR_PATH_ELT(Name)
+#include "ConstraintLocatorPathElts.def"
   };
 
   /// Determine the number of numeric values used for the given path
@@ -356,23 +275,8 @@ public:
     friend class ConstraintLocator;
 
   public:
-    class ApplyArgToParam;
-    class SynthesizedArgument;
-    class AnyTupleElement;
-    class TupleElement;
-    class NamedTupleElement;
-    class KeyPathComponent;
-    class GenericArgument;
-    class AnyRequirement;
-    class ConditionalRequirement;
-    class TypeParameterRequirement;
-    class ContextualType;
-    class Witness;
-    class Requirement;
-    class GenericParameter;
-    class OpenedGeneric;
-    class KeyPathDynamicMember;
-    class UnresolvedMember;
+#define LOCATOR_PATH_ELT(Name) class Name;
+#include "ConstraintLocatorPathElts.def"
 
     PathElement(PathElementKind kind)
       : storage(encodeStorage(kind, 0)), storedKind(StoredKindAndValue)
@@ -701,6 +605,16 @@ template <class X>
 inline typename llvm::cast_retty<X, LocatorPathElt>::ret_type
 dyn_cast(const LocatorPathElt &) = delete; // Use LocatorPathElt::getAs instead.
 
+#define SIMPLE_LOCATOR_PATH_ELT(Name) \
+class LocatorPathElt:: Name final : public LocatorPathElt { \
+public: \
+  Name () : LocatorPathElt(ConstraintLocator:: Name) {} \
+                                                        \
+  static bool classof(const LocatorPathElt *elt) { \
+    return elt->getKind() == ConstraintLocator:: Name; \
+  } \
+};
+#include "ConstraintLocatorPathElts.def"
 
 // The following LocatorPathElt subclasses are used to expose accessors for
 // specific path element information. They shouldn't introduce additional
@@ -925,15 +839,6 @@ public:
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::KeyPathDynamicMember;
-  }
-};
-
-class LocatorPathElt::UnresolvedMember final : public LocatorPathElt {
-public:
-  UnresolvedMember() : LocatorPathElt(PathElementKind::UnresolvedMember, 0) {}
-
-  static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == ConstraintLocator::UnresolvedMember;
   }
 };
 

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -81,7 +81,7 @@ public:
     case ExistentialSuperclassType:
     case SequenceElementType:
     case AutoclosureResult:
-    case Requirement:
+    case ProtocolRequirement:
     case Witness:
     case ImplicitlyUnwrappedDisjunctionChoice:
     case DynamicLookupResult:
@@ -148,7 +148,7 @@ public:
     case GenericArgument:
     case NamedTupleElement:
     case TupleElement:
-    case Requirement:
+    case ProtocolRequirement:
     case Witness:
     case KeyPathComponent:
     case ConditionalRequirement:
@@ -179,7 +179,7 @@ public:
     /// Describes the kind of data stored here.
     enum StoredKind : unsigned char {
       StoredGenericParameter,
-      StoredRequirement,
+      StoredProtocolRequirement,
       StoredWitness,
       StoredGenericSignature,
       StoredKeyPathDynamicMemberBase,
@@ -291,8 +291,8 @@ public:
       case StoredGenericParameter:
         return PathElementKind::GenericParameter;
 
-      case StoredRequirement:
-        return PathElementKind::Requirement;
+      case StoredProtocolRequirement:
+        return PathElementKind::ProtocolRequirement;
 
       case StoredWitness:
         return PathElementKind::Witness;
@@ -788,15 +788,15 @@ public:
   }
 };
 
-class LocatorPathElt::Requirement final : public LocatorPathElt {
+class LocatorPathElt::ProtocolRequirement final : public LocatorPathElt {
 public:
-  Requirement(ValueDecl *decl)
-      : LocatorPathElt(LocatorPathElt::StoredRequirement, decl) {}
+  ProtocolRequirement(ValueDecl *decl)
+      : LocatorPathElt(LocatorPathElt::StoredProtocolRequirement, decl) {}
 
   ValueDecl *getDecl() const { return getStoredPointer<ValueDecl>(); }
 
   static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == ConstraintLocator::Requirement;
+    return elt->getKind() == ConstraintLocator::ProtocolRequirement;
   }
 };
 

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -441,9 +441,13 @@ public:
     return path[0].castTo<T>();
   }
 
-  /// Check whether the last element in the path of this locator
-  /// is of a given kind.
-  bool isLastElement(ConstraintLocator::PathElementKind kind) const;
+  /// Check whether the last element in the path of this locator (if any)
+  /// is a given \c LocatorPathElt subclass.
+  template <class T>
+  bool isLastElement() const {
+    auto path = getPath();
+    return !path.empty() && path.back().is<T>();
+  }
 
   /// Attempts to cast the last path element of the locator to a specific
   /// \c LocatorPathElt subclass, returning \c None if either unsuccessful or

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -128,7 +128,7 @@ SIMPLE_LOCATOR_PATH_ELT(ParentType)
 
 /// The requirement that we're matching during protocol conformance
 /// checking.
-CUSTOM_LOCATOR_PATH_ELT(Requirement)
+CUSTOM_LOCATOR_PATH_ELT(ProtocolRequirement)
 
 /// Type parameter requirements.
 ABSTRACT_LOCATOR_PATH_ELT(AnyRequirement)

--- a/lib/Sema/ConstraintLocatorPathElts.def
+++ b/lib/Sema/ConstraintLocatorPathElts.def
@@ -1,0 +1,170 @@
+//===--- ConstraintLocatorPathElts.def - Constraint Locator Path Elements -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file enumerates the elements that can make up the path of a
+/// ConstraintLocator.
+///
+//===----------------------------------------------------------------------===//
+
+/// Describes any kind of path element.
+#ifndef LOCATOR_PATH_ELT
+#define LOCATOR_PATH_ELT(Name)
+#endif
+
+/// Defines a path element which is characterized only by its kind, and as such
+/// doesn't store additional values.
+#ifndef SIMPLE_LOCATOR_PATH_ELT
+#define SIMPLE_LOCATOR_PATH_ELT(Name) LOCATOR_PATH_ELT(Name)
+#endif
+
+/// Defines a path element that requires a class definition to be provided in
+/// order to expose things like accessors for path element info.
+#ifndef CUSTOM_LOCATOR_PATH_ELT
+#define CUSTOM_LOCATOR_PATH_ELT(Name) LOCATOR_PATH_ELT(Name)
+#endif
+
+/// Defines an abstract path element superclass which doesn't itself have a path
+/// element kind.
+#ifndef ABSTRACT_LOCATOR_PATH_ELT
+#define ABSTRACT_LOCATOR_PATH_ELT(Name) CUSTOM_LOCATOR_PATH_ELT(Name)
+#endif
+
+/// Matching an argument to a parameter.
+CUSTOM_LOCATOR_PATH_ELT(ApplyArgToParam)
+
+/// The argument of function application.
+SIMPLE_LOCATOR_PATH_ELT(ApplyArgument)
+
+/// The function being applied.
+SIMPLE_LOCATOR_PATH_ELT(ApplyFunction)
+
+/// An argument passed in an autoclosure parameter
+/// position, which must match the autoclosure return type.
+SIMPLE_LOCATOR_PATH_ELT(AutoclosureResult)
+
+/// The result of a closure.
+SIMPLE_LOCATOR_PATH_ELT(ClosureResult)
+
+/// The lookup for a constructor member.
+SIMPLE_LOCATOR_PATH_ELT(ConstructorMember)
+
+/// The desired contextual type passed in to the constraint system.
+CUSTOM_LOCATOR_PATH_ELT(ContextualType)
+
+/// A result of an expression involving dynamic lookup.
+SIMPLE_LOCATOR_PATH_ELT(DynamicLookupResult)
+
+/// The superclass of a protocol existential type.
+SIMPLE_LOCATOR_PATH_ELT(ExistentialSuperclassType)
+
+/// The argument type of a function.
+SIMPLE_LOCATOR_PATH_ELT(FunctionArgument)
+
+/// The result type of a function.
+SIMPLE_LOCATOR_PATH_ELT(FunctionResult)
+
+/// A generic argument.
+/// FIXME: Add support for named generic arguments?
+CUSTOM_LOCATOR_PATH_ELT(GenericArgument)
+
+/// Locator for a binding from an IUO disjunction choice.
+SIMPLE_LOCATOR_PATH_ELT(ImplicitlyUnwrappedDisjunctionChoice)
+
+/// The instance of a metatype type.
+SIMPLE_LOCATOR_PATH_ELT(InstanceType)
+
+/// A generic parameter being opened.
+///
+/// Also contains the generic parameter type itself.
+CUSTOM_LOCATOR_PATH_ELT(GenericParameter)
+
+/// A component of a key path.
+CUSTOM_LOCATOR_PATH_ELT(KeyPathComponent)
+
+/// The result type of a key path component. Not used for subscripts.
+SIMPLE_LOCATOR_PATH_ELT(KeyPathComponentResult)
+
+/// The member looked up via keypath based dynamic lookup.
+CUSTOM_LOCATOR_PATH_ELT(KeyPathDynamicMember)
+
+/// The root of a key path.
+SIMPLE_LOCATOR_PATH_ELT(KeyPathRoot)
+
+/// The type of the key path expression.
+SIMPLE_LOCATOR_PATH_ELT(KeyPathType)
+
+/// The value of a key path.
+SIMPLE_LOCATOR_PATH_ELT(KeyPathValue)
+
+/// An implicit @lvalue-to-inout conversion; only valid for operator
+/// arguments.
+SIMPLE_LOCATOR_PATH_ELT(LValueConversion)
+
+/// A member.
+/// FIXME: Do we need the actual member name here?
+SIMPLE_LOCATOR_PATH_ELT(Member)
+
+/// The base of a member expression.
+SIMPLE_LOCATOR_PATH_ELT(MemberRefBase)
+
+/// This is referring to a type produced by opening a generic type at the
+/// base of the locator.
+CUSTOM_LOCATOR_PATH_ELT(OpenedGeneric)
+
+/// An optional payload.
+SIMPLE_LOCATOR_PATH_ELT(OptionalPayload)
+
+/// The parent of a nested type.
+SIMPLE_LOCATOR_PATH_ELT(ParentType)
+
+/// The requirement that we're matching during protocol conformance
+/// checking.
+CUSTOM_LOCATOR_PATH_ELT(Requirement)
+
+/// Type parameter requirements.
+ABSTRACT_LOCATOR_PATH_ELT(AnyRequirement)
+  /// The Nth conditional requirement in the parent locator's conformance.
+  CUSTOM_LOCATOR_PATH_ELT(ConditionalRequirement)
+
+  /// A single requirement placed on the type parameters.
+  CUSTOM_LOCATOR_PATH_ELT(TypeParameterRequirement)
+
+/// RValue adjustment.
+SIMPLE_LOCATOR_PATH_ELT(RValueAdjustment)
+
+/// The element type of a sequence in a for ... in ... loop.
+SIMPLE_LOCATOR_PATH_ELT(SequenceElementType)
+
+/// The lookup for a subscript member.
+SIMPLE_LOCATOR_PATH_ELT(SubscriptMember)
+
+/// The missing argument synthesized by the solver.
+CUSTOM_LOCATOR_PATH_ELT(SynthesizedArgument)
+
+/// Tuple elements.
+ABSTRACT_LOCATOR_PATH_ELT(AnyTupleElement)
+  /// A tuple element referenced by position.
+  CUSTOM_LOCATOR_PATH_ELT(TupleElement)
+
+  /// A tuple element referenced by name.
+  CUSTOM_LOCATOR_PATH_ELT(NamedTupleElement)
+
+/// An unresolved member.
+SIMPLE_LOCATOR_PATH_ELT(UnresolvedMember)
+
+/// The candidate witness during protocol conformance checking.
+CUSTOM_LOCATOR_PATH_ELT(Witness)
+
+#undef LOCATOR_PATH_ELT
+#undef CUSTOM_LOCATOR_PATH_ELT
+#undef SIMPLE_LOCATOR_PATH_ELT
+#undef ABSTRACT_LOCATOR_PATH_ELT

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1206,8 +1206,8 @@ static void addSelfConstraint(ConstraintSystem &cs, Type objectTy, Type selfTy,
 /// Determine whether the given locator is for a witness or requirement.
 static bool isRequirementOrWitness(const ConstraintLocatorBuilder &locator) {
   if (auto last = locator.last()) {
-    return last->getKind() == ConstraintLocator::Requirement ||
-    last->getKind() == ConstraintLocator::Witness;
+    return last->getKind() == ConstraintLocator::ProtocolRequirement ||
+           last->getKind() == ConstraintLocator::Witness;
   }
 
   return false;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -724,8 +724,8 @@ swift::matchWitness(TypeChecker &tc,
       selfTy = reqGenericEnv->mapTypeIntoContext(selfTy);
 
     // Open up the type of the requirement.
-    reqLocator = cs->getConstraintLocator(static_cast<Expr *>(nullptr),
-                                          LocatorPathElt::Requirement(req));
+    reqLocator = cs->getConstraintLocator(
+        static_cast<Expr *>(nullptr), LocatorPathElt::ProtocolRequirement(req));
     OpenedTypeMap reqReplacements;
     std::tie(openedFullReqType, reqType)
       = cs->getTypeOfMemberReference(selfTy, req, dc,


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/26297. This PR uses macros to define the different kinds of locator path elements, which then allows us to define a `LocatorPathElt` subclass for each one. `ConstraintLocator::isLastElement` is then changed to take a `LocatorPathElt` subclass, making it consistent with the other last-element casting members.

Finally this PR renames the `Requirement` path element to `ProtocolRequirement` in order to help avoid confusion with `AnyRequirement`.