### PR TITLE
[SyntaxParse] Adjust parseMatchingToken()

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -899,10 +899,6 @@ public:
   parseMatchingTokenSyntax(tok K, Diag<> ErrorDiag, SourceLoc OtherLoc,
                            bool silenceDiag = false);
 
-  llvm::Optional<ParsedTokenSyntax>
-  parseMatchingTokenSyntax(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
-                           SourceLoc OtherLoc);
-
   /// Returns the proper location for a missing right brace, parenthesis, etc.
   SourceLoc getLocForMissingMatchingToken() const;
 
@@ -923,7 +919,6 @@ public:
                          llvm::function_ref<ParserStatus()> callback);
   ParserStatus parseListSyntax(tok RightK, SourceLoc LeftLoc,
                                llvm::Optional<ParsedTokenSyntax> &LastComma,
-                               SourceLoc &RightLoc,
                                llvm::Optional<ParsedTokenSyntax> &Right,
                                llvm::SmallVectorImpl<ParsedSyntax>& Junk,
                                bool AllowSepAfterLast, Diag<> ErrorDiag,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -895,6 +895,10 @@ public:
   bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
                           SourceLoc OtherLoc);
 
+  ParsedSyntaxResult<ParsedTokenSyntax>
+  parseMatchingTokenSyntax(tok K, Diag<> ErrorDiag, SourceLoc OtherLoc,
+                           bool silenceDiag = false);
+
   llvm::Optional<ParsedTokenSyntax>
   parseMatchingTokenSyntax(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
                            SourceLoc OtherLoc);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1999,13 +1999,11 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
       }
 
       // Parse ')'.
-      SourceLoc RParenLoc;
       auto RParen = parseMatchingTokenSyntax(
-          tok::r_paren, RParenLoc, diag::convention_attribute_expected_rparen,
-          LParenLoc);
-      if (!RParen)
+          tok::r_paren, diag::convention_attribute_expected_rparen, LParenLoc);
+      if (RParen.isError())
         return makeParserError();
-      builder.useRightParen(std::move(*RParen));
+      builder.useRightParen(RParen.get());
 
       return makeParserSuccess();
     }();
@@ -2033,13 +2031,11 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
       builder.useArgument(consumeTokenSyntax(tok::string_literal));
 
       // Parse ')'.
-      SourceLoc RParenLoc;
       auto RParen = parseMatchingTokenSyntax(
-          tok::r_paren, RParenLoc, diag::opened_attribute_expected_rparen,
-          LParenLoc);
-      if (!RParen)
+          tok::r_paren, diag::opened_attribute_expected_rparen, LParenLoc);
+      if (RParen.isError())
         return makeParserError();
-      builder.useRightParen(std::move(*RParen));
+      builder.useRightParen(RParen.get());
 
       return makeParserSuccess();
     }();
@@ -2085,12 +2081,11 @@ ParsedSyntaxResult<ParsedAttributeSyntax> Parser::parseTypeAttributeSyntax() {
       builder.useArgument(argBuilder.build());
 
       // Parse ')'.
-      SourceLoc RParenLoc;
       auto RParen = parseMatchingTokenSyntax(
-          tok::r_paren, RParenLoc, diag::expected_rparen_expr_list, LParenLoc);
-      if (!RParen)
+          tok::r_paren, diag::expected_rparen_expr_list, LParenLoc);
+      if (RParen.isError())
         return makeParserError();
