### PR TITLE
[Diagnostics][NFC] Begin using compound diagnostics for type checking errors

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -947,8 +947,11 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
     for (unsigned idx = 0; idx < childNotes.size(); ++idx) {
       if (auto child = diagnosticInfoForDiagnostic(childNotes[idx])) {
         childInfo.push_back(*child);
-        childInfoPtrs.push_back(&childInfo[idx]);
       }
+    }
+    // Don't save a pointer to each element until insertion is finished.
+    for (unsigned idx = 0; idx < childInfo.size(); ++idx) {
+      childInfoPtrs.push_back(&childInfo[idx]);
     }
     info->ChildDiagnosticInfo = childInfoPtrs;
     for (auto &consumer : Consumers) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -950,9 +950,9 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
       }
     }
     // Don't save a pointer to each element until insertion is finished.
-    for (unsigned idx = 0; idx < childInfo.size(); ++idx) {
+    for (unsigned idx = 0; idx < childInfo.size(); ++idx)
       childInfoPtrs.push_back(&childInfo[idx]);
-    }
+
     info->ChildDiagnosticInfo = childInfoPtrs;
     for (auto &consumer : Consumers) {
       consumer->handleDiagnostic(SourceMgr, info->Loc, info->Kind,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -109,9 +109,14 @@ public:
 
   template <typename... ArgTypes>
   InFlightDiagnostic emitDiagnostic(ArgTypes &&... Args) const;
+  
+  void diagnoseWithNotes(InFlightDiagnostic parentDiag,
+                         llvm::function_ref<void(void)> builder) const;
 
 protected:
   TypeChecker &getTypeChecker() const { return CS.TC; }
+  
+  DiagnosticEngine &getDiags() const { return CS.TC.Diags; };
 
   DeclContext *getDC() const { return CS.DC; }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2571,7 +2571,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
   bool diagnosed = true;
   {
-    DiagnosticTransaction transaction(TC.Diags);
+    CompoundDiagnosticTransaction transaction(TC.Diags);
 
     const auto *fix = viableSolutions.front().second;
     auto *commonAnchor = commonCalleeLocator->getAnchor();
@@ -2729,6 +2729,7 @@ bool ConstraintSystem::diagnoseAmbiguity(Expr *expr,
   // FIXME: Should be able to pick the best locator, e.g., based on some
   // depth-first numbering of expressions.
   if (bestOverload) {
+    CompoundDiagnosticTransaction transaction(TC.Diags);
     auto &overload = diff.overloads[*bestOverload];
     auto name = getOverloadChoiceName(overload.choices);
     auto anchor = simplifyLocatorToAnchor(overload.locator);


### PR DESCRIPTION
- use compound diagnostics when diagnosing ambiguity in `ConstraintSystem`
- begin to use compound diagnostics in `CSDiagnostics` for some failures
- fixed a bug when emitting compound diagnostics with 3 or more notes

The goal is to see how well the compound diagnostic api works in more complex cases. The main takeaway here is:

- `diagnoseWithNotes` works well in simpler cases with 1-2 notes and simple control flow
- for more complicated cases like diagnosing ambiguity with multiple notes and complex control flow, it's often better to use `CompoundDiagnosticTransaction` directly for grouping

Next up is actually starting to use this information to improve printed diagnostic output :)

cc @xedin 
We don't use the grouping information yet when printing diagnostics, so we could hold off on landing this if it seems like too drastic a change.