### PR TITLE
[ClangImporter] Don't use local scope decls to find a function's home

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/LocalVsFileScope.h
+++ b/test/ClangImporter/Inputs/custom-modules/LocalVsFileScope.h
@@ -1,0 +1,3 @@
+#include "LocalVsFileScopeBase.h"
+
+void theFunctionInQuestion(int);

--- a/test/ClangImporter/Inputs/custom-modules/LocalVsFileScopeBase.h
+++ b/test/ClangImporter/Inputs/custom-modules/LocalVsFileScopeBase.h
@@ -1,0 +1,3 @@
+void aFunctionInBase(void) {
+  void theFunctionInQuestion(int);
+}

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -233,3 +233,11 @@ module ConditionallyFoo {
 module ForwardDeclarationsHelper {
   header "ForwardDeclarationsHelper.h"
 }
+
+module LocalVsFileScopeBase {
+  header "LocalVsFileScopeBase.h"
+}
+module LocalVsFileScope {
+  header "LocalVsFileScope.h"
+  export *
+}

--- a/test/ClangImporter/cfuncs_scope.swift
+++ b/test/ClangImporter/cfuncs_scope.swift
@@ -1,0 +1,18 @@
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules 2>&1 | %FileCheck %s
+
+import LocalVsFileScope
+
+func testLocalVsFileScope() {
+  LocalVsFileScopeBase.theFunctionInQuestion()
+  // CHECK: :[[@LINE-1]]:3: error: module 'LocalVsFileScopeBase' has no member named 'theFunctionInQuestion'
+
+  theFunctionInQuestion()
+  // CHECK: :[[@LINE-1]]:25: error: missing argument
+  // CHECK: LocalVsFileScope.theFunctionInQuestion:1:{{[0-9]+}}: note:
+  // This is not a wonderful test because it's relying on the diagnostic
+  // engine's synthesis of fake declarations to figure out what module the
+  // importer assigned the function to. But, well, that's what we get.
+
+  aFunctionInBase() // just make sure it's imported
+  // CHECK-NOT: :[[@LINE-1]]:{{[0-9]+}}:
+}


### PR DESCRIPTION
In C, a function can be declared at local scope:

```c
void aFunctionInBase(void) {
  void theFunctionInQuestion(int);
}
```

and then again in a different header at top-level scope:

```c
void theFunctionInQuestion(int);
```

If the first one appears first, it becomes what Clang considers the "canonical" declaration, which (up until now) Swift has been using to decide what module to import a function into. (Since a C function can be redeclared arbitrarily many times, we have to pick one.) This is important for diagnostics and anything else that might ask "where did this Swift declaration come from". Instead of the very first redeclaration, use the first non-local one to determine the "home" module.

(The standard library wants a guarantee that forward declarations they put in SwiftShims won't interfere with declarations found elsewhere. I don't think Clang can *ever* provide that, so if there's ever a mismatch between the standard library's forward declarations and the "real" declarations the standard library's might win out at the LLVM level—say, in terms of attributes. But this at least removes a place where that could be visible to users even when it isn't otherwise a problem.)