-      builder.useRightParen(std::move(*RParen));
+      builder.useRightParen(RParen.get());
 
       return makeParserSuccess();
     }();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -976,11 +976,10 @@ ParsedSyntaxResult<ParsedTypeSyntax> Parser::parseTypeTupleBody() {
 
   Optional<ParsedTokenSyntax> Comma;
 
-  SourceLoc RParenLoc;
   Optional<ParsedTokenSyntax> RParen;
 
   ParserStatus Status =
-      parseListSyntax(tok::r_paren, LParenLoc, Comma, RParenLoc, RParen, Junk,
+      parseListSyntax(tok::r_paren, LParenLoc, Comma, RParen, Junk,
                       false, diag::expected_rparen_tuple_type_list, [&]() {
     Optional<BacktrackingScope> Backtracking;
     SmallVector<ParsedSyntax, 0> LocalJunk;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -130,18 +130,15 @@ Parser::parseLayoutConstraintSyntax() {
     return false;
   };
 
-  if (parseTrivialConstraintBody()) {
+  auto hasError = parseTrivialConstraintBody();
+  if (hasError)
     ignoreUntil(tok::r_paren);
-    if (Tok.is(tok::r_paren))
-      builder.useRightParen(consumeTokenSyntax(tok::r_paren));
-  } else {
-    SourceLoc rParenLoc;
-    auto rParen = parseMatchingTokenSyntax(tok::r_paren, rParenLoc,
-                             diag::expected_rparen_layout_constraint,
-                             lParenLoc);
-    if (rParen)
-      builder.useRightParen(std::move(*rParen));
-  }
+  auto rParen = parseMatchingTokenSyntax(
+      tok::r_paren, diag::expected_rparen_layout_constraint, lParenLoc,
+      /*silenceDiag=*/hasError);
+  if (!rParen.isNull())
+    builder.useRightParen(rParen.get());
+
   return makeParsedResult(builder.build());
 }
 
@@ -1231,11 +1228,11 @@ Parser::parseTypeArray(ParsedTypeSyntax Base, SourceLoc BaseLoc) {
   // Ignore integer literal between '[' and ']'
   ignoreIf(tok::integer_literal);
 
-  SourceLoc RSquareLoc;
+  auto RSquareLoc = Tok.getLoc();
   auto RSquare = parseMatchingTokenSyntax(
-      tok::r_square, RSquareLoc, diag::expected_rbracket_array_type, LSquareLoc);
+      tok::r_square, diag::expected_rbracket_array_type, LSquareLoc);
 
-  if (RSquare) {
+  if (!RSquare.isNull()) {
     // If we parsed something valid, diagnose it with a fixit to rewrite it to
     // Swift syntax.
     diagnose(LSquareLoc, diag::new_array_syntax)
@@ -1247,11 +1244,9 @@ Parser::parseTypeArray(ParsedTypeSyntax Base, SourceLoc BaseLoc) {
   ParserStatus status;
 
   builder.useElementType(std::move(Base));
-  if (RSquare) {
-    builder.useRightSquareBracket(std::move(*RSquare));
-  } else {
-    status.setIsParseError();
-  }
+  if (!RSquare.isNull())
+    builder.useRightSquareBracket(RSquare.get());
+  status |= RSquare.getStatus();
 
   return makeParsedResult(builder.build(), status);
 }
@@ -1289,11 +1284,8 @@ ParsedSyntaxResult<ParsedTypeSyntax> Parser::parseTypeCollection() {
   auto Diag = Colon ? diag::expected_rbracket_dictionary_type
                     : diag::expected_rbracket_array_type;
 
-  SourceLoc RSquareLoc;
-  auto RSquare =
-      parseMatchingTokenSyntax(tok::r_square, RSquareLoc, Diag, LSquareLoc);
-  if (!RSquare)
-    Status.setIsParseError();
+  auto RSquare = parseMatchingTokenSyntax(tok::r_square, Diag, LSquareLoc);
+  Status |= RSquare.getStatus();
 
   if (Colon) {
     ParsedDictionaryTypeSyntaxBuilder builder(*SyntaxContext);
@@ -1301,15 +1293,15 @@ ParsedSyntaxResult<ParsedTypeSyntax> Parser::parseTypeCollection() {
     builder.useKeyType(std::move(*ElementType));
     builder.useColon(std::move(*Colon));
     builder.useValueType(std::move(*ValueType));
-    if (RSquare)
-      builder.useRightSquareBracket(std::move(*RSquare));
+    if (!RSquare.isNull())
+      builder.useRightSquareBracket(RSquare.get());
     return makeParsedResult(builder.build(), Status);
   } else {
     ParsedArrayTypeSyntaxBuilder builder(*SyntaxContext);
     builder.useLeftSquareBracket(std::move(LSquare));
     builder.useElementType(std::move(*ElementType));
-    if (RSquare)
-      builder.useRightSquareBracket(std::move(*RSquare));
+    if (!RSquare.isNull())
+      builder.useRightSquareBracket(RSquare.get());
     return makeParsedResult(builder.build(), Status);
   }
 }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1254,22 +1254,38 @@ Optional<ParsedTokenSyntax> Parser::parseTokenSyntax(tok K, SourceLoc &TokLoc,
   return None;
 }
 
-Optional<ParsedTokenSyntax>
-Parser::parseMatchingTokenSyntax(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag, SourceLoc OtherLoc) {
-  Diag<> OtherNote;
-  switch (K) {
-  case tok::r_paren:  OtherNote = diag::opening_paren; break;
-  case tok::r_square: OtherNote = diag::opening_bracket; break;
-  case tok::r_brace:  OtherNote = diag::opening_brace; break;
-  default: llvm_unreachable("unknown matching token!");
-  }
+ParsedSyntaxResult<ParsedTokenSyntax>
+Parser::parseMatchingTokenSyntax(tok K, Diag<> ErrorDiag, SourceLoc OtherLoc,
+                                 bool silenceDiag) {
+  if (Tok.is(K))
+    return makeParsedResult(consumeTokenSyntax(K));
+  checkForInputIncomplete();
 
-  auto Token = parseTokenSyntax(K, TokLoc, ErrorDiag);
-  if (!Token) {
-    TokLoc = getLocForMissingMatchingToken();
+  if (!silenceDiag) {
+    diagnose(Tok, ErrorDiag);
+
+    Diag<> OtherNote;
+    switch (K) {
+    case tok::r_paren:  OtherNote = diag::opening_paren; break;
+    case tok::r_square: OtherNote = diag::opening_bracket; break;
+    case tok::r_brace:  OtherNote = diag::opening_brace; break;
+    default: llvm_unreachable("unknown matching token!");
+    }
     diagnose(OtherLoc, OtherNote);
   }
-  return Token;
+  return makeParserError();
+}
+
+Optional<ParsedTokenSyntax>
+Parser::parseMatchingTokenSyntax(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
+                                 SourceLoc OtherLoc) {
+  TokLoc = Tok.getLoc();
+  auto result = parseMatchingTokenSyntax(K, ErrorDiag, OtherLoc);
+  if (result.isNull()) {
+    TokLoc = getLocForMissingMatchingToken();
+    return None;
+  }
+  return result.get();
 }
 
 SourceLoc Parser::getLocForMissingMatchingToken() const {


### PR DESCRIPTION
* Now returns `ParsedSyntaxResult<ParsedTokenSyntax>` instead of `Optional<ParsedTokenSyntax>`.
* Remove `TokLoc` parameter because Syntax parsing doesn't need the location.
* Add `silenceDiag` parameter flag which prevents diagnostics even if it cannot be parsed.
  This simplifies the client code. For example for:
  ```swift
    var a: (<type A>, <type B>
  ```
  If parsing `<type B>` ends up with an error, we do still want to parse `)`, but we don't want to emit `missing ')'` error even if it's missing.