### PR TITLE
Add `-enable-experimental-differentiable-programming` frontend flag.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -327,6 +327,10 @@ namespace swift {
     /// set to true.
     bool ExperimentalDependenciesIncludeIntrafileOnes = false;
 
+    /// Whether to enable experimental differentiable programming features:
+    /// `@differentiable` declaration attribute, etc.
+    bool EnableExperimentalDifferentiableProgramming = false;
+
     /// Whether to enable #quote, #unquote and @quoted.
     bool EnableExperimentalQuasiquotes = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -415,6 +415,10 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
   HelpText<"Disable automatic generation of bridging PCH files">;
 
 // Experimental feature options
+def enable_experimental_differentiable_programming : Flag<["-"], "enable-experimental-differentiable-programming">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable experimental differentiable programming features">;
+
 def enable_experimental_quasiquotes : Flag<["-"], "enable-experimental-quasiquotes">,
   Flags<[FrontendOption]>,
   HelpText<"Experimental work-in-progress implementation of quasiquotes">;


### PR DESCRIPTION
This flag will enable all differentiable programming features.
The default will be `true` on tensorflow branch but `false` on master branch.

Features will first be updated on tensorflow branch to use this flag, before
being upstreamed to master. The goal is to achieve a minimal code diff between
the two branches.

The [TF-820](https://bugs.swift.org/browse/TF-820) master issue tracks upstreaming differentiable programming.

---

Rationale: we chose to add a frontend flag rather than a `build-script`/CMake flag for easier testing. Differentiable programming `lit` tests can be run by specifying this additional flag without recompiling the compiler and standard library.