### PR TITLE
[Runtime] Refactor HeapObject override checks to use a macro.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -72,6 +72,19 @@ static inline bool isValidPointerForNativeRetain(const void *p) {
 #endif
 }
 
+// Call the appropriate implementation of the `name` function, passing `args`
+// to the call. This checks for an override in the function pointer. If an
+// override is present, it calls that override. Otherwise it directly calls
+// the default implementation. This allows the compiler to inline the default
+// implementation and avoid the performance penalty of indirecting through
+// the function pointer in the common case.
+#define CALL_IMPL(name, args) do { \
+    if (SWIFT_UNLIKELY(_ ## name != _ ## name ## _)) \
+      return _ ## name args; \
+    return _ ## name ## _ args; \
+} while(0)
+
+
 static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
                                        size_t requiredSize,
                                        size_t requiredAlignmentMask) {
@@ -95,9 +108,7 @@ static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
 HeapObject *swift::swift_allocObject(HeapMetadata const *metadata,
                                      size_t requiredSize,
                                      size_t requiredAlignmentMask) {
-  if (SWIFT_UNLIKELY(_swift_allocObject != _swift_allocObject_))
-    return _swift_allocObject(metadata, requiredSize, requiredAlignmentMask);
-  return _swift_allocObject_(metadata, requiredSize, requiredAlignmentMask);
+  CALL_IMPL(swift_allocObject, (metadata, requiredSize, requiredAlignmentMask));
 }
 
 HeapObject *(*swift::_swift_allocObject)(HeapMetadata const *metadata,
@@ -305,9 +316,7 @@ static HeapObject *_swift_retain_(HeapObject *object) {
 }
 
 HeapObject *swift::swift_retain(HeapObject *object) {
-  if (SWIFT_UNLIKELY(_swift_retain != _swift_retain_))
-    return _swift_retain(object);
-  return _swift_retain_(object);
+  CALL_IMPL(swift_retain, (object));
 }
 
 HeapObject *(*swift::_swift_retain)(HeapObject *object) = _swift_retain_;
@@ -327,9 +336,7 @@ static HeapObject *_swift_retain_n_(HeapObject *object, uint32_t n) {
 }
 
 HeapObject *swift::swift_retain_n(HeapObject *object, uint32_t n) {
-  if (SWIFT_UNLIKELY(_swift_retain_n != _swift_retain_n_))
-    return _swift_retain_n(object, n);
-  return _swift_retain_n_(object, n);
+  CALL_IMPL(swift_retain_n, (object, n));
 }
 
 HeapObject *(*swift::_swift_retain_n)(HeapObject *object, uint32_t n) =
@@ -349,9 +356,7 @@ static void _swift_release_(HeapObject *object) {
 }
 
 void swift::swift_release(HeapObject *object) {
-  if (SWIFT_UNLIKELY(_swift_release != _swift_release_))
-    _swift_release(object);
-  _swift_release_(object);
+  CALL_IMPL(swift_release, (object));
 }
 
 void (*swift::_swift_release)(HeapObject *object) = _swift_release_;
@@ -369,9 +374,7 @@ static void _swift_release_n_(HeapObject *object, uint32_t n) {
 }
 
 void swift::swift_release_n(HeapObject *object, uint32_t n) {
-  if (SWIFT_UNLIKELY(_swift_release_n != _swift_release_n_))
-    return _swift_release_n(object, n);
-  return _swift_release_n_(object, n);
+  CALL_IMPL(swift_release_n, (object, n));
 }
 
 void (*swift::_swift_release_n)(HeapObject *object, uint32_t n) =
@@ -509,9 +512,7 @@ static HeapObject *_swift_tryRetain_(HeapObject *object) {
 }
 
 HeapObject *swift::swift_tryRetain(HeapObject *object) {
-  if (SWIFT_UNLIKELY(_swift_tryRetain != _swift_tryRetain_))
-    return _swift_tryRetain(object);
-  return _swift_tryRetain_(object);
+  CALL_IMPL(swift_tryRetain, (object));
 }
 
 HeapObject *(*swift::_swift_tryRetain)(HeapObject *object) = _swift_tryRetain_;


### PR DESCRIPTION
This gives us a one-stop shop for making changes to the override mechanism.

rdar://problem/54752086