### PR TITLE
Use the accessor names as written in Objective-C.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4930,7 +4930,7 @@ getNameFromObjcAttribute(const ObjCAttr *attr, DeclName preferredName) {
 ObjCSelector
 AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
   // If the getter has an @objc attribute with a name, use that.
-  if (auto getter = getParsedAccessor(AccessorKind::Get)) {
+  if (auto getter = getAccessor(AccessorKind::Get)) {
       if (auto name = getNameFromObjcAttribute(getter->getAttrs().
           getAttribute<ObjCAttr>(), preferredName))
         return *name;
@@ -4960,7 +4960,7 @@ AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
 ObjCSelector
 AbstractStorageDecl::getObjCSetterSelector(Identifier preferredName) const {
   // If the setter has an @objc attribute with a name, use that.
-  auto setter = getParsedAccessor(AccessorKind::Set);
+  auto setter = getAccessor(AccessorKind::Set);
   auto objcAttr = setter ? setter->getAttrs().getAttribute<ObjCAttr>()
                          : nullptr;
   if (auto name = getNameFromObjcAttribute(objcAttr, DeclName(preferredName))) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4930,7 +4930,7 @@ getNameFromObjcAttribute(const ObjCAttr *attr, DeclName preferredName) {
 ObjCSelector
 AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
   // If the getter has an @objc attribute with a name, use that.
-  if (auto getter = getAccessor(AccessorKind::Get)) {
+  if (auto getter = getOpaqueAccessor(AccessorKind::Get)) {
       if (auto name = getNameFromObjcAttribute(getter->getAttrs().
           getAttribute<ObjCAttr>(), preferredName))
         return *name;
@@ -4960,7 +4960,7 @@ AbstractStorageDecl::getObjCGetterSelector(Identifier preferredName) const {
 ObjCSelector
 AbstractStorageDecl::getObjCSetterSelector(Identifier preferredName) const {
   // If the setter has an @objc attribute with a name, use that.
-  auto setter = getAccessor(AccessorKind::Set);
+  auto setter = getOpaqueAccessor(AccessorKind::Set);
   auto objcAttr = setter ? setter->getAttrs().getAttribute<ObjCAttr>()
                          : nullptr;
   if (auto name = getNameFromObjcAttribute(objcAttr, DeclName(preferredName))) {

--- a/test/PrintAsObjC/Inputs/propertyWithOddGetterSetterNames.h
+++ b/test/PrintAsObjC/Inputs/propertyWithOddGetterSetterNames.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@protocol PowerProtocol <NSObject>
+@property (nonatomic, getter=getPower, setter=setPower:) int64_t level;
+@end

--- a/test/PrintAsObjC/getter_setter.swift
+++ b/test/PrintAsObjC/getter_setter.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-ir -o %t/getter_setter.ir -emit-objc-header-path %t/getter_setter.h -import-objc-header %S/Inputs/propertyWithOddGetterSetterNames.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck --check-prefix="HEADER" %s < %t/getter_setter.h
+// RUN: %FileCheck --check-prefix="IRCHECK1" %s < %t/getter_setter.ir
+// RUN: %FileCheck --check-prefix="IRCHECK2" %s < %t/getter_setter.ir
+//
+// REQUIRES: objc_interop
+
+import Foundation
+
+// rdar://problem/55519276: Make sure we're using the right selector names as
+// written in Objective-C.
+public final class Saiyan: NSObject, PowerProtocol {
+  public var level: Int64
+  // FIXME: The getter and setter names should show up here.
+  // HEADER: @property (nonatomic) int64_t level;
+  // IRCHECK1: METACLASS_DATA__TtC13getter_setter6Saiyan
+  // IRCHECK1-NOT: selector_data(getPower)
+  // IRCHECK1-NOT: selector_data(setPower:)
+  // IRCHECK1: INSTANCE_METHODS__TtC13getter_setter6Saiyan
+  // IRCHECK2: METACLASS_DATA__TtC13getter_setter6Saiyan
+  // IRCHECK2: selector_data(level)
+  // IRCHECK2: selector_data(setLevel:)
+  // IRCHECK2: INSTANCE_METHODS__TtC13getter_setter6Saiyan
+  public override init() {
+    level = 9001
+  }
+}

--- a/test/PrintAsObjC/getter_setter.swift
+++ b/test/PrintAsObjC/getter_setter.swift
@@ -12,15 +12,14 @@ import Foundation
 // written in Objective-C.
 public final class Saiyan: NSObject, PowerProtocol {
   public var level: Int64
-  // FIXME: The getter and setter names should show up here.
-  // HEADER: @property (nonatomic) int64_t level;
+  // HEADER: @property (nonatomic, getter=getPower, setter=setPower:) int64_t level;
   // IRCHECK1: METACLASS_DATA__TtC13getter_setter6Saiyan
-  // IRCHECK1-NOT: selector_data(getPower)
-  // IRCHECK1-NOT: selector_data(setPower:)
+  // IRCHECK1: selector_data(getPower)
+  // IRCHECK1: selector_data(setPower:)
   // IRCHECK1: INSTANCE_METHODS__TtC13getter_setter6Saiyan
   // IRCHECK2: METACLASS_DATA__TtC13getter_setter6Saiyan
-  // IRCHECK2: selector_data(level)
-  // IRCHECK2: selector_data(setLevel:)
+  // IRCHECK2-NOT: selector_data(level)
+  // IRCHECK2-NOT: selector_data(setLevel:)
   // IRCHECK2: INSTANCE_METHODS__TtC13getter_setter6Saiyan
   public override init() {
     level = 9001


### PR DESCRIPTION
Not 100% sure if my approach taken here is correct. It is unclear to me what the semantics of `getParsedAccessor` are supposed to be in the presence of user-written accessor names in Objective-C (as opposed to those written in Swift). Should they be passed through? Or not passed through because they are considered implicit? I've assumed that the existing behavior of `getParsedAccessor` is correct, so we use `getAccessor` instead.

Fixes rdar://problem/55519276.

Related: commit 0c5d52d8609aaa3016621887d03571c7582984a5 (PR #26461) where `getParsedAccessor` was introduced.
