### PR TITLE
[AutoDiff] Rename "associated function" to "derivative function".

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5623,10 +5623,9 @@ differentiable_function
   differentiable_function [wrt 0] %0 : $(T) -> T \
     with {%1 : $(T) -> (T, (T) -> T), %2 : $(T) -> (T, (T) -> T)}
 
-Bundles a function with its associated differentiation functions into a
-``@differentiable`` function. There are two derivative functions:
-a Jacobian-vector products (JVP) function and a vector-Jacobian products (VJP)
-function.
+Bundles a function with its derivative functions into a ``@differentiable``
+function. There are two derivative functions: a Jacobian-vector products (JVP)
+function and a vector-Jacobian products (VJP) function.
 
 ``[wrt ...]`` specifies parameter indices that the original function is
 differentiable with respect to. When not specified, it defaults to all

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5624,7 +5624,7 @@ differentiable_function
     with {%1 : $(T) -> (T, (T) -> T), %2 : $(T) -> (T, (T) -> T)}
 
 Bundles a function with its associated differentiation functions into a
-``@differentiable`` function. There are two associated functions:
+``@differentiable`` function. There are two derivative functions:
 a Jacobian-vector products (JVP) function and a vector-Jacobian products (VJP)
 function.
 
@@ -5634,10 +5634,10 @@ parameters.
 
 A ``with`` clause specifies the differentiation functions associated
 with the original function. When a ``with`` clause is not specified, the first
-operand will be differentiated to produce associated functions, and a ``with``
+operand will be differentiated to produce derivative functions, and a ``with``
 clause will be added to the instruction.
 
-In raw SIL, it is optional to provide an associated function ``with`` clause.
+In raw SIL, it is optional to provide an derivative function ``with`` clause.
 In canonical SIL, a ``with`` clause is mandatory.
 
 
@@ -5660,7 +5660,7 @@ differentiable_function_extract
   differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T
   differentiable_function_extract [vjp] %0 : $@differentiable (T) -> T
 
-Extracts the original function or an associated function from the given
+Extracts the original function or an derivative function from the given
 ``@differentiable`` function. It must be provided with an extractee:
 ``[original]``, ``[jvp]`` or ``[vjp]``.
 

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5636,7 +5636,7 @@ with the original function. When a ``with`` clause is not specified, the first
 operand will be differentiated to produce derivative functions, and a ``with``
 clause will be added to the instruction.
 
-In raw SIL, it is optional to provide an derivative function ``with`` clause.
+In raw SIL, it is optional to provide a derivative function ``with`` clause.
 In canonical SIL, a ``with`` clause is mandatory.
 
 
@@ -5659,7 +5659,7 @@ differentiable_function_extract
   differentiable_function_extract [jvp] %0 : $@differentiable (T) -> T
   differentiable_function_extract [vjp] %0 : $@differentiable (T) -> T
 
-Extracts the original function or an derivative function from the given
+Extracts the original function or a derivative function from the given
 ``@differentiable`` function. It must be provided with an extractee:
 ``[original]``, ``[jvp]`` or ``[vjp]``.
 

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5609,15 +5609,15 @@ differentiable_function
                       sil-differentiable-function-parameter-indices?
                       sil-differentiable-function-order?
                       sil-value ':' sil-type
-                      sil-differentiable-function-associated-functions-clause?
+                      sil-differentiable-function-derivative-functions-clause?
                       
   sil-differentiable-function-parameter-indices ::=
       '[' 'wrt' [0-9]+ (',', [0-9]+)* ']'
   sil-differentiable-function-order ::= '[' 'order' [0-9]+ ']'
-  sil-differentiable-associated-functions-clause ::=
-      'with' sil-differentiable-associated-function-list
-      (',' sil-differentiable-associated-function-list)*
-  sil-differentiable-function-associated-function-list ::=
+  sil-differentiable-derivative-functions-clause ::=
+      'with' sil-differentiable-derivative-function-list
+      (',' sil-differentiable-derivative-function-list)*
+  sil-differentiable-function-derivative-function-list ::=
       '{' sil-value ',' sil-value '}'
 
   differentiable_function [wrt 0] %0 : $(T) -> T \

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -155,9 +155,9 @@ public:
                                              ModuleDecl *Module);
 
   // SWIFT_ENABLE_TENSORFLOW
-  // Mangle the autodiff associated function (JVP/VJP) with the given:
+  // Mangle the derivative function (JVP/VJP) with the given:
   // - Mangled original function name.
