### PR TITLE
[NFC] Fix occasional @lvalue exposures

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4569,7 +4569,7 @@ diagnoseAmbiguousMultiStatementClosure(ClosureExpr *closure) {
       auto type = getTypeOfExpressionWithoutApplying(
           resultExpr, CS.DC, decl, FreeTypeVariableBinding::UnresolvedType);
       if (type)
-        resultType = type;
+        resultType = type->getRValueType();
     }
     
     // If we found a type, presuppose it was the intended result and insert a

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1274,7 +1274,7 @@ func rdar17170728() {
     // expected-error@-1 {{missing argument label 'into:' in call}}
     // expected-error@-2 {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
-    // expected-error@-1 {{binary operator '+' cannot be applied to operands of type '@lvalue Bool' and 'Bool'}}
+    // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
     // expected-error@-2 {{'nil' cannot be used in context expecting type 'Bool'}}
   }
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -355,3 +355,9 @@ func lvalueCapture<T>(c: GenericClass<T>) {
     cc = wc!
   }
 }
+
+// Don't expose @lvalue-ness in diagnostics.
+let closure = { // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{16-16= () -> Bool in }}
+  var helper = true
+  return helper
+}


### PR DESCRIPTION
One example:
```swift
let closure = {
                ^ () -> @lvalue Bool in
  var helper = true
  return helper
}
```