### PR TITLE
Remove IteratorRange in favor of llvm::iterator_range

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1672,7 +1672,7 @@ private:
 public:
   template <typename ATTR, bool AllowInvalid>
   using AttributeKindRange =
-      OptionalTransformRange<llvm::iterator_range<const_iterator>,
+      OptionalTransformRange<iterator_range<const_iterator>,
                              ToAttributeKind<ATTR, AllowInvalid>,
                              const_iterator>;
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -667,7 +667,7 @@ public:
 
 /// The range of declarations stored within an iterable declaration
 /// context.
-typedef llvm::iterator_range<DeclIterator> DeclRange;
+using DeclRange = iterator_range<DeclIterator>;
 
 /// The kind of an \c IterableDeclContext.
 enum class IterableDeclContextKind : uint8_t {  

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -667,7 +667,7 @@ public:
 
 /// The range of declarations stored within an iterable declaration
 /// context.
-typedef IteratorRange<DeclIterator> DeclRange;
+typedef llvm::iterator_range<DeclIterator> DeclRange;
 
 /// The kind of an \c IterableDeclContext.
 enum class IterableDeclContextKind : uint8_t {  

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3965,13 +3965,12 @@ public:
   };
   using IndirectFormalResultIter =
       llvm::filter_iterator<const SILResultInfo *, IndirectFormalResultFilter>;
-  using IndirectFormalResultRange = IteratorRange<IndirectFormalResultIter>;
+  using IndirectFormalResultRange =
+      llvm::iterator_range<IndirectFormalResultIter>;
 
   /// A range of SILResultInfo for all formally indirect results.
   IndirectFormalResultRange getIndirectFormalResults() const {
-    auto filter =
-        llvm::make_filter_range(getResults(), IndirectFormalResultFilter());
-    return makeIteratorRange(filter.begin(), filter.end());
+    return llvm::make_filter_range(getResults(), IndirectFormalResultFilter());
   }
 
   struct DirectFormalResultFilter {
@@ -3981,13 +3980,11 @@ public:
   };
   using DirectFormalResultIter =
       llvm::filter_iterator<const SILResultInfo *, DirectFormalResultFilter>;
-  using DirectFormalResultRange = IteratorRange<DirectFormalResultIter>;
+  using DirectFormalResultRange = llvm::iterator_range<DirectFormalResultIter>;
 
   /// A range of SILResultInfo for all formally direct results.
   DirectFormalResultRange getDirectFormalResults() const {
-    auto filter =
-        llvm::make_filter_range(getResults(), DirectFormalResultFilter());
-    return makeIteratorRange(filter.begin(), filter.end());
+    return llvm::make_filter_range(getResults(), DirectFormalResultFilter());
   }
 
   /// Get a single non-address SILType that represents all formal direct

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3965,8 +3965,7 @@ public:
   };
   using IndirectFormalResultIter =
       llvm::filter_iterator<const SILResultInfo *, IndirectFormalResultFilter>;
-  using IndirectFormalResultRange =
-      llvm::iterator_range<IndirectFormalResultIter>;
+  using IndirectFormalResultRange = iterator_range<IndirectFormalResultIter>;
 
   /// A range of SILResultInfo for all formally indirect results.
   IndirectFormalResultRange getIndirectFormalResults() const {
@@ -3980,7 +3979,7 @@ public:
   };
   using DirectFormalResultIter =
       llvm::filter_iterator<const SILResultInfo *, DirectFormalResultFilter>;
