### PR TITLE
IRGen: Always use symbolic references in mangled names (on Mach-O platforms)

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -393,6 +393,8 @@ public:
       auto SecBuf = this->getReader().readBytes(
           RemoteAddress(SectionHdrAddress + (I * SectionEntrySize)),
           SectionEntrySize);
+      if (!SecBuf)
+        return false;
       auto SecHdr =
           reinterpret_cast<const typename T::Section *>(SecBuf.get());
       SecHdrVec.push_back(SecHdr);

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -376,11 +376,8 @@ public:
     // Try to resolve to the underlying type, if we can.
     if (opaqueDescriptor->getKind() ==
                             Node::Kind::OpaqueTypeDescriptorSymbolicReference) {
-      if (!OpaqueUnderlyingTypeReader)
-        return nullptr;
-      
       auto underlyingTy = OpaqueUnderlyingTypeReader(
-                           (const void *)opaqueDescriptor->getIndex(), ordinal);
+                                         opaqueDescriptor->getIndex(), ordinal);
       
       if (!underlyingTy)
         return nullptr;
@@ -598,7 +595,7 @@ private:
   unsigned PointerSize;
   std::function<Demangle::Node * (RemoteRef<char>)>
     TypeRefDemangler;
-  std::function<const TypeRef* (const void*, unsigned)>
+  std::function<const TypeRef* (uint64_t, unsigned)>
     OpaqueUnderlyingTypeReader;
   
 public:
