### PR TITLE
Sema: Don't visit local types when computing captures

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -365,6 +365,11 @@ public:
       return false;
     }
 
+    // Don't walk into local types; we'll walk their initializers when we check
+    // the local type itself.
+    if (isa<NominalTypeDecl>(D))
+      return false;
+
     return true;
   }
 

--- a/test/SILGen/Inputs/lazy_properties_other.swift
+++ b/test/SILGen/Inputs/lazy_properties_other.swift
@@ -1,0 +1,14 @@
+public class C2 {
+  public final func f() {
+    func local() {
+      _ = {
+        class Local {
+          lazy var a = {
+            return b
+          }()
+          var b = 123
+        }
+      }
+    }
+  }
+}

--- a/test/SILGen/lazy_properties_multi.swift
+++ b/test/SILGen/lazy_properties_multi.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/lazy_properties_other.swift -module-name lazy_properties_multi | %FileCheck %s
+// RUN: %target-swift-emit-silgen %S/Inputs/lazy_properties_other.swift -primary-file %s -module-name lazy_properties_multi | %FileCheck %s
+// RUN: %target-swift-emit-silgen %S/Inputs/lazy_properties_other.swift %s -module-name lazy_properties_multi | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s %S/Inputs/lazy_properties_other.swift -module-name lazy_properties_multi | %FileCheck %s
+
+
+public class C1 {
+  // CHECK-LABEL: sil [ossa] @$s21lazy_properties_multi2C1C1f1cyAA2C2C_tF : $@convention(method) (@guaranteed C2, @guaranteed C1) -> () {
+  // CHECK: [[FN:%.*]] = function_ref @$s21lazy_properties_multi2C2C1fyyF : $@convention(method) (@guaranteed C2)
+  // CHECK: apply [[FN]](%0) : $@convention(method) (@guaranteed C2) -> ()
+  public func f(c: C2) {
+    c.f()
+  }
+}


### PR DESCRIPTION
Ordinarily in valid code, pattern binding initializers in local types cannot
capture anything from the outer scope. However one exception is lazy property
initializers, which can reference the lazy property initializer context's
'self' parameter.

If we computed captures for the outer function before synthesizing the lazy
property getter, we would think that the 'self' parameter was a capture of
the outer function, with hilarious results.

Fixes <rdar://problem/54712320>.
