### PR TITLE
[ConstraintSystem] Detect and diagnose type mismatch failures of `ino…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -381,8 +381,8 @@ ERROR(cannot_convert_argument_value,none,
       (Type,Type))
 
 NOTE(candidate_has_invalid_argument_at_position,none,
-     "candidate expects value of type %0 for parameter #%1",
-     (Type, unsigned))
+     "candidate expects %select{|in-out }2value of type %0 for parameter #%1",
+     (Type, unsigned, bool))
 
 ERROR(cannot_convert_array_to_variadic,none,
       "cannot pass array of type %0 as variadic arguments of type %1",

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2142,6 +2142,12 @@ bool ContextualFailure::diagnoseConversionToNil() const {
 }
 
 void ContextualFailure::tryFixIts(InFlightDiagnostic &diagnostic) const {
+  auto *locator = getLocator();
+  // Can't apply any of the fix-its below if this failure
+  // is related to `inout` argument.
+  if (locator->isLastElement<LocatorPathElt::LValueConversion>())
+    return;
+
   if (trySequenceSubsequenceFixIts(diagnostic))
     return;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5084,9 +5084,11 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
 }
 
 bool ArgumentMismatchFailure::diagnoseAsNote() {
+  auto *locator = getLocator();
   if (auto *callee = getCallee()) {
     emitDiagnostic(callee, diag::candidate_has_invalid_argument_at_position,
-                   getToType(), getParamPosition());
+                   getToType(), getParamPosition(),
+                   locator->isLastElement<LocatorPathElt::LValueConversion>());
     return true;
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3988,6 +3988,12 @@ Expr *simplifyLocatorToAnchor(ConstraintLocator *locator);
 Expr *getArgumentExpr(Expr *expr, unsigned index);
 
 /// Determine whether given locator points to one of the arguments
+/// associated with the call to an operator. If the operator name
+/// is empty `true` is returned for any kind of operator.
+bool isOperatorArgument(ConstraintLocator *locator,
+                        StringRef expectedOperator = "");
+
+/// Determine whether given locator points to one of the arguments
 /// associated with implicit `~=` (pattern-matching) operator
 bool isArgumentOfPatternMatchingOperator(ConstraintLocator *locator);
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -522,6 +522,7 @@ let _: Color = .frob(1, i)  // expected-error {{missing argument label 'b:' in c
 // expected-error@-1 {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
 let _: Color = .frob(1, b: i)  // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{28-28=&}}
 let _: Color = .frob(1, &d) // expected-error {{missing argument label 'b:' in call}}
+// expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 let _: Color = .frob(1, b: &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
 someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -549,10 +549,9 @@ struct MultipleMemberAccesses {
 
 func sr10670() {
   struct S {
-    init(_ x: inout String) {}
-    init(_ x: inout [Int]) {}
+    init(_ x: inout String) {} // expected-note {{candidate expects value of type 'String' for parameter #1}}
+    init(_ x: inout [Int]) {}  // expected-note {{candidate expects value of type '[Int]' for parameter #1}}
   }
   var a = 0
-  S.init(&a) // expected-error {{cannot invoke 'S.Type.init' with an argument list of type '(inout Int)'}}
-  // expected-note@-1 {{overloads for 'S.Type.init' exist with these partially matching parameter lists: (inout String), (inout [Int])}}
+  S.init(&a) // expected-error {{no exact matches in call to initializer}}
 }

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -549,8 +549,8 @@ struct MultipleMemberAccesses {
 
 func sr10670() {
   struct S {
-    init(_ x: inout String) {} // expected-note {{candidate expects value of type 'String' for parameter #1}}
-    init(_ x: inout [Int]) {}  // expected-note {{candidate expects value of type '[Int]' for parameter #1}}
+    init(_ x: inout String) {} // expected-note {{candidate expects in-out value of type 'String' for parameter #1}}
+    init(_ x: inout [Int]) {}  // expected-note {{candidate expects in-out value of type '[Int]' for parameter #1}}
   }
   var a = 0
   S.init(&a) // expected-error {{no exact matches in call to initializer}}


### PR DESCRIPTION
…ut` parameters

Currently absence of `subtyping` is the only problem detected and diagnosed specifically
for `inout` parameters, but there could be type mismatches in `inout` positions as well
 and we can use `argument-to-parameter mismatch fix to detect and diagnose them.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
