### PR TITLE
Circular validation cleanups, part 3

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -58,9 +58,6 @@ public:
   using BuiltTypeDecl = swift::GenericTypeDecl *; // nominal or type alias
   using BuiltProtocolDecl = swift::ProtocolDecl *;
   explicit ASTBuilder(ASTContext &ctx) : Ctx(ctx) {}
-  
-  /// The resolver to use for type checking, if necessary.
-  LazyResolver *Resolver = nullptr;
 
   ASTContext &getASTContext() { return Ctx; }
   DeclContext *getNotionalDC();

--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -33,6 +33,7 @@ SWIFT_TYPEID_NAMED(InfixOperatorDecl *, InfixOperatorDecl)
 SWIFT_TYPEID_NAMED(IterableDeclContext *, IterableDeclContext)
 SWIFT_TYPEID_NAMED(ModuleDecl *, ModuleDecl)
 SWIFT_TYPEID_NAMED(NominalTypeDecl *, NominalTypeDecl)
+SWIFT_TYPEID_NAMED(OpaqueTypeDecl *, OpaqueTypeDecl)
 SWIFT_TYPEID_NAMED(OperatorDecl *, OperatorDecl)
 SWIFT_TYPEID_NAMED(Optional<PropertyWrapperMutability>,
                    PropertyWrapperMutability)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -34,6 +34,7 @@ class IterableDeclContext;
 class ModuleDecl;
 class NominalTypeDecl;
 class OperatorDecl;
+class OpaqueTypeDecl;
 class PrecedenceGroupDecl;
 struct PropertyWrapperBackingPropertyInfo;
 struct PropertyWrapperTypeInfo;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2608,6 +2608,9 @@ public:
   /// if the base declaration is \c open, the override might have to be too.
   bool hasOpenAccess(const DeclContext *useDC) const;
 
+  /// FIXME: This is deprecated.
+  bool isRecursiveValidation() const;
+
   /// Retrieve the "interface" type of this value, which uses
   /// GenericTypeParamType if the declaration is generic. For a generic
   /// function, this will have a GenericFunctionType with a

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2764,12 +2764,6 @@ public:
   /// Get the representative for this value's opaque result type, if it has one.
   OpaqueReturnTypeRepr *getOpaqueResultTypeRepr() const;
 
-  /// Set the opaque return type decl for this decl.
-  ///
-  /// `this` must be of a decl type that supports opaque return types, and
-  /// must not have previously had an opaque result type set.
-  void setOpaqueResultTypeDecl(OpaqueTypeDecl *D);
-
   /// Retrieve the attribute associating this declaration with a
   /// function builder, if there is one.
   CustomAttr *getAttachedFunctionBuilder() const;
@@ -4530,8 +4524,6 @@ protected:
     Bits.AbstractStorageDecl.IsStatic = IsStatic;
   }
 
-  OpaqueTypeDecl *OpaqueReturn = nullptr;
-
 public:
 
   /// Should this declaration be treated as if annotated with transparent
@@ -4788,14 +4780,6 @@ public:
   bool hasAnyNativeDynamicAccessors() const;
 
   bool hasAnyDynamicReplacementAccessors() const;
-
-  OpaqueTypeDecl *getOpaqueResultTypeDecl() const {
-    return OpaqueReturn;
-  }
-  void setOpaqueResultTypeDecl(OpaqueTypeDecl *decl) {
-    assert(!OpaqueReturn && "already has opaque type decl");
-    OpaqueReturn = decl;
-  }
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
@@ -5982,8 +5966,6 @@ class FuncDecl : public AbstractFunctionDecl {
 
   TypeLoc FnRetType;
 
-  OpaqueTypeDecl *OpaqueReturn = nullptr;
-
 protected:
   FuncDecl(DeclKind Kind,
            SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
@@ -6129,15 +6111,7 @@ public:
   }
 
   OperatorDecl *getOperatorDecl() const;
-  
-  OpaqueTypeDecl *getOpaqueResultTypeDecl() const {
-    return OpaqueReturn;
-  }
-  void setOpaqueResultTypeDecl(OpaqueTypeDecl *decl) {
-    assert(!OpaqueReturn && "already has opaque type decl");
-    OpaqueReturn = decl;
-  }
-  
+
   /// Returns true if the function is forced to be statically dispatched.
   bool hasForcedStaticDispatch() const {
     return Bits.FuncDecl.ForcedStaticDispatch;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -857,17 +857,6 @@ public:
     return getValidationState() > ValidationState::Unchecked;
   }
 
-  /// Manually indicate that validation is complete for the declaration. For
-  /// example: during importing, code synthesis, or derived conformances.
-  ///
-  /// For normal code validation, please use DeclValidationRAII instead.
-  ///
-  /// FIXME -- Everything should use DeclValidationRAII instead of this.
-  void setValidationToChecked() {
-    if (!isBeingValidated())
-      Bits.Decl.ValidationState = unsigned(ValidationState::Checked);
-  }
-
   bool escapedFromIfConfig() const {
     return Bits.Decl.EscapedFromIfConfig;
   }

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -60,8 +60,7 @@ public:
 
   /// Look up an opaque return type by the mangled name of the declaration
   /// that defines it.
-  virtual OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                                 LazyResolver *resolver) {
+  virtual OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName) {
     return nullptr;
   }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -354,8 +354,7 @@ public:
 
   /// Look up an opaque return type by the mangled name of the declaration
   /// that defines it.
