### PR TITLE
[Constant Evaluator] Add support for interpreting SIL code with partial applies (i.e., closure creations).

### DIFF
--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -784,3 +784,52 @@ func testArrayAppendNonEmpty(_ x: String) -> [String] {
 func interpretArrayAppendNonEmpty() -> [String] {
   return testArrayAppendNonEmpty("mkdir")
 }
+
+// CHECK-LABEL: @testClosureInit
+// CHECK-NOT: error:
+@_semantics("constant_evaluable")
+func testClosureInit(_ x: Int) -> () -> Int {
+  return { x }
+}
+
+@_semantics("test_driver")
+func interpretClosureCreation() -> () -> Int {
+  return testClosureInit(19)
+}
+
+// CHECK-LABEL: @testClosureChaining
+// CHECK-NOT: error:
+@_semantics("constant_evaluable")
+func testClosureChaining(_ x: Int, _ y: Int) -> () -> Int {
+  let clo: (Int) -> Int = { $0 + x }
+  return { clo(y) }
+}
+
+@_semantics("test_driver")
+func interpretClosureChains() -> () -> Int {
+  return testClosureChaining(191, 201)
+}
+
+// CHECK-LABEL: @testClosureWithNonConstantCaptures
+// CHECK-NOT: error:
+@_semantics("constant_evaluable")
+func testClosureWithNonConstantCaptures(_ x: @escaping () -> Int) -> () -> Int {
+  return x
+}
+
+@_semantics("test_driver")
+func interpretClosureWithNonConstantCaptures(_ x: Int) -> () -> Int {
+  return testClosureWithNonConstantCaptures({ x })
+}
+
+// CHECK-LABEL: @testAutoClosure
+// CHECK-NOT: error:
+@_semantics("constant_evaluable")
+func testAutoClosure(_ x: @escaping @autoclosure () -> Int) -> () -> Int {
+  return x
+}
+
+@_semantics("test_driver")
+func interpretAutoClosure(_ x: Int) -> () -> Int {
+  return testAutoClosure(x)
+}

--- a/test/SILOptimizer/constant_evaluator_test.sil
+++ b/test/SILOptimizer/constant_evaluator_test.sil
@@ -1222,6 +1222,7 @@ sil [serialized] [_semantics "array.init.empty"] @$sS2ayxGycfC : $@convention(me
 // _allocateUninitializedArray<A>(_:)
 sil [serialized] [always_inline] [_semantics "array.uninitialized_intrinsic"] @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 
+// CHECK-LABEL: @interpretArrayInit
 sil @interpretArrayInit : $@convention(thin) () -> @owned Array<Int> {
 bb0:
   %0 = metatype $@thin Array<Int>.Type
@@ -1232,6 +1233,7 @@ bb0:
 } // CHECK: Returns Array<Int>
   // CHECK: size: 0 contents []
 
+// CHECK-LABEL: @interpretEmptyArrayLiteral
 sil [ossa] @interpretEmptyArrayLiteral : $@convention(thin) () -> @owned Array<String> {
 bb0:
   %0 = integer_literal $Builtin.Word, 0
@@ -1268,6 +1270,7 @@ bb0:
   return %9 : $Array<Int64>
 }
 
+// CHECK-LABEL: @interpretArrayLiteral
 sil [ossa] @interpretArrayLiteral : $@convention(thin) () -> @owned Array<Int64> {
 bb0:
   %7 = function_ref @initializeArrayWithLiterals : $@convention(thin) () -> @owned Array<Int64>
@@ -1282,6 +1285,7 @@ bb0:
 // Array.append(_:)
 sil [serialized] [_semantics "array.append_element"] @$sSa6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
 
+// CHECK-LABEL: @interpretArrayAppend
 sil [ossa] @interpretArrayAppend : $@convention(thin) () -> @owned Array<Int64> {
   %0 = integer_literal $Builtin.Int64, 71
   %1 = struct $Int64 (%0 : $Builtin.Int64)
@@ -1305,6 +1309,7 @@ sil [ossa] @interpretArrayAppend : $@convention(thin) () -> @owned Array<Int64> 
   // CHECK: size: 1
   // CHECK: agg: 1 elt: int: 71
 
+// CHECK-LABEL: @interpretArrayAppendNonEmpty
 sil [ossa] @interpretArrayAppendNonEmpty : $@convention(thin) () -> @owned Array<Int64> {
 bb0:
   %0 = integer_literal $Builtin.Int64, 100
@@ -1334,6 +1339,7 @@ bb0:
 /// Test appending of a static string to an array. The construction of a static
 /// string is a bit complicated due to the use of instructions like "ptrtoint".
 /// This tests that array append works with such complex constant values as well.
+// CHECK-LABEL: @interpretArrayAppendStaticString
 sil @interpretArrayAppendStaticString : $@convention(thin) () -> @owned Array<StaticString> {
   %0 = string_literal utf8 "constant" // string to be appended.
 
@@ -1365,3 +1371,55 @@ sil @interpretArrayAppendStaticString : $@convention(thin) () -> @owned Array<St
   // CHECK: size: 1
   // CHECK: string: "constant"
 
+// Test partial apply and closure creation.
+
+sil private @closure1 : $@convention(thin) (Int32) -> Int32 {
+bb0(%0 : $Int32):
+  return %0 : $Int32
+}
+
+// CHECK-LABEL: @interpretPartialApply
+sil @interpretPartialApply: $@convention(thin) () -> @owned @callee_guaranteed () -> Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 81
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %2 = function_ref @closure1 : $@convention(thin) (Int32) -> Int32
+  %3 = partial_apply [callee_guaranteed] %2(%1) : $@convention(thin) (Int32) -> Int32
+  return %3 : $@callee_guaranteed () -> Int32
+} // CHECK: Returns closure: target: closure1 captures
+  // CHECK: %1
+  // CHECK: values:
+  // CHECK: int: 81
+
+sil private @closure2 : $@convention(thin) (Int32, Int32) -> Int32 {
+bb0(%0 : $Int32, %1: $Int32):
+  return %0 : $Int32
+}
+
+sil private @closure3 : $@convention(thin) (@guaranteed @callee_guaranteed (Int32) -> Int32) -> Int32 {
+bb0(%0 : $@callee_guaranteed (Int32) -> Int32):
+  %3 = integer_literal $Builtin.Int32, 19
+  %4 = struct $Int32 (%3 : $Builtin.Int32)
+  %5 = apply %0(%4) : $@callee_guaranteed (Int32) -> Int32
+  return %5 : $Int32
+}
+
+// CHECK-LABEL: @interpretPartialApplyChain
+sil @interpretPartialApplyChain: $@convention(thin) () -> @owned @callee_guaranteed () -> Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 991
+  %1 = struct $Int32 (%0 : $Builtin.Int32)
+  %2 = function_ref @closure2 : $@convention(thin) (Int32, Int32) -> Int32
+  %3 = partial_apply [callee_guaranteed] %2(%1) : $@convention(thin) (Int32, Int32) -> Int32
+  %5 = function_ref @closure3 : $@convention(thin) (@guaranteed @callee_guaranteed (Int32) -> Int32) -> Int32
+  strong_retain %3 : $@callee_guaranteed (Int32) -> Int32
+  %7 = partial_apply [callee_guaranteed] %5(%3) : $@convention(thin) (@guaranteed @callee_guaranteed (Int32) -> Int32) -> Int32
+  strong_release %3 : $@callee_guaranteed (Int32) -> Int32
+  return %7 : $@callee_guaranteed () -> Int32
+} // CHECK: Returns closure: target: closure3 captures
+  // CHECK: %3
+  // CHECK: values:
+  // CHECK:   closure: target: closure2 captures
+  // CHECK:     %1
+  // CHECK:   values:
+  // CHECK:     int: 991


### PR DESCRIPTION
A new SymbolicValue: SymbolicClosure represents a closure. It
tracks the SILFunction corresponding to the target of the closure
and the SIL and Symbolic Values of the captured arguments. The
representation does not impose that all captured values must have an
associated symbolic value. This allows the evaluator to track
creations of closures whose captured arguments or bodies are not
constant evaluable.

This commit does not add support for closure applications. It only
adds suppport for closure creations, which correspond to partial_apply
instructions in SIL.