### PR TITLE
assocFn -> derivativeFn everywhere except Differentiation.cpp.

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -970,14 +970,14 @@ template<typename ImplClass>
 void SILCloner<ImplClass>::visitDifferentiableFunctionInst(
     DifferentiableFunctionInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  Optional<std::pair<SILValue, SILValue>> assocFns = None;
+  Optional<std::pair<SILValue, SILValue>> derivativeFns = None;
   if (Inst->hasDerivativeFunctions())
-    assocFns = std::make_pair(getOpValue(Inst->getJVPFunction()),
+    derivativeFns = std::make_pair(getOpValue(Inst->getJVPFunction()),
                               getOpValue(Inst->getVJPFunction()));
   recordClonedInstruction(
       Inst, getBuilder().createDifferentiableFunction(
                 getOpLocation(Inst->getLoc()), Inst->getParameterIndices(),
-                getOpValue(Inst->getOriginalFunction()), assocFns));
+                getOpValue(Inst->getOriginalFunction()), derivativeFns));
 }
 
 template<typename ImplClass>

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1045,10 +1045,10 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   // Generator for the resultant function type, i.e. the AD associated function.
   BuiltinGenericSignatureBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinGenericSignatureBuilder &builder) -> Type {
-        auto assocFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
+        auto derivativeFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
             paramIndices, /*resultIndex*/ 0, kind,
             LookUpConformanceInModule(Context.TheBuiltinModule));
-        return assocFnTy->getResult();
+        return derivativeFnTy->getResult();
       }};
   builder.addParameter(firstArgGen);
   for (auto argGen : fnArgGens)

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -694,9 +694,9 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
         autoDiffAssociatedFunctionIdentifier->getParameterIndices(),
         getDecl()->getInterfaceType()->castTo<AnyFunctionType>());
     SILAutoDiffIndices indices(/*source*/ 0, silParameterIndices);
-    auto assocFnKind = autoDiffAssociatedFunctionIdentifier->getKind();
+    auto derivativeFnKind = autoDiffAssociatedFunctionIdentifier->getKind();
     return mangler.mangleAutoDiffAssociatedFunctionHelper(
-        originalMangled, assocFnKind, indices);
+        originalMangled, derivativeFnKind, indices);
   }
 
   // As a special case, Clang functions and globals don't get mangled at all.

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -899,10 +899,10 @@ namespace {
       for (AutoDiffAssociatedFunctionKind kind :
                {AutoDiffAssociatedFunctionKind::JVP,
                 AutoDiffAssociatedFunctionKind::VJP}) {
-        auto assocFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
+        auto derivativeFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
             paramIndices, 0, kind, TC,
             LookUpConformanceInModule(&TC.M));
-        auto silTy = SILType::getPrimitiveObjectType(assocFnTy);
+        auto silTy = SILType::getPrimitiveObjectType(derivativeFnTy);
         DifferentiableFunctionExtractee extractee(kind);
         // Assert that we have the right extractee. A terrible bug in the past
         // was caused by implicit conversions from `unsigned` to

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -150,16 +150,16 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   /// Get or create an autodiff associated function thunk for the given
   /// SILDeclRef, SILFunction, and associated function type.
-  SILFunction *getOrCreateAutoDiffThunk(SILDeclRef assocFnRef,
-                                        SILFunction *assocFn,
-                                        CanSILFunctionType assocFnTy);
+  SILFunction *getOrCreateAutoDiffThunk(SILDeclRef derivativeFnRef,
+                                        SILFunction *derivativeFn,
+                                        CanSILFunctionType derivativeFnTy);
 
   // SWIFT_ENABLE_TENSORFLOW
   /// Get or create an autodiff associated function vtable entry thunk for the
   /// given SILDeclRef and associated function type.
   SILFunction *
-  getOrCreateAutoDiffClassMethodThunk(SILDeclRef assocFnRef,
-                                      CanSILFunctionType assocFnTy);
+  getOrCreateAutoDiffClassMethodThunk(SILDeclRef derivativeFnRef,
+                                      CanSILFunctionType derivativeFnTy);
 
   /// Emit a vtable thunk for a derived method if its natural abstraction level
   /// diverges from the overridden base method. If no thunking is needed,
@@ -187,8 +187,8 @@ public:
   /// - The last result in the returned pullback.
   SILFunction *getOrCreateAutoDiffAssociatedFunctionThunk(
       SILFunction *original, SILAutoDiffIndices &indices,
-      SILFunction *assocFn, AutoDiffAssociatedFunctionKind assocFnKind,
-      bool reorderSelf);
+      SILFunction *derivativeFn,
+      AutoDiffAssociatedFunctionKind derivativeFnKind, bool reorderSelf);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1041,19 +1041,19 @@ static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
     origFnArgVals.push_back(arg.getValue());
 
   // Get the associated function.
