### PR TITLE
[WIP] [CMake] Add a mode SWIFT_INSTALL_AS_SYMLINK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+if(SWIFT_INSTALL_AS_SYMLINKS)
+  cmake_minimum_required(VERSION 3.14.0)
+endif()
+
 # TODO: Fix RPATH usage to be CMP0068 compliant
 # Disable Policy CMP0068 for CMake 3.9
 # rdar://37725888


### PR DESCRIPTION
Alternative approach to #13220 for generating an xctoolchain made of symlinks. I don't think I like it as much, but what do others think?

Pros:
- Piggybacks on CMake's notion of what gets installed, including component control, instead of having a separate list in an external script (build-script-impl)

Cons:
- Relies on `swift_install_in_component`, which ideally we'd be able to drop entirely in favor of CMake's `install` or at least LLVM's notion of components.
- Basically reverse-engineering the arguments of `install`, which is not great.
- Does not automatically pick up new libraries like #13220 would (though that's less important these days). #13220 symlinks all of lib/swift/; this has symlinks for everything *in* lib/swift/
- Probably has weird silent failures.
- No obvious way to make it work for LLDB and/or Clang in addition to Swift.