### PR TITLE
Circular validation cleanups, part 4

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2372,13 +2372,9 @@ CanType ASTMangler::getDeclTypeForMangling(
   }
 
 
-  Type type = decl->getInterfaceType()
-                  ->getReferenceStorageReferent();
-  if (type->hasArchetype()) {
-    assert(isa<ParamDecl>(decl) && "Only ParamDecl's still have archetypes");
-    type = type->mapTypeOutOfContext();
-  }
-  CanType canTy = type->getCanonicalType();
+  auto canTy = decl->getInterfaceType()
+                   ->getReferenceStorageReferent()
+                   ->getCanonicalType();
 
   if (auto gft = dyn_cast<GenericFunctionType>(canTy)) {
     genericSig = gft.getGenericSignature();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2744,13 +2744,7 @@ void ValueDecl::setInterfaceType(Type type) {
   if (type) {
     assert(!type->hasTypeVariable() && "Type variable in interface type");
     assert(!type->is<InOutType>() && "Interface type must be materializable");
-
-    // ParamDecls in closure contexts can have type variables
-    // archetype in them during constraint generation.
-    if (!(isa<ParamDecl>(this) && isa<AbstractClosureExpr>(getDeclContext()))) {
-      assert(!type->hasArchetype() &&
-             "Archetype in interface type");
-    }
+    assert(!type->hasArchetype() && "Archetype in interface type");
 
     if (type->hasError())
       setInvalid();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2731,8 +2731,11 @@ Type ValueDecl::getInterfaceType() const {
     // Our clients that don't register the lazy resolver are relying on the
     // fact that they can't pull an interface type out to avoid doing work.
     // This is a necessary evil until we can wean them off.
-    if (auto resolver = getASTContext().getLazyResolver())
+    if (auto resolver = getASTContext().getLazyResolver()) {
       resolver->resolveDeclSignature(const_cast<ValueDecl *>(this));
+      if (!hasInterfaceType())
+        return ErrorType::get(getASTContext());
+    }
   }
   return TypeAndAccess.getPointer();
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -868,7 +868,7 @@ calculateTypeRelationForDecl(const Decl *D, Type ExpectedType,
                              bool UseFuncResultType = true) {
   auto VD = dyn_cast<ValueDecl>(D);
   auto DC = D->getDeclContext();
-  if (!VD || !VD->getInterfaceType())
+  if (!VD)
     return CodeCompletionResult::ExpectedTypeRelation::Unrelated;
 
   if (auto FD = dyn_cast<AbstractFunctionDecl>(VD)) {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -888,9 +888,6 @@ bool swift::ide::isReferenceableByImplicitMemberExpr(
   if (VD->isOperator())
     return false;
 
-  if (!VD->getInterfaceType())
-    return false;
-
   if (T->getOptionalObjectType() &&
       VD->getModuleContext()->isStdlibModule()) {
     // In optional context, ignore '.init(<some>)', 'init(nilLiteral:)',

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -139,10 +139,6 @@ void ContextInfoCallbacks::getImplicitMembers(
       if (VD->isOperator())
         return false;
 
-      if (!VD->getInterfaceType()) {
-        return false;
-      }
-
       // Enum element decls can always be referenced by implicit member
       // expression.
       if (isa<EnumElementDecl>(VD))

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -136,8 +136,6 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       if (!typeDecl)
         return CanType();
 
-      assert(typeDecl->hasInterfaceType() &&
-             "bridged type must be type-checked");
       return typeDecl->getDeclaredInterfaceType()->getCanonicalType();
     })();
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -107,8 +107,6 @@ getBridgingFn(Optional<SILDeclRef> &cacheSlot,
       llvm::report_fatal_error("unable to set up the ObjC bridge!");
     }
 
-    assert(fd->hasInterfaceType() && "bridging functions must be type-checked");
-
     // Check that the function takes the expected arguments and returns the
     // expected result type.
     SILDeclRef c(fd);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2028,8 +2028,9 @@ namespace {
 
         // If a type was explicitly specified, use its opened type.
         if (auto type = param->getTypeLoc().getType()) {
+          paramType = closureExpr->mapTypeIntoContext(type);
           // FIXME: Need a better locator for a pattern as a base.
-          paramType = CS.openUnboundGenericType(type, locator);
+          paramType = CS.openUnboundGenericType(paramType, locator);
           internalType = paramType;
         } else {
           // Otherwise, create fresh type variables.

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -843,18 +843,6 @@ static void addImplicitConstructorsToStruct(StructDecl *decl, ASTContext &ctx) {
   assert(!decl->hasUnreferenceableStorage() &&
          "User-defined structs cannot have unreferenceable storage");
 
-  // Bail out if we're validating one of our stored properties already;
-  // we'll revisit the issue later.
-  for (auto member : decl->getMembers()) {
-    if (auto var = dyn_cast<VarDecl>(member)) {
-      if (!var->isMemberwiseInitialized(/*preferDeclaredProperties=*/true))
-        continue;
-
-      if (!var->getInterfaceType())
-        return;
-    }
-  }
-
   decl->setAddedImplicitInitializers();
 
   // Check whether there is a user-declared constructor or an instance
@@ -915,7 +903,7 @@ static void addImplicitConstructorsToClass(ClassDecl *decl, ASTContext &ctx) {
   if (!decl->hasClangNode()) {
     for (auto member : decl->getMembers()) {
       if (auto ctor = dyn_cast<ConstructorDecl>(member)) {
-        if (!ctor->getInterfaceType())
+        if (ctor->isRecursiveValidation())
           return;
       }
     }

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -117,12 +117,6 @@ static CodableConformanceType varConformsToCodable(TypeChecker &tc,
   //   var x: Int // <- we get to valuate x's var decl here, but its type
   //              //    hasn't yet been evaluated
   // }
-  //
-  // If the var decl didn't validate, it may still not have a type; confirm it
-  // has a type before ensuring the type conforms to Codable.
-  if (!varDecl->getInterfaceType())
-    return TypeNotValidated;
-
   bool isIUO = varDecl->isImplicitlyUnwrappedOptional();
   return typeConformsToCodable(context, varDecl->getValueInterfaceType(),
                                isIUO, proto);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -47,8 +47,8 @@ associatedValuesNotConformingToProtocol(DeclContext *DC, EnumDecl *theEnum,
                                         ProtocolDecl *protocol) {
   SmallVector<ParamDecl *, 3> nonconformingAssociatedValues;
   for (auto elt : theEnum->getAllElements()) {
-    if (!elt->getInterfaceType())
-      continue;
+    // FIXME: Remove this once getInterfaceType() on a ParamDecl works.
+    (void) elt->getInterfaceType();
     
     auto PL = elt->getParameterList();
     if (!PL)

--- a/lib/Sema/TypeCheckCircularity.cpp
+++ b/lib/Sema/TypeCheckCircularity.cpp
@@ -249,10 +249,7 @@ bool CircularityChecker::expandStruct(CanType type, StructDecl *S,
       S->getModuleContext(), S);
 
   for (auto field: S->getStoredProperties()) {
-    if (!field->getInterfaceType())
-      continue;
-
-    auto fieldType =field->getInterfaceType().subst(subMap);
+    auto fieldType =field->getValueInterfaceType().subst(subMap);
     if (addMember(type, field, fieldType, depth))
       return true;
   }
@@ -281,9 +278,6 @@ bool CircularityChecker::expandEnum(CanType type, EnumDecl *E,
       continue;
 
     if (!elt->hasAssociatedValues())
-      continue;
-
-    if (!elt->getInterfaceType())
       continue;
 
     auto eltType = elt->getArgumentInterfaceType().subst(subMap);
@@ -614,9 +608,6 @@ void CircularityChecker::diagnoseNonWellFoundedEnum(EnumDecl *E) {
       return false;
 
     for (auto elt: elts) {
-      if (!elt->getInterfaceType())
-        return false;
-
       if (!elt->isIndirect() && !E->isIndirect())
         return false;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1350,8 +1350,7 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   bool hadParameterError = false;
 
-  auto resolution = TypeResolution::forContextual(closure);
-  if (TC.typeCheckParameterList(PL, resolution, options)) {
+  if (TC.typeCheckParameterList(PL, closure, options)) {
     // If we encounter an error validating the parameter list, don't bail.
     // Instead, go on to validate any potential result type, and bail
     // afterwards.  This allows for better diagnostics, and keeps the
@@ -1361,8 +1360,9 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
 
   // Validate the result type, if present.
   if (closure->hasExplicitResultType() &&
-      TypeChecker::validateType(TC.Context, closure->getExplicitResultTypeLoc(),
-                                resolution,
+      TypeChecker::validateType(TC.Context,
+                                closure->getExplicitResultTypeLoc(),
+                                TypeResolution::forContextual(closure),
                                 TypeResolverContext::InExpression)) {
     return false;
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -440,12 +440,6 @@ static bool findNonMembers(TypeChecker &TC,
     if (!isValid(D))
       return false;
 
-    // FIXME: Circularity hack.
-    if (!D->getInterfaceType()) {
-      AllDeclRefs = false;
-      continue;
-    }
-
     if (matchesDeclRefKind(D, refKind))
       ResultValues.push_back(D);
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4045,8 +4045,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     
     // We want the function to be available for name lookup as soon
     // as it has a valid interface type.
-    auto resolution = TypeResolution::forInterface(FD);
-    typeCheckParameterList(FD->getParameters(), resolution,
+    typeCheckParameterList(FD->getParameters(), FD,
                            TypeResolverContext::AbstractFunctionDecl);
     validateResultType(FD, FD->getBodyResultTypeLoc());
     // FIXME: Roll all of this interface type computation into a request.
@@ -4072,8 +4071,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(CD);
 
-    auto res = TypeResolution::forInterface(CD);
-    typeCheckParameterList(CD->getParameters(), res,
+    typeCheckParameterList(CD->getParameters(), CD,
                            TypeResolverContext::AbstractFunctionDecl);
     CD->computeType();
     break;
@@ -4084,8 +4082,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(DD);
 
-    auto res = TypeResolution::forInterface(DD);
-    typeCheckParameterList(DD->getParameters(), res,
+    typeCheckParameterList(DD->getParameters(), DD,
                            TypeResolverContext::AbstractFunctionDecl);
     DD->computeType();
     break;
@@ -4096,8 +4093,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     DeclValidationRAII IBV(SD);
 
-    auto res = TypeResolution::forInterface(SD);
-    typeCheckParameterList(SD->getIndices(), res,
+    typeCheckParameterList(SD->getIndices(), SD,
                            TypeResolverContext::SubscriptDecl);
     validateResultType(SD, SD->getElementTypeLoc());
     SD->computeType();
@@ -4112,8 +4108,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     DeclValidationRAII IBV(EED);
 
     if (auto *PL = EED->getParameterList()) {
-      auto res = TypeResolution::forInterface(ED);
-      typeCheckParameterList(PL, res,
+      typeCheckParameterList(PL, ED,
                              TypeResolverContext::EnumElementDecl);
     }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -813,11 +813,8 @@ bool swift::isRepresentableInObjC(
 bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
   // If you change this function, you must add or modify a test in PrintAsObjC.
 
-  if (!VD->getInterfaceType()) {
-    VD->diagnose(diag::recursive_decl_reference, VD->getDescriptiveKind(),
-                 VD->getName());
-    return false;
-  }
+  // FIXME: Computes isInvalid() below.
+  (void) VD->getInterfaceType();
 
   if (VD->isInvalid())
     return false;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -430,12 +430,6 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
   for (auto decl : decls) {
     auto *typeDecl = cast<TypeDecl>(decl);
 
-    // FIXME: This should happen before we attempt shadowing checks.
-    if (!typeDecl->getInterfaceType()) {
-      // FIXME: recursion-breaking hack
-      continue;
-    }
-
     auto memberType = typeDecl->getDeclaredInterfaceType();
 
     if (isUnsupportedMemberTypeAccess(type, typeDecl)) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -794,8 +794,10 @@ static bool validateParameterType(ParamDecl *decl, TypeResolution resolution,
 
 /// Type check a parameter list.
 bool TypeChecker::typeCheckParameterList(ParameterList *PL,
-                                         TypeResolution resolution,
+                                         DeclContext *dc,
                                          TypeResolutionOptions options) {
+  auto resolution = TypeResolution::forInterface(dc);
+
   bool hadError = false;
   
   for (auto param : *PL) {

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -141,17 +141,17 @@ static ConstructorDecl *findInitialValueInit(
       continue;
     }
 
-    Type paramType;
-    if (!wrappedValueParam->isInOut() && !wrappedValueParam->isVariadic()) {
-      paramType = wrappedValueParam->getInterfaceType();
-      if (wrappedValueParam->isAutoClosure()) {
-        if (auto *fnType = paramType->getAs<FunctionType>())
-          paramType = fnType->getResult();
-      }
-    }
-    
-    if (!paramType)
+    if (!wrappedValueParam->hasInterfaceType())
       continue;
+
+    if (wrappedValueParam->isInOut() || wrappedValueParam->isVariadic())
+      continue;
+
+    auto paramType = wrappedValueParam->getInterfaceType();
+    if (wrappedValueParam->isAutoClosure()) {
+      if (auto *fnType = paramType->getAs<FunctionType>())
+        paramType = fnType->getResult();
+    }
 
     // The parameter type must be the same as the type of `valueVar` or an
     // autoclosure thereof.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -334,7 +334,7 @@ swift::matchWitness(
     return RequirementMatch(witness, MatchKind::WitnessInvalid);
 
   // If we're currently validating the witness, bail out.
-  if (!witness->getInterfaceType())
+  if (witness->isRecursiveValidation())
     return RequirementMatch(witness, MatchKind::Circularity);
 
   // Get the requirement and witness attributes.

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -798,12 +798,6 @@ namespace {
           auto children = E->getAllElements();
           std::transform(children.begin(), children.end(),
                          std::back_inserter(arr), [&](EnumElementDecl *eed) {
-            // If there's still no interface type then there's
-            // not much else we can do here.
-            if (!eed->getInterfaceType()) {
-              return Space();
-            }
-
             // Don't force people to match unavailable cases; they can't even
             // write them.
             if (AvailableAttr::isUnavailable(eed)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1354,7 +1354,7 @@ public:
   bool typeCheckCatchPattern(CatchStmt *S, DeclContext *dc);
 
   /// Type check a parameter list.
-  bool typeCheckParameterList(ParameterList *PL, TypeResolution resolution,
+  bool typeCheckParameterList(ParameterList *PL, DeclContext *dc,
                               TypeResolutionOptions options);
 
   /// Coerce a pattern to the given type.

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -570,8 +570,9 @@ class SR771 {
 extension SR771 {
     print("The room where it happened, the room where it happened")
     // expected-error @-1 {{expected 'func' keyword in instance method declaration}}
-    // expected-error @-2 {{invalid redeclaration of 'print()'}}
-    // expected-error @-3 {{expected parameter name followed by ':'}}
+    // expected-error @-2 {{expected '{' in body of function declaration}}
+    // expected-error @-3 {{invalid redeclaration of 'print()'}}
+    // expected-error @-4 {{expected parameter name followed by ':'}}
 }
 
 

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -265,8 +265,8 @@ class Base24646184 {
   func foo(ok: SubTy) { }
 }
 class Derived24646184 : Base24646184 {
-  override init(_: Ty) { } // expected-error {{'init(_:)' has already been overridden}}
-  override init(_: SubTy) { } // expected-note {{'init(_:)' previously overridden here}}
+  override init(_: Ty) { } // expected-note {{'init(_:)' previously overridden here}}
+  override init(_: SubTy) { } // expected-error {{'init(_:)' has already been overridden}}
   override func foo(_: Ty) { } // expected-note {{'foo' previously overridden here}}
   override func foo(_: SubTy) { } // expected-error {{'foo' has already been overridden}}
 

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -22,13 +22,15 @@ class InitClass {
   @objc dynamic init(bar: Int) {}
 }
 class InitSubclass: InitClass {}
-// expected-error@-1 {{'init(bar:)' has already been overridden}}
-// expected-error@-2 {{'init(baz:)' has already been overridden}}
+// expected-note@-1{{'init(baz:)' previously overridden here}}
+// expected-note@-2{{'init(bar:)' previously overridden here}}
 extension InitSubclass {
   convenience init(arg: Bool) {} // expected-error{{overriding non-@objc declarations from extensions is not supported}}
-  convenience override init(baz: Int) {} // expected-note{{'init(baz:)' previously overridden here}}
-  // expected-error@-1 {{cannot override a non-dynamic class declaration from an extension}}
-  convenience override init(bar: Int) {} // expected-note{{'init(bar:)' previously overridden here}}
+  convenience override init(baz: Int) {}
+  // expected-error@-1 {{'init(baz:)' has already been overridden}}
+  // expected-error@-2 {{cannot override a non-dynamic class declaration from an extension}}
+  convenience override init(bar: Int) {}
+  // expected-error@-1 {{'init(bar:)' has already been overridden}}
 }
 
 struct InitStruct {

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -66,8 +66,7 @@ class SomeClass {}
 weak let V = SomeClass()  // expected-error {{'weak' must be a mutable variable, because it may change at runtime}}
 
 let a = b ; let b = a
-// expected-note@-1 {{'a' declared here}}
-// expected-error@-2 {{ambiguous use of 'a'}}
+// expected-error@-1 {{let 'a' references itself}}
 
 // <rdar://problem/17501765> Swift should warn about immutable default initialized values
 let uselessValue : String?


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/27546 which completes the changeover to make `ValueDecl::getInterfaceType()` return ErrorType on circularity, instead of an empty Type.