### PR TITLE
[update-checkout] remove master-rebranch

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -403,16 +403,16 @@
                 "sourcekit-lsp": "swift-5.1-branch"
             }
         },
-        "master-rebranch" : {
+        "master-20190619" : {
             "aliases": ["apple/stable/20190619",
-                        "master-rebranch-apple-stable-20190619",
-                        "master-rebranch"],
+                        "master-apple-stable-20190619"
+                       ],
             "repos": {
                 "llvm": "apple/stable/20190619",
                 "clang": "apple/stable/20190619",
                 "compiler-rt": "apple/stable/20190619",
-                "swift": "master-rebranch",
-                "lldb": "master-rebranch",
+                "swift": "master",
+                "lldb": "master",
                 "cmark": "master",
                 "llbuild": "master",
                 "swiftpm": "master",


### PR DESCRIPTION
`lldb\master-rebranch` doesn't exist anymore 
`swift\master-rebranch` doesn't serve any purpose anymore, I think? 
the dated branches are still actively used for clang & llvm, and if swift needs changes from either repo it still needs to be cherry-picked into the dated branches to show up on stable. 

This will fix PR testing for those respective branches/repos. 