### PR TITLE
Fix SE-0249 source compatibility break

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6412,6 +6412,7 @@ done:
 
   auto loc = locator.getBaseLocator();
   if (definitelyFunctionType) {
+    increaseScore(SK_FunctionConversion);
     return SolutionKind::Solved;
   } else if (!anyComponentsUnresolved ||
              (definitelyKeyPathType && capability == ReadOnly)) {

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -82,3 +82,23 @@ class Foo {
 func testFoo<T: Foo>(_: T) {
   let _: X<T> = .init(foo: \.optBar!.optWibble?.boolProperty)
 }
+
+// rdar://problem/56131416
+
+enum Rdar56131416 {
+  struct Pass<T> {}
+  static func f<T, U>(_ value: T, _ prop: KeyPath<T, U>) -> Pass<U> { fatalError() }
+
+  struct Fail<T> {}
+  static func f<T, U>(_ value: T, _ transform: (T) -> U) -> Fail<U> { fatalError() }
+  
+  static func takesCorrectType(_: Pass<UInt>) {}
+}
+
+func rdar56131416() {
+  // This call should not be ambiguous.
+  let result = Rdar56131416.f(1, \.magnitude) // no-error
+  
+  // This type should be selected correctly.
+  Rdar56131416.takesCorrectType(result)
+}


### PR DESCRIPTION
In some situations where both the KeyPath and closure solutions for an expression with a keypath literal were valid, the type checker could not choose between them and Swift would emit an “ambiguous use” error. This change increases the typechecking score of the closure solution so that the typechecker will favor the KeyPath solution, preserving source compatibility for existing APIs.

Fixes rdar://problem/56131416.