### PR TITLE
[mandatory-combine] Improve basic block traversal when initializing worklist

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -127,20 +127,18 @@ public:
 //===----------------------------------------------------------------------===//
 
 void MandatoryCombiner::addReachableCodeToWorklist(SILFunction &function) {
-  SmallBlotSetVector<SILBasicBlock *, 32> blockWorklist;
-  SmallBlotSetVector<SILBasicBlock *, 32> blocksVisited;
-  SmallVector<SILInstruction *, 128> instructions;
+  SmallVector<SILBasicBlock *, 32> blockWorklist;
+  SmallPtrSet<SILBasicBlock *, 32> blockAlreadyAddedToWorklist;
+  SmallVector<SILInstruction *, 128> initialInstructionWorklist;
 
-  blockWorklist.insert(&*function.begin());
+  {
+    auto *firstBlock = &*function.begin();
+    blockWorklist.push_back(firstBlock);
+    blockAlreadyAddedToWorklist.insert(firstBlock);
+  }
+
   while (!blockWorklist.empty()) {
-    auto *block = blockWorklist.pop_back_val().getValueOr(nullptr);
-    if (block == nullptr) {
-      continue;
-    }
-
-    if (!blocksVisited.insert(block).second) {
-      continue;
-    }
+    auto *block = blockWorklist.pop_back_val();
 
     for (auto iterator = block->begin(), end = block->end(); iterator != end;) {
       auto *instruction = &*iterator;
@@ -150,14 +148,17 @@ void MandatoryCombiner::addReachableCodeToWorklist(SILFunction &function) {
         continue;
       }
 
-      instructions.push_back(instruction);
+      initialInstructionWorklist.push_back(instruction);
     }
 
-    for_each(block->getSuccessorBlocks(),
-             [&](SILBasicBlock *block) { blockWorklist.insert(block); });
+    llvm::copy_if(block->getSuccessorBlocks(),
+                  std::back_inserter(blockWorklist),
+                  [&](SILBasicBlock *block) -> bool {
+                    return blockAlreadyAddedToWorklist.insert(block).second;
+                  });
   }
 
-  worklist.addInitialGroup(instructions);
+  worklist.addInitialGroup(initialInstructionWorklist);
 }
 
 bool MandatoryCombiner::doOneIteration(SILFunction &function,

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -282,6 +282,12 @@ class MandatoryCombine final : public SILFunctionTransform {
   void run() override {
     auto *function = getFunction();
 
+    // If this function is an external declaration, bail. We only want to visit
+    // functions with bodies.
+    if (function->isExternalDeclaration()) {
+      return;
+    }
+
     MandatoryCombiner combiner(createdInstructions);
     bool madeChange = combiner.runOnFunction(*function);
 


### PR DESCRIPTION
This PR contains two different small improvements to mandatory combine that will not change the output of the pass, but generally make the pass safer and easier to maintain. Specifically:

1. The first patch just causes mandatory combine to bail early when we see a function that is an external declaration before we do anything else. This just provides a nice invariant I use in the next patch.

2. The second patch cleans up the worklist initialization in mandatory combine. Specifically, I:
a. Simplified the data structures.
b. Changed the "visited block" set to ensure that we only add blocks once to the worklist instead of inserting the blocks into the worklist and then using the set to filter out if we had already popped the block off the worklist before. This is more efficient and simplifies the code. I changed the name of the set to fit closer to its new role: blockAlreadyAddedToWorklist.

----

[mandatory-combine] Simplify block traversal used to initialize worklist.

Previously, we were using a pointer set to ensure that was checked when a value
was popped off the worklist. In this commit, I change the code so that we
instead use the set to guard insertion into the worklist.

I changed the name of the set to blockAlreadyAddedToWorklist. Hopefully that
will make things a bit clearer.