-  SILValue assocFn = SGF.B.createDifferentiableFunctionExtract(
+  SILValue derivativeFn = SGF.B.createDifferentiableFunctionExtract(
       loc, kind, origFnVal);
-  auto assocFnType = assocFn->getType().castTo<SILFunctionType>();
+  auto derivativeFnType = derivativeFn->getType().castTo<SILFunctionType>();
 
-  // We don't need to destroy the original function or retain the `assocFn`,
-  // because they are trivial (because they are @noescape).
+  // We don't need to destroy the original function or retain the
+  // `derivativeFn`, because they are trivial (because they are @noescape).
   assert(origFnVal->getType().isTrivial(SGF.F));
-  assert(assocFn->getType().isTrivial(SGF.F));
-  bool assocFnNeedsDestroy = false;
+  assert(derivativeFn->getType().isTrivial(SGF.F));
+  bool derivativeFnNeedsDestroy = false;
 
   // Unwrap curry levels.
   SmallVector<SILFunctionType *, 2> curryLevels;
-  SILFunctionType *currentLevel = assocFnType;
+  SILFunctionType *currentLevel = derivativeFnType;
   unsigned numParameters = 0;
   while (currentLevel != nullptr) {
     curryLevels.push_back(currentLevel);
@@ -1074,7 +1074,7 @@ static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
 #endif
 
   // Apply all the curry levels except the last one, whose results we handle
-  // specially. We overwrite `assocFn` with the application results.
+  // specially. We overwrite `derivativeFn` with the application results.
   unsigned currentParameter = 0;
   auto curryLevelsWithoutLast =
       ArrayRef<SILFunctionType *>(curryLevels).drop_back(1);
@@ -1082,17 +1082,17 @@ static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
     auto curryLevelArgVals = ArrayRef<SILValue>(origFnArgVals).slice(
         currentParameter, curryLevel->getNumParameters());
     auto applyResult = SGF.B.createApply(
-        loc, assocFn, SubstitutionMap(), curryLevelArgVals,
+        loc, derivativeFn, SubstitutionMap(), curryLevelArgVals,
         /*isNonThrowing*/ false);
     currentParameter += curryLevel->getNumParameters();
 
-    assocFn = applyResult;
+    derivativeFn = applyResult;
 
-    // Our new `assocFn` needs to be released because it's an owned result from
-    // a function call.
+    // Our new `derivativeFn` needs to be released because it's an owned result
+    // from a function call.
     assert(curryLevel->getSingleResult().getConvention() ==
            ResultConvention::Owned);
-    assocFnNeedsDestroy = true;
+    derivativeFnNeedsDestroy = true;
   }
 
   assert(curryLevels.back()->getNumResults() == 2);
@@ -1109,10 +1109,10 @@ static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
         currentParameter);
     for (auto origFnArgVal : curryLevelArgVals)
       applyArgs.push_back(origFnArgVal);
-    auto differential = SGF.B.createApply(
-        loc, assocFn, SubstitutionMap(), applyArgs, /*isNonThrowing*/ false);
+    auto differential = SGF.B.createApply(loc, derivativeFn, SubstitutionMap(),
+                                          applyArgs, /*isNonThrowing*/ false);
 
