### PR TITLE
[Property wrappers] Don't infer "final" for the projected property.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1164,7 +1164,7 @@ IsFinalRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
 
       // Backing storage for 'lazy' or property wrappers is always final.
       if (VD->isLazyStorageProperty() ||
-          VD->getOriginalWrappedProperty())
+          VD->getOriginalWrappedProperty(PropertyWrapperSynthesizedPropertyKind::Backing))
         return true;
 
       if (auto *nominalDecl = VD->getDeclContext()->getSelfClassDecl()) {

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -495,6 +495,18 @@ struct ComposedInit {
   }
 }
 
+// rdar://problem/55982409 - crash due to improperly inferred 'final'
+@propertyWrapper
+public struct MyWrapper<T> {
+  public var wrappedValue: T
+  public var projectedValue: Self { self }
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+open class TestMyWrapper {
+  public init() {}
+  @MyWrapper open var useMyWrapper: Int? = nil
+}
 
 // CHECK-LABEL: sil_vtable ClassUsingWrapper {
 // CHECK-NEXT:  #ClassUsingWrapper.x!getter.1: (ClassUsingWrapper) -> () -> Int : @$s17property_wrappers17ClassUsingWrapperC1xSivg   // ClassUsingWrapper.x.getter
@@ -503,3 +515,6 @@ struct ComposedInit {
 // CHECK-NEXT:  #ClassUsingWrapper.init!allocator.1: (ClassUsingWrapper.Type) -> () -> ClassUsingWrapper : @$s17property_wrappers17ClassUsingWrapperCACycfC
 // CHECK-NEXT: #ClassUsingWrapper.deinit!deallocator.1: @$s17property_wrappers17ClassUsingWrapperCfD
 // CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_vtable [serialized] TestMyWrapper
+// CHECK: #TestMyWrapper.$useMyWrapper!getter.1


### PR DESCRIPTION
Fixes crash reported as rdar://problem/55982409.
