### PR TITLE
[SyntaxParse] Fix attribute generation in ASTGen

### DIFF
--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -67,10 +67,8 @@ public:
 
 private:
   DeclAttributes
-  generateDeclAttributes(const syntax::DeclSyntax &D,
-                         const Optional<syntax::AttributeListSyntax> &attrs,
-                         const Optional<syntax::ModifierListSyntax> &modifiers,
-                         SourceLoc Loc, bool includeComments);
+  generateDeclAttributes(const syntax::Syntax &D, SourceLoc Loc,
+                         bool includeComments);
 
   void generateFreeStandingGenericWhereClause(
                                 const syntax::GenericWhereClauseSyntax &syntax,

--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -57,21 +57,14 @@ Decl *ASTGen::generate(const DeclSyntax &D, const SourceLoc Loc) {
 }
 
 DeclAttributes
-ASTGen::generateDeclAttributes(const DeclSyntax &D,
-                               const Optional<AttributeListSyntax> &attrs,
-                               const Optional<ModifierListSyntax> &modifiers,
-                               SourceLoc Loc, bool includeComments) {
-  SourceLoc attrsLoc;
-  if (attrs) {
-    attrsLoc = advanceLocBegin(Loc, *attrs->getFirstToken());
-  } else if (modifiers) {
-    attrsLoc = advanceLocBegin(Loc, *modifiers->getFirstToken());
-  } else {
-    // We might have comment attributes.
-    attrsLoc = advanceLocBegin(Loc, *D.getFirstToken());
+ASTGen::generateDeclAttributes(const Syntax &D, SourceLoc Loc,
+                               bool includeComments) {
+  // Find the AST attribute-list from the lookup table.
+  if (auto firstTok = D.getFirstToken()) {
+    auto declLoc = advanceLocBegin(Loc, *firstTok);
+    if (hasDeclAttributes(declLoc))
+      return getDeclAttributes(declLoc);
   }
-  if (hasDeclAttributes(attrsLoc))
-    return getDeclAttributes(attrsLoc);
   return DeclAttributes();
 }
 
@@ -111,8 +104,7 @@ TypeDecl *ASTGen::generate(const AssociatedtypeDeclSyntax &D,
   Identifier name;
   SourceLoc nameLoc = generateIdentifierDeclName(idToken, Loc, name);
 
-  DeclAttributes attrs =
-      generateDeclAttributes(D, D.getAttributes(), D.getModifiers(), Loc, true);
+  DeclAttributes attrs = generateDeclAttributes(D, Loc, true);
 
   DebuggerContextChange DCC(P, name, DeclKind::AssociatedType);
 
@@ -147,8 +139,7 @@ TypeDecl *ASTGen::generate(const TypealiasDeclSyntax &D, const SourceLoc Loc) {
   auto keywordLoc = advanceLocBegin(Loc, D.getTypealiasKeyword());
   Identifier name;
   SourceLoc nameLoc = generateIdentifierDeclName(idToken, Loc, name);
-  auto attrs =
-      generateDeclAttributes(D, D.getAttributes(), D.getModifiers(), Loc, true);
+  auto attrs = generateDeclAttributes(D, Loc, true);
   SourceLoc equalLoc;
 
   DebuggerContextChange DCC(P, name, DeclKind::TypeAlias);
@@ -986,14 +977,7 @@ GenericParamList *ASTGen::generate(const GenericParameterClauseSyntax &clause,
 
   for (auto elem : clause.getGenericParameterList()) {
 
-    DeclAttributes attrs;
-    if (auto attrsSyntax = elem.getAttributes()) {
-      if (auto firstTok = attrsSyntax->getFirstToken()) {
-        auto attrsLoc = advanceLocBegin(Loc, *firstTok);
-        if (hasDeclAttributes(attrsLoc))
-          attrs = getDeclAttributes(attrsLoc);
-      }
-    }
+    DeclAttributes attrs = generateDeclAttributes(elem, Loc, false);
     Identifier name = Context.getIdentifier(elem.getName().getIdentifierText());
     SourceLoc nameLoc = advanceLocBegin(Loc, elem.getName());
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2714,6 +2714,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
                                   StructureMarkerKind::Declaration);
 
   // Parse attributes.
+  SourceLoc AttrsLoc = Tok.getLoc();
   DeclAttributes Attributes;
   if (Tok.hasComment())
     Attributes.add(new (Context) RawDocCommentAttr(Tok.getCommentRange()));
@@ -2725,12 +2726,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
   StaticSpellingKind StaticSpelling = StaticSpellingKind::None;
   parseDeclModifierList(Attributes, StaticLoc, StaticSpelling);
 
-  if (!Attributes.isEmpty()) {
-    auto startLoc = Attributes.getStartLoc();
-    if (startLoc.isInvalid())
-      startLoc = Tok.getLoc();
-    Generator.addDeclAttributes(Attributes, startLoc);
-  }
+  if (!Attributes.isEmpty())
+    Generator.addDeclAttributes(Attributes, AttrsLoc);
 
   // We emit diagnostics for 'try let ...' in parseDeclVar().
   SourceLoc tryLoc;

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -78,10 +78,11 @@ Parser::parseGenericParameterClauseSyntax() {
       SyntaxParsingContext TmpCtxt(SyntaxContext);
       TmpCtxt.setTransparent();
 
+      auto AttrsLoc = Tok.getLoc();
       DeclAttributes attrsAST;
       parseDeclAttributeList(attrsAST);
       if (!attrsAST.isEmpty())
-        Generator.addDeclAttributes(attrsAST, attrsAST.getStartLoc());
+        Generator.addDeclAttributes(attrsAST, AttrsLoc);
       auto attrs = SyntaxContext->popIf<ParsedAttributeListSyntax>();
       if (attrs)
         paramBuilder.useAttributes(std::move(*attrs));

--- a/test/Parse/attr_available_ignored.swift
+++ b/test/Parse/attr_available_ignored.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+@available(*, deprecated: 0.1) // expected-warning {{unexpected version number in 'available' attribute for non-specific platform '*'}}
+public typealias PublicAlias = Int
+public var value1: PublicAlias { return 1 }
+
+@available(*, deprecated: 0.1) // expected-warning {{unexpected version number in 'available' attribute for non-specific platform '*'}}
+@available(iOS, deprecated: 99.9)
+private typealias PrivateAlias = Int // expected-note {{type declared here}}
+public var value2: PrivateAlias { return 1 } // expected-error {{variable cannot be declared public because its type uses a private type}}


### PR DESCRIPTION
For the intermediate lookup table of the parsed decl attributes, use location the first token of the attributes instead of the start location of the *parsed* attribute list because some attributes can be ignored during the parsing.

rdar://problem/55952739
