### PR TITLE
[Typechecker] Reapply fix for SR-11298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,40 +80,6 @@ Swift 5.2
     }
   }
   ```
-  
-  As a result, this could lead to code that currently compiles today to throw an error.
-  
-  ```swift
-  protocol Foo {
-    var someProperty: Int { get set }
-  }
-  
-  class Bar: Foo {
-    var someProperty = 0
-  }
-  
-  extension Foo where Self: Bar {
-    var anotherProperty1: Int {
-      get { return someProperty }
-      // This will now error, because the protocol requirement
-      // is implicitly mutating and the setter is implicitly 
-      // nonmutating.
-      set { someProperty = newValue } // Error
-    }
-  }
-  ```
-
-  **Workaround**: Define a new mutable variable inside the setter that has a reference to `self`:
-  
-  ```swift
-  var anotherProperty1: Int {
-    get { return someProperty }
-    set {
-      var mutableSelf = self
-      mutableSelf.someProperty = newValue // Okay
-    }
-  }
-  ```
 
 * [SE-0253][]:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,63 @@ Swift 5.2
   (foo as Magic)(5)
   ```
 
+* [SR-11298][]:
+
+  A class-constrained protocol extension, where the extended protocol does
+  not impose a class constraint, will now infer the constraint implicitly.
+
+  ```swift
+  protocol Foo {}
+  class Bar: Foo {
+    var someProperty: Int = 0
+  }
+
+  // Even though 'Foo' does not impose a class constraint, it is automatically
+  // inferred due to the Self: Bar constraint.
+  extension Foo where Self: Bar {
+    var anotherProperty: Int {
+      get { return someProperty }
+      // As a result, the setter is now implicitly nonmutating, just like it would
+      // be if 'Foo' had a class constraint.
+      set { someProperty = newValue }
+    }
+  }
+  ```
+  
+  As a result, this could lead to code that currently compiles today to throw an error.
+  
+  ```swift
+  protocol Foo {
+    var someProperty: Int { get set }
+  }
+  
+  class Bar: Foo {
+    var someProperty = 0
+  }
+  
+  extension Foo where Self: Bar {
+    var anotherProperty1: Int {
+      get { return someProperty }
+      // This will now error, because the protocol requirement
+      // is implicitly mutating and the setter is implicitly 
+      // nonmutating.
+      set { someProperty = newValue } // Error
+    }
+  }
+  ```
+
+  **Workaround**: Define a new mutable variable inside the setter that has a reference to `self`:
+  
+  ```swift
+  var anotherProperty1: Int {
+    get { return someProperty }
+    set {
+      var mutableSelf = self
+      mutableSelf.someProperty = newValue // Okay
+    }
+  }
+  ```
+
 * [SE-0253][]:
 
   Values of types that declare `func callAsFunction` methods can be called
@@ -83,7 +140,7 @@ Swift 5.2
 
 * [SR-4206][]:
 
