### PR TITLE
SymbolicValue is_pod -> is_trivial

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -558,8 +558,8 @@ public:
 
 static_assert(sizeof(SymbolicValue) == 2 * sizeof(void *),
               "SymbolicValue should stay small");
-static_assert(std::is_pod<SymbolicValue>::value,
-              "SymbolicValue should stay POD");
+static_assert(std::is_trivial<SymbolicValue>::value,
+              "SymbolicValue should stay trivial");
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, SymbolicValue val) {
   val.print(os);


### PR DESCRIPTION
is_pod is getting deprecated in C++20. All we really care about is that the type stay trivial. (And that's just a performance thing, I don't think we rely on that anywhere).