-  using DirectFormalResultRange = llvm::iterator_range<DirectFormalResultIter>;
+  using DirectFormalResultRange = iterator_range<DirectFormalResultIter>;
 
   /// A range of SILResultInfo for all formally direct results.
   DirectFormalResultRange getDirectFormalResults() const {

--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -67,14 +67,14 @@ public:
 
   ArrayRef<Optional<ValueT>> getArray() const { return vector; }
 
-  llvm::iterator_range<const_iterator> getRange() const {
+  iterator_range<const_iterator> getRange() const {
     return {begin(), end()};
   }
 
   using const_reverse_iterator = typename VectorT::const_reverse_iterator;
   const_reverse_iterator rbegin() const { return vector.rbegin(); }
   const_reverse_iterator rend() const { return vector.rend(); }
-  llvm::iterator_range<const_reverse_iterator> getReverseRange() const {
+  iterator_range<const_reverse_iterator> getReverseRange() const {
     return {rbegin(), rend()};
   }
 

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -43,6 +43,7 @@ namespace llvm {
   template<typename T> class TinyPtrVector;
   template<typename T> class Optional;
   template <typename ...PTs> class PointerUnion;
+  template <typename IteratorT> class iterator_range;
   class SmallBitVector;
 
   // Other common classes.
@@ -63,6 +64,7 @@ namespace swift {
 
   // Containers.
   using llvm::ArrayRef;
+  using llvm::iterator_range;
   using llvm::MutableArrayRef;
   using llvm::None;
   using llvm::Optional;

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -44,7 +44,6 @@
 
 namespace swift {
   using llvm::make_range;
-  using llvm::iterator_range;
 
   template<typename T>
   inline auto reversed(T &&container)

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -251,36 +251,12 @@ inline Iterator prev_or_begin(Iterator it, Iterator begin) {
 
 /// @}
 
-/// A range of iterators.
-/// TODO: Add `llvm::iterator_range::empty()`, then remove this helper, along
-/// with the superfluous TransformIterator.
-template<typename Iterator>
-class IteratorRange {
-  Iterator First, Last;
-
-public:
-  using iterator = Iterator;
-
-  IteratorRange(Iterator first, Iterator last) : First(first), Last(last) { }
-  iterator begin() const { return First; }
-  iterator end() const { return Last; }
-  bool empty() const { return First == Last; }
-
-  typename std::iterator_traits<iterator>::value_type front() const { 
-    assert(!empty() && "Front of empty range");
-    return *begin(); 
-  }
-};
-
-/// Create a new iterator range.
-template<typename Iterator>
-inline IteratorRange<Iterator> 
-makeIteratorRange(Iterator first, Iterator last) {
-  return IteratorRange<Iterator>(first, last);
-}
 
 /// An iterator that transforms the result of an underlying bidirectional
 /// iterator with a given operation.
+///
+/// Slightly different semantics from llvm::map_iterator, but we should
+/// probably figure out how to merge them eventually.
 ///
 /// \tparam Iterator the underlying iterator.
 ///

--- a/include/swift/SIL/Notifications.h
+++ b/include/swift/SIL/Notifications.h
@@ -194,7 +194,7 @@ public:
   using iterator = llvm::mapped_iterator<
       decltype(handlerSet)::const_iterator,
       decltype(&DeserializationNotificationHandlerSet::getUnderlyingHandler)>;
-  using range = llvm::iterator_range<iterator>;
+  using range = iterator_range<iterator>;
 
   /// Returns an iterator to the first element of the handler set.
   ///

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -209,8 +209,7 @@ public:
 
   using IndirectSILResultTypeIter =
       llvm::mapped_iterator<IndirectSILResultIter, SILResultTypeFunc>;
-  using IndirectSILResultTypeRange =
-      llvm::iterator_range<IndirectSILResultTypeIter>;
+  using IndirectSILResultTypeRange = iterator_range<IndirectSILResultTypeIter>;
 
   /// Return a range of SILTypes for each result passed as an address-typed SIL
   /// argument.
@@ -234,7 +233,7 @@ public:
   };
   using DirectSILResultIter =
       llvm::filter_iterator<const SILResultInfo *, DirectSILResultFilter>;
-  using DirectSILResultRange = llvm::iterator_range<DirectSILResultIter>;
+  using DirectSILResultRange = iterator_range<DirectSILResultIter>;
 
   /// Return a range of direct result information for results directly returned
   /// by SIL value.
@@ -245,8 +244,7 @@ public:
 
   using DirectSILResultTypeIter =
       llvm::mapped_iterator<DirectSILResultIter, SILResultTypeFunc>;
-  using DirectSILResultTypeRange =
-      llvm::iterator_range<DirectSILResultTypeIter>;
+  using DirectSILResultTypeRange = iterator_range<DirectSILResultTypeIter>;
 
   /// Return a range of SILTypes for each result directly returned
   /// by SIL value.
@@ -280,7 +278,7 @@ public:
 
   using SILParameterTypeIter =
       llvm::mapped_iterator<const SILParameterInfo *, SILParameterTypeFunc>;
-  using SILParameterTypeRange = llvm::iterator_range<SILParameterTypeIter>;
+  using SILParameterTypeRange = iterator_range<SILParameterTypeIter>;
 
   /// Return a range of SILTypes for each function parameter, not including
   /// indirect results.
@@ -301,7 +299,7 @@ public:
 
   using SILYieldTypeIter =
       llvm::mapped_iterator<const SILYieldInfo *, SILParameterTypeFunc>;
-  using SILYieldTypeRange = llvm::iterator_range<SILYieldTypeIter>;
+  using SILYieldTypeRange = iterator_range<SILYieldTypeIter>;
 
   SILYieldTypeRange getYieldSILTypes() const {
     return llvm::map_range(funcTy->getYields(), SILParameterTypeFunc(silConv));

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -193,10 +193,9 @@ public:
     if (silConv.loweredAddresses)
       return funcTy->getIndirectFormalResults();
 
-    auto filter = llvm::make_filter_range(
-        makeIteratorRange((const SILResultInfo *)0, (const SILResultInfo *)0),
+    return llvm::make_filter_range(
+        llvm::make_range((const SILResultInfo *)0, (const SILResultInfo *)0),
         SILFunctionType::IndirectFormalResultFilter());
-    return makeIteratorRange(filter.begin(), filter.end());
   }
 
   struct SILResultTypeFunc {
@@ -210,16 +209,13 @@ public:
 
   using IndirectSILResultTypeIter =
       llvm::mapped_iterator<IndirectSILResultIter, SILResultTypeFunc>;
-  using IndirectSILResultTypeRange = IteratorRange<IndirectSILResultTypeIter>;
+  using IndirectSILResultTypeRange =
+      llvm::iterator_range<IndirectSILResultTypeIter>;
 
   /// Return a range of SILTypes for each result passed as an address-typed SIL
   /// argument.
   IndirectSILResultTypeRange getIndirectSILResultTypes() const {
-    return makeIteratorRange(
-        IndirectSILResultTypeIter(getIndirectSILResults().begin(),
-                                  SILResultTypeFunc(silConv)),
-        IndirectSILResultTypeIter(getIndirectSILResults().end(),
-                                  SILResultTypeFunc(silConv)));
+    return llvm::map_range(getIndirectSILResults(), SILResultTypeFunc(silConv));
   }
 
   /// Get the number of SIL results directly returned by SIL value.
@@ -238,28 +234,24 @@ public:
   };
   using DirectSILResultIter =
       llvm::filter_iterator<const SILResultInfo *, DirectSILResultFilter>;
-  using DirectSILResultRange = IteratorRange<DirectSILResultIter>;
+  using DirectSILResultRange = llvm::iterator_range<DirectSILResultIter>;
 
   /// Return a range of direct result information for results directly returned
   /// by SIL value.
   DirectSILResultRange getDirectSILResults() const {
-    auto filter = llvm::make_filter_range(
+    return llvm::make_filter_range(
         funcTy->getResults(), DirectSILResultFilter(silConv.loweredAddresses));
-    return makeIteratorRange(filter.begin(), filter.end());
   }
 
   using DirectSILResultTypeIter =
       llvm::mapped_iterator<DirectSILResultIter, SILResultTypeFunc>;
-  using DirectSILResultTypeRange = IteratorRange<DirectSILResultTypeIter>;
+  using DirectSILResultTypeRange =
+      llvm::iterator_range<DirectSILResultTypeIter>;
 
   /// Return a range of SILTypes for each result directly returned
   /// by SIL value.
   DirectSILResultTypeRange getDirectSILResultTypes() const {
-    return makeIteratorRange(
-        DirectSILResultTypeIter(getDirectSILResults().begin(),
-                                SILResultTypeFunc(silConv)),
-        DirectSILResultTypeIter(getDirectSILResults().end(),
-                                SILResultTypeFunc(silConv)));
+    return llvm::map_range(getDirectSILResults(), SILResultTypeFunc(silConv));
   }
 
   //===--------------------------------------------------------------------===//
@@ -288,16 +280,13 @@ public:
 
   using SILParameterTypeIter =
       llvm::mapped_iterator<const SILParameterInfo *, SILParameterTypeFunc>;
-  using SILParameterTypeRange = IteratorRange<SILParameterTypeIter>;
+  using SILParameterTypeRange = llvm::iterator_range<SILParameterTypeIter>;
 
   /// Return a range of SILTypes for each function parameter, not including
   /// indirect results.
   SILParameterTypeRange getParameterSILTypes() const {
-    return makeIteratorRange(
-        SILParameterTypeIter(funcTy->getParameters().begin(),
-                             SILParameterTypeFunc(silConv)),
-        SILParameterTypeIter(funcTy->getParameters().end(),
-                             SILParameterTypeFunc(silConv)));
+    return llvm::map_range(funcTy->getParameters(),
+                           SILParameterTypeFunc(silConv));
   }
 
   //===--------------------------------------------------------------------===//
@@ -312,14 +301,10 @@ public:
 
   using SILYieldTypeIter =
       llvm::mapped_iterator<const SILYieldInfo *, SILParameterTypeFunc>;
-  using SILYieldTypeRange = IteratorRange<SILYieldTypeIter>;
+  using SILYieldTypeRange = llvm::iterator_range<SILYieldTypeIter>;
 
   SILYieldTypeRange getYieldSILTypes() const {
-    return makeIteratorRange(
-        SILYieldTypeIter(funcTy->getYields().begin(),
-                         SILParameterTypeFunc(silConv)),
-        SILYieldTypeIter(funcTy->getYields().end(),
-                         SILParameterTypeFunc(silConv)));
+    return llvm::map_range(funcTy->getYields(), SILParameterTypeFunc(silConv));
   }
 
   SILYieldInfo getYieldInfoForOperandIndex(unsigned opIndex) const {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -168,12 +168,12 @@ public:
   reverse_iterator rbegin() const;
   reverse_iterator rend() const;
 
-  using range = llvm::iterator_range<iterator>;
+  using range = iterator_range<iterator>;
   range getValues() const;
-  using reverse_range = llvm::iterator_range<reverse_iterator>;
+  using reverse_range = iterator_range<reverse_iterator>;
   reverse_range getReversedValues() const;
 
-  using type_range = llvm::iterator_range<
+  using type_range = iterator_range<
     llvm::mapped_iterator<iterator, SILType(*)(SILValue), SILType>>;
   type_range getTypes() const;
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -281,7 +281,7 @@ public:
   template <typename Subclass>
   using DowncastUserFilterRange =
       DowncastFilterRange<Subclass,
-                          llvm::iterator_range<llvm::mapped_iterator<
+                          iterator_range<llvm::mapped_iterator<
                               use_iterator, UseToUser, SILInstruction *>>>;
 
   /// Iterate over the use list of this ValueBase visiting all users that are of

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -102,7 +102,7 @@ class ClosureScopeAnalysis : public SILAnalysis {
       return None;
     }
   };
-  using IndexRange = llvm::iterator_range<int *>;
+  using IndexRange = iterator_range<int *>;
 
 public:
   // A range of SILFunction scopes converted from their scope indices and

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -102,7 +102,7 @@ class ClosureScopeAnalysis : public SILAnalysis {
       return None;
     }
   };
-  using IndexRange = IteratorRange<int *>;
+  using IndexRange = llvm::iterator_range<int *>;
 
 public:
   // A range of SILFunction scopes converted from their scope indices and

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -674,7 +674,7 @@ public:
   unsigned succ_size() const { return Succs.size(); }
 
 private:
-  using InnerSuccRange = IteratorRange<decltype(Succs)::const_iterator>;
+  using InnerSuccRange = llvm::iterator_range<decltype(Succs)::const_iterator>;
 
 public:
   using SuccRange =

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -591,11 +591,11 @@ public:
     return getSubregionData().rend();
   }
 
-  llvm::iterator_range<subregion_iterator> getSubregions() const {
+  iterator_range<subregion_iterator> getSubregions() const {
     return {subregion_begin(), subregion_end()};
   }
 
-  llvm::iterator_range<subregion_reverse_iterator>
+  iterator_range<subregion_reverse_iterator>
   getReverseSubregions() const {
     return {subregion_rbegin(), subregion_rend()};
   }
@@ -674,7 +674,7 @@ public:
   unsigned succ_size() const { return Succs.size(); }
 
 private:
-  using InnerSuccRange = llvm::iterator_range<decltype(Succs)::const_iterator>;
+  using InnerSuccRange = iterator_range<decltype(Succs)::const_iterator>;
 
 public:
   using SuccRange =
@@ -964,7 +964,7 @@ public:
   const_iterator end() const { return IDToRegionMap.end(); }
   unsigned size() const { return IDToRegionMap.size(); }
   bool empty() const { return IDToRegionMap.empty(); }
-  llvm::iterator_range<const_iterator> getRegions() const {
+  iterator_range<const_iterator> getRegions() const {
     return {begin(), end()};
   }
 

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -38,13 +38,12 @@ template <class T> class NullablePtr;
 /// Transform a Use Range (Operand*) into a User Range (SILInstruction*)
 using UserTransform = std::function<SILInstruction *(Operand *)>;
 using ValueBaseUserRange =
-    TransformRange<IteratorRange<ValueBase::use_iterator>, UserTransform>;
+    TransformRange<llvm::iterator_range<ValueBase::use_iterator>,UserTransform>;
 
 inline ValueBaseUserRange
 makeUserRange(iterator_range<ValueBase::use_iterator> range) {
   auto toUser = [](Operand *operand) { return operand->getUser(); };
-  return makeTransformRange(makeIteratorRange(range.begin(), range.end()),
-                            UserTransform(toUser));
+  return makeTransformRange(range, UserTransform(toUser));
 }
 
 using DeadInstructionSet = llvm::SmallSetVector<SILInstruction *, 8>;

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -38,7 +38,7 @@ template <class T> class NullablePtr;
 /// Transform a Use Range (Operand*) into a User Range (SILInstruction*)
 using UserTransform = std::function<SILInstruction *(Operand *)>;
 using ValueBaseUserRange =
-    TransformRange<llvm::iterator_range<ValueBase::use_iterator>,UserTransform>;
+    TransformRange<iterator_range<ValueBase::use_iterator>, UserTransform>;
 
 inline ValueBaseUserRange
 makeUserRange(iterator_range<ValueBase::use_iterator> range) {

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -37,8 +37,7 @@ static void findAllClangImports(const clang::Module *module,
     modules.insert(getTopLevelName(imported));
   }
 
-  for (auto sub :
-       makeIteratorRange(module->submodule_begin(), module->submodule_end())) {
+  for (auto sub : module->submodules()) {
     findAllClangImports(sub, modules);
   }
 }

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -2034,7 +2034,7 @@ void DeclAndTypePrinter::print(Type ty) {
 }
 
 void DeclAndTypePrinter::printAdHocCategory(
-    llvm::iterator_range<const ValueDecl * const *> members) {
+    iterator_range<const ValueDecl * const *> members) {
   getImpl().printAdHocCategory(members);
 }
 

--- a/lib/PrintAsObjC/DeclAndTypePrinter.h
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.h
@@ -74,7 +74,7 @@ public:
   ///
   /// All members must have the same parent type. The list must not be empty.
   void
-  printAdHocCategory(llvm::iterator_range<const ValueDecl * const *> members);
+  printAdHocCategory(iterator_range<const ValueDecl * const *> members);
 
   /// Returns the name of an <os/object.h> type minus the leading "OS_",
   /// or an empty string if \p decl is not an <os/object.h> type.

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2027,13 +2027,14 @@ public:
         require(initConv.getNumDirectSILResults() == 1,
                 "wrong number of init function results");
         require(Dest->getType().getObjectType() ==
-                initConv.getDirectSILResultTypes().front(),
+                *initConv.getDirectSILResultTypes().begin(),
                 "wrong init function result type");
         break;
       case 1:
         require(initConv.getNumDirectSILResults() == 0,
                 "wrong number of init function results");
-        require(Dest->getType() == initConv.getIndirectSILResultTypes().front(),
+        require(Dest->getType() ==
+                *initConv.getIndirectSILResultTypes().begin(),
                 "wrong indirect init function result type");
         break;
       default:

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -419,7 +419,7 @@ public:
     originalDestroyBlocks.insert(use->getUser()->getParent());
   }
 
-  llvm::iterator_range<BlockSetVec::const_iterator>
+  iterator_range<BlockSetVec::const_iterator>
   getOriginalDestroyBlocks() const {
     return originalDestroyBlocks;
   }


### PR DESCRIPTION
Now that `llvm::iterator_range` has `empty`, there's not enough reason to keep our own version of it in the Swift repo.

No functionality change.