### PR TITLE
AST: teach Decl::getLoc() to return serialized source loc.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -667,6 +667,13 @@ private:
   void operator=(const Decl&) = delete;
   SourceLoc getLocFromSource() const;
 
+  struct CachedExternalSourceLocs {
+    SourceLoc Loc;
+    SourceLoc StartLoc;
+    SourceLoc EndLoc;
+  };
+  mutable CachedExternalSourceLocs *CachedLocs = nullptr;
+  CachedExternalSourceLocs *calculateSerializedLocs() const;
 protected:
 
   Decl(DeclKind kind, llvm::PointerUnion<DeclContext *, ASTContext *> context)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -764,7 +764,7 @@ public:
 
   /// Returns the preferred location when referring to declarations
   /// in diagnostics.
-  SourceLoc getLoc() const;
+  SourceLoc getLoc(bool SerializedOK = true) const;
 
   /// Returns the source range of the entire declaration.
   SourceRange getSourceRange() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -672,8 +672,8 @@ private:
     SourceLoc StartLoc;
     SourceLoc EndLoc;
   };
-  mutable CachedExternalSourceLocs *CachedLocs = nullptr;
-  CachedExternalSourceLocs *calculateSerializedLocs() const;
+  mutable CachedExternalSourceLocs const *CachedLocs = nullptr;
+  const CachedExternalSourceLocs *calculateSerializedLocs() const;
 protected:
 
   Decl(DeclKind kind, llvm::PointerUnion<DeclContext *, ASTContext *> context)

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -47,7 +47,6 @@ class SourceManager {
   };
   std::map<const char *, VirtualFile> VirtualFiles;
   mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
-  std::map<const char *, unsigned> ExternalBufferId;
 public:
   SourceManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
                     llvm::vfs::getRealFileSystem())

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -47,7 +47,7 @@ class SourceManager {
   };
   std::map<const char *, VirtualFile> VirtualFiles;
   mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
-
+  std::map<const char *, unsigned> ExternalBufferId;
 public:
   SourceManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
                     llvm::vfs::getRealFileSystem())
@@ -245,9 +245,10 @@ public:
                                SourceLoc();
   }
 
+  SourceLoc getLocFromExternalSource(StringRef Path, unsigned Line, unsigned Col);
 private:
   const VirtualFile *getVirtualFile(SourceLoc Loc) const;
