### PR TITLE
[build-script-impl] Fix cross-compilation of swift.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2248,6 +2248,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     build_tests_this_time=${SWIFT_INCLUDE_TESTS}
                 fi
 
+                if [[ $(is_cross_tools_host ${host}) ]] ; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DLLVM_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-tblgen
+                    )
+                fi
+
                 # Command-line parameters override any autodetection that we
                 # might have done.
                 if [[ "${NATIVE_LLVM_TOOLS_PATH}" ]] ; then


### PR DESCRIPTION
Swift requires now tablegen to build Options.inc, so build script
has to be taught about picking the host llvm-tablegen instead of
the target llvm-tablegen.

<rdar://problem/55916729>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
