### PR TITLE
Update checkout for lldb.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -470,7 +470,7 @@
                 "llvm": "swift-DEVELOPMENT-SNAPSHOT-2019-09-24-a",
                 "clang": "fcefc0babd0915287ee479d2baee5bb020de014b",
                 "swift": "tensorflow",
-                "lldb": "8fc11a104c0930656469442bbc059eb1a2a52955",
+                "lldb": "80f1d3cce6d5dc2424b0ef4622e0b2ca186453fd",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2019-09-24-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2019-09-24-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2019-09-24-a",


### PR DESCRIPTION
https://github.com/apple/swift-lldb/commit/80f1d3cce6d5dc2424b0ef4622e0b2ca186453fd

Necessary since the old commit https://github.com/apple/swift-lldb/commit/8fc11a104c0930656469442bbc059eb1a2a52955 doesn't exist in `tensorflow` branch history and can't be fetched:
```
swift-dev/lldb failed (ret=128): ['git', 'checkout', u'8fc11a104c0930656469442bbc059eb1a2a52955']
fatal: reference is not a tree: 8fc11a104c0930656469442bbc059eb1a2a52955

update-checkout failed, fix errors and try again
```

I pushed a [workaround branch](https://github.com/apple/swift-lldb/tree/tensorflow-merge-old) but updating the checkout is more robust.