### PR TITLE
Disable test/AutoDiff/transposing_attr_type_checking.swift.

### DIFF
--- a/test/AutoDiff/transposing_attr_type_checking.swift
+++ b/test/AutoDiff/transposing_attr_type_checking.swift
@@ -1,3 +1,5 @@
+// FIXME(TF-847): Re-enable this test.
+// XFAIL: *
 // RUN: %target-swift-frontend -typecheck -verify %s
 
 // ~~~~~~~~~~~~~ Test top-level functions. ~~~~~~~~~~~~~

--- a/test/SILOptimizer/OSLogConstantEvaluableTest.swift
+++ b/test/SILOptimizer/OSLogConstantEvaluableTest.swift
@@ -4,12 +4,14 @@
 // Run the (mandatory) passes on which constant evaluator depends, and run the
 // constant evaluator on the SIL produced after the dependent passes are run.
 //
-// TODO(TF-799): Re-enable RUN lines after SR-11336 is fixed.
-// UN: %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 1024 -test-constant-evaluable-subset %t/OSLogConstantEvaluableTest_silgen.sil > %t/OSLogConstantEvaluableTest.sil 2> %t/error-output
+// RUN: %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 1024 -test-constant-evaluable-subset %t/OSLogConstantEvaluableTest_silgen.sil > %t/OSLogConstantEvaluableTest.sil 2> %t/error-output
 //
-// UN: %FileCheck %s < %t/error-output
+// RUN: %FileCheck %s < %t/error-output
 //
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// TODO(TF-799): Re-enable test after SR-11336 is fixed.
+// XFAIL: *
 
 // Test that the functions defined in the OSLogPrototype overlay annotated as
 // constant evaluable are so (with the constexpr-limit defined above).

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -4,10 +4,9 @@
 // Run the (mandatory) passes on which constant evaluator depends, and test the
 // constant evaluator on the SIL produced after the dependent passes are run.
 //
-// TODO(TF-799): Re-enable RUN lines after SR-11336 is fixed.
-// UN: not %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 3000 -test-constant-evaluable-subset %t/constant_evaluable_subset_test_silgen.sil > /dev/null 2> %t/error-output
+// RUN: not %target-sil-opt -silgen-cleanup -raw-sil-inst-lowering -allocbox-to-stack -mandatory-inlining -constexpr-limit 3000 -test-constant-evaluable-subset %t/constant_evaluable_subset_test_silgen.sil > /dev/null 2> %t/error-output
 //
-// UN: %FileCheck %s < %t/error-output
+// RUN: %FileCheck %s < %t/error-output
 //
 // Test the constant evaluator on the output of the mandatory pipeline. This is
 // to test that constant evaluability is not affected by mandatory
@@ -18,6 +17,9 @@
 // RUN: not %target-sil-opt -silgen-cleanup -diagnose-invalid-escaping-captures -diagnose-static-exclusivity -capture-promotion -access-enforcement-selection -allocbox-to-stack -noreturn-folding -mark-uninitialized-fixup -definite-init -raw-sil-inst-lowering -closure-lifetime-fixup -semantic-arc-opts -destroy-hoisting -ownership-model-eliminator -mandatory-inlining -predictable-memaccess-opts -os-log-optimization -diagnostic-constant-propagation -predictable-deadalloc-elim -guaranteed-arc-opts -diagnose-unreachable -diagnose-infinite-recursion -yield-once-check -dataflow-diagnostics -split-non-cond_br-critical-edges -constexpr-limit 3000 -test-constant-evaluable-subset %t/constant_evaluable_subset_test_silgen.sil > /dev/null 2> %t/error-output-mandatory
 //
 // RUN: %FileCheck %s < %t/error-output-mandatory
+
+// TODO(TF-799): Re-enable test after SR-11336 is fixed.
+// XFAIL: *
 
 // Test Swift code snippets that are expected to be constant evaluable and those
 // that are not. If any of the test here fails, it indicates a change in the


### PR DESCRIPTION
[TF-847](https://bugs.swift.org/browse/TF-847) tracks re-enabling the test.
Use `XFAIL: *` to disable tests instead of commenting RUN lines.