### PR TITLE
[SyntaxParse] Parse object literal and unresolved member expressions

### DIFF
--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -88,6 +88,8 @@ public:
   Expr *generate(const syntax::ArrayExprSyntax &Expr, const SourceLoc Loc);
   Expr *generate(const syntax::DictionaryExprSyntax &Expr, const SourceLoc Loc);
   Expr *generate(const syntax::TupleExprSyntax &E, const SourceLoc Loc);
+  Expr *generate(const syntax::FunctionCallExprSyntax &E, const SourceLoc Loc);
+  Expr *generate(const syntax::MemberAccessExprSyntax &E, const SourceLoc Loc);
   Expr *generate(const syntax::EditorPlaceholderExprSyntax &Expr,
                  const SourceLoc Loc);
   Expr *generate(const syntax::SpecializeExprSyntax &Expr, const SourceLoc Loc);
@@ -107,6 +109,8 @@ public:
   Expr *generate(const syntax::PoundDsohandleExprSyntax &Expr,
                  const SourceLoc Loc);
   Expr *generate(const syntax::ObjectLiteralExprSyntax &Expr,
+                 const SourceLoc Loc);
+  Expr *generate(const syntax::CodeCompletionExprSyntax &Expr,
                  const SourceLoc Loc);
   Expr *generate(const syntax::UnknownExprSyntax &Expr, const SourceLoc Loc);
 

--- a/include/swift/Parse/ASTGen.h
+++ b/include/swift/Parse/ASTGen.h
@@ -106,6 +106,8 @@ public:
                  const SourceLoc Loc);
   Expr *generate(const syntax::PoundDsohandleExprSyntax &Expr,
                  const SourceLoc Loc);
+  Expr *generate(const syntax::ObjectLiteralExprSyntax &Expr,
+                 const SourceLoc Loc);
   Expr *generate(const syntax::UnknownExprSyntax &Expr, const SourceLoc Loc);
 
   std::pair<DeclName, DeclNameLoc> generateUnqualifiedDeclName(

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1456,6 +1456,9 @@ public:
   ParserResult<Expr> parseExprSelector();
   ParserResult<Expr> parseExprSuper();
   ParsedSyntaxResult<ParsedExprSyntax> parseExprSuperSyntax();
+  ParserResult<Expr> parseExprUnresolvedMember(bool isExprBasic);
+  ParsedSyntaxResult<ParsedExprSyntax>
+  parseExprUnresolvedMemberSyntax(bool isExprBasic);
   ParserResult<Expr> parseExprStringLiteral();
 
   // todo [gsoc]: create new result type for ParsedSyntax

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1574,14 +1574,19 @@ public:
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
                              Expr *&trailingClosure);
-
+  ParserStatus parseExprListSyntax(
+  tok leftK, tok rightK, bool isPostfix, bool isExprBasic,
+  llvm::function_ref<void(
+      ParsedTokenSyntax &&, ParsedTupleExprElementListSyntax &&,
+      Optional<ParsedTokenSyntax> &&, Optional<ParsedClosureExprSyntax> &&)>
+                      callback);
   ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);
+  ParsedSyntaxResult<ParsedClosureExprSyntax>
+  parseTrailingClosureSyntax(SourceRange calleeRange);
 
-  /// Parse an object literal.
-  ///
-  /// \param LK The literal kind as determined by the first token.
-  ParserResult<Expr> parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LK,
-                                            bool isExprBasic);
+  ParserResult<Expr> parseExprObjectLiteral(bool isExprBasic);
+  ParsedSyntaxResult<ParsedExprSyntax>
+  parseExprObjectLiteralSyntax(bool isExprBasic);
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          bool isExprBasic);
   ParserResult<Expr> parseExprCollection();

