### PR TITLE
[ASTScopes] Use RequestEvaluator for ASTScope expansion to detect recursion

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -30,6 +30,9 @@
 
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/NameLookup.h" // for DeclVisibilityKind
+// extractNearestSourceLoc, simple_display declarations must come before this
+// Alternatively, declare these in SimpleDisplay.h or elsewhere
+//#include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/NullablePtr.h"
@@ -88,6 +91,12 @@ struct AnnotatedInsertionPoint {
   ASTScopeImpl *insertionPoint;
   const char *explanation;
 };
+} // namespace ast_scope
+
+SourceLoc extractNearestSourceLoc(
+    std::tuple<ast_scope::ASTScopeImpl *, ast_scope::ScopeCreator *>);
+
+namespace ast_scope {
 
 #pragma mark the root ASTScopeImpl class
 
@@ -333,6 +342,7 @@ private:
 public:
   /// expandScope me, sending deferred nodes to my descendants.
   /// Return the scope into which to place subsequent decls
+  ASTScopeImpl *expandAndBeCurrentDetectingRecursion(ScopeCreator &);
   ASTScopeImpl *expandAndBeCurrent(ScopeCreator &);
 
   unsigned getASTAncestorScopeCount() const { return astAncestorScopeCount; }

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -30,9 +30,7 @@
 
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/NameLookup.h" // for DeclVisibilityKind
-// extractNearestSourceLoc, simple_display declarations must come before this
-// Alternatively, declare these in SimpleDisplay.h or elsewhere
-//#include "swift/AST/SimpleRequest.h"
+#include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/NullablePtr.h"
@@ -93,10 +91,12 @@ struct AnnotatedInsertionPoint {
 };
 } // namespace ast_scope
 
-SourceLoc extractNearestSourceLoc(
-    std::tuple<ast_scope::ASTScopeImpl *, ast_scope::ScopeCreator *>);
-
 namespace ast_scope {
+
+void simple_display(llvm::raw_ostream &out, const ASTScopeImpl *);
+void simple_display(llvm::raw_ostream &out, const ScopeCreator *);
+
+SourceLoc extractNearestSourceLoc(std::tuple<ASTScopeImpl *, ScopeCreator *>);
 
 #pragma mark the root ASTScopeImpl class
 

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -346,9 +346,7 @@ public:
 
   /// Expand or reexpand the scope if unexpanded or if not current.
   /// There are several places in the compiler that mutate the AST after the
-  /// fact, above and beyond adding Decls to the SourceFile. These are
-  /// documented in: rdar://53018839, rdar://53027266, rdar://53027733,
-  /// rdar://53028050
+  /// fact, above and beyond adding Decls to the SourceFile.
   ASTScopeImpl *expandAndBeCurrent(ScopeCreator &);
 
   unsigned getASTAncestorScopeCount() const { return astAncestorScopeCount; }
@@ -546,7 +544,7 @@ public:
   /// The number of \c Decls in the \c SourceFile that were already seen.
   /// Since parsing can be interleaved with type-checking, on every
   /// lookup, look at creating scopes for any \c Decls beyond this number.
-  /// rdar://55562483 Unify with numberOfChildrenWhenLastExpanded
+  /// TODO: Unify with numberOfChildrenWhenLastExpanded
   size_t numberOfDeclsAlreadySeen = 0;
 
   ASTSourceFileScope(SourceFile *SF, ScopeCreator *scopeCreator);
@@ -1164,7 +1162,6 @@ public:
   /// false positives, that that doesn't hurt anything. However, the result of
   /// the conservative source range computation doesn't seem to be stable. So
   /// keep the original here, and use it for source range queries.
-  /// rdar://55263708
 
   const SourceRange sourceRangeWhenCreated;
 
@@ -1267,7 +1264,6 @@ protected:
 };
 
 class PatternEntryInitializerScope final : public AbstractPatternEntryScope {
-  // Should be able to remove this when rdar://53921703 is accomplished.
   Expr *initAsWrittenWhenCreated;
 
 public:

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -30,6 +30,10 @@ class GenericContext;
 class GenericParamList;
 class TypeAliasDecl;
 class TypeDecl;
+namespace ast_scope {
+class ASTScopeImpl;
+class ScopeCreator;
+} // namespace ast_scope
 
 /// Display a nominal type or extension thereof.
 void simple_display(
@@ -321,6 +325,28 @@ public:
   SourceLoc getNearestLoc() const;
                                
   // Separate caching.
+  bool isCached() const { return true; }
+};
+
+/// Expand the given ASTScope. Requestified to detect recursion.
+class ExpandASTScopeRequest
+    : public SimpleRequest<ExpandASTScopeRequest,
+                           ast_scope::ASTScopeImpl *(ast_scope::ASTScopeImpl *,
+                                                     ast_scope::ScopeCreator *),
+                           CacheKind::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<ast_scope::ASTScopeImpl *>
+  evaluate(Evaluator &evaluator, ast_scope::ASTScopeImpl *,
+           ast_scope::ScopeCreator *) const;
+
+public:
+  // Caching
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -333,7 +333,7 @@ class ExpandASTScopeRequest
     : public SimpleRequest<ExpandASTScopeRequest,
                            ast_scope::ASTScopeImpl *(ast_scope::ASTScopeImpl *,
                                                      ast_scope::ScopeCreator *),
-                           CacheKind::Uncached> {
+                           CacheKind::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -346,8 +346,10 @@ private:
            ast_scope::ScopeCreator *) const;
 
 public:
-  // Caching
-  bool isCached() const { return true; }
+  // Separate caching.
+  bool isCached() const;
+  Optional<ast_scope::ASTScopeImpl *> getCachedResult() const;
+  void cacheResult(ast_scope::ASTScopeImpl *) const {}
 };
 
 #define SWIFT_TYPEID_ZONE NameLookup

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -18,6 +18,10 @@
 SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
               NominalTypeDecl *(CustomAttr *, DeclContext *), Cached,
               NoLocationInfo)
