### PR TITLE
[AutoDiff] Fix 'autodiff_function_extract' operand ownership kind.

### DIFF
--- a/lib/SIL/LinearLifetimeChecker.cpp
+++ b/lib/SIL/LinearLifetimeChecker.cpp
@@ -223,7 +223,6 @@ void State::initializeConsumingUse(BranchPropagatedUser consumingUser,
     } else {
       llvm::errs() << "Value: N/A\n";
     }
-    (*value)->getFunction()->dump();
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
                  << userBlock->getDebugID() << "\n\n";
   });
@@ -326,7 +325,6 @@ void State::checkPredsForDoubleConsume(BranchPropagatedUser consumingUser,
     } else {
       llvm::errs() << "N/A. \n";
     }
-    (*value)->getFunction()->dump();
 
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
                  << userBlock->getDebugID() << "\n\n";
@@ -357,7 +355,6 @@ void State::checkPredsForDoubleConsume(SILBasicBlock *userBlock) {
     } else {
       llvm::errs() << "N/A. \n";
     }
-    (*value)->getFunction()->dump();
 
     llvm::errs() << "Block: bb" << userBlock->getDebugID() << "\n\n";
   });

--- a/lib/SIL/LinearLifetimeChecker.cpp
+++ b/lib/SIL/LinearLifetimeChecker.cpp
@@ -223,6 +223,7 @@ void State::initializeConsumingUse(BranchPropagatedUser consumingUser,
     } else {
       llvm::errs() << "Value: N/A\n";
     }
+    (*value)->getFunction()->dump();
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
                  << userBlock->getDebugID() << "\n\n";
   });
@@ -325,6 +326,7 @@ void State::checkPredsForDoubleConsume(BranchPropagatedUser consumingUser,
     } else {
       llvm::errs() << "N/A. \n";
     }
+    (*value)->getFunction()->dump();
 
     llvm::errs() << "User: " << *consumingUser << "Block: bb"
                  << userBlock->getDebugID() << "\n\n";
@@ -355,6 +357,7 @@ void State::checkPredsForDoubleConsume(SILBasicBlock *userBlock) {
     } else {
       llvm::errs() << "N/A. \n";
     }
+    (*value)->getFunction()->dump();
 
     llvm::errs() << "Block: bb" << userBlock->getDebugID() << "\n\n";
   });

--- a/lib/SIL/OperandOwnership.cpp
+++ b/lib/SIL/OperandOwnership.cpp
@@ -340,7 +340,6 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
 // SWIFT_ENABLE_TENSORFLOW
 FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunction)
-FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunctionExtract)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.
@@ -360,6 +359,9 @@ FORWARD_ANY_OWNERSHIP_INST(DifferentiableFunctionExtract)
 FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, MustBeLive, TupleExtract)
 FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, MustBeLive,
                                            StructExtract)
+// SWIFT_ENABLE_TENSORFLOW
+FORWARD_CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Guaranteed, MustBeLive,
+                                           DifferentiableFunctionExtract)
 #undef CONSTANT_OR_TRIVIAL_OWNERSHIP_INST
 
 OperandOwnershipKindMap

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5441,7 +5441,7 @@ RValue RValueEmitter::visitDifferentiableFunctionExtractOriginalExpr(
   auto diffFunc = SGF.emitRValueAsSingleValue(E->getSubExpr());
   auto borrowedDiffFunc = diffFunc.borrow(SGF, E);
   auto *borrowedOrigFunc = SGF.B.createDifferentiableFunctionExtractOriginal(
-      E, borrowedDiffFunc.forward(SGF));
+      E, borrowedDiffFunc.getValue());
   auto ownedOrigFunc = SGF.B.emitCopyValueOperation(E, borrowedOrigFunc);
   return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(ownedOrigFunc));
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5439,9 +5439,11 @@ RValue RValueEmitter::visitDifferentiableFunctionExpr(
 RValue RValueEmitter::visitDifferentiableFunctionExtractOriginalExpr(
     DifferentiableFunctionExtractOriginalExpr *E, SGFContext C) {
   auto diffFunc = SGF.emitRValueAsSingleValue(E->getSubExpr());
-  auto *origFunc = SGF.B.createDifferentiableFunctionExtractOriginal(
-      E, diffFunc.forward(SGF));
-  return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(origFunc));
+  auto borrowedDiffFunc = diffFunc.borrow(SGF, E);
+  auto *borrowedOrigFunc = SGF.B.createDifferentiableFunctionExtractOriginal(
+      E, borrowedDiffFunc.forward(SGF));
+  auto ownedOrigFunc = SGF.B.emitCopyValueOperation(E, borrowedOrigFunc);
+  return RValue(SGF, E, SGF.emitManagedRValueWithCleanup(ownedOrigFunc));
 }
 // SWIFT_ENABLE_TENSORFLOW END
 

--- a/test/AutoDiff/differentiable_function_silgen.swift
+++ b/test/AutoDiff/differentiable_function_silgen.swift
@@ -37,14 +37,17 @@ func apply() {
 // CHECK-AST:              (declref_expr type='(Float) -> Float'
 
 // CHECK-SILGEN-LABEL: @{{.*}}myfunction{{.*}}
-// CHECK-SILGEN: bb0([[DIFFED:%.*]] : @guaranteed $@differentiable @callee_guaranteed (Float) -> Float):
-// CHECK-SILGEN:   [[ORIG:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = begin_borrow [[ORIG]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   apply [[BORROWED_ORIG]]({{%.*}}) : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   destroy_value [[ORIG]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[DIFFED_COPY:%.*]] = copy_value [[DIFFED]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   [[ORIG:%.*]] = differentiable_function_extract [original] [[DIFFED_COPY]] : $@differentiable @callee_guaranteed (Float) -> Float
-// CHECK-SILGEN:   return [[ORIG]] : $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN: bb0([[DIFF:%.*]] : @guaranteed $@differentiable @callee_guaranteed (Float) -> Float):
+// CHECK-SILGEN:   [[COPIED_DIFF:%.*]] = copy_value [[DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_DIFF:%.*]] = begin_borrow [[COPIED_DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   apply [[BORROWED_DIFF]]({{%.*}}) : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   end_borrow [[BORROWED_DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   destroy_value [[COPIED_DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[COPIED_DIFF:%.*]] = copy_value [[DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_DIFF:%.*]] = begin_borrow [[COPIED_DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[BORROWED_ORIG:%.*]] = differentiable_function_extract [original] [[BORROWED_DIFF]] : $@differentiable @callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   [[COPIED_ORIG:%.*]] = copy_value [[BORROWED_ORIG]] : $@callee_guaranteed (Float) -> Float
+// CHECK-SILGEN:   return [[COPIED_ORIG]] : $@callee_guaranteed (Float) -> Float
 
 // CHECK-SILGEN-LABEL: @{{.*}}apply{{.*}}
 // CHECK-SILGEN:       [[ORIG:%.*]] = function_ref @{{.*}}thin{{.*}} : $@convention(thin) (Float) -> Float


### PR DESCRIPTION
`ValueOwnershipKindClassifier` and `OperandOwnershipKindClassifier` should have the same classification for `autodiff_function_extract`. `ValueOwnershipKindClassifier`'s classification was fixed by #27199, which gave the correct ownership verification results. Now we fix it in `OperandOwnershipKindClassifier`.

`DifferentiableFunctionExtractOriginalExpr`'s SILGen is now corrected to borrowing the argument and emitting a copy for the extracted original function.