### PR TITLE
[ownership] Allow for the ownership verifier to be run in non-asserts…

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -387,6 +387,18 @@ public:
           NumLowBitsAvailable
   };
 
+  /// If this SILValue is a result of an instruction, return its
+  /// defining instruction. Returns nullptr otherwise.
+  SILInstruction *getDefiningInstruction() {
+    return Value->getDefiningInstruction();
+  }
+
+  /// If this SILValue is a result of an instruction, return its
+  /// defining instruction. Returns nullptr otherwise.
+  const SILInstruction *getDefiningInstruction() const {
+    return Value->getDefiningInstruction();
+  }
+
   /// Returns the ValueOwnershipKind that describes this SILValue's ownership
   /// semantics if the SILValue has ownership semantics. Returns is a value
   /// without any Ownership Semantics.


### PR DESCRIPTION
… builds if -sil-verify-all is set.

This is matching the behavior of the rest of the verifier. NOTE: Both early exit
if said flag is not set, so this should not hit compile time in any way unless
the flag is set (in which case someone is asking for more verification...).

While I was here, I also noticed an ancillary bug where we were not checking if
a value was from in a block that was in a SILGlobalVariable or a SILFunction. We
already had a check that stopped this early when validating ownership of
SILInstructions. I guess we have never had a situation where the verifier was
given values to run on SILGlobalVariable blocks.
