### PR TITLE
[AutoDiff] Typo in TransposingAttr::TransposingAttr

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1581,7 +1581,7 @@ TransposingAttr::TransposingAttr(ASTContext &context, bool implicit,
                                  SourceLoc atLoc, SourceRange baseRange,
                                  TypeRepr *baseType, DeclNameWithLoc original,
                                  AutoDiffIndexSubset *indices)
-    : DeclAttribute(DAK_Differentiating, atLoc, baseRange, implicit),
+    : DeclAttribute(DAK_Transposing, atLoc, baseRange, implicit),
       BaseType(baseType), Original(std::move(original)),
       ParameterIndexSubset(indices) {}
 


### PR DESCRIPTION
Previously, TransposingAttr::TransposingAttr would set the DeclAttribute to be
DAK_Differentiating. This is incorrect, as it should be DAK_Transposing. This
commit fixes that.

Note: I noticed that this bug hasn't been observed because this code path is
currently unused. However, it is planned to be used in the future, so I will
not remove the code. This unfortunately makes it impossible to write a test
that would have caught this regression.

