### PR TITLE
[SyntaxParse] Fix crashers for generic parameter with attributes

### DIFF
--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -976,6 +976,9 @@ GenericParamList *ASTGen::generate(const GenericParameterClauseSyntax &clause,
   params.reserve(clause.getGenericParameterList().getNumChildren());
 
   for (auto elem : clause.getGenericParameterList()) {
+    auto nameTok = elem.getName();
+    if (nameTok.isMissing())
+      break;
 
     DeclAttributes attrs = generateDeclAttributes(elem, Loc, false);
     Identifier name = Context.getIdentifier(elem.getName().getIdentifierText());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1632,6 +1632,9 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
       }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
+    } else {
+      // Synthesize an r_brace syntax node if the token is absent
+      SyntaxContext->synthesize(tok::identifier, AtLoc.getAdvancedLoc(1));
     }
 
     diagnose(Tok, diag::expected_attribute_name);

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -145,3 +145,6 @@ enum sr8202_enum<@indirect T> {} // expected-error {{'indirect' is a declaration
 protocol P {
   @available(swift, introduced: 4.2) associatedtype Assoc // expected-error {{'@availability' attribute cannot be applied to this declaration}}
 }
+
+struct genericParamIncomplete1<@> {} // expected-error {{expected an attribute name}} expected-error {{expected an identifier to name generic parameter}}
+struct genericParamIncomplete2<@objc> {} // expected-error {{expected an identifier to name generic parameter}}


### PR DESCRIPTION
It used to crash for:
Attribute without its name (e.g. `Foo<@>`)
Missing name with attributes (e.g. `Foo<@available(*, unavailable)`>

- Synthesize identifier token so that the `SyntaxParsingContext` can successfully construct the `Attribute` syntax.
- Don't throw away the parsed attributes if the parameter name is missing. Instead, construct `GenericParamater` syntax anyway, and handle it in `ASTGen`.
