### PR TITLE
[Doc] Fix errors in SIL.rst.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5601,7 +5601,7 @@ Automatic Differentiation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 differentiable_function
-`````````````````
+```````````````````````
 
 ::
 
@@ -5645,7 +5645,7 @@ In canonical SIL, a ``with`` clause is mandatory.
 
 
 differentiable_function_extract
-`````````````````````````
+```````````````````````````````
 
 ::
 

--- a/test/AutoDiff/differentiable_function_silgen.swift
+++ b/test/AutoDiff/differentiable_function_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s -check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s -check-prefix=CHECK-AST
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s -check-prefix=CHECK-SILGEN
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s -check-prefix=CHECK-SIL
 


### PR DESCRIPTION
Fix "Title underline too short" errors:

    Warning, treated as error:
    /Users/danielzheng/swift-dev/swift/docs/SIL.rst:5604:Title underline too short.
    
    differentiable_function
    `````````````````
    make: *** [/Users/danielzheng/swift-dev/build/Xcode-ReleaseAssert+swift-DebugAssert/swift-macosx-x86_64/docs/CMakeFiles/docs_html] Error 2
    Command /bin/sh failed with exit code 2

Todo: install Sphinx on TensorFlow CI machines to catch these errors.