-  A method override is no longer allowed to have a generic signature with 
+  A method override is no longer allowed to have a generic signature with
   requirements not imposed by the base method. For example:
 
   ```
@@ -7799,4 +7856,5 @@ Swift 1.0
 [SR-8974]: <https://bugs.swift.org/browse/SR-8974>
 [SR-9043]: <https://bugs.swift.org/browse/SR-9043>
 [SR-9827]: <https://bugs.swift.org/browse/SR-9827>
+[SR-11298]: <https://bugs.swift.org/browse/SR-11298>
 [SR-11429]: <https://bugs.swift.org/browse/SR-11429>

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -261,7 +261,10 @@ public:
 
   /// Returns the kind of context this is.
   DeclContextKind getContextKind() const;
-  
+
+  /// Returns whether this context has value semantics.
+  bool hasValueSemantics() const;
+
   /// Determines whether this context is itself a local scope in a
   /// code block.  A context that appears in such a scope, like a
   /// local type declaration, does not itself become a local context.

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -265,6 +265,9 @@ public:
   /// Returns whether this context has value semantics.
   bool hasValueSemantics() const;
 
+  /// Returns whether this context is an extension constrained to a class type.
+  bool isClassConstrainedProtocolExtension() const;
+
   /// Determines whether this context is itself a local scope in a
   /// code block.  A context that appears in such a scope, like a
   /// local type declaration, does not itself become a local context.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5632,12 +5632,6 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
       if (auto AD = dyn_cast<AccessorDecl>(FD)) {
         if (AD->isGetter() && !AD->getAccessorKeywordLoc().isValid())
           return;
-
-        auto accessorDC = AD->getDeclContext();
-        // Do not suggest the fix-it if `Self` is a class type.
-        if (accessorDC->isTypeContext() && !accessorDC->hasValueSemantics()) {
-          return;
-        }
       }
 
       auto &d = getASTContext().Diags;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5628,10 +5628,16 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
     if (FD && !FD->isMutating() && !FD->isImplicit() && FD->isInstanceMember()&&
         !FD->getDeclContext()->getDeclaredInterfaceType()
                  ->hasReferenceSemantics()) {
-      // Do not suggest the fix it in implicit getters
+      // Do not suggest the fix-it in implicit getters
       if (auto AD = dyn_cast<AccessorDecl>(FD)) {
         if (AD->isGetter() && !AD->getAccessorKeywordLoc().isValid())
           return;
+
+        auto accessorDC = AD->getDeclContext();
+        // Do not suggest the fix-it if `Self` is a class type.
+        if (accessorDC->isTypeContext() && !accessorDC->hasValueSemantics()) {
+          return;
+        }
       }
 
       auto &d = getASTContext().Diags;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1039,8 +1039,6 @@ bool DeclContext::hasValueSemantics() const {
   if (getExtendedProtocolDecl())
     return !isClassConstrainedProtocolExtension();
   return !getDeclaredInterfaceType()->hasReferenceSemantics();
-
-  return false;
 }
 
 bool DeclContext::isClassConstrainedProtocolExtension() const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1035,6 +1035,14 @@ DeclContextKind DeclContext::getContextKind() const {
   llvm_unreachable("Unhandled DeclContext ASTHierarchy");
 }
 
+bool DeclContext::hasValueSemantics() const {
+  if (auto contextTy = getSelfTypeInContext()) {
+    return !contextTy->hasReferenceSemantics();
+  }
+
+  return false;
+}
+
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::AbstractFunctionDecl:

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1043,6 +1043,17 @@ bool DeclContext::hasValueSemantics() const {
   return false;
 }
 
+bool DeclContext::isClassConstrainedProtocolExtension() const {
+  if (auto ED = dyn_cast<ExtensionDecl>(this)) {
+    if (ED->getExtendedType()->isExistentialType()) {
+      return ED->getGenericSignature()->requiresClass(
+          ED->getSelfInterfaceType());
+    }
+  }
+
+  return false;
+}
+
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::AbstractFunctionDecl:

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1036,21 +1036,18 @@ DeclContextKind DeclContext::getContextKind() const {
 }
 
 bool DeclContext::hasValueSemantics() const {
-  if (auto contextTy = getSelfTypeInContext()) {
-    return !contextTy->hasReferenceSemantics();
-  }
+  if (getExtendedProtocolDecl())
+    return !isClassConstrainedProtocolExtension();
+  return !getDeclaredInterfaceType()->hasReferenceSemantics();
 
   return false;
 }
 
 bool DeclContext::isClassConstrainedProtocolExtension() const {
-  if (auto ED = dyn_cast<ExtensionDecl>(this)) {
-    if (ED->getExtendedType()->isExistentialType()) {
-      return ED->getGenericSignature()->requiresClass(
-          ED->getSelfInterfaceType());
-    }
+  if (getExtendedProtocolDecl()) {
+    auto ED = cast<ExtensionDecl>(this);
+    return ED->getGenericSignature()->requiresClass(ED->getSelfInterfaceType());
   }
-
   return false;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2092,8 +2092,8 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
     if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
       // If this decl is on a class-constrained protocol extension, then
-      // the respect the explicit mutatingness. Otherwise, we would throw an
-      // error and break source compatibility.
+      // respect the explicit mutatingness. Otherwise, we would throw an
+      // error.
       if (FD->getDeclContext()->isClassConstrainedProtocolExtension())
         return SelfAccessKind::Mutating;
       return SelfAccessKind::NonMutating;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2087,17 +2087,10 @@ OperatorPrecedenceGroupRequest::evaluate(Evaluator &evaluator,
   return group;
 }
 
-bool swift::doesContextHaveValueSemantics(DeclContext *dc) {
-  if (Type contextTy = dc->getDeclaredInterfaceType())
-    return !contextTy->hasReferenceSemantics();
-  return false;
-}
-
 llvm::Expected<SelfAccessKind>
 SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
-    if (!FD->isInstanceMember() ||
-        !doesContextHaveValueSemantics(FD->getDeclContext())) {
+    if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
       return SelfAccessKind::NonMutating;
     }
     return SelfAccessKind::Mutating;
@@ -2119,8 +2112,7 @@ SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
     case AccessorKind::MutableAddress:
     case AccessorKind::Set:
     case AccessorKind::Modify:
-      if (AD->isInstanceMember() &&
-          doesContextHaveValueSemantics(AD->getDeclContext()))
+      if (AD->isInstanceMember() && AD->getDeclContext()->hasValueSemantics())
         return SelfAccessKind::Mutating;
       break;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2091,6 +2091,9 @@ llvm::Expected<SelfAccessKind>
 SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
     if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
+      // If this decl is on a class-constrained protocol extension, then
+      // the respect the explicit mutatingness. Otherwise, we would throw an
+      // error and break source compatibility.
       if (FD->getDeclContext()->isClassConstrainedProtocolExtension())
         return SelfAccessKind::Mutating;
       return SelfAccessKind::NonMutating;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2091,6 +2091,8 @@ llvm::Expected<SelfAccessKind>
 SelfAccessKindRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   if (FD->getAttrs().getAttribute<MutatingAttr>(true)) {
     if (!FD->isInstanceMember() || !FD->getDeclContext()->hasValueSemantics()) {
+      if (FD->getDeclContext()->isClassConstrainedProtocolExtension())
+        return SelfAccessKind::Mutating;
       return SelfAccessKind::NonMutating;
     }
     return SelfAccessKind::Mutating;

--- a/lib/Sema/TypeCheckDecl.h
+++ b/lib/Sema/TypeCheckDecl.h
@@ -25,8 +25,6 @@ class DeclContext;
 class ValueDecl;
 class Pattern;
 
-bool doesContextHaveValueSemantics(DeclContext *dc);
-
 /// Walks up the override chain for \p CD until it finds an initializer that is
 /// required and non-implicit. If no such initializer exists, returns the
 /// declaration where \c required was introduced (i.e. closest to the root

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -270,8 +270,9 @@ void swift::validatePatternBindingEntries(TypeChecker &tc,
 llvm::Expected<bool>
 IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
-  bool result = (!storage->isStatic() &&
-                 doesContextHaveValueSemantics(storage->getDeclContext()));
+  auto storageDC = storage->getDeclContext();
+  bool result = (!storage->isStatic() && storageDC->isTypeContext() &&
+                 storageDC->hasValueSemantics());
 
   // 'lazy' overrides the normal accessor-based rules and heavily
   // restricts what accessors can be used.  The getter is considered
@@ -299,7 +300,7 @@ IsGetterMutatingRequest::evaluate(Evaluator &evaluator,
 
   // Protocol requirements are always written as '{ get }' or '{ get set }';
   // the @_borrowed attribute determines if getReadImpl() becomes Get or Read.
-  if (isa<ProtocolDecl>(storage->getDeclContext()))
+  if (isa<ProtocolDecl>(storageDC))
     return checkMutability(AccessorKind::Get);
 
   switch (storage->getReadImpl()) {
@@ -325,8 +326,9 @@ IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
                                   AbstractStorageDecl *storage) const {
   // By default, the setter is mutating if we have an instance member of a
   // value type, but this can be overridden below.
-  bool result = (!storage->isStatic() &&
-                 doesContextHaveValueSemantics(storage->getDeclContext()));
+  auto storageDC = storage->getDeclContext();
+  bool result = (!storage->isStatic() && storageDC->isTypeContext() &&
+                 storageDC->hasValueSemantics());
 
   // If we have an attached property wrapper, the setter is mutating
   // or not based on the composition of the wrappers.

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -126,7 +126,7 @@ struct WrapperContext {
 }
 
 // Class-constrained extension where protocol does not impose class requirement
-
+// SR-11298
 protocol DoesNotImposeClassReq_1 {}
 	
 class JustAClass: DoesNotImposeClassReq_1 {
@@ -140,8 +140,8 @@ extension DoesNotImposeClassReq_1 where Self: JustAClass {
   }
 }
 	
-let instanceOfJustAClass = JustAClass() // expected-note {{change 'let' to 'var' to make it mutable}}
-instanceOfJustAClass.wrappingProperty = "" // expected-error {{cannot assign to property: 'instanceOfJustAClass' is a 'let' constant}}
+let instanceOfJustAClass = JustAClass()
+instanceOfJustAClass.wrappingProperty = "" // Okay
 
 protocol DoesNotImposeClassReq_2 {
   var property: String { get set }
@@ -150,7 +150,7 @@ protocol DoesNotImposeClassReq_2 {
 extension DoesNotImposeClassReq_2 where Self : AnyObject {
   var wrappingProperty: String {
     get { property }
-    set { property = newValue } // Okay
+    set { property = newValue } // expected-error {{cannot assign to property: 'self' is immutable}}
   }
 }
 

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -157,7 +157,7 @@ extension DoesNotImposeClassReq_1 where Self: JustAClass {
     wrappingProperty3 = "" // Okay
   }
   
-  func bar() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{2-2=mutating }}
+  func bar() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{3-3=mutating }}
     property = "" // Okay
     wrappingProperty1 = "" // Okay
     wrappingProperty2 = "" // Okay
@@ -178,6 +178,7 @@ instanceOfJustAClass1.wrappingProperty2 = "" // Okay
 instanceOfJustAClass1.wrappingProperty3 = "" // expected-error {{cannot assign to property: 'instanceOfJustAClass1' is a 'let' constant}}
 instanceOfJustAClass1.foo() // expected-error {{cannot use mutating member on immutable value: 'instanceOfJustAClass1' is a 'let' constant}}
 instanceOfJustAClass1.bar() // Okay
+instanceOfJustAClass1.baz() // Okay
 
 var instanceOfJustAClass2 = JustAClass()
 instanceOfJustAClass2.foo() // Okay
@@ -204,22 +205,22 @@ extension DoesNotImposeClassReq_2 where Self : AnyObject {
   
   mutating func foo() {
     property = "" // Okay
-    wrappingProperty1 = "" // Okay
-    wrappingProperty2 = "" // Okay
+    wrappingProperty1 = "" // Okay (the error is on the setter declaration above)
+    wrappingProperty2 = "" // Okay (the error is on the setter declaration above)
     wrappingProperty3 = "" // Okay
   }
   
-  func bar() { // expected-note 2{{mark method 'mutating' to make 'self' mutable}}{{2-2=mutating }}
+  func bar() { // expected-note 2{{mark method 'mutating' to make 'self' mutable}}{{3-3=mutating }}
     property = "" // expected-error {{cannot assign to property: 'self' is immutable}}
-    wrappingProperty1 = "" // Okay
-    wrappingProperty2 = "" // Okay
+    wrappingProperty1 = "" // Okay (the error is on the setter declaration above)
+    wrappingProperty2 = "" // Okay (the error is on the setter declaration above)
     wrappingProperty3 = "" // expected-error {{cannot assign to property: 'self' is immutable}}
   }
   
   nonmutating func baz() { // expected-note 2{{mark method 'mutating' to make 'self' mutable}}
     property = "" // expected-error {{cannot assign to property: 'self' is immutable}}
-    wrappingProperty1 = "" // Okay
-    wrappingProperty2 = "" // Okay
+    wrappingProperty1 = "" // Okay (the error is on the setter declaration above)
+    wrappingProperty2 = "" // Okay (the error is on the setter declaration above)
     wrappingProperty3 = "" // expected-error {{cannot assign to property: 'self' is immutable}}
   }
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -164,7 +164,7 @@ extension DoesNotImposeClassReq_1 where Self: JustAClass {
     wrappingProperty3 = "" // expected-error {{cannot assign to property: 'self' is immutable}}
   }
   
-  nonmutating func baz() { // expected-note {{mark method 'mutating' to make 'self' mutable}}
+  nonmutating func baz() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{3-14=mutating}}
     property = "" // Okay
     wrappingProperty1 = "" // Okay
     wrappingProperty2 = "" // Okay
@@ -191,11 +191,13 @@ extension DoesNotImposeClassReq_2 where Self : AnyObject {
   var wrappingProperty1: String {
     get { property }
     set { property = newValue } // expected-error {{cannot assign to property: 'self' is immutable}}
+    // expected-note@-1 {{mark accessor 'mutating' to make 'self' mutable}}{{5-5=mutating }}
   }
   
   var wrappingProperty2: String {
     get { property }
     nonmutating set { property = newValue } // expected-error {{cannot assign to property: 'self' is immutable}}
+    // expected-note@-1 {{mark accessor 'mutating' to make 'self' mutable}}{{5-16=mutating}}
   }
   
   var wrappingProperty3: String {
@@ -217,7 +219,7 @@ extension DoesNotImposeClassReq_2 where Self : AnyObject {
     wrappingProperty3 = "" // expected-error {{cannot assign to property: 'self' is immutable}}
   }
   
-  nonmutating func baz() { // expected-note 2{{mark method 'mutating' to make 'self' mutable}}
+  nonmutating func baz() { // expected-note 2{{mark method 'mutating' to make 'self' mutable}}{{3-14=mutating}}
     property = "" // expected-error {{cannot assign to property: 'self' is immutable}}
     wrappingProperty1 = "" // Okay (the error is on the setter declaration above)
     wrappingProperty2 = "" // Okay (the error is on the setter declaration above)

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -227,6 +227,30 @@ extension DoesNotImposeClassReq_2 where Self : AnyObject {
   }
 }
 
+protocol DoesNotImposeClassReq_3 {
+  var someProperty: Int { get set }
+}
+
+class JustAClass1: DoesNotImposeClassReq_3 {
+  var someProperty = 0
+}
+
+extension DoesNotImposeClassReq_3 where Self: JustAClass1 {
+  var anotherProperty1: Int {
+    get { return someProperty }
+    set { someProperty = newValue } // Okay
+  }
+
+  var anotherProperty2: Int {
+    get { return someProperty }
+    set { someProperty = newValue } // Okay
+  }
+}
+
+let justAClass1 = JustAClass1() // expected-note {{change 'let' to 'var' to make it mutable}}
+justAClass1.anotherProperty1 = 1234 // Okay
+justAClass1.anotherProperty2 = 4321 // expected-error {{cannot assign to property: 'justAClass1' is a 'let' constant}}
+
 // Reject extension of nominal type via parameterized typealias
 
 struct Nest<Egg> { typealias Contents = Egg }


### PR DESCRIPTION
This re-applies the previously accepted fix for [SR-11298](https://bugs.swift.org/browse/SR-11298).

1. The first commit unreverts #27611
2. The second commit applies a tweak so we don't incorrectly mark explicitly `mutating` methods in a class-constrained protocol extension as `nonmutating`.

Resolves [SR-11298](https://bugs.swift.org/browse/SR-11298)