### PR TITLE
[build-script] Pass updated arguments to SwiftSyntax's build script

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3443,7 +3443,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${BUILD_LIBPARSER_ONLY}" ]; then
                     # We don't have a toolchain so we should install to the specified dir
                     DYLIB_DIR="${INSTALL_DESTDIR}"
-                    MODULE_DIR="${INSTALL_DESTDIR}"
+                    MODULE_DIR="${INSTALL_DESTDIR}/${product}.swiftmodule/${SWIFT_HOST_VARIANT_ARCH}"
                     # Create the install dir if it doesn't exist
                     call mkdir -p "${INSTALL_DESTDIR}"
                     # Install libParser is necessary
@@ -3453,14 +3453,14 @@ for host in "${ALL_HOSTS[@]}"; do
                 else
                     # We have a toolchain so install to the toolchain
                     DYLIB_DIR="${host_install_destdir}${host_install_prefix}/lib/swift/${SWIFT_HOST_VARIANT}"
-                    MODULE_DIR="${DYLIB_DIR}/${SWIFT_HOST_VARIANT_ARCH}"
+                    MODULE_DIR="${DYLIB_DIR}/${product}.swiftmodule/${SWIFT_HOST_VARIANT_ARCH}"
                 fi
                 if [[ "${SKIP_SWIFTSYNTAX_SWIFTSIDE}" ]]; then
                     continue
                 fi
                 set_swiftsyntax_build_command
                 if [[ -z "${SKIP_INSTALL_SWIFTSYNTAX_MODULE}" ]] ; then
-                    call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --swiftmodule-dir "${MODULE_DIR}" --install
+                    call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --swiftmodule-base-name "${MODULE_DIR}" --install
                 else
                     call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --install
                 fi


### PR DESCRIPTION
Update the parameters passed to SwiftSyntax's build script to fix an issue that caused SwiftSyntax's module to not be properly installed.

Corresponds to https://github.com/apple/swift-syntax/pull/151