### PR TITLE
[AutoDiff] Fix `@differentiable(linear)` type parsing ambiguity.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2529,7 +2529,8 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, SourceLoc AtLoc,
       // Determine if we have '@differentiable(linear) (T) -> U'
       // or '@differentiable (linear) -> U'.
       if (Tok.getText() == "linear" && consumeIf(tok::identifier)) {
-        if (Tok.is(tok::r_paren) && peekToken().is(tok::l_paren)) {
+        if (Tok.is(tok::r_paren) &&
+            peekToken().isAny(tok::l_paren, tok::at_sign, tok::identifier)) {
           // It is being used as an attribute argument, so cancel backtrack
           // as function is linear differentiable.
           linear = true;
@@ -2538,8 +2539,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, SourceLoc AtLoc,
         } else if (Tok.is(tok::l_paren)) {
           // Handle invalid '@differentiable(linear (T) -> U'
           if (!justChecking)
-            diagnose(Tok,
-                     diag::differentiable_attribute_expected_rparen);
+            diagnose(Tok, diag::differentiable_attribute_expected_rparen);
           backtrack.cancelBacktrack();
           return false;
         }

--- a/test/AutoDiff/differentiable_func_type_parse.swift
+++ b/test/AutoDiff/differentiable_func_type_parse.swift
@@ -38,6 +38,6 @@ struct B {
   let property: @differentiable(linear) (linear) -> linear // okay
   let property: @differentiable linear // okay
   let property: linear // okay
-  // FIXME(bartchr): TF-576 have this able to be parsed.
-  //let property: @differentiable(linear) linear // okay
+  let property: @differentiable(linear) linear // okay
+  let property: @differentiable(linear) @convention(c) linear // okay
 }


### PR DESCRIPTION
Handle the case where `@differentiable(linear)` is followed by a type alias or another type attribute.
```swift
typealias linear = (Float) -> Float
let property: @differentiable(linear) linear // okay
let property: @differentiable(linear) @convention(c) linear // okay
```

Resolves [TF-576](https://bugs.swift.org/browse/TF-576).