### PR TITLE
Fix StringInterpolationProtocol validation crasher

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6999,11 +6999,8 @@ StaticSpellingKind FuncDecl::getCorrectStaticSpelling() const {
 }
 
 Type FuncDecl::getResultInterfaceType() const {
-  if (!hasInterfaceType())
-    return nullptr;
-
   Type resultTy = getInterfaceType();
-  if (resultTy->is<ErrorType>())
+  if (resultTy.isNull() || resultTy->is<ErrorType>())
     return resultTy;
 
   if (hasImplicitSelfDecl())

--- a/validation-test/compiler_crashers_2_fixed/0208-rdar55864759.swift
+++ b/validation-test/compiler_crashers_2_fixed/0208-rdar55864759.swift
@@ -1,0 +1,3 @@
+// RUN: not %target-swift-frontend -typecheck %s %S/Inputs/0208-rdar55864759-protocol.swift
+struct StringInterpolation: MagicStringInterpolationProtocol {}
+

--- a/validation-test/compiler_crashers_2_fixed/Inputs/0208-rdar55864759-protocol.swift
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/0208-rdar55864759-protocol.swift
@@ -1,0 +1,6 @@
+protocol MagicStringInterpolationProtocol: StringInterpolationProtocol {}
+
+extension MagicStringInterpolationProtocol {
+  mutating func appendInterpolation<Value>(_ value: Value) {}
+}
+


### PR DESCRIPTION
Some old circularity-breaking code caused an unexpected null type, which led to crashes in the decl checker when trying to check that an `appendInterpolation` method in a different file would satisfy the informal requirement for one in a `StringInterpolationProtocol` conformer. This code appears to now be unnecessary, so this commit removes it. Fixes rdar://problem/55864759.
