### PR TITLE
[ownership] Emit a PrettyStackTrace msg telling to re-run with -sil-v…

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -383,7 +383,25 @@ struct OwnershipModelEliminator : SILModuleTransform {
         continue;
 
       // Verify here to make sure ownership is correct before we strip.
-      F.verify();
+      {
+        // Add a pretty stack trace entry to tell users who see a verification
+        // failure triggered by this verification check that they need to re-run
+        // with -sil-verify-all to actually find the pass that introduced the
+        // verification error.
+        //
+        // DISCUSSION: This occurs due to the crash from the verification
+        // failure happening in the pass itself. This causes us to dump the
+        // SILFunction and emit a msg that this pass (OME) is the culprit. This
+        // is generally correct for most passes, but not for OME since we are
+        // verifying before we have even modified the function to ensure that
+        // all ownership invariants have been respected before we lower
+        // ownership from the function.
+        llvm::PrettyStackTraceString silVerifyAllMsgOnFailure(
+            "Found verification error when verifying before lowering "
+            "ownership. Please re-run with -sil-verify-all to identify the "
+            "actual pass that introduced the verification error.");
+        F.verify();
+      }
 
       if (stripOwnership(F)) {
         auto InvalidKind =


### PR DESCRIPTION
…erify-all if we hit a verifier error before ownership lowering.

We have been getting a bunch of different bugs reported that were initially
identified as being caused by the ownership model eliminator (due to this
verification failure), but that turned out in reality to be a different failure.

To ease triaging, this commit puts in a pretty stack trace msg that tells the
person doing the triaging to re-run with -sil-verify-all enabled to track down
the actual pass that introduces the verification failure.
