### PR TITLE
[32bits] Update assert on SymbolicValue size

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -556,7 +556,7 @@ public:
   void dump() const;
 };
 
-static_assert(sizeof(SymbolicValue) == 2 * sizeof(void *),
+static_assert(sizeof(SymbolicValue) == 2 * sizeof(uint64_t),
               "SymbolicValue should stay small");
 static_assert(std::is_pod<SymbolicValue>::value,
               "SymbolicValue should stay POD");


### PR DESCRIPTION
Since the storage is a multiple of uint64_t (following what LLVM's APInt does, copy implemented [here](https://github.com/apple/swift/blob/master/lib/SIL/SILConstants.cpp#L251)) we want to check for 2*uin64_t here, even on 32bit platforms.
Right now, this breaks 5.1 builds on 32bits(arm&co).