### PR TITLE
[AST] emitLetToVarNoteIfSimple should also check if the method/accessor is explicitly non-mutating

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5689,7 +5689,7 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
                               isa<AccessorDecl>(FD));
       if (auto nonmutatingAttr =
               FD->getAttrs().getAttribute<NonMutatingAttr>()) {
-        diags.fixItReplace(nonmutatingAttr->getLocation(), "mutating ");
+        diags.fixItReplace(nonmutatingAttr->getLocation(), "mutating");
       } else {
         diags.fixItInsert(FD->getFuncLoc(), "mutating ");
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5683,11 +5683,16 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
         if (AD->isGetter() && !AD->getAccessorKeywordLoc().isValid())
           return;
       }
-                   
+
       auto &d = getASTContext().Diags;
-      d.diagnose(FD->getFuncLoc(), diag::change_to_mutating,
-                 isa<AccessorDecl>(FD))
-       .fixItInsert(FD->getFuncLoc(), "mutating ");
+      auto diags = d.diagnose(FD->getFuncLoc(), diag::change_to_mutating,
+                              isa<AccessorDecl>(FD));
+      if (auto nonmutatingAttr =
+              FD->getAttrs().getAttribute<NonMutatingAttr>()) {
+        diags.fixItReplace(nonmutatingAttr->getLocation(), "mutating ");
+      } else {
+        diags.fixItInsert(FD->getFuncLoc(), "mutating ");
+      }
       return;
     }
   }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -681,3 +681,23 @@ struct SS {
     j = j // expected-error {{cannot assign to value: 'j' is a 'let' constant}}
   }
 }
+
+protocol JustAProtocol {
+  var name: String { get set }
+}
+
+extension JustAProtocol {
+  var foo: String {
+    get { return name }
+    nonmutating set { name = newValue } // expected-error {{cannot assign to property: 'self' is immutable}} 
+    // expected-note@-1 {{mark accessor 'mutating' to make 'self' mutable}}{{5-16=mutating}}
+  }
+
+  nonmutating func bar() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{3-14=mutating}}
+    name = "Hello" // expected-error {{cannot assign to property: 'self' is immutable}}
+  }
+  
+  func baz() { // expected-note {{mark method 'mutating' to make 'self' mutable}}{{3-3=mutating }}
+    name = "World" // expected-error {{cannot assign to property: 'self' is immutable}}
+  }
+}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -159,7 +159,7 @@ struct SomeStruct {
       return 42
     }
     nonmutating
-    set {      // expected-note {{mark accessor 'mutating' to make 'self' mutable}} {{5-5=mutating }}
+    set {      // expected-note {{mark accessor 'mutating' to make 'self' mutable}} {{5-16=mutating}}
       iv = newValue // expected-error {{cannot assign to property: 'self' is immutable}}
     }
   }


### PR DESCRIPTION
`emitLetToVarNoteIfSimple()` emits a diagnostic with a fix-it to add `mutating` to a method or accessor. However, it's possible that the method or accessor is explicitly `nonmutating`. In that case, we end up adding the `mutating` after `nonmutating`, leading to another error: `Method must not be declared both nonmutating and mutating` (if we have a method) or `Expected 'get', 'set', 'willSet', or 'didSet' keyword to start an accessor definition` (if we have an accessor, like a `set`).

We should check whether we have an explicit `nonmutating` attribute and instead of inserting the fix-it, we should replace `nonmutating` with `mutating`.

(I noticed when I was writing some tests!)