### PR TITLE
tests: make Driver.driver-compile pass on Windows again

### DIFF
--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -128,7 +128,7 @@
 // FILELIST: -supplementary-output-file-map {{(["][^"]+supplementaryOutputs[^"]+["]|[^ ]+supplementaryOutputs[^ ]+)}}
 // FILELIST: -output-filelist {{[^-]}}
 
-// UPDATE-CODE: DISTINCTIVE-PATH{{/|\\\\}}usr{{/|\\\\}}bin{{/|\\\\}}swift
+// UPDATE-CODE: {{DISTINCTIVE-PATH|distinctive-path}}{{/|\\\\}}usr{{/|\\\\}}bin{{/|\\\\}}swift{{c?(\.exe)?}}
 // UPDATE-CODE: -frontend -c
 // UPDATE-CODE: -emit-remap-file-path {{.+}}.remap
 


### PR DESCRIPTION
The newer clang will normalise the path to lower case, and the actual
executable path is used on Windows.  This makes the distinctive-path get
lowercased and the swift binary is named swiftc.exe.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
