### PR TITLE
Revert "Merge pull request #27057 from theblixguy/unrevert/SR-11298"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,63 +58,6 @@ Swift 5.2
   (foo as Magic)(5)
   ```
 
-* [SR-11298][]:
-
-  A class-constrained protocol extension, where the extended protocol does
-  not impose a class constraint, will now infer the constraint implicitly.
-
-  ```swift
-  protocol Foo {}
-  class Bar: Foo {
-    var someProperty: Int = 0
-  }
-
-  // Even though 'Foo' does not impose a class constraint, it is automatically
-  // inferred due to the Self: Bar constraint.
-  extension Foo where Self: Bar {
-    var anotherProperty: Int {
-      get { return someProperty }
-      // As a result, the setter is now implicitly nonmutating, just like it would
-      // be if 'Foo' had a class constraint.
-      set { someProperty = newValue }
-    }
-  }
-  ```
-  
-  As a result, this could lead to code that currently compiles today to throw an error.
-  
-  ```swift
-  protocol Foo {
-    var someProperty: Int { get set }
-  }
-  
-  class Bar: Foo {
-    var someProperty = 0
-  }
-  
-  extension Foo where Self: Bar {
-    var anotherProperty1: Int {
-      get { return someProperty }
-      // This will now error, because the protocol requirement
-      // is implicitly mutating and the setter is implicitly 
-      // nonmutating.
-      set { someProperty = newValue } // Error
-    }
-  }
-  ```
-
-  **Workaround**: Define a new mutable variable inside the setter that has a reference to `self`:
-  
-  ```swift
-  var anotherProperty1: Int {
-    get { return someProperty }
-    set {
-      var mutableSelf = self
-      mutableSelf.someProperty = newValue // Okay
-    }
-  }
-  ```
-
 * [SE-0253][]:
 
   Values of types that declare `func callAsFunction` methods can be called
@@ -140,7 +83,7 @@ Swift 5.2
 
 * [SR-4206][]:
 
-  A method override is no longer allowed to have a generic signature with
+  A method override is no longer allowed to have a generic signature with 
   requirements not imposed by the base method. For example:
 
   ```
@@ -7856,5 +7799,4 @@ Swift 1.0
 [SR-8974]: <https://bugs.swift.org/browse/SR-8974>
 [SR-9043]: <https://bugs.swift.org/browse/SR-9043>
 [SR-9827]: <https://bugs.swift.org/browse/SR-9827>
-[SR-11298]: <https://bugs.swift.org/browse/SR-11298>
 [SR-11429]: <https://bugs.swift.org/browse/SR-11429>

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -261,10 +261,7 @@ public:
 
   /// Returns the kind of context this is.
   DeclContextKind getContextKind() const;
