### PR TITLE
[Test] Modify Runtime.swift.gyb to only test 9999 availability when running against a runtime that isn't part of the OS.

### DIFF
--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -800,8 +800,14 @@ AvailabilityVersionsTestSuite.test("_stdlib_isOSVersionAtLeast") {
   expectTrue(isAtLeastOS(0, 1066, 0))
   expectTrue(isAtLeastOS(0, 0, 1066))
   
-  // 9999 is a special version that's always available
-  expectTrue(isAtLeastOS(9999, 0, 0))
+  // When using a runtime that's not part of the OS, 9999 is a special version
+  // that's always available. The _swift_classIsSwiftMask symbol is absent in OS
+  // libraries, so detect based on that.
+  let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
+  let _swift_classIsSwiftMaskPtr = dlsym(RTLD_DEFAULT, "_swift_classIsSwiftMask")
+  if _swift_classIsSwiftMaskPtr != nil {
+    expectTrue(isAtLeastOS(9999, 0, 0))
+  }
 #endif
 }
 


### PR DESCRIPTION
rdar://problem/55727341