### PR TITLE
[tensorflow merge] fix qualified decl name parse

### DIFF
--- a/test/AutoDiff/transposing_attr_type_checking.swift
+++ b/test/AutoDiff/transposing_attr_type_checking.swift
@@ -1,5 +1,3 @@
-// FIXME(TF-847): Re-enable this test.
-// XFAIL: *
 // RUN: %target-swift-frontend -typecheck -verify %s
 
 // ~~~~~~~~~~~~~ Test top-level functions. ~~~~~~~~~~~~~


### PR DESCRIPTION
Some of our custom modifications got clobbered during the merge. I brought them back.

Fixes https://bugs.swift.org/browse/TF-847