### PR TITLE
IRGen: Strip a bitcast that might be there because a runtime function…

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -650,11 +650,16 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                                       {argTypes.begin(), argTypes.end()},
                                       /*isVararg*/ false);
 
-  cache =
-      cast<llvm::Function>(Module.getOrInsertFunction(functionName.c_str(), fnTy).getCallee());
+  auto addr = Module.getOrInsertFunction(functionName.c_str(), fnTy).getCallee();
+  auto fnptr = addr;
+  // Strip off any bitcast we might have due to this function being declared of
+  // a different type previously.
+  if (auto bitcast = dyn_cast<llvm::BitCastInst>(fnptr))
+    fnptr = cast<llvm::Constant>(bitcast->getOperand(0));
+  cache = cast<llvm::Constant>(addr);
 
   // Add any function attributes and set the calling convention.
-  if (auto fn = dyn_cast<llvm::Function>(cache)) {
+  if (auto fn = dyn_cast<llvm::Function>(fnptr)) {
     fn->setCallingConv(cc);
 
     bool IsExternal =

--- a/test/IRGen/objc_object_getClass.swift
+++ b/test/IRGen/objc_object_getClass.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -module-name A | %FileCheck %s
+
+// REQUIRES: CPU=armv7k
+// REQUIRES: OS=watchos
+
+import Foundation
+
+func getAClass(managedObjectClass : AnyClass) -> AnyClass{
+  let metaClass: AnyClass = object_getClass(managedObjectClass)!
+  return metaClass
+}
+
+public class ObjCSubclass : NSObject {
+  public final var field: Int32 = 0
+}
+
+func test(_ o: ObjCSubclass) {
+  o.field = 10
+}
+
+// CHECK: declare i8* @object_getClass(i8*)
+// CHECK: call %objc_class* bitcast (i8* (i8*)* @object_getClass to %objc_class* (%objc_object*)*)(%objc_object* %{{.*}})


### PR DESCRIPTION
… was previously declared of a different type

rdar://55914836