### PR TITLE
Move swiftpm to swift_build_support infra

### DIFF
--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -203,6 +203,7 @@ def _apply_default_arguments(args):
         args.test_tvos = False
         args.test_watchos = False
         args.test_android = False
+        args.test_swiftpm = False
         args.test_indexstoredb = False
         args.test_sourcekitlsp = False
 
@@ -552,6 +553,9 @@ def create_argument_parser():
 
     option(['-p', '--swiftpm'], store_true('build_swiftpm'),
            help='build swiftpm')
+
+    option(['--install-swiftpm'], store_true('install_swiftpm'),
+           help='install swiftpm')
 
     option(['--swiftsyntax'], store_true('build_swiftsyntax'),
            help='build swiftSyntax')
@@ -951,6 +955,8 @@ def create_argument_parser():
            help='skip testing Android device targets on the host machine (the '
                 'phone itself)')
 
+    option('--skip-test-swiftpm', toggle_false('test_swiftpm'),
+           help='skip testing swiftpm')
     option('--skip-test-indexstore-db', toggle_false('test_indexstoredb'),
            help='skip testing indexstore-db')
     option('--skip-test-sourcekit-lsp', toggle_false('test_sourcekitlsp'),

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -10,8 +10,68 @@
 #
 # ----------------------------------------------------------------------------
 
-from . import product
+import os
+import platform
 
+from . import product
+from .. import shell
+from .. import targets
 
 class SwiftPM(product.Product):
-    pass
+    @classmethod
+    def product_source_name(cls):
+        return "swiftpm"
+
+    @classmethod
+    def is_build_script_impl_product(cls):
+        return False
+
+    def build(self, host_target):
+        run_build_script_helper('build', host_target, self, self.args)
+
+    def test(self, host_target):
+        if self.args.test and self.args.test_swiftpm:
+            run_build_script_helper('test', host_target, self, self.args)
+
+    def install(self, host_target):
+        if self.args.install_swiftpm:
+            run_build_script_helper('install', host_target, self, self.args)
+
+def run_build_script_helper(action, host_target, product, args):
+    script_path = os.path.join(
+        product.source_dir, 'Utilities', 'bootstrap')
+    toolchain_path = args.install_destdir
+    if platform.system() == 'Darwin':
+        # The prefix is an absolute path, so concatenate without os.path.
+        toolchain_path += \
+            product.targets.darwin_toolchain_prefix(args.install_prefix)
+
+    swiftc = os.path.join(toolchain_path, "usr", "bin", "swiftc")
+    sbt = os.path.join(toolchain_path, "usr", "bin", "swift-build-tool")
+    llbuild_src = os.path.join(
+            os.path.dirname(product.source_dir), "llbuild")
+
+    # FIXME: We require llbuild build directory in order to build. Is
+    # there a better way to get this?
+    build_root = os.path.dirname(product.build_dir)
+    llbuild_build_dir = os.path.join(
+            build_root, '%s-%s' % ("llbuild", host_target))
+
+    helper_cmd = [script_path]
+
+    if action != "build":
+        helper_cmd.append(action)
+    if args.build_variant != "Debug":
+        helper_cmd.append("--release")
+
+    install_prefix = args.install_destdir + args.install_prefix
+
+    helper_cmd += [
+        "--swiftc=" + swiftc,
+        "--sbt=" + sbt,
+        "--build", product.build_dir,
+        "--llbuild-source-dir=" + llbuild_src,
+        "--llbuild-build-dir=" + llbuild_build_dir,
+        "--prefix", install_prefix
+    ]
+    shell.call(helper_cmd)


### PR DESCRIPTION
We should have done this ages ago. This will allow cleaning up most of
the hacks in SwiftPM's build script.

Dependencies:

- https://github.com/apple/swift/pull/27580