-  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                         LazyResolver *resolver);
+  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName);
   
   /// Find ValueDecls in the module and pass them to the given consumer object.
   ///

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -117,6 +117,13 @@ private:
   /// The scope map that describes this source file.
   std::unique_ptr<ASTScope> Scope;
 
+  /// The set of validated opaque return type decls in the source file.
+  llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
+  llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
+  /// The set of parsed decls with opaque return types that have not yet
+  /// been validated.
+  llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
+
   friend ASTContext;
   friend Impl;
 public:
@@ -129,13 +136,6 @@ public:
 
   /// The list of local type declarations in the source file.
   llvm::SetVector<TypeDecl *> LocalTypeDecls;
-
-  /// The set of validated opaque return type decls in the source file.
-  llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
-  llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
-  /// The set of parsed decls with opaque return types that have not yet
-  /// been validated.
-  llvm::DenseSet<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
 
   /// A set of special declaration attributes which require the
   /// Foundation module to be imported to work. If the foundation
@@ -430,14 +430,13 @@ public:
   void setSyntaxRoot(syntax::SourceFileSyntax &&Root);
   bool hasSyntaxRoot() const;
 
-  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName,
-                                         LazyResolver *resolver) override;
+  OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName) override;
 
   void addUnvalidatedDeclWithOpaqueResultType(ValueDecl *vd) {
     UnvalidatedDeclsWithOpaqueReturnTypes.insert(vd);
   }
 
-  void markDeclWithOpaqueResultTypeAsValidated(ValueDecl *vd);
+  ArrayRef<OpaqueTypeDecl *> getOpaqueReturnTypeDecls();
 
 private:
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1188,7 +1188,7 @@ public:
   void cacheResult(GenericSignature value) const;
 };
 
-/// Compute the interface type of the underlying definition type of a typealias declaration.
+/// Compute the underlying interface type of a typealias.
 class UnderlyingTypeRequest :
     public SimpleRequest<UnderlyingTypeRequest,
                          Type(TypeAliasDecl *),
@@ -1211,6 +1211,7 @@ public:
   void diagnoseCycle(DiagnosticEngine &diags) const;
 };
 
+/// Looks up the precedence group of an operator declaration.
 class OperatorPrecedenceGroupRequest
     : public SimpleRequest<OperatorPrecedenceGroupRequest,
                            PrecedenceGroupDecl *(InfixOperatorDecl *),
@@ -1266,6 +1267,25 @@ private:
 
   // Evaluation.
   llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
+/// Builds an opaque result type for a declaration.
+class OpaqueResultTypeRequest
+    : public SimpleRequest<OpaqueResultTypeRequest,
+                           OpaqueTypeDecl *(ValueDecl *),
+                           CacheKind::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  llvm::Expected<OpaqueTypeDecl *>
+  evaluate(Evaluator &evaluator, ValueDecl *VD) const;
 
 public:
   // Caching.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1292,6 +1292,28 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Determines if a function declaration is 'static'.
