### PR TITLE
Fix property wrapper crasher

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2235,46 +2235,6 @@ RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
                    subs, {}, calleeTypeInfo, ApplyOptions::None, C);
 }
 
-RValue SILGenFunction::emitApplyOfPropertyWrapperBackingInitializer(
-    SILLocation loc,
-    VarDecl *var,
-    RValue &&originalValue,
-    SGFContext C) {
-  SILDeclRef constant(var, SILDeclRef::Kind::PropertyWrapperBackingInitializer);
-  auto fnRef = ManagedValue::forUnmanaged(emitGlobalFunctionRef(loc, constant));
-  auto fnType = fnRef.getType().castTo<SILFunctionType>();
-
-  SubstitutionMap subs;
-  auto varDC = var->getInnermostDeclContext();
-  if (auto genericSig = varDC->getGenericSignatureOfContext()) {
-    subs = SubstitutionMap::get(
-        genericSig,
-        [&](SubstitutableType *type) {
-          if (auto gp = type->getAs<GenericTypeParamType>()) {
-            return F.mapTypeIntoContext(gp);
-          }
-
-          return Type(type);
-        },
-        LookUpConformanceInModule(varDC->getParentModule()));
-  }
-
-  auto substFnType = fnType->substGenericArgs(SGM.M, subs);
-
-  CanType resultType =
-      F.mapTypeIntoContext(var->getPropertyWrapperBackingPropertyType())
-        ->getCanonicalType();
-  AbstractionPattern origResultType(resultType);
-  CalleeTypeInfo calleeTypeInfo(substFnType, origResultType, resultType);
-  ResultPlanPtr resultPlan =
-      ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
-  ArgumentScope argScope(*this, loc);
-  SmallVector<ManagedValue, 2> args;
-  std::move(originalValue).getAll(args);
-  return emitApply(std::move(resultPlan), std::move(argScope), loc, fnRef, subs,
-                   args, calleeTypeInfo, ApplyOptions::None, C);
-}
-
 RValue RValueEmitter::visitDestructureTupleExpr(DestructureTupleExpr *E,
                                                 SGFContext C) {
   // Emit the sub-expression tuple and destructure it into elements.

--- a/test/SILGen/property_wrappers_library_evolution.swift
+++ b/test/SILGen/property_wrappers_library_evolution.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/property_wrapper_defs.swift
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t -enable-library-evolution
+import property_wrapper_defs
+
+// rdar://problem/55995892
+// This is a crash that occurs only with -enable-library-evolution.
+
+public enum E { case a }
+struct M { @MyPublished private var e = E.a }


### PR DESCRIPTION
Due to insufficiently robust argument emission code, certain combinations of language features could cause a call to a property wrapper backing initializer to prepare the argument incorrectly, causing an assertion failure in SILGenApply. This commit moves `SILGenFunction::emitApplyOfPropertyWrapperBackingInitializer()` into SILGenApply so it can use `CallEmission` and `PreparedArguments` to emit the call with full generality.

Fixes rdar://problem/55995892.

(I'm going to be honest: SIL-level generics are not my strong suit. I rewrote this function with full generality because I don't know how to fix it in a more targeted way, but I could be doing something very wrong that happens to pass all of our tests. Reviewers, please examine it closely.)