-  // - Associated function kind.
+  // - Derivative function kind.
   // - Parameter/result indices.
   std::string mangleAutoDiffDerivativeFunctionHelper(
       StringRef name, AutoDiffDerivativeFunctionKind kind,

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -159,8 +159,8 @@ public:
   // - Mangled original function name.
   // - Associated function kind.
   // - Parameter/result indices.
-  std::string mangleAutoDiffAssociatedFunctionHelper(
-      StringRef name, AutoDiffAssociatedFunctionKind kind,
+  std::string mangleAutoDiffDerivativeFunctionHelper(
+      StringRef name, AutoDiffDerivativeFunctionKind kind,
       const SILAutoDiffIndices &indices);
 
   // SWIFT_ENABLE_TENSORFLOW

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1555,7 +1555,7 @@ class DifferentiableAttr final
   AutoDiffIndexSubset *ParameterIndices = nullptr;
   /// The trailing where clause (optional).
   TrailingWhereClause *WhereClause = nullptr;
-  /// The generic signature for autodiff associated functions. Resolved by the
+  /// The generic signature for autodiff derivative functions. Resolved by the
   /// type checker based on the original function's generic signature and the
   /// attribute's where clause requirements. This is set only if the attribute
   /// has a where clause.
@@ -1650,10 +1650,10 @@ public:
 
   // Print the attribute to the given stream.
   // If `omitWrtClause` is true, omit printing the `wrt:` clause.
-  // If `omitAssociatedFunctions` is true, omit printing associated functions.
+  // If `omitDerivativeFunctions` is true, omit printing derivative functions.
   void print(llvm::raw_ostream &OS, const Decl *D,
              bool omitWrtClause = false,
-             bool omitAssociatedFunctions = false) const;
+             bool omitDerivativeFunctions = false) const;
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Differentiable;

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -432,7 +432,7 @@ struct AutoDiffLinearMapKind {
 };
 
 /// The kind of an associated function.
-struct AutoDiffAssociatedFunctionKind {
+struct AutoDiffDerivativeFunctionKind {
   enum innerty : uint8_t {
    // The Jacobian-vector products function.
    JVP = 0,
@@ -440,11 +440,11 @@ struct AutoDiffAssociatedFunctionKind {
    VJP = 1
   } rawValue;
 
-  AutoDiffAssociatedFunctionKind() = default;
-  AutoDiffAssociatedFunctionKind(innerty rawValue) : rawValue(rawValue) {}
-  AutoDiffAssociatedFunctionKind(AutoDiffLinearMapKind linMapKind)
+  AutoDiffDerivativeFunctionKind() = default;
+  AutoDiffDerivativeFunctionKind(innerty rawValue) : rawValue(rawValue) {}
+  AutoDiffDerivativeFunctionKind(AutoDiffLinearMapKind linMapKind)
       : rawValue(static_cast<innerty>(linMapKind.rawValue)) {}
-  explicit AutoDiffAssociatedFunctionKind(StringRef string);
+  explicit AutoDiffDerivativeFunctionKind(StringRef string);
   operator innerty() const { return rawValue; }
   AutoDiffLinearMapKind getLinearMapKind() {
     return (AutoDiffLinearMapKind::innerty)rawValue;
@@ -456,23 +456,23 @@ struct AutoDiffAssociatedFunctionKind {
 ///
 /// Is uniquely allocated within an ASTContext so that it can be hashed and
 /// compared by opaque pointer value.
-class AutoDiffAssociatedFunctionIdentifier : public llvm::FoldingSetNode {
-  const AutoDiffAssociatedFunctionKind kind;
+class AutoDiffDerivativeFunctionIdentifier : public llvm::FoldingSetNode {
+  const AutoDiffDerivativeFunctionKind kind;
   AutoDiffIndexSubset *const parameterIndices;
 
-  AutoDiffAssociatedFunctionIdentifier(
-      AutoDiffAssociatedFunctionKind kind,
+  AutoDiffDerivativeFunctionIdentifier(
+      AutoDiffDerivativeFunctionKind kind,
       AutoDiffIndexSubset *parameterIndices) :
     kind(kind), parameterIndices(parameterIndices) {}
 
 public:
-  AutoDiffAssociatedFunctionKind getKind() const { return kind; }
+  AutoDiffDerivativeFunctionKind getKind() const { return kind; }
   AutoDiffIndexSubset *getParameterIndices() const {
     return parameterIndices;
   }
 
-  static AutoDiffAssociatedFunctionIdentifier *get(
-      AutoDiffAssociatedFunctionKind kind,
+  static AutoDiffDerivativeFunctionIdentifier *get(
+      AutoDiffDerivativeFunctionKind kind,
       AutoDiffIndexSubset *parameterIndices, ASTContext &C);
 
   void Profile(llvm::FoldingSetNodeID &ID) {
@@ -520,15 +520,15 @@ AutoDiffIndexSubset *getLoweredParameterIndices(AutoDiffIndexSubset *indices,
 /// `Builtin.autodiffApply`, e.g. `Builtin.autodiffApply_jvp_arity2_order1`.
 /// Returns true if the function name is parsed successfully.
 bool getBuiltinAutoDiffApplyConfig(StringRef operationName,
-                                   AutoDiffAssociatedFunctionKind &kind,
+                                   AutoDiffDerivativeFunctionKind &kind,
                                    unsigned &arity, bool &rethrows);
 
 /// Computes the correct linkage for an associated function given the linkage of
 /// the original function. If the original linkage is not external and
-/// `isAssocFnExported` is true, use the original function's linkage. Otherwise,
+/// `isDerivativeFnExported` is true, use the original function's linkage. Otherwise,
 /// return hidden linkage.
-SILLinkage getAutoDiffAssociatedFunctionLinkage(SILLinkage originalLinkage,
-                                                bool isAssocFnExported);
+SILLinkage getAutoDiffDerivativeFunctionLinkage(SILLinkage originalLinkage,
+                                                bool isDerivativeFnExported);
 
 } // end namespace autodiff
 

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -431,7 +431,7 @@ struct AutoDiffLinearMapKind {
   operator innerty() const { return rawValue; }
 };
 
-/// The kind of an derivative function.
+/// The kind of a derivative function.
 struct AutoDiffDerivativeFunctionKind {
   enum innerty : uint8_t {
    // The Jacobian-vector products function.
@@ -523,10 +523,10 @@ bool getBuiltinAutoDiffApplyConfig(StringRef operationName,
                                    AutoDiffDerivativeFunctionKind &kind,
                                    unsigned &arity, bool &rethrows);
 
-/// Computes the correct linkage for an derivative function given the linkage of
+/// Computes the correct linkage for a derivative function given the linkage of
 /// the original function. If the original linkage is not external and
-/// `isDerivativeFnExported` is true, use the original function's linkage. Otherwise,
-/// return hidden linkage.
+/// `isDerivativeFnExported` is true, use the original function's linkage.
+/// Otherwise, return hidden linkage.
 SILLinkage getAutoDiffDerivativeFunctionLinkage(SILLinkage originalLinkage,
                                                 bool isDerivativeFnExported);
 

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -431,7 +431,7 @@ struct AutoDiffLinearMapKind {
   operator innerty() const { return rawValue; }
 };
 
-/// The kind of an associated function.
+/// The kind of an derivative function.
 struct AutoDiffDerivativeFunctionKind {
   enum innerty : uint8_t {
    // The Jacobian-vector products function.
@@ -452,7 +452,7 @@ struct AutoDiffDerivativeFunctionKind {
 };
 
 /// In conjunction with the original function declaration, identifies an
-/// autodiff associated function.
+/// autodiff derivative function.
 ///
 /// Is uniquely allocated within an ASTContext so that it can be hashed and
 /// compared by opaque pointer value.
@@ -523,7 +523,7 @@ bool getBuiltinAutoDiffApplyConfig(StringRef operationName,
                                    AutoDiffDerivativeFunctionKind &kind,
                                    unsigned &arity, bool &rethrows);
 
-/// Computes the correct linkage for an associated function given the linkage of
+/// Computes the correct linkage for an derivative function given the linkage of
 /// the original function. If the original linkage is not external and
 /// `isDerivativeFnExported` is true, use the original function's linkage. Otherwise,
 /// return hidden linkage.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1597,15 +1597,15 @@ ERROR(sil_inst_autodiff_attr_expected_rsquare,PointsToFirstBadToken,
 ERROR(sil_inst_autodiff_expected_parameter_index,PointsToFirstBadToken,
       "expected the index of a parameter to differentiate with respect to", ())
 ERROR(sil_inst_autodiff_operand_list_expected_lbrace,PointsToFirstBadToken,
-      "expected '{' to start an associated function list", ())
+      "expected '{' to start an derivative function list", ())
 ERROR(sil_inst_autodiff_operand_list_expected_comma,PointsToFirstBadToken,
-      "expected ',' between operands in an associated function list", ())
+      "expected ',' between operands in an derivative function list", ())
 ERROR(sil_inst_autodiff_operand_list_expected_rbrace,PointsToFirstBadToken,
-      "expected '}' to start an associated function list", ())
+      "expected '}' to start an derivative function list", ())
 ERROR(sil_inst_autodiff_num_operand_list_order_mismatch,PointsToFirstBadToken,
       "the number of operand lists does not match the order", ())
 ERROR(sil_inst_autodiff_expected_associated_function_kind_attr,PointsToFirstBadToken,
-      "expected an associated function kind attribute, e.g. '[jvp]'", ())
+      "expected an derivative function kind attribute, e.g. '[jvp]'", ())
 ERROR(sil_inst_autodiff_expected_function_type_operand,PointsToFirstBadToken,
       "expected an operand of a function type", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1597,15 +1597,15 @@ ERROR(sil_inst_autodiff_attr_expected_rsquare,PointsToFirstBadToken,
 ERROR(sil_inst_autodiff_expected_parameter_index,PointsToFirstBadToken,
       "expected the index of a parameter to differentiate with respect to", ())
 ERROR(sil_inst_autodiff_operand_list_expected_lbrace,PointsToFirstBadToken,
-      "expected '{' to start an derivative function list", ())
+      "expected '{' to start a derivative function list", ())
 ERROR(sil_inst_autodiff_operand_list_expected_comma,PointsToFirstBadToken,
-      "expected ',' between operands in an derivative function list", ())
+      "expected ',' between operands in a derivative function list", ())
 ERROR(sil_inst_autodiff_operand_list_expected_rbrace,PointsToFirstBadToken,
-      "expected '}' to start an derivative function list", ())
+      "expected '}' to start a derivative function list", ())
 ERROR(sil_inst_autodiff_num_operand_list_order_mismatch,PointsToFirstBadToken,
       "the number of operand lists does not match the order", ())
 ERROR(sil_inst_autodiff_expected_associated_function_kind_attr,PointsToFirstBadToken,
-      "expected an derivative function kind attribute, e.g. '[jvp]'", ())
+      "expected a derivative function kind attribute, e.g. '[jvp]'", ())
 ERROR(sil_inst_autodiff_expected_function_type_operand,PointsToFirstBadToken,
       "expected an operand of a function type", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2881,7 +2881,7 @@ ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in '@differentiable' "
       "attribute", (DeclName))
 ERROR(differentiable_attr_invalid_access,none,
-      "deriavtive function %0 is required to either be public or "
+      "derivative function %0 is required to either be public or "
       "'@usableFromInline' because the original function %1 is public or "
       "'@usableFromInline'", (DeclName, DeclName))
 ERROR(differentiable_attr_result_not_differentiable,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2859,8 +2859,7 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
 ERROR(differentiable_attr_void_result,none,
       "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_associated_function_protocol,none,
-      "cannot specify associated differentiation function on protocol "
-      "requirement", ())
+      "cannot specify derivative functions on protocol requirements", ())
 ERROR(differentiable_attr_overload_not_found,none,
       "%0 does not have expected type %1", (DeclName, Type))
 ERROR(differentiable_attr_no_currying,none,
@@ -2874,7 +2873,7 @@ NOTE(differentiable_attr_duplicate_note,none,
 ERROR(differentiable_attr_function_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclName))
 ERROR(differentiable_attr_specified_not_function,none,
-      "%0 is not a function to be used as associated differentiation function",
+      "%0 is not a function to be used as derivative function",
       (DeclName))
 ERROR(differentiable_attr_class_derivative_not_final,none,
       "class member derivative must be final", ())
@@ -2882,9 +2881,9 @@ ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in '@differentiable' "
       "attribute", (DeclName))
 ERROR(differentiable_attr_invalid_access,none,
-      "associated differentiation function %0 is required to either be public "
-      "or @usableFromInline because the original function %1 is public or "
-      "@usableFromInline", (DeclName, DeclName))
+      "deriavtive function %0 is required to either be public or "
+      "'@usableFromInline' because the original function %1 is public or "
+      "'@usableFromInline'", (DeclName, DeclName))
 ERROR(differentiable_attr_result_not_differentiable,none,
       "can only differentiate functions with results that conform to "
       "'Differentiable', but %0 does not conform to 'Differentiable'", (Type))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3100,10 +3100,10 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   /// Given `indices` and `kind`, calculates the type of the corresponding
-  /// autodiff associated function.
+  /// autodiff derivative function.
   ///
   /// By default, if the original type has a self parameter list and parameter
-  /// indices include self, the computed associated function type will return a
+  /// indices include self, the computed derivative function type will return a
   /// linear map taking/returning self's tangent *last* instead of first, for
   /// consistency with SIL.
   ///
@@ -3121,11 +3121,11 @@ public:
       GenericSignature *whereClauseGenericSignature = nullptr,
       bool makeSelfParamFirst = false);
 
-  /// Given the type of an autodiff associated function, returns the
+  /// Given the type of an autodiff derivative function, returns the
   /// corresponding original function type.
   AnyFunctionType *getAutoDiffOriginalFunctionType();
   
-  /// Given the type of a transposing associated function, returns the
+  /// Given the type of a transposing derivative function, returns the
   /// corresponding original function type.
   AnyFunctionType *
   getTransposeOriginalFunctionType(TransposingAttr *attr,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3114,9 +3114,9 @@ public:
   /// \note The original function type (`self`) need not be `@differentiable`.
   /// The resulting function will preserve all `ExtInfo` of the original
   /// function, including `@differentiable`.
-  AnyFunctionType *getAutoDiffAssociatedFunctionType(
+  AnyFunctionType *getAutoDiffDerivativeFunctionType(
       AutoDiffIndexSubset *indices, unsigned resultIndex,
-      AutoDiffAssociatedFunctionKind kind,
+      AutoDiffDerivativeFunctionKind kind,
       LookupConformanceFn lookupConformance,
       GenericSignature *whereClauseGenericSignature = nullptr,
       bool makeSelfParamFirst = false);
@@ -4222,11 +4222,11 @@ public:
 
   /// Returns the type of a differentiation function that is associated with
   /// a function of this type.
-  CanSILFunctionType getAutoDiffAssociatedFunctionType(
+  CanSILFunctionType getAutoDiffDerivativeFunctionType(
       AutoDiffIndexSubset *parameterIndices, unsigned resultIndex,
-      AutoDiffAssociatedFunctionKind kind, Lowering::TypeConverter &TC,
+      AutoDiffDerivativeFunctionKind kind, Lowering::TypeConverter &TC,
       LookupConformanceFn lookupConformance,
-      CanGenericSignature associatedFunctionGenericSignature = nullptr);
+      CanGenericSignature derivativeFunctionGenericSignature = nullptr);
 
   /// Returns a bit vector that specifices which parameters you can
   /// differentiate with respect to for this differentiable function type. (e.g.

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -973,7 +973,7 @@ void SILCloner<ImplClass>::visitDifferentiableFunctionInst(
   Optional<std::pair<SILValue, SILValue>> derivativeFns = None;
   if (Inst->hasDerivativeFunctions())
     derivativeFns = std::make_pair(getOpValue(Inst->getJVPFunction()),
-                              getOpValue(Inst->getVJPFunction()));
+                                   getOpValue(Inst->getVJPFunction()));
   recordClonedInstruction(
       Inst, getBuilder().createDifferentiableFunction(
                 getOpLocation(Inst->getLoc()), Inst->getParameterIndices(),

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -157,7 +157,7 @@ struct SILDeclRef {
   
   // SWIFT_ENABLE_TENSORFLOW
   /// When this is non-null, it modifies the SILDeclRef to refer to the
-  /// corresponding autodiff associated function.
+  /// corresponding autodiff derivative function.
   AutoDiffDerivativeFunctionIdentifier *autoDiffDerivativeFunctionIdentifier;
 
   /// Produces a null SILDeclRef.
@@ -363,7 +363,7 @@ struct SILDeclRef {
   }
 
   /// Returns the entry point for the original function corresponding to an
-  /// autodiff associated function.
+  /// autodiff derivative function.
   SILDeclRef asAutoDiffOriginalFunction() const {
     assert(autoDiffDerivativeFunctionIdentifier);
     SILDeclRef r = *this;

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -35,7 +35,7 @@ namespace swift {
   class AbstractFunctionDecl;
   class AbstractClosureExpr;
   // SWIFT_ENABLE_TENSORFLOW
-  class AutoDiffAssociatedFunctionIdentifier;
+  class AutoDiffDerivativeFunctionIdentifier;
   class ValueDecl;
   class FuncDecl;
   class ClosureExpr;
@@ -158,21 +158,21 @@ struct SILDeclRef {
   // SWIFT_ENABLE_TENSORFLOW
   /// When this is non-null, it modifies the SILDeclRef to refer to the
   /// corresponding autodiff associated function.
-  AutoDiffAssociatedFunctionIdentifier *autoDiffAssociatedFunctionIdentifier;
+  AutoDiffDerivativeFunctionIdentifier *autoDiffDerivativeFunctionIdentifier;
 
   /// Produces a null SILDeclRef.
   SILDeclRef() : loc(), kind(Kind::Func),
                  isCurried(0), isForeign(0), isDirectReference(0),
                  // SWIFT_ENABLE_TENSORFLOW
                  defaultArgIndex(0),
-                 autoDiffAssociatedFunctionIdentifier(nullptr) {}
+                 autoDiffDerivativeFunctionIdentifier(nullptr) {}
   
   /// Produces a SILDeclRef of the given kind for the given decl.
   explicit SILDeclRef(ValueDecl *decl, Kind kind,
                       bool isCurried = false,
                       // SWIFT_ENABLE_TENSORFLOW
                       bool isForeign = false,
-                      AutoDiffAssociatedFunctionIdentifier *autoDiffFuncId =
+                      AutoDiffDerivativeFunctionIdentifier *autoDiffFuncId =
                           nullptr);
   
   /// Produces a SILDeclRef for the given ValueDecl or
@@ -308,8 +308,8 @@ struct SILDeclRef {
       && isDirectReference == rhs.isDirectReference
       // SWIFT_ENABLE_TENSORFLOW
       && defaultArgIndex == rhs.defaultArgIndex
-      && autoDiffAssociatedFunctionIdentifier ==
-             rhs.autoDiffAssociatedFunctionIdentifier;
+      && autoDiffDerivativeFunctionIdentifier ==
+             rhs.autoDiffDerivativeFunctionIdentifier;
   }
   bool operator!=(SILDeclRef rhs) const {
     return !(*this == rhs);
@@ -330,7 +330,7 @@ struct SILDeclRef {
                       curried, willBeDirect, willBeForeign,
                       // SWIFT_ENABLE_TENSORFLOW
                       defaultArgIndex,
-                      autoDiffAssociatedFunctionIdentifier);
+                      autoDiffDerivativeFunctionIdentifier);
   }
   
   /// Returns the foreign (or native) entry point corresponding to the same
@@ -340,7 +340,7 @@ struct SILDeclRef {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       // SWIFT_ENABLE_TENSORFLOW
                       isCurried, isDirectReference, foreign, defaultArgIndex,
-                      autoDiffAssociatedFunctionIdentifier);
+                      autoDiffDerivativeFunctionIdentifier);
   }
   
   SILDeclRef asDirectReference(bool direct = true) const {
@@ -354,20 +354,20 @@ struct SILDeclRef {
   // SWIFT_ENABLE_TENSORFLOW
   /// Returns the entry point for the corresponding autodiff associated
   /// function.
-  SILDeclRef asAutoDiffAssociatedFunction(
-      AutoDiffAssociatedFunctionIdentifier *id) const {
-    assert(!autoDiffAssociatedFunctionIdentifier);
+  SILDeclRef asAutoDiffDerivativeFunction(
+      AutoDiffDerivativeFunctionIdentifier *id) const {
+    assert(!autoDiffDerivativeFunctionIdentifier);
     SILDeclRef r = *this;
-    r.autoDiffAssociatedFunctionIdentifier = id;
+    r.autoDiffDerivativeFunctionIdentifier = id;
     return r;
   }
 
   /// Returns the entry point for the original function corresponding to an
   /// autodiff associated function.
   SILDeclRef asAutoDiffOriginalFunction() const {
-    assert(autoDiffAssociatedFunctionIdentifier);
+    assert(autoDiffDerivativeFunctionIdentifier);
     SILDeclRef r = *this;
-    r.autoDiffAssociatedFunctionIdentifier = nullptr;
+    r.autoDiffDerivativeFunctionIdentifier = nullptr;
     return r;
   }
 
@@ -454,14 +454,14 @@ private:
                       bool isForeign,
                       // SWIFT_ENABLE_TENSORFLOW
                       unsigned defaultArgIndex,
-                      AutoDiffAssociatedFunctionIdentifier *autoDiffFuncId)
+                      AutoDiffDerivativeFunctionIdentifier *autoDiffFuncId)
     : loc(Loc::getFromOpaqueValue(opaqueLoc)),
       kind(kind),
       isCurried(isCurried),
       isForeign(isForeign), isDirectReference(isDirectReference),
       // SWIFT_ENABLE_TENSORFLOW
       defaultArgIndex(defaultArgIndex),
-      autoDiffAssociatedFunctionIdentifier(autoDiffFuncId)
+      autoDiffDerivativeFunctionIdentifier(autoDiffFuncId)
   {}
 
 };
@@ -503,7 +503,7 @@ template<> struct DenseMapInfo<swift::SILDeclRef> {
     unsigned h5 = UnsignedInfo::getHashValue(Val.isDirectReference);
     // SWIFT_ENABLE_TENSORFLOW
     unsigned h6 =
-        PointerInfo::getHashValue(Val.autoDiffAssociatedFunctionIdentifier);
+        PointerInfo::getHashValue(Val.autoDiffDerivativeFunctionIdentifier);
     return h1 ^ (h2 << 4) ^ (h3 << 9) ^ (h4 << 7) ^ (h5 << 11) ^ (h6 << 13);
   }
   static bool isEqual(swift::SILDeclRef const &LHS,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7846,8 +7846,8 @@ class TryApplyInst final
 
 // SWIFT_ENABLE_TENSORFLOW
 /// `differentiable_function` - given a function and differentiation indices and
-/// its associated differentiation functions, create an `@differentiable`
-/// function that represents a bundle of these functions and configurations.
+/// its derivative functions, create an `@differentiable` function that
+/// represents a bundle of these functions and configurations.
 class DifferentiableFunctionInst final :
     public InstructionBaseWithTrailingOperands<
                SILInstructionKind::DifferentiableFunctionInst,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7912,16 +7912,16 @@ public:
   }
 
   /// Returns the derivative function (JVP or VJP) that matches the given kind.
-  SILValue getDerivativeFunction(AutoDiffAssociatedFunctionKind kind) const {
+  SILValue getDerivativeFunction(AutoDiffDerivativeFunctionKind kind) const {
     switch (kind) {
-    case AutoDiffAssociatedFunctionKind::JVP: return getJVPFunction();
-    case AutoDiffAssociatedFunctionKind::VJP: return getVJPFunction();
+    case AutoDiffDerivativeFunctionKind::JVP: return getJVPFunction();
+    case AutoDiffDerivativeFunctionKind::VJP: return getVJPFunction();
     }
   }
 };
 
 /// `differentiable_function_extract` - given an `@differentiable` function
-/// representing a bundle of the original function and associated functions,
+/// representing a bundle of the original function and derivative functions,
 /// extract the specified function.
 class DifferentiableFunctionExtractInst
     : public InstructionBase<
@@ -7937,12 +7937,12 @@ public:
     Extractee() = default;
     Extractee(innerty rawValue) : rawValue(rawValue) {}
     explicit Extractee(unsigned rawValue) : Extractee((innerty)rawValue) {}
-    Extractee(AutoDiffAssociatedFunctionKind kind);
+    Extractee(AutoDiffDerivativeFunctionKind kind);
     explicit Extractee(StringRef name);
     operator innerty() const { return rawValue; }
 
-    Optional<AutoDiffAssociatedFunctionKind>
-    getExtracteeAsAssociatedFunction() const;
+    Optional<AutoDiffDerivativeFunctionKind>
+    getExtracteeAsDerivativeFunction() const;
   };
 
 private:
@@ -7961,8 +7961,8 @@ public:
 
   Extractee getExtractee() const { return extractee; }
 
-  AutoDiffAssociatedFunctionKind getAssociatedFunctionKind() const {
-    auto kind = extractee.getExtracteeAsAssociatedFunction();
+  AutoDiffDerivativeFunctionKind getDerivativeFunctionKind() const {
+    auto kind = extractee.getExtracteeAsDerivativeFunction();
     assert(kind);
     return *kind;
   }

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -91,15 +91,15 @@ template <class T> class SILVTableVisitor {
     // SWIFT_ENABLE_TENSORFLOW
     for (auto *DA : fd->getAttrs().getAttributes<DifferentiableAttr>()) {
       auto constant = SILDeclRef(fd, SILDeclRef::Kind::Func);
-      auto jvpConstant = constant.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::JVP,
+      auto jvpConstant = constant.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::JVP,
               DA->getParameterIndices(), fd->getASTContext()));
       maybeAddEntry(jvpConstant);
 
-      auto vjpConstant = constant.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::VJP,
+      auto vjpConstant = constant.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::VJP,
               DA->getParameterIndices(), fd->getASTContext()));
       maybeAddEntry(vjpConstant);
     }
@@ -118,15 +118,15 @@ template <class T> class SILVTableVisitor {
     // SWIFT_ENABLE_TENSORFLOW
     for (auto *DA : cd->getAttrs().getAttributes<DifferentiableAttr>()) {
       auto constant = SILDeclRef(cd, SILDeclRef::Kind::Allocator);
-      auto jvpConstant = constant.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::JVP,
+      auto jvpConstant = constant.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::JVP,
               DA->getParameterIndices(), cd->getASTContext()));
       maybeAddEntry(jvpConstant);
 
-      auto vjpConstant = constant.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::VJP,
+      auto vjpConstant = constant.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::VJP,
               DA->getParameterIndices(), cd->getASTContext()));
       maybeAddEntry(vjpConstant);
     }

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -181,13 +181,13 @@ private:
     asDerived().addMethod(funcDeclRef);
 
     for (auto *DA : func->getAttrs().getAttributes<DifferentiableAttr>()) {
-      asDerived().addMethod(funcDeclRef.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::JVP,
+      asDerived().addMethod(funcDeclRef.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::JVP,
               DA->getParameterIndices(), func->getASTContext())));
-      asDerived().addMethod(funcDeclRef.asAutoDiffAssociatedFunction(
-          AutoDiffAssociatedFunctionIdentifier::get(
-              AutoDiffAssociatedFunctionKind::VJP,
+      asDerived().addMethod(funcDeclRef.asAutoDiffDerivativeFunction(
+          AutoDiffDerivativeFunctionIdentifier::get(
+              AutoDiffDerivativeFunctionKind::VJP,
               DA->getParameterIndices(), func->getASTContext())));
     }
   }

--- a/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
@@ -43,7 +43,7 @@ protected:
   /// analysis information for a function.
   /// This base class stores the administrative information needed for
   /// invalidation and updating the analysis.
-  /// In the following "this function" refers to the associated function.
+  /// In the following "this function" refers to the derivative function.
   template<typename FunctionInfo> class FunctionInfoBase {
   public:
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -448,9 +448,9 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   /// For uniquifying `AutoDiffIndexSubset` allocations.
   llvm::FoldingSet<AutoDiffIndexSubset> AutoDiffIndexSubsets;
 
-  /// For uniquifying `AutoDiffAssociatedFunctionIdentifier` allocations.
-  llvm::FoldingSet<AutoDiffAssociatedFunctionIdentifier>
-      AutoDiffAssociatedFunctionIdentifiers;
+  /// For uniquifying `AutoDiffDerivativeFunctionIdentifier` allocations.
+  llvm::FoldingSet<AutoDiffDerivativeFunctionIdentifier>
+      AutoDiffDerivativeFunctionIdentifiers;
 
   /// A cache of information about whether particular nominal types
   /// are representable in a foreign language.
@@ -4827,12 +4827,12 @@ AutoDiffIndexSubset::get(ASTContext &ctx, const SmallBitVector &indices) {
   return newNode;
 }
 
-AutoDiffAssociatedFunctionIdentifier *
-AutoDiffAssociatedFunctionIdentifier::get(
-    AutoDiffAssociatedFunctionKind kind, AutoDiffIndexSubset *parameterIndices,
+AutoDiffDerivativeFunctionIdentifier *
+AutoDiffDerivativeFunctionIdentifier::get(
+    AutoDiffDerivativeFunctionKind kind, AutoDiffIndexSubset *parameterIndices,
     ASTContext &C) {
   assert(parameterIndices);
-  auto &foldingSet = C.getImpl().AutoDiffAssociatedFunctionIdentifiers;
+  auto &foldingSet = C.getImpl().AutoDiffDerivativeFunctionIdentifiers;
   llvm::FoldingSetNodeID id;
   id.AddInteger((unsigned)kind);
   id.AddPointer(parameterIndices);
@@ -4842,9 +4842,9 @@ AutoDiffAssociatedFunctionIdentifier::get(
   if (existing)
     return existing;
 
-  void *mem = C.Allocate(sizeof(AutoDiffAssociatedFunctionIdentifier),
-                         alignof(AutoDiffAssociatedFunctionIdentifier));
-  auto *newNode = ::new (mem) AutoDiffAssociatedFunctionIdentifier(
+  void *mem = C.Allocate(sizeof(AutoDiffDerivativeFunctionIdentifier),
+                         alignof(AutoDiffDerivativeFunctionIdentifier));
+  auto *newNode = ::new (mem) AutoDiffDerivativeFunctionIdentifier(
       kind, parameterIndices);
   foldingSet.InsertNode(newNode, insertPos);
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -379,8 +379,8 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   return finalize();
 }
 
-std::string ASTMangler::mangleAutoDiffAssociatedFunctionHelper(
-    StringRef name, AutoDiffAssociatedFunctionKind kind,
+std::string ASTMangler::mangleAutoDiffDerivativeFunctionHelper(
+    StringRef name, AutoDiffDerivativeFunctionKind kind,
     const SILAutoDiffIndices &indices) {
   // TODO(TF-20): Make the mangling scheme robust.
   // TODO(TF-680): Mangle `@differentiable` atttribute requirements as well.
@@ -388,10 +388,10 @@ std::string ASTMangler::mangleAutoDiffAssociatedFunctionHelper(
 
   Buffer << "AD__" << name << '_';
   switch (kind) {
-  case AutoDiffAssociatedFunctionKind::JVP:
+  case AutoDiffDerivativeFunctionKind::JVP:
     Buffer << "_jvp_";
     break;
-  case AutoDiffAssociatedFunctionKind::VJP:
+  case AutoDiffDerivativeFunctionKind::VJP:
     Buffer << "_vjp_";
     break;
   }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -520,7 +520,7 @@ static void printDifferentiableAttrArguments(
       stream << diffParamsString;
     }
   }
-  // Print associated function names, unless they are to be omitted.
+  // Print derivative function names, unless they are to be omitted.
   if (!omitDerivativeFunctions) {
     // Print jvp function name, if specified.
     if (auto jvp = attr->getJVP()) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -480,7 +480,7 @@ static std::string getTransposingParametersClauseString(
 static void printDifferentiableAttrArguments(
     const DifferentiableAttr *attr, ASTPrinter &printer, PrintOptions Options,
     const Decl *D, bool omitWrtClause = false,
-    bool omitAssociatedFunctions = false) {
+    bool omitDerivativeFunctions = false) {
   // Create a temporary string for the attribute argument text.
   std::string attrArgText;
   llvm::raw_string_ostream stream(attrArgText);
@@ -521,7 +521,7 @@ static void printDifferentiableAttrArguments(
     }
   }
   // Print associated function names, unless they are to be omitted.
-  if (!omitAssociatedFunctions) {
+  if (!omitDerivativeFunctions) {
     // Print jvp function name, if specified.
     if (auto jvp = attr->getJVP()) {
       printCommaIfNecessary();
@@ -1517,11 +1517,11 @@ GenericEnvironment *DifferentiableAttr::getDerivativeGenericEnvironment(
 
 void DifferentiableAttr::print(llvm::raw_ostream &OS, const Decl *D,
                                bool omitWrtClause,
-                               bool omitAssociatedFunctions) const {
+                               bool omitDerivativeFunctions) const {
   StreamPrinter P(OS);
   P << "@" << getAttrName();
   printDifferentiableAttrArguments(this, P, PrintOptions(), D, omitWrtClause,
-                                   omitAssociatedFunctions);
+                                   omitDerivativeFunctions);
 }
 
 // SWIFT_ENABLE_TENSORFLOW

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -994,8 +994,8 @@ static ValueDecl *getGetObjCTypeEncodingOperation(ASTContext &Context,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-static ValueDecl *getAutoDiffApplyAssociatedFunction(
-    ASTContext &Context, Identifier Id, AutoDiffAssociatedFunctionKind kind,
+static ValueDecl *getAutoDiffApplyDerivativeFunction(
+    ASTContext &Context, Identifier Id, AutoDiffDerivativeFunctionKind kind,
     unsigned arity, bool rethrows) {
   assert(arity >= 1);
   // JVP:
@@ -1045,7 +1045,7 @@ static ValueDecl *getAutoDiffApplyAssociatedFunction(
   // Generator for the resultant function type, i.e. the AD associated function.
   BuiltinGenericSignatureBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinGenericSignatureBuilder &builder) -> Type {
-        auto derivativeFnTy = origFnTy->getAutoDiffAssociatedFunctionType(
+        auto derivativeFnTy = origFnTy->getAutoDiffDerivativeFunctionType(
             paramIndices, /*resultIndex*/ 0, kind,
             LookUpConformanceInModule(Context.TheBuiltinModule));
         return derivativeFnTy->getResult();
@@ -1840,13 +1840,13 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   }
   // SWIFT_ENABLE_TENSORFLOW
   if (OperationName.startswith("autodiffApply_")) {
-    AutoDiffAssociatedFunctionKind kind;
+    AutoDiffDerivativeFunctionKind kind;
     unsigned arity;
     bool rethrows;
     if (!autodiff::getBuiltinAutoDiffApplyConfig(OperationName, kind, arity,
                                                  rethrows))
       return nullptr;
-    return getAutoDiffApplyAssociatedFunction(Context, Id, kind, arity,
+    return getAutoDiffApplyDerivativeFunction(Context, Id, kind, arity,
                                               rethrows);
   }
   auto BV = llvm::StringSwitch<BuiltinValueKind>(OperationName)

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1035,14 +1035,14 @@ static ValueDecl *getAutoDiffApplyDerivativeFunction(
     }
   };
   // Eagerly build the type of the first arg, then use that to compute the type
-  // of the associated function type.
+  // of the derivative function type.
   auto *origFnTy =
       firstArgGen.build(builder)->castTo<AnyFunctionType>();
   origFnTy = origFnTy->getWithoutDifferentiability()->withExtInfo(
       origFnTy->getExtInfo().withNoEscape(false));
   auto *paramIndices = AutoDiffIndexSubset::get(
       Context, SmallBitVector(origFnTy->getNumParams(), true));
-  // Generator for the resultant function type, i.e. the AD associated function.
+  // Generator for the resultant function type, i.e. the AD derivative function.
   BuiltinGenericSignatureBuilder::LambdaGenerator resultGen{
       [=, &Context](BuiltinGenericSignatureBuilder &builder) -> Type {
         auto derivativeFnTy = origFnTy->getAutoDiffDerivativeFunctionType(

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4677,7 +4677,7 @@ AnyFunctionType *AnyFunctionType::getAutoDiffDerivativeFunctionType(
       curryLevels.back(), curryLevels.back()->getParams(), retTy,
       curryLevels.size() == 1 ? whereClauseGenSig : nullptr);
 
-  // Wrap the associated function type in additional curry levels.
+  // Wrap the derivative function type in additional curry levels.
   auto curryLevelsWithoutLast =
       ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
   for (auto pair : enumerate(reversed(curryLevelsWithoutLast))) {
@@ -4716,7 +4716,7 @@ AnyFunctionType::getAutoDiffOriginalFunctionType() {
       curryLevels.back(), curryLevels.back()->getParams(), originalResult,
       curryLevels.size() == 1 ? getOptGenericSignature() : nullptr);
 
-  // Wrap the associated function type in additional curry levels.
+  // Wrap the derivative function type in additional curry levels.
   auto curryLevelsWithoutLast =
       ArrayRef<AnyFunctionType *>(curryLevels).drop_back(1);
   for (auto pair : enumerate(reversed(curryLevelsWithoutLast))) {

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -63,8 +63,8 @@ public:
     auto origFnTy = fnTy->getWithoutDifferentiability();
     if (Index == DifferentiableFunctionExtractee::Original)
       return SILType::getPrimitiveObjectType(origFnTy);
-    auto kind = *Index.getExtracteeAsAssociatedFunction();
-    auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
+    auto kind = *Index.getExtracteeAsDerivativeFunction();
+    auto assocTy = origFnTy->getAutoDiffDerivativeFunctionType(
         ParameterIndices, /*resultIndex*/ 0, kind,
         IGM.getSILTypes(), LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);
@@ -152,8 +152,8 @@ public:
   SILType getType(DiffFuncIndex field) {
     if (field == DifferentiableFunctionExtractee::Original)
       return SILType::getPrimitiveObjectType(origFnTy->getCanonicalType());
-    auto kind = *field.getExtracteeAsAssociatedFunction();
-    auto assocTy = origFnTy->getAutoDiffAssociatedFunctionType(
+    auto kind = *field.getExtracteeAsDerivativeFunction();
+    auto assocTy = origFnTy->getAutoDiffDerivativeFunctionType(
         parameterIndices, /*resultIndex*/ 0, kind, IGM.getSILTypes(),
         LookUpConformanceInModule(IGM.getSwiftModule()));
     return SILType::getPrimitiveObjectType(assocTy);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1872,7 +1872,7 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
 // SWIFT_ENABLE_TENSORFLOW
 void IRGenSILFunction::
 visitDifferentiableFunctionInst(DifferentiableFunctionInst *i) {
-  // The original function and associated functions can be thin or thick.
+  // The original function and derivative functions can be thin or thick.
   auto origExp = getLoweredExplosion(i->getOriginalFunction());
   Explosion e;
   e.add(origExp.claimAll());

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1545,7 +1545,7 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
   unsigned uncurryLevel = 0;
   bool IsObjC = false;
   // SWIFT_ENABLE_TENSORFLOW
-  AutoDiffAssociatedFunctionIdentifier *autoDiffFuncId = nullptr;
+  AutoDiffDerivativeFunctionIdentifier *autoDiffFuncId = nullptr;
 
   if (!P.consumeIf(tok::sil_exclamation)) {
     // Construct SILDeclRef.
@@ -1635,13 +1635,13 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
         // SWIFT_ENABLE_TENSORFLOW
         ParseState = 3;
       } else if (Id.str() == "jvp" || Id.str() == "vjp") {
-        AutoDiffAssociatedFunctionKind kind;
+        AutoDiffDerivativeFunctionKind kind;
         AutoDiffIndexSubset *parameterIndices = nullptr;
 
         if (Id.str() == "jvp")
-          kind = AutoDiffAssociatedFunctionKind::JVP;
+          kind = AutoDiffDerivativeFunctionKind::JVP;
         else if (Id.str() == "vjp")
-          kind = AutoDiffAssociatedFunctionKind::VJP;
+          kind = AutoDiffDerivativeFunctionKind::VJP;
         else
           llvm_unreachable("Should only have JVP and VJP here");
 
@@ -1658,7 +1658,7 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
         }
         P.consumeToken();
 
-        autoDiffFuncId = AutoDiffAssociatedFunctionIdentifier::get(
+        autoDiffFuncId = AutoDiffDerivativeFunctionIdentifier::get(
             kind, parameterIndices, SILMod.getASTContext());
 
         break;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2960,9 +2960,9 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     // Parse an optional operand list `with { <operand> , <operand> }`.
     if (P.Tok.is(tok::identifier) && P.Tok.getText() == "with") {
       P.consumeToken(tok::identifier);
-      // Parse associated function values as an operand list.
+      // Parse derivative function values as an operand list.
       // FIXME(rxwei): Change this to *not* require a type signature once
-      // we can infer AD associated function types.
+      // we can infer derivative function types.
       SILValue derivFn1, derivFn2;
       if (P.parseToken(tok::l_brace,
               diag::sil_inst_autodiff_operand_list_expected_lbrace) ||
@@ -3003,7 +3003,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
             diag::sil_inst_autodiff_expected_associated_function_kind_attr) ||
         P.parseToken(tok::r_square,
                      diag::sil_inst_autodiff_attr_expected_rsquare,
-                     "associated function kind"))
+                     "derivative function kind"))
       return true;
     if (parseTypedValueRef(functionOperand, B) ||
         parseSILDebugLocation(InstLoc, B))

--- a/lib/SIL/SILFunctionBuilder.cpp
+++ b/lib/SIL/SILFunctionBuilder.cpp
@@ -80,7 +80,7 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
   // - Thunks. Those are currently handled in SILGenThunk.cpp.
   if ((!isa<AccessorDecl>(decl) || cast<AccessorDecl>(decl)->isGetter()) &&
       constant.kind != SILDeclRef::Kind::DefaultArgGenerator &&
-      !constant.autoDiffAssociatedFunctionIdentifier &&
+      !constant.autoDiffDerivativeFunctionIdentifier &&
       !constant.isStoredPropertyInitializer() &&
       !constant.isThunk()) {
     for (auto *A : Attrs.getAttributes<DifferentiableAttr>()) {
@@ -99,15 +99,15 @@ void SILFunctionBuilder::addFunctionAttributes(SILFunction *F,
       if (auto *jvpFn = A->getJVPFunction()) {
         Mangle::ASTMangler mangler;
         jvpName = ctx.getIdentifier(
-            mangler.mangleAutoDiffAssociatedFunctionHelper(
-                constant.mangle(), AutoDiffAssociatedFunctionKind::JVP,
+            mangler.mangleAutoDiffDerivativeFunctionHelper(
+                constant.mangle(), AutoDiffDerivativeFunctionKind::JVP,
                 indices)).str();
       }
       if (auto *vjpFn = A->getVJPFunction()) {
         Mangle::ASTMangler mangler;
         vjpName = ctx.getIdentifier(
-            mangler.mangleAutoDiffAssociatedFunctionHelper(
-                constant.mangle(), AutoDiffAssociatedFunctionKind::VJP,
+            mangler.mangleAutoDiffDerivativeFunctionHelper(
+                constant.mangle(), AutoDiffDerivativeFunctionKind::VJP,
                 indices)).str();
       }
       auto *silDiffAttr = SILDifferentiableAttr::create(

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -625,12 +625,12 @@ DifferentiableFunctionInst *DifferentiableFunctionInst::create(
 }
 
 DifferentiableFunctionExtractInst::Extractee::Extractee(
-    AutoDiffAssociatedFunctionKind kind) {
+    AutoDiffDerivativeFunctionKind kind) {
   switch (kind) {
-  case AutoDiffAssociatedFunctionKind::JVP:
+  case AutoDiffDerivativeFunctionKind::JVP:
     rawValue = JVP;
     return;
-  case AutoDiffAssociatedFunctionKind::VJP:
+  case AutoDiffDerivativeFunctionKind::VJP:
     rawValue = VJP;
     return;
   }
@@ -646,16 +646,16 @@ DifferentiableFunctionExtractInst::Extractee::Extractee(StringRef string) {
   rawValue = *result;
 }
 
-Optional<AutoDiffAssociatedFunctionKind>
-DifferentiableFunctionExtractInst::Extractee::getExtracteeAsAssociatedFunction()
+Optional<AutoDiffDerivativeFunctionKind>
+DifferentiableFunctionExtractInst::Extractee::getExtracteeAsDerivativeFunction()
     const {
   switch (rawValue) {
   case Original:
     return None;
   case JVP:
-    return {AutoDiffAssociatedFunctionKind::JVP};
+    return {AutoDiffDerivativeFunctionKind::JVP};
   case VJP:
-    return {AutoDiffAssociatedFunctionKind::VJP};
+    return {AutoDiffDerivativeFunctionKind::VJP};
   }
 }
 
@@ -664,12 +664,12 @@ getExtracteeType(SILValue function, Extractee extractee, SILModule &module) {
   auto fnTy = function->getType().castTo<SILFunctionType>();
   assert(fnTy->getExtInfo().isDifferentiable());
   auto originalFnTy = fnTy->getWithoutDifferentiability();
-  auto kindOpt = extractee.getExtracteeAsAssociatedFunction();
+  auto kindOpt = extractee.getExtracteeAsDerivativeFunction();
   if (!kindOpt) {
     assert(extractee == Extractee::Original);
     return SILType::getPrimitiveObjectType(originalFnTy);
   }
-  auto resultFnTy = originalFnTy->getAutoDiffAssociatedFunctionType(
+  auto resultFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
         fnTy->getDifferentiationParameterIndices(), /*resultIndex*/ 0,
         *kindOpt, module.Types,
         LookUpConformanceInModule(module.getSwiftModule()));

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -349,15 +349,15 @@ void SILDeclRef::print(raw_ostream &OS) const {
     OS << ((isDot || uncurryLevel != 0) ? '.' : '!')  << "direct";
 
   // SWIFT_ENABLE_TENSORFLOW
-  if (autoDiffAssociatedFunctionIdentifier) {
-    auto *autoDiffFuncId = autoDiffAssociatedFunctionIdentifier;
+  if (autoDiffDerivativeFunctionIdentifier) {
+    auto *autoDiffFuncId = autoDiffDerivativeFunctionIdentifier;
     OS << ((isDot || uncurryLevel != 0 || isForeign || isDirectReference)
                ? '.' : '!');
     switch (autoDiffFuncId->getKind()) {
-    case AutoDiffAssociatedFunctionKind::JVP:
+    case AutoDiffDerivativeFunctionKind::JVP:
       OS << "jvp.";
       break;
-    case AutoDiffAssociatedFunctionKind::VJP:
+    case AutoDiffDerivativeFunctionKind::VJP:
       OS << "vjp.";
       break;
     }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1505,9 +1505,9 @@ public:
       require(jvpType, "The JVP function must have a function type");
       require(!jvpType->isDifferentiable(),
               "The JVP function must not be @differentiable");
-      auto expectedJVPType = origTy->getAutoDiffAssociatedFunctionType(
+      auto expectedJVPType = origTy->getAutoDiffDerivativeFunctionType(
           dfi->getParameterIndices(), /*resultIndex*/ 0,
-          AutoDiffAssociatedFunctionKind::JVP, TC,
+          AutoDiffDerivativeFunctionKind::JVP, TC,
           LookUpConformanceInModule(M));
       requireSameType(SILType::getPrimitiveObjectType(jvpType),
                       SILType::getPrimitiveObjectType(expectedJVPType),
@@ -1517,9 +1517,9 @@ public:
       require(vjpType, "The VJP function must have a function type");
       require(!vjpType->isDifferentiable(),
               "The VJP function must not be @differentiable");
-      auto expectedVJPType = origTy->getAutoDiffAssociatedFunctionType(
+      auto expectedVJPType = origTy->getAutoDiffDerivativeFunctionType(
           dfi->getParameterIndices(), /*resultIndex*/ 0,
-          AutoDiffAssociatedFunctionKind::VJP, TC,
+          AutoDiffDerivativeFunctionKind::VJP, TC,
           LookUpConformanceInModule(M));
       requireSameType(SILType::getPrimitiveObjectType(vjpType),
                       SILType::getPrimitiveObjectType(expectedVJPType),

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -185,10 +185,10 @@ public:
   /// If `reorderSelf` is true, reorder self so that it appears as:
   /// - The last parameter in the returned differential.
   /// - The last result in the returned pullback.
-  SILFunction *getOrCreateAutoDiffAssociatedFunctionThunk(
+  SILFunction *getOrCreateAutoDiffDerivativeFunctionThunk(
       SILFunction *original, SILAutoDiffIndices &indices,
       SILFunction *derivativeFn,
-      AutoDiffAssociatedFunctionKind derivativeFnKind, bool reorderSelf);
+      AutoDiffDerivativeFunctionKind derivativeFnKind, bool reorderSelf);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -148,15 +148,15 @@ public:
                                CanSILFunctionType constantTy);
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Get or create an autodiff associated function thunk for the given
-  /// SILDeclRef, SILFunction, and associated function type.
+  /// Get or create an autodiff derivative function thunk for the given
+  /// SILDeclRef, SILFunction, and derivative function type.
   SILFunction *getOrCreateAutoDiffThunk(SILDeclRef derivativeFnRef,
                                         SILFunction *derivativeFn,
                                         CanSILFunctionType derivativeFnTy);
 
   // SWIFT_ENABLE_TENSORFLOW
-  /// Get or create an autodiff associated function vtable entry thunk for the
-  /// given SILDeclRef and associated function type.
+  /// Get or create an autodiff derivative function vtable entry thunk for the
+  /// given SILDeclRef and derivative function type.
   SILFunction *
   getOrCreateAutoDiffClassMethodThunk(SILDeclRef derivativeFnRef,
                                       CanSILFunctionType derivativeFnTy);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1031,8 +1031,8 @@ static ManagedValue emitBuiltinTypeTrait(SILGenFunction &SGF,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-static ManagedValue emitBuiltinAutoDiffApplyAssociatedFunction(
-    AutoDiffAssociatedFunctionKind kind, unsigned arity,
+static ManagedValue emitBuiltinAutoDiffApplyDerivativeFunction(
+    AutoDiffDerivativeFunctionKind kind, unsigned arity,
     bool rethrows, SILGenFunction &SGF, SILLocation loc,
     SubstitutionMap substitutions, ArrayRef<ManagedValue> args, SGFContext C) {
   auto origFnVal = args[0].getValue();
@@ -1143,13 +1143,13 @@ static ManagedValue emitBuiltinAutoDiffApply(SILGenFunction &SGF,
       cast<DotSyntaxBaseIgnoredExpr>(callExpr->getDirectCallee())->getRHS())
           ->getDecl());
   auto builtinName = builtinDecl->getName().str();
-  AutoDiffAssociatedFunctionKind kind;
+  AutoDiffDerivativeFunctionKind kind;
   unsigned arity;
   bool rethrows;
   auto successfullyParsed = autodiff::getBuiltinAutoDiffApplyConfig(
       builtinName, kind, arity, rethrows);
   assert(successfullyParsed);
-  return emitBuiltinAutoDiffApplyAssociatedFunction(kind, arity,
+  return emitBuiltinAutoDiffApplyDerivativeFunction(kind, arity,
                                                     rethrows, SGF, loc,
                                                     substitutions, args, C);
 }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1040,7 +1040,7 @@ static ManagedValue emitBuiltinAutoDiffApplyDerivativeFunction(
   for (auto& arg : args.drop_front(1))
     origFnArgVals.push_back(arg.getValue());
 
-  // Get the associated function.
+  // Get the derivative function.
   SILValue derivativeFn = SGF.B.createDifferentiableFunctionExtract(
       loc, kind, origFnVal);
   auto derivativeFnType = derivativeFn->getType().castTo<SILFunctionType>();

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -89,7 +89,7 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
   if (usesObjCDynamicDispatch) {
     implFn = getDynamicThunk(derived, Types.getConstantInfo(derived).SILFnType);
   // SWIFT_ENABLE_TENSORFLOW
-  } else if (auto *adafi = derived.autoDiffAssociatedFunctionIdentifier) {
+  } else if (auto *adafi = derived.autoDiffDerivativeFunctionIdentifier) {
     // For JVP/VJP methods, create a vtable entry thunk. The thunk contains an
     // `differentiable_function` instruction, which is later filled during the
     // differentiation transform.
@@ -153,12 +153,12 @@ SILGenModule::emitVTableMethod(ClassDecl *theClass,
   }
   // SWIFT_ENABLE_TENSORFLOW
   // TODO: Use proper mangling.
-  if (auto *adafi = derived.autoDiffAssociatedFunctionIdentifier) {
+  if (auto *adafi = derived.autoDiffDerivativeFunctionIdentifier) {
     switch (adafi->getKind()) {
-      case AutoDiffAssociatedFunctionKind::JVP:
+      case AutoDiffDerivativeFunctionKind::JVP:
         name += "_jvp";
         break;
-      case AutoDiffAssociatedFunctionKind::VJP:
+      case AutoDiffDerivativeFunctionKind::VJP:
         name += "_vjp";
         break;
     }
@@ -684,13 +684,13 @@ SILFunction *SILGenModule::emitProtocolWitness(
   // SWIFT_ENABLE_TENSORFLOW
   // TODO: Proper mangling for autodiff witness thunks.
   if (auto *autoDiffFuncId =
-          requirement.autoDiffAssociatedFunctionIdentifier) {
+          requirement.autoDiffDerivativeFunctionIdentifier) {
     std::string kindString;
     switch (autoDiffFuncId->getKind()) {
-    case AutoDiffAssociatedFunctionKind::JVP:
+    case AutoDiffDerivativeFunctionKind::JVP:
       kindString = "jvp";
       break;
-    case AutoDiffAssociatedFunctionKind::VJP:
+    case AutoDiffDerivativeFunctionKind::VJP:
       kindString = "vjp";
       break;
     }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1145,7 +1145,7 @@ public:
   /// purposes.
   void foldDifferentiableFunctionExtraction(DifferentiableFunctionInst *source);
 
-  /// Get or create an derivative function index subset thunk from
+  /// Get or create a derivative function index subset thunk from
   /// `actualIndices` to `desiredIndices` for the given derivative function
   /// value and original function operand.
   /// Calls `getOrCreateSubsetParametersThunkForLinearMap` to thunk the linear
@@ -1156,7 +1156,7 @@ public:
       AutoDiffDerivativeFunctionKind kind, SILAutoDiffIndices desiredIndices,
       SILAutoDiffIndices actualIndices);
 
-  /// Get or create an derivative function index subset thunk from
+  /// Get or create a derivative function index subset thunk from
   /// `actualIndices` to `desiredIndices` for the given derivative function
   /// value and original function operand.
   SILFunction *getOrCreateSubsetParametersThunkForLinearMap(
@@ -1165,7 +1165,7 @@ public:
       SILAutoDiffIndices desiredIndices, SILAutoDiffIndices actualIndices);
 
 public:
-  /// Declare an external reference to an derivative function of `original`,
+  /// Declare an external reference to a derivative function of `original`,
   /// given a `[differentiable]` attribute of `original` and the associated
   /// function kind.
   SILFunction *
@@ -2530,7 +2530,7 @@ static SubstitutionMap getSubstitutionMap(
   return substMap;
 }
 
-/// Emits a reference to an derivative function of `original`, differentiated
+/// Emits a reference to a derivative function of `original`, differentiated
 /// with respect to a superset of `desiredIndices`. Returns the `SILValue` for
 /// the derivative function and the actual indices that the derivative function
 /// is with respect to.

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -621,7 +621,7 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
 
     // Now that this member is in the `TangentVector` type, it should be marked
     // `@differentiable` so that the differentiation transform will synthesize
-    // associated functions for it. We only add this to public stored
+    // derivative functions for it. We only add this to public stored
     // properties, because their access outside the module will go through a
     // call to the getter.
     if (member->getEffectiveAccess() > AccessLevel::Internal &&

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2248,7 +2248,7 @@ public:
 };
   
 /// An AST walker that determines the underlying type of an opaque return decl
-/// from its associated function body.
+/// from its derivative function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
   TypeChecker &TC;
   AbstractFunctionDecl *Implementation;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -650,7 +650,7 @@ static bool overridesDifferentiableAttribute(ValueDecl *derivedDecl,
     std::string baseDAString;
     llvm::raw_string_ostream stream(baseDAString);
     baseDA->print(stream, derivedDecl, omitWrtClause,
-                  /*omitAssociatedFunctions*/ true);
+                  /*omitDerivativeFunctions*/ true);
     diags.diagnose(
         derivedDecl, diag::overriding_decl_missing_differentiable_attr,
         StringRef(stream.str()).trim());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2263,7 +2263,7 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
     std::string reqDiffAttrString;
     llvm::raw_string_ostream stream(reqDiffAttrString);
     reqAttr->print(stream, req, omitWrtClause,
-                   /*omitAssociatedFunctions*/ true);
+                   /*omitDerivativeFunctions*/ true);
     diags.diagnose(match.Witness,
                    diag::protocol_witness_missing_differentiable_attr,
                    StringRef(stream.str()).trim());

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -237,14 +237,14 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   // function with a `@differentiable` attribute.
   auto diffAttrs = AFD->getAttrs().getAttributes<DifferentiableAttr>();
   for (auto *DA : diffAttrs) {
-    auto *jvpId = AutoDiffAssociatedFunctionIdentifier::get(
-        AutoDiffAssociatedFunctionKind::JVP, DA->getParameterIndices(),
+    auto *jvpId = AutoDiffDerivativeFunctionIdentifier::get(
+        AutoDiffDerivativeFunctionKind::JVP, DA->getParameterIndices(),
         AFD->getASTContext());
-    addSymbol(SILDeclRef(AFD).asAutoDiffAssociatedFunction(jvpId));
-    auto *vjpId = AutoDiffAssociatedFunctionIdentifier::get(
-        AutoDiffAssociatedFunctionKind::VJP, DA->getParameterIndices(),
+    addSymbol(SILDeclRef(AFD).asAutoDiffDerivativeFunction(jvpId));
+    auto *vjpId = AutoDiffDerivativeFunctionIdentifier::get(
+        AutoDiffDerivativeFunctionKind::VJP, DA->getParameterIndices(),
         AFD->getASTContext());
-    addSymbol(SILDeclRef(AFD).asAutoDiffAssociatedFunction(vjpId));
+    addSymbol(SILDeclRef(AFD).asAutoDiffDerivativeFunction(vjpId));
   }
 
   visitDefaultArguments(AFD, AFD->getParameters());
@@ -300,16 +300,16 @@ void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
   // var/subscript with a `@differentiable` attribute.
   auto diffAttrs = ASD->getAttrs().getAttributes<DifferentiableAttr>();
   for (auto *DA : diffAttrs) {
-    auto *jvpId = AutoDiffAssociatedFunctionIdentifier::get(
-        AutoDiffAssociatedFunctionKind::JVP, DA->getParameterIndices(),
+    auto *jvpId = AutoDiffDerivativeFunctionIdentifier::get(
+        AutoDiffDerivativeFunctionKind::JVP, DA->getParameterIndices(),
         ASD->getASTContext());
     addSymbol(SILDeclRef(ASD->getAccessor(AccessorKind::Get))
-                  .asAutoDiffAssociatedFunction(jvpId));
-    auto *vjpId = AutoDiffAssociatedFunctionIdentifier::get(
-        AutoDiffAssociatedFunctionKind::VJP, DA->getParameterIndices(),
+                  .asAutoDiffDerivativeFunction(jvpId));
+    auto *vjpId = AutoDiffDerivativeFunctionIdentifier::get(
+        AutoDiffDerivativeFunctionKind::VJP, DA->getParameterIndices(),
         ASD->getASTContext());
     addSymbol(SILDeclRef(ASD->getAccessor(AccessorKind::Get))
-                  .asAutoDiffAssociatedFunction(vjpId));
+                  .asAutoDiffDerivativeFunction(vjpId));
   }
 
   // Explicitly look at each accessor here: see visitAccessorDecl.

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -20,6 +20,6 @@ private func foo3(_ x: Float) -> Float { return 1 }
 private func dfoo3(_ x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }
 
 // Error: vjp not exported.
-@differentiable(vjp: dbar1) // expected-error {{associated differentiation function 'dbar1' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
+@differentiable(vjp: dbar1) // expected-error {{derivative function 'dbar1' is required to either be public or '@usableFromInline' because the original function 'bar1' is public or '@usableFromInline'}}
 public func bar1(_ x: Float) -> Float { return 1 }
 private func dbar1(_ x: Float) -> (Float, (Float) -> Float) { return (1, {$0}) }

--- a/test/AutoDiff/generics.swift
+++ b/test/AutoDiff/generics.swift
@@ -245,7 +245,7 @@ public func TF_688<Scalar: Differentiable>(
   reduction(x)
 }
 
-// TF-697: Test generic requirements of generated AD associated function.
+// TF-697: Test generic requirements of generated derivative function.
 protocol TF_697_Module: Differentiable {
     associatedtype Input
     associatedtype Output: Differentiable


### PR DESCRIPTION
`assocFn` -> `derivativeFn`
`AssocFn` -> `DerivativeFn`
`assocFunc` -> `derivativeFunc`
`AssocFunc` -> `DerivativeFunc`
`associatedFunction` -> `derivativeFunction`
`AssociatedFunction` -> `DerivativeFunction`
`autodiff associated function` -> `derivative function`
`autodiff-associated function` -> `derivative function`
`AD associated function` -> `derivative function`
`associated differentiation function` -> `derivative function`

This is a follow-up to #27597.

Resolves [TF-882](https://bugs.swift.org/browse/TF-882).