### PR TITLE
[ASTMangler] Do not crash when mangling a retroactive conformance

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1388,7 +1388,7 @@ void ASTMangler::appendRetroactiveConformances(Type type) {
     module = Mod ? Mod : nominal->getModuleContext();
     subMap = type->getContextSubstitutionMap(module, nominal);
   }
-  
+
   appendRetroactiveConformances(subMap, module);
 }
 
@@ -2528,7 +2528,7 @@ ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
 
   auto conformingType = conformance->getType();
   appendType(conformingType->getCanonicalType());
-  
+
   appendProtocolName(conformance->getProtocol());
 
   bool needsModule = true;
@@ -2649,6 +2649,10 @@ void ASTMangler::appendDependentProtocolConformance(
 void ASTMangler::appendConcreteProtocolConformance(
                                       const ProtocolConformance *conformance) {
   auto module = conformance->getDeclContext()->getParentModule();
+  if (!CurGenericSignature && conformance->getGenericSignature()) {
+    CurGenericSignature =
+        conformance->getGenericSignature()->getCanonicalSignature();
+  }
 
   // Conforming type.
   Type conformingType = conformance->getType();
@@ -2679,7 +2683,7 @@ void ASTMangler::appendConcreteProtocolConformance(
         assert(CurGenericSignature &&
                "Need a generic signature to resolve conformance");
         auto conformanceAccessPath =
-          CurGenericSignature->getConformanceAccessPath(type, proto);
+            CurGenericSignature->getConformanceAccessPath(type, proto);
         appendDependentProtocolConformance(conformanceAccessPath);
       } else if (auto opaqueType = canType->getAs<OpaqueTypeArchetypeType>()) {
         GenericSignature opaqueSignature = opaqueType->getBoundSignature();

--- a/test/IRGen/retroactive_conformance_path.swift
+++ b/test/IRGen/retroactive_conformance_path.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+// Check that the ASTMangler does not crash when mangling a retroactive conformance
+// and also do a executable test to make sure the code works as expected.
+
+extension Result: RandomAccessCollection, BidirectionalCollection, Collection, Sequence where Success: RandomAccessCollection, Success.Index == Int {
+  public typealias Element = Result<Success.Element, Failure>
+  public typealias Index = Int
+  public var startIndex: Int {
+    switch self {
+      case .success(let array):
+        return array.startIndex
+      case .failure:
+        return 0
+    }
+  }
+   public var endIndex: Int {
+    switch self {
+      case .success(let array):
+        return array.endIndex
+      case .failure:
+        return 1
+    }
+   }
+   public subscript(position: Int) -> Result<Success.Element, Failure> {
+    switch self {
+    case .success(let array):
+      return .success(array[position])
+    case .failure(let error):
+      return .failure(error)
+    }
+   }
+}
+
+let coll: [Int] = [4, 8, 15, 16, 23, 42]
+let result: Result<[Int], Error> = .success(coll)
+// CHECK: success(15)
+print(result[2])


### PR DESCRIPTION
We have a crash when trying to get the conformance access path in `appendConcreteProtocolConformance` because `CurGenericSignature` is null. 

I think the reason why this is happening is because we're calling `appendType` before calling `appendGenericSignature` (or some other method which also sets `CurGenericSignature`), which means in some cases we don't have a `CurGenericSignature` to grab the conformance path from when mangling a retroactive conformance.

For example, the stack trace for the failure case looks like this:

```
-> IRGenMangler::mangleTypeForReflection
  -> IRGenMangler::withSymbolicReferences
    -> ASTMangler::appendType
      -> ASTMangler::appendRetroactiveConformances
        -> ASTMangler::appendConcreteProtocolConformance
```

Another one looks like this:

```
-> getMangledName
  -> ASTMangler::mangleTypeForDebugger
    -> ASTMangler::appendType
      -> ASTMangler::appendRetroactiveConformances
        -> ASTMangler::appendConcreteProtocolConformance
```

In both these paths, when `appendConcreteProtocolConformance ` is called, we don't have a `CurGenericSignature`. For example - in the second scenario, `mangleTypeForDebugger` is called with a null `DeclContext` so we never call `bindGenericParameters` which would then go on to set `CurGenericSignature`.

To fix this, I have made `appendConcreteProtocolConformance` more defensive. I am not sure if this is the right thing to do, but it makes the failing cases compile & work.

Resolves [SR-11521](https://bugs.swift.org/browse/SR-11521)
Resolves [SR-11561](https://bugs.swift.org/browse/SR-11561)
Resolves [SR-11573](https://bugs.swift.org/browse/SR-11573)
Resolves rdar://problem/55705702
Resolves rdar://problem/55987394
Resolves feedback://7351428