--- a/lib/Parse/ASTGen.cpp
+++ b/lib/Parse/ASTGen.cpp
@@ -250,6 +250,10 @@ Expr *ASTGen::generate(const ExprSyntax &E, const SourceLoc Loc) {
     result = generate(*dictionaryExpr, Loc);
   else if (auto tupleExpr = E.getAs<TupleExprSyntax>())
     result = generate(*tupleExpr, Loc);
+  else if (auto callExpr  = E.getAs<FunctionCallExprSyntax>())
+    result = generate(*callExpr, Loc);
+  else if (auto memberExpr  = E.getAs<MemberAccessExprSyntax>())
+    result = generate(*memberExpr, Loc);
   else if (auto integerLiteralExpr = E.getAs<IntegerLiteralExprSyntax>())
     result = generate(*integerLiteralExpr, Loc);
   else if (auto floatLiteralExpr = E.getAs<FloatLiteralExprSyntax>())
@@ -270,6 +274,8 @@ Expr *ASTGen::generate(const ExprSyntax &E, const SourceLoc Loc) {
     result = generate(*poundDsohandleExpr, Loc);
   else if (auto objectLiteralExpr = E.getAs<ObjectLiteralExprSyntax>())
     result = generate(*objectLiteralExpr, Loc);
+  else if (auto completionExpr = E.getAs<CodeCompletionExprSyntax>())
+    result = generate(*completionExpr, Loc);
   else if (auto unknownExpr = E.getAs<UnknownExprSyntax>())
     result = generate(*unknownExpr, Loc);
   else {
@@ -595,6 +601,67 @@ void ASTGen::generateExprTupleElementList(const TupleExprElementListSyntax &elem
          exprLabels.size() == exprLabelLocs.size());
 }
 
+Expr *ASTGen::generate(const FunctionCallExprSyntax &E, const SourceLoc Loc) {
+  auto callee = E.getCalledExpression();
+
+  SourceLoc LParenLoc, RParenLoc;
+  SmallVector<Expr *, 2> args;
+  SmallVector<Identifier, 2> argLabels;
+  SmallVector<SourceLoc, 2> argLabelLocs;
+  generateExprTupleElementList(E.getArgumentList(), Loc,
+                               /*isForCallArguments=*/true, args, argLabels,
+                               argLabelLocs);
+  Expr *trailingClosure = nullptr;
+  if (auto CE = E.getTrailingClosure())
+    trailingClosure = generate(*CE, Loc);
+  if (auto LParen = E.getLeftParen()) {
+    LParenLoc = advanceLocBegin(Loc, *LParen);
+    if (auto RParen = E.getRightParen())
+      RParenLoc = advanceLocBegin(Loc, *RParen);
+    else
+      RParenLoc = advanceLocEnd(Loc, E.getArgumentList());
+  }
+
+  if (auto memberAccess = callee.getAs<MemberAccessExprSyntax>()) {
+    if (!memberAccess->getBase()) {
+      // This is UnresolvedMemberExpr with call arguments.
+      if (memberAccess->getName().isMissing())
+        return nullptr;
+
+      SourceLoc dotLoc = advanceLocBegin(Loc, memberAccess->getDot());
+      DeclName name;
+      DeclNameLoc nameLoc;
+      std::tie(name, nameLoc) = generateUnqualifiedDeclName(
+          memberAccess->getName(), memberAccess->getDeclNameArguments(), Loc);
+
+      return UnresolvedMemberExpr::create(
+          Context, dotLoc, nameLoc, name, LParenLoc, args, argLabels,
+          argLabelLocs, RParenLoc, trailingClosure,
+          /*implicit=*/false);
+    }
+  }
+  llvm_unreachable("call expression not implemented");
+  return nullptr;
+}
+
+Expr *ASTGen::generate(const MemberAccessExprSyntax &E, const SourceLoc Loc) {
+  if (!E.getBase()) {
+    // This is an UnresolvedMemberExpr.
+    if (E.getName().isMissing())
+      return nullptr;
+
+    DeclName name;
+    DeclNameLoc nameLoc;
+    std::tie(name, nameLoc) =
+        generateUnqualifiedDeclName(E.getName(), E.getDeclNameArguments(), Loc);
+    SourceLoc dotLoc = advanceLocBegin(Loc, E.getDot());
+
+    return UnresolvedMemberExpr::create(Context, dotLoc, nameLoc, name,
+                                        /*implicit=*/false);
+  }
+  llvm_unreachable("member access expression not implemented");
+  return nullptr;
+}
 
 Expr *ASTGen::generate(const IntegerLiteralExprSyntax &Expr,
                        const SourceLoc Loc) {
@@ -681,6 +748,30 @@ Expr *ASTGen::generate(const ObjectLiteralExprSyntax &E, const SourceLoc Loc) {
   return ObjectLiteralExpr::create(Context, poundLoc, kind, LParenLoc, args,
                                    argLabels, argLabelLocs, RParenLoc,
                                    trailingClosure, /*implicit=*/false);
+}
+
+Expr *ASTGen::generate(const CodeCompletionExprSyntax &E, const SourceLoc Loc) {
+  if (!E.getBase()) {
+    if (auto punctuator = E.getPeriodOrParen()) {
+      // '.' <cc-token>
+      if (punctuator->getTokenKind() == tok::period ||
+          punctuator->getTokenKind() == tok::period_prefix) {
+        auto ccLoc = advanceLocBegin(Loc, E.getCodeCompletionToken());
+        auto dotLoc = advanceLocBegin(Loc, *punctuator);
+        
+        auto CCE = new (Context) CodeCompletionExpr(ccLoc);
+        if (P.CodeCompletion)
+          P.CodeCompletion->completeUnresolvedMember(CCE, dotLoc);
+        return CCE;
+      }
+    } else {
+      llvm_unreachable("'(' <cc-token> is not suppported");
+    }
+  } else {
+    // TODO: implement
+  }
+  llvm_unreachable("code completion expression not implemented");
+  return nullptr;
 }
 
 Expr *ASTGen::generate(const UnknownExprSyntax &Expr, const SourceLoc Loc) {

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -558,5 +558,7 @@ EXPR_NODES = [
              Child('Arguments', kind='TupleExprElementList',
                    collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
+             Child('TrailingClosure', kind='ClosureExpr',
+                   is_optional=True),
          ]),
 ]


### PR DESCRIPTION
- Object literals e.g. `#imageLiteral(name: "ImageName")`
- Unresolved member expressions e.g. `.rgb(1.0, 0.3, 8.2)` 