+SWIFT_REQUEST(NameLookup, ExpandASTScopeRequest,
+              ast_scope::ASTScopeImpl* (ast_scope::ASTScopeImpl*, ast_scope::ScopeCreator*),
+              Uncached,
+              NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
               NominalTypeDecl *(ExtensionDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -20,7 +20,7 @@ SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExpandASTScopeRequest,
               ast_scope::ASTScopeImpl* (ast_scope::ASTScopeImpl*, ast_scope::ScopeCreator*),
-              Uncached,
+              SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, ExtendedNominalRequest,
               NominalTypeDecl *(ExtensionDecl *), SeparatelyCached,

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -54,13 +54,6 @@ namespace swift {
 
 #undef HAS_TRIVIAL_DISPLAY
 
-  namespace ast_scope {
-  class ASTScopeImpl;
-  class ScopeCreator;
-  } // namespace ast_scope
-  void simple_display(llvm::raw_ostream &out, const ast_scope::ASTScopeImpl *);
-  void simple_display(llvm::raw_ostream &out, const ast_scope::ScopeCreator *);
-
   template<typename T>
   typename std::enable_if<HasTrivialDisplay<T>::value>::type
   simple_display(llvm::raw_ostream &out, const T &value) {

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -54,6 +54,13 @@ namespace swift {
 
 #undef HAS_TRIVIAL_DISPLAY
 
+  namespace ast_scope {
+  class ASTScopeImpl;
+  class ScopeCreator;
+  } // namespace ast_scope
+  void simple_display(llvm::raw_ostream &out, const ast_scope::ASTScopeImpl *);
+  void simple_display(llvm::raw_ostream &out, const ast_scope::ScopeCreator *);
+
   template<typename T>
   typename std::enable_if<HasTrivialDisplay<T>::value>::type
   simple_display(llvm::raw_ostream &out, const T &value) {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -2088,7 +2088,7 @@ bool ASTSourceFileScope::crossCheckWithAST() {
   return scopeCreator->containsAllDeclContextsFromAST();
 }
 
-void swift::simple_display(llvm::raw_ostream &out,
-                           const ast_scope::ScopeCreator *scopeCreator) {
+void ast_scope::simple_display(llvm::raw_ostream &out,
+                               const ScopeCreator *scopeCreator) {
   scopeCreator->print(out);
 }

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -40,7 +40,6 @@ llvm::SmallVector<const ASTScopeImpl *, 0> ASTScopeImpl::unqualifiedLookup(
     SourceFile *sourceFile, const DeclName name, const SourceLoc loc,
     const DeclContext *const startingContext, DeclConsumer consumer) {
   SmallVector<const ASTScopeImpl *, 0> history;
-
   const auto *start =
       findStartingScopeForLookup(sourceFile, name, loc, startingContext);
   if (start)
@@ -59,7 +58,6 @@ const ASTScopeImpl *ASTScopeImpl::findStartingScopeForLookup(
 
   auto *const fileScope = sourceFile->getScope().impl;
   // Parser may have added decls to source file, since previous lookup
-  fileScope->addNewDeclsToScopeTree();
   if (name.isOperator())
     return fileScope; // operators always at file scope
 
@@ -116,7 +114,7 @@ ASTScopeImpl::findInnermostEnclosingScope(SourceLoc loc,
 const ASTScopeImpl *ASTScopeImpl::findInnermostEnclosingScopeImpl(
     SourceLoc loc, NullablePtr<raw_ostream> os, SourceManager &sourceMgr,
     ScopeCreator &scopeCreator) {
-  reexpandIfObsolete(scopeCreator);
+  expandAndBeCurrentDetectingRecursion(scopeCreator);
   auto child = findChildContaining(loc, sourceMgr);
   if (!child)
     return this;

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -204,5 +204,9 @@ bool IterableTypeScope::doesDeclHaveABody() const {
 
 void ast_scope::simple_display(llvm::raw_ostream &out,
                                const ASTScopeImpl *scope) {
-  scope->print(out);
+  // Cannot call scope->print(out) because printing an ASTFunctionBodyScope
+  // gets the source range which can cause a request to parse it.
+  // That in turn causes the request dependency printing code to blow up
+  // as the AnyRequest ends up with a null.
+  out << scope->getClassName() << "\n";
 }

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -201,3 +201,8 @@ bool GenericTypeOrExtensionScope::doesDeclHaveABody() const { return false; }
 bool IterableTypeScope::doesDeclHaveABody() const {
   return getBraces().Start != getBraces().End;
 }
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const ast_scope::ASTScopeImpl *scope) {
+  scope->print(out);
+}

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -202,7 +202,7 @@ bool IterableTypeScope::doesDeclHaveABody() const {
   return getBraces().Start != getBraces().End;
 }
 
-void swift::simple_display(llvm::raw_ostream &out,
-                           const ast_scope::ASTScopeImpl *scope) {
+void ast_scope::simple_display(llvm::raw_ostream &out,
+                               const ASTScopeImpl *scope) {
   scope->print(out);
 }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -232,8 +232,8 @@ SourceRange DefaultArgumentInitializerScope::getSourceRangeOfThisASTNode(
 
 SourceRange PatternEntryDeclScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  // TODO: Once rdar://53627317 is accomplished, the following may be able to be
-  // simplified.
+  // TODO: Once the creation of two PatternBindingDecls at same location is
+  // eliminated, the following may be able to be simplified.
   if (!getChildren().empty()) { // why needed???
     bool hasOne = false;
     getPattern()->forEachVariable([&](VarDecl *) { hasOne = true; });
@@ -247,8 +247,8 @@ SourceRange PatternEntryDeclScope::getSourceRangeOfThisASTNode(
 
 SourceRange PatternEntryInitializerScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  // See rdar://53921703
-  // Note: grep for "When the initializer is removed we don't actually clear the
+  // TODO: Don't remove the initializer in the rest of the compiler:
+  // Search for "When the initializer is removed we don't actually clear the
   // pointer" because we do!
   return initAsWrittenWhenCreated->getSourceRange();
 }

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -757,7 +757,7 @@ SourceLoc getLocAfterExtendedNominal(const ExtensionDecl *const ext) {
       .getEnd();
 }
 
-SourceLoc swift::extractNearestSourceLoc(
+SourceLoc ast_scope::extractNearestSourceLoc(
     std::tuple<ASTScopeImpl *, ScopeCreator *> scopeAndCreator) {
   const ASTScopeImpl *scope = std::get<0>(scopeAndCreator);
   return scope->getSourceRangeOfThisASTNode().Start;

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -756,3 +756,9 @@ SourceLoc getLocAfterExtendedNominal(const ExtensionDecl *const ext) {
   return Lexer::getCharSourceRangeFromSourceRange(SM, etr->getSourceRange())
       .getEnd();
 }
+
+SourceLoc swift::extractNearestSourceLoc(
+    std::tuple<ASTScopeImpl *, ScopeCreator *> scopeAndCreator) {
+  const ASTScopeImpl *scope = std::get<0>(scopeAndCreator);
+  return scope->getSourceRangeOfThisASTNode().Start;
+}


### PR DESCRIPTION
When expanding an ASTScope, use a request in order to catch recursive expansion.
(This PR is intended to go in *after* https://github.com/apple/swift/pull/27313 and includes those changes.)
Also unify ASTSourceFileScope expansion with other kinds of scope expansion as per rdar://55562483