### PR TITLE
[5.1] Fix sub-scalar index distances in foreign UTF8 views

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -95,6 +95,7 @@ internal func _cocoaStringUTF8Count(
   _ target: _CocoaString,
   range: Range<Int>
 ) -> Int? {
+  if range.isEmpty { return 0 }
   var count = 0
   let len = _stdlib_binary_CFStringGetLength(target)
   let converted = _swift_stdlib_CFStringGetBytes(

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -505,7 +505,7 @@ extension String.UTF8View {
       // _cocoaStringUTF8Count gave us the scalar aligned count, but we still
       // need to compensate for sub-scalar indexing, e.g. if `i` is in the
       // middle of a two-byte UTF8 scalar.
-      let refinedCount = count - (i.transcodedOffset + j.transcodedOffset)
+      let refinedCount = (count - i.transcodedOffset) + j.transcodedOffset
       _internalInvariant(refinedCount == _distance(from: i, to: j))
       return refinedCount
     }

--- a/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
+++ b/test/stdlib/Inputs/FoundationBridge/FoundationBridge.h
@@ -86,12 +86,12 @@ static inline BOOL NSStringBridgeTestEqual(NSString * _Nonnull a, NSString * _No
 }
 
 static inline NSString *getNSStringWithUnpairedSurrogate() {
-  unichar chars[16] = {
+  unichar chars[19] = {
     0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
     0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
     0x0020, 0x0020, 0x0020, 0x0020, 0x0020, 0x0020,
     0xD800 };
-  return [NSString stringWithCharacters:chars length:1];
+  return [NSString stringWithCharacters:chars length:19];
 }
 
 NS_ASSUME_NONNULL_END

--- a/test/stdlib/Inputs/NSSlowString/NSSlowString.m
+++ b/test/stdlib/Inputs/NSSlowString/NSSlowString.m
@@ -22,7 +22,7 @@
     return self.stringHolder.length;
 }
 
-- (id)copy {
+- (id)copyWithZone:(NSZone *)unused {
 	return self;
 }
 

--- a/test/stdlib/TestNSString.swift
+++ b/test/stdlib/TestNSString.swift
@@ -60,6 +60,7 @@ class TestNSString : TestNSStringSuper {
   func test_unpairedSurrogates() {
     let evil = getNSStringWithUnpairedSurrogate();
     print("\(evil)")
+    print(evil.data(using: .utf8))
   }
   
 }


### PR DESCRIPTION
(cherry picked from commit 0887299d9ec23c5bf643eeab18e3a453c51cc204)

Fixes rdar://55736405