### PR TITLE
Update FloatingPointTypes.swift.gyb

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1263,7 +1263,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 
 ${SelfDocComment}
 @frozen
-@available(*, unavailable, message: "Float80 is only available on non-Windows x86 targets.")
+@available(*, unavailable, message: "Float80 is not available on target platform.")
 public struct ${Self} {
   /// Creates a value initialized to zero.
   @_transparent


### PR DESCRIPTION
IMO the original message can be confusing because the `Float80` type seems to be available only on MacOS.

You can reproduce this error by compiling source code that it and targets an iOS device.