### PR TITLE
[Build System: build-script-impl] Fix the compiler-rt copy logic in build-script-impl.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2927,24 +2927,27 @@ for host in "${ALL_HOSTS[@]}"; do
             # When we are building LLVM copy over the compiler-rt
             # builtins for iOS/tvOS/watchOS to ensure that Swift's
             # stdlib can use compiler-rt builtins when targetting iOS/tvOS/watchOS.
-            if [[ "${product}" == "llvm" && "${BUILD_LLVM}" == "1" ]]; then
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
-                    HOST_CXX_DIR=$(dirname "${HOST_CXX}")
-                    DEST_CXX_BUILTINS_VERSION=$(ls "$(build_directory_bin ${host} llvm)/../lib/clang" | awk '{print $0}')
+            if [[ "${product}" = "llvm" ]] && [[ "${BUILD_LLVM}" = "1" ]] && [[ "$(uname -s)" = "Darwin" ]]; then
+                HOST_CXX_DIR=$(dirname "${HOST_CXX}")
+                HOST_LIB_CLANG_DIR="${HOST_CXX_DIR}/../lib/clang"
+                DEST_LIB_CLANG_DIR="$(build_directory_bin ${host} llvm)/../lib/clang"
+
+                if [[ -d "${HOST_LIB_CLANG_DIR}" ]] && [[ -d "${DEST_LIB_CLANG_DIR}" ]]; then
+                    DEST_CXX_BUILTINS_VERSION=$(ls "${DEST_LIB_CLANG_DIR}" | awk '{print $0}')
                     DEST_BUILTINS_DIR="$(build_directory_bin ${host} llvm)/../lib/clang/$DEST_CXX_BUILTINS_VERSION/lib/darwin"
 
-                    if [ -d "$DEST_BUILTINS_DIR" ]; then
-                        for HOST_CXX_BUILTINS_PATH in "$HOST_CXX_DIR/../lib/clang"/*; do
-                            HOST_CXX_BUILTINS_DIR="$HOST_CXX_BUILTINS_PATH/lib/darwin"
-                            echo "copying compiler-rt embedded builtins from $HOST_CXX_BUILTINS_DIR into the local clang build directory $DEST_BUILTINS_DIR."
+                    if [[ -d "${DEST_BUILTINS_DIR}" ]]; then
+                        for HOST_CXX_BUILTINS_PATH in "${HOST_LIB_CLANG_DIR}"/*; do
+                            HOST_CXX_BUILTINS_DIR="${HOST_CXX_BUILTINS_PATH}/lib/darwin"
+                            echo "copying compiler-rt embedded builtins from ${HOST_CXX_BUILTINS_DIR} into the local clang build directory ${DEST_BUILTINS_DIR}."
 
                             for OS in ios watchos tvos; do
                                 LIB_NAME="libclang_rt.$OS.a"
                                 HOST_LIB_PATH="$HOST_CXX_BUILTINS_DIR/$LIB_NAME"
-                                if [ -f "$HOST_LIB_PATH" ]; then
-                                    call cp "$HOST_LIB_PATH" "$DEST_BUILTINS_DIR/$LIB_NAME"
+                                if [[ -f "${HOST_LIB_PATH}" ]]; then
+                                    call cp "${HOST_LIB_PATH}" "${DEST_BUILTINS_DIR}/${LIB_NAME}"
                                 elif [[ "${VERBOSE_BUILD}" ]]; then
-                                    echo "no file exists at $HOST_LIB_PATH"
+                                    echo "no file exists at ${HOST_LIB_PATH}"
                                 fi
                             done
                         done


### PR DESCRIPTION
Don't `ls` directories that don't exist. Also clean up and make the conditionals and shell variable uses more consistent.