+class IsStaticRequest :
+    public SimpleRequest<IsStaticRequest,
+                         bool(FuncDecl *),
+                         CacheKind::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  llvm::Expected<bool>
+  evaluate(Evaluator &evaluator, FuncDecl *value) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<bool> getCachedResult() const;
+  void cacheResult(bool value) const;
+};
+
 // Allow AnyValue to compare two Type values, even though Type doesn't
 // support ==.
 template<>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -147,3 +147,5 @@ SWIFT_REQUEST(TypeChecker, USRGenerationRequest, std::string(const ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsABICompatibleOverrideRequest,
               bool(ValueDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsStaticRequest,
+              bool(FuncDecl *), SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -88,6 +88,9 @@ SWIFT_REQUEST(TypeChecker, MangleLocalTypeDeclRequest,
 SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, OpaqueResultTypeRequest,
+              OpaqueTypeDecl *(ValueDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OperatorPrecedenceGroupRequest,
               PrecedenceGroupDecl *(PrecedenceGroupDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -36,9 +36,6 @@ namespace swift {
   class ValueDecl;
   class DeclName;
 
-  /// Typecheck a declaration parsed during code completion.
-  void typeCheckCompletionDecl(Decl *D);
-
   /// Typecheck binding initializer at \p bindingIndex.
   void typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned bindingIndex);
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -278,7 +278,7 @@ public:
   virtual TypeDecl *lookupLocalType(StringRef MangledName) const override;
   
   virtual OpaqueTypeDecl *
-  lookupOpaqueResultType(StringRef MangledName, LazyResolver *resolver) override;
+  lookupOpaqueResultType(StringRef MangledName) override;
 
   virtual TypeDecl *
   lookupNestedType(Identifier name,

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -259,8 +259,7 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
     if (!parentModule)
       return Type();
 
-    auto opaqueDecl = parentModule->lookupOpaqueResultType(mangledName,
-                                                           Resolver);
+    auto opaqueDecl = parentModule->lookupOpaqueResultType(mangledName);
     if (!opaqueDecl)
       return Type();
     // TODO: multiple opaque types

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3190,12 +3190,6 @@ public:
     void verifyParsed(AccessorDecl *FD) {
       PrettyStackTraceDecl debugStack("verifying AccessorDecl", FD);
 
-      auto storage = FD->getStorage();
-      if (storage->isStatic() != FD->isStatic()) {
-        Out << "accessor static-ness must match static-ness of storage\n";
-        abort();
-      }
-
       verifyParsedBase(FD);
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2706,7 +2706,7 @@ bool ValueDecl::hasInterfaceType() const {
 }
 
 bool ValueDecl::isRecursiveValidation() const {
-  if (hasValidationStarted() || !hasInterfaceType())
+  if (hasValidationStarted() && !hasInterfaceType())
     return true;
 
   if (auto *vd = dyn_cast<VarDecl>(this))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6880,7 +6880,14 @@ OperatorDecl *FuncDecl::getOperatorDecl() const {
                              const_cast<FuncDecl *>(this)
                            },
                            nullptr);
- }
+}
+
+bool FuncDecl::isStatic() const {
+  ASTContext &ctx = getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+    IsStaticRequest{const_cast<FuncDecl *>(this)},
+    false);
+}
 
 AccessorDecl *AccessorDecl::createImpl(ASTContext &ctx,
                                        SourceLoc declLoc,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -487,9 +487,9 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
       // If the decl is currently being validated, this is likely a recursive
       // reference and we'll want to skip ahead so as to avoid having its type
       // attempt to desugar itself.
-      auto ifaceType = decl->getInterfaceType();
-      if (!ifaceType)
+      if (decl->isRecursiveValidation())
         continue;
+      auto ifaceType = decl->getInterfaceType();
 
       // FIXME: the canonical type makes a poor signature, because we don't
       // canonicalize away default arguments.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -895,3 +895,17 @@ void EnumRawValuesRequest::diagnoseCycle(DiagnosticEngine &diags) const {
 void EnumRawValuesRequest::noteCycleStep(DiagnosticEngine &diags) const {
 
 }
+
+//----------------------------------------------------------------------------//
+// IsStaticRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<bool> IsStaticRequest::getCachedResult() const {
+  auto *FD = std::get<0>(getStorage());
+  return FD->getCachedIsStatic();
+}
+
+void IsStaticRequest::cacheResult(bool result) const {
+  auto *FD = std::get<0>(getStorage());
+  FD->setStatic(result);
+}

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -52,6 +52,8 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
   case DeclContextKind::SerializedLocal:
   case DeclContextKind::TopLevelCodeDecl:
   case DeclContextKind::EnumElementDecl:
+  case DeclContextKind::GenericTypeDecl:
+  case DeclContextKind::SubscriptDecl:
     // Nothing to do for these.
     break;
 
@@ -61,7 +63,7 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
         auto i = patternInit->getBindingIndex();
         if (PBD->getInit(i)) {
           PBD->getPattern(i)->forEachVariable([](VarDecl *VD) {
-            typeCheckCompletionDecl(VD);
+            (void) VD->getInterfaceType();
           });
           if (!PBD->isInitializerChecked(i))
             typeCheckPatternBinding(PBD, i);
@@ -72,29 +74,18 @@ void typeCheckContextImpl(DeclContext *DC, SourceLoc Loc) {
 
   case DeclContextKind::AbstractFunctionDecl: {
     auto *AFD = cast<AbstractFunctionDecl>(DC);
-
-    // FIXME: This shouldn't be necessary, but we crash otherwise.
-    if (auto *AD = dyn_cast<AccessorDecl>(AFD))
-      typeCheckCompletionDecl(AD->getStorage());
-
     typeCheckAbstractFunctionBodyUntil(AFD, Loc);
     break;
   }
 
   case DeclContextKind::ExtensionDecl:
-    typeCheckCompletionDecl(cast<ExtensionDecl>(DC));
-    break;
-
-  case DeclContextKind::GenericTypeDecl:
-    typeCheckCompletionDecl(cast<GenericTypeDecl>(DC));
+    // Make sure the extension has been bound, in case it is in an
+    // inactive #if or something weird like that.
+    cast<ExtensionDecl>(DC)->computeExtendedNominal();
     break;
 
   case DeclContextKind::FileUnit:
     llvm_unreachable("module scope context handled above");
-
-  case DeclContextKind::SubscriptDecl:
-    typeCheckCompletionDecl(cast<SubscriptDecl>(DC));
-    break;
   }
 }
 } // anonymous namespace

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -440,7 +440,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
     emitGlobalDecl(decl);
   for (auto *localDecl : SF.LocalTypeDecls)
     emitGlobalDecl(localDecl);
-  for (auto *opaqueDecl : SF.OpaqueReturnTypes)
+  for (auto *opaqueDecl : SF.getOpaqueReturnTypeDecls())
     maybeEmitOpaqueTypeDecl(opaqueDecl);
 
   SF.collectLinkLibraries([this](LinkLibrary linkLib) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3808,8 +3808,7 @@ static void validateResultType(ValueDecl *decl,
         : ErrorType::get(decl->getASTContext()));
   } else {
     auto *dc = decl->getInnermostDeclContext();
-    auto resolution = TypeResolution::forInterface(
-      dc, dc->getGenericSignatureOfContext());
+    auto resolution = TypeResolution::forInterface(dc);
     TypeChecker::validateType(dc->getASTContext(),
                               resultTyLoc, resolution,
                               TypeResolverContext::FunctionResult);
@@ -4074,8 +4073,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     
     // We want the function to be available for name lookup as soon
     // as it has a valid interface type.
-    auto resolution = TypeResolution::forInterface(FD,
-                                                   FD->getGenericSignature());
+    auto resolution = TypeResolution::forInterface(FD);
     typeCheckParameterList(FD->getParameters(), resolution,
                            TypeResolverContext::AbstractFunctionDecl);
     validateResultType(FD, FD->getBodyResultTypeLoc());
@@ -4114,7 +4112,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(CD);
 
-    auto res = TypeResolution::forInterface(CD, CD->getGenericSignature());
+    auto res = TypeResolution::forInterface(CD);
     typeCheckParameterList(CD->getParameters(), res,
                            TypeResolverContext::AbstractFunctionDecl);
     CD->computeType();
@@ -4126,7 +4124,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(DD);
 
-    auto res = TypeResolution::forInterface(DD, DD->getGenericSignature());
+    auto res = TypeResolution::forInterface(DD);
     typeCheckParameterList(DD->getParameters(), res,
                            TypeResolverContext::AbstractFunctionDecl);
     DD->computeType();
@@ -4138,7 +4136,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(SD);
 
-    auto res = TypeResolution::forInterface(SD, SD->getGenericSignature());
+    auto res = TypeResolution::forInterface(SD);
     typeCheckParameterList(SD->getIndices(), res,
                            TypeResolverContext::SubscriptDecl);
     validateResultType(SD, SD->getElementTypeLoc());
@@ -4154,7 +4152,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     DeclValidationRAII IBV(EED);
 
     if (auto *PL = EED->getParameterList()) {
-      auto res = TypeResolution::forInterface(ED, ED->getGenericSignature());
+      auto res = TypeResolution::forInterface(ED);
       typeCheckParameterList(PL, res,
                              TypeResolverContext::EnumElementDecl);
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3966,12 +3966,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       setBoundVarsTypeError(parentPattern, Context);
     }
 
-    if (VD->getOpaqueResultTypeDecl()) {
-      if (auto SF = VD->getInnermostDeclContext()->getParentSourceFile()) {
-        SF->markDeclWithOpaqueResultTypeAsValidated(VD);
-      }
-    }
-
     break;
   }
 
@@ -4111,13 +4105,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         }
       }
     }
-
-    // Mark the opaque result type as validated, if there is one.
-    if (FD->getOpaqueResultTypeDecl()) {
-      if (auto sf = FD->getDeclContext()->getParentSourceFile()) {
-        sf->markDeclWithOpaqueResultTypeAsValidated(FD);
-      }
-    }
     
     break;
   }
