### PR TITLE
More idiomatic use of llvm::hash_combine in many places

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -54,7 +54,7 @@ class AnyRequest {
   friend llvm::DenseMapInfo<swift::AnyRequest>;
 
   static hash_code hashForHolder(uint64_t typeID, hash_code requestHash) {
-    return hash_combine(hash_value(typeID), requestHash);
+    return hash_combine(typeID, requestHash);
   }
 
   /// Abstract base class used to hold the specific request kind.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -380,8 +380,7 @@ struct WhereClauseOwner {
   SourceLoc getLoc() const;
 
   friend hash_code hash_value(const WhereClauseOwner &owner) {
-    return hash_combine(hash_value(owner.dc),
-                        hash_value(owner.source.getOpaqueValue()));
+    return llvm::hash_combine(owner.dc, owner.source.getOpaqueValue());
   }
 
   friend bool operator==(const WhereClauseOwner &lhs,

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -68,8 +68,7 @@ public:
   TypeLoc clone(ASTContext &ctx) const;
   
   friend llvm::hash_code hash_value(const TypeLoc &owner) {
-    return hash_combine(llvm::hash_value(owner.Ty.getPointer()),
-                        llvm::hash_value(owner.TyR));
+    return llvm::hash_combine(owner.Ty.getPointer(), owner.TyR);
   }
 
   friend bool operator==(const TypeLoc &lhs,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -441,12 +441,10 @@ namespace swift {
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Bridging PCH hash.
     llvm::hash_code getPCHHashComponents() const {
-      auto code = llvm::hash_value(Target.str());
       SmallString<16> Scratch;
       llvm::raw_svector_ostream OS(Scratch);
       OS << EffectiveLanguageVersion;
-      code = llvm::hash_combine(code, OS.str());
-      return code;
+      return llvm::hash_combine(Target.str(), OS.str());
     }
 
   private:

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -265,10 +265,8 @@ template <> struct DenseMapInfo<swift::SourceRange> {
   }
 
   static unsigned getHashValue(const swift::SourceRange &Val) {
-    return hash_combine(DenseMapInfo<const void *>::getHashValue(
-                            Val.Start.getOpaquePointerValue()),
-                        DenseMapInfo<const void *>::getHashValue(
-                            Val.End.getOpaquePointerValue()));
+    return hash_combine(Val.Start.getOpaquePointerValue(),
+                        Val.End.getOpaquePointerValue());
   }
 
   static bool isEqual(const swift::SourceRange &LHS,

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -99,23 +99,21 @@ public:
   /// Return a hash code of any components from these options that should
   /// contribute to a Swift Bridging PCH hash.
   llvm::hash_code getPCHHashComponents() const {
-    using llvm::hash_value;
     using llvm::hash_combine;
+    using llvm::hash_combine_range;
 
-    auto Code = hash_value(ModuleCachePath);
-    Code = hash_combine(Code, llvm::hash_combine_range(ExtraArgs.begin(),
-                                                       ExtraArgs.end()));
-    Code = hash_combine(Code, OverrideResourceDir);
-    Code = hash_combine(Code, TargetCPU);
-    Code = hash_combine(Code, BridgingHeader);
-    Code = hash_combine(Code, PrecompiledHeaderOutputDir);
-    Code = hash_combine(Code, static_cast<uint8_t>(Mode));
-    Code = hash_combine(Code, DetailedPreprocessingRecord);
-    Code = hash_combine(Code, ImportForwardDeclarations);
-    Code = hash_combine(Code, InferImportAsMember);
-    Code = hash_combine(Code, DisableSwiftBridgeAttr);
-    Code = hash_combine(Code, DisableOverlayModules);
-    return Code;
+    return hash_combine(ModuleCachePath,
+                        hash_combine_range(ExtraArgs.begin(), ExtraArgs.end()),
+                        OverrideResourceDir,
+                        TargetCPU,
+                        BridgingHeader,
+                        PrecompiledHeaderOutputDir,
+                        static_cast<uint8_t>(Mode),
+                        DetailedPreprocessingRecord,
+                        ImportForwardDeclarations,
+                        InferImportAsMember,
+                        DisableSwiftBridgeAttr,
+                        DisableOverlayModules);
   }
 };
 

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -38,8 +38,7 @@ struct CursorInfoOwner {
   CursorInfoOwner(SourceFile *File, SourceLoc Loc): File(File), Loc(Loc) { }
 
   friend llvm::hash_code hash_value(const CursorInfoOwner &CI) {
-    return hash_combine(hash_value(CI.File),
-      hash_value(CI.Loc.getOpaquePointerValue()));
+    return llvm::hash_combine(CI.File, CI.Loc.getOpaquePointerValue());
   }
 
   friend bool operator==(const CursorInfoOwner &lhs, const CursorInfoOwner &rhs) {
@@ -97,9 +96,9 @@ struct RangeInfoOwner {
   RangeInfoOwner(SourceFile *File, unsigned Offset, unsigned Length);
 
   friend llvm::hash_code hash_value(const RangeInfoOwner &CI) {
-    return hash_combine(hash_value(CI.File),
-                        hash_value(CI.StartLoc.getOpaquePointerValue()),
-                        hash_value(CI.EndLoc.getOpaquePointerValue()));
+    return llvm::hash_combine(CI.File,
+                              CI.StartLoc.getOpaquePointerValue(),
+                              CI.EndLoc.getOpaquePointerValue());
   }
 
   friend bool operator==(const RangeInfoOwner &lhs, const RangeInfoOwner &rhs) {
@@ -183,9 +182,9 @@ struct OverridenDeclsOwner {
       Transitive(Transitive) {}
 
   friend llvm::hash_code hash_value(const OverridenDeclsOwner &CI) {
-    return hash_combine(hash_value(CI.VD),
-                        hash_value(CI.IncludeProtocolRequirements),
-                        hash_value(CI.Transitive));
+    return llvm::hash_combine(CI.VD,
+                              CI.IncludeProtocolRequirements,
+                              CI.Transitive);
   }
 
   friend bool operator==(const OverridenDeclsOwner &lhs,

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -38,8 +38,7 @@ struct DeclApplicabilityOwner {
     DC(DC), Ty(Ty), ExtensionOrMember(VD) {}
 
   friend llvm::hash_code hash_value(const DeclApplicabilityOwner &CI) {
-    return hash_combine(hash_value(CI.Ty.getPointer()),
-                        hash_value(CI.ExtensionOrMember));
+    return llvm::hash_combine(CI.Ty.getPointer(), CI.ExtensionOrMember);
   }
 
   friend bool operator==(const DeclApplicabilityOwner &lhs,
@@ -96,8 +95,8 @@ struct TypePair {
   TypePair(Type FirstTy, Type SecondTy): FirstTy(FirstTy), SecondTy(SecondTy) {}
   TypePair(): TypePair(Type(), Type()) {}
   friend llvm::hash_code hash_value(const TypePair &TI) {
-    return hash_combine(hash_value(TI.FirstTy.getPointer()),
-                        hash_value(TI.SecondTy.getPointer()));
+    return llvm::hash_combine(TI.FirstTy.getPointer(),
+                              TI.SecondTy.getPointer());
   }
 
   friend bool operator==(const TypePair &lhs,
@@ -133,9 +132,7 @@ struct TypeRelationCheckInput {
     OpenArchetypes(OpenArchetypes) {}
 
   friend llvm::hash_code hash_value(const TypeRelationCheckInput &TI) {
-    return hash_combine(hash_value(TI.Pair),
-                        hash_value(TI.Relation),
-                        hash_value(TI.OpenArchetypes));
+    return llvm::hash_combine(TI.Pair, TI.Relation, TI.OpenArchetypes);
   }
 
   friend bool operator==(const TypeRelationCheckInput &lhs,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -46,17 +46,15 @@ CompilerInstance::CompilerInstance() = default;
 CompilerInstance::~CompilerInstance() = default;
 
 std::string CompilerInvocation::getPCHHash() const {
-  using llvm::hash_code;
-  using llvm::hash_value;
   using llvm::hash_combine;
 
-  auto Code = hash_value(LangOpts.getPCHHashComponents());
-  Code = hash_combine(Code, FrontendOpts.getPCHHashComponents());
-  Code = hash_combine(Code, ClangImporterOpts.getPCHHashComponents());
-  Code = hash_combine(Code, SearchPathOpts.getPCHHashComponents());
-  Code = hash_combine(Code, DiagnosticOpts.getPCHHashComponents());
-  Code = hash_combine(Code, SILOpts.getPCHHashComponents());
-  Code = hash_combine(Code, IRGenOpts.getPCHHashComponents());
+  auto Code = hash_combine(LangOpts.getPCHHashComponents(),
+                           FrontendOpts.getPCHHashComponents(),
+                           ClangImporterOpts.getPCHHashComponents(),
+                           SearchPathOpts.getPCHHashComponents(),
+                           DiagnosticOpts.getPCHHashComponents(),
+                           SILOpts.getPCHHashComponents(),
+                           IRGenOpts.getPCHHashComponents());
 
   return llvm::APInt(64, Code).toString(36, /*Signed=*/false);
 }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -380,34 +380,36 @@ class ModuleInterfaceLoaderImpl {
   /// with dead entries -- when other factors change, such as the contents of
   /// the .swiftinterface input or its dependencies.
   std::string getCacheHash(const CompilerInvocation &SubInvocation) {
-    // Start with the compiler version (which will be either tag names or revs).
-    // Explicitly don't pass in the "effective" language version -- this would
-    // mean modules built in different -swift-version modes would rebuild their
-    // dependencies.
-    llvm::hash_code H = hash_value(swift::version::getSwiftFullVersion());
-
-    // Simplest representation of input "identity" (not content) is just a
-    // pathname, and probably all we can get from the VFS in this regard
-    // anyways.
-    H = hash_combine(H, interfacePath);
-
-    // Include the normalized target triple. In practice, .swiftinterface files
-    // will be in target-specific subdirectories and would have
-    // target-specific pieces #if'd out. However, it doesn't hurt to
-    // include it, and it guards against mistakenly reusing cached modules
-    // across targets. Note that this normalization explicitly doesn't
-    // include the minimum deployment target (e.g. the '12.0' in 'ios12.0').
     auto normalizedTargetTriple =
         getTargetSpecificModuleTriple(SubInvocation.getLangOptions().Target);
-    H = hash_combine(H, normalizedTargetTriple.str());
 
-    // The SDK path is going to affect how this module is imported, so include
-    // it.
-    H = hash_combine(H, SubInvocation.getSDKPath());
+    llvm::hash_code H = hash_combine(
+        // Start with the compiler version (which will be either tag names or
+        // revs). Explicitly don't pass in the "effective" language version --
+        // this would mean modules built in different -swift-version modes would
+        // rebuild their dependencies.
+        swift::version::getSwiftFullVersion(),
 
-    // Whether or not we're tracking system dependencies affects the
-    // invalidation behavior of this cache item.
-    H = hash_combine(H, SubInvocation.getFrontendOptions().TrackSystemDeps);
+        // Simplest representation of input "identity" (not content) is just a
+        // pathname, and probably all we can get from the VFS in this regard
+        // anyways.
+        interfacePath,
+
+        // Include the normalized target triple. In practice, .swiftinterface
+        // files will be in target-specific subdirectories and would have
+        // target-specific pieces #if'd out. However, it doesn't hurt to include
+        // it, and it guards against mistakenly reusing cached modules across
+        // targets. Note that this normalization explicitly doesn't include the
+        // minimum deployment target (e.g. the '12.0' in 'ios12.0').
+        normalizedTargetTriple.str(),
+
+        // The SDK path is going to affect how this module is imported, so
+        // include it.
+        SubInvocation.getSDKPath(),
+
+        // Whether or not we're tracking system dependencies affects the
+        // invalidation behavior of this cache item.
+        SubInvocation.getFrontendOptions().TrackSystemDeps);
 
     return llvm::APInt(64, H).toString(36, /*Signed=*/false);
   }


### PR DESCRIPTION
- No need to hash input values first
- Pass many values to a single hash_combine to save on intermediates
- Use hash_combine_range instead of a loop of hash_combines

No functionality change.