### PR TITLE
[build-script] Fix issue with installing SwiftSyntax if target dir does not exist

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3443,7 +3443,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [ "${BUILD_LIBPARSER_ONLY}" ]; then
                     # We don't have a toolchain so we should install to the specified dir
                     DYLIB_DIR="${INSTALL_DESTDIR}"
-                    MODULE_DIR="${INSTALL_DESTDIR}/${product}.swiftmodule/${SWIFT_HOST_VARIANT_ARCH}"
+                    MODULE_DIR="${INSTALL_DESTDIR}/${product}.swiftmodule"
                     # Create the install dir if it doesn't exist
                     call mkdir -p "${INSTALL_DESTDIR}"
                     # Install libParser is necessary
@@ -3453,14 +3453,15 @@ for host in "${ALL_HOSTS[@]}"; do
                 else
                     # We have a toolchain so install to the toolchain
                     DYLIB_DIR="${host_install_destdir}${host_install_prefix}/lib/swift/${SWIFT_HOST_VARIANT}"
-                    MODULE_DIR="${DYLIB_DIR}/${product}.swiftmodule/${SWIFT_HOST_VARIANT_ARCH}"
+                    MODULE_DIR="${DYLIB_DIR}/${product}.swiftmodule"
                 fi
                 if [[ "${SKIP_SWIFTSYNTAX_SWIFTSIDE}" ]]; then
                     continue
                 fi
                 set_swiftsyntax_build_command
                 if [[ -z "${SKIP_INSTALL_SWIFTSYNTAX_MODULE}" ]] ; then
-                    call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --swiftmodule-base-name "${MODULE_DIR}" --install
+                    mkdir -p "${MODULE_DIR}"
+                    call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --swiftmodule-base-name "${MODULE_DIR}/${SWIFT_HOST_VARIANT_ARCH}" --install
                 else
                     call "${swiftsyntax_build_command[@]}" --dylib-dir="${DYLIB_DIR}" --install
                 fi


### PR DESCRIPTION
Fix an issue that I introduced in https://github.com/apple/swift/pull/27566 that causes the build script to fail if the target directory into which SwiftSyntax shall be installed, does not exist yet.