### PR TITLE
Put More Faith In Raw Values From Synthesized Enums

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2853,6 +2853,7 @@ namespace {
         auto enumDecl = Impl.createDeclWithClangNode<EnumDecl>(
             decl, AccessLevel::Public, loc, enumName,
             Impl.importSourceLoc(decl->getLocation()), None, nullptr, enumDC);
+        enumDecl->setHasFixedRawValues();
         enumDecl->computeType();
 
         // Annotate as 'frozen' if appropriate.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1654,6 +1654,13 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
       continue;
     }
 
+    // If the raw values of the enum case are fixed, then we trust our callers
+    // to have set things up correctly.  This comes up with imported enums
+    // and deserialized @objc enums which always have their raw values setup
+    // beforehand.
+    if (ED->LazySemanticInfo.hasFixedRawValues())
+      continue;
+
     // Check that the raw value is unique.
     RawValueKey key{prevValue};
     RawValueSource source{elt, lastExplicitValueElt};


### PR DESCRIPTION
By requestifying the raw value accessor and pushing the semantic check
into IRGen, we are now partially validating enums that are
synthesized by the clang importer and deserialization - something that
we were not doing before.  The previous check would only skip
the auto-incrementer step when this was the case.  We now also skip the
uniqueness check.

Resolves rdar://56037318