@@ -4156,12 +4143,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
                            TypeResolverContext::SubscriptDecl);
     validateResultType(SD, SD->getElementTypeLoc());
     SD->computeType();
-
-    if (SD->getOpaqueResultTypeDecl()) {
-      if (auto SF = SD->getInnermostDeclContext()->getParentSourceFile()) {
-        SF->markDeclWithOpaqueResultTypeAsValidated(SD);
-      }
-    }
 
     break;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1239,6 +1239,12 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
 }
 
 llvm::Expected<bool>
+IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
+  return (decl->getStaticLoc().isValid() ||
+          decl->getStaticSpelling() != StaticSpellingKind::None);
+}
+
+llvm::Expected<bool>
 IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // If we can't infer dynamic here, don't.
   if (!DeclAttribute::canAttributeAppearOnDecl(DAK_Dynamic, decl))

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -83,43 +83,47 @@ TypeChecker::gatherGenericParamBindingsText(
 
 /// Get the opaque type representing the return type of a declaration, or
 /// create it if it does not yet exist.
-Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
-                                              ValueDecl *originatingDecl,
-                                              OpaqueReturnTypeRepr *repr) {
+llvm::Expected<OpaqueTypeDecl *>
+OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
+                                  ValueDecl *originatingDecl) const {
+  auto *repr = originatingDecl->getOpaqueResultTypeRepr();
+  assert(repr && "Declaration does not have an opaque result type");
+  auto *dc = originatingDecl->getInnermostDeclContext();
+  auto &ctx = dc->getASTContext();
+
   // Protocol requirements can't have opaque return types.
   //
   // TODO: Maybe one day we could treat this as sugar for an associated type.
   if (isa<ProtocolDecl>(originatingDecl->getDeclContext())
       && originatingDecl->isProtocolRequirement()) {
-    
+
     SourceLoc fixitLoc;
     if (auto vd = dyn_cast<VarDecl>(originatingDecl)) {
       fixitLoc = vd->getParentPatternBinding()->getStartLoc();
     } else {
       fixitLoc = originatingDecl->getStartLoc();
     }
-    
-    diagnose(repr->getLoc(), diag::opaque_type_in_protocol_requirement)
+
+    ctx.Diags.diagnose(repr->getLoc(),
+                       diag::opaque_type_in_protocol_requirement)
       .fixItInsert(fixitLoc, "associatedtype <#AssocType#>\n")
       .fixItReplace(repr->getSourceRange(), "<#AssocType#>");
     
-    return ErrorType::get(Context);
-  }
-  
-  // If the decl already has an opaque type decl for its return type, use it.
-  if (auto existingDecl = originatingDecl->getOpaqueResultTypeDecl()) {
-    return existingDecl->getDeclaredInterfaceType();
+    return nullptr;
   }
   
   // Check the availability of the opaque type runtime support.
-  if (!Context.LangOpts.DisableAvailabilityChecking) {
-    auto runningOS = overApproximateAvailabilityAtLocation(repr->getLoc(),
-                                    originatingDecl->getInnermostDeclContext());
-    auto availability = Context.getOpaqueTypeAvailability();
+  if (!ctx.LangOpts.DisableAvailabilityChecking) {
+    auto runningOS =
+      TypeChecker::overApproximateAvailabilityAtLocation(
+        repr->getLoc(),
+        originatingDecl->getInnermostDeclContext());
+    auto availability = ctx.getOpaqueTypeAvailability();
     if (!runningOS.isContainedIn(availability)) {
-      diagnosePotentialOpaqueTypeUnavailability(repr->getSourceRange(),
-       originatingDecl->getInnermostDeclContext(),
-       UnavailabilityReason::requiresVersionRange(availability.getOSVersion()));
+      TypeChecker::diagnosePotentialOpaqueTypeUnavailability(
+        repr->getSourceRange(),
+        originatingDecl->getInnermostDeclContext(),
+        UnavailabilityReason::requiresVersionRange(availability.getOSVersion()));
     }
   }
   
@@ -128,18 +132,20 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   TypeResolutionOptions options(TypeResolverContext::GenericRequirement);
   TypeLoc constraintTypeLoc(repr->getConstraint());
   // Pass along the error type if resolving the repr failed.
+  auto resolution = TypeResolution::forInterface(
+    dc, dc->getGenericSignatureOfContext());
   bool validationError
-    = validateType(Context, constraintTypeLoc, resolution, options);
+    = TypeChecker::validateType(ctx, constraintTypeLoc, resolution, options);
   auto constraintType = constraintTypeLoc.getType();
   if (validationError)
-    return constraintType;
+    return nullptr;
   
   // Error out if the constraint type isn't a class or existential type.
   if (!constraintType->getClassOrBoundGenericClass()
       && !constraintType->isExistentialType()) {
-    diagnose(repr->getConstraint()->getLoc(),
-             diag::opaque_type_invalid_constraint);
-    return constraintTypeLoc.getType();
+    ctx.Diags.diagnose(repr->getConstraint()->getLoc(),
+                       diag::opaque_type_invalid_constraint);
+    return nullptr;
   }
   
   if (constraintType->hasArchetype())
@@ -157,8 +163,7 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
                outerGenericSignature->getGenericParams().back()->getDepth() + 1;
   }
   
-  auto returnTypeParam = GenericTypeParamType::get(returnTypeDepth, 0,
-                                                   Context);
+  auto returnTypeParam = GenericTypeParamType::get(returnTypeDepth, 0, ctx);
 
   SmallVector<GenericTypeParamType *, 2> genericParamTypes;
   genericParamTypes.push_back(returnTypeParam);
@@ -184,7 +189,7 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   }
   
   auto interfaceSignature = evaluateOrDefault(
-      Context.evaluator,
+      ctx.evaluator,
       AbstractGenericSignatureRequest{
         outerGenericSignature.getPointer(),
         std::move(genericParamTypes),
@@ -194,24 +199,21 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   // Create the OpaqueTypeDecl for the result type.
   // It has the same parent context and generic environment as the originating
   // decl.
-  auto dc = originatingDecl->getDeclContext();
-  
+  auto parentDC = originatingDecl->getDeclContext();
   auto originatingGenericContext = originatingDecl->getAsGenericContext();
   GenericParamList *genericParams = originatingGenericContext
     ? originatingGenericContext->getGenericParams()
     : nullptr;
 
-  auto opaqueDecl = new (Context) OpaqueTypeDecl(originatingDecl,
-                                                 genericParams,
-                                                 dc,
-                                                 interfaceSignature,
-                                                 returnTypeParam);
+  auto opaqueDecl = new (ctx) OpaqueTypeDecl(originatingDecl,
+                                             genericParams,
+                                             parentDC,
+                                             interfaceSignature,
+                                             returnTypeParam);
   opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);
   }
