### PR TITLE
[5.1] [ClangImporter] Include -Xcc options in the PCH hash

### DIFF
--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -107,7 +107,8 @@ public:
     using llvm::hash_combine;
 
     auto Code = hash_value(ModuleCachePath);
-    // ExtraArgs ignored - already considered in Clang's module hashing.
+    Code = hash_combine(Code, llvm::hash_combine_range(ExtraArgs.begin(),
+                                                       ExtraArgs.end()));
     Code = hash_combine(Code, OverrideResourceDir);
     Code = hash_combine(Code, TargetCPU);
     Code = hash_combine(Code, BridgingHeader);

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -46,6 +46,12 @@
 // RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
 // NO-VALIDATION: PCH file {{.*}} not found
 
+// Test that -Xcc options are considered in the PCH hash.
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h -Xcc -Ifoo
+// RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch-Xcc %S/Inputs/sdk-bridging-header.h -Xcc -Ibar
+// RUN: ls %t/pch-Xcc/*swift*clang*.pch | count 3
+
 import Foundation
 
 let not = MyPredicate.not()


### PR DESCRIPTION
- __Explanation__: When possible, Swift will precompile an app or unit test target's bridging header in order to make compilation faster. This is something SourceKit can take advantage of too for faster code completion and live issues. However, due to a workaround for another issue, SourceKit sometimes gets a different set of compiler flags from Xcode than a proper build does, resulting in a different interpretation of the bridging header. In this case, it's important that SourceKit not share its precompiled header with the normal build, or else the compiler can end up crashing due to the conflicting interpretations. This change makes sure the additional flags are used in choosing a unique location for the precompiled header.

- __Scope__: In theory, affects all Xcode targets with bridging headers; in practice, will mostly affect test targets for frameworks, especially those with custom module maps.

- __Issue__: rdar://problem/33837253

- __Risk__: Very low. This change is always conservatively correct.

- __Testing__: Added a regression test and ran the source compat suite; also verified that the reproducer from rdar://problem/41559684 no longer occurs. (The reproducer in rdar://problem/33837253 isn't one that occurs reliably.)

- __Reviewed by__: @benlangmuir 
