### PR TITLE
[build-script] Remove redundant test check in sourcekitlsp's build product description

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -28,7 +28,7 @@ class SourceKitLSP(product.Product):
             'build', host_target, self, self.args)
 
     def test(self, host_target):
-        if self.args.test and self.args.test_sourcekitlsp:
+        if self.args.test_sourcekitlsp:
             indexstoredb.run_build_script_helper(
                 'test', host_target, self, self.args)
 


### PR DESCRIPTION
I believe the test for `args.test` is redundant since if `test` is `False` then `test_sourcekitlsp` is also being set to `False` in https://github.com/apple/swift/blob/master/utils/build_swift/driver_arguments.py#L207.