### PR TITLE
[swift-reflection-dump] Adjust for LLVM API change

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -112,10 +112,10 @@ static bool needToRelocate(SectionRef S) {
       "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
       "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
     };
-    StringRef Name;
-    if (auto EC = S.getName(Name))
-      reportError(EC);
-    return ELFSectionsList.count(Name);
+    auto NameOrErr = S.getName();
+    if (!NameOrErr)
+      reportError(errorToErrorCode(NameOrErr.takeError()));
+    return ELFSectionsList.count(*NameOrErr);
   }
 
   return true;


### PR DESCRIPTION
getName now returns an Expected instead of taking a StringRef reference.