### PR TITLE
IRGen: We can't look through opaque archetypes if the underlying type contains a private type

### DIFF
--- a/test/IRGen/Inputs/opaque_result_type_private_underlying_2.swift
+++ b/test/IRGen/Inputs/opaque_result_type_private_underlying_2.swift
@@ -1,0 +1,17 @@
+public protocol A {
+  associatedtype Assoc
+  func bindAssoc() -> Assoc
+}
+
+public protocol Q {}
+
+fileprivate struct PrivateS : Q {
+  init() {}
+}
+
+public struct G : A {
+  public init() {}
+   public func bindAssoc() -> some Q {
+     return PrivateS()
+   }
+}

--- a/test/IRGen/opaque_result_type_private_underlying.swift
+++ b/test/IRGen/opaque_result_type_private_underlying.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_underlying_2.swift
+
+public struct G2 : A {
+  public init() {}
+   public func bindAssoc() -> some Q {
+     return G().bindAssoc()
+   }
+}


### PR DESCRIPTION
Not without more context at least (where the substitution happens). The
private type could be from a different TU.

Yes, this can probably happen in earlier uses of opaque archetype
substitution. For now, fix the known failure.

rdar://56093964