-
-  originatingDecl->setOpaqueResultTypeDecl(opaqueDecl);
   
   // The declared interface type is an opaque ArchetypeType.
   SubstitutionMap subs;
@@ -221,7 +223,7 @@ Type TypeChecker::getOrCreateOpaqueResultType(TypeResolution resolution,
   auto opaqueTy = OpaqueTypeArchetypeType::get(opaqueDecl, subs);
   auto metatype = MetatypeType::get(opaqueTy);
   opaqueDecl->setInterfaceType(metatype);
-  return opaqueTy;
+  return opaqueDecl;
 }
 
 /// Determine whether the given type is \c Self, an associated type of \c Self,

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -504,10 +504,6 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // member entirely.
       auto *protocol = cast<ProtocolDecl>(assocType->getDeclContext());
 
-      // If we're validating the protocol recursively, bail out.
-      if (!protocol->hasInterfaceType())
-        continue;
-
       auto conformance = conformsToProtocol(type, protocol, dc,
                                             conformanceOptions);
       if (!conformance) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1135,14 +1135,6 @@ recur:
     var->getTypeLoc() = tyLoc;
     var->getTypeLoc().setType(var->getType());
 
-    // FIXME: Copy pasted from validateDecl(). This needs to be converted to
-    // use requests.
-    if (var->getOpaqueResultTypeDecl()) {
-      if (auto sf = var->getInnermostDeclContext()->getParentSourceFile()) {
-        sf->markDeclWithOpaqueResultTypeAsValidated(var);
-      }
-    }
-
     // FIXME: Should probably just remove the forbidden prefix stuff, it no
     // longer makes a lot of sense in a request-based world.
     checkForForbiddenPrefix(var);

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -695,9 +695,11 @@ static bool validateTypedPattern(TypeChecker &TC,
     auto named = dyn_cast<NamedPattern>(
                            TP->getSubPattern()->getSemanticsProvidingPattern());
     if (named) {
-      auto opaqueTy = TC.getOrCreateOpaqueResultType(resolution,
-                                                     named->getDecl(),
-                                                     opaqueRepr);
+      auto *var = named->getDecl();
+      auto opaqueDecl = var->getOpaqueResultTypeDecl();
+      auto opaqueTy = (opaqueDecl
+                       ? opaqueDecl->getDeclaredInterfaceType()
+                       : ErrorType::get(TC.Context));
       TL.setType(named->getDecl()->getDeclContext()
                                  ->mapTypeIntoContext(opaqueTy));
       hadError = opaqueTy->hasError();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -492,8 +492,11 @@ static Type mapErrorTypeToOriginal(Type type) {
 static Type getWitnessTypeForMatching(TypeChecker &tc,
                                       NormalProtocolConformance *conformance,
                                       ValueDecl *witness) {
-  if (!witness->getInterfaceType())
+  if (witness->isRecursiveValidation())
     return Type();
+
+  // FIXME: This is here to trigger the isInvalid() computation.
+  (void) witness->getInterfaceType();
 
   if (witness->isInvalid())
     return Type();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2449,7 +2449,6 @@ Type TypeResolver::resolveOpaqueReturnType(TypeRepr *repr,
   if (definingDeclNode->getKind() == Node::Kind::Global)
     definingDeclNode = definingDeclNode->getChild(0);
   ASTBuilder builder(Context);
-  builder.Resolver = resolution.Resolver;
   auto opaqueNode =
     builder.getNodeFactory().createNode(Node::Kind::OpaqueReturnTypeOf);
   opaqueNode->addChild(definingDeclNode, builder.getNodeFactory());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -58,16 +58,13 @@ TypeResolution TypeResolution::forStructural(DeclContext *dc) {
   return TypeResolution(dc, TypeResolutionStage::Structural);
 }
 
-TypeResolution TypeResolution::forInterface(DeclContext *dc,
-                                            LazyResolver *resolver) {
-  return forInterface(dc, dc->getGenericSignatureOfContext(), resolver);
+TypeResolution TypeResolution::forInterface(DeclContext *dc) {
+  return forInterface(dc, dc->getGenericSignatureOfContext());
 }
 
 TypeResolution TypeResolution::forInterface(DeclContext *dc,
-                                            GenericSignature genericSig,
-                                            LazyResolver *resolver) {
+                                            GenericSignature genericSig) {
   TypeResolution result(dc, TypeResolutionStage::Interface);
-  result.Resolver = resolver;
   result.complete.genericSig = genericSig;
   result.complete.builder = nullptr;
   return result;

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -295,8 +295,6 @@ class TypeResolution {
   GenericSignatureBuilder *getGenericSignatureBuilder() const;
 
 public:
-  LazyResolver *Resolver = nullptr;
-  
   /// Form a type resolution for the structure of a type, which does not
   /// attempt to resolve member types of type parameters to a particular
   /// associated type.
@@ -304,14 +302,12 @@ public:
 
   /// Form a type resolution for an interface type, which is a complete
   /// description of the type using generic parameters.
-  static TypeResolution forInterface(DeclContext *dc,
-                                     LazyResolver *resolver = nullptr);
+  static TypeResolution forInterface(DeclContext *dc);
 
   /// Form a type resolution for an interface type, which is a complete
   /// description of the type using generic parameters.
   static TypeResolution forInterface(DeclContext *dc,
-                                     GenericSignature genericSig,
-                                     LazyResolver *resolver = nullptr);
+                                     GenericSignature genericSig);
 
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given declaration

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -618,22 +618,6 @@ swift::handleSILGenericParams(ASTContext &Ctx, GenericParamList *genericParams,
   return createTypeChecker(Ctx).handleSILGenericParams(genericParams, DC);
 }
 
-void swift::typeCheckCompletionDecl(Decl *D) {
-  auto &Ctx = D->getASTContext();
-
-  DiagnosticSuppression suppression(Ctx.Diags);
-  (void)createTypeChecker(Ctx);
-  if (auto ext = dyn_cast<ExtensionDecl>(D)) {
-    if (auto *nominal = ext->computeExtendedNominal()) {
-      // FIXME(InterfaceTypeRequest): Remove this.
-      (void)nominal->getInterfaceType();
-    }
-  } else {
-    // FIXME(InterfaceTypeRequest): Remove this.
-    (void)cast<ValueDecl>(D)->getInterfaceType();
-  }
-}
-
 void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
                                     unsigned bindingIndex) {
   assert(!PBD->isInitializerChecked(bindingIndex) &&

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1974,10 +1974,6 @@ public:
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.
   DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
-  
-  Type getOrCreateOpaqueResultType(TypeResolution resolution,
-                                   ValueDecl *originatingDecl,
-                                   OpaqueReturnTypeRepr *repr);
 };
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1261,7 +1261,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     auto name = getIdentifier(DefiningDeclNameID);
     pathTrace.addOpaqueReturnType(name);
     
-    if (auto opaque = baseModule->lookupOpaqueResultType(name.str(), nullptr)) {
+    if (auto opaque = baseModule->lookupOpaqueResultType(name.str())) {
       values.push_back(opaque);
     }
     break;
@@ -1664,8 +1664,7 @@ giveUpFastPath:
       pathTrace.addOpaqueReturnType(name);
     
       auto lookupModule = M ? M : baseModule;
-      if (auto opaqueTy = lookupModule->lookupOpaqueResultType(name.str(),
-                                                               nullptr)) {
+      if (auto opaqueTy = lookupModule->lookupOpaqueResultType(name.str())) {
         values.push_back(opaqueTy);
       }
       break;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2714,8 +2714,9 @@ public:
       AddAttribute(new (ctx) HasStorageAttr(/*isImplicit:*/true));
 
     if (opaqueReturnTypeID) {
-      var->setOpaqueResultTypeDecl(
-                         cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
+      ctx.evaluator.cacheOutput(
+          OpaqueResultTypeRequest{var},
+          cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
     }
 
     // If this is a lazy property, record its backing storage.
@@ -2824,7 +2825,7 @@ public:
     DeclID overriddenID;
     DeclID accessorStorageDeclID;
     bool needsNewVTableEntry, isTransparent;
-    DeclID opaqueResultTypeDeclID;
+    DeclID opaqueReturnTypeID;
     ArrayRef<uint64_t> nameAndDependencyIDs;
 
     if (!isAccessor) {
@@ -2839,7 +2840,7 @@ public:
                                           numNameComponentsBiased,
                                           rawAccessLevel,
                                           needsNewVTableEntry,
-                                          opaqueResultTypeDeclID,
+                                          opaqueReturnTypeID,
                                           nameAndDependencyIDs);
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
@@ -3030,9 +3031,11 @@ public:
     fn->setForcedStaticDispatch(hasForcedStaticDispatch);
     fn->setNeedsNewVTableEntry(needsNewVTableEntry);
 
-    if (opaqueResultTypeDeclID)
-      fn->setOpaqueResultTypeDecl(
-                     cast<OpaqueTypeDecl>(MF.getDecl(opaqueResultTypeDeclID)));
+    if (opaqueReturnTypeID) {
+      ctx.evaluator.cacheOutput(
+          OpaqueResultTypeRequest{fn},
+          cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
+    }
 
     // Set the interface type.
     fn->computeType();
@@ -3707,8 +3710,9 @@ public:
       AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
     
     if (opaqueReturnTypeID) {
-      subscript->setOpaqueResultTypeDecl(
-                         cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
+      ctx.evaluator.cacheOutput(
+          OpaqueResultTypeRequest{subscript},
+          cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
     }
     
     return subscript;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -961,8 +961,7 @@ TypeDecl *SerializedASTFile::lookupLocalType(llvm::StringRef MangledName) const{
 }
 
 OpaqueTypeDecl *
-SerializedASTFile::lookupOpaqueResultType(StringRef MangledName,
-                                          LazyResolver *resolver) {
+SerializedASTFile::lookupOpaqueResultType(StringRef MangledName) {
   return File.lookupOpaqueResultType(MangledName);
 }
 

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -19,4 +19,7 @@ if (true ꝸꝸꝸ false) {} // expected-note {{identifier 'ꝸꝸꝸ' contains 
 // expected-error @+2 {{expected ',' separator}}
 // expected-error @+1 {{type '(Int, Int)' cannot conform to 'BinaryInteger'; only struct/enum/class types can conform to protocols}}
 if (5 ‒ 5) == 0 {} // expected-note {{unicode character '‒' looks similar to '-'; did you mean to use '-'?}} {{7-10=-}}
-// expected-note @-1 {{required by referencing operator function '==' on 'BinaryInteger' where 'Self' = '(Int, Int)'}}
+// expected-note @-1 {{required by referencing operator function '==' on 'BinaryInteger' where}}
+
+// FIXME: rdar://56002633
+// Above note should read "required by referencing operator function '==' on 'BinaryInteger' where 'Self' = '(Int, Int)'"


### PR DESCRIPTION
This PR continues refactoring validateDecl() with the goal of replacing it with a request for computing a declaration's interface type.

One of the main differences between validateDecl() and requests is that on circularity, requests diagnose an error. On the other hand, validateDecl() would begin by checking if the declaration or any of its parent contexts were already being validated, and return silently without setting the declaration's type.

This PR refactors the circularity checking so that validateDecl() now only concerns itself with the declaration being validated, and not any of its parent contexts. A new method, `ValueDecl::isRecursiveValidation()` can be used to check if parent contexts are being validated. This is only meant to be a temporary fix, since all of its usages should be refactored to break cycles in a more principled manner.

For now, `getInterfaceType()` still returns an empty type if the declaration is being validated. The next PR will change this.

Another refactoring in this PR is that synthesizing opaque type declarations is now done using requests as well, instead of a side effect of calling `validateDecl()`.