### PR TITLE
Make using line more explicit for cl.exe.

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -447,7 +447,7 @@ template<typename Runtime>
 static std::pair<ReflectionContextOwner, TypeRefBuilder &>
 makeReflectionContextForMetadataReader(
                                    std::shared_ptr<ObjectMemoryReader> reader) {
-  using ReflectionContext = ReflectionContext<Runtime>;
+  using ReflectionContext = swift::reflection::ReflectionContext<Runtime>;
   auto context = new ReflectionContext(reader);
   auto &builder = context->getBuilder();
   for (unsigned i = 0, e = reader->getImages().size(); i < e; ++i) {


### PR DESCRIPTION
The using line was confussing cl.exe, which was seeing both
swift::ReflectionContext and swift::reflection::ReflectionContext. Make
it clear that we are talking about the second one.