-
-  /// Returns whether this context has value semantics.
-  bool hasValueSemantics() const;
-
+  
   /// Determines whether this context is itself a local scope in a
   /// code block.  A context that appears in such a scope, like a
   /// local type declaration, does not itself become a local context.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5672,18 +5672,12 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
     if (FD && !FD->isMutating() && !FD->isImplicit() && FD->isInstanceMember()&&
         !FD->getDeclContext()->getDeclaredInterfaceType()
                  ->hasReferenceSemantics()) {
-      // Do not suggest the fix-it in implicit getters
+      // Do not suggest the fix it in implicit getters
       if (auto AD = dyn_cast<AccessorDecl>(FD)) {
         if (AD->isGetter() && !AD->getAccessorKeywordLoc().isValid())
           return;
-
-        auto accessorDC = AD->getDeclContext();
-        // Do not suggest the fix-it if `Self` is a class type.
-        if (accessorDC->isTypeContext() && !accessorDC->hasValueSemantics()) {
-          return;
-        }
       }
-
+                   
       auto &d = getASTContext().Diags;
       d.diagnose(FD->getFuncLoc(), diag::change_to_mutating,
                  isa<AccessorDecl>(FD))

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1035,14 +1035,6 @@ DeclContextKind DeclContext::getContextKind() const {
   llvm_unreachable("Unhandled DeclContext ASTHierarchy");
 }
 
-bool DeclContext::hasValueSemantics() const {
-  if (auto contextTy = getSelfTypeInContext()) {
-    return !contextTy->hasReferenceSemantics();
-  }
-
-  return false;
-}
-
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::AbstractFunctionDecl:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2090,10 +2090,17 @@ OperatorPrecedenceGroupRequest::evaluate(Evaluator &evaluator,
   return group;
 }
 
+bool swift::doesContextHaveValueSemantics(DeclContext *dc) {
+  if (Type contextTy = dc->getDeclaredInterfaceType())
+    return !contextTy->hasReferenceSemantics();
+  return false;
+}
+
 llvm::Expected<SelfAccessKind>
 SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
-    if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
+    if (!FD->isInstanceMember() ||
+        !doesContextHaveValueSemantics(FD->getDeclContext())) {
       return SelfAccessKind::NonMutating;
     }
     return SelfAccessKind::Mutating;
@@ -2115,7 +2122,8 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
     case AccessorKind::MutableAddress:
     case AccessorKind::Set:
     case AccessorKind::Modify:
-      if (AD->isInstanceMember() && AD->getDeclContext()->hasValueSemantics())
+      if (AD->isInstanceMember() &&
+          doesContextHaveValueSemantics(AD->getDeclContext()))
         return SelfAccessKind::Mutating;
       break;
 

--- a/lib/Sema/TypeCheckDecl.h
+++ b/lib/Sema/TypeCheckDecl.h
@@ -25,6 +25,8 @@ class DeclContext;
 class ValueDecl;
 class Pattern;
 
+bool doesContextHaveValueSemantics(DeclContext *dc);
+
 /// Walks up the override chain for \p CD until it finds an initializer that is
 /// required and non-implicit. If no such initializer exists, returns the
 /// declaration where \c required was introduced (i.e. closest to the root

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -269,9 +269,8 @@ void swift::validatePatternBindingEntries(TypeChecker &tc,
 llvm::Expected<bool>
 IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
-  auto storageDC = storage->getDeclContext();
-  bool result = (!storage->isStatic() && storageDC->isTypeContext() &&
-                 storageDC->hasValueSemantics());
+  bool result = (!storage->isStatic() &&
+                 doesContextHaveValueSemantics(storage->getDeclContext()));
 
   // 'lazy' overrides the normal accessor-based rules and heavily
   // restricts what accessors can be used.  The getter is considered
@@ -299,7 +298,7 @@ IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
 
   // Protocol requirements are always written as '{ get }' or '{ get set }';
   // the @_borrowed attribute determines if getReadImpl() becomes Get or Read.
-  if (isa<ProtocolDecl>(storageDC))
+  if (isa<ProtocolDecl>(storage->getDeclContext()))
     return checkMutability(AccessorKind::Get);
 
   switch (storage->getReadImpl()) {
@@ -325,9 +324,8 @@ IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
   // By default, the setter is mutating if we have an instance member of a
   // value type, but this can be overridden below.
-  auto storageDC = storage->getDeclContext();
-  bool result = (!storage->isStatic() && storageDC->isTypeContext() &&
-                 storageDC->hasValueSemantics());
+  bool result = (!storage->isStatic() &&
+                 doesContextHaveValueSemantics(storage->getDeclContext()));
 
   // If we have an attached property wrapper, the setter is mutating
   // or not based on the composition of the wrappers.

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -126,7 +126,7 @@ struct WrapperContext {
 }
 
 // Class-constrained extension where protocol does not impose class requirement
-// SR-11298
+
 protocol DoesNotImposeClassReq_1 {}
 	
 class JustAClass: DoesNotImposeClassReq_1 {
@@ -140,8 +140,8 @@ extension DoesNotImposeClassReq_1 where Self: JustAClass {
   }
 }
 	
-let instanceOfJustAClass = JustAClass()
-instanceOfJustAClass.wrappingProperty = "" // Okay
+let instanceOfJustAClass = JustAClass() // expected-note {{change 'let' to 'var' to make it mutable}}
+instanceOfJustAClass.wrappingProperty = "" // expected-error {{cannot assign to property: 'instanceOfJustAClass' is a 'let' constant}}
 
 protocol DoesNotImposeClassReq_2 {
   var property: String { get set }
@@ -150,7 +150,7 @@ protocol DoesNotImposeClassReq_2 {
 extension DoesNotImposeClassReq_2 where Self : AnyObject {
   var wrappingProperty: String {
     get { property }
-    set { property = newValue } // expected-error {{cannot assign to property: 'self' is immutable}}
+    set { property = newValue } // Okay
   }
 }
 


### PR DESCRIPTION
This reverts #27057, reintroducing [SR-11298](https://bugs.swift.org/browse/SR-11298), because the source compat implications were broader than expected.

rdar://problem/56165420