### PR TITLE
[AutoDiff] Fix differentiation crasher: control flow + non-varied res…

### DIFF
--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6181,14 +6181,15 @@ public:
     auto origResult = origFormalResults[getIndices().source];
 
     // If original result is non-varied, it will always have a zero derivative.
-    // Skip full pullback generation and simply return zero for wrt parameters.
+    // Skip full pullback generation and simply emit zero derivatives for wrt
+    // parameters.
     //
     // NOTE(TF-876): This shortcut is currently necessary for functions
     // returning non-varied result with >1 basic block where some basic blocks
     // have no dominated active values; control flow differentiation does not
     // handle this case. See TF-876 for context.
     if (!getActivityInfo().isVaried(origResult, getIndices().parameters)) {
-      handleNonVariedResult(origResult);
+      emitZeroDerivativesForNonvariedResult(origResult);
       return errorOccurred;
     }
 
@@ -6455,8 +6456,9 @@ public:
   }
 
   /// If original result is non-varied, it will always have a zero derivative.
-  /// Skip full pullback generation and simply return zero for wrt parameters.
-  void handleNonVariedResult(SILValue origNonvariedResult) {
+  /// Skip full pullback generation and simply emit zero derivatives for wrt
+  /// parameters.
+  void emitZeroDerivativesForNonvariedResult(SILValue origNonvariedResult) {
     auto &pullback = getPullback();
     auto pbLoc = getPullback().getLocation();
     /*

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6474,7 +6474,7 @@ public:
     */
     LLVM_DEBUG(getADDebugStream() << getOriginal().getName()
                                   << " has non-varied result, returning zero"
-                                     " for all pullback results");
+                                     " for all pullback results\n");
     auto *pullbackEntry = pullback.createBasicBlock();
     createEntryArguments(&pullback);
     builder.setInsertionPoint(pullbackEntry);

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6190,7 +6190,7 @@ public:
     // handle this case. See TF-876 for context.
     if (!getActivityInfo().isVaried(origResult, getIndices().parameters)) {
       emitZeroDerivativesForNonvariedResult(origResult);
-      return errorOccurred;
+      return false;
     }
 
     // Get dominated active values in original blocks.

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -6484,10 +6484,12 @@ public:
     SmallVector<SILValue, 4> directResults;
     auto indirectResultIt = pullback.getIndirectResults().begin();
     for (auto resultInfo : pullback.getLoweredFunctionType()->getResults()) {
+      auto resultType =
+          pullback.mapTypeIntoContext(resultInfo.getType())->getCanonicalType();
       if (resultInfo.isFormalDirect())
-        directResults.push_back(emitZeroDirect(resultInfo.getType(), pbLoc));
+        directResults.push_back(emitZeroDirect(resultType, pbLoc));
       else
-        emitZeroIndirect(resultInfo.getType(), *indirectResultIt++, pbLoc);
+        emitZeroIndirect(resultType, *indirectResultIt++, pbLoc);
     }
     builder.createReturn(pbLoc, joinElements(directResults, builder, pbLoc));
     LLVM_DEBUG(getADDebugStream() << "Generated pullback for "

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift
@@ -258,6 +258,19 @@ extension Tracked where T : Differentiable & FloatingPoint, T == T.TangentVector
 }
 
 // Differential operators for `Tracked<Float>`.
+public func gradient(
+  at x: Tracked<Float>, in f: @differentiable (Tracked<Float>) -> Tracked<Float>
+) -> Tracked<Float> {
+  return pullback(at: x, in: f)(1)
+}
+
+public func gradient(
+  at x: Tracked<Float>, _ y: Tracked<Float>,
+  in f: @differentiable (Tracked<Float>, Tracked<Float>) -> Tracked<Float>
+) -> (Tracked<Float>, Tracked<Float>) {
+  return pullback(at: x, y, in: f)(1)
+}
+
 public extension Differentiable {
   @inlinable
   func gradient(

--- a/test/AutoDiff/nonvaried_result.swift
+++ b/test/AutoDiff/nonvaried_result.swift
@@ -1,0 +1,91 @@
+// RUN: %target-run-simple-swift
+// TODO: Test forward-mode differentiation when it supports control flow.
+// UN: %target_run_simple_swift_forward_mode_differentiation
+// REQUIRES: executable_test
+
+// Test differentiation edge case: functions with non-varied results.
+// The differentials of these functions should return zero.
+// The pullbacks of these functions should return zero with respect to the
+// parameters for which the result is non-varying.
+
+import StdlibUnittest
+import DifferentiationUnittest
+
+var NonVariedResultTests = TestSuite("TestCaseTests")
+
+NonVariedResultTests.testWithLeakChecking("SingleBasicBlock") {
+  @differentiable(wrt: y)
+  func simple(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in simple(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: simple))
+}
+
+NonVariedResultTests.testWithLeakChecking("Conditionals") {
+  @differentiable(wrt: y)
+  func `if`(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    if x > 0 {}
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in `if`(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: `if`))
+
+  @differentiable(wrt: y)
+  func `guard`(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    guard x > 0 else { return x }
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in `guard`(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: `guard`))
+
+  @differentiable(wrt: y)
+  func `switch`(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    switch x.value {
+    case 0: break
+    default: break
+    }
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in `switch`(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: `switch`))
+}
+
+NonVariedResultTests.testWithLeakChecking("Loops") {
+  @differentiable(wrt: y)
+  func `for`(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    for i in 0..<10 {}
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in `for`(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: `for`))
+
+  @differentiable(wrt: y)
+  func `while`(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    while 0 < 0 {}
+    return x
+  }
+  expectEqual(0, gradient(at: 3) { x in `while`(10, x) })
+  expectEqual((1, 0), gradient(at: 3, 4, in: `while`))
+}
+
+NonVariedResultTests.testWithLeakChecking("Complex") {
+  @differentiable(wrt: y)
+  func complex(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
+    for i in 0..<10 {
+      for j in 0..<10 {
+        if x > 0 {}
+        while 0 < 0 {}
+        switch x.value {
+        case 0: break
+        default: break
+        }
+      }
+    }
+    return x + x + x
+  }
+  expectEqual(0, gradient(at: 3) { x in complex(10, x) })
+  expectEqual((3, 0), gradient(at: 3, 4, in: complex))
+}
+
+runAllTests()

--- a/test/AutoDiff/nonvaried_result.swift
+++ b/test/AutoDiff/nonvaried_result.swift
@@ -1,3 +1,4 @@
+// RUN: %target-swift-frontend -Xllvm -sil-print-after=differentiation %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
 // RUN: %target-run-simple-swift
 // TODO: Test forward-mode differentiation when it supports control flow.
 // UN: %target_run_simple_swift_forward_mode_differentiation
@@ -18,9 +19,46 @@ NonVariedResultTests.testWithLeakChecking("SingleBasicBlock") {
   func simple(_ x: Tracked<Float>, _ y: Tracked<Float>) -> Tracked<Float> {
     return x
   }
-  expectEqual(0, gradient(at: 3) { x in simple(10, x) })
+  expectEqual(0, gradient(at: 3) { simple(10, $0) })
   expectEqual((1, 0), gradient(at: 3, 4, in: simple))
 }
+
+// CHECK-LABEL: sil hidden [ossa] @AD__${{.*}}simple{{.*}}pullback_src_0_wrt_1 : $@convention(thin) (@guaranteed Tracked<Float>, @owned _AD__$s4nullyycfU_6simpleL_y23DifferentiationUnittest7TrackedVySfGAF_AFtF_bb0__PB__src_0_wrt_1) -> @owned Tracked<Float> {
+// CHECK: bb0([[SEED:%.*]] : @guaranteed $Tracked<Float>, [[PB_STRUCT:%.*]] : [[PB_STRUCT_TYPE:.*]]):
+// CHECK:   [[BUF:%.*]] = alloc_stack $Tracked<Float>
+// CHECK:   [[ZERO_FN:%.*]] = witness_method $Tracked<Float>, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE:%.*]] = metatype $@thick Tracked<Float>.Type
+// CHECK:   {{%.*}} = apply [[ZERO_FN]]<Tracked<Float>>([[BUF]], [[METATYPE]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[ZERO_VALUE:%.*]] = load [take] [[BUF]] : $*Tracked<Float>
+// CHECK:   dealloc_stack [[BUF]] : $*Tracked<Float>
+// CHECK:   return [[ZERO_VALUE]]
+
+NonVariedResultTests.testWithLeakChecking("SingleBasicBlockGeneric") {
+  // Test zero wrt multiple arguments.
+  @differentiable(wrt: (x, y, z))
+  func simpleGeneric<T: Differentiable>(
+    _ x: T, _ y: T, _ z: Tracked<Float>
+  ) -> T where T == T.TangentVector {
+    return .zero
+  }
+  expectEqual((0, 0, 0), gradient(at: 3, 4, 5) { simpleGeneric($0, $1, $2) })
+}
+
+// CHECK-LABEL: sil hidden [ossa] @AD__${{.*}}simpleGeneric{{.*}}pullback_src_0_wrt_0_1_2 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable, τ_0_0 == τ_0_0.TangentVector> (@in_guaranteed τ_0_0.TangentVector, @owned _AD__$s4nullyycfU0_13simpleGenericL_yxx_x23DifferentiationUnittest7TrackedVySfGts14DifferentiableRz13TangentVectorsAGPQzRszlF_bb0__PB__src_0_wrt_0_1_2<τ_0_0>) -> (@out τ_0_0.TangentVector, @out τ_0_0.TangentVector, @owned Tracked<Float>) {
+// CHECK: bb0([[DX:%.*]] : $*τ_0_0, [[DY:%.*]] : $*τ_0_0, [[SEED:%.*]] : $*τ_0_0, [[PB_STRUCT:%.*]] : [[PB_STRUCT_TYPE:.*]]):
+// CHECK:   [[ZERO_FN_X:%.*]] = witness_method $τ_0_0, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE_X:%.*]] = metatype $@thick τ_0_0.Type
+// CHECK:   {{.*}} = apply [[ZERO_FN_X]]<τ_0_0>([[DX]], [[METATYPE_X]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[ZERO_FN_Y:%.*]] = witness_method $τ_0_0, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE_Y:%.*]] = metatype $@thick τ_0_0.Type
+// CHECK:   {{.*}} = apply [[ZERO_FN_Y:%.*]]<τ_0_0>([[DY]], [[METATYPE_Y]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[BUF_Z:%.*]] = alloc_stack $Tracked<Float>
+// CHECK:   [[ZERO_FN_Z:%.*]] = witness_method $Tracked<Float>, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE_Z:%.*]] = metatype $@thick Tracked<Float>.Type
+// CHECK:   {{%.*}} = apply [[ZERO_FN_Z]]<Tracked<Float>>([[BUF_Z]], [[METATYPE_Z]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[ZERO_VALUE_Z:%.*]] = load [take] [[BUF_Z]] : $*Tracked<Float>
+// CHECK:   dealloc_stack [[BUF_Z]] : $*Tracked<Float>
+// CHECK:   return [[ZERO_VALUE_Z]]
 
 NonVariedResultTests.testWithLeakChecking("Conditionals") {
   @differentiable(wrt: y)
@@ -28,7 +66,7 @@ NonVariedResultTests.testWithLeakChecking("Conditionals") {
     if x > 0 {}
     return x
   }
-  expectEqual(0, gradient(at: 3) { x in `if`(10, x) })
+  expectEqual(0, gradient(at: 3) { `if`(10, $0) })
   expectEqual((1, 0), gradient(at: 3, 4, in: `if`))
 
   @differentiable(wrt: y)
@@ -47,7 +85,7 @@ NonVariedResultTests.testWithLeakChecking("Conditionals") {
     }
     return x
   }
-  expectEqual(0, gradient(at: 3) { x in `switch`(10, x) })
+  expectEqual(0, gradient(at: 3) { `switch`(10, $0) })
   expectEqual((1, 0), gradient(at: 3, 4, in: `switch`))
 }
 
@@ -57,7 +95,7 @@ NonVariedResultTests.testWithLeakChecking("Loops") {
     for i in 0..<10 {}
     return x
   }
-  expectEqual(0, gradient(at: 3) { x in `for`(10, x) })
+  expectEqual(0, gradient(at: 3) { `for`(10, $0) })
   expectEqual((1, 0), gradient(at: 3, 4, in: `for`))
 
   @differentiable(wrt: y)
@@ -65,7 +103,7 @@ NonVariedResultTests.testWithLeakChecking("Loops") {
     while 0 < 0 {}
     return x
   }
-  expectEqual(0, gradient(at: 3) { x in `while`(10, x) })
+  expectEqual(0, gradient(at: 3) { `while`(10, $0) })
   expectEqual((1, 0), gradient(at: 3, 4, in: `while`))
 }
 
@@ -84,8 +122,41 @@ NonVariedResultTests.testWithLeakChecking("Complex") {
     }
     return x + x + x
   }
