### PR TITLE
omitNeedlessWords: Several clarifying improvements to type name matching

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -321,10 +321,6 @@ enum class NameRole {
   /// The base name of a function or method.
   BaseName,
 
-  /// The base name of a method where the omission type name is the
-  /// 'self' type.
-  BaseNameSelf,
-
   /// The first parameter of a function or method.
   FirstParameter,
 

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -315,25 +315,6 @@ namespace swift {
     size_t findWord(StringRef string, StringRef word);
   } // end namespace camel_case
 
-/// Describes the role that a particular name has within a
-/// signature, which can affect how we omit needless words.
-enum class NameRole {
-  /// The base name of a function or method.
-  BaseName,
-
-  /// The first parameter of a function or method.
-  FirstParameter,
-
-  // Subsequent parameters in a function or method.
-  SubsequentParameter,
-
-  // The name of a property.
-  Property,
-
-  // A partial name; used internally.
-  Partial,
-};
-
 /// Flags used by \c OmissionTypeName to describe the input type.
 enum class OmissionTypeFlags {
   /// Whether the parameter with this type has a default argument.

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -680,13 +680,6 @@ static Words::iterator matchTypeNameFromBackWithSpecialCases(
       auto newShortenedNameWord
         = omitNeedlessWords(shortenedNameWord, typeName.CollectionElement,
                             NameRole::Partial, allPropertyNames);
-      if (shortenedNameWord == newShortenedNameWord &&
-          shortenedNameWord.back() == 'e') {
-        (void)shortenedNameWord.drop_back();
-        newShortenedNameWord =
-          omitNeedlessWords(shortenedNameWord, typeName.CollectionElement,
-                            NameRole::Partial, allPropertyNames);
-      }
 
       if (shortenedNameWord != newShortenedNameWord) {
         unsigned targetSize = newShortenedNameWord.size();

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -576,6 +576,27 @@ static bool textMatchesPropertyName(StringRef text,
   return false;
 }
 
+namespace {
+/// Describes the role that a particular name has within a
+/// signature, which can affect how we omit needless words.
+enum class NameRole {
+  /// The base name of a function or method.
+  BaseName,
+
+  /// The first parameter of a function or method.
+  FirstParameter,
+
+  // Subsequent parameters in a function or method.
+  SubsequentParameter,
+
+  // The name of a property.
+  Property,
+
+  // A partial name; used internally.
+  Partial,
+};
+} // end anonymous namespace
+
 static StringRef omitNeedlessWords(StringRef name,
                                    OmissionTypeName typeName,
                                    NameRole role,


### PR DESCRIPTION
In writing up CToSwiftNameTranslation.md, I want to describe the omit-needless-words algorithm, at least as a high level, which meant that I had to understand it first. The code was fairly well-commented already, but that didn't stop it from being complicated. I think the refactorings I've done here have simplified the type name matching parts quite a bit, mainly by breaking them up into smaller composable pieces.

No intended functionality change.