### PR TITLE
[tests] Add mechanism to override lit environment

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1665,5 +1665,12 @@ if platform.system() == 'Linux':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
 
+# Copy environment variables specified in --param copy_env=..., overriding
+# anything computed here. It's assumed that the person setting this knows what
+# they're doing.
+copy_env = lit_config.params.get('copy_env', None)
+if copy_env is not None:
+  for key in copy_env.split(':'):
+    config.environment[key] = os.environ[key]
 
 lit_config.note("Available features: " + ", ".join(sorted(config.available_features)))


### PR DESCRIPTION
lit runs its tests with only the environment variables set up by its configuration, which is great for repeatability, but sometimes you want to allow a few controlled leaks. With this change, you can now specify `--param copy_env=FOO:BAR:BAZ` to cause the environment variables `FOO`, `BAR`, and `BAZ` to be visible in lit tests during that run.