### PR TITLE
swift-reflection-dump: resolve ambiguity (NFC)

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -447,7 +447,7 @@ template<typename Runtime>
 static std::pair<ReflectionContextOwner, TypeRefBuilder &>
 makeReflectionContextForMetadataReader(
                                    std::shared_ptr<ObjectMemoryReader> reader) {
-  using ReflectionContext = ReflectionContext<Runtime>;
+  using ReflectionContext = swift::reflection::ReflectionContext<Runtime>;
   auto context = new ReflectionContext(reader);
   auto &builder = context->getBuilder();
   for (unsigned i = 0, e = reader->getImages().size(); i < e; ++i) {


### PR DESCRIPTION
```
swift\tools\swift-reflection-dump\swift-reflection-dump.cpp(450): error C2872: 'ReflectionContext': ambiguous symbol
swift\include\swift\ABI\Metadata.h(1001): note: could be 'swift::ReflectionContext'
swift\include\swift\Reflection\ReflectionContext.h(86): note: or 'swift::reflection::ReflectionContext'
```

Use the qualified name to avoid the ambiguity.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
