### PR TITLE
[global-string-table] Fix for ownership.

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SILOptimizer/Utils/CastOptimizer.h"
 #include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/Statistic.h"
@@ -1527,7 +1528,11 @@ static bool
 constantFoldGlobalStringTablePointerBuiltin(BuiltinInst *bi,
                                             bool enableDiagnostics) {
   // Look through string initializer to extract the string_literal instruction.
-  SILValue builtinOperand = bi->getOperand(0);
+  //
+  // We allow for a single borrow to be stripped here if we are here in
+  // [ossa]. The begin borrow occurs b/c SILGen treats builtins as having
+  // arguments with a +0 convention (implying a borrow).
+  SILValue builtinOperand = stripBorrow(bi->getOperand(0));
   SILFunction *caller = bi->getFunction();
 
   FullApplySite stringInitSite = FullApplySite::isa(builtinOperand);

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-ownership-stripping-after-serialization -primary-file %s -o /dev/null -verify
 //
 // These are tests for diagnostics produced by constant propagation pass.
 // Due to the change in the implementation of Integer initializers some of the


### PR DESCRIPTION
This involves teaching the constant folder to look through a borrow when trying
to find the string literal. I also added an additional run with ownership
lowering after diagnostics enabled to make sure this doesn't break again.
