### PR TITLE
Fix for "private extension String { private extension String <eof>"

### DIFF
--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -310,12 +310,14 @@ SourceRange GenericTypeOrExtensionWholePortion::getChildlessSourceRangeOf(
 
 SourceRange
 ExtensionScope::moveStartPastExtendedNominal(const SourceRange sr) const {
-  const auto start = getLocAfterExtendedNominal(decl);
+  const auto afterExtendedNominal = getLocAfterExtendedNominal(decl);
   // Illegal code can have an endLoc that is before the end of the
-  // ExtendedNominal, so push the end back, too, in that case.
-  const auto end =
-      getSourceManager().isBeforeInBuffer(sr.End, start) ? start : sr.End;
-  return SourceRange(start, end);
+  // ExtendedNominal
+  if (getSourceManager().isBeforeInBuffer(sr.End, afterExtendedNominal)) {
+    // Must not have the source range returned include the extended nominal
+    return SourceRange(sr.Start, sr.Start);
+  }
+  return SourceRange(afterExtendedNominal, sr.End);
 }
 
 SourceRange

--- a/test/NameBinding/scope_map_lookup_extension_extension.swift
+++ b/test/NameBinding/scope_map_lookup_extension_extension.swift
@@ -1,0 +1,6 @@
+// Ensure scope construction does not crash on this illegal code
+// RUN: not %target-swift-frontend -typecheck %s 2> %t.errors
+// RUN: %FileCheck %s <%t.errors
+// CHECK-NOT: Program arguments:
+private extension String {
+  private extension String


### PR DESCRIPTION
Fix for rdar://55914036

Ensure that, when computing the source range for an `ExtensionDeclScope` (WholePortion), it never goes beyond the range for the `ExtensionDecl`, even for illegal code