### PR TITLE
SerializeLoc: serialize basic decl source location information to .swiftsourceinfo file

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -310,12 +310,12 @@ function(_compile_swift_files
     set(module_base "${module_dir}/${SWIFTFILE_MODULE_NAME}")
     if(SWIFTFILE_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
       set(specific_module_dir "${module_base}.swiftmodule")
-      set(specific_module_private_dir "${specific_module_dir}/Private")
-      set(source_info_file "${specific_module_private_dir}/${SWIFTFILE_ARCHITECTURE}.swiftsourceinfo")
+      set(specific_module_project_dir "${specific_module_dir}/Project")
+      set(source_info_file "${specific_module_project_dir}/${SWIFTFILE_ARCHITECTURE}.swiftsourceinfo")
       set(module_base "${module_base}.swiftmodule/${SWIFTFILE_ARCHITECTURE}")
     else()
       set(specific_module_dir)
-      set(specific_module_private_dir)
+      set(specific_module_project_dir)
       set(source_info_file "${module_base}.swiftsourceinfo")
     endif()
     set(module_file "${module_base}.swiftmodule")
@@ -354,7 +354,7 @@ function(_compile_swift_files
                                DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}"
                                COMPONENT "${SWIFTFILE_INSTALL_IN_COMPONENT}"
                                OPTIONAL
-                               PATTERN "Private" EXCLUDE)
+                               PATTERN "Project" EXCLUDE)
   else()
     swift_install_in_component(FILES ${module_outputs}
                                DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}"
@@ -495,7 +495,7 @@ function(_compile_swift_files
         COMMAND
           "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir}
           ${specific_module_dir}
-          ${specific_module_private_dir}
+          ${specific_module_project_dir}
         COMMAND
           "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -131,6 +131,10 @@ public:
     return None;
   }
 
+  virtual Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const {
+    return None;
+  }
+
   virtual void collectAllGroups(std::vector<StringRef> &Names) const {}
 
   /// Returns an implementation-defined "discriminator" for \p D, which

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -87,7 +87,6 @@ struct LineColumn {
 struct BasicDeclLocs {
   StringRef SourceFilePath;
   LineColumn Loc;
-  LineColumn NameLoc;
   LineColumn StartLoc;
   LineColumn EndLoc;
 };

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -78,6 +78,19 @@ struct CommentInfo {
   uint32_t SourceOrder;
 };
 
+struct LineColumn {
+  uint32_t Line;
+  uint32_t Column;
+};
+
+struct BasicDeclLocs {
+  StringRef SourceFilePath;
+  Optional<LineColumn> Loc;
+  Optional<LineColumn> NameLoc;
+  Optional<LineColumn> StartLoc;
+  Optional<LineColumn> EndLoc;
+};
+
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_RAW_COMMENT_H

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -79,16 +79,17 @@ struct CommentInfo {
 };
 
 struct LineColumn {
-  uint32_t Line;
-  uint32_t Column;
+  uint32_t Line = 0;
+  uint32_t Column = 0;
+  bool isValid() const { return Line && Column; }
 };
 
 struct BasicDeclLocs {
   StringRef SourceFilePath;
-  Optional<LineColumn> Loc;
-  Optional<LineColumn> NameLoc;
-  Optional<LineColumn> StartLoc;
-  Optional<LineColumn> EndLoc;
+  LineColumn Loc;
+  LineColumn NameLoc;
+  LineColumn StartLoc;
+  LineColumn EndLoc;
 };
 
 } // namespace swift

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -276,6 +276,7 @@ public:
 
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
   Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
+  Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
 
   virtual bool walk(ASTWalker &walker) override;
 

--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -40,9 +40,9 @@ bool printTypeUSR(Type Ty, raw_ostream &OS);
 /// \returns true if it failed, false on success.
 bool printDeclTypeUSR(const ValueDecl *D, raw_ostream &OS);
 
-/// Prints out the USR for the given Decl.
+/// Prints out the USR for the given ValueDecl.
 /// \returns true if it failed, false on success.
-bool printDeclUSR(const ValueDecl *D, raw_ostream &OS);
+bool printValueDeclUSR(const ValueDecl *D, raw_ostream &OS);
 
 /// Prints out the USR for the given ModuleEntity.
 /// \returns true if it failed, false on success.
@@ -57,9 +57,9 @@ bool printAccessorUSR(const AbstractStorageDecl *D, AccessorKind AccKind,
 /// \returns true if it failed, false on success.
 bool printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS);
 
-/// Prints out the Decl USRs suitable for keys .swiftdoc and .swiftsourceinfo files.
+/// Prints out the USR for the given Decl.
 /// \returns true if it failed, false on success.
-bool printDeclUSRForModuleDoc(const Decl *D, raw_ostream &OS);
+bool printDeclUSR(const Decl *D, raw_ostream &OS);
 
 } // namespace ide
 } // namespace swift

--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
+class Decl;
 class AbstractStorageDecl;
 class ValueDecl;
 class ExtensionDecl;
@@ -55,6 +56,10 @@ bool printAccessorUSR(const AbstractStorageDecl *D, AccessorKind AccKind,
 /// Prints out the extension USR for the given extension Decl.
 /// \returns true if it failed, false on success.
 bool printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS);
+
+/// Prints out the Decl USRs suitable for keys .swiftdoc and .swiftsourceinfo files.
+/// \returns true if it failed, false on success.
+bool printDeclUSRForModuleDoc(const Decl *D, raw_ostream &OS);
 
 } // namespace ide
 } // namespace swift

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -395,6 +395,7 @@ class CompilerInstance {
   struct PartialModuleInputs {
     std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer;
     std::unique_ptr<llvm::MemoryBuffer> ModuleDocBuffer;
+    std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoBuffer;
   };
 
   /// Contains \c MemoryBuffers for partial serialized module files and
@@ -555,13 +556,17 @@ private:
 
   Optional<unsigned> getRecordedBufferID(const InputFile &input, bool &failed);
 
+  struct ModuleBuffers {
+    std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer;
+    std::unique_ptr<llvm::MemoryBuffer> ModuleDocBuffer;
+    std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoBuffer;
+  };
+
   /// Given an input file, return a buffer to use for its contents,
   /// and a buffer for the corresponding module doc file if one exists.
   /// On failure, return a null pointer for the first element of the returned
   /// pair.
-  std::pair<std::unique_ptr<llvm::MemoryBuffer>,
-            std::unique_ptr<llvm::MemoryBuffer>>
-  getInputBufferAndModuleDocBufferIfPresent(const InputFile &input);
+  ModuleBuffers getInputBuffersIfPresent(const InputFile &input);
 
   /// Try to open the module doc file corresponding to the input parameter.
   /// Return None for error, nullptr if no such file exists, or the buffer if
@@ -569,6 +574,11 @@ private:
   Optional<std::unique_ptr<llvm::MemoryBuffer>>
   openModuleDoc(const InputFile &input);
 
+  /// Try to open the module source info file corresponding to the input parameter.
+  /// Return None for error, nullptr if no such file exists, or the buffer if
+  /// one was found.
+  Optional<std::unique_ptr<llvm::MemoryBuffer>>
+  openModuleSourceInfo(const InputFile &input);
 public:
   /// Parses and type-checks all input files.
   void performSema();

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -560,13 +560,19 @@ private:
     std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer;
     std::unique_ptr<llvm::MemoryBuffer> ModuleDocBuffer;
     std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoBuffer;
+    ModuleBuffers(std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer,
+                  std::unique_ptr<llvm::MemoryBuffer> ModuleDocBuffer = nullptr,
+                  std::unique_ptr<llvm::MemoryBuffer> ModuleSourceInfoBuffer = nullptr):
+                    ModuleBuffer(std::move(ModuleBuffer)),
+                    ModuleDocBuffer(std::move(ModuleDocBuffer)),
+                    ModuleSourceInfoBuffer(std::move(ModuleSourceInfoBuffer)) {}
   };
 
   /// Given an input file, return a buffer to use for its contents,
   /// and a buffer for the corresponding module doc file if one exists.
   /// On failure, return a null pointer for the first element of the returned
   /// pair.
-  ModuleBuffers getInputBuffersIfPresent(const InputFile &input);
+  Optional<ModuleBuffers> getInputBuffersIfPresent(const InputFile &input);
 
   /// Try to open the module doc file corresponding to the input parameter.
   /// Return None for error, nullptr if no such file exists, or the buffer if

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -149,8 +149,10 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
     StringRef ModuleDocFilename,
+    StringRef ModuleSourceInfoFilename,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) override;
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
 
   bool isCached(StringRef DepPath) override;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -53,6 +53,7 @@ protected:
   bool findModule(AccessPathElem moduleID,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+                  std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
                   bool &isFramework, bool &isSystemModule);
 
   /// Attempts to search the provided directory for a loadable serialized
@@ -70,19 +71,29 @@ protected:
   virtual std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
