### PR TITLE
Reenable runtime tests

### DIFF
--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -6,7 +6,6 @@
 // doesn't pass through the crash, and `not` may not be available when running
 // on a remote host.
 
-// REQUIRES: rdar55490694
 // This is not supported on watchos, ios, or tvos
 // UNSUPPORTED: OS=watchos
 // UNSUPPORTED: OS=ios

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,8 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %{python} %S/../Inputs/not.py "%target-run %t/a.out" 2>&1 | PYTHONPATH=%lldb-python-path %{python} %utils/symbolicate-linux-fatal %t/a.out - | %{python} %utils/backtrace-check -u
-
-// REQUIRES: rdar55490694
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb


### PR DESCRIPTION
<!-- What's in this pull request? -->
Reenable runtime tests disabled in #27380 and #27408

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes rdar://problem/55490694

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
