### PR TITLE
Local lazy vars

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5107,6 +5107,14 @@ public:
   /// Retrieve the backing storage property for a lazy property.
   VarDecl *getLazyStorageProperty() const;
 
+  /// Visit the backing storage of this lazy variable, provided that
+  /// the storage had already been created.
+  ///
+  /// This is a convenience method for local and top-level lazy variables,
+  /// the implicit storage for which is not directly added to the AST and
+  /// should therefore be visited explicity where necessary.
+  void visitLazyStorageIfCreated(llvm::function_ref<void (Decl *)>) const;
+
   /// Whether this is a property with a property wrapper that was initialized
   /// via a value of the original type, e.g.,
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2817,8 +2817,6 @@ ERROR(lazy_requires_initializer,none,
 ERROR(lazy_requires_single_var,none,
       "'lazy' cannot destructure an initializer", ())
 
-ERROR(lazy_must_be_property,none,
-      "lazy is only valid for members of a struct or class", ())
 ERROR(lazy_not_observable,none,
       "lazy properties must not have observers", ())
 ERROR(lazy_not_strong,none,

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -303,6 +303,16 @@ public:
     cache.insert({getCanonicalRequest(request), std::move(output)});
   }
 
+  /// Consults the general cache for whether the output for the given request
+  /// had already been cached.
+  template<typename Request,
+           typename std::enable_if<!Request::hasExternalCache>::type* = nullptr>
+  bool hasBeenCached(const Request &request) {
+    assert(request.isCached() && "Request output should not be cached");
+
+    return cache.find_as(request) != cache.end();
+  }
+
   /// Clear the cache stored within this evaluator.
   ///
   /// Note that this does not clear the caches of requests that use external

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1192,14 +1192,6 @@ void SILGenFunction::visitPatternBindingDecl(PatternBindingDecl *PBD) {
 void SILGenFunction::visitVarDecl(VarDecl *D) {
   // We handle emitting the variable storage when we see the pattern binding.
 
-  // If this is a local lazy var, visit its storage first.
-  if (D->getAttrs().hasAttribute<LazyAttr>() &&
-      D->getDeclContext()->isLocalContext()) {
-    const auto lazyStorage = D->getLazyStorageProperty();
-    visitPatternBindingDecl(lazyStorage->getParentPatternBinding());
-    visitVarDecl(lazyStorage);
-  }
-
   // Emit the variable's accessors.
   D->visitEmittedAccessors([&](AccessorDecl *accessor) {
     SGM.emitFunction(accessor);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1192,6 +1192,14 @@ void SILGenFunction::visitPatternBindingDecl(PatternBindingDecl *PBD) {
 void SILGenFunction::visitVarDecl(VarDecl *D) {
   // We handle emitting the variable storage when we see the pattern binding.
 
+  // If this is a local lazy var, visit its storage first.
+  if (D->getAttrs().hasAttribute<LazyAttr>() &&
+      D->getDeclContext()->isLocalContext()) {
+    const auto lazyStorage = D->getLazyStorageProperty();
+    visitPatternBindingDecl(lazyStorage->getParentPatternBinding());
+    visitVarDecl(lazyStorage);
+  }
+
   // Emit the variable's accessors.
   D->visitEmittedAccessors([&](AccessorDecl *accessor) {
     SGM.emitFunction(accessor);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -657,7 +657,7 @@ void AttributeChecker::visitNonOverrideAttr(NonOverrideAttr *attr) {
 }
 
 void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
-  // lazy may only be used on properties.
+  // lazy may only be used on a VarDecl.
   auto *VD = cast<VarDecl>(D);
 
   auto attrs = VD->getAttrs();
@@ -669,13 +669,10 @@ void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
 
   // 'lazy' is not allowed on a global variable or on a static property (which
   // are already lazily initialized).
-  // TODO: we can't currently support lazy properties on non-type-contexts.
   if (VD->isStatic() ||
       (varDC->isModuleScopeContext() &&
        !varDC->getParentSourceFile()->isScriptMode())) {
     diagnoseAndRemoveAttr(attr, diag::lazy_on_already_lazy_global);
-  } else if (!VD->getDeclContext()->isTypeContext()) {
-    diagnoseAndRemoveAttr(attr, diag::lazy_must_be_property);
   }
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -127,6 +127,12 @@ namespace {
 
       // Explicit closures start their own sequence.
       if (auto CE = dyn_cast<ClosureExpr>(E)) {
+        // Lazy var synthesized accessors are contextualized in-place.
+        if (const auto AD = dyn_cast<AccessorDecl>(CE->getParent()))
+          if (const auto VD = dyn_cast<VarDecl>(AD->getStorage()))
+            if (VD->getAttrs().hasAttribute<LazyAttr>())
+              return { false, E };
+
         // In the repl, the parent top-level context may have been re-written.
         if (CE->getParent() != ParentDC) {
           if ((CE->getParent()->getContextKind() !=

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -45,12 +45,6 @@ class TestClass {
     didSet {
     }
   }
-
-  init() {
-    lazy var localvar = 42  // expected-error {{lazy is only valid for members of a struct or class}} {{5-10=}}
-    localvar += 1
-    _ = localvar
-  }
 }
 
 

--- a/test/decl/var/lazy_synthesis.swift
+++ b/test/decl/var/lazy_synthesis.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -dump-ast %s | %FileCheck %s
+
+func compute() -> Bool {
+  return true
+}
+
+struct Foo {
+  // CHECK-DAG: pattern_named {{.*}} '$__lazy_storage_$_foo'
+  // CHECK-DAG: var_decl {{.*}} "$__lazy_storage_$_foo" type='Bool?'
+  // CHECK-DAG: pattern_named {{.*}} 'foo'
+  // CHECK-DAG: var_decl {{.*}} "foo" type='Bool'
+  lazy var foo = compute()
+}
+
+func foo() {
+  // CHECK: pattern_named {{.*}} '$__lazy_storage_$_local'
+  // CHECK: var_decl {{.*}} "$__lazy_storage_$_local" type='Bool?'
+  // CHECK: pattern_named {{.*}} 'local'
+  // CHECK: var_decl {{.*}} "local" type='Bool'
+  lazy var local = compute()
+}

--- a/test/decl/var/lazy_top_level_and_local.swift
+++ b/test/decl/var/lazy_top_level_and_local.swift
@@ -12,6 +12,12 @@ func thrower() throws -> Bool {
 /*=====================================*/
 
 lazy var topLevelLazy1 = compute()
+lazy var topLevelLazy2 = thrower()
+// expected-error@-1 {{call can throw, but errors cannot be thrown out of a lazy getter}}
+lazy var topLevelLazy3 = try thrower()
+// expected-error@-1 {{call can throw, but errors cannot be thrown out of a lazy getter}}
+lazy var topLevelLazy4 = try? thrower()
+lazy var topLevelLazy5 = try! thrower()
 
 /*=====================================*/
 /*                Local                */
@@ -44,7 +50,30 @@ func testLocalLazyUsage() -> Bool {
   #endif
 }
 
+func testLocalLazyErrorHandling() {
+  do {
+    lazy var lazy1 = try thrower()
+    // expected-error@-1 {{call can throw, but errors cannot be thrown out of a lazy getter}}
+    lazy var lazy2 = thrower()
+    // expected-error@-1 {{call can throw, but errors cannot be thrown out of a lazy getter}}
+  } catch { // expected-warning {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+    return
+  }
+  lazy var lazy2 = { () -> Bool in
+    do {
+      return try thrower()
+    } catch {
+      return true
+    }
+  }()
+  lazy var lazy3 = try? thrower()
+  lazy var lazy4 = try! thrower()
+}
+
 class LocalLazyWrapperClass {
+  lazy var foo = try thrower()
+  // expected-error@-1 {{call can throw, but errors cannot be thrown out of a lazy getter}}
+
   func compute() -> Bool { return true }
 
   func testLocalLazyInitializers() {

--- a/test/decl/var/lazy_top_level_and_local.swift
+++ b/test/decl/var/lazy_top_level_and_local.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s -verify -module-name main
+
+func compute() -> Bool {
+  return true
+}
+func thrower() throws -> Bool {
+  return true
+}
+
+/*=====================================*/
+/*              Top-level              */
+/*=====================================*/
+
+lazy var topLevelLazy1 = compute()
+
+/*=====================================*/
+/*                Local                */
+/*=====================================*/
+
+func testLocalLazyUsage() -> Bool {
+  lazy var lazy1 = compute()
+
+  if lazy1 {
+    lazy var lazy2 = compute()
+
+    guard lazy2 else {
+      lazy var lazy3 = compute()
+      return lazy3
+    }
+    for _ in [lazy1, lazy2] {
+      lazy var lazy4 = compute()
+      lazy1 = lazy4
+    }
+    _ = [lazy1, lazy2].map { _ -> Bool in
+      lazy var lazy5 = compute()
+      return lazy5
+    }
+  }
+  #if DEBUG
+  lazy var lazy6 = compute()
+  return lazy6
+  #else
+  return lazy1
+  #endif
+}
+
+class LocalLazyWrapperClass {
+  func compute() -> Bool { return true }
+
+  func testLocalLazyInitializers() {
+    lazy let a = 0
+    // expected-error@-1 {{'lazy' cannot be used on a let}}
+
+    lazy var b: Int
+    // expected-error@-1 {{lazy properties must have an initializer}}
+
+    lazy var (c1, c2) = (0, 1)
+    // expected-error@-1 2 {{'lazy' cannot destructure an initializer}}
+
+    lazy var d: Int = 0 { willSet {} }
+    // expected-error@-1 {{lazy properties must not have observers}}
+    // expected-warning@-2 {{variable 'd' was never used}}
+
+    lazy var e = { 0 }()
+
+    lazy var f = self.compute()
+
+    lazy var g = { [unowned self] in return self.compute }()
+
+    lazy var h = { [weak self] in return self?.compute }()
+  }
+}


### PR DESCRIPTION
To make this a high-quality contribution I really need some feedback and ideas, especially from people that wrote and maintain the parts of the compiler involved in this change.
___

The most important step to directly implementing support for local lazy variables is obviously preparation. Preparation here means to provide an efficient way to supplement the list of elements contained within a `BraceStmt` after allocating it. I have next to no experience in using `TrailingObjects`, but from looking at all the other use sites and, specifically, how extensions and nominal types use `IterableDeclContext`, it seems like it was not designed for arrays of dynamic size. I decided to use an approach similar to `IterableDeclContext`, but am still thinking whether this is a positive change. I also thought about how having `ASTNode` be a base class rather than a pointer union would make the iterable approach less brittle. 

Next was the need for a way to access the innermost `BraceStmt` that contains the `VarDecl` at hand. Propagating the brace statement through lazy accessor generation and request evaluation proved to be almost impossible, hence the decision to add a `ParentBraceStmt` field to `VarDecl`.

___

### Edit: Implemented in #35803