### PR TITLE
[SILProfiler] Do not visit closure bodies twice

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -247,6 +247,11 @@ struct MapRegionCounters : public ASTWalker {
     if (skipExpr(E))
       return {true, E};
 
+    // Profiling for closures should be handled separately. Do not visit
+    // closure expressions twice.
+    if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
+      return {false, E};
+
     // If AST visitation begins with an expression, the counter map must be
     // empty. Set up a counter for the root.
     if (Parent.isNull()) {
@@ -604,6 +609,11 @@ struct PGOMapping : public ASTWalker {
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (skipExpr(E))
       return {true, E};
+
+    // Profiling for closures should be handled separately. Do not visit
+    // closure expressions twice.
+    if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
+      return {false, E};
 
     unsigned parent = getParentCounter();
 
@@ -1045,6 +1055,11 @@ public:
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (skipExpr(E))
       return {true, E};
+
+    // Profiling for closures should be handled separately. Do not visit
+    // closure expressions twice.
+    if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
+      return {false, E};
 
     if (!RegionStack.empty())
       extendRegion(E);

--- a/test/Profiler/coverage_empty_region_stack1.swift
+++ b/test/Profiler/coverage_empty_region_stack1.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_empty %s | %FileCheck %s
+
+// Skip the sil prologue, which reproduces the swift source of this file
+// and confounds FileCheck.
+// CHECK-LABEL: sil @main
+
+func singleDefaultArgument(i: Int = {
+  // CHECK: sil_coverage_map {{.*}}closure #1 () -> Swift.Int in default argument 0
+  // CHECK-NEXT:   [[@LINE-2]]:37 -> [[@LINE+6]]:2 : 0
+  // CHECK-NEXT: }
+  struct SingleDefaultArgumentStruct {
+    let sdasi: Int
+  }
+  return 2
+}()) {
+  // CHECK: sil_coverage_map {{.*}}singleDefaultArgument(i: Swift.Int) -> ()
+  // CHECK-NEXT:   [[@LINE-2]]:6 -> [[@LINE+3]]:2 : 0
+  // CHECK-NEXT: }
+  print(i)
+}


### PR DESCRIPTION
Closure bodies should only be visited for coverage purposes once -- when
the associated SILFunction is created.

This resolves an assertion failure about an empty region stack (this
root cause of which was double-visitation of a closure body).