### PR TITLE
swift-reflection-dump: ELF ObjectMemoryReader support for relocations

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -119,10 +119,11 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
         }
       }
 
-      // TODO: ObjectMemoryReader for ELF and PE platforms still does not
+      // TODO: ObjectMemoryReader for PE platforms still does not
       // implement symbol relocations. For now, on non-Mach-O platforms,
       // only symbolic reference things in the same module.
-      if (IGM.TargetInfo.OutputObjectFormat != llvm::Triple::MachO) {
+      if (IGM.TargetInfo.OutputObjectFormat != llvm::Triple::MachO
+          && IGM.TargetInfo.OutputObjectFormat != llvm::Triple::ELF) {
         auto formalAccessScope = type->getFormalAccessScope(nullptr, true);
         if ((formalAccessScope.isPublic() || formalAccessScope.isInternal()) &&
             (!IGM.CurSourceFile ||

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,7 +1,11 @@
 // REQUIRES: no_asan
 // RUN: %empty-directory(%t)
+
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypeLowering -o %t/TypesToReflect
+
 // RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) -binary-filename %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-reflection-dump -binary-filename %t/TypesToReflect -binary-filename %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)


### PR DESCRIPTION
Collect the relative and symbol relocations from ELF images in order to resolve pointer values
read from disk. This allows us to enable symbolic-referencing-all-the-things for ELF platforms.