### PR TITLE
[Docs] Add a section to Diagnostics.md on -verify mode

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -232,7 +232,7 @@ code for the target that is not the build machine:
 
 * ``%target-typecheck-verify-swift``: parse and type check the current Swift file
   for the target platform and verify diagnostics, like ``swift -frontend -typecheck -verify
-  %s``.
+  %s``. For further explanation of `-verify` mode, see [Diagnostics.md](Diagnostics.md).
 
   Use this substitution for testing semantic analysis in the compiler.
 


### PR DESCRIPTION
As a follow up to adding column specification to the diagnostics verifier I've been meaning to document the `// expected-` syntax now that it's gotten a bit more complicated. Even though a lot of this can be determined by inspection, I think it's useful to have a short reference for new contributors and people encountering features like `{{none}}` and `*` for the first time.

I suppose this could go in `Testing.md`, but `Diagnostics.md` seemed like a better fit since it includes more of the relevant terminology.