### PR TITLE
[Diagnostics] Extend single parameter tuple splat to support generic parameters

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3493,6 +3493,8 @@ ERROR(single_tuple_parameter_mismatch_special,none,
 ERROR(single_tuple_parameter_mismatch_normal,none,
       "%0 %1 expects a single parameter of type %2%3",
       (DescriptiveDeclKind, DeclBaseName, Type, StringRef))
+NOTE(note_maybe_forgot_to_form_tuple,none,
+     "did you mean to pass a tuple?", ())
 ERROR(unknown_single_tuple_parameter_mismatch,none,
       "single parameter of type %0 is expected in call", (Type))
 ERROR(cannot_convert_single_tuple_into_multiple_arguments,none,

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -104,7 +104,7 @@ enum E_32551313<L, R> {
 
 struct Foo_32551313 {
   static func bar() -> E_32551313<(String, Foo_32551313?), (String, String)>? {
-    return E_32551313.Left("", Foo_32551313()) // expected-error {{extra argument in call}}
+    return E_32551313.Left("", Foo_32551313()) // expected-error {{enum case 'Left' expects a single parameter of type 'L' [with L = (String, Foo_32551313?)]}} {{28-28=(}} {{46-46=)}}
   }
 }
 

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -104,7 +104,8 @@ enum E_32551313<L, R> {
 
 struct Foo_32551313 {
   static func bar() -> E_32551313<(String, Foo_32551313?), (String, String)>? {
-    return E_32551313.Left("", Foo_32551313()) // expected-error {{enum case 'Left' expects a single parameter of type 'L' [with L = (String, Foo_32551313?)]}} {{28-28=(}} {{46-46=)}}
+    return E_32551313.Left("", Foo_32551313()) // expected-error {{enum case 'Left' expects a single parameter of type 'L' [with L = (String, Foo_32551313?)]}}
+    // expected-note@-1 {{did you mean to pass a tuple?}} {{28-28=(}} {{46-46=)}}
   }
 }
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -69,12 +69,12 @@ func genericTuple<T, U>(_ x: (T, U)) {}
 
 do {
   generic(3)
-  generic(3, 4) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
+  generic(3, 4) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
   generic((3))
   generic((3, 4))
 
   genericLabeled(x: 3)
-  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{20-20=(}} {{25-25=)}}
+  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{20-20=(}} {{25-25=)}}
   genericLabeled(x: (3))
   genericLabeled(x: (3, 4))
 
@@ -92,7 +92,7 @@ do {
   let d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
+  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -114,7 +114,7 @@ do {
   var d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
+  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{11-11=(}} {{15-15=)}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -256,12 +256,12 @@ do {
   let s = Concrete()
 
   s.generic(3)
-  s.generic(3, 4) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
+  s.generic(3, 4) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
   s.generic((3))
   s.generic((3, 4))
 
   s.genericLabeled(x: 3)
-  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{22-22=(}} {{27-27=)}}
+  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{22-22=(}} {{27-27=)}}
   s.genericLabeled(x: (3))
   s.genericLabeled(x: (3, 4))
 
@@ -281,7 +281,7 @@ do {
   let d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
+  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -304,7 +304,7 @@ do {
   var d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
+  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{13-13=(}} {{17-17=)}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -390,12 +390,12 @@ do {
   var s = Concrete()
 
   s.mutatingGeneric(3)
-  s.mutatingGeneric(3, 4) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(3, 4) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
 
   s.mutatingGenericLabeled(x: 3)
-  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{30-30=(}} {{35-35=)}}
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{30-30=(}} {{35-35=)}}
   s.mutatingGenericLabeled(x: (3))
   s.mutatingGenericLabeled(x: (3, 4))
 
@@ -415,7 +415,7 @@ do {
   let d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -438,7 +438,7 @@ do {
   var d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
+  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -929,10 +929,10 @@ struct GenericInitLabeledTuple<T> {
 }
 
 do {
-  _ = GenericInit(3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((3, 4))
 
-  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{28-28=(}} {{33-33=)}}
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{28-28=(}} {{33-33=)}}
   _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
@@ -967,7 +967,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1003,7 +1003,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
+  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1127,12 +1127,12 @@ enum GenericEnum<T> {
 }
 
 do {
-  _ = GenericEnum.one(3, 4) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(3, 4) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((3, 4))
 
-  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{29-29=(}} {{34-34=)}}
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{29-29=(}} {{34-34=)}}
   _ = GenericEnum.labeled(x: (3, 4))
-  _ = GenericEnum.labeled(3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{27-27=(}} {{31-31=)}}
+  _ = GenericEnum.labeled(3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{27-27=(}} {{31-31=)}}
   _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
@@ -1163,7 +1163,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1199,7 +1199,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
+  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} expected-note {{did you mean to pass a tuple?}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -69,12 +69,12 @@ func genericTuple<T, U>(_ x: (T, U)) {}
 
 do {
   generic(3)
-  generic(3, 4) // expected-error {{extra argument in call}}
+  generic(3, 4) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
   generic((3))
   generic((3, 4))
 
   genericLabeled(x: 3)
-  genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{18-18=(}} {{25-25=)}}
   genericLabeled(x: (3))
   genericLabeled(x: (3, 4))
 
@@ -92,7 +92,7 @@ do {
   let d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{extra argument in call}}
+  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -114,7 +114,7 @@ do {
   var d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{extra argument in call}}
+  generic(a, b) // expected-error {{global function 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{11-11=(}} {{15-15=)}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -256,12 +256,12 @@ do {
   let s = Concrete()
 
   s.generic(3)
-  s.generic(3, 4) // expected-error {{extra argument in call}}
+  s.generic(3, 4) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
   s.generic((3))
   s.generic((3, 4))
 
   s.genericLabeled(x: 3)
-  s.genericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{20-20=(}} {{27-27=)}}
   s.genericLabeled(x: (3))
   s.genericLabeled(x: (3, 4))
 
@@ -281,7 +281,7 @@ do {
   let d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{extra argument in call}}
+  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -304,7 +304,7 @@ do {
   var d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{extra argument in call}}
+  s.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{13-13=(}} {{17-17=)}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -390,12 +390,12 @@ do {
   var s = Concrete()
 
   s.mutatingGeneric(3)
-  s.mutatingGeneric(3, 4) // expected-error {{extra argument in call}}
+  s.mutatingGeneric(3, 4) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
 
   s.mutatingGenericLabeled(x: 3)
-  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{28-28=(}} {{35-35=)}}
   s.mutatingGenericLabeled(x: (3))
   s.mutatingGenericLabeled(x: (3, 4))
 
@@ -415,7 +415,7 @@ do {
   let d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
+  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -438,7 +438,7 @@ do {
   var d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
+  s.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{21-21=(}} {{25-25=)}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -929,10 +929,10 @@ struct GenericInitLabeledTuple<T> {
 }
 
 do {
-  _ = GenericInit(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInit(3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((3, 4))
 
-  _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{26-26=(}} {{33-33=)}}
   _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
@@ -967,7 +967,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
+  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1003,7 +1003,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
+  _ = GenericInit(a, b) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -1127,12 +1127,12 @@ enum GenericEnum<T> {
 }
 
 do {
-  _ = GenericEnum.one(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one(3, 4) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((3, 4))
 
-  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{27-27=(}} {{34-34=)}}
   _ = GenericEnum.labeled(x: (3, 4))
-  _ = GenericEnum.labeled(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.labeled(3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{27-27=(}} {{31-31=)}}
   _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
 
   _ = GenericEnum.two(3, 4)
@@ -1163,7 +1163,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1199,7 +1199,7 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one(a, b) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1262,10 +1262,10 @@ do {
 
   let sTwo = GenericConforms<(Double, Double)>()
 
-  sTwo.requirement(3.0, 4.0) // expected-error {{instance method 'requirement' expects a single parameter of type '(Double, Double)'}} {{20-20=(}} {{28-28=)}}
+  sTwo.requirement(3.0, 4.0) // expected-error {{instance method 'requirement' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{20-20=(}} {{28-28=)}}
   sTwo.requirement((3.0, 4.0))
 
-  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{instance method 'requirementLabeled' expects a single parameter of type '(Double, Double)'}}
+  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{instance method 'requirementLabeled' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{27-27=(}} {{38-38=)}}
   sTwo.requirementLabeled(x: (3.0, 4.0))
 }
 
@@ -1289,7 +1289,7 @@ do {
 
   let sTwo = GenericConforms<(Double, Double)>()
 
-  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type '(Double, Double)'}} {{20-20=(}} {{24-24=)}}
+  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{20-20=(}} {{24-24=)}}
   sTwo.requirement((a, b))
   sTwo.requirement(d)
 }
@@ -1314,7 +1314,7 @@ do {
 
   var sTwo = GenericConforms<(Double, Double)>()
 
-  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type '(Double, Double)'}} {{20-20=(}} {{24-24=)}}
+  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{20-20=(}} {{24-24=)}}
   sTwo.requirement((a, b))
   sTwo.requirement(d)
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -74,7 +74,7 @@ do {
   generic((3, 4))
 
   genericLabeled(x: 3)
-  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{18-18=(}} {{25-25=)}}
+  genericLabeled(x: 3, 4) // expected-error {{global function 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{20-20=(}} {{25-25=)}}
   genericLabeled(x: (3))
   genericLabeled(x: (3, 4))
 
@@ -261,7 +261,7 @@ do {
   s.generic((3, 4))
 
   s.genericLabeled(x: 3)
-  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{20-20=(}} {{27-27=)}}
+  s.genericLabeled(x: 3, 4) // expected-error {{instance method 'genericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{22-22=(}} {{27-27=)}}
   s.genericLabeled(x: (3))
   s.genericLabeled(x: (3, 4))
 
@@ -395,7 +395,7 @@ do {
   s.mutatingGeneric((3, 4))
 
   s.mutatingGenericLabeled(x: 3)
-  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{28-28=(}} {{35-35=)}}
+  s.mutatingGenericLabeled(x: 3, 4) // expected-error {{instance method 'mutatingGenericLabeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{30-30=(}} {{35-35=)}}
   s.mutatingGenericLabeled(x: (3))
   s.mutatingGenericLabeled(x: (3, 4))
 
@@ -932,7 +932,7 @@ do {
   _ = GenericInit(3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{19-19=(}} {{23-23=)}}
   _ = GenericInit((3, 4))
 
-  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{26-26=(}} {{33-33=)}}
+  _ = GenericInitLabeled(x: 3, 4) // expected-error {{initializer expects a single parameter of type 'T' [with T = (Int, Int)]}} {{28-28=(}} {{33-33=)}}
   _ = GenericInitLabeled(x: (3, 4))
 
   _ = GenericInitTwo(3, 4)
@@ -1060,7 +1060,7 @@ do {
   _ = s1[(3.0, 4.0)]
 
   let s1a  = GenericSubscriptLabeled<(Double, Double)>()
-  _ = s1a [x: 3.0, 4.0] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{12-12=(}} {{23-23=)}}
+  _ = s1a [x: 3.0, 4.0] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{14-14=(}} {{23-23=)}}
   _ = s1a [x: (3.0, 4.0)]
 
   let s2 = GenericSubscriptTwo<Double>()
@@ -1072,7 +1072,7 @@ do {
   _ = s3[(3.0, 4.0)]
 
   let s3a = GenericSubscriptLabeledTuple<Double>()
-  _ = s3a[x: 3.0, 4.0] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{11-11=(}} {{22-22=)}}
+  _ = s3a[x: 3.0, 4.0] // expected-error {{subscript expects a single parameter of type '(Double, Double)'}} {{13-13=(}} {{22-22=)}}
   _ = s3a[x: (3.0, 4.0)]
 }
 
@@ -1130,7 +1130,7 @@ do {
   _ = GenericEnum.one(3, 4) // expected-error {{enum case 'one' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{23-23=(}} {{27-27=)}}
   _ = GenericEnum.one((3, 4))
 
-  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{27-27=(}} {{34-34=)}}
+  _ = GenericEnum.labeled(x: 3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{29-29=(}} {{34-34=)}}
   _ = GenericEnum.labeled(x: (3, 4))
   _ = GenericEnum.labeled(3, 4) // expected-error {{enum case 'labeled' expects a single parameter of type 'T' [with T = (Int, Int)]}} {{27-27=(}} {{31-31=)}}
   _ = GenericEnum.labeled((3, 4)) // expected-error {{missing argument label 'x:' in call}}
@@ -1265,7 +1265,7 @@ do {
   sTwo.requirement(3.0, 4.0) // expected-error {{instance method 'requirement' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{20-20=(}} {{28-28=)}}
   sTwo.requirement((3.0, 4.0))
 
-  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{instance method 'requirementLabeled' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{27-27=(}} {{38-38=)}}
+  sTwo.requirementLabeled(x: 3.0, 4.0) // expected-error {{instance method 'requirementLabeled' expects a single parameter of type 'GenericConforms<(Double, Double)>.Element' (aka '(Double, Double)')}} {{29-29=(}} {{38-38=)}}
   sTwo.requirementLabeled(x: (3.0, 4.0))
 }
 

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -236,6 +236,7 @@ struct Initialization {
   var x2: Double
 
   @Wrapper(stored: 17) // expected-error {{initializer expects a single parameter of type 'T' [with T = (wrappedValue: Int, stored: Int)]}}
+  // expected-note@-1 {{did you mean to pass a tuple?}}
   var x3 = 42
 
   @Wrapper(stored: 17)

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -235,8 +235,8 @@ struct Initialization {
   @Wrapper(stored: 17)
   var x2: Double
 
-  @Wrapper(stored: 17)
-  var x3 = 42 // expected-error{{extra argument 'wrappedValue' in call}}
+  @Wrapper(stored: 17) // expected-error {{initializer expects a single parameter of type 'T' [with T = (wrappedValue: Int, stored: Int)]}}
+  var x3 = 42
 
   @Wrapper(stored: 17)
   var x4


### PR DESCRIPTION
Currently single parameter tuple splat fix/diagnostic supports only
cases where parameter is a concrete tuple type, let's enhance that to
support generic parameters as well e.g.:

```swift
func foo<T>(_: T) {}
foo(0, 1, 2) // `T` expects arguments to form a tuple e.g. `foo((0, 1, 2))`
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
