### PR TITLE
[Runtime] Handle existential target types in swift_dynamicCastMetatypeImpl

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -403,7 +403,7 @@ static bool _conformsToProtocols(const OpaqueValue *value,
   for (auto protocol : existentialType->getProtocols()) {
     if (!_conformsToProtocol(value, type, protocol, conformances))
       return false;
-    if (protocol.needsWitnessTable()) {
+    if (conformances != nullptr && protocol.needsWitnessTable()) {
       assert(*conformances != nullptr);
       ++conformances;
     }
@@ -1117,9 +1117,8 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
 
   case MetadataKind::Existential: {
     auto targetTypeAsExistential = static_cast<const ExistentialTypeMetadata *>(targetType);
-    for (auto protocol : targetTypeAsExistential->getProtocols())
-      if (!swift_conformsToProtocol(sourceType, protocol.getSwiftProtocol()))
-        return nullptr;
+    if (!_conformsToProtocols(nullptr, sourceType, targetTypeAsExistential, nullptr))
+      return nullptr;
     return origSourceType;
   }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1115,6 +1115,14 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
     }
     break;
 
+  case MetadataKind::Existential: {
+    auto targetTypeAsExistential = static_cast<const ExistentialTypeMetadata *>(targetType);
+    for (auto protocol : targetTypeAsExistential->getProtocols())
+      if (!swift_conformsToProtocol(sourceType, protocol.getSwiftProtocol()))
+        return nullptr;
+    return origSourceType;
+  }
+
   default:
     // The cast succeeds only if the metadata pointers are statically
     // equivalent.

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
+// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE --dump-input fail %s
 // RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s
@@ -132,17 +132,13 @@ anyClassToCOrE(D()).print() // CHECK: D!
 anyClassToCOrE(X()).print() // CHECK: E!
 
 protocol P {}
-@objc protocol PObjC {}
 struct PS: P {}
 enum PE: P {}
-class PC: P, PObjC {}
+class PC: P {}
 class PCSub: PC {}
 
 func nongenericAnyIsP(type: Any.Type) -> Bool {
   return type is P.Type
-}
-func nongenericAnyIsPObjC(type: Any.Type) -> Bool {
-  return type is PObjC.Type
 }
 func nongenericAnyIsPAndAnyObject(type: Any.Type) -> Bool {
   return type is (P & AnyObject).Type
@@ -163,17 +159,6 @@ print(nongenericAnyIsP(type: PC.self)) // CHECK: true
 print(genericAnyIs(type: PC.self, to: P.self)) // CHECK-ONONE: true
 print(nongenericAnyIsP(type: PCSub.self)) // CHECK: true
 print(genericAnyIs(type: PCSub.self, to: P.self)) // CHECK-ONONE: true
-
-// CHECK-LABEL: casting types to ObjC protocols with generics:
-print("casting types to ObjC protocols with generics:")
-print(nongenericAnyIsPObjC(type: PS.self)) // CHECK: false
-print(genericAnyIs(type: PS.self, to: PObjC.self)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PE.self)) // CHECK: false
-print(genericAnyIs(type: PE.self, to: PObjC.self)) // CHECK: false
-print(nongenericAnyIsPObjC(type: PC.self)) // CHECK: true
-print(genericAnyIs(type: PC.self, to: PObjC.self)) // CHECK-ONONE: true
-print(nongenericAnyIsPObjC(type: PCSub.self)) // CHECK: true
-print(genericAnyIs(type: PCSub.self, to: PObjC.self)) // CHECK-ONONE: true
 
 // CHECK-LABEL: casting types to protocol & AnyObject existentials:
 print("casting types to protocol & AnyObject existentials:")

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
 // RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s
@@ -100,6 +100,24 @@ func allToAll<T, U>(_ t: T, _: U.Type) -> Bool {
 func allMetasToAllMetas<T, U>(_: T.Type, _: U.Type) -> Bool {
   return T.self is U.Type
 }
+
+protocol P {}
+struct PS: P {}
+enum PE: P {}
+class PC: P {}
+
+func nongenericAnyIsP(type: Any.Type) -> Bool {
+  return type is P.Type
+}
+func genericAnyIs<T>(type: Any.Type, to: T.Type) -> Bool {
+  return type is T.Type
+}
+print("nongenericAnyIsP(type: PS.self)", nongenericAnyIsP(type: PS.self)) // CHECK: nongenericAnyIsP(type: PS.self) true
+print("genericAnyIs(type: PS.self, to: P.self)", genericAnyIs(type: PS.self, to: P.self)) // CHECK-ONONE: genericAnyIs(type: PS.self, to: P.self) true
+print("nongenericAnyIsP(type: PE.self)", nongenericAnyIsP(type: PE.self)) // CHECK: nongenericAnyIsP(type: PE.self) true
+print("genericAnyIs(type: PE.self, to: P.self)", genericAnyIs(type: PE.self, to: P.self)) // CHECK-ONONE: genericAnyIs(type: PE.self, to: P.self) true
+print("nongenericAnyIsP(type: PC.self)", nongenericAnyIsP(type: PC.self)) // CHECK: nongenericAnyIsP(type: PC.self) true
+print("genericAnyIs(type: PC.self, to: P.self)", genericAnyIs(type: PC.self, to: P.self)) // CHECK-ONONE: genericAnyIs(type: PC.self, to: P.self) true
 
 print(allToInt(22)) // CHECK: 22
 print(anyToInt(44)) // CHECK: 44

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Onone %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
 // RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE --dump-input fail %s
+// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
 // RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE --dump-input fail %s
+// RUN: %target-build-swift -O %s -o %t/a.out.optimized
+// RUN: %target-codesign %t/a.out.optimized
+// RUN: %target-run %t/a.out.optimized | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P {}
+@objc protocol PObjC {}
+struct PS: P {}
+enum PE: P {}
+class PC: P, PObjC {}
+class PCSub: PC {}
+
+func nongenericAnyIsPObjC(type: Any.Type) -> Bool {
+  return type is PObjC.Type
+}
+func genericAnyIs<T>(type: Any.Type, to: T.Type) -> Bool {
+  return type is T.Type
+}
+
+// CHECK-LABEL: casting types to ObjC protocols with generics:
+print("casting types to ObjC protocols with generics:")
+print(nongenericAnyIsPObjC(type: PS.self)) // CHECK: false
+print(genericAnyIs(type: PS.self, to: PObjC.self)) // CHECK: false
+print(nongenericAnyIsPObjC(type: PE.self)) // CHECK: false
+print(genericAnyIs(type: PE.self, to: PObjC.self)) // CHECK: false
+print(nongenericAnyIsPObjC(type: PC.self)) // CHECK: true
+print(genericAnyIs(type: PC.self, to: PObjC.self)) // CHECK-ONONE: true
+print(nongenericAnyIsPObjC(type: PCSub.self)) // CHECK: true
+print(genericAnyIs(type: PCSub.self, to: PObjC.self)) // CHECK-ONONE: true


### PR DESCRIPTION
This fixes cases like `type is T.Type` when T is generic specialized to a protocol type.

Note: the compiler can still optimize these checks away and will optimize this check down to `false` in some cases. We'll want to fix that as well.

rdar://problem/56044443