+      StringRef ModuleSourceInfoFilename,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) = 0;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) = 0;
 
   std::error_code
   openModuleFiles(AccessPathElem ModuleID,
                   StringRef ModulePath, StringRef ModuleDocPath,
+                  StringRef ModuleSourceInfoPath,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
+                  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+                  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
   std::error_code
   openModuleDocFile(AccessPathElem ModuleID,
                     StringRef ModuleDocPath,
                     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
+
+  std::error_code
+  openModuleSourceInfoFile(AccessPathElem ModuleID,
+                           StringRef ModulePath,
+                           StringRef ModuleSourceInfoPath,
+                           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
   /// If the module loader subclass knows that all options have been tried for
   /// loading an architecture-specific file out of a swiftmodule bundle, try
@@ -116,6 +127,7 @@ public:
   FileUnit *loadAST(ModuleDecl &M, Optional<SourceLoc> diagLoc,
                     std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
                     std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
+                    std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
                     bool isFramework, bool treatAsPartialModule);
 
   /// Check whether the module with a given name can be imported without
@@ -163,8 +175,10 @@ class SerializedModuleLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
+      StringRef ModuleSourceInfoFilename,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) override;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
 
   bool maybeDiagnoseTargetMismatch(SourceLoc sourceLocation,
                                    StringRef moduleName,
@@ -203,8 +217,10 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
   std::error_code findModuleFilesInDirectory(
       AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
       StringRef ModuleDocFilename,
+      StringRef ModuleSourceInfoFilename,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) override;
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) override;
 
   bool maybeDiagnoseTargetMismatch(SourceLoc sourceLocation,
                                    StringRef moduleName,
@@ -316,6 +332,8 @@ public:
   Optional<unsigned> getSourceOrderForDecl(const Decl *D) const override;
 
   Optional<StringRef> getGroupNameByUSR(StringRef USR) const override;
+
+  Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
 
   void collectAllGroups(std::vector<StringRef> &Names) const override;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -79,7 +79,7 @@ protected:
   std::error_code
   openModuleFiles(AccessPathElem ModuleID,
                   StringRef ModulePath, StringRef ModuleDocPath,
-                  StringRef ModuleSourceInfoPath,
+                  StringRef ModuleSourceInfoName,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
@@ -92,7 +92,7 @@ protected:
   std::error_code
   openModuleSourceInfoFile(AccessPathElem ModuleID,
                            StringRef ModulePath,
-                           StringRef ModuleSourceInfoPath,
+                           StringRef ModuleSourceInfoFileName,
                            std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
   /// If the module loader subclass knows that all options have been tried for

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -89,11 +89,11 @@ protected:
                     StringRef ModuleDocPath,
                     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer);
 
-  std::error_code
-  openModuleSourceInfoFile(AccessPathElem ModuleID,
-                           StringRef ModulePath,
-                           StringRef ModuleSourceInfoFileName,
-                           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
+  void
+  openModuleSourceInfoFileIfPresent(AccessPathElem ModuleID,
+                                    StringRef ModulePath,
+                                    StringRef ModuleSourceInfoFileName,
+                  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer);
 
   /// If the module loader subclass knows that all options have been tried for
   /// loading an architecture-specific file out of a swiftmodule bundle, try

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -587,6 +587,8 @@ static unsigned getUnnamedParamIndex(const ParamDecl *D) {
 
   if (auto AFD = dyn_cast<AbstractFunctionDecl>(D->getDeclContext())) {
     ParamList = AFD->getParameters();
+  } else if (auto EED = dyn_cast<EnumElementDecl>(D->getDeclContext())) {
+    ParamList = EED->getParameterList();
   } else {
     auto ACE = cast<AbstractClosureExpr>(D->getDeclContext());
     ParamList = ACE->getParameters();

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -279,7 +279,7 @@ bool ide::printModuleUSR(ModuleEntity Mod, raw_ostream &OS) {
   }
 }
 
-bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
+bool ide::printValueDeclUSR(const ValueDecl *D, raw_ostream &OS) {
   auto result = evaluateOrDefault(D->getASTContext().evaluator,
                                   USRGenerationRequest { D },
                                   std::string());
@@ -327,25 +327,25 @@ bool ide::printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS) {
   for (auto D : ED->getMembers()) {
     if (auto VD = dyn_cast<ValueDecl>(D)) {
       OS << getUSRSpacePrefix() << "e:";
-      return printDeclUSR(VD, OS);
+      return printValueDeclUSR(VD, OS);
     }
   }
   OS << getUSRSpacePrefix() << "e:";
-  printDeclUSR(nominal, OS);
+  printValueDeclUSR(nominal, OS);
   for (auto Inherit : ED->getInherited()) {
     if (auto T = Inherit.getType()) {
       if (T->getAnyNominal())
-        return printDeclUSR(T->getAnyNominal(), OS);
+        return printValueDeclUSR(T->getAnyNominal(), OS);
     }
   }
   return true;
 }
 
-bool ide::printDeclUSRForModuleDoc(const Decl *D, raw_ostream &OS) {
+bool ide::printDeclUSR(const Decl *D, raw_ostream &OS) {
   if (D->isImplicit())
     return true;
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
-    if (ide::printDeclUSR(VD, OS)) {
+    if (ide::printValueDeclUSR(VD, OS)) {
       return true;
     }
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -341,3 +341,19 @@ bool ide::printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS) {
   return true;
 }
 
+bool ide::printDeclUSRForModuleDoc(const Decl *D, raw_ostream &OS) {
+  if (D->isImplicit())
+    return true;
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+    if (ide::printDeclUSR(VD, OS)) {
+      return true;
+    }
+  } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+    if (ide::printExtensionUSR(ED, OS)) {
+      return true;
+    }
+  } else {
+    return true;
+  }
+  return false;
+}

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2793,7 +2793,7 @@ static void chooseModuleAuxiliaryOutputFilePath(Compilation &C,
                                                 StringRef workingDirectory,
                                                 CommandOutput *Output,
                                                 file_types::ID fileID,
-                                                bool isPrivate,
+                                                bool isProject = false,
                                                 Optional<options::ID> optId = llvm::None) {
   if (hasExistingAdditionalOutput(*Output, fileID))
     return;
@@ -2819,9 +2819,9 @@ static void chooseModuleAuxiliaryOutputFilePath(Compilation &C,
     bool isTempFile = C.isTemporaryFile(ModulePath);
     auto ModuleName = llvm::sys::path::filename(ModulePath);
     llvm::SmallString<128> Path(llvm::sys::path::parent_path(ModulePath));
-    if (isPrivate) {
-      llvm::sys::path::append(Path, "Private");
-      // If the build system has created a Private dir for us to include the file, use it.
+    if (isProject) {
+      llvm::sys::path::append(Path, "Project");
+      // If the build system has created a Project dir for us to include the file, use it.
       if (!llvm::sys::fs::exists(Path)) {
         llvm::sys::path::remove_filename(Path);
       }
@@ -2840,7 +2840,7 @@ void Driver::chooseSwiftSourceInfoOutputPath(Compilation &C,
                                              CommandOutput *Output) const {
   chooseModuleAuxiliaryOutputFilePath(C, OutputMap, workingDirectory, Output,
                                       file_types::TY_SwiftSourceInfoFile,
-                                      /*isPrivate*/true, options::OPT_emit_module_source_info_path);
+                                      /*isProject*/true, options::OPT_emit_module_source_info_path);
 }
 
 void Driver::chooseSwiftModuleDocOutputPath(Compilation &C,
@@ -2848,7 +2848,7 @@ void Driver::chooseSwiftModuleDocOutputPath(Compilation &C,
                                             StringRef workingDirectory,
                                             CommandOutput *Output) const {
   chooseModuleAuxiliaryOutputFilePath(C, OutputMap, workingDirectory, Output,
-                                      file_types::TY_SwiftModuleDocFile, /*isPrivate*/false);
+                                      file_types::TY_SwiftModuleDocFile);
 }
 
 void Driver::chooseRemappingOutputPath(Compilation &C,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2793,7 +2793,7 @@ static void chooseModuleAuxiliaryOutputFilePath(Compilation &C,
                                                 StringRef workingDirectory,
                                                 CommandOutput *Output,
                                                 file_types::ID fileID,
-                                                bool isProject = false,
+                                                bool shouldUseProjectFolder = false,
                                                 Optional<options::ID> optId = llvm::None) {
   if (hasExistingAdditionalOutput(*Output, fileID))
     return;
@@ -2819,7 +2819,7 @@ static void chooseModuleAuxiliaryOutputFilePath(Compilation &C,
     bool isTempFile = C.isTemporaryFile(ModulePath);
     auto ModuleName = llvm::sys::path::filename(ModulePath);
     llvm::SmallString<128> Path(llvm::sys::path::parent_path(ModulePath));
-    if (isProject) {
+    if (shouldUseProjectFolder) {
       llvm::sys::path::append(Path, "Project");
       // If the build system has created a Project dir for us to include the file, use it.
       if (!llvm::sys::fs::exists(Path)) {
@@ -2840,7 +2840,8 @@ void Driver::chooseSwiftSourceInfoOutputPath(Compilation &C,
                                              CommandOutput *Output) const {
   chooseModuleAuxiliaryOutputFilePath(C, OutputMap, workingDirectory, Output,
                                       file_types::TY_SwiftSourceInfoFile,
-                                      /*isProject*/true, options::OPT_emit_module_source_info_path);
+                                      /*shouldUseProjectFolder*/true,
+                                      options::OPT_emit_module_source_info_path);
 }
 
 void Driver::chooseSwiftModuleDocOutputPath(Compilation &C,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -526,7 +526,7 @@ CompilerInstance::openModuleSourceInfo(const InputFile &input) {
   std::string NonPrivatePath = moduleSourceInfoFilePath.str().str();
   StringRef fileName = llvm::sys::path::filename(NonPrivatePath);
   llvm::sys::path::remove_filename(moduleSourceInfoFilePath);
-  llvm::sys::path::append(moduleSourceInfoFilePath, "Private");
+  llvm::sys::path::append(moduleSourceInfoFilePath, "Project");
   llvm::sys::path::append(moduleSourceInfoFilePath, fileName);
   if (auto sourceInfoFileOrErr = swift::vfs::getFileOrSTDIN(getFileSystem(),
                                                             moduleSourceInfoFilePath))

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1036,7 +1036,10 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   if (ModuleBuffer) {
     *ModuleBuffer = std::move(*ModuleBufferOrErr);
   }
-
+  // Open .swiftsourceinfo file if it's present.
+  SerializedModuleLoaderBase::openModuleSourceInfoFile(ModuleID, ModPath,
+                                                       ModuleSourceInfoFilename,
+                                                       ModuleSourceInfoBuffer);
   // Delegate back to the serialized module loader to load the module doc.
   llvm::SmallString<256> DocPath{DirPath};
   path::append(DocPath, ModuleDocFilename);

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -988,8 +988,10 @@ bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
 std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
   StringRef ModuleDocFilename,
+  StringRef ModuleSourceInfoFilename,
   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) {
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
 
   // If running in OnlySerialized mode, ModuleInterfaceLoader
   // should not have been constructed at all.

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1037,7 +1037,8 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
     *ModuleBuffer = std::move(*ModuleBufferOrErr);
   }
   // Open .swiftsourceinfo file if it's present.
-  SerializedModuleLoaderBase::openModuleSourceInfoFile(ModuleID, ModPath,
+  SerializedModuleLoaderBase::openModuleSourceInfoFileIfPresent(ModuleID,
+                                                                ModPath,
                                                        ModuleSourceInfoFilename,
                                                        ModuleSourceInfoBuffer);
   // Delegate back to the serialized module loader to load the module doc.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -817,7 +817,7 @@ ArrayRef<StringRef> copyAssociatedUSRs(llvm::BumpPtrAllocator &Allocator,
     if (auto *OVD = OD.dyn_cast<const ValueDecl*>()) {
       if (shouldCopyAssociatedUSRForDecl(OVD)) {
         llvm::raw_svector_ostream OS(SS);
-        Ignored = printDeclUSR(OVD, OS);
+        Ignored = printValueDeclUSR(OVD, OS);
       }
     } else if (auto *OND = OD.dyn_cast<const clang::NamedDecl*>()) {
       Ignored = clang::index::generateUSRForDecl(OND, SS);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -346,7 +346,7 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
     bool Failed;
     {
       llvm::raw_svector_ostream OS(SS);
-      Failed = ide::printDeclUSR(VD, OS);
+      Failed = ide::printValueDeclUSR(VD, OS);
     }
     if (!Failed && !SS.empty()) {
       OS << "<USR>" << SS << "</USR>";

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -545,7 +545,7 @@ public:
   RenameRangeCollector(const ValueDecl *D, StringRef newName)
       : newName(newName.str()) {
     llvm::raw_string_ostream OS(USR);
-    printDeclUSR(D, OS);
+    printValueDeclUSR(D, OS);
   }
 
   ArrayRef<RenameLoc> results() const { return locations; }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -183,7 +183,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
           if (ide::printExtensionUSR(ExtD, OS))
             return true;
         } else {
-          if (ide::printDeclUSR(D, OS))
+          if (ide::printValueDeclUSR(D, OS))
             return true;
         }
         result.USR = stringStorage.copyString(OS.str());

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -291,7 +291,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     auto addDiffItems = [&](ValueDecl *VD) {
       llvm::SmallString<64> Buffer;
       llvm::raw_svector_ostream OS(Buffer);
-      if (swift::ide::printDeclUSR(VD, OS))
+      if (swift::ide::printValueDeclUSR(VD, OS))
         return;
       auto Items = DiffStore.getDiffItems(Buffer.str());
       results.insert(results.end(), Items.begin(), Items.end());
@@ -1384,7 +1384,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     auto *OD = AFD->getOverriddenDecl();
     llvm::SmallString<64> Buffer;
     llvm::raw_svector_ostream OS(Buffer);
-    if (swift::ide::printDeclUSR(OD, OS))
+    if (swift::ide::printValueDeclUSR(OD, OS))
       return SourceLoc();
     return OverridingRemoveNames.find(OS.str()) == OverridingRemoveNames.end() ?
       SourceLoc() : OverrideLoc;
@@ -1406,7 +1406,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           llvm::SmallString<64> Buffer;
           llvm::raw_svector_ostream OS(Buffer);
           auto *RD = DSC->getFn()->getReferencedDecl().getDecl();
-          if (swift::ide::printDeclUSR(RD, OS))
+          if (swift::ide::printValueDeclUSR(RD, OS))
             return false;
           return USRs.find(OS.str()) != USRs.end();
         }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1293,13 +1293,13 @@ bool ModuleFile::readDeclLocsBlock(llvm::BitstreamCursor &cursor) {
       unsigned kind = cursor.readRecord(entry.ID, scratch, &blobData);
 
       switch (kind) {
-      case sourceinfo_block::BASIC_DECL_LOCS:
+      case decl_locs_block::BASIC_DECL_LOCS:
         BasicDeclLocsData = blobData;
         break;
-      case sourceinfo_block::TEXT_DATA:
+      case decl_locs_block::TEXT_DATA:
         SourceLocsTextData = blobData;
         break;
-      case sourceinfo_block::DECL_USRS:
+      case decl_locs_block::DECL_USRS:
         DeclUSRsTable = readDeclUSRsTable(scratch, blobData);
         break;
       default:

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2387,8 +2387,8 @@ Optional<BasicDeclLocs> ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const
   auto UsrId = *It;
   uint32_t NumSize = 4;
   // Size of BasicDeclLocs in the buffer.
-  // FilePathOffset + 4 * LineColumn
-  uint32_t LineColumnCount = 4;
+  // FilePathOffset + LocNum * LineColumn
+  uint32_t LineColumnCount = 3;
   uint32_t RecordSize = NumSize + NumSize * 2 * LineColumnCount;
   uint32_t RecordOffset = RecordSize * UsrId;
   assert(RecordOffset < BasicDeclLocsData.size());
@@ -2408,7 +2408,6 @@ Optional<BasicDeclLocs> ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const
 Result.X.Line = ReadNext();                                                                       \
 Result.X.Column = ReadNext();
   READ_FIELD(Loc)
-  READ_FIELD(NameLoc)
   READ_FIELD(StartLoc)
   READ_FIELD(EndLoc)
 #undef READ_FIELD

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2358,7 +2358,7 @@ Optional<CommentInfo> ModuleFile::getCommentForDecl(const Decl *D) const {
   // Compute the USR.
   llvm::SmallString<128> USRBuffer;
   llvm::raw_svector_ostream OS(USRBuffer);
-  if (ide::printDeclUSRForModuleDoc(D, OS))
+  if (ide::printDeclUSR(D, OS))
     return None;
 
   return getCommentForDeclByUSR(USRBuffer.str());
@@ -2378,7 +2378,7 @@ Optional<BasicDeclLocs> ModuleFile::getBasicDeclLocsForDecl(const Decl *D) const
   // Compute the USR.
   llvm::SmallString<128> USRBuffer;
   llvm::raw_svector_ostream OS(USRBuffer);
-  if (ide::printDeclUSRForModuleDoc(D, OS))
+  if (ide::printDeclUSR(D, OS))
     return None;
 
   auto It = DeclUSRsTable->find(OS.str());

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1255,6 +1255,7 @@ public:
 
   data_type ReadData(internal_key_type key, const uint8_t *data,
                      unsigned length) {
+    static uint32_t INVALID_VALUE = UINT32_MAX;
     data_type result;
     result.SourceFilePath =
       F.getSourceFilePathById(endian::readNext<uint32_t, little, unaligned>(data));
@@ -1262,7 +1263,7 @@ public:
       LineColumn Result;
       Result.Line = endian::readNext<uint32_t, little, unaligned>(data);
       Result.Column = endian::readNext<uint32_t, little, unaligned>(data);
-      if (Result.Line == UINT32_MAX || Result.Column == UINT32_MAX) {
+      if (Result.Line == INVALID_VALUE || Result.Column == INVALID_VALUE) {
         return None;
       }
       return Result;

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -406,16 +406,6 @@ private:
   std::unique_ptr<GroupNameTable> GroupNamesMap;
   std::unique_ptr<SerializedDeclCommentTable> DeclCommentTable;
 
-  class BasicDeclLocTableInfo;
-  using SerializedBasicDeclLocsTable =
-      llvm::OnDiskIterableChainedHashTable<BasicDeclLocTableInfo>;
-  std::unique_ptr<SerializedBasicDeclLocsTable> BasicDeclLocsTable;
-
-  class SourceFilePathTableInfo;
-  using SerializedSourceFilePathTable =
-      llvm::OnDiskIterableChainedHashTable<SourceFilePathTableInfo>;
-  std::unique_ptr<SerializedSourceFilePathTable> SourceFilePathsTable;
-
   class DeclUSRTableInfo;
   using SerializedDeclUSRTable =
       llvm::OnDiskIterableChainedHashTable<DeclUSRTableInfo>;
@@ -569,22 +559,16 @@ private:
 
   /// Read an on-disk decl hash table stored in
   /// \c sourceinfo_block::BasicDeclLocsLayout format.
-  std::unique_ptr<SerializedBasicDeclLocsTable>
-  readBasicDeclLocsTable(ArrayRef<uint64_t> fields, StringRef blobData);
+  StringRef BasicDeclLocsData;
 
   /// Read an on-disk decl hash table stored in
   /// \c sourceinfo_block::SourceFilePathsLayout format.
-  std::unique_ptr<SerializedSourceFilePathTable>
-  readSourceFilePathsTable(ArrayRef<uint64_t> fields, StringRef blobData);
+  StringRef SourceLocsTextData;
 
   /// Read an on-disk decl hash table stored in
   /// \c sourceinfo_block::DeclUSRSLayout format.
   std::unique_ptr<SerializedDeclUSRTable>
   readDeclUSRsTable(ArrayRef<uint64_t> fields, StringRef blobData);
-
-  StringRef getSourceFilePathById(unsigned Id) const;
-
-  uint32_t getDeclUSRId(StringRef USR) const;
 
   /// Recursively reads a pattern from \c DeclTypeCursor.
   llvm::Expected<Pattern *> readPattern(DeclContext *owningDC);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -411,6 +411,13 @@ private:
       llvm::OnDiskIterableChainedHashTable<DeclUSRTableInfo>;
   std::unique_ptr<SerializedDeclUSRTable> DeclUSRsTable;
 
+  /// A blob of 0 terminated string segments referenced in \c SourceLocsTextData
+  StringRef SourceLocsTextData;
+
+  /// An array of fixed size source location data for each USR appearing in
+  /// \c DeclUSRsTable.
+  StringRef BasicDeclLocsData;
+
   struct ModuleBits {
     /// The decl ID of the main class in this module file, if it has one.
     unsigned EntryPointDeclID : 31;
@@ -556,14 +563,6 @@ private:
   ///
   /// Returns false if there was an error.
   bool readModuleSourceInfoIfPresent();
-
-  /// Read an on-disk decl hash table stored in
-  /// \c sourceinfo_block::BasicDeclLocsLayout format.
-  StringRef BasicDeclLocsData;
-
-  /// Read an on-disk decl hash table stored in
-  /// \c sourceinfo_block::SourceFilePathsLayout format.
-  StringRef SourceLocsTextData;
 
   /// Read an on-disk decl hash table stored in
   /// \c sourceinfo_block::DeclUSRSLayout format.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -638,6 +638,19 @@ enum BlockID {
   ///
   /// \sa comment_block
   COMMENT_BLOCK_ID,
+
+  /// The module source location container block, which contains all other
+  /// source location blocks.
+  ///
+  /// This is part of a stable format and must not be renumbered!
+  MODULE_SOURCEINFO_BLOCK_ID = 192,
+
+  /// The source location block, which contains decl locations.
+  ///
+  /// This is part of a stable format and must not be renumbered!
+  ///
+  /// \sa sourceinfo_block
+  DECL_LOCS_BLOCK_ID,
 };
 
 /// The record types within the control block.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -642,14 +642,23 @@ enum BlockID {
   /// The module source location container block, which contains all other
   /// source location blocks.
   ///
-  /// This is part of a stable format and must not be renumbered!
+  /// This is part of a stable format and should not be renumbered.
+  ///
+  /// Though we strive to keep the format stable, breaking the format of
+  /// .swiftsourceinfo doesn't have consequences as serious as breaking the
+  /// format of .swiftdoc because .swiftsourceinfo file is for local development
+  /// use only.
   MODULE_SOURCEINFO_BLOCK_ID = 192,
 
   /// The source location block, which contains decl locations.
   ///
-  /// This is part of a stable format and must not be renumbered!
+  /// This is part of a stable format and should not be renumbered.
   ///
-  /// \sa sourceinfo_block
+  /// Though we strive to keep the format stable, breaking the format of
+  /// .swiftsourceinfo doesn't have consequences as serious as breaking the format
+  /// of .swiftdoc because .swiftsourceinfo file is for local development use only.
+  ///
+  /// \sa decl_locs_block
   DECL_LOCS_BLOCK_ID,
 };
 

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -702,6 +702,8 @@ Result.X.Column = Locs->X.Column;
     auto LocData = getLocData(D);
     if (!USR.hasValue() || !LocData.hasValue())
       return true;
+    assert(*USR * sizeof(DeclLocationsTableData) == Buffer.size() &&
+           "USR id is used as an index to access basic location array");
     appendToBuffer(*LocData);
     return true;
   }

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -513,7 +513,6 @@ namespace {
 struct DeclLocationsTableData {
   uint32_t SourceFileOffset;
   LineColumn Loc;
-  LineColumn NameLoc;
   LineColumn StartLoc;
   LineColumn EndLoc;
 };
@@ -621,7 +620,6 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
 writer.write<uint32_t>(data.X.Line);                                                              \
 writer.write<uint32_t>(data.X.Column);
     WRITE_LINE_COLUMN(Loc)
-    WRITE_LINE_COLUMN(NameLoc);
     WRITE_LINE_COLUMN(StartLoc);
     WRITE_LINE_COLUMN(EndLoc);
 #undef WRITE_LINE_COLUMN
@@ -657,13 +655,6 @@ writer.write<uint32_t>(data.X.Column);
     llvm::sys::fs::make_absolute(SourceFilePath);
     Result.SourceFileOffset = FWriter.getTextOffset(SourceFilePath);
     Result.Loc = getLineColumn(SM, D->getLoc());
-    if (auto *VD = dyn_cast<ValueDecl>(D)) {
-      Result.NameLoc = getLineColumn(SM, VD->getNameLoc());
-    } else if(auto *OD = dyn_cast<OperatorDecl>(D)) {
-      Result.NameLoc = getLineColumn(SM, OD->getNameLoc());
-    } else if(auto *PD = dyn_cast<PrecedenceGroupDecl>(D)) {
-      Result.NameLoc = getLineColumn(SM, PD->getNameLoc());
-    }
     Result.StartLoc = getLineColumn(SM, D->getStartLoc());
     Result.EndLoc = getLineColumn(SM, D->getEndLoc());
     return Result;
@@ -685,7 +676,6 @@ writer.write<uint32_t>(data.X.Column);
 Result.X.Line = Locs->X.Line;                                                                     \
 Result.X.Column = Locs->X.Column;
       COPY_LINE_COLUMN(Loc)
-      COPY_LINE_COLUMN(NameLoc)
       COPY_LINE_COLUMN(StartLoc)
       COPY_LINE_COLUMN(EndLoc)
 #undef COPY_LINE_COLUMN

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -417,7 +417,7 @@ static void writeDeclCommentTable(
       {
         USRBuffer.clear();
         llvm::raw_svector_ostream OS(USRBuffer);
-        if (ide::printDeclUSR(VD, OS))
+        if (ide::printValueDeclUSR(VD, OS))
           return true;
       }
 
@@ -628,7 +628,7 @@ writer.write<uint32_t>(data.X.Column);
   Optional<uint32_t> calculateUSRId(Decl *D) {
     llvm::SmallString<512> Buffer;
     llvm::raw_svector_ostream OS(Buffer);
-    if (ide::printDeclUSRForModuleDoc(D, OS))
+    if (ide::printDeclUSR(D, OS))
       return None;
     return USRWriter.getNewUSRID(OS.str());
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -273,27 +273,27 @@ SerializedModuleLoaderBase::openModuleSourceInfoFile(AccessPathElem ModuleID,
 
   llvm::vfs::FileSystem &FS = *Ctx.SourceMgr.getFileSystem();
   {
-    llvm::SmallString<128> PrivatePath(ModulePath);
-    llvm::sys::path::remove_filename(PrivatePath);
-    llvm::sys::path::append(PrivatePath, "Private");
-    llvm::sys::path::append(PrivatePath, ModuleSourceInfoFilename);
+    llvm::SmallString<128> ProjectPath(ModulePath);
+    llvm::sys::path::remove_filename(ProjectPath);
+    llvm::sys::path::append(ProjectPath, "Project");
+    llvm::sys::path::append(ProjectPath, ModuleSourceInfoFilename);
 
     // Try to open the module source info file.  If it does not exist, ignore
     // the error.  However, pass though all other errors.
     if (llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleSourceInfoOrErr =
-      FS.getBufferForFile(PrivatePath)) {
+      FS.getBufferForFile(ProjectPath)) {
       *ModuleSourceInfoBuffer = std::move(*ModuleSourceInfoOrErr);
       return std::error_code();
     }
   }
   {
-    llvm::SmallString<128> NonPrivatePath(ModulePath);
-    llvm::sys::path::remove_filename(NonPrivatePath);
-    llvm::sys::path::append(NonPrivatePath, ModuleSourceInfoFilename);
+    llvm::SmallString<128> NonProjectPath(ModulePath);
+    llvm::sys::path::remove_filename(NonProjectPath);
+    llvm::sys::path::append(NonProjectPath, ModuleSourceInfoFilename);
 
     // Try to open the module source info file adjacent to the .swiftmodule file.
     if (llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleSourceInfoOrErr =
-      FS.getBufferForFile(NonPrivatePath)) {
+      FS.getBufferForFile(NonProjectPath)) {
       *ModuleSourceInfoBuffer = std::move(*ModuleSourceInfoOrErr);
       return std::error_code();
     }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -263,10 +263,43 @@ std::error_code SerializedModuleLoaderBase::openModuleDocFile(
   return std::error_code();
 }
 
+std::error_code
+SerializedModuleLoaderBase::openModuleSourceInfoFile(AccessPathElem ModuleID,
+                                                     StringRef ModulePath,
+                                                     StringRef ModuleSourceInfoPath,
+                                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
+  if (!ModuleSourceInfoBuffer)
+    return std::error_code();
+
+  llvm::vfs::FileSystem &FS = *Ctx.SourceMgr.getFileSystem();
+
+  // Try to open the module source info file.  If it does not exist, ignore
+  // the error.  However, pass though all other errors.
+  if (llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleSourceInfoOrErr =
+    FS.getBufferForFile(ModuleSourceInfoPath)) {
+    *ModuleSourceInfoBuffer = std::move(*ModuleSourceInfoOrErr);
+    return std::error_code();
+  }
+  llvm::SmallString<128> Path(ModulePath);
+  llvm::sys::path::replace_extension(Path,
+                                     file_types::getExtension(file_types::TY_SwiftSourceInfoFile));
+
+  // Try to open the module source info file adjacent to the .swiftmodule file.
+  if (llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ModuleSourceInfoOrErr =
+      FS.getBufferForFile(Path.str())) {
+     *ModuleSourceInfoBuffer = std::move(*ModuleSourceInfoOrErr);
+     return std::error_code();
+   }
+  // Failing to load .swiftsourceinfo file isn't critical, so don't return any errors.
+  return std::error_code();
+}
+
 std::error_code SerializedModuleLoaderBase::openModuleFiles(
     AccessPathElem ModuleID, StringRef ModulePath, StringRef ModuleDocPath,
+    StringRef ModuleSourceInfoPath,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
   assert(((ModuleBuffer && ModuleDocBuffer) ||
           (!ModuleBuffer && !ModuleDocBuffer)) &&
          "Module and Module Doc buffer must both be initialized or NULL");
@@ -299,6 +332,11 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
   if (ModuleDocErr)
     return ModuleDocErr;
 
+  auto ModuleSourceInfoErr =
+    openModuleSourceInfoFile(ModuleID, ModulePath, ModuleSourceInfoPath, ModuleSourceInfoBuffer);
+  if (ModuleSourceInfoErr)
+    return ModuleSourceInfoErr;
+
   *ModuleBuffer = std::move(ModuleOrErr.get());
 
   return std::error_code();
@@ -306,9 +344,10 @@ std::error_code SerializedModuleLoaderBase::openModuleFiles(
 
 std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-    StringRef ModuleDocFilename,
+    StringRef ModuleDocFilename, StringRef ModuleSourceInfoFilename,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
   if (LoadMode == ModuleLoadingMode::OnlyInterface)
     return std::make_error_code(std::errc::not_supported);
 
@@ -316,11 +355,16 @@ std::error_code SerializedModuleLoader::findModuleFilesInDirectory(
   llvm::sys::path::append(ModulePath, ModuleFilename);
   llvm::SmallString<256> ModuleDocPath{DirPath};
   llvm::sys::path::append(ModuleDocPath, ModuleDocFilename);
+  llvm::SmallString<256> ModuleSourceInfoPath{DirPath};
+  llvm::sys::path::append(ModuleSourceInfoPath, "Private");
+  llvm::sys::path::append(ModuleSourceInfoPath, ModuleSourceInfoFilename);
   return SerializedModuleLoaderBase::openModuleFiles(ModuleID,
                                                      ModulePath,
                                                      ModuleDocPath,
+                                                     ModuleSourceInfoPath,
                                                      ModuleBuffer,
-                                                     ModuleDocBuffer);
+                                                     ModuleDocBuffer,
+                                                     ModuleSourceInfoBuffer);
 }
 
 bool SerializedModuleLoader::maybeDiagnoseTargetMismatch(
@@ -361,15 +405,19 @@ bool SerializedModuleLoader::maybeDiagnoseTargetMismatch(
 struct ModuleFilenamePair {
   llvm::SmallString<64> module;
   llvm::SmallString<64> moduleDoc;
+  llvm::SmallString<64> moduleSourceInfo;
 
   ModuleFilenamePair(StringRef baseName)
-    : module(baseName), moduleDoc(baseName)
+    : module(baseName), moduleDoc(baseName), moduleSourceInfo(baseName)
   {
     module += '.';
     module += file_types::getExtension(file_types::TY_SwiftModuleFile);
 
     moduleDoc += '.';
     moduleDoc += file_types::getExtension(file_types::TY_SwiftModuleDocFile);
+
+    moduleSourceInfo += '.';
+    moduleSourceInfo += file_types::getExtension(file_types::TY_SwiftSourceInfoFile);
   }
 };
 
@@ -377,6 +425,7 @@ bool
 SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
            std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
            std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+           std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
            bool &isFramework, bool &isSystemModule) {
   llvm::SmallString<64> moduleName(moduleID.first.str());
   ModuleFilenamePair fileNames(moduleName);
@@ -400,7 +449,9 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
     for (const auto &targetFileNames : targetFileNamePairs) {
       auto result = findModuleFilesInDirectory(moduleID, currPath,
                         targetFileNames.module, targetFileNames.moduleDoc,
-                        moduleBuffer, moduleDocBuffer);
+                        targetFileNames.moduleSourceInfo,
+                        moduleBuffer, moduleDocBuffer,
+                        moduleSourceInfoBuffer);
       if (!result) {
         return true;
       } else if (result == std::errc::not_supported) {
@@ -452,7 +503,8 @@ SerializedModuleLoaderBase::findModule(AccessPathElem moduleID,
 
           auto result = findModuleFilesInDirectory(
               moduleID, path, fileNames.module.str(), fileNames.moduleDoc.str(),
-              moduleBuffer, moduleDocBuffer);
+              fileNames.moduleSourceInfo.str(),
+              moduleBuffer, moduleDocBuffer, moduleSourceInfoBuffer);
           if (!result)
             return true;
           else if (result == std::errc::not_supported)
@@ -520,6 +572,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
     ModuleDecl &M, Optional<SourceLoc> diagLoc,
     std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
     bool isFramework, bool treatAsPartialModule) {
   assert(moduleInputBuffer);
 
@@ -540,6 +593,7 @@ FileUnit *SerializedModuleLoaderBase::loadAST(
   serialization::ValidationInfo loadInfo =
       ModuleFile::load(std::move(moduleInputBuffer),
                        std::move(moduleDocInputBuffer),
+                       std::move(moduleSourceInfoInputBuffer),
                        isFramework, loadedModuleFile,
                        &extendedInfo);
   if (loadInfo.status == serialization::Status::Valid) {
@@ -770,7 +824,7 @@ bool SerializedModuleLoaderBase::canImportModule(
   // Look on disk.
   bool isFramework = false;
   bool isSystemModule = false;
-  return findModule(mID, nullptr, nullptr, isFramework, isSystemModule);
+  return findModule(mID, nullptr, nullptr, nullptr, isFramework, isSystemModule);
 }
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
@@ -792,9 +846,11 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
   std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer;
   std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer;
+  std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer;
 
   // Look on disk.
   if (!findModule(moduleID, &moduleInputBuffer, &moduleDocInputBuffer,
+                  &moduleSourceInfoInputBuffer,
                   isFramework, isSystemModule)) {
     return nullptr;
   }
@@ -814,8 +870,8 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
   SWIFT_DEFER { M->setHasResolvedImports(); };
 
   if (!loadAST(*M, moduleID.second, std::move(moduleInputBuffer),
-               std::move(moduleDocInputBuffer), isFramework,
-               /*treatAsPartialModule*/false)) {
+               std::move(moduleDocInputBuffer), std::move(moduleSourceInfoInputBuffer),
+               isFramework, /*treatAsPartialModule*/false)) {
     M->setFailedToLoad();
   }
 
@@ -850,7 +906,7 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
   auto *M = ModuleDecl::create(moduleID.first, Ctx);
   SWIFT_DEFER { M->setHasResolvedImports(); };
 
-  if (!loadAST(*M, moduleID.second, std::move(moduleInputBuffer), {},
+  if (!loadAST(*M, moduleID.second, std::move(moduleInputBuffer), {}, {},
                isFramework, treatAsPartialModule)) {
     return nullptr;
   }
@@ -884,9 +940,10 @@ void SerializedModuleLoaderBase::loadObjCMethods(
 
 std::error_code MemoryBufferSerializedModuleLoader::findModuleFilesInDirectory(
     AccessPathElem ModuleID, StringRef DirPath, StringRef ModuleFilename,
-    StringRef ModuleDocFilename,
+    StringRef ModuleDocFilename, StringRef ModuleSourceInfoFilename,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer) {
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer) {
   // This is a soft error instead of an llvm_unreachable because this API is
   // primarily used by LLDB which makes it more likely that unwitting changes to
   // the Swift compiler accidentally break the contract.
@@ -1008,6 +1065,11 @@ void SerializedASTFile::lookupObjCMethods(
 Optional<CommentInfo>
 SerializedASTFile::getCommentForDecl(const Decl *D) const {
   return File.getCommentForDecl(D);
+}
+
+Optional<BasicDeclLocs>
+SerializedASTFile::getBasicLocsForDecl(const Decl *D) const {
+  return File.getBasicDeclLocsForDecl(D);
 }
 
 Optional<StringRef>

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -1,4 +1,4 @@
-//===---= SourceInfoFormat.h - The internals of swiftsourceinfo files ----===//
+//===--- SourceInfoFormat.h - Format swiftsourceinfo files ---*- c++ -*---===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -66,27 +66,26 @@ const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
 namespace sourceinfo_block {
   enum RecordKind {
     BASIC_DECL_LOCS = 1,
-    DECL_USRS = 96,
-    SOURCE_FILE_PATHS,
+    DECL_USRS,
+    TEXT_DATA,
   };
 
   using BasicDeclLocsLayout = BCRecordLayout<
     BASIC_DECL_LOCS, // record ID
-    BCVBR<16>,       // table offset within the blob (an llvm::OnDiskHashTable)
-    BCBlob           // map from Decl USR ID to basic source locations.
+    BCBlob           // an array of fixed size location data
   >;
 
   using DeclUSRSLayout = BCRecordLayout<
     DECL_USRS,         // record ID
     BCVBR<16>,         // table offset within the blob (an llvm::OnDiskHashTable)
-    BCBlob             // map from decl USR ID to actual USR
+    BCBlob             // map from actual USR to USR Id
   >;
 
-  using SourceFilePathsLayout = BCRecordLayout<
-    SOURCE_FILE_PATHS, // record ID
-    BCVBR<16>,         // table offset within the blob (an llvm::OnDiskHashTable)
-    BCBlob             // map from file ID to actual file path
+  using TextDataLayout = BCRecordLayout<
+    TEXT_DATA,        // record ID
+    BCBlob            // a list of 0-terminated string segments
   >;
+
 } // namespace sourceinfo_block
 
 } // end namespace serialization

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -63,7 +63,7 @@ const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
 /// to make backwards-compatible changes using the LLVM bitcode format.
 ///
 /// \sa DECL_LOCS_BLOCK_ID
-namespace sourceinfo_block {
+namespace decl_locs_block {
   enum RecordKind {
     BASIC_DECL_LOCS = 1,
     DECL_USRS,

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -1,0 +1,95 @@
+//===---= SourceInfoFormat.h - The internals of swiftsourceinfo files ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file Contains various constants and helper types to deal with serialized
+/// source information (.swiftsourceinfo files).
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_SOURCEINFOFORMAT_H
+#define SWIFT_SERIALIZATION_SOURCEINFOFORMAT_H
+
+#include "llvm/Bitcode/RecordLayout.h"
+
+namespace swift {
+namespace serialization {
+
+using llvm::BCArray;
+using llvm::BCBlob;
+using llvm::BCFixed;
+using llvm::BCGenericRecordLayout;
+using llvm::BCRecordLayout;
+using llvm::BCVBR;
+
+/// Magic number for serialized source info files.
+const unsigned char SWIFTSOURCEINFO_SIGNATURE[] = { 0xD6, 0x9C, 0xB7, 0x23 };
+
+/// Serialized sourceinfo format major version number.
+///
+/// Increment this value when making a backwards-incompatible change, i.e. where
+/// an \e old compiler will \e not be able to read the new format. This should
+/// be rare. When incrementing this value, reset SWIFTDOC_VERSION_MINOR to 0.
+///
+/// See docs/StableBitcode.md for information on how to make
+/// backwards-compatible changes using the LLVM bitcode format.
+const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 1;
+
+/// Serialized swiftsourceinfo format minor version number.
+///
+/// Increment this value when making a backwards-compatible change that might be
+/// interesting to test for. A backwards-compatible change is one where an \e
+/// old compiler can read the new format without any problems (usually by
+/// ignoring new information).
+const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 1; // Last change: skipping 0 for testing purposes
+
+/// The hash seed used for the string hashes(llvm::djbHash) in a .swiftsourceinfo file.
+const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
+
+/// The record types within the DECL_LOCS block.
+///
+/// Be very careful when changing this block; it must remain
+/// backwards-compatible. Adding new records is okay---they will be ignored---
+/// but modifying existing ones must be done carefully. You may need to update
+/// the version when you do so. See docs/StableBitcode.md for information on how
+/// to make backwards-compatible changes using the LLVM bitcode format.
+///
+/// \sa DECL_LOCS_BLOCK_ID
+namespace sourceinfo_block {
+  enum RecordKind {
+    BASIC_DECL_LOCS = 1,
+    DECL_USRS = 96,
+    SOURCE_FILE_PATHS,
+  };
+
+  using BasicDeclLocsLayout = BCRecordLayout<
+    BASIC_DECL_LOCS, // record ID
+    BCVBR<16>,       // table offset within the blob (an llvm::OnDiskHashTable)
+    BCBlob           // map from Decl USR ID to basic source locations.
+  >;
+
+  using DeclUSRSLayout = BCRecordLayout<
+    DECL_USRS,         // record ID
+    BCVBR<16>,         // table offset within the blob (an llvm::OnDiskHashTable)
+    BCBlob             // map from decl USR ID to actual USR
+  >;
+
+  using SourceFilePathsLayout = BCRecordLayout<
+    SOURCE_FILE_PATHS, // record ID
+    BCVBR<16>,         // table offset within the blob (an llvm::OnDiskHashTable)
+    BCBlob             // map from file ID to actual file path
+  >;
+} // namespace sourceinfo_block
+
+} // end namespace serialization
+} // end namespace swift
+
+#endif

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -31,13 +31,13 @@ using llvm::BCRecordLayout;
 using llvm::BCVBR;
 
 /// Magic number for serialized source info files.
-const unsigned char SWIFTSOURCEINFO_SIGNATURE[] = { 0xD6, 0x9C, 0xB7, 0x23 };
+const unsigned char SWIFTSOURCEINFO_SIGNATURE[] = { 0xF0, 0x9F, 0x8F, 0x8E };
 
 /// Serialized sourceinfo format major version number.
 ///
 /// Increment this value when making a backwards-incompatible change, i.e. where
 /// an \e old compiler will \e not be able to read the new format. This should
-/// be rare. When incrementing this value, reset SWIFTDOC_VERSION_MINOR to 0.
+/// be rare. When incrementing this value, reset SWIFTSOURCEINFO_VERSION_MINOR to 0.
 ///
 /// See docs/StableBitcode.md for information on how to make
 /// backwards-compatible changes using the LLVM bitcode format.
@@ -56,11 +56,14 @@ const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
 
 /// The record types within the DECL_LOCS block.
 ///
-/// Be very careful when changing this block; it must remain
-/// backwards-compatible. Adding new records is okay---they will be ignored---
-/// but modifying existing ones must be done carefully. You may need to update
-/// the version when you do so. See docs/StableBitcode.md for information on how
-/// to make backwards-compatible changes using the LLVM bitcode format.
+/// Though we strive to keep the format stable, breaking the format of
+/// .swiftsourceinfo doesn't have consequences as serious as breaking the format
+/// of .swiftdoc, because .swiftsourceinfo file is for local development use only.
+///
+/// When changing this block, backwards-compatible changes are prefered.
+/// You may need to update the version when you do so. See docs/StableBitcode.md
+/// for information on how to make backwards-compatible changes using the LLVM
+/// bitcode format.
 ///
 /// \sa DECL_LOCS_BLOCK_ID
 namespace decl_locs_block {

--- a/test/Driver/sourceinfo_file.swift
+++ b/test/Driver/sourceinfo_file.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: mkdir -p %t/build/Private
-// RUN: %swiftc_driver -driver-print-jobs -emit-module %s -emit-module-path %t/build/sourceinfo_file.swiftmodule -module-name sourceinfo_file | %FileCheck %s -check-prefix CHECK-PRIVATE
+// RUN: mkdir -p %t/build/Project
+// RUN: %swiftc_driver -driver-print-jobs -emit-module %s -emit-module-path %t/build/sourceinfo_file.swiftmodule -module-name sourceinfo_file | %FileCheck %s -check-prefix CHECK-PROJECT
 
-// CHECK-PRIVATE: build{{/|\\\\}}Private{{/|\\\\}}sourceinfo_file.swiftsourceinfo
+// CHECK-PROJECT: build{{/|\\\\}}Project{{/|\\\\}}sourceinfo_file.swiftsourceinfo
 
 // RUN: %empty-directory(%t/build)
-// RUN: %swiftc_driver -driver-print-jobs -emit-module %s -emit-module-path %t/build/sourceinfo_file.swiftmodule -module-name sourceinfo_file | %FileCheck %s -check-prefix CHECK-NOPRIVATE
+// RUN: %swiftc_driver -driver-print-jobs -emit-module %s -emit-module-path %t/build/sourceinfo_file.swiftmodule -module-name sourceinfo_file | %FileCheck %s -check-prefix CHECK-NOPROJECT
 
-// CHECK-NOPRIVATE-NOT: Private/sourceinfo_file.swiftsourceinfo
-// CHECK-NOPRIVATE: build{{/|\\\\}}sourceinfo_file.swiftsourceinfo
+// CHECK-NOPROJECT-NOT: Project/sourceinfo_file.swiftsourceinfo
+// CHECK-NOPROJECT: build{{/|\\\\}}sourceinfo_file.swiftsourceinfo
 
 // RUN: %empty-directory(%t/build)
 // RUN: %swiftc_driver -driver-print-jobs -emit-module %s -emit-module-path %t/build/sourceinfo_file.swiftmodule -module-name sourceinfo_file -emit-module-source-info-path %t/build/DriverPath.swiftsourceinfo | %FileCheck %s -check-prefix CHECK-DRIVER-OPT

--- a/test/Serialization/Inputs/comments-batch/File1.swift
+++ b/test/Serialization/Inputs/comments-batch/File1.swift
@@ -1,0 +1,2 @@
+/// Comment in File1
+public func FuncFromFile1() {}

--- a/test/Serialization/Inputs/comments-batch/File2.swift
+++ b/test/Serialization/Inputs/comments-batch/File2.swift
@@ -1,0 +1,2 @@
+/// Comment in File2
+public func FuncFromFile2() {}

--- a/test/Serialization/Inputs/comments-batch/File3.swift
+++ b/test/Serialization/Inputs/comments-batch/File3.swift
@@ -1,0 +1,2 @@
+/// Comment in File3
+public func FuncFromFile3() {}

--- a/test/Serialization/Inputs/comments-batch/File4.swift
+++ b/test/Serialization/Inputs/comments-batch/File4.swift
@@ -1,0 +1,2 @@
+/// Comment in File4
+public func FuncFromFile4() {}

--- a/test/Serialization/Inputs/comments-batch/File5.swift
+++ b/test/Serialization/Inputs/comments-batch/File5.swift
@@ -1,0 +1,2 @@
+/// Comment in File5
+public func FuncFromFile5() {}

--- a/test/Serialization/Inputs/def_comments.swift
+++ b/test/Serialization/Inputs/def_comments.swift
@@ -1,3 +1,31 @@
 /// second_decl_class_1 Aaa.
 public class second_decl_class_1 {
 }
+
+public struct second_decl_struct_1 {
+    public var instanceVar: Int {
+        get { return 1 }
+        set {}
+    }
+    public enum NestedEnum {}
+    public typealias NestedTypealias = Int
+}
+
+public enum second_decl_enum_1 {
+    case Case1
+    case Case2(Int)
+}
+
+public class second_decl_class_2 {
+    public init() {}
+}
+
+public protocol second_decl_protocol_1 {
+    associatedtype NestedTypealias
+    subscript(i: Int) -> Double { get set }
+}
+
+public var (decl_var_2, decl_var_3): (Int, Float) = (1, 1.0)
+
+#sourceLocation(file:"NonExistingSource.swift", line:100000)
+public func functionAfterPoundSourceLoc() {}

--- a/test/Serialization/comments-batch-mode.swift
+++ b/test/Serialization/comments-batch-mode.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-batch-mode -emit-module -emit-module-doc -emit-module-path %t/Foo.swiftmodule %S/Inputs/comments-batch/File1.swift %S/Inputs/comments-batch/File2.swift %S/Inputs/comments-batch/File3.swift %S/Inputs/comments-batch/File4.swift %S/Inputs/comments-batch/File5.swift -module-name Foo -emit-module-source-info-path %t/Foo.swiftsourceinfo -emit-module-doc-path %t/Foo.swiftdoc
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -source-filename %s -I %t | %FileCheck %s -check-prefix=FIRST
+
+// FIRST: Inputs/comments-batch/File1.swift:2:13: Func/FuncFromFile1 RawComment=[/// Comment in File1\n]
+// FIRST: Inputs/comments-batch/File2.swift:2:13: Func/FuncFromFile2 RawComment=[/// Comment in File2\n]
+// FIRST: Inputs/comments-batch/File3.swift:2:13: Func/FuncFromFile3 RawComment=[/// Comment in File3\n]
+// FIRST: Inputs/comments-batch/File4.swift:2:13: Func/FuncFromFile4 RawComment=[/// Comment in File4\n]
+// FIRST: Inputs/comments-batch/File5.swift:2:13: Func/FuncFromFile5 RawComment=[/// Comment in File5\n]

--- a/test/Serialization/comments-batch-mode.swift
+++ b/test/Serialization/comments-batch-mode.swift
@@ -1,9 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-batch-mode -emit-module -emit-module-doc -emit-module-path %t/Foo.swiftmodule %S/Inputs/comments-batch/File1.swift %S/Inputs/comments-batch/File2.swift %S/Inputs/comments-batch/File3.swift %S/Inputs/comments-batch/File4.swift %S/Inputs/comments-batch/File5.swift -module-name Foo -emit-module-source-info-path %t/Foo.swiftsourceinfo -emit-module-doc-path %t/Foo.swiftdoc
-// RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -source-filename %s -I %t | %FileCheck %s -check-prefix=FIRST
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -source-filename %s -I %t | %FileCheck %s
 
-// FIRST: Inputs/comments-batch/File1.swift:2:13: Func/FuncFromFile1 RawComment=[/// Comment in File1\n]
-// FIRST: Inputs/comments-batch/File2.swift:2:13: Func/FuncFromFile2 RawComment=[/// Comment in File2\n]
-// FIRST: Inputs/comments-batch/File3.swift:2:13: Func/FuncFromFile3 RawComment=[/// Comment in File3\n]
-// FIRST: Inputs/comments-batch/File4.swift:2:13: Func/FuncFromFile4 RawComment=[/// Comment in File4\n]
-// FIRST: Inputs/comments-batch/File5.swift:2:13: Func/FuncFromFile5 RawComment=[/// Comment in File5\n]
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -wmo -emit-module -emit-module-doc -emit-module-path %t/Foo.swiftmodule %S/Inputs/comments-batch/File1.swift %S/Inputs/comments-batch/File2.swift %S/Inputs/comments-batch/File3.swift %S/Inputs/comments-batch/File4.swift %S/Inputs/comments-batch/File5.swift -module-name Foo -emit-module-source-info-path %t/Foo.swiftsourceinfo -emit-module-doc-path %t/Foo.swiftdoc
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -source-filename %s -I %t | %FileCheck %s
+
+// CHECK: Inputs/comments-batch/File1.swift:2:13: Func/FuncFromFile1 RawComment=[/// Comment in File1\n]
+// CHECK: Inputs/comments-batch/File2.swift:2:13: Func/FuncFromFile2 RawComment=[/// Comment in File2\n]
+// CHECK: Inputs/comments-batch/File3.swift:2:13: Func/FuncFromFile3 RawComment=[/// Comment in File3\n]
+// CHECK: Inputs/comments-batch/File4.swift:2:13: Func/FuncFromFile4 RawComment=[/// Comment in File4\n]
+// CHECK: Inputs/comments-batch/File5.swift:2:13: Func/FuncFromFile5 RawComment=[/// Comment in File5\n]

--- a/test/Serialization/comments-framework.swift
+++ b/test/Serialization/comments-framework.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule)
+// RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule/Private)
 
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftdoc-name %s
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftdoc-name -emit-module-source-info-path %t/comments.framework/Modules/comments.swiftmodule/Private/%target-swiftsourceinfo-name %s
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -F %t | %FileCheck %s
 
 // RUN: cp -r %t/comments.framework/Modules/comments.swiftmodule %t/comments.swiftmodule
@@ -23,8 +24,8 @@ public class first_decl_class_1 {
   public func decl_func_3() {}
 }
 
-// CHECK: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
-// CHECK: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
-// CHECK: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
-// CHECK: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
+// CHECK: comments-framework.swift:12:14: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
+// CHECK: comments-framework.swift:15:15: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
+// CHECK: comments-framework.swift:20:15: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
+// CHECK: comments-framework.swift:24:15: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
 

--- a/test/Serialization/comments-framework.swift
+++ b/test/Serialization/comments-framework.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule)
-// RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule/Private)
+// RUN: %empty-directory(%t/comments.framework/Modules/comments.swiftmodule/Project)
 
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftdoc-name -emit-module-source-info-path %t/comments.framework/Modules/comments.swiftmodule/Private/%target-swiftsourceinfo-name %s
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/comments.framework/Modules/comments.swiftmodule/%target-swiftdoc-name -emit-module-source-info-path %t/comments.framework/Modules/comments.swiftmodule/Project/%target-swiftsourceinfo-name %s
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -F %t | %FileCheck %s
 
 // RUN: cp -r %t/comments.framework/Modules/comments.swiftmodule %t/comments.swiftmodule

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -14,6 +14,13 @@
 // RUN: %FileCheck %s -check-prefix=TESTING < %t.testing.txt
 // RUN: %FileCheck %s -check-prefix=TESTING-NEGATIVE < %t.testing.txt
 
+// Test the case when we have .swiftsourceinfo
+//
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-testing -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.testing.txt
+// RUN: %FileCheck %s -check-prefix=SOURCE-LOC < %t.testing.txt
+
 /// PublicClass Documentation
 public class PublicClass {
   /// Public Function Documentation
@@ -73,4 +80,9 @@ private class PrivateClass {
 // TESTING: InternalClass Documentation
 // TESTING: Internal Function Documentation
 
-
+// SOURCE-LOC: comments-hidden.swift:37:15: Func/PublicClass.__UnderscoredPublic RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:39:10: Constructor/PublicClass.init RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:41:10: Subscript/PublicClass.subscript RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:43:10: Constructor/PublicClass.init RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:45:10: Subscript/PublicClass.subscript RawComment=none BriefComment=none DocCommentAsXML=none
+// SOURCE-LOC: comments-hidden.swift:50:15: Func/-= RawComment=none BriefComment=none DocCommentAsXML=none

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -89,3 +89,12 @@ extension first_decl_class_1 : P1 {}
 // SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
 // SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
 // SECOND: NonExistingSource.swift:100000:13: Func/functionAfterPoundSourceLoc
+
+// Test the case when we have to import via a .swiftinterface file.
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Hidden)
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/Hidden/comments.swiftmodule -emit-module-interface-path %t/comments.swiftinterface -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s -enable-library-evolution -swift-version 5
+// RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
+// RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t -swift-version 5 | %FileCheck %s -check-prefix=FIRST

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -1,19 +1,21 @@
 // Test the case when we have a single file in a module.
 //
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -emit-module-source-info-path %t/comments.swiftsourceinfo %s
 // RUN: llvm-bcanalyzer %t/comments.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
+// RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t | %FileCheck %s -check-prefix=FIRST
 
 // Test the case when we have a multiple files in a module.
 //
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/first.swiftmodule -emit-module-doc -emit-module-doc-path %t/first.swiftdoc -primary-file %s %S/Inputs/def_comments.swift
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/second.swiftmodule -emit-module-doc -emit-module-doc-path %t/second.swiftdoc %s -primary-file %S/Inputs/def_comments.swift
-// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %t/first.swiftmodule %t/second.swiftmodule
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/first.swiftmodule -emit-module-doc -emit-module-doc-path %t/first.swiftdoc -primary-file %s %S/Inputs/def_comments.swift -emit-module-source-info-path %t/first.swiftsourceinfo
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/second.swiftmodule -emit-module-doc -emit-module-doc-path %t/second.swiftdoc %s -primary-file %S/Inputs/def_comments.swift -emit-module-source-info-path %t/second.swiftsourceinfo
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %t/first.swiftmodule %t/second.swiftmodule -emit-module-source-info-path %t/comments.swiftsourceinfo
 // RUN: llvm-bcanalyzer %t/comments.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: llvm-bcanalyzer %t/comments.swiftdoc | %FileCheck %s -check-prefix=BCANALYZER
+// RUN: llvm-bcanalyzer %t/comments.swiftsourceinfo | %FileCheck %s -check-prefix=BCANALYZER
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=FIRST < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=SECOND < %t.printed.txt
@@ -58,14 +60,32 @@ public protocol P1 { }
 /// Comment for no member extension
 extension first_decl_class_1 : P1 {}
 
-// FIRST: Class/first_decl_generic_class_1 RawComment=[/// first_decl_generic_class_1 Aaa.\n]
-// FIRST: Destructor/first_decl_generic_class_1.deinit RawComment=[/// deinit of first_decl_generic_class_1 Aaa.\n]
-// FIRST: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
-// FIRST: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
-// FIRST: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
-// FIRST: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
+// FIRST: comments.swift:26:14: Class/first_decl_generic_class_1 RawComment=[/// first_decl_generic_class_1 Aaa.\n]
+// FIRST: comments.swift:28:3: Destructor/first_decl_generic_class_1.deinit RawComment=[/// deinit of first_decl_generic_class_1 Aaa.\n]
+// FIRST: comments.swift:33:14: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]
+// FIRST: comments.swift:36:15: Func/first_decl_class_1.decl_func_1 RawComment=[/// decl_func_1 Aaa.\n]
+// FIRST: comments.swift:41:15: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
+// FIRST: comments.swift:45:15: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
 
-// SECOND: Extension/ RawComment=[/// Comment for bar1\n] BriefComment=[Comment for bar1]
-// SECOND: Extension/ RawComment=[/// Comment for bar2\n] BriefComment=[Comment for bar2]
-// SECOND: Extension/ RawComment=[/// Comment for no member extension\n] BriefComment=[Comment for no member extension]
-// SECOND: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
+// SECOND: comments.swift:49:1: Extension/ RawComment=[/// Comment for bar1\n] BriefComment=[Comment for bar1]
+// SECOND: comments.swift:54:1: Extension/ RawComment=[/// Comment for bar2\n] BriefComment=[Comment for bar2]
+// SECOND: comments.swift:61:1: Extension/ RawComment=[/// Comment for no member extension\n] BriefComment=[Comment for no member extension]
+// SECOND: Inputs/def_comments.swift:2:14: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
+// SECOND: Inputs/def_comments.swift:5:15: Struct/second_decl_struct_1
+// SECOND: Inputs/def_comments.swift:7:9: Accessor/second_decl_struct_1.<getter for second_decl_struct_1.instanceVar>
+// SECOND: Inputs/def_comments.swift:8:9: Accessor/second_decl_struct_1.<setter for second_decl_struct_1.instanceVar>
+// SECOND: Inputs/def_comments.swift:10:17: Enum/second_decl_struct_1.NestedEnum
+// SECOND: Inputs/def_comments.swift:11:22: TypeAlias/second_decl_struct_1.NestedTypealias
+// SECOND: Inputs/def_comments.swift:14:13: Enum/second_decl_enum_1
+// SECOND: Inputs/def_comments.swift:15:10: EnumElement/second_decl_enum_1.Case1
+// SECOND: Inputs/def_comments.swift:16:10: EnumElement/second_decl_enum_1.Case2
+// SECOND: Inputs/def_comments.swift:20:12: Constructor/second_decl_class_2.init
+// SECOND: Inputs/def_comments.swift:23:17: Protocol/second_decl_protocol_1
+// SECOND: Inputs/def_comments.swift:24:20: AssociatedType/second_decl_protocol_1.NestedTypealias
+// SECOND: Inputs/def_comments.swift:25:5: Subscript/second_decl_protocol_1.subscript
+// SECOND: Inputs/def_comments.swift:25:35: Accessor/second_decl_protocol_1.<getter for second_decl_protocol_1.subscript>
+// SECOND: Inputs/def_comments.swift:25:39: Accessor/second_decl_protocol_1.<setter for second_decl_protocol_1.subscript>
+// SECOND: Inputs/def_comments.swift:28:13: Var/decl_var_2 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: NonExistingSource.swift:100000:13: Func/functionAfterPoundSourceLoc

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1612,6 +1612,7 @@ config.substitutions.append(('%xcode-extra-frameworks-dir', extra_frameworks_dir
 
 config.substitutions.append(('%target-swiftmodule-name', run_cpu + '.swiftmodule'))
 config.substitutions.append(('%target-swiftdoc-name', run_cpu + '.swiftdoc'))
+config.substitutions.append(('%target-swiftsourceinfo-name', run_cpu + '.swiftsourceinfo'))
 
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -184,7 +184,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
     // documentation file.
     // FIXME: refactor the frontend to provide an easy way to figure out the
     // correct filename here.
-    auto FUnit = Loader->loadAST(*Mod, None, std::move(Buf), nullptr,
+    auto FUnit = Loader->loadAST(*Mod, None, std::move(Buf), nullptr, nullptr,
                                  /*isFramework*/false,
                                  /*treatAsPartialModule*/false);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -829,7 +829,7 @@ bool SwiftLangSupport::printDisplayName(const swift::ValueDecl *D,
 }
 
 bool SwiftLangSupport::printUSR(const ValueDecl *D, llvm::raw_ostream &OS) {
-  return ide::printDeclUSR(D, OS);
+  return ide::printValueDeclUSR(D, OS);
 }
 
 bool SwiftLangSupport::printDeclTypeUSR(const ValueDecl *D, llvm::raw_ostream &OS) {

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -983,7 +983,7 @@ static StringRef getTypeName(SDKContext &Ctx, Type Ty,
 static StringRef calculateUsr(SDKContext &Ctx, ValueDecl *VD) {
   llvm::SmallString<64> SS;
   llvm::raw_svector_ostream OS(SS);
-  if (!ide::printDeclUSR(VD, OS)) {
+  if (!ide::printValueDeclUSR(VD, OS)) {
     return Ctx.buffer(SS.str());
   }
   return StringRef();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2515,11 +2515,11 @@ public:
       getBasicLocsForDecl(D);
     if (!moduleLoc.hasValue())
       return;
-    if (!moduleLoc->Loc.hasValue())
+    if (!moduleLoc->Loc.isValid())
       return;
     OS << moduleLoc->SourceFilePath
-       << ":" << moduleLoc->Loc->Line
-       << ":" << moduleLoc->Loc->Column << ": ";
+       << ":" << moduleLoc->Loc.Line
+       << ":" << moduleLoc->Loc.Column << ": ";
   }
 
   bool walkToDeclPre(Decl *D) override {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2819,7 +2819,7 @@ private:
   void printUSR(const ValueDecl *VD, SourceLoc Loc) {
     printLoc(Loc);
     OS << ' ';
-    if (ide::printDeclUSR(VD, OS))
+    if (ide::printValueDeclUSR(VD, OS))
       OS << "ERROR:no-usr";
     OS << '\n';
   }
@@ -2905,7 +2905,7 @@ private:
     std::string USR;
     {
       llvm::raw_string_ostream OS(USR);
-      printDeclUSR(VD, OS);
+      printValueDeclUSR(VD, OS);
     }
 
     std::string error;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2510,6 +2510,18 @@ public:
     }
   }
 
+  void printSerializedLoc(Decl *D) {
+    auto moduleLoc = cast<FileUnit>(D->getDeclContext()->getModuleScopeContext())->
+      getBasicLocsForDecl(D);
+    if (!moduleLoc.hasValue())
+      return;
+    if (!moduleLoc->Loc.hasValue())
+      return;
+    OS << moduleLoc->SourceFilePath
+       << ":" << moduleLoc->Loc->Line
+       << ":" << moduleLoc->Loc->Column << ": ";
+  }
+
   bool walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
       return true;
@@ -2518,8 +2530,10 @@ public:
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getLineAndColumn(Loc);
-        OS << SM.getDisplayNameForLoc(VD->getLoc())
+        OS << SM.getDisplayNameForLoc(Loc)
            << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
+      } else {
+        printSerializedLoc(D);
       }
       OS << Decl::getKindName(VD->getKind()) << "/";
       printDeclName(VD);
@@ -2535,8 +2549,10 @@ public:
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getLineAndColumn(Loc);
-        OS << SM.getDisplayNameForLoc(D->getLoc())
+        OS << SM.getDisplayNameForLoc(Loc)
         << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
+      } else {
+        printSerializedLoc(D);
       }
       OS << Decl::getKindName(D->getKind()) << "/";
       OS << " ";

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -108,11 +108,12 @@ protected:
 
     std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
     std::unique_ptr<llvm::MemoryBuffer> moduleDocBuffer;
+    std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoBuffer;
 
     auto error =
       loader->findModuleFilesInDirectory({moduleName, SourceLoc()}, tempDir,
-        "Library.swiftmodule", "Library.swiftdoc",
-        &moduleBuffer, &moduleDocBuffer);
+        "Library.swiftmodule", "Library.swiftdoc", "Library.swiftsourceinfo",
+        &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer);
     ASSERT_FALSE(error);
     ASSERT_FALSE(diags.hadAnyError());
 


### PR DESCRIPTION
After setting up the .swiftsourceinfo file, this patch starts to actually serialize and de-serialize source locations for declaration. The binary format of .swiftsourceinfo currently contains these three records:

BasicDeclLocs: a hash table mapping from a USR ID to a list of basic source locations. The USR id could be retrieved from the following DeclUSRs record using an actual decl USR. The basic source locations include a file ID and the results from Decl::getLoc(), ValueDecl::getNameLoc(), Decl::getStartLoc() and Decl::getEndLoc(). The file ID could be used to retrieve the actual file name from the following SourceFilePaths record. Each location is encoded as a line:column pair.

DeclUSRS: a hash table mapping from USR to a USR ID used by location records.

SourceFilePaths: a hash table mapping from a file ID to actual file name.

BasicDeclLocs should be sufficient for most diagnostic cases. If additional source locations are needed, we could always add new source location records without breaking the backward compatibility. When de-serializing the source location from a module-imported decl, we calculate its USR, retrieve the USR ID from the DeclUSRS record, and use the USR ID to look up the basic location list in the BasicDeclLocs record.

For more details about .swiftsourceinfo file: https://forums.swift.org/t/proposal-emitting-source-information-file-during-compilation

rdar://56167685