### PR TITLE
[Diagnostics] Add a fix-it for try instead of throws in function decl…

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -788,7 +788,7 @@ Parser::parseFunctionSignature(Identifier SimpleName,
       .fixItReplace(throwsLoc, "throws");
   } else if (Tok.is(tok::kw_try)) {
     diagnose(Tok.getLoc(), diag::throw_in_function_type)
-        .fixItReplace(tryLoc, "throws");
+        .fixItReplace(Tok.getLoc(), "throws");
     ignoreToken();
   }
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -786,6 +786,10 @@ Parser::parseFunctionSignature(Identifier SimpleName,
     throwsLoc = consumeToken();
     diagnose(throwsLoc, diag::throw_in_function_type)
       .fixItReplace(throwsLoc, "throws");
+  } else if (Tok.is(tok::kw_try)) {
+    diagnose(Tok.getLoc(), diag::throw_in_function_type)
+        .fixItReplace(tryLoc, "throws");
+    ignoreToken();
   }
 
   SourceLoc arrowLoc;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -782,14 +782,10 @@ Parser::parseFunctionSignature(Identifier SimpleName,
   } else if (Tok.is(tok::kw_rethrows)) {
     throwsLoc = consumeToken();
     rethrows = true;
-  } else if (Tok.is(tok::kw_throw)) {
+  } else if (Tok.isAny(tok::kw_throw, tok::kw_try)) {
     throwsLoc = consumeToken();
     diagnose(throwsLoc, diag::throw_in_function_type)
       .fixItReplace(throwsLoc, "throws");
-  } else if (Tok.is(tok::kw_try)) {
-    SourceLoc tryLoc = consumeToken();
-    diagnose(tryLoc, diag::throw_in_function_type)
-        .fixItReplace(tryLoc, "throws");
   }
 
   SourceLoc arrowLoc;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -787,9 +787,9 @@ Parser::parseFunctionSignature(Identifier SimpleName,
     diagnose(throwsLoc, diag::throw_in_function_type)
       .fixItReplace(throwsLoc, "throws");
   } else if (Tok.is(tok::kw_try)) {
-    diagnose(Tok.getLoc(), diag::throw_in_function_type)
-        .fixItReplace(Tok.getLoc(), "throws");
-    ignoreToken();
+    SourceLoc tryLoc = consumeToken();
+    diagnose(tryLoc, diag::throw_in_function_type)
+        .fixItReplace(tryLoc, "throws");
   }
 
   SourceLoc arrowLoc;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -399,17 +399,19 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   // Don't consume 'throws', if the next token is not '->', so we can emit a
   // more useful diagnostic when parsing a function decl.
   SourceLoc throwsLoc;
-  if (Tok.isAny(tok::kw_throws, tok::kw_rethrows, tok::kw_throw) &&
+  if (Tok.isAny(tok::kw_throws, tok::kw_rethrows, tok::kw_throw, tok::kw_try) &&
       peekToken().is(tok::arrow)) {
     if (Tok.isNot(tok::kw_throws)) {
       // 'rethrows' is only allowed on function declarations for now.
-      // 'throw' is probably a typo for 'throws'.
+      // 'throw' or 'try' are probably typos for 'throws'.
       Diag<> DiagID = Tok.is(tok::kw_rethrows) ?
         diag::rethrowing_function_type : diag::throw_in_function_type;
       diagnose(Tok.getLoc(), DiagID)
         .fixItReplace(Tok.getLoc(), "throws");
     }
-    throwsLoc = consumeToken();
+    if (Tok.isNot(tok::try)) {
+      throwsLoc = consumeToken();
+    }
   }
 
   if (Tok.is(tok::arrow)) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -409,9 +409,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       diagnose(Tok.getLoc(), DiagID)
         .fixItReplace(Tok.getLoc(), "throws");
     }
-    if (Tok.isNot(tok::try)) {
-      throwsLoc = consumeToken();
-    }
+    throwsLoc = consumeToken();
   }
 
   if (Tok.is(tok::arrow)) {

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -127,3 +127,9 @@ func fixitThrow2() throws {
 }
 
 let fn: () -> throws Void  // expected-error{{'throws' may only occur before '->'}} {{12-12=throws }} {{15-22=}}
+
+// SR-11574
+func fixitTry0<T>(a: T) try where T:ExpressibleByStringLiteral {} // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{25-28=throws}}
+func fixitTry1<T>(a: T) try {} // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{25-28=throws}}
+func fixitTry2() try {} // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{18-21=throws}}
+let fixitTry3 : () try -> Int // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{20-23=throws}}


### PR DESCRIPTION
…s and types.

Sometimes one would misstype `throws` for `try` so we provide a fix-it for that.
It might happen in two cases:

In function declarations:
```swift
func foo() try {}
```

In function types:
```swift
let f = () try -> Int
```

Resolves [SR-11574](https://bugs.swift.org/browse/SR-11574).