### PR TITLE
[SkipFunctionBodies] Build everything but the stdlib with function body skipping

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -335,7 +335,7 @@ function(_compile_swift_files
 
     if (NOT SWIFTFILE_IS_STDLIB_CORE)
       list(APPEND swift_module_flags
-           "-Xfrontend -experimental-skip-non-inlinable-function-bodies")
+           "-Xfrontend" "-experimental-skip-non-inlinable-function-bodies")
     endif()
 
     # If we have extra regexp flags, check if we match any of the regexps. If so

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -333,6 +333,11 @@ function(_compile_swift_files
            "-emit-module-interface-path" "${interface_file}")
     endif()
 
+    if (NOT SWIFTFILE_IS_STDLIB_CORE)
+      list(APPEND swift_module_flags
+           "-Xfrontend -experimental-skip-non-inlinable-function-bodies")
+    endif()
+
     # If we have extra regexp flags, check if we match any of the regexps. If so
     # add the relevant flags to our swift_flags.
     if (SWIFT_EXPERIMENTAL_EXTRA_REGEXP_FLAGS OR SWIFT_EXPERIMENTAL_EXTRA_NEGATIVE_REGEXP_FLAGS)


### PR DESCRIPTION
Per a conversation with @atrick, see what the impact is of building everything but the stdlib with function body skipping, so we can see if the issues are stdlib-specific. Granted, not many of the benchmarks use the overlays...