-  expectEqual(0, gradient(at: 3) { x in complex(10, x) })
+  expectEqual(0, gradient(at: 3) { complex(10, $0) })
   expectEqual((3, 0), gradient(at: 3, 4, in: complex))
 }
+
+// CHECK-LABEL: sil hidden [ossa] @AD__${{.*}}complex{{.*}}pullback_src_0_wrt_1 : $@convention(thin) (@guaranteed Tracked<Float>, @owned _AD__$s4nullyycfU3_7complexL_y23DifferentiationUnittest7TrackedVySfGAF_AFtF_bb15__PB__src_0_wrt_1) -> @owned Tracked<Float> {
+// CHECK: bb0([[SEED:%.*]] : @guaranteed $Tracked<Float>, [[PB_STRUCT:%.*]] : @owned [[PB_STRUCT_TYPE:.*]]):
+// CHECK:   destroy_value [[PB_STRUCT]] : [[PB_STRUCT_TYPE]]
+// CHECK:   [[BUF:%.*]] = alloc_stack $Tracked<Float>
+// CHECK:   [[ZERO_FN:%.*]] = witness_method $Tracked<Float>, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE:%.*]] = metatype $@thick Tracked<Float>.Type
+// CHECK:   {{%.*}} = apply [[ZERO_FN]]<Tracked<Float>>([[BUF]], [[METATYPE]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[ZERO_VALUE:%.*]] = load [take] [[BUF]] : $*Tracked<Float>
+// CHECK:   dealloc_stack [[BUF]] : $*Tracked<Float>
+// CHECK:   return [[ZERO_VALUE]]
+
+NonVariedResultTests.testWithLeakChecking("ComplexGeneric") {
+  @differentiable(wrt: y)
+  func complexGeneric<T: Differentiable>(_ x: T, _ y: T) -> T {
+    for i in 0..<10 {
+      for j in 0..<10 {
+        while 0 < 0 {}
+      }
+    }
+    return x
+  }
+  expectEqual(0, pullback(at: Tracked<Float>(3)) { complexGeneric(10, $0) }(1))
+}
+
+// CHECK-LABEL: sil hidden [ossa] @AD__${{.*}}complexGeneric{{.*}}pullback_src_0_wrt_1 : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0.TangentVector, @owned _AD__$s4nullyycfU4_14complexGenericL_yxx_xts14DifferentiableRzlF_bb9__PB__src_0_wrt_1<τ_0_0>) -> @out τ_0_0.TangentVector {
+// CHECK: bb0([[DY:%.*]] : $*τ_0_0.TangentVector, [[SEED:%.*]] : $*τ_0_0.TangentVector, [[PB_STRUCT:%.*]] : @owned [[PB_STRUCT_TYPE:.*]]):
+// CHECK:   destroy_value [[PB_STRUCT]] : [[PB_STRUCT_TYPE]]
+// CHECK:   [[ZERO_FN:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter.1 : <Self where Self : AdditiveArithmetic> (Self.Type) -> () -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[METATYPE:%.*]] = metatype $@thick τ_0_0.TangentVector.Type
+// CHECK:   {{%.*}} = apply [[ZERO_FN]]<τ_0_0.TangentVector>([[DY]], [[METATYPE]]) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   [[VOID:%.*]] = tuple ()
+// CHECK:   return [[VOID]]
 
 runAllTests()


### PR DESCRIPTION
…ult.

Fix `PullbackEmitter` crash for functions with multiple basic blocks, where some
basic blocks have no dominated active values.

This occurs because `PullbackEmitter` currently assumes that all bbs in
multiple-bb functions dominate some active values (at least the entry bb
will contain an active value). This assumption is not always true.

One fix is to add `PullbackEmitter` support for "bbs with no dominated active
values". This sounds plausible but requires nontrivial work.

Instead, we can infer:
- If no original bbs dominate active values,
- Then the original result must be non-varied (it is useful, so non-active
  implies non-varied),
- Which can be detected easily, and tells us statically that the derivative of
  the original result must be zero,
- So we can skip full pullback generation and simply return zero for wrt
  parameters. This is a simpler fix and is robust for arbitrarily complex
  functions with non-varied result.

A similar shortcut may be necessary for forward-mode differentiation when
it supports control flow.

Resolves [TF-876](https://bugs.swift.org/browse/TF-876).
Note that the shortcut should be semantically sound: see [TF-878](https://bugs.swift.org/browse/TF-878) for details.