### PR TITLE
[ome] Just erase the destructure rather than trying to get rid of dea…

### DIFF
--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -285,9 +285,8 @@ static void splitDestructure(SILBuilder &B, SILInstruction *I, SILValue Op) {
     Result->replaceAllUsesWith(ProjInst);
   }
 
-  // We may have exposed trivially dead instructions due to
-  // simplifyInstruction... delete I and any such instructions!
-  recursivelyDeleteTriviallyDeadInstructions(I, true);
+  // Now that all of its uses have been eliminated, erase the destructure.
+  I->eraseFromParent();
 }
 
 bool OwnershipModelEliminatorVisitor::visitDestructureStructInst(

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -321,11 +321,24 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2)
 
 // CHECK-LABEL: sil [canonical] @test_simplify_instruction : $@convention(thin) (@owned Builtin.NativeObject, Builtin.Int32) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[ARG:%.*]] : $Builtin.NativeObject,
-// CHECK-NEXT:   return [[ARG]]
+// CHECK:   return [[ARG]]
 // CHECK: } // end sil function 'test_simplify_instruction'
 sil [canonical] [ossa] @test_simplify_instruction : $@convention(thin) (@owned Builtin.NativeObject, Builtin.Int32) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : $Builtin.Int32):
   %2 = tuple(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32)
   (%3, %4) = destructure_tuple %2 : $(Builtin.NativeObject, Builtin.Int32)
   return %3 : $Builtin.NativeObject
+}
+
+// Just make sure that we do not crash on this function.
+//
+// CHECK-LABEL: sil @do_not_crash_due_to_debug_value_use : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
+// CHECK: } // end sil function 'do_not_crash_due_to_debug_value_use'
+sil [ossa] @do_not_crash_due_to_debug_value_use : $@convention(thin) (Builtin.Int32, Builtin.Int32) -> () {
+bb0(%0a : $Builtin.Int32, %0b : $Builtin.Int32):
+  %0 = tuple(%0a : $Builtin.Int32, %0b : $Builtin.Int32)
+  (%1, %2) = destructure_tuple %0 : $(Builtin.Int32, Builtin.Int32)
+  debug_value %0 : $(Builtin.Int32, Builtin.Int32), let, name "myName2"
+  %9999 = tuple()
+  return %9999 : $()
 }


### PR DESCRIPTION
…d instructions due to simplifyInstruction.

This ensures that we do not run into any iterator invalidation issues. It does
worsen the passes output slightly, but avoiding the complexity is worth it and
other later passes will clean up the dead code.

rdar://55811732
(cherry picked from commit 1b29d860b8164b2c9927d49ee86923faf3fae766)

----

— CCC Info —

Radar: <rdar://problem/55811732> 
Explanation: The optimizer was being too aggressive around using a recursive API that deleted instructions when they only had uses by debug value instructions. Turns out in certain cases we were not careful enough around iterator invalidation and we delete an instruction causing the invalidation. I changed the code in question to just remove the specific instruction in question and allow for any dead uses we found to be cleaned up by later passes.
Scope of issue: Caused the compiler to crash in an edge case.
Origination: This was introduced as part of the ownership sil work to lower destructure operations -> non-ownership sil variants.
Risk: Low.
Testing: Added a regression test for this case and verified that we do not crash any more.
Reviewers: Erik Eckstein