-    assocFn = SILValue();
+    derivativeFn = SILValue();
 
     SGF.B.createStore(loc, differential,
                       SGF.B.createTupleElementAddr(loc, indResBuffer, 1),
@@ -1125,10 +1125,10 @@ static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
   auto curryLevelArgVals = ArrayRef<SILValue>(origFnArgVals).slice(
       currentParameter);
   auto resultTuple = SGF.B.createApply(
-      loc, assocFn, SubstitutionMap(), curryLevelArgVals,
+      loc, derivativeFn, SubstitutionMap(), curryLevelArgVals,
       /*isNonThrowing*/ false);
 
-  assocFn = SILValue();
+  derivativeFn = SILValue();
 
   return SGF.emitManagedRValueWithCleanup(resultTuple);
 }

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -72,37 +72,39 @@ SILFunction *SILGenModule::getDynamicThunk(SILDeclRef constant,
 
 // SWIFT_ENABLE_TENSORFLOW
 SILFunction *
-SILGenModule::getOrCreateAutoDiffThunk(SILDeclRef assocFnDeclRef,
-                                       SILFunction *assocFn,
-                                       CanSILFunctionType assocFnTy) {
-  auto *autoDiffFuncId = assocFnDeclRef.autoDiffAssociatedFunctionIdentifier;
+SILGenModule::getOrCreateAutoDiffThunk(SILDeclRef derivativeFnDeclRef,
+                                       SILFunction *derivativeFn,
+                                       CanSILFunctionType derivativeFnTy) {
+  auto *autoDiffFuncId =
+      derivativeFnDeclRef.autoDiffAssociatedFunctionIdentifier;
   assert(autoDiffFuncId);
-  auto *assocFnDecl = assocFnDeclRef.getDecl();
+  auto *derivativeFnDecl = derivativeFnDeclRef.getDecl();
 
   SILGenFunctionBuilder builder(*this);
-  auto originalFn = assocFnDeclRef.asAutoDiffOriginalFunction();
+  auto originalFn = derivativeFnDeclRef.asAutoDiffOriginalFunction();
   auto originalLinkage = originalFn.getLinkage(ForDefinition);
   auto linkage = autodiff::getAutoDiffAssociatedFunctionLinkage(
       originalLinkage, /*isAssocFnExported*/ true);
-  auto name = assocFnDeclRef.mangle();
+  auto name = derivativeFnDeclRef.mangle();
   auto *thunk = builder.getOrCreateFunction(
-      assocFnDecl, name, linkage, assocFnTy, IsBare, IsTransparent,
-      assocFnDeclRef.isSerialized(), IsNotDynamic, ProfileCounter(), IsThunk);
+      derivativeFnDecl, name, linkage, derivativeFnTy, IsBare, IsTransparent,
+      derivativeFnDeclRef.isSerialized(), IsNotDynamic, ProfileCounter(),
+      IsThunk);
   if (!thunk->empty())
     return thunk;
 
-  if (auto genSig = assocFnTy->getGenericSignature())
+  if (auto genSig = derivativeFnTy->getGenericSignature())
     thunk->setGenericEnvironment(genSig->getGenericEnvironment());
   SILGenFunction SGF(*this, *thunk, SwiftModule);
   SmallVector<ManagedValue, 4> params;
-  auto loc = assocFnDeclRef.getAsRegularLocation();
+  auto loc = derivativeFnDeclRef.getAsRegularLocation();
   SGF.collectThunkParams(loc, params);
-  auto assocFnRef = SGF.B.createFunctionRef(loc, assocFn);
-  auto autoDiffAssocFnSILTy = SILType::getPrimitiveObjectType(assocFnTy);
+  auto derivativeFnRef = SGF.B.createFunctionRef(loc, derivativeFn);
+  auto autoDiffAssocFnSILTy = SILType::getPrimitiveObjectType(derivativeFnTy);
   SmallVector<SILValue, 4> args(thunk->getArguments().begin(),
                                 thunk->getArguments().end());
   auto apply = SGF.emitApplyWithRethrow(
-      loc, assocFnRef, autoDiffAssocFnSILTy,
+      loc, derivativeFnRef, autoDiffAssocFnSILTy,
       SGF.getForwardingSubstitutionMap(), args);
   SGF.B.createReturn(loc, apply);
   return thunk;
@@ -110,22 +112,24 @@ SILGenModule::getOrCreateAutoDiffThunk(SILDeclRef assocFnDeclRef,
 
 // SWIFT_ENABLE_TENSORFLOW
 SILFunction *SILGenModule::getOrCreateAutoDiffClassMethodThunk(
-    SILDeclRef assocFnDeclRef, CanSILFunctionType constantTy) {
-  auto *autoDiffFuncId = assocFnDeclRef.autoDiffAssociatedFunctionIdentifier;
+    SILDeclRef derivativeFnDeclRef, CanSILFunctionType constantTy) {
+  auto *autoDiffFuncId =
+      derivativeFnDeclRef.autoDiffAssociatedFunctionIdentifier;
   assert(autoDiffFuncId);
-  auto *assocFnDecl = assocFnDeclRef.getDecl();
+  auto *derivativeFnDecl = derivativeFnDeclRef.getDecl();
 
   SILGenFunctionBuilder builder(*this);
-  auto originalFn = assocFnDeclRef.asAutoDiffOriginalFunction();
+  auto originalFn = derivativeFnDeclRef.asAutoDiffOriginalFunction();
   auto originalLinkage = originalFn.getLinkage(ForDefinition);
   auto linkage = autodiff::getAutoDiffAssociatedFunctionLinkage(
       originalLinkage, /*isAssocFnExported*/ true);
   // TODO(TF-685): Use principled thunk mangling.
   // Do not simply reuse reabstraction thunk mangling.
-  auto name = assocFnDeclRef.mangle() + "_vtable_entry_thunk";
+  auto name = derivativeFnDeclRef.mangle() + "_vtable_entry_thunk";
   auto *thunk = builder.getOrCreateFunction(
-      assocFnDecl, name, linkage, constantTy, IsBare, IsTransparent,
-      assocFnDeclRef.isSerialized(), IsNotDynamic, ProfileCounter(), IsThunk);
+      derivativeFnDecl, name, linkage, constantTy, IsBare, IsTransparent,
+      derivativeFnDeclRef.isSerialized(), IsNotDynamic, ProfileCounter(),
+      IsThunk);
   if (!thunk->empty())
     return thunk;
 
@@ -133,12 +137,12 @@ SILFunction *SILGenModule::getOrCreateAutoDiffClassMethodThunk(
     thunk->setGenericEnvironment(genSig->getGenericEnvironment());
   SILGenFunction SGF(*this, *thunk, SwiftModule);
   SmallVector<ManagedValue, 4> params;
-  auto loc = assocFnDeclRef.getAsRegularLocation();
+  auto loc = derivativeFnDeclRef.getAsRegularLocation();
   SGF.collectThunkParams(loc, params);
   auto originalFnRef = SGF.emitGlobalFunctionRef(loc, originalFn);
   auto *loweredIndices = autodiff::getLoweredParameterIndices(
       autoDiffFuncId->getParameterIndices(),
-      assocFnDecl->getInterfaceType()->castTo<AnyFunctionType>());
+      derivativeFnDecl->getInterfaceType()->castTo<AnyFunctionType>());
   auto diffFn = SGF.B.createDifferentiableFunction(
       loc, loweredIndices, originalFnRef);
   auto diffAssocFn = SGF.B.createDifferentiableFunctionExtract(


### PR DESCRIPTION
This PR contains refactoring changes related to https://bugs.swift.org/browse/TF-882. More PRs to come.