### PR TITLE
SILGen: Fix setting variables with property wrappers marked objc dynamic

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1430,7 +1430,14 @@ namespace {
 
         // Create the allocating setter function. It captures the base address.
         auto setterInfo = SGF.getConstantInfo(setter);
-        SILValue setterFRef = SGF.emitGlobalFunctionRef(loc, setter, setterInfo);
+        SILValue setterFRef;
+        if (setter.hasDecl() && setter.getDecl()->isObjCDynamic()) {
+          auto methodTy = SILType::getPrimitiveObjectType(
+              SGF.SGM.Types.getConstantFunctionType(setter));
+          setterFRef = SGF.B.createObjCMethod(
+              loc, base.getValue(), setter, methodTy);
+        } else
+          setterFRef = SGF.emitGlobalFunctionRef(loc, setter, setterInfo);
         CanSILFunctionType setterTy = setterFRef->getType().castTo<SILFunctionType>();
         SILFunctionConventions setterConv(setterTy, SGF.SGM.M);
 

--- a/test/IRGen/objc_properties.swift
+++ b/test/IRGen/objc_properties.swift
@@ -78,6 +78,30 @@ class Class17127126 {
   static var sharedInstance: AnyObject { get set }
 }
 
+@propertyWrapper
+public struct SomeWrapper {
+  private var value: Int
+
+
+  public init(wrappedValue: Int) {
+    value = wrappedValue
+  }
+
+
+  public var wrappedValue: Int {
+    get { value }
+    set { value = newValue }
+  }
+}
+
+class SomeWrapperTests {
+  @objc @SomeWrapper dynamic var someWrapper: Int = 0
+
+  func testAssignment() {
+    // This used to crash irgen.
+    someWrapper = 1000
+  }
+}
 // CHECK-NEW: [[SHARED_NAME:@.*]] = private unnamed_addr constant [11 x i8] c"sharedProp\00"
 // CHECK-NEW: [[SHARED_ATTRS:@.*]] = private unnamed_addr constant [5 x i8] c"Tq,N\00"
 

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -253,3 +253,30 @@ func testPropSetWithPreposition(object: ObjectWithSplitProperty?) {
   // CHECK: #ObjectWithSplitProperty.flagForSomething!setter.1.foreign : (ObjectWithSplitProperty) -> (Bool) -> (), $@convention(objc_method) ({{Bool|ObjCBool}}, ObjectWithSplitProperty) -> ()
   object?.flagForSomething = false
 }
+
+@propertyWrapper
+public struct SomeWrapper {
+  private var value: Int
+
+
+  public init(wrappedValue: Int) {
+    value = wrappedValue
+  }
+
+
+  public var wrappedValue: Int {
+    get { value }
+    set { value = newValue }
+  }
+}
+
+class SomeWrapperTests {
+  @objc @SomeWrapper dynamic var someWrapper: Int = 0
+// CHECK-LABEL: sil hidden [ossa] @$s15objc_properties16SomeWrapperTestsC14testAssignmentyyF
+// CHECK: [[M:%.*]] = objc_method %0 : $SomeWrapperTests, #SomeWrapperTests.someWrapper!setter.1.foreign
+// CHECK: [[C:%.*]] = partial_apply [callee_guaranteed] [[M]]({{.*}}) : $@convention(objc_method)
+// CHECK: assign_by_wrapper {{%.*}}: $Int to {{%.*}} : $*SomeWrapper, init {{.*}} : $@callee_guaranteed (Int) -> SomeWrapper, set [[C]] : $@callee_guaranteed (Int) -> ()
+  func testAssignment() {
+    someWrapper = 1000
+  }
+}


### PR DESCRIPTION
rdar://54181647