### PR TITLE
[Constant Evaluator] Add a flag for denoting top-level evaluation mode

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -422,7 +422,7 @@ NOTE(constexpr_witness_call_with_no_conformance, none,
 NOTE(constexpr_unknown_control_flow_due_to_skip,none, "branch depends on "
      "non-constant value produced by an unevaluated instructions", ())
 NOTE(constexpr_returned_by_unevaluated_instruction,none,
-     "return value of an unevaluated instruction is not a constant", ())
+     "result of an unevaluated instruction is not a constant", ())
 NOTE(constexpr_mutated_by_unevaluated_instruction,none, "value mutable by an "
     "unevaluated instruction is not a constant", ())
 

--- a/test/SILOptimizer/constant_evaluator_skip_test.sil
+++ b/test/SILOptimizer/constant_evaluator_skip_test.sil
@@ -93,7 +93,7 @@ bb0:
   %10 = builtin "cmp_slt_Int32"(%8 : $Builtin.Int32, %9 : $Builtin.Int32) : $Builtin.Int1
   cond_br %10, bb2, bb3
     // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: branch depends on non-constant value produced by an unevaluated instructions
-    // CHECK: {{.*}}: note: value mutable by an unevaluated instruction is not a constant
+    // CHECK: {{.*}}: note: result of an unevaluated instruction is not a constant
 bb2:
   br bb4
 

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -449,7 +449,7 @@ bb0:
 sil hidden @interpretAndDiagnoseNonConstantVars : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %4 = struct_extract %0 : $Int, #Int._value
-    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: cannot evaluate expression as constant here
+    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: encountered use of a variable not tracked by the evaluator
   %10 = tuple ()
   return %10 : $()
 }


### PR DESCRIPTION
and separate out the code for top-level evaluation from the normal
step-by-step evaluation. This ensures that step-by-step evaluation
does not accidentally rely on any logic meant for top-level evaluation.

This change should not affect the observable behavior of the evaluator.