-
+  Optional<unsigned> getExternalSourceBufferId(StringRef Path);
   int getLineOffset(SourceLoc Loc) const {
     if (auto VFile = getVirtualFile(Loc))
       return VFile->LineOffset;

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -248,7 +248,7 @@ public:
   SourceLoc getLocFromExternalSource(StringRef Path, unsigned Line, unsigned Col);
 private:
   const VirtualFile *getVirtualFile(SourceLoc Loc) const;
-  Optional<unsigned> getExternalSourceBufferId(StringRef Path);
+  unsigned getExternalSourceBufferId(StringRef Path);
   int getLineOffset(SourceLoc Loc) const {
     if (auto VFile = getVirtualFile(Loc))
       return VFile->LineOffset;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -512,6 +512,9 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
 #include "swift/AST/DeclNodes.def"
   if (isa<ModuleDecl>(this))
     return SourceLoc();
+  // When the decl is context-free, we should get loc from source buffer.
+  if (!getDeclContext())
+    return getLocFromSource();
   auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
   switch(File->getKind()) {
   case FileUnitKind::Source:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -490,7 +490,7 @@ const Decl::CachedExternalSourceLocs *Decl::calculateSerializedLocs() const {
   auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
   auto Locs = File->getBasicLocsForDecl(this);
   if (!Locs.hasValue()) {
-    static const Decl::CachedExternalSourceLocs NullLocs;
+    static const Decl::CachedExternalSourceLocs NullLocs{};
     return &NullLocs;
   }
   auto *Result = getASTContext().Allocate<Decl::CachedExternalSourceLocs>();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -486,14 +486,14 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getLocFromSource();
   llvm_unreachable("Unknown decl kind");
 }
 
-Decl::CachedExternalSourceLocs*
-Decl::calculateSerializedLocs() const {
-  auto *Result = getASTContext().Allocate<Decl::CachedExternalSourceLocs>();
+const Decl::CachedExternalSourceLocs *Decl::calculateSerializedLocs() const {
   auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
   auto Locs = File->getBasicLocsForDecl(this);
   if (!Locs.hasValue()) {
-    return Result;
+    static const Decl::CachedExternalSourceLocs NullLocs;
+    return &NullLocs;
   }
+  auto *Result = getASTContext().Allocate<Decl::CachedExternalSourceLocs>();
   auto &SM = getASTContext().SourceMgr;
 #define CASE(X)                                                               \
 Result->X = SM.getLocFromExternalSource(Locs->SourceFilePath, Locs->X.Line,   \

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -358,16 +358,18 @@ llvm::Optional<unsigned> SourceManager::resolveFromLineCol(unsigned BufferId,
 }
 
 unsigned SourceManager::getExternalSourceBufferId(StringRef Path) {
-  auto It = ExternalBufferId.find(Path.data());
-  if (It != ExternalBufferId.end()) {
-    return It->second;
+  auto It = BufIdentIDMap.find(Path);
+  if (It != BufIdentIDMap.end()) {
+    return It->getSecond();
   }
   unsigned Id = 0u;
   auto InputFileOrErr = swift::vfs::getFileOrSTDIN(*getFileSystem(), Path);
   if (InputFileOrErr) {
+    // This assertion ensures we can look up from the map in the future when
+    // using the same Path.
+    assert(InputFileOrErr.get()->getBufferIdentifier() == Path);
     Id = addNewSourceBuffer(std::move(InputFileOrErr.get()));
   }
-  ExternalBufferId.insert({Path.data(), Id});
   return Id;
 }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -837,7 +837,7 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
   if (!shouldIndex(D, /*IsRef=*/false))
     return false;
 
-  SourceLoc Loc = D->getLoc();
+  SourceLoc Loc = D->getLoc(/*SerializedOK*/false);
   if (Loc.isInvalid() && !IsModuleFile)
     return false;
 
@@ -1186,7 +1186,7 @@ bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDec
   if (auto *extD = dyn_cast<ExtensionDecl>(container))
     loc = getLocForExtension(extD);
   else
-    loc = container->getLoc();
+    loc = container->getLoc(/*SerializedOK*/false);
 
   IndexSymbol info;
   if (initIndexSymbol(witness, loc, /*IsRef=*/true, info))
@@ -1208,6 +1208,8 @@ bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDec
 bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
                                           bool IsRef, IndexSymbol &Info) {
   assert(D);
+  if (Loc.isValid() && SrcMgr.findBufferContainingLoc(Loc) != BufferID)
+    return true;
   if (auto *VD = dyn_cast<VarDecl>(D)) {
     // Always base the symbol information on the canonical VarDecl
     D = VD->getCanonicalVarDecl();
@@ -1266,7 +1268,7 @@ static NominalTypeDecl *getNominalParent(ValueDecl *D) {
 
 bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
                                                   IndexSymbol &Info) {
-  if (initIndexSymbol(D, D->getLoc(), /*IsRef=*/false, Info))
+  if (initIndexSymbol(D, D->getLoc(/*SerializedOK*/false), /*IsRef=*/false, Info))
     return true;
 
   if (isDynamicVarAccessorOrFunc(D, Info.symInfo)) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -644,8 +644,10 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
   // We can assume we are running on at least the minimum deployment target.
   auto OverApproximateContext =
     AvailabilityContext::forDeploymentTarget(Context);
-
-  while (DC && loc.isInvalid()) {
+  auto isInvalidLoc = [SF](SourceLoc loc) {
+    return SF ? loc.isInvalid() : true;
+  };
+  while (DC && isInvalidLoc(loc)) {
     const Decl *D = DC->getInnermostDeclarationDeclContext();
     if (!D)
       break;

--- a/test/SourceKit/CompileNotifications/arg-parsing.swift
+++ b/test/SourceKit/CompileNotifications/arg-parsing.swift
@@ -3,7 +3,7 @@
 // ARG_PARSE_0: {
 // ARG_PARSE_0:  key.notification: source.notification.compile-will-start
 // ARG_PARSE_0:  key.compileid: [[CID1:".*"]]
-// ARG_PARSE_0:  key.compilerargs-string: "{{.*}}.swift -no-such-arg"
+// ARG_PARSE_0:  key.compilerargs-string: "{{.*}}.swift -no-such-arg -Xfrontend -ignore-module-source-info"
 // ARG_PARSE_0: }
 // ARG_PARSE_0: {
 // ARG_PARSE_0:   key.notification: source.notification.compile-did-finish
@@ -24,7 +24,7 @@
 // ARG_PARSE_1: {
 // ARG_PARSE_1:  key.notification: source.notification.compile-will-start
 // ARG_PARSE_1:  key.compileid: [[CID1:".*"]]
-// ARG_PARSE_1:  key.compilerargs-string: "{{.*}}.swift -no-such-arg"
+// ARG_PARSE_1:  key.compilerargs-string: "{{.*}}.swift -no-such-arg -Xfrontend -ignore-module-source-info"
 // ARG_PARSE_1: }
 // ARG_PARSE_1: {
 // ARG_PARSE_1:   key.notification: source.notification.compile-did-finish

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -351,7 +351,10 @@ if test_options:
     config.swift_test_options += test_options
 
 config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
+config.swift_frontend_test_options += ' -ignore-module-source-info'
 config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
+config.swift_driver_test_options += ' -Xfrontend'
+config.swift_driver_test_options += ' -ignore-module-source-info'
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
@@ -878,7 +881,7 @@ if run_vendor == 'apple':
     config.target_sdk_name = xcrun_sdk_name
     config.target_ld = "%s ld -L%r" % (xcrun_prefix, make_path(test_resource_dir, config.target_sdk_name))
     config.target_swift_frontend = (
-        "%s -frontend %s -sdk %r %s %s -ignore-module-source-info" %
+        "%s -frontend %s -sdk %r %s %s" %
         (config.swiftc, target_options, config.variant_sdk,
          config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = (

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1503,7 +1503,7 @@ private:
 
   void printLoc(SourceLoc Loc, raw_ostream &OS) {
     OS << '@';
-    if (Loc.isValid()) {
+    if (Loc.isValid() && SM.findBufferContainingLoc(Loc) == BufferID) {
       auto LineCol = SM.getLineAndColumn(Loc, BufferID);
       OS  << LineCol.first << ':' << LineCol.second;
     }
@@ -1520,16 +1520,16 @@ private:
         OS << 'i';
       if (isa<ConstructorDecl>(D) && Entity.IsRef) {
         OS << "Ctor";
-        printLoc(D->getLoc(), OS);
+        printLoc(D->getLoc(/*SerializedOK*/false), OS);
         if (Entity.CtorTyRef) {
           OS << '-';
           OS << Decl::getKindName(Entity.CtorTyRef->getKind());
-          printLoc(Entity.CtorTyRef->getLoc(), OS);
+          printLoc(Entity.CtorTyRef->getLoc(/*SerializedOK*/false), OS);
         }
       } else {
         OS << Decl::getKindName(D->getKind());
         if (Entity.IsRef)
-          printLoc(D->getLoc(), OS);
+          printLoc(D->getLoc(/*SerializedOK*/false), OS);
       }
 
     } else {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -174,6 +174,7 @@ UID_KEYS = [
     KEY('VFSName', 'key.vfs.name'),
     KEY('VFSOptions', 'key.vfs.options'),
     KEY('Files', 'key.files'),
+    KEY('IgnoreSourceInfoFile', 'key.ignore_source_info_file'),
 ]
 
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -174,7 +174,6 @@ UID_KEYS = [
     KEY('VFSName', 'key.vfs.name'),
     KEY('VFSOptions', 'key.vfs.options'),
     KEY('Files', 'key.files'),
-    KEY('IgnoreSourceInfoFile', 'key.ignore_source_info_file'),
 ]
 
 


### PR DESCRIPTION
When Decl::getLoc() is called upon a serialized AST and the
serialized source location is available, we lazily open the
external buffer and return a valid SourceLoc instance pointing
into the buffer.