### PR TITLE
test: make multithread_module pass on Windows

### DIFF
--- a/test/IRGen/Inputs/multithread_module/main.swift
+++ b/test/IRGen/Inputs/multithread_module/main.swift
@@ -10,7 +10,7 @@ class Derived : Base {
 	}
 }
 
-private struct MyStruct : MyProto {
+public struct MyStruct : MyProto {
 
 	var x: Int
 


### PR DESCRIPTION
Ensure that `MyStruct` is marked public so that the type metadata is
exported for use in other modules.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
