### PR TITLE
[csvcolumn_to_scurve] Avoid division by zero.

### DIFF
--- a/utils/dev-scripts/csvcolumn_to_scurve.py
+++ b/utils/dev-scripts/csvcolumn_to_scurve.py
@@ -14,7 +14,10 @@ def get_data(input_file, before_column, after_column):
         for row in csv.DictReader(input_file):
             before = float(row[before_column])
             after = float(row[after_column])
-            delta = after / before
+            if before > 0:
+                delta = after / before
+            else:
+                delta = 1
             yield delta
 
     def f(input_data):


### PR DESCRIPTION
Check whether the value in the "before" column is zero (specifically, whether the file size in that column is greater than zero since filesizes are non-negative) before dividing the value in the "after" column by it.