### PR TITLE
[ClangImporter] Include -Xcc options in the PCH hash

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -103,7 +103,8 @@ public:
     using llvm::hash_combine;
 
     auto Code = hash_value(ModuleCachePath);
-    // ExtraArgs ignored - already considered in Clang's module hashing.
+    Code = hash_combine(Code, llvm::hash_combine_range(ExtraArgs.begin(),
+                                                       ExtraArgs.end()));
     Code = hash_combine(Code, OverrideResourceDir);
     Code = hash_combine(Code, TargetCPU);
     Code = hash_combine(Code, BridgingHeader);

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -46,6 +46,12 @@
 // RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
 // NO-VALIDATION: PCH file {{.*}} not found
 
+// Test that -Xcc options are considered in the PCH hash.
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h -Xcc -Ifoo
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h -Xcc -Ibar
+// RUN: ls %t/pch-Xcc/*swift*clang*.pch | count 3
+
 import Foundation
 
 let not = MyPredicate.not()


### PR DESCRIPTION
While most -Xcc options turn into options that affect the Clang module cache hash, some, like search paths, do not, and that can have a drastic effect on PCH contents. When combined with places where Xcode will modify invocations to add extra -Xcc options (see rdar://problem/23297285), this can lead to crashes where the modified-invocation PCH is used to compile source files in incremental mode, and then the original, non-precompiled bridging header is used for module merging. Let's just be conservative and include -Xcc options in the Swift-side PCH uniqueness hash.

rdar://problem/33837253