@@ -613,9 +610,8 @@ public:
                                Dem, /*useOpaqueTypeSymbolicReferences*/ true);
       }),
       OpaqueUnderlyingTypeReader(
-      [&reader](const void *descriptor, unsigned ordinal) -> const TypeRef* {
-        auto context = (typename Runtime::StoredPointer)descriptor;
-        return reader.readUnderlyingTypeForOpaqueTypeDescriptor(context,
+      [&reader](uint64_t descriptorAddr, unsigned ordinal) -> const TypeRef* {
+        return reader.readUnderlyingTypeForOpaqueTypeDescriptor(descriptorAddr,
                                                                 ordinal);
       })
   {}

--- a/include/swift/Remote/CMemoryReader.h
+++ b/include/swift/Remote/CMemoryReader.h
@@ -66,8 +66,13 @@ public:
 
   bool readString(RemoteAddress address, std::string &dest) override {
     auto length = getStringLength(address);
-    if (!length)
-      return false;
+    if (length == 0) {
+      // A length of zero unfortunately might mean either that there's a zero
+      // length string at the location we're trying to read, or that reading
+      // failed. We can do a one-byte read to tell them apart.
+      auto buf = readBytes(address, 1);
+      return buf && ((const char*)buf.get())[0] == 0;
+    }
 
     auto Buf = readBytes(address, length);
     if (!Buf)

--- a/lib/Basic/QuotedString.cpp
+++ b/lib/Basic/QuotedString.cpp
@@ -36,7 +36,7 @@ void swift::printAsQuotedString(llvm::raw_ostream &out, llvm::StringRef text) {
         };
         out << "\\u{" << hexdigit[c >> 4] << hexdigit[c & 0xF] << '}';
       } else {
-        out << c;
+        out << (char)c;
       }
       break;
     }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -317,6 +317,7 @@ Node::iterator Node::end() const {
 }
 
 void Node::addChild(NodePointer Child, NodeFactory &Factory) {
+  assert(Child);
   switch (NodePayloadKind) {
     case PayloadKind::None:
       InlineChildren[0] = Child;

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -93,26 +93,43 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
   AllowSymbolicReferences = true;
   CanSymbolicReference = [&IGM](SymbolicReferent s) -> bool {
     if (auto type = s.dyn_cast<const NominalTypeDecl *>()) {
-      // FIXME: Sometimes we fail to emit metadata for Clang imported types
-      // even after noting use of their type descriptor or metadata. Work
-      // around by not symbolic-referencing imported types for now.
-      if (type->hasClangNode())
+      // The short-substitution types in the standard library have compact
+      // manglings already, and the runtime ought to have a lookup table for
+      // them. Symbolic referencing would be wasteful.
+      if (type->getModuleContext()->isStdlibModule()
+          && Mangle::getStandardTypeSubst(type->getName().str())) {
         return false;
+      }
       
-      // TODO: We ought to be able to use indirect symbolic references even
-      // when the referent may be in another file, once the on-disk
-      // ObjectMemoryReader can handle them.
-      // Private entities are known to be accessible.
-      auto formalAccessScope = type->getFormalAccessScope(nullptr, true);
-      if ((formalAccessScope.isPublic() || formalAccessScope.isInternal()) &&
-          (!IGM.CurSourceFile ||
-           IGM.CurSourceFile != type->getParentSourceFile()))
-        return false;
-      
-      // @objc protocols don't have descriptors.
-      if (auto proto = dyn_cast<ProtocolDecl>(type))
-        if (proto->isObjC())
+      // TODO: We could assign a symbolic reference discriminator to refer
+      // to objc protocol refs.
+      if (auto proto = dyn_cast<ProtocolDecl>(type)) {
+        if (proto->isObjC()) {
           return false;
+        }
+      }
+
+      // Classes defined in Objective-C don't have descriptors.
+      // TODO: We could assign a symbolic reference discriminator to refer
+      // to objc class refs.
+      if (auto clas = dyn_cast<ClassDecl>(type)) {
+        if (clas->hasClangNode()
+            && clas->getForeignClassKind() != ClassDecl::ForeignKind::CFType) {
+          return false;
+        }
+      }
+
+      // TODO: ObjectMemoryReader for ELF and PE platforms still does not
+      // implement symbol relocations. For now, on non-Mach-O platforms,
+      // only symbolic reference things in the same module.
+      if (IGM.TargetInfo.OutputObjectFormat != llvm::Triple::MachO) {
+        auto formalAccessScope = type->getFormalAccessScope(nullptr, true);
+        if ((formalAccessScope.isPublic() || formalAccessScope.isInternal()) &&
+            (!IGM.CurSourceFile ||
+             IGM.CurSourceFile != type->getParentSourceFile())) {
+          return false;
+        }
+      }
       
       return true;
     } else if (auto opaque = s.dyn_cast<const OpaqueTypeDecl *>()) {

--- a/test/IRGen/access_type_metadata_by_mangled_name.swift
+++ b/test/IRGen/access_type_metadata_by_mangled_name.swift
@@ -2,11 +2,11 @@
 
 // CHECK: @"$s36access_type_metadata_by_mangled_name3FooCyAA3BarCyAA3ZimCyAA4ZangCGGGMD" = linkonce_odr hidden global { i32, i32 }
 
-// CHECK-little-SAME: @"symbolic 36access_type_metadata_by_mangled_name3FooCyAA3BarCyAA3ZimCyAA4ZangCGGG"
-// CHECK-little-SAME: i32 -71
+// CHECK-little-SAME: @"symbolic{{.*}}36access_type_metadata_by_mangled_name3FooC{{.*}}AA3BarC{{.*}}AA3ZimC{{.*}}AA4ZangC{{.*}}"
+// CHECK-little-SAME: i32 -{{[0-9]+}}
 
-// CHECK-big-SAME:    i32 -71
-// CHECK-big-SAME:    @"symbolic 36access_type_metadata_by_mangled_name3FooCyAA3BarCyAA3ZimCyAA4ZangCGGG"
+// CHECK-big-SAME:    i32 -{{[0-9]+}}
+// CHECK-big-SAME:    @"symbolic{{.*}}36access_type_metadata_by_mangled_name3FooC{{.*}}AA3BarC{{.*}}AA3ZimCyAA4ZangC{{.*}}"
 
 // CHECK-SAME: align 8
 

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -41,7 +41,7 @@ protocol HasThreeAssocTypes {
 // GLOBAL-SAME:    @"$s23associated_type_witness13WithUniversalVAA8AssockedAAMc"
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness13WithUniversalVAA8AssockedAA5AssocAaDP_AA1P",
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness13WithUniversalVAA8AssockedAA5AssocAaDP_AA1Q"
-// GLOBAL-SAME:    i64 add (i64 ptrtoint (<{ [36 x i8], i8 }>* @"symbolic 23associated_type_witness9UniversalV" to i64), i64 1) to i8*)
+// GLOBAL-SAME:    i64 add (i64 ptrtoint (<{ {{.*}} }>* @"symbolic{{.*}}23associated_type_witness9UniversalV" to i64), i64 1) to i8*)
 // GLOBAL-SAME:  ]
 struct WithUniversal : Assocked {
   typealias Assoc = Universal
@@ -52,7 +52,7 @@ struct WithUniversal : Assocked {
 // GLOBAL-SAME:    @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAMc"
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5Assoc_AA1P"
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5Assoc_AA1Q"
-// GLOBAL-SAME:    @"symbolic 23associated_type_witness9UniversalV"
+// GLOBAL-SAME:    @"symbolic{{.*}}23associated_type_witness9UniversalV"
 // GLOBAL-SAME:  ]
 struct GenericWithUniversal<T> : Assocked {
   typealias Assoc = Universal
@@ -90,7 +90,7 @@ struct Pair<T, U> : P, Q {}
 // GLOBAL-SAME:    @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc"
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1P"
 // GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1Q"
-// GLOBAL-SAME:    @"symbolic 23associated_type_witness4PairVyxq_G"
+// GLOBAL-SAME:    @"symbolic{{.*}}23associated_type_witness4PairV{{.*}}"
 // GLOBAL-SAME:  ]
 
 struct Computed<T, U> : Assocked {

--- a/test/IRGen/class_update_callback_with_stub.swift
+++ b/test/IRGen/class_update_callback_with_stub.swift
@@ -29,7 +29,7 @@ import resilient_objc_class
 // -- field descriptor
 // CHECK-SAME: @"$s31class_update_callback_with_stub17ResilientSubclassCMF"
 // -- superclass
-// CHECK-SAME: @"symbolic 15resilient_class22ResilientOutsideParentC"
+// CHECK-SAME: @"symbolic{{[^"]*}}15resilient_class22ResilientOutsideParentC"
 // -- metadata bounds
 // CHECK-SAME: @"$s31class_update_callback_with_stub17ResilientSubclassCMo"
 // -- extra class flags -- has Objective-C resilient class stub

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -61,7 +61,7 @@ sil_vtable C2 {}
 // -- %a: S.x
 // CHECK: [[KP_A:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"symbolic 8keypaths1SV"
+// CHECK-SAME: @"symbolic{{.*}}8keypaths1SV"
 // CHECK-SAME: @"symbolic Si
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
@@ -71,7 +71,7 @@ sil_vtable C2 {}
 // -- %b: S.y
 // CHECK: [[KP_B:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"symbolic 8keypaths1SV
+// CHECK-SAME: @"symbolic{{.*}}8keypaths1SV
 // CHECK-SAME: @"symbolic SS
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
@@ -82,8 +82,8 @@ sil_vtable C2 {}
 // -- %c: S.z
 // CHECK: [[KP_C:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: [[WORD]]* @keypath_once
-// CHECK-SAME: @"symbolic 8keypaths1SV
-// CHECK-SAME: @"symbolic 8keypaths1CC
+// CHECK-SAME: @"symbolic{{.*}}8keypaths1SV
+// CHECK-SAME: @"symbolic{{.*}}8keypaths1CC
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // -- offset of S.z, mutable
@@ -237,7 +237,7 @@ sil_vtable C2 {}
 // CHECK: [[KP_I:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"generic environment l"
-// CHECK-SAME: @"symbolic 8keypaths3GenVyxxG"
+// CHECK-SAME: @"symbolic{{[^"]*}}8keypaths3GenV{{[^"]*}}"
 // CHECK-SAME: @"symbolic x"
 //             -- size 8
 // CHECK-SAME: i32 8,
@@ -250,7 +250,7 @@ sil_vtable C2 {}
 // CHECK: [[KP_J:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"generic environment l"
-// CHECK-SAME: @"symbolic 8keypaths3GenVyxxG"
+// CHECK-SAME: @"symbolic{{[^"]*}}8keypaths3GenV{{[^"]*}}"
 // CHECK-SAME: @"symbolic x"
 //             -- size 8
 // CHECK-SAME: i32 8,
@@ -305,7 +305,7 @@ sil_vtable C2 {}
 // -- %gcx: GC<T>.x
 // CHECK: [[KP_GCX:@keypath(\..*)?]] = private global <{ {{.*}} }> <{
 // CHECK-SAME: @"generic environment l"
-// CHECK-SAME: @"symbolic 8keypaths2GCCyxG"
+// CHECK-SAME: @"symbolic{{[^"]*}}8keypaths2GCC{{[^"]*}}"
 // CHECK-SAME: @"symbolic x"
 //             -- class with runtime-resolved offset, mutable
 // CHECK-SAME: <i32 0x3fffffe>

--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -156,10 +156,10 @@ extension Container.Conformancy3: HasAssoc where T == Outer {
 }
 
 // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO12Conformancy3Vyx_GAA8HasAssocA2A5OuterORszrlWP" =
-// CHECK-CONSTANTS-SAME: @"symbolic 15nested_generics5OuterO"
+// CHECK-CONSTANTS-SAME: @"symbolic{{.*}}15nested_generics5OuterO"
 
 // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO12Conformancy2Vyx_qd__GAA8HasAssocA2A5OuterORszrlWP" =
-// CHECK-CONSTANTS-SAME: @"symbolic 15nested_generics5OuterO"
+// CHECK-CONSTANTS-SAME: @"symbolic{{.*}}15nested_generics5OuterO"
 
 // CHECK-CONSTANTS-LABEL: @"$s15nested_generics9ContainerO11ConformancyVyx_qd__GAA8HasAssocAAWP" =
-// CHECK-CONSTANTS-SAME: @"symbolic 15nested_generics5OuterO"
+// CHECK-CONSTANTS-SAME: @"symbolic{{.*}}15nested_generics5OuterO"

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -43,7 +43,7 @@ struct Conformer: Q, QQ {
 // CHECK: ]
 // CHECK: [[CONFORMER_P_WITNESS_TABLE]] = hidden global [5 x i8*] [
 // CHECK:   @"associated conformance 18sil_witness_tables9ConformerVAA1PAA5AssocAaDP_AA1A"
-// CHECK:   "symbolic 18sil_witness_tables14AssocConformerV"
+// CHECK:   "symbolic{{.*}}18sil_witness_tables14AssocConformerV"
 // CHECK:   i8* bitcast (void (%swift.type*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP12staticMethod{{[_0-9a-zA-Z]*}}FZTW" to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1PA2aDP14instanceMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)
 // CHECK: ]

--- a/test/IRGen/witness_table_indirect_conformances.swift
+++ b/test/IRGen/witness_table_indirect_conformances.swift
@@ -33,7 +33,7 @@ struct Z: P2 {
 // CHECK: @"$s35witness_table_indirect_conformances1WVAA2P3AAWP" = hidden global [5 x i8*] [
 // CHECK-SAME: @"$s35witness_table_indirect_conformances1WVAA2P3AAMc"
 // CHECK-SAME: @"associated conformance 35witness_table_indirect_conformances1WVAA2P3AA05AssocE0AaDP_AA2P2"
-// CHECK-SAME: @"symbolic 35witness_table_indirect_conformances1ZV"
+// CHECK-SAME: @"symbolic{{.*}}35witness_table_indirect_conformances1ZV"
 // CHECK-SAME: i8* bitcast (void (%T35witness_table_indirect_conformances1ZV*, %T35witness_table_indirect_conformances1WV*, %swift.type*, i8**)* @"$s35witness_table_indirect_conformances1WVAA2P3A2aDP08getAssocE00gE0QzyFTW" to i8*)]
 struct W: P3 {
 	typealias AssocP3 = Z

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -21,7 +21,7 @@ struct SB: B {
 }
 // CHECK-LABEL: @"$s34witness_table_objc_associated_type2SBVAA1BAAWP" = hidden global [4 x i8*] [
 // CHECK:         @"associated conformance 34witness_table_objc_associated_type2SBVAA1BAA2AAAaDP_AA1A"
-// CHECK:         @"symbolic 34witness_table_objc_associated_type2SAV"
+// CHECK:         @"symbolic{{.*}}34witness_table_objc_associated_type2SAV"
 // CHECK:         i8* bitcast {{.*}} @"$s34witness_table_objc_associated_type2SBVAA1BA2aDP3fooyyFTW"
 // CHECK:       ]
 
@@ -31,7 +31,7 @@ struct SO: C {
   func foo() {}
 }
 // CHECK-LABEL: @"$s34witness_table_objc_associated_type2SOVAA1CAAWP" = hidden global [3 x i8*] [
-// CHECK:         @"symbolic 34witness_table_objc_associated_type2COC"
+// CHECK:         @"symbolic{{.*}}34witness_table_objc_associated_type2COC"
 // CHECK:         i8* bitcast {{.*}} @"$s34witness_table_objc_associated_type2SOVAA1CA2aDP3fooyyFTW"
 // CHECK:       ]
 

--- a/test/Reflection/Inputs/main.swift
+++ b/test/Reflection/Inputs/main.swift
@@ -1,0 +1,3 @@
+// a dummy main.swift we can use to build executables to test reflection on
+// intentionally left blank
+

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,7 +1,11 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
+
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect
+
 // RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
+// RUN: %target-swift-reflection-dump -binary-filename %t/TypesToReflect | %FileCheck %s
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -81,128 +81,208 @@ template <typename T> static T unwrap(llvm::Expected<T> value) {
   exit(EXIT_FAILURE);
 }
 
-static void reportError(std::error_code EC) {
-  assert(EC);
-  llvm::errs() << "swift-reflection-test error: " << EC.message() << ".\n";
-  exit(EXIT_FAILURE);
-}
-
 using NativeReflectionContext =
     swift::reflection::ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
 using ReadBytesResult = swift::remote::MemoryReader::ReadBytesResult;
 
-static uint64_t getSectionAddress(SectionRef S) {
-  // See COFFObjectFile.cpp for the implementation of 
-  // COFFObjectFile::getSectionAddress. The image base address is added
-  // to all the addresses of the sections, thus the behavior is slightly different from
-  // the other platforms.
-  if (auto C = dyn_cast<COFFObjectFile>(S.getObject()))
-    return S.getAddress() - C->getImageBase();
-  return S.getAddress();
-}
-
-static bool needToRelocate(SectionRef S) {
-  if (!getSectionAddress(S))
-    return false;
-
-  if (auto EO = dyn_cast<ELFObjectFileBase>(S.getObject())) {
-    static const llvm::StringSet<> ELFSectionsList = {
-      ".data", ".rodata", "swift5_protocols", "swift5_protocol_conformances",
-      "swift5_typeref", "swift5_reflstr", "swift5_assocty", "swift5_replace",
-      "swift5_type_metadata", "swift5_fieldmd", "swift5_capture", "swift5_builtin"
-    };
-    StringRef Name;
-    if (auto EC = S.getName(Name))
-      reportError(EC);
-    return ELFSectionsList.count(Name);
-  }
-
-  return true;
-}
+// Since ObjectMemoryReader maintains ownership of the ObjectFiles and their
+// raw data, we can vend ReadBytesResults with no-op destructors.
+static void no_op_destructor(const void*) {}
 
 
 class Image {
-  const ObjectFile *O;
-  uint64_t VASize;
-
-  struct RelocatedRegion {
-    uint64_t Start, Size;
-    const char *Base;
+private:
+  struct Segment {
+    uint64_t Addr;
+    StringRef Contents;
   };
+  
+  uint64_t HeaderAddress;
+  std::vector<Segment> Segments;
+  
+  void scanMachO(const MachOObjectFile *O) {
+    using namespace llvm::MachO;
 
-  std::vector<RelocatedRegion> RelocatedRegions;
+    HeaderAddress = UINT64_MAX;
+    
+    for (const auto &Load : O->load_commands()) {
+      if (Load.C.cmd == LC_SEGMENT_64) {
+        auto Seg = O->getSegment64LoadCommand(Load);
+        if (Seg.filesize == 0)
+          continue;
+        
+        auto contents = O->getData().slice(Seg.fileoff,
+                                           Seg.fileoff + Seg.filesize);
+        
+        if (contents.empty() || contents.size() != Seg.filesize)
+          continue;
+        
+        Segments.push_back({Seg.vmaddr, contents});
+        HeaderAddress = std::min(HeaderAddress, Seg.vmaddr);
+      } else if (Load.C.cmd == LC_SEGMENT) {
+        auto Seg = O->getSegmentLoadCommand(Load);
+        if (Seg.filesize == 0)
+          continue;
+        
+        auto contents = O->getData().slice(Seg.fileoff,
+                                           Seg.fileoff + Seg.filesize);
+        
+        if (contents.empty() || contents.size() != Seg.filesize)
+          continue;
+        
+        Segments.push_back({Seg.vmaddr, contents});
+        HeaderAddress = std::min(HeaderAddress, (uint64_t)Seg.vmaddr);
+      }
+    }
+  }
+  
+  template<typename ELFT>
+  void scanELFType(const ELFObjectFile<ELFT> *O) {
+    using namespace llvm::ELF;
+
+    HeaderAddress = UINT64_MAX;
+
+    auto phdrs = O->getELFFile()->program_headers();
+    if (!phdrs) {
+      llvm::consumeError(phdrs.takeError());
+      return;
+    }
+
+    for (auto &ph : *phdrs) {
+      if (ph.p_filesz == 0)
+        continue;
+      
+      auto contents = O->getData().slice(ph.p_offset,
+                                         ph.p_offset + ph.p_filesz);
+      if (contents.empty() || contents.size() != ph.p_filesz)
+        continue;
+      
+      Segments.push_back({ph.p_vaddr, contents});
+      HeaderAddress = std::min(HeaderAddress, (uint64_t)ph.p_vaddr);
+    }
+  }
+  
+  void scanELF(const ELFObjectFileBase *O) {
+    if (auto le32 = dyn_cast<ELFObjectFile<ELF32LE>>(O)) {
+      scanELFType(le32);
+    } else if (auto be32 = dyn_cast<ELFObjectFile<ELF32BE>>(O)) {
+      scanELFType(be32);
+    } else if (auto le64 = dyn_cast<ELFObjectFile<ELF64LE>>(O)) {
+      scanELFType(le64);
+    } else if (auto be64 = dyn_cast<ELFObjectFile<ELF64BE>>(O)) {
+      scanELFType(be64);
+    }
+    
+    // FIXME: ReflectionContext tries to read bits of the ELF structure that
+    // aren't normally mapped by a phdr. Until that's fixed,
+    // allow access to the whole file 1:1 in address space that isn't otherwise
+    // mapped.
+    Segments.push_back({HeaderAddress, O->getData()});
+  }
+  
+  void scanCOFF(const COFFObjectFile *O) {
+    HeaderAddress = O->getImageBase();
+    
+    for (auto SectionRef : O->sections()) {
+      auto Section = O->getCOFFSection(SectionRef);
+      
+      if (Section->SizeOfRawData == 0)
+        continue;
+      
+      auto SectionBase = O->getImageBase() + Section->VirtualAddress;
+      auto SectionContent =
+        O->getData().slice(Section->PointerToRawData,
+                           Section->PointerToRawData + Section->SizeOfRawData);
+      if (SectionContent.empty()
+          || SectionContent.size() != Section->SizeOfRawData)
+        continue;
+      
+      Segments.push_back({SectionBase, SectionContent});
+    }
+    
+    Segments.push_back({HeaderAddress, O->getData()});
+  }
 
 public:
-  explicit Image(const ObjectFile *O) : O(O), VASize(O->getData().size()) {
-    for (SectionRef S : O->sections()) {
-      if (!needToRelocate(S))
+  explicit Image(const ObjectFile *O) {
+    // Unfortunately llvm doesn't provide a uniform interface for iterating
+    // loadable segments or dynamic relocations in executable images yet.
+    if (auto macho = dyn_cast<MachOObjectFile>(O)) {
+      scanMachO(macho);
+    } else if (auto elf = dyn_cast<ELFObjectFileBase>(O)) {
+      scanELF(elf);
+    } else if (auto coff = dyn_cast<COFFObjectFile>(O)) {
+      scanCOFF(coff);
+    } else {
+      fputs("unsupported image format\n", stderr);
+      abort();
+    }
+    
+    // ObjectMemoryReader uses the most significant 16 bits of the address to
+    // index multiple images, so if an object maps stuff out of that range
+    // we won't be able to read it. 2**48 of virtual address space ought to be
+    // enough for anyone, but warn if we blow that limit.
+    for (auto Segment : Segments) {
+      if (Segment.Addr >= 0xFFFFFFFFFFFFull) {
+        fputs("warning: segment mapped at address above 2**48\n", stderr);
         continue;
-      auto SectionAddr = getSectionAddress(S);
-      if (SectionAddr)
-        VASize = std::max(VASize, SectionAddr + S.getSize());
+      }
+    }
+  }
+    
+  uint64_t getStartAddress() const {
+    return HeaderAddress;
+  }
 
-     llvm::Expected<llvm::StringRef> Content = S.getContents();
-      if (!Content)
-        reportError(errorToErrorCode(Content.takeError()));
-
-      auto PhysOffset = (uintptr_t)Content->data() - (uintptr_t)O->getData().data();
+  StringRef getContentsAtAddress(uint64_t Addr, uint64_t Size) const {
+    for (auto &Segment : Segments) {
+      auto addrInSegment = Segment.Addr <= Addr
+        && Addr + Size <= Segment.Addr + Segment.Contents.size();
       
-      if (PhysOffset == SectionAddr) {
+      if (!addrInSegment)
         continue;
-      }
 
-      RelocatedRegions.push_back(RelocatedRegion{
-        SectionAddr,
-        Content->size(),
-        Content->data()});
+      auto offset = Addr - Segment.Addr;
+          
+      return Segment.Contents.drop_front(offset);
     }
-  }
-
-  RemoteAddress getStartAddress() const {
-    return RemoteAddress((uintptr_t)O->getData().data());
-  }
-
-  bool isAddressValid(RemoteAddress Addr, uint64_t Size) const {
-    auto start = getStartAddress().getAddressData();
-    return start <= Addr.getAddressData()
-      && Addr.getAddressData() + Size <= start + VASize;
-  }
-
-  ReadBytesResult readBytes(RemoteAddress Addr, uint64_t Size) {
-    if (!isAddressValid(Addr, Size))
-      return ReadBytesResult(nullptr, [](const void *) {});
-    
-    auto addrValue = Addr.getAddressData();
-    auto base = O->getData().data();
-    auto offset = addrValue - (uint64_t)base;
-    for (auto &region : RelocatedRegions) {
-      if (region.Start <= offset && offset < region.Start + region.Size) {
-        // Read shouldn't need to straddle section boundaries.
-        if (offset + Size > region.Start + region.Size)
-          return ReadBytesResult(nullptr, [](const void *) {});
-
-        offset -= region.Start;
-        base = region.Base;
-        break;
-      }
-    }
-    
-    return ReadBytesResult(base + offset, [](const void *) {});
+    return {};
   }
 };
 
+/// MemoryReader that reads from the on-disk representation of an executable
+/// or dynamic library image.
+///
+/// This reader uses a remote addressing scheme where the most significant
+/// 16 bits of the address value serve as an index into the array of loaded images,
+/// and the low 48 bits correspond to the preferred virtual address mapping of
+/// the image.
 class ObjectMemoryReader : public MemoryReader {
   std::vector<Image> Images;
 
+  StringRef getContentsAtAddress(uint64_t Addr, uint64_t Size) {
+    auto imageIndex = Addr >> 48;
+    if (imageIndex >= Images.size())
+      return StringRef();
+    
+    return Images[imageIndex]
+      .getContentsAtAddress(Addr & 0xFFFFFFFFFFFFull, Size);
+  }
+  
 public:
   explicit ObjectMemoryReader(
       const std::vector<const ObjectFile *> &ObjectFiles) {
+    // We use a 16-bit index for images, so can't take more than 64K at once.
+    if (ObjectFiles.size() >= 0x10000) {
+      fputs("can't dump more than 65,536 images at once", stderr);
+      abort();
+    }
     for (const ObjectFile *O : ObjectFiles)
       Images.emplace_back(O);
   }
 
-  const std::vector<Image> &getImages() const { return Images; }
+  ArrayRef<Image> getImages() const { return Images; }
 
   bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
                        void *outBuffer) override {
@@ -221,25 +301,41 @@ public:
 
     return false;
   }
+  
+  RemoteAddress getImageStartAddress(unsigned i) const {
+    assert(i < Images.size());
+    
+    return RemoteAddress(Images[i].getStartAddress() | ((uint64_t)i << 48));
+  }
 
+  // TODO: We could consult the dynamic symbol tables of the images to
+  // implement this.
   RemoteAddress getSymbolAddress(const std::string &name) override {
     return RemoteAddress(nullptr);
   }
 
   ReadBytesResult readBytes(RemoteAddress Addr, uint64_t Size) override {
-    auto I = std::find_if(Images.begin(), Images.end(), [=](const Image &I) {
-      return I.isAddressValid(Addr, Size);
-    });
-    return I == Images.end() ? ReadBytesResult(nullptr, [](const void *) {})
-                             : I->readBytes(Addr, Size);
+    auto addrValue = Addr.getAddressData();
+    auto resultBuffer = getContentsAtAddress(addrValue, Size);
+    return ReadBytesResult(resultBuffer.data(), no_op_destructor);
   }
 
   bool readString(RemoteAddress Addr, std::string &Dest) override {
-    ReadBytesResult R = readBytes(Addr, 1);
-    if (!R)
+    auto addrValue = Addr.getAddressData();
+    auto resultBuffer = getContentsAtAddress(addrValue, 1);
+    if (resultBuffer.empty())
       return false;
-    StringRef Str((const char *)R.get());
-    Dest.append(Str.begin(), Str.end());
+    
+    // Make sure there's a null terminator somewhere in the contents.
+    unsigned i = 0;
+    for (unsigned e = resultBuffer.size(); i < e; ++i) {
+      if (resultBuffer[i] == 0)
+        goto found_terminator;
+    }
+    return false;
+    
+  found_terminator:
+    Dest.append(resultBuffer.begin(), resultBuffer.begin() + i);
     return true;
   }
 };
@@ -275,8 +371,9 @@ static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
 
   auto Reader = std::make_shared<ObjectMemoryReader>(ObjectFiles);
   NativeReflectionContext Context(Reader);
-  for (const Image &I : Reader->getImages())
-    Context.addImage(I.getStartAddress());
+  for (unsigned i = 0, e = Reader->getImages().size(); i < e; ++i) {
+    Context.addImage(Reader->getImageStartAddress(i));
+ }
 
   switch (Action) {
   case ActionType::DumpReflectionSections:


### PR DESCRIPTION
Wire up support in `swift-reflection-dump` to correctly handle pointer values and walk the binding table in Mach-O images to follow unresolved symbol references, so that we can safely unconditionally use symbolic references in runtime mangled names without regressing offline reflection support.