### PR TITLE
[windows] Adapt Windows build script to latest changes.

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -145,7 +145,7 @@ cmake "%source_root%\llvm"^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
-    -DCMAKE_INSTALL_PREFIX=%install_directory%^
+    -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
     -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
     -DLLVM_ENABLE_PDB:BOOL=YES^
     -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
@@ -215,27 +215,27 @@ cmake "%source_root%\swift"^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
-    -DCMAKE_INSTALL_PREFIX=%install_directory%^
-    -DClang_DIR=%build_root%\llvm\lib\cmake\clang^
-    -DSWIFT_PATH_TO_CMARK_BUILD=%build_root%\cmark^
-    -DSWIFT_PATH_TO_CMARK_SOURCE=%source_root%\cmark^
-    -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE=%source_root%\swift-corelibs-libdispatch^
-    -DLLVM_DIR=%build_root%\llvm\lib\cmake\llvm^
-    -DSWIFT_INCLUDE_DOCS=NO^
-    -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=%source_root%\icu-%icu_version%\include\unicode^
-    -DSWIFT_WINDOWS_x86_64_ICU_UC=%source_root%\icu-%icu_version%\lib64\icuuc.lib^
-    -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=%source_root%\icu-%icu_version%\include^
-    -DSWIFT_WINDOWS_x86_64_ICU_I18N=%source_root%\icu-%icu_version%\lib64\icuin.lib^
-    -DSWIFT_BUILD_DYNAMIC_STDLIB=YES^
-    -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY=YES^
-    -DSWIFT_BUILD_STATIC_STDLIB=NO^
-    -DSWIFT_BUILD_STATIC_SDK_OVERLAY=NO^
-    -DLLVM_INSTALL_TOOLCHAIN_ONLY=YES^
-    -DSWIFT_BUILD_SOURCEKIT=YES^
-    -DSWIFT_ENABLE_SOURCEKIT_TESTS=NO^
+    -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
+    -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^
+    -DSWIFT_PATH_TO_CMARK_BUILD:PATH=%build_root%\cmark^
+    -DSWIFT_PATH_TO_CMARK_SOURCE:PATH=%source_root%\cmark^
+    -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH=%source_root%\swift-corelibs-libdispatch^
+    -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
+    -DSWIFT_INCLUDE_DOCS:BOOL=NO^
+    -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE:PATH=%source_root%\icu-%icu_version%\include\unicode^
+    -DSWIFT_WINDOWS_x86_64_ICU_UC:PATH=%source_root%\icu-%icu_version%\lib64\icuuc.lib^
+    -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE:PATH=%source_root%\icu-%icu_version%\include^
+    -DSWIFT_WINDOWS_x86_64_ICU_I18N:PATH=%source_root%\icu-%icu_version%\lib64\icuin.lib^
+    -DSWIFT_BUILD_DYNAMIC_STDLIB:BOOL=YES^
+    -DSWIFT_BUILD_DYNAMIC_SDK_OVERLAY:BOOL=YES^
+    -DSWIFT_BUILD_STATIC_STDLIB:BOOL=NO^
+    -DSWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL=NO^
+    -DLLVM_INSTALL_TOOLCHAIN_ONLY:BOOL=YES^
+    -DSWIFT_BUILD_SOURCEKIT:BOOL=YES^
+    -DSWIFT_ENABLE_SOURCEKIT_TESTS:BOOL=NO^
     -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
     -DSWIFT_PARALLEL_LINK_JOBS=8^
-    -DPYTHON_EXECUTABLE=%PYTHON_HOME%\python.exe^
+    -DPYTHON_EXECUTABLE:PATH=%PYTHON_HOME%\python.exe^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
@@ -271,21 +271,17 @@ cmake "%source_root%\lldb"^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=clang-cl^
     -DCMAKE_CXX_COMPILER=clang-cl^
-    -DCMAKE_INSTALL_PREFIX=%install_directory%^
-    -DLLDB_PATH_TO_CMARK_SOURCE=%source_root%\cmark^
-    -DLLDB_PATH_TO_CLANG_SOURCE=%source_root%\clang^
-    -DLLDB_PATH_TO_LLVM_SOURCE=%source_root%\llvm^
-    -DLLDB_PATH_TO_SWIFT_SOURCE=%source_root%\swift^
-    -DLLDB_PATH_TO_CMARK_BUILD=%build_root%\cmark^
-    -DLLDB_PATH_TO_CLANG_BUILD=%build_root%\llvm^
-    -DLLDB_PATH_TO_LLVM_BUILD=%build_root%\llvm^
-    -DLLDB_PATH_TO_SWIFT_BUILD=%build_root%\swift^
-    -DLLVM_ENABLE_ASSERTIONS=YES^
-    -DLLVM_ALLOW_STATIC_BINDINGS=YES^
-    -DPYTHON_HOME=%PYTHON_HOME%^
+    -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
+    -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
+    -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^
+    -DSwift_DIR:PATH=%build_root%\swift\lib\cmake\swift^
+    -DLLVM_ENABLE_ASSERTIONS:BOOL=YES^
+    -DLLDB_ALLOW_STATIC_BINDINGS:BOOL=YES^
+    -DPYTHON_HOME:PATH=%PYTHON_HOME%^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
-    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%
+    -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
+    -DLLDB_INCLUDE_TESTS:BOOL=NO %exitOnError%
 
 popd
 
@@ -296,7 +292,7 @@ goto :eof
 endlocal
 
 
-:build_lldb
+:build_libdispatch
 :: Configures, builds, and installs Dispatch
 setlocal enableextensions enabledelayedexpansion
 
@@ -308,13 +304,13 @@ cmake "%source_root%\swift-corelibs-libdispatch"^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=clang-cl^
     -DCMAKE_CXX_COMPILER=clang-cl^
-    -DCMAKE_SWIFT_COMPILER=%install_directory%\bin\swiftc.exe^
-    -DSwift_DIR=%build_root%\swift\lib\cmake\swift^
-    -DCMAKE_INSTALL_PREFIX=%install_directory%^
-    -DBUILD_SHARED_LIBS=YES^
-    -DENABLE_TESTING=NO^
+    -DCMAKE_SWIFT_COMPILER:PATH=%install_directory%\bin\swiftc.exe^
+    -DSwift_DIR:PATH=%build_root%\swift\lib\cmake\swift^
+    -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
+    -DBUILD_SHARED_LIBS:BOOL=YES^
+    -DENABLE_TESTING:BOOL=NO^
     -DCMAKE_C_COMPILER_TARGET=x86_64-unknown-windows-msvc^
-    -DENABLE_SWIFT=YES^
+    -DENABLE_SWIFT:BOOL=YES^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO %exitOnError%


### PR DESCRIPTION
LLDB in Windows was failing to build in the community CI. From comparing
the invocation of build-script-impl and windows-build.bat it seems that
we have migrated from LLDB_PATH_TO_*_SOURCE/BUILD variables to *_DIR
variables.

Additionally I needed to disable building the test on Windows because
the community CI doesn't build LLD, which seems to be needed for the
tests. I don't understand exactly why before the test were being skipped
automatically.

Also, a lot of CMake variables have been annotated with their expected
types. At least the new *_DIR variables were being interpreted as
strings in one occassion and the path separators were making CMake fail.
The other case was a boolean that must have been interpreted as a
string.

@compnerd: You might need to make some of these changes in the Azure CI configuration too, but I leave that to your decision. I also took the liberty to modify the documentation a little.