### PR TITLE
Constant fold string comparisons

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -358,7 +358,7 @@ bool SILCombiner::stringCompareConstantFolding(SILBasicBlock *Pred) {
         auto TrueStruct = B.createStruct(AI->getLoc(), AI->getType(), {C1});
 
         AI->replaceAllUsesWith(TrueStruct);
-        Changed |= true;
+        Changed = true;
       }
     }
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -244,6 +244,8 @@ public:
   bool tryOptimizeKeypath(ApplyInst *AI);
   bool tryOptimizeInoutKeypath(BeginApplyInst *AI);
 
+  bool stringCompareConstantFolding(SILBasicBlock *Pred);
+
   // Optimize concatenation of string literals.
   // Constant-fold concatenation of string literals known at compile-time.
   SILInstruction *optimizeConcatenationOfStringLiterals(ApplyInst *AI);

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -377,6 +377,7 @@ bool BBEnumTagDataflowState::initWithFirstPred(SILBasicBlock *FirstPredBB) {
 
 void BBEnumTagDataflowState::mergeSinglePredTermInfoIntoState(
     SILBasicBlock *Pred) {
+
   // Grab the terminator of our one predecessor and if it is a switch enum, mix
   // it into this state.
   TermInst *PredTerm = Pred->getTerminator();

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -377,7 +377,6 @@ bool BBEnumTagDataflowState::initWithFirstPred(SILBasicBlock *FirstPredBB) {
 
 void BBEnumTagDataflowState::mergeSinglePredTermInfoIntoState(
     SILBasicBlock *Pred) {
-
   // Grab the terminator of our one predecessor and if it is a switch enum, mix
   // it into this state.
   TermInst *PredTerm = Pred->getTerminator();

--- a/test/SILOptimizer/string_compare.swift
+++ b/test/SILOptimizer/string_compare.swift
@@ -1,0 +1,91 @@
+// RUN: %target-swift-frontend -parse-as-library -O -emit-ir  %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -Osize -emit-ir  %s | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// UNSUPPORTED: PTRSIZE=32
+
+// This is an end-to-end test to ensure that the optimizer generates
+// optimal code for comparing string literals
+
+// CHECK-LABEL: define {{.*}}test0
+// CHECK:      entry:
+// CHECK-NEXT:   ret i1 true
+// CHECK-NEXT: }
+public func test0() -> Bool {
+  return "Hello, " + "Swift" == "Hello, Swift"
+}
+
+// CHECK-LABEL: define {{.*}}test1
+// CHECK:      entry:
+// CHECK-NEXT:   ret i64 2
+// CHECK-NEXT: }
+public func test1() -> Int {
+  let str = "a"
+  if str == "1" { return 0 }
+  if str == "2" { return 1 }
+  if str == "a" { return 2 }
+  if str == "b" { return 3 }
+  return -1
+}
+
+// CHECK-LABEL: define {{.*}}test2
+// CHECK:      entry:
+// CHECK-NEXT:   ret i64 4
+// CHECK-NEXT: }
+public func test2() -> Int {
+  if "a" == "b" { return 1 }
+
+  let x = "abc"
+  if x == "123" { return 2 }
+  else if x == "456" { return 3 }
+  else { return 4 }
+}
+
+// CHECK-LABEL: define {{.*}}test3
+// CHECK:      entry:
+// CHECK-NEXT:   ret i64 2
+// CHECK-NEXT: }
+public func test3() -> Int {
+  let str = "2"
+
+  switch str {
+    case "1": return 1
+    case "2": return 2
+    case "3": return 3
+    case "4": return 4
+    default : return 0
+  }
+}
+
+// CHECK-LABEL: define {{.*}}test4
+// CHECK:      entry:
+// CHECK-NEXT:   ret i64 1
+// CHECK-NEXT: }
+public func test4() -> Int {
+  let str = "1"
+
+  switch str {
+    case "1": return 1
+    case "2": return 2
+    case "3": return 3
+    case "4": return 4
+    default : return 0
+  }
+}
+
+// CHECK-LABEL: define {{.*}}test5
+// CHECK:      entry:
+// CHECK-NEXT:   ret i64 0
+// CHECK-NEXT: }
+public func test5() -> Int {
+  let str = "x"
+
+  switch str {
+    case "1": return 1
+    case "2": return 2
+    case "3": return 3
+    case "4": return 4
+    default : return 0
+  }
+}
+


### PR DESCRIPTION
This patch adds constant folding for string comparisons. Most if not all string comparisons that compare constant values can now happen at compile time. This works for both switch and if statements. 

## Example
### Input
```
func test() -> Int {
  let i = "3"
  switch i {
      case "1": return 1
      case "2": return 2
      default: return 3
  }
}
```
### Old output
```
	.cfi_startproc
	pushq	%rbp
	.cfi_def_cfa_offset 16
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
	.cfi_def_cfa_register %rbp
	pushq	%rbx
	pushq	%rax
	.cfi_offset %rbx, -24
	movabsq	$-2233785415175766016, %rbx
	movl	$51, %edi
	movq	%rbx, %rsi
	callq	_$ss12_SmallStringV15_invariantCheckyyF
	movl	$51, %edi
	movq	%rbx, %rsi
	callq	_$ss13_StringObjectV15_invariantCheckyyF
	movl	$51, %edi
	movq	%rbx, %rsi
	callq	_$ss11_StringGutsV15_invariantCheckyyF
	movl	$51, %edi
	movq	%rbx, %rsi
	callq	_$sSS15_invariantCheckyyF
	movl	$50, %edi
	movq	%rbx, %rsi
	callq	_$ss12_SmallStringV15_invariantCheckyyF
	movl	$50, %edi
	movq	%rbx, %rsi
	callq	_$ss13_StringObjectV15_invariantCheckyyF
	movl	$50, %edi
	movq	%rbx, %rsi
	callq	_$ss11_StringGutsV15_invariantCheckyyF
	movl	$50, %edi
	movq	%rbx, %rsi
	callq	_$sSS15_invariantCheckyyF
	movl	$50, %edi
	movl	$51, %edx
	movq	%rbx, %rsi
	movq	%rbx, %rcx
	xorl	%r8d, %r8d
	callq	_$ss27_stringCompareWithSmolCheck__9expectingSbs11_StringGutsV_ADs01_G16ComparisonResultOtF
	movzbl	%al, %eax
	andl	$1, %eax
	xorq	$3, %rax
	addq	$8, %rsp
	popq	%rbx
	popq	%rbp
	retq
	.cfi_endproc
```
### New output
```
	pushq	%rbp
	movq	%rsp, %rbp
	movl	$3, %eax
	popq	%rbp
	retq
```

## TODO
- [ ] Where is the correct place for this function to go?
- [ ] How do I correctly query for the string comparison function?
- [ ] Tests? Where should my tests go and are there any